### PR TITLE
feat: add configurable maxContextActions field for planner context gathering

### DIFF
--- a/apps/open-swe/src/types.ts
+++ b/apps/open-swe/src/types.ts
@@ -336,6 +336,25 @@ export const GraphConfiguration = z.object({
         description: "Controls randomness (0 = deterministic, 2 = creative)",
       },
     }),
+
+  /**
+   * The maximum number of context gathering actions to take during planning.
+   * Each action consists of 2 messages (request & result), plus 1 human message.
+   * Total messages = maxContextActions * 2 + 1
+   * @default 6
+   */
+  maxContextActions: z
+    .number()
+    .optional()
+    .langgraph.metadata({
+      x_oap_ui_config: {
+        type: "number",
+        default: 6,
+        min: 1,
+        max: 20,
+        description: "Maximum number of context gathering actions during planning",
+      },
+    }),
 });
 
 export type GraphConfig = LangGraphRunnableConfig<
@@ -344,3 +363,4 @@ export type GraphConfig = LangGraphRunnableConfig<
     assistant_id: string;
   }
 >;
+


### PR DESCRIPTION
This PR adds a configurable `maxContextActions` field to control how many context-gathering actions the planner can take before generating a plan.

## Changes Made

1. **Added `maxContextActions` to GraphConfiguration** (`apps/open-swe/src/types.ts`)
   - Default value of 6 actions
   - Number input type with min/max constraints (1-20)
   - Comprehensive documentation explaining the calculation formula

2. **Updated planner subgraph to use configurable value** (`apps/open-swe/src/subgraphs/planner/index.ts`)
   - Replaced hardcoded `maxActionsCount = 13` with dynamic calculation
   - Now calculates as `maxContextActions * 2 + 1` (each action = 2 messages + 1 initial human message)
   - Added proper fallback to default value when config not provided

3. **Verified inheritance structure** (`apps/open-swe/src/subgraphs/planner/types.ts`)
   - Confirmed that the planner subgraph already inherits the configuration through `GraphAnnotation` extension
   - No additional changes needed due to LangGraph's automatic config propagation

## Benefits

- Users can now control the depth of context gathering before plan generation
- Maintains backward compatibility with sensible default
- Follows existing configuration patterns in the codebase
- Clear documentation of the message calculation formula