### PR TITLE
feat: add dynamic repository selector to chat interface

### DIFF
--- a/apps/web/src/components/repository-selector.tsx
+++ b/apps/web/src/components/repository-selector.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export type TargetRepository = {
+  owner: string;
+  repo: string;
+};
+
+const DUMMY_REPOSITORIES: TargetRepository[] = [
+  { owner: "facebook", repo: "react" },
+  { owner: "microsoft", repo: "vscode" },
+  { owner: "vercel", repo: "next.js" },
+  { owner: "nodejs", repo: "node" },
+  { owner: "langchain-ai", repo: "open-swe" },
+];
+
+interface RepositorySelectorProps {
+  value?: TargetRepository;
+  onValueChange: (repository: TargetRepository) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function RepositorySelector({
+  value,
+  onValueChange,
+  disabled = false,
+  placeholder = "Select a repository...",
+}: RepositorySelectorProps) {
+  const handleValueChange = (repositoryKey: string) => {
+    const repository = DUMMY_REPOSITORIES.find(
+      (repo) => `${repo.owner}/${repo.repo}` === repositoryKey
+    );
+    if (repository) {
+      onValueChange(repository);
+    }
+  };
+
+  const selectedValue = value ? `${value.owner}/${value.repo}` : undefined;
+
+  return (
+    <Select
+      value={selectedValue}
+      onValueChange={handleValueChange}
+      disabled={disabled}
+    >
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {DUMMY_REPOSITORIES.map((repo) => {
+          const key = `${repo.owner}/${repo.repo}`;
+          return (
+            <SelectItem key={key} value={key}>
+              {key}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/components/thread/index.tsx
+++ b/apps/web/src/components/thread/index.tsx
@@ -139,6 +139,7 @@ export function Thread() {
   } = useFileUpload();
   const [firstTokenReceived, setFirstTokenReceived] = useState(false);
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
+  const [selectedRepository, setSelectedRepository] = useState<TargetRepository | null>(null);
 
   const stream = useStreamContext();
   const messages = stream.messages;
@@ -575,4 +576,5 @@ export function Thread() {
     </div>
   );
 }
+
 

--- a/apps/web/src/components/thread/index.tsx
+++ b/apps/web/src/components/thread/index.tsx
@@ -498,6 +498,15 @@ export function Thread() {
                       />
 
                       <div className="flex items-center gap-6 p-2 pt-4">
+                        <div className="flex items-center space-x-2">
+                          <Label className="text-sm text-gray-600">
+                            Repository:
+                          </Label>
+                          <RepositorySelector
+                            value={selectedRepository}
+                            onValueChange={setSelectedRepository}
+                          />
+                        </div>
                         <div>
                           <div className="flex items-center space-x-2">
                             <Switch
@@ -577,6 +586,7 @@ export function Thread() {
     </div>
   );
 }
+
 
 
 

--- a/apps/web/src/components/thread/index.tsx
+++ b/apps/web/src/components/thread/index.tsx
@@ -217,10 +217,11 @@ export function Thread() {
     const context =
       Object.keys(artifactContext).length > 0 ? artifactContext : undefined;
 
-    const targetRepository = {
-      owner: "langchain-ai",
+    const targetRepository = selectedRepository || {
+      owner: "langchain-ai", 
       repo: "open-swe",
     };
+
     stream.submit(
       {
         messages: [...toolMessages, newHumanMessage],
@@ -576,5 +577,6 @@ export function Thread() {
     </div>
   );
 }
+
 
 

--- a/apps/web/src/components/thread/index.tsx
+++ b/apps/web/src/components/thread/index.tsx
@@ -46,6 +46,7 @@ import {
   ArtifactTitle,
   useArtifactContext,
 } from "./artifact";
+import { RepositorySelector, TargetRepository } from "../repository-selector";
 
 function StickyToBottomContent(props: {
   content: ReactNode;
@@ -574,3 +575,4 @@ export function Thread() {
     </div>
   );
 }
+

--- a/apps/web/src/components/thread/index.tsx
+++ b/apps/web/src/components/thread/index.tsx
@@ -505,6 +505,7 @@ export function Thread() {
                           <RepositorySelector
                             value={selectedRepository}
                             onValueChange={setSelectedRepository}
+                            disabled={messages.length > 0}
                           />
                         </div>
                         <div>
@@ -586,6 +587,7 @@ export function Thread() {
     </div>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Summary

Refactored the hardcoded `targetRepository` implementation to use a dynamic repository selector component in the chat interface. Users can now select from a list of repositories before starting their conversation, with the selection persisting within the same thread but resetting for new chats.

## Changes Made

### 1. Created Repository Selector Component
- **File**: `apps/web/src/components/repository-selector.tsx`
- Built using existing select UI components with proper TypeScript typing
- Includes 5 dummy repositories: facebook/react, microsoft/vscode, vercel/next.js, nodejs/node, and langchain-ai/open-swe
- Converts between display format (`owner/repo`) and `TargetRepository` object internally

### 2. Integrated Selector into Thread Interface
- **File**: `apps/web/src/components/thread/index.tsx`
- Added repository selector to the main thread input area
- Implemented local state management using `useState<TargetRepository | null>(null)`
- Connected selector value to the stream submission process

### 3. Dynamic Repository Usage
- Replaced hardcoded `targetRepository` with selected value from the repository selector
- Maintains backward compatibility with fallback to hardcoded value when no selection is made
- Updated `handleSubmit` function to use `selectedRepository` state

### 4. User Experience Features
- **Selection Timing**: Repository can only be selected before sending the first message
- **State Persistence**: Selection persists within the same thread session
- **Auto Reset**: Repository selection automatically resets when starting a new chat thread
- **Disabled State**: Selector becomes disabled after first message is sent (`disabled={messages.length > 0}`)

## Technical Details

- Leverages existing select component architecture with compound components pattern
- Maintains type safety with `TargetRepository` interface throughout the implementation
- Uses React's natural component lifecycle for state reset behavior
- Integrates seamlessly with existing Stream provider and state management

## Testing

The implementation has been designed to work with the existing chat flow:
1. User starts a new chat thread
2. Repository selector is enabled and shows placeholder
3. User selects a repository from the dropdown
4. User sends their first message (selector becomes disabled)
5. Selected repository is used for all AI agent operations in that thread
6. Starting a new chat resets the selection

Ready for integration with real repository data source.