### PR TITLE
fix: prevent unnecessary loading state in TaskListSidebar during thread re-fetch

### DIFF
--- a/apps/web/src/components/task-list-sidebar.tsx
+++ b/apps/web/src/components/task-list-sidebar.tsx
@@ -123,4 +123,3 @@ export default function TaskListSidebar({ onCollapse }: TaskListSidebarProps) {
     </div>
   );
 }
-

--- a/apps/web/src/components/task-list-sidebar.tsx
+++ b/apps/web/src/components/task-list-sidebar.tsx
@@ -61,7 +61,7 @@ export default function TaskListSidebar({ onCollapse }: TaskListSidebarProps) {
       </div>
 
       <div className="flex-1 overflow-hidden">
-        {threadsLoading ? (
+        {threadsLoading && threads.length === 0 ? (
           <div className="flex h-full items-center justify-center">
             <div className="text-center text-gray-500">
               <Archive className="mx-auto mb-2 h-5 w-5 animate-pulse opacity-50" />
@@ -123,3 +123,4 @@ export default function TaskListSidebar({ onCollapse }: TaskListSidebarProps) {
     </div>
   );
 }
+


### PR DESCRIPTION
## Problem
The TaskListSidebar was showing a loading spinner whenever `threadsLoading` was true, even when existing threads were available to display. This created a poor user experience during re-fetch operations where the UI would unnecessarily switch from showing threads to a loading state.

## Solution
Updated the loading condition in TaskListSidebar component (line 58) from:
```javascript
threadsLoading
```
to:
```javascript
threadsLoading && threads.length === 0
```

This ensures the loading spinner only appears when:
1. The threads are actively loading (`threadsLoading` is true), AND
2. There are no existing threads to display (`threads.length === 0`)

## Result
- Users now see existing threads remain visible during re-fetch operations
- Loading spinner only shows when there are genuinely no threads to display
- Improved user experience with less jarring UI state changes