### PR TITLE
feat: improve thread date formatting with relative time display

### DIFF
--- a/apps/web/src/components/thread-item.tsx
+++ b/apps/web/src/components/thread-item.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { memo } from "react";
+import { formatDistanceToNow, differenceInHours, differenceInMinutes, format } from "date-fns";
 import { GitBranch, ArrowRight, ListTodo } from "lucide-react";
 import { ThreadWithTasks, useThreads } from "@/providers/Thread";
 import { cn } from "@/lib/utils";
@@ -101,3 +102,4 @@ export const ThreadItem = memo(function ThreadItem({
     </div>
   );
 });
+

--- a/apps/web/src/components/thread-item.tsx
+++ b/apps/web/src/components/thread-item.tsx
@@ -1,6 +1,11 @@
 "use client";
 import { memo } from "react";
-import { formatDistanceToNow, differenceInHours, differenceInMinutes, format } from "date-fns";
+import {
+  formatDistanceToNow,
+  differenceInHours,
+  differenceInMinutes,
+  format,
+} from "date-fns";
 import { GitBranch, ArrowRight, ListTodo } from "lucide-react";
 import { ThreadWithTasks, useThreads } from "@/providers/Thread";
 import { cn } from "@/lib/utils";
@@ -18,22 +23,22 @@ interface ThreadItemProps {
 function formatRelativeDate(dateString: string): string {
   const date = new Date(dateString);
   const now = new Date();
-  
+
   const minutesAgo = differenceInMinutes(now, date);
   const hoursAgo = differenceInHours(now, date);
-  
+
   // Within the last hour - show minutes ago
   if (minutesAgo < 60) {
     return `${minutesAgo} min ago`;
   }
-  
+
   // Between 1-24 hours ago - show hours ago
   if (hoursAgo < 24) {
-    return `${hoursAgo} hour${hoursAgo === 1 ? '' : 's'} ago`;
+    return `${hoursAgo} hour${hoursAgo === 1 ? "" : "s"} ago`;
   }
-  
+
   // More than 24 hours ago - show month, day format
-  return format(date, 'MMM do');
+  return format(date, "MMM do");
 }
 
 export const ThreadItem = memo(function ThreadItem({
@@ -120,6 +125,3 @@ export const ThreadItem = memo(function ThreadItem({
     </div>
   );
 });
-
-
-

--- a/apps/web/src/components/thread-item.tsx
+++ b/apps/web/src/components/thread-item.tsx
@@ -48,10 +48,7 @@ export const ThreadItem = memo(function ThreadItem({
   const isSidebar = variant === "sidebar";
   const isRecentlyUpdated = recentlyUpdatedThreads.has(thread.thread_id);
 
-  const displayDate = new Date(thread.created_at).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  const displayDate = formatRelativeDate(thread.created_at);
 
   return (
     <div
@@ -123,5 +120,6 @@ export const ThreadItem = memo(function ThreadItem({
     </div>
   );
 });
+
 
 

--- a/apps/web/src/components/thread-item.tsx
+++ b/apps/web/src/components/thread-item.tsx
@@ -15,6 +15,27 @@ interface ThreadItemProps {
   className?: string;
 }
 
+function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  
+  const minutesAgo = differenceInMinutes(now, date);
+  const hoursAgo = differenceInHours(now, date);
+  
+  // Within the last hour - show minutes ago
+  if (minutesAgo < 60) {
+    return `${minutesAgo} min ago`;
+  }
+  
+  // Between 1-24 hours ago - show hours ago
+  if (hoursAgo < 24) {
+    return `${hoursAgo} hour${hoursAgo === 1 ? '' : 's'} ago`;
+  }
+  
+  // More than 24 hours ago - show month, day format
+  return format(date, 'MMM do');
+}
+
 export const ThreadItem = memo(function ThreadItem({
   thread,
   onClick,
@@ -102,4 +123,5 @@ export const ThreadItem = memo(function ThreadItem({
     </div>
   );
 });
+
 


### PR DESCRIPTION
This PR enhances the date formatting in the thread-item component to provide more intuitive relative time displays for users.

## Changes Made

- **Added date-fns imports**: Imported `formatDistanceToNow`, `differenceInHours`, `differenceInMinutes`, and `format` functions
- **Created formatRelativeDate helper**: Implemented a helper function that formats dates based on age:
  - Within last hour: "X min ago" (e.g., "12 min ago")
  - 1-24 hours ago: "X hour(s) ago" (e.g., "4 hours ago") 
  - Over 24 hours: "MMM do" format (e.g., "Jul 12th")
- **Updated ThreadItem component**: Replaced the simple `toLocaleDateString()` call with the new relative date formatting logic

## Benefits

- **Better UX**: Users can quickly understand how recent threads are without having to calculate time differences
- **Consistent formatting**: Uses date-fns for reliable date handling across different locales and edge cases
- **Improved readability**: Recent threads show relative time while older threads show clear date references

The implementation maintains backward compatibility while providing a much more user-friendly date display experience in both the sidebar and homepage thread listings.