### PR TITLE
feat: migrate to Daytona SDK v0.21.0

### DIFF
--- a/apps/open-swe/package.json
+++ b/apps/open-swe/package.json
@@ -22,7 +22,7 @@
     "postinstall": "turbo build"
   },
   "dependencies": {
-    "@daytonaio/sdk": "^0.18.1",
+    "@daytonaio/sdk": "^0.21.0",
     "@langchain/anthropic": "^0.3.20",
     "@langchain/core": "^0.3.56",
     "@langchain/google-genai": "^0.2.9",
@@ -60,3 +60,4 @@
   },
   "packageManager": "yarn@3.5.1"
 }
+

--- a/apps/open-swe/src/nodes/initialize.ts
+++ b/apps/open-swe/src/nodes/initialize.ts
@@ -54,7 +54,7 @@ export async function initialize(
 
   logger.info("Creating sandbox...");
   const sandbox = await daytonaClient().create({
-    image: SNAPSHOT_NAME,
+    snapshot: SNAPSHOT_NAME,
   });
 
   const res = await cloneRepo(sandbox, targetRepository, {
@@ -96,3 +96,4 @@ export async function initialize(
     codebaseTree,
   };
 }
+


### PR DESCRIPTION
`anthropic_gen_oai_style`
This PR migrates the open-swe agent to use Daytona SDK v0.21.0, addressing the breaking changes introduced in the new version.

## Changes Made

### 1. SDK Version Update
- Updated `@daytonaio/sdk` dependency from `^0.18.1` to `^0.21.0` in `package.json`

### 2. Sandbox Creation Migration
- Updated `initialize.ts` to use the new snapshot-based sandbox creation
- Replaced `image: SNAPSHOT_NAME` with `snapshot: SNAPSHOT_NAME` in the `daytonaClient().create()` call
- This aligns with the new `CreateSandboxFromSnapshotParams` interface

## Migration Context

This migration follows the Daytona SDK v0.21.0 migration guide, which introduces:
- Snapshot-based sandbox creation replacing the legacy image-based flow
- New parameter types (`CreateSandboxFromSnapshotParams`, `CreateSandboxFromImageParams`)
- Standardized `Resources` type replacing `SandboxResources`
- Updated callback parameter names

## Verification

- ✅ SDK version updated to v0.21.0
- ✅ Sandbox creation code updated to use snapshot parameter
- ✅ No instances of deprecated `SandboxResources` type found
- ✅ No callback parameter updates needed (no `onImageBuildLogs` usage found)

The changes ensure compatibility with the new SDK while maintaining existing functionality.