### PR TITLE
feat: upgrade Daytona SDK to v0.21.0 with snapshot-based architecture

### DIFF
--- a/apps/open-swe/package.json
+++ b/apps/open-swe/package.json
@@ -22,7 +22,7 @@
     "postinstall": "turbo build"
   },
   "dependencies": {
-    "@daytonaio/sdk": "^0.18.1",
+    "@daytonaio/sdk": "^0.21.0",
     "@langchain/anthropic": "^0.3.20",
     "@langchain/core": "^0.3.56",
     "@langchain/google-genai": "^0.2.9",
@@ -60,3 +60,4 @@
   },
   "packageManager": "yarn@3.5.1"
 }
+

--- a/apps/open-swe/src/nodes/initialize.ts
+++ b/apps/open-swe/src/nodes/initialize.ts
@@ -54,7 +54,7 @@ export async function initialize(
 
   logger.info("Creating sandbox...");
   const sandbox = await daytonaClient().create({
-    image: SNAPSHOT_NAME,
+    snapshot: SNAPSHOT_NAME,
   });
 
   const res = await cloneRepo(sandbox, targetRepository, {
@@ -96,3 +96,4 @@ export async function initialize(
     codebaseTree,
   };
 }
+

--- a/apps/open-swe/src/nodes/initialize.ts
+++ b/apps/open-swe/src/nodes/initialize.ts
@@ -1,3 +1,4 @@
+import { CreateSandboxFromSnapshotParams } from "@daytonaio/sdk";
 import { createLogger, LogLevel } from "../utils/logger.js";
 import {
   GraphState,
@@ -96,4 +97,5 @@ export async function initialize(
     codebaseTree,
   };
 }
+
 

--- a/apps/open-swe/src/utils/sandbox.ts
+++ b/apps/open-swe/src/utils/sandbox.ts
@@ -1,4 +1,11 @@
-import { Daytona, Sandbox, SandboxState } from "@daytonaio/sdk";
+import { 
+  Daytona, 
+  Sandbox, 
+  SandboxState,
+  CreateSandboxFromSnapshotParams,
+  CreateSandboxFromImageParams,
+  Resources
+} from "@daytonaio/sdk";
 import { createLogger, LogLevel } from "./logger.js";
 
 const logger = createLogger(LogLevel.INFO, "Sandbox");
@@ -74,3 +81,4 @@ export async function deleteSandbox(
     return false;
   }
 }
+


### PR DESCRIPTION
This PR upgrades the Daytona SDK from v0.18.1 to v0.21.0 and migrates the codebase to use the new snapshot-based architecture as outlined in the official migration guide.

## Changes Made

### 1. Package Dependencies
- Updated `@daytonaio/sdk` from `^0.18.1` to `^0.21.0` in `apps/open-swe/package.json`

### 2. Sandbox Creation Logic
- Modified `apps/open-swe/src/nodes/initialize.ts` to use the new snapshot-based approach
- Changed parameter from `image: SNAPSHOT_NAME` to `snapshot: SNAPSHOT_NAME` in the sandbox creation call

### 3. Type Imports
- Added new parameter types to relevant files:
  - `CreateSandboxFromSnapshotParams` - for creating sandboxes from snapshots
  - `CreateSandboxFromImageParams` - for creating sandboxes from images  
  - `Resources` - standardized resource configuration type
- Updated imports in `apps/open-swe/src/utils/sandbox.ts` and `apps/open-swe/src/nodes/initialize.ts`

### 4. Deprecated Type Cleanup
- Verified no usage of deprecated `SandboxResources` type (none found in codebase)
- Verified no usage of deprecated `onImageBuildLogs` callbacks (none found in codebase)

## Migration Details

This migration aligns with Daytona SDK v0.21.0's breaking changes that introduce:
- Snapshot-based sandbox creation replacing the legacy image-based flow
- More explicit parameter types for different creation scenarios
- Standardized resource management with the new `Resources` type

The changes ensure continued compatibility with the updated Daytona backend while maintaining existing functionality.