### PR TITLE
fix: resolve zod version mismatch causing Vercel build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "typescript": "^5"
   },
   "resolutions": {
-    "@langchain/langgraph-sdk": "^0.0.83"
+    "@langchain/langgraph-sdk": "^0.0.83",
+    "zod": "^3.24.2"
   },
   "packageManager": "yarn@3.5.1"
 }
+

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
     "@langchain/core": "^0.3.56",
     "@langchain/langgraph": "^0.3.1",
     "@langchain/langgraph-sdk": "^0.0.83",
-    "zod": "^3.23.8"
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
@@ -58,3 +58,4 @@
     "dist/**/*"
   ]
 }
+


### PR DESCRIPTION
## Problem

The Vercel build was failing with TypeScript compilation errors in `packages/shared`:

```
Type 'InteropZodType<TValue>' is not assignable to type 'ZodTypeAny'
Expected 3 type arguments, but got 2
```

These errors were caused by a zod version mismatch across the monorepo:
- `packages/shared` was using zod `^3.23.8` (resolving to 3.24.3)
- `apps/web` was using zod `^3.24.2` (resolving to 3.25.32)

## Solution

This PR implements two minimal changes to ensure consistent zod versions:

1. **Updated zod version in packages/shared**: Changed from `^3.23.8` to `^3.24.2` to match `apps/web`
2. **Added yarn workspace resolution**: Added `"zod": "^3.24.2"` to root package.json resolutions to enforce a single zod version across all packages

These changes eliminate the type incompatibility between different zod versions that was causing the build failure, while maintaining compatibility with existing code.