### PR TITLE
feat: add 'open-swe' label to created pull requests

### DIFF
--- a/apps/open-swe/src/utils/git.ts
+++ b/apps/open-swe/src/utils/git.ts
@@ -529,6 +529,22 @@ export async function createPullRequest({
     });
 
     logger.info(`🐙 Pull request created: ${pullRequest.html_url}`);
+
+    // Step 3: Add the 'open-swe' label to the pull request
+    try {
+      await octokit.issues.addLabels({
+        owner,
+        repo,
+        issue_number: pullRequest.number,
+        labels: ['open-swe'],
+      });
+      logger.info(`Added 'open-swe' label to pull request #${pullRequest.number}`);
+    } catch (labelError) {
+      logger.warn(`Failed to add 'open-swe' label to pull request #${pullRequest.number}`, {
+        labelError,
+      });
+    }
+
     return pullRequest;
   } catch (error) {
     if (error instanceof Error && error.message.includes("already exists")) {
@@ -650,3 +666,4 @@ export async function cloneRepo(
     throw e;
   }
 }
+


### PR DESCRIPTION
Enhanced the `createPullRequest` function in `apps/open-swe/src/utils/git.ts` to automatically add the 'open-swe' label to pull requests after creation.

## Changes Made:
- Modified the `createPullRequest` function to use the GitHub API (`octokit.issues.addLabels()`) to add the 'open-swe' label to newly created pull requests
- Added proper error handling with try-catch block to ensure PR creation doesn't fail if labeling fails
- Implemented logging to indicate successful label addition and warning messages for labeling failures

## Benefits:
- Automatically tags all pull requests created by the open-swe app for better organization and tracking
- Maintains robust error handling to prevent PR creation failures due to labeling issues
- Provides clear logging for debugging and monitoring purposes