### PR TITLE
Fix: light theme repo hover styling

### DIFF
--- a/apps/web/src/components/github/repo-branch-selectors/index.tsx
+++ b/apps/web/src/components/github/repo-branch-selectors/index.tsx
@@ -6,9 +6,9 @@ export function RepositoryBranchSelectors() {
   const [threadId] = useQueryState("threadId");
   const chatStarted = !!threadId;
   const defaultButtonStyles =
-    "bg-inherit border-none text-gray-500 hover:text-gray-300 text-xs p-0 h-fit hover:bg-inherit";
+    "bg-inherit border-none text-gray-500 hover:text-black dark:hover:text-gray-300 text-xs p-0 h-fit hover:bg-inherit";
   const defaultStylesChatStarted =
-    "hover:bg-inherit cursor-default hover:cursor-default hover:text-gray-300 hover:border-gray-300 hover:ring-inherit";
+    "hover:bg-inherit cursor-default hover:cursor-default hover:text-black dark:hover:text-gray-300 hover:border-gray-300 hover:ring-inherit";
 
   return (
     <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes #274 light theme repo + branch dropdown hover styling was unreadable 