### PR TITLE
Feat: cancel-run buttons [manager, planner, programmer]

### DIFF
--- a/apps/web/src/components/v2/manager-chat.tsx
+++ b/apps/web/src/components/v2/manager-chat.tsx
@@ -5,9 +5,12 @@ import { useState } from "react";
 import { StickToBottom } from "use-stick-to-bottom";
 import { TooltipIconButton } from "../ui/tooltip-icon-button";
 import { AnimatePresence, motion } from "framer-motion";
-import { Bot, Copy, CopyCheck, Send, User } from "lucide-react";
+import { Bot, Copy, CopyCheck, Send, User, Loader2 } from "lucide-react";
 import { Textarea } from "../ui/textarea";
 import { Button } from "../ui/button";
+import { useStream } from "@langchain/langgraph-sdk/react";
+import { ManagerGraphState } from "@open-swe/shared/open-swe/manager/types";
+import { cn } from "@/lib/utils";
 
 function MessageCopyButton({ content }: { content: string }) {
   const [copied, setCopied] = useState(false);
@@ -61,6 +64,7 @@ interface ManagerChatProps {
   chatInput: string;
   setChatInput: (input: string) => void;
   handleSendMessage: () => void;
+  stream: ReturnType<typeof useStream<ManagerGraphState>>;
 }
 
 export function ManagerChat({
@@ -68,6 +72,7 @@ export function ManagerChat({
   chatInput,
   setChatInput,
   handleSendMessage,
+  stream,
 }: ManagerChatProps) {
   return (
     <div className="border-border bg-muted/30 flex h-full w-1/3 flex-col border-r dark:bg-gray-950">
@@ -135,21 +140,36 @@ export function ManagerChat({
             onKeyDown={(e) => {
               if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                 e.preventDefault();
-                handleSendMessage();
+                if (stream.isLoading) {
+                  stream.stop();
+                } else {
+                  handleSendMessage();
+                }
               }
             }}
           />
           <Button
-            onClick={handleSendMessage}
-            disabled={!chatInput.trim()}
-            size="icon"
-            variant="brand"
+            onClick={stream.isLoading ? () => stream.stop() : handleSendMessage}
+            disabled={stream.isLoading ? false : !chatInput.trim()}
+            size={stream.isLoading ? "sm" : "icon"}
+            variant={stream.isLoading ? "destructive" : "brand"}
+            className={cn(
+              "self-end transition-all duration-200 disabled:opacity-50",
+              stream.isLoading ? "h-12 px-4 py-2" : "h-10 w-10 p-0",
+            )}
           >
-            <Send className="size-4" />
+            {stream.isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Cancel
+              </>
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
           </Button>
         </div>
         <div className="text-muted-foreground mt-2 text-xs">
-          Press Cmd+Enter to send
+          Press Cmd+Enter to {stream.isLoading ? "cancel" : "send"}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/v2/thread-view.tsx
+++ b/apps/web/src/components/v2/thread-view.tsx
@@ -22,7 +22,7 @@ import {
   ScrollToBottom,
 } from "../../utils/scroll-utils";
 import { ManagerChat } from "./manager-chat";
-import { toast } from "sonner";
+import { useCancelStream } from "@/hooks/useCancelStream";
 
 const PROGRAMMER_ASSISTANT_ID = process.env.NEXT_PUBLIC_PROGRAMMER_ASSISTANT_ID;
 const PLANNER_ASSISTANT_ID = process.env.NEXT_PUBLIC_PLANNER_ASSISTANT_ID;
@@ -77,33 +77,20 @@ export function ThreadView({
     }
   }, [programmerSession?.runId]);
 
-  // Cancel functions using SDK client methods
-  const cancelPlannerRun = async () => {
-    if (!plannerThreadId || !plannerRunId) return;
+  // Cancel hooks with better error handling
+  const { cancelRun: cancelPlannerRun } = useCancelStream({
+    stream: plannerStream,
+    threadId: plannerThreadId,
+    runId: plannerRunId,
+    streamName: "Planner",
+  });
 
-    try {
-      await plannerStream.client.runs.cancel(plannerThreadId, plannerRunId);
-      toast.success("Planner run cancelled successfully");
-    } catch (error) {
-      console.error("Error cancelling planner run:", error);
-      toast.error("Failed to cancel planner run");
-    }
-  };
-
-  const cancelProgrammerRun = async () => {
-    if (!programmerSession?.threadId || !programmerSession?.runId) return;
-
-    try {
-      await programmerStream.client.runs.cancel(
-        programmerSession.threadId,
-        programmerSession.runId,
-      );
-      toast.success("Programmer run cancelled successfully");
-    } catch (error) {
-      console.error("Error cancelling programmer run:", error);
-      toast.error("Failed to cancel programmer run");
-    }
-  };
+  const { cancelRun: cancelProgrammerRun } = useCancelStream({
+    stream: programmerStream,
+    threadId: programmerSession?.threadId,
+    runId: programmerSession?.runId,
+    streamName: "Programmer",
+  });
 
   const handleSendMessage = () => {
     if (chatInput.trim()) {

--- a/apps/web/src/hooks/useCancelStream.tsx
+++ b/apps/web/src/hooks/useCancelStream.tsx
@@ -1,0 +1,51 @@
+import { UseStream } from "@langchain/langgraph-sdk/react";
+import { toast } from "sonner";
+
+interface UseCancelStreamProps {
+  stream: UseStream<any>;
+  threadId?: string;
+  runId?: string;
+  streamName: string; // "Planner" | "Programmer"
+}
+
+export function useCancelStream({
+  stream,
+  threadId,
+  runId,
+  streamName,
+}: UseCancelStreamProps) {
+  const cancelRun = async () => {
+    if (!threadId || !runId) {
+      toast.error(`Cannot cancel ${streamName}: Missing thread or run ID`);
+      return;
+    }
+
+    try {
+      await stream.client.runs.cancel(threadId, runId);
+      toast.success(`${streamName} cancelled successfully`, {
+        description: "The running operation has been stopped",
+      });
+    } catch (error) {
+      // Check if this is an expected cancellation error vs actual error
+      const isAbortError =
+        error instanceof Error &&
+        (error.name === "AbortError" || error.message.includes("abort"));
+
+      if (isAbortError) {
+        // Expected cancellation - show neutral notification
+        toast.info(`${streamName} operation cancelled`, {
+          description: "The stream was successfully stopped",
+        });
+      } else {
+        // Actual error - show error notification
+        console.error(`Error cancelling ${streamName} run:`, error);
+        toast.error(`Failed to cancel ${streamName}`, {
+          description:
+            error instanceof Error ? error.message : "Unknown error occurred",
+        });
+      }
+    }
+  };
+
+  return { cancelRun };
+}


### PR DESCRIPTION
## **🛑 Improve Cancel Stream Implementation**

### **Summary**
Refactored cancel functionality across Manager, Planner & Programmer to use native LangGraph SDK methods with better UX.

### **Key Changes**
- **SDK**: Programmer / Planner use `stream.client.runs.cancel()` 
<img width="1145" alt="Screenshot 2025-06-27 at 3 33 11 PM" src="https://github.com/user-attachments/assets/0783591d-403e-4297-bb1e-60a3acfcc261" />
<img width="571" alt="Screenshot 2025-06-27 at 3 33 44 PM" src="https://github.com/user-attachments/assets/57cf3cbe-9777-4a85-b71a-3d9b20065e05" />
<img width="1145" alt="Screenshot 2025-06-27 at 3 33 50 PM" src="https://github.com/user-attachments/assets/c981f7f6-6aaa-4df7-bea3-6b4a7c2bde39" />

- **Reusable Hook**: Created `useCancelStream` to eliminate duplicate code
- **Better Errors**: Smart error detection - shows appropriate notifications instead of runtime abort errors
- **Improved UX**: Proper loading states and smooth button transitions
