### PR TITLE
Fix: scroll to bottom UX improvement

### DIFF
--- a/apps/web/src/components/v2/thread-view.tsx
+++ b/apps/web/src/components/v2/thread-view.tsx
@@ -198,7 +198,7 @@ export function ThreadView({
                   </Tabs>
                 }
                 footer={
-                  <div className="absolute right-0 bottom-4 left-0 flex w-full justify-center">
+                  <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
                     <ScrollToBottom className="animate-in fade-in-0 zoom-in-95" />
                   </div>
                 }


### PR DESCRIPTION
Fixes #327 

- reduce width and improve position of scroll to bottom button to not interfere with accepting / rejecting plans. 