### PR TITLE
feat: New algo for when and how to summarize conversation history

### DIFF
--- a/apps/open-swe/src/graphs/planner/nodes/proposed-plan.ts
+++ b/apps/open-swe/src/graphs/planner/nodes/proposed-plan.ts
@@ -147,6 +147,7 @@ export async function interruptProposedPlan(
     branchName: state.branchName,
     targetRepository: state.targetRepository,
     githubIssueId: state.githubIssueId,
+    internalMessages: state.messages,
   };
 
   if (state.autoAcceptPlan) {

--- a/apps/open-swe/src/graphs/programmer/index.ts
+++ b/apps/open-swe/src/graphs/programmer/index.ts
@@ -14,6 +14,7 @@ import {
   diagnoseError,
   requestHelp,
   updatePlan,
+  summarizeHistory,
 } from "./nodes/index.js";
 import { isAIMessage } from "@langchain/core/messages";
 import { initializeSandbox } from "../shared/initialize-sandbox.js";
@@ -76,6 +77,7 @@ const workflow = new StateGraph(GraphAnnotation, GraphConfiguration)
   })
   .addNode("open-pr", openPullRequest)
   .addNode("diagnose-error", diagnoseError)
+  .addNode("summarize-history", summarizeHistory)
   .addEdge(START, "initialize")
   .addEdge("initialize", "generate-action")
   .addConditionalEdges("generate-action", routeGeneratedAction, [
@@ -87,6 +89,7 @@ const workflow = new StateGraph(GraphAnnotation, GraphConfiguration)
   .addEdge("update-plan", "generate-action")
   .addEdge("generate-conclusion", "open-pr")
   .addEdge("diagnose-error", "generate-action")
+  .addEdge("summarize-history", "generate-action")
   .addEdge("open-pr", END);
 
 // Zod types are messed up

--- a/apps/open-swe/src/graphs/programmer/nodes/index.ts
+++ b/apps/open-swe/src/graphs/programmer/nodes/index.ts
@@ -7,3 +7,4 @@ export * from "./open-pr.js";
 export * from "./diagnose-error.js";
 export * from "./request-help.js";
 export * from "./update-plan.js";
+export * from "./summarize-history.js";

--- a/apps/open-swe/src/graphs/programmer/nodes/summarize-history.ts
+++ b/apps/open-swe/src/graphs/programmer/nodes/summarize-history.ts
@@ -1,0 +1,217 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+  GraphConfig,
+  GraphState,
+  GraphUpdate,
+  PlanItem,
+} from "@open-swe/shared/open-swe/types";
+import { loadModel, Task } from "../../../utils/load-model.js";
+import {
+  AIMessage,
+  BaseMessage,
+  RemoveMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
+import { formatPlanPrompt } from "../../../utils/plan-prompt.js";
+import { createLogger, LogLevel } from "../../../utils/logger.js";
+import { getMessageContentString } from "@open-swe/shared/messages";
+import { getMessageString } from "../../../utils/message/content.js";
+import { getActivePlanItems } from "@open-swe/shared/open-swe/tasks";
+import { getCompletedPlanItems } from "../../../utils/current-task.js";
+import { createConversationHistorySummaryToolFields } from "@open-swe/shared/open-swe/tools";
+import { z } from "zod";
+import { DO_NOT_RENDER_ID_PREFIX } from "@open-swe/shared/constants";
+import { getUserRequest } from "../../../utils/user-request.js";
+import { getMessagesSinceLastSummary } from "../../../utils/tokens.js";
+
+const taskSummarySysPrompt = `You are operating as a terminal-based agentic coding assistant built by LangChain. It wraps LLM models to enable natural language interaction with a local codebase. You are expected to be precise, safe, and helpful.
+
+<role>
+Context Extraction Assistant
+</role>
+
+<primary_objective>
+Your sole objective in this task is to extract the highest quality/most relevant context from the conversation history below.
+</primary_objective>
+
+<objective_information>
+You're nearing the total number of input tokens you can accept, so you must extract the highest quality/most relevant pieces of information from your conversation history.
+This context will then overwrite the conversation history presented below. Because of this, ensure the context you extract is only the most important information to your overall goal.
+To aid with this, you'll be provided with the user's request, as well as all of the tasks in the plan you generated to fulfil the user's request. Additionally, if a task has already been completed you'll be provided with the summary of the steps taken to complete it.
+</objective_information>
+
+Here is the user's request:
+<user_request>
+{USER_REQUEST}
+</user_request>
+
+Here is the full list of tasks in the plan you're in the middle of, as well as the summary of the completed tasks:
+<tasks_and_summaries>
+{PLAN_PROMPT}
+</tasks_and_summaries>
+
+<instructions>
+The conversation history below will be replaced with the context you extract in this step. Because of this, you must do your very best to extract and record all of the most important context from the conversation history.
+You want to ensure that you don't repeat any actions you've already completed (e.g. file search operations, checking codebase information, etc.), so the context you extract from the conversation history should be focused on the most important information to your overall goal.
+
+You MUST adhere to the following criteria when extracting the most important context from the conversation history:
+  - Include full file paths for all relevant files to the users request & tasks.
+  - Include file summaries/snippets from the relevant files. Avoid including entire files as you're trying to condense the conversation history.
+  - Include insights, and learnings you've discovered about the codebase or specific files while completing the task.
+  - Only record information once, and avoid duplications. Duplicate information or actions in the conversation history should be merged into a single entry.
+</instructions>
+
+Here is the full conversation history you'll be extracting context from, to then replace. Carefully read over it all, and think deeply about what information is most important to your overall goal that should be saved:
+<conversation_history>
+{CONVERSATION_HISTORY}
+</conversation_history>
+
+With all of this in mind, please carefully read over the entire conversation history, and extract the most important and relevant context to replace it so that you can free up space in the conversation history.
+Respond ONLY with the extracted context. Do not include any additional information, or text before or after the extracted context.
+`;
+
+const logger = createLogger(LogLevel.INFO, "SummarizeConversationHistory");
+
+const formatPrompt = (inputs: {
+  userRequest: string;
+  plan: PlanItem[];
+  conversationHistoryToSummarize: BaseMessage[];
+}): string => {
+  return taskSummarySysPrompt
+    .replace(
+      "{PLAN_PROMPT}",
+      formatPlanPrompt(inputs.plan, {
+        useLastCompletedTask: true,
+        includeSummaries: true,
+      }),
+    )
+    .replace("{USER_REQUEST}", inputs.userRequest)
+    .replace(
+      "{CONVERSATION_HISTORY}",
+      inputs.conversationHistoryToSummarize.map(getMessageString).join("\n"),
+    );
+};
+
+/**
+ * Create an AI & tool message pair for the generated task summary.
+ * This is not included in the internal message state, but is exposed to
+ * users so they can see the summary of the actions that were taken.
+ */
+function createUserFacingConversationSummaryMessages(
+  summary: string,
+): BaseMessage[] {
+  const conversationSummaryTool = createConversationHistorySummaryToolFields();
+  const conversationSummaryToolCallArgs: z.infer<
+    typeof conversationSummaryTool.schema
+  > = {
+    conversation_history_summary: summary,
+  };
+  const conversationSummaryToolCallId = uuidv4();
+  const conversationSummaryPublicMessages = [
+    new AIMessage({
+      id: uuidv4(),
+      content: "",
+      tool_calls: [
+        {
+          id: conversationSummaryToolCallId,
+          name: conversationSummaryTool.name,
+          args: conversationSummaryToolCallArgs,
+        },
+      ],
+    }),
+    new ToolMessage({
+      id: `${DO_NOT_RENDER_ID_PREFIX}${uuidv4()}`,
+      tool_call_id: conversationSummaryToolCallId,
+      content: "",
+    }),
+  ];
+
+  return conversationSummaryPublicMessages;
+}
+
+function createInternalSummaryMessages(summary: string): BaseMessage[] {
+  const dummySummarizeHistoryToolName = "summarize_conversation_history";
+  const dummySummarizeHistoryToolCallId = uuidv4();
+  return [
+    new AIMessage({
+      id: uuidv4(),
+      content:
+        "Looks like I'm running out of tokens. I'm going to summarize the conversation history to free up space.",
+      tool_calls: [
+        {
+          id: dummySummarizeHistoryToolCallId,
+          name: dummySummarizeHistoryToolName,
+          args: {
+            reasoning:
+              "I'm running out of tokens. I'm going to summarize all of the messages since my last summary message to free up space.",
+          },
+        },
+      ],
+      additional_kwargs: {
+        summary_message: true,
+      },
+    }),
+    new ToolMessage({
+      id: uuidv4(),
+      tool_call_id: dummySummarizeHistoryToolCallId,
+      content: summary,
+      additional_kwargs: {
+        summary_message: true,
+      },
+    }),
+  ];
+}
+
+export async function summarizeHistory(
+  state: GraphState,
+  config: GraphConfig,
+): Promise<GraphUpdate> {
+  const activePlanItems = getActivePlanItems(state.taskPlan);
+  const lastCompletedTask = getCompletedPlanItems(activePlanItems).pop();
+  if (!lastCompletedTask) {
+    throw new Error("Unable to find last completed task.");
+  }
+
+  const model = await loadModel(config, Task.SUMMARIZER);
+
+  const userRequest = getUserRequest(state.messages);
+  const plan = getActivePlanItems(state.taskPlan);
+  const conversationHistoryToSummarize = getMessagesSinceLastSummary(
+    state.internalMessages,
+  );
+
+  logger.info(
+    `Summarizing ${conversationHistoryToSummarize.length} messages in the conversation history...`,
+  );
+
+  const response = await model.invoke([
+    {
+      role: "user",
+      content: formatPrompt({
+        userRequest,
+        plan,
+        conversationHistoryToSummarize,
+      }),
+    },
+  ]);
+
+  const summaryString = getMessageContentString(response.content);
+  const taskSummaryMessages =
+    createUserFacingConversationSummaryMessages(summaryString);
+
+  const newInternalMessages = [
+    ...conversationHistoryToSummarize.map(
+      (m) => new RemoveMessage({ id: m.id ?? "" }),
+    ),
+    ...createInternalSummaryMessages(summaryString),
+  ];
+
+  logger.info(
+    `Summarized ${conversationHistoryToSummarize.length} messages in the conversation history. Removing and replacing with a summary message.`,
+  );
+
+  return {
+    messages: taskSummaryMessages,
+    internalMessages: newInternalMessages,
+  };
+}

--- a/apps/open-swe/src/utils/message/modify-array.ts
+++ b/apps/open-swe/src/utils/message/modify-array.ts
@@ -1,25 +1,4 @@
-import {
-  BaseMessage,
-  isAIMessage,
-  isHumanMessage,
-  isToolMessage,
-  RemoveMessage,
-} from "@langchain/core/messages";
-
-export function removeLastTaskMessages(messages: BaseMessage[]): BaseMessage[] {
-  return messages
-    .filter((m) => {
-      if (
-        m.additional_kwargs?.summary_message ||
-        (!isAIMessage(m) && !isToolMessage(m)) ||
-        !m.id
-      ) {
-        return false;
-      }
-      return true;
-    })
-    .map((m) => new RemoveMessage({ id: m.id ?? "" }));
-}
+import { BaseMessage, isHumanMessage } from "@langchain/core/messages";
 
 export function removeFirstHumanMessage(
   messages: BaseMessage[],

--- a/apps/open-swe/src/utils/tokens.ts
+++ b/apps/open-swe/src/utils/tokens.ts
@@ -6,6 +6,9 @@ import {
 } from "@langchain/core/messages";
 import { getMessageContentString } from "@open-swe/shared/messages";
 
+// After 100k tokens, summarize the conversation history.
+export const MAX_INTERNAL_TOKENS = 100_000;
+
 export function calculateConversationHistoryTokenCount(
   messages: BaseMessage[],
 ) {
@@ -27,4 +30,13 @@ export function calculateConversationHistoryTokenCount(
 
   // Estimate 1 token for every 4 characters.
   return Math.ceil(totalChars / 4);
+}
+
+export function getMessagesSinceLastSummary(
+  messages: BaseMessage[],
+): BaseMessage[] {
+  const allMessagesAfterLastSummary = messages.slice(
+    messages.findIndex((m) => m.additional_kwargs?.summary_message),
+  );
+  return allMessagesAfterLastSummary;
 }

--- a/packages/shared/src/open-swe/tools.ts
+++ b/packages/shared/src/open-swe/tools.ts
@@ -359,3 +359,30 @@ export function createWriteTechnicalNotesToolFields() {
     schema: writeTechnicalNotesSchema,
   };
 }
+
+export function createTaskSummaryToolFields() {
+  const taskSummarySchema = z.object({
+    original_task: z.string(),
+    task_summary: z.string(),
+  });
+
+  return {
+    name: "task_summary",
+    description:
+      "<not used as an actual tool call. only used as shared types between the client and agent>",
+    schema: taskSummarySchema,
+  };
+}
+
+export function createConversationHistorySummaryToolFields() {
+  const conversationHistorySummarySchema = z.object({
+    conversation_history_summary: z.string(),
+  });
+
+  return {
+    name: "conversation_history_summary",
+    description:
+      "<not used as an actual tool call. only used as shared types between the client and agent>",
+    schema: conversationHistorySummarySchema,
+  };
+}


### PR DESCRIPTION
Instead of always summarizing and removing messages after each task is completed, we now will only summarize and remove messages after the total input size is 100,000 tokens.
We still summarize after each task is complete, but we don't remove the messages from the summary. (tbd if we should still do this?)
We also now pass in all of the planner messages to the programmer