### PR TITLE
feat: add app installation

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,7 +29,7 @@
     "@eslint/js": "^9.19.0",
     "@tsconfig/recommended": "^1.0.8",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.13.5",
+    "@types/node": "^24.1.0",
     "@types/node-fetch": "^2.6.4",
     "@types/react": "^19.1.8",
     "@typescript-eslint/eslint-plugin": "^8.38.0",

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "strict": true,
+    "types": ["node"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,7 +4143,7 @@ __metadata:
     "@eslint/js": ^9.19.0
     "@tsconfig/recommended": ^1.0.8
     "@types/express": ^4.17.21
-    "@types/node": ^22.13.5
+    "@types/node": ^24.1.0
     "@types/node-fetch": ^2.6.4
     "@types/react": ^19.1.8
     "@typescript-eslint/eslint-plugin": ^8.38.0
@@ -7041,6 +7041,15 @@ __metadata:
   dependencies:
     undici-types: ~6.21.0
   checksum: 8a8cb8468187845c77403a41e98fe0fdd148741456382eb01bfaee6431303111eae5f2716ce9069b884518862ab96bcc04adf1c90a10ff35e88db19732b383c0
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^24.1.0":
+  version: 24.1.0
+  resolution: "@types/node@npm:24.1.0"
+  dependencies:
+    undici-types: ~7.8.0
+  checksum: 01f9a97909eec619d937af3bc00ac49461e1846656b4d060f648145df06508eb6d77c200637a792481ee93a73976ced46cfbbdfe307e79be0f58ccdc415dfcd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We need the `installation_id` as well as the token to kick off events to the LangGraph server. This adds the authentication work that allows you to authenticate the app in GitHub. 

Once we do it once, we save that installation id and then use it to get the token every time. 