### PR TITLE
feat: filter threads by selected Github org [draft]

### DIFF
--- a/apps/web/src/app/(v2)/chat/page.tsx
+++ b/apps/web/src/app/(v2)/chat/page.tsx
@@ -2,14 +2,16 @@
 
 import { DefaultView } from "@/components/v2/default-view";
 import { useThreadsSWR } from "@/hooks/useThreadsSWR";
-import { GitHubAppProvider } from "@/providers/GitHubApp";
+import { GitHubAppProvider, useGitHubAppProvider } from "@/providers/GitHubApp";
 import { Toaster } from "@/components/ui/sonner";
 import { Suspense } from "react";
 import { MANAGER_GRAPH_ID } from "@open-swe/shared/constants";
 
-export default function ChatPage() {
+function ChatPageContent() {
+  const { currentInstallation } = useGitHubAppProvider();
   const { threads, isLoading: threadsLoading } = useThreadsSWR({
     assistantId: MANAGER_GRAPH_ID,
+    currentInstallation,
   });
 
   if (!threads) {
@@ -17,14 +19,20 @@ export default function ChatPage() {
   }
 
   return (
+    <DefaultView
+      threads={threads}
+      threadsLoading={threadsLoading}
+    />
+  );
+}
+
+export default function ChatPage() {
+  return (
     <div className="bg-background h-screen">
       <Suspense>
         <Toaster />
         <GitHubAppProvider>
-          <DefaultView
-            threads={threads}
-            threadsLoading={threadsLoading}
-          />
+          <ChatPageContent />
         </GitHubAppProvider>
       </Suspense>
     </div>

--- a/apps/web/src/app/(v2)/chat/threads/page.tsx
+++ b/apps/web/src/app/(v2)/chat/threads/page.tsx
@@ -11,7 +11,7 @@ import { useThreadsSWR } from "@/hooks/useThreadsSWR";
 import { ThreadCard, ThreadCardLoading } from "@/components/v2/thread-card";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { InstallationSelector } from "@/components/github/installation-selector";
-import { GitHubAppProvider } from "@/providers/GitHubApp";
+import { GitHubAppProvider, useGitHubAppProvider } from "@/providers/GitHubApp";
 import { MANAGER_GRAPH_ID } from "@open-swe/shared/constants";
 import { useThreadsStatus } from "@/hooks/useThreadsStatus";
 import { cn } from "@/lib/utils";
@@ -29,8 +29,10 @@ type FilterStatus =
 
 function AllThreadsPageContent() {
   const router = useRouter();
+  const { currentInstallation } = useGitHubAppProvider();
   const { threads, isLoading: threadsLoading } = useThreadsSWR({
     assistantId: MANAGER_GRAPH_ID,
+    currentInstallation,
   });
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<FilterStatus>("all");
@@ -81,7 +83,6 @@ function AllThreadsPageContent() {
   };
 
   return (
-    <GitHubAppProvider>
       <div className="bg-background flex h-screen flex-col">
         {/* Header */}
         <div className="border-border bg-card border-b px-4 py-3">
@@ -252,14 +253,15 @@ function AllThreadsPageContent() {
           </div>
         </div>
       </div>
-    </GitHubAppProvider>
   );
 }
 
 export default function AllThreadsPage() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <AllThreadsPageContent />
+      <GitHubAppProvider>
+        <AllThreadsPageContent />
+      </GitHubAppProvider>
     </Suspense>
   );
 }


### PR DESCRIPTION
fixes #355 
Only show threads of the currently selected github org while on homepage or /chat/threads page 
<img width="1712" height="703" alt="Screenshot 2025-07-23 at 4 33 22 PM" src="https://github.com/user-attachments/assets/b9ade978-1c04-4cbd-be0e-df3547cf55de" />
<img width="1710" height="792" alt="Screenshot 2025-07-23 at 4 33 27 PM" src="https://github.com/user-attachments/assets/ae2c7038-3933-4fee-9d6f-f3b7dbc4b3ff" />
<img width="1725" height="877" alt="Screenshot 2025-07-23 at 4 33 36 PM" src="https://github.com/user-attachments/assets/e2a9e415-d82b-42d4-9665-6be203ce900b" />
<img width="1725" height="624" alt="Screenshot 2025-07-23 at 4 33 43 PM" src="https://github.com/user-attachments/assets/de0da39b-66d9-476b-b165-94ea0845b19a" />
