### PR TITLE
fix: checks for doc cache on mcp tool call

### DIFF
--- a/apps/open-swe/src/utils/tool-output-processing.ts
+++ b/apps/open-swe/src/utils/tool-output-processing.ts
@@ -38,6 +38,14 @@ export async function processToolCallContent(
     const url = toolCall.args?.url || toolCall.args?.uri || toolCall.args?.path;
     const parsedResult = typeof url === "string" ? parseUrl(url) : null;
     const parsedUrl = parsedResult?.success ? parsedResult.url.href : undefined;
+
+    // avoid generating TOC again if it's already in the cache
+    if (parsedUrl && state.documentCache[parsedUrl]) {
+      return {
+        content: state.documentCache[parsedUrl],
+      };
+    }
+
     const processedContent = await handleMcpDocumentationOutput(
       result,
       config,


### PR DESCRIPTION
### Modified Files
- `apps/open-swe/src/utils/tool-output-processing.ts` now checks document cache before calling the `handleMcpDocumentationOutput`