### PR TITLE
chore: model change to 4.1

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -339,9 +339,9 @@ export class ModelManager {
         [Task.SUMMARIZER]: "gemini-2.5-pro",
       },
       openai: {
-        [Task.PLANNER]: "o3",
+        [Task.PLANNER]: "gpt-4.1",
         [Task.PROGRAMMER]: "gpt-4.1",
-        [Task.REVIEWER]: "o3",
+        [Task.REVIEWER]: "gpt-4.1",
         [Task.ROUTER]: "gpt-4o-mini",
         [Task.SUMMARIZER]: "gpt-4.1-mini",
       },


### PR DESCRIPTION
Modified `apps/open-swe/src/utils/llms/model-manager.ts` to change fallback to 4.1 until parallel tool calling fix has been implemented in fallback models