### PR TITLE
fix: early return if no api key is provided

### DIFF
--- a/apps/web/src/components/v2/terminal-input.tsx
+++ b/apps/web/src/components/v2/terminal-input.tsx
@@ -109,6 +109,7 @@ export function TerminalInput({
         MISSING_API_KEYS_TOAST_CONTENT,
         MISSING_API_KEYS_TOAST_OPTIONS,
       );
+      return;
     }
 
     setLoading(true);

--- a/apps/web/src/features/settings-page/api-keys.tsx
+++ b/apps/web/src/features/settings-page/api-keys.tsx
@@ -53,6 +53,14 @@ const API_KEY_DEFINITIONS = {
   // ],
 };
 
+const shouldAutofocus = (apiKeyId: string, hasValue: boolean): boolean => {
+  if (apiKeyId === "anthropicApiKey") {
+    return !hasValue;
+  }
+
+  return false;
+};
+
 export function APIKeysTab() {
   const { getConfig, updateConfig } = useConfigStore();
   const config = getConfig(DEFAULT_CONFIG_KEY);
@@ -186,6 +194,7 @@ export function APIKeysTab() {
                           }
                           placeholder={`Enter your ${apiKey.name} API key`}
                           className="font-mono text-sm"
+                          autoFocus={shouldAutofocus(apiKey.id, !!apiKey.value)}
                         />
                         <Button
                           variant="ghost"


### PR DESCRIPTION
also auto-focus on anthropic api key input if no keys are defined