### PR TITLE
feat: update langbench to run extracted tests

### DIFF
--- a/apps/open-swe/langbench/evaluator.eval.ts
+++ b/apps/open-swe/langbench/evaluator.eval.ts
@@ -96,12 +96,12 @@ async function processPR(prData: PRData): Promise<PRProcessResult> {
       logger.info(
         `Checking out test files from merge commit: ${prData.merge_commit_sha}`,
       );
-      await checkoutFilesFromCommit(
+      await checkoutFilesFromCommit({
         sandbox,
         repoDir,
-        prData.merge_commit_sha,
-        testFiles,
-      );
+        commitSha: prData.merge_commit_sha,
+        filePaths: testFiles,
+      });
     }
 
     // Run tests on detected test files

--- a/apps/open-swe/langbench/evaluator.eval.ts
+++ b/apps/open-swe/langbench/evaluator.eval.ts
@@ -48,15 +48,6 @@ async function processPR(prData: PRData): Promise<PRProcessResult> {
     // Use test files from PR data (already fetched and stored)
     const testFiles = prData.test_files || [];
     result.test_files = testFiles;
-
-    if (testFiles.length > 0) {
-      logger.info(
-        `Found ${testFiles.length} test files modified in PR #${prData.pr_number}:`,
-      );
-      testFiles.forEach((file) => logger.info(`  - ${file}`));
-    } else {
-      logger.info(`No test files found in PR #${prData.pr_number}`);
-    }
     // Create sandbox
     sandbox = await daytona.create(DEFAULT_SANDBOX_CREATE_PARAMS);
 
@@ -118,12 +109,12 @@ async function processPR(prData: PRData): Promise<PRProcessResult> {
       logger.info(
         `Running pytest on ${testFiles.length} detected test files...`,
       );
-      const testResults = await runPytestOnFiles(
+      const testResults = await runPytestOnFiles({
         sandbox,
         testFiles,
         repoDir,
-        300,
-      );
+        timeoutSec: 300,
+      });
       result.test_results = testResults;
 
       logger.info(`Test execution completed for PR #${prData.pr_number}`, {

--- a/apps/open-swe/langbench/evaluator.eval.ts
+++ b/apps/open-swe/langbench/evaluator.eval.ts
@@ -53,9 +53,7 @@ async function processPR(prData: PRData): Promise<PRProcessResult> {
 
     // Validate sandbox was created properly
     if (!sandbox || !sandbox.id) {
-      throw new Error(
-        "Failed to create valid sandbox",
-      );
+      throw new Error("Failed to create valid sandbox");
     }
 
     result.workspaceId = sandbox.id;

--- a/apps/open-swe/langbench/evaluator.eval.ts
+++ b/apps/open-swe/langbench/evaluator.eval.ts
@@ -54,7 +54,7 @@ async function processPR(prData: PRData): Promise<PRProcessResult> {
     // Validate sandbox was created properly
     if (!sandbox || !sandbox.id) {
       throw new Error(
-        `Failed to create valid sandbox. Sandbox object: ${JSON.stringify(sandbox)}`,
+        "Failed to create valid sandbox",
       );
     }
 

--- a/apps/open-swe/langbench/runEvals.eval.ts
+++ b/apps/open-swe/langbench/runEvals.eval.ts
@@ -15,7 +15,6 @@ dotenv.config();
 
 const logger = createLogger(LogLevel.INFO, "PR Processor");
 
-
 // Load PRs data
 const prsData: PRData[] = JSON.parse(
   readFileSync("langbench/static/langgraph_prs.json", "utf8"),

--- a/apps/open-swe/langbench/static/langgraph_prs.json
+++ b/apps/open-swe/langbench/static/langgraph_prs.json
@@ -12,7 +12,13 @@
     "body": "## Overview\r\n\r\nThis PR introduces a new API that provides a cleaner, more type-safe way to pass runtime context to LangGraph nodes/tasks. It replaces the current pattern of using `config['configurable']` and `config_schema` with a dedicated `context` parameter and wrapper `Runtime` object.\r\n\r\n## What's Changed\r\n\r\n### Before/After: Basic Context Usage\r\n\r\n### Before (Old Pattern)\r\n```python\r\nfrom langchain_core.runnables import RunnableConfig\r\n\r\ndef node(state: State, config: RunnableConfig):\r\n    user_id = config.get(\"configurable\", {}).get(\"user_id\")\r\n    return {\"result\": f\"Hello {user_id}\"}\r\n\r\ngraph.invoke(input_data, config={\"configurable\": {\"user_id\": \"123\"}})\r\n```\r\n\r\n### After (New Pattern)\r\n```python\r\nfrom dataclasses import dataclass\r\nfrom langgraph.runtime import Runtime\r\n\r\n@dataclass\r\nclass ContextSchema:\r\n    user_id: str\r\n\r\ndef node(state: State, runtime: Runtime[ContextSchema]):\r\n    user_id = runtime.context.user_id\r\n    return {\"result\": f\"Hello {user_id}\"}\r\n\r\ngraph.invoke(input_data, context={\"user_id\": \"123\"})\r\n```\r\n\r\nOR, you can use the `get_runtime` method:\r\n```python\r\nfrom langgraph.runtime import get_runtime\r\n\r\ndef node(state: State):\r\n    user_id = get_runtime(ContextSchema).context.user_id\r\n    return {\"result\": f\"Hello {user_id}\"}\r\n```\r\n\r\n<details>\r\n<summary>Before/After: Store and Stream Writer Access</summary>\r\n\r\n### Before (Old pattern)\r\n```py\r\nfrom langgraph.store.base import BaseStore\r\nfrom langchain_core.runnables import RunnableConfig\r\n\r\ndef update_memory(state: MessagesState, config: RunnableConfig, *, store: BaseStore):\r\n    user_id = config.get(\"configurable\", {}).get(\"user_id\")\r\n    namespace = (user_id, \"memories\")\r\n    memory_id = str(uuid.uuid4())\r\n    store.put(namespace, memory_id, {\"memory\": memory})\r\n```\r\n\r\n### After (new pattern)\r\n```py\r\nfrom langgraph.runtime import Runtime\r\n\r\ndef update_memory(state: MessagesState, runtime: Runtime[ContextSchema]):\r\n    user_id = runtime.context.user_id\r\n    namespace = (user_id, \"memories\")\r\n    memory_id = str(uuid.uuid4())\r\n    runtime.store.put(namespace, memory_id, {\"memory\": memory})\r\n```\r\n</details>\r\n\r\n## Key Benefits\r\n- **Type Safety**: Type checked `context` input to `invoke` / `stream`, plus typed access to `Runtime` attributes\r\n- **Cleaner API**: Direct `context` parameter instead of nested `config['configurable']`\r\n- **Better DX**: IDE autocomplete for context fields and `Runtime` attributes\r\n- **Unified Runtime**: Single `Runtime` object provides access to context, store, and stream writer, with room for expanding to streamlined config/checkpoint information in the near future.\r\n\r\n## Breaking Changes & Migration\r\n\r\n### Deprecated APIs\r\n- `StateGraph(..., config_schema=X)` -> `StateGraph(..., context_schema=X)`\r\n- `Pregel.config_schema` → `Pregel.get_context_jsonschema()` - this is largely meant to be external and we don't anticipate this affecting many users\r\n\r\n### Migration Details\r\n- Maintains backward compatibility with existing `config['configurable']` usage\r\n- Deprecation warnings guide users to the new API\r\n\r\n## Future Work\r\n\r\n- [ ] Deprecate injection pattern for `store`, `stream_writer`, maybe `previous`, update docs to recommend popping from runtime.\r\n- [ ] Support `Runtime` injection for tools, right now only `get_runtime` is supported\r\n- [ ] LangGraph style guide with recommended best practices\r\n\r\nEventually, I think we should move away from storing and popping things from `config[\"configurable\"]`, which can be a fully internal refactor. Though I would love to do this pre v1, it should largely be internal, so can be done afterwards. Config changes should be in a different PR than this one to keep things reasonably scoped. This PR is already pretty big. Lots of plumbing.\r\n\r\n## Related Issues\r\nCloses #5023\r\n",
     "created_at": "2025-06-28T01:04:08Z",
     "merged_at": "2025-07-15T13:20:20Z",
-    "pre_merge_commit_sha": "e0bf4a7bc35d9bb9b9c52a0c652446ff9c9734ba"
+    "pre_merge_commit_sha": "e0bf4a7bc35d9bb9b9c52a0c652446ff9c9734ba",
+    "test_files": [
+      "libs/langgraph/tests/test_deprecation.py",
+      "libs/langgraph/tests/test_pregel.py",
+      "libs/langgraph/tests/test_runnable.py",
+      "libs/langgraph/tests/test_runtime.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/4374",
@@ -27,7 +33,12 @@
     "body": "This PR does a few things:\r\n1. Surfaces interrupts when `stream_mode='values'` (particularly relevant for `invoke`, where this is the default behavior) \r\n2. Adds an `interrupt_id` property to the `Interrupt` dataclass so that interrupts can effectively be mapped to resumes\r\n3. Minor docs updates to reflect the new pattern (no need for a special section on interrupts with `invoke` and `ainvoke`)\r\n\r\n* In a different PR (the one with the multiple resume values), as it's more relevant there: add an `interrupts` property to `StateSnapshot` so that `interrupts` can easily be iterated over if users are attempting to map interrupts to resumes.\r\n\r\nI **don't** recommend we release this until we have multi-resumes working.\r\n\r\n## Example\r\n\r\nWe have the following setup where we're sending multiple prompts to the child graph, which uses `interrupt`:\r\n\r\n```py\r\ndef child_graph(state):\r\n    human_input = interrupt(state[\"prompt\"])\r\n\r\n    return {\r\n        \"human_inputs\": [human_input],\r\n    }\r\n```\r\n\r\n<img width=\"142\" alt=\"Screenshot 2025-04-23 at 10 01 12 AM\" src=\"https://github.com/user-attachments/assets/c6238bf1-54ad-4e48-ab0b-60a0bfc18485\" />\r\n\r\nOld behavior:\r\n\r\n```py\r\ninitial_input = {\"prompts\": [\"a\", \"b\"]}\r\n\r\nprint(parent_graph.invoke(input=initial_input,config=thread_config,stream_mode=\"values\"))\r\n#> {'prompts': ['a', 'b'], 'human_inputs': []}\r\n\r\nprint(parent_graph.invoke(Command(resume=\"hello 1\"),config=thread_config,stream_mode=\"values\"))\r\n#> {'prompts': ['a', 'b'], 'human_inputs': ['hello 1']}\r\n\r\nprint(parent_graph.invoke(Command(resume=\"hello 2\"),config=thread_config,stream_mode=\"values\"))\r\n#> {'prompts': ['a', 'b'], 'human_inputs': ['hello 1', 'hello 2']}\r\n```\r\n\r\nNew behavior:\r\n\r\n```py\r\ninitial_input = {\"prompts\": [\"a\", \"b\"]}\r\n\r\nprint(parent_graph.invoke(input=initial_input,config=thread_config,stream_mode=\"values\"))\r\n\"\"\"\r\n{\r\n  \"prompts\": [\"a\", \"b\"],\r\n  \"human_inputs\": [],\r\n  \"__interrupt__\": [\r\n    Interrupt(\r\n      value=\"a\",\r\n      resumable=True,\r\n      ns=[\"child_graph:38d43a18-a5e7-8ab2-ca83-9d80f6e9ca83\"]\r\n    ),\r\n    Interrupt(\r\n      value=\"b\",\r\n      resumable=True,\r\n      ns=[\"child_graph:dad810e8-738e-9f90-41cd-30c0091eb79b\"]\r\n    )\r\n  ]\r\n}\r\n\"\"\"\r\n\r\nprint(parent_graph.invoke(Command(resume=\"hello 1\"),config=thread_config,stream_mode=\"values\"))\r\n\"\"\"\r\n{\r\n  \"prompts\": [\"a\", \"b\"],\r\n  \"human_inputs\": [\"hello 1\"],\r\n  \"__interrupt__\": [\r\n    Interrupt(\r\n      value=\"b\",\r\n      resumable=True,\r\n      ns=[\"child_graph:dad810e8-738e-9f90-41cd-30c0091eb79b\"]\r\n    )\r\n  ]\r\n}\r\n\"\"\"\r\n\r\nprint(parent_graph.invoke(Command(resume=\"hello 2\"),config=thread_config,stream_mode=\"values\"))\r\n#> {'prompts': ['a', 'b'], 'human_inputs': ['hello 1', 'hello 2']}\r\n```",
     "created_at": "2025-04-22T17:17:21Z",
     "merged_at": "2025-04-24T15:21:28Z",
-    "pre_merge_commit_sha": "b81c21f311fd131d5969c33d238be2eeed5cc522"
+    "pre_merge_commit_sha": "b81c21f311fd131d5969c33d238be2eeed5cc522",
+    "test_files": [
+      "libs/langgraph/tests/test_large_cases.py",
+      "libs/langgraph/tests/test_pregel.py",
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3126",
@@ -42,7 +53,10 @@
     "body": "Alternative to https://github.com/langchain-ai/langgraph/pull/3124\r\n\r\nCurrently if a tool interrupts, the entire tool node executes again after resuming. So tools can get executed twice if parallel tool calls are generated. Here we allow ToolNode to accept tool calls, so we can use the `Send` API to distribute the tool calls to multiple instances of the tool node.\r\n\r\n```python\r\nfrom langchain_anthropic import ChatAnthropic\r\nfrom langchain_core.tools import tool\r\nfrom langgraph.checkpoint.memory import MemorySaver\r\nfrom langgraph.prebuilt import create_react_agent\r\nfrom langgraph.types import Command, Send, interrupt\r\n\r\n\r\n@tool\r\ndef human_assistance(query: str) -> str:\r\n    \"\"\"Request assistance from a human.\"\"\"\r\n    human_response = interrupt({\"query\": query})\r\n    return human_response[\"data\"]\r\n\r\n\r\n@tool\r\ndef get_weather(location: str) -> str:\r\n    \"\"\"Use this tool to get the weather.\"\"\"\r\n    return \"It's sunny!\"\r\n\r\n\r\ntools = [get_weather, human_assistance]\r\nllm = ChatAnthropic(model=\"claude-3-5-sonnet-20240620\")\r\n\r\nagent = create_react_agent(\r\n    llm,\r\n    tools,\r\n    checkpointer=MemorySaver(),\r\n    tool_call_parallelism=\"parallel_tool_nodes\",\r\n)\r\n\r\n\r\nuser_input = (\r\n    \"Could you please (1) request assistance for building an AI agent \"\r\n    \"from a human, and (2) search for the weather in Boston, MA? \"\r\n    \"Generate two tool calls at once.\"\r\n)\r\n\r\nconfig = {\"configurable\": {\"thread_id\": \"1\"}}\r\n\r\nfor event in agent.stream(\r\n    {\"messages\": [{\"role\": \"user\", \"content\": user_input}]},\r\n    config,\r\n    stream_mode=\"values\",\r\n):\r\n    event[\"messages\"][-1].pretty_print()\r\n```\r\n```\r\n...\r\n```\r\n```python\r\nhuman_response = \"You should check out LangGraph to build your agent.\"\r\nhuman_command = Command(resume={\"data\": human_response})\r\n\r\nfor event in agent.stream(human_command, config, stream_mode=\"values\"):\r\n    event[\"messages\"][-1].pretty_print()\r\n```",
     "created_at": "2025-01-21T17:58:50Z",
     "merged_at": "2025-01-31T17:20:59Z",
-    "pre_merge_commit_sha": "4b3e07b67aa5a992531cab169286c3cda0c38a0a"
+    "pre_merge_commit_sha": "4b3e07b67aa5a992531cab169286c3cda0c38a0a",
+    "test_files": [
+      "libs/langgraph/tests/test_prebuilt.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3095",
@@ -57,7 +71,10 @@
     "body": "- both issues are related to the fact that waiters for futures are notified of completion before \"done\" callbacks are called\r\n- 1st issue manifested as interrupt stream event being emitted before the result of a task that logically finished first (it's in the line above in body of the entrypoint function) -> this is solved by always returning to use code a fresh future chained on the original future, because chaining is done via done callbacks (therefore the chained future will only resolve after done callbacks of the original feature are called)\r\n- 2nd issue mainfested as sometimes (very rarely) the last stream event not being printed before stream() finishes. this is solved by ensuring we only return out of PregelRunner.tick() once all \"done\" callbacks are called, previously we were approximating this through use of asyncio.sleep(0) / time.sleep(0). The new solution instead waits on a threading/asyncio.Event which will only be set by the last \"done\" callback to fire\r\n- this PR also disables incomplete support for calling sync tasks from async entrypoints",
     "created_at": "2025-01-17T23:35:26Z",
     "merged_at": "2025-01-17T23:44:52Z",
-    "pre_merge_commit_sha": "e4a5c8fd28ceca30171073aebd64b802699c54ba"
+    "pre_merge_commit_sha": "e4a5c8fd28ceca30171073aebd64b802699c54ba",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/2848",
@@ -72,7 +89,10 @@
     "body": "```python\r\nclass WeatherResponse(BaseModel):\r\n    \"\"\"Respond to the user with this\"\"\"\r\n\r\n    temperature: float = Field(description=\"The temperature in fahrenheit\")\r\n    wind_direction: str = Field(\r\n        description=\"The direction of the wind in abbreviated form\"\r\n    )\r\n    wind_speed: float = Field(description=\"The speed of the wind in mph\")\r\n\r\n@tool\r\ndef get_weather(city: Literal[\"nyc\", \"sf\"]):\r\n    \"\"\"Use this to get weather information.\"\"\"\r\n    if city == \"nyc\":\r\n        return \"It is cloudy in NYC, with 5 mph winds in the North-East direction and a temperature of 70 degrees\"\r\n    elif city == \"sf\":\r\n        return \"It is 75 degrees and sunny in SF, with 3 mph winds in the South-East direction\"\r\n    else:\r\n        raise AssertionError(\"Unknown city\")\r\n\r\nmodel = ChatOpenAI()\r\ntools = [get_weather]\r\nagent_with_structured_output = create_react_agent(model, tools, response_format=WeatherResponse)\r\nagent_with_structured_output.invoke({\"messages\": [(\"user\", \"what's the weather in nyc?\")]})\r\n```\r\n\r\n```pycon\r\n{\r\n    'messages': [...],\r\n    'structured_response': WeatherResponse(temperature=70.0, wind_directon='NE', wind_speed=5.0)\r\n}\r\n```",
     "created_at": "2024-12-20T20:31:20Z",
     "merged_at": "2025-01-10T16:06:59Z",
-    "pre_merge_commit_sha": "35c3ba0104804bee045675ee8bce754deccacfc2"
+    "pre_merge_commit_sha": "35c3ba0104804bee045675ee8bce754deccacfc2",
+    "test_files": [
+      "libs/langgraph/tests/test_prebuilt.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/1004",
@@ -87,7 +107,10 @@
     "body": "We noticed that it is currently not possible to interrupt a graph multiple times.\r\n\r\nOnce the graph resumes execution after an interruption, it just continues executing, ignoring `interrupt_before` and `interrupt_after`.\r\n\r\nThe reason is that after resuming this condition in `_should_interrupt` seems to always return false:\r\n```\r\nany(\r\n    checkpoint[\"channel_versions\"].get(chan, null_version)\r\n    > seen.get(chan, null_version)\r\n    for chan in snapshot_channels\r\n)\r\n```\r\n\r\nIn this PR I added a unit test in `test_interruption.py` to spec the desired behavior. I modified the code to pass the unit test, but since I do not understand what this code does it's probably not the right thing.\r\n\r\nIt would be great to get some guidance on how to fix this properly.\r\n",
     "created_at": "2024-07-12T16:42:14Z",
     "merged_at": "2024-07-12T19:53:17Z",
-    "pre_merge_commit_sha": "558a513a1acbc0ae88ae24d6e5cc13325ab00ad1"
+    "pre_merge_commit_sha": "558a513a1acbc0ae88ae24d6e5cc13325ab00ad1",
+    "test_files": [
+      "libs/langgraph/tests/test_interruption.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/5801",
@@ -102,7 +125,10 @@
     "body": "Fixes https://github.com/langchain-ai/langgraph/issues/5784\r\n\r\n* Removes usage of `is_last_step`, no longer needed with `remaining_steps`\r\n* Make `remaining_steps` `NotRequired` so that json schema doesn't suggest need for user input\r\n* Move `PregelScratchpad` to shared utils file to prevent circular import issue (it's used from `channels/managed` and other pregel files).\r\n* Ensures that managed values wrapped in `NotRequired` or `Required` are still recognized!",
     "created_at": "2025-08-01T18:31:32Z",
     "merged_at": "2025-08-03T11:12:54Z",
-    "pre_merge_commit_sha": "db8ed4e9e424ed29c8165602f17ee800c671681b"
+    "pre_merge_commit_sha": "db8ed4e9e424ed29c8165602f17ee800c671681b",
+    "test_files": [
+      "libs/langgraph/tests/test_managed_values.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/5796",
@@ -117,7 +143,10 @@
     "body": "Fixes https://github.com/langchain-ai/langgraph/issues/5795\r\n\r\n* Must use `category=None` on decorator so that we get type checking support but no dupe warning\r\n* Fixed tuple on `config_type` warning causing false warning",
     "created_at": "2025-08-01T14:27:51Z",
     "merged_at": "2025-08-01T14:33:46Z",
-    "pre_merge_commit_sha": "38bbd92e01d8437b70c45355b6005fa40c204844"
+    "pre_merge_commit_sha": "38bbd92e01d8437b70c45355b6005fa40c204844",
+    "test_files": [
+      "libs/langgraph/tests/test_deprecation.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/5708",
@@ -132,7 +161,10 @@
     "body": "Fixes https://github.com/langchain-ai/langgraph/issues/5698\r\n\r\nI would like to do a more general refactor of this logic at some point as well using typing introspection utilities. Claude code first pass: https://github.com/langchain-ai/langgraph/pull/5709",
     "created_at": "2025-07-29T19:14:10Z",
     "merged_at": "2025-07-29T20:11:37Z",
-    "pre_merge_commit_sha": "479373bd81f538b81362ae8bea9d1b6923e1f60e"
+    "pre_merge_commit_sha": "479373bd81f538b81362ae8bea9d1b6923e1f60e",
+    "test_files": [
+      "libs/langgraph/tests/test_runnable.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/4983",
@@ -147,7 +179,15 @@
     "body": "* rename `input` -> `input_schema`\r\n* rename `output` -> `output_schema`\r\n* make graphs generic on `OutputT` to prep for future type checking\r\n\r\nAll renaming operations are backwards compatible in that we populate old input / output into their respective new schemas!",
     "created_at": "2025-06-06T18:53:54Z",
     "merged_at": "2025-06-06T23:44:56Z",
-    "pre_merge_commit_sha": "5920d8aa92fb8a76c7629a65acac5480387de0a5"
+    "pre_merge_commit_sha": "5920d8aa92fb8a76c7629a65acac5480387de0a5",
+    "test_files": [
+      "libs/langgraph/tests/test_deprecation.py",
+      "libs/langgraph/tests/test_large_cases.py",
+      "libs/langgraph/tests/test_pregel.py",
+      "libs/langgraph/tests/test_pregel_async.py",
+      "libs/langgraph/tests/test_state.py",
+      "libs/langgraph/tests/test_type_checking.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3889",
@@ -162,7 +202,10 @@
     "body": "- Previously the global resume value was passed to subgraphs without being consumed\r\n- This would result in two parallel subgraph calls being able to use the same resume value\r\n- Note this behavior can't be implemented over the wire, that will be fixed in future PR\r\n\r\nCloses #3398 ",
     "created_at": "2025-03-18T03:32:30Z",
     "merged_at": "2025-03-18T04:26:34Z",
-    "pre_merge_commit_sha": "dd16ae4ba5243b4f0e4228f9a00aac477146c301"
+    "pre_merge_commit_sha": "dd16ae4ba5243b4f0e4228f9a00aac477146c301",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3110",
@@ -177,7 +220,10 @@
     "body": "\r\n\r\n- this was not possible in async where all done callbacks are called in next tick\r\n- in sync case this would manifest as the first task done callback seeing counter == 1 and thus setting event\r\n- the fix is to unset the event whenever a task is scheduled",
     "created_at": "2025-01-20T19:41:44Z",
     "merged_at": "2025-01-21T18:16:10Z",
-    "pre_merge_commit_sha": "d48b25420ba7553a7154d3960fb1bf327d497e9d"
+    "pre_merge_commit_sha": "d48b25420ba7553a7154d3960fb1bf327d497e9d",
+    "test_files": [
+      "libs/langgraph/tests/test_large_cases.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3037",
@@ -192,7 +238,12 @@
     "body": "- order was incorrectly based on task id, instead of the correct task path\r\n- this requires storing task paths on checkpointers\r\n- addition of task_path to put_writes is made backwards compatible by checking signature on call, and treating it as an optional arg",
     "created_at": "2025-01-15T02:12:35Z",
     "merged_at": "2025-01-15T19:42:08Z",
-    "pre_merge_commit_sha": "0adbd89d9aaad57e8e4431f308c4372a740e4cbf"
+    "pre_merge_commit_sha": "0adbd89d9aaad57e8e4431f308c4372a740e4cbf",
+    "test_files": [
+      "libs/langgraph/tests/test_algo.py",
+      "libs/langgraph/tests/test_large_cases.py",
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/2393",
@@ -207,7 +258,11 @@
     "body": "- This works similarly to the input() function from stdlib\r\n- calling it in a node interrupts execution\r\n- invoking the graph with Command(resume=...) will set ... as the return value of interrupt() so that the node can access the \"answer\" to the \"question\"\r\n- This PR also starts the work to control the graph on invoke/stream with Command() input, to be continued in a future PR\r\n\r\n```py\r\n    class State(TypedDict):\r\n        my_key: Annotated[str, operator.add]\r\n        market: str\r\n\r\n    async def tool_two_node(s: State) -> State:\r\n        if s[\"market\"] == \"DE\":\r\n            answer = interrupt(\"Just because...\")\r\n        else:\r\n            answer = \" all good\"\r\n        return {\"my_key\": answer}\r\n\r\n    tool_two_graph = StateGraph(State)\r\n    tool_two_graph.add_node(\"tool_two\", tool_two_node)\r\n    tool_two_graph.add_edge(START, \"tool_two\")\r\n    tool_two = tool_two_graph.compile()\r\n\r\n        tool_two = tool_two_graph.compile(checkpointer=checkpointer)\r\n\r\n        # flow: interrupt -> resume with answer\r\n        thread2 = {\"configurable\": {\"thread_id\": \"2\"}}\r\n        # stop when about to enter node\r\n        assert [\r\n            c\r\n            async for c in tool_two.astream(\r\n                {\"my_key\": \"value ⛰️\", \"market\": \"DE\"}, thread2\r\n            )\r\n        ] == [\r\n            {\"__interrupt__\": [Interrupt(value=\"Just because...\", when=\"during\")]},\r\n        ]\r\n        # resume with answer\r\n        assert [\r\n            c async for c in tool_two.astream(Command(resume=\" my answer\"), thread2)\r\n        ] == [\r\n            {\"tool_two\": {\"my_key\": \" my answer\"}},\r\n        ]\r\n```",
     "created_at": "2024-11-12T01:45:14Z",
     "merged_at": "2024-11-13T21:34:20Z",
-    "pre_merge_commit_sha": "7a3ea427432dd5e8f4ee101a8c773f3afbc3214c"
+    "pre_merge_commit_sha": "7a3ea427432dd5e8f4ee101a8c773f3afbc3214c",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel.py",
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/1776",
@@ -222,7 +277,11 @@
     "body": "- adds the ability for nodes (including in subgraphs) to emit chunks directly to the output stream, emitted chunks can have any type\r\n- when stream_mode=custom isnt requested by the caller emitted chunks are ignored",
     "created_at": "2024-09-19T23:46:37Z",
     "merged_at": "2024-09-20T16:18:51Z",
-    "pre_merge_commit_sha": "531890e35a35f9b381d375167a7b104184378153"
+    "pre_merge_commit_sha": "531890e35a35f9b381d375167a7b104184378153",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel.py",
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/1735",
@@ -237,7 +296,10 @@
     "body": "- previous behavior was to buffer all output from subgraph until it finished, now subgraph steps are emitted as soon as produced, while the subgraph is still running\r\n- this is slightly slower in benchmark scripts, but worth it as it's much \"faster\" in real-world latency",
     "created_at": "2024-09-17T01:04:29Z",
     "merged_at": "2024-09-17T17:14:26Z",
-    "pre_merge_commit_sha": "f59435a892e96fb9092e0055a6df2e1dfc5111a9"
+    "pre_merge_commit_sha": "f59435a892e96fb9092e0055a6df2e1dfc5111a9",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/1630",
@@ -252,7 +314,11 @@
     "body": "- Orchestrator and Executor classes to run LangGraph in a distributed fashion using Kafka as a message bus for communication\r\n- Orchestrator and Executor run on-demand when a new message is published to the topic they listen to\r\n- Orchestrator is responsible for running the Pregel algorithm (deciding next tasks to run) and sending messages to the executor topic\r\n- Executor is responsible for executing each task (node), and sending messages to the orchestrator topic when done",
     "created_at": "2024-09-06T01:01:06Z",
     "merged_at": "2024-09-11T00:31:59Z",
-    "pre_merge_commit_sha": "34d530d5d83837fa080c1db2d055fe952cfc8488"
+    "pre_merge_commit_sha": "34d530d5d83837fa080c1db2d055fe952cfc8488",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel.py",
+      "libs/langgraph/tests/test_pregel_async.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/809",
@@ -267,7 +333,10 @@
     "body": "When an instance of a callable class is passed as the path arg to add_conditional_edges but no path_map is provided, get_type_hints(path) is called, which raises a TypeError (since get_type_hints only accepts a module, class, method, or function).\r\n\r\nThis patch fixes the error by trying to get type hints from path.\\_\\_call\\_\\_ first, which should work for instances of callable classes.\r\n\r\nTested: Added a test that raises TypeError without the fix in this patch but passes with the fix.",
     "created_at": "2024-06-25T21:38:27Z",
     "merged_at": "2024-06-26T23:24:59Z",
-    "pre_merge_commit_sha": "6ae59581643b51751731ae64c609a8bc21779714"
+    "pre_merge_commit_sha": "6ae59581643b51751731ae64c609a8bc21779714",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel.py"
+    ]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/651",
@@ -282,6 +351,9 @@
     "body": "This change allows users or graph nodes to remove messages by `id` via `langchain_core.messages.RemoveMessage`\r\n\r\nExamples:\r\n\r\n* allow users to delete messages from state by calling\r\n\r\n```python\r\ngraph.update_state(config, values=[RemoveMessage(id=state.values[-1].id)])\r\n```\r\n\r\n* allow nodes to delete messages\r\n\r\n```python\r\ngraph.add_node(\"delete_messages\", lambda state: [RemoveMessage(id=state[-1].id)])\r\n```",
     "created_at": "2024-06-12T14:35:51Z",
     "merged_at": "2024-07-03T05:43:54Z",
-    "pre_merge_commit_sha": "5e8aa5d9f2e24b197ffa187c6b7b36602761d1a4"
+    "pre_merge_commit_sha": "5e8aa5d9f2e24b197ffa187c6b7b36602761d1a4",
+    "test_files": [
+      "libs/langgraph/tests/test_pregel.py"
+    ]
   }
 ]

--- a/apps/open-swe/langbench/static/langgraph_prs.json
+++ b/apps/open-swe/langbench/static/langgraph_prs.json
@@ -54,9 +54,7 @@
     "created_at": "2025-01-21T17:58:50Z",
     "merged_at": "2025-01-31T17:20:59Z",
     "pre_merge_commit_sha": "4b3e07b67aa5a992531cab169286c3cda0c38a0a",
-    "test_files": [
-      "libs/langgraph/tests/test_prebuilt.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_prebuilt.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3095",
@@ -72,9 +70,7 @@
     "created_at": "2025-01-17T23:35:26Z",
     "merged_at": "2025-01-17T23:44:52Z",
     "pre_merge_commit_sha": "e4a5c8fd28ceca30171073aebd64b802699c54ba",
-    "test_files": [
-      "libs/langgraph/tests/test_pregel_async.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_pregel_async.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/2848",
@@ -90,9 +86,7 @@
     "created_at": "2024-12-20T20:31:20Z",
     "merged_at": "2025-01-10T16:06:59Z",
     "pre_merge_commit_sha": "35c3ba0104804bee045675ee8bce754deccacfc2",
-    "test_files": [
-      "libs/langgraph/tests/test_prebuilt.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_prebuilt.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/1004",
@@ -108,9 +102,7 @@
     "created_at": "2024-07-12T16:42:14Z",
     "merged_at": "2024-07-12T19:53:17Z",
     "pre_merge_commit_sha": "558a513a1acbc0ae88ae24d6e5cc13325ab00ad1",
-    "test_files": [
-      "libs/langgraph/tests/test_interruption.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_interruption.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/5801",
@@ -126,9 +118,7 @@
     "created_at": "2025-08-01T18:31:32Z",
     "merged_at": "2025-08-03T11:12:54Z",
     "pre_merge_commit_sha": "db8ed4e9e424ed29c8165602f17ee800c671681b",
-    "test_files": [
-      "libs/langgraph/tests/test_managed_values.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_managed_values.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/5796",
@@ -144,9 +134,7 @@
     "created_at": "2025-08-01T14:27:51Z",
     "merged_at": "2025-08-01T14:33:46Z",
     "pre_merge_commit_sha": "38bbd92e01d8437b70c45355b6005fa40c204844",
-    "test_files": [
-      "libs/langgraph/tests/test_deprecation.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_deprecation.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/5708",
@@ -162,9 +150,7 @@
     "created_at": "2025-07-29T19:14:10Z",
     "merged_at": "2025-07-29T20:11:37Z",
     "pre_merge_commit_sha": "479373bd81f538b81362ae8bea9d1b6923e1f60e",
-    "test_files": [
-      "libs/langgraph/tests/test_runnable.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_runnable.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/4983",
@@ -203,9 +189,7 @@
     "created_at": "2025-03-18T03:32:30Z",
     "merged_at": "2025-03-18T04:26:34Z",
     "pre_merge_commit_sha": "dd16ae4ba5243b4f0e4228f9a00aac477146c301",
-    "test_files": [
-      "libs/langgraph/tests/test_pregel.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_pregel.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3110",
@@ -221,9 +205,7 @@
     "created_at": "2025-01-20T19:41:44Z",
     "merged_at": "2025-01-21T18:16:10Z",
     "pre_merge_commit_sha": "d48b25420ba7553a7154d3960fb1bf327d497e9d",
-    "test_files": [
-      "libs/langgraph/tests/test_large_cases.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_large_cases.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/3037",
@@ -297,9 +279,7 @@
     "created_at": "2024-09-17T01:04:29Z",
     "merged_at": "2024-09-17T17:14:26Z",
     "pre_merge_commit_sha": "f59435a892e96fb9092e0055a6df2e1dfc5111a9",
-    "test_files": [
-      "libs/langgraph/tests/test_pregel_async.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_pregel_async.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/1630",
@@ -334,9 +314,7 @@
     "created_at": "2024-06-25T21:38:27Z",
     "merged_at": "2024-06-26T23:24:59Z",
     "pre_merge_commit_sha": "6ae59581643b51751731ae64c609a8bc21779714",
-    "test_files": [
-      "libs/langgraph/tests/test_pregel.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_pregel.py"]
   },
   {
     "url": "https://api.github.com/repos/langchain-ai/langgraph/pulls/651",
@@ -352,8 +330,6 @@
     "created_at": "2024-06-12T14:35:51Z",
     "merged_at": "2024-07-03T05:43:54Z",
     "pre_merge_commit_sha": "5e8aa5d9f2e24b197ffa187c6b7b36602761d1a4",
-    "test_files": [
-      "libs/langgraph/tests/test_pregel.py"
-    ]
+    "test_files": ["libs/langgraph/tests/test_pregel.py"]
   }
 ]

--- a/apps/open-swe/langbench/types.ts
+++ b/apps/open-swe/langbench/types.ts
@@ -1,3 +1,5 @@
+import { Sandbox } from "@daytonaio/sdk";
+
 export interface PRData {
   url: string;
   htmlUrl: string;
@@ -52,4 +54,11 @@ export interface PRProcessResult {
   testResults?: TestResults;
   error?: string;
   preMergeSha?: string;
+}
+
+export interface RunPytestOptions {
+  sandbox: Sandbox;
+  testFiles: string[];
+  repoDir: string;
+  timeoutSec?: number;
 }

--- a/apps/open-swe/langbench/types.ts
+++ b/apps/open-swe/langbench/types.ts
@@ -24,6 +24,23 @@ export interface TestResults {
   testDetails: string[];
 }
 
+export interface PytestJsonTest {
+  nodeid: string;
+  outcome: "passed" | "failed" | "error" | "skipped";
+}
+
+export interface PytestJsonSummary {
+  passed?: number;
+  failed?: number;
+  error?: number;
+  skipped?: number;
+}
+
+export interface PytestJsonReport {
+  tests?: PytestJsonTest[];
+  summary?: PytestJsonSummary;
+}
+
 export interface PRProcessResult {
   pr_number: number;
   repo_name: string;

--- a/apps/open-swe/langbench/types.ts
+++ b/apps/open-swe/langbench/types.ts
@@ -1,18 +1,18 @@
 export interface PRData {
   url: string;
-  html_url: string;
-  diff_url: string;
-  patch_url: string;
-  repo_owner: string;
-  repo_name: string;
-  pr_number: number;
-  merge_commit_sha: string;
-  pre_merge_commit_sha: string;
+  htmlUrl: string;
+  diffUrl: string;
+  patchUrl: string;
+  repoOwner: string;
+  repoName: string;
+  prNumber: number;
+  mergeCommitSha: string;
+  preMergeCommitSha: string;
   title: string;
   body: string;
-  created_at: string;
-  merged_at: string;
-  test_files: string[];
+  createdAt: string;
+  mergedAt: string;
+  testFiles: string[];
 }
 
 export interface TestResults {
@@ -42,14 +42,14 @@ export interface PytestJsonReport {
 }
 
 export interface PRProcessResult {
-  pr_number: number;
-  repo_name: string;
-  workspace_id?: string;
+  prNumber: number;
+  repoName: string;
+  workspaceId?: string;
   success: boolean;
-  evals_found: boolean;
-  evals_files: string[];
-  test_files: string[];
-  test_results?: TestResults;
+  evalsFound: boolean;
+  evalsFiles: string[];
+  testFiles: string[];
+  testResults?: TestResults;
   error?: string;
-  pre_merge_sha?: string;
+  preMergeSha?: string;
 }

--- a/apps/open-swe/langbench/types.ts
+++ b/apps/open-swe/langbench/types.ts
@@ -12,6 +12,16 @@ export interface PRData {
   body: string;
   created_at: string;
   merged_at: string;
+  test_files: string[];
+}
+
+export interface TestResults {
+  success: boolean;
+  error: string | null;
+  totalTests: number;
+  passedTests: number;
+  failedTests: number;
+  testDetails: string[];
 }
 
 export interface PRProcessResult {
@@ -21,6 +31,8 @@ export interface PRProcessResult {
   success: boolean;
   evals_found: boolean;
   evals_files: string[];
+  test_files: string[];
+  test_results?: TestResults;
   error?: string;
   pre_merge_sha?: string;
 }

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -44,7 +44,7 @@ export async function getTestFilesFromDiff(diffUrl: string): Promise<string[]> {
 /**
  * Check if a file path represents a test file in libs/langgraph/tests/
  */
-export function isLangGraphTestFile(filePath: string): boolean {
+function isLangGraphTestFile(filePath: string): boolean {
   return filePath.includes("libs/langgraph/tests/") && filePath.endsWith(".py");
 }
 

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -80,7 +80,7 @@ export async function runPytestOnFiles(
 
   // Join test files for pytest command
   const testFilesArg = testFiles.join(" ");
-  const runTestCommand = `${RUN_PYTHON_IN_VENV} -m pytest ${testFilesArg} -v --tb=short --json-report --json-report-file=/tmp/pytest_report.json`;
+  const command = `${RUN_PYTHON_IN_VENV} -m pytest ${testFilesArg} -v --tb=short --json-report --json-report-file=/tmp/pytest_report.json`;
   logger.info("Running pytest command", { command });
 
   logger.info(

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -5,7 +5,8 @@ import { ENV_CONSTANTS } from "../src/utils/env-setup.js";
 const logger = createLogger(LogLevel.DEBUG, "Langbench Utils");
 
 /**
- * Fetch diff content from a diff URL and extract test file names
+ * Fetch diff content from a diff URL and extract test file names, this function is used in one-off situtations to get the test files from the diff url.
+ *
  */
 export async function getTestFilesFromDiff(diffUrl: string): Promise<string[]> {
   try {
@@ -22,7 +23,6 @@ export async function getTestFilesFromDiff(diffUrl: string): Promise<string[]> {
     for (const line of lines) {
       // Look for diff file headers
       if (line.startsWith("diff --git ")) {
-        // Extract file path from "diff --git a/path/to/file.py b/path/to/file.py"
         const match = line.match(/diff --git a\/(.+?) b\//);
         if (match) {
           const filePath = match[1];
@@ -226,46 +226,6 @@ export const parsePytestJsonReport = (
     failedTests,
     detailsCount: testDetails.length,
   });
-
-  return {
-    totalTests,
-    passedTests,
-    failedTests,
-    testDetails,
-  };
-};
-
-/**
- * Fallback: Parse pytest text output to extract test results (legacy)
- */
-export const parsePytestOutput = (
-  output: string,
-): Omit<TestResult, "success" | "error"> => {
-  const lines = output.split("\n");
-  let totalTests = 0;
-  let passedTests = 0;
-  let failedTests = 0;
-  const testDetails: string[] = [];
-
-  // Collect test details and count results from individual test lines
-  for (const line of lines) {
-    if (
-      line.includes("::") &&
-      (line.includes("PASSED") ||
-        line.includes("FAILED") ||
-        line.includes("ERROR"))
-    ) {
-      testDetails.push(line.trim());
-
-      if (line.includes("PASSED")) {
-        passedTests++;
-      } else if (line.includes("FAILED") || line.includes("ERROR")) {
-        failedTests++;
-      }
-    }
-  }
-
-  totalTests = passedTests + failedTests;
 
   return {
     totalTests,

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -111,7 +111,7 @@ export const runPytestOnFiles = async (
     installCommand,
     repoDir,
     undefined,
-    timeoutSec * 2, 
+    timeoutSec * 2,
   );
 
   logger.info("Installation completed", {

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -98,7 +98,6 @@ export async function runPytestOnFiles(
     "Installing pytest, pytest-mock, pytest-asyncio, syrupy, pytest-json-report, and langgraph in virtual environment...",
   );
 
-  // Execute install commands separately for better error identification
   for (const [index, command] of PYTEST_INSTALL_COMMANDS.entries()) {
     logger.info(
       `Running install command ${index + 1}/${PYTEST_INSTALL_COMMANDS.length}: ${command}`,

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -142,16 +142,10 @@ export const runPytestOnFiles = async (
         parsed = parsePytestJsonReport(jsonReport);
         logger.debug("Successfully parsed JSON report", { jsonReport });
       } else {
-        logger.warn("Failed to read JSON report, falling back to text parsing");
-        const output = execution.result || "";
-        parsed = parsePytestOutput(output);
+        throw new Error("Failed to read JSON report");
       }
     } catch (jsonError) {
-      logger.warn("Failed to parse JSON report, falling back to text parsing", {
-        jsonError,
-      });
-      const output = execution.result || "";
-      parsed = parsePytestOutput(output);
+      throw new Error("Failed to parse JSON report", { cause: jsonError });
     }
 
     logger.info("Pytest execution completed", {

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -1,7 +1,6 @@
-import { Sandbox } from "@daytonaio/sdk";
 import { createLogger, LogLevel } from "../src/utils/logger.js";
 import { ENV_CONSTANTS } from "../src/utils/env-setup.js";
-import { TestResults, PytestJsonReport } from "./types.js";
+import { TestResults, PytestJsonReport, RunPytestOptions } from "./types.js";
 import { readFile } from "../src/utils/read-write.js";
 
 const logger = createLogger(LogLevel.DEBUG, "Langbench Utils");
@@ -58,13 +57,6 @@ const PYTEST_INSTALL_COMMANDS = [
   `${RUN_PIP_IN_VENV} install pytest pytest-mock pytest-asyncio syrupy pytest-json-report`,
   `${RUN_PIP_IN_VENV} install -e ./libs/langgraph`,
 ];
-
-export interface RunPytestOptions {
-  sandbox: Sandbox;
-  testFiles: string[];
-  repoDir: string;
-  timeoutSec?: number;
-}
 
 /**
  * Run pytest on specific test files and return structured results

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -7,7 +7,6 @@ const logger = createLogger(LogLevel.DEBUG, "Langbench Utils");
 
 /**
  * Fetch diff content from a diff URL and extract test file names, this function is used in one-off situtations to get the test files from the diff url.
- *
  */
 export async function getTestFilesFromDiff(diffUrl: string): Promise<string[]> {
   try {

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -1,0 +1,229 @@
+import { Sandbox } from "@daytonaio/sdk";
+import { createLogger, LogLevel } from "../src/utils/logger.js";
+import { ENV_CONSTANTS } from "../src/utils/env-setup.js";
+
+const logger = createLogger(LogLevel.DEBUG, "Langbench Utils");
+
+/**
+ * Fetch diff content from a diff URL and extract test file names
+ */
+export async function getTestFilesFromDiff(diffUrl: string): Promise<string[]> {
+  try {
+    const response = await fetch(diffUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch diff: ${response.statusText}`);
+    }
+
+    const diffContent = await response.text();
+    const testFiles: string[] = [];
+
+    // Parse the diff to find modified files
+    const lines = diffContent.split("\n");
+    for (const line of lines) {
+      // Look for diff file headers
+      if (line.startsWith("diff --git ")) {
+        // Extract file path from "diff --git a/path/to/file.py b/path/to/file.py"
+        const match = line.match(/diff --git a\/(.+?) b\//);
+        if (match) {
+          const filePath = match[1];
+          // Check if this is a test file in libs/langgraph/tests/
+          if (isLangGraphTestFile(filePath)) {
+            testFiles.push(filePath);
+          }
+        }
+      }
+    }
+
+    return [...new Set(testFiles)]; // Remove duplicates
+  } catch (error) {
+    logger.error(`Failed to fetch or parse diff from ${diffUrl}:`, { error });
+    return [];
+  }
+}
+
+/**
+ * Check if a file path represents a test file in libs/langgraph/tests/
+ */
+export function isLangGraphTestFile(filePath: string): boolean {
+  return filePath.includes("libs/langgraph/tests/") && filePath.endsWith(".py");
+}
+
+// Use shared constants from env-setup utility
+const { RUN_PYTHON_IN_VENV, RUN_PIP_IN_VENV } = ENV_CONSTANTS;
+
+// Installation commands for pytest and dependencies
+const PYTEST_INSTALL_COMMANDS = [
+  `${RUN_PIP_IN_VENV} install pytest pytest-mock pytest-asyncio syrupy`,
+  `${RUN_PIP_IN_VENV} install -e ./libs/langgraph`,
+];
+
+export interface TestResult {
+  success: boolean;
+  error: string | null;
+  totalTests: number;
+  passedTests: number;
+  failedTests: number;
+  testDetails: string[];
+}
+
+export interface ExecOptions {
+  command: string;
+  workingDir: string;
+  env?: Record<string, string>;
+  timeoutSec: number;
+}
+
+/**
+ * Run pytest on specific test files and return structured results
+ */
+export const runPytestOnFiles = async (
+  sandbox: Sandbox,
+  testFiles: string[],
+  repoDir: string,
+  timeoutSec: number = 300,
+): Promise<TestResult> => {
+  if (testFiles.length === 0) {
+    logger.info("No test files provided, skipping pytest execution");
+    return {
+      success: true,
+      error: null,
+      totalTests: 0,
+      passedTests: 0,
+      failedTests: 0,
+      testDetails: [],
+    };
+  }
+
+  logger.info(`Running pytest on ${testFiles.length} test files`, {
+    testFiles,
+  });
+
+  // Join test files for pytest command
+  const testFilesArg = testFiles.join(" ");
+  const command = `${RUN_PYTHON_IN_VENV} -m pytest ${testFilesArg} -v --tb=short`;
+  logger.info("Running pytest command", { command });
+
+  logger.info(
+    "Installing pytest, pytest-mock, pytest-asyncio, syrupy, and langgraph in virtual environment...",
+  );
+  const installCommand = PYTEST_INSTALL_COMMANDS.join(" && ");
+  const installResult = await sandbox.process.executeCommand(
+    installCommand,
+    repoDir,
+    undefined,
+    timeoutSec * 2, 
+  );
+
+  logger.info("Installation completed", {
+    exitCode: installResult.exitCode,
+    output: installResult.result?.slice(0, 500),
+  });
+
+  try {
+    const execution = await sandbox.process.executeCommand(
+      command,
+      repoDir,
+      undefined,
+      timeoutSec,
+    );
+
+    const output = execution.result || "";
+    const parsed = parsePytestOutput(output);
+
+    logger.info("Pytest execution completed", {
+      exitCode: execution.exitCode,
+      totalTests: parsed.totalTests,
+      passedTests: parsed.passedTests,
+      failedTests: parsed.failedTests,
+      command,
+      stdout: output,
+      fullExecution: JSON.stringify(execution, null, 2), // Show full execution object
+    });
+
+    return {
+      success: execution.exitCode === 0,
+      error:
+        execution.exitCode !== 0 ? `Exit code: ${execution.exitCode}` : null,
+      ...parsed,
+    };
+  } catch (error) {
+    logger.error("Failed to run pytest", { error });
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+      totalTests: 0,
+      passedTests: 0,
+      failedTests: 0,
+      testDetails: [],
+    };
+  }
+};
+
+/**
+ * Parse pytest output to extract test results
+ */
+export const parsePytestOutput = (
+  output: string,
+): Omit<TestResult, "success" | "error"> => {
+  const lines = output.split("\n");
+  let totalTests = 0;
+  let passedTests = 0;
+  let failedTests = 0;
+  const testDetails: string[] = [];
+
+  // Collect test details and count results from individual test lines
+  for (const line of lines) {
+    if (
+      line.includes("::") &&
+      (line.includes("PASSED") ||
+        line.includes("FAILED") ||
+        line.includes("ERROR"))
+    ) {
+      testDetails.push(line.trim());
+
+      if (line.includes("PASSED")) {
+        passedTests++;
+      } else if (line.includes("FAILED") || line.includes("ERROR")) {
+        failedTests++;
+      }
+    }
+  }
+
+  totalTests = passedTests + failedTests;
+
+  // If we didn't find individual test results, try parsing summary line
+  if (totalTests === 0) {
+    const summaryLine = lines.find(
+      (line) =>
+        line.includes("passed") ||
+        line.includes("failed") ||
+        line.includes("error"),
+    );
+
+    if (summaryLine) {
+      const passedMatch = summaryLine.match(/(\d+)\s+passed/);
+      const failedMatch = summaryLine.match(/(\d+)\s+failed/);
+      const errorMatch = summaryLine.match(/(\d+)\s+error/);
+
+      if (passedMatch) passedTests = parseInt(passedMatch[1], 10);
+      if (failedMatch) failedTests = parseInt(failedMatch[1], 10);
+      if (errorMatch) failedTests += parseInt(errorMatch[1], 10);
+
+      totalTests = passedTests + failedTests;
+    }
+  }
+
+  logger.debug("Parsed pytest output", {
+    totalTests,
+    passedTests,
+    failedTests,
+    detailsCount: testDetails.length,
+  });
+
+  return {
+    totalTests,
+    passedTests,
+    failedTests,
+    testDetails,
+  };
+};

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -82,7 +82,7 @@ export async function runPytestOnFiles(
 
   // Join test files for pytest command
   const testFilesArg = testFiles.join(" ");
-  const command = `${RUN_PYTHON_IN_VENV} -m pytest ${testFilesArg} -v --tb=short --json-report --json-report-file=/tmp/pytest_report.json`;
+  const runTestCommand = `${RUN_PYTHON_IN_VENV} -m pytest ${testFilesArg} -v --tb=short --json-report --json-report-file=/tmp/pytest_report.json`;
   logger.info("Running pytest command", { command });
 
   logger.info(

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -52,10 +52,8 @@ function isLangGraphTestFile(filePath: string): boolean {
 const { RUN_PYTHON_IN_VENV, RUN_PIP_IN_VENV } = ENV_CONSTANTS;
 
 // Installation commands for pytest and dependencies
-const PYTEST_INSTALL_COMMANDS = [
-  `${RUN_PIP_IN_VENV} install pytest pytest-mock pytest-asyncio syrupy pytest-json-report`,
-  `${RUN_PIP_IN_VENV} install -e ./libs/langgraph`,
-];
+const PIP_INSTALL_COMMAND = `${RUN_PIP_IN_VENV} install pytest pytest-mock pytest-asyncio syrupy pytest-json-report`;
+const LANGGRAPH_INSTALL_COMMAND = `${RUN_PIP_IN_VENV} install -e ./libs/langgraph`;
 
 /**
  * Run pytest on specific test files and return structured results
@@ -89,29 +87,50 @@ export async function runPytestOnFiles(
     "Installing pytest, pytest-mock, pytest-asyncio, syrupy, pytest-json-report, and langgraph in virtual environment...",
   );
 
-  for (const [index, command] of PYTEST_INSTALL_COMMANDS.entries()) {
-    logger.info(
-      `Running install command ${index + 1}/${PYTEST_INSTALL_COMMANDS.length}: ${command}`,
-    );
-    const installResult = await sandbox.process.executeCommand(
-      command,
-      repoDir,
-      undefined,
-      timeoutSec * 2,
-    );
+  // Execute pip install command
+  logger.info(`Running pip install command: ${PIP_INSTALL_COMMAND}`);
+  const pipInstallResult = await sandbox.process.executeCommand(
+    PIP_INSTALL_COMMAND,
+    repoDir,
+    undefined,
+    timeoutSec * 2,
+  );
 
-    logger.info(`Install command ${index + 1} completed`, {
-      exitCode: installResult.exitCode,
-      output: installResult.result?.slice(0, 500),
+  logger.info(`Pip install command completed`, {
+    exitCode: pipInstallResult.exitCode,
+    output: pipInstallResult.result?.slice(0, 500),
+  });
+
+  if (pipInstallResult.exitCode !== 0) {
+    logger.error(`Pip install command failed`, {
+      command: PIP_INSTALL_COMMAND,
+      exitCode: pipInstallResult.exitCode,
+      output: pipInstallResult.result,
     });
+  }
 
-    if (installResult.exitCode !== 0) {
-      logger.error(`Install command ${index + 1} failed`, {
-        command,
-        exitCode: installResult.exitCode,
-        output: installResult.result,
-      });
-    }
+  // Execute langgraph install command
+  logger.info(
+    `Running langgraph install command: ${LANGGRAPH_INSTALL_COMMAND}`,
+  );
+  const langgraphInstallResult = await sandbox.process.executeCommand(
+    LANGGRAPH_INSTALL_COMMAND,
+    repoDir,
+    undefined,
+    timeoutSec * 2,
+  );
+
+  logger.info(`Langgraph install command completed`, {
+    exitCode: langgraphInstallResult.exitCode,
+    output: langgraphInstallResult.result?.slice(0, 500),
+  });
+
+  if (langgraphInstallResult.exitCode !== 0) {
+    logger.error(`Langgraph install command failed`, {
+      command: LANGGRAPH_INSTALL_COMMAND,
+      exitCode: langgraphInstallResult.exitCode,
+      output: langgraphInstallResult.result,
+    });
   }
 
   try {

--- a/apps/open-swe/src/utils/github/git.ts
+++ b/apps/open-swe/src/utils/github/git.ts
@@ -645,7 +645,9 @@ export async function checkoutFilesFromCommit(
           `Failed to checkout file ${filePath} from commit ${commitSha}: ${result.result || "Unknown error"}`,
         );
       } else {
-        logger.info(`Successfully checked out ${filePath} from commit ${commitSha}`);
+        logger.info(
+          `Successfully checked out ${filePath} from commit ${commitSha}`,
+        );
       }
     } catch (error) {
       logger.warn(`Error checking out file ${filePath}:`, { error });

--- a/apps/open-swe/src/utils/github/git.ts
+++ b/apps/open-swe/src/utils/github/git.ts
@@ -614,15 +614,21 @@ async function performClone(
   return branchName;
 }
 
+export interface CheckoutFilesOptions {
+  sandbox: Sandbox;
+  repoDir: string;
+  commitSha: string;
+  filePaths: string[];
+}
+
 /**
  * Checkout specific files from a given commit
  */
 export async function checkoutFilesFromCommit(
-  sandbox: Sandbox,
-  repoDir: string,
-  commitSha: string,
-  filePaths: string[],
+  options: CheckoutFilesOptions,
 ): Promise<void> {
+  const { sandbox, repoDir, commitSha, filePaths } = options;
+  
   if (filePaths.length === 0) {
     return;
   }

--- a/apps/open-swe/src/utils/github/git.ts
+++ b/apps/open-swe/src/utils/github/git.ts
@@ -613,3 +613,42 @@ async function performClone(
 
   return branchName;
 }
+
+/**
+ * Checkout specific files from a given commit
+ */
+export async function checkoutFilesFromCommit(
+  sandbox: Sandbox,
+  repoDir: string,
+  commitSha: string,
+  filePaths: string[],
+): Promise<void> {
+  if (filePaths.length === 0) {
+    return;
+  }
+
+  logger.info(
+    `Checking out ${filePaths.length} files from commit ${commitSha}`,
+  );
+
+  for (const filePath of filePaths) {
+    try {
+      const result = await sandbox.process.executeCommand(
+        `git checkout ${commitSha} -- "${filePath}"`,
+        repoDir,
+        undefined,
+        30, // 30 second timeout for git checkout
+      );
+
+      if (result.exitCode !== 0) {
+        logger.warn(
+          `Failed to checkout file ${filePath} from commit ${commitSha}: ${result.result || "Unknown error"}`,
+        );
+      } else {
+        logger.info(`Successfully checked out ${filePath} from commit ${commitSha}`);
+      }
+    } catch (error) {
+      logger.warn(`Error checking out file ${filePath}:`, { error });
+    }
+  }
+}

--- a/apps/open-swe/src/utils/github/git.ts
+++ b/apps/open-swe/src/utils/github/git.ts
@@ -628,7 +628,7 @@ export async function checkoutFilesFromCommit(
   options: CheckoutFilesOptions,
 ): Promise<void> {
   const { sandbox, repoDir, commitSha, filePaths } = options;
-  
+
   if (filePaths.length === 0) {
     return;
   }

--- a/apps/open-swe/src/utils/github/git.ts
+++ b/apps/open-swe/src/utils/github/git.ts
@@ -634,10 +634,10 @@ export async function checkoutFilesFromCommit(
   for (const filePath of filePaths) {
     try {
       const result = await sandbox.process.executeCommand(
-        `git checkout ${commitSha} -- "${filePath}"`,
+        `git checkout --force ${commitSha} -- "${filePath}"`,
         repoDir,
         undefined,
-        30, // 30 second timeout for git checkout
+        30,
       );
 
       if (result.exitCode !== 0) {


### PR DESCRIPTION
This PR makes updates to langbench

- updates each test cases with the test files that are modified in it 
- updates the evaluation pipeline to setup the enviroment, install dependencies, and run the tests
- the evaluated test outputs are then processed to understand how many test cases passed
- the entire repository is reverted to before the merge commit but the tests are checkout out post merge commit. this is done so that when we kick off the langgraph job the agent has access to the test cases it needs to pass. 