### PR TITLE
fix: adjust JWT issued-at time to handle clock skew in local environment

### DIFF
--- a/packages/shared/src/jwt.ts
+++ b/packages/shared/src/jwt.ts
@@ -5,10 +5,12 @@ import jsonwebtoken from "jsonwebtoken";
  */
 export function generateJWT(appId: string, privateKey: string): string {
   const now = Math.floor(Date.now() / 1000);
+  const issuedAtTime = now - 60;
+  const expirationTime = issuedAtTime + 10 * 60;
 
   const payload = {
-    iat: now,
-    exp: now + 10 * 60,
+    iat: issuedAtTime,
+    exp: expirationTime,
     iss: appId,
   };
 


### PR DESCRIPTION
This PR modifies JWT generation for GitHub App authentication to account for potential clock skew between the local machine and GitHub's servers.

### Changes:

- Updated generateJWT to subtract 60 seconds from the current time when setting the iat field.
- Ensures the token is not considered "issued in the future" if local time is slightly ahead.
- Keeps the exp value within GitHub’s required 10-minute maximum window.

### Rationale:

In local development, JWT authentication was failing when the local machine’s clock was slightly ahead of GitHub's. This caused the GitHub API to reject the token as invalid. By subtracting 60 seconds from the iat value, we ensure reliable authentication without compromising security.

This adjustment follows the recommendation in [GitHub’s official documentation on generating JWTs for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app?apiVersion=2022-11-28&versionId=free-pro-team%40latest&productId=rest), which uses the same offset to prevent clock-skew-related authentication failures. The example code provided in GitHub’s documentation, written in Ruby, demonstrates this approach.

<img width="400" height="400" alt="Screenshot 2025-08-11 152541" src="https://github.com/user-attachments/assets/6a135af8-1a37-4c3a-9e9a-daeabe797fbc" />

### References:
Fixes #744
