### PR TITLE
fix: Correct documentation link paths to match docs.json structure

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -21,10 +21,10 @@ The agent can be used through a web interface or triggered automatically via Git
   <Card title="Setup" icon="robot" href="/setup/development">
     How to set up Open SWE for development
   </Card>
-  <Card title="Examples" icon="database" href="/labs/swe/examples">
+  <Card title="Examples" icon="database" href="usage/examples">
     Examples of tasks you can try out
   </Card>
-  <Card title="Usage" icon="database" href="/labs/swe/usage/intro">
+  <Card title="Usage" icon="database" href="/usage/intro">
     Open SWE features, and how to use them
   </Card>
 </CardGroup>

--- a/apps/docs/setup/intro.mdx
+++ b/apps/docs/setup/intro.mdx
@@ -15,7 +15,7 @@ The setup process is organized into focused sections to help you get up and runn
   <Card
     title="Development Setup"
     icon="code"
-    href="/labs/swe/setup/development"
+    href="/setup/development"
   >
     Complete guide to cloning the repository, installing dependencies,
     configuring environment variables, and starting the development servers.
@@ -23,7 +23,7 @@ The setup process is organized into focused sections to help you get up and runn
   <Card
     title="Authentication"
     icon="shield-check"
-    href="/labs/swe/setup/authentication"
+    href="/setup/authentication"
   >
     Understanding the authentication flow, GitHub App configuration, and
     security mechanisms used throughout Open SWE.

--- a/apps/docs/usage/intro.mdx
+++ b/apps/docs/usage/intro.mdx
@@ -10,11 +10,11 @@ Open SWE provides two primary ways to interact with the coding agent, each desig
 ## Usage Methods
 
 <CardGroup cols={2}>
-  <Card title="Web Interface" icon="browser" href="/labs/swe/usage/ui">
+  <Card title="Web Interface" icon="browser" href="/usage/ui">
     Interactive chat interface with manual and auto modes for direct agent
     communication
   </Card>
-  <Card title="GitHub Webhooks" icon="webhook" href="/labs/swe/usage/webhook">
+  <Card title="GitHub Webhooks" icon="webhook" href="/usage/github">
     Automated triggers through GitHub issue labels for seamless repository
     integration
   </Card>


### PR DESCRIPTION
## Fix documentation link inconsistencies (#774)

### Description
This PR fixes inconsistent link paths throughout the documentation by removing the incorrect `/labs/swe/` prefix from internal documentation links.

### Current:
Multiple documentation pages had inconsistent link paths that didn't match the actual documentation structure defined in `docs.json`:

1. **Setup card on homepage** had inconsistent messaging and redirect behavior
2. **Internal documentation links** used incorrect `/labs/swe/` prefix throughout the codebase
3. **Card links** in various documentation pages pointed to wrong paths