### PR TITLE
fix: adds default config to true

### DIFF
--- a/apps/open-swe/src/utils/should-create-issue.ts
+++ b/apps/open-swe/src/utils/should-create-issue.ts
@@ -1,5 +1,5 @@
 import { GraphConfig } from "@open-swe/shared/open-swe/types";
 
 export function shouldCreateIssue(config: GraphConfig): boolean {
-  return !!config.configurable?.shouldCreateIssue;
+  return config.configurable?.shouldCreateIssue !== false;
 }


### PR DESCRIPTION
```
const prBody = `${shouldCreateIssue(config) ? `Fixes #${state.githubIssueId}` : ""}${reviewPullNumber ? `\n\nTriggered from pull request: #${reviewPullNumber}` : ""}${userLogin ? `\n\nOwner: @${userLogin}` : ""}\n\n${body}`;
```

in the default state, since we're not passing the value of `shouldCreateIssue` in the config, this results shouldCreateIssue(config) results in false -> doesn't create the Fixes text.
