### PR TITLE
chore: Remove logs in restart run route

### DIFF
--- a/apps/web/src/app/api/restart-run/route.ts
+++ b/apps/web/src/app/api/restart-run/route.ts
@@ -178,7 +178,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       programmerSession: newProgrammerSession,
     });
   } catch (error) {
-    console.error("Failed to restart run", error);
     return NextResponse.json(
       { error: "Failed to restart run" },
       { status: 500 },

--- a/apps/web/src/app/api/restart-run/route.ts
+++ b/apps/web/src/app/api/restart-run/route.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { v4 as uuidv4 } from "uuid";
 import {
   GITHUB_TOKEN_COOKIE,
@@ -70,13 +69,6 @@ async function createNewSession(
 ): Promise<AgentSession> {
   const newThreadId = uuidv4();
   const hasNext = inputs.threadState.next.length > 0;
-
-  console.log("\n\nCONFIG");
-  console.dir(getCustomConfigurableFields(inputs.threadConfig), {
-    depth: null,
-  });
-  console.log("\n\nCONFIGURABLE");
-  console.dir(inputs.threadConfig.configurable, { depth: null });
 
   const run = await client.runs.create(newThreadId, inputs.graphId, {
     command: {

--- a/apps/web/src/app/api/restart-run/route.ts
+++ b/apps/web/src/app/api/restart-run/route.ts
@@ -177,7 +177,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       plannerSession: newPlannerSession,
       programmerSession: newProgrammerSession,
     });
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       { error: "Failed to restart run" },
       { status: 500 },


### PR DESCRIPTION
Small cleanup to the `restart-run` API route.
Removed temporary `console.log/dir` and a stray `console.error`, dropped the `eslint-disable no-console`, and switched to a bare `catch {}`. No functional changes—responses stay the same.