### PR TITLE
docs: fix webhook URL path in development setup docs

### DIFF
--- a/apps/docs/setup/development.mdx
+++ b/apps/docs/setup/development.mdx
@@ -169,7 +169,7 @@ Before starting, ensure you have the following installed:
        # Then expose your local LangGraph server
        ngrok http 2024
        ```
-       Use the ngrok URL + `/webhook/github` (e.g., `https://abc123.ngrok.io/webhook/github`)
+       Use the ngrok URL + `/webhooks/github` (e.g., `https://abc123.ngrok.io/webhooks/github`)
 
     3. **Webhook secret**: Generate and save this value:
        ```bash


### PR DESCRIPTION
Github webhooks trigger on `webhooks/github` instead of `webhook/github` as mentioned in the documentation.

Code reference -> 
https://github.com/langchain-ai/open-swe/blob/998655385b192ab9711e87cc25113911b176318a/apps/open-swe/src/routes/github/unified-webhook.ts#L67