### PR TITLE
docs: Fix link to LangGraph in introduction

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -3,7 +3,7 @@ title: "Introduction"
 description: "An introduction to Open SWE"
 ---
 
-Open SWE is an open-source cloud-based coding agent built with [LangGraph](/oss/javascript/langgraph/overview). It's designed to autonomously understand, plan, and execute code changes across entire repositories.
+Open SWE is an open-source cloud-based coding agent built with [LangGraph](https://docs.langchain.com/oss/javascript/langgraph/overview). It's designed to autonomously understand, plan, and execute code changes across entire repositories.
 
 ## How It Works
 


### PR DESCRIPTION
Updated the LangGraph link to use HTTPS.