### PR TITLE
fix: avoid ARG_MAX on sandbox writes by using SDK write()

### DIFF
--- a/apps/agent/langgraph.json
+++ b/apps/agent/langgraph.json
@@ -4,7 +4,7 @@
   "graphs": {
     "agent": "agent.server:get_agent"
   },
-  "dependencies": [".", "../../../deepagents/libs/deepagents"],
+  "dependencies": ["."],
   "http": {
     "app": "agent.webapp:app"
   },

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "markdownify>=1.2.2",
     "langchain-anthropic>1.1.0",
     "langgraph-cli[inmem]>=0.4.12",
+    # LangSmith SDK for sandbox management
+    "langsmith>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -976,7 +976,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.6.9"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -989,9 +989,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/e0/463a70b43d6755b01598bb59932eec8e2029afcab455b5312c318ac457b5/langsmith-0.6.9.tar.gz", hash = "sha256:aae04cec6e6d8e133f63ba71c332ce0fbd2cda95260db7746ff4c3b6a3c41db1", size = 973557, upload-time = "2026-02-05T20:10:55.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/48/3151de6df96e0977b8d319b03905e29db0df6929a85df1d922a030b7e68d/langsmith-0.7.1.tar.gz", hash = "sha256:e3fec2f97f7c5192f192f4873d6a076b8c6469768022323dded07087d8cb70a4", size = 984367, upload-time = "2026-02-10T01:55:24.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/8e/063e09c5e8a3dcd77e2a8f0bff3f71c1c52a9d238da1bcafd2df3281da17/langsmith-0.6.9-py3-none-any.whl", hash = "sha256:86ba521e042397f6fbb79d63991df9d5f7b6a6dd6a6323d4f92131291478dcff", size = 319228, upload-time = "2026-02-05T20:10:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/6f2b008a456b4f5fd0fb1509bb7e1e9368c1a0c9641a535f224a9ddc10f3/langsmith-0.7.1-py3-none-any.whl", hash = "sha256:92cfa54253d35417184c297ad25bfd921d95f15d60a1ca75f14d4e7acd152a29", size = 322515, upload-time = "2026-02-10T01:55:22.531Z" },
 ]
 
 [package.optional-dependencies]
@@ -1028,6 +1028,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-cli", extra = ["inmem"] },
     { name = "langgraph-sdk" },
+    { name = "langsmith" },
     { name = "markdownify" },
     { name = "pyjwt" },
     { name = "uvicorn" },
@@ -1051,6 +1052,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.8" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.12" },
     { name = "langgraph-sdk", specifier = ">=0.1.0" },
+    { name = "langsmith", specifier = ">=0.7.1" },
     { name = "markdownify", specifier = ">=1.2.2" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
Override LangSmithBackend.write() to call the LangSmith SDK's native
write() (request body) instead of BaseSandbox's execute()-based write,
which sent the full content in a shell command and could exceed ARG_MAX
for large content (e.g. conversation history offload).
