### PR TITLE
fix: Handle missing Linear comment user in prompt

### DIFF
--- a/apps/agent/agent/webapp.py
+++ b/apps/agent/agent/webapp.py
@@ -625,7 +625,8 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         if relevant_comments:
             comments_text = "\n\n## Comments:\n"
             for comment in relevant_comments:
-                author = comment.get("user", {}).get("name", "Unknown")
+                user = comment.get("user") or {}
+                author = user.get("name", "User")
                 body = comment.get("body", "")
                 body_image_urls = extract_image_urls(body)
                 if body_image_urls:


### PR DESCRIPTION
Issue: The webhook sometimes includes a payload were `user = None`, and the code tried to call `.get("name") `on that None, causing a 500 error.

Fix: Instead of assuming `comment["user"]` is always a dictionary, we first normalize it:
If `user` is missing or `None`, we replace it with `{}`.
Then we read `name` from that dict, falling back to `"User"`.
