### PR TITLE
Fix dead documentation link in .env.example comment

### DIFF
--- a/apps/open-swe/.env.example
+++ b/apps/open-swe/.env.example
@@ -51,7 +51,7 @@ OPEN_SWE_APP_URL="http://localhost:3000"
 # encrypted in the web app can be decrypted in the agent.
 SECRETS_ENCRYPTION_KEY=""
 # Whether or not to append the string "[skip ci]" to the commit message.
-# See the documentation for how to set this up: docs.langchain.com/labs/swe/setup/ci#skip-ci-until-last-commit
+# See the documentation for how to set this up: https://github.com/langchain-ai/open-swe/blob/main/apps/docs/setup/ci.mdx
 SKIP_CI_UNTIL_LAST_COMMIT="true"
 
 # For the CLI to work, you need to set these variables.


### PR DESCRIPTION
Fixes #860. Updates the dead docs.langchain.com link to point to the correct GitHub documentation path.