### PR TITLE
feat: add sanitizeBranchName utility function [closes OPE-12]

### DIFF
--- a/packages/shared/src/__tests__/git.test.ts
+++ b/packages/shared/src/__tests__/git.test.ts
@@ -1,0 +1,53 @@
+import { sanitizeBranchName } from "../git.js";
+
+describe("sanitizeBranchName", () => {
+  it("should return a valid branch name unchanged", () => {
+    expect(sanitizeBranchName("feature/my-branch")).toBe("feature/my-branch");
+  });
+
+  it("should replace spaces with hyphens", () => {
+    expect(sanitizeBranchName("my new branch")).toBe("my-new-branch");
+  });
+
+  it("should replace invalid characters with hyphens", () => {
+    expect(sanitizeBranchName("feat~branch^1:test")).toBe("feat-branch-1-test");
+    expect(sanitizeBranchName("branch?name*here")).toBe("branch-name-here");
+    expect(sanitizeBranchName("branch[0]")).toBe("branch-0");
+  });
+
+  it("should replace consecutive dots with a hyphen", () => {
+    expect(sanitizeBranchName("branch..name")).toBe("branch-name");
+  });
+
+  it("should replace @{ sequence", () => {
+    expect(sanitizeBranchName("branch@{0}")).toBe("branch-0");
+  });
+
+  it("should strip leading dots and slashes", () => {
+    expect(sanitizeBranchName(".branch")).toBe("branch");
+    expect(sanitizeBranchName("/branch")).toBe("branch");
+  });
+
+  it("should strip trailing dots and slashes", () => {
+    expect(sanitizeBranchName("branch.")).toBe("branch");
+    expect(sanitizeBranchName("branch/")).toBe("branch");
+  });
+
+  it("should handle .lock in path components", () => {
+    expect(sanitizeBranchName("my.lock/branch")).toBe("my-lock/branch");
+    expect(sanitizeBranchName("branch.lock")).toBe("branch-lock");
+  });
+
+  it("should collapse multiple consecutive hyphens", () => {
+    expect(sanitizeBranchName("branch~~name")).toBe("branch-name");
+  });
+
+  it("should return fallback for empty or all-invalid input", () => {
+    expect(sanitizeBranchName("")).toBe("branch");
+    expect(sanitizeBranchName("...")).toBe("branch");
+  });
+
+  it("should handle backslashes", () => {
+    expect(sanitizeBranchName("feature\\branch")).toBe("feature-branch");
+  });
+});

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -5,6 +5,32 @@ import {
   getLocalWorkingDirectory,
 } from "./open-swe/local-mode.js";
 
+/**
+ * Strips invalid git branch characters from a string and returns a valid branch name.
+ */
+// eslint-disable-next-line no-control-regex
+const INVALID_BRANCH_CHARS = /[\x00-\x1f\x7f~^:?*[\]{}\\]/g;
+
+export function sanitizeBranchName(name: string): string {
+  let sanitized = name
+    .replace(/@\{/g, "--")
+    .replace(INVALID_BRANCH_CHARS, "-")
+    .replace(/\s+/g, "-")
+    .replace(/\.{2,}/g, "-")
+    .replace(/\/\//g, "/")
+    .replace(/\.lock(\/|$)/g, "-lock$1");
+
+  sanitized = sanitized.replace(/^[./]+/, "").replace(/[./]+$/, "");
+
+  sanitized = sanitized.replace(/-{2,}/g, "-").replace(/-$/g, "");
+
+  if (!sanitized) {
+    return "branch";
+  }
+
+  return sanitized;
+}
+
 export function getRepoAbsolutePath(
   targetRepository: TargetRepository,
   config?: GraphConfig,


### PR DESCRIPTION
## Description
Adds a `sanitizeBranchName` utility function to `packages/shared/src/git.ts` that strips invalid git branch characters from a string and returns a valid branch name.

The function handles all git branch name rules:
- Replaces ASCII control characters, `~`, `^`, `:`, `?`, `*`, `[`, `]`, `{`, `}`, `\` with hyphens
- Replaces whitespace with hyphens
- Handles the invalid `@{` sequence
- Replaces consecutive dots (`..`)
- Replaces double slashes (`//`) with single slash
- Handles `.lock` in path components
- Strips leading/trailing dots and slashes
- Collapses consecutive hyphens
- Returns `"branch"` as fallback for empty/all-invalid input

Changes:
- Added `sanitizeBranchName` function to `packages/shared/src/git.ts`
- Added comprehensive test suite in `packages/shared/src/__tests__/git.test.ts` with 11 test cases

Resolves OPE-12

## Test Plan
- [x] Run `yarn test` — all 15 tests pass (11 new + 4 existing)
- [x] Run `yarn lint` — no errors
- [x] Run `yarn format` — all files formatted