### PR TITLE
feat: add sanitizeBranchName utility function [closes OPE-14]

### DIFF
--- a/packages/shared/src/__tests__/git.test.ts
+++ b/packages/shared/src/__tests__/git.test.ts
@@ -1,0 +1,49 @@
+import { sanitizeBranchName } from "../git.js";
+
+describe("sanitizeBranchName", () => {
+  it("should return a simple valid name unchanged", () => {
+    expect(sanitizeBranchName("feature/my-branch")).toBe("feature/my-branch");
+  });
+
+  it("should replace spaces with hyphens", () => {
+    expect(sanitizeBranchName("my new branch")).toBe("my-new-branch");
+  });
+
+  it("should replace invalid characters with hyphens", () => {
+    expect(sanitizeBranchName("feat~branch^name")).toBe("feat-branch-name");
+  });
+
+  it("should collapse consecutive dots into a hyphen", () => {
+    expect(sanitizeBranchName("feat..branch")).toBe("feat-branch");
+  });
+
+  it("should strip leading dots, hyphens, and slashes", () => {
+    expect(sanitizeBranchName("..feature")).toBe("feature");
+    expect(sanitizeBranchName("-feature")).toBe("feature");
+    expect(sanitizeBranchName("/feature")).toBe("feature");
+  });
+
+  it("should strip trailing dots, hyphens, and slashes", () => {
+    expect(sanitizeBranchName("feature.")).toBe("feature");
+    expect(sanitizeBranchName("feature-")).toBe("feature");
+    expect(sanitizeBranchName("feature/")).toBe("feature");
+  });
+
+  it("should replace .lock at path boundaries", () => {
+    expect(sanitizeBranchName("my.lock/branch")).toBe("my-lock/branch");
+    expect(sanitizeBranchName("branch.lock")).toBe("branch-lock");
+  });
+
+  it("should replace @{ sequence", () => {
+    expect(sanitizeBranchName("branch@{0}")).toBe("branch-{0}");
+  });
+
+  it("should collapse multiple hyphens into one", () => {
+    expect(sanitizeBranchName("a~~b")).toBe("a-b");
+  });
+
+  it("should return fallback for empty or all-invalid input", () => {
+    expect(sanitizeBranchName("")).toBe("branch");
+    expect(sanitizeBranchName("...")).toBe("branch");
+  });
+});

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -5,6 +5,27 @@ import {
   getLocalWorkingDirectory,
 } from "./open-swe/local-mode.js";
 
+/**
+ * Strips invalid git branch characters from a string and returns a valid branch name.
+ */
+export function sanitizeBranchName(name: string): string {
+  let sanitized = name
+    .replace(/[\s~^:?*[\]\\]+/g, "-")
+    .replace(/\.{2,}/g, "-")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\.lock(\/|$)/g, "-lock$1")
+    .replace(/@\{/g, "-{")
+    .replace(/^[.\-/]+/, "")
+    .replace(/[.\-/]+$/, "")
+    .replace(/-{2,}/g, "-");
+
+  if (!sanitized) {
+    sanitized = "branch";
+  }
+
+  return sanitized;
+}
+
 export function getRepoAbsolutePath(
   targetRepository: TargetRepository,
   config?: GraphConfig,


### PR DESCRIPTION
## Description
Adds a `sanitizeBranchName` utility function to the shared package's `git.ts` module. This function strips invalid git branch characters from a string and returns a valid branch name.

The function handles all git branch naming rules:
- Replaces spaces, `~`, `^`, `:`, `?`, `*`, `[`, `]`, `\` with hyphens
- Collapses consecutive dots (`..`) into a hyphen
- Collapses duplicate slashes
- Replaces `.lock` at path boundaries
- Replaces `@{` sequences
- Strips leading/trailing dots, hyphens, and slashes
- Collapses multiple consecutive hyphens
- Falls back to `"branch"` for empty/all-invalid input

Changes:
- Added `sanitizeBranchName` to `packages/shared/src/git.ts`
- Added comprehensive test suite in `packages/shared/src/__tests__/git.test.ts` (10 tests)

Resolves OPE-14

## Test Plan
- [x] All 10 unit tests pass (`yarn test:single packages/shared/src/__tests__/git.test.ts`)
- [x] Full build passes (`yarn build`)
- [x] Lint passes with 0 errors (`yarn lint`)
- [x] Format passes (`yarn format`)