### PR TITLE
fix: extract auth URL from non-2xx responses on first auth attempt

### DIFF
--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -148,6 +148,17 @@ async def get_github_token_for_user(ls_user_id: str, tenant_id: str) -> dict[str
             return {"error": f"Unexpected auth result: {response_data}"}
 
     except httpx.HTTPStatusError as e:
+        # The auth API may return a non-2xx response that still contains a "url" field
+        # in the response body (e.g. on a first-time authentication attempt where the
+        # user has not yet authorised the GitHub OAuth app).  Extract the URL so that
+        # callers can surface the proper auth link instead of a generic error message.
+        try:
+            error_data = e.response.json()
+            auth_url = error_data.get("url")
+            if auth_url:
+                return {"auth_url": auth_url}
+        except Exception:  # noqa: BLE001
+            pass
         logger.error("GitHub auth API HTTP error: %s - %s", e.response.status_code, e.response.text)
         return {"error": f"HTTP error: {e.response.status_code} - {e.response.text}"}
     except Exception as e:  # noqa: BLE001

--- a/tests/test_auth_sources.py
+++ b/tests/test_auth_sources.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from agent.utils import auth
@@ -85,3 +87,44 @@ def test_leave_failure_comment_falls_back_to_slack_thread_when_ephemeral_fails(
     asyncio.run(auth.leave_failure_comment("slack", "auth failed"))
 
     assert thread_called == {"channel_id": "C123", "thread_ts": "1.2", "message": "auth failed"}
+
+
+def test_get_github_token_for_user_returns_auth_url_on_http_error_with_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the auth API responds with a non-2xx status that still carries a
+    "url" field in the JSON body (e.g. first-time OAuth authorisation required),
+    get_github_token_for_user should return {"auth_url": ...} rather than a
+    generic error dict so callers can surface the proper auth link to the user.
+    """
+
+    # Build a fake httpx response that raises HTTPStatusError but contains a URL
+    fake_url = "https://github.com/login/oauth/authorize?client_id=test"
+    fake_response = MagicMock(spec=httpx.Response)
+    fake_response.status_code = 401
+    fake_response.text = f'{{"url": "{fake_url}"}}'
+    fake_response.json.return_value = {"url": fake_url}
+
+    http_error = httpx.HTTPStatusError(
+        "401 Unauthorized", request=MagicMock(), response=fake_response
+    )
+
+    async def fake_post(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        raise http_error
+
+    monkeypatch.setattr(auth, "GITHUB_OAUTH_PROVIDER_ID", "test-provider")
+    monkeypatch.setattr(auth, "X_SERVICE_AUTH_JWT_SECRET", "test-secret")
+
+    with patch.object(auth, "get_service_jwt_token_for_user", return_value="fake-jwt"):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=http_error)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(auth.get_github_token_for_user("user-123", "tenant-456"))
+
+    assert result == {"auth_url": fake_url}, (
+        f"Expected auth_url to be extracted from error response body, got: {result}"
+    )


### PR DESCRIPTION
## Summary

Fixes #997

When a user triggers the agent for the first time, the LangSmith auth API can return a non-2xx HTTP status (e.g. 401) whose response body still contains a `url` field pointing to the GitHub OAuth consent page.

### Root cause

`get_github_token_for_user` called `response.raise_for_status()` **before** parsing the response body. The resulting `httpx.HTTPStatusError` handler discarded the URL and returned a generic `{"error": ...}` dict. Upstream in `save_encrypted_token_from_email`, the missing `auth_url` key meant that the correct "🔐 GitHub Authentication Required" branch was never reached, so users received a generic "❌ GitHub Auth Error … Please try again or contact support" comment with no actionable link.

### Fix

In the `httpx.HTTPStatusError` handler of `get_github_token_for_user`, try to parse the response body and return `{"auth_url": url}` when the `"url"` field is present. This allows the existing downstream logic in `save_encrypted_token_from_email` to post the proper auth link comment without any further changes.

## Changes

- `agent/utils/auth.py`: parse error response body for `url` field before falling back to generic error
- `tests/test_auth_sources.py`: add test that verifies the new behaviour