### PR TITLE
chore: add deprecation warning to readme [closes #1034]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 > [!CAUTION]
 > **⚠️ DEPRECATED — This project is no longer maintained and should not be used.**
+>
+> If you're looking to build and deploy agents, check out [LangSmith Agent Builder](https://www.langchain.com/langsmith/agent-builder) instead.
 
 <div align="center">
   <picture>


### PR DESCRIPTION
## Description
Adds a prominent deprecation warning at the top of the README stating the project is no longer maintained and should not be used.

Resolves #1034

## Test Plan
- [ ] Verify the deprecation banner renders correctly on the GitHub repo page