### PR TITLE
feat: support resuming from github pr comments/reviews [closes #889]

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -44,19 +44,23 @@ TASK_EXECUTION_SECTION = """---
 If you make changes, communicate updates in the source channel:
 - Use `linear_comment` for Linear-triggered tasks.
 - Use `slack_thread_reply` for Slack-triggered tasks.
+- Use `github_comment_on_pr` for GitHub PR comment-triggered tasks.
+- Use `github_comment_on_issue` for GitHub issue-triggered tasks.
 
 For tasks that require code changes, follow this order:
 
 1. **Understand** — Read the issue/task carefully. Explore relevant files before making any changes.
 2. **Implement** — Make focused, minimal changes. Do not modify code outside the scope of the task.
 3. **Verify** — Run tests and linters to confirm correctness before submitting.
-4. **Submit** — Call `commit_and_open_pr`.
-5. **Comment** — Call `linear_comment` or `slack_thread_reply` with a summary and the PR link.
+4. **Submit** — Call `commit_and_open_pr` to push changes to the existing PR branch.
+5. **Comment** — Call `linear_comment`, `slack_thread_reply`, `github_comment_on_pr`, or `github_comment_on_issue` with a summary and the PR link.
+
+**Strict requirement:** You must call `commit_and_open_pr` before posting any completion message for a code change task. Only claim "PR updated/opened" if `commit_and_open_pr` returns `success` and a PR link. If it returns "No changes detected" or any error, you must state that explicitly and do not claim an update.
 
 For questions or status checks (no code changes needed):
 
 1. **Answer** — Gather the information needed to respond.
-2. **Comment** — Call `linear_comment` or `slack_thread_reply` with your answer. Never leave a question unanswered."""
+2. **Comment** — Call `linear_comment`, `slack_thread_reply`, `github_comment_on_pr`, or `github_comment_on_issue` with your answer. Never leave a question unanswered."""
 
 
 TOOL_USAGE_SECTION = """---
@@ -80,7 +84,16 @@ Posts a comment to a Linear ticket given a `ticket_id`. Call this **after** `com
 
 #### `slack_thread_reply`
 Posts a message to the active Slack thread. Use this for clarifying questions, status updates, and final summaries when the task was triggered from Slack.
-Remember that Slack does not use standard markdown formatting. Ensure you always conform to the Slack specific markdown format when sending messages"""
+Format messages using Slack's mrkdwn format, NOT standard Markdown.
+    Key differences: *bold*, _italic_, ~strikethrough~, <url|link text>,
+    bullet lists with "• ", ```code blocks```, > blockquotes.
+    Do NOT use **bold**, [link](url), or other standard Markdown syntax.
+
+#### `github_comment_on_pr`
+Posts a comment to a GitHub Pull Request. Provide the `pr_number` explicitly. Use this when the task was triggered from a GitHub PR comment — to reply with updates, answers, or a summary after completing work.
+
+#### `github_comment_on_issue`
+Posts a comment to a GitHub issue. Provide the `issue_number` explicitly. Use this when the task was triggered from a GitHub issue or issue comment — to reply with updates, answers, or a summary after completing work."""
 
 
 TOOL_BEST_PRACTICES_SECTION = """---
@@ -214,12 +227,17 @@ When you have completed your implementation, follow these steps in order:
 
 **IMPORTANT: Never ask the user for permission or confirmation before calling `commit_and_open_pr`. Do not say "if you want, I can proceed" or "shall I open the PR?". When your implementation is done and checks pass, call the tool immediately and autonomously.**
 
-4. **Comment on the Linear ticket** via `linear_comment` immediately after `commit_and_open_pr` succeeds. Include:
-   - A brief summary of what was done
-   - The PR link returned by `commit_and_open_pr`
-   - An `@mention` of the user who triggered the task by their Linear display name
+**IMPORTANT: Even if you made commits directly via `git commit` or `git revert` in the sandbox, you MUST still call `commit_and_open_pr` to push those commits to GitHub. Never report the work as done without pushing.**
 
-   Example comment:
+**IMPORTANT: Never claim a PR was created or updated unless `commit_and_open_pr` returned `success` and a PR link. If it returns "No changes detected" or any error, report that instead.**
+
+4. **Notify the source** immediately after `commit_and_open_pr` succeeds. Include a brief summary and the PR link:
+   - Linear-triggered: use `linear_comment` with an `@mention` of the user who triggered the task
+   - Slack-triggered: use `slack_thread_reply`
+   - GitHub PR comment-triggered: use `github_comment_on_pr`
+   - GitHub issue-triggered: use `github_comment_on_issue`
+
+   Example:
    ```
    @username, I've completed the implementation and opened a PR: <pr_url>
 
@@ -228,7 +246,7 @@ When you have completed your implementation, follow these steps in order:
    - <change 2>
    ```
 
-Always call the `commit_and_open_pr` tool followed by the `linear_comment` tool once implementation is complete and code quality checks pass."""
+Always call `commit_and_open_pr` followed by the appropriate reply tool once implementation is complete and code quality checks pass."""
 
 
 SYSTEM_PROMPT = (

--- a/agent/server.py
+++ b/agent/server.py
@@ -36,6 +36,8 @@ from .prompt import construct_system_prompt
 from .tools import (
     commit_and_open_pr,
     fetch_url,
+    github_comment_on_issue,
+    github_comment_on_pr,
     http_request,
     linear_comment,
     slack_thread_reply,
@@ -384,7 +386,15 @@ async def get_agent(config: RunnableConfig) -> Pregel:  # noqa: PLR0915
             linear_issue_number=linear_issue_number,
             agents_md=agents_md,
         ),
-        tools=[http_request, fetch_url, commit_and_open_pr, linear_comment, slack_thread_reply],
+        tools=[
+            http_request,
+            fetch_url,
+            commit_and_open_pr,
+            linear_comment,
+            slack_thread_reply,
+            github_comment_on_pr,
+            github_comment_on_issue,
+        ],
         backend=sandbox_backend,
         middleware=[
             ToolErrorMiddleware(),

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -1,5 +1,7 @@
 from .commit_and_open_pr import commit_and_open_pr
 from .fetch_url import fetch_url
+from .github_comment_on_issue import github_comment_on_issue
+from .github_comment_on_pr import github_comment_on_pr
 from .http_request import http_request
 from .linear_comment import linear_comment
 from .slack_thread_reply import slack_thread_reply
@@ -7,6 +9,8 @@ from .slack_thread_reply import slack_thread_reply
 __all__ = [
     "commit_and_open_pr",
     "fetch_url",
+    "github_comment_on_issue",
+    "github_comment_on_pr",
     "http_request",
     "linear_comment",
     "slack_thread_reply",

--- a/agent/tools/github_comment_on_issue.py
+++ b/agent/tools/github_comment_on_issue.py
@@ -1,0 +1,46 @@
+import asyncio
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..utils.github_pr_webhook import post_github_issue_comment
+from ..utils.github_token import get_github_token
+
+
+def github_comment_on_issue(message: str, issue_number: int) -> dict[str, Any]:
+    """Post a comment to a GitHub issue.
+
+    Use this tool to communicate progress and updates to stakeholders on GitHub.
+
+    **When to use:**
+    - After calling `commit_and_open_pr`, post a comment to let stakeholders know
+      the task is complete and summarize what was done.
+    - When answering a question or sharing an update triggered from a GitHub issue comment.
+
+    Args:
+        message: Markdown-formatted comment text to post to the GitHub issue.
+        issue_number: Issue number to comment on.
+
+    Returns:
+        Dictionary with 'success' (bool) key.
+    """
+    config = get_config()
+    configurable = config.get("configurable", {})
+    repo_config = configurable.get("repo", {})
+    owner = repo_config.get("owner")
+    name = repo_config.get("name")
+
+    if not owner or not name:
+        return {"success": False, "error": "Missing repo owner/name in config"}
+
+    github_token = get_github_token()
+    if not github_token:
+        return {"success": False, "error": "Missing GitHub token"}
+
+    if not message.strip():
+        return {"success": False, "error": "Message cannot be empty"}
+
+    success = asyncio.run(
+        post_github_issue_comment(owner, name, issue_number, github_token, message)
+    )
+    return {"success": success}

--- a/agent/tools/github_comment_on_pr.py
+++ b/agent/tools/github_comment_on_pr.py
@@ -1,0 +1,44 @@
+import asyncio
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..utils.github_pr_webhook import post_github_pr_comment
+from ..utils.github_token import get_github_token
+
+
+def github_comment_on_pr(message: str, pr_number: int) -> dict[str, Any]:
+    """Post a comment to the current GitHub Pull Request.
+
+    Use this tool to communicate progress and updates to stakeholders on GitHub.
+
+    **When to use:**
+    - After calling `commit_and_open_pr`, post a comment to let stakeholders know
+      the task is complete and summarize what was done.
+    - When answering a question or sharing an update triggered from a GitHub PR comment.
+
+    Args:
+        message: Markdown-formatted comment text to post to the GitHub PR.
+        pr_number: Pull request number to comment on.
+
+    Returns:
+        Dictionary with 'success' (bool) key.
+    """
+    config = get_config()
+    configurable = config.get("configurable", {})
+    repo_config = configurable.get("repo", {})
+    owner = repo_config.get("owner")
+    name = repo_config.get("name")
+
+    if not owner or not name:
+        return {"success": False, "error": "Missing repo owner/name in config"}
+
+    github_token = get_github_token()
+    if not github_token:
+        return {"success": False, "error": "Missing GitHub token"}
+
+    if not message.strip():
+        return {"success": False, "error": "Message cannot be empty"}
+
+    success = asyncio.run(post_github_pr_comment(owner, name, pr_number, github_token, message))
+    return {"success": success}

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -13,6 +13,7 @@ from langgraph.config import get_config
 from langgraph_sdk import get_client
 
 from ..encryption import encrypt_token
+from .github_pr_webhook import post_github_pr_comment
 from .linear import comment_on_linear_issue
 from .slack import post_slack_ephemeral_message, post_slack_thread_reply
 
@@ -40,12 +41,16 @@ logger.debug(
 def _retry_instruction(source: str) -> str:
     if source == "slack":
         return "Once authenticated, mention me again in this Slack thread to retry."
+    if source == "github":
+        return "Once authenticated, tag @open-swe again in a PR comment to retry."
     return "Once authenticated, reply to this issue mentioning @openswe to retry."
 
 
 def _source_account_label(source: str) -> str:
     if source == "slack":
         return "Slack"
+    if source == "github":
+        return "GitHub"
     return "Linear"
 
 
@@ -58,6 +63,8 @@ def _auth_link_text(source: str, auth_url: str) -> str:
 def _work_item_label(source: str) -> str:
     if source == "slack":
         return "thread"
+    if source == "github":
+        return "pull request"
     return "issue"
 
 
@@ -239,6 +246,23 @@ async def leave_failure_comment(
                 thread_ts,
             )
             await post_slack_thread_reply(channel_id, thread_ts, message)
+        return
+    if source == "github":
+        github_pr = configurable.get("github_pr", {})
+        if isinstance(github_pr, dict):
+            repo = configurable.get("repo", {})
+            owner = repo.get("owner") if isinstance(repo, dict) else None
+            name = repo.get("name") if isinstance(repo, dict) else None
+            pr_number = github_pr.get("pr_number")
+            github_token = github_pr.get("github_token")
+            if owner and name and pr_number and github_token:
+                logger.info(
+                    "Posting auth failure comment to GitHub PR #%s on %s/%s",
+                    pr_number,
+                    owner,
+                    name,
+                )
+                await post_github_pr_comment(owner, name, pr_number, github_token, message)
         return
     raise ValueError(f"Unknown source: {source}")
 

--- a/agent/utils/github_pr_webhook.py
+++ b/agent/utils/github_pr_webhook.py
@@ -1,0 +1,237 @@
+"""GitHub PR webhook utilities — fetching comments, reacting, and thread resolution."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import re
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+OPEN_SWE_BRANCH_PREFIX = "open-swe/"
+
+
+def _gh_headers(token: str) -> dict[str, str]:
+    return {**GITHUB_API_HEADERS, "Authorization": f"Bearer {token}"}
+
+
+def verify_github_signature(body: bytes, signature: str, secret: str) -> bool:
+    """Verify GitHub webhook HMAC-SHA256 signature."""
+    if not secret:
+        return True
+    expected = "sha256=" + hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def extract_thread_id_from_branch(branch_name: str) -> str | None:
+    """Extract the LangGraph thread ID from an open-swe branch name."""
+    if not branch_name.startswith(OPEN_SWE_BRANCH_PREFIX):
+        return None
+    return branch_name[len(OPEN_SWE_BRANCH_PREFIX) :]
+
+
+async def react_to_github_comment(
+    owner: str,
+    repo: str,
+    comment_id: int,
+    token: str,
+    reaction: str = "eyes",
+    *,
+    is_pr_review_comment: bool = False,
+) -> bool:
+    """Add an emoji reaction to a GitHub comment."""
+    if is_pr_review_comment:
+        url = f"https://api.github.com/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"
+    else:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                url,
+                headers=_gh_headers(token),
+                json={"content": reaction},
+            )
+            return response.status_code in (200, 201)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to react to GitHub comment %s", comment_id)
+            return False
+
+
+async def fetch_issue_comments(
+    owner: str, repo: str, issue_number: int, token: str
+) -> list[dict[str, Any]]:
+    """Fetch all issue comments (general PR comments) for a PR."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    comments: list[dict[str, Any]] = []
+    page = 1
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                response = await client.get(
+                    url,
+                    headers=_gh_headers(token),
+                    params={"per_page": "100", "page": str(page)},
+                )
+                if response.status_code != 200:  # noqa: PLR2004
+                    break
+                data = response.json()
+                if not data:
+                    break
+                comments.extend(data)
+                page += 1
+            except httpx.HTTPError:
+                logger.exception("Failed to fetch issue comments page %d", page)
+                break
+    return comments
+
+
+async def fetch_pr_review_comments(
+    owner: str, repo: str, pr_number: int, token: str
+) -> list[dict[str, Any]]:
+    """Fetch all review comments (inline code comments) for a PR."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/comments"
+    comments: list[dict[str, Any]] = []
+    page = 1
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                response = await client.get(
+                    url,
+                    headers=_gh_headers(token),
+                    params={"per_page": "100", "page": str(page)},
+                )
+                if response.status_code != 200:  # noqa: PLR2004
+                    break
+                data = response.json()
+                if not data:
+                    break
+                comments.extend(data)
+                page += 1
+            except httpx.HTTPError:
+                logger.exception("Failed to fetch PR review comments page %d", page)
+                break
+    return comments
+
+
+async def fetch_pr_reviews(
+    owner: str, repo: str, pr_number: int, token: str
+) -> list[dict[str, Any]]:
+    """Fetch all reviews (top-level review messages) for a PR."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
+    reviews: list[dict[str, Any]] = []
+    page = 1
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                response = await client.get(
+                    url,
+                    headers=_gh_headers(token),
+                    params={"per_page": "100", "page": str(page)},
+                )
+                if response.status_code != 200:  # noqa: PLR2004
+                    break
+                data = response.json()
+                if not data:
+                    break
+                reviews.extend(data)
+                page += 1
+            except httpx.HTTPError:
+                logger.exception("Failed to fetch PR reviews page %d", page)
+                break
+    return reviews
+
+
+async def post_github_pr_comment(
+    owner: str, repo: str, pr_number: int, token: str, body: str
+) -> bool:
+    """Post a comment on a GitHub PR (issue comment)."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                url,
+                headers=_gh_headers(token),
+                json={"body": body},
+            )
+            return response.status_code == 201  # noqa: PLR2004
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to post comment on PR #%d", pr_number)
+            return False
+
+
+async def post_github_issue_comment(
+    owner: str, repo: str, issue_number: int, token: str, body: str
+) -> bool:
+    """Post a comment on a GitHub issue."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                url,
+                headers=_gh_headers(token),
+                json={"body": body},
+            )
+            return response.status_code == 201  # noqa: PLR2004
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to post comment on issue #%d", issue_number)
+            return False
+
+
+def collect_comments_since_last_tag(
+    comments: list[dict[str, Any]],
+    triggering_comment_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Collect comments from the last @open-swe mention onward."""
+    if not comments:
+        return []
+
+    sorted_comments = sorted(comments, key=lambda c: c.get("created_at", ""))
+
+    trigger_idx = None
+    if triggering_comment_id:
+        for i, c in enumerate(sorted_comments):
+            if c.get("id") == triggering_comment_id:
+                trigger_idx = i
+                break
+
+    if trigger_idx is None:
+        trigger_idx = len(sorted_comments) - 1
+
+    prev_mention_idx = trigger_idx
+    for i in range(trigger_idx - 1, -1, -1):
+        body = sorted_comments[i].get("body", "")
+        if re.search(r"@open-swe\b", body, re.IGNORECASE):
+            prev_mention_idx = i
+            break
+
+    return sorted_comments[prev_mention_idx:]
+
+
+def format_review_comment_for_prompt(comment: dict[str, Any]) -> str:
+    """Format a PR review comment (inline code comment) for the agent prompt."""
+    author = comment.get("user", {}).get("login", "Unknown")
+    body = comment.get("body", "")
+    path = comment.get("path", "")
+    line = comment.get("line") or comment.get("original_line")
+    start_line = comment.get("start_line") or comment.get("original_start_line")
+    comment_id = comment.get("id", "")
+
+    location = ""
+    if path:
+        location = f" in `{path}`"
+        if start_line and line and start_line != line:
+            location += f" (lines {start_line}-{line})"
+        elif line:
+            location += f" (line {line})"
+
+    return f"**@{author}** (comment_id: {comment_id}){location}:\n{body}"

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -16,6 +16,16 @@ from langgraph_sdk import get_client
 from langgraph_sdk.client import LangGraphClient
 
 from .utils.comments import get_recent_comments
+from .utils.github_pr_webhook import (
+    collect_comments_since_last_tag,
+    extract_thread_id_from_branch,
+    fetch_issue_comments,
+    fetch_pr_review_comments,
+    fetch_pr_reviews,
+    format_review_comment_for_prompt,
+    react_to_github_comment,
+    verify_github_signature,
+)
 from .utils.multimodal import dedupe_urls, extract_image_urls, fetch_image_block
 from .utils.slack import (
     add_slack_reaction,
@@ -34,6 +44,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 LINEAR_WEBHOOK_SECRET = os.environ.get("LINEAR_WEBHOOK_SECRET", "")
+GITHUB_WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
 SLACK_SIGNING_SECRET = os.environ.get("SLACK_SIGNING_SECRET", "")
 SLACK_BOT_USER_ID = os.environ.get("SLACK_BOT_USER_ID", "")
 SLACK_BOT_USERNAME = os.environ.get("SLACK_BOT_USERNAME", "")
@@ -988,6 +999,356 @@ async def slack_webhook(request: Request, background_tasks: BackgroundTasks) -> 
 async def slack_webhook_verify() -> dict[str, str]:
     """Verify endpoint for Slack webhook setup."""
     return {"status": "ok", "message": "Slack webhook endpoint is active"}
+
+
+async def _get_github_token_for_pr(owner: str, repo: str, pr_number: int) -> str | None:
+    """Resolve a GitHub token for reacting to comments on a PR.
+
+    Finds the thread ID from the PR branch name, then reads the encrypted
+    token from thread metadata.
+    """
+    from .encryption import decrypt_token
+
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+
+    try:
+        pr_data = None
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+            if response.status_code == 200:  # noqa: PLR2004
+                pr_data = response.json()
+
+        if not pr_data:
+            return None
+
+        head_branch = pr_data.get("head", {}).get("ref", "")
+        thread_id = extract_thread_id_from_branch(head_branch)
+        if not thread_id:
+            return None
+
+        thread = await langgraph_client.threads.get(thread_id)
+        metadata = thread.get("metadata", {})
+        encrypted = metadata.get("github_token_encrypted")
+        if encrypted:
+            return decrypt_token(encrypted)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not resolve GitHub token for PR #%d", pr_number)
+    return None
+
+
+async def process_github_pr_comment(  # noqa: PLR0912, PLR0915
+    event_data: dict[str, Any],
+) -> None:
+    """Process a GitHub PR comment by creating or queuing a LangGraph run."""
+    owner = event_data["owner"]
+    repo = event_data["repo"]
+    pr_number = event_data["pr_number"]
+    head_branch = event_data["head_branch"]
+    triggering_comment_id = event_data.get("triggering_comment_id")
+    triggering_user = event_data.get("triggering_user", "")
+    triggering_user_email = event_data.get("triggering_user_email")
+    comment_type = event_data.get("comment_type", "issue_comment")
+    is_review_comment = comment_type == "pr_review_comment"
+
+    github_token = event_data.get("github_token")
+    if not github_token:
+        github_token = await _get_github_token_for_pr(owner, repo, pr_number)
+
+    if github_token and triggering_comment_id:
+        await react_to_github_comment(
+            owner,
+            repo,
+            triggering_comment_id,
+            github_token,
+            "eyes",
+            is_pr_review_comment=is_review_comment,
+        )
+
+    thread_id = extract_thread_id_from_branch(head_branch)
+    if not thread_id:
+        logger.warning("Could not extract thread ID from branch %s", head_branch)
+        return
+
+    all_comments: list[dict[str, Any]] = []
+    review_comments: list[dict[str, Any]] = []
+
+    if github_token:
+        issue_comments = await fetch_issue_comments(owner, repo, pr_number, github_token)
+        for c in issue_comments:
+            c["_comment_type"] = "issue_comment"
+        all_comments.extend(issue_comments)
+
+        review_comments = await fetch_pr_review_comments(owner, repo, pr_number, github_token)
+        for c in review_comments:
+            c["_comment_type"] = "pr_review_comment"
+        all_comments.extend(review_comments)
+
+        reviews = await fetch_pr_reviews(owner, repo, pr_number, github_token)
+        for r in reviews:
+            if r.get("body"):
+                r["_comment_type"] = "pr_review"
+                r["created_at"] = r.get("submitted_at", r.get("created_at", ""))
+                all_comments.append(r)
+
+    relevant_comments = collect_comments_since_last_tag(all_comments, triggering_comment_id)
+
+    comments_text = ""
+    if relevant_comments:
+        comments_parts: list[str] = []
+        for comment in relevant_comments:
+            ctype = comment.get("_comment_type", "issue_comment")
+            author = comment.get("user", {}).get("login", "Unknown")
+            body = comment.get("body", "")
+
+            if ctype == "pr_review_comment":
+                comments_parts.append(format_review_comment_for_prompt(comment))
+            elif ctype == "pr_review":
+                state = comment.get("state", "")
+                state_label = f" [{state}]" if state else ""
+                comments_parts.append(f"**@{author}** (review{state_label}):\n{body}")
+            else:
+                comment_id = comment.get("id", "")
+                comments_parts.append(f"**@{author}** (comment_id: {comment_id}):\n{body}")
+
+        comments_text = "\n\n## PR Comments:\n\n" + "\n\n---\n\n".join(comments_parts)
+
+    pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_number}"
+    prompt = (
+        "You've been tagged in GitHub PR comments. Please resolve them.\n\n"
+        f"## Repository\n{owner}/{repo}\n\n"
+        f"## Pull Request\n#{pr_number}: {pr_url}\n\n"
+        f"## Triggered by\n@{triggering_user}\n\n"
+        f"{comments_text}\n\n"
+        "Use `github_comment_on_pr` to communicate in this PR for clarifications, "
+        "status updates, and final summaries. Use `commit_and_open_pr` to push any code changes."
+    )
+
+    content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]
+
+    image_urls = extract_image_urls(comments_text)
+    if image_urls:
+        image_urls = dedupe_urls(image_urls)
+        async with httpx.AsyncClient() as client:
+            for image_url in image_urls:
+                image_block = await fetch_image_block(image_url, client)
+                if image_block:
+                    content_blocks.append(image_block)
+
+    configurable: dict[str, Any] = {
+        "repo": {"owner": owner, "name": repo},
+        "github_pr": {
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "head_branch": head_branch,
+            "triggering_user": triggering_user,
+            "triggering_user_email": triggering_user_email,
+            "github_token": github_token,
+        },
+        "user_email": triggering_user_email,
+        "source": "github",
+    }
+
+    logger.info("Checking if thread %s is active before creating run", thread_id)
+    thread_active = await is_thread_active(thread_id)
+
+    if thread_active:
+        logger.info("Thread %s is active, queuing message", thread_id)
+        queued = await queue_message_for_thread(thread_id=thread_id, message_content=prompt)
+        if queued:
+            logger.info("Message queued for thread %s", thread_id)
+        else:
+            logger.error("Failed to queue message for thread %s", thread_id)
+    else:
+        logger.info("Creating LangGraph run for thread %s", thread_id)
+        langgraph_client = get_client(url=LANGGRAPH_URL)
+        await langgraph_client.runs.create(
+            thread_id,
+            "agent",
+            input={"messages": [{"role": "user", "content": content_blocks}]},
+            config={"configurable": configurable},
+            if_not_exists="create",
+        )
+        logger.info("LangGraph run created for thread %s", thread_id)
+
+
+def _is_pr_comment(payload: dict[str, Any]) -> bool:
+    """Check if an issue_comment event is actually on a PR (not a plain issue)."""
+    issue = payload.get("issue", {})
+    return "pull_request" in issue
+
+
+@app.post("/webhooks/github")
+async def github_webhook(  # noqa: PLR0911, PLR0912, PLR0915
+    request: Request, background_tasks: BackgroundTasks
+) -> dict[str, str]:
+    """Handle GitHub webhooks for PR comments, PR review comments, and PR reviews."""
+    logger.info("Received GitHub webhook")
+    body = await request.body()
+
+    signature = request.headers.get("X-Hub-Signature-256", "")
+    if GITHUB_WEBHOOK_SECRET and not verify_github_signature(
+        body, signature, GITHUB_WEBHOOK_SECRET
+    ):
+        logger.warning("Invalid GitHub webhook signature")
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        logger.exception("Failed to parse GitHub webhook JSON")
+        return {"status": "error", "message": "Invalid JSON"}
+
+    event_type = request.headers.get("X-GitHub-Event", "")
+    action = payload.get("action", "")
+
+    repo_data = payload.get("repository", {})
+    owner = repo_data.get("owner", {}).get("login", "")
+    repo = repo_data.get("name", "")
+
+    if event_type == "issue_comment" and action == "created":
+        if not _is_pr_comment(payload):
+            return {"status": "ignored", "reason": "Comment is on an issue, not a PR"}
+
+        comment = payload.get("comment", {})
+        comment_body = comment.get("body", "")
+
+        if not re.search(r"@open-swe\b", comment_body, re.IGNORECASE):
+            return {"status": "ignored", "reason": "Comment doesn't mention @open-swe"}
+
+        if comment.get("performed_via_github_app"):
+            return {"status": "ignored", "reason": "Comment is from a GitHub App"}
+
+        issue = payload.get("issue", {})
+        pr_number = issue.get("number")
+        pr_url = issue.get("pull_request", {}).get("url", "")
+
+        pr_data = None
+        if pr_url:
+            async with httpx.AsyncClient() as client:
+                try:
+                    resp = await client.get(
+                        pr_url,
+                        headers={
+                            "Accept": "application/vnd.github+json",
+                            "X-GitHub-Api-Version": "2022-11-28",
+                        },
+                    )
+                    if resp.status_code == 200:  # noqa: PLR2004
+                        pr_data = resp.json()
+                except httpx.HTTPError:
+                    logger.exception("Failed to fetch PR details from %s", pr_url)
+
+        head_branch = ""
+        if pr_data:
+            head_branch = pr_data.get("head", {}).get("ref", "")
+
+        if not head_branch or not extract_thread_id_from_branch(head_branch):
+            return {
+                "status": "ignored",
+                "reason": "PR branch is not an open-swe branch",
+            }
+
+        user = comment.get("user", {})
+        event_data = {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "head_branch": head_branch,
+            "triggering_comment_id": comment.get("id"),
+            "triggering_user": user.get("login", ""),
+            "triggering_user_email": user.get("email"),
+            "comment_type": "issue_comment",
+        }
+
+        background_tasks.add_task(process_github_pr_comment, event_data)
+        return {"status": "accepted", "message": f"Processing PR comment on #{pr_number}"}
+
+    if event_type == "pull_request_review_comment" and action == "created":
+        comment = payload.get("comment", {})
+        comment_body = comment.get("body", "")
+
+        if not re.search(r"@open-swe\b", comment_body, re.IGNORECASE):
+            return {"status": "ignored", "reason": "Review comment doesn't mention @open-swe"}
+
+        if comment.get("performed_via_github_app"):
+            return {"status": "ignored", "reason": "Comment is from a GitHub App"}
+
+        pr = payload.get("pull_request", {})
+        pr_number = pr.get("number")
+        head_branch = pr.get("head", {}).get("ref", "")
+
+        if not head_branch or not extract_thread_id_from_branch(head_branch):
+            return {
+                "status": "ignored",
+                "reason": "PR branch is not an open-swe branch",
+            }
+
+        user = comment.get("user", {})
+        event_data = {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "head_branch": head_branch,
+            "triggering_comment_id": comment.get("id"),
+            "triggering_user": user.get("login", ""),
+            "triggering_user_email": user.get("email"),
+            "comment_type": "pr_review_comment",
+        }
+
+        background_tasks.add_task(process_github_pr_comment, event_data)
+        return {
+            "status": "accepted",
+            "message": f"Processing PR review comment on #{pr_number}",
+        }
+
+    if event_type == "pull_request_review" and action == "submitted":
+        review = payload.get("review", {})
+        review_body = review.get("body", "") or ""
+
+        if not re.search(r"@open-swe\b", review_body, re.IGNORECASE):
+            return {"status": "ignored", "reason": "Review doesn't mention @open-swe"}
+
+        pr = payload.get("pull_request", {})
+        pr_number = pr.get("number")
+        head_branch = pr.get("head", {}).get("ref", "")
+
+        if not head_branch or not extract_thread_id_from_branch(head_branch):
+            return {
+                "status": "ignored",
+                "reason": "PR branch is not an open-swe branch",
+            }
+
+        user = review.get("user", {})
+        event_data = {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "head_branch": head_branch,
+            "triggering_comment_id": review.get("id"),
+            "triggering_user": user.get("login", ""),
+            "triggering_user_email": user.get("email"),
+            "comment_type": "pr_review",
+        }
+
+        background_tasks.add_task(process_github_pr_comment, event_data)
+        return {
+            "status": "accepted",
+            "message": f"Processing PR review on #{pr_number}",
+        }
+
+    return {"status": "ignored", "reason": f"Unhandled event: {event_type}/{action}"}
+
+
+@app.get("/webhooks/github")
+async def github_webhook_verify() -> dict[str, str]:
+    """Verify endpoint for GitHub webhook setup."""
+    return {"status": "ok", "message": "GitHub webhook endpoint is active"}
 
 
 @app.get("/health")

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -1,0 +1,139 @@
+"""Tests for GitHub PR webhook utilities and webhook endpoint."""
+
+import hashlib
+import hmac
+
+from agent.utils.github_pr_webhook import (
+    collect_comments_since_last_tag,
+    extract_thread_id_from_branch,
+    format_review_comment_for_prompt,
+    verify_github_signature,
+)
+from agent.webapp import _is_pr_comment
+
+
+class TestVerifyGithubSignature:
+    def test_returns_true_when_no_secret(self):
+        assert verify_github_signature(b"body", "sig", "") is True
+
+    def test_valid_signature(self):
+        secret = "test-secret"
+        body = b'{"action": "created"}'
+        expected = "sha256=" + hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        assert verify_github_signature(body, expected, secret) is True
+
+    def test_invalid_signature(self):
+        assert verify_github_signature(b"body", "sha256=invalid", "secret") is False
+
+
+class TestExtractThreadIdFromBranch:
+    def test_extracts_thread_id(self):
+        assert extract_thread_id_from_branch("open-swe/abc-123-def") == "abc-123-def"
+
+    def test_returns_none_for_non_open_swe_branch(self):
+        assert extract_thread_id_from_branch("feature/my-feature") is None
+
+    def test_returns_none_for_empty_string(self):
+        assert extract_thread_id_from_branch("") is None
+
+    def test_returns_empty_for_prefix_only(self):
+        result = extract_thread_id_from_branch("open-swe/")
+        assert result == ""
+
+
+class TestCollectCommentsSinceLastTag:
+    def test_empty_comments(self):
+        assert collect_comments_since_last_tag([]) == []
+
+    def test_single_comment_with_tag(self):
+        comments = [
+            {"id": 1, "body": "Hey @open-swe fix this", "created_at": "2024-01-01T00:00:00Z"},
+        ]
+        result = collect_comments_since_last_tag(comments, triggering_comment_id=1)
+        assert len(result) == 1
+        assert result[0]["id"] == 1
+
+    def test_collects_from_last_tag(self):
+        comments = [
+            {"id": 1, "body": "First comment", "created_at": "2024-01-01T00:00:00Z"},
+            {"id": 2, "body": "@open-swe do something", "created_at": "2024-01-02T00:00:00Z"},
+            {"id": 3, "body": "Follow up", "created_at": "2024-01-03T00:00:00Z"},
+            {"id": 4, "body": "@open-swe fix this too", "created_at": "2024-01-04T00:00:00Z"},
+        ]
+        result = collect_comments_since_last_tag(comments, triggering_comment_id=4)
+        assert len(result) == 3
+        assert result[0]["id"] == 2
+
+    def test_no_previous_tag_returns_from_trigger(self):
+        comments = [
+            {"id": 1, "body": "First comment", "created_at": "2024-01-01T00:00:00Z"},
+            {"id": 2, "body": "Second comment", "created_at": "2024-01-02T00:00:00Z"},
+            {"id": 3, "body": "@open-swe fix this", "created_at": "2024-01-03T00:00:00Z"},
+        ]
+        result = collect_comments_since_last_tag(comments, triggering_comment_id=3)
+        assert len(result) == 1
+        assert result[0]["id"] == 3
+
+    def test_case_insensitive_tag(self):
+        comments = [
+            {"id": 1, "body": "@Open-SWE do this", "created_at": "2024-01-01T00:00:00Z"},
+            {"id": 2, "body": "Follow up", "created_at": "2024-01-02T00:00:00Z"},
+            {"id": 3, "body": "@open-swe fix this", "created_at": "2024-01-03T00:00:00Z"},
+        ]
+        result = collect_comments_since_last_tag(comments, triggering_comment_id=3)
+        assert len(result) == 3
+        assert result[0]["id"] == 1
+
+
+class TestFormatReviewCommentForPrompt:
+    def test_basic_format(self):
+        comment = {
+            "user": {"login": "testuser"},
+            "body": "Please fix this",
+            "path": "src/main.py",
+            "line": 42,
+            "id": 123,
+        }
+        result = format_review_comment_for_prompt(comment)
+        assert "**@testuser**" in result
+        assert "comment_id: 123" in result
+        assert "`src/main.py`" in result
+        assert "line 42" in result
+        assert "Please fix this" in result
+
+    def test_line_range(self):
+        comment = {
+            "user": {"login": "reviewer"},
+            "body": "Refactor this block",
+            "path": "lib/utils.py",
+            "start_line": 10,
+            "line": 20,
+            "id": 456,
+        }
+        result = format_review_comment_for_prompt(comment)
+        assert "lines 10-20" in result
+
+    def test_no_path(self):
+        comment = {
+            "user": {"login": "reviewer"},
+            "body": "General comment",
+            "id": 789,
+        }
+        result = format_review_comment_for_prompt(comment)
+        assert "**@reviewer**" in result
+        assert "General comment" in result
+
+
+class TestIsPrComment:
+    def test_pr_comment(self):
+        payload = {
+            "issue": {
+                "number": 1,
+                "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/1"},
+            }
+        }
+        assert _is_pr_comment(payload) is True
+
+    def test_issue_comment(self):
+        payload = {"issue": {"number": 1}}
+        assert _is_pr_comment(payload) is False


### PR DESCRIPTION
## Description
Adds a new GitHub webhook endpoint (`POST /webhooks/github`) that handles PR comments, PR review comments, and PR review messages. When a user tags `@open-swe` in any of these, the webhook resolves the LangGraph thread from the `open-swe/{thread_id}` branch name, collects comments since the last `@open-swe` tag, reacts with 👀, and creates/queues a run. Also adds `github_comment_on_pr` and `github_comment_on_issue` tools so the agent can reply on GitHub.

## Test Plan
- [ ] Configure a GitHub webhook pointing to `/webhooks/github` with `issue_comment`, `pull_request_review_comment`, and `pull_request_review` events
- [ ] Tag `@open-swe` in a PR comment on an open-swe branch and verify the agent picks it up, reacts with 👀, and processes the request
- [ ] Verify PR review comments include file path and line range in the agent prompt