### PR TITLE
feat: read slack messages from links in linear and slack webhooks

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import time
 from typing import Any
 
@@ -354,3 +355,132 @@ async def fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[d
 
     messages.sort(key=lambda item: _parse_ts(item.get("ts")))
     return messages
+
+
+SLACK_MESSAGE_LINK_RE = re.compile(
+    r"https?://[a-zA-Z0-9\-]+\.slack\.com/archives/([A-Z0-9]+)/p(\d+)"
+    r"(?:\?[^\s>)]*thread_ts=([\d.]+)[^\s>)]*)?",
+)
+
+
+def extract_slack_message_links(text: str) -> list[dict[str, str]]:
+    """Extract Slack message links from text and return parsed components."""
+    if not text:
+        return []
+    results: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for match in SLACK_MESSAGE_LINK_RE.finditer(text):
+        channel_id = match.group(1)
+        raw_ts = match.group(2)
+        message_ts = raw_ts[:-6] + "." + raw_ts[-6:] if len(raw_ts) > 6 else raw_ts
+        thread_ts = match.group(3) or ""
+        key = (channel_id, message_ts)
+        if key in seen:
+            continue
+        seen.add(key)
+        results.append(
+            {
+                "channel_id": channel_id,
+                "message_ts": message_ts,
+                "thread_ts": thread_ts,
+                "url": match.group(0),
+            }
+        )
+    return results
+
+
+async def _fetch_single_slack_message(
+    channel_id: str,
+    message_ts: str,
+    thread_ts: str = "",
+) -> dict[str, Any] | None:
+    """Fetch a single Slack message by channel and timestamp."""
+    if not SLACK_BOT_TOKEN:
+        return None
+
+    async with httpx.AsyncClient() as http_client:
+        try:
+            if thread_ts:
+                params: dict[str, str | int] = {
+                    "channel": channel_id,
+                    "ts": thread_ts,
+                    "latest": message_ts,
+                    "inclusive": 1,
+                    "limit": 1,
+                }
+                response = await http_client.get(
+                    f"{SLACK_API_BASE_URL}/conversations.replies",
+                    headers=_slack_headers(),
+                    params=params,
+                )
+            else:
+                params = {
+                    "channel": channel_id,
+                    "latest": message_ts,
+                    "inclusive": 1,
+                    "limit": 1,
+                }
+                response = await http_client.get(
+                    f"{SLACK_API_BASE_URL}/conversations.history",
+                    headers=_slack_headers(),
+                    params=params,
+                )
+            response.raise_for_status()
+            data = response.json()
+            if not data.get("ok"):
+                logger.warning(
+                    "Slack API error fetching message %s in %s: %s",
+                    message_ts,
+                    channel_id,
+                    data.get("error"),
+                )
+                return None
+            messages = data.get("messages", [])
+            for msg in messages:
+                if isinstance(msg, dict) and str(msg.get("ts")) == str(message_ts):
+                    return msg
+            if messages and isinstance(messages[0], dict):
+                return messages[0]
+        except httpx.HTTPError:
+            logger.exception(
+                "Failed to fetch Slack message %s in channel %s", message_ts, channel_id
+            )
+    return None
+
+
+async def fetch_slack_messages_from_links(text: str) -> str:
+    """Extract Slack message links from text, fetch their content, and return formatted context."""
+    links = extract_slack_message_links(text)
+    if not links:
+        return ""
+
+    fetch_tasks = [
+        _fetch_single_slack_message(
+            link["channel_id"], link["message_ts"], link.get("thread_ts", "")
+        )
+        for link in links
+    ]
+    fetched_messages = await asyncio.gather(*fetch_tasks, return_exceptions=True)
+
+    user_ids: set[str] = set()
+    valid_messages: list[tuple[dict[str, str], dict[str, Any]]] = []
+    for link, result in zip(links, fetched_messages, strict=True):
+        if isinstance(result, dict):
+            valid_messages.append((link, result))
+            uid = result.get("user")
+            if isinstance(uid, str) and uid:
+                user_ids.add(uid)
+
+    if not valid_messages:
+        return ""
+
+    user_names = await get_slack_user_names(sorted(user_ids)) if user_ids else {}
+
+    sections: list[str] = []
+    for link, msg in valid_messages:
+        uid = msg.get("user", "")
+        author = user_names.get(uid, uid) if uid else "Unknown"
+        msg_text = msg.get("text", "[no text]")
+        sections.append(f"[Slack message from {link['url']}]\n@{author}: {msg_text}")
+
+    return "\n\n".join(sections)

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -19,6 +19,7 @@ from .utils.comments import get_recent_comments
 from .utils.multimodal import dedupe_urls, extract_image_urls, fetch_image_block
 from .utils.slack import (
     add_slack_reaction,
+    fetch_slack_messages_from_links,
     fetch_slack_thread_messages,
     format_slack_messages_for_prompt,
     get_slack_user_info,
@@ -559,6 +560,11 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
 
     identifier = full_issue.get("identifier", "") or issue_data.get("identifier", "")
 
+    slack_context = await fetch_slack_messages_from_links(f"{description}\n{comments_text}")
+    slack_context_section = (
+        f"\n\n## Referenced Slack Messages\n{slack_context}" if slack_context else ""
+    )
+
     triggered_by_line = f"## Triggered by: {user_name}\n\n" if user_name else ""
     tag_instruction = (
         f"When calling linear_comment, tag @{user_name} if you are asking them a question, need their input, or are notifying them of something important (e.g. a completed PR). For simple answers, tagging is not required."
@@ -571,7 +577,8 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         f"{triggered_by_line}"
         f"## Linear Ticket: {identifier} - Ticket ID: {issue_id}\n\n"
         f"## Description:\n{description}\n"
-        f"{comments_text}\n\n"
+        f"{comments_text}"
+        f"{slack_context_section}\n\n"
         f"Please analyze this issue and implement the necessary changes. "
         f"When you're done, commit and push your changes. {tag_instruction}"
     )
@@ -719,6 +726,11 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
     )
     trigger_user = user_name or (f"<@{user_id}>" if user_id else "Unknown user")
 
+    slack_linked_context = await fetch_slack_messages_from_links(f"{context_text}\n{clean_text}")
+    slack_linked_section = (
+        f"\n\n## Referenced Slack Messages\n{slack_linked_context}" if slack_linked_context else ""
+    )
+
     prompt = (
         "You were mentioned in Slack.\n\n"
         f"## Repository\n{repo_config.get('owner')}/{repo_config.get('name')}\n\n"
@@ -726,7 +738,8 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
         f"## Slack Thread\n- Channel: {channel_id}\n- Thread TS: {thread_ts}\n"
         f"- Context starts at: {context_source}\n\n"
         f"## Conversation Context\n{context_text}\n\n"
-        f"## Latest Mention Request\n{clean_text}\n\n"
+        f"## Latest Mention Request\n{clean_text}"
+        f"{slack_linked_section}\n\n"
         "Use `slack_thread_reply` to communicate in this Slack thread for clarifications, "
         "status updates, and final summaries."
     )

--- a/tests/test_slack_context.py
+++ b/tests/test_slack_context.py
@@ -4,6 +4,8 @@ import pytest
 
 from agent import webapp
 from agent.utils.slack import (
+    extract_slack_message_links,
+    fetch_slack_messages_from_links,
     format_slack_messages_for_prompt,
     replace_bot_mention_with_username,
     select_slack_context_messages,
@@ -206,3 +208,104 @@ def test_get_slack_repo_config_existing_thread_without_repo_uses_default(
     assert threads_client.requested_thread_id == generate_thread_id_from_slack_thread(
         "C123", "1.234"
     )
+
+
+# ---------------------------------------------------------------------------
+# extract_slack_message_links tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_slack_message_links_single_message() -> None:
+    text = "Check this: https://myorg.slack.com/archives/C08UK957CMC/p1773090218882099"
+    links = extract_slack_message_links(text)
+    assert len(links) == 1
+    assert links[0]["channel_id"] == "C08UK957CMC"
+    assert links[0]["message_ts"] == "1773090218.882099"
+    assert links[0]["thread_ts"] == ""
+
+
+def test_extract_slack_message_links_threaded_message() -> None:
+    text = (
+        "See https://langchain.slack.com/archives/C08UK957CMC/p1773090218882099"
+        "?thread_ts=1773090000.100000&cid=C08UK957CMC"
+    )
+    links = extract_slack_message_links(text)
+    assert len(links) == 1
+    assert links[0]["channel_id"] == "C08UK957CMC"
+    assert links[0]["message_ts"] == "1773090218.882099"
+    assert links[0]["thread_ts"] == "1773090000.100000"
+
+
+def test_extract_slack_message_links_multiple() -> None:
+    text = (
+        "First: https://org.slack.com/archives/C111/p1000000000000001 "
+        "Second: https://org.slack.com/archives/C222/p2000000000000002"
+    )
+    links = extract_slack_message_links(text)
+    assert len(links) == 2
+    assert links[0]["channel_id"] == "C111"
+    assert links[1]["channel_id"] == "C222"
+
+
+def test_extract_slack_message_links_deduplicates() -> None:
+    url = "https://org.slack.com/archives/C111/p1000000000000001"
+    text = f"{url} and again {url}"
+    links = extract_slack_message_links(text)
+    assert len(links) == 1
+
+
+def test_extract_slack_message_links_no_links() -> None:
+    assert extract_slack_message_links("no links here") == []
+    assert extract_slack_message_links("") == []
+
+
+def test_extract_slack_message_links_in_angle_brackets() -> None:
+    text = "Check <https://myorg.slack.com/archives/C08UK957CMC/p1773090218882099>"
+    links = extract_slack_message_links(text)
+    assert len(links) == 1
+    assert links[0]["channel_id"] == "C08UK957CMC"
+
+
+# ---------------------------------------------------------------------------
+# fetch_slack_messages_from_links tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_slack_messages_from_links_no_links() -> None:
+    result = asyncio.run(fetch_slack_messages_from_links("no links here"))
+    assert result == ""
+
+
+def test_fetch_slack_messages_from_links_fetches_and_formats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent.utils.slack as slack_mod
+
+    async def fake_fetch_single(channel_id: str, message_ts: str, thread_ts: str = "") -> dict:
+        return {"user": "U123", "text": "Hello from linked message", "ts": message_ts}
+
+    async def fake_get_user_names(user_ids: list[str]) -> dict[str, str]:
+        return {"U123": "alice"}
+
+    monkeypatch.setattr(slack_mod, "_fetch_single_slack_message", fake_fetch_single)
+    monkeypatch.setattr(slack_mod, "get_slack_user_names", fake_get_user_names)
+
+    text = "See https://org.slack.com/archives/C111/p1000000000000001"
+    result = asyncio.run(fetch_slack_messages_from_links(text))
+    assert "@alice: Hello from linked message" in result
+    assert "Slack message from" in result
+
+
+def test_fetch_slack_messages_from_links_handles_fetch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent.utils.slack as slack_mod
+
+    async def fake_fetch_single(channel_id: str, message_ts: str, thread_ts: str = "") -> None:
+        return None
+
+    monkeypatch.setattr(slack_mod, "_fetch_single_slack_message", fake_fetch_single)
+
+    text = "See https://org.slack.com/archives/C111/p1000000000000001"
+    result = asyncio.run(fetch_slack_messages_from_links(text))
+    assert result == ""


### PR DESCRIPTION
## Description
Adds support for reading Slack messages from links included in Linear issues/comments and Slack thread messages. A new utility (`extract_slack_message_links` / `fetch_slack_messages_from_links`) parses Slack message URLs, fetches their content via the Slack API, resolves user names, and appends the context as a "Referenced Slack Messages" section in the prompt sent to the agent. This is integrated into both `process_linear_issue` and `process_slack_mention` webhooks.

## Test Plan
- [ ] Verify Slack message links in Linear issue descriptions/comments are fetched and included in the agent prompt
- [ ] Verify Slack message links shared in Slack threads are fetched and included in the agent prompt
- [ ] 9 new unit tests covering link extraction, message fetching, deduplication, and error handling all pass