### PR TITLE
chore: add deprecation warning to readme [closes #1039]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!CAUTION]
-> **This repository is deprecated and no longer maintained.** It should not be used in production or as a dependency. No further updates, bug fixes, or security patches will be provided. If you are looking for an actively maintained solution, please explore other options.
+> **This repository is deprecated and no longer maintained.** It should not be used in production or as a dependency. No further updates, bug fixes, or security patches will be provided. If you are looking for an actively maintained solution, check out [LangSmith Agent Builder](https://www.langchain.com/langsmith/agent-builder).
 
 <div align="center">
   <picture>


### PR DESCRIPTION
## Description
Adds a prominent deprecation warning at the top of the README using GitHub's `[!CAUTION]` alert syntax, stating the repository is no longer maintained and should not be used.

## Test Plan
- [ ] Verify the deprecation banner renders correctly on the GitHub repo page