### PR TITLE
fix: use OPEN_SWE_TAGS in Linear webhook and deduplicate bot-message prefixes

### DIFF
--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -64,7 +64,7 @@ LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
 
 LINEAR_API_KEY = os.environ.get("LINEAR_API_KEY", "")
 
-_GITHUB_BOT_MESSAGE_PREFIXES = (
+_BOT_MESSAGE_PREFIXES = (
     "🔐 **GitHub Authentication Required**",
     "✅ **Pull Request Created**",
     "✅ **Pull Request Updated**",
@@ -73,6 +73,8 @@ _GITHUB_BOT_MESSAGE_PREFIXES = (
     "🤖 **Agent Response**",
     "❌ **Agent Error**",
 )
+# Backward-compatible alias used by GitHub comment filtering helpers
+_GITHUB_BOT_MESSAGE_PREFIXES = _BOT_MESSAGE_PREFIXES
 
 
 def get_repo_config_from_team_mapping(
@@ -841,22 +843,12 @@ async def linear_webhook(  # noqa: PLR0911, PLR0912, PLR0915
         return {"status": "ignored", "reason": "Comment is from a bot"}
 
     comment_body = data.get("body", "")
-    bot_message_prefixes = [
-        "🔐 **GitHub Authentication Required**",
-        "✅ **Pull Request Created**",
-        "✅ **Pull Request Updated**",
-        "**Pull Request Created**",
-        "**Pull Request Updated**",
-        "🤖 **Agent Response**",
-        "❌ **Agent Error**",
-    ]
-    for prefix in bot_message_prefixes:
-        if comment_body.startswith(prefix):
-            logger.debug("Ignoring webhook: comment is our own bot message")
-            return {"status": "ignored", "reason": "Comment is our own bot message"}
-    if "@openswe" not in comment_body.lower():
-        logger.debug("Ignoring webhook: comment doesn't mention @openswe")
-        return {"status": "ignored", "reason": "Comment doesn't mention @openswe"}
+    if any(comment_body.startswith(prefix) for prefix in _BOT_MESSAGE_PREFIXES):
+        logger.debug("Ignoring webhook: comment is our own bot message")
+        return {"status": "ignored", "reason": "Comment is our own bot message"}
+    if not any(tag in comment_body.lower() for tag in OPEN_SWE_TAGS):
+        logger.debug("Ignoring webhook: comment doesn't mention @openswe or @open-swe")
+        return {"status": "ignored", "reason": "Comment doesn't mention @openswe or @open-swe"}
 
     issue = data.get("issue", {})
     if not issue:

--- a/tests/test_linear_webhook.py
+++ b/tests/test_linear_webhook.py
@@ -1,0 +1,149 @@
+"""Unit tests for the Linear webhook early-filter logic.
+
+These tests cover the comment-body checks that run *before* any external I/O
+(Linear API calls, LangGraph runs, etc.), so no network stubs are needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent import webapp
+from agent.utils.github_comments import OPEN_SWE_TAGS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _linear_comment_payload(body: str, *, bot_actor: bool = False) -> dict:
+    """Return a minimal Linear Comment webhook payload."""
+    return {
+        "type": "Comment",
+        "action": "create",
+        "data": {
+            "body": body,
+            # Linear sets botActor to a non-empty actor object for bot comments,
+            # or null/absent for human comments.
+            "botActor": {"id": "bot-id", "name": "OpenSWE Bot"} if bot_actor else None,
+            "issue": {"id": "issue-123", "title": "Test issue"},
+        },
+    }
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """TestClient with webhook-secret verification disabled."""
+    monkeypatch.setattr(webapp, "LINEAR_WEBHOOK_SECRET", "")
+    return TestClient(webapp.app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_linear_webhook_ignores_non_comment_event(client: TestClient) -> None:
+    response = client.post(
+        "/webhooks/linear",
+        json={"type": "Issue", "action": "create", "data": {}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+def test_linear_webhook_ignores_non_create_action(client: TestClient) -> None:
+    response = client.post(
+        "/webhooks/linear",
+        json={"type": "Comment", "action": "update", "data": {"body": "@openswe do something"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+def test_linear_webhook_ignores_bot_actor_comment(client: TestClient) -> None:
+    response = client.post(
+        "/webhooks/linear",
+        json=_linear_comment_payload("@openswe do something", bot_actor=True),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "🔐 **GitHub Authentication Required**",
+        "✅ **Pull Request Created**",
+        "✅ **Pull Request Updated**",
+        "**Pull Request Created**",
+        "**Pull Request Updated**",
+        "🤖 **Agent Response**",
+        "❌ **Agent Error**",
+    ],
+)
+def test_linear_webhook_ignores_our_own_bot_messages(client: TestClient, prefix: str) -> None:
+    """Comments that start with one of our bot-message prefixes must be filtered."""
+    response = client.post(
+        "/webhooks/linear",
+        json=_linear_comment_payload(f"{prefix}\n\nsome content here"),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+def test_linear_webhook_ignores_comment_without_openswe_tag(client: TestClient) -> None:
+    response = client.post(
+        "/webhooks/linear",
+        json=_linear_comment_payload("Please look at this issue"),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+@pytest.mark.parametrize("tag", list(OPEN_SWE_TAGS))
+def test_linear_webhook_accepts_all_openswe_tags(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tag: str
+) -> None:
+    """@openswe, @open-swe, and @openswe-dev must all trigger processing."""
+
+    # Patch downstream I/O so we don't need real Linear/LangGraph services.
+    async def fake_process_linear_issue(issue: dict, repo_config: dict) -> None:
+        pass
+
+    monkeypatch.setattr(webapp, "process_linear_issue", fake_process_linear_issue)
+    monkeypatch.setattr(
+        webapp,
+        "fetch_linear_issue_details",
+        lambda issue_id: _async_return(
+            {
+                "id": issue_id,
+                "title": "Test issue",
+                "team": {"name": "Open SWE"},
+                "project": None,
+            }
+        ),
+    )
+
+    response = client.post(
+        "/webhooks/linear",
+        json=_linear_comment_payload(f"Hey {tag} please fix this"),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# Small async helper
+# ---------------------------------------------------------------------------
+
+
+async def _async_return(value):  # noqa: ANN001, ANN201
+    return value


### PR DESCRIPTION
## Problem

The Linear webhook's comment filter checked only for the literal string `"@openswe"`, while the GitHub webhook (merged in PR #1014) uses the shared `OPEN_SWE_TAGS` tuple which also covers `"@open-swe"` and `"@openswe-dev"`.

This inconsistency had two practical consequences:

1. **Silent ignore of valid triggers** — A Linear comment that says `@open-swe please fix this` would never be processed; the webhook returned `ignored` without any feedback to the user.
2. **Stale-duplication risk** — The `bot_message_prefixes` list inside `linear_webhook` was a copy-paste of the module-level `_GITHUB_BOT_MESSAGE_PREFIXES` tuple. If one was ever updated (e.g. a new bot-message prefix added), the other could silently fall out of sync.

## Changes

* **`agent/webapp.py`**
  * Replace hardcoded `"@openswe" not in comment_body.lower()` guard with `not any(tag in comment_body.lower() for tag in OPEN_SWE_TAGS)`, making all three supported mention styles consistent across both webhooks.
  * Extract the inline `bot_message_prefixes` list into a module-level `_BOT_MESSAGE_PREFIXES` constant (same content) and keep `_GITHUB_BOT_MESSAGE_PREFIXES = _BOT_MESSAGE_PREFIXES` as an alias so existing callers in the GitHub comment filter are unaffected.

* **`tests/test_linear_webhook.py`** (new)
  * Tests for all early-return filter paths (non-Comment event, non-create action, bot actor, bot-message prefixes, missing tag).
  * Parametrised test asserting that **all three** `OPEN_SWE_TAGS` (`@openswe`, `@open-swe`, `@openswe-dev`) are accepted by the Linear webhook.

## Test Plan
- [x] `make test` — 71 tests pass (57 existing + 14 new)
- [x] `ruff check` and `ruff format --check` — no issues