### PR TITLE
fix: reduce token usage by improving agent and subagent efficiency

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -50,7 +50,7 @@ If you make changes, communicate updates in the source channel:
 
 For tasks that require code changes, follow this order:
 
-1. **Understand** — Read the issue/task carefully. Explore relevant files before making any changes.
+1. **Understand** — Read the issue/task carefully. Before reading any file or grepping anything, map the repo structure first by running `find . -type f | grep -v node_modules | grep -v dist | grep -v ".git" | head -150` from `{working_dir}`. This gives you the complete real file tree so you never have to guess filenames. Subagent output is findings, not a filesystem map — always build your own map first.
 2. **Implement** — Make focused, minimal changes. Do not modify code outside the scope of the task.
 3. **Verify** — Run tests and linters to confirm correctness before submitting.
 4. **Submit** — Call `commit_and_open_pr` to push changes to the existing PR branch.
@@ -103,7 +103,24 @@ TOOL_BEST_PRACTICES_SECTION = """---
 - **History:** Use `git log` and `git blame` via `execute` for additional context when needed.
 - **Parallel Tool Calling:** Call multiple tools at once when they don't depend on each other.
 - **URL Content:** Use `fetch_url` to fetch URL contents. Only use for URLs the user has provided or discovered during exploration.
-- **Scripts may require dependencies:** Always ensure dependencies are installed before running a script."""
+- **Scripts may require dependencies:** Always ensure dependencies are installed before running a script.
+
+### Subagent Task Descriptions
+
+When dispatching a `task` subagent for research or investigation:
+
+- **Search for causes, not symptoms.** For UI bugs (flickers, empty states, loading issues), search for data fetching patterns, state management hooks, and loading flags — NOT for visible UI string labels (e.g. `"Messages"`, `"Details"`). UI labels match hundreds of files and provide no signal.
+- **Be specific about what to return.** End every task description with: "Return a structured findings table with these columns: file path | line number | severity (critical/high/medium/low) | one-sentence description of the issue | the single problematic line of code. One row per issue. No prose paragraphs, no fix code blocks, no full file dumps. If no issues found, say so explicitly."
+- **One focused task beats two overlapping ones.** If you need to understand a bug, dispatch a single subagent that covers the full technical surface (data fetching + state + component tree) rather than two parallel ones that split on superficial angles and risk returning empty results.
+- **Never overlap file scope across parallel subagents.** Each parallel subagent must get a strictly non-overlapping set of files. Never assign the same file to more than one subagent — if subagent A reads file X, subagent B and C must not read file X.
+- **Integration subagents must be grep-only.** If you need a third subagent to check cross-layer connections, its task description must explicitly say "grep only — do not read files" and list specific grep patterns to run. Never assign file reads to an integration/cross-layer subagent — it should only verify that patterns exist across file boundaries, not re-read files already covered by other subagents.
+- **Do not tell subagents to read entire files.** Instead of "read X completely", tell subagents to search for specific functions, patterns, or behaviours. Subagents should grep and read targeted sections — not dump entire files into their response.
+
+### Avoiding Redundant Tool Calls
+
+- **Todos:** Only call `write_todos` when the todo list content actually changes. Do not rewrite it with the same content between steps.
+- **Re-reads:** Never re-read a file you have already read unless you have modified it since.
+- **Re-runs:** If a command succeeded and you have not changed any files since, do not re-run it. Only re-run after making changes."""
 
 
 CODING_STANDARDS_SECTION = """---

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -107,6 +107,8 @@ TOOL_BEST_PRACTICES_SECTION = """---
 
 ### Subagent Task Descriptions
 
+**When NOT to use a subagent:** Never dispatch a subagent to read a specific file, retrieve exact code, or run a single grep — use `read_file` and `grep` directly. Subagents are only for broad investigation across a large codebase where you need to search many files in parallel. If the task can be done in 1-3 direct tool calls, do it yourself.
+
 When dispatching a `task` subagent for research or investigation:
 
 - **Search for causes, not symptoms.** For UI bugs (flickers, empty states, loading issues), search for data fetching patterns, state management hooks, and loading flags — NOT for visible UI string labels (e.g. `"Messages"`, `"Details"`). UI labels match hundreds of files and provide no signal.

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -50,7 +50,7 @@ If you make changes, communicate updates in the source channel:
 
 For tasks that require code changes, follow this order:
 
-1. **Understand** — Read the issue/task carefully. Before reading any file or grepping anything, map the repo structure first by running `find . -type f | grep -v node_modules | grep -v dist | grep -v ".git" | head -150` from `{working_dir}`. This gives you the complete real file tree so you never have to guess filenames. Subagent output is findings, not a filesystem map — always build your own map first.
+1. **Understand** — Read the issue/task carefully. Before reading any file or grepping anything, map the repo structure first by running `git ls-files | tree --fromfile -L 3` from `{working_dir}` (adjust `-L` depth as needed; 3 is a good starting point). This gives you the complete real file tree so you never have to guess filenames. Subagent output is findings, not a filesystem map — always build your own map first.
 2. **Implement** — Make focused, minimal changes. Do not modify code outside the scope of the task.
 3. **Verify** — Run tests and linters to confirm correctness before submitting.
 4. **Submit** — Call `commit_and_open_pr` to push changes to the existing PR branch.

--- a/agent/server.py
+++ b/agent/server.py
@@ -21,7 +21,7 @@ import asyncio
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 # Now safe to import agent (which imports LangChain modules)
-from deepagents import create_deep_agent
+from deepagents import SubAgent, create_deep_agent
 from deepagents.backends.protocol import SandboxBackendProtocol
 from langsmith.sandbox import SandboxClientError
 
@@ -392,6 +392,24 @@ async def get_agent(config: RunnableConfig) -> Pregel:  # noqa: PLR0915
             github_comment,
         ],
         backend=sandbox_backend,
+        subagents=[
+            SubAgent(
+                name="general-purpose",
+                description="General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. Use this agent to perform searches, investigations, and analysis across the codebase.",
+                system_prompt=(
+                    "In order to complete the objective, you have access to a number of standard tools.\n\n"
+                    "When your task is research or investigation:\n"
+                    "- Search for technical identifiers (function names, hook names, state variable names, API endpoints) — NEVER search for visible UI text like tab names, button labels, or display strings; these match hundreds of files and give no signal\n"
+                    "- Return a structured findings table: file path | line number | severity | one-sentence description | single problematic code line. One row per issue. No prose paragraphs, no fix code blocks, no full file dumps.\n"
+                    "- Never say 'the summary above' or reference prior context — your response is the only output the caller receives\n"
+                    "- If a search returns no results, try 1-2 different specific technical terms; if still no results after that, report 'no findings for this area' and stop — do not keep searching with variations of the same dead-end pattern\n"
+                    "- Stay within your assigned file scope — do not read files outside what your task description specifies\n"
+                    "- If your task says 'grep only' or 'do not read files', use ONLY grep/search commands — never open a file, just return grep match results\n"
+                    "- Never re-read a file you have already read unless you modified it\n"
+                    "- Never re-run a command that already succeeded unless you made code changes since"
+                ),
+            )
+        ],
         middleware=[
             ToolErrorMiddleware(),
             check_message_queue_before_model,

--- a/agent/server.py
+++ b/agent/server.py
@@ -388,6 +388,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:  # noqa: PLR0915
                     "- Search for technical identifiers (function names, hook names, state variable names, API endpoints) — NEVER search for visible UI text like tab names, button labels, or display strings; these match hundreds of files and give no signal\n"
                     "- Return a structured findings table: file path | line number | severity | one-sentence description | single problematic code line. One row per issue. No prose paragraphs, no fix code blocks, no full file dumps.\n"
                     "- Never say 'the summary above' or reference prior context — your response is the only output the caller receives\n"
+                    "- If asked to return file contents or exact code, return the verbatim text — never summarize or paraphrase code you are asked to retrieve\n"
                     "- If a search returns no results, try 1-2 different specific technical terms; if still no results after that, report 'no findings for this area' and stop — do not keep searching with variations of the same dead-end pattern\n"
                     "- Stay within your assigned file scope — do not read files outside what your task description specifies\n"
                     "- If your task says 'grep only' or 'do not read files', use ONLY grep/search commands — never open a file, just return grep match results\n"


### PR DESCRIPTION
Problem                                                                                                                                                      
A production run on langchain-ai/smith-frontend consumed 12 million tokens to fix a single UI flicker bug. Trace analysis revealed a cascade of inefficiencies rooted in how the agent dispatches and uses subagents, and how it explores codebases.                                                                        

https://smith.langchain.com/o/ebbaf2eb-769b-4505-aca2-d11de10372a4/host/deployments/a2a0ec69-99f0-4303-8d39-2791b2a66138?peek=019cd988-22bb-7060-bb7c-e0deca8576b7&peeked_trace=019cd988-22bb-7060-bb7c-e0deca8576b7

 Root Cause

  Step 1 — Bad subagent task descriptions

  The main agent dispatched 2 parallel subagents to investigate the flicker. Subagent 1 was told to search for:
  "Messages" and "Details" as string literals in tab components
  These are visible UI labels. On a large frontend codebase they match hundreds of unrelated files — menus, tooltips, tests, docs. The subagent spent 186 seconds
   grepping and found nothing useful.

  Step 2 — Subagent returned unusable output

  Subagent 1 returned 226 characters:
  The summary above covers everything. Let me know if you'd like me to dig deeper...
  It referenced "the summary above" — context that doesn't exist from the parent agent's perspective. The parent received zero actionable data.

  Step 3 — Failed greps compounded into wasted turns

  With no useful subagent output, the main agent took over and repeated the same bad search strategy. When grepping for useRunV2Streaming, it guessed the
  filename (useRunsV2.ts) instead of mapping the filesystem first. The file didn't exist at that path — so the grep returned nothing. Instead of stopping, the
  agent ran 5 variations of the same failing grep across 5 separate turns:

 ```
 grep "useRunV2Streaming" glob="**/hooks/useRunsV2.ts*"  → no results
  grep "export function useRunV2Streaming" glob="**/useRunsV2.ts"  → no results
  grep "useRunV2Streaming" glob="**/useRunsV2.ts"  → no results
  grep "useRunV2Streaming" path="/workspace/.../src"  → no results
  grep "export function useRunV2Streaming" path="/workspace/.../src"  → finally found
```

  Each failed turn re-sent the full growing conversation history. The agent also directly grepped for "Messages" as a string literal — the same flood strategy as
   subagent 1 — returning hundreds of useless matches it then had to process.

  Step 4 — Main agent recovered with 94 extra turns

  With no useful subagent output and failed searches, the main agent spent 94 turns on exploration. The same files were read 3-6 times each without modification
  between reads. git diff --stat was run twice with no changes between the calls.

  Step 5 — Context compounding

  Every turn re-sends the entire conversation history. 94 extra turns at an average 50k input tokens = ~4.7M extra tokens from the recovery phase alone. Combined
   with the subagents, the run hit 12M tokens.

  Step 6 — Secondary issues found in follow-up traces

  - Subagents dispatched for file retrieval instead of using read_file directly
  - Subagent returned prose summary when asked for exact verbatim code
  - 3 parallel subagents assigned overlapping file scopes → 3× duplicate output
  - write_todos called on every single step, adding permanent context overhead
  - README and unrelated package.json read and held in context permanently

grep fix:
https://dev.smith.langchain.com/public/029c273f-8489-40b7-b3be-be2f1b8f8d17/r

