### PR TITLE
fix: prevent redundant file reads in agent prompt

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -86,7 +86,7 @@ Posts a comment to a Linear ticket given a `ticket_id`. Call this **after** `com
 #### `slack_thread_reply`
 Posts a message to the active Slack thread. Use this for clarifying questions, status updates, and final summaries when the task was triggered from Slack.
 Format messages using Slack's mrkdwn format, NOT standard Markdown.
-    Key differences: *bold*, _italic_, ~strikethrough~, <url|link text>,
+    Key differences: *bold*, _italic_, ~strikethrough~, <url|link text>,ec
     bullet lists with "• ", ```code blocks```, > blockquotes.
     Do NOT use **bold**, [link](url), or other standard Markdown syntax.
 
@@ -103,7 +103,9 @@ TOOL_BEST_PRACTICES_SECTION = """---
 - **History:** Use `git log` and `git blame` via `execute` for additional context when needed.
 - **Parallel Tool Calling:** Call multiple tools at once when they don't depend on each other.
 - **URL Content:** Use `fetch_url` to fetch URL contents. Only use for URLs the user has provided or discovered during exploration.
-- **Scripts may require dependencies:** Always ensure dependencies are installed before running a script."""
+- **Scripts may require dependencies:** Always ensure dependencies are installed before running a script.
+- **No redundant file reads:** If you have already read a file in this session — whether directly or via a subagent task — do NOT read it again. Keep track of files you have read and reuse that knowledge. Only re-read a file if you need a specific section you have not yet seen.
+- **Trust subagent results:** If a `task` subagent already explored files or returned file contents, use that output directly. Do not re-read those same files yourself afterwards."""
 
 
 CODING_STANDARDS_SECTION = """---


### PR DESCRIPTION
Agent was re-reading the same files https://smith.langchain.com/public/5dcdb24d-c322-46c1-b52f-2c5058c18633/r

The agent had no instruction preventing it from re-reading files it had already seen. This meant two things were happening:                                                                                                                         
                           
  1. When a `task` subagent explored the repo and returned file contents, the agent                                                                                   
     didn't trust that output — it would re-read the exact same files itself to                                                                                       
     "verify". The subagent's work was effectively thrown away.                                                                                                       
                                                                                                                                                                      
  2. The agent had no memory of what it had already read across turns. So every                                                                                       
     time it needed context about a file, it would just read it again from scratch.                                                                                   
                                                                                                                                                                      
  In the trace this resulted in nodes.py                                                                                         
  being read 16 times and test_transactions.py being read 16 times. Each re-read                                                                                      
  adds the full file contents into message history, which gets sent back to Claude                                                                                    
  on every subsequent turn — compounding token cost for the rest of the session.                                                                                      
                                                                                                                                                                      
  The fix adds two explicit rules to TOOL_BEST_PRACTICES_SECTION:                                                                                                     
  - Don't re-read a file already seen this session unless you need a section not                                                                                      
    yet seen                                                                                                                                                          
  - If a subagent already returned file contents, use that output directly — don't
    re-read the same files afterwards  
