### PR TITLE
feat: add slack reaction webhook for langsmith feedback

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -58,6 +58,8 @@ For tasks that require code changes, follow this order:
 
 **Strict requirement:** You must call `commit_and_open_pr` before posting any completion message for a code change task. Only claim "PR updated/opened" if `commit_and_open_pr` returns `success` and a PR link. If it returns "No changes detected" or any error, you must state that explicitly and do not claim an update.
 
+**Slack feedback reactions:** For Slack-triggered tasks, your FINAL `slack_thread_reply` message (the completion summary) MUST end with a line asking the user to react with :+1: or :-1: to provide feedback. Example ending: "React with :+1: or :-1: to let me know how I did!"
+
 For questions or status checks (no code changes needed):
 
 1. **Answer** — Gather the information needed to respond.

--- a/agent/utils/langsmith_feedback.py
+++ b/agent/utils/langsmith_feedback.py
@@ -1,0 +1,40 @@
+"""LangSmith feedback utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _get_langsmith_api_key() -> str | None:
+    return os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGSMITH_API_KEY_PROD")
+
+
+async def submit_langsmith_feedback(
+    run_id: str,
+    score: int,
+    comment: str = "",
+) -> bool:
+    """Submit thumbs up/down feedback to LangSmith for a run."""
+    api_key = _get_langsmith_api_key()
+    if not api_key:
+        logger.warning("No LangSmith API key configured, skipping feedback")
+        return False
+
+    try:
+        from langsmith import Client
+
+        client = Client(api_key=api_key)
+        client.create_feedback(
+            run_id=run_id,
+            key="user_feedback",
+            score=score,
+            comment=comment,
+            feedback_source_type="api",
+        )
+        return True
+    except Exception:
+        logger.exception("Failed to submit LangSmith feedback for run %s", run_id)
+        return False

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -312,6 +312,37 @@ async def get_slack_user_names(user_ids: list[str]) -> dict[str, str]:
     return user_names
 
 
+async def get_slack_message_thread_ts(channel_id: str, message_ts: str) -> str | None:
+    """Get the thread_ts for a Slack message, returning None if not in a thread."""
+    if not SLACK_BOT_TOKEN:
+        return None
+
+    async with httpx.AsyncClient() as http_client:
+        try:
+            response = await http_client.get(
+                f"{SLACK_API_BASE_URL}/conversations.history",
+                headers=_slack_headers(),
+                params={
+                    "channel": channel_id,
+                    "latest": message_ts,
+                    "oldest": message_ts,
+                    "inclusive": "true",
+                    "limit": 1,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            if not data.get("ok"):
+                logger.warning("Slack conversations.history failed: %s", data.get("error"))
+                return None
+            messages = data.get("messages", [])
+            if messages and isinstance(messages[0], dict):
+                return messages[0].get("thread_ts")
+        except httpx.HTTPError:
+            logger.exception("Slack conversations.history request failed")
+    return None
+
+
 async def fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[dict[str, Any]]:
     """Fetch all messages for a Slack thread."""
     if not SLACK_BOT_TOKEN:

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -36,12 +36,14 @@ from .utils.github_comments import (
 )
 from .utils.github_token import get_github_token_from_thread
 from .utils.github_user_email_map import GITHUB_USER_EMAIL_MAP
+from .utils.langsmith_feedback import submit_langsmith_feedback
 from .utils.linear_team_repo_map import LINEAR_TEAM_TO_REPO
 from .utils.multimodal import dedupe_urls, extract_image_urls, fetch_image_block
 from .utils.slack import (
     add_slack_reaction,
     fetch_slack_thread_messages,
     format_slack_messages_for_prompt,
+    get_slack_message_thread_ts,
     get_slack_user_info,
     get_slack_user_names,
     post_slack_thread_reply,
@@ -689,6 +691,62 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         logger.info("LangGraph run created successfully for thread %s", thread_id)
 
 
+_POSITIVE_REACTIONS = frozenset({"thumbsup", "+1"})
+_NEGATIVE_REACTIONS = frozenset({"thumbsdown", "-1"})
+
+
+async def process_slack_reaction(event: dict[str, Any]) -> None:
+    """Process a Slack reaction event and submit LangSmith feedback."""
+    reaction = event.get("reaction", "")
+    if reaction in _POSITIVE_REACTIONS:
+        score = 1
+    elif reaction in _NEGATIVE_REACTIONS:
+        score = 0
+    else:
+        return
+
+    item = event.get("item", {})
+    channel_id = item.get("channel", "")
+    message_ts = item.get("ts", "")
+    if not channel_id or not message_ts:
+        logger.warning("Missing channel/ts in reaction event item")
+        return
+
+    parent_thread_ts = await get_slack_message_thread_ts(channel_id, message_ts)
+    thread_ts = parent_thread_ts or message_ts
+
+    thread_id = generate_thread_id_from_slack_thread(channel_id, thread_ts)
+
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    try:
+        runs = await langgraph_client.runs.list(thread_id, limit=10)
+    except Exception:
+        logger.exception("Failed to list runs for thread %s", thread_id)
+        return
+
+    run_id = None
+    for run in runs:
+        if run.get("status") in ("success", "error", "interrupted"):
+            run_id = run.get("run_id")
+            break
+
+    if not run_id:
+        logger.info("No completed run found for thread %s, skipping feedback", thread_id)
+        return
+
+    user_id = event.get("user", "")
+    comment = "👍" if score == 1 else "👎"
+    success = await submit_langsmith_feedback(
+        run_id=str(run_id),
+        score=score,
+        comment=f"Slack reaction {comment} from user {user_id}",
+    )
+    if success:
+        logger.info("Submitted LangSmith feedback for run %s: score=%s", run_id, score)
+    else:
+        logger.warning("Failed to submit LangSmith feedback for run %s", run_id)
+
+
 async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[str, str]) -> None:
     """Process a Slack app mention by creating or interrupting a thread run."""
     channel_id = event_data.get("channel_id", "")
@@ -978,6 +1036,11 @@ async def slack_webhook(request: Request, background_tasks: BackgroundTasks) -> 
         return {"status": "ignored", "reason": "Not an event callback"}
 
     event = payload.get("event", {})
+
+    if event.get("type") == "reaction_added":
+        background_tasks.add_task(process_slack_reaction, event)
+        return {"status": "accepted", "message": "Slack reaction queued"}
+
     if event.get("type") != "app_mention":
         message_text = event.get("text", "")
         has_username_mention = bool(


### PR DESCRIPTION
## Description
Adds a new Slack webhook handler for `reaction_added` events that submits 👍/👎 feedback to LangSmith. When a user reacts with `:+1:` or `:-1:` to a message in a thread where the agent ran, the reaction is mapped to the most recent LangGraph run and submitted as LangSmith feedback (score 1 or 0). Also updates the agent's system prompt to instruct it to ask users to react with :+1:/:thumbsdown: in its final Slack message for Slack-triggered tasks.

## Test Plan
- [ ] Add `reaction_added` to Slack app Event Subscriptions and add `reactions:read` scope
- [ ] Trigger agent from Slack, react with 👍/👎 on a message in the thread, verify feedback appears in LangSmith
- [ ] Verify agent's final Slack message includes the feedback reaction prompt