### PR TITLE
fix: codebase bugs — trailing space, missing spaces, wrong type annotation [closes OPE-22]

### DIFF
--- a/agent/middleware/ensure_no_empty_msg.py
+++ b/agent/middleware/ensure_no_empty_msg.py
@@ -66,7 +66,7 @@ def ensure_no_empty_msg(state: AgentState, runtime: Runtime) -> dict[str, Any] |
         tc_id = str(uuid4())
         last_msg.tool_calls = [{"name": "no_op", "args": {}, "id": tc_id}]
         no_op_tool_msg = ToolMessage(
-            content="No operation performed."
+            content="No operation performed. "
             + "Please continue with the task, ensuring you ALWAYS call at least one tool in"
             + " every message unless you are absolutely sure the task has been fully completed.",
             tool_call_id=tc_id,
@@ -90,7 +90,7 @@ def ensure_no_empty_msg(state: AgentState, runtime: Runtime) -> dict[str, Any] |
         tc_id = str(uuid4())
         last_msg.tool_calls = [{"name": "confirming_completion", "args": {}, "id": tc_id}]
         no_op_tool_msg = ToolMessage(
-            content="Confirming task completion. I see you did not call a tool, which would end the task, however you haven't called a tool to message the user or open a pull request."
+            content="Confirming task completion. I see you did not call a tool, which would end the task, however you haven't called a tool to message the user or open a pull request. "
             + "This may indicate premature termination - please ensure you fully complete the task before ending it. "
             + "If you do not call any tools it will end the task.",
             name="confirming_completion",

--- a/agent/server.py
+++ b/agent/server.py
@@ -2,7 +2,6 @@
 # ruff: noqa: E402
 
 # Suppress deprecation warnings from langchain_core (e.g., Pydantic V1 on Python 3.14+)
-# ruff: noqa: E402
 import logging
 import warnings
 

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -111,7 +111,7 @@ async def get_ls_user_id_from_email(email: str) -> dict[str, str | None]:
             response.raise_for_status()
             members = response.json()
 
-            if members and len(members) > 0:
+            if members:
                 member = members[0]
                 return {
                     "ls_user_id": member.get("ls_user_id"),

--- a/agent/utils/github_user_email_map.py
+++ b/agent/utils/github_user_email_map.py
@@ -72,7 +72,7 @@ GITHUB_USER_EMAIL_MAP: dict[str, str] = {
     "j-broekhuizen": "jb@langchain.dev",
     "jacobalbert3": "jacob.albert@langchain.dev",
     "jacoblee93": "jacob@langchain.dev",
-    "jdrogers940 ": "josh@langchain.dev",
+    "jdrogers940": "josh@langchain.dev",
     "jeeyoonhyun": "jeeyoon@langchain.dev",
     "jessieibarra": "jessie.ibarra@langchain.dev",
     "jfglanc": "jan.glanc@langchain.dev",

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 from langchain.chat_models import init_chat_model
 
 OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 
 
-def make_model(model_id: str, **kwargs: dict):
+def make_model(model_id: str, **kwargs: Any):
     model_kwargs = kwargs.copy()
 
     if model_id.startswith("openai:"):


### PR DESCRIPTION
## Description
Audited the codebase and fixed several bugs: a trailing space in a dict key in `github_user_email_map.py` that silently broke user lookup for `jdrogers940`, missing spaces in string concatenations in `ensure_no_empty_msg.py` that produced garbled prompt text, an incorrect `**kwargs: dict` type annotation in `model.py`, a duplicate `# ruff: noqa` comment in `server.py`, and a redundant length check in `auth.py`.

Resolves OPE-22

## Test Plan
- [ ] Verify `jdrogers940` GitHub user lookup now matches correctly
- [ ] Verify no_op and confirming_completion prompt messages have proper spacing