### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync --locked --extra dev
       - name: Run lint
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync --locked --extra dev
       - name: Run format check
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync --locked --extra dev
       - name: Run unit tests

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `amannn/action-semantic-pull-request` | [`v5`](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5) | [`v6`](https://github.com/amannn/action-semantic-pull-request/releases/tag/v6) | [Diff](https://github.com/amannn/action-semantic-pull-request/compare/v5...v6) | pr_lint.yml |
| `astral-sh/setup-uv` | [`v4`](https://github.com/astral-sh/setup-uv/releases/tag/v4) | [`v7`](https://github.com/astral-sh/setup-uv/releases/tag/v7) | [Diff](https://github.com/astral-sh/setup-uv/compare/v4...v7) | ci.yml |

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
