### PR TITLE
test: add comprehensive tests for commit_and_open_pr tool and git utilities

### DIFF
--- a/tests/test_commit_and_open_pr.py
+++ b/tests/test_commit_and_open_pr.py
@@ -1,0 +1,318 @@
+"""Tests for the commit_and_open_pr tool."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from deepagents.backends.protocol import ExecuteResponse
+
+from agent.tools.commit_and_open_pr import commit_and_open_pr
+
+
+class _FakeSandboxBackend:
+    """Minimal sandbox backend that records executed commands."""
+
+    def __init__(
+        self,
+        *,
+        has_uncommitted: bool = True,
+        has_unpushed: bool = False,
+        current_branch: str = "main",
+        commit_ok: bool = True,
+        push_ok: bool = True,
+    ) -> None:
+        self._has_uncommitted = has_uncommitted
+        self._has_unpushed = has_unpushed
+        self._current_branch = current_branch
+        self._commit_ok = commit_ok
+        self._push_ok = push_ok
+        self.commands: list[str] = []
+        self.written_files: dict[str, str] = {}
+
+    def execute(self, command: str) -> ExecuteResponse:
+        self.commands.append(command)
+
+        if "git status --porcelain" in command:
+            output = "M file.py\n" if self._has_uncommitted else ""
+            return ExecuteResponse(output=output, exit_code=0, truncated=False)
+
+        if "git fetch origin" in command:
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+        if "git log --oneline" in command:
+            output = "abc1234 some commit\n" if self._has_unpushed else ""
+            return ExecuteResponse(output=output, exit_code=0, truncated=False)
+
+        if "git rev-parse --abbrev-ref HEAD" in command:
+            return ExecuteResponse(output=self._current_branch + "\n", exit_code=0, truncated=False)
+
+        if "git checkout" in command:
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+        if "git config user.name" in command or "git config user.email" in command:
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+        if "git add -A" in command:
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+        if "git commit -m" in command:
+            code = 0 if self._commit_ok else 1
+            output = "" if self._commit_ok else "nothing to commit"
+            return ExecuteResponse(output=output, exit_code=code, truncated=False)
+
+        if "git push" in command or "credential.helper" in command:
+            code = 0 if self._push_ok else 1
+            output = "" if self._push_ok else "rejected"
+            return ExecuteResponse(output=output, exit_code=code, truncated=False)
+
+        if "rm -f" in command or "chmod" in command:
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+        if "test -d" in command:
+            return ExecuteResponse(output="/workspace", exit_code=0, truncated=False)
+
+        if command.strip() == "pwd":
+            return ExecuteResponse(output="/workspace\n", exit_code=0, truncated=False)
+
+        return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+    def write(self, path: str, content: str) -> None:
+        self.written_files[path] = content
+
+
+def _make_config(
+    thread_id: str = "test-thread-id",
+    repo_owner: str = "test-owner",
+    repo_name: str = "test-repo",
+) -> dict[str, Any]:
+    return {
+        "configurable": {
+            "thread_id": thread_id,
+            "repo": {"owner": repo_owner, "name": repo_name},
+        },
+        "metadata": {},
+    }
+
+
+def _run_commit_tool(
+    sandbox: _FakeSandboxBackend,
+    config: dict[str, Any] | None = None,
+    title: str = "feat: test PR",
+    body: str = "## Description\nTest PR body",
+    commit_message: str | None = None,
+    github_token: str = "fake-token",
+    default_branch: str = "main",
+    pr_url: str = "https://github.com/test-owner/test-repo/pull/42",
+    pr_number: int = 42,
+) -> dict[str, Any]:
+    """Run commit_and_open_pr with mocked dependencies."""
+    if config is None:
+        config = _make_config()
+
+    with (
+        patch("agent.tools.commit_and_open_pr.get_config", return_value=config),
+        patch("agent.tools.commit_and_open_pr.get_sandbox_backend_sync", return_value=sandbox),
+        patch("agent.tools.commit_and_open_pr.get_github_token", return_value=github_token),
+        patch(
+            "agent.tools.commit_and_open_pr.get_github_default_branch",
+            new_callable=AsyncMock,
+            return_value=default_branch,
+        ),
+        patch(
+            "agent.tools.commit_and_open_pr.create_github_pr",
+            new_callable=AsyncMock,
+            return_value=(pr_url, pr_number, False),
+        ),
+    ):
+        return commit_and_open_pr(title, body, commit_message)
+
+
+class TestCommitAndOpenPrHappyPath:
+    def test_basic_success(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True)
+        result = _run_commit_tool(sandbox)
+
+        assert result["success"] is True
+        assert result["pr_url"] == "https://github.com/test-owner/test-repo/pull/42"
+        assert result["error"] is None
+
+    def test_uses_title_as_default_commit_message(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True)
+        _run_commit_tool(sandbox, title="feat: add feature X")
+
+        commit_cmds = [c for c in sandbox.commands if "git commit -m" in c]
+        assert len(commit_cmds) == 1
+        assert "add feature X" in commit_cmds[0]
+
+    def test_uses_custom_commit_message(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True)
+        _run_commit_tool(sandbox, commit_message="custom msg here")
+
+        commit_cmds = [c for c in sandbox.commands if "git commit -m" in c]
+        assert len(commit_cmds) == 1
+        assert "custom msg here" in commit_cmds[0]
+
+    def test_checks_out_target_branch(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True, current_branch="main")
+        _run_commit_tool(sandbox)
+
+        checkout_cmds = [c for c in sandbox.commands if "git checkout" in c]
+        assert len(checkout_cmds) >= 1
+        assert "open-swe/test-thread-id" in checkout_cmds[0]
+
+    def test_skips_checkout_if_already_on_target_branch(self) -> None:
+        sandbox = _FakeSandboxBackend(
+            has_uncommitted=True, current_branch="open-swe/test-thread-id"
+        )
+        _run_commit_tool(sandbox)
+
+        checkout_cmds = [c for c in sandbox.commands if "git checkout" in c]
+        assert len(checkout_cmds) == 0
+
+    def test_existing_pr_returns_pr_existing_true(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True)
+        config = _make_config()
+
+        with (
+            patch("agent.tools.commit_and_open_pr.get_config", return_value=config),
+            patch(
+                "agent.tools.commit_and_open_pr.get_sandbox_backend_sync",
+                return_value=sandbox,
+            ),
+            patch(
+                "agent.tools.commit_and_open_pr.get_github_token",
+                return_value="fake-token",
+            ),
+            patch(
+                "agent.tools.commit_and_open_pr.get_github_default_branch",
+                new_callable=AsyncMock,
+                return_value="main",
+            ),
+            patch(
+                "agent.tools.commit_and_open_pr.create_github_pr",
+                new_callable=AsyncMock,
+                return_value=(
+                    "https://github.com/test/pr/99",
+                    99,
+                    True,
+                ),
+            ),
+        ):
+            result = commit_and_open_pr("feat: test", "body")
+
+        assert result["success"] is True
+        assert result["pr_existing"] is True
+
+    def test_unpushed_commits_only(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=False, has_unpushed=True)
+        result = _run_commit_tool(sandbox)
+
+        assert result["success"] is True
+        commit_cmds = [c for c in sandbox.commands if "git commit -m" in c]
+        assert len(commit_cmds) == 0
+
+
+class TestCommitAndOpenPrErrorCases:
+    def test_no_thread_id(self) -> None:
+        sandbox = _FakeSandboxBackend()
+        config = _make_config()
+        config["configurable"]["thread_id"] = None
+
+        result = _run_commit_tool(sandbox, config=config)
+        assert result["success"] is False
+        assert "thread_id" in result["error"].lower()
+
+    def test_no_repo_config(self) -> None:
+        sandbox = _FakeSandboxBackend()
+        config = _make_config()
+        config["configurable"]["repo"] = {}
+
+        result = _run_commit_tool(sandbox, config=config)
+        assert result["success"] is False
+        assert "repo" in result["error"].lower()
+
+    def test_no_sandbox(self) -> None:
+        config = _make_config()
+
+        with (
+            patch("agent.tools.commit_and_open_pr.get_config", return_value=config),
+            patch("agent.tools.commit_and_open_pr.get_sandbox_backend_sync", return_value=None),
+        ):
+            result = commit_and_open_pr("feat: test", "body")
+
+        assert result["success"] is False
+        assert "sandbox" in result["error"].lower()
+
+    def test_no_changes(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=False, has_unpushed=False)
+        result = _run_commit_tool(sandbox)
+
+        assert result["success"] is False
+        assert "no changes" in result["error"].lower()
+
+    def test_commit_failure(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True, commit_ok=False)
+        result = _run_commit_tool(sandbox)
+
+        assert result["success"] is False
+        assert "commit failed" in result["error"].lower()
+
+    def test_push_failure(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True, push_ok=False)
+        result = _run_commit_tool(sandbox)
+
+        assert result["success"] is False
+        assert "push failed" in result["error"].lower()
+
+    def test_missing_github_token(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True)
+        result = _run_commit_tool(sandbox, github_token=None)
+
+        assert result["success"] is False
+        assert "token" in result["error"].lower()
+
+    def test_pr_creation_failure(self) -> None:
+        sandbox = _FakeSandboxBackend(has_uncommitted=True)
+        config = _make_config()
+
+        with (
+            patch("agent.tools.commit_and_open_pr.get_config", return_value=config),
+            patch(
+                "agent.tools.commit_and_open_pr.get_sandbox_backend_sync",
+                return_value=sandbox,
+            ),
+            patch(
+                "agent.tools.commit_and_open_pr.get_github_token",
+                return_value="fake-token",
+            ),
+            patch(
+                "agent.tools.commit_and_open_pr.get_github_default_branch",
+                new_callable=AsyncMock,
+                return_value="main",
+            ),
+            patch(
+                "agent.tools.commit_and_open_pr.create_github_pr",
+                new_callable=AsyncMock,
+                return_value=(None, None, False),
+            ),
+        ):
+            result = commit_and_open_pr("feat: test", "body")
+
+        assert result["success"] is False
+        assert "pr" in result["error"].lower()
+
+    def test_exception_returns_error_dict(self) -> None:
+        config = _make_config()
+
+        with (
+            patch("agent.tools.commit_and_open_pr.get_config", return_value=config),
+            patch(
+                "agent.tools.commit_and_open_pr.get_sandbox_backend_sync",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            result = commit_and_open_pr("feat: test", "body")
+
+        assert result["success"] is False
+        assert "RuntimeError" in result["error"]

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,311 @@
+"""Tests for git utilities in agent.utils.github."""
+
+from __future__ import annotations
+
+from deepagents.backends.protocol import ExecuteResponse
+
+from agent.utils.github import (
+    _CRED_FILE_PATH,
+    cleanup_git_credentials,
+    git_add_all,
+    git_checkout_branch,
+    git_commit,
+    git_config_user,
+    git_current_branch,
+    git_get_remote_url,
+    git_has_uncommitted_changes,
+    git_has_unpushed_commits,
+    git_push,
+    is_valid_git_repo,
+    remove_directory,
+    setup_git_credentials,
+)
+
+
+class _FakeSandbox:
+    """Minimal sandbox backend for testing git utilities."""
+
+    def __init__(self, responses: dict[str, ExecuteResponse] | None = None) -> None:
+        self._responses = responses or {}
+        self.commands: list[str] = []
+        self.written_files: dict[str, str] = {}
+
+    def execute(self, command: str) -> ExecuteResponse:
+        self.commands.append(command)
+        for pattern, response in self._responses.items():
+            if pattern in command:
+                return response
+        return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+    def write(self, path: str, content: str) -> None:
+        self.written_files[path] = content
+
+
+# ---------------------------------------------------------------------------
+# is_valid_git_repo
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidGitRepo:
+    def test_valid_repo(self) -> None:
+        sandbox = _FakeSandbox(
+            {"test -d": ExecuteResponse(output="exists\n", exit_code=0, truncated=False)}
+        )
+        assert is_valid_git_repo(sandbox, "/workspace/repo") is True
+
+    def test_not_a_repo(self) -> None:
+        sandbox = _FakeSandbox(
+            {"test -d": ExecuteResponse(output="", exit_code=1, truncated=False)}
+        )
+        assert is_valid_git_repo(sandbox, "/workspace/repo") is False
+
+    def test_dir_exists_but_no_git(self) -> None:
+        sandbox = _FakeSandbox(
+            {"test -d": ExecuteResponse(output="\n", exit_code=0, truncated=False)}
+        )
+        assert is_valid_git_repo(sandbox, "/workspace/repo") is False
+
+
+# ---------------------------------------------------------------------------
+# remove_directory
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveDirectory:
+    def test_success(self) -> None:
+        sandbox = _FakeSandbox()
+        assert remove_directory(sandbox, "/workspace/old-repo") is True
+        assert any("rm -rf" in cmd for cmd in sandbox.commands)
+
+    def test_failure(self) -> None:
+        sandbox = _FakeSandbox(
+            {"rm -rf": ExecuteResponse(output="permission denied", exit_code=1, truncated=False)}
+        )
+        assert remove_directory(sandbox, "/workspace/protected") is False
+
+
+# ---------------------------------------------------------------------------
+# git_has_uncommitted_changes
+# ---------------------------------------------------------------------------
+
+
+class TestGitHasUncommittedChanges:
+    def test_clean_repo(self) -> None:
+        sandbox = _FakeSandbox(
+            {"git status --porcelain": ExecuteResponse(output="", exit_code=0, truncated=False)}
+        )
+        assert git_has_uncommitted_changes(sandbox, "/repo") is False
+
+    def test_dirty_repo(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git status --porcelain": ExecuteResponse(
+                    output="M agent/server.py\n?? new_file.py\n",
+                    exit_code=0,
+                    truncated=False,
+                )
+            }
+        )
+        assert git_has_uncommitted_changes(sandbox, "/repo") is True
+
+    def test_command_failure(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git status --porcelain": ExecuteResponse(
+                    output="fatal: not a git repository",
+                    exit_code=128,
+                    truncated=False,
+                )
+            }
+        )
+        assert git_has_uncommitted_changes(sandbox, "/repo") is False
+
+
+# ---------------------------------------------------------------------------
+# git_has_unpushed_commits
+# ---------------------------------------------------------------------------
+
+
+class TestGitHasUnpushedCommits:
+    def test_no_unpushed(self) -> None:
+        sandbox = _FakeSandbox(
+            {"git log": ExecuteResponse(output="", exit_code=0, truncated=False)}
+        )
+        assert git_has_unpushed_commits(sandbox, "/repo") is False
+
+    def test_has_unpushed(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git log": ExecuteResponse(
+                    output="abc1234 fix something\ndef5678 add feature\n",
+                    exit_code=0,
+                    truncated=False,
+                )
+            }
+        )
+        assert git_has_unpushed_commits(sandbox, "/repo") is True
+
+
+# ---------------------------------------------------------------------------
+# git_current_branch
+# ---------------------------------------------------------------------------
+
+
+class TestGitCurrentBranch:
+    def test_returns_branch_name(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git rev-parse --abbrev-ref HEAD": ExecuteResponse(
+                    output="feature/my-branch\n", exit_code=0, truncated=False
+                )
+            }
+        )
+        assert git_current_branch(sandbox, "/repo") == "feature/my-branch"
+
+    def test_returns_empty_on_failure(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git rev-parse --abbrev-ref HEAD": ExecuteResponse(
+                    output="", exit_code=1, truncated=False
+                )
+            }
+        )
+        assert git_current_branch(sandbox, "/repo") == ""
+
+
+# ---------------------------------------------------------------------------
+# git_checkout_branch
+# ---------------------------------------------------------------------------
+
+
+class TestGitCheckoutBranch:
+    def test_checkout_B_succeeds(self) -> None:
+        sandbox = _FakeSandbox(
+            {"git checkout -B": ExecuteResponse(output="", exit_code=0, truncated=False)}
+        )
+        assert git_checkout_branch(sandbox, "/repo", "open-swe/thread-1") is True
+
+    def test_falls_back_to_checkout_b(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git checkout -B": ExecuteResponse(output="", exit_code=1, truncated=False),
+                "git checkout -b": ExecuteResponse(output="", exit_code=0, truncated=False),
+            }
+        )
+        assert git_checkout_branch(sandbox, "/repo", "open-swe/thread-1") is True
+
+    def test_all_fallbacks_fail(self) -> None:
+        sandbox = _FakeSandbox(
+            {"git checkout": ExecuteResponse(output="error", exit_code=1, truncated=False)}
+        )
+        assert git_checkout_branch(sandbox, "/repo", "nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# git_config_user
+# ---------------------------------------------------------------------------
+
+
+class TestGitConfigUser:
+    def test_sets_name_and_email(self) -> None:
+        sandbox = _FakeSandbox()
+        git_config_user(sandbox, "/repo", "bot", "bot@example.com")
+        assert any("user.name" in cmd and "bot" in cmd for cmd in sandbox.commands)
+        assert any("user.email" in cmd and "bot@example.com" in cmd for cmd in sandbox.commands)
+
+
+# ---------------------------------------------------------------------------
+# git_add_all / git_commit
+# ---------------------------------------------------------------------------
+
+
+class TestGitAddAndCommit:
+    def test_add_all(self) -> None:
+        sandbox = _FakeSandbox()
+        result = git_add_all(sandbox, "/repo")
+        assert result.exit_code == 0
+        assert any("git add -A" in cmd for cmd in sandbox.commands)
+
+    def test_commit(self) -> None:
+        sandbox = _FakeSandbox()
+        result = git_commit(sandbox, "/repo", "fix: something")
+        assert result.exit_code == 0
+        assert any("git commit -m" in cmd for cmd in sandbox.commands)
+
+    def test_commit_message_is_shell_escaped(self) -> None:
+        sandbox = _FakeSandbox()
+        git_commit(sandbox, "/repo", "fix: handle 'quotes' and $pecial chars")
+        commit_cmd = [c for c in sandbox.commands if "git commit" in c][0]
+        assert "$pecial" not in commit_cmd or "'" in commit_cmd
+
+
+# ---------------------------------------------------------------------------
+# git_get_remote_url
+# ---------------------------------------------------------------------------
+
+
+class TestGitGetRemoteUrl:
+    def test_returns_url(self) -> None:
+        sandbox = _FakeSandbox(
+            {
+                "git remote get-url origin": ExecuteResponse(
+                    output="https://github.com/org/repo.git\n", exit_code=0, truncated=False
+                )
+            }
+        )
+        assert git_get_remote_url(sandbox, "/repo") == "https://github.com/org/repo.git"
+
+    def test_returns_none_on_failure(self) -> None:
+        sandbox = _FakeSandbox(
+            {"git remote get-url origin": ExecuteResponse(output="", exit_code=1, truncated=False)}
+        )
+        assert git_get_remote_url(sandbox, "/repo") is None
+
+
+# ---------------------------------------------------------------------------
+# setup_git_credentials / cleanup_git_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestGitCredentials:
+    def test_setup_writes_cred_file(self) -> None:
+        sandbox = _FakeSandbox()
+        setup_git_credentials(sandbox, "ghp_test123")
+        assert _CRED_FILE_PATH in sandbox.written_files
+        assert "ghp_test123" in sandbox.written_files[_CRED_FILE_PATH]
+        assert any("chmod 600" in cmd for cmd in sandbox.commands)
+
+    def test_cleanup_removes_cred_file(self) -> None:
+        sandbox = _FakeSandbox()
+        cleanup_git_credentials(sandbox)
+        assert any("rm -f" in cmd and _CRED_FILE_PATH in cmd for cmd in sandbox.commands)
+
+
+# ---------------------------------------------------------------------------
+# git_push
+# ---------------------------------------------------------------------------
+
+
+class TestGitPush:
+    def test_push_without_token(self) -> None:
+        sandbox = _FakeSandbox()
+        result = git_push(sandbox, "/repo", "my-branch")
+        assert result.exit_code == 0
+        assert any("git push origin" in cmd for cmd in sandbox.commands)
+        assert _CRED_FILE_PATH not in sandbox.written_files
+
+    def test_push_with_token_sets_up_and_cleans_credentials(self) -> None:
+        sandbox = _FakeSandbox()
+        result = git_push(sandbox, "/repo", "my-branch", "ghp_token")
+        assert result.exit_code == 0
+        assert _CRED_FILE_PATH in sandbox.written_files
+        assert any("rm -f" in cmd for cmd in sandbox.commands)
+
+    def test_push_with_token_cleans_up_even_on_failure(self) -> None:
+        sandbox = _FakeSandbox(
+            {"credential.helper": ExecuteResponse(output="rejected", exit_code=1, truncated=False)}
+        )
+        result = git_push(sandbox, "/repo", "my-branch", "ghp_token")
+        assert result.exit_code == 1
+        cleanup_cmds = [c for c in sandbox.commands if "rm -f" in c]
+        assert len(cleanup_cmds) >= 1


### PR DESCRIPTION
## Summary

Adds **42 new tests** covering the `commit_and_open_pr` tool and the git utility functions in `agent/utils/github`, two core components that previously had zero test coverage.

## Changes

### `tests/test_commit_and_open_pr.py` (16 tests)
Tests for the `commit_and_open_pr` tool using a `_FakeSandboxBackend` with mocked dependencies.

**Happy path (7 tests):**
- Basic success with PR URL and success flag
- Uses PR title as default commit message
- Uses custom commit message when provided
- Checks out target branch based on thread_id
- Skips checkout when already on target branch
- Detects and reports existing PRs (`pr_existing=True`)
- Handles unpushed-only commits (skips `git commit`, pushes directly)

**Error cases (9 tests):**
- Missing `thread_id` in config
- Missing repo config
- No sandbox available
- No uncommitted or unpushed changes
- Commit failure
- Push failure
- Missing GitHub token
- PR creation failure (returns None)
- Unhandled exception returns error dict

### `tests/test_git_utils.py` (26 tests)
Tests for all git utility functions using a `_FakeSandbox` with configurable command responses.

- **`is_valid_git_repo`** (3 tests): valid repo, not a repo, directory without `.git`
- **`remove_directory`** (2 tests): success and permission failure
- **`git_has_uncommitted_changes`** (3 tests): clean, dirty, command failure
- **`git_has_unpushed_commits`** (2 tests): with/without unpushed commits
- **`git_current_branch`** (2 tests): returns branch name, empty on failure
- **`git_checkout_branch`** (3 tests): `-B` success, `-b` fallback, all fallbacks fail
- **`git_config_user`** (1 test): sets name and email
- **`git_add_all` / `git_commit`** (3 tests): basic operation, shell escaping
- **`git_get_remote_url`** (2 tests): returns URL or None
- **`setup/cleanup_git_credentials`** (2 tests): writes credential file with correct permissions, cleanup removes file
- **`git_push`** (3 tests): without token, with token (sets up and cleans credentials), cleanup on push failure

## Test Results

```
113 passed, 6 warnings in 6.98s
```

All 113 tests pass (71 existing + 42 new), zero regressions. Linted and formatted with `ruff`.