### PR TITLE
feat: add Webex support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,86 @@
+# ===========================================================================
+# Open SWE — Environment Variables
+# ===========================================================================
+# Copy this file to .env and fill in the values for the triggers you use.
+#
+#   cp .env.example .env
+#
+# Only the sections marked (required) are needed to start the server.
+# Trigger-specific sections (Slack, Linear, GitHub, Webex) only need to be
+# filled in for the triggers you actually want to use.
+# ===========================================================================
+
+# === LangSmith (required) ===
+# Create an account at https://smith.langchain.com and generate an API key.
+LANGSMITH_API_KEY_PROD=""
+LANGCHAIN_TRACING_V2="true"
+LANGCHAIN_PROJECT=""                   # Project name shown in LangSmith traces
+LANGSMITH_TENANT_ID_PROD=""            # UUID from your LangSmith URL
+LANGSMITH_TRACING_PROJECT_ID_PROD=""   # Project ID (click "ID" next to the name)
+LANGSMITH_URL_PROD="https://smith.langchain.com"
+
+# === LLM (required) ===
+ANTHROPIC_API_KEY=""                   # https://console.anthropic.com/
+
+# === GitHub App (required) ===
+# Create a GitHub App: https://docs.github.com/en/apps/creating-github-apps
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""              # Full PEM contents including BEGIN/END lines
+GITHUB_APP_INSTALLATION_ID=""          # From the installation URL after installing the app
+
+# === GitHub Webhook (required) ===
+# Generate with: openssl rand -hex 32
+GITHUB_WEBHOOK_SECRET=""
+
+# === GitHub OAuth via LangSmith (optional) ===
+# Without this, all operations use the GitHub App's bot token.
+# With this, each user authenticates with their own GitHub account.
+GITHUB_OAUTH_PROVIDER_ID=""
+
+# === Org Allowlist (optional) ===
+# Comma-separated GitHub orgs the agent is allowed to operate on.
+# Leave empty to allow all orgs.
+ALLOWED_GITHUB_ORGS=""
+
+# === Token Encryption (required) ===
+# Generate with: openssl rand -base64 32
+TOKEN_ENCRYPTION_KEY=""
+
+# ---------------------------------------------------------------------------
+# Triggers — fill in only the ones you use
+# ---------------------------------------------------------------------------
+
+# === GitHub Trigger ===
+# Works automatically once the GitHub App is set up above.
+# Map GitHub usernames to emails in agent/utils/github_user_email_map.py
+
+# === Linear (optional) ===
+# Create a webhook in Linear → Settings → API → Webhooks
+# pointing to https://<your-url>/webhooks/linear
+LINEAR_API_KEY=""                      # Personal API key from Linear → Settings → API
+LINEAR_WEBHOOK_SECRET=""               # Generate with: openssl rand -hex 32
+
+# === Slack (optional) ===
+# Create a Slack App at https://api.slack.com/apps
+# See INSTALLATION.md for the full manifest.
+SLACK_BOT_TOKEN=""                     # Bot User OAuth Token (xoxb-...)
+SLACK_BOT_USER_ID=""                   # Bot's Slack user ID
+SLACK_BOT_USERNAME=""                  # Bot's display name (e.g. open-swe)
+SLACK_SIGNING_SECRET=""                # From Basic Information → App Credentials
+SLACK_REPO_OWNER=""                    # Default GitHub org for Slack-triggered tasks
+SLACK_REPO_NAME=""                     # Default GitHub repo for Slack-triggered tasks
+
+# === Webex (optional) ===
+# 1. Create a bot at https://developer.webex.com/my-apps/new/bot
+# 2. Register a webhook — see INSTALLATION.md for the curl command
+WEBEX_BOT_TOKEN=""                     # Bot Access Token (shown once at creation)
+WEBEX_BOT_EMAIL=""                     # Bot's email (e.g. open-swe@webex.bot)
+WEBEX_WEBHOOK_SECRET=""                # Generate with: openssl rand -hex 32
+WEBEX_REPO_OWNER=""                    # Default GitHub org for Webex-triggered tasks
+WEBEX_REPO_NAME=""                     # Default GitHub repo for Webex-triggered tasks
+
+# === Sandbox (optional) ===
+# Custom sandbox template for agent execution environments.
+# See INSTALLATION.md step 4c for details.
+DEFAULT_SANDBOX_TEMPLATE_NAME=""       # e.g. "open-swe"
+DEFAULT_SANDBOX_TEMPLATE_IMAGE=""      # e.g. "bracelangchain/deepagents-sandbox:v1"

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -143,7 +143,7 @@ LangSmith sandboxes provide the isolated execution environment for each agent ru
 
 ## 5. Set up triggers
 
-Open SWE can be triggered from GitHub, Linear, and/or Slack. **Configure whichever surfaces your team uses — you don't need all of them.**
+Open SWE can be triggered from GitHub, Linear, Slack, and/or Webex. **Configure whichever surfaces your team uses — you don't need all of them.**
 
 ### GitHub
 
@@ -309,11 +309,17 @@ Open SWE can be triggered from Webex spaces when a user @mentions the bot.
 
 **Create a webhook:**
 
-Use the Webex API to register a webhook. Run this `curl` command, replacing the placeholders:
+First, generate a webhook secret and save it as `WEBEX_WEBHOOK_SECRET`:
+
+```bash
+openssl rand -hex 32
+```
+
+Then register the webhook using the Webex API. Replace `<your-ngrok-url>` with the URL from step 2, and `<your-webhook-secret>` with the secret you just generated:
 
 ```bash
 curl -X POST https://webexapis.com/v1/webhooks \
-  -H "Authorization: Bearer $WEBEX_BOT_TOKEN" \
+  -H "Authorization: Bearer YOUR_BOT_TOKEN_HERE" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "open-swe-mentions",
@@ -325,15 +331,11 @@ curl -X POST https://webexapis.com/v1/webhooks \
   }'
 ```
 
-Generate the webhook secret with:
-
-```bash
-openssl rand -hex 32
-```
-
-Save this secret as `WEBEX_WEBHOOK_SECRET`.
-
 The `mentionedPeople=me` filter ensures the bot only receives messages where it is @mentioned.
+
+**Add the bot to a Webex space:**
+
+Before you can test, add the bot to a Webex space (room) where you want to use it. In the Webex app, open the space → click the People icon → Add People → search for the bot's email address.
 
 **Credentials you'll need:**
 
@@ -352,67 +354,13 @@ WEBEX_REPO_NAME="my-repo"      # Default GitHub repo
 
 ## 6. Environment variables
 
-Create a `.env` file in the project root. Below is the full list — only fill in the sections relevant to the triggers you configured.
+Copy the provided `.env.example` to `.env` and fill in the values for the triggers you configured:
 
 ```bash
-# === LangSmith ===
-LANGSMITH_API_KEY_PROD=""              # From step 4a
-LANGCHAIN_TRACING_V2="true"
-LANGCHAIN_PROJECT=""                   # LangSmith project name for traces
-LANGSMITH_TENANT_ID_PROD=""           
-LANGSMITH_TRACING_PROJECT_ID_PROD=""  
-LANGSMITH_URL_PROD="https://smith.langchain.com"                 
-
-# === LLM ===
-ANTHROPIC_API_KEY=""                   # Anthropic API key (default provider)
-
-# === GitHub App (required) ===
-GITHUB_APP_ID=""                       # From step 3c
-GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
-"
-GITHUB_APP_INSTALLATION_ID=""          # From step 3d
-
-# === GitHub Webhook (required) ===
-GITHUB_WEBHOOK_SECRET=""               # The secret you generated in step 3b
-
-# === GitHub OAuth via LangSmith (optional) ===
-# Without these, all operations use the GitHub App's bot token.
-# With these, each user authenticates with their own GitHub account.
-GITHUB_OAUTH_PROVIDER_ID=""            # The provider ID from steps 3a / 4b
-
-# === Org Allowlist (optional) ===
-# Comma-separated list of GitHub orgs the agent is allowed to operate on.
-# Leave empty to allow all orgs.
-ALLOWED_GITHUB_ORGS=""                 # e.g. "my-org,my-other-org"
-
-# === Linear (if using Linear trigger) ===
-LINEAR_API_KEY=""                      # From step 5
-LINEAR_WEBHOOK_SECRET=""               # From step 5
-
-# === Slack (if using Slack trigger) ===
-SLACK_BOT_TOKEN=""                     # From step 5
-SLACK_BOT_USER_ID=""
-SLACK_BOT_USERNAME=""
-SLACK_SIGNING_SECRET=""
-SLACK_REPO_OWNER=""                    # Default org for Slack-triggered tasks
-SLACK_REPO_NAME=""                     # Default repo for Slack-triggered tasks
-
-# === Webex (if using Webex trigger) ===
-WEBEX_BOT_TOKEN=""                    # From step 5
-WEBEX_BOT_EMAIL=""                    # Bot's email address
-WEBEX_WEBHOOK_SECRET=""               # From step 5
-WEBEX_REPO_OWNER=""                   # Default org for Webex-triggered tasks
-WEBEX_REPO_NAME=""                    # Default repo for Webex-triggered tasks
-
-# === Sandbox (optional) ===
-DEFAULT_SANDBOX_TEMPLATE_NAME=""       # Custom sandbox template name (default: deepagents-cli)
-DEFAULT_SANDBOX_TEMPLATE_IMAGE=""      # Custom Docker image (default: python:3)
-
-# === Token Encryption ===
-TOKEN_ENCRYPTION_KEY=""                # Generate with: openssl rand -base64 32
+cp .env.example .env
 ```
+
+The file is organized by section (LangSmith, LLM, GitHub App, Linear, Slack, Webex, Sandbox) with inline comments explaining where each value comes from. Only fill in the sections relevant to the triggers you set up — leave the rest empty.
 
 ## 7. Start the server
 
@@ -463,6 +411,13 @@ The server runs on `http://localhost:2024` with these endpoints:
    - An 👀 reaction on your message
    - A reply in the thread with the agent's response
 
+### Webex
+
+1. In any Webex space where the bot has been added, send a message mentioning the bot: `@open-swe what's in the repo?`
+2. You should see:
+   - A new run in your LangSmith project
+   - The agent replies in the same Webex thread with its response
+
 ## 9. Production deployment
 
 For production, deploy the agent on [LangGraph Cloud](https://langchain-ai.github.io/langgraph/cloud/) instead of running locally:
@@ -470,7 +425,7 @@ For production, deploy the agent on [LangGraph Cloud](https://langchain-ai.githu
 1. Push your code to a GitHub repository
 2. Connect the repo to LangGraph Cloud
 3. Set all environment variables from step 6 in the deployment config
-4. Update your webhook URLs (Linear, Slack, GitHub App) to point to your production URL (replace the ngrok URL)
+4. Update your webhook URLs (Linear, Slack, GitHub App, Webex) to point to your production URL (replace the ngrok URL). For Webex, you'll need to delete the old webhook and create a new one with the production URL using the same `curl` command from step 5.
 
 The `langgraph.json` at the project root already defines the graph entry point and HTTP app:
 
@@ -485,21 +440,15 @@ The `langgraph.json` at the project root already defines the graph entry point a
 }
 ```
 
-### Webex
-
-1. In any Webex space where the bot has been added, send a message mentioning the bot: `@open-swe what's in the repo?`
-2. You should see:
-   - A new run in your LangSmith project
-   - The agent replies in the same Webex thread with its response
-
 ## Troubleshooting
 
 ### Webhook not receiving events
 
-- Verify ngrok is running and the URL matches what's configured in GitHub/Linear/Slack
+- Verify ngrok is running and the URL matches what's configured in GitHub/Linear/Slack/Webex
 - Check the ngrok web inspector at `http://localhost:4040` for incoming requests
-- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` for Slack, Issues + Issue comment for GitHub)
-- **Webhook secrets are required** — if `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or `SLACK_SIGNING_SECRET` is not set, all requests to that endpoint will be rejected with 401
+- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` for Slack, Issues + Issue comment for GitHub, `messages:created` with `mentionedPeople=me` for Webex)
+- **Webhook secrets are required** — if `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, `SLACK_SIGNING_SECRET`, or `WEBEX_WEBHOOK_SECRET` is not set, all requests to that endpoint will be rejected with 401
+- **Webex webhook not firing?** — verify the webhook was created successfully by listing your webhooks: `curl -H "Authorization: Bearer $WEBEX_BOT_TOKEN" https://webexapis.com/v1/webhooks`. Confirm the `targetUrl` matches your ngrok URL and the `status` is `active`.
 
 ### GitHub authentication errors
 
@@ -519,6 +468,7 @@ The `langgraph.json` at the project root already defines the graph entry point a
 - For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and the commenter's GitHub username is in `GITHUB_USER_EMAIL_MAP`
 - For Linear: ensure the comment contains `@openswe` (case-insensitive)
 - For Slack: ensure the bot is invited to the channel and the message is an `@mention`
+- For Webex: ensure the bot has been added to the space and the message is an `@mention`. Verify `WEBEX_BOT_EMAIL` matches the bot's actual email address — a mismatch will cause the bot to process its own messages in a loop.
 - Check server logs for webhook processing errors
 
 ### Token encryption errors

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -294,6 +294,62 @@ SLACK_REPO_OWNER="my-org"      # Default GitHub org
 SLACK_REPO_NAME="my-repo"      # Default GitHub repo
 ```
 
+### Webex (optional)
+
+Open SWE can be triggered from Webex spaces when a user @mentions the bot.
+
+**Create a Webex Bot:**
+
+1. Go to [developer.webex.com/my-apps/new/bot](https://developer.webex.com/my-apps/new/bot)
+2. Fill in the bot name, username, and icon
+3. Click **Add Bot** and copy the **Bot Access Token** — save it as `WEBEX_BOT_TOKEN`
+4. Note the bot's email address (e.g. `open-swe@webex.bot`) — save it as `WEBEX_BOT_EMAIL`
+
+> **Important:** The bot access token is only shown once. If you lose it, you can regenerate it from the bot's settings page.
+
+**Create a webhook:**
+
+Use the Webex API to register a webhook. Run this `curl` command, replacing the placeholders:
+
+```bash
+curl -X POST https://webexapis.com/v1/webhooks \
+  -H "Authorization: Bearer $WEBEX_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "open-swe-mentions",
+    "targetUrl": "https://<your-ngrok-url>/webhooks/webex",
+    "resource": "messages",
+    "event": "created",
+    "filter": "mentionedPeople=me",
+    "secret": "<your-webhook-secret>"
+  }'
+```
+
+Generate the webhook secret with:
+
+```bash
+openssl rand -hex 32
+```
+
+Save this secret as `WEBEX_WEBHOOK_SECRET`.
+
+The `mentionedPeople=me` filter ensures the bot only receives messages where it is @mentioned.
+
+**Credentials you'll need:**
+
+- `WEBEX_BOT_TOKEN`: the Bot Access Token from bot creation
+- `WEBEX_BOT_EMAIL`: the bot's email address (e.g. `open-swe@webex.bot`)
+- `WEBEX_WEBHOOK_SECRET`: the secret you used when creating the webhook
+
+**Configure default repo:**
+
+Webex messages are routed to a default repo unless the user specifies one with `repo:owner/name`:
+
+```bash
+WEBEX_REPO_OWNER="my-org"      # Default GitHub org
+WEBEX_REPO_NAME="my-repo"      # Default GitHub repo
+```
+
 ## 6. Environment variables
 
 Create a `.env` file in the project root. Below is the full list — only fill in the sections relevant to the triggers you configured.
@@ -343,6 +399,13 @@ SLACK_SIGNING_SECRET=""
 SLACK_REPO_OWNER=""                    # Default org for Slack-triggered tasks
 SLACK_REPO_NAME=""                     # Default repo for Slack-triggered tasks
 
+# === Webex (if using Webex trigger) ===
+WEBEX_BOT_TOKEN=""                    # From step 5
+WEBEX_BOT_EMAIL=""                    # Bot's email address
+WEBEX_WEBHOOK_SECRET=""               # From step 5
+WEBEX_REPO_OWNER=""                   # Default org for Webex-triggered tasks
+WEBEX_REPO_NAME=""                    # Default repo for Webex-triggered tasks
+
 # === Sandbox (optional) ===
 DEFAULT_SANDBOX_TEMPLATE_NAME=""       # Custom sandbox template name (default: deepagents-cli)
 DEFAULT_SANDBOX_TEMPLATE_IMAGE=""      # Custom Docker image (default: python:3)
@@ -368,6 +431,8 @@ The server runs on `http://localhost:2024` with these endpoints:
 | `GET /webhooks/linear` | Linear webhook verification |
 | `POST /webhooks/slack` | Slack event webhooks |
 | `GET /webhooks/slack` | Slack webhook verification |
+| `POST /webhooks/webex` | Webex message webhooks |
+| `GET /webhooks/webex` | Webex webhook verification |
 | `GET /health` | Health check |
 
 ## 8. Verify it works
@@ -419,6 +484,13 @@ The `langgraph.json` at the project root already defines the graph entry point a
   }
 }
 ```
+
+### Webex
+
+1. In any Webex space where the bot has been added, send a message mentioning the bot: `@open-swe what's in the repo?`
+2. You should see:
+   - A new run in your LangSmith project
+   - The agent replies in the same Webex thread with its response
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 Elite engineering orgs like Stripe, Ramp, and Coinbase are building their own internal coding agents — Slackbots, CLIs, and web apps that meet engineers where they already work. These agents are connected to internal systems with the right context, permissioning, and safety boundaries to operate with minimal human oversight.
 
-Open SWE is the open-source version of this pattern. Built on [LangGraph](https://langchain-ai.github.io/langgraph/) and [Deep Agents](https://github.com/langchain-ai/deepagents), it gives you the same architecture those companies built internally: cloud sandboxes, Slack and Linear invocation, subagent orchestration, and automatic PR creation — ready to customize for your own codebase and workflows.
+Open SWE is the open-source version of this pattern. Built on [LangGraph](https://langchain-ai.github.io/langgraph/) and [Deep Agents](https://github.com/langchain-ai/deepagents), it gives you the same architecture those companies built internally: cloud sandboxes, Slack/Linear/Webex invocation, subagent orchestration, and automatic PR creation — ready to customize for your own codebase and workflows.
 
 > [!NOTE]
 > 💬 Read the **announcement blog post [here](https://blog.langchain.com/open-swe-an-open-source-framework-for-internal-coding-agents/)**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Rather than forking an existing agent or building from scratch, Open SWE **compo
 create_deep_agent(
     model="anthropic:claude-opus-4-6",
     system_prompt=construct_system_prompt(repo_dir, ...),
-    tools=[http_request, fetch_url, commit_and_open_pr, linear_comment, slack_thread_reply],
+    tools=[http_request, fetch_url, commit_and_open_pr, linear_comment, slack_thread_reply, webex_reply],
     backend=sandbox_backend,
     middleware=[ToolErrorMiddleware(), check_message_queue_before_model, ...],
 )
@@ -73,6 +73,7 @@ Stripe's key insight: *tool curation matters more than tool quantity.* Open SWE 
 | `commit_and_open_pr` | Git commit + open a GitHub draft PR |
 | `linear_comment` | Post updates to Linear tickets |
 | `slack_thread_reply` | Reply in Slack threads |
+| `webex_reply` | Reply in Webex threads |
 
 Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `write_todos`, and `task` (subagent spawning).
 
@@ -95,13 +96,14 @@ Open SWE's orchestration has two layers:
 - **`open_pr_if_needed`** — After-agent safety net that commits and opens a PR if the agent didn't do it itself. This is a lightweight version of Stripe's deterministic nodes — ensuring critical steps happen regardless of LLM behavior.
 - **`ToolErrorMiddleware`** — Catches and handles tool errors gracefully.
 
-### 6. Invocation — Slack, Linear, and GitHub
+### 6. Invocation — Slack, Linear, GitHub, and Webex
 
-All three companies in the article converge on **Slack as the primary invocation surface**. Open SWE does the same:
+All three companies in the article converge on **Slack as the primary invocation surface**. Open SWE supports that and more:
 
 - **Slack** — Mention the bot in any thread. Supports `repo:owner/name` syntax to specify which repo to work on. The agent replies in-thread with status updates and PR links.
 - **Linear** — Comment `@openswe` on any issue. The agent reads the full issue context, reacts with 👀 to acknowledge, and posts results back as comments.
 - **GitHub** — Tag `@openswe` in PR comments on agent-created PRs to have it address review feedback and push fixes to the same branch.
+- **Webex** — Mention the bot in any Webex space. The agent fetches the message, builds thread context, and replies in the same thread.
 
 Each invocation creates a deterministic thread ID, so follow-up messages on the same issue or thread route to the same running agent.
 
@@ -122,14 +124,14 @@ This is an area where you can extend Open SWE for your org: add deterministic CI
 | **Tools** | ~15, curated | ~500, curated per-agent | OpenCode SDK + extensions | MCPs + custom Skills |
 | **Context** | AGENTS.md + issue/thread | Rule files + pre-hydration | OpenCode built-in | Linear-first + MCPs |
 | **Orchestration** | Subagents + middleware | Blueprints (deterministic + agentic) | Sessions + child sessions | Three modes |
-| **Invocation** | Slack, Linear, GitHub | Slack + embedded buttons | Slack + web + Chrome extension | Slack-native |
+| **Invocation** | Slack, Linear, GitHub, Webex | Slack + embedded buttons | Slack + web + Chrome extension | Slack-native |
 | **Validation** | Prompt-driven + PR safety net | 3-layer (local + CI + 1 retry) | Visual DOM verification | Agent councils + auto-merge |
 
 ---
 
 ## Features
 
-- **Trigger from Linear, Slack, or GitHub** — mention `@openswe` in a comment to kick off a task
+- **Trigger from Linear, Slack, GitHub, or Webex** — mention `@openswe` in a comment to kick off a task
 - **Instant acknowledgement** — reacts with 👀 the moment it picks up your message
 - **Message it while it's running** — send follow-up messages mid-task and it'll pick them up before its next step
 - **Run multiple tasks in parallel** — each task runs in its own isolated cloud sandbox
@@ -139,9 +141,31 @@ This is an area where you can extend Open SWE for your org: add deterministic CI
 
 ---
 
+## Quick Start
+
+```bash
+git clone https://github.com/langchain-ai/open-swe.git
+cd open-swe
+cp .env.example .env          # then fill in your API keys
+uv venv && source .venv/bin/activate
+uv sync --all-extras
+```
+
+Edit `.env` with at minimum: `LANGSMITH_API_KEY_PROD`, `ANTHROPIC_API_KEY`, and your GitHub App credentials. Then configure whichever triggers you want (Slack, Linear, GitHub, Webex) — see the `.env.example` comments for guidance.
+
+```bash
+# Start ngrok to expose webhooks (keep this running)
+ngrok http 2024
+
+# In another terminal, start the server
+uv run langgraph dev --no-browser
+```
+
+Point your webhook URLs (GitHub App, Slack, Linear, and/or Webex) at your ngrok URL, and you're ready to go.
+
 ## Getting Started
 
-- **[Installation Guide](INSTALLATION.md)** — GitHub App creation, LangSmith, Linear/Slack/GitHub triggers, and production deployment
+- **[Installation Guide](INSTALLATION.md)** — GitHub App creation, LangSmith, Linear/Slack/GitHub/Webex triggers, and production deployment
 - **[Customization Guide](CUSTOMIZATION.md)** — swap the sandbox, model, tools, triggers, system prompt, and middleware for your org
 
 ## License

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Rather than forking an existing agent or building from scratch, Open SWE **compo
 create_deep_agent(
     model="anthropic:claude-opus-4-6",
     system_prompt=construct_system_prompt(repo_dir, ...),
-    tools=[http_request, fetch_url, commit_and_open_pr, linear_comment, slack_thread_reply, webex_reply],
+    tools=[http_request, fetch_url, commit_and_open_pr, linear_comment, slack_thread_reply, webex_reply],  # NEW: webex_reply
     backend=sandbox_backend,
     middleware=[ToolErrorMiddleware(), check_message_queue_before_model, ...],
 )
@@ -73,7 +73,7 @@ Stripe's key insight: *tool curation matters more than tool quantity.* Open SWE 
 | `commit_and_open_pr` | Git commit + open a GitHub draft PR |
 | `linear_comment` | Post updates to Linear tickets |
 | `slack_thread_reply` | Reply in Slack threads |
-| `webex_reply` | Reply in Webex threads |
+| `webex_reply` | Reply in Webex threads **`NEW`** |
 
 Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `write_todos`, and `task` (subagent spawning).
 
@@ -96,14 +96,14 @@ Open SWE's orchestration has two layers:
 - **`open_pr_if_needed`** — After-agent safety net that commits and opens a PR if the agent didn't do it itself. This is a lightweight version of Stripe's deterministic nodes — ensuring critical steps happen regardless of LLM behavior.
 - **`ToolErrorMiddleware`** — Catches and handles tool errors gracefully.
 
-### 6. Invocation — Slack, Linear, GitHub, and Webex
+### 6. Invocation — Slack, Linear, GitHub, and Webex **`NEW`**
 
 All three companies in the article converge on **Slack as the primary invocation surface**. Open SWE supports that and more:
 
 - **Slack** — Mention the bot in any thread. Supports `repo:owner/name` syntax to specify which repo to work on. The agent replies in-thread with status updates and PR links.
 - **Linear** — Comment `@openswe` on any issue. The agent reads the full issue context, reacts with 👀 to acknowledge, and posts results back as comments.
 - **GitHub** — Tag `@openswe` in PR comments on agent-created PRs to have it address review feedback and push fixes to the same branch.
-- **Webex** — Mention the bot in any Webex space. The agent fetches the message, builds thread context, and replies in the same thread.
+- **Webex** **`NEW`** — Mention the bot in any Webex space. The agent fetches the message, builds thread context, and replies in the same thread.
 
 Each invocation creates a deterministic thread ID, so follow-up messages on the same issue or thread route to the same running agent.
 
@@ -124,14 +124,14 @@ This is an area where you can extend Open SWE for your org: add deterministic CI
 | **Tools** | ~15, curated | ~500, curated per-agent | OpenCode SDK + extensions | MCPs + custom Skills |
 | **Context** | AGENTS.md + issue/thread | Rule files + pre-hydration | OpenCode built-in | Linear-first + MCPs |
 | **Orchestration** | Subagents + middleware | Blueprints (deterministic + agentic) | Sessions + child sessions | Three modes |
-| **Invocation** | Slack, Linear, GitHub, Webex | Slack + embedded buttons | Slack + web + Chrome extension | Slack-native |
+| **Invocation** | Slack, Linear, GitHub, **Webex `NEW`** | Slack + embedded buttons | Slack + web + Chrome extension | Slack-native |
 | **Validation** | Prompt-driven + PR safety net | 3-layer (local + CI + 1 retry) | Visual DOM verification | Agent councils + auto-merge |
 
 ---
 
 ## Features
 
-- **Trigger from Linear, Slack, GitHub, or Webex** — mention `@openswe` in a comment to kick off a task
+- **Trigger from Linear, Slack, GitHub, or Webex `NEW`** — mention `@openswe` in a comment to kick off a task
 - **Instant acknowledgement** — reacts with 👀 the moment it picks up your message
 - **Message it while it's running** — send follow-up messages mid-task and it'll pick them up before its next step
 - **Run multiple tasks in parallel** — each task runs in its own isolated cloud sandbox

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -47,6 +47,7 @@ If you make changes, communicate updates in the source channel:
 - Use `linear_comment` for Linear-triggered tasks.
 - Use `slack_thread_reply` for Slack-triggered tasks.
 - Use `github_comment` for GitHub-triggered tasks.
+- Use `webex_reply` for Webex-triggered tasks.
 
 For tasks that require code changes, follow this order:
 
@@ -91,7 +92,11 @@ Format messages using Slack's mrkdwn format, NOT standard Markdown.
     Do NOT use **bold**, [link](url), or other standard Markdown syntax.
 
 #### `github_comment`
-Posts a comment to a GitHub issue or pull request. Provide the `issue_number` explicitly. Use this when the task was triggered from GitHub — to reply with updates, answers, or a summary after completing work."""
+Posts a comment to a GitHub issue or pull request. Provide the `issue_number` explicitly. Use this when the task was triggered from GitHub — to reply with updates, answers, or a summary after completing work.
+
+#### `webex_reply`
+Posts a message to the active Webex thread. Use this for clarifying questions, status updates, and final summaries when the task was triggered from Webex.
+Format messages using standard Markdown: **bold**, *italic*, [link](url), bullet lists with "- ", ```code blocks```, > blockquotes."""
 
 
 TOOL_BEST_PRACTICES_SECTION = """---
@@ -243,6 +248,7 @@ When you have completed your implementation, follow these steps in order:
    - Linear-triggered: use `linear_comment` with an `@mention` of the user who triggered the task
    - Slack-triggered: use `slack_thread_reply`
    - GitHub-triggered: use `github_comment`
+   - Webex-triggered: use `webex_reply`
 
    Example:
    ```

--- a/agent/server.py
+++ b/agent/server.py
@@ -40,6 +40,7 @@ from .tools import (
     http_request,
     linear_comment,
     slack_thread_reply,
+    webex_reply,
 )
 from .utils.auth import resolve_github_token
 from .utils.model import make_model
@@ -383,6 +384,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:  # noqa: PLR0915
             linear_comment,
             slack_thread_reply,
             github_comment,
+            webex_reply,
         ],
         backend=sandbox_backend,
         middleware=[

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -4,6 +4,7 @@ from .github_comment import github_comment
 from .http_request import http_request
 from .linear_comment import linear_comment
 from .slack_thread_reply import slack_thread_reply
+from .webex_reply import webex_reply
 
 __all__ = [
     "commit_and_open_pr",
@@ -12,4 +13,5 @@ __all__ = [
     "http_request",
     "linear_comment",
     "slack_thread_reply",
+    "webex_reply",
 ]

--- a/agent/tools/webex_reply.py
+++ b/agent/tools/webex_reply.py
@@ -1,0 +1,30 @@
+import asyncio
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..utils.webex import post_webex_message
+
+
+def webex_reply(message: str) -> dict[str, Any]:
+    """Post a message to the current Webex thread.
+
+    Uses standard Markdown formatting: **bold**, *italic*, [link](url),
+    bullet lists with "- ", ```code blocks```, > blockquotes."""
+    config = get_config()
+    configurable = config.get("configurable", {})
+    webex_thread = configurable.get("webex_thread", {})
+
+    room_id = webex_thread.get("room_id")
+    parent_id = webex_thread.get("parent_id")
+    if not room_id:
+        return {
+            "success": False,
+            "error": "Missing webex_thread.room_id in config",
+        }
+
+    if not message.strip():
+        return {"success": False, "error": "Message cannot be empty"}
+
+    success = asyncio.run(post_webex_message(room_id, message, parent_id=parent_id))
+    return {"success": success}

--- a/agent/utils/webex.py
+++ b/agent/utils/webex.py
@@ -1,0 +1,185 @@
+"""Webex Messaging API utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from agent.utils.langsmith import get_langsmith_trace_url
+
+logger = logging.getLogger(__name__)
+
+WEBEX_API_BASE_URL = "https://webexapis.com/v1"
+WEBEX_BOT_TOKEN = os.environ.get("WEBEX_BOT_TOKEN", "")
+WEBEX_BOT_EMAIL = os.environ.get("WEBEX_BOT_EMAIL", "")
+
+
+def _webex_headers() -> dict[str, str]:
+    if not WEBEX_BOT_TOKEN:
+        return {}
+    return {
+        "Authorization": f"Bearer {WEBEX_BOT_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+def verify_webex_signature(body: bytes, signature: str, secret: str) -> bool:
+    """Verify Webex webhook signature (HMAC-SHA1 via X-Spark-Signature header)."""
+    if not secret:
+        logger.warning("WEBEX_WEBHOOK_SECRET is not configured — rejecting webhook request")
+        return False
+    if not signature:
+        return False
+    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha1).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+async def fetch_webex_message(message_id: str) -> dict[str, Any] | None:
+    """Fetch a single message by ID.
+
+    Webex webhook payloads omit the message text (encrypted at rest).
+    This call retrieves the full message including text content.
+    """
+    if not WEBEX_BOT_TOKEN:
+        return None
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(
+                f"{WEBEX_API_BASE_URL}/messages/{message_id}",
+                headers=_webex_headers(),
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPError:
+            logger.exception("Failed to fetch Webex message %s", message_id)
+            return None
+
+
+async def post_webex_message(
+    room_id: str,
+    text: str,
+    parent_id: str | None = None,
+) -> bool:
+    """Post a message to a Webex room, optionally as a thread reply."""
+    if not WEBEX_BOT_TOKEN:
+        return False
+
+    payload: dict[str, str] = {
+        "roomId": room_id,
+        "markdown": text,
+    }
+    if parent_id:
+        payload["parentId"] = parent_id
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                f"{WEBEX_API_BASE_URL}/messages",
+                headers=_webex_headers(),
+                json=payload,
+            )
+            response.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            logger.exception("Failed to post Webex message to room %s", room_id)
+            return False
+
+
+async def get_webex_person(person_id: str) -> dict[str, Any] | None:
+    """Fetch person details (displayName, emails, etc.) by person ID."""
+    if not WEBEX_BOT_TOKEN:
+        return None
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(
+                f"{WEBEX_API_BASE_URL}/people/{person_id}",
+                headers=_webex_headers(),
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPError:
+            logger.exception("Failed to fetch Webex person %s", person_id)
+            return None
+
+
+async def fetch_webex_thread_messages(
+    room_id: str,
+    parent_id: str,
+    max_messages: int = 50,
+) -> list[dict[str, Any]]:
+    """Fetch messages in a Webex thread (replies to a parent message)."""
+    if not WEBEX_BOT_TOKEN:
+        return []
+
+    params: dict[str, str | int] = {
+        "roomId": room_id,
+        "parentId": parent_id,
+        "max": max_messages,
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(
+                f"{WEBEX_API_BASE_URL}/messages",
+                headers=_webex_headers(),
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+            items = data.get("items", [])
+            if isinstance(items, list):
+                return items
+        except httpx.HTTPError:
+            logger.exception("Failed to fetch Webex thread messages for room %s", room_id)
+    return []
+
+
+def strip_bot_mention(text: str) -> str:
+    """Remove bot mention tokens from Webex message text."""
+    if not text:
+        return ""
+    stripped = text
+    if WEBEX_BOT_EMAIL:
+        stripped = stripped.replace(WEBEX_BOT_EMAIL, "")
+    bot_name = WEBEX_BOT_EMAIL.split("@")[0] if WEBEX_BOT_EMAIL else ""
+    if bot_name:
+        stripped = stripped.replace(f"@{bot_name}", "")
+        stripped = stripped.replace(bot_name, "")
+    return stripped.strip()
+
+
+def format_webex_messages_for_prompt(
+    messages: list[dict[str, Any]],
+) -> str:
+    """Format Webex thread messages into readable prompt text."""
+    if not messages:
+        return "(no thread messages available)"
+
+    lines: list[str] = []
+    for message in messages:
+        text = message.get("text", "").strip() or "[non-text message]"
+        person_email = message.get("personEmail", "unknown")
+        lines.append(f"{person_email}: {text}")
+    return "\n".join(lines)
+
+
+async def post_webex_trace_reply(
+    room_id: str,
+    parent_id: str | None,
+    run_id: str,
+) -> None:
+    """Post a trace URL reply in a Webex thread."""
+    trace_url = get_langsmith_trace_url(run_id)
+    if trace_url:
+        await post_webex_message(
+            room_id,
+            f"Working on it! [View trace]({trace_url})",
+            parent_id=parent_id,
+        )

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -51,6 +51,16 @@ from .utils.slack import (
     strip_bot_mention,
     verify_slack_signature,
 )
+from .utils.webex import (
+    fetch_webex_message,
+    fetch_webex_thread_messages,
+    format_webex_messages_for_prompt,
+    get_webex_person,
+    post_webex_message,
+    post_webex_trace_reply,
+    strip_bot_mention as strip_webex_bot_mention,
+    verify_webex_signature,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +73,11 @@ SLACK_BOT_USER_ID = os.environ.get("SLACK_BOT_USER_ID", "")
 SLACK_BOT_USERNAME = os.environ.get("SLACK_BOT_USERNAME", "")
 SLACK_REPO_OWNER = os.environ.get("SLACK_REPO_OWNER", "langchain-ai")
 SLACK_REPO_NAME = os.environ.get("SLACK_REPO_NAME", "open-swe")
+
+WEBEX_WEBHOOK_SECRET = os.environ.get("WEBEX_WEBHOOK_SECRET", "")
+WEBEX_BOT_EMAIL = os.environ.get("WEBEX_BOT_EMAIL", "")
+WEBEX_REPO_OWNER = os.environ.get("WEBEX_REPO_OWNER", "langchain-ai")
+WEBEX_REPO_NAME = os.environ.get("WEBEX_REPO_NAME", "open-swe")
 
 LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
     "LANGGRAPH_URL_PROD", "http://localhost:2024"
@@ -268,6 +283,15 @@ def generate_thread_id_from_slack_thread(channel_id: str, thread_id: str) -> str
     composite = f"{channel_id}:{thread_id}"
     md5_hex = hashlib.md5(composite.encode("utf-8")).hexdigest()
     return str(uuid.UUID(hex=md5_hex))
+
+
+def generate_thread_id_from_webex(room_id: str, parent_id: str) -> str:
+    """Generate a deterministic thread ID from a Webex room and parent message."""
+    hash_bytes = hashlib.sha256(f"webex:{room_id}:{parent_id}".encode()).hexdigest()
+    return (
+        f"{hash_bytes[:8]}-{hash_bytes[8:12]}-{hash_bytes[12:16]}-"
+        f"{hash_bytes[16:20]}-{hash_bytes[20:32]}"
+    )
 
 
 def _extract_repo_config_from_thread(thread: dict[str, Any]) -> dict[str, str] | None:
@@ -1491,3 +1515,174 @@ async def github_webhook(request: Request, background_tasks: BackgroundTasks) ->
 
     logger.info("Ignoring unsupported GitHub payload shape for event=%s", event_type)
     return {"status": "ignored", "reason": f"Unsupported payload for event type: {event_type}"}
+
+
+# ---------------------------------------------------------------------------
+# Webex webhooks
+# ---------------------------------------------------------------------------
+
+
+def _get_webex_repo_config(message_text: str) -> dict[str, str]:
+    """Resolve repository configuration from a Webex message.
+
+    Supports `repo:owner/name` or `github.com/owner/name` inline syntax,
+    falling back to WEBEX_REPO_OWNER / WEBEX_REPO_NAME defaults.
+    """
+    owner: str | None = None
+    name: str | None = None
+
+    if "repo:" in message_text or "repo " in message_text:
+        match = re.search(r"repo[: ]([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)", message_text)
+        if match:
+            owner, name = match.group(1).split("/", 1)
+
+    if not owner or not name:
+        github_match = re.search(r"github\.com/([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)", message_text)
+        if github_match:
+            owner, name = github_match.group(1).split("/", 1)
+
+    if not owner or not name:
+        owner = WEBEX_REPO_OWNER.strip() or "langchain-ai"
+        name = WEBEX_REPO_NAME.strip() or "open-swe"
+
+    return {"owner": owner, "name": name}
+
+
+async def process_webex_mention(  # noqa: PLR0912, PLR0915
+    data: dict[str, Any],
+    repo_config: dict[str, str],
+) -> None:
+    """Process a Webex bot mention by creating or queuing a thread run."""
+    message_id = data.get("id", "")
+    room_id = data.get("roomId", "")
+    person_id = data.get("personId", "")
+    person_email = data.get("personEmail", "")
+
+    if not message_id or not room_id:
+        logger.warning("Missing Webex message id or roomId, skipping")
+        return
+
+    full_message = await fetch_webex_message(message_id)
+    if not full_message:
+        logger.warning("Could not fetch Webex message %s, skipping", message_id)
+        return
+
+    raw_text = full_message.get("text", "")
+    clean_text = strip_webex_bot_mention(raw_text) or "(no text in mention)"
+
+    parent_id = full_message.get("parentId") or message_id
+
+    person = await get_webex_person(person_id) if person_id else None
+    display_name = (person.get("displayName", "") if person else "") or person_email
+    user_email = person_email
+
+    thread_context = ""
+    if full_message.get("parentId"):
+        thread_messages = await fetch_webex_thread_messages(room_id, parent_id)
+        if thread_messages:
+            thread_context = format_webex_messages_for_prompt(thread_messages)
+
+    context_section = (
+        f"## Conversation Context\n{thread_context}\n\n" if thread_context else ""
+    )
+
+    prompt = (
+        "You were mentioned in Webex.\n\n"
+        f"## Repository\n{repo_config.get('owner')}/{repo_config.get('name')}\n\n"
+        f"## Triggered by\n{display_name}\n\n"
+        f"## Webex Room\n- Room ID: {room_id}\n"
+        f"- Parent ID: {parent_id}\n\n"
+        f"{context_section}"
+        f"## Latest Mention Request\n{clean_text}\n\n"
+        "Use `webex_reply` to communicate in this Webex thread for clarifications, "
+        "status updates, and final summaries."
+    )
+
+    thread_id = generate_thread_id_from_webex(room_id, parent_id)
+
+    configurable: dict[str, Any] = {
+        "repo": repo_config,
+        "webex_thread": {
+            "room_id": room_id,
+            "parent_id": parent_id,
+            "triggering_person_id": person_id,
+            "triggering_person_email": person_email,
+            "triggering_display_name": display_name,
+        },
+        "user_email": user_email,
+        "source": "webex",
+    }
+
+    thread_active = await is_thread_active(thread_id)
+    if thread_active:
+        logger.info("Thread %s is active, queuing Webex message for middleware pickup", thread_id)
+        queued = await queue_message_for_thread(
+            thread_id=thread_id,
+            message_content={"text": prompt, "image_urls": []},
+        )
+        if queued:
+            logger.info("Webex message queued for thread %s", thread_id)
+        else:
+            logger.error("Failed to queue Webex message for thread %s", thread_id)
+        return
+
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    run = await langgraph_client.runs.create(
+        thread_id,
+        "agent",
+        input={"messages": [{"role": "user", "content": prompt}]},
+        config={"configurable": configurable, "metadata": _AGENT_VERSION_METADATA},
+        if_not_exists="create",
+        multitask_strategy="interrupt",
+    )
+    await post_webex_trace_reply(room_id, parent_id, run["run_id"])
+
+
+@app.post("/webhooks/webex")
+async def webex_webhook(request: Request, background_tasks: BackgroundTasks) -> dict[str, str]:
+    """Handle Webex webhook notifications for messages:created events."""
+    body = await request.body()
+
+    signature = request.headers.get("X-Spark-Signature", "")
+    if not verify_webex_signature(body, signature, WEBEX_WEBHOOK_SECRET):
+        logger.warning("Invalid Webex webhook signature")
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        logger.exception("Failed to parse Webex webhook JSON")
+        return {"status": "error", "message": "Invalid JSON"}
+
+    resource = payload.get("resource")
+    event = payload.get("event")
+    if resource != "messages" or event != "created":
+        logger.debug("Ignoring Webex webhook: resource=%s, event=%s", resource, event)
+        return {"status": "ignored", "reason": f"Not a messages:created event ({resource}:{event})"}
+
+    data = payload.get("data", {})
+    person_email = data.get("personEmail", "")
+
+    if WEBEX_BOT_EMAIL and person_email.lower() == WEBEX_BOT_EMAIL.lower():
+        logger.debug("Ignoring Webex webhook: message is from the bot itself")
+        return {"status": "ignored", "reason": "Message is from the bot"}
+
+    message_text = data.get("text", "")
+    repo_config = _get_webex_repo_config(message_text)
+
+    if not _is_repo_org_allowed(repo_config):
+        logger.warning(
+            "Rejecting Webex webhook: org '%s' not in ALLOWED_GITHUB_ORGS",
+            repo_config.get("owner"),
+        )
+        return {"status": "ignored", "reason": "Repository org not in allowlist"}
+
+    logger.info("Accepted Webex webhook, scheduling background task")
+    background_tasks.add_task(process_webex_mention, data, repo_config)
+    return {"status": "accepted", "message": "Processing Webex mention"}
+
+
+@app.get("/webhooks/webex")
+async def webex_webhook_verify() -> dict[str, str]:
+    """Verify endpoint for Webex webhook setup."""
+    return {"status": "ok", "message": "Webex webhook endpoint is active"}

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -56,10 +56,11 @@ from .utils.webex import (
     fetch_webex_thread_messages,
     format_webex_messages_for_prompt,
     get_webex_person,
-    post_webex_message,
     post_webex_trace_reply,
-    strip_bot_mention as strip_webex_bot_mention,
     verify_webex_signature,
+)
+from .utils.webex import (
+    strip_bot_mention as strip_webex_bot_mention,
 )
 
 logger = logging.getLogger(__name__)
@@ -1582,9 +1583,7 @@ async def process_webex_mention(  # noqa: PLR0912, PLR0915
         if thread_messages:
             thread_context = format_webex_messages_for_prompt(thread_messages)
 
-    context_section = (
-        f"## Conversation Context\n{thread_context}\n\n" if thread_context else ""
-    )
+    context_section = f"## Conversation Context\n{thread_context}\n\n" if thread_context else ""
 
     prompt = (
         "You were mentioned in Webex.\n\n"

--- a/tests/test_webex.py
+++ b/tests/test_webex.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent import webapp
+from agent.utils.webex import (
+    format_webex_messages_for_prompt,
+    strip_bot_mention,
+    verify_webex_signature,
+)
+from agent.webapp import generate_thread_id_from_webex
+
+_TEST_WEBHOOK_SECRET = "test-webex-secret"
+
+
+def _sign_body_webex(body: bytes, secret: str = _TEST_WEBHOOK_SECRET) -> str:
+    """Compute the X-Spark-Signature header (HMAC-SHA1)."""
+    return hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
+
+
+def _post_webex_webhook(client: TestClient, payload: dict, secret: str = _TEST_WEBHOOK_SECRET):
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    return client.post(
+        "/webhooks/webex",
+        content=body,
+        headers={
+            "X-Spark-Signature": _sign_body_webex(body, secret),
+            "Content-Type": "application/json",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+def test_verify_webex_signature_valid() -> None:
+    body = b'{"test": "payload"}'
+    secret = "mysecret"
+    sig = hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
+    assert verify_webex_signature(body, sig, secret) is True
+
+
+def test_verify_webex_signature_invalid() -> None:
+    body = b'{"test": "payload"}'
+    assert verify_webex_signature(body, "badsig", "mysecret") is False
+
+
+def test_verify_webex_signature_empty_secret() -> None:
+    assert verify_webex_signature(b"body", "sig", "") is False
+
+
+def test_verify_webex_signature_empty_signature() -> None:
+    assert verify_webex_signature(b"body", "", "secret") is False
+
+
+# ---------------------------------------------------------------------------
+# Thread ID generation
+# ---------------------------------------------------------------------------
+
+
+def test_generate_thread_id_from_webex_is_deterministic() -> None:
+    first = generate_thread_id_from_webex("room123", "msg456")
+    second = generate_thread_id_from_webex("room123", "msg456")
+    assert first == second
+    assert len(first) == 36
+
+
+def test_generate_thread_id_from_webex_differs_by_room() -> None:
+    id_a = generate_thread_id_from_webex("roomA", "msg1")
+    id_b = generate_thread_id_from_webex("roomB", "msg1")
+    assert id_a != id_b
+
+
+def test_generate_thread_id_from_webex_differs_by_parent() -> None:
+    id_a = generate_thread_id_from_webex("room1", "parentA")
+    id_b = generate_thread_id_from_webex("room1", "parentB")
+    assert id_a != id_b
+
+
+# ---------------------------------------------------------------------------
+# Bot mention stripping
+# ---------------------------------------------------------------------------
+
+
+def test_strip_bot_mention_removes_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent.utils import webex
+
+    monkeypatch.setattr(webex, "WEBEX_BOT_EMAIL", "open-swe@webex.bot")
+    assert strip_bot_mention("open-swe@webex.bot please help") == "please help"
+
+
+def test_strip_bot_mention_removes_at_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent.utils import webex
+
+    monkeypatch.setattr(webex, "WEBEX_BOT_EMAIL", "open-swe@webex.bot")
+    assert strip_bot_mention("@open-swe please help") == "please help"
+
+
+def test_strip_bot_mention_empty() -> None:
+    assert strip_bot_mention("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Message formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_webex_messages_for_prompt_basic() -> None:
+    messages = [
+        {"text": "hello there", "personEmail": "alice@example.com"},
+        {"text": "please fix the bug", "personEmail": "bob@example.com"},
+    ]
+    result = format_webex_messages_for_prompt(messages)
+    assert "alice@example.com: hello there" in result
+    assert "bob@example.com: please fix the bug" in result
+
+
+def test_format_webex_messages_for_prompt_empty() -> None:
+    assert format_webex_messages_for_prompt([]) == "(no thread messages available)"
+
+
+def test_format_webex_messages_for_prompt_missing_text() -> None:
+    messages = [{"personEmail": "alice@example.com"}]
+    result = format_webex_messages_for_prompt(messages)
+    assert "[non-text message]" in result
+
+
+# ---------------------------------------------------------------------------
+# Repo config parsing
+# ---------------------------------------------------------------------------
+
+
+def test_get_webex_repo_config_repo_colon_syntax() -> None:
+    config = webapp._get_webex_repo_config("please fix repo:my-org/my-repo bug")
+    assert config == {"owner": "my-org", "name": "my-repo"}
+
+
+def test_get_webex_repo_config_repo_space_syntax() -> None:
+    config = webapp._get_webex_repo_config("check repo my-org/my-repo now")
+    assert config == {"owner": "my-org", "name": "my-repo"}
+
+
+def test_get_webex_repo_config_github_url() -> None:
+    config = webapp._get_webex_repo_config("see https://github.com/langchain-ai/open-swe/issues/1")
+    assert config == {"owner": "langchain-ai", "name": "open-swe"}
+
+
+def test_get_webex_repo_config_repo_beats_github_url() -> None:
+    config = webapp._get_webex_repo_config(
+        "see https://github.com/langchain-ai/open-swe but use repo:other-org/other-repo"
+    )
+    assert config == {"owner": "other-org", "name": "other-repo"}
+
+
+def test_get_webex_repo_config_falls_back_to_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(webapp, "WEBEX_REPO_OWNER", "default-owner")
+    monkeypatch.setattr(webapp, "WEBEX_REPO_NAME", "default-repo")
+    config = webapp._get_webex_repo_config("please fix the bug")
+    assert config == {"owner": "default-owner", "name": "default-repo"}
+
+
+# ---------------------------------------------------------------------------
+# Webhook endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_webex_webhook_rejects_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(webapp, "WEBEX_WEBHOOK_SECRET", _TEST_WEBHOOK_SECRET)
+    client = TestClient(webapp.app)
+
+    body = json.dumps({"resource": "messages", "event": "created", "data": {}}).encode()
+    response = client.post(
+        "/webhooks/webex",
+        content=body,
+        headers={
+            "X-Spark-Signature": "invalidsig",
+            "Content-Type": "application/json",
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_webex_webhook_ignores_non_message_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(webapp, "WEBEX_WEBHOOK_SECRET", _TEST_WEBHOOK_SECRET)
+    client = TestClient(webapp.app)
+
+    response = _post_webex_webhook(
+        client,
+        {
+            "resource": "rooms",
+            "event": "created",
+            "data": {},
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+def test_webex_webhook_ignores_bot_own_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(webapp, "WEBEX_WEBHOOK_SECRET", _TEST_WEBHOOK_SECRET)
+    monkeypatch.setattr(webapp, "WEBEX_BOT_EMAIL", "open-swe@webex.bot")
+    client = TestClient(webapp.app)
+
+    response = _post_webex_webhook(
+        client,
+        {
+            "resource": "messages",
+            "event": "created",
+            "data": {"personEmail": "open-swe@webex.bot"},
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+    assert "bot" in response.json()["reason"].lower()
+
+
+def test_webex_webhook_accepts_valid_mention(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, object] = {}
+
+    async def fake_process_webex_mention(data: dict, repo_config: dict) -> None:
+        called["data"] = data
+        called["repo_config"] = repo_config
+
+    monkeypatch.setattr(webapp, "WEBEX_WEBHOOK_SECRET", _TEST_WEBHOOK_SECRET)
+    monkeypatch.setattr(webapp, "WEBEX_BOT_EMAIL", "open-swe@webex.bot")
+    monkeypatch.setattr(webapp, "process_webex_mention", fake_process_webex_mention)
+    client = TestClient(webapp.app)
+
+    response = _post_webex_webhook(
+        client,
+        {
+            "resource": "messages",
+            "event": "created",
+            "data": {
+                "id": "msg123",
+                "roomId": "room456",
+                "personEmail": "alice@example.com",
+                "text": "repo:my-org/my-repo fix the bug",
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "accepted"
+
+
+def test_webex_webhook_verify_endpoint() -> None:
+    client = TestClient(webapp.app)
+    response = client.get("/webhooks/webex")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Summary

Adds Cisco Webex as an invocation surface, same pattern as the existing Slack and Linear integrations. Each org creates their own Webex bot on the developer portal, registers a webhook, and the agent handles the rest.

**Changes:**
- `POST /webhooks/webex` endpoint with HMAC-SHA1 signature verification (`X-Spark-Signature`)
- `webex_reply` agent tool for posting threaded markdown messages back to Webex
- `agent/utils/webex.py` with utilities for message fetching, posting, thread context, bot-mention stripping
- Prompt updates to include `webex_reply` in tool descriptions and task execution flow
- `.env.example` created, `INSTALLATION.md` and `README.md` updated with Webex setup
- 23 unit tests

## Environment variables

| Variable | Description |
|---|---|
| `WEBEX_BOT_TOKEN` | Bot access token from the Webex Developer Portal |
| `WEBEX_BOT_EMAIL` | Bot email address (used to filter out self-messages) |
| `WEBEX_WEBHOOK_SECRET` | HMAC-SHA1 secret for webhook signature verification |
| `WEBEX_REPO_OWNER` | Default GitHub org for Webex-triggered tasks |
| `WEBEX_REPO_NAME` | Default GitHub repo for Webex-triggered tasks |

## How it works

1. User @mentions the bot in a Webex space
2. Webex sends a `messages:created` webhook (filtered by `mentionedPeople=me`)
3. Handler verifies the signature, fetches the full message text (Webex encrypts payloads at rest), builds thread context
4. Agent runs in a sandbox, uses `webex_reply` to post updates back to the same thread

Users can specify a target repo with `repo:owner/name` in the message, otherwise it falls back to `WEBEX_REPO_OWNER/WEBEX_REPO_NAME`.

## Testing

Tested locally end-to-end: bot receives mention in Webex, agent runs in sandbox, replies in-thread.

`make lint`, `make format`, and `make test` all pass.

<img width="1085" height="914" alt="Screenshot 2026-03-20 at 1 22 40 PM" src="https://github.com/user-attachments/assets/0f2e9274-8ed8-4cea-aef6-6a453cf9564a" />
