### PR TITLE
feat: support applying labels when creating github prs [closes OPE-30]

### DIFF
--- a/agent/tools/commit_and_open_pr.py
+++ b/agent/tools/commit_and_open_pr.py
@@ -28,6 +28,7 @@ def commit_and_open_pr(
     title: str,
     body: str,
     commit_message: str | None = None,
+    labels: list[str] | None = None,
 ) -> dict[str, Any]:
     """Commit all current changes and open a GitHub Pull Request.
 
@@ -100,6 +101,7 @@ def commit_and_open_pr(
         title: PR title following the format above (e.g. "fix: resolve auth bug [closes AA-123]")
         body: PR description following the template above with ## Description and ## Test Plan
         commit_message: Optional git commit message. If not provided, the PR title is used.
+        labels: Optional list of GitHub label names to apply to the PR (e.g. ["preview-self-hosted", "bug"]).
 
     Returns:
         Dictionary containing:
@@ -205,6 +207,7 @@ def commit_and_open_pr(
                 head_branch=target_branch,
                 base_branch=base_branch,
                 body=body,
+                labels=labels,
             )
         )
 

--- a/agent/utils/github.py
+++ b/agent/utils/github.py
@@ -166,6 +166,7 @@ async def create_github_pr(
     head_branch: str,
     base_branch: str,
     body: str,
+    labels: list[str] | None = None,
 ) -> tuple[str | None, int | None, bool]:
     """Create a draft GitHub pull request via the API.
 
@@ -177,6 +178,7 @@ async def create_github_pr(
         head_branch: Source branch name
         base_branch: Target branch name
         body: PR description
+        labels: Optional list of label names to apply to the PR
 
     Returns:
         Tuple of (pr_url, pr_number, pr_existing) if successful, (None, None, False) otherwise
@@ -215,6 +217,10 @@ async def create_github_pr(
                 pr_url = pr_data.get("html_url")
                 pr_number = pr_data.get("number")
                 logger.info("PR created successfully: %s", pr_url)
+                if labels and pr_number:
+                    await _apply_labels(
+                        http_client, repo_owner, repo_name, github_token, pr_number, labels
+                    )
                 return pr_url, pr_number, False
 
             if pr_response.status_code == HTTP_UNPROCESSABLE_ENTITY:
@@ -228,6 +234,15 @@ async def create_github_pr(
                 )
                 if existing:
                     logger.info("Using existing PR for head branch: %s", existing[0])
+                    if labels and existing[1]:
+                        await _apply_labels(
+                            http_client,
+                            repo_owner,
+                            repo_name,
+                            github_token,
+                            existing[1],
+                            labels,
+                        )
                     return existing[0], existing[1], True
             else:
                 logger.error(
@@ -244,6 +259,38 @@ async def create_github_pr(
         except httpx.HTTPError:
             logger.exception("Failed to create PR via GitHub API")
             return None, None, False
+
+
+async def _apply_labels(
+    http_client: httpx.AsyncClient,
+    repo_owner: str,
+    repo_name: str,
+    github_token: str,
+    pr_number: int,
+    labels: list[str],
+) -> None:
+    """Apply labels to a GitHub pull request (issue endpoint)."""
+    try:
+        response = await http_client.post(
+            f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pr_number}/labels",
+            headers={
+                "Authorization": f"Bearer {github_token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            json={"labels": labels},
+        )
+        if response.status_code == 200:  # noqa: PLR2004
+            logger.info("Labels %s applied to PR #%s", labels, pr_number)
+        else:
+            logger.error(
+                "Failed to apply labels to PR #%s (%s): %s",
+                pr_number,
+                response.status_code,
+                response.text,
+            )
+    except httpx.HTTPError:
+        logger.exception("Failed to apply labels to PR #%s", pr_number)
 
 
 async def _find_existing_pr(


### PR DESCRIPTION
## Description
Adds an optional `labels` parameter to `commit_and_open_pr` and `create_github_pr` so the agent can apply GitHub labels to PRs at creation time. After creating (or finding an existing) PR, a second API call to `POST /repos/{owner}/{repo}/issues/{pr_number}/labels` applies the requested labels.

Resolves OPE-30

## Test Plan
- [ ] Call `commit_and_open_pr` with `labels=["some-label"]` and verify the label appears on the created PR
- [ ] Call `commit_and_open_pr` without `labels` and verify existing behavior is unchanged