### PR TITLE
feat: add OpenSandbox as a sandbox provider integration

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -45,6 +45,7 @@ Set the `SANDBOX_TYPE` environment variable to switch providers. Each provider h
 | `daytona` | `agent/integrations/daytona.py` | `DAYTONA_API_KEY`, `SANDBOX_TYPE="daytona"` |
 | `runloop` | `agent/integrations/runloop.py` | `RUNLOOP_API_KEY`, `SANDBOX_TYPE="runloop"` |
 | `modal` | `agent/integrations/modal.py` | Modal credentials, `SANDBOX_TYPE="modal"` |
+| `opensandbox` | `agent/integrations/opensandbox.py` | `OPEN_SANDBOX_API_KEY`, `OPEN_SANDBOX_DOMAIN`, `SANDBOX_TYPE="opensandbox"` |
 | `local` | `agent/integrations/local.py` | None (no isolation — development only), `SANDBOX_TYPE="local"` |
 
 > **Warning**: `local` runs commands directly on your host with no sandboxing. Only use for local development with human-in-the-loop enabled.

--- a/agent/integrations/opensandbox.py
+++ b/agent/integrations/opensandbox.py
@@ -87,9 +87,9 @@ class OpenSandboxBackend(BaseSandbox):
         responses: list[FileDownloadResponse] = []
         for path in paths:
             try:
-                content = self._sandbox.files.read_file(path)
+                data = self._sandbox.files.read_bytes(path)
                 responses.append(
-                    FileDownloadResponse(path=path, content=content.encode("utf-8"), error=None)
+                    FileDownloadResponse(path=path, content=data, error=None)
                 )
             except Exception:
                 responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))

--- a/agent/integrations/opensandbox.py
+++ b/agent/integrations/opensandbox.py
@@ -1,0 +1,165 @@
+"""OpenSandbox backend implementation for Open SWE Agent.
+
+Uses the OpenSandbox Python SDK (sync) to provide sandbox isolation.
+Requires: pip install opensandbox
+
+Environment variables:
+    OPEN_SANDBOX_API_KEY: API key for OpenSandbox server authentication.
+    OPEN_SANDBOX_DOMAIN: OpenSandbox server domain (default: localhost:8080).
+    OPEN_SANDBOX_PROTOCOL: HTTP protocol, "http" or "https" (default: http).
+    OPENSANDBOX_IMAGE: Container image to use (default: python:3.12).
+    OPENSANDBOX_TIMEOUT_SECONDS: Sandbox TTL in seconds (default: 3600).
+    OPENSANDBOX_USE_SERVER_PROXY: Route execd traffic through the server (default: true).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import timedelta
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+    SandboxBackendProtocol,
+    WriteResult,
+)
+from deepagents.backends.sandbox import BaseSandbox
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.models.execd import RunCommandOpts
+from opensandbox.sync.sandbox import SandboxSync
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+DEFAULT_IMAGE = "python:3.12"
+DEFAULT_TIMEOUT_SECONDS = 3600
+DEFAULT_COMMAND_TIMEOUT = 300  # 5 minutes
+
+
+class OpenSandboxBackend(BaseSandbox):
+    """OpenSandbox backend conforming to SandboxBackendProtocol.
+
+    Inherits file operation methods from BaseSandbox (which delegates to execute()).
+    Overrides write/download_files/upload_files with native SDK calls for efficiency.
+    """
+
+    def __init__(self, sandbox: SandboxSync) -> None:
+        self._sandbox = sandbox
+        self._default_timeout: int = DEFAULT_COMMAND_TIMEOUT
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for the sandbox backend."""
+        return self._sandbox.id
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        """Execute a command in the sandbox and return ExecuteResponse."""
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        opts = RunCommandOpts(timeout=timedelta(seconds=effective_timeout))
+        result = self._sandbox.commands.run(command, opts=opts)
+
+        # Combine stdout and stderr
+        stdout_text = "".join(msg.text for msg in result.logs.stdout) if result.logs.stdout else ""
+        stderr_text = "".join(msg.text for msg in result.logs.stderr) if result.logs.stderr else ""
+
+        output = stdout_text
+        if stderr_text:
+            output = f"{output}\n{stderr_text}" if output else stderr_text
+
+        return ExecuteResponse(
+            output=output,
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Write content using the OpenSandbox SDK to avoid ARG_MAX issues."""
+        try:
+            self._sandbox.files.write_file(file_path, content)
+            return WriteResult(path=file_path, files_update=None)
+        except Exception as e:
+            return WriteResult(error=f"Failed to write file '{file_path}': {e}")
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Download multiple files from the sandbox."""
+        responses: list[FileDownloadResponse] = []
+        for path in paths:
+            try:
+                content = self._sandbox.files.read_file(path)
+                responses.append(
+                    FileDownloadResponse(path=path, content=content.encode("utf-8"), error=None)
+                )
+            except Exception:
+                responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+        return responses
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload multiple files to the sandbox."""
+        responses: list[FileUploadResponse] = []
+        for path, content in files:
+            try:
+                self._sandbox.files.write_file(path, content)
+                responses.append(FileUploadResponse(path=path, error=None))
+            except Exception:
+                responses.append(FileUploadResponse(path=path, error="permission_denied"))
+        return responses
+
+
+def _get_connection_config() -> ConnectionConfigSync:
+    """Build ConnectionConfigSync from environment variables."""
+    api_key = os.getenv("OPEN_SANDBOX_API_KEY", "")
+    domain = os.getenv("OPEN_SANDBOX_DOMAIN", "localhost:8080")
+    protocol = os.getenv("OPEN_SANDBOX_PROTOCOL", "http")
+    use_server_proxy = os.getenv("OPENSANDBOX_USE_SERVER_PROXY", "true").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+    if not api_key:
+        raise ValueError(
+            "OPEN_SANDBOX_API_KEY environment variable is required. "
+            "Set it to your OpenSandbox server API key."
+        )
+
+    return ConnectionConfigSync(
+        api_key=api_key,
+        domain=domain,
+        protocol=protocol,
+        use_server_proxy=use_server_proxy,
+    )
+
+
+def create_opensandbox_sandbox(
+    sandbox_id: str | None = None,
+) -> SandboxBackendProtocol:
+    """Create or connect to an OpenSandbox sandbox.
+
+    Args:
+        sandbox_id: Optional existing sandbox ID to connect to.
+                   If None, creates a new sandbox.
+
+    Returns:
+        SandboxBackendProtocol instance
+    """
+    config = _get_connection_config()
+
+    if sandbox_id:
+        logger.info("Connecting to existing OpenSandbox: %s", sandbox_id)
+        sandbox = SandboxSync.connect(sandbox_id, connection_config=config)
+        return OpenSandboxBackend(sandbox)
+
+    image = os.getenv("OPENSANDBOX_IMAGE", DEFAULT_IMAGE)
+    timeout_seconds = int(os.getenv("OPENSANDBOX_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS)))
+
+    logger.info("Creating new OpenSandbox with image: %s (timeout: %ds)", image, timeout_seconds)
+    sandbox = SandboxSync.create(
+        image,
+        timeout=timedelta(seconds=timeout_seconds),
+        connection_config=config,
+    )
+    logger.info("OpenSandbox created: %s", sandbox.id)
+
+    return OpenSandboxBackend(sandbox)

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -4,6 +4,7 @@ from agent.integrations.daytona import create_daytona_sandbox
 from agent.integrations.langsmith import create_langsmith_sandbox
 from agent.integrations.local import create_local_sandbox
 from agent.integrations.modal import create_modal_sandbox
+from agent.integrations.opensandbox import create_opensandbox_sandbox
 from agent.integrations.runloop import create_runloop_sandbox
 
 SANDBOX_FACTORIES = {
@@ -11,6 +12,7 @@ SANDBOX_FACTORIES = {
     "daytona": create_daytona_sandbox,
     "modal": create_modal_sandbox,
     "runloop": create_runloop_sandbox,
+    "opensandbox": create_opensandbox_sandbox,
     "local": create_local_sandbox,
 }
 
@@ -19,7 +21,7 @@ def create_sandbox(sandbox_id: str | None = None):
     """Create or reconnect to a sandbox using the configured provider.
 
     The provider is selected via the SANDBOX_TYPE environment variable.
-    Supported values: langsmith (default), daytona, modal, runloop, local.
+    Supported values: langsmith (default), daytona, modal, runloop, opensandbox, local.
 
     Args:
         sandbox_id: Optional existing sandbox ID to reconnect to.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "langchain-daytona>=0.0.3",
     "langchain-modal>=0.0.2",
     "langchain-runloop>=0.0.3",
+    "opensandbox>=0.1.5",
     "exa-py>=2.10.1",
 ]
 

--- a/tests/test_opensandbox.py
+++ b/tests/test_opensandbox.py
@@ -64,6 +64,12 @@ class _FakeFiles:
             return self.files[path]
         raise FileNotFoundError(path)
 
+    def read_bytes(self, path: str, **kwargs) -> bytes:
+        if path in self.files:
+            v = self.files[path]
+            return v if isinstance(v, bytes) else v.encode("utf-8")
+        raise FileNotFoundError(path)
+
 
 class _FakeSandboxSync:
     def __init__(

--- a/tests/test_opensandbox.py
+++ b/tests/test_opensandbox.py
@@ -1,0 +1,271 @@
+"""Unit tests for the OpenSandbox integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepagents.backends.protocol import ExecuteResponse, WriteResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers – fake OpenSandbox SDK objects
+# ---------------------------------------------------------------------------
+
+class _FakeOutputMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeLogs:
+    def __init__(
+        self,
+        stdout: list[_FakeOutputMessage] | None = None,
+        stderr: list[_FakeOutputMessage] | None = None,
+    ) -> None:
+        self.stdout = stdout or []
+        self.stderr = stderr or []
+
+
+class _FakeExecution:
+    def __init__(
+        self,
+        exit_code: int = 0,
+        logs: _FakeLogs | None = None,
+    ) -> None:
+        self.exit_code = exit_code
+        self.logs = logs or _FakeLogs()
+
+
+class _FakeCommands:
+    def __init__(self, execution: _FakeExecution | None = None) -> None:
+        self._execution = execution or _FakeExecution()
+        self.last_command: str | None = None
+        self.last_opts = None
+
+    def run(self, command: str, *, opts=None, handlers=None):
+        self.last_command = command
+        self.last_opts = opts
+        return self._execution
+
+
+class _FakeFiles:
+    def __init__(self) -> None:
+        self.written: dict[str, str | bytes] = {}
+        self.files: dict[str, str] = {}
+
+    def write_file(self, path: str, data, **kwargs) -> None:
+        self.written[path] = data
+
+    def read_file(self, path: str, **kwargs) -> str:
+        if path in self.files:
+            return self.files[path]
+        raise FileNotFoundError(path)
+
+
+class _FakeSandboxSync:
+    def __init__(
+        self,
+        sandbox_id: str = "test-sandbox-123",
+        commands: _FakeCommands | None = None,
+        files: _FakeFiles | None = None,
+    ) -> None:
+        self.id = sandbox_id
+        self.commands = commands or _FakeCommands()
+        self.files = files or _FakeFiles()
+
+
+# ---------------------------------------------------------------------------
+# Tests – OpenSandboxBackend
+# ---------------------------------------------------------------------------
+
+class TestOpenSandboxBackend:
+    def _make_backend(self, **kwargs):
+        from agent.integrations.opensandbox import OpenSandboxBackend
+
+        sandbox = _FakeSandboxSync(**kwargs)
+        return OpenSandboxBackend(sandbox), sandbox
+
+    def test_id_property(self):
+        backend, _ = self._make_backend(sandbox_id="abc-123")
+        assert backend.id == "abc-123"
+
+    def test_execute_stdout_only(self):
+        execution = _FakeExecution(
+            exit_code=0,
+            logs=_FakeLogs(stdout=[_FakeOutputMessage("hello world")]),
+        )
+        backend, sandbox = self._make_backend(commands=_FakeCommands(execution))
+
+        result = backend.execute("echo hello world")
+
+        assert isinstance(result, ExecuteResponse)
+        assert result.output == "hello world"
+        assert result.exit_code == 0
+        assert result.truncated is False
+        assert sandbox.commands.last_command == "echo hello world"
+
+    def test_execute_stderr_only(self):
+        execution = _FakeExecution(
+            exit_code=1,
+            logs=_FakeLogs(stderr=[_FakeOutputMessage("error occurred")]),
+        )
+        backend, _ = self._make_backend(commands=_FakeCommands(execution))
+
+        result = backend.execute("bad-cmd")
+
+        assert result.output == "error occurred"
+        assert result.exit_code == 1
+
+    def test_execute_combined_stdout_stderr(self):
+        execution = _FakeExecution(
+            exit_code=0,
+            logs=_FakeLogs(
+                stdout=[_FakeOutputMessage("out1"), _FakeOutputMessage("out2")],
+                stderr=[_FakeOutputMessage("warn")],
+            ),
+        )
+        backend, _ = self._make_backend(commands=_FakeCommands(execution))
+
+        result = backend.execute("some-cmd")
+
+        assert result.output == "out1out2\nwarn"
+
+    def test_execute_empty_output(self):
+        execution = _FakeExecution(exit_code=0, logs=_FakeLogs())
+        backend, _ = self._make_backend(commands=_FakeCommands(execution))
+
+        result = backend.execute("true")
+
+        assert result.output == ""
+        assert result.exit_code == 0
+
+    def test_execute_timeout_forwarded(self):
+        backend, sandbox = self._make_backend()
+
+        backend.execute("sleep 10", timeout=30)
+
+        assert sandbox.commands.last_opts is not None
+        assert sandbox.commands.last_opts.timeout == timedelta(seconds=30)
+
+    def test_execute_default_timeout(self):
+        backend, sandbox = self._make_backend()
+
+        backend.execute("ls")
+
+        assert sandbox.commands.last_opts is not None
+        assert sandbox.commands.last_opts.timeout == timedelta(seconds=300)  # 5 min default
+
+    def test_write_success(self):
+        backend, sandbox = self._make_backend()
+
+        result = backend.write("/tmp/test.txt", "hello")
+
+        assert isinstance(result, WriteResult)
+        assert result.error is None
+        assert result.path == "/tmp/test.txt"
+        assert sandbox.files.written["/tmp/test.txt"] == "hello"
+
+    def test_write_failure(self):
+        files = _FakeFiles()
+        files.write_file = MagicMock(side_effect=PermissionError("read-only"))
+        backend, _ = self._make_backend(files=files)
+
+        result = backend.write("/readonly/file.txt", "data")
+
+        assert result.error is not None
+        assert "read-only" in result.error
+
+    def test_download_files_success(self):
+        files = _FakeFiles()
+        files.files = {"/app/a.txt": "content-a", "/app/b.txt": "content-b"}
+        backend, _ = self._make_backend(files=files)
+
+        responses = backend.download_files(["/app/a.txt", "/app/b.txt"])
+
+        assert len(responses) == 2
+        assert responses[0].content == b"content-a"
+        assert responses[0].error is None
+        assert responses[1].content == b"content-b"
+
+    def test_download_files_not_found(self):
+        backend, _ = self._make_backend()
+
+        responses = backend.download_files(["/no/such/file.txt"])
+
+        assert len(responses) == 1
+        assert responses[0].content is None
+        assert responses[0].error == "file_not_found"
+
+    def test_upload_files_success(self):
+        backend, sandbox = self._make_backend()
+
+        responses = backend.upload_files([("/tmp/f.bin", b"binary-data")])
+
+        assert len(responses) == 1
+        assert responses[0].error is None
+        assert sandbox.files.written["/tmp/f.bin"] == b"binary-data"
+
+    def test_upload_files_failure(self):
+        files = _FakeFiles()
+        files.write_file = MagicMock(side_effect=OSError("disk full"))
+        backend, _ = self._make_backend(files=files)
+
+        responses = backend.upload_files([("/tmp/f.bin", b"data")])
+
+        assert len(responses) == 1
+        assert responses[0].error == "permission_denied"
+
+
+# ---------------------------------------------------------------------------
+# Tests – factory function
+# ---------------------------------------------------------------------------
+
+class TestCreateOpenSandboxSandbox:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_api_key_raises(self):
+        from agent.integrations.opensandbox import create_opensandbox_sandbox
+
+        with pytest.raises(ValueError, match="OPEN_SANDBOX_API_KEY"):
+            create_opensandbox_sandbox()
+
+    @patch("agent.integrations.opensandbox.SandboxSync")
+    @patch.dict(
+        "os.environ",
+        {
+            "OPEN_SANDBOX_API_KEY": "test-key",
+            "OPEN_SANDBOX_DOMAIN": "sandbox.example.com",
+        },
+    )
+    def test_create_new_sandbox(self, mock_sandbox_cls):
+        from agent.integrations.opensandbox import create_opensandbox_sandbox
+
+        fake = _FakeSandboxSync()
+        mock_sandbox_cls.create.return_value = fake
+
+        backend = create_opensandbox_sandbox(sandbox_id=None)
+
+        mock_sandbox_cls.create.assert_called_once()
+        assert backend.id == fake.id
+
+    @patch("agent.integrations.opensandbox.SandboxSync")
+    @patch.dict(
+        "os.environ",
+        {
+            "OPEN_SANDBOX_API_KEY": "test-key",
+            "OPEN_SANDBOX_DOMAIN": "sandbox.example.com",
+        },
+    )
+    def test_reconnect_existing_sandbox(self, mock_sandbox_cls):
+        from agent.integrations.opensandbox import create_opensandbox_sandbox
+
+        fake = _FakeSandboxSync(sandbox_id="existing-456")
+        mock_sandbox_cls.connect.return_value = fake
+
+        backend = create_opensandbox_sandbox(sandbox_id="existing-456")
+
+        mock_sandbox_cls.connect.assert_called_once()
+        assert backend.id == "existing-456"
+        mock_sandbox_cls.create.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1797,6 +1797,7 @@ dependencies = [
     { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "markdownify" },
+    { name = "opensandbox" },
     { name = "pyjwt" },
     { name = "uvicorn" },
 ]
@@ -1826,6 +1827,7 @@ requires-dist = [
     { name = "langgraph-sdk", specifier = ">=0.1.0" },
     { name = "langsmith", specifier = ">=0.7.1" },
     { name = "markdownify", specifier = ">=1.2.2" },
+    { name = "opensandbox", specifier = ">=0.1.5" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -1851,6 +1853,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+]
+
+[[package]]
+name = "opensandbox"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/ef/ceab5616a4a96c60de36d93eaa0bdb5251b91ec01e2d4a71e28959c365ea/opensandbox-0.1.5.tar.gz", hash = "sha256:90471035bc6e61056a731d9e8e693fa6f51b84894e42bd09e49515e67c8dcd59", size = 95161, upload-time = "2026-02-12T03:17:57.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/c5/1950ec9dbdc4d8f1e2bf8a34514a5bc0754f243f81cdcef0adaf3224ff26/opensandbox-0.1.5-py3-none-any.whl", hash = "sha256:f21d2f45c88695c341067e3b932a71bae220e5260c06cfeb7a6f0e2e8c0677e0", size = 240958, upload-time = "2026-02-12T03:17:55.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add [[OpenSandbox](https://github.com/alibaba/OpenSandbox)](https://github.com/alibaba/OpenSandbox) as a new sandbox provider integration
- Implement `OpenSandboxBackend` extending `BaseSandbox` with full `execute()`, `write()`, `upload_files()`, `download_files()` support
- Register `"opensandbox"` in the sandbox factory, switchable via `SANDBOX_TYPE=opensandbox`
- Add 16 unit tests covering creation, reconnection, execution, file operations, and error handling

## What is [OpenSandbox](https://github.com/alibaba/OpenSandbox)?

[OpenSandbox](https://github.com/alibaba/OpenSandbox) is an open-source, high-performance sandbox runtime from Alibaba, designed for AI coding agents. It provides secure, isolated container environments with a simple REST/SDK API for shell execution and file operations.

## Usage

```bash
export SANDBOX_TYPE=opensandbox
export OPEN_SANDBOX_API_KEY=your-key
export OPEN_SANDBOX_DOMAIN=your-server:8080  # optional, defaults to localhost
```

## Test plan

- [x] 16 unit tests passing (`pytest tests/test_opensandbox.py`)
- [ ] Manual integration test with a running OpenSandbox instance
- [ ] Verify sandbox creation, command execution, and file read/write via real API