### PR TITLE
feat: support text snippets shared in Slack messages [closes OPE-34]

### DIFF
--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -134,31 +134,32 @@ async def fetch_slack_text_files(
 
             title = f.get("title") or f.get("name") or "Untitled snippet"
 
-            # Some snippets include content inline
+            # Prefer fetching full content from url_private; fall back to
+            # inline fields only when no URL is available (preview can be
+            # truncated by Slack).
+            url_private = f.get("url_private")
+            if url_private:
+                try:
+                    headers: dict[str, str] = {}
+                    if slack_bot_token:
+                        headers["Authorization"] = f"Bearer {slack_bot_token}"
+                    response = await client.get(
+                        url_private, headers=headers, follow_redirects=True
+                    )
+                    response.raise_for_status()
+                    content = response.text
+                    if len(content) > 50_000:
+                        content = content[:50_000] + "\n... (truncated)"
+                    results.append({"title": title, "content": content})
+                    logger.info("Fetched text snippet '%s' (%d chars)", title, len(content))
+                    continue
+                except Exception:
+                    logger.exception("Failed to fetch text file from %s", url_private)
+
+            # Fall back to inline content if URL fetch failed or unavailable
             inline = f.get("plain_text") or f.get("preview")
             if inline:
                 results.append({"title": title, "content": inline})
-                continue
-
-            url_private = f.get("url_private")
-            if not url_private:
-                continue
-
-            try:
-                headers: dict[str, str] = {}
-                if slack_bot_token:
-                    headers["Authorization"] = f"Bearer {slack_bot_token}"
-                response = await client.get(
-                    url_private, headers=headers, follow_redirects=True
-                )
-                response.raise_for_status()
-                content = response.text
-                if len(content) > 50_000:
-                    content = content[:50_000] + "\n... (truncated)"
-                results.append({"title": title, "content": content})
-                logger.info("Fetched text snippet '%s' (%d chars)", title, len(content))
-            except Exception:
-                logger.exception("Failed to fetch text file from %s", url_private)
 
     return results
 

--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -99,5 +99,69 @@ async def fetch_image_block(
         return None
 
 
+_TEXT_MIMETYPES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-yaml",
+    "application/x-sh",
+    "application/x-python",
+)
+
+
+async def fetch_slack_text_files(
+    context_messages: list[dict[str, Any]],
+    client: httpx.AsyncClient,
+) -> list[dict[str, str]]:
+    """Fetch text snippet/file content from Slack messages.
+
+    Returns a list of dicts with keys: title, content.
+    """
+    slack_bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+    results: list[dict[str, str]] = []
+
+    for msg in context_messages:
+        for f in msg.get("files", []):
+            if not isinstance(f, dict):
+                continue
+            mimetype = f.get("mimetype", "")
+            if not any(
+                mimetype.startswith(prefix) if prefix.endswith("/") else mimetype == prefix
+                for prefix in _TEXT_MIMETYPES
+            ):
+                continue
+
+            title = f.get("title") or f.get("name") or "Untitled snippet"
+
+            # Some snippets include content inline
+            inline = f.get("plain_text") or f.get("preview")
+            if inline:
+                results.append({"title": title, "content": inline})
+                continue
+
+            url_private = f.get("url_private")
+            if not url_private:
+                continue
+
+            try:
+                headers: dict[str, str] = {}
+                if slack_bot_token:
+                    headers["Authorization"] = f"Bearer {slack_bot_token}"
+                response = await client.get(
+                    url_private, headers=headers, follow_redirects=True
+                )
+                response.raise_for_status()
+                content = response.text
+                if len(content) > 50_000:
+                    content = content[:50_000] + "\n... (truncated)"
+                results.append({"title": title, "content": content})
+                logger.info("Fetched text snippet '%s' (%d chars)", title, len(content))
+            except Exception:
+                logger.exception("Failed to fetch text file from %s", url_private)
+
+    return results
+
+
 def dedupe_urls(urls: list[str]) -> list[str]:
     return list(dict.fromkeys(urls))

--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -99,22 +99,14 @@ async def fetch_image_block(
         return None
 
 
-_TEXT_MIMETYPES = (
-    "text/",
-    "application/json",
-    "application/xml",
-    "application/javascript",
-    "application/x-yaml",
-    "application/x-sh",
-    "application/x-python",
-)
-
-
 async def fetch_slack_text_files(
     context_messages: list[dict[str, Any]],
     client: httpx.AsyncClient,
 ) -> list[dict[str, str]]:
     """Fetch text snippet/file content from Slack messages.
+
+    Detects text files by the presence of ``plain_text`` or ``preview``
+    fields, which Slack only includes for text-based files.
 
     Returns a list of dicts with keys: title, content.
     """
@@ -125,11 +117,9 @@ async def fetch_slack_text_files(
         for f in msg.get("files", []):
             if not isinstance(f, dict):
                 continue
-            mimetype = f.get("mimetype", "")
-            if not any(
-                mimetype.startswith(prefix) if prefix.endswith("/") else mimetype == prefix
-                for prefix in _TEXT_MIMETYPES
-            ):
+            # Slack includes plain_text/preview only for text-based files,
+            # so their presence is a reliable signal regardless of mimetype.
+            if not (f.get("plain_text") or f.get("preview")):
                 continue
 
             title = f.get("title") or f.get("name") or "Untitled snippet"

--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -143,9 +143,7 @@ async def fetch_slack_text_files(
                     headers: dict[str, str] = {}
                     if slack_bot_token:
                         headers["Authorization"] = f"Bearer {slack_bot_token}"
-                    response = await client.get(
-                        url_private, headers=headers, follow_redirects=True
-                    )
+                    response = await client.get(url_private, headers=headers, follow_redirects=True)
                     response.raise_for_status()
                     content = response.text
                     if len(content) > 50_000:

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -178,6 +178,15 @@ def format_slack_messages_for_prompt(
             else:
                 bot_name = message.get("username") or "Bot"
             author = f"@{bot_name}(bot)"
+        files = message.get("files")
+        if isinstance(files, list) and files:
+            file_names = [
+                f.get("title") or f.get("name") or "untitled"
+                for f in files
+                if isinstance(f, dict)
+            ]
+            if file_names:
+                text += " " + " ".join(f"[attached: {name}]" for name in file_names)
         lines.append(f"{author}: {text}")
     return "\n".join(lines)
 

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -181,9 +181,7 @@ def format_slack_messages_for_prompt(
         files = message.get("files")
         if isinstance(files, list) and files:
             file_names = [
-                f.get("title") or f.get("name") or "untitled"
-                for f in files
-                if isinstance(f, dict)
+                f.get("title") or f.get("name") or "untitled" for f in files if isinstance(f, dict)
             ]
             if file_names:
                 text += " " + " ".join(f"[attached: {name}]" for name in file_names)

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -181,7 +181,7 @@ def format_slack_messages_for_prompt(
         files = message.get("files")
         if isinstance(files, list) and files:
             file_names = [
-                f.get("title") or f.get("name") or "untitled" for f in files if isinstance(f, dict)
+                f.get("title") or f.get("name") or "Untitled" for f in files if isinstance(f, dict)
             ]
             if file_names:
                 text += " " + " ".join(f"[attached: {name}]" for name in file_names)

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -787,22 +787,25 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
             and f.get("url_private")
         ]
     )
-    async with httpx.AsyncClient() as http_client:
-        if image_urls:
-            logger.info("Preparing %d image(s) for Slack mention", len(image_urls))
-            for image_url in image_urls:
-                image_block = await fetch_image_block(image_url, http_client)
-                if image_block:
-                    content_blocks.append(image_block)
+    has_files = any(msg.get("files") for msg in context_messages)
+    if image_urls or has_files:
+        async with httpx.AsyncClient() as http_client:
+            if image_urls:
+                logger.info("Preparing %d image(s) for Slack mention", len(image_urls))
+                for image_url in image_urls:
+                    image_block = await fetch_image_block(image_url, http_client)
+                    if image_block:
+                        content_blocks.append(image_block)
 
-        text_files = await fetch_slack_text_files(context_messages, http_client)
-        if text_files:
-            logger.info("Including %d text snippet(s) for Slack mention", len(text_files))
-            for tf in text_files:
-                snippet_block = create_text_block(
-                    f"## Slack Snippet: {tf['title']}\n```\n{tf['content']}\n```"
-                )
-                content_blocks.append(snippet_block)
+            if has_files:
+                text_files = await fetch_slack_text_files(context_messages, http_client)
+                if text_files:
+                    logger.info("Including %d text snippet(s) for Slack mention", len(text_files))
+                    for tf in text_files:
+                        snippet_block = create_text_block(
+                            f"## Slack Snippet: {tf['title']}\n```\n{tf['content']}\n```"
+                        )
+                        content_blocks.append(snippet_block)
 
     configurable: dict[str, Any] = {
         "repo": repo_config,

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -37,7 +37,12 @@ from .utils.github_token import get_github_token_from_thread
 from .utils.github_user_email_map import GITHUB_USER_EMAIL_MAP
 from .utils.linear import post_linear_trace_comment
 from .utils.linear_team_repo_map import LINEAR_TEAM_TO_REPO
-from .utils.multimodal import dedupe_urls, extract_image_urls, fetch_image_block
+from .utils.multimodal import (
+    dedupe_urls,
+    extract_image_urls,
+    fetch_image_block,
+    fetch_slack_text_files,
+)
 from .utils.repo import extract_repo_from_text
 from .utils.slack import (
     add_slack_reaction,
@@ -782,13 +787,22 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
             and f.get("url_private")
         ]
     )
-    if image_urls:
-        logger.info("Preparing %d image(s) for Slack mention", len(image_urls))
-        async with httpx.AsyncClient() as http_client:
+    async with httpx.AsyncClient() as http_client:
+        if image_urls:
+            logger.info("Preparing %d image(s) for Slack mention", len(image_urls))
             for image_url in image_urls:
                 image_block = await fetch_image_block(image_url, http_client)
                 if image_block:
                     content_blocks.append(image_block)
+
+        text_files = await fetch_slack_text_files(context_messages, http_client)
+        if text_files:
+            logger.info("Including %d text snippet(s) for Slack mention", len(text_files))
+            for tf in text_files:
+                snippet_block = create_text_block(
+                    f"## Slack Snippet: {tf['title']}\n```\n{tf['content']}\n```"
+                )
+                content_blocks.append(snippet_block)
 
     configurable: dict[str, Any] = {
         "repo": repo_config,

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -111,8 +111,8 @@ def test_fetch_slack_text_files_fetches_from_url_private() -> None:
         {
             "files": [
                 {
-                    "mimetype": "text/plain",
                     "title": "my snippet",
+                    "preview": "hello...",
                     "url_private": "https://files.slack.com/files/snippet.txt",
                 }
             ]
@@ -140,7 +140,6 @@ def test_fetch_slack_text_files_falls_back_to_inline_when_no_url() -> None:
         {
             "files": [
                 {
-                    "mimetype": "text/plain",
                     "title": "inline snippet",
                     "plain_text": "inline content here",
                 }
@@ -161,7 +160,6 @@ def test_fetch_slack_text_files_falls_back_to_inline_on_fetch_error() -> None:
         {
             "files": [
                 {
-                    "mimetype": "text/plain",
                     "title": "fallback snippet",
                     "url_private": "https://files.slack.com/files/fail.txt",
                     "preview": "preview content",
@@ -180,7 +178,8 @@ def test_fetch_slack_text_files_falls_back_to_inline_on_fetch_error() -> None:
     assert result[0] == {"title": "fallback snippet", "content": "preview content"}
 
 
-def test_fetch_slack_text_files_skips_image_files() -> None:
+def test_fetch_slack_text_files_skips_binary_files() -> None:
+    """Files without plain_text or preview are binary — should be skipped."""
     messages = [
         {
             "files": [
@@ -200,38 +199,13 @@ def test_fetch_slack_text_files_skips_image_files() -> None:
     mock_client.get.assert_not_called()
 
 
-def test_fetch_slack_text_files_handles_application_json() -> None:
-    messages = [
-        {
-            "files": [
-                {
-                    "mimetype": "application/json",
-                    "title": "config.json",
-                    "url_private": "https://files.slack.com/files/config.json",
-                }
-            ]
-        }
-    ]
-    mock_response = AsyncMock()
-    mock_response.text = '{"key": "value"}'
-    mock_response.raise_for_status = lambda: None
-
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = mock_response
-
-    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
-
-    assert len(result) == 1
-    assert result[0] == {"title": "config.json", "content": '{"key": "value"}'}
-
-
 def test_fetch_slack_text_files_truncates_large_content() -> None:
     messages = [
         {
             "files": [
                 {
-                    "mimetype": "text/plain",
                     "title": "huge file",
+                    "preview": "x" * 100,
                     "url_private": "https://files.slack.com/files/huge.txt",
                 }
             ]

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from agent.utils.multimodal import extract_image_urls
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from agent.utils.multimodal import extract_image_urls, fetch_slack_text_files
 
 
 def test_extract_image_urls_empty() -> None:
@@ -96,3 +101,160 @@ def test_extract_image_urls_mixed_markdown_and_direct() -> None:
         "https://example.com/another.gif",
     }
     assert len(result) == 3
+
+
+# --- fetch_slack_text_files tests ---
+
+
+def test_fetch_slack_text_files_fetches_from_url_private() -> None:
+    messages = [
+        {
+            "files": [
+                {
+                    "mimetype": "text/plain",
+                    "title": "my snippet",
+                    "url_private": "https://files.slack.com/files/snippet.txt",
+                }
+            ]
+        }
+    ]
+    mock_response = AsyncMock()
+    mock_response.text = "hello world"
+    mock_response.raise_for_status = lambda: None
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-test"}):
+        result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert len(result) == 1
+    assert result[0] == {"title": "my snippet", "content": "hello world"}
+    mock_client.get.assert_called_once()
+    call_kwargs = mock_client.get.call_args
+    assert call_kwargs[1]["headers"]["Authorization"] == "Bearer xoxb-test"
+
+
+def test_fetch_slack_text_files_falls_back_to_inline_when_no_url() -> None:
+    messages = [
+        {
+            "files": [
+                {
+                    "mimetype": "text/plain",
+                    "title": "inline snippet",
+                    "plain_text": "inline content here",
+                }
+            ]
+        }
+    ]
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert len(result) == 1
+    assert result[0] == {"title": "inline snippet", "content": "inline content here"}
+    mock_client.get.assert_not_called()
+
+
+def test_fetch_slack_text_files_falls_back_to_inline_on_fetch_error() -> None:
+    messages = [
+        {
+            "files": [
+                {
+                    "mimetype": "text/plain",
+                    "title": "fallback snippet",
+                    "url_private": "https://files.slack.com/files/fail.txt",
+                    "preview": "preview content",
+                }
+            ]
+        }
+    ]
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.side_effect = httpx.HTTPStatusError(
+        "error", request=AsyncMock(), response=AsyncMock()
+    )
+
+    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert len(result) == 1
+    assert result[0] == {"title": "fallback snippet", "content": "preview content"}
+
+
+def test_fetch_slack_text_files_skips_image_files() -> None:
+    messages = [
+        {
+            "files": [
+                {
+                    "mimetype": "image/png",
+                    "title": "screenshot.png",
+                    "url_private": "https://files.slack.com/files/img.png",
+                }
+            ]
+        }
+    ]
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert result == []
+    mock_client.get.assert_not_called()
+
+
+def test_fetch_slack_text_files_handles_application_json() -> None:
+    messages = [
+        {
+            "files": [
+                {
+                    "mimetype": "application/json",
+                    "title": "config.json",
+                    "url_private": "https://files.slack.com/files/config.json",
+                }
+            ]
+        }
+    ]
+    mock_response = AsyncMock()
+    mock_response.text = '{"key": "value"}'
+    mock_response.raise_for_status = lambda: None
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert len(result) == 1
+    assert result[0] == {"title": "config.json", "content": '{"key": "value"}'}
+
+
+def test_fetch_slack_text_files_truncates_large_content() -> None:
+    messages = [
+        {
+            "files": [
+                {
+                    "mimetype": "text/plain",
+                    "title": "huge file",
+                    "url_private": "https://files.slack.com/files/huge.txt",
+                }
+            ]
+        }
+    ]
+    mock_response = AsyncMock()
+    mock_response.text = "x" * 60_000
+    mock_response.raise_for_status = lambda: None
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert len(result) == 1
+    assert len(result[0]["content"]) == 50_000 + len("\n... (truncated)")
+    assert result[0]["content"].endswith("\n... (truncated)")
+
+
+def test_fetch_slack_text_files_no_files() -> None:
+    messages = [{"text": "just a message"}]
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+    result = asyncio.run(fetch_slack_text_files(messages, mock_client))
+
+    assert result == []

--- a/tests/test_slack_context.py
+++ b/tests/test_slack_context.py
@@ -130,6 +130,34 @@ def test_convert_mentions_to_slack_format_preserves_existing_slack_mentions() ->
     assert convert_mentions_to_slack_format(text) == text
 
 
+def test_format_slack_messages_for_prompt_includes_attached_files() -> None:
+    formatted = format_slack_messages_for_prompt(
+        [
+            {
+                "ts": "1.0",
+                "text": "check this",
+                "user": "U123",
+                "files": [
+                    {"title": "snippet.py", "mimetype": "text/plain"},
+                    {"name": "data.json", "mimetype": "application/json"},
+                ],
+            }
+        ],
+        {"U123": "alice"},
+    )
+
+    assert formatted == "@alice(U123): check this [attached: snippet.py] [attached: data.json]"
+
+
+def test_format_slack_messages_for_prompt_no_files_no_annotation() -> None:
+    formatted = format_slack_messages_for_prompt(
+        [{"ts": "1.0", "text": "no files here", "user": "U123"}],
+        {"U123": "alice"},
+    )
+
+    assert formatted == "@alice(U123): no files here"
+
+
 def test_format_slack_messages_for_prompt_uses_name_and_id() -> None:
     formatted = format_slack_messages_for_prompt(
         [{"ts": "1.0", "text": "hello", "user": "U123"}],


### PR DESCRIPTION
## Description
When users shared text snippets in Slack (code, config files, etc.), the agent couldn't see them — it only extracted image files.

Now the agent detects text files via Slack's plain_text/preview metadata, fetches their full content from Slack's API, and includes them in the prompt as ## Slack Snippet blocks.

The conversation context also shows [attached: filename] annotations so the agent knows files were shared.

## trace

https://dev.smith.langchain.com/public/660d3fa4-442b-4e4c-bcee-ced45cfc72f2/r