### PR TITLE
Reset stale SANDBOX_CREATING sentinel

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -207,6 +207,13 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     sandbox_id = await get_sandbox_id_from_metadata(thread_id)
 
     if sandbox_id == SANDBOX_CREATING and not sandbox_backend:
+        logger.warning(
+            "Found stale SANDBOX_CREATING for thread %s with no cached backend, resetting",
+            thread_id,
+        )
+        await client.threads.update(thread_id=thread_id, metadata={"sandbox_id": None})
+        sandbox_id = None
+    elif sandbox_id == SANDBOX_CREATING:
         logger.info("Sandbox creation in progress, waiting...")
         sandbox_id = await _wait_for_sandbox_id(thread_id)
 

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -241,6 +241,51 @@ class TestRefreshProxyOnSandboxReuse:
             mock_proxy.assert_called_once_with("sandbox-cached", "ghs_fresh")
 
     @pytest.mark.asyncio
+    async def test_resets_stale_sandbox_creating_without_cached_backend(self) -> None:
+        config = self._execution_config()
+        mock_backend = MagicMock(id="sandbox-new")
+        mock_client = MagicMock()
+        mock_client.threads.update = AsyncMock()
+
+        with (
+            patch(
+                "agent.server.resolve_github_token",
+                new_callable=AsyncMock,
+                return_value=("ghp", "enc"),
+            ),
+            patch(
+                "agent.server.get_sandbox_id_from_metadata",
+                new_callable=AsyncMock,
+                return_value=SANDBOX_CREATING,
+            ),
+            patch(
+                "agent.server.get_github_app_installation_token",
+                new_callable=AsyncMock,
+                return_value="ghs_fresh",
+            ),
+            patch("agent.server._wait_for_sandbox_id", new_callable=AsyncMock),
+            patch(
+                "agent.server._create_sandbox_with_proxy",
+                new_callable=AsyncMock,
+                return_value=mock_backend,
+            ),
+            patch("agent.server.make_model", return_value=MagicMock()),
+            patch("agent.server.construct_system_prompt", return_value="prompt"),
+            patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
+            patch.dict("agent.server.SANDBOX_BACKENDS", {}, clear=True),
+            patch("agent.server.asyncio.to_thread", new_callable=AsyncMock),
+            patch("agent.server.client", mock_client),
+            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
+        ):
+            from agent.server import get_agent
+
+            await get_agent(config)
+
+        reset_call = mock_client.threads.update.await_args_list[0][1]
+        assert reset_call["thread_id"] == "thread-123"
+        assert reset_call["metadata"] == {"sandbox_id": None}
+
+    @pytest.mark.asyncio
     async def test_refreshes_proxy_when_reconnecting_to_existing_langsmith_sandbox(self) -> None:
         """Reconnected sandboxes should also get a fresh proxy token."""
         config = self._execution_config()


### PR DESCRIPTION
## Summary\n- reset the SANDBOX_CREATING metadata if a restart leaves the sentinel but no cached backend is running\n- wait only when there is a backend tracked, so restarts recover instead of timing out\n- add regression coverage to ensure the sentinel reset path triggers\n\n## Testing\n- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/cc/github-radar/workbench/langchain-ai/open-swe-issue1116
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 0 items / 1 error

==================================== ERRORS ====================================
__________________ ERROR collecting tests/test_proxy_auth.py ___________________
ImportError while importing test module '/home/cc/github-radar/workbench/langchain-ai/open-swe-issue1116/tests/test_proxy_auth.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_proxy_auth.py:11: in <module>
    from agent.integrations.langsmith import _configure_github_proxy
agent/integrations/__init__.py:3: in <module>
    from deepagents.backends import LangSmithSandbox
E   ModuleNotFoundError: No module named 'deepagents'
=============================== warnings summary ===============================
../../../../.local/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /home/cc/.local/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
ERROR tests/test_proxy_auth.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 warning, 1 error in 0.13s ========================== *(fails: deepagents package missing in this workspace)*