### PR TITLE
fix: forward Slack image attachments to queued follow-up messages

### DIFF
--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 import httpx
@@ -682,6 +683,22 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         await post_linear_trace_comment(issue_id, run["run_id"], triggering_comment_id)
 
 
+def _extract_slack_image_urls(messages: Sequence[dict[str, Any] | None]) -> list[str]:
+    """Collect image URLs from Slack message text and image file uploads."""
+    valid_messages = [m for m in messages if isinstance(m, dict)]
+    return dedupe_urls(
+        [url for msg in valid_messages for url in extract_image_urls(msg.get("text", ""))]
+        + [
+            f["url_private"]
+            for msg in valid_messages
+            for f in msg.get("files", [])
+            if isinstance(f, dict)
+            and f.get("mimetype", "").startswith("image/")
+            and f.get("url_private")
+        ]
+    )
+
+
 async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[str, str]) -> None:
     """Process a Slack app mention by creating or interrupting a thread run."""
     channel_id = event_data.get("channel_id", "")
@@ -769,27 +786,6 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
         "Use `slack_thread_reply` to communicate in this Slack thread for clarifications, "
         "status updates, and final summaries."
     )
-    content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]
-
-    image_urls = dedupe_urls(
-        [url for msg in context_messages for url in extract_image_urls(msg.get("text", ""))]
-        + [
-            f["url_private"]
-            for msg in context_messages
-            for f in msg.get("files", [])
-            if isinstance(f, dict)
-            and f.get("mimetype", "").startswith("image/")
-            and f.get("url_private")
-        ]
-    )
-    if image_urls:
-        logger.info("Preparing %d image(s) for Slack mention", len(image_urls))
-        async with httpx.AsyncClient() as http_client:
-            for image_url in image_urls:
-                image_block = await fetch_image_block(image_url, http_client)
-                if image_block:
-                    content_blocks.append(image_block)
-
     configurable: dict[str, Any] = {
         "repo": repo_config,
         "slack_thread": {
@@ -813,16 +809,35 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
             "Thread %s is active, queuing Slack message for middleware pickup",
             thread_id,
         )
-        queued_payload = {"text": prompt, "image_urls": []}
+        current_message = next(
+            (m for m in context_messages if str(m.get("ts")) == str(event_ts)),
+            None,
+        )
+        current_image_urls = _extract_slack_image_urls([current_message]) if current_message else []
+        queued_payload = {"text": prompt, "image_urls": current_image_urls}
         queued = await queue_message_for_thread(
             thread_id=thread_id,
             message_content=queued_payload,
         )
         if queued:
-            logger.info("Slack message queued for thread %s", thread_id)
+            logger.info(
+                "Slack message queued for thread %s with %d image(s)",
+                thread_id,
+                len(current_image_urls),
+            )
         else:
             logger.error("Failed to queue Slack message for thread %s", thread_id)
         return
+
+    content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]
+    image_urls = _extract_slack_image_urls(context_messages)
+    if image_urls:
+        logger.info("Preparing %d image(s) for Slack mention", len(image_urls))
+        async with httpx.AsyncClient() as http_client:
+            for image_url in image_urls:
+                image_block = await fetch_image_block(image_url, http_client)
+                if image_block:
+                    content_blocks.append(image_block)
 
     run = await langgraph_client.runs.create(
         thread_id,

--- a/tests/test_slack_image_queue.py
+++ b/tests/test_slack_image_queue.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from agent import webapp
+
+
+def test_process_slack_mention_queues_current_message_image_urls(monkeypatch) -> None:
+    current_image = "https://files.slack.com/new-screenshot.png"
+    current_ts = "1700000099.NEWMSG"
+    captured: dict[str, object] = {}
+
+    thread_messages: list[dict[str, object]] = [
+        {
+            "ts": current_ts,
+            "text": f"<@UBOT> here is the bug\n![screenshot]({current_image})",
+            "user": "U_USER",
+        }
+    ]
+
+    async def fake_fetch_slack_thread_messages(
+        channel_id: str, thread_ts: str
+    ) -> list[dict[str, object]]:
+        return thread_messages
+
+    async def fake_is_thread_active(thread_id: str) -> bool:
+        return True
+
+    async def fake_get_slack_repo_config(
+        message: str, channel_id: str, thread_ts: str
+    ) -> dict[str, str]:
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    async def fake_upsert_metadata(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def fake_add_reaction(*args: Any, **kwargs: Any) -> bool:
+        return True
+
+    async def fake_get_slack_user_info(user_id: str) -> dict[str, object] | None:
+        return None
+
+    async def fake_get_slack_user_names(user_ids: list[str]) -> dict[str, str]:
+        return {}
+
+    async def fake_queue_message_for_thread(thread_id: str, message_content: object) -> bool:
+        captured["thread_id"] = thread_id
+        captured["message_content"] = message_content
+        return True
+
+    monkeypatch.setattr(webapp, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages)
+    monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
+    monkeypatch.setattr(webapp, "get_slack_repo_config", fake_get_slack_repo_config)
+    monkeypatch.setattr(webapp, "_upsert_slack_thread_repo_metadata", fake_upsert_metadata)
+    monkeypatch.setattr(webapp, "add_slack_reaction", fake_add_reaction)
+    monkeypatch.setattr(webapp, "get_slack_user_info", fake_get_slack_user_info)
+    monkeypatch.setattr(webapp, "get_slack_user_names", fake_get_slack_user_names)
+    monkeypatch.setattr(webapp, "queue_message_for_thread", fake_queue_message_for_thread)
+
+    asyncio.run(
+        webapp.process_slack_mention(
+            {
+                "channel_id": "C_TEST",
+                "thread_ts": current_ts,
+                "event_ts": current_ts,
+                "user_id": "U_USER",
+                "text": f"<@UBOT> here is the bug\n![screenshot]({current_image})",
+                "bot_user_id": "UBOT",
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    message_content = captured["message_content"]
+    assert isinstance(message_content, dict)
+    assert message_content["image_urls"] == [current_image]
+
+
+def test_process_slack_mention_queue_excludes_historical_context_images(monkeypatch) -> None:
+    historical_image = "https://files.slack.com/old-historical.png"
+    current_image = "https://files.slack.com/new-screenshot.png"
+    historical_ts = "1700000000.OLD"
+    current_ts = "1700000099.NEW"
+    captured: dict[str, object] = {}
+
+    thread_messages: list[dict[str, object]] = [
+        {
+            "ts": historical_ts,
+            "text": f"earlier context ![old]({historical_image})",
+            "user": "U_HIST",
+        },
+        {
+            "ts": current_ts,
+            "text": f"<@UBOT> new issue ![new]({current_image})",
+            "user": "U_USER",
+        },
+    ]
+
+    async def fake_fetch_slack_thread_messages(
+        channel_id: str, thread_ts: str
+    ) -> list[dict[str, object]]:
+        return thread_messages
+
+    async def fake_is_thread_active(thread_id: str) -> bool:
+        return True
+
+    async def fake_get_slack_repo_config(
+        message: str, channel_id: str, thread_ts: str
+    ) -> dict[str, str]:
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    async def fake_upsert_metadata(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def fake_add_reaction(*args: Any, **kwargs: Any) -> bool:
+        return True
+
+    async def fake_get_slack_user_info(user_id: str) -> dict[str, object] | None:
+        return None
+
+    async def fake_get_slack_user_names(user_ids: list[str]) -> dict[str, str]:
+        return {}
+
+    async def fake_queue_message_for_thread(thread_id: str, message_content: object) -> bool:
+        captured["message_content"] = message_content
+        return True
+
+    monkeypatch.setattr(webapp, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages)
+    monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
+    monkeypatch.setattr(webapp, "get_slack_repo_config", fake_get_slack_repo_config)
+    monkeypatch.setattr(webapp, "_upsert_slack_thread_repo_metadata", fake_upsert_metadata)
+    monkeypatch.setattr(webapp, "add_slack_reaction", fake_add_reaction)
+    monkeypatch.setattr(webapp, "get_slack_user_info", fake_get_slack_user_info)
+    monkeypatch.setattr(webapp, "get_slack_user_names", fake_get_slack_user_names)
+    monkeypatch.setattr(webapp, "queue_message_for_thread", fake_queue_message_for_thread)
+
+    asyncio.run(
+        webapp.process_slack_mention(
+            {
+                "channel_id": "C_TEST",
+                "thread_ts": historical_ts,
+                "event_ts": current_ts,
+                "user_id": "U_USER",
+                "text": f"<@UBOT> new issue ![new]({current_image})",
+                "bot_user_id": "UBOT",
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    message_content = captured["message_content"]
+    assert isinstance(message_content, dict)
+    assert message_content["image_urls"] == [current_image]
+    assert historical_image not in message_content["image_urls"]
+
+
+def test_process_slack_mention_queue_empty_image_urls_for_text_only_follow_up(
+    monkeypatch,
+) -> None:
+    current_ts = "1700000099.TEXTONLY"
+    captured: dict[str, object] = {}
+
+    thread_messages: list[dict[str, object]] = [
+        {
+            "ts": current_ts,
+            "text": "<@UBOT> just a text follow-up no image here",
+            "user": "U_USER",
+        }
+    ]
+
+    async def fake_fetch_slack_thread_messages(
+        channel_id: str, thread_ts: str
+    ) -> list[dict[str, object]]:
+        return thread_messages
+
+    async def fake_is_thread_active(thread_id: str) -> bool:
+        return True
+
+    async def fake_get_slack_repo_config(
+        message: str, channel_id: str, thread_ts: str
+    ) -> dict[str, str]:
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    async def fake_upsert_metadata(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def fake_add_reaction(*args: Any, **kwargs: Any) -> bool:
+        return True
+
+    async def fake_get_slack_user_info(user_id: str) -> dict[str, object] | None:
+        return None
+
+    async def fake_get_slack_user_names(user_ids: list[str]) -> dict[str, str]:
+        return {}
+
+    async def fake_queue_message_for_thread(thread_id: str, message_content: object) -> bool:
+        captured["message_content"] = message_content
+        return True
+
+    monkeypatch.setattr(webapp, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages)
+    monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
+    monkeypatch.setattr(webapp, "get_slack_repo_config", fake_get_slack_repo_config)
+    monkeypatch.setattr(webapp, "_upsert_slack_thread_repo_metadata", fake_upsert_metadata)
+    monkeypatch.setattr(webapp, "add_slack_reaction", fake_add_reaction)
+    monkeypatch.setattr(webapp, "get_slack_user_info", fake_get_slack_user_info)
+    monkeypatch.setattr(webapp, "get_slack_user_names", fake_get_slack_user_names)
+    monkeypatch.setattr(webapp, "queue_message_for_thread", fake_queue_message_for_thread)
+
+    asyncio.run(
+        webapp.process_slack_mention(
+            {
+                "channel_id": "C_TEST",
+                "thread_ts": current_ts,
+                "event_ts": current_ts,
+                "user_id": "U_USER",
+                "text": "<@UBOT> just a text follow-up no image here",
+                "bot_user_id": "UBOT",
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    message_content = captured["message_content"]
+    assert isinstance(message_content, dict)
+    assert message_content["image_urls"] == []
+
+
+def test_process_slack_mention_non_busy_path_fetches_image_into_content_blocks(
+    monkeypatch,
+) -> None:
+    current_image = "https://files.slack.com/new-screenshot.png"
+    current_ts = "1700000099.NEW"
+    captured: dict[str, object] = {}
+
+    thread_messages: list[dict[str, object]] = [
+        {
+            "ts": current_ts,
+            "text": f"<@UBOT> check this ![screenshot]({current_image})",
+            "user": "U_USER",
+        }
+    ]
+
+    async def fake_fetch_slack_thread_messages(
+        channel_id: str, thread_ts: str
+    ) -> list[dict[str, object]]:
+        return thread_messages
+
+    async def fake_is_thread_active(thread_id: str) -> bool:
+        return False
+
+    async def fake_get_slack_repo_config(
+        message: str, channel_id: str, thread_ts: str
+    ) -> dict[str, str]:
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    async def fake_upsert_metadata(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def fake_add_reaction(*args: Any, **kwargs: Any) -> bool:
+        return True
+
+    async def fake_get_slack_user_info(user_id: str) -> dict[str, object] | None:
+        return None
+
+    async def fake_get_slack_user_names(user_ids: list[str]) -> dict[str, str]:
+        return {}
+
+    async def fake_post_slack_trace_reply(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def fake_fetch_image_block(*args: Any, **kwargs: Any) -> dict[str, object] | None:
+        return {"type": "image", "source_type": "base64", "data": "fake"}
+
+    class _FakeRunsClient:
+        async def create(self, *args: Any, **kwargs: Any) -> dict[str, str]:
+            captured["run_input"] = kwargs.get("input")
+            return {"run_id": "fake-run"}
+
+    class _FakeLangGraphClient:
+        runs = _FakeRunsClient()
+
+    monkeypatch.setattr(webapp, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages)
+    monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
+    monkeypatch.setattr(webapp, "get_slack_repo_config", fake_get_slack_repo_config)
+    monkeypatch.setattr(webapp, "_upsert_slack_thread_repo_metadata", fake_upsert_metadata)
+    monkeypatch.setattr(webapp, "add_slack_reaction", fake_add_reaction)
+    monkeypatch.setattr(webapp, "get_slack_user_info", fake_get_slack_user_info)
+    monkeypatch.setattr(webapp, "get_slack_user_names", fake_get_slack_user_names)
+    monkeypatch.setattr(webapp, "post_slack_trace_reply", fake_post_slack_trace_reply)
+    monkeypatch.setattr(webapp, "fetch_image_block", fake_fetch_image_block)
+    monkeypatch.setattr(webapp, "get_client", lambda url: _FakeLangGraphClient())
+
+    asyncio.run(
+        webapp.process_slack_mention(
+            {
+                "channel_id": "C_TEST",
+                "thread_ts": current_ts,
+                "event_ts": current_ts,
+                "user_id": "U_USER",
+                "text": f"<@UBOT> check this ![screenshot]({current_image})",
+                "bot_user_id": "UBOT",
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    run_input = captured["run_input"]
+    assert isinstance(run_input, dict)
+    content_blocks = run_input["messages"][0]["content"]
+    block_types = [block.get("type") for block in content_blocks]
+    assert "text" in block_types
+    assert "image" in block_types


### PR DESCRIPTION
## Description

Slack image attachments were silently dropped when a user sent a follow-up with an image while open-swe was already running on that thread.

`process_slack_mention` built the correct `image_urls` list from the thread context, but on the busy path hardcoded `image_urls=[]` in the queued payload:

```python
# agent/webapp.py (before)
queued_payload = {"text": prompt, "image_urls": []}
```

`check_message_queue_before_model` then read an empty list and never fetched the images, so the agent saw the follow-up text but not the screenshot. Regression introduced in #1050.

The rest of the queue pipeline — including Slack-auth in `fetch_image_block` — was already wired correctly. Only the queue producer was missing the forward.

This PR also reorders `process_slack_mention` so the `is_thread_active` check runs before the image fetch loop. Previously, images were fetched from `files.slack.com` on the busy path even though the results were then discarded by the `image_urls=[]` queue payload.

On the busy path the queue now carries images filtered to the **current mention only**, not the full thread context. Re-injecting historical images would duplicate what the agent already saw in its prior turn.

## Test Plan

New `tests/test_slack_image_queue.py`:

- [x] Busy path forwards current mention's image URL to the queue payload
- [x] Busy path excludes historical context images
- [x] Busy path produces empty `image_urls` for a text-only follow-up
- [x] Non-busy path still fetches images into `content_blocks`

Full suite: `111 passed`.