### PR TITLE
Security: Potential credential leakage via authenticated redirects when fetching Slack/Linear images

### DIFF
--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -8,7 +8,7 @@ import mimetypes
 import os
 import re
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from langchain_core.messages.content import create_image_block
@@ -64,7 +64,45 @@ async def fetch_image_block(
                     "SLACK_BOT_TOKEN not set; cannot authenticate image fetch for %s",
                     image_url,
                 )
-        response = await client.get(image_url, headers=headers, follow_redirects=True)
+        if headers:
+            response = await client.get(image_url, headers=headers, follow_redirects=False)
+            redirect_count = 0
+            parsed_origin = urlparse(image_url)
+            origin = (
+                parsed_origin.scheme.lower(),
+                (parsed_origin.hostname or "").lower(),
+                parsed_origin.port,
+            )
+            while response.is_redirect:
+                if redirect_count >= 5:
+                    logger.warning(
+                        "Too many redirects while fetching authenticated image %s",
+                        image_url,
+                    )
+                    return None
+                location = response.headers.get("Location")
+                if not location:
+                    logger.warning(
+                        "Redirect missing location while fetching authenticated image %s",
+                        image_url,
+                    )
+                    return None
+                next_url = urljoin(str(response.request.url), location)
+                parsed_next = urlparse(next_url)
+                next_origin = (
+                    parsed_next.scheme.lower(),
+                    (parsed_next.hostname or "").lower(),
+                    parsed_next.port,
+                )
+                next_headers = headers if next_origin == origin else None
+                response = await client.get(
+                    next_url,
+                    headers=next_headers,
+                    follow_redirects=False,
+                )
+                redirect_count += 1
+        else:
+            response = await client.get(image_url, follow_redirects=True)
         response.raise_for_status()
         content_type = response.headers.get("Content-Type", "").split(";")[0].strip()
         if not content_type:


### PR DESCRIPTION
## Problem

`fetch_image_block` attaches `Authorization` headers for `uploads.linear.app` and `files.slack.com`, while also enabling automatic redirects. If redirects are followed across origins, sensitive tokens may be exposed to unintended endpoints depending on client redirect behavior and edge cases.

**Severity**: `medium`
**File**: `agent/utils/multimodal.py`

## Solution

Disable automatic redirects when authorization headers are present and handle redirects manually. Only forward auth headers to explicitly validated same-origin destinations (or strict allowlist).

## Changes

- `agent/utils/multimodal.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
