### PR TITLE
fix: remove deprecated temperature parameter for Opus 4.7 compatibility

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -277,7 +277,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     return create_deep_agent(
         model=make_model(
             os.environ.get("LLM_MODEL_ID", DEFAULT_LLM_MODEL_ID),
-            temperature=0,
             max_tokens=20_000,
         ),
         system_prompt=construct_system_prompt(


### PR DESCRIPTION
## Description: 
Opus 4.7 rejects the temperature parameter with a 400 Bad Request error (temperature is deprecated for this model). Removed temperature=0 from the make_model call in server.py since it's unnecessary for both 4.6 and 4.7.

<img width="1036" height="340" alt="Screenshot 2026-04-17 at 9 45 33 AM" src="https://github.com/user-attachments/assets/8d73049f-5ba7-45e3-aef7-7870467f2083" />

## Deployment Checklist 

- [ ] Update deployed env vars (LangSmith/production): - Set LLM_MODEL_ID=anthropic:claude-opus-4-7 in deployment config 

## Trace

https://dev.smith.langchain.com/public/74a09f5f-78c0-4511-9f37-271dda1d7448/r