### PR TITLE
fix: update LangSmith trace URL format to use peek query params

### DIFF
--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -8,8 +8,8 @@ import os
 logger = logging.getLogger(__name__)
 
 
-def _compose_langsmith_url_base() -> str:
-    """Build the LangSmith URL base from environment variables."""
+def _compose_langsmith_project_url() -> str:
+    """Build the LangSmith project URL base from environment variables."""
     host_url = os.environ.get("LANGSMITH_URL_PROD", "https://smith.langchain.com")
     tenant_id = os.environ.get("LANGSMITH_TENANT_ID_PROD")
     project_id = os.environ.get("LANGSMITH_TRACING_PROJECT_ID_PROD")
@@ -17,14 +17,14 @@ def _compose_langsmith_url_base() -> str:
         raise ValueError(
             "LANGSMITH_TENANT_ID_PROD and LANGSMITH_TRACING_PROJECT_ID_PROD must be set"
         )
-    return f"{host_url}/o/{tenant_id}/projects/p/{project_id}/r"
+    return f"{host_url}/o/{tenant_id}/projects/p/{project_id}"
 
 
 def get_langsmith_trace_url(run_id: str) -> str | None:
     """Build the LangSmith trace URL for a given run ID."""
     try:
-        url_base = _compose_langsmith_url_base()
-        return f"{url_base}/{run_id}?poll=true"
+        base = _compose_langsmith_project_url()
+        return f"{base}?peek={run_id}&peeked_trace={run_id}"
     except Exception:  # noqa: BLE001
         logger.warning("Failed to build LangSmith trace URL for run %s", run_id, exc_info=True)
         return None


### PR DESCRIPTION
trace link from the tracing project 

https://dev.smith.langchain.com/o/d6684905-655c-429b-bd14-ba302d94c03b/projects/p/00e14091-aa22-4ef8-84d9-aec107bd98f7?peek=019db6c1-e59b-73a1-958b-ee98a94e7a0a&peeked_trace=019db6c1-e59b-73a1-958b-ee98a94e7a0a

Trace from slack response 

https://dev.smith.langchain.com/o/d6684905-655c-429b-bd14-ba302d94c03b/projects/p/00e14091-aa22-4ef8-84d9-aec107bd98f7?peek=019db6c1-e59b-73a1-958b-ee98a94e7a0a&peeked_trace=019db6c1-e59b-73a1-958b-ee98a94e7a0a