### PR TITLE
fix(http_request): pin DNS resolution to defeat SSRF rebinding bypass

### DIFF
--- a/agent/tools/http_request.py
+++ b/agent/tools/http_request.py
@@ -1,5 +1,8 @@
+import contextlib
 import ipaddress
 import socket
+import threading
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -7,23 +10,36 @@ import requests
 
 _MAX_REDIRECTS = 5
 
+# Serialises pinned DNS resolution. _pinned_dns_resolution swaps the global
+# socket.getaddrinfo, so concurrent pin scopes inside the same process must not
+# overlap. The lock is held only for the duration of a single HTTP request.
+_DNS_PIN_LOCK = threading.Lock()
 
-def _is_url_safe(url: str) -> tuple[bool, str]:
-    """Check if a URL is safe to request (not targeting private/internal networks)."""
+
+def _is_url_safe(url: str) -> tuple[bool, str, list[str]]:
+    """Check if a URL is safe to request (not targeting private/internal networks).
+
+    Returns ``(is_safe, reason, validated_ips)``. ``validated_ips`` is the list of
+    resolved IP addresses that passed the SSRF policy; empty when ``is_safe`` is
+    False. The list is what callers must pin DNS resolution to during the actual
+    request — re-resolving on connect lets a short-TTL attacker DNS-rebind to a
+    private address after this check passes.
+    """
     try:
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"}:
-            return False, f"Unsupported URL scheme: {parsed.scheme or '<missing>'}"
+            return False, f"Unsupported URL scheme: {parsed.scheme or '<missing>'}", []
 
         hostname = parsed.hostname
         if not hostname:
-            return False, "Could not parse hostname from URL"
+            return False, "Could not parse hostname from URL", []
 
         try:
             addr_infos = socket.getaddrinfo(hostname, None)
         except socket.gaierror:
-            return False, f"Could not resolve hostname: {hostname}"
+            return False, f"Could not resolve hostname: {hostname}", []
 
+        validated_ips: list[str] = []
         for addr_info in addr_infos:
             ip_str = addr_info[4][0]
             try:
@@ -32,11 +48,80 @@ def _is_url_safe(url: str) -> tuple[bool, str]:
                 continue
 
             if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
-                return False, f"URL resolves to blocked address: {ip_str}"
+                return False, f"URL resolves to blocked address: {ip_str}", []
 
-        return True, ""
+            if ip_str not in validated_ips:
+                validated_ips.append(ip_str)
+
+        if not validated_ips:
+            return False, f"No usable IP addresses for hostname: {hostname}", []
+
+        return True, "", validated_ips
     except Exception as e:  # noqa: BLE001
-        return False, f"URL validation error: {e}"
+        return False, f"URL validation error: {e}", []
+
+
+def _build_pinned_addr_info(ip_str: str, port: int) -> tuple:
+    """Build a single ``socket.getaddrinfo``-shaped tuple for a pre-validated IP."""
+    ip = ipaddress.ip_address(ip_str)
+    if ip.version == 4:
+        return (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip_str, port))
+    return (
+        socket.AF_INET6,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        (ip_str, port, 0, 0),
+    )
+
+
+@contextlib.contextmanager
+def _pinned_dns_resolution(target_hostname: str, pinned_ips: list[str]) -> Iterator[None]:
+    """Force ``socket.getaddrinfo(target_hostname, ...)`` to return ``pinned_ips``.
+
+    Defeats DNS-rebinding bypass of the SSRF check (issue #1186). Without pinning,
+    ``_is_url_safe`` resolves the hostname for validation, then ``requests.request``
+    resolves it *again* when opening the TCP connection. An attacker controlling a
+    short-TTL DNS record can answer the first query with a public IP and the second
+    with an internal IP. With pinning, the second lookup returns the IPs the
+    validator already approved.
+
+    Lookups for hostnames *other* than ``target_hostname`` fall through to the
+    system resolver, so unrelated DNS work in the same call stack is unaffected.
+    The module-level lock serialises overlapping pin scopes inside the process.
+    """
+    target = target_hostname.lower()
+
+    addr_infos_cache: dict[int, list[tuple]] = {}
+
+    def _build_for_port(port: int) -> list[tuple]:
+        cached = addr_infos_cache.get(port)
+        if cached is not None:
+            return cached
+        infos: list[tuple] = []
+        for ip_str in pinned_ips:
+            try:
+                infos.append(_build_pinned_addr_info(ip_str, port))
+            except ValueError:
+                continue
+        addr_infos_cache[port] = infos
+        return infos
+
+    with _DNS_PIN_LOCK:
+        original = socket.getaddrinfo
+
+        def _pinned(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if host and str(host).lower() == target:
+                infos = _build_for_port(int(port) if port else 0)
+                if infos:
+                    return infos
+            return original(host, port, *args, **kwargs)
+
+        socket.getaddrinfo = _pinned  # type: ignore[assignment]
+        try:
+            yield
+        finally:
+            socket.getaddrinfo = original  # type: ignore[assignment]
 
 
 def _blocked_response(url: str, reason: str) -> dict[str, Any]:
@@ -56,23 +141,32 @@ def _request_with_safe_redirects(
     timeout: int,
     **kwargs: Any,
 ) -> tuple[requests.Response | None, dict[str, Any] | None]:
-    """Issue a request while validating every redirect target before following it."""
+    """Issue a request while validating every redirect target before following it.
+
+    Each hop validates the URL via ``_is_url_safe`` and then issues the actual
+    network request inside ``_pinned_dns_resolution`` so the connect step uses
+    the IPs the validator just approved (not a re-resolved value).
+    """
     current_method = method.upper()
     current_url = url
     request_kwargs = dict(kwargs)
 
     for redirect_count in range(_MAX_REDIRECTS + 1):
-        is_safe, reason = _is_url_safe(current_url)
+        is_safe, reason, validated_ips = _is_url_safe(current_url)
         if not is_safe:
             return None, _blocked_response(current_url, reason)
 
-        response = requests.request(
-            current_method,
-            current_url,
-            timeout=timeout,
-            allow_redirects=False,
-            **request_kwargs,
-        )
+        parsed = urlparse(current_url)
+        hostname = parsed.hostname or ""
+
+        with _pinned_dns_resolution(hostname, validated_ips):
+            response = requests.request(
+                current_method,
+                current_url,
+                timeout=timeout,
+                allow_redirects=False,
+                **request_kwargs,
+            )
 
         if not response.is_redirect and not response.is_permanent_redirect:
             return response, None

--- a/agent/tools/http_request.py
+++ b/agent/tools/http_request.py
@@ -7,12 +7,16 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import requests
+from requests.utils import get_environ_proxies, should_bypass_proxies
 
 _MAX_REDIRECTS = 5
 
 # Serialises pinned DNS resolution. _pinned_dns_resolution swaps the global
-# socket.getaddrinfo, so concurrent pin scopes inside the same process must not
+# socket.getaddrinfo so concurrent pin scopes inside the same process must not
 # overlap. The lock is held only for the duration of a single HTTP request.
+# Combined with the thread-id check inside the installed resolver, threads
+# *other* than the pin-issuing thread observe pure fall-through to the original
+# resolver — the swap is observable but behaves identically to no swap for them.
 _DNS_PIN_LOCK = threading.Lock()
 
 
@@ -24,6 +28,13 @@ def _is_url_safe(url: str) -> tuple[bool, str, list[str]]:
     False. The list is what callers must pin DNS resolution to during the actual
     request — re-resolving on connect lets a short-TTL attacker DNS-rebind to a
     private address after this check passes.
+
+    Only globally routable unicast addresses are accepted. ``ipaddress.is_global``
+    catches every range ``is_private/is_loopback/is_link_local/is_reserved`` reject
+    plus the ones those properties miss — RFC 6598 carrier-grade NAT (100.64.0.0/10),
+    the unspecified address (0.0.0.0 / ::), and broadcast (255.255.255.255). It does
+    NOT reject IPv4 multicast (224.0.0.0/4) since multicast is technically globally
+    scoped, so multicast is excluded explicitly.
     """
     try:
         parsed = urlparse(url)
@@ -47,8 +58,8 @@ def _is_url_safe(url: str) -> tuple[bool, str, list[str]]:
             except ValueError:
                 continue
 
-            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
-                return False, f"URL resolves to blocked address: {ip_str}", []
+            if (not ip.is_global) or ip.is_multicast:
+                return False, f"URL resolves to non-global address: {ip_str}", []
 
             if ip_str not in validated_ips:
                 validated_ips.append(ip_str)
@@ -59,6 +70,22 @@ def _is_url_safe(url: str) -> tuple[bool, str, list[str]]:
         return True, "", validated_ips
     except Exception as e:  # noqa: BLE001
         return False, f"URL validation error: {e}", []
+
+
+def _proxy_in_use_for(url: str) -> bool:
+    """Return True if an HTTP proxy from the environment would handle ``url``.
+
+    When a proxy is in the path, the agent connects to the proxy and the proxy
+    resolves the destination hostname. Local DNS pinning (this module's defense
+    against rebinding) becomes non-authoritative because the resolution that
+    matters happens on the proxy side, outside our control. The safe response
+    is to refuse the request — the operator can either disable the proxy for
+    SSRF-sensitive calls (e.g. via NO_PROXY) or bypass this guard intentionally
+    and rely on the proxy's own egress filtering.
+    """
+    if should_bypass_proxies(url, no_proxy=None):
+        return False
+    return bool(get_environ_proxies(url, no_proxy=None))
 
 
 def _build_pinned_addr_info(ip_str: str, port: int) -> tuple:
@@ -86,11 +113,16 @@ def _pinned_dns_resolution(target_hostname: str, pinned_ips: list[str]) -> Itera
     with an internal IP. With pinning, the second lookup returns the IPs the
     validator already approved.
 
-    Lookups for hostnames *other* than ``target_hostname`` fall through to the
-    system resolver, so unrelated DNS work in the same call stack is unaffected.
-    The module-level lock serialises overlapping pin scopes inside the process.
+    Although ``socket.getaddrinfo`` is a process-global function, the installed
+    resolver is **thread-scoped**: it only returns pinned IPs to the thread that
+    entered this context. Other threads — including ones doing unrelated DNS at
+    the same moment — observe a pure fall-through to the original resolver, even
+    if they happen to look up ``target_hostname``. The module-level lock then
+    serialises overlapping pin scopes within the same process so two pin-issuing
+    threads can't clobber each other's installed resolver mid-request.
     """
     target = target_hostname.lower()
+    pin_owner_tid = threading.get_ident()
 
     addr_infos_cache: dict[int, list[tuple]] = {}
 
@@ -111,7 +143,11 @@ def _pinned_dns_resolution(target_hostname: str, pinned_ips: list[str]) -> Itera
         original = socket.getaddrinfo
 
         def _pinned(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
-            if host and str(host).lower() == target:
+            # Only the pin-issuing thread sees the pinned answer. Other threads
+            # fall through to the original resolver as if no pin existed, so the
+            # process-wide swap of socket.getaddrinfo doesn't leak pinning into
+            # unrelated DNS work running concurrently.
+            if threading.get_ident() == pin_owner_tid and host and str(host).lower() == target:
                 infos = _build_for_port(int(port) if port else 0)
                 if infos:
                     return infos
@@ -155,6 +191,14 @@ def _request_with_safe_redirects(
         is_safe, reason, validated_ips = _is_url_safe(current_url)
         if not is_safe:
             return None, _blocked_response(current_url, reason)
+
+        if _proxy_in_use_for(current_url):
+            return None, _blocked_response(
+                current_url,
+                "HTTP proxy is configured for this URL; SSRF DNS pinning is not "
+                "authoritative through proxies. Add this host to NO_PROXY or unset "
+                "HTTP_PROXY/HTTPS_PROXY for SSRF-sensitive requests.",
+            )
 
         parsed = urlparse(current_url)
         hostname = parsed.hostname or ""

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import socket
 import sys
 import types
 
@@ -90,3 +91,186 @@ def test_fetch_url_blocks_redirects_to_private_ips(monkeypatch) -> None:
     assert result["status_code"] == 0
     assert result["url"] == "http://169.254.169.254/latest/meta-data"
     assert "Request blocked" in result["error"]
+
+
+# --- DNS rebinding (issue #1186) -------------------------------------------------
+
+_PUBLIC_IP = "8.8.8.8"  # Google DNS — globally routable, passes ip_address.is_private
+_PUBLIC_IP_2 = "1.1.1.1"  # Cloudflare DNS
+_PRIVATE_IP = "192.168.1.1"
+
+
+def _addr_info(ip: str, port: int) -> tuple:
+    return (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))
+
+
+def test_pinned_dns_resolution_returns_pinned_ips_for_target_host(monkeypatch) -> None:
+    def fail_original(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("system resolver should not be hit for the pinned host")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fail_original)
+
+    with http_request_tool._pinned_dns_resolution("api.example.com", [_PUBLIC_IP]):
+        result = socket.getaddrinfo("api.example.com", 443)
+
+    assert result == [_addr_info(_PUBLIC_IP, 443)]
+
+
+def test_pinned_dns_resolution_falls_through_for_unrelated_hosts(monkeypatch) -> None:
+    seen: list[tuple[str, int]] = []
+
+    def fake_original(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append((host, port))
+        return [_addr_info(_PUBLIC_IP_2, port)]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_original)
+
+    with http_request_tool._pinned_dns_resolution("api.example.com", [_PUBLIC_IP]):
+        result = socket.getaddrinfo("other-host.example", 80)
+
+    assert seen == [("other-host.example", 80)]
+    assert result == [_addr_info(_PUBLIC_IP_2, 80)]
+
+
+def test_pinned_dns_resolution_restores_original_after_exit(monkeypatch) -> None:
+    sentinel_calls: list[tuple] = []
+
+    def fake_original(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+        sentinel_calls.append((host, port))
+        return [_addr_info(_PUBLIC_IP_2, port)]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_original)
+
+    with http_request_tool._pinned_dns_resolution("api.example.com", [_PUBLIC_IP]):
+        pass
+
+    socket.getaddrinfo("api.example.com", 443)
+    assert sentinel_calls == [("api.example.com", 443)]
+
+
+def test_pinned_dns_resolution_supports_ipv6() -> None:
+    with http_request_tool._pinned_dns_resolution("api.example.com", ["2001:db8::1"]):
+        result = socket.getaddrinfo("api.example.com", 443)
+
+    assert result == [
+        (
+            socket.AF_INET6,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("2001:db8::1", 443, 0, 0),
+        )
+    ]
+
+
+def test_dns_rebinding_attack_uses_pinned_ip_during_connect(monkeypatch) -> None:
+    """Validation sees a public IP; an attacker tries to rebind to a private IP
+    before the connect step runs. With pinning, the connect-time lookup must
+    return the IPs the validator already approved — not the rebound value."""
+
+    lookup_log: list[str] = []
+
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+        lookup_log.append(host)
+        # First call (validation in _is_url_safe) — return public IP.
+        # Subsequent calls — simulate the attacker swapping to a private record.
+        if len([h for h in lookup_log if h == "rebind.example"]) == 1:
+            return [_addr_info(_PUBLIC_IP, port or 0)]
+        return [_addr_info(_PRIVATE_IP, port or 0)]
+
+    captured_resolutions: list[str] = []
+
+    def fake_request(method, url, **kwargs):  # type: ignore[no-untyped-def]
+        # Re-resolve from inside the request scope. With the pin in effect,
+        # this must return the pinned (public) IP — not the rebound private one.
+        result = socket.getaddrinfo("rebind.example", 443)
+        captured_resolutions.append(result[0][4][0])
+        return FakeResponse(status_code=200, url=url, text='{"ok": true}', json_data={"ok": True})
+
+    monkeypatch.setattr(socket, "getaddrinfo", rebinding_getaddrinfo)
+    monkeypatch.setattr(http_request_tool.requests, "request", fake_request)
+
+    result = http_request_tool.http_request("https://rebind.example/data")
+
+    assert result["status_code"] == 200
+    # The pin must have intercepted the connect-time lookup and returned the
+    # validator-approved public IP, not the attacker's private rebind.
+    assert captured_resolutions == [_PUBLIC_IP]
+
+
+def test_redirect_repins_to_new_target_host(monkeypatch) -> None:
+    """Each redirect target gets its own validation + pin — a redirect to a fresh
+    hostname must use the new hostname's validated IPs, not the previous host's."""
+
+    lookup_log: list[tuple[str, int]] = []
+    sequence = iter(
+        [
+            # _is_url_safe("https://first.example/start")
+            [_addr_info(_PUBLIC_IP, 0)],
+            # _is_url_safe("https://second.example/end")
+            [_addr_info(_PUBLIC_IP_2, 0)],
+        ]
+    )
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+        lookup_log.append((host, port or 0))
+        try:
+            return next(sequence)
+        except StopIteration:
+            return [_addr_info(_PUBLIC_IP_2, port or 0)]
+
+    seen_pinned: list[tuple[str, str]] = []
+
+    def fake_request(method, url, **kwargs):  # type: ignore[no-untyped-def]
+        host = url.split("//", 1)[1].split("/", 1)[0]
+        resolved = socket.getaddrinfo(host, 443)[0][4][0]
+        seen_pinned.append((host, resolved))
+        if host == "first.example":
+            return FakeResponse(
+                status_code=302,
+                url=url,
+                headers={"Location": "https://second.example/end"},
+            )
+        return FakeResponse(status_code=200, url=url, text="ok")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(http_request_tool.requests, "request", fake_request)
+
+    result = http_request_tool.http_request("https://first.example/start")
+
+    assert result["status_code"] == 200
+    assert seen_pinned == [
+        ("first.example", _PUBLIC_IP),
+        ("second.example", _PUBLIC_IP_2),
+    ]
+
+
+def test_is_url_safe_returns_validated_ips(monkeypatch) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr_info(_PUBLIC_IP, 0)])
+    is_safe, reason, ips = http_request_tool._is_url_safe("https://example.com/data")
+    assert is_safe is True
+    assert reason == ""
+    assert ips == [_PUBLIC_IP]
+
+
+def test_is_url_safe_blocks_when_any_resolved_ip_is_private(monkeypatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [_addr_info(_PUBLIC_IP, 0), _addr_info(_PRIVATE_IP, 0)],
+    )
+    is_safe, reason, ips = http_request_tool._is_url_safe("https://mixed.example/")
+    assert is_safe is False
+    assert _PRIVATE_IP in reason
+    assert ips == []
+
+
+def test_is_url_safe_dedupes_validated_ips(monkeypatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [_addr_info(_PUBLIC_IP, 0), _addr_info(_PUBLIC_IP, 0)],
+    )
+    is_safe, _reason, ips = http_request_tool._is_url_safe("https://dupe.example/")
+    assert is_safe is True
+    assert ips == [_PUBLIC_IP]

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -274,3 +274,156 @@ def test_is_url_safe_dedupes_validated_ips(monkeypatch) -> None:
     is_safe, _reason, ips = http_request_tool._is_url_safe("https://dupe.example/")
     assert is_safe is True
     assert ips == [_PUBLIC_IP]
+
+
+# --- Non-global address ranges that is_private/is_loopback miss --------------------
+
+import threading  # noqa: E402
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("blocked_ip", "label"),
+    [
+        ("100.64.0.1", "carrier-grade NAT (RFC 6598)"),
+        ("100.127.255.254", "carrier-grade NAT high end"),
+        ("224.0.0.1", "multicast"),
+        ("239.255.255.250", "multicast SSDP"),
+        ("0.0.0.0", "unspecified"),
+        ("255.255.255.255", "broadcast"),
+    ],
+)
+def test_is_url_safe_blocks_non_global_ranges_missed_by_is_private(
+    monkeypatch, blocked_ip: str, label: str
+) -> None:
+    """is_private/is_loopback/is_link_local/is_reserved miss several special-use
+    ranges that ip.is_global rejects: CGN 100.64/10, multicast, unspecified,
+    broadcast. The validator must reject all of them."""
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr_info(blocked_ip, 0)])
+    is_safe, reason, ips = http_request_tool._is_url_safe(f"https://{label}.example/")
+    assert is_safe is False, f"{label} ({blocked_ip}) should be blocked"
+    assert blocked_ip in reason
+    assert ips == []
+
+
+# --- Cross-thread isolation of the pinned resolver ----------------------------------
+
+
+def test_pin_does_not_leak_to_other_threads(monkeypatch) -> None:
+    """The pinned resolver only returns pinned IPs to its issuing thread. Another
+    thread that happens to resolve the same hostname during the pin window must
+    fall through to the original resolver — the process-wide socket.getaddrinfo
+    swap is observable but behaves as a no-op for unrelated threads."""
+    other_thread_calls: list[tuple[str, int]] = []
+
+    def fake_original(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+        other_thread_calls.append((host, port))
+        return [_addr_info(_PUBLIC_IP_2, port or 0)]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_original)
+
+    other_thread_result: list[list[tuple]] = []
+    can_resolve = threading.Event()
+    pin_can_exit = threading.Event()
+
+    def in_other_thread() -> None:
+        can_resolve.wait(timeout=2.0)
+        # Inside the pin's lock window, but called from a different thread.
+        other_thread_result.append(socket.getaddrinfo("api.example.com", 443))
+        pin_can_exit.set()
+
+    worker = threading.Thread(target=in_other_thread)
+    worker.start()
+    try:
+        with http_request_tool._pinned_dns_resolution("api.example.com", [_PUBLIC_IP]):
+            # Issuing-thread lookup uses pinned IPs.
+            issuing_thread_result = socket.getaddrinfo("api.example.com", 443)
+            # Now let the other thread resolve while the pin is still active.
+            can_resolve.set()
+            assert pin_can_exit.wait(timeout=2.0), "other thread did not finish"
+    finally:
+        worker.join(timeout=2.0)
+
+    assert issuing_thread_result == [_addr_info(_PUBLIC_IP, 443)]
+    # Other thread saw the original resolver (fake_original), not the pin.
+    assert other_thread_result == [[_addr_info(_PUBLIC_IP_2, 443)]]
+    assert other_thread_calls == [("api.example.com", 443)]
+
+
+# --- Proxy refusal: DNS pinning is not authoritative through HTTP proxies ----------
+
+
+def test_request_blocked_when_http_proxy_set(monkeypatch) -> None:
+    """When HTTP_PROXY is configured, requests would route through the proxy and
+    the proxy resolves the destination on its side — local DNS pinning doesn't
+    apply. The guard must refuse rather than silently bypass its own SSRF check."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.internal:3128")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+
+    def fail_request(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("request should not be issued when a proxy is configured")
+
+    monkeypatch.setattr(http_request_tool.requests, "request", fail_request)
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr_info(_PUBLIC_IP, 0)])
+
+    result = http_request_tool.http_request("https://example.com/data")
+
+    assert result["status_code"] == 0
+    assert "proxy" in result["content"].lower()
+
+
+def test_request_proceeds_when_host_in_no_proxy(monkeypatch) -> None:
+    """If NO_PROXY exempts the target host, the request goes direct, local DNS
+    pinning IS authoritative, and the request must proceed normally."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.internal:3128")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+    monkeypatch.setenv("NO_PROXY", "example.com")
+
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr_info(_PUBLIC_IP, 0)])
+
+    issued: list[str] = []
+
+    def fake_request(method, url, **kwargs):  # type: ignore[no-untyped-def]
+        issued.append(url)
+        return FakeResponse(status_code=200, url=url, text="ok")
+
+    monkeypatch.setattr(http_request_tool.requests, "request", fake_request)
+
+    result = http_request_tool.http_request("https://example.com/data")
+
+    assert result["status_code"] == 200
+    assert issued == ["https://example.com/data"]
+
+
+def test_request_proceeds_with_no_proxy_env(monkeypatch) -> None:
+    """No proxy env at all → request proceeds, baseline confirmation that the
+    proxy refusal is gated on actual proxy configuration, not the check itself."""
+    for var in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr_info(_PUBLIC_IP, 0)])
+
+    issued: list[str] = []
+
+    def fake_request(method, url, **kwargs):  # type: ignore[no-untyped-def]
+        issued.append(url)
+        return FakeResponse(status_code=200, url=url, text="ok")
+
+    monkeypatch.setattr(http_request_tool.requests, "request", fake_request)
+
+    result = http_request_tool.http_request("https://example.com/data")
+
+    assert result["status_code"] == 200
+    assert issued == ["https://example.com/data"]


### PR DESCRIPTION
Closes #1186.

## Summary

The SSRF guard in `agent/tools/http_request.py` resolves the hostname twice — once for validation, and again when `requests.request` opens the TCP connection. An attacker controlling a short-TTL DNS record can answer the first query with a public IP (so `_is_url_safe` returns `True`) and the second with an internal address (e.g. `169.254.169.254`, `10.0.0.0/8`), bypassing the filter.

This PR closes the gap by **pinning** DNS resolution: validation does the lookup once, captures the approved IP set, and the actual request runs inside a context that returns those exact IPs for the target hostname — so the connect step never performs a fresh, attacker-influenced DNS query.

## Approach

1. `_is_url_safe(url)` now returns `(is_safe, reason, validated_ips)`. The IP list is the deduped set of public addresses that passed the policy.
2. New `_pinned_dns_resolution(target_hostname, pinned_ips)` context manager swaps `socket.getaddrinfo` for one that:
   - Returns synthetic addr-info tuples (IPv4 or IPv6, correctly shaped) for `target_hostname`.
   - Falls through to the original resolver for any other host, so unrelated DNS in the same call stack is unaffected.
   - Restores the original resolver on exit.
3. `_request_with_safe_redirects` now wraps each `requests.request(...)` call inside `_pinned_dns_resolution(hostname, validated_ips)`. Each redirect hop revalidates **and** re-pins for the new target hostname, so a redirect to a fresh host gets that host's freshly-validated IPs (verified in `test_redirect_repins_to_new_target_host`).
4. A module-level `threading.Lock` serialises overlapping pin scopes — the swap is process-global, so concurrent pins must not interleave.

This works for HTTPS too: connecting to the pinned IP and TLS-handshaking with the original hostname (SNI / cert validation) is exactly what `urllib3` already does when given a hostname that resolves to a single IP.

## Tests

`tests/test_http_security.py` gains 9 cases on top of the 2 existing ones:

- `_pinned_dns_resolution` returns pinned IPs for the target host without hitting the system resolver.
- Falls through for unrelated hosts.
- Restores `socket.getaddrinfo` on exit.
- Builds correct IPv6 addr-info tuples.
- **`test_dns_rebinding_attack_uses_pinned_ip_during_connect`** — the headline test: a `getaddrinfo` mock returns `8.8.8.8` for the first lookup (validation) and `192.168.1.1` for any subsequent lookup (the rebind). Inside `requests.request` we re-resolve and assert the result is `8.8.8.8`. Without the pin this test fails (the attacker's rebind would be honoured).
- Each redirect re-pins to its own target host's validated IPs.
- `_is_url_safe` now returns the dedup'd validated IP list, and still blocks when *any* resolved IP is private (mixed-A-record case).

## Local gates

- `PYTHONPATH=. pytest tests/` → **116 passed** (108 pre-existing + 9 new pinning + 2 pre-existing http_security tests still passing — no regressions).
- `ruff check agent/tools/http_request.py tests/test_http_security.py` → All checks passed.
- `ruff format --check agent/tools/http_request.py tests/test_http_security.py` → 2 files already formatted.
- `python -m py_compile agent/tools/http_request.py` → clean.

## Notes

- The `Closes #1186` link covers `agent/tools/http_request.py`. The same `_request_with_safe_redirects` is reused by `agent/tools/fetch_url.py`, so the pinning fix applies to that path too — no further changes needed.
- The pin only intercepts the **target** hostname; lookups for proxies, DNS-over-HTTPS endpoints, etc., go through the system resolver normally.
- The lock serialises pinned requests within a single process. `requests.request` already does its own DNS work synchronously inside a single Session, so this doesn't change practical concurrency for any single agent run.