### PR TITLE
fix: lower default LangSmith sandbox size to fit "large" tier

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -16,8 +16,8 @@ from langsmith.sandbox import SandboxClient
 logger = logging.getLogger(__name__)
 
 DEFAULT_SNAPSHOT_FS_CAPACITY_BYTES = 32 * 1024**3
-DEFAULT_SANDBOX_VCPUS = 4
-DEFAULT_SANDBOX_MEM_BYTES = 15 * 1024**3  # 15 GiB
+DEFAULT_SANDBOX_VCPUS = 2
+DEFAULT_SANDBOX_MEM_BYTES = 7936 * 1024**2  # 7936 MiB ("large" tier cap)
 
 
 def _get_langsmith_api_key() -> str | None:


### PR DESCRIPTION
## Summary
- Current defaults (`DEFAULT_SANDBOX_VCPUS=4`, `DEFAULT_SANDBOX_MEM_BYTES=15 GiB`) exceed the LangSmith sandbox API's maximum supported size, so every sandbox creation 400s and the deployment is unable to start runs.
- Lower the defaults to **2 vCPU / 7936 MiB**, matching the "large" tier cap reported in the API error, so deployments without `DEFAULT_SANDBOX_VCPUS` / `DEFAULT_SANDBOX_MEM_BYTES` env overrides boot into a working state.

## Why
Production hit this on 2026-04-30:
```
sandbox size 4 vCPU / 15360 MiB exceeds the maximum supported size;
must fit within one of: small (1 vCPU / 1792 MiB),
medium (1 vCPU / 3840 MiB), or large (2 vCPU / 7936 MiB)
```
Env-var override unblocked our deployment, but other open-swe deployments on LangSmith sandboxes will hit the same wall until the in-code defaults are aligned with the API's accepted sizes.

## Test plan
- [ ] Verify a fresh deployment without `DEFAULT_SANDBOX_VCPUS` / `DEFAULT_SANDBOX_MEM_BYTES` overrides successfully creates a sandbox.
- [ ] Confirm existing deployments overriding via env still get their custom sizes.