### PR TITLE
fix(open-swe): middleware tests—reuse runnable config for GitHub token

### DIFF
--- a/agent/middleware/open_pr.py
+++ b/agent/middleware/open_pr.py
@@ -93,17 +93,12 @@ async def open_pr_if_needed(
         pr_title = pr_payload.get("title", "feat: Open SWE PR")
         pr_body = pr_payload.get("body", "Automated PR created by Open SWE agent.")
         commit_message = pr_payload.get("commit_message", pr_title)
-        github_token = get_github_token()
+        github_token = get_github_token(config)
         user_identity = await asyncio.to_thread(
             resolve_triggering_user_identity, config, github_token
         )
         pr_body = add_pr_collaboration_note(pr_body, user_identity)
         commit_message = add_user_coauthor_trailer(commit_message, user_identity)
-
-        installation_token = await get_github_app_installation_token()
-        if not installation_token:
-            logger.error("Failed to get GitHub App installation token for thread %s", thread_id)
-            return None
 
         if not thread_id:
             raise ValueError("No thread_id found in config")
@@ -130,6 +125,11 @@ async def open_pr_if_needed(
 
         if not has_changes:
             logger.info("No changes detected, skipping PR creation")
+            return None
+
+        installation_token = await get_github_app_installation_token()
+        if not installation_token:
+            logger.error("Failed to get GitHub App installation token for thread %s", thread_id)
             return None
 
         logger.info("Changes detected, preparing PR for thread %s", thread_id)

--- a/agent/utils/github_token.py
+++ b/agent/utils/github_token.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from langgraph.config import get_config
@@ -30,10 +31,15 @@ def _decrypt_github_token(encrypted_token: str | None) -> str | None:
     return decrypt_token(encrypted_token)
 
 
-def get_github_token() -> str | None:
-    """Resolve a GitHub token from run metadata."""
-    config = get_config()
-    return _decrypt_github_token(_read_encrypted_github_token(config.get("metadata", {})))
+def get_github_token(run_config: Mapping[str, Any] | None = None) -> str | None:
+    """Resolve a GitHub token from run metadata.
+
+    Pass ``run_config`` when LangGraph runnable config is already available (e.g. after
+    ``get_config()`` in callers). Omit to read from ``get_config()`` (required runnable
+    context).
+    """
+    resolved = run_config if run_config is not None else get_config()
+    return _decrypt_github_token(_read_encrypted_github_token(resolved.get("metadata", {})))
 
 
 async def get_github_token_from_thread(thread_id: str) -> tuple[str | None, str | None]:


### PR DESCRIPTION
## Summary

Fixes failing `tests/test_open_pr_middleware.py` jobs on CI.

### Root cause

`open_pr_if_needed` patched `agent.middleware.open_pr.get_config`, but later called `get_github_token()` which unconditionally called LangGraph `get_config()` again from `agent.utils.github_token`, outside the patched path. That raises `RuntimeError: Called get_config outside of a runnable context`, was swallowed by the middleware `except`, and the assertions never observed `get_sandbox_backend`.

### Changes

1. **`get_github_token`**: Accept an optional runnable config mapping. When callers already have LangGraph config (e.g. the middleware after `get_config()`), use that mapping for encrypted token metadata instead of calling `get_config()` again.

2. **`open_pr_if_needed`**: Fetch the GitHub App installation token **after** confirming there are sandbox changes (`has_changes`). Matches when the token is needed (PR/GitHub API) and fixes tests that validate the safety-net path without mocking installation token retrieval.

### Testing

`uv run pytest tests/test_open_pr_middleware.py` and full `pytest tests/` passed locally.