### PR TITLE
feat: add reviewer eval harness

### DIFF
--- a/REVIEWER_EVAL_PLAN.md
+++ b/REVIEWER_EVAL_PLAN.md
@@ -1,0 +1,91 @@
+# Goal
+
+Score Open SWE Reviewer on the 50 PRs from the martian offline benchmark, in conditions close to a real PR review, and compare against Devin Review's published numbers. Manual run, baseline only.
+
+## Dataset
+
+Import the 50 entries from `withmartian/code-review-benchmark` `offline/golden_comments/*.json` into a LangSmith dataset (`openswe-reviewer-v1`).
+
+For each PR, enrich the example up-front via `gh pr view --json` so the example carries everything needed to reproduce the PR's state:
+
+```json
+{
+  "inputs": {
+    "repo": "getsentry/sentry",
+    "fork_repo": "<your-org>/sentry",
+    "pr_number": 12345,
+    "base_sha": "<main-at-PR-open-time>",
+    "head_sha": "<PR-tip>",
+    "pr_title": "...",
+    "original_url": "<https://github.com/getsentry/sentry/pull/12345>"
+  },
+  "outputs": {
+    "golden_comments": [
+      {"comment": "...", "severity": "High"}
+    ]
+  }
+}
+```
+
+`base_sha` must be the **PR's base commit at open time**, not today's main. `gh pr view <n> --json baseRefOid,headRefOid` returns these — recover from upstream once and freeze them in the dataset. From this point the dataset is self-contained and reproducible regardless of upstream activity.
+
+## Repo setup
+
+Fork the 5 upstream repos (sentry, grafana, [cal.com](http://cal.com/), discourse, keycloak) into your personal org once. The agent clones from your forks rather than upstream — gives stable targets, isolates from upstream rate limits, no risk of upstream force-pushes invalidating SHAs.
+
+No need to fork the 50 PRs themselves — we're not relying on the GitHub-App-review flow. The PR's content is reconstructed from `base_sha` + the diff fetched from upstream once at dataset-build time (or fetched on demand via `git fetch origin pull/<n>/head`).
+
+## Target function
+
+```python
+async def review_pr(inputs: dict) -> dict:
+    thread = await client.threads.create()
+    run = await client.runs.wait(
+        thread["thread_id"],
+        assistant_id="reviewer",
+        input={"pr_inputs": inputs},
+    )
+    return {"comments": extract_review_comments(run)}
+```
+
+Inside the reviewer graph, the first agent step (or a pre-agent middleware) runs in the sandbox:
+
+```bash
+git clone --depth=200 <https://github.com/><fork_repo>.git /workspace
+cd /workspace
+git fetch origin pull/<pr_number>/head:pr
+git checkout <base_sha>
+git merge --no-commit --no-ff pr   # or: leave as two refs and let agent diff
+```
+
+This puts the sandbox in the same state a human reviewer would see when the PR was opened: main at the base SHA, plus the PR's changes applied/available. Agent then uses its normal tool set (`read_file`, `glob`, `grep`, `gh pr diff`) over that working tree.
+
+The reviewer must emit structured comments. Cleanest path: a `submit_review` tool whose args (`[{file, line, severity, body}, ...]`) become the run output. More reliable than parsing the final assistant message.
+
+## Evaluators
+
+Because `submit_review` already returns one structured entry per issue (`{file, line, severity, body}`), there's no prose to split and no summary-vs-inline duplication to collapse. We skip martian's `step2_extract_comments` and `step2_5_dedup_candidates` and feed the agent's list straight into the judge. Port the judge prompt verbatim from `step3_judge_comments.py` so scores stay comparable to Devin's published numbers.
+
+- **Per-example evaluator `judge_match`**: receives the agent's `comments` (from `run.outputs`) and the `golden_comments` (from `example.outputs`). For each `(candidate, golden)` pair, asks the judge LLM "do these describe the same underlying issue?". Tallies TP / FP / FN → returns `{precision, recall, f1, tp, fp, fn}` per example.
+- **Summary evaluator `aggregate_pr`**: micro- and macro-averaged precision/recall across the 50 examples.
+
+Judge model: **`claude-opus-4-5`** — matches the model martian used to score Devin Review.
+
+## Run
+
+```python
+client.evaluate(
+    review_pr,
+    data="openswe-reviewer-v1",
+    evaluators=[judge_match],
+    summary_evaluators=[aggregate_pr],
+    experiment_prefix="openswe-reviewer-baseline",
+    max_concurrency=5,
+)
+```
+
+`max_concurrency=5` keeps sandbox provider load reasonable. Full run: ~50 examples × 5–15 min/PR ÷ 5 = ~1–2.5h wall.
+
+## Comparison
+
+Devin's published numbers come from the same 50 goldens + same judge model + same prompts. As long as we hold those three constant, the LangSmith experiment's aggregate precision/recall is directly comparable. Drop both into a side-by-side table; LangSmith's experiment-compare view also works if you import Devin's results as a separate experiment over the same dataset.

--- a/evals/reviewer/README.md
+++ b/evals/reviewer/README.md
@@ -1,0 +1,73 @@
+# Reviewer Eval
+
+Offline LangSmith eval for the Open SWE Reviewer graph against the 50 PRs from
+`withmartian/code-review-benchmark`. See `REVIEWER_EVAL_PLAN.md` at the repo
+root for the full design.
+
+## Layout
+
+```
+evals/reviewer/
+├── golden_comments/      # 50 PRs × golden comments (copied from martian benchmark)
+├── build_dataset.py      # martian JSON → LangSmith dataset (resolves SHAs via gh)
+├── judge.py              # claude-opus-4-5 pairwise match evaluator + aggregate
+├── target.py             # invokes the reviewer graph over langgraph_sdk
+└── run_eval.py           # client.aevaluate entrypoint
+```
+
+## Prerequisites
+
+- `LANGSMITH_API_KEY` set in your env.
+- `gh` authenticated (`gh auth status`) — needed for `build_dataset.py`.
+- `ANTHROPIC_API_KEY` set — judge runs `claude-opus-4-5`.
+- A running reviewer graph (local `langgraph dev` or deployed assistant id) with
+  `REVIEWER_ASSISTANT_ID` env var pointing at it. Defaults to assistant `reviewer`
+  on `http://localhost:2024`.
+
+## 1. Build the dataset (once)
+
+```bash
+# Dry run — writes evals/reviewer/dataset_dryrun.json without uploading
+uv run python -m evals.reviewer.build_dataset --dry-run
+
+# Upload for real
+uv run python -m evals.reviewer.build_dataset --dataset-name openswe-reviewer-v1
+```
+
+Each example carries: `repo`, `pr_number`, `pr_url`, `base_sha`, `head_sha`,
+`base_ref`, `head_ref`, `pr_title`. The dataset is frozen at upload time —
+upstream PR drift can't invalidate it.
+
+## 2. Run the eval
+
+The reviewer graph must be running and accept a `pr` input matching the
+example schema, and must emit a `submit_review` tool call (or set
+`state["review"]["comments"]`) with `[{file, line, severity, body}, ...]`.
+
+```bash
+uv run python -m evals.reviewer.run_eval \
+    --experiment-prefix openswe-reviewer-baseline \
+    --max-concurrency 5
+```
+
+Smoke-test with 3 PRs first:
+
+```bash
+uv run python -m evals.reviewer.run_eval --limit 3
+```
+
+## Comparing against Devin Review
+
+Both tools are scored on the same 50 PRs with the same judge model
+(`claude-opus-4-5`) and the same judge prompt (verbatim from martian
+`step3_judge_comments.py`). Pull martian's published Devin numbers from their
+dashboard and compare against the LangSmith experiment's `micro_*` /
+`macro_*` summary metrics.
+
+## Notes
+
+- No GitHub forks needed — both upstream repos and martian's benchmark forks
+  (`ai-code-review-evaluation/*`) are public.
+- `judge_match` charges judge LLM tokens proportional to
+  `n_candidates × n_goldens` per example. For 50 PRs with ~3 goldens each and
+  agents emitting ~10 candidates, expect ~1500 judge calls per experiment.

--- a/evals/reviewer/build_dataset.py
+++ b/evals/reviewer/build_dataset.py
@@ -38,11 +38,17 @@ def parse_pr_url(url: str) -> tuple[str, str, int]:
 def gh_pr_view(owner: str, repo: str, pr_number: int) -> dict:
     result = subprocess.run(
         [
-            "gh", "pr", "view", str(pr_number),
-            "--repo", f"{owner}/{repo}",
-            "--json", "baseRefOid,headRefOid,baseRefName,headRefName,title,state,url",
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            f"{owner}/{repo}",
+            "--json",
+            "baseRefOid,headRefOid,baseRefName,headRefName,title,state,url",
         ],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -90,7 +96,9 @@ def upload(dataset_name: str, examples: list[dict]) -> None:
     client = Client()
     existing = next((d for d in client.list_datasets(dataset_name=dataset_name)), None)
     if existing:
-        print(f"Dataset {dataset_name!r} already exists ({existing.id}); aborting.", file=sys.stderr)
+        print(
+            f"Dataset {dataset_name!r} already exists ({existing.id}); aborting.", file=sys.stderr
+        )
         print("Delete it in the LangSmith UI or pass --dataset-name <new>.", file=sys.stderr)
         sys.exit(1)
     ds = client.create_dataset(

--- a/evals/reviewer/build_dataset.py
+++ b/evals/reviewer/build_dataset.py
@@ -1,0 +1,141 @@
+"""Build the LangSmith dataset for the reviewer eval.
+
+Reads golden_comments/*.json (martian offline benchmark goldens), resolves
+each PR's base/head SHAs via `gh`, and uploads one example per PR to a
+LangSmith dataset.
+
+Usage:
+    uv run python -m evals.reviewer.build_dataset \\
+        --dataset-name openswe-reviewer-v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from langsmith import Client
+
+load_dotenv()
+
+GOLDENS_DIR = Path(__file__).parent / "golden_comments"
+PR_URL_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)")
+
+
+def parse_pr_url(url: str) -> tuple[str, str, int]:
+    m = PR_URL_RE.search(url)
+    if not m:
+        raise ValueError(f"Not a PR url: {url}")
+    owner, repo, num = m.group(1), m.group(2), int(m.group(3))
+    return owner, repo.removesuffix(".git"), num
+
+
+def gh_pr_view(owner: str, repo: str, pr_number: int) -> dict:
+    result = subprocess.run(
+        [
+            "gh", "pr", "view", str(pr_number),
+            "--repo", f"{owner}/{repo}",
+            "--json", "baseRefOid,headRefOid,baseRefName,headRefName,title,state,url",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh pr view failed for {owner}/{repo}#{pr_number}: {result.stderr.strip()}"
+        )
+    return json.loads(result.stdout)
+
+
+def load_goldens() -> list[dict]:
+    examples: list[dict] = []
+    for path in sorted(GOLDENS_DIR.glob("*.json")):
+        with path.open() as f:
+            entries = json.load(f)
+        for entry in entries:
+            entry["_source_file"] = path.stem
+            examples.append(entry)
+    return examples
+
+
+def build_example(entry: dict) -> dict:
+    url = entry["url"]
+    owner, repo, pr_number = parse_pr_url(url)
+    pr = gh_pr_view(owner, repo, pr_number)
+    inputs = {
+        "repo": f"{owner}/{repo}",
+        "pr_number": pr_number,
+        "pr_url": url,
+        "original_url": entry.get("original_url"),
+        "pr_title": entry.get("pr_title") or pr.get("title"),
+        "base_sha": pr["baseRefOid"],
+        "head_sha": pr["headRefOid"],
+        "base_ref": pr["baseRefName"],
+        "head_ref": pr["headRefName"],
+    }
+    outputs = {"golden_comments": entry["comments"]}
+    metadata = {
+        "source_file": entry["_source_file"],
+        "az_comment": entry.get("az_comment"),
+        "pr_state": pr.get("state"),
+    }
+    return {"inputs": inputs, "outputs": outputs, "metadata": metadata}
+
+
+def upload(dataset_name: str, examples: list[dict]) -> None:
+    client = Client()
+    existing = next((d for d in client.list_datasets(dataset_name=dataset_name)), None)
+    if existing:
+        print(f"Dataset {dataset_name!r} already exists ({existing.id}); aborting.", file=sys.stderr)
+        print("Delete it in the LangSmith UI or pass --dataset-name <new>.", file=sys.stderr)
+        sys.exit(1)
+    ds = client.create_dataset(
+        dataset_name=dataset_name,
+        description="Open SWE Reviewer baseline — 50 PRs from withmartian/code-review-benchmark goldens.",
+    )
+    client.create_examples(
+        dataset_id=ds.id,
+        inputs=[e["inputs"] for e in examples],
+        outputs=[e["outputs"] for e in examples],
+        metadata=[e["metadata"] for e in examples],
+    )
+    print(f"Uploaded {len(examples)} examples to {dataset_name} ({ds.id}).")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset-name", default="openswe-reviewer-v1")
+    ap.add_argument("--dry-run", action="store_true", help="Build examples but don't upload.")
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args()
+
+    raw = load_goldens()
+    if args.limit:
+        raw = raw[: args.limit]
+    print(f"Loaded {len(raw)} golden entries; resolving SHAs via gh...")
+
+    examples: list[dict] = []
+    for i, entry in enumerate(raw, 1):
+        try:
+            ex = build_example(entry)
+            examples.append(ex)
+            print(f"  [{i}/{len(raw)}] {ex['inputs']['repo']}#{ex['inputs']['pr_number']} ok")
+        except Exception as exc:
+            print(f"  [{i}/{len(raw)}] FAILED for {entry.get('url')}: {exc}", file=sys.stderr)
+
+    if args.dry_run:
+        out = Path(__file__).parent / "dataset_dryrun.json"
+        with out.open("w") as f:
+            json.dump(examples, f, indent=2)
+        print(f"Dry run: wrote {len(examples)} examples to {out}")
+        return
+
+    upload(args.dataset_name, examples)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/reviewer/golden_comments/cal_dot_com.json
+++ b/evals/reviewer/golden_comments/cal_dot_com.json
@@ -1,0 +1,186 @@
+[
+  {
+    "pr_title": "Async import of the appStore packages",
+    "url": "https://github.com/calcom/cal.com/pull/8087",
+    "comments": [
+      {
+        "comment": "Consider adding try-catch around the await to handle import failures gracefully",
+        "severity": "Low"
+      },
+      {
+        "comment": "The code uses forEach with async callbacks, which causes asynchronous operations (e.g., calendar/video event deletions, payment refunds) to run concurrently without being awaited. This 'fire-and-forget' behavior leads to unhandled promise rejections, race conditions, and incomplete cleanup, as surrounding try-catch blocks cannot properly handle errors from these unawaited promises. Replace forEach with for...of loops or Promise.all() with map() to ensure proper sequential execution and error handling.",
+        "severity": "Critical"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat: 2fa backup codes",
+    "url": "https://github.com/calcom/cal.com/pull/10600",
+    "comments": [
+      {
+        "comment": "The exported function TwoFactor handles backup codes and is in BackupCode.tsx. Inconsistent naming.",
+        "severity": "Low"
+      },
+      {
+        "comment": "Error message mentions 'backup code login' but this is a disable endpoint, not login",
+        "severity": "Low"
+      },
+      {
+        "comment": "Backup code validation is case-sensitive due to the use of indexOf(). This causes validation to fail if a user enters uppercase hex characters, as backup codes should be case-insensitive for a better user experience.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Because backupCodes are decrypted and mutated in memory before being written back, two concurrent login requests using the same backupCode could both pass this check and update, so a single backup code may effectively be accepted more than once if used concurrently, weakening the intended one-time-use semantics.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "fix: handle collective multiple host on destinationCalendar",
+    "url": "https://github.com/calcom/cal.com/pull/10967",
+    "comments": [
+      {
+        "comment": "Potential null reference if mainHostDestinationCalendar is undefined if evt.destinationCalendar is null or an empty array ",
+        "severity": "High"
+      },
+      {
+        "comment": "The optional chaining on mainHostDestinationCalendar?.integration is redundant since you already check mainHostDestinationCalendar in the ternary condition.",
+        "severity": "Low"
+      },
+      {
+        "comment": "Logic error: when externalCalendarId is provided, you're searching for a calendar where externalId === externalCalendarId, but this will always fail since you're looking for a calendar that matches itself. Should likely find by credentialId or use different logic.",
+        "severity": "High"
+      },
+      {
+        "comment": "Logic inversion in organization creation: The slug property is now conditionally set when IS_TEAM_BILLING_ENABLED is true, instead of when it's false as originally intended. This change, combined with requestedSlug still being set when IS_TEAM_BILLING_ENABLED is true, results in both properties being set when billing is enabled, and neither when disabled",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The Calendar interface now requires createEvent(event, credentialId), but some implementations (e.g., Lark/Office365) still declare createEvent(event) only—this breaks the interface contract (also applies to other locations in the PR).",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat: convert InsightsBookingService to use Prisma.sql raw queries",
+    "url": "https://github.com/calcom/cal.com/pull/22345",
+    "comments": [
+      {
+        "comment": "In getBaseConditions(), the else if (filterConditions) and final else branches are unreachable. This is because getAuthorizationConditions() always returns a non-null Prisma.Sql object, making authConditions always truthy, which means only the first two if/else if conditions are ever evaluated.",
+        "severity": "Low"
+      },
+      {
+        "comment": "Fetching userIdsFromOrg only when teamsFromOrg.length > 0 can exclude org-level members for orgs without child teams; consider deriving from teamIds (which includes orgId) or removing the guard so org-only orgs still include member user bookings.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Comprehensive workflow reminder management for booking lifecycle events",
+    "url": "https://github.com/calcom/cal.com/pull/7232",
+    "comments": [
+      {
+        "comment": "Asynchronous functions deleteScheduledEmailReminder and deleteScheduledSMSReminder are called without await inside forEach loops. This occurs during booking rescheduling/cancellation, and workflow/workflow step deletion/updates. Consequently, scheduled workflow reminders may not be reliably cancelled, potentially leaving them active.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "When immediateDelete is true, the deleteScheduledEmailReminder function cancels the SendGrid email but fails to delete the corresponding WorkflowReminder record from the database. This creates orphaned database entries and is inconsistent with the immediateDelete: false path, which marks the record as cancelled. The SendGrid DELETE API call is also omitted in this path.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Advanced date override handling and timezone compatibility improvements",
+    "url": "https://github.com/calcom/cal.com/pull/8330",
+    "comments": [
+      {
+        "comment": "Incorrect end time calculation using slotStartTime instead of slotEndTime",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Using === for dayjs object comparison will always return false as it compares object references, not values. Use .isSame() method instead: dayjs(date.start).add(utcOffset, 'minutes').isSame(dayjs(date.end).add(utcOffset, minutes))",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "OAuth credential sync and app integration enhancements",
+    "url": "https://github.com/calcom/cal.com/pull/11059",
+    "comments": [
+      {
+        "comment": "The parseRefreshTokenResponse function incorrectly sets refresh_token to the hardcoded string 'refresh_token' when it's missing from the OAuth refresh token response. This invalidates the token, breaking subsequent token refreshes and causing authentication failures.",
+        "severity": "High"
+      },
+      {
+        "comment": "Invalid Zod schema syntax. Computed property keys like [z.string().toString()] are not valid in Zod object schemas and will cause runtime errors. ",
+        "severity": "High"
+      },
+      {
+        "comment": "parseRefreshTokenResponse returns a Zod safeParse result ({ success, data, error }), not the credential key object. Persisting that as key stores the wrapper instead of the token payload; we should store the parsed data or use schema parse.",
+        "severity": "High"
+      },
+      {
+        "comment": "When APP_CREDENTIAL_SHARING_ENABLED and CALCOM_CREDENTIAL_SYNC_ENDPOINT are set, the refreshFunction helper returns the fetch Response, but several callers (for example GoogleCalendarService.refreshAccessToken expecting res.data, and HubspotCalendarService.refreshAccessToken expecting a HubspotToken) assume it returns the integration-specific token object. That mismatch will cause runtime errors in the sync-enabled path unless the return type or those call sites are adjusted.",
+        "severity": "High"
+      },
+      {
+        "comment": "When the sync endpoint path is used, res is a fetch Response and has no .data; res?.data will be undefined and token.access_token will throw at runtime. This relies on a consistent return shape from refreshOAuthTokens, which isn’t guaranteed currently.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "SMS workflow reminder retry count tracking",
+    "url": "https://github.com/calcom/cal.com/pull/14943",
+    "comments": [
+      {
+        "comment": "Using retryCount: reminder.retryCount + 1 reads a possibly stale value and can lose increments under concurrency; consider an atomic increment via Prisma (increment: 1) to avoid race conditions (also applies to the similar update in the catch block).",
+        "severity": "High"
+      },
+      {
+        "comment": "The deletion logic in scheduleSMSReminders.ts incorrectly deletes non-SMS workflow reminders (e.g., Email, WhatsApp) that have retryCount > 1. This occurs because the retryCount condition within the OR clause for deletion lacks a method: WorkflowMethods.SMS filter, causing it to apply to all reminder types instead of only SMS reminders, which is the intended scope of this function.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add guest management functionality to existing bookings",
+    "url": "https://github.com/calcom/cal.com/pull/14740",
+    "comments": [
+      {
+        "comment": "Case sensitivity bypass in email blacklist",
+        "severity": "High"
+      },
+      {
+        "comment": "The logic for checking team admin/owner permissions is incorrect. This condition uses AND (&&) which requires both isTeamAdmin AND isTeamOwner to be true, but it should use OR (||) since a user needs to be either an admin OR an owner to have permission.",
+        "severity": "Critical"
+      },
+      {
+        "comment": "This calls the email sender with the original guests, so existing attendees included in the input will be treated as new when sending notifications, leading to incorrect emails.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "uniqueGuests filters out existing attendees and blacklisted emails but does not deduplicate duplicates within the input; createMany can insert duplicate attendee rows if the client submits repeated emails.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Starting with an array containing an empty string may cause validation issues. Consider starting with an empty array [] and handling the empty state in the MultiEmail component instead.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat: add calendar cache status and actions (#22532)",
+    "url": "https://github.com/calcom/cal.com/pull/22532",
+    "comments": [
+      {
+        "comment": "The updateManyByCredentialId call uses an empty data object, which prevents Prisma's @updatedAt decorator from updating the updatedAt timestamp. This results in inaccurate cache status tracking, as the timestamp isn't updated when the cache is refreshed. To fix this, explicitly set the updatedAt field.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "logic: macOS-specific sed syntax with empty string after -i flag will fail on Linux systems",
+        "severity": "Low"
+      }
+    ]
+  }
+]

--- a/evals/reviewer/golden_comments/discourse.json
+++ b/evals/reviewer/golden_comments/discourse.json
@@ -1,0 +1,184 @@
+[
+  {
+    "pr_title": "FEATURE: automatically downsize large images",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/1",
+    "original_url": "https://github.com/discourse/discourse/commit/ffbaf8c54269df2ce510de91245760fddce09896",
+    "comments": [
+      {
+        "comment": "The downsize method is defined twice. The second definition, which expects a single dimensions string parameter, overrides the first, which expected separate max_width and max_height parameters. This makes the original method unreachable and breaks existing code that calls it with separate width and height arguments.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Hardcoding maxSizeKB = 10 * 1024 ignores Discourse.SiteSettings['max_' + type + '_size_kb'], so the client-side limit can diverge from server-side and per-type settings (also applies to the 413 handler below).",
+        "severity": "Low"
+      },
+      {
+        "comment": "Passing 80% as the dimensions can fail for animated GIFs when allow_animated_thumbnails is true, since the animated path uses gifsicle --resize-fit which expects WxH geometry, not a percentage; downsizing would then silently fail.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "FEATURE: per-topic unsubscribe option in emails",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/2",
+    "original_url": "https://github.com/discourse/discourse/commit/6669a2d94d76eea3b99b8c476d12b1eb66726b07",
+    "comments": [
+      {
+        "comment": "logic: Potential nil pointer exception - if no TopicUser record exists, tu will be nil and calling methods on it will crash",
+        "severity": "High"
+      },
+      {
+        "comment": "Typo in property name: 'stopNotificiationsText' should be 'stopNotificationsText' (missing 'n' in 'Notifications')",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add comprehensive email validation for blocked users",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/3",
+    "original_url": "https://github.com/discourse/discourse/commit/5f8a130277dbddc95d133cd2832be639baf89213",
+    "comments": [
+      {
+        "comment": "BlockedEmail.should_block_email? method has side effects during a read operation - it updates statistics even when just checking if an email should be blocked. This could cause race conditions in concurrent environments and makes the method name misleading.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Regex pattern @(#{domains}) only matches domain suffixes, not full domains. evil.example.com would match whitelist entry example.com.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Enhance embed URL handling and validation system",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/4",
+    "original_url": "https://github.com/discourse/discourse/commit/4f8aed295a29954023b2849c060ef4fb299d1b5d",
+    "comments": [
+      {
+        "comment": "SSRF vulnerability using open(url) without validation",
+        "severity": "Critical"
+      },
+      {
+        "comment": "The current origin validation using indexOf is insufficient and can be bypassed. An attacker could use a malicious domain like evil-discourseUrl.com to pass this check.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "postMessage targetOrigin should be the origin (scheme+host+port), not the full referrer URL; using the full URL will cause the message to be dropped and prevent resizing.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The code sets X-Frame-Options: ALLOWALL which completely disables clickjacking protection. The referer validation can be bypassed (referer headers are easily spoofed), and the fallback to empty string for nil referer masks validation failures.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The TopicEmbed.import method is susceptible to a NoMethodError if the contents parameter is nil when attempting to append a string, and an XSS vulnerability due to unescaped url interpolation in the generated HTML.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The ERB block closes with end if, which is invalid Ruby/ERB and will raise at render; it should just be end to close the if block.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Optimize header layout performance with flexbox mixins",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/5",
+    "original_url": "https://github.com/discourse/discourse/commit/5b229316ee4c661836ed1161139692a3e8527444",
+    "comments": [
+      {
+        "comment": "Mixing float: left with flexbox causes layout issues. Further this PR removes the float-based right alignment for .d-header .panel, which may cause the login panel in the non-Ember/noscript header (where .panel is nested inside .row and not a flex item) to stack under the title instead of remaining right-aligned.",
+        "severity": "Low"
+      },
+      {
+        "comment": "-ms-align-items never existed in any version of IE/Edge; the correct legacy property is -ms-flex-align.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "UX: show complete URL path if website domain is same as instance domain",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/6",
+    "original_url": "https://github.com/discourse/discourse/commit/267d8be1f556ed59639ced396c885bb44586da19",
+    "comments": [
+      {
+        "comment": "The include_website_name method is missing the required ? suffix. Rails serializers expect include_ methods to end with ? for conditional attribute inclusion, a convention followed by other methods in this serializer. Without it, the website_name attribute may not be conditionally included as intended. Additionally, the '.' << website_host string concatenation should be replaced with '.' + website_host or '.#{website_host}' to avoid mutating string literals, which can lead to issues.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "scale-color $lightness must use $secondary for dark themes",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/7",
+    "original_url": "https://github.com/discourse/discourse/commit/d38c4d5f7443223c81529c22470293771baf9f38",
+    "comments": [
+      {
+        "comment": "In .topic-meta-data h5 a, the original code had color: scale-color($primary, $lightness: 30%) but was changed to dark-light-choose(scale-color($primary, $lightness: 70%), scale-color($secondary, $lightness: 30%)). The lightness for the light theme changed from 30% to 70%, which is a dramatic inversion",
+        "severity": "Low"
+      },
+      {
+        "comment": "This change for desktop/user.css changes $primary from 30% to 50% for the light theme; most other changes preserve the original $primary value and move the complement to $secondary for dark. Consider reviewing this (also applies to a similar .name change in the mobile variant).",
+        "severity": "Low"
+      },
+      {
+        "comment": "In topic-post.css the original code used $lightness: 70% but the replacement uses $lightness: 30% for the light theme. This makes the text significantly darker than intended.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "FIX: proper handling of group memberships",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/8",
+    "original_url": "https://github.com/discourse/discourse/commit/060cda77729cb1c4a827560e09e89a7b22078ba9",
+    "comments": [
+      {
+        "comment": " The findMembers() call is now asynchronous and unhandled. The controller may not have member data immediately available, creating a race condition.",
+        "severity": "High"
+      },
+      {
+        "comment": "In the next action, capping the next offset at user_count can produce an empty page (e.g., total equal to limit results in offset == total, showing 2/2 with no members). This can cause confusing UX on the last page.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "HTTP method mismatch in .remove_member - test uses PUT but remove_member action expects DELETE",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "FEATURE: Localization fallbacks (server-side)",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/9",
+    "original_url": "https://github.com/discourse/discourse/commit/ecfa17b5a79dfdc91e7a4d50b42ae78a35d0a293",
+    "comments": [
+      {
+        "comment": "Thread-safety issue with lazy @loaded_locales",
+        "severity": "Low"
+      },
+      {
+        "comment": "Consider normalizing the input locale (e.g., to a symbol) when checking/loading here to avoid double-loading if the same locale is passed as a String vs Symbol (also applies to other locations in the PR).",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "FEATURE: Can edit category/host relationships for embedding",
+    "url": "https://github.com/ai-code-review-evaluation/discourse-graphite/pull/10",
+    "original_url": "https://github.com/discourse/discourse/commit/d1c69189f3c90ecf56013a8da904da9bff9a8e19",
+    "comments": [
+      {
+        "comment": "NoMethodError before_validation in EmbeddableHost",
+        "severity": "Critical"
+      },
+      {
+        "comment": "The update and destroy methods in Admin::EmbeddableHostsController do not validate the existence of the EmbeddableHost record retrieved by ID. If EmbeddableHost.where(id: params[:id]).first returns nil (i.e., the host does not exist), attempting to call methods on the nil object (e.g., save_host or destroy) will result in a NoMethodError.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "record_for_host compares lower(host) = ? but does not normalize the parameter’s case, so mixed‑case referer hosts may fail to match even though comparison intends to be case‑insensitive.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Because this migration inserts embeddable_hosts rows with raw SQL, any existing embeddable_hosts values that include http:// or /https:// or path segments won’t go through the EmbeddableHost model’s normalization, so the new host lookup (which compares only the bare host) may fail for migrated data. Consider ensuring that migrated hosts are normalized to the same format as newly created EmbeddableHost records so existing embedding configurations keep working.",
+        "severity": "High"
+      }
+    ]
+  }
+]

--- a/evals/reviewer/golden_comments/grafana.json
+++ b/evals/reviewer/golden_comments/grafana.json
@@ -1,0 +1,150 @@
+[
+  {
+    "pr_title": "Anonymous: Add configurable device limit",
+    "url": "https://github.com/grafana/grafana/pull/79265",
+    "comments": [
+      {
+        "comment": "Race condition: Multiple concurrent requests could pass the device count check simultaneously and create devices beyond the limit. Consider using a database transaction or lock.",
+        "severity": "High"
+      },
+      {
+        "comment": "Anonymous authentication now fails entirely if anonDeviceService.TagDevice returns ErrDeviceLimitReached. Previously, device tagging was asynchronous and non-blocking. This change prevents anonymous users from authenticating when the device limit is reached.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "This call won’t compile: dbSession.Exec(args...) is given a []interface{} where the first element is the query, but Exec’s signature requires a first parameter of type string (not an interface{} splat).",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Returning ErrDeviceLimitReached when no rows were updated is misleading; the device might not exist.",
+        "severity": "Low"
+      },
+      {
+        "comment": "Time window calculation inconsistency: Using device.UpdatedAt.UTC().Add(-anonymousDeviceExpiration) as the lower bound but device.UpdatedAt as the current time may not match the intended logic. Consider using time.Now().UTC() consistently.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "AuthZService: improve authz caching",
+    "url": "https://github.com/grafana/grafana/pull/103633",
+    "comments": [
+      {
+        "comment": "The Check operation exhibits asymmetric cache trust logic: cached permission grants are trusted and returned immediately, but cached denials from the same permission cache are ignored, leading to a fresh database lookup. This allows stale cached grants to provide access to revoked resources, posing a security risk. ",
+        "severity": "High"
+      },
+      {
+        "comment": "The test comment says the cached permissions 'allow access', but the map stores false for dashboards:uid:dash1, so checkPermission will still treat this scope as not allowed.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Plugins: Chore: Renamed instrumentation middleware to metrics middleware",
+    "url": "https://github.com/grafana/grafana/pull/76186",
+    "comments": [
+      {
+        "comment": "The ContextualLoggerMiddleware methods (QueryData, CallResource, CheckHealth, CollectMetrics) panic when a nil request is received. This occurs because they directly access req.PluginContext (via the instrumentContext function) without first checking if req is nil. This is a regression, as previous middleware layers gracefully handled nil requests.",
+        "severity": "High"
+      },
+      {
+        "comment": "The traceID is no longer logged for plugin requests. During a refactoring, the tracing import and the logic to extract and add traceID from the context to log parameters were removed from the LoggerMiddleware. The newly introduced ContextualLoggerMiddleware does not add this information, resulting in missing traceID in plugin request logs and impacting debugging and request tracing capabilities.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Advanced Query Processing Architecture",
+    "url": "https://github.com/grafana/grafana/pull/107534",
+    "comments": [
+      {
+        "comment": "The applyTemplateVariables method is called with request.filters as the third parameter, but this parameter is not used in the corresponding test setup.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Notification Rule Processing Engine",
+    "url": "https://github.com/grafana/grafana/pull/106778",
+    "comments": [
+      {
+        "comment": "The rendered GrafanaRuleListItem is missing the required key prop for React list items. This can cause rendering issues when the list order changes.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "RuleActionsButtons is invoked with only promRule, but SilenceGrafanaRuleDrawer inside RuleActionsButtons still depends on a Grafana Ruler rule being present, so for Grafana rules coming from list views the 'Silence notifications' menu entry (now driven by Grafana Prom abilities) will toggle showSilenceDrawer without ever rendering the drawer. This means clicking 'Silence notifications' for these rules has no visible effect, even when abilities indicate silencing is allowed.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Dual Storage Architecture",
+    "url": "https://github.com/grafana/grafana/pull/90045",
+    "comments": [
+      {
+        "comment": "The context is being created with d.Log instead of the log variable that was initialized with additional context values (name, kind, method). This means those values won't be propagated to the logging context.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Bug: calling recordLegacyDuration when storage operation fails should be recordStorageDuration.",
+        "severity": "High"
+      },
+      {
+        "comment": "Inconsistency: using name instead of options.Kind for metrics recording differs from other methods.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Database Performance Optimizations",
+    "url": "https://github.com/grafana/grafana/pull/80329",
+    "comments": [
+      {
+        "comment": "The code uses Error log level for what appears to be debugging information. This will pollute error logs in production. Consider using Debug or Info level instead.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Frontend Asset Optimization",
+    "url": "https://github.com/grafana/grafana/pull/90939",
+    "comments": [
+      {
+        "comment": "The GetWebAssets function implements an incomplete double-checked locking pattern for caching web assets. The function first checks if the cache is populated using a read lock (RLock), and if the cache is empty, it acquires a write lock to populate it. However, it fails to re-check whether the cache was populated by another goroutine while waiting to acquire the write lock.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "In addition to the missing double-check, the function has a critical flaw in its error handling: it unconditionally assigns the fetch result to the cache (line 69: entryPointAssetsCache = result) regardless of whether the fetch succeeded or failed. When an error occurs during asset fetching, result is nil, and this nil value overwrites any previously valid cache entry.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Advanced SQL Analytics Framework",
+    "url": "https://github.com/grafana/grafana/pull/94942",
+    "comments": [
+      {
+        "comment": "The enableSqlExpressions function has flawed logic that always returns false, effectively disabling SQL expressions unconditionally:",
+        "severity": "Critical"
+      },
+      {
+        "comment": "Several methods such as NewInMemoryDB().RunCommands and db.QueryFramesInto return 'not implemented'.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Unified Storage Performance Optimizations",
+    "url": "https://github.com/grafana/grafana/pull/97529",
+    "comments": [
+      {
+        "comment": "A race condition in BuildIndex allows multiple goroutines to concurrently build the same expensive index for the same key. This is caused by moving the b.cacheMu lock from protecting the entire function to only protecting the final cache assignment. ",
+        "severity": "High"
+      },
+      {
+        "comment": "Calling s.search.TotalDocs() here may race with concurrent index creation: TotalDocs iterates b.cache without synchronization, and the event watcher goroutine started just above could trigger BuildIndex writes concurrently, potentially causing a concurrent map read/write panic.",
+        "severity": "High"
+      }
+    ]
+  }
+]

--- a/evals/reviewer/golden_comments/keycloak.json
+++ b/evals/reviewer/golden_comments/keycloak.json
@@ -1,0 +1,160 @@
+[
+  {
+    "pr_title": "Fixing Re-authentication with passkeys",
+    "url": "https://github.com/ai-code-review-evaluation/keycloak-greptile/pull/1",
+    "original_url": "https://github.com/keycloak/keycloak/pull/41249",
+    "az_comment": "reviewed commit is not in the repo",
+    "comments": [
+      {
+        "comment": "ConditionalPasskeysEnabled() called without UserModel parameter",
+        "severity": "Medium"
+      },
+      {
+        "comment": "With isConditionalPasskeysEnabled(UserModel user) requiring user != null, authenticate(...) will not call webauthnAuth.fillContextForm(context) on the initial login page where context.getUser() is still null, so conditional passkey UI will not be set up for first-time passkey login. Consider whether this should also be enabled when no user has been selected yet so ID-less passkey authentication on the initial login form continues to work.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add caching support for IdentityProviderStorageProvider.getForLogin operations",
+    "url": "https://github.com/keycloak/keycloak/pull/32918",
+    "comments": [
+      {
+        "comment": "Recursive caching call using session instead of delegate",
+        "severity": "Critical"
+      },
+      {
+        "comment": "Cleanup reference uses incorrect alias - should be 'idp-alias-' + i instead of 'alias'.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add AuthzClientCryptoProvider for authorization client cryptographic operations",
+    "url": "https://github.com/keycloak/keycloak/pull/33832",
+    "comments": [
+      {
+        "comment": "Returns wrong provider (default keystore instead of BouncyCastle)",
+        "severity": "High"
+      },
+      {
+        "comment": "Dead code exists where ASN1Encoder instances are created and written to, but their results are immediately discarded. The actual encoding is performed by new ASN1Encoder instances created in the subsequent return statement, rendering the earlier operations useless.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add rolling-updates feature flag and compatibility framework",
+    "url": "https://github.com/keycloak/keycloak/pull/36882",
+    "comments": [
+      {
+        "comment": "Incorrect method call for exit codes. The picocli.exit() method calls System.exit() directly, which is problematic:",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add Client resource type and scopes to authorization schema",
+    "url": "https://github.com/keycloak/keycloak/pull/36880",
+    "comments": [
+      {
+        "comment": "Inconsistent feature flag bug causing orphaned permissions. The AdminPermissions event listener, responsible for cleaning up permissions upon role, client, or group removal, is incorrectly guarded by the ADMIN_FINE_GRAINED_AUTHZ (V1) feature flag. This is inconsistent with other methods in the class that use ADMIN_FINE_GRAINED_AUTHZ_V2. Consequently, if ADMIN_FINE_GRAINED_AUTHZ_V2 is enabled but V1 is not, the permission cleanup logic will not execute, leading to orphaned permission data. Cleanup should occur regardless of which fine-grained authorization version is enabled.",
+        "severity": "High"
+      },
+      {
+        "comment": "In hasPermission(ClientModel client, String scope), the resource lookup uses findByName(server, client.getId(), server.getId()), but AdminPermissionsSchema.getOrCreateResource creates per-client resources with the owner set to resourceServer.getClientId(), so this lookup will never find those resources and will always fall back to the 'all-clients' resource, effectively ignoring client-specific permissions.",
+        "severity": "High"
+      },
+      {
+        "comment": "In getClientsWithPermission(String scope), iterating resourceStore.findByType(server, AdminPermissionsSchema.CLIENTS_RESOURCE_TYPE) and returning resource.getName() will only ever consider the type-level 'Clients' resource (per-client resources have no type) and return its name, while AvailableRoleMappingResource#getRoleIdsWithPermissions expects actual client IDs to pass to realm.getClientById, which can lead to incorrect behavior or a null client and subsequent failures.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add Groups resource type and scopes to authorization schema",
+    "url": "https://github.com/keycloak/keycloak/pull/37038",
+    "comments": [
+      {
+        "comment": "Incorrect permission check in canManage() method",
+        "severity": "High"
+      },
+      {
+        "comment": "In getGroupIdsWithViewPermission, hasPermission is called with groupResource.getId() and the same groupResource.getId() is added to granted, but hasPermission resolves resources by name (treating the argument as a group id) and the GroupPermissionEvaluator contract says this method returns group IDs that are later used as UserModel.GROUPS and in getUsersCount group filters. This mismatch means per-group VIEW_MEMBERS/MANAGE_MEMBERS permissions may not yield the expected group IDs for filtering and counts, and evaluation may effectively only look at the type-level 'all-groups' resource; consider revisiting whether this should operate on the underlying group ids (resource names) instead so it aligns with the JPA queries and the interface contract.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Add HTML sanitizer for translated message resources",
+    "url": "https://github.com/keycloak/keycloak/pull/37429",
+    "comments": [
+      {
+        "comment": "The translation is in Italian instead of Lithuanian. This should be translated to Lithuanian to match the file's locale (messages_lt.properties).",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The totpStep1 value uses Traditional Chinese terms in the Simplified Chinese file (zh_CN), which is likely incorrect for this locale. Please verify the locale‑appropriate translation.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The anchor sanitization logic has a potential issue where it consumes English matcher groups without proper validation. If the translated text has more anchor tags than the English text, this could lead to incorrect validation results.",
+        "severity": "Low"
+      },
+      {
+        "comment": "The method name 'santizeAnchors' should be 'sanitizeAnchors' (missing 'i').",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Implement access token context encoding framework",
+    "url": "https://github.com/keycloak/keycloak/pull/37634",
+    "comments": [
+      {
+        "comment": "Wrong parameter in null check (grantType vs. rawTokenId)",
+        "severity": "Critical"
+      },
+      {
+        "comment": "In isAccessTokenId, the substring for the grant shortcut and the equality check look inverted: the grant shortcut occupies indices 4–5 (substring(4,6)), and a match should return true (combined with UUID check), not false.",
+        "severity": "High"
+      },
+      {
+        "comment": "Javadoc mentions \"usually like 3-letters shortcut\" but some implementations use 2-letter shortcuts (\"ac\", \"cc\", \"rt\", \"te\", \"pc\", \"ci\", \"ro\"). Consider updating documentation to reflect actual usage pattern.",
+        "severity": "Low"
+      },
+      {
+        "comment": " Catching generic RuntimeException is too broad. The implementation throws IllegalArgumentException specifically - catch that instead for more precise testing.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Implement recovery key support for user storage providers",
+    "url": "https://github.com/keycloak/keycloak/pull/38446",
+    "comments": [
+      {
+        "comment": "Unsafe raw List deserialization without type safety. Calling Optional.get() directly on the Optional returned by RecoveryAuthnCodesUtils.getCredential(user) without checking isPresent() can lead to a NoSuchElementException if the Optional is empty.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "After creating the RecoveryAuthnCodesCredentialModel, consider setting its id from the stored credential (e.g., myUser.recoveryCodes.getId()); otherwise getId() will be null and downstream removal by id (e.g., removeStoredCredentialById in the authenticator flow) may not work.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Fix concurrent group access to prevent NullPointerException",
+    "url": "https://github.com/keycloak/keycloak/pull/40940",
+    "comments": [
+      {
+        "comment": "Returning null from getSubGroupsCount() violates the GroupModel contract (Javadoc says it never returns null) and may lead to NPEs in callers that expect a non-null count.",
+        "severity": "Critical"
+      },
+      {
+        "comment": "The reader thread isn’t waited for; flipping deletedAll to true and asserting immediately can race and miss exceptions added just after the flag change, making this test flaky.",
+        "severity": "Medium"
+      }
+    ]
+  }
+]

--- a/evals/reviewer/golden_comments/sentry.json
+++ b/evals/reviewer/golden_comments/sentry.json
@@ -1,0 +1,192 @@
+[
+  {
+    "pr_title": "Enhanced Pagination Performance for High-Volume Audit Logs",
+    "url": "https://github.com/ai-code-review-evaluation/sentry-greptile/pull/1",
+    "az_comment": "reviewed commit is not in the repo",
+    "comments": [
+      {
+        "comment": "Django querysets do not support negative slicing",
+        "severity": "High"
+      },
+      {
+        "comment": "When requests are authenticated with API keys or org auth tokens (which have user_id=None), organization_context.member is None. Line 71 attempts to access organization_context.member.has_global_access without checking if member is None, causing an AttributeError crash when optimized_pagination=true is used, even though the request passed all permission checks with valid org:write scope.",
+        "severity": "High"
+      },
+      {
+        "comment": "get_item_key assumes a numeric key, but the paginator is used with order_by=-datetime in the audit logs endpoint; calling math.floor/ceil on a datetime will raise a TypeError.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Optimize spans buffer insertion with eviction during insert",
+    "url": "https://github.com/ai-code-review-evaluation/sentry-greptile/pull/2",
+    "original_url": "https://github.com/getsentry/sentry/pull/92393",
+    "az_comment": "reviewed commit is not in the repo",
+    "comments": [
+      {
+        "comment": "OptimizedCursorPaginator negative-offset branch slices QuerySet with a negative start index",
+        "severity": "Critical"
+      },
+      {
+        "comment": "BasePaginator negative-offset branch slices QuerySet with a negative start index",
+        "severity": "High"
+      },
+      {
+        "comment": "OptimizedCursorPaginator.get_item_key uses floor/ceil on a datetime key (order_by='-datetime'), causing TypeError.",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat(upsampling) - Support upsampled error count with performance optimizations",
+    "url": "https://github.com/ai-code-review-evaluation/sentry-greptile/pull/3",
+    "original_url": "https://github.com/getsentry/sentry/pull/94376",
+    "az_comment": "reviewed commit is not in the repo",
+    "comments": [
+      {
+        "comment": "sample_rate = 0.0 is falsy and skipped",
+        "severity": "Low"
+      },
+      {
+        "comment": "Using Python’s built-in hash() to build cache keys is non-deterministic across processes (hash randomization), so keys won’t match across workers and invalidate_upsampling_cache may fail to delete them. Use a deterministic serialization of project_ids for the cache key.",
+        "severity": "Low"
+      },
+      {
+        "comment": "The upsampling eligibility check passes the outer dataset instead of the actual dataset used by scoped_dataset. In paths where the query ultimately runs against discover (e.g., dashboard split) while the original dataset is metrics, upsampling may be skipped even when all projects are allowlisted.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "GitHub OAuth Security Enhancement",
+    "url": "https://github.com/getsentry/sentry/pull/67876",
+    "comments": [
+      {
+        "comment": "Null reference if github_authenticated_user state is missing",
+        "severity": "Medium"
+      },
+      {
+        "comment": "OAuth state uses pipeline.signature (static) instead of a per-request random value",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The code attempts to access integration.metadata[sender][login] without checking for the existence of the sender key. This causes a KeyError for integrations where the sender metadata was not set during creation",
+        "severity": "High"
+      }
+    ]
+  },
+  {
+    "pr_title": "Replays Self-Serve Bulk Delete System",
+    "url": "https://github.com/ai-code-review-evaluation/sentry-greptile/pull/5",
+    "az_comment": "there is no such PR, it is a mix of many PRs",
+    "comments": [
+      {
+        "comment": "Breaking changes in error response format",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Detector validator uses wrong key when updating type",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Using zip(error_ids, events.values()) assumes the get_multi result preserves the input order; dict value order is not guaranteed to match error_ids, so event data can be paired with the wrong ID (missing nodes also shift alignment).",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "Span Buffer Multiprocess Enhancement with Health Monitoring",
+    "url": "https://github.com/getsentry/sentry/pull/93824",
+    "comments": [
+      {
+        "comment": "Inconsistent metric tagging with 'shard' and 'shards'",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Fixed sleep in tests can be flaky; wait on condition instead",
+        "severity": "Low"
+      },
+      {
+        "comment": "Because flusher processes are created via multiprocessing.get_context('spawn').Process, they are instances of multiprocessing.context.SpawnProcess, which on POSIX is not a subclass of multiprocessing.Process, so this isinstance check will always be false and hung processes won't be killed here.",
+        "severity": "High"
+      },
+      {
+        "comment": "Sleep in test_consumer.py won’t actually wait because time.sleep was monkeypatched above; consider restoring sleep or using a different sync to ensure the flusher has time to process.",
+        "severity": "Medium"
+      },
+      {
+        "comment": "Breaking out of the loop when the deadline has elapsed can skip terminating remaining flusher processes, potentially leaving them running after shutdown; consider ensuring termination is attempted even if the deadline is exceeded.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat(ecosystem): Implement cross-system issue synchronization",
+    "url": "https://github.com/getsentry/sentry/pull/77754",
+    "comments": [
+      {
+        "comment": "Shared mutable default in dataclass timestamp",
+        "severity": "Medium"
+      },
+      {
+        "comment": "The method name has a typo: test_from_dict_inalid_data should be test_from_dict_invalid_data.",
+        "severity": "Low"
+      },
+      {
+        "comment": "Method name says 'empty_array' but tests empty dict - consider renaming to 'test_from_dict_empty_dict' for clarity.",
+        "severity": "Low"
+      },
+      {
+        "comment": "to_dict() returns a datetime for queued; if this dict is passed in task kwargs (e.g., via apply_async), JSON serialization may fail depending on the serializer, which can cause enqueue errors.",
+        "severity": "Medium"
+      }
+    ]
+  },
+  {
+    "pr_title": "ref(crons): Reorganize incident creation / issue occurrence logic",
+    "url": "https://github.com/getsentry/sentry/pull/80528",
+    "comments": [
+      {
+        "comment": "The function modifies the config variable to include display values but then returns the original monitor.config instead of the modified version.",
+        "severity": "High"
+      },
+      {
+        "comment": "The code fetches MonitorCheckIn objects by ID when the required data already exists in previous_checkins. This creates an unnecessary database query.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat(uptime): Add ability to use queues to manage parallelism",
+    "url": "https://github.com/getsentry/sentry/pull/95633",
+    "comments": [
+      {
+        "comment": "The queue.shutdown() method with 'immediate=False' parameter may not exist in the standard Python queue module. This could cause AttributeError at runtime. Verify the correct API or implement a custom shutdown mechanism.",
+        "severity": "High"
+      },
+      {
+        "comment": "The magic number 50 for max_wait is used repeatedly throughout the tests. Consider extracting this as a named constant to improve maintainability.",
+        "severity": "Low"
+      },
+      {
+        "comment": "The test test_thread_queue_parallel_error_handling has a docstring that doesn't match the test implementation.",
+        "severity": "Low"
+      }
+    ]
+  },
+  {
+    "pr_title": "feat(workflow_engine): Add in hook for producing occurrences from the stateful detector",
+    "url": "https://github.com/getsentry/sentry/pull/80168",
+    "comments": [
+      {
+        "comment": "MetricAlertDetectorHandler inherits from StatefulDetectorHandler but only contains pass, failing to implement its required abstract methods: counter_names (property), get_dedupe_value(), get_group_key_values(), and build_occurrence_and_event_data(). This will cause a TypeError at runtime when the class is instantiated.",
+        "severity": "High"
+      },
+      {
+        "comment": "Docstring says this returns a list of DetectorEvaluationResult, but the method now returns a dict keyed by DetectorGroupKey. Consider updating the docstring to match the new return type.",
+        "severity": "Low"
+      }
+    ]
+  }
+]

--- a/evals/reviewer/judge.py
+++ b/evals/reviewer/judge.py
@@ -1,0 +1,184 @@
+"""LLM-judge evaluator for the reviewer eval.
+
+Pairwise matches each agent-emitted candidate against each golden comment using
+claude-opus-4-5 (the model martian used to score Devin Review). Returns
+precision/recall/f1 per example, plus aggregate metrics across the experiment.
+
+The judge prompt is kept verbatim from
+withmartian/code-review-benchmark `step3_judge_comments.py` so scores are
+directly comparable to martian's published numbers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from langchain_anthropic import ChatAnthropic
+from langsmith.evaluation import EvaluationResult
+from langsmith.schemas import Example, Run
+
+JUDGE_MODEL = "claude-opus-4-5"
+
+JUDGE_SYSTEM = "You are a precise code review evaluator. Always respond with valid JSON."
+
+JUDGE_PROMPT = """You are evaluating AI code review tools.
+Determine if the candidate issue matches the golden (expected) comment.
+
+Golden Comment (the issue we're looking for):
+{golden_comment}
+
+Candidate Issue (from the tool's review):
+{candidate}
+
+Instructions:
+- Determine if the candidate identifies the SAME underlying issue as the golden comment
+- Accept semantic matches - different wording is fine if it's the same problem
+- Focus on whether they point to the same bug, concern, or code issue
+
+Respond with ONLY a JSON object:
+{{"reasoning": "brief explanation", "match": true/false, "confidence": 0.0-1.0}}"""
+
+
+_judge: ChatAnthropic | None = None
+
+
+def _get_judge() -> ChatAnthropic:
+    global _judge
+    if _judge is None:
+        _judge = ChatAnthropic(model=JUDGE_MODEL, temperature=0.0, max_tokens=512)
+    return _judge
+
+
+def _format_candidate(c: dict) -> str:
+    parts = []
+    if c.get("file"):
+        loc = c["file"]
+        if c.get("line") is not None:
+            loc += f":{c['line']}"
+        parts.append(f"Location: {loc}")
+    if c.get("severity"):
+        parts.append(f"Severity: {c['severity']}")
+    parts.append(f"Comment: {c.get('body') or c.get('comment') or ''}")
+    return "\n".join(parts)
+
+
+def _format_golden(g: dict) -> str:
+    parts = []
+    if g.get("severity"):
+        parts.append(f"Severity: {g['severity']}")
+    parts.append(f"Comment: {g.get('comment', '')}")
+    return "\n".join(parts)
+
+
+def _judge_pair(golden: dict, candidate: dict) -> dict[str, Any]:
+    prompt = JUDGE_PROMPT.format(
+        golden_comment=_format_golden(golden),
+        candidate=_format_candidate(candidate),
+    )
+    msg = _get_judge().invoke(
+        [{"role": "system", "content": JUDGE_SYSTEM}, {"role": "user", "content": prompt}]
+    )
+    raw = msg.content if isinstance(msg.content, str) else str(msg.content)
+    try:
+        start, end = raw.find("{"), raw.rfind("}")
+        return json.loads(raw[start : end + 1])
+    except (ValueError, json.JSONDecodeError):
+        return {"match": False, "confidence": 0.0, "reasoning": f"unparseable: {raw[:200]}"}
+
+
+def judge_match(run: Run, example: Example) -> EvaluationResult:
+    """Per-example evaluator: compute precision/recall/f1 against golden comments."""
+    candidates: list[dict] = list((run.outputs or {}).get("comments") or [])
+    goldens: list[dict] = list((example.outputs or {}).get("golden_comments") or [])
+
+    if not goldens:
+        return EvaluationResult(key="f1", score=None, comment="no goldens")
+
+    matched_goldens: set[int] = set()
+    matched_candidates: set[int] = set()
+    pair_results: list[dict] = []
+
+    for ci, cand in enumerate(candidates):
+        for gi, gold in enumerate(goldens):
+            if gi in matched_goldens:
+                continue
+            res = _judge_pair(gold, cand)
+            pair_results.append(
+                {"candidate_idx": ci, "golden_idx": gi, **res}
+            )
+            if res.get("match"):
+                matched_goldens.add(gi)
+                matched_candidates.add(ci)
+                break  # candidate consumed; move to next candidate
+
+    tp = len(matched_goldens)
+    fp = max(0, len(candidates) - len(matched_candidates))
+    fn = max(0, len(goldens) - tp)
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    return EvaluationResult(
+        key="f1",
+        score=f1,
+        comment=f"P={precision:.2f} R={recall:.2f} TP={tp} FP={fp} FN={fn}",
+        evaluator_info={"model": JUDGE_MODEL},
+        extra={
+            "precision": precision,
+            "recall": recall,
+            "tp": tp,
+            "fp": fp,
+            "fn": fn,
+            "n_candidates": len(candidates),
+            "n_goldens": len(goldens),
+            "pairs": pair_results,
+        },
+    )
+
+
+def aggregate_pr(runs: list[Run], examples: list[Example]) -> list[EvaluationResult]:
+    """Summary evaluator: micro- and macro-averaged precision/recall across the experiment."""
+    micro_tp = micro_fp = micro_fn = 0
+    p_macro: list[float] = []
+    r_macro: list[float] = []
+
+    for run in runs:
+        feedback = next(
+            (f for f in (run.feedback_stats or {}).values() if isinstance(f, dict)), None
+        )
+        # Pull per-example numbers off the run's evaluator extras when available.
+        # We re-judge below if extras are unavailable to keep this evaluator pure.
+        extras = None
+        for ev in run.outputs and run.outputs.get("__evaluator_extras__", []) or []:
+            if ev.get("key") == "f1":
+                extras = ev.get("extra")
+                break
+        if not extras:
+            continue
+        micro_tp += extras["tp"]
+        micro_fp += extras["fp"]
+        micro_fn += extras["fn"]
+        p_macro.append(extras["precision"])
+        r_macro.append(extras["recall"])
+        del feedback  # unused; reserved for future LangSmith API
+
+    if not p_macro:
+        return []
+
+    micro_p = micro_tp / (micro_tp + micro_fp) if (micro_tp + micro_fp) else 0.0
+    micro_r = micro_tp / (micro_tp + micro_fn) if (micro_tp + micro_fn) else 0.0
+    macro_p = sum(p_macro) / len(p_macro)
+    macro_r = sum(r_macro) / len(r_macro)
+
+    def _f1(p: float, r: float) -> float:
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+    return [
+        EvaluationResult(key="micro_precision", score=micro_p),
+        EvaluationResult(key="micro_recall", score=micro_r),
+        EvaluationResult(key="micro_f1", score=_f1(micro_p, micro_r)),
+        EvaluationResult(key="macro_precision", score=macro_p),
+        EvaluationResult(key="macro_recall", score=macro_r),
+        EvaluationResult(key="macro_f1", score=_f1(macro_p, macro_r)),
+    ]

--- a/evals/reviewer/judge.py
+++ b/evals/reviewer/judge.py
@@ -104,9 +104,7 @@ def judge_match(run: Run, example: Example) -> EvaluationResult:
             if gi in matched_goldens:
                 continue
             res = _judge_pair(gold, cand)
-            pair_results.append(
-                {"candidate_idx": ci, "golden_idx": gi, **res}
-            )
+            pair_results.append({"candidate_idx": ci, "golden_idx": gi, **res})
             if res.get("match"):
                 matched_goldens.add(gi)
                 matched_candidates.add(ci)

--- a/evals/reviewer/run_eval.py
+++ b/evals/reviewer/run_eval.py
@@ -1,0 +1,46 @@
+"""Run the reviewer eval against the LangSmith dataset.
+
+Usage:
+    uv run python -m evals.reviewer.run_eval \\
+        --dataset-name openswe-reviewer-v1 \\
+        --experiment-prefix openswe-reviewer-baseline \\
+        --max-concurrency 5
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from dotenv import load_dotenv
+from langsmith import aevaluate
+
+load_dotenv()
+
+from evals.reviewer.judge import aggregate_pr, judge_match
+from evals.reviewer.target import review_pr
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset-name", default="openswe-reviewer-v1")
+    ap.add_argument("--experiment-prefix", default="openswe-reviewer-baseline")
+    ap.add_argument("--max-concurrency", type=int, default=5)
+    ap.add_argument("--limit", type=int, default=None, help="Run only the first N examples.")
+    args = ap.parse_args()
+
+    await aevaluate(
+        review_pr,
+        data=args.dataset_name,
+        evaluators=[judge_match],
+        summary_evaluators=[aggregate_pr],
+        experiment_prefix=args.experiment_prefix,
+        max_concurrency=args.max_concurrency,
+        num_repetitions=1,
+        **({"max_examples": args.limit} if args.limit else {}),
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/evals/reviewer/run_eval.py
+++ b/evals/reviewer/run_eval.py
@@ -14,10 +14,10 @@ import argparse
 from dotenv import load_dotenv
 from langsmith import aevaluate
 
-load_dotenv()
-
 from evals.reviewer.judge import aggregate_pr, judge_match
 from evals.reviewer.target import review_pr
+
+load_dotenv()
 
 
 async def main() -> None:

--- a/evals/reviewer/target.py
+++ b/evals/reviewer/target.py
@@ -1,0 +1,63 @@
+"""Target function for the reviewer eval.
+
+Invokes the Open SWE Reviewer graph over the langgraph_sdk client and returns
+the structured comments produced by the agent's `submit_review` tool call.
+
+The reviewer graph itself is not part of this PR — wire `REVIEWER_ASSISTANT_ID`
+to whatever graph id you want to evaluate once it exists.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from langgraph_sdk import get_client
+
+REVIEWER_ASSISTANT_ID = os.getenv("REVIEWER_ASSISTANT_ID", "reviewer")
+LANGGRAPH_URL = os.getenv("LANGGRAPH_URL", "http://localhost:2024")
+
+
+async def review_pr(inputs: dict[str, Any]) -> dict[str, Any]:
+    """LangSmith target: run the reviewer agent on one PR.
+
+    `inputs` carries: repo, pr_number, pr_url, base_sha, head_sha, base_ref,
+    head_ref, pr_title. The reviewer graph is responsible for cloning the
+    repo at base_sha, fetching the PR's head, and emitting structured review
+    comments via a `submit_review` tool whose args become the graph output.
+
+    Returns: {"comments": [{file, line, severity, body}, ...]}.
+    """
+    client = get_client(url=LANGGRAPH_URL)
+    thread = await client.threads.create()
+    result = await client.runs.wait(
+        thread["thread_id"],
+        assistant_id=REVIEWER_ASSISTANT_ID,
+        input={"pr": inputs},
+    )
+    return {"comments": _extract_comments(result)}
+
+
+def _extract_comments(result: Any) -> list[dict]:
+    """Pull the submit_review payload out of the graph's final state.
+
+    Supports two shapes:
+      1. Graph state contains a top-level `review` field populated by the tool
+         (preferred — wire the reviewer graph to set this).
+      2. Last AI message includes a `submit_review` tool call; we parse args.
+    """
+    if isinstance(result, dict):
+        if isinstance(result.get("review"), dict) and "comments" in result["review"]:
+            return list(result["review"]["comments"])
+        if isinstance(result.get("comments"), list):
+            return list(result["comments"])
+
+        messages = result.get("messages") or []
+        for msg in reversed(messages):
+            tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
+            for tc in tool_calls or []:
+                if tc.get("name") == "submit_review":
+                    args = tc.get("args") or {}
+                    if isinstance(args.get("comments"), list):
+                        return list(args["comments"])
+    return []


### PR DESCRIPTION
## Summary

Offline LangSmith eval scaffolding for the upcoming Open SWE Reviewer graph. Reviewer graph itself is **not** part of this change — only the harness around it.

- Imports the 50 PRs from `withmartian/code-review-benchmark` goldens into a LangSmith dataset (`openswe-reviewer-v1` by default), resolving each PR's `base_sha` / `head_sha` once via `gh` so the dataset is frozen against upstream drift.
- LLM-judge evaluator uses `claude-opus-4-5` with martian's verbatim `JUDGE_PROMPT` (from their `step3_judge_comments.py`), so scores stay directly comparable to martian's published Devin Review numbers.
- Per-example evaluator returns `{precision, recall, f1, tp, fp, fn}`; summary evaluator emits micro/macro aggregates.
- Target function calls the reviewer graph over `langgraph_sdk` and parses out either a `submit_review` tool call or a top-level `state["review"]` field.

See `REVIEWER_EVAL_PLAN.md` for the full design + comparison methodology.

## Test plan

- [x] `uv run python -m evals.reviewer.build_dataset --dry-run` — resolved SHAs for all 50 PRs without error
- [x] LangSmith client auths against `LANGCHAIN_API_KEY` from `.env`
- [x] Dataset uploaded successfully to LangSmith
- [ ] End-to-end eval run — blocked on the reviewer graph