### PR TITLE
fix: Slack assistant status endpoint

### DIFF
--- a/agent/middleware/refresh_slack_status.py
+++ b/agent/middleware/refresh_slack_status.py
@@ -1,6 +1,6 @@
 """Middleware that keeps Slack's assistant status current during agent work.
 
-Slack's ``assistants.threads.setStatus`` indicator expires after two minutes
+Slack's ``assistant.threads.setStatus`` indicator expires after two minutes
 if no message is sent. This middleware refreshes the indicator while model and
 tool calls are actively running, then clears it when the run exits without
 relying on the model to post a final Slack reply.

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -287,7 +287,7 @@ async def set_slack_assistant_status(
 ) -> bool:
     """Set the assistant typing/status indicator on a Slack thread.
 
-    Wraps Slack's `assistants.threads.setStatus` API. The `chat:write` scope
+    Wraps Slack's `assistant.threads.setStatus` API. The `chat:write` scope
     on the bot token is sufficient. Status auto-clears when the bot posts to
     the thread, and Slack itself expires it after ~2 minutes — callers that
     want it visible across longer runs must refresh it periodically.
@@ -316,18 +316,18 @@ async def set_slack_assistant_status(
     async with httpx.AsyncClient() as http_client:
         try:
             response = await http_client.post(
-                f"{SLACK_API_BASE_URL}/assistants.threads.setStatus",
+                f"{SLACK_API_BASE_URL}/assistant.threads.setStatus",
                 headers=_slack_headers(),
                 json=payload,
             )
             response.raise_for_status()
             data = response.json()
             if not data.get("ok"):
-                logger.warning("Slack assistants.threads.setStatus failed: %s", data.get("error"))
+                logger.warning("Slack assistant.threads.setStatus failed: %s", data.get("error"))
                 return False
             return True
         except httpx.HTTPError:
-            logger.exception("Slack assistants.threads.setStatus request failed")
+            logger.exception("Slack assistant.threads.setStatus request failed")
             return False
 
 

--- a/tests/test_slack_assistants_status.py
+++ b/tests/test_slack_assistants_status.py
@@ -74,7 +74,7 @@ async def test_set_slack_assistant_status_calls_correct_endpoint(
     assert ok is True
     client_cm.post.assert_awaited_once()
     args, kwargs = client_cm.post.call_args
-    assert args[0].endswith("/assistants.threads.setStatus")
+    assert args[0].endswith("/assistant.threads.setStatus")
     assert kwargs["json"] == {
         "channel_id": "C1",
         "thread_ts": "1.0",


### PR DESCRIPTION
## Summary

Fix the Slack Assistants API status call to use Slack's documented `assistant.threads.setStatus` Web API method instead of the pluralized `assistants.threads.setStatus` path.

## Root Cause

The previous integration posted to the wrong endpoint path, so Slack status/typing updates could fail while normal `chat.postMessage` progress replies still rendered.

## Impact

Slack-triggered runs should now be able to show the assistant status indicator when `SLACK_ASSISTANTS_API_ENABLED` is enabled and the bot token is configured.

## Validation

- `uv run pytest -vvv tests/test_slack_assistants_status.py tests/test_refresh_slack_status_middleware.py`
