### PR TITLE
chore: Use Claude Code style spinner vocab for Slack loading messages

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -39,14 +39,16 @@ DEFAULT_ASSISTANT_STATUS = "is thinking…"
 # Curated rotating loading strings shown by Slack while the indicator is active.
 # Capped at 10 by Slack's API.
 DEFAULT_LOADING_MESSAGES: tuple[str, ...] = (
-    "reading the repo…",
-    "tracing call sites…",
-    "thinking through edge cases…",
-    "running commands…",
-    "drafting changes…",
-    "double-checking the diff…",
-    "writing tests…",
-    "tidying up…",
+    "Pondering…",
+    "Cogitating…",
+    "Ruminating…",
+    "Noodling…",
+    "Percolating…",
+    "Marinating…",
+    "Simmering…",
+    "Conjuring…",
+    "Tinkering…",
+    "Schlepping…",
 )
 
 


### PR DESCRIPTION
## Summary
- Replaces the rotating Slack `loading_messages` strings with Claude-Code-style single-word "-ing" verbs (Pondering…, Cogitating…, …) for a calmer, more recognizable feel.
- No behavior changes: same rotation mechanism, same call sites, bottom per-tool `status` untouched.

## Test plan
- [ ] Trigger a Slack-thread agent run and confirm the top shimmer cycles through the new vocab.