### PR TITLE
fix: move feedback-reaction ask into tip rotation

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -138,8 +138,6 @@ For tasks that require code changes, follow this order:
 
 **Strict requirement:** Never claim "PR updated/opened" unless `gh` returned success and you have the PR URL from command output or `GH_TOKEN=dummy gh pr view --json url --jq .url`. If push or PR creation fails, state that explicitly.
 
-For Slack-triggered tasks, end your final `slack_thread_reply` completion summary by asking the user to react with `:+1:` or `:-1:` to provide feedback.
-
 For questions or status checks (no code changes needed):
 
 1. **Answer** — Gather the information needed to respond.

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -700,6 +700,7 @@ TRACE_REPLY_TIPS: tuple[str, ...] = (
     "Tag me on a PR comment of an open-swe PR to have me address review feedback on the same branch.",
     "I can spawn subagents for independent subtasks — useful for parallel research or fan-out work.",
     "Click `View trace` above to watch every tool call and model response live in LangSmith.",
+    "React to my final reply with :+1: or :-1: to share feedback — it helps me get better.",
 )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #1278. Appending "Please react with \`:+1:\` or \`:-1:\` to share feedback" to every Slack completion message ended up being repetitive — once you've seen it, you've seen it.

- Dropped the instruction from the prompt (`agent/prompt.py`).
- Added the same ask as one of the rotating tips on the trace reply, so users still see it occasionally without it cluttering each final summary.

## Test plan

- [x] \`make lint\`
- [x] \`make test\` (283 passed)