### PR TITLE
fix: surface GitHub error details when publish_review fails

### DIFF
--- a/agent/reviewer_publish.py
+++ b/agent/reviewer_publish.py
@@ -122,9 +122,20 @@ async def post_pull_request_review(
         try:
             response = await client.post(url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
-        except httpx.HTTPError:
+        except httpx.HTTPStatusError as e:
+            body = (e.response.text or "")[:500]
+            logger.exception(
+                "Failed to POST PR review for %s/%s#%s: %s %s",
+                owner,
+                repo,
+                pr_number,
+                e.response.status_code,
+                body,
+            )
+            return {"_error": f"HTTP {e.response.status_code}: {body}"}
+        except httpx.HTTPError as e:
             logger.exception("Failed to POST PR review for %s/%s#%s", owner, repo, pr_number)
-            return None
+            return {"_error": f"{type(e).__name__}: {e}"}
     data = response.json()
     return data if isinstance(data, dict) else None
 

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -159,6 +159,11 @@ async def _publish_review_async(
     )
     if review_response is None:
         return {"success": False, "error": "Failed to POST PR review"}
+    if isinstance(review_response, dict) and "_error" in review_response:
+        return {
+            "success": False,
+            "error": f"Failed to POST PR review: {review_response['_error']}",
+        }
     review_id = review_response.get("id") if isinstance(review_response, dict) else None
 
     if review_id is not None and inline_comments:


### PR DESCRIPTION
## Summary
- `post_pull_request_review` previously swallowed `httpx.HTTPError` and returned `None`, so the `publish_review` tool result was just `"Failed to POST PR review"` — no status, no GitHub error body.
- Capture status code + response body on `HTTPStatusError` (and the exception type/message on other transport errors) and propagate them through `publish_review`'s tool result, so the agent and traces can actually see why a publish failed (e.g. 422 invalid inline comment, 404 app-not-installed, expired installation token).

Motivation: a recent reviewer run on `langchain-ai/chat-langchain#574` failed with the generic message and was undiagnosable from the trace alone — root cause only existed in logs.

## Test plan
- [x] `uv run pytest -vvv tests/test_reviewer_publish.py` — all existing tests pass (failure-path mocks return the helper directly, so the new shape is covered the next time we land a test that exercises `_error`).
- [x] `make lint`