### PR TITLE
ci: nightly promote of main to prod for LangGraph deploys

### DIFF
--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -1,0 +1,25 @@
+name: Promote main to prod
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: promote-main-to-prod
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Force-push main to prod
+        run: |
+          git push --force origin HEAD:refs/heads/prod


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/promote_main_to_prod.yml`, a cron workflow that force-pushes `main` to `prod` daily at 08:00 UTC (midnight PST / 1am PDT).
- `workflow_dispatch` is retained so hotfixes can be promoted to prod on demand from the Actions tab.

## Why
LangGraph Cloud cancels every in-flight run when a new revision deploys (documented as expected behavior). With auto-deploy currently tracking `main`, every merge today kills 30-minute coding-agent runs in progress — trace data shows cancel clusters tracking merge timestamps to the minute, and >18% of root runs today errored with `CancelledError`. Days with 0–2 commits had 0% cancels; days with 17–19 commits had 9–19%.

Plan after this lands:
1. Bootstrap: `git push origin main:prod` once.
2. Switch the LangGraph deployment's tracked branch from `main` to `prod` in the platform UI.
3. Routine merges flow through the nightly mirror; rare hotfixes use `workflow_dispatch`.

## Test plan
- [ ] After merge, push `main:prod` once to bootstrap the branch.
- [ ] Trigger the workflow manually via Actions → "Promote main to prod" → "Run workflow"; confirm `prod` advances to current `main` SHA.
- [ ] Switch deployment's tracked branch to `prod` and verify a normal merge to `main` does NOT trigger a redeploy.
- [ ] Wait for the 08:00 UTC cron run; confirm `prod` advances and the deploy fires.