### PR TITLE
fix(auth): prevent internal error details from leaking to users via Linear/Slack comments

### DIFF
--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -349,10 +349,19 @@ async def save_encrypted_token_from_email(
     token = auth_result.get("token")
     if not token:
         error = auth_result.get("error", "unknown")
+        # Do not leak internal error details (which may contain upstream HTTP
+        # response bodies, internal URLs, or stack traces) to external users
+        # via Linear/Slack comments. Log the detailed error server-side only
+        # and surface a generic message to the user.
+        logger.error(
+            "GitHub auth failed for thread (source=%s): %s",
+            source,
+            error,
+        )
         message = (
             "❌ **GitHub Auth Error**\n\n"
-            f"Failed to authenticate with GitHub: {error}\n\n"
-            "Please try again or contact support."
+            "Failed to authenticate with GitHub. "
+            "Please try again or contact support if this persists."
         )
         await leave_failure_comment(source, message)
         raise ValueError(f"No token found: {error}")


### PR DESCRIPTION
## Summary

When GitHub authentication fails in `agent/utils/auth.py`, the `error` field from `get_github_token_for_user` is interpolated directly into a comment posted to Linear or Slack. This error string can contain internal API URLs, upstream HTTP response bodies, and exception details — information that should not be exposed to end users.

**CWE-200: Exposure of Sensitive Information to an Unauthorized Actor**

## What changed

In `save_encrypted_token_from_email` (~line 351), the fix:

1. **Logs the detailed error server-side** via `logger.error(...)` so operators retain full diagnostic information.
2. **Replaces the user-facing message** with a generic "Failed to authenticate with GitHub" string that no longer includes the raw `error` value.

The change is a single-file, 11-line diff — no behavior change to the happy path.

## Data flow

`auth_result.get("error")` ← returned from `get_github_token_for_user`, which wraps upstream HTTP calls and can surface raw response bodies. Before this fix, that value flowed directly into the `message` string passed to `leave_failure_comment`, which posts to Linear or Slack. After the fix, it flows only to `logger.error`.

## Testing

- Verified the fix applies cleanly on `main`.
- Confirmed `leave_failure_comment` no longer receives the raw error string.
- Confirmed the `ValueError` raised at the end of the block still includes the error for server-side debugging.

## Security analysis

This is exploitable whenever GitHub auth fails — for example, due to an expired token, a misconfigured OAuth app, or a transient upstream error. The leaked details could reveal internal service URLs, API response formats, or infrastructure information to anyone viewing the Linear/Slack thread. While this is low severity (it requires an auth failure to trigger and exposes infrastructure details rather than credentials), it is a straightforward information disclosure that should be closed.

Before submitting, we considered whether this path is actually reachable in practice and whether the error content is truly sensitive. It is reachable — any transient GitHub API failure triggers it — and we confirmed the error strings can contain full HTTP response bodies from upstream calls, which include internal URLs and service identifiers that should not be user-facing.