### PR TITLE
feat: proxy dashboard API through Vercel (first-party cookies)

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/dashboard/api/:path*",
+      "destination": "https://open-swe-test-3c1f9e43498f5f4ebe6b59a83263e931.us.langgraph.app/dashboard/api/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a Vercel rewrite that proxies \`/dashboard/api/*\` from \`openswe.vercel.app\` → the LangSmith deployment. From the browser's perspective the API is now same-origin, so the \`osw_session\` cookie is first-party and survives the round-trip — fixes the post-login 401 loop on Safari / Brave / Firefox / privacy-mode Chrome.

## Why
With the frontend on Vercel and the API on \`*.langgraph.app\`, the auth callback's \`Set-Cookie\` was being silently dropped by browsers as a third-party cookie (\`SameSite=None\` cross-site). \`/me\` then returned 401 forever. The rewrite makes the API appear to live on the same origin as the page, so the cookie is attributed to \`openswe.vercel.app\` and browsers treat it like any normal first-party session cookie.

## Pair with deployment-side changes
- GitHub App **Callback URL** → \`https://openswe.vercel.app/dashboard/api/auth/callback\`
- LangSmith deployment env: \`DASHBOARD_API_BASE_URL=https://openswe.vercel.app\`
- Vercel env: remove (or empty) \`VITE_DASHBOARD_API_BASE_URL\` — the frontend already falls back to relative URLs, which is what the rewrite expects.

## Test plan
- [ ] Clear cookies for \`openswe.vercel.app\` and \`*.langgraph.app\` to wipe any stale \`osw_session\`.
- [ ] Visit \`https://openswe.vercel.app\` → "Continue with GitHub" → land on \`/profile\`.
- [ ] Devtools → Application → Cookies → confirm \`osw_session\` is set on \`openswe.vercel.app\` (not \`langgraph.app\`).
- [ ] Reload \`/profile\` — still logged in, no 401.
- [ ] Save a profile; verify it persists across reloads.