### PR TITLE
chore: point Vercel rewrite at the prod LangSmith deployment

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/dashboard/api/:path*",
-      "destination": "https://open-swe-test-3c1f9e43498f5f4ebe6b59a83263e931.us.langgraph.app/dashboard/api/:path*"
+      "destination": "https://open-swe-v3-f2834ffc0df05a46a10262a9690e8490.us.langgraph.app/dashboard/api/:path*"
     }
   ]
 }


### PR DESCRIPTION
PR #1303 was merged before this URL change landed on the branch. Updates the rewrite destination from the open-swe-test deployment to the prod open-swe-v3 deployment so \`openswe.vercel.app\` proxies to the right backend.

## Test plan
- [ ] Merge.
- [ ] Vercel redeploys \`openswe.vercel.app\`.
- [ ] \`curl -s -o /dev/null -w "%{http_code}\n" https://openswe.vercel.app/dashboard/api/options\` returns 200.
- [ ] \`https://openswe.vercel.app\` → "Continue with GitHub" → \`/profile\`.