### PR TITLE
feat: OAuth-based account links replace hardcoded user mapping

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -205,12 +205,20 @@ GitHub triggering works automatically once your GitHub App is set up (step 3). U
 - Tag `@openswe` in issue comments for follow-up instructions
 - Tag `@openswe` in PR review comments to have it address review feedback
 
-To control which GitHub users can trigger the agent, add them to the `GITHUB_USER_EMAIL_MAP` in `agent/utils/github_user_email_map.py`:
+Users authorize the agent by signing into the dashboard once with their GitHub account (`/login`). Their email + encrypted GitHub OAuth token are stored in the LangGraph Store, and every subsequent webhook (GitHub PR/issue, Slack, Linear) resolves their identity from there. There is no per-user mapping file to maintain.
 
-```python
-GITHUB_USER_EMAIL_MAP = {
-    "their-github-username": "their-email@example.com",
-}
+To restrict dashboard logins to members of a specific GitHub organization, set:
+
+```bash
+ALLOWED_AUTH_ORG="langchain-ai"      # leave empty to allow any GitHub user
+```
+
+When set, non-members are redirected to a "not authorized" page instead of getting a session cookie.
+
+If your team's work email domain isn't the user's primary email on GitHub, set:
+
+```bash
+WORK_EMAIL_DOMAIN="langchain.dev"    # prefer this domain when scanning verified emails
 ```
 
 You should also configure which GitHub organizations and/or repositories the agent is allowed to operate on. You can specify allowed orgs, specific `owner/repo` pairs, or both:
@@ -227,9 +235,24 @@ A GitHub or Linear webhook is accepted if the resolved repo's org is in `ALLOWED
 
 ### Linear (optional)
 
-Open SWE listens for Linear comments that mention `@openswe`.
+Open SWE listens for Linear comments that mention `@openswe`. Linear access has two parts: a webhook (for incoming events) and an **OAuth application** (used both as a workspace service account and for end-user account linking).
 
-**Create a webhook:**
+**Create the OAuth app:**
+
+1. In Linear, go to **Settings → API → Applications → New application**
+2. Fill in:
+   - **Name**: `Open SWE`
+   - **Callback URLs**: `https://<your-api-base>/dashboard/api/auth/linear/callback` (used by individual user account-linking from the dashboard)
+   - **Public** vs **Private** doesn't matter for an internal workspace install
+3. Save the application, then copy the **Client ID** and **Client Secret** — these become `LINEAR_CLIENT_ID` and `LINEAR_CLIENT_SECRET`.
+4. **Install the app as an agent into your workspace.** From the application page in Linear, visit the install URL with `actor=app` appended:
+   ```
+   https://linear.app/oauth/authorize?response_type=code&client_id=<LINEAR_CLIENT_ID>&redirect_uri=<your-callback>&scope=read,write,app:assignable,app:mentionable&actor=app
+   ```
+   Approve the install as a workspace admin. This registers Open SWE as an in-workspace agent — comments it posts will be attributed to the app, not to the installing user.
+5. Once the app is installed, server-side API calls fetch a token automatically via the `client_credentials` grant. No long-lived token to copy or rotate manually — `LINEAR_CLIENT_ID` + `LINEAR_CLIENT_SECRET` are enough.
+
+**Create the webhook:**
 
 1. In Linear, go to **Settings → API → Webhooks → New webhook**
 2. Fill in:
@@ -238,12 +261,6 @@ Open SWE listens for Linear comments that mention `@openswe`.
    - **Secret**: generate with `openssl rand -hex 32` — save this as `LINEAR_WEBHOOK_SECRET`
 3. Under **Data change events**, enable **Comments → Create** only
 4. Click **Create webhook**
-
-**Get your API key:**
-
-1. Go to **Settings → API → Personal API keys → New API key**
-2. Name it `open-swe`, select **All access**, and copy the key
-3. Save it as `LINEAR_API_KEY`
 
 **Configure team-to-repo mapping:**
 
@@ -296,7 +313,8 @@ Users can also override the team/project mapping per-comment by including `repo:
     },
     "oauth_config": {
         "redirect_urls": [
-            "https://smith.langchain.com/host-oauth-callback/<your-provider-id>"
+            "https://smith.langchain.com/host-oauth-callback/<your-provider-id>",
+            "https://<your-api-base>/dashboard/api/auth/slack/callback"
         ],
         "scopes": {
             "bot": [
@@ -315,6 +333,11 @@ Users can also override the team/project mapping per-comment by including `repo:
                 "team:read",
                 "users:read",
                 "users:read.email"
+            ],
+            "user": [
+                "openid",
+                "email",
+                "profile"
             ]
         }
     },
@@ -337,6 +360,7 @@ Users can also override the team/project mapping per-comment by including `repo:
 </details>
 
 3. Install the app to your workspace and copy the **Bot User OAuth Token** (`xoxb-...`)
+4. Under **Basic Information → App Credentials** copy the **Client ID** and **Client Secret**. These are used for the dashboard's "Sign in with Slack" account-linking flow.
 
 **Credentials you'll need:**
 
@@ -344,6 +368,7 @@ Users can also override the team/project mapping per-comment by including `repo:
 - `SLACK_SIGNING_SECRET`: found under **Basic Information → App Credentials**
 - `SLACK_BOT_USER_ID`: the bot's user ID (find it in Slack by clicking the bot's profile)
 - `SLACK_BOT_USERNAME`: the bot's display name (e.g. `open-swe`)
+- `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET`: used by the dashboard's account-linking flow. Same Slack app — these are pulled from **Basic Information → App Credentials**.
 
 **Default repo:**
 
@@ -397,7 +422,8 @@ DEFAULT_REPO_OWNER=""                  # Default GitHub org (e.g. "my-org")
 DEFAULT_REPO_NAME=""                   # Default GitHub repo (e.g. "my-repo")
 
 # === Linear (if using Linear trigger) ===
-LINEAR_API_KEY=""                      # From step 5
+LINEAR_CLIENT_ID=""                    # OAuth app client id (replaces legacy LINEAR_API_KEY)
+LINEAR_CLIENT_SECRET=""                # OAuth app client secret
 LINEAR_WEBHOOK_SECRET=""               # From step 5
 
 # === Slack (if using Slack trigger) ===
@@ -405,6 +431,15 @@ SLACK_BOT_TOKEN=""                     # From step 5
 SLACK_BOT_USER_ID=""
 SLACK_BOT_USERNAME=""
 SLACK_SIGNING_SECRET=""
+SLACK_CLIENT_ID=""                     # From Slack app Basic Information — enables dashboard account linking
+SLACK_CLIENT_SECRET=""
+
+# === Dashboard / Identity (optional) ===
+ALLOWED_AUTH_ORG=""                    # Restrict dashboard login to active members of this GitHub org
+WORK_EMAIL_DOMAIN=""                   # Prefer this verified email domain on GitHub OAuth (e.g. langchain.dev)
+DASHBOARD_BASE_URL=""                  # Public URL of the dashboard frontend (required for auth-failure deep links)
+DASHBOARD_API_BASE_URL=""              # Public URL of the agent server (used to build OAuth redirect URIs)
+DASHBOARD_JWT_SECRET=""                # HMAC secret for dashboard session JWTs — `openssl rand -base64 64`
 
 # === Exa (optional — enables web search tool) ===
 EXA_API_KEY=""                         # From https://dashboard.exa.ai
@@ -537,10 +572,23 @@ The `langgraph.json` at the project root already defines the graph entry point a
 
 ### Agent not responding to comments
 
-- For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and the commenter's GitHub username is in `GITHUB_USER_EMAIL_MAP`
-- For Linear: ensure the comment contains `@openswe` (case-insensitive)
-- For Slack: ensure the bot is invited to the channel and the message is an `@mention`
+- For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and that the commenter has signed in to the dashboard at least once so their GitHub identity is in the store (`["oauth_tokens"]`)
+- For Linear: ensure the comment contains `@openswe` (case-insensitive). If the commenter's Linear email doesn't match a LangSmith account, they need to **Connect Linear** from the dashboard's "Linked accounts" page first
+- For Slack: ensure the bot is invited to the channel and the message is an `@mention`. Same caveat about Slack-email mismatches — direct users to "Connect Slack" in the dashboard
 - Check server logs for webhook processing errors
+
+### Migrating from `LINEAR_API_KEY` / `GITHUB_USER_EMAIL_MAP`
+
+If you're upgrading from a previous deploy that used the hardcoded `GITHUB_USER_EMAIL_MAP` and personal `LINEAR_API_KEY`:
+
+1. Create the Linear OAuth app (see Linear section) and set `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET`. The personal `LINEAR_API_KEY` is no longer read — delete it from your environment.
+2. Set `DASHBOARD_BASE_URL`, `DASHBOARD_API_BASE_URL`, and `DASHBOARD_JWT_SECRET` if you haven't already.
+3. Deploy the new code.
+4. Run the seed migration script once to backfill the email side of the OAuth-tokens namespace for users who haven't logged in to the dashboard yet:
+   ```bash
+   LANGGRAPH_URL=https://your-deployment uv run python -m scripts.seed_email_map
+   ```
+   This ensures existing users keep working without each having to log in to the dashboard before their next agent invocation.
 
 ### Token encryption errors
 

--- a/agent/dashboard/account_links.py
+++ b/agent/dashboard/account_links.py
@@ -1,0 +1,144 @@
+"""Account links between a dashboard user (GitHub login) and external identities.
+
+Each provider has its own namespace keyed by the provider's stable user ID so
+that webhook resolution is a single ``get_item`` call. Dashboard reads use
+``search_items`` with a Python-side filter — fine for an internal tool with a
+small user set; revisit if this becomes hot.
+
+OAuth access tokens are deliberately not persisted here: tokens are obtained
+once during the link callback to verify the user's identity, then discarded.
+We only keep the verified IDs and email.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+import httpx
+from langgraph_sdk import get_client
+
+logger = logging.getLogger(__name__)
+
+Provider = Literal["slack", "linear"]
+
+SLACK_LINKS_NAMESPACE: list[str] = ["account_links", "slack"]
+LINEAR_LINKS_NAMESPACE: list[str] = ["account_links", "linear"]
+
+
+def _client():
+    return get_client()
+
+
+def _namespace(provider: Provider) -> list[str]:
+    if provider == "slack":
+        return SLACK_LINKS_NAMESPACE
+    return LINEAR_LINKS_NAMESPACE
+
+
+async def _get_value(namespace: list[str], key: str) -> dict[str, Any] | None:
+    try:
+        item = await _client().store.get_item(namespace, key)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return None
+        raise
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def upsert_slack_link(
+    *,
+    github_login: str,
+    slack_user_id: str,
+    slack_team_id: str,
+    slack_email: str | None,
+) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "github_login": github_login,
+        "slack_user_id": slack_user_id,
+        "slack_team_id": slack_team_id,
+        "slack_email": slack_email or "",
+        "linked_at": datetime.now(UTC).isoformat(),
+    }
+    await _client().store.put_item(SLACK_LINKS_NAMESPACE, slack_user_id, value)
+    return value
+
+
+async def upsert_linear_link(
+    *,
+    github_login: str,
+    linear_user_id: str,
+    linear_workspace_id: str,
+    linear_email: str | None,
+) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "github_login": github_login,
+        "linear_user_id": linear_user_id,
+        "linear_workspace_id": linear_workspace_id,
+        "linear_email": linear_email or "",
+        "linked_at": datetime.now(UTC).isoformat(),
+    }
+    await _client().store.put_item(LINEAR_LINKS_NAMESPACE, linear_user_id, value)
+    return value
+
+
+async def get_slack_link_by_user(slack_user_id: str) -> dict[str, Any] | None:
+    if not slack_user_id:
+        return None
+    return await _get_value(SLACK_LINKS_NAMESPACE, slack_user_id)
+
+
+async def get_linear_link_by_user(linear_user_id: str) -> dict[str, Any] | None:
+    if not linear_user_id:
+        return None
+    return await _get_value(LINEAR_LINKS_NAMESPACE, linear_user_id)
+
+
+async def _scan_namespace(namespace: list[str]) -> list[dict[str, Any]]:
+    result = await _client().store.search_items(namespace, limit=1000)
+    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+    out: list[dict[str, Any]] = []
+    for item in items or []:
+        value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+        if isinstance(value, dict):
+            out.append(value)
+    return out
+
+
+async def _find_link_for_login(provider: Provider, github_login: str) -> dict[str, Any] | None:
+    if not github_login:
+        return None
+    for record in await _scan_namespace(_namespace(provider)):
+        if record.get("github_login") == github_login:
+            return record
+    return None
+
+
+async def get_links_for_login(github_login: str) -> dict[str, dict[str, Any] | None]:
+    return {
+        "slack": await _find_link_for_login("slack", github_login),
+        "linear": await _find_link_for_login("linear", github_login),
+    }
+
+
+async def delete_link_for_login(provider: Provider, github_login: str) -> bool:
+    record = await _find_link_for_login(provider, github_login)
+    if not record:
+        return False
+    if provider == "slack":
+        key = record.get("slack_user_id")
+    else:
+        key = record.get("linear_user_id")
+    if not isinstance(key, str) or not key:
+        return False
+    try:
+        await _client().store.delete_item(_namespace(provider), key)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return False
+        raise
+    return True

--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -8,25 +8,20 @@ from typing import Any
 import httpx
 from langgraph_sdk import get_client
 
-from ..utils.github_user_email_map import GITHUB_USER_EMAIL_MAP
 from .options import SUPPORTED_MODEL_IDS, model_supports_effort
-from .profiles import PROFILES_NAMESPACE
+from .profiles import PROFILES_NAMESPACE, get_login_for_email
 
 logger = logging.getLogger(__name__)
 
 
-def resolve_login_from_email(email: str | None) -> str | None:
-    """Reverse-lookup ``GITHUB_USER_EMAIL_MAP`` for the GitHub login of an email."""
+async def resolve_login_from_email(email: str | None) -> str | None:
+    """Look up the GitHub login linked to a verified email in the store."""
     if not isinstance(email, str) or not email.strip():
         return None
-    normalized = email.strip().lower()
-    for gh_login, mapped in GITHUB_USER_EMAIL_MAP.items():
-        if mapped.lower() == normalized:
-            return gh_login
-    return None
+    return await get_login_for_email(email)
 
 
-def resolve_github_login(config: dict[str, Any]) -> str | None:
+async def resolve_github_login(config: dict[str, Any]) -> str | None:
     """Best-effort resolution of the triggering user's GitHub login from config."""
     configurable = (config or {}).get("configurable") or {}
 
@@ -36,7 +31,7 @@ def resolve_github_login(config: dict[str, Any]) -> str | None:
 
     slack_thread = configurable.get("slack_thread") or {}
     email = configurable.get("user_email") or slack_thread.get("triggering_user_email")
-    return resolve_login_from_email(email if isinstance(email, str) else None)
+    return await resolve_login_from_email(email if isinstance(email, str) else None)
 
 
 async def get_profile_default_repo(login: str | None) -> dict[str, str] | None:

--- a/agent/dashboard/linear_oauth.py
+++ b/agent/dashboard/linear_oauth.py
@@ -1,0 +1,98 @@
+"""Linear user OAuth flow used purely for account-linking verification.
+
+The access token obtained here is used once to call the ``viewer`` GraphQL
+query, then discarded. Persistent Linear API calls go through
+``agent.utils.linear_app_token.get_linear_app_token`` (workspace install via
+``client_credentials``); user OAuth tokens are not retained.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+LINEAR_AUTHORIZE_URL = "https://linear.app/oauth/authorize"
+LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token"
+LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+LINEAR_USER_SCOPES = "read"
+
+
+def build_authorize_url(*, client_id: str, redirect_uri: str, state: str) -> str:
+    return (
+        f"{LINEAR_AUTHORIZE_URL}?client_id={client_id}"
+        f"&redirect_uri={redirect_uri}"
+        f"&response_type=code"
+        f"&scope={LINEAR_USER_SCOPES}"
+        f"&prompt=consent"
+        f"&state={state}"
+    )
+
+
+async def exchange_code(*, code: str, redirect_uri: str) -> str:
+    client_id = os.environ.get("LINEAR_CLIENT_ID", "")
+    client_secret = os.environ.get("LINEAR_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise HTTPException(500, "Linear OAuth client credentials not configured")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(
+            LINEAR_TOKEN_URL,
+            data={
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "authorization_code",
+            },
+        )
+    if response.status_code != 200:
+        logger.warning("Linear token exchange failed: %s %s", response.status_code, response.text)
+        raise HTTPException(400, f"Linear token exchange failed: {response.status_code}")
+    data = response.json()
+    token = data.get("access_token")
+    if not isinstance(token, str) or not token:
+        raise HTTPException(400, f"Linear token response missing access_token: {data}")
+    return token
+
+
+async def fetch_viewer_identity(access_token: str) -> dict[str, str]:
+    """Fetch the authenticated user's identity from Linear via the ``viewer`` query."""
+    query = """
+    query Viewer {
+      viewer {
+        id
+        email
+        name
+        organization {
+          id
+          urlKey
+        }
+      }
+    }
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(
+            LINEAR_GRAPHQL_URL,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+            json={"query": query},
+        )
+    if response.status_code != 200:
+        raise HTTPException(400, f"Linear viewer fetch failed: {response.status_code}")
+    payload = response.json()
+    viewer = (payload.get("data") or {}).get("viewer") or {}
+    user_id = viewer.get("id")
+    if not isinstance(user_id, str) or not user_id:
+        raise HTTPException(400, "Linear viewer response missing id")
+    organization = viewer.get("organization") or {}
+    return {
+        "linear_user_id": user_id,
+        "linear_email": viewer.get("email") or "",
+        "linear_workspace_id": organization.get("id") or "",
+    }

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -19,8 +19,10 @@ logger = logging.getLogger(__name__)
 
 COOKIE_NAME = "osw_session"
 STATE_COOKIE_NAME = "osw_oauth_state"
+LINK_STATE_COOKIE_NAME = "osw_link_state"
 SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
 STATE_TTL_SECONDS = 600
+LINK_STATE_TTL_SECONDS = 600
 JWT_ALG = "HS256"
 
 GITHUB_APP_CLIENT_ID = os.environ.get("GITHUB_APP_CLIENT_ID", "")
@@ -132,6 +134,38 @@ def decode_state(state: str) -> dict[str, Any]:
         raise HTTPException(400, f"invalid state: {e}") from e
 
 
+def issue_link_state(
+    *,
+    provider: str,
+    github_login: str,
+    redirect_to: str,
+    nonce_hash: str,
+) -> str:
+    """State JWT for the Slack/Linear account-linking OAuth round-trip.
+
+    Carries the originating dashboard ``github_login`` so the callback can
+    attach the verified provider identity to the right user, independent of
+    the session cookie's presence at callback time.
+    """
+    now = int(time.time())
+    payload = {
+        "provider": provider,
+        "github_login": github_login,
+        "redirect_to": redirect_to,
+        "nonce_hash": nonce_hash,
+        "iat": now,
+        "exp": now + LINK_STATE_TTL_SECONDS,
+    }
+    return jwt.encode(payload, _secret(), algorithm=JWT_ALG)
+
+
+def decode_link_state(state: str) -> dict[str, Any]:
+    try:
+        return jwt.decode(state, _secret(), algorithms=[JWT_ALG])
+    except jwt.PyJWTError as e:
+        raise HTTPException(400, f"invalid link state: {e}") from e
+
+
 def require_session(request: Request) -> dict[str, Any]:
     token = request.cookies.get(COOKIE_NAME)
     if not token:
@@ -162,7 +196,14 @@ async def exchange_code(code: str) -> str:
 
 
 async def fetch_github_user(access_token: str) -> tuple[dict[str, Any], str | None]:
-    """Return ``(user, primary_email)`` for the authenticated user."""
+    """Return ``(user, work_email)`` for the authenticated user.
+
+    Picks the most useful email by scanning verified addresses on the account:
+    when ``WORK_EMAIL_DOMAIN`` is set, the first verified address in that
+    domain wins; otherwise we fall back to the primary, then to the public
+    email on the user profile. This avoids seeding e.g. ``foo@gmail.com``
+    when the user has their work address on GitHub but not as primary.
+    """
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/vnd.github+json",
@@ -172,11 +213,34 @@ async def fetch_github_user(access_token: str) -> tuple[dict[str, Any], str | No
         u = await client.get("https://api.github.com/user", headers=headers)
         u.raise_for_status()
         user = u.json()
-        email = user.get("email")
-        if not email:
-            e = await client.get("https://api.github.com/user/emails", headers=headers)
-            if e.status_code == 200:
-                primary = next((x for x in e.json() if x.get("primary")), None)
-                if primary:
-                    email = primary.get("email")
-    return user, email
+        emails: list[dict[str, Any]] = []
+        e = await client.get("https://api.github.com/user/emails", headers=headers)
+        if e.status_code == 200:
+            payload = e.json()
+            if isinstance(payload, list):
+                emails = [x for x in payload if isinstance(x, dict)]
+
+    return user, _pick_work_email(emails) or user.get("email")
+
+
+def _pick_work_email(emails: list[dict[str, Any]]) -> str | None:
+    """Pick the best email from GitHub's ``/user/emails`` response."""
+    if not emails:
+        return None
+    work_domain = os.environ.get("WORK_EMAIL_DOMAIN", "").strip().lower()
+    verified = [e for e in emails if e.get("verified")]
+    if work_domain:
+        for entry in verified:
+            address = entry.get("email")
+            if isinstance(address, str) and address.lower().endswith(f"@{work_domain}"):
+                return address
+    primary = next((x for x in verified if x.get("primary")), None)
+    if primary:
+        address = primary.get("email")
+        if isinstance(address, str) and address:
+            return address
+    if verified:
+        address = verified[0].get("email")
+        if isinstance(address, str) and address:
+            return address
+    return None

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -1,13 +1,17 @@
 """User profile schema and LangGraph Store CRUD.
 
-Storage is split into two namespaces to avoid the read-modify-write race
-between profile-edit writes and OAuth-callback token refreshes:
+Storage is split across namespaces to avoid read-modify-write races between
+unrelated flows:
 
 * ``["profiles"]`` — user-editable settings (model, effort, default_repo).
-* ``["oauth_tokens"]`` — encrypted GitHub OAuth access token + email.
+* ``["oauth_tokens"]`` — encrypted GitHub OAuth access token + work email.
+  Canonical source for ``github_login → email`` resolution.
+* ``["email_to_login"]`` — inverted index for ``email → github_login`` lookups.
+  Kept in sync with ``oauth_tokens``.
 
-Each upsert only touches its own namespace, so the two flows can't clobber
-each other's fields even when they interleave.
+Each upsert only touches its own namespace where possible. The OAuth-token
+upsert is the one exception — it also writes the inverted-index entry — so
+the two writes happen back-to-back but never clobber profile data.
 """
 
 from __future__ import annotations
@@ -27,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 PROFILES_NAMESPACE: list[str] = ["profiles"]
 OAUTH_TOKENS_NAMESPACE: list[str] = ["oauth_tokens"]
+EMAIL_TO_LOGIN_NAMESPACE: list[str] = ["email_to_login"]
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
 
 
 class ProfileUpdate(BaseModel):
@@ -90,21 +99,67 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
     return value
 
 
+async def _update_email_index(login: str, new_email: str, *, prior_email: str | None) -> None:
+    """Maintain the email→login inverted index alongside an oauth_tokens write.
+
+    Drops a stale reverse-entry only when the user's email actually changed,
+    so a typo'd write doesn't wipe the prior pointer.
+    """
+    if prior_email and prior_email != new_email:
+        try:
+            await _client().store.delete_item(EMAIL_TO_LOGIN_NAMESPACE, prior_email)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code != 404:
+                logger.warning("Failed to drop stale email index for %s: %s", prior_email, e)
+    if new_email:
+        await _client().store.put_item(
+            EMAIL_TO_LOGIN_NAMESPACE,
+            new_email,
+            {"login": login, "email": new_email, "updated_at": datetime.now(UTC).isoformat()},
+        )
+
+
 async def upsert_access_token(login: str, email: str, access_token: str) -> None:
     """Persist (or refresh) the user's encrypted GitHub OAuth token.
 
-    Only touches ``["oauth_tokens"]`` — the user-editable profile is left
-    intact even if a save is in flight in another request.
+    Writes ``["oauth_tokens"]`` and the matching ``["email_to_login"]`` index
+    entry. The user-editable profile in ``["profiles"]`` is untouched.
     """
     if not access_token:
         return
+    normalized = _normalize_email(email) if email else ""
+    existing = await _get_value(OAUTH_TOKENS_NAMESPACE, login) or {}
+    prior_email = existing.get("email") if isinstance(existing.get("email"), str) else None
     value: dict[str, Any] = {
         "login": login,
-        "email": email,
+        "email": normalized,
         "encrypted_gh_token": encrypt_token(access_token),
         "updated_at": datetime.now(UTC).isoformat(),
     }
     await _client().store.put_item(OAUTH_TOKENS_NAMESPACE, login, value)
+    await _update_email_index(login, normalized, prior_email=prior_email)
+
+
+async def upsert_email_record(login: str, email: str) -> None:
+    """Seed (or update) the email-only record for a github login.
+
+    Used by the migration script and any flow that knows the user's email
+    without yet having an OAuth token (e.g. seeded from the legacy hardcoded
+    map). Idempotent: existing tokens are preserved if present.
+    """
+    if not login or not email:
+        return
+    normalized = _normalize_email(email)
+    existing = await _get_value(OAUTH_TOKENS_NAMESPACE, login) or {}
+    prior_email = existing.get("email") if isinstance(existing.get("email"), str) else None
+    value: dict[str, Any] = {
+        **existing,
+        "login": login,
+        "email": normalized,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    await _client().store.put_item(OAUTH_TOKENS_NAMESPACE, login, value)
+    await _update_email_index(login, normalized, prior_email=prior_email)
 
 
 async def get_access_token(login: str) -> str | None:
@@ -115,6 +170,27 @@ async def get_access_token(login: str) -> str | None:
     if not encrypted:
         return None
     return decrypt_token(encrypted) or None
+
+
+async def get_email_for_github_login(login: str) -> str | None:
+    if not login:
+        return None
+    record = await _get_value(OAUTH_TOKENS_NAMESPACE, login)
+    if not record:
+        return None
+    email = record.get("email")
+    return email if isinstance(email, str) and email else None
+
+
+async def get_login_for_email(email: str) -> str | None:
+    if not email:
+        return None
+    normalized = _normalize_email(email)
+    record = await _get_value(EMAIL_TO_LOGIN_NAMESPACE, normalized)
+    if not record:
+        return None
+    login = record.get("login")
+    return login if isinstance(login, str) and login else None
 
 
 async def list_profiles() -> list[dict[str, Any]]:

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -11,16 +11,29 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
 
+from ..utils.github_org_membership import is_user_active_org_member
+from . import linear_oauth, slack_oauth
+from .account_links import (
+    Provider,
+    delete_link_for_login,
+    get_links_for_login,
+    upsert_linear_link,
+    upsert_slack_link,
+)
 from .admin import is_admin
 from .oauth import (
     COOKIE_NAME,
+    LINK_STATE_COOKIE_NAME,
+    LINK_STATE_TTL_SECONDS,
     SESSION_TTL_SECONDS,
     STATE_COOKIE_NAME,
     STATE_TTL_SECONDS,
+    decode_link_state,
     decode_state,
     exchange_code,
     fetch_github_user,
     hash_state_nonce,
+    issue_link_state,
     issue_session,
     issue_state,
     new_state_nonce,
@@ -105,6 +118,24 @@ def _clear_state_cookie(response: Response) -> None:
     )
 
 
+def _set_link_state_cookie(response: Response, nonce: str) -> None:
+    response.set_cookie(
+        key=LINK_STATE_COOKIE_NAME,
+        value=nonce,
+        max_age=LINK_STATE_TTL_SECONDS,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        path="/dashboard/api/auth",
+    )
+
+
+def _clear_link_state_cookie(response: Response) -> None:
+    response.delete_cookie(
+        LINK_STATE_COOKIE_NAME, path="/dashboard/api/auth", samesite="lax", secure=True
+    )
+
+
 @router.get("/auth/login")
 async def auth_login(request: Request, redirect_to: str | None = None) -> RedirectResponse:
     client_id = os.environ.get("GITHUB_APP_CLIENT_ID", "")
@@ -148,6 +179,18 @@ async def auth_callback(request: Request, code: str, state: str) -> RedirectResp
     if not login:
         raise HTTPException(400, "could not resolve GitHub login")
 
+    allowed_org = os.environ.get("ALLOWED_AUTH_ORG", "").strip()
+    if allowed_org and not await is_user_active_org_member(login, allowed_org):
+        logger.warning(
+            "Rejecting dashboard login for %s — not an active member of %s",
+            login,
+            allowed_org,
+        )
+        denied_url = f"{_frontend_base_url()}/not-authorized?org={allowed_org}"
+        response = RedirectResponse(denied_url, status_code=302)
+        _clear_state_cookie(response)
+        return response
+
     await upsert_access_token(login, email or "", access_token)
 
     session_jwt = issue_session(login=login, email=email, avatar_url=user.get("avatar_url"))
@@ -172,6 +215,189 @@ async def me(session: dict[str, Any] = _SESSION_DEP) -> dict[str, Any]:
         "avatar_url": session.get("avatar_url"),
         "is_admin": is_admin(session.get("email")),
     }
+
+
+def _provider_callback_uri(provider: Provider) -> str:
+    return f"{_api_base_url()}/dashboard/api/auth/{provider}/callback"
+
+
+def _provider_client_creds(provider: Provider) -> tuple[str, str]:
+    if provider == "slack":
+        return (
+            os.environ.get("SLACK_CLIENT_ID", "").strip(),
+            os.environ.get("SLACK_CLIENT_SECRET", "").strip(),
+        )
+    return (
+        os.environ.get("LINEAR_CLIENT_ID", "").strip(),
+        os.environ.get("LINEAR_CLIENT_SECRET", "").strip(),
+    )
+
+
+def _start_link_flow(
+    *,
+    provider: Provider,
+    github_login: str,
+    redirect_to: str | None,
+) -> RedirectResponse:
+    client_id, client_secret = _provider_client_creds(provider)
+    if not client_id or not client_secret:
+        raise HTTPException(500, f"{provider} OAuth client credentials not configured")
+    safe_redirect = sanitize_redirect_to(redirect_to) or _frontend_base_url()
+    nonce = new_state_nonce()
+    state = issue_link_state(
+        provider=provider,
+        github_login=github_login,
+        redirect_to=safe_redirect,
+        nonce_hash=hash_state_nonce(nonce),
+    )
+    redirect_uri = _provider_callback_uri(provider)
+    if provider == "slack":
+        url = slack_oauth.build_authorize_url(
+            client_id=client_id, redirect_uri=redirect_uri, state=state
+        )
+    else:
+        url = linear_oauth.build_authorize_url(
+            client_id=client_id, redirect_uri=redirect_uri, state=state
+        )
+    response = RedirectResponse(url, status_code=302)
+    _set_link_state_cookie(response, nonce)
+    return response
+
+
+def _validate_link_state(
+    *,
+    provider: Provider,
+    state: str,
+    cookie_nonce: str | None,
+) -> dict[str, Any]:
+    payload = decode_link_state(state)
+    if payload.get("provider") != provider:
+        raise HTTPException(400, "link state provider mismatch")
+    state_nonce_hash = payload.get("nonce_hash")
+    if (
+        not isinstance(state_nonce_hash, str)
+        or not cookie_nonce
+        or not hmac.compare_digest(hash_state_nonce(cookie_nonce), state_nonce_hash)
+    ):
+        raise HTTPException(400, "link state mismatch — please retry")
+    return payload
+
+
+@router.get("/auth/slack/login")
+async def slack_link_login(
+    request: Request,
+    redirect_to: str | None = None,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> RedirectResponse:
+    return _start_link_flow(
+        provider="slack",
+        github_login=session["sub"],
+        redirect_to=redirect_to,
+    )
+
+
+@router.get("/auth/slack/callback")
+async def slack_link_callback(
+    request: Request,
+    code: str,
+    state: str,
+) -> RedirectResponse:
+    payload = _validate_link_state(
+        provider="slack",
+        state=state,
+        cookie_nonce=request.cookies.get(LINK_STATE_COOKIE_NAME),
+    )
+    github_login = payload.get("github_login")
+    if not isinstance(github_login, str) or not github_login:
+        raise HTTPException(400, "missing github_login in link state")
+
+    access_token = await slack_oauth.exchange_code(
+        code=code, redirect_uri=_provider_callback_uri("slack")
+    )
+    identity = await slack_oauth.fetch_userinfo(access_token)
+
+    await upsert_slack_link(
+        github_login=github_login,
+        slack_user_id=identity["slack_user_id"],
+        slack_team_id=identity["slack_team_id"],
+        slack_email=identity.get("slack_email"),
+    )
+
+    redirect_to = sanitize_redirect_to(payload.get("redirect_to")) or _frontend_base_url()
+    response = RedirectResponse(f"{redirect_to}?linked=slack", status_code=302)
+    _clear_link_state_cookie(response)
+    return response
+
+
+@router.get("/auth/linear/login")
+async def linear_link_login(
+    request: Request,
+    redirect_to: str | None = None,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> RedirectResponse:
+    return _start_link_flow(
+        provider="linear",
+        github_login=session["sub"],
+        redirect_to=redirect_to,
+    )
+
+
+@router.get("/auth/linear/callback")
+async def linear_link_callback(
+    request: Request,
+    code: str,
+    state: str,
+) -> RedirectResponse:
+    payload = _validate_link_state(
+        provider="linear",
+        state=state,
+        cookie_nonce=request.cookies.get(LINK_STATE_COOKIE_NAME),
+    )
+    github_login = payload.get("github_login")
+    if not isinstance(github_login, str) or not github_login:
+        raise HTTPException(400, "missing github_login in link state")
+
+    access_token = await linear_oauth.exchange_code(
+        code=code, redirect_uri=_provider_callback_uri("linear")
+    )
+    identity = await linear_oauth.fetch_viewer_identity(access_token)
+
+    await upsert_linear_link(
+        github_login=github_login,
+        linear_user_id=identity["linear_user_id"],
+        linear_workspace_id=identity["linear_workspace_id"],
+        linear_email=identity.get("linear_email"),
+    )
+
+    redirect_to = sanitize_redirect_to(payload.get("redirect_to")) or _frontend_base_url()
+    response = RedirectResponse(f"{redirect_to}?linked=linear", status_code=302)
+    _clear_link_state_cookie(response)
+    return response
+
+
+@router.get("/account-links")
+async def list_account_links(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await get_links_for_login(session["sub"])
+
+
+@router.delete("/account-links/{provider}")
+async def delete_account_link(
+    provider: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> Response:
+    provider_typed: Provider
+    if provider == "slack":
+        provider_typed = "slack"
+    elif provider == "linear":
+        provider_typed = "linear"
+    else:
+        raise HTTPException(400, "unknown provider")
+    removed = await delete_link_for_login(provider_typed, session["sub"])
+    if not removed:
+        raise HTTPException(404, f"no {provider} link to delete")
+    return Response(status_code=204)
 
 
 @router.get("/options")

--- a/agent/dashboard/slack_oauth.py
+++ b/agent/dashboard/slack_oauth.py
@@ -1,0 +1,94 @@
+"""Slack user OAuth (Sign in with Slack) for account-linking verification.
+
+Uses Slack's OpenID Connect endpoints. The ``openid email profile`` scopes
+return the workspace-scoped user_id and team_id we need to key the account
+link, plus the verified email. The access token is discarded after the
+``openid.connect.userinfo`` call — bot-side calls keep using ``SLACK_BOT_TOKEN``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+SLACK_AUTHORIZE_URL = "https://slack.com/openid/connect/authorize"
+SLACK_TOKEN_URL = "https://slack.com/api/openid.connect.token"
+SLACK_USERINFO_URL = "https://slack.com/api/openid.connect.userinfo"
+SLACK_USER_SCOPES = "openid,email,profile"
+
+
+def build_authorize_url(*, client_id: str, redirect_uri: str, state: str) -> str:
+    return (
+        f"{SLACK_AUTHORIZE_URL}?response_type=code"
+        f"&scope={SLACK_USER_SCOPES}"
+        f"&client_id={client_id}"
+        f"&redirect_uri={redirect_uri}"
+        f"&state={state}"
+    )
+
+
+async def exchange_code(*, code: str, redirect_uri: str) -> str:
+    client_id = os.environ.get("SLACK_CLIENT_ID", "")
+    client_secret = os.environ.get("SLACK_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise HTTPException(500, "Slack OAuth client credentials not configured")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(
+            SLACK_TOKEN_URL,
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
+        )
+    if response.status_code != 200:
+        logger.warning("Slack token exchange failed: %s %s", response.status_code, response.text)
+        raise HTTPException(400, f"Slack token exchange failed: {response.status_code}")
+    data = response.json()
+    if not data.get("ok", False):
+        logger.warning("Slack token exchange ok=false: %s", data)
+        raise HTTPException(400, f"Slack token exchange ok=false: {data.get('error')}")
+    token = data.get("access_token")
+    if not isinstance(token, str) or not token:
+        raise HTTPException(400, "Slack token response missing access_token")
+    return token
+
+
+async def fetch_userinfo(access_token: str) -> dict[str, str]:
+    """Return verified Slack identity for the authorized user.
+
+    The OIDC userinfo response uses prefixed keys like
+    ``https://slack.com/user_id`` to disambiguate from generic OIDC claims.
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(
+            SLACK_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    if response.status_code != 200:
+        raise HTTPException(400, f"Slack userinfo failed: {response.status_code}")
+    payload: dict[str, Any] = response.json()
+    if not payload.get("ok", False):
+        raise HTTPException(400, f"Slack userinfo ok=false: {payload.get('error')}")
+    user_id = payload.get("https://slack.com/user_id") or payload.get("sub")
+    team_id = payload.get("https://slack.com/team_id") or ""
+    email = payload.get("email") or ""
+    if not isinstance(user_id, str) or not user_id:
+        raise HTTPException(400, "Slack userinfo response missing user_id")
+    if not isinstance(team_id, str):
+        team_id = ""
+    if not isinstance(email, str):
+        email = ""
+    return {
+        "slack_user_id": user_id,
+        "slack_team_id": team_id,
+        "slack_email": email,
+    }

--- a/agent/server.py
+++ b/agent/server.py
@@ -408,9 +408,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     github_token, new_encrypted, new_expires_at = await resolve_github_token(config, thread_id)
     config["metadata"]["github_token_encrypted"] = new_encrypted
     config["metadata"]["github_token_expires_at"] = new_expires_at
-    triggering_user_identity = await asyncio.to_thread(
-        resolve_triggering_user_identity, config, github_token
-    )
+    triggering_user_identity = await resolve_triggering_user_identity(config, github_token)
     del github_token
 
     sandbox_backend = await ensure_sandbox_for_thread(thread_id)
@@ -426,7 +424,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
     model_id = os.environ.get("LLM_MODEL_ID", DEFAULT_LLM_MODEL_ID)
     profile_effort: str | None = None
-    profile_login = resolve_github_login(config)
+    profile_login = await resolve_github_login(config)
     if profile_login:
         profile = await load_profile(profile_login)
         if profile:

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -13,10 +13,11 @@ from langgraph.config import get_config
 from langgraph.graph.state import RunnableConfig
 from langgraph_sdk import get_client
 
+from ..dashboard.account_links import get_linear_link_by_user, get_slack_link_by_user
+from ..dashboard.profiles import get_access_token, get_email_for_github_login
 from ..encryption import encrypt_token
 from .github_app import get_github_app_installation_token_with_expiry
 from .github_token import get_github_token_from_thread
-from .github_user_email_map import GITHUB_USER_EMAIL_MAP
 from .linear import comment_on_linear_issue
 from .slack import post_slack_ephemeral_message, post_slack_thread_reply
 
@@ -319,14 +320,35 @@ async def save_encrypted_token_from_email(
     tenant_id = user_info.get("tenant_id")
     if not ls_user_id or not tenant_id:
         account_label = _source_account_label(source)
+        configurable = config.get("configurable", {})
+        provider_user_id: str | None = None
+        if source == "slack":
+            slack_thread = configurable.get("slack_thread") or {}
+            if isinstance(slack_thread, dict):
+                tid = slack_thread.get("triggering_user_id")
+                if isinstance(tid, str):
+                    provider_user_id = tid
+        elif source == "linear":
+            linear_issue = configurable.get("linear_issue") or {}
+            if isinstance(linear_issue, dict):
+                tid = linear_issue.get("triggering_user_id")
+                if isinstance(tid, str):
+                    provider_user_id = tid
+        deep_link = _account_links_deep_link(source, provider_user_id)
+        link_block = (
+            f"\n\nIf you've already linked your {account_label} account in the dashboard, "
+            "you should not see this message — let an admin know.\n\n"
+            f"Otherwise, sign in here to link your accounts:\n{deep_link}"
+            if deep_link
+            else ""
+        )
         message = (
             "🔐 **GitHub Authentication Required**\n\n"
             f"Could not find a LangSmith account for **{email}**.\n\n"
-            "Please ensure this email is invited to the main LangSmith organization. "
-            f"If your {account_label} account uses a different email than your LangSmith account, "
-            "you may need to update one of them to match.\n\n"
-            "Once your email is added to LangSmith, "
-            f"{_retry_instruction(source)}"
+            "Please ensure this email is invited to the main LangSmith organization, "
+            f"or link your {account_label} account to a GitHub identity via the dashboard."
+            f"{link_block}\n\n"
+            f"Once linked, {_retry_instruction(source)}"
         )
         await leave_failure_comment(source, message)
         raise ValueError(f"No ls_user_id found from email {email}")
@@ -378,6 +400,69 @@ async def _resolve_bot_installation_token(thread_id: str) -> tuple[str, str, str
     return bot_token, encrypted, expires_at
 
 
+async def _resolve_token_via_account_link(
+    configurable: dict[str, Any], thread_id: str
+) -> tuple[str, str, str | None] | None:
+    """Try to fulfil auth via an explicit dashboard account link.
+
+    Looks up the provider's user_id against the corresponding link namespace;
+    if a link is found and the linked GitHub user has an OAuth token stored
+    via the dashboard, that token is used directly. Returns ``None`` when
+    no link / no stored token is found, in which case callers should fall
+    through to the source-specific email-based resolution path.
+    """
+    source = configurable.get("source")
+    if source == "slack":
+        slack_thread = configurable.get("slack_thread") or {}
+        provider_user_id = (
+            slack_thread.get("triggering_user_id") if isinstance(slack_thread, dict) else None
+        )
+        if not isinstance(provider_user_id, str) or not provider_user_id:
+            return None
+        link = await get_slack_link_by_user(provider_user_id)
+    elif source == "linear":
+        linear_issue = configurable.get("linear_issue") or {}
+        provider_user_id = (
+            linear_issue.get("triggering_user_id") if isinstance(linear_issue, dict) else None
+        )
+        if not isinstance(provider_user_id, str) or not provider_user_id:
+            return None
+        link = await get_linear_link_by_user(provider_user_id)
+    else:
+        return None
+
+    if not link:
+        return None
+    github_login = link.get("github_login")
+    if not isinstance(github_login, str) or not github_login:
+        return None
+    token = await get_access_token(github_login)
+    if not token:
+        logger.info(
+            "Found %s link for user %s → github_login=%s but no stored OAuth token",
+            source,
+            provider_user_id,
+            github_login,
+        )
+        return None
+    encrypted = await persist_encrypted_github_token(thread_id, token, expires_at=None)
+    logger.info(
+        "Resolved GitHub token via %s account link for github_login=%s", source, github_login
+    )
+    return token, encrypted, None
+
+
+def _account_links_deep_link(source: str, provider_user_id: str | None) -> str | None:
+    """Build a deep link into the dashboard's account-links page."""
+    base = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
+    if not base:
+        return None
+    url = f"{base}/account-links?source={source}"
+    if provider_user_id:
+        url = f"{url}&user_id={provider_user_id}"
+    return url
+
+
 async def resolve_github_token(
     config: RunnableConfig, thread_id: str
 ) -> tuple[str, str, str | None]:
@@ -414,10 +499,17 @@ async def resolve_github_token(
             if cached_token and cached_encrypted:
                 return cached_token, cached_encrypted, cached_expires_at
             github_login = configurable.get("github_login")
-            email = GITHUB_USER_EMAIL_MAP.get(github_login or "")
+            email = await get_email_for_github_login(github_login or "")
             if not email:
-                raise ValueError(f"No email mapping found for GitHub user '{github_login}'")
+                raise ValueError(
+                    f"No stored email for GitHub user '{github_login}'. "
+                    "Ask them to log in to the dashboard once."
+                )
             return await save_encrypted_token_from_email(email, source)
+
+        via_link = await _resolve_token_via_account_link(configurable, thread_id)
+        if via_link is not None:
+            return via_link
         return await save_encrypted_token_from_email(configurable.get("user_email"), source)
     except ValueError as exc:
         logger.error("GitHub auth failed for thread %s: %s", thread_id, str(exc))

--- a/agent/utils/authorship.py
+++ b/agent/utils/authorship.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from .github_user_email_map import GITHUB_USER_EMAIL_MAP
+from ..dashboard.profiles import get_email_for_github_login
 
 logger = logging.getLogger(__name__)
 
@@ -40,20 +40,20 @@ def _github_noreply_email(login: str, user_id: Any = None) -> str:
     return f"{normalized_login}@users.noreply.github.com"
 
 
-def _identity_from_github_token(github_token: str | None) -> CollaboratorIdentity | None:
+async def _identity_from_github_token(github_token: str | None) -> CollaboratorIdentity | None:
     if not github_token:
         return None
 
     try:
-        response = httpx.get(
-            "https://api.github.com/user",
-            headers={
-                "Authorization": f"Bearer {github_token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-            timeout=5.0,
-        )
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                "https://api.github.com/user",
+                headers={
+                    "Authorization": f"Bearer {github_token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
         if response.status_code != 200:  # noqa: PLR2004
             logger.debug("GitHub user lookup returned %s", response.status_code)
             return None
@@ -78,15 +78,16 @@ def _identity_from_github_token(github_token: str | None) -> CollaboratorIdentit
         return None
 
 
-def _identity_from_config(config: dict[str, Any]) -> CollaboratorIdentity | None:
+async def _identity_from_config(config: dict[str, Any]) -> CollaboratorIdentity | None:
     configurable = config.get("configurable", {})
 
     github_login = _normalize_text(configurable.get("github_login"))
     if github_login:
         github_user_id = configurable.get("github_user_id")
-        commit_email = _github_noreply_email(github_login, github_user_id) or _normalize_text(
-            GITHUB_USER_EMAIL_MAP.get(github_login)
-        )
+        commit_email = _github_noreply_email(github_login, github_user_id)
+        if not commit_email:
+            mapped = await get_email_for_github_login(github_login)
+            commit_email = _normalize_text(mapped)
         if commit_email:
             return CollaboratorIdentity(
                 display_name=github_login,
@@ -114,7 +115,7 @@ def _identity_from_config(config: dict[str, Any]) -> CollaboratorIdentity | None
     return None
 
 
-def resolve_triggering_user_identity(
+async def resolve_triggering_user_identity(
     config: dict[str, Any],
     github_token: str | None = None,
 ) -> CollaboratorIdentity | None:
@@ -125,7 +126,10 @@ def resolve_triggering_user_identity(
     Slack/Linear supplied an explicit user name and email.
     """
 
-    return _identity_from_github_token(github_token) or _identity_from_config(config)
+    via_token = await _identity_from_github_token(github_token)
+    if via_token is not None:
+        return via_token
+    return await _identity_from_config(config)
 
 
 def add_user_coauthor_trailer(

--- a/agent/utils/github_comments.py
+++ b/agent/utils/github_comments.py
@@ -6,13 +6,15 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import os
 import re
+from collections.abc import Iterable
 from typing import Any
 
 import httpx
 
+from .github_org_membership import INTERNAL_BOT_LOGINS, is_user_active_org_member
 from .github_token import GitHubAuthError
-from .github_user_email_map import GITHUB_USER_EMAIL_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +31,7 @@ __all__ = [
     "parse_github_review_command",
     "post_github_comment",
     "react_to_github_comment",
+    "resolve_trusted_authors",
     "sanitize_github_comment_body",
     "verify_github_signature",
 ]
@@ -108,10 +111,21 @@ def sanitize_github_comment_body(body: str) -> str:
     return sanitized
 
 
-def format_github_comment_body_for_prompt(author: str, body: str) -> str:
-    """Format a GitHub comment body for prompt inclusion."""
+def format_github_comment_body_for_prompt(
+    author: str,
+    body: str,
+    *,
+    trusted_authors: set[str] | None = None,
+) -> str:
+    """Format a GitHub comment body for prompt inclusion.
+
+    When ``trusted_authors`` is provided and contains ``author``, the body is
+    passed through untouched. Otherwise it's wrapped in the untrusted-comment
+    tags so the agent treats it as adversarial input. The trust set is meant
+    to be computed once per webhook via :func:`resolve_trusted_authors`.
+    """
     sanitized_body = sanitize_github_comment_body(body)
-    if author in GITHUB_USER_EMAIL_MAP:
+    if trusted_authors and author in trusted_authors:
         return sanitized_body
 
     return (
@@ -119,6 +133,37 @@ def format_github_comment_body_for_prompt(author: str, body: str) -> str:
         f"{sanitized_body}\n"
         f"{UNTRUSTED_GITHUB_COMMENT_CLOSE_TAG}"
     )
+
+
+async def resolve_trusted_authors(authors: Iterable[str]) -> set[str]:
+    """Return the subset of authors trusted to author prompt-included comments.
+
+    Trust = active membership in ``ALLOWED_AUTH_ORG`` (or the internal-bot
+    allowlist). If ``ALLOWED_AUTH_ORG`` is unset, every author is treated as
+    untrusted — the safe default for OSS deployments.
+    """
+    org = os.environ.get("ALLOWED_AUTH_ORG", "").strip()
+    if not org:
+        return set()
+    unique = {a for a in authors if isinstance(a, str) and a}
+    if not unique:
+        return set()
+    trusted: set[str] = set()
+    to_check: list[str] = []
+    for author in unique:
+        if author in INTERNAL_BOT_LOGINS:
+            trusted.add(author)
+        else:
+            to_check.append(author)
+    if to_check:
+        results = await asyncio.gather(
+            *(is_user_active_org_member(a, org) for a in to_check),
+            return_exceptions=False,
+        )
+        for author, ok in zip(to_check, results, strict=True):
+            if ok:
+                trusted.add(author)
+    return trusted
 
 
 async def react_to_github_comment(
@@ -434,12 +479,16 @@ def build_pr_prompt(
     comments: list[dict[str, Any]],
     pr_url: str,
     repo_config: dict[str, str] | None = None,
+    *,
+    trusted_authors: set[str] | None = None,
 ) -> str:
     """Format PR comments into a human message for the agent."""
     lines: list[str] = []
     for c in comments:
         author = c.get("author", "unknown")
-        body = format_github_comment_body_for_prompt(author, c.get("body", ""))
+        body = format_github_comment_body_for_prompt(
+            author, c.get("body", ""), trusted_authors=trusted_authors
+        )
         if c.get("type") == "review_comment":
             path = c.get("path", "")
             line = c.get("line", "")

--- a/agent/utils/linear.py
+++ b/agent/utils/linear.py
@@ -3,45 +3,60 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 import httpx
 
 from agent.utils.langsmith import get_langsmith_trace_url
+from agent.utils.linear_app_token import get_linear_app_token, invalidate_linear_app_token
 
 logger = logging.getLogger(__name__)
 
-LINEAR_API_KEY = os.environ.get("LINEAR_API_KEY", "")
 LINEAR_API_URL = "https://api.linear.app/graphql"
 
 
-def _headers() -> dict[str, str]:
-    return {
-        "Authorization": LINEAR_API_KEY,
-        "Content-Type": "application/json",
-    }
-
-
 async def _graphql_request(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Execute a GraphQL request against the Linear API."""
-    if not LINEAR_API_KEY:
-        return {"error": "LINEAR_API_KEY is not set"}
+    """Execute a GraphQL request against the Linear API.
+
+    Uses the workspace OAuth-app token (auto-refreshed when expired). A 401
+    response invalidates the cached token and retries once before giving up.
+    """
+    payload = {"query": query, "variables": variables or {}}
+    try:
+        token = await get_linear_app_token()
+    except RuntimeError as exc:
+        return {"error": str(exc)}
 
     async with httpx.AsyncClient() as http_client:
-        try:
-            response = await http_client.post(
-                LINEAR_API_URL,
-                headers=_headers(),
-                json={"query": query, "variables": variables or {}},
-            )
-            response.raise_for_status()
+        for attempt in range(2):
+            try:
+                response = await http_client.post(
+                    LINEAR_API_URL,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+            except Exception as e:  # noqa: BLE001
+                return {"error": str(e)}
+
+            if response.status_code == 401 and attempt == 0:
+                invalidate_linear_app_token()
+                try:
+                    token = await get_linear_app_token(force_refresh=True)
+                except RuntimeError as exc:
+                    return {"error": str(exc)}
+                continue
+            try:
+                response.raise_for_status()
+            except Exception as e:  # noqa: BLE001
+                return {"error": str(e)}
             result = response.json()
             if result.get("errors"):
                 return {"error": result["errors"]}
             return result.get("data", {})
-        except Exception as e:  # noqa: BLE001
-            return {"error": str(e)}
+    return {"error": "Linear API request retry exhausted"}
 
 
 async def comment_on_linear_issue(

--- a/agent/utils/linear_app_token.py
+++ b/agent/utils/linear_app_token.py
@@ -1,0 +1,93 @@
+"""Workspace-level OAuth token for Linear, used for all server-side API calls.
+
+Replaces the legacy ``LINEAR_API_KEY`` personal access token with a token
+issued by Linear's OAuth ``client_credentials`` grant. Tokens last ~30 days;
+this module caches one in process and refetches transparently when it
+expires or when an API call returns 401.
+
+The OAuth app itself must be installed into the workspace once with the
+``actor=app`` query parameter on the authorize URL so that resources created
+with these tokens are attributed to the app (the "open-swe" agent), not to a
+user. See ``INSTALLATION.md`` for the one-time setup steps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token"
+_TTL_SAFETY_MARGIN = timedelta(minutes=5)
+_DEFAULT_TTL = timedelta(days=30)
+
+
+class _TokenCache:
+    def __init__(self) -> None:
+        self._token: str | None = None
+        self._expires_at: datetime | None = None
+        self._lock = asyncio.Lock()
+
+    async def get(self, *, force_refresh: bool = False) -> str:
+        async with self._lock:
+            now = datetime.now(UTC)
+            if (
+                not force_refresh
+                and self._token
+                and self._expires_at
+                and now < self._expires_at - _TTL_SAFETY_MARGIN
+            ):
+                return self._token
+            self._token, self._expires_at = await self._fetch()
+            return self._token
+
+    def invalidate(self) -> None:
+        self._token = None
+        self._expires_at = None
+
+    async def _fetch(self) -> tuple[str, datetime]:
+        client_id = os.environ.get("LINEAR_CLIENT_ID", "")
+        client_secret = os.environ.get("LINEAR_CLIENT_SECRET", "")
+        if not client_id or not client_secret:
+            raise RuntimeError(
+                "LINEAR_CLIENT_ID / LINEAR_CLIENT_SECRET are not configured; "
+                "Linear OAuth app credentials are required."
+            )
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                LINEAR_OAUTH_TOKEN_URL,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "scope": "read,write,app:assignable,app:mentionable",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+        token = data.get("access_token")
+        if not isinstance(token, str) or not token:
+            raise RuntimeError(f"Linear OAuth response missing access_token: {data}")
+        expires_in = data.get("expires_in")
+        if isinstance(expires_in, int | float) and expires_in > 0:
+            expires_at = datetime.now(UTC) + timedelta(seconds=int(expires_in))
+        else:
+            expires_at = datetime.now(UTC) + _DEFAULT_TTL
+        logger.info("Refreshed Linear app token; expires at %s", expires_at.isoformat())
+        return token, expires_at
+
+
+_cache = _TokenCache()
+
+
+async def get_linear_app_token(*, force_refresh: bool = False) -> str:
+    return await _cache.get(force_refresh=force_refresh)
+
+
+def invalidate_linear_app_token() -> None:
+    _cache.invalidate()

--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -13,6 +13,8 @@ from urllib.parse import urlparse
 import httpx
 from langchain_core.messages.content import create_image_block
 
+from .linear_app_token import get_linear_app_token
+
 logger = logging.getLogger(__name__)
 
 IMAGE_MARKDOWN_RE = re.compile(r"!\[[^\]]*\]\((https?://[^\s)]+)\)")
@@ -47,12 +49,15 @@ async def fetch_image_block(
         headers = None
         host = (urlparse(image_url).hostname or "").lower()
         if host == "uploads.linear.app" or host.endswith(".uploads.linear.app"):
-            linear_api_key = os.environ.get("LINEAR_API_KEY", "")
-            if linear_api_key:
-                headers = {"Authorization": linear_api_key}
+            try:
+                linear_token = await get_linear_app_token()
+            except RuntimeError:
+                linear_token = ""
+            if linear_token:
+                headers = {"Authorization": f"Bearer {linear_token}"}
             else:
                 logger.warning(
-                    "LINEAR_API_KEY not set; cannot authenticate image fetch for %s",
+                    "Linear app token unavailable; cannot authenticate image fetch for %s",
                     image_url,
                 )
         elif host == "files.slack.com" or host.endswith(".files.slack.com"):

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -22,6 +22,7 @@ from .dashboard.agent_overrides import (
     get_profile_default_repo,
     resolve_login_from_email,
 )
+from .dashboard.profiles import get_email_for_github_login
 from .reviewer_findings import (
     REVIEWER_THREAD_KIND,
     ReviewerPRMeta,
@@ -50,13 +51,14 @@ from .utils.github_comments import (
     get_thread_id_from_branch,
     parse_github_review_command,
     react_to_github_comment,
+    resolve_trusted_authors,
     sanitize_github_comment_body,
     verify_github_signature,
 )
 from .utils.github_org_membership import INTERNAL_BOT_LOGINS, is_user_active_org_member
 from .utils.github_token import get_github_token_from_thread, invalidate_cached_github_token
-from .utils.github_user_email_map import GITHUB_USER_EMAIL_MAP
 from .utils.linear import post_linear_trace_comment
+from .utils.linear_app_token import get_linear_app_token, invalidate_linear_app_token
 from .utils.linear_team_repo_map import LINEAR_TEAM_TO_REPO
 from .utils.multimodal import dedupe_urls, extract_image_urls, fetch_image_block
 from .utils.repo import extract_repo_from_text
@@ -155,7 +157,6 @@ ALLOWED_GITHUB_REPOS: frozenset[str] = frozenset(
     if repo.strip()
 )
 
-LINEAR_API_KEY = os.environ.get("LINEAR_API_KEY", "")
 
 _GITHUB_BOT_MESSAGE_PREFIXES = (
     "🔐 **GitHub Authentication Required**",
@@ -193,21 +194,45 @@ def get_repo_config_from_team_mapping(
     return fallback
 
 
+async def _linear_graphql_call(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Issue a Linear GraphQL request with the OAuth app token, retrying on 401."""
+    try:
+        token = await get_linear_app_token()
+    except RuntimeError as exc:
+        logger.warning("Linear app token unavailable: %s", exc)
+        return None
+
+    async with httpx.AsyncClient() as client:
+        for attempt in range(2):
+            try:
+                response = await client.post(
+                    "https://api.linear.app/graphql",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+            except httpx.HTTPError:
+                return None
+
+            if response.status_code == 401 and attempt == 0:
+                invalidate_linear_app_token()
+                try:
+                    token = await get_linear_app_token(force_refresh=True)
+                except RuntimeError:
+                    return None
+                continue
+            try:
+                response.raise_for_status()
+            except httpx.HTTPError:
+                return None
+            return response.json()
+    return None
+
+
 async def react_to_linear_comment(comment_id: str, emoji: str = "👀") -> bool:
-    """Add an emoji reaction to a Linear comment.
-
-    Args:
-        comment_id: The Linear comment ID
-        emoji: The emoji to react with (default: eyes 👀)
-
-    Returns:
-        True if successful, False otherwise
-    """
-    if not LINEAR_API_KEY:
-        return False
-
-    url = "https://api.linear.app/graphql"
-
+    """Add an emoji reaction to a Linear comment."""
     mutation = """
     mutation ReactionCreate($commentId: String!, $emoji: String!) {
         reactionCreate(input: { commentId: $commentId, emoji: $emoji }) {
@@ -215,41 +240,16 @@ async def react_to_linear_comment(comment_id: str, emoji: str = "👀") -> bool:
         }
     }
     """
-
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.post(
-                url,
-                headers={
-                    "Authorization": LINEAR_API_KEY,
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "query": mutation,
-                    "variables": {"commentId": comment_id, "emoji": emoji},
-                },
-            )
-            response.raise_for_status()
-            result = response.json()
-            return bool(result.get("data", {}).get("reactionCreate", {}).get("success"))
-        except Exception:  # noqa: BLE001
-            return False
+    result = await _linear_graphql_call(
+        {"query": mutation, "variables": {"commentId": comment_id, "emoji": emoji}}
+    )
+    if not result:
+        return False
+    return bool(result.get("data", {}).get("reactionCreate", {}).get("success"))
 
 
 async def fetch_linear_issue_details(issue_id: str) -> dict[str, Any] | None:
-    """Fetch full issue details from Linear API including description and comments.
-
-    Args:
-        issue_id: The Linear issue ID
-
-    Returns:
-        Full issue data dict, or None if fetch failed
-    """
-    if not LINEAR_API_KEY:
-        return None
-
-    url = "https://api.linear.app/graphql"
-
+    """Fetch full issue details from Linear API including description and comments."""
     query = """
     query GetIssue($issueId: String!) {
         issue(id: $issueId) {
@@ -282,26 +282,10 @@ async def fetch_linear_issue_details(issue_id: str) -> dict[str, Any] | None:
         }
     }
     """
-
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.post(
-                url,
-                headers={
-                    "Authorization": LINEAR_API_KEY,
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "query": query,
-                    "variables": {"issueId": issue_id},
-                },
-            )
-            response.raise_for_status()
-            result = response.json()
-
-            return result.get("data", {}).get("issue")
-        except httpx.HTTPError:
-            return None
+    result = await _linear_graphql_call({"query": query, "variables": {"issueId": issue_id}})
+    if not result:
+        return None
+    return result.get("data", {}).get("issue")
 
 
 def generate_thread_id_from_issue(issue_id: str) -> str:
@@ -525,7 +509,9 @@ async def get_slack_repo_config(
                 if isinstance(slack_user, dict)
                 else None
             )
-            profile_repo = await get_profile_default_repo(resolve_login_from_email(slack_email))
+            profile_repo = await get_profile_default_repo(
+                await resolve_login_from_email(slack_email)
+            )
             if profile_repo:
                 logger.info(
                     "Applying dashboard default_repo for Slack user %s: %s/%s",
@@ -674,20 +660,24 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
 
     user_email = None
     user_name = None
+    triggering_user_id = ""
     comment_author = issue_data.get("comment_author", {})
     if comment_author:
         user_email = comment_author.get("email")
         user_name = comment_author.get("name")
+        triggering_user_id = comment_author.get("id", "") or ""
     if not user_email:
         creator = full_issue.get("creator", {})
         if creator:
             user_email = creator.get("email")
             user_name = user_name or creator.get("name")
+            triggering_user_id = triggering_user_id or (creator.get("id", "") or "")
     if not user_email:
         assignee = full_issue.get("assignee", {})
         if assignee:
             user_email = assignee.get("email")
             user_name = user_name or assignee.get("name")
+            triggering_user_id = triggering_user_id or (assignee.get("id", "") or "")
 
     logger.info("User email for issue %s: %s", issue_id, user_email)
 
@@ -823,6 +813,7 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
             "identifier": identifier,
             "linear_project_id": linear_project_id,
             "linear_issue_number": linear_issue_number,
+            "triggering_user_id": triggering_user_id,
             "triggering_user_name": user_name or "",
         },
         "user_email": user_email,
@@ -1182,7 +1173,7 @@ async def linear_webhook(  # noqa: PLR0911, PLR0912, PLR0915
         comment_user_email = (data.get("user") or {}).get("email")
         try:
             profile_repo = await get_profile_default_repo(
-                resolve_login_from_email(comment_user_email)
+                await resolve_login_from_email(comment_user_email)
             )
         except Exception:  # noqa: BLE001
             logger.exception("Failed to apply dashboard default_repo for Linear user")
@@ -1407,14 +1398,18 @@ _SUPPORTED_GH_COMMENT_ACTIONS = {
 }
 
 
-def _build_github_issue_comments_text(comments: list[dict[str, Any]]) -> str:
+def _build_github_issue_comments_text(
+    comments: list[dict[str, Any]], *, trusted_authors: set[str] | None = None
+) -> str:
     lines: list[str] = []
     for comment in comments:
         body = comment.get("body", "")
         if not body or any(body.startswith(prefix) for prefix in _GITHUB_BOT_MESSAGE_PREFIXES):
             continue
         author = comment.get("author", "unknown")
-        formatted_body = format_github_comment_body_for_prompt(author, body)
+        formatted_body = format_github_comment_body_for_prompt(
+            author, body, trusted_authors=trusted_authors
+        )
         lines.append(f"\n**{author}:**\n{formatted_body}\n")
 
     if not lines:
@@ -1432,12 +1427,15 @@ def build_github_issue_prompt(
     *,
     github_login: str,
     issue_author: str = "",
+    trusted_authors: set[str] | None = None,
 ) -> str:
     """Build the user prompt for a GitHub issue-triggered run."""
     triggered_by_line = f"## Triggered by: {github_login}\n\n" if github_login else ""
-    comments_text = _build_github_issue_comments_text(comments)
+    comments_text = _build_github_issue_comments_text(comments, trusted_authors=trusted_authors)
     sanitized_title = sanitize_github_comment_body(title)
-    formatted_body = format_github_comment_body_for_prompt(issue_author or github_login, body)
+    formatted_body = format_github_comment_body_for_prompt(
+        issue_author or github_login, body, trusted_authors=trusted_authors
+    )
     return (
         "Please work on the following GitHub issue:\n\n"
         f"## Repository: {repo_config.get('owner')}/{repo_config.get('name')}\n\n"
@@ -1452,17 +1450,24 @@ def build_github_issue_prompt(
     )
 
 
-def build_github_issue_followup_prompt(github_login: str, comment_body: str) -> str:
+def build_github_issue_followup_prompt(
+    github_login: str, comment_body: str, *, trusted_authors: set[str] | None = None
+) -> str:
     """Build the prompt for a follow-up GitHub issue comment."""
-    return (
-        f"**{github_login}:**\n{format_github_comment_body_for_prompt(github_login, comment_body)}"
+    formatted = format_github_comment_body_for_prompt(
+        github_login, comment_body, trusted_authors=trusted_authors
     )
+    return f"**{github_login}:**\n{formatted}"
 
 
-def build_github_issue_update_prompt(github_login: str, title: str, body: str) -> str:
+def build_github_issue_update_prompt(
+    github_login: str, title: str, body: str, *, trusted_authors: set[str] | None = None
+) -> str:
     """Build the prompt for a follow-up GitHub issue title/body update."""
     sanitized_title = sanitize_github_comment_body(title)
-    formatted_body = format_github_comment_body_for_prompt(github_login, body)
+    formatted_body = format_github_comment_body_for_prompt(
+        github_login, body, trusted_authors=trusted_authors
+    )
     return (
         f"**{github_login}:** updated the GitHub issue title/body.\n\n"
         f"Title: {sanitized_title}\n\n"
@@ -2160,9 +2165,9 @@ async def process_github_pr_comment(payload: dict[str, Any], event_type: str) ->
             else:
                 logger.warning("Failed to persist branch_name metadata for thread %s", thread_id)
 
-    email = GITHUB_USER_EMAIL_MAP.get(github_login, "")
+    email = await get_email_for_github_login(github_login) or ""
     if not email:
-        logger.warning("No email mapping for GitHub user '%s', skipping", github_login)
+        logger.warning("No stored email for GitHub user '%s', skipping", github_login)
         return
 
     github_token = await _get_or_resolve_thread_github_token(thread_id, email)
@@ -2214,7 +2219,10 @@ async def process_github_pr_comment(payload: dict[str, Any], event_type: str) ->
         logger.info("No comments found since last @open-swe tag for PR %s", pr_number)
         return
 
-    prompt = build_pr_prompt(comments, pr_url, repo_config=repo_config)
+    trusted_authors = await resolve_trusted_authors(c.get("author", "") for c in comments)
+    prompt = build_pr_prompt(
+        comments, pr_url, repo_config=repo_config, trusted_authors=trusted_authors
+    )
     await _trigger_or_queue_run(
         thread_id,
         prompt,
@@ -2255,9 +2263,9 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
         logger.warning("Missing GitHub issue id/number, skipping")
         return
 
-    email = GITHUB_USER_EMAIL_MAP.get(github_login, "")
+    email = await get_email_for_github_login(github_login) or ""
     if not email:
-        logger.warning("No email mapping for GitHub user '%s', skipping", github_login)
+        logger.warning("No stored email for GitHub user '%s', skipping", github_login)
         return
 
     thread_id = generate_thread_id_from_github_issue(issue_id)
@@ -2301,12 +2309,18 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
 
     if existing_thread:
         if event_type == "issue_comment":
+            follow_up_author = comment.get("user", {}).get("login", github_login) or github_login
+            trusted_authors = await resolve_trusted_authors([follow_up_author])
             prompt = build_github_issue_followup_prompt(
-                comment.get("user", {}).get("login", github_login) or github_login,
+                follow_up_author,
                 comment.get("body", ""),
+                trusted_authors=trusted_authors,
             )
         else:
-            prompt = build_github_issue_update_prompt(github_login, title, description)
+            trusted_authors = await resolve_trusted_authors([github_login])
+            prompt = build_github_issue_update_prompt(
+                github_login, title, description, trusted_authors=trusted_authors
+            )
     else:
         try:
             comments = await fetch_issue_comments(
@@ -2328,6 +2342,9 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
             )
             comments.sort(key=lambda item: item.get("created_at", ""))
 
+        trusted_authors = await resolve_trusted_authors(
+            [issue_author or github_login, github_login, *(c.get("author", "") for c in comments)]
+        )
         prompt = build_github_issue_prompt(
             repo_config,
             issue_number,
@@ -2337,6 +2354,7 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
             comments,
             github_login=github_login,
             issue_author=issue_author,
+            trusted_authors=trusted_authors,
         )
     configurable: dict[str, Any] = {
         "source": "github",

--- a/scripts/seed_email_map.py
+++ b/scripts/seed_email_map.py
@@ -1,10 +1,36 @@
-"""Mapping of GitHub usernames to LangSmith email addresses.
+"""Seed `["oauth_tokens"]` + `["email_to_login"]` from the legacy hardcoded map.
 
-Add entries here as:
-    "github-username": "user@example.com",
+This is a one-shot migration. Once the dashboard's GitHub OAuth login is wired
+up, every user who logs in will refresh their own record automatically — but
+existing users would otherwise get the "no stored email" auth-required prompt
+the first time they trigger the agent from Slack / Linear / GitHub. Run this
+once at deploy time to backfill the email side of those records (tokens
+remain empty until each user logs in to the dashboard).
+
+Idempotent: running it twice leaves the same final state. Existing records
+are merged, so a previously-saved encrypted token is preserved.
+
+Usage::
+
+    LANGGRAPH_URL=https://your-deployment uv run python -m scripts.seed_email_map
 """
 
-GITHUB_USER_EMAIL_MAP: dict[str, str] = {
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+import httpx
+from langgraph_sdk import get_client
+
+logger = logging.getLogger(__name__)
+
+# Snapshot of the legacy `GITHUB_USER_EMAIL_MAP` taken at migration time. The
+# source-of-truth moves to the LangGraph Store after this script runs.
+LEGACY_GITHUB_USER_EMAIL_MAP: dict[str, str] = {
     "aran-yogesh": "yogesh.mahendran@langchain.dev",
     "AaryanPotdar": "aaryan.potdar@langchain.dev",
     "agola11": "ankush@langchain.dev",
@@ -126,3 +152,82 @@ GITHUB_USER_EMAIL_MAP: dict[str, str] = {
     "SumedhArani": "sumedh@langchain.dev",
     "suraj-langchain": "suraj@langchain.dev",
 }
+
+
+def _load_dotenv_if_available() -> None:
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+    load_dotenv()
+
+
+async def seed_all() -> None:
+    from agent.dashboard.profiles import upsert_email_record
+
+    client = get_client()
+    seeded = 0
+    skipped = 0
+    errors = 0
+
+    for raw_login, email in LEGACY_GITHUB_USER_EMAIL_MAP.items():
+        login = raw_login.strip()
+        if not login or not email:
+            skipped += 1
+            continue
+        try:
+            await upsert_email_record(login, email)
+            seeded += 1
+        except httpx.HTTPError as exc:
+            logger.error("Failed to seed %s → %s: %s", login, email, exc)
+            errors += 1
+            continue
+
+    logger.info("Seeded %d records; skipped %d; errors %d", seeded, skipped, errors)
+    # Touch the client so it doesn't sit unused (and to surface connection errors).
+    _ = client
+
+
+def _resolve_value(item: Any) -> dict[str, Any] | None:
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def verify_seed() -> None:
+    """Spot-check that records made it into the store."""
+    client = get_client()
+    sample_logins = list(LEGACY_GITHUB_USER_EMAIL_MAP.keys())[:5]
+    for raw_login in sample_logins:
+        login = raw_login.strip()
+        try:
+            item = await client.store.get_item(["oauth_tokens"], login)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                logger.warning("Spot check: %s not found in oauth_tokens", login)
+                continue
+            raise
+        record = _resolve_value(item)
+        if record is None:
+            logger.warning("Spot check: %s value missing/invalid", login)
+            continue
+        logger.info("Spot check: %s → %s", login, record.get("email"))
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    _load_dotenv_if_available()
+    if not os.environ.get("LANGGRAPH_URL") and not os.environ.get("LANGGRAPH_URL_PROD"):
+        logger.error("LANGGRAPH_URL (or LANGGRAPH_URL_PROD) must be set")
+        sys.exit(1)
+    asyncio.run(_run())
+
+
+async def _run() -> None:
+    await seed_all()
+    await verify_seed()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dashboard_account_links.py
+++ b/tests/test_dashboard_account_links.py
@@ -1,0 +1,114 @@
+"""Tests for the dashboard account-link store helpers and email index."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from agent.dashboard import account_links, profiles
+
+
+class _NotFound(httpx.HTTPStatusError):
+    def __init__(self) -> None:
+        request = httpx.Request("GET", "http://test")
+        response = httpx.Response(404, request=request)
+        super().__init__("not found", request=request, response=response)
+
+
+class _InMemoryStore:
+    def __init__(self) -> None:
+        self._data: dict[tuple[tuple[str, ...], str], dict[str, Any]] = {}
+
+    async def get_item(self, namespace: list[str], key: str) -> dict[str, Any]:
+        ns = tuple(namespace)
+        if (ns, key) not in self._data:
+            raise _NotFound()
+        return {"value": self._data[(ns, key)]}
+
+    async def put_item(self, namespace: list[str], key: str, value: dict[str, Any]) -> None:
+        ns = tuple(namespace)
+        self._data[(ns, key)] = value
+
+    async def delete_item(self, namespace: list[str], key: str) -> None:
+        ns = tuple(namespace)
+        if (ns, key) not in self._data:
+            raise _NotFound()
+        del self._data[(ns, key)]
+
+    async def search_items(self, namespace: list[str], *, limit: int = 1000) -> dict[str, Any]:
+        ns = tuple(namespace)
+        items = [{"value": v} for (n, _), v in self._data.items() if n == ns][:limit]
+        return {"items": items}
+
+
+class _FakeClient:
+    def __init__(self, store: _InMemoryStore) -> None:
+        self.store = store
+
+
+@pytest.fixture
+def fake_store(monkeypatch: pytest.MonkeyPatch) -> _InMemoryStore:
+    store = _InMemoryStore()
+    client = _FakeClient(store)
+    monkeypatch.setattr(account_links, "_client", lambda: client)
+    monkeypatch.setattr(profiles, "_client", lambda: client)
+    return store
+
+
+async def test_slack_link_roundtrip(fake_store: _InMemoryStore) -> None:
+    await account_links.upsert_slack_link(
+        github_login="johannes117",
+        slack_user_id="U01ABC",
+        slack_team_id="T01XYZ",
+        slack_email="johannes@langchain.dev",
+    )
+
+    found = await account_links.get_slack_link_by_user("U01ABC")
+    assert found is not None
+    assert found["github_login"] == "johannes117"
+    assert found["slack_email"] == "johannes@langchain.dev"
+
+    links = await account_links.get_links_for_login("johannes117")
+    assert links["slack"] is not None
+    assert links["slack"]["slack_user_id"] == "U01ABC"
+    assert links["linear"] is None
+
+
+async def test_linear_link_delete(fake_store: _InMemoryStore) -> None:
+    await account_links.upsert_linear_link(
+        github_login="johannes117",
+        linear_user_id="lin-user-123",
+        linear_workspace_id="lin-ws-1",
+        linear_email="johannes@langchain.dev",
+    )
+    removed = await account_links.delete_link_for_login("linear", "johannes117")
+    assert removed is True
+
+    again = await account_links.delete_link_for_login("linear", "johannes117")
+    assert again is False
+
+    assert await account_links.get_linear_link_by_user("lin-user-123") is None
+
+
+async def test_email_index_tracks_oauth_token_writes(fake_store: _InMemoryStore) -> None:
+    await profiles.upsert_email_record("johannes117", "Johannes@LangChain.dev")
+    assert await profiles.get_email_for_github_login("johannes117") == "johannes@langchain.dev"
+    assert await profiles.get_login_for_email("johannes@langchain.dev") == "johannes117"
+    assert await profiles.get_login_for_email("JOHANNES@LANGCHAIN.DEV") == "johannes117"
+
+
+async def test_email_index_updates_when_email_changes(fake_store: _InMemoryStore) -> None:
+    await profiles.upsert_email_record("octocat", "old@example.com")
+    assert await profiles.get_login_for_email("old@example.com") == "octocat"
+
+    await profiles.upsert_email_record("octocat", "new@example.com")
+    assert await profiles.get_email_for_github_login("octocat") == "new@example.com"
+    assert await profiles.get_login_for_email("new@example.com") == "octocat"
+    assert await profiles.get_login_for_email("old@example.com") is None
+
+
+async def test_get_email_for_missing_login_returns_none(fake_store: _InMemoryStore) -> None:
+    assert await profiles.get_email_for_github_login("does-not-exist") is None
+    assert await profiles.get_login_for_email("nobody@example.com") is None

--- a/tests/test_github_comment_prompts.py
+++ b/tests/test_github_comment_prompts.py
@@ -104,6 +104,7 @@ def test_build_github_issue_prompt_only_wraps_external_comments() -> None:
             },
         ],
         github_login="octocat",
+        trusted_authors={"bracesproul"},
     )
 
     assert "**bracesproul:**\nInternal guidance" in prompt
@@ -111,3 +112,24 @@ def test_build_github_issue_prompt_only_wraps_external_comments() -> None:
     assert github_comments.UNTRUSTED_GITHUB_COMMENT_OPEN_TAG in prompt
     assert github_comments.UNTRUSTED_GITHUB_COMMENT_CLOSE_TAG in prompt
     assert "External Untrusted Comments" not in prompt
+
+
+def test_build_github_issue_prompt_wraps_all_when_no_trust_set() -> None:
+    prompt = webapp.build_github_issue_prompt(
+        {"owner": "langchain-ai", "name": "open-swe"},
+        42,
+        "12345",
+        "Fix the flaky test",
+        "The test is failing intermittently.",
+        [
+            {
+                "author": "bracesproul",
+                "body": "Internal guidance",
+                "created_at": "2026-03-09T00:00:00Z",
+            },
+        ],
+        github_login="octocat",
+    )
+
+    assert "Internal guidance" in prompt
+    assert github_comments.UNTRUSTED_GITHUB_COMMENT_OPEN_TAG in prompt

--- a/tests/test_github_issue_webhook.py
+++ b/tests/test_github_issue_webhook.py
@@ -87,7 +87,9 @@ def test_build_github_issue_prompt_includes_issue_context() -> None:
 
 
 def test_build_github_issue_followup_prompt_only_includes_comment() -> None:
-    prompt = webapp.build_github_issue_followup_prompt("bracesproul", "Please handle this")
+    prompt = webapp.build_github_issue_followup_prompt(
+        "bracesproul", "Please handle this", trusted_authors={"bracesproul"}
+    )
 
     assert prompt == "**bracesproul:**\nPlease handle this"
     assert "## Repository" not in prompt
@@ -955,7 +957,16 @@ def test_process_github_issue_uses_resolved_user_token_for_reaction(monkeypatch)
     monkeypatch.setattr(webapp, "fetch_issue_comments", fake_fetch_issue_comments)
     monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
     monkeypatch.setattr(webapp, "get_client", lambda url: _FakeLangGraphClient())
-    monkeypatch.setattr(webapp, "GITHUB_USER_EMAIL_MAP", {"octocat": "octocat@example.com"})
+
+    async def fake_email_lookup(login: str) -> str | None:
+        return "octocat@example.com" if login == "octocat" else None
+
+    monkeypatch.setattr(webapp, "get_email_for_github_login", fake_email_lookup)
+
+    async def fake_trusted_authors(authors):
+        return set()
+
+    monkeypatch.setattr(webapp, "resolve_trusted_authors", fake_trusted_authors)
 
     asyncio.run(
         webapp.process_github_issue(
@@ -1030,10 +1041,16 @@ def test_process_github_issue_existing_thread_uses_followup_prompt(monkeypatch) 
     monkeypatch.setattr(webapp, "fetch_issue_comments", fake_fetch_issue_comments)
     monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
     monkeypatch.setattr(webapp, "get_client", lambda url: _FakeLangGraphClient())
-    monkeypatch.setattr(webapp, "GITHUB_USER_EMAIL_MAP", {"octocat": "octocat@example.com"})
-    monkeypatch.setattr(
-        github_comments, "GITHUB_USER_EMAIL_MAP", {"octocat": "octocat@example.com"}
-    )
+
+    async def fake_email_lookup(login: str) -> str | None:
+        return "octocat@example.com" if login == "octocat" else None
+
+    monkeypatch.setattr(webapp, "get_email_for_github_login", fake_email_lookup)
+
+    async def fake_trusted_authors(authors):
+        return {"octocat"}
+
+    monkeypatch.setattr(webapp, "resolve_trusted_authors", fake_trusted_authors)
 
     asyncio.run(
         webapp.process_github_issue(

--- a/tests/test_github_token_ttl.py
+++ b/tests/test_github_token_ttl.py
@@ -276,7 +276,11 @@ def test_process_github_pr_comment_invalidates_and_reauths_on_401(
     monkeypatch.setattr(webapp, "react_to_github_comment", fake_react)
     monkeypatch.setattr(webapp, "fetch_pr_comments_since_last_tag", fake_fetch_pr_comments)
     monkeypatch.setattr(webapp, "_trigger_or_queue_run", fake_trigger_or_queue_run)
-    monkeypatch.setattr(webapp, "GITHUB_USER_EMAIL_MAP", {"octo": "octo@example.com"})
+
+    async def fake_email_lookup(login: str) -> str | None:
+        return "octo@example.com" if login == "octo" else None
+
+    monkeypatch.setattr(webapp, "get_email_for_github_login", fake_email_lookup)
 
     asyncio.run(
         webapp.process_github_pr_comment(

--- a/tests/test_oauth_email_pick.py
+++ b/tests/test_oauth_email_pick.py
@@ -1,0 +1,47 @@
+"""Tests for the work-email picker used during GitHub OAuth callback."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.dashboard.oauth import _pick_work_email
+
+
+def test_picks_work_domain_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORK_EMAIL_DOMAIN", "langchain.dev")
+    emails = [
+        {"email": "personal@gmail.com", "primary": True, "verified": True},
+        {"email": "work@langchain.dev", "primary": False, "verified": True},
+    ]
+    assert _pick_work_email(emails) == "work@langchain.dev"
+
+
+def test_falls_back_to_primary_when_no_work_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORK_EMAIL_DOMAIN", "langchain.dev")
+    emails = [
+        {"email": "personal@gmail.com", "primary": True, "verified": True},
+        {"email": "alt@example.com", "primary": False, "verified": True},
+    ]
+    assert _pick_work_email(emails) == "personal@gmail.com"
+
+
+def test_skips_unverified_emails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORK_EMAIL_DOMAIN", "langchain.dev")
+    emails = [
+        {"email": "fake@langchain.dev", "primary": False, "verified": False},
+        {"email": "real@gmail.com", "primary": True, "verified": True},
+    ]
+    assert _pick_work_email(emails) == "real@gmail.com"
+
+
+def test_returns_none_for_empty_list() -> None:
+    assert _pick_work_email([]) is None
+
+
+def test_no_work_domain_uses_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WORK_EMAIL_DOMAIN", raising=False)
+    emails = [
+        {"email": "a@example.com", "primary": True, "verified": True},
+        {"email": "b@langchain.dev", "primary": False, "verified": True},
+    ]
+    assert _pick_work_email(emails) == "a@example.com"

--- a/tests/test_resolve_token_via_account_link.py
+++ b/tests/test_resolve_token_via_account_link.py
@@ -1,0 +1,115 @@
+"""Webhook resolution preferring an explicit account link over LangSmith email."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent.utils import auth as auth_module
+
+
+@pytest.fixture
+def fake_persist(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    async def fake_persist_encrypted_github_token(
+        thread_id: str, token: str, expires_at: str | None = None
+    ) -> str:
+        captured["thread_id"] = thread_id
+        captured["token"] = token
+        captured["expires_at"] = expires_at
+        return "encrypted-bytes"
+
+    monkeypatch.setattr(
+        auth_module, "persist_encrypted_github_token", fake_persist_encrypted_github_token
+    )
+    return captured
+
+
+async def test_resolves_via_slack_link(
+    monkeypatch: pytest.MonkeyPatch, fake_persist: dict[str, Any]
+) -> None:
+    async def fake_get_slack_link_by_user(slack_user_id: str) -> dict[str, Any] | None:
+        if slack_user_id == "U01":
+            return {"github_login": "octocat"}
+        return None
+
+    async def fake_get_access_token(login: str) -> str | None:
+        return "gho_user_token" if login == "octocat" else None
+
+    monkeypatch.setattr(auth_module, "get_slack_link_by_user", fake_get_slack_link_by_user)
+    monkeypatch.setattr(auth_module, "get_access_token", fake_get_access_token)
+
+    result = await auth_module._resolve_token_via_account_link(
+        {"source": "slack", "slack_thread": {"triggering_user_id": "U01"}},
+        thread_id="t1",
+    )
+    assert result is not None
+    token, encrypted, expires_at = result
+    assert token == "gho_user_token"
+    assert encrypted == "encrypted-bytes"
+    assert expires_at is None
+    assert fake_persist["token"] == "gho_user_token"
+
+
+async def test_returns_none_when_no_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_slack_link_by_user(slack_user_id: str) -> dict[str, Any] | None:
+        return None
+
+    monkeypatch.setattr(auth_module, "get_slack_link_by_user", fake_get_slack_link_by_user)
+    result = await auth_module._resolve_token_via_account_link(
+        {"source": "slack", "slack_thread": {"triggering_user_id": "U_UNKNOWN"}},
+        thread_id="t1",
+    )
+    assert result is None
+
+
+async def test_returns_none_when_link_has_no_stored_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_slack_link_by_user(slack_user_id: str) -> dict[str, Any] | None:
+        return {"github_login": "ghost"}
+
+    async def fake_get_access_token(login: str) -> str | None:
+        return None
+
+    monkeypatch.setattr(auth_module, "get_slack_link_by_user", fake_get_slack_link_by_user)
+    monkeypatch.setattr(auth_module, "get_access_token", fake_get_access_token)
+
+    result = await auth_module._resolve_token_via_account_link(
+        {"source": "slack", "slack_thread": {"triggering_user_id": "U01"}},
+        thread_id="t1",
+    )
+    assert result is None
+
+
+async def test_resolves_via_linear_link(
+    monkeypatch: pytest.MonkeyPatch, fake_persist: dict[str, Any]
+) -> None:
+    async def fake_get_linear_link_by_user(linear_user_id: str) -> dict[str, Any] | None:
+        if linear_user_id == "lin-42":
+            return {"github_login": "octocat"}
+        return None
+
+    async def fake_get_access_token(login: str) -> str | None:
+        return "gho_linear_user"
+
+    monkeypatch.setattr(auth_module, "get_linear_link_by_user", fake_get_linear_link_by_user)
+    monkeypatch.setattr(auth_module, "get_access_token", fake_get_access_token)
+
+    result = await auth_module._resolve_token_via_account_link(
+        {"source": "linear", "linear_issue": {"triggering_user_id": "lin-42"}},
+        thread_id="t1",
+    )
+    assert result is not None
+    assert result[0] == "gho_linear_user"
+
+
+async def test_github_source_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The github source goes through its own email-map path; never via link lookup."""
+    result = await auth_module._resolve_token_via_account_link(
+        {"source": "github", "github_login": "octocat"},
+        thread_id="t1",
+    )
+    assert result is None

--- a/tests/test_slack_context.py
+++ b/tests/test_slack_context.py
@@ -382,7 +382,7 @@ def test_get_slack_repo_config_applies_profile_default_repo(
     async def fake_get_slack_user_info(user_id: str) -> dict:
         return {"profile": {"email": "mason@example.com"}}
 
-    def fake_resolve_login_from_email(email: str | None) -> str | None:
+    async def fake_resolve_login_from_email(email: str | None) -> str | None:
         return "mason"
 
     async def fake_get_profile_default_repo(login: str | None) -> dict[str, str] | None:

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -32,6 +32,13 @@ export function AppHeader({ user }: { user: SessionUser }) {
           >
             Profile
           </Link>
+          <Link
+            to="/account-links"
+            className="text-muted-foreground hover:text-foreground"
+            activeProps={{ className: "text-foreground font-medium" }}
+          >
+            Linked accounts
+          </Link>
           {user.is_admin && (
             <Link
               to="/admin"

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -86,6 +86,29 @@ export interface ReposPayload {
   repositories: Array<Repository>;
 }
 
+export interface SlackLink {
+  github_login: string;
+  slack_user_id: string;
+  slack_team_id: string;
+  slack_email: string;
+  linked_at: string;
+}
+
+export interface LinearLink {
+  github_login: string;
+  linear_user_id: string;
+  linear_workspace_id: string;
+  linear_email: string;
+  linked_at: string;
+}
+
+export interface AccountLinks {
+  slack: SlackLink | null;
+  linear: LinearLink | null;
+}
+
+export type LinkProvider = "slack" | "linear";
+
 export const api = {
   me: () => request<SessionUser>("/me"),
   options: () => request<{ models: Array<ModelOption> }>("/options"),
@@ -93,6 +116,9 @@ export const api = {
   saveProfile: (body: ProfileUpdate) =>
     request<Profile>("/profile", { method: "PUT", body: JSON.stringify(body) }),
   repos: () => request<ReposPayload>("/repos"),
+  accountLinks: () => request<AccountLinks>("/account-links"),
+  deleteAccountLink: (provider: LinkProvider) =>
+    request<void>(`/account-links/${provider}`, { method: "DELETE" }),
   adminListProfiles: () => request<Array<Profile>>("/admin/profiles"),
   adminSaveProfile: (login: string, body: ProfileUpdate & { email?: string }) =>
     request<Profile>(`/admin/profiles/${encodeURIComponent(login)}`, {
@@ -106,4 +132,10 @@ export function loginUrl(redirectTo?: string): string {
   const target = redirectTo ?? (typeof window !== "undefined" ? window.location.origin : "");
   const qs = target ? `?redirect_to=${encodeURIComponent(target)}` : "";
   return `${API_BASE}/dashboard/api/auth/login${qs}`;
+}
+
+export function providerLinkUrl(provider: LinkProvider, redirectTo?: string): string {
+  const target = redirectTo ?? (typeof window !== "undefined" ? window.location.href : "");
+  const qs = target ? `?redirect_to=${encodeURIComponent(target)}` : "";
+  return `${API_BASE}/dashboard/api/auth/${provider}/login${qs}`;
 }

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -10,13 +10,20 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ProfileRouteImport } from './routes/profile'
+import { Route as NotAuthorizedRouteImport } from './routes/not-authorized'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AdminRouteImport } from './routes/admin'
+import { Route as AccountLinksRouteImport } from './routes/account-links'
 import { Route as IndexRouteImport } from './routes/index'
 
 const ProfileRoute = ProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotAuthorizedRoute = NotAuthorizedRouteImport.update({
+  id: '/not-authorized',
+  path: '/not-authorized',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -29,6 +36,11 @@ const AdminRoute = AdminRouteImport.update({
   path: '/admin',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AccountLinksRoute = AccountLinksRouteImport.update({
+  id: '/account-links',
+  path: '/account-links',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -37,35 +49,62 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/account-links': typeof AccountLinksRoute
   '/admin': typeof AdminRoute
   '/login': typeof LoginRoute
+  '/not-authorized': typeof NotAuthorizedRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/account-links': typeof AccountLinksRoute
   '/admin': typeof AdminRoute
   '/login': typeof LoginRoute
+  '/not-authorized': typeof NotAuthorizedRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/account-links': typeof AccountLinksRoute
   '/admin': typeof AdminRoute
   '/login': typeof LoginRoute
+  '/not-authorized': typeof NotAuthorizedRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/admin' | '/login' | '/profile'
+  fullPaths:
+    | '/'
+    | '/account-links'
+    | '/admin'
+    | '/login'
+    | '/not-authorized'
+    | '/profile'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/admin' | '/login' | '/profile'
-  id: '__root__' | '/' | '/admin' | '/login' | '/profile'
+  to:
+    | '/'
+    | '/account-links'
+    | '/admin'
+    | '/login'
+    | '/not-authorized'
+    | '/profile'
+  id:
+    | '__root__'
+    | '/'
+    | '/account-links'
+    | '/admin'
+    | '/login'
+    | '/not-authorized'
+    | '/profile'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AccountLinksRoute: typeof AccountLinksRoute
   AdminRoute: typeof AdminRoute
   LoginRoute: typeof LoginRoute
+  NotAuthorizedRoute: typeof NotAuthorizedRoute
   ProfileRoute: typeof ProfileRoute
 }
 
@@ -76,6 +115,13 @@ declare module '@tanstack/react-router' {
       path: '/profile'
       fullPath: '/profile'
       preLoaderRoute: typeof ProfileRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/not-authorized': {
+      id: '/not-authorized'
+      path: '/not-authorized'
+      fullPath: '/not-authorized'
+      preLoaderRoute: typeof NotAuthorizedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -92,6 +138,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/account-links': {
+      id: '/account-links'
+      path: '/account-links'
+      fullPath: '/account-links'
+      preLoaderRoute: typeof AccountLinksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,8 +157,10 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AccountLinksRoute: AccountLinksRoute,
   AdminRoute: AdminRoute,
   LoginRoute: LoginRoute,
+  NotAuthorizedRoute: NotAuthorizedRoute,
   ProfileRoute: ProfileRoute,
 }
 export const routeTree = rootRouteImport

--- a/ui/src/routes/account-links.tsx
+++ b/ui/src/routes/account-links.tsx
@@ -1,0 +1,162 @@
+import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { AccountLinks, LinearLink, LinkProvider, SlackLink } from "@/lib/api";
+import { AppHeader } from "@/components/AppHeader";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { api, providerLinkUrl } from "@/lib/api";
+import { useSession } from "@/lib/session";
+
+interface SearchParams {
+  source?: LinkProvider;
+  user_id?: string;
+  linked?: LinkProvider;
+}
+
+export const Route = createFileRoute("/account-links")({
+  component: AccountLinksPage,
+  validateSearch: (search: Record<string, unknown>): SearchParams => ({
+    source: search.source === "slack" || search.source === "linear" ? search.source : undefined,
+    user_id: typeof search.user_id === "string" ? search.user_id : undefined,
+    linked: search.linked === "slack" || search.linked === "linear" ? search.linked : undefined,
+  }),
+});
+
+function AccountLinksPage() {
+  const session = useSession();
+  const search = Route.useSearch();
+  const qc = useQueryClient();
+
+  const links = useQuery({
+    queryKey: ["account-links"],
+    queryFn: api.accountLinks,
+    enabled: !!session.data,
+  });
+
+  const disconnect = useMutation({
+    mutationFn: (provider: LinkProvider) => api.deleteAccountLink(provider),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["account-links"] }),
+  });
+
+  if (session.isLoading) {
+    return (
+      <main className="container mx-auto p-6">
+        <Skeleton className="h-64 w-full" />
+      </main>
+    );
+  }
+
+  if (!session.data) return <Navigate to="/login" />;
+
+  const slack = links.data?.slack ?? null;
+  const linear = links.data?.linear ?? null;
+  const highlightedProvider = search.linked ?? search.source ?? null;
+
+  return (
+    <div className="min-h-svh">
+      <AppHeader user={session.data} />
+      <main className="container mx-auto p-6">
+        <Card className="mx-auto max-w-2xl">
+          <CardHeader>
+            <CardTitle>Linked accounts</CardTitle>
+            <CardDescription>
+              Connect your Slack and Linear identities so open-swe knows which GitHub account to
+              use when you tag it from those tools.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {links.isLoading ? (
+              <Skeleton className="h-32 w-full" />
+            ) : (
+              <>
+                <ProviderRow
+                  provider="slack"
+                  label="Slack"
+                  link={slack}
+                  highlighted={highlightedProvider === "slack"}
+                  onDisconnect={() => disconnect.mutate("slack")}
+                  disconnecting={disconnect.isPending && disconnect.variables === "slack"}
+                />
+                <ProviderRow
+                  provider="linear"
+                  label="Linear"
+                  link={linear}
+                  highlighted={highlightedProvider === "linear"}
+                  onDisconnect={() => disconnect.mutate("linear")}
+                  disconnecting={disconnect.isPending && disconnect.variables === "linear"}
+                />
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}
+
+interface ProviderRowProps {
+  provider: LinkProvider;
+  label: string;
+  link: SlackLink | LinearLink | null;
+  highlighted: boolean;
+  onDisconnect: () => void;
+  disconnecting: boolean;
+}
+
+function ProviderRow({
+  provider,
+  label,
+  link,
+  highlighted,
+  onDisconnect,
+  disconnecting,
+}: ProviderRowProps) {
+  const email = link
+    ? "slack_email" in link
+      ? link.slack_email
+      : link.linear_email
+    : "";
+  const subtitle = link
+    ? email
+      ? `Connected as ${email}`
+      : "Connected"
+    : "Needs authentication";
+
+  return (
+    <div
+      className={
+        "flex items-center justify-between rounded-md border p-4 " +
+        (highlighted ? "border-primary" : "")
+      }
+    >
+      <div>
+        <div className="font-medium">{label}</div>
+        <div className="text-muted-foreground text-sm">{subtitle}</div>
+      </div>
+      {link ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDisconnect}
+          disabled={disconnecting}
+        >
+          {disconnecting ? "Disconnecting…" : "Disconnect"}
+        </Button>
+      ) : (
+        <Button asChild size="sm">
+          <a href={providerLinkUrl(provider)}>Connect</a>
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export type { AccountLinks };

--- a/ui/src/routes/not-authorized.tsx
+++ b/ui/src/routes/not-authorized.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { loginUrl } from "@/lib/api";
+
+interface SearchParams {
+  org?: string;
+}
+
+export const Route = createFileRoute("/not-authorized")({
+  component: NotAuthorizedPage,
+  validateSearch: (search: Record<string, unknown>): SearchParams => ({
+    org: typeof search.org === "string" ? search.org : undefined,
+  }),
+});
+
+function NotAuthorizedPage() {
+  const { org } = Route.useSearch();
+  return (
+    <main className="container mx-auto flex min-h-svh items-center p-6">
+      <Card className="mx-auto max-w-md">
+        <CardHeader>
+          <CardTitle>Not authorized</CardTitle>
+          <CardDescription>
+            {org
+              ? `Dashboard access is restricted to members of ${org}.`
+              : "Dashboard access is restricted to an approved GitHub organization."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-muted-foreground text-sm">
+            If you believe you should have access, ask an admin to add you to the org.
+          </p>
+          <Button asChild>
+            <a href={loginUrl()}>Try a different account</a>
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces hardcoded `GITHUB_USER_EMAIL_MAP` + personal `LINEAR_API_KEY` with OAuth-verified account links persisted in the LangGraph Store
- New "Connect Slack" / "Connect Linear" flows on the dashboard; webhook resolution checks the explicit link before the legacy LangSmith-email path
- Linear API access migrates to a workspace-installed OAuth app (`client_credentials` grant) — the install-time `actor=app` makes bot comments still appear as `open-swe`
- Dashboard login is gated by `ALLOWED_AUTH_ORG` so the surface is safe to expose publicly
- `github_comments` trust signal switches from email-map-presence to active org membership, pre-computed once per webhook

## Required setup before deploying

1. **Linear** — create an OAuth app (Settings → API → Applications), copy `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET`, and admin-install it with `actor=app` (see updated `INSTALLATION.md`). Then remove `LINEAR_API_KEY` from env.
2. **Slack** — update the existing Slack app manifest to add `user` scopes (`openid`, `email`, `profile`) and the dashboard's `/dashboard/api/auth/slack/callback` URL. Copy `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` from Basic Information.
3. **Dashboard** — set `ALLOWED_AUTH_ORG=langchain-ai`, `WORK_EMAIL_DOMAIN=langchain.dev`, and verify `DASHBOARD_BASE_URL` / `DASHBOARD_API_BASE_URL` / `DASHBOARD_JWT_SECRET` are populated.
4. **Seed** — after the new build is live, run once:
   ```
   LANGGRAPH_URL=https://your-deployment uv run python -m scripts.seed_email_map
   ```
   This backfills the email side of `["oauth_tokens"]` for everyone in the old hardcoded map so they don't get auth-required prompts on their next invocation.

## Test plan
- [ ] `make lint` clean (verified locally)
- [ ] `make test` passes — 321 tests, 15 new (verified locally)
- [ ] Dashboard login with a non-`langchain-ai` GitHub account redirects to `/not-authorized`
- [ ] Dashboard login with a `langchain-ai` GitHub account that has `@langchain.dev` as a verified-but-not-primary email picks the work email
- [ ] "Connect Slack" round-trip: state cookie + JWT validate, link visible in `/account-links`, disconnect removes it
- [ ] "Connect Linear" round-trip: same shape
- [ ] Slack mention from a linked user: agent runs using their stored GitHub OAuth token (no LangSmith lookup)
- [ ] Slack mention from an *un*linked user whose email isn't in LangSmith: thread reply includes a deep link to `/account-links?source=slack&user_id=...`
- [ ] Linear comment created by the bot appears as `open-swe`, not as the installing user
- [ ] GitHub PR webhook from a user who was in the seeded map but hasn't logged in to the dashboard: still resolves correctly (email comes from the seed)