### PR TITLE
feat(open-swe): add PR babysitter agent

### DIFF
--- a/agent/babysitter.py
+++ b/agent/babysitter.py
@@ -140,7 +140,9 @@ async def get_babysitter_agent(config: RunnableConfig) -> Pregel:
 
     return create_deep_agent(
         model=make_model(model_id, **model_kwargs),
-        system_prompt=_system_prompt(f"{work_dir}/{repo_name}" if repo_name else work_dir, configurable),
+        system_prompt=_system_prompt(
+            f"{work_dir}/{repo_name}" if repo_name else work_dir, configurable
+        ),
         tools=[],
         backend=sandbox_backend,
         middleware=[

--- a/agent/babysitter.py
+++ b/agent/babysitter.py
@@ -1,0 +1,154 @@
+"""Babysitter graph factory for keeping a PR healthy."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+from typing import Any
+
+from langgraph.graph.state import RunnableConfig
+from langgraph.pregel import Pregel
+
+logger = logging.getLogger(__name__)
+
+warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
+warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
+
+from deepagents import create_deep_agent
+from langchain.agents.middleware import ModelCallLimitMiddleware
+
+from .middleware import (
+    SanitizeToolInputsMiddleware,
+    SlackAssistantStatusMiddleware,
+    ToolErrorMiddleware,
+    check_message_queue_before_model,
+    ensure_no_empty_msg,
+)
+from .server import (
+    DEFAULT_LLM_MAX_TOKENS,
+    DEFAULT_LLM_MODEL_ID,
+    DEFAULT_LLM_REASONING,
+    DEFAULT_RECURSION_LIMIT,
+    MODEL_CALL_RECURSION_LIMIT,
+    _anthropic_effort_for,
+    _anthropic_thinking_for,
+    _openai_reasoning_for,
+    ensure_sandbox_for_thread,
+    graph_loaded_for_execution,
+)
+from .utils.auth import resolve_github_token
+from .utils.github_token import get_github_token_from_thread
+from .utils.model import ModelKwargs, make_model
+from .utils.sandbox_paths import aresolve_sandbox_work_dir
+
+BABYSITTER_PROMPT_TEMPLATE = """You are Open SWE's PR babysitter.
+
+You keep one GitHub pull request healthy by watching CI and review feedback,
+making small targeted fixes, pushing them to the PR branch, and reporting what
+you did.
+
+Working directory: `{working_dir}`.
+
+GitHub access:
+- The `gh` CLI is installed and authenticated by a sandbox proxy. Always invoke
+  it as `GH_TOKEN=dummy gh <command>`.
+- Target PR: {repo_owner}/{repo_name}#{pr_number}
+- PR URL: {pr_url}
+
+Workflow:
+1. Inspect the PR, current head, checks, and recent comments.
+2. If CI failed, fetch failed logs (`gh pr checks`, `gh run view --log-failed`)
+   and reproduce locally when practical.
+3. If there are review comments, only act on concrete requested changes.
+4. Clone or update the repo, checkout the PR branch/head, make the smallest
+   correct fix, and run focused validation.
+5. Commit and push to the PR branch. Never force-push. Never merge.
+6. Leave a concise PR comment summarizing fixes and validation.
+
+Guardrails:
+- Do not modify unrelated files.
+- Ignore comments authored by Open SWE.
+- If the failure is flaky, infrastructure-related, blocked on secrets, or
+  needs product/design judgment, comment with what you found instead of editing.
+- Stop after one focused fix attempt for this run.
+"""
+
+
+def _system_prompt(working_dir: str, configurable: dict[str, Any]) -> str:
+    repo = configurable.get("repo") if isinstance(configurable.get("repo"), dict) else {}
+    return BABYSITTER_PROMPT_TEMPLATE.format(
+        working_dir=working_dir,
+        repo_owner=repo.get("owner", "<owner>"),
+        repo_name=repo.get("name", "<repo>"),
+        pr_number=configurable.get("pr_number", "<pr_number>"),
+        pr_url=configurable.get("pr_url", ""),
+    )
+
+
+async def get_babysitter_agent(config: RunnableConfig) -> Pregel:
+    """Get or create a babysitter agent with a sandbox."""
+    thread_id = config["configurable"].get("thread_id", None)
+    config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
+
+    if thread_id is None or not graph_loaded_for_execution(config):
+        logger.info("No thread_id or not for execution, returning babysitter without sandbox")
+        return create_deep_agent(system_prompt="", tools=[]).with_config(config)
+
+    if config["configurable"].get("source"):
+        cached_token, cached_encrypted, cached_expires_at = await get_github_token_from_thread(
+            thread_id
+        )
+        if cached_token and cached_encrypted:
+            config["metadata"]["github_token_encrypted"] = cached_encrypted
+            config["metadata"]["github_token_expires_at"] = cached_expires_at
+            del cached_token
+        else:
+            _token, new_encrypted, new_expires_at = await resolve_github_token(config, thread_id)
+            config["metadata"]["github_token_encrypted"] = new_encrypted
+            config["metadata"]["github_token_expires_at"] = new_expires_at
+            del _token
+
+    sandbox_backend = await ensure_sandbox_for_thread(thread_id)
+    work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+
+    configurable = config["configurable"]
+    repo = configurable.get("repo") if isinstance(configurable.get("repo"), dict) else {}
+    repo_name = str(repo.get("name", ""))
+
+    configured_model_id = configurable.get("babysitter_model_id")
+    model_id = (
+        configured_model_id
+        if isinstance(configured_model_id, str) and configured_model_id
+        else os.environ.get("LLM_MODEL_ID", DEFAULT_LLM_MODEL_ID)
+    )
+    configured_effort = configurable.get("babysitter_reasoning_effort")
+    reasoning_effort = configured_effort if isinstance(configured_effort, str) else None
+    model_kwargs: ModelKwargs = {"max_tokens": DEFAULT_LLM_MAX_TOKENS}
+    if model_id.startswith("openai:"):
+        reasoning = _openai_reasoning_for(reasoning_effort)
+        model_kwargs["reasoning"] = reasoning if reasoning is not None else DEFAULT_LLM_REASONING
+    elif model_id.startswith("anthropic:"):
+        thinking = _anthropic_thinking_for(reasoning_effort)
+        if thinking is not None:
+            model_kwargs["thinking"] = thinking
+        effort = _anthropic_effort_for(reasoning_effort)
+        if effort is not None:
+            model_kwargs["effort"] = effort
+
+    return create_deep_agent(
+        model=make_model(model_id, **model_kwargs),
+        system_prompt=_system_prompt(f"{work_dir}/{repo_name}" if repo_name else work_dir, configurable),
+        tools=[],
+        backend=sandbox_backend,
+        middleware=[
+            SanitizeToolInputsMiddleware(),
+            ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
+            ToolErrorMiddleware(),
+            check_message_queue_before_model,
+            ensure_no_empty_msg,
+            SlackAssistantStatusMiddleware(),
+        ],
+    ).with_config(config)

--- a/agent/babysitter_state.py
+++ b/agent/babysitter_state.py
@@ -1,0 +1,52 @@
+"""Thread metadata helpers for the PR babysitter agent."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from langgraph_sdk import get_client
+
+BABYSITTER_THREAD_KIND = "babysitter"
+
+
+class BabysitterPRMeta(TypedDict, total=False):
+    owner: str
+    name: str
+    number: int
+    url: str
+    title: str
+    head_ref: str
+    base_ref: str
+    head_sha: str
+    base_sha: str
+
+
+async def set_babysitter_thread_metadata(
+    thread_id: str,
+    *,
+    pr: BabysitterPRMeta | None = None,
+    watch: bool | None = None,
+    last_checked_at: str | None = None,
+    last_seen_head_sha: str | None = None,
+    last_action_key: str | None = None,
+    fix_attempt_count: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Persist babysitter-thread metadata with merge semantics."""
+    client = get_client()
+    metadata: dict[str, Any] = {"kind": BABYSITTER_THREAD_KIND}
+    if pr is not None:
+        metadata["pr"] = pr
+    if watch is not None:
+        metadata["watch"] = watch
+    if last_checked_at is not None:
+        metadata["last_checked_at"] = last_checked_at
+    if last_seen_head_sha is not None:
+        metadata["last_seen_head_sha"] = last_seen_head_sha
+    if last_action_key is not None:
+        metadata["last_action_key"] = last_action_key
+    if fix_attempt_count is not None:
+        metadata["fix_attempt_count"] = fix_attempt_count
+    if extra:
+        metadata.update(extra)
+    await client.threads.update(thread_id=thread_id, metadata=metadata)

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -10,6 +10,8 @@ from typing import Any
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
+from langgraph_sdk import get_client
+from pydantic import BaseModel
 
 from .admin import is_admin
 from .oauth import (
@@ -40,6 +42,9 @@ from .profiles import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/dashboard/api", tags=["dashboard"])
+LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
+    "LANGGRAPH_URL_PROD", "http://localhost:2024"
+)
 
 
 def _require_admin(session: dict[str, Any]) -> dict[str, Any]:
@@ -207,6 +212,23 @@ class AdminProfileUpdate(ProfileUpdate):
     email: str | None = None
 
 
+class BabysitterConfigUpdate(BaseModel):
+    enabled: bool
+    poll_interval_seconds: int = 600
+    max_attempts_per_sha: int = 2
+
+
+_BABYSITTER_CONFIG: dict[str, Any] = {
+    "enabled": os.environ.get("BABYSITTER_CRON_ENABLED", "").lower() in {"1", "true", "yes"},
+    "poll_interval_seconds": int(os.environ.get("BABYSITTER_POLL_INTERVAL_SECONDS", "600")),
+    "max_attempts_per_sha": int(os.environ.get("BABYSITTER_MAX_ATTEMPTS_PER_SHA", "2")),
+}
+
+
+def get_babysitter_runtime_config() -> dict[str, Any]:
+    return dict(_BABYSITTER_CONFIG)
+
+
 @router.put("/admin/profiles/{login}")
 async def admin_put_profile(
     login: str,
@@ -222,6 +244,72 @@ async def admin_put_profile(
         default_repo=update.default_repo,
     )
     return await upsert_profile(login, email, base)
+
+
+@router.get("/agents/active")
+async def list_active_agents(
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> list[dict[str, Any]]:
+    """List currently active LangGraph threads/runs for dashboard controls."""
+    client = get_client(url=LANGGRAPH_URL)
+    threads = await client.threads.search(status="busy", limit=100)
+    out: list[dict[str, Any]] = []
+    for thread in threads:
+        if not isinstance(thread, dict):
+            continue
+        thread_id = thread.get("thread_id")
+        if not isinstance(thread_id, str):
+            continue
+        metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+        runs = await client.runs.list(thread_id, limit=5)
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            status = run.get("status")
+            if status not in {"pending", "running"}:
+                continue
+            out.append(
+                {
+                    "thread_id": thread_id,
+                    "run_id": run.get("run_id"),
+                    "status": status,
+                    "assistant_id": run.get("assistant_id"),
+                    "created_at": run.get("created_at"),
+                    "metadata": metadata,
+                }
+            )
+    return out
+
+
+@router.post("/agents/{thread_id}/runs/{run_id}/cancel")
+async def cancel_agent_run(
+    thread_id: str,
+    run_id: str,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> Response:
+    client = get_client(url=LANGGRAPH_URL)
+    await client.runs.cancel(thread_id, run_id, wait=False, action="interrupt")
+    return Response(status_code=204)
+
+
+@router.get("/babysitter/config")
+async def get_babysitter_config(
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    return dict(_BABYSITTER_CONFIG)
+
+
+@router.put("/babysitter/config")
+async def put_babysitter_config(
+    update: BabysitterConfigUpdate,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    if update.poll_interval_seconds < 60:
+        raise HTTPException(400, "poll interval must be at least 60 seconds")
+    if update.max_attempts_per_sha < 0:
+        raise HTTPException(400, "max attempts must be non-negative")
+    _BABYSITTER_CONFIG.update(update.model_dump())
+    return dict(_BABYSITTER_CONFIG)
 
 
 def _next_link_url(link_header: str | None) -> str | None:

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -1,5 +1,6 @@
 """Custom FastAPI routes for LangGraph server."""
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -8,6 +9,7 @@ import os
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -17,11 +19,17 @@ from langchain_core.messages.content import create_text_block
 from langgraph_sdk import get_client
 from langgraph_sdk.client import LangGraphClient
 
+from .babysitter_state import (
+    BABYSITTER_THREAD_KIND,
+    BabysitterPRMeta,
+    set_babysitter_thread_metadata,
+)
 from .dashboard import router as dashboard_router
 from .dashboard.agent_overrides import (
     get_profile_default_repo,
     resolve_login_from_email,
 )
+from .dashboard.routes import get_babysitter_runtime_config
 from .reviewer_findings import (
     REVIEWER_THREAD_KIND,
     ReviewerPRMeta,
@@ -91,7 +99,18 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     validate_sandbox_startup_config()
-    yield
+    task: asyncio.Task[None] | None = None
+    if os.environ.get("BABYSITTER_CRON_ENABLED", "").lower() in {"1", "true", "yes"}:
+        task = asyncio.create_task(_babysitter_cron_loop())
+    try:
+        yield
+    finally:
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
 app = FastAPI(lifespan=lifespan)
@@ -338,6 +357,11 @@ def generate_thread_id_from_slack_thread(channel_id: str, thread_id: str) -> str
 
 def generate_reviewer_thread_id(owner: str, repo: str, pr_number: int) -> str:
     stable_key = f"{owner}/{repo}/pr/{pr_number}/reviewer"
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, stable_key))
+
+
+def generate_babysitter_thread_id(owner: str, repo: str, pr_number: int) -> str:
+    stable_key = f"{owner}/{repo}/pr/{pr_number}/babysitter"
     return str(uuid.uuid5(uuid.NAMESPACE_URL, stable_key))
 
 
@@ -1653,6 +1677,146 @@ async def trigger_pr_review_from_ref(
     return {"success": True, "queued": False, "thread_id": thread_id, "pr_url": pr_url}
 
 
+def build_github_pr_babysit_prompt(
+    repo_config: dict[str, str],
+    pr_number: int,
+    pr_url: str,
+    head_sha: str,
+    reason: str,
+) -> str:
+    return (
+        "Babysit this GitHub pull request.\n\n"
+        f"## Repository: {repo_config.get('owner')}/{repo_config.get('name')}\n\n"
+        f"## Pull Request: {pr_url}\n\n"
+        f"## PR Number: {pr_number}\n\n"
+        f"## Head SHA: {head_sha}\n\n"
+        f"## Trigger: {reason}\n\n"
+        "Inspect failed checks and actionable review comments, make a focused fix if appropriate, "
+        "push to the PR branch, and comment with the outcome."
+    )
+
+
+def _build_babysitter_configurable(
+    *,
+    source: str,
+    github_login: str,
+    github_user_id: int | None,
+    repo_config: dict[str, str],
+    pr_number: int,
+    pr_url: str,
+    base_sha: str,
+    head_sha: str,
+    branch_name: str,
+    reason: str,
+) -> dict[str, Any]:
+    configurable: dict[str, Any] = {
+        "source": source,
+        "github_login": github_login,
+        "github_user_id": github_user_id,
+        "repo": repo_config,
+        "pr_number": pr_number,
+        "pr_url": pr_url,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "babysit_reason": reason,
+    }
+    if branch_name:
+        configurable["branch_name"] = branch_name
+    return configurable
+
+
+async def trigger_pr_babysitter_from_ref(
+    pr_ref: GitHubPrRef,
+    *,
+    source: str,
+    github_login: str = "",
+    github_user_id: int | None = None,
+    reason: str = "manual",
+    create_run: bool = True,
+) -> dict[str, Any]:
+    repo_config = {"owner": pr_ref.owner, "name": pr_ref.repo}
+    if not _is_repo_allowed_for_reviewer(repo_config):
+        return {"success": False, "error": "Repository not allowed for babysitter"}
+
+    app_token, app_token_expires_at = await get_github_app_installation_token_with_expiry()
+    if not app_token:
+        return {"success": False, "error": "No GitHub App token available"}
+
+    pr_metadata = await fetch_github_pr_metadata(pr_ref, token=app_token)
+    if not pr_metadata:
+        return {"success": False, "error": "Could not fetch pull request metadata"}
+
+    base = pr_metadata.get("base", {})
+    head = pr_metadata.get("head", {})
+    base_sha = base.get("sha", "")
+    head_sha = head.get("sha", "")
+    branch_name = head.get("ref", "")
+    base_ref = base.get("ref", "")
+    pr_url = pr_metadata.get("html_url", "") or pr_ref.url
+    pr_title = pr_metadata.get("title", "")
+    if not base_sha or not head_sha:
+        return {"success": False, "error": "Pull request metadata is missing base/head SHA"}
+
+    thread_id = generate_babysitter_thread_id(pr_ref.owner, pr_ref.repo, pr_ref.number)
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    if not await _ensure_thread_exists_for_metadata(thread_id, langgraph_client):
+        return {"success": False, "error": "Could not create babysitter thread"}
+
+    try:
+        await persist_encrypted_github_token(thread_id, app_token, expires_at=app_token_expires_at)
+    except Exception:
+        logger.warning("Could not persist bot token for babysitter thread %s", thread_id)
+        return {"success": False, "error": "Could not persist babysitter token"}
+
+    pr_meta: BabysitterPRMeta = {
+        "owner": pr_ref.owner,
+        "name": pr_ref.repo,
+        "number": pr_ref.number,
+        "url": pr_url,
+        "title": pr_title,
+        "head_ref": branch_name,
+        "base_ref": base_ref,
+        "head_sha": head_sha,
+        "base_sha": base_sha,
+    }
+    await set_babysitter_thread_metadata(
+        thread_id,
+        pr=pr_meta,
+        watch=True,
+        last_seen_head_sha=head_sha,
+    )
+
+    if not create_run:
+        return {"success": True, "queued": False, "thread_id": thread_id, "pr_url": pr_url}
+
+    prompt = build_github_pr_babysit_prompt(repo_config, pr_ref.number, pr_url, head_sha, reason)
+    configurable = _build_babysitter_configurable(
+        source=source,
+        github_login=github_login,
+        github_user_id=github_user_id,
+        repo_config=repo_config,
+        pr_number=pr_ref.number,
+        pr_url=pr_url,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        branch_name=branch_name,
+        reason=reason,
+    )
+
+    if await is_thread_active(thread_id):
+        queued = await queue_message_for_thread(thread_id, prompt)
+        return {"success": queued, "queued": queued, "thread_id": thread_id, "pr_url": pr_url}
+
+    await langgraph_client.runs.create(
+        thread_id,
+        "babysitter",
+        input={"messages": [{"role": "user", "content": prompt}]},
+        config={"configurable": configurable, "metadata": _AGENT_VERSION_METADATA},
+        if_not_exists="create",
+    )
+    return {"success": True, "queued": False, "thread_id": thread_id, "pr_url": pr_url}
+
+
 def _build_reviewer_configurable(
     *,
     source: str,
@@ -1843,6 +2007,83 @@ async def process_github_pr_review_command(
             pr_ref.number,
             result.get("error"),
         )
+
+
+def parse_github_babysit_command(body: str) -> tuple[str | None, str | None]:
+    """Return (command, optional_pr_url) for @open-swe babysit commands."""
+    lowered = body.lower()
+    if not any(tag in lowered for tag in OPEN_SWE_TAGS):
+        return None, None
+    if "stop babysitting" in lowered or "stop babysit" in lowered:
+        return "stop", None
+    if "babysit" not in lowered:
+        return None, None
+    for token in body.split():
+        if "github.com/" in token and "/pull/" in token:
+            return "start", token.strip("<>()[]{}.,")
+    return "start", None
+
+
+async def process_github_pr_babysit_command(
+    payload: dict[str, Any],
+    event_type: str,
+    command: str,
+    pr_url_override: str | None,
+) -> None:
+    repo = payload.get("repository", {})
+    repo_config = {
+        "owner": repo.get("owner", {}).get("login", ""),
+        "name": repo.get("name", ""),
+    }
+    pr_data = payload.get("pull_request") or payload.get("issue", {})
+    sender = payload.get("sender", {})
+    github_login = sender.get("login", "")
+    github_user_id = sender.get("id")
+
+    if pr_url_override:
+        pr_ref = parse_github_pr_url(pr_url_override)
+        if pr_ref is None:
+            return
+    else:
+        pr_number = pr_data.get("number")
+        if not pr_number:
+            return
+        pr_ref = GitHubPrRef(
+            owner=repo_config["owner"],
+            repo=repo_config["name"],
+            number=pr_number,
+            url=pr_data.get("html_url", "") or pr_data.get("url", ""),
+        )
+
+    comment = payload.get("comment") or payload.get("review", {})
+    comment_id = comment.get("id")
+    node_id = comment.get("node_id") if event_type == "pull_request_review" else None
+    app_token = await get_github_app_installation_token()
+    if comment_id and app_token:
+        await react_to_github_comment(
+            repo_config,
+            comment_id,
+            event_type=event_type,
+            token=app_token,
+            pull_number=pr_data.get("number"),
+            node_id=node_id,
+        )
+
+    thread_id = generate_babysitter_thread_id(pr_ref.owner, pr_ref.repo, pr_ref.number)
+    if command == "stop":
+        metadata = await _get_thread_metadata_safe(thread_id)
+        if metadata is not None and metadata.get("kind") == BABYSITTER_THREAD_KIND:
+            await set_babysitter_thread_metadata(thread_id, watch=False)
+        return
+
+    await trigger_pr_babysitter_from_ref(
+        pr_ref,
+        source="github",
+        github_login=github_login,
+        github_user_id=github_user_id,
+        reason="manual babysit command",
+        create_run=True,
+    )
 
 
 async def _fetch_open_pr_for_branch(
@@ -2057,6 +2298,173 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
         config={"configurable": configurable, "metadata": _AGENT_VERSION_METADATA},
         if_not_exists="create",
     )
+
+
+async def _fetch_pr_check_runs(
+    repo_config: dict[str, str], head_sha: str, *, token: str
+) -> list[dict[str, Any]]:
+    owner = repo_config.get("owner", "")
+    repo = repo_config.get("name", "")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    async with httpx.AsyncClient() as http_client:
+        response = await http_client.get(
+            f"https://api.github.com/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
+            headers=headers,
+            params={"per_page": "100"},
+        )
+        response.raise_for_status()
+    data = response.json()
+    runs = data.get("check_runs") if isinstance(data, dict) else None
+    return [r for r in runs or [] if isinstance(r, dict)]
+
+
+def _failed_check_names(check_runs: list[dict[str, Any]]) -> list[str]:
+    failed: list[str] = []
+    for run in check_runs:
+        conclusion = run.get("conclusion")
+        status = run.get("status")
+        if status == "completed" and conclusion in {"failure", "timed_out", "action_required"}:
+            name = run.get("name")
+            failed.append(str(name or run.get("id") or "unknown"))
+    return failed
+
+
+async def _maybe_run_babysitter_for_thread(
+    thread_id: str,
+    metadata: dict[str, Any],
+    *,
+    app_token: str,
+) -> None:
+    pr = metadata.get("pr")
+    if not isinstance(pr, dict):
+        return
+    owner = pr.get("owner")
+    repo_name = pr.get("name")
+    pr_number = pr.get("number")
+    if not isinstance(owner, str) or not isinstance(repo_name, str) or not isinstance(pr_number, int):
+        return
+
+    repo_config = {"owner": owner, "name": repo_name}
+    pr_ref = GitHubPrRef(
+        owner=owner,
+        repo=repo_name,
+        number=pr_number,
+        url=str(pr.get("url") or ""),
+    )
+    pr_metadata = await fetch_github_pr_metadata(pr_ref, token=app_token)
+    if not pr_metadata:
+        return
+    if pr_metadata.get("state") != "open" or pr_metadata.get("merged"):
+        await set_babysitter_thread_metadata(thread_id, watch=False)
+        return
+
+    head = pr_metadata.get("head", {})
+    base = pr_metadata.get("base", {})
+    head_sha = str(head.get("sha") or "")
+    if not head_sha:
+        return
+    check_runs = await _fetch_pr_check_runs(repo_config, head_sha, token=app_token)
+    failed_checks = _failed_check_names(check_runs)
+    head_changed = metadata.get("last_seen_head_sha") not in {None, head_sha}
+    if not failed_checks and not head_changed:
+        await set_babysitter_thread_metadata(
+            thread_id,
+            last_checked_at=datetime.now(UTC).isoformat(),
+            last_seen_head_sha=head_sha,
+        )
+        return
+
+    action_key = f"{head_sha}:{','.join(sorted(failed_checks)) or 'head_changed'}"
+    if metadata.get("last_action_key") == action_key:
+        return
+    runtime_config = get_babysitter_runtime_config()
+    max_attempts = int(runtime_config.get("max_attempts_per_sha", 2))
+    attempts = int(metadata.get("fix_attempt_count") or 0)
+    if metadata.get("last_seen_head_sha") == head_sha and attempts >= max_attempts:
+        return
+    if await is_thread_active(thread_id):
+        return
+
+    pr_meta: BabysitterPRMeta = {
+        "owner": owner,
+        "name": repo_name,
+        "number": pr_number,
+        "url": pr_metadata.get("html_url", "") or pr_ref.url,
+        "title": pr_metadata.get("title", ""),
+        "head_ref": head.get("ref", ""),
+        "base_ref": base.get("ref", ""),
+        "head_sha": head_sha,
+        "base_sha": base.get("sha", ""),
+    }
+    await set_babysitter_thread_metadata(
+        thread_id,
+        pr=pr_meta,
+        watch=True,
+        last_checked_at=datetime.now(UTC).isoformat(),
+        last_seen_head_sha=head_sha,
+        last_action_key=action_key,
+        fix_attempt_count=attempts + 1,
+    )
+    await persist_encrypted_github_token(thread_id, app_token)
+
+    reason = (
+        f"failed checks: {', '.join(failed_checks)}" if failed_checks else "PR head changed"
+    )
+    prompt = build_github_pr_babysit_prompt(repo_config, pr_number, pr_meta["url"], head_sha, reason)
+    configurable = _build_babysitter_configurable(
+        source="babysitter_cron",
+        github_login="",
+        github_user_id=None,
+        repo_config=repo_config,
+        pr_number=pr_number,
+        pr_url=pr_meta["url"],
+        base_sha=str(base.get("sha") or ""),
+        head_sha=head_sha,
+        branch_name=str(head.get("ref") or ""),
+        reason=reason,
+    )
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    await langgraph_client.runs.create(
+        thread_id,
+        "babysitter",
+        input={"messages": [{"role": "user", "content": prompt}]},
+        config={"configurable": configurable, "metadata": _AGENT_VERSION_METADATA},
+        if_not_exists="create",
+    )
+
+
+async def run_babysitter_cron_once() -> None:
+    if not get_babysitter_runtime_config().get("enabled"):
+        return
+    app_token = await get_github_app_installation_token()
+    if not app_token:
+        logger.warning("No GitHub App token available for babysitter cron")
+        return
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    threads = await langgraph_client.threads.search(
+        metadata={"kind": BABYSITTER_THREAD_KIND, "watch": True},
+        limit=int(os.environ.get("BABYSITTER_CRON_THREAD_LIMIT", "50")),
+    )
+    for thread in threads:
+        thread_id = thread.get("thread_id") if isinstance(thread, dict) else None
+        metadata = thread.get("metadata") if isinstance(thread, dict) else None
+        if not isinstance(thread_id, str) or not isinstance(metadata, dict):
+            continue
+        try:
+            await _maybe_run_babysitter_for_thread(thread_id, metadata, app_token=app_token)
+        except Exception:
+            logger.exception("Babysitter cron failed for thread %s", thread_id)
+
+
+async def _babysitter_cron_loop() -> None:
+    while True:
+        await run_babysitter_cron_once()
+        interval = int(get_babysitter_runtime_config().get("poll_interval_seconds", 600))
+        await asyncio.sleep(interval)
 
 
 async def _refresh_thread_github_token_after_401(thread_id: str, email: str) -> str | None:
@@ -2506,6 +2914,18 @@ async def github_webhook(request: Request, background_tasks: BackgroundTasks) ->
         "pull_request_review_comment",
         "pull_request_review",
     }:
+        babysit_command, babysit_pr_url = parse_github_babysit_command(comment_body)
+        if babysit_command:
+            if not _is_repo_allowed_for_reviewer(webhook_repo_config):
+                return {"status": "ignored", "reason": "Repository not in reviewer allowlist"}
+            background_tasks.add_task(
+                process_github_pr_babysit_command,
+                payload,
+                event_type,
+                babysit_command,
+                babysit_pr_url,
+            )
+            return {"status": "accepted", "message": "Processing GitHub PR babysit command"}
         is_review_command, pr_url_override = parse_github_review_command(comment_body)
         if is_review_command:
             if not _is_repo_allowed_for_reviewer(webhook_repo_config):

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -2019,8 +2019,9 @@ def parse_github_babysit_command(body: str) -> tuple[str | None, str | None]:
     if "babysit" not in lowered:
         return None, None
     for token in body.split():
-        if "github.com/" in token and "/pull/" in token:
-            return "start", token.strip("<>()[]{}.,")
+        candidate = token.strip("<>()[]{}.,")
+        if parse_github_pr_url(candidate) is not None:
+            return "start", candidate
     return "start", None
 
 
@@ -2345,7 +2346,11 @@ async def _maybe_run_babysitter_for_thread(
     owner = pr.get("owner")
     repo_name = pr.get("name")
     pr_number = pr.get("number")
-    if not isinstance(owner, str) or not isinstance(repo_name, str) or not isinstance(pr_number, int):
+    if (
+        not isinstance(owner, str)
+        or not isinstance(repo_name, str)
+        or not isinstance(pr_number, int)
+    ):
         return
 
     repo_config = {"owner": owner, "name": repo_name}
@@ -2411,10 +2416,10 @@ async def _maybe_run_babysitter_for_thread(
     )
     await persist_encrypted_github_token(thread_id, app_token)
 
-    reason = (
-        f"failed checks: {', '.join(failed_checks)}" if failed_checks else "PR head changed"
+    reason = f"failed checks: {', '.join(failed_checks)}" if failed_checks else "PR head changed"
+    prompt = build_github_pr_babysit_prompt(
+        repo_config, pr_number, pr_meta["url"], head_sha, reason
     )
-    prompt = build_github_pr_babysit_prompt(repo_config, pr_number, pr_meta["url"], head_sha, reason)
     configurable = _build_babysitter_configurable(
         source="babysitter_cron",
         github_login="",

--- a/langgraph.json
+++ b/langgraph.json
@@ -3,7 +3,8 @@
   "python_version": "3.12",
   "graphs": {
     "agent": "agent.server:get_agent",
-    "reviewer": "agent.reviewer:get_reviewer_agent"
+    "reviewer": "agent.reviewer:get_reviewer_agent",
+    "babysitter": "agent.babysitter:get_babysitter_agent"
   },
   "dependencies": ["."],
   "http": {

--- a/tests/test_github_issue_webhook.py
+++ b/tests/test_github_issue_webhook.py
@@ -94,6 +94,18 @@ def test_build_github_issue_followup_prompt_only_includes_comment() -> None:
     assert "## Title" not in prompt
 
 
+def test_parse_github_babysit_command_accepts_github_pr_url() -> None:
+    assert webapp.parse_github_babysit_command(
+        "@open-swe babysit https://github.com/langchain-ai/open-swe/pull/1314"
+    ) == ("start", "https://github.com/langchain-ai/open-swe/pull/1314")
+
+
+def test_parse_github_babysit_command_rejects_embedded_github_pr_url() -> None:
+    assert webapp.parse_github_babysit_command(
+        "@open-swe babysit https://example.com/github.com/langchain-ai/open-swe/pull/1314"
+    ) == ("start", None)
+
+
 def test_reviewer_repo_allowlist_allows_matching_repo(monkeypatch) -> None:
     monkeypatch.setattr(webapp, "ALLOWED_REVIEWER_GITHUB_ORGS", frozenset())
     monkeypatch.setattr(

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -41,6 +41,15 @@ export function AppHeader({ user }: { user: SessionUser }) {
               Admin
             </Link>
           )}
+          {user.is_admin && (
+            <Link
+              to="/agents"
+              className="text-muted-foreground hover:text-foreground"
+              activeProps={{ className: "text-foreground font-medium" }}
+            >
+              Active agents
+            </Link>
+          )}
         </nav>
         <div className="ml-auto flex items-center gap-3">
           {user.is_admin && <Badge variant="secondary">admin</Badge>}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -86,6 +86,21 @@ export interface ReposPayload {
   repositories: Array<Repository>;
 }
 
+export interface ActiveAgent {
+  thread_id: string;
+  run_id: string;
+  status: string;
+  assistant_id?: string;
+  created_at?: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface BabysitterConfig {
+  enabled: boolean;
+  poll_interval_seconds: number;
+  max_attempts_per_sha: number;
+}
+
 export const api = {
   me: () => request<SessionUser>("/me"),
   options: () => request<{ models: Array<ModelOption> }>("/options"),
@@ -93,6 +108,18 @@ export const api = {
   saveProfile: (body: ProfileUpdate) =>
     request<Profile>("/profile", { method: "PUT", body: JSON.stringify(body) }),
   repos: () => request<ReposPayload>("/repos"),
+  activeAgents: () => request<Array<ActiveAgent>>("/agents/active"),
+  cancelRun: (threadId: string, runId: string) =>
+    request<void>(
+      `/agents/${encodeURIComponent(threadId)}/runs/${encodeURIComponent(runId)}/cancel`,
+      { method: "POST" },
+    ),
+  babysitterConfig: () => request<BabysitterConfig>("/babysitter/config"),
+  saveBabysitterConfig: (body: BabysitterConfig) =>
+    request<BabysitterConfig>("/babysitter/config", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
   adminListProfiles: () => request<Array<Profile>>("/admin/profiles"),
   adminSaveProfile: (login: string, body: ProfileUpdate & { email?: string }) =>
     request<Profile>(`/admin/profiles/${encodeURIComponent(login)}`, {

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AdminRouteImport } from './routes/admin'
+import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as IndexRouteImport } from './routes/index'
 
 const ProfileRoute = ProfileRouteImport.update({
@@ -29,6 +30,11 @@ const AdminRoute = AdminRouteImport.update({
   path: '/admin',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AgentsRoute = AgentsRouteImport.update({
+  id: '/agents',
+  path: '/agents',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -38,12 +44,14 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
+  '/agents': typeof AgentsRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
+  '/agents': typeof AgentsRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
 }
@@ -51,19 +59,21 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
+  '/agents': typeof AgentsRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/admin' | '/login' | '/profile'
+  fullPaths: '/' | '/admin' | '/agents' | '/login' | '/profile'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/admin' | '/login' | '/profile'
-  id: '__root__' | '/' | '/admin' | '/login' | '/profile'
+  to: '/' | '/admin' | '/agents' | '/login' | '/profile'
+  id: '__root__' | '/' | '/admin' | '/agents' | '/login' | '/profile'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AgentsRoute: typeof AgentsRoute
   AdminRoute: typeof AdminRoute
   LoginRoute: typeof LoginRoute
   ProfileRoute: typeof ProfileRoute
@@ -92,6 +102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/agents': {
+      id: '/agents'
+      path: '/agents'
+      fullPath: '/agents'
+      preLoaderRoute: typeof AgentsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +121,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AgentsRoute: AgentsRoute,
   AdminRoute: AdminRoute,
   LoginRoute: LoginRoute,
   ProfileRoute: ProfileRoute,

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -1,0 +1,172 @@
+import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { AppHeader } from "@/components/AppHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { api } from "@/lib/api";
+import { useSession } from "@/lib/session";
+
+export const Route = createFileRoute("/agents")({ component: AgentsPage });
+
+function AgentsPage() {
+  const session = useSession();
+  const qc = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const agents = useQuery({
+    queryKey: ["activeAgents"],
+    queryFn: api.activeAgents,
+    enabled: !!session.data?.is_admin,
+    refetchInterval: 10000,
+  });
+  const config = useQuery({
+    queryKey: ["babysitterConfig"],
+    queryFn: api.babysitterConfig,
+    enabled: !!session.data?.is_admin,
+  });
+  const saveConfig = useMutation({
+    mutationFn: api.saveBabysitterConfig,
+    onSuccess: (saved) => {
+      qc.setQueryData(["babysitterConfig"], saved);
+      setError(null);
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+  const cancel = useMutation({
+    mutationFn: ({ threadId, runId }: { threadId: string; runId: string }) =>
+      api.cancelRun(threadId, runId),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["activeAgents"] }),
+    onError: (e: Error) => setError(e.message),
+  });
+
+  if (session.isLoading) {
+    return (
+      <main className="container mx-auto p-6">
+        <Skeleton className="h-64 w-full" />
+      </main>
+    );
+  }
+  if (!session.data) return <Navigate to="/login" />;
+  if (!session.data.is_admin) return <Navigate to="/profile" />;
+
+  const current = config.data ?? {
+    enabled: false,
+    poll_interval_seconds: 600,
+    max_attempts_per_sha: 2,
+  };
+
+  return (
+    <div className="min-h-svh">
+      <AppHeader user={session.data} />
+      <main className="container mx-auto grid grid-cols-1 gap-6 p-6 lg:grid-cols-[320px_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Babysitter</CardTitle>
+            <CardDescription>Configuration for PR babysitting.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {config.isLoading ? (
+              <Skeleton className="h-40 w-full" />
+            ) : (
+              <>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={current.enabled}
+                    onChange={(e) =>
+                      saveConfig.mutate({ ...current, enabled: e.currentTarget.checked })
+                    }
+                  />
+                  Enabled
+                </label>
+                <div className="space-y-2">
+                  <Label htmlFor="poll">Poll interval</Label>
+                  <Input
+                    id="poll"
+                    type="number"
+                    min={60}
+                    value={current.poll_interval_seconds}
+                    onChange={(e) =>
+                      saveConfig.mutate({
+                        ...current,
+                        poll_interval_seconds: Number(e.currentTarget.value),
+                      })
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="attempts">Max attempts per SHA</Label>
+                  <Input
+                    id="attempts"
+                    type="number"
+                    min={0}
+                    value={current.max_attempts_per_sha}
+                    onChange={(e) =>
+                      saveConfig.mutate({
+                        ...current,
+                        max_attempts_per_sha: Number(e.currentTarget.value),
+                      })
+                    }
+                  />
+                </div>
+              </>
+            )}
+            {error && <p className="text-destructive text-sm">{error}</p>}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Active agents</CardTitle>
+            <CardDescription>{agents.data?.length ?? 0} running or pending runs</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {agents.isLoading ? (
+              <Skeleton className="h-48 w-full" />
+            ) : agents.data?.length ? (
+              agents.data.map((agent) => {
+                const pr = agent.metadata.pr as
+                  | { owner?: string; name?: string; number?: number; title?: string }
+                  | undefined;
+                return (
+                  <div
+                    key={`${agent.thread_id}:${agent.run_id}`}
+                    className="flex items-center gap-4 rounded-md border p-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">
+                        {agent.assistant_id ?? "agent"} · {agent.status}
+                      </div>
+                      <div className="text-muted-foreground truncate text-sm">
+                        {pr?.owner && pr?.name && pr?.number
+                          ? `${pr.owner}/${pr.name}#${pr.number}`
+                          : agent.thread_id}
+                      </div>
+                    </div>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={cancel.isPending}
+                      onClick={() =>
+                        cancel.mutate({ threadId: agent.thread_id, runId: agent.run_id })
+                      }
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                );
+              })
+            ) : (
+              <p className="text-muted-foreground text-sm">No active agents.</p>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a PR-scoped babysitter graph and metadata helpers
- add cron polling plus GitHub comment commands for starting/stopping babysitting
- add dashboard active agents/config UI and cancel endpoint

## Tests
- uv run --extra dev ruff check agent/babysitter.py agent/babysitter_state.py agent/webapp.py agent/dashboard/routes.py
- bun run typecheck
- uv run --extra dev pytest -q tests/test_reviewer_watch.py tests/test_github_issue_webhook.py