### PR TITLE
fix: fall back to bot PR author

### DIFF
--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -416,7 +416,11 @@ async def resolve_github_token(
             github_login = configurable.get("github_login")
             email = GITHUB_USER_EMAIL_MAP.get(github_login or "")
             if not email:
-                raise ValueError(f"No email mapping found for GitHub user '{github_login}'")
+                logger.info(
+                    "No email mapping found for GitHub user %r; using GitHub App token",
+                    github_login,
+                )
+                return await _resolve_bot_installation_token(thread_id)
             return await save_encrypted_token_from_email(email, source)
         return await save_encrypted_token_from_email(configurable.get("user_email"), source)
     except ValueError as exc:

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -2059,7 +2059,7 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
     )
 
 
-async def _refresh_thread_github_token_after_401(thread_id: str, email: str) -> str | None:
+async def _refresh_thread_github_token_after_401(thread_id: str, email: str | None) -> str | None:
     """Invalidate the cached token after a 401 and try to resolve a fresh one."""
     logger.warning(
         "GitHub returned 401 for thread %s; invalidating cached token and re-resolving",
@@ -2069,7 +2069,7 @@ async def _refresh_thread_github_token_after_401(thread_id: str, email: str) -> 
     return await _get_or_resolve_thread_github_token(thread_id, email)
 
 
-async def _get_or_resolve_thread_github_token(thread_id: str, email: str) -> str | None:
+async def _get_or_resolve_thread_github_token(thread_id: str, email: str | None) -> str | None:
     """Resolve and persist a GitHub token for a thread when available.
 
     Skips the cached ciphertext when its ``github_token_expires_at`` is past.
@@ -2090,6 +2090,17 @@ async def _get_or_resolve_thread_github_token(thread_id: str, email: str) -> str
     github_token, _encrypted_token, _expires_at = await get_github_token_from_thread(thread_id)
     if github_token:
         return github_token
+
+    if not email:
+        bot_token, expires_at = await get_github_app_installation_token_with_expiry()
+        if bot_token:
+            try:
+                await persist_encrypted_github_token(thread_id, bot_token, expires_at=expires_at)
+            except Exception:
+                logger.warning("Could not persist bot token for thread %s", thread_id)
+            return bot_token
+        logger.warning("No email mapping and GitHub App token unavailable for thread %s", thread_id)
+        return None
 
     auth_result = await resolve_github_token_from_email(email)
     github_token = auth_result.get("token")
@@ -2162,8 +2173,7 @@ async def process_github_pr_comment(payload: dict[str, Any], event_type: str) ->
 
     email = GITHUB_USER_EMAIL_MAP.get(github_login, "")
     if not email:
-        logger.warning("No email mapping for GitHub user '%s', skipping", github_login)
-        return
+        logger.info("No email mapping for GitHub user %r; using GitHub App token", github_login)
 
     github_token = await _get_or_resolve_thread_github_token(thread_id, email)
     if not github_token:
@@ -2257,8 +2267,7 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
 
     email = GITHUB_USER_EMAIL_MAP.get(github_login, "")
     if not email:
-        logger.warning("No email mapping for GitHub user '%s', skipping", github_login)
-        return
+        logger.info("No email mapping for GitHub user %r; using GitHub App token", github_login)
 
     thread_id = generate_thread_id_from_github_issue(issue_id)
     existing_thread = await _thread_exists(thread_id)

--- a/tests/test_auth_sources.py
+++ b/tests/test_auth_sources.py
@@ -85,3 +85,35 @@ def test_leave_failure_comment_falls_back_to_slack_thread_when_ephemeral_fails(
     asyncio.run(auth.leave_failure_comment("slack", "auth failed"))
 
     assert thread_called == {"channel_id": "C123", "thread_ts": "1.2", "message": "auth failed"}
+
+
+def test_github_source_without_email_mapping_uses_bot_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_github_token_from_thread(thread_id: str) -> tuple[None, None, None]:
+        return None, None, None
+
+    async def fake_resolve_bot_installation_token(thread_id: str) -> tuple[str, str, str]:
+        return "bot-token", "encrypted-bot-token", "2026-05-20T00:00:00+00:00"
+
+    async def fake_save_encrypted_token_from_email(email: str | None, source: str):
+        raise AssertionError("unmapped GitHub users should not resolve a user token")
+
+    monkeypatch.setattr(auth, "is_bot_token_only_mode", lambda: False)
+    monkeypatch.setattr(auth, "get_github_token_from_thread", fake_get_github_token_from_thread)
+    monkeypatch.setattr(
+        auth, "_resolve_bot_installation_token", fake_resolve_bot_installation_token
+    )
+    monkeypatch.setattr(
+        auth, "save_encrypted_token_from_email", fake_save_encrypted_token_from_email
+    )
+    monkeypatch.setattr(auth, "GITHUB_USER_EMAIL_MAP", {"octocat": "octocat@example.com"})
+
+    result = asyncio.run(
+        auth.resolve_github_token(
+            {"configurable": {"source": "github", "github_login": "external-user"}},
+            "thread-id",
+        )
+    )
+
+    assert result == ("bot-token", "encrypted-bot-token", "2026-05-20T00:00:00+00:00")

--- a/tests/test_github_issue_webhook.py
+++ b/tests/test_github_issue_webhook.py
@@ -981,6 +981,83 @@ def test_process_github_issue_uses_resolved_user_token_for_reaction(monkeypatch)
     assert captured["run_created"] is True
 
 
+def test_process_github_issue_without_email_mapping_uses_bot_token(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_get_or_resolve_thread_github_token(
+        thread_id: str, email: str | None
+    ) -> str | None:
+        captured["email"] = email
+        return "bot-token"
+
+    async def fake_get_github_app_installation_token() -> str | None:
+        return "bot-token"
+
+    async def fake_react_to_github_comment(
+        repo_config: dict[str, str],
+        comment_id: int,
+        *,
+        event_type: str,
+        token: str,
+        pull_number: int | None = None,
+        node_id: str | None = None,
+    ) -> bool:
+        captured["reaction_token"] = token
+        return True
+
+    async def fake_fetch_issue_comments(
+        repo_config: dict[str, str], issue_number: int, *, token: str | None = None
+    ) -> list[dict[str, object]]:
+        captured["fetch_token"] = token
+        return []
+
+    async def fake_is_thread_active(thread_id: str) -> bool:
+        return False
+
+    class _FakeRunsClient:
+        async def create(self, *args, **kwargs) -> None:
+            captured["run_config"] = kwargs["config"]["configurable"]
+
+    class _FakeLangGraphClient:
+        runs = _FakeRunsClient()
+
+    monkeypatch.setattr(
+        webapp, "_get_or_resolve_thread_github_token", fake_get_or_resolve_thread_github_token
+    )
+    monkeypatch.setattr(
+        webapp, "get_github_app_installation_token", fake_get_github_app_installation_token
+    )
+    monkeypatch.setattr(webapp, "_thread_exists", lambda thread_id: asyncio.sleep(0, result=False))
+    monkeypatch.setattr(webapp, "react_to_github_comment", fake_react_to_github_comment)
+    monkeypatch.setattr(webapp, "fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(webapp, "is_thread_active", fake_is_thread_active)
+    monkeypatch.setattr(webapp, "get_client", lambda url: _FakeLangGraphClient())
+    monkeypatch.setattr(webapp, "GITHUB_USER_EMAIL_MAP", {"octocat": "octocat@example.com"})
+
+    asyncio.run(
+        webapp.process_github_issue(
+            {
+                "issue": {
+                    "id": 12345,
+                    "number": 42,
+                    "title": "Fix the flaky test",
+                    "body": "The test is failing intermittently.",
+                    "html_url": "https://github.com/langchain-ai/open-swe/issues/42",
+                },
+                "comment": {"id": 999, "body": "@openswe please handle this"},
+                "repository": {"owner": {"login": "langchain-ai"}, "name": "open-swe"},
+                "sender": {"login": "external-user"},
+            },
+            "issue_comment",
+        )
+    )
+
+    assert captured["email"] == ""
+    assert captured["reaction_token"] == "bot-token"
+    assert captured["fetch_token"] == "bot-token"
+    assert captured["run_config"]["github_login"] == "external-user"
+
+
 def test_process_github_issue_existing_thread_uses_followup_prompt(monkeypatch) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Description
GitHub-triggered runs now use a mapped user OAuth token when available and fall back to the Open SWE GitHub App token for unmapped users. This lets PRs open under the mapped user account when possible, otherwise as open-swe.

## Release Note
none

## Test Plan
- [x] Covered mapped and unmapped GitHub auth paths with focused unit tests.