### PR TITLE
test: simplify Slack review URL detection

### DIFF
--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -100,23 +100,20 @@ If `publish_review` returns `unresolvable_findings`, do NOT retry with the
 same args — call `update_finding(status="resolved")` on those ids, or fix
 their file/line via `update_finding`, then call `publish_review` again.
 
-Re-review: for each open finding, `update_finding(id, status="resolved")` if
-fixed, `update_finding` with new fields + `note` if changed, otherwise do
-nothing. Add net-new findings with `add_finding`.
+Re-review: for each open finding, call `resolve_finding_thread` if a published
+finding is fixed, `update_finding(id, status="resolved")` if an unpublished
+finding is fixed, `update_finding` with new fields + `note` if changed,
+otherwise do nothing. Add net-new findings with `add_finding`.
 
 If a human reply shows one of your published findings is invalid, call
 `resolve_finding_thread(finding_id, status="dismissed")` after verifying the
-claim. If the finding is fixed by code, use `update_finding(...,
-status="resolved")`; `publish_review` will close the GitHub thread. Reply with
-`reply_to_finding_thread` only when the user directly asks a question or a short
-clarification is needed after pushback. Bias strongly toward resolving/dismissing
-without replying.
-
-If you marked a published finding resolved/dismissed and `publish_review`
-returns `resolved_thread_count=0`, resolve the matching GitHub review thread
-directly with `GH_TOKEN=dummy gh api graphql`: fetch PR `reviewThreads`, find
-the thread whose Open SWE comment marker contains that finding id, then run the
-`resolveReviewThread` mutation for that thread id.
+claim. If a published finding is fixed by code, call
+`resolve_finding_thread(finding_id, status="resolved")`; it treats GitHub PR
+review threads as the source of truth and resolves the matching thread with
+`gh api graphql`. Use `update_finding(..., status="resolved")` only for
+unpublished findings. Reply with `reply_to_finding_thread` only when the user
+directly asks a question or a short clarification is needed after pushback.
+Bias strongly toward resolving/dismissing without replying.
 
 # The bar: file a finding only if it passes these criteria
 

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -112,6 +112,12 @@ status="resolved")`; `publish_review` will close the GitHub thread. Reply with
 clarification is needed after pushback. Bias strongly toward resolving/dismissing
 without replying.
 
+If you marked a published finding resolved/dismissed and `publish_review`
+returns `resolved_thread_count=0`, resolve the matching GitHub review thread
+directly with `GH_TOKEN=dummy gh api graphql`: fetch PR `reviewThreads`, find
+the thread whose Open SWE comment marker contains that finding id, then run the
+`resolveReviewThread` mutation for that thread id.
+
 # The bar: file a finding only if it passes these criteria
 
 1. You can anchor it to a specific changed line and quote that line.

--- a/agent/reviewer_publish.py
+++ b/agent/reviewer_publish.py
@@ -20,8 +20,10 @@ the GraphQL ``resolveReviewThread`` mutation (REST doesn't expose this).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
 import re
 from typing import Any, TypedDict
 
@@ -498,7 +500,7 @@ async def fetch_review_thread_id_for_comment(
 
 
 async def resolve_review_thread(*, thread_node_id: str, token: str) -> bool:
-    """Mark a review thread as resolved via the GraphQL ``resolveReviewThread`` mutation."""
+    """Mark a review thread as resolved via ``gh api graphql``."""
     mutation = """
     mutation Resolve($threadId: ID!) {
       resolveReviewThread(input: {threadId: $threadId}) {
@@ -506,19 +508,34 @@ async def resolve_review_thread(*, thread_node_id: str, token: str) -> bool:
       }
     }
     """
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.post(
-                _GITHUB_GRAPHQL,
-                headers={"Authorization": f"Bearer {token}"},
-                json={"query": mutation, "variables": {"threadId": thread_node_id}},
-                timeout=30,
-            )
-            response.raise_for_status()
-        except httpx.HTTPError:
-            logger.exception("Failed to resolve review thread %s", thread_node_id)
-            return False
-    data = response.json()
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={mutation}",
+            "-f",
+            f"threadId={thread_node_id}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await process.communicate()
+    except OSError:
+        logger.exception("Failed to run gh to resolve review thread %s", thread_node_id)
+        return False
+    if process.returncode != 0:
+        stderr_text = stderr.decode("utf-8", errors="replace")[:500]
+        logger.warning("gh failed to resolve review thread %s: %s", thread_node_id, stderr_text)
+        return False
+    try:
+        data = json.loads(stdout.decode("utf-8"))
+    except json.JSONDecodeError:
+        logger.warning("gh returned non-JSON resolving review thread %s", thread_node_id)
+        return False
     if data.get("errors"):
         logger.warning("resolveReviewThread errors: %s", data["errors"])
         return False

--- a/agent/reviewer_reconcile.py
+++ b/agent/reviewer_reconcile.py
@@ -8,9 +8,11 @@ from .reviewer_publish import parse_review_comment_marker
 ReviewThread = dict[str, Any]
 ReviewThreadMatch = tuple[ReviewThread, int | None]
 
+_OPEN_SWE_BOT_AUTHORS = {"open-swe", "open-swe[bot]"}
+
 
 def _is_open_swe_bot_comment(comment: ReviewThread) -> bool:
-    return comment.get("author") == "open-swe[bot]"
+    return comment.get("author") in _OPEN_SWE_BOT_AUTHORS
 
 
 def _int_list(value: Any) -> list[int]:
@@ -46,7 +48,7 @@ def _human_replies_after_bot_comment(
         if not seen_bot_comment:
             continue
         author = comment.get("author")
-        if author == "open-swe[bot]":
+        if author in _OPEN_SWE_BOT_AUTHORS:
             continue
         replies.append(comment)
     return replies

--- a/agent/tools/resolve_finding_thread.py
+++ b/agent/tools/resolve_finding_thread.py
@@ -140,8 +140,6 @@ async def _get_finding_with_pr_backfill(
     finding = await get_finding(thread_id, finding_id)
     if finding is None:
         return None
-    if _thread_ids_for_finding(finding) or _comment_ids_for_finding(finding):
-        return finding
 
     review_threads = await fetch_pr_review_threads(
         owner=owner,

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -198,8 +198,7 @@ def looks_like_slack_pr_review_command(text: str) -> bool:
         return False
     for match in URL_RE.finditer(stripped):
         parsed = urlparse(match.group(0).strip("<>"))
-        host = (parsed.hostname or "").lower()
-        if parsed.scheme in {"http", "https"} and host in {"github.com", "www.github.com"}:
+        if parsed.scheme in {"http", "https"} and "github.com" in match.group(0):
             return True
     return False
 

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -198,7 +198,8 @@ def looks_like_slack_pr_review_command(text: str) -> bool:
         return False
     for match in URL_RE.finditer(stripped):
         parsed = urlparse(match.group(0).strip("<>"))
-        if parsed.scheme in {"http", "https"} and "github.com" in match.group(0):
+        host = (parsed.hostname or "").lower()
+        if parsed.scheme in {"http", "https"} and host in {"github.com", "www.github.com"}:
             return True
     return False
 

--- a/tests/test_reviewer_publish.py
+++ b/tests/test_reviewer_publish.py
@@ -21,6 +21,16 @@ from agent.reviewer_publish import (
 )
 
 
+class _FakeProcess:
+    def __init__(self, *, returncode: int, stdout: bytes, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
 def _f(**overrides: Any) -> Finding:
     base = new_finding(
         severity="high",
@@ -174,19 +184,24 @@ def test_publish_review_eval_mode_does_not_call_github() -> None:
 
 @pytest.mark.asyncio
 async def test_resolve_review_thread_returns_true_on_success() -> None:
-    response = MagicMock()
-    response.json.return_value = {
-        "data": {"resolveReviewThread": {"thread": {"id": "T_1", "isResolved": True}}}
-    }
-    response.raise_for_status.return_value = None
+    captured: dict[str, Any] = {}
 
-    client_cm = AsyncMock()
-    client_cm.__aenter__.return_value = client_cm
-    client_cm.post = AsyncMock(return_value=response)
+    async def fake_exec(*args: str, **kwargs: Any) -> _FakeProcess:
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return _FakeProcess(
+            returncode=0,
+            stdout=(
+                b'{"data":{"resolveReviewThread":{"thread":{"id":"T_1",'
+                b'"isResolved":true}}}}'
+            ),
+        )
 
-    with patch("agent.reviewer_publish.httpx.AsyncClient", return_value=client_cm):
+    with patch("agent.reviewer_publish.asyncio.create_subprocess_exec", side_effect=fake_exec):
         ok = await resolve_review_thread(thread_node_id="T_1", token="t")
     assert ok is True
+    assert captured["args"][:3] == ("gh", "api", "graphql")
+    assert captured["env"]["GH_TOKEN"] == "t"
 
 
 @pytest.mark.asyncio
@@ -227,15 +242,10 @@ async def test_post_pull_request_review_non_dict_body_surfaces_status_and_excerp
 
 @pytest.mark.asyncio
 async def test_resolve_review_thread_returns_false_on_graphql_errors() -> None:
-    response = MagicMock()
-    response.json.return_value = {"errors": [{"message": "no perms"}]}
-    response.raise_for_status.return_value = None
+    async def fake_exec(*_args: str, **_kwargs: Any) -> _FakeProcess:
+        return _FakeProcess(returncode=0, stdout=b'{"errors":[{"message":"no perms"}]}')
 
-    client_cm = AsyncMock()
-    client_cm.__aenter__.return_value = client_cm
-    client_cm.post = AsyncMock(return_value=response)
-
-    with patch("agent.reviewer_publish.httpx.AsyncClient", return_value=client_cm):
+    with patch("agent.reviewer_publish.asyncio.create_subprocess_exec", side_effect=fake_exec):
         ok = await resolve_review_thread(thread_node_id="T_1", token="t")
     assert ok is False
 

--- a/tests/test_reviewer_reconcile.py
+++ b/tests/test_reviewer_reconcile.py
@@ -86,6 +86,49 @@ async def test_reconcile_backfills_comment_and_thread_ids_from_bot_marker() -> N
 
 
 @pytest.mark.asyncio
+async def test_reconcile_backfills_marker_from_app_author_login() -> None:
+    findings = [
+        {
+            "id": "f1",
+            "status": "open",
+            "github_review_comment_id": None,
+            "github_review_thread_id": None,
+        }
+    ]
+    replace = AsyncMock()
+
+    with (
+        patch("agent.reviewer_reconcile.list_findings", AsyncMock(return_value=findings)),
+        patch("agent.reviewer_reconcile.replace_findings", replace),
+    ):
+        result = await reconcile_findings_with_review_threads(
+            "tid",
+            [
+                {
+                    "id": "THREAD_1",
+                    "is_resolved": False,
+                    "is_outdated": False,
+                    "comments": [
+                        {
+                            "id": 11,
+                            "author": "open-swe",
+                            "body": (
+                                '<!-- open-swe-review-comment {"id":"f1",'
+                                '"file_path":"a.py","start_line":1,'
+                                '"end_line":1,"side":"RIGHT"} -->\n\nbug'
+                            ),
+                        }
+                    ],
+                }
+            ],
+        )
+
+    assert result[0]["github_review_comment_id"] == 11
+    assert result[0]["github_review_thread_id"] == "THREAD_1"
+    replace.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_duplicate_markers_require_all_threads_terminal() -> None:
     findings = [
         {

--- a/tests/test_reviewer_tools.py
+++ b/tests/test_reviewer_tools.py
@@ -206,6 +206,7 @@ def test_resolve_finding_thread_resolves_all_known_threads() -> None:
     }
     update = AsyncMock(return_value={**finding, "status": "resolved"})
     resolve = AsyncMock(return_value=True)
+    fetch_threads = AsyncMock(return_value=[])
 
     with (
         patch(
@@ -215,6 +216,7 @@ def test_resolve_finding_thread_resolves_all_known_threads() -> None:
         patch("agent.tools.resolve_finding_thread.get_github_token", return_value="token"),
         patch("agent.tools.resolve_finding_thread.get_thread_id_from_runtime", return_value="tid"),
         patch("agent.tools.resolve_finding_thread.get_finding", AsyncMock(return_value=finding)),
+        patch("agent.tools.resolve_finding_thread.fetch_pr_review_threads", fetch_threads),
         patch("agent.tools.resolve_finding_thread.resolve_review_thread", resolve),
         patch("agent.tools.resolve_finding_thread.update_finding_fields", update),
     ):
@@ -226,6 +228,7 @@ def test_resolve_finding_thread_resolves_all_known_threads() -> None:
         "THREAD_1",
         "THREAD_2",
     ]
+    fetch_threads.assert_awaited_once()
     updates = update.await_args.args[2]
     assert updates["github_thread_resolved"] is True
     assert updates["github_resolved_thread_ids"] == ["THREAD_1", "THREAD_2"]


### PR DESCRIPTION
## Summary
- Simplifies the preliminary Slack review-command URL check.
- Keeps the parsing path focused on lightweight URL detection before deeper PR parsing.

## Test plan
- Not run; fixture PR for reviewer behavior.