### PR TITLE
test: auto comment resolution

### DIFF
--- a/agent/utils/text_truncate.py
+++ b/agent/utils/text_truncate.py
@@ -8,4 +8,6 @@ def truncate_with_ellipsis(text: str, max_len: int) -> str:
     """
     if len(text) <= max_len:
         return text
-    return text[:max_len] + "..."
+    if max_len <= 3:
+        return "..."[:max_len]
+    return text[: max_len - 3] + "..."

--- a/agent/utils/text_truncate.py
+++ b/agent/utils/text_truncate.py
@@ -1,0 +1,11 @@
+"""Small text helpers."""
+
+
+def truncate_with_ellipsis(text: str, max_len: int) -> str:
+    """Truncate text to max_len characters, appending '...' if truncated.
+
+    The returned string is guaranteed to be at most max_len characters long.
+    """
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."


### PR DESCRIPTION
Test PR for verifying auto comment resolution in open-swe reviewer.

Adds a small `truncate_with_ellipsis` helper that contains a deliberate bug for the reviewer to find. A follow-up commit will fix it to verify the reviewer's comment-resolution behavior.

Do not merge.