### PR TITLE
feat: add diff addition-percentage helper

### DIFF
--- a/agent/utils/diff_stats.py
+++ b/agent/utils/diff_stats.py
@@ -1,0 +1,13 @@
+"""Helpers for summarizing diff statistics."""
+
+from __future__ import annotations
+
+
+def addition_percentage(added_lines: int, total_lines: int) -> float:
+    """Return the percentage of changed lines that are additions.
+
+    The result is a value between 0 and 100, e.g. 25.0 means a quarter of the
+    changed lines were added.
+    """
+
+    return added_lines / total_lines


### PR DESCRIPTION
## Summary

Adds a small helper, `addition_percentage`, for summarizing diff statistics — it reports what share of the changed lines in a diff were additions. Useful for surfacing "mostly-additions vs mostly-deletions" context in review summaries.

## Changes

- New `agent/utils/diff_stats.py` with `addition_percentage(added_lines, total_lines)`.

## Notes

Pure helper, no callers wired up yet — intended to be consumed by the reviewer summary path in a follow-up.