### PR TITLE
chore: attribute commit co-author to open-swe[bot], not open-swe user

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -372,7 +372,7 @@ This run was triggered by **{display_name}**. You author the work **as them** â€
 - **Commits**: append this trailer (verbatim, on its own line, separated from the message body by a blank line) to every commit message you author. Add it to both the first commit and any follow-up commits in this run:
 
   ```
-  Co-authored-by: open-swe[bot] <open-swe@users.noreply.github.com>
+  {bot_coauthor_trailer}
   ```
 
 - **PR body**: append this line to the bottom of the PR description (separated from the body by a blank line) when you open or update the draft PR. Do not duplicate it if it is already present. If the PR body already contains a legacy footer like `_Opened collaboratively by {display_name} and open-swe._`, replace that legacy footer with this line instead of appending a second footer:
@@ -390,6 +390,7 @@ def _render_collaboration_section(identity: CollaboratorIdentity | None) -> str:
     return COLLABORATION_TEMPLATE.format(
         display_name=identity.display_name,
         pr_attribution_footer=PR_ATTRIBUTION_FOOTER,
+        bot_coauthor_trailer=f"Co-authored-by: {OPEN_SWE_BOT_NAME} <{OPEN_SWE_BOT_EMAIL}>",
     )
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -69,7 +69,11 @@ from .tools import (
     web_search,
 )
 from .utils.auth import resolve_github_token
-from .utils.authorship import resolve_triggering_user_identity
+from .utils.authorship import (
+    OPEN_SWE_BOT_EMAIL,
+    OPEN_SWE_BOT_NAME,
+    resolve_triggering_user_identity,
+)
 from .utils.github_app import get_github_app_installation_token
 from .utils.model import (
     DEFAULT_LLM_REASONING,
@@ -181,8 +185,8 @@ async def _refresh_github_proxy_or_recreate(
 async def _configure_git_identity(sandbox_backend: SandboxBackendProtocol) -> None:
     await asyncio.to_thread(
         sandbox_backend.execute,
-        "git config --global user.name 'open-swe[bot]' && "
-        "git config --global user.email 'open-swe@users.noreply.github.com'",
+        f"git config --global user.name '{OPEN_SWE_BOT_NAME}' && "
+        f"git config --global user.email '{OPEN_SWE_BOT_EMAIL}'",
     )
 
 

--- a/agent/utils/authorship.py
+++ b/agent/utils/authorship.py
@@ -11,7 +11,9 @@ import httpx
 logger = logging.getLogger(__name__)
 
 OPEN_SWE_BOT_NAME = "open-swe[bot]"
-OPEN_SWE_BOT_EMAIL = "open-swe@users.noreply.github.com"
+# GitHub App bot noreply address (<app-user-id>+<slug>[bot]@users.noreply.github.com).
+# Resolves to the open-swe[bot] account, not the separate "open-swe" user account.
+OPEN_SWE_BOT_EMAIL = "215916821+open-swe[bot]@users.noreply.github.com"
 
 PR_ATTRIBUTION_FOOTER = "Made by [Open SWE](https://openswe.vercel.app)"
 

--- a/tests/test_github_comment_prompts.py
+++ b/tests/test_github_comment_prompts.py
@@ -5,10 +5,14 @@ from agent.dashboard.agent_overrides import profile_create_prs
 from agent.prompt import construct_system_prompt
 from agent.utils import github_comments
 from agent.utils.authorship import (
+    OPEN_SWE_BOT_EMAIL,
+    OPEN_SWE_BOT_NAME,
     CollaboratorIdentity,
     add_pr_collaboration_note,
     resolve_triggering_user_identity,
 )
+
+_BOT_TRAILER = f"Co-authored-by: {OPEN_SWE_BOT_NAME} <{OPEN_SWE_BOT_EMAIL}>"
 
 
 def test_build_pr_prompt_wraps_external_comments_without_trust_section() -> None:
@@ -100,7 +104,7 @@ def test_construct_system_prompt_includes_coauthor_trailer_when_identity_present
     # Values are shell-escaped via shlex.quote; safe tokens need no quoting.
     assert "git config user.name octocat" in prompt
     assert "git config user.email 1234+octocat@users.noreply.github.com" in prompt
-    assert "Co-authored-by: open-swe[bot] <open-swe@users.noreply.github.com>" in prompt
+    assert _BOT_TRAILER in prompt
     assert "Made by [Open SWE](https://openswe.vercel.app)" in prompt
 
 
@@ -120,7 +124,7 @@ def test_construct_system_prompt_includes_github_login_in_pr_footer() -> None:
     # A name with a space is shlex-quoted; the safe email is left bare.
     assert "git config user.name 'Mona Lisa'" in prompt
     assert "git config user.email 1234+octocat@users.noreply.github.com" in prompt
-    assert "Co-authored-by: open-swe[bot] <open-swe@users.noreply.github.com>" in prompt
+    assert _BOT_TRAILER in prompt
     assert "Made by [Open SWE](https://openswe.vercel.app)" in prompt
     assert (
         "replace that legacy footer with this line instead of appending a second footer" in prompt


### PR DESCRIPTION
The `Co-authored-by` trailer and the sandbox bot git identity used `open-swe@users.noreply.github.com`, which resolves to the separate **open-swe user account**, not the **open-swe[bot]** GitHub App. Commits were being co-credited to the wrong account.

Switch `OPEN_SWE_BOT_EMAIL` to the bot's noreply address (`215916821+open-swe[bot]@users.noreply.github.com`, the standard `<app-user-id>+<slug>[bot]@users.noreply.github.com` form). This fixes both the co-author trailer and the fallback author identity.

The prompt trailer and the `git config --global` command in the sandbox now derive from the constant instead of hardcoding the address.