### PR TITLE
chore: deploy dashboard as a static SPA instead of SSR

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,8 +1,15 @@
 {
+  "framework": null,
+  "buildCommand": "bun run build",
+  "outputDirectory": ".output/public",
   "rewrites": [
     {
       "source": "/dashboard/api/:path*",
       "destination": "https://open-swe-v3-f2834ffc0df05a46a10262a9690e8490.us.langgraph.app/dashboard/api/:path*"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/_shell.html"
     }
   ]
 }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -15,7 +15,7 @@ const config = defineConfig({
       projects: ["./tsconfig.json"],
     }),
     tailwindcss(),
-    tanstackStart(),
+    tanstackStart({ spa: { enabled: true } }),
     viteReact(),
   ],
 })


### PR DESCRIPTION
Enable TanStack Start SPA mode so the build prerenders a static shell (/_shell.html) and emits a fully static bundle under .output/public, removing the Nitro serverless function from the Vercel deploy. The dashboard is a thin client (all data via client-side fetch to the FastAPI /dashboard/api/*), so SSR rendered nothing of value.

Point Vercel at the static output and add a SPA catch-all rewrite to the shell for client-side routing, keeping the API proxy rewrite first.