### PR TITLE
fix: auto-create local sandbox root dir

### DIFF
--- a/agent/integrations/local.py
+++ b/agent/integrations/local.py
@@ -10,7 +10,8 @@ def create_local_sandbox(sandbox_id: str | None = None):
     Only use for local development with human-in-the-loop enabled.
 
     The root directory defaults to the current working directory and can be
-    overridden via the LOCAL_SANDBOX_ROOT_DIR environment variable.
+    overridden via the LOCAL_SANDBOX_ROOT_DIR environment variable. It is
+    created if it does not already exist.
 
     Args:
         sandbox_id: Ignored for local sandboxes; accepted for interface compatibility.
@@ -19,6 +20,7 @@ def create_local_sandbox(sandbox_id: str | None = None):
         LocalShellBackend instance implementing SandboxBackendProtocol.
     """
     root_dir = os.getenv("LOCAL_SANDBOX_ROOT_DIR", os.getcwd())
+    os.makedirs(root_dir, exist_ok=True)
 
     return LocalShellBackend(
         root_dir=root_dir,

--- a/tests/test_local_integration.py
+++ b/tests/test_local_integration.py
@@ -1,0 +1,29 @@
+import agent.integrations.local as local_mod
+
+
+class _StubLocalShellBackend:
+    def __init__(self, *, root_dir, inherit_env):
+        self.root_dir = root_dir
+        self.inherit_env = inherit_env
+
+
+def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
+    root = tmp_path / "nested" / "openswe-sandbox"
+    monkeypatch.setenv("LOCAL_SANDBOX_ROOT_DIR", str(root))
+    monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
+
+    backend = local_mod.create_local_sandbox()
+
+    assert root.is_dir()
+    assert backend.root_dir == str(root)
+    assert backend.inherit_env is True
+
+
+def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
+    monkeypatch.delenv("LOCAL_SANDBOX_ROOT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
+
+    backend = local_mod.create_local_sandbox()
+
+    assert backend.root_dir == str(tmp_path)


### PR DESCRIPTION
`create_local_sandbox` reads `LOCAL_SANDBOX_ROOT_DIR` (default cwd) but never created it. A custom path — or a `/tmp` dir cleared on reboot — fails the run with `RuntimeError: Failed to resolve a writable sandbox work directory`: the backend can't `chdir` into a missing dir, so every work-dir probe (`pwd`, `$HOME`) exits non-zero and no candidate is found.

`mkdir -p` the resolved root dir at creation. Adds a test for the missing-dir and default-cwd cases.