### PR TITLE
feat: animate mobile sidebar opening

### DIFF
--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -88,6 +88,7 @@ export function SidebarFrame({
       className={cn(
         "relative flex h-svh shrink-0 flex-col",
         "max-md:fixed max-md:inset-0 max-md:z-40 max-md:!w-full",
+        "max-md:animate-in max-md:fade-in-0 max-md:slide-in-from-left-4 max-md:duration-200 max-md:ease-out",
         className,
       )}
     >


### PR DESCRIPTION
## Description
Adds a subtle mobile-only slide/fade animation when the dashboard sidebar opens, keeping desktop behavior unchanged.

## Self-Hosted Release Note
none

## Test Plan
- [ ] Demo the mobile PWA sidebar open transition on a narrow viewport

### Demo
<!-- attach screenshot or recording of the mobile sidebar opening -->

Made by [Open SWE](https://openswe.vercel.app)