### PR TITLE
fix: revert co-author email to open-swe user noreply

### DIFF
--- a/agent/utils/authorship.py
+++ b/agent/utils/authorship.py
@@ -11,9 +11,10 @@ import httpx
 logger = logging.getLogger(__name__)
 
 OPEN_SWE_BOT_NAME = "open-swe[bot]"
-# GitHub App bot noreply address (<app-user-id>+<slug>[bot]@users.noreply.github.com).
-# Resolves to the open-swe[bot] account, not the separate "open-swe" user account.
-OPEN_SWE_BOT_EMAIL = "215916821+open-swe[bot]@users.noreply.github.com"
+# Use the open-swe user noreply address: the bot's numeric noreply
+# (215916821+open-swe[bot]@...) doesn't resolve to a GitHub account Vercel
+# accepts, which broke preview deploys on commits carrying this co-author.
+OPEN_SWE_BOT_EMAIL = "open-swe@users.noreply.github.com"
 
 PR_ATTRIBUTION_FOOTER = "Made by [Open SWE](https://openswe.vercel.app)"
 


### PR DESCRIPTION
The bot's numeric noreply address `215916821+open-swe[bot]@users.noreply.github.com` (introduced in ae946d1a) doesn't resolve to a GitHub account Vercel accepts, which broke preview deploys on PRs in langchainplus.

Revert `OPEN_SWE_BOT_EMAIL` back to `open-swe@users.noreply.github.com`. The constant-driven refactor from that commit is kept, so this is a one-line value change.