### PR TITLE
feat: make web threads readable by any org user

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -755,9 +755,10 @@ async def api_delete_schedule(
 
 @router.get("/threads")
 async def api_list_threads(
+    all: bool = False,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> list[dict[str, Any]]:
-    return await list_dashboard_threads(session["sub"], email=session.get("email"))
+    return await list_dashboard_threads(session["sub"], email=session.get("email"), include_all=all)
 
 
 @router.post("/threads")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -120,6 +120,11 @@ def _assert_thread_owner(metadata: dict[str, Any], login: str, email: str | None
         raise HTTPException(404, "thread not found")
 
 
+def _assert_thread_viewable(metadata: dict[str, Any]) -> None:
+    if _thread_source(metadata) not in _SURFACED_SOURCES:
+        raise HTTPException(404, "thread not found")
+
+
 def _metadata_repo(metadata: dict[str, Any]) -> tuple[str, str, str]:
     owner = metadata.get("repo_owner")
     name = metadata.get("repo_name")
@@ -205,12 +210,15 @@ async def _latest_run_status(thread_id: str) -> str | None:
 
 
 async def list_dashboard_threads(
-    login: str, *, email: str | None = None, limit: int = 50
+    login: str, *, email: str | None = None, limit: int = 50, include_all: bool = False
 ) -> list[dict[str, Any]]:
     client = langgraph_client()
-    searches: list[dict[str, Any]] = [{"github_login": login}]
-    if email and email.strip():
-        searches.append({"triggering_user_email": email.strip().lower()})
+    if include_all:
+        searches: list[dict[str, Any]] = [{"source": source} for source in _SURFACED_SOURCES]
+    else:
+        searches = [{"github_login": login}]
+        if email and email.strip():
+            searches.append({"triggering_user_email": email.strip().lower()})
 
     seen: dict[str, dict[str, Any]] = {}
     for metadata_filter in searches:
@@ -224,7 +232,10 @@ async def list_dashboard_threads(
             if not isinstance(thread, dict):
                 continue
             meta = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-            if not _user_owns_thread(meta, login, email):
+            if include_all:
+                if _thread_source(meta) not in _SURFACED_SOURCES:
+                    continue
+            elif not _user_owns_thread(meta, login, email):
                 continue
             thread_id = thread.get("thread_id") or thread.get("id")
             if isinstance(thread_id, str) and thread_id not in seen:
@@ -246,7 +257,7 @@ async def get_dashboard_thread(
         raise HTTPException(404, "thread not found") from exc
 
     metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-    _assert_thread_owner(metadata, login, email)
+    _assert_thread_viewable(metadata)
 
     messages: list[dict[str, Any]] = []
     try:
@@ -485,7 +496,7 @@ async def stream_dashboard_thread(
         raise HTTPException(404, "thread not found") from exc
 
     metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-    _assert_thread_owner(metadata, login, email)
+    _assert_thread_viewable(metadata)
 
     stream = await langgraph_client().threads.join_stream(
         thread_id,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -120,11 +120,6 @@ def _assert_thread_owner(metadata: dict[str, Any], login: str, email: str | None
         raise HTTPException(404, "thread not found")
 
 
-def _assert_thread_viewable(metadata: dict[str, Any]) -> None:
-    if _thread_source(metadata) not in _SURFACED_SOURCES:
-        raise HTTPException(404, "thread not found")
-
-
 def _metadata_repo(metadata: dict[str, Any]) -> tuple[str, str, str]:
     owner = metadata.get("repo_owner")
     name = metadata.get("repo_name")
@@ -213,12 +208,9 @@ async def list_dashboard_threads(
     login: str, *, email: str | None = None, limit: int = 50, include_all: bool = False
 ) -> list[dict[str, Any]]:
     client = langgraph_client()
-    if include_all:
-        searches: list[dict[str, Any]] = [{"source": source} for source in _SURFACED_SOURCES]
-    else:
-        searches = [{"github_login": login}]
-        if email and email.strip():
-            searches.append({"triggering_user_email": email.strip().lower()})
+    searches: list[dict[str, Any]] = [{}] if include_all else [{"github_login": login}]
+    if not include_all and email and email.strip():
+        searches.append({"triggering_user_email": email.strip().lower()})
 
     seen: dict[str, dict[str, Any]] = {}
     for metadata_filter in searches:
@@ -232,10 +224,7 @@ async def list_dashboard_threads(
             if not isinstance(thread, dict):
                 continue
             meta = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-            if include_all:
-                if _thread_source(meta) not in _SURFACED_SOURCES:
-                    continue
-            elif not _user_owns_thread(meta, login, email):
+            if not include_all and not _user_owns_thread(meta, login, email):
                 continue
             thread_id = thread.get("thread_id") or thread.get("id")
             if isinstance(thread_id, str) and thread_id not in seen:
@@ -257,7 +246,6 @@ async def get_dashboard_thread(
         raise HTTPException(404, "thread not found") from exc
 
     metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-    _assert_thread_viewable(metadata)
 
     messages: list[dict[str, Any]] = []
     try:
@@ -491,12 +479,9 @@ async def stream_dashboard_thread(
     thread_id: str, login: str, *, email: str | None = None, last_event_id: str | None = None
 ) -> AsyncIterator[str]:
     try:
-        thread = await langgraph_client().threads.get(thread_id)
+        await langgraph_client().threads.get(thread_id)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
-
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-    _assert_thread_viewable(metadata)
 
     stream = await langgraph_client().threads.join_stream(
         thread_id,


### PR DESCRIPTION
## What

Any logged-in org user can now read and stream any agent thread in the web view — including reviewer/analyzer threads — instead of only the thread owner.

- Removes the per-thread owner/source gate on `GET /threads/{id}` and `GET /threads/{id}/stream`.
- `GET /threads?all=true` lists every thread regardless of source. Default list stays per-user.
- Writes (`send`/`cancel`/`delete`) remain owner-only.

All routes remain behind `require_session` + the org-login gate, so access is limited to authenticated org users, not the public.

## Test Plan

- [x] `make lint`
- [x] `make test TEST_FILE=tests/test_dashboard_web_handoff.py`