### PR TITLE
fix: guard reviewer GraphQL against null repository

### DIFF
--- a/agent/reviewer_publish.py
+++ b/agent/reviewer_publish.py
@@ -503,12 +503,21 @@ async def fetch_pr_review_threads(
                 )
                 return out
             data = response.json()
-            threads = (
-                data.get("data", {})
-                .get("repository", {})
-                .get("pullRequest", {})
-                .get("reviewThreads", {})
-            )
+            data_root = data.get("data") if isinstance(data, dict) else None
+            repository = data_root.get("repository") if isinstance(data_root, dict) else None
+            if not isinstance(repository, dict):
+                logger.warning(
+                    "Null repository in review-threads response for %s/%s#%s "
+                    "(token likely lacks access: SAML, expired token, or private/deleted repo)",
+                    owner,
+                    repo,
+                    pr_number,
+                )
+                return out
+            pull_request = repository.get("pullRequest")
+            threads = pull_request.get("reviewThreads") if isinstance(pull_request, dict) else None
+            if not isinstance(threads, dict):
+                return out
             for thread in threads.get("nodes", []) or []:
                 if not isinstance(thread, dict):
                     continue
@@ -668,8 +677,10 @@ async def resolve_review_thread(*, thread_node_id: str, token: str) -> bool:
     if data.get("errors"):
         logger.warning("resolveReviewThread errors: %s", data["errors"])
         return False
-    thread = data.get("data", {}).get("resolveReviewThread", {}).get("thread", {})
-    return bool(thread.get("isResolved"))
+    data_root = data.get("data") if isinstance(data, dict) else None
+    resolved = data_root.get("resolveReviewThread") if isinstance(data_root, dict) else None
+    thread = resolved.get("thread") if isinstance(resolved, dict) else None
+    return bool(thread.get("isResolved")) if isinstance(thread, dict) else False
 
 
 async def reply_to_review_comment(

--- a/tests/test_reviewer_publish.py
+++ b/tests/test_reviewer_publish.py
@@ -357,6 +357,24 @@ async def test_resolve_review_thread_returns_true_on_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_pr_review_threads_handles_null_repository() -> None:
+    """GitHub returns ``repository: null`` when the token can't read the repo
+    (SAML, expired token, private/deleted). ``dict.get(k, {})`` does not coalesce
+    explicit null, so the fetch must guard against it and return collected threads."""
+    response = MagicMock()
+    response.json.return_value = {"data": {"repository": None}}
+    response.raise_for_status.return_value = None
+
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = client_cm
+    client_cm.post = AsyncMock(return_value=response)
+
+    with patch("agent.reviewer_publish.httpx.AsyncClient", return_value=client_cm):
+        threads = await fetch_pr_review_threads(owner="o", repo="r", pr_number=1, token="t")
+    assert threads == []
+
+
+@pytest.mark.asyncio
 async def test_post_pull_request_review_non_dict_body_surfaces_status_and_excerpt() -> None:
     """A non-dict GitHub response body must surface status code + body excerpt
     via ``_error`` rather than collapsing to a bare ``None`` (which the


### PR DESCRIPTION
`publish_review` repeatedly crashed with `AttributeError("'NoneType' object has no attribute 'get'")` in `fetch_pr_review_threads` (11+ prod traces in 6h, all 3 referenced runs reproduce it).

GitHub returns `repository: null` when the token can't read the target repo (SAML enforcement, expired token, private/deleted repo). `dict.get(key, default)` only returns the default for *absent* keys, not explicit `null`, so `data.get("data", {}).get("repository", {}).get(...)` lands `.get()` on `None`. Retries re-hit the same resolver, so no review ever posts.

## What changed
- `fetch_pr_review_threads`: step-wise `isinstance` guards (matching the sibling function that already did this). On null `repository`, log a warning with owner/repo/pr + likely cause and return threads collected so far, mirroring the existing `httpx.HTTPError` early return.
- `resolve_review_thread`: swept the same latent `.get(..., {}).get(...)` GraphQL chain.
- `agent/tools/publish_review.py`: swept — its `.get()` chains are on local findings/config, not GraphQL responses; no change needed.
- Test: `{"data": {"repository": null}}` returns `[]` without raising.

Tool-layer defensive fix only; agent error-surfacing behavior is unchanged.