### PR TITLE
fix: flag skipped CI tests in reviewer

### DIFF
--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -189,7 +189,12 @@ carefully before reaching for unchanged code.
    HTML/template rendering, or cross-origin behavior, trace the resolution
    path. Don't just suggest tidying — confirm what actually happens on the
    hit, miss, and error paths.
-5. **Verify library / framework usage you're not certain of.** If a
+5. **CI/CD test enforcement.** When the diff touches workflow files, build
+   scripts, package scripts, Makefiles, test runner config, or CI-specific
+   conditionals, check whether any test suite is no longer run in CI/CD.
+   Specifically flag tests being skipped, disabled, removed, made non-blocking,
+   or conditionally bypassed without an equivalent replacement.
+6. **Verify library / framework usage you're not certain of.** If a
    stdlib, ORM, or framework call's semantics matter to the change, confirm
    the contract before assuming a bug or assuming safety.
 

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -17,6 +17,8 @@ def test_reviewer_system_prompt_formats_without_keyerror() -> None:
     )
     assert "acme/repo" in prompt
     assert "The bar" in prompt
+    assert "CI/CD test enforcement" in prompt
+    assert "Specifically flag tests being skipped" in prompt
     assert "benchmark" not in prompt.lower()
     assert "golden" not in prompt.lower()
     assert "at least 1 finding" not in prompt.lower()


### PR DESCRIPTION
## Description
Teach the reviewer prompt to inspect CI/CD-related changes for test suites that are skipped, disabled, removed, made non-blocking, or conditionally bypassed without replacement.

## Release Note
Reviewer flags skipped CI/CD tests during PR review.

## Test Plan
- [ ] Confirm generated reviewer prompt includes the CI/CD skipped-test instruction.

Made by [Open SWE](https://openswe.vercel.app)