### PR TITLE
fix: add 30-day thread ttl

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -15,7 +15,7 @@
     "ttl": {
       "strategy": "delete",
       "sweep_interval_minutes": 60,
-      "default_ttl": 20160
+      "default_ttl": 43200
     }
   },
   "env": ".env"

--- a/langgraph.json
+++ b/langgraph.json
@@ -11,5 +11,12 @@
   "http": {
     "app": "agent.webapp:app"
   },
-  "env": ".env" 
+  "checkpointer": {
+    "ttl": {
+      "strategy": "delete",
+      "sweep_interval_minutes": 60,
+      "default_ttl": 20160
+    }
+  },
+  "env": ".env"
 }


### PR DESCRIPTION
## Description
Configure LangGraph checkpoint TTL so Open SWE threads and their checkpoints are deleted after 30 days.

## Release Note
Open SWE threads now expire after 30 days.

## Test Plan
- [ ] Confirm `langgraph.json` parses and sets `default_ttl` to 43200 minutes.

Made by [Open SWE](https://openswe.vercel.app)