### PR TITLE
feat: add dark mode support to web UI

### DIFF
--- a/ui/src/components/SidebarUserMenu.tsx
+++ b/ui/src/components/SidebarUserMenu.tsx
@@ -1,10 +1,24 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import { IoLogOutOutline, IoSettingsOutline } from "react-icons/io5";
+import {
+  IoDesktopOutline,
+  IoLogOutOutline,
+  IoMoonOutline,
+  IoSettingsOutline,
+  IoSunnyOutline,
+} from "react-icons/io5";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { api, type SessionUser } from "@/lib/api";
+import { useTheme, type Theme } from "@/lib/theme";
+import { cn } from "@/lib/utils";
+
+const THEME_OPTIONS: Array<{ value: Theme; label: string; icon: typeof IoSunnyOutline }> = [
+  { value: "light", label: "Light", icon: IoSunnyOutline },
+  { value: "dark", label: "Dark", icon: IoMoonOutline },
+  { value: "system", label: "System", icon: IoDesktopOutline },
+];
 
 interface SidebarUserMenuProps {
   user: SessionUser;
@@ -14,6 +28,7 @@ interface SidebarUserMenuProps {
 export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserMenuProps) {
   const qc = useQueryClient();
   const navigate = useNavigate();
+  const { theme, setTheme } = useTheme();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -67,6 +82,35 @@ export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserM
           role="menu"
           className="absolute right-0 bottom-full left-0 mb-2 overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
         >
+          <div className="px-2 py-1.5">
+            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              Theme
+            </span>
+            <div className="mt-1.5 grid grid-cols-3 gap-1">
+              {THEME_OPTIONS.map((option) => {
+                const Icon = option.icon;
+                const active = theme === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setTheme(option.value)}
+                    aria-pressed={active}
+                    className={cn(
+                      "flex flex-col items-center gap-1 rounded-sm border px-1 py-1.5 text-[10px] transition-colors",
+                      active
+                        ? "border-primary/40 bg-primary/10 text-primary"
+                        : "border-transparent text-muted-foreground hover:bg-muted",
+                    )}
+                  >
+                    <Icon className="size-3.5" />
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="my-1 h-px bg-border" />
           {showSettingsLink && (
             <Link
               to="/my-settings"

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from "react"
+
+export type Theme = "light" | "dark" | "system"
+export type ResolvedTheme = "light" | "dark"
+
+export const THEME_STORAGE_KEY = "open-swe-theme"
+
+function isTheme(value: string | null): value is Theme {
+  return value === "light" || value === "dark" || value === "system"
+}
+
+function readStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system"
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+  return isTheme(stored) ? stored : "system"
+}
+
+function systemPrefersDark(): boolean {
+  if (typeof window === "undefined") return false
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+}
+
+export function resolveTheme(theme: Theme): ResolvedTheme {
+  if (theme === "system") return systemPrefersDark() ? "dark" : "light"
+  return theme
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  if (typeof document === "undefined") return
+  const root = document.documentElement
+  root.classList.toggle("dark", resolved === "dark")
+  root.style.colorScheme = resolved
+}
+
+/** Theme state with system detection, persistence, and `.dark` class syncing. */
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>("system")
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light")
+
+  useEffect(() => {
+    const stored = readStoredTheme()
+    setThemeState(stored)
+    setResolvedTheme(resolveTheme(stored))
+  }, [])
+
+  useEffect(() => {
+    const resolved = resolveTheme(theme)
+    setResolvedTheme(resolved)
+    applyTheme(resolved)
+
+    if (theme !== "system") return
+    const media = window.matchMedia("(prefers-color-scheme: dark)")
+    const onChange = () => {
+      const next = systemPrefersDark() ? "dark" : "light"
+      setResolvedTheme(next)
+      applyTheme(next)
+    }
+    media.addEventListener("change", onChange)
+    return () => media.removeEventListener("change", onChange)
+  }, [theme])
+
+  const setTheme = useCallback((next: Theme) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next)
+    }
+    setThemeState(next)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(resolvedTheme === "dark" ? "light" : "dark")
+  }, [resolvedTheme, setTheme])
+
+  return { theme, resolvedTheme, setTheme, toggleTheme }
+}

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 export type Theme = "light" | "dark" | "system"
 export type ResolvedTheme = "light" | "dark"
@@ -36,34 +36,35 @@ function applyTheme(resolved: ResolvedTheme) {
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>("system")
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light")
+  const themeRef = useRef<Theme>("system")
 
   useEffect(() => {
     const stored = readStoredTheme()
+    themeRef.current = stored
     setThemeState(stored)
     setResolvedTheme(resolveTheme(stored))
-  }, [])
+    applyTheme(resolveTheme(stored))
 
-  useEffect(() => {
-    const resolved = resolveTheme(theme)
-    setResolvedTheme(resolved)
-    applyTheme(resolved)
-
-    if (theme !== "system") return
     const media = window.matchMedia("(prefers-color-scheme: dark)")
     const onChange = () => {
+      if (themeRef.current !== "system") return
       const next = systemPrefersDark() ? "dark" : "light"
       setResolvedTheme(next)
       applyTheme(next)
     }
     media.addEventListener("change", onChange)
     return () => media.removeEventListener("change", onChange)
-  }, [theme])
+  }, [])
 
   const setTheme = useCallback((next: Theme) => {
     if (typeof window !== "undefined") {
       window.localStorage.setItem(THEME_STORAGE_KEY, next)
     }
+    themeRef.current = next
+    const resolved = resolveTheme(next)
     setThemeState(next)
+    setResolvedTheme(resolved)
+    applyTheme(resolved)
   }, [])
 
   const toggleTheme = useCallback(() => {

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -12,6 +12,11 @@ import { useState } from "react"
 
 import appCss from "../styles.css?url"
 import { makeQueryClient } from "@/lib/query"
+import { THEME_STORAGE_KEY } from "@/lib/theme"
+
+const themeInitScript = `(function(){try{var t=localStorage.getItem(${JSON.stringify(
+  THEME_STORAGE_KEY
+)});var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
 
 export const Route = createRootRoute({
   head: () => ({
@@ -47,6 +52,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <HeadContent />
       </head>
       <body>

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -12,11 +12,8 @@ import { useState } from "react"
 
 import appCss from "../styles.css?url"
 import { makeQueryClient } from "@/lib/query"
-import { THEME_STORAGE_KEY } from "@/lib/theme"
 
-const themeInitScript = `(function(){try{var t=localStorage.getItem(${JSON.stringify(
-  THEME_STORAGE_KEY
-)});var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
+const themeInitScript = `(function(){try{var t=localStorage.getItem("open-swe-theme");var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
 
 export const Route = createRootRoute({
   head: () => ({

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -16,6 +16,25 @@
   --ui-danger: oklch(0.577 0.245 27.325);
 }
 
+.dark .agents-ui,
+.dark.agents-ui {
+  --ui-bg: oklch(0.148 0.004 228.8);
+  --ui-surface: oklch(0.218 0.008 223.9);
+  --ui-panel: oklch(0.218 0.008 223.9);
+  --ui-panel-2: oklch(0.274 0.006 286.033);
+  --ui-border: oklch(1 0 0 / 10%);
+  --ui-border-subtle: oklch(1 0 0 / 6%);
+  --ui-text: oklch(0.987 0.002 197.1);
+  --ui-text-muted: oklch(0.723 0.014 214.4);
+  --ui-text-dim: oklch(0.56 0.021 213.5);
+  --ui-accent: oklch(0.715 0.143 215.221);
+  --ui-accent-bubble: oklch(0.274 0.04 223);
+  --ui-sidebar: oklch(0.218 0.008 223.9);
+  --ui-sidebar-hover: oklch(0.275 0.011 216.9);
+  --ui-success: oklch(0.62 0.17 145);
+  --ui-danger: oklch(0.704 0.191 22.216);
+}
+
 .agents-ui {
   color: var(--ui-text);
   background: var(--ui-bg);
@@ -26,6 +45,10 @@
 .agents-ui * {
   scrollbar-width: thin;
   scrollbar-color: oklch(0.85 0.01 214) transparent;
+}
+
+.dark .agents-ui * {
+  scrollbar-color: oklch(0.4 0.01 214) transparent;
 }
 
 .agents-ui .shimmer-text {


### PR DESCRIPTION
## Description
The UI already shipped `.dark` design tokens but nothing applied them. This adds a persisted, system-aware theme: a `useTheme` hook syncs the `.dark` class + `color-scheme`, an inline head script applies the saved choice before paint (no flash), and a Light/Dark/System switcher lives in the sidebar user menu. The `agents-ui` surface gets matching dark overrides for its `--ui-*` variables.

## Release Note
Dark mode is now available in the dashboard, with a Light/Dark/System toggle in the sidebar user menu that follows your OS preference by default.

## Test Plan
- [ ] Toggle Light/Dark/System in the sidebar menu and confirm the dashboard and agents surfaces re-theme correctly
- [ ] Set System, change OS appearance, and confirm the UI follows live
- [ ] Reload with a saved theme and confirm there's no light-mode flash before paint

Made by [Open SWE](https://openswe.vercel.app)