### PR TITLE
feat: add non-blocking sandbox command auditing with LangSmith reporting

### DIFF
--- a/agent/utils/sandbox_safety.py
+++ b/agent/utils/sandbox_safety.py
@@ -1,0 +1,204 @@
+"""Non-blocking sandbox command auditing.
+
+Every shell command executed inside a sandbox is classified by risk level using
+static regex rules and asynchronously reported to LangSmith.  Classification
+and reporting never delay command execution.
+
+Risk levels:
+- HIGH  — Command matches a destructive pattern (e.g. ``rm -rf /``, ``mkfs``).
+          Blocked outright; the underlying sandbox never receives it.
+- MEDIUM — Command matches a potentially dangerous pattern (e.g. ``git push --force``).
+           Logged at WARNING level and allowed to proceed.
+- LOW   — Normal developer command.  Allowed silently.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Static classification rules
+# ---------------------------------------------------------------------------
+
+# Commands that can irrecoverably destroy the host OS or expose root filesystem.
+_HIGH_RISK_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\brm\s+-[rf]*\s*/"),                  # rm -rf /
+    re.compile(r"\brm\s+-[rf]*\s+--no-preserve-root"), # rm -rf --no-preserve-root
+    re.compile(r"\bmkfs\b"),                            # filesystem formatting
+    re.compile(r"\bdd\s+.*of=/dev/"),                  # raw disk overwrite
+    re.compile(r"\bchmod\s+-R\s+777\s*/"),             # world-writable root
+    re.compile(r"\bshutdown\b"),
+    re.compile(r"\breboot\b"),
+    re.compile(r"\bpoweroff\b"),
+]
+
+# Commands that are risky but not catastrophic — log a warning and proceed.
+_MEDIUM_RISK_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\brm\s+-[rf]+"),           # generic rm -rf (non-root)
+    re.compile(r"\bgit\s+push\b.*--force"), # force-push
+]
+
+
+def classify_command(command: str) -> tuple[str, str]:
+    """Return ``(risk_level, reason)`` for *command* using static rules only.
+
+    This function is intentionally free of network calls or LLM invocations so
+    that it adds negligible latency to every sandbox ``execute()`` call.
+    """
+    for pattern in _HIGH_RISK_PATTERNS:
+        if pattern.search(command):
+            return "HIGH", "Matched critical blocked command pattern."
+    for pattern in _MEDIUM_RISK_PATTERNS:
+        if pattern.search(command):
+            return "MEDIUM", "Matched potentially destructive command pattern."
+    return "LOW", "No dangerous patterns matched."
+
+
+# ---------------------------------------------------------------------------
+# LangSmith audit (fire-and-forget)
+# ---------------------------------------------------------------------------
+
+def _emit_langsmith_audit(
+    thread_id: str | None,
+    command: str,
+    risk_level: str,
+    reason: str,
+    duration: float,
+    exit_code: int | None,
+) -> None:
+    """Send one structured audit record to LangSmith.
+
+    Runs inside a daemon thread started by :class:`AuditedSandboxWrapper`.
+    Any exception is silently swallowed so that audit failures are never
+    surfaced to the agent.
+    """
+    try:
+        import os
+        import uuid
+
+        from langsmith import Client as LangSmithClient
+
+        api_key = os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGSMITH_API_KEY_PROD")
+        if not api_key:
+            return
+
+        run_id = str(uuid.uuid4())
+        client = LangSmithClient(api_key=api_key)
+        client.create_run(
+            id=run_id,
+            name="sandbox_command",
+            run_type="tool",
+            inputs={"command": command},
+            tags=[f"risk:{risk_level.lower()}", "sandbox-audit"],
+            extra={
+                "metadata": {
+                    "thread_id": thread_id,
+                    "risk_level": risk_level,
+                    "reason": reason,
+                }
+            },
+        )
+        client.update_run(
+            run_id=run_id,
+            outputs={
+                "exit_code": exit_code,
+                "duration_seconds": round(duration, 3),
+                "blocked": risk_level == "HIGH",
+            },
+        )
+    except Exception:
+        pass  # audit must never affect the main execution path
+
+
+def _audit_async(
+    thread_id: str | None,
+    command: str,
+    risk_level: str,
+    reason: str,
+    duration: float,
+    exit_code: int | None,
+) -> None:
+    """Dispatch :func:`_emit_langsmith_audit` in a daemon thread."""
+    threading.Thread(
+        target=_emit_langsmith_audit,
+        args=(thread_id, command, risk_level, reason, duration, exit_code),
+        daemon=True,
+    ).start()
+
+
+# ---------------------------------------------------------------------------
+# Wrapper
+# ---------------------------------------------------------------------------
+
+class AuditedSandboxWrapper:
+    """Non-blocking proxy that classifies and audits every sandbox ``execute()`` call.
+
+    Wrap a raw sandbox backend with this class to gain:
+
+    * **Static risk classification** — regex-based, zero latency overhead.
+    * **HIGH-risk blocking** — truly destructive commands (e.g. ``rm -rf /``)
+      are rejected before reaching the sandbox.
+    * **Async LangSmith reporting** — all commands are asynchronously emitted
+      as ``sandbox_command`` tool runs in LangSmith when
+      ``LANGSMITH_API_KEY`` is set.  The background thread is a daemon and
+      will not block process shutdown.
+
+    All other sandbox methods (file I/O, glob, grep …) are transparently
+    forwarded to the underlying backend via ``__getattr__``.
+    """
+
+    def __init__(self, raw_sandbox: SandboxBackendProtocol, thread_id: str | None = None):
+        self._raw_sandbox = raw_sandbox
+        self._thread_id = thread_id
+
+    @property
+    def id(self) -> str:
+        return self._raw_sandbox.id
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        start = time.monotonic()
+        risk_level, reason = classify_command(command)
+
+        if risk_level == "HIGH":
+            duration = time.monotonic() - start
+            logger.warning(
+                "sandbox:blocked thread=%s risk=HIGH command=%r reason=%s",
+                self._thread_id,
+                command,
+                reason,
+            )
+            _audit_async(self._thread_id, command, risk_level, reason, duration, exit_code=1)
+            return ExecuteResponse(
+                output=f"[BLOCKED] Command rejected by sandbox safety rules: {reason}",
+                exit_code=1,
+                truncated=False,
+            )
+
+        if risk_level == "MEDIUM":
+            logger.warning(
+                "sandbox:medium-risk thread=%s command=%r reason=%s",
+                self._thread_id,
+                command,
+                reason,
+            )
+
+        try:
+            res = self._raw_sandbox.execute(command, timeout=timeout)
+        except Exception:
+            duration = time.monotonic() - start
+            _audit_async(self._thread_id, command, risk_level, reason, duration, exit_code=None)
+            raise
+
+        duration = time.monotonic() - start
+        _audit_async(self._thread_id, command, risk_level, reason, duration, res.exit_code)
+        return res
+
+    def __getattr__(self, name: str):
+        return getattr(self._raw_sandbox, name)

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -20,6 +20,7 @@ from deepagents.backends.protocol import (
 from langgraph.config import get_config
 
 from .sandbox import create_sandbox
+from .sandbox_safety import AuditedSandboxWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,10 @@ def set_sandbox_backend(
     if isinstance(sandbox_backend, SandboxBackendProxy):
         SANDBOX_BACKENDS[thread_id] = sandbox_backend
         return sandbox_backend
+
+    # Wrap with command auditing unless already wrapped.
+    if not isinstance(sandbox_backend, AuditedSandboxWrapper):
+        sandbox_backend = AuditedSandboxWrapper(sandbox_backend, thread_id)
 
     existing = SANDBOX_BACKENDS.get(thread_id)
     if isinstance(existing, SandboxBackendProxy):

--- a/tests/test_sandbox_safety.py
+++ b/tests/test_sandbox_safety.py
@@ -1,0 +1,197 @@
+"""Tests for sandbox command auditing (agent/utils/sandbox_safety.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+
+from agent.utils.sandbox_safety import AuditedSandboxWrapper, classify_command
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockSandbox(SandboxBackendProtocol):
+    """Minimal sandbox stub that records executed commands."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    @property
+    def id(self) -> str:
+        return "mock-sandbox-001"
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        self.executed.append(command)
+        return ExecuteResponse(output=f"ok: {command}", exit_code=0, truncated=False)
+
+
+# ---------------------------------------------------------------------------
+# classify_command
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyCommand:
+    def test_high_risk_rm_rf_root(self):
+        level, _ = classify_command("rm -rf /")
+        assert level == "HIGH"
+
+    def test_high_risk_no_preserve_root(self):
+        level, _ = classify_command("rm -rf --no-preserve-root /")
+        assert level == "HIGH"
+
+    def test_high_risk_mkfs(self):
+        level, _ = classify_command("mkfs.ext4 /dev/sda1")
+        assert level == "HIGH"
+
+    def test_high_risk_dd_disk(self):
+        level, _ = classify_command("dd if=/dev/zero of=/dev/sda")
+        assert level == "HIGH"
+
+    def test_high_risk_shutdown(self):
+        level, _ = classify_command("shutdown -h now")
+        assert level == "HIGH"
+
+    def test_medium_risk_rm_rf(self):
+        level, _ = classify_command("rm -rf ./dist")
+        assert level == "MEDIUM"
+
+    def test_medium_risk_force_push(self):
+        level, _ = classify_command("git push origin main --force")
+        assert level == "MEDIUM"
+
+    def test_low_risk_git_status(self):
+        level, _ = classify_command("git status")
+        assert level == "LOW"
+
+    def test_low_risk_pytest(self):
+        level, _ = classify_command("uv run pytest -vvv tests/")
+        assert level == "LOW"
+
+    def test_low_risk_ls(self):
+        level, _ = classify_command("ls -la")
+        assert level == "LOW"
+
+    def test_low_risk_curl_in_legitimate_context(self):
+        # curl is not in the medium patterns — only force-push and rm -rf
+        level, _ = classify_command("curl https://example.com")
+        assert level == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# AuditedSandboxWrapper — execution routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_sandbox() -> _MockSandbox:
+    return _MockSandbox()
+
+
+@pytest.fixture()
+def wrapper(mock_sandbox: _MockSandbox) -> AuditedSandboxWrapper:
+    return AuditedSandboxWrapper(mock_sandbox, thread_id="test-thread-001")
+
+
+@pytest.fixture(autouse=True)
+def _suppress_audit_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent real LangSmith network calls during tests."""
+    monkeypatch.setattr("agent.utils.sandbox_safety._audit_async", lambda *a, **k: None)
+
+
+class TestAuditedSandboxWrapperExecution:
+    def test_low_risk_command_executes(self, wrapper: AuditedSandboxWrapper, mock_sandbox: _MockSandbox):
+        res = wrapper.execute("git status")
+        assert res.exit_code == 0
+        assert "git status" in mock_sandbox.executed
+
+    def test_medium_risk_command_executes_with_warning(
+        self, wrapper: AuditedSandboxWrapper, mock_sandbox: _MockSandbox, caplog
+    ):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agent.utils.sandbox_safety"):
+            res = wrapper.execute("rm -rf ./build")
+
+        assert res.exit_code == 0
+        assert "rm -rf ./build" in mock_sandbox.executed
+        assert "medium-risk" in caplog.text
+
+    def test_high_risk_command_is_blocked(
+        self, wrapper: AuditedSandboxWrapper, mock_sandbox: _MockSandbox
+    ):
+        res = wrapper.execute("rm -rf /")
+        assert res.exit_code == 1
+        assert "[BLOCKED]" in res.output
+        # Underlying sandbox must not have received the command
+        assert "rm -rf /" not in mock_sandbox.executed
+
+    def test_high_risk_mkfs_is_blocked(self, wrapper: AuditedSandboxWrapper, mock_sandbox: _MockSandbox):
+        res = wrapper.execute("mkfs.ext4 /dev/sda")
+        assert res.exit_code == 1
+        assert not mock_sandbox.executed
+
+    def test_sandbox_exception_propagates(
+        self, wrapper: AuditedSandboxWrapper, mock_sandbox: _MockSandbox
+    ):
+        mock_sandbox.execute = MagicMock(side_effect=RuntimeError("sandbox error"))
+        with pytest.raises(RuntimeError, match="sandbox error"):
+            wrapper.execute("ls")
+
+    def test_id_property_delegates(self, wrapper: AuditedSandboxWrapper):
+        assert wrapper.id == "mock-sandbox-001"
+
+    def test_getattr_delegates_to_raw_sandbox(
+        self, wrapper: AuditedSandboxWrapper, mock_sandbox: _MockSandbox
+    ):
+        # Access an attribute not overridden by the wrapper
+        assert wrapper._raw_sandbox is mock_sandbox
+
+
+# ---------------------------------------------------------------------------
+# AuditedSandboxWrapper — audit emission (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEmission:
+    def test_audit_fired_for_low_risk(self, wrapper: AuditedSandboxWrapper, monkeypatch: pytest.MonkeyPatch):
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            "agent.utils.sandbox_safety._audit_async",
+            lambda *a, **k: calls.append((a, k)),
+        )
+        wrapper.execute("git log --oneline")
+        assert len(calls) == 1
+        args = calls[0][0]
+        assert args[2] == "LOW"  # risk_level
+
+    def test_audit_fired_for_high_risk(self, wrapper: AuditedSandboxWrapper, monkeypatch: pytest.MonkeyPatch):
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            "agent.utils.sandbox_safety._audit_async",
+            lambda *a, **k: calls.append((a, k)),
+        )
+        wrapper.execute("shutdown now")
+        assert len(calls) == 1
+        args = calls[0][0]
+        assert args[2] == "HIGH"
+
+    def test_audit_not_raised_on_langsmith_failure(
+        self, wrapper: AuditedSandboxWrapper, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A LangSmith error inside the audit thread must not bubble up."""
+        monkeypatch.setattr(
+            "agent.utils.sandbox_safety._emit_langsmith_audit",
+            MagicMock(side_effect=Exception("network error")),
+        )
+        # Restore real _audit_async so it calls _emit_langsmith_audit
+        from agent.utils import sandbox_safety
+        monkeypatch.setattr(sandbox_safety, "_audit_async", sandbox_safety._audit_async)
+
+        # Should not raise
+        res = wrapper.execute("git status")
+        assert res.exit_code == 0


### PR DESCRIPTION
## Problem
The sandbox had no visibility into which shell commands the agent executed,
making it impossible to audit risky operations in production deployments.
## Solution
Add `AuditedSandboxWrapper` — a transparent proxy around the sandbox backend:
- Classifies every command by risk level using static regex rules (zero latency)
- HIGH-risk commands (rm -rf /, mkfs, shutdown …) are blocked outright
- MEDIUM-risk commands (rm -rf <path>, git push --force) emit a WARNING log and proceed
- All commands are asynchronously reported to LangSmith as `sandbox_command` tool
  runs (fire-and-forget daemon thread, silently no-ops when LANGSMITH_API_KEY is absent)
- The wrapper is wired in automatically via `set_sandbox_backend()`
## Testing
21 unit tests covering classification logic, blocking, warning pass-through,
audit emission, and exception propagation.