### PR TITLE
feat(open-swe): surface Slack channel description + repo links in agent context [INF-0000]

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -503,6 +503,79 @@ async def fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[d
     return messages
 
 
+async def fetch_slack_channel_info(channel_id: str) -> dict[str, str] | None:
+    """Fetch a Slack channel's topic and purpose (the UI "Description").
+
+    Returns ``{"topic": ..., "purpose": ...}`` with empty strings when unset.
+    Failures are logged but never raised.
+    """
+    if not SLACK_BOT_TOKEN or not channel_id:
+        return None
+
+    async with httpx.AsyncClient() as http_client:
+        try:
+            response = await http_client.get(
+                f"{SLACK_API_BASE_URL}/conversations.info",
+                headers=_slack_headers(),
+                params={"channel": channel_id},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPError:
+            logger.exception("Slack conversations.info request failed for channel=%s", channel_id)
+            return None
+
+    if not payload.get("ok"):
+        logger.warning("Slack conversations.info failed: %s", payload.get("error"))
+        return None
+
+    channel = payload.get("channel")
+    if not isinstance(channel, dict):
+        return None
+
+    def _value(field: str) -> str:
+        section = channel.get(field)
+        value = section.get("value") if isinstance(section, dict) else None
+        return value if isinstance(value, str) else ""
+
+    return {"topic": _value("topic"), "purpose": _value("purpose")}
+
+
+REPO_LINK_RE = re.compile(
+    r"https?://(github\.com|gitlab\.com|codeberg\.org)/"
+    r"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)",
+)
+
+
+def extract_repo_links(text: str) -> list[dict[str, str]]:
+    """Extract GitHub/GitLab/Codeberg repo references from free text.
+
+    Strips a trailing ``.git`` and ignores deep paths (``/tree/...`` etc.).
+    Returns de-duplicated ``{"host","owner","name","url"}`` dicts in order.
+    """
+    if not text:
+        return []
+
+    seen: set[tuple[str, str, str]] = set()
+    links: list[dict[str, str]] = []
+    for match in REPO_LINK_RE.finditer(text):
+        host, owner, name = match.group(1), match.group(2), match.group(3)
+        name = name.removesuffix(".git")
+        key = (host, owner.lower(), name.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        links.append(
+            {
+                "host": host,
+                "owner": owner,
+                "name": name,
+                "url": f"https://{host}/{owner}/{name}",
+            }
+        )
+    return links
+
+
 SLACK_MESSAGE_URL_RE = re.compile(
     r"https?://[a-zA-Z0-9\-]+\.slack\.com/archives/([A-Za-z0-9]+)/p(\d{16})(?:\?[^\s>]*)?"
 )

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -85,6 +85,8 @@ from .utils.multimodal import dedupe_urls, extract_image_urls, fetch_image_block
 from .utils.repo import extract_repo_from_text
 from .utils.slack import (
     GitHubPrRef,
+    extract_repo_links,
+    fetch_slack_channel_info,
     fetch_slack_thread_messages,
     format_slack_messages_for_prompt,
     get_slack_user_info,
@@ -568,14 +570,16 @@ async def get_slack_repo_config(
     channel_id: str,
     thread_ts: str,
     slack_user_id: str | None = None,
+    channel_info: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Resolve repository configuration for Slack-triggered runs.
 
     Priority:
         1. Repo carried over from the existing Slack thread's metadata.
-        2. The triggering user's dashboard ``default_repo`` (if they have a
+        2. A GitHub repo link in the channel description (topic/purpose).
+        3. The triggering user's dashboard ``default_repo`` (if they have a
            profile and their Slack email maps to a known GitHub login).
-        3. ``SLACK_REPO_*`` env defaults.
+        4. ``SLACK_REPO_*`` env defaults.
     """
     default_owner = SLACK_REPO_OWNER.strip() or DEFAULT_REPO_OWNER
     default_name = SLACK_REPO_NAME.strip() or DEFAULT_REPO_NAME
@@ -595,6 +599,21 @@ async def get_slack_repo_config(
                 "Failed to fetch Slack thread %s for repo resolution",
                 thread_id,
             )
+
+    if not repo_config and channel_info:
+        description = f"{channel_info.get('purpose', '')}\n{channel_info.get('topic', '')}"
+        github_links = [
+            link for link in extract_repo_links(description) if link["host"] == "github.com"
+        ]
+        if github_links:
+            link = github_links[0]
+            logger.info(
+                "Applying channel-description repo for channel %s: %s/%s",
+                channel_id,
+                link["owner"],
+                link["name"],
+            )
+            repo_config = {"owner": link["owner"], "name": link["name"]}
 
     if not repo_config and slack_user_id:
         try:
@@ -928,6 +947,31 @@ async def _post_account_link_prompt(
         logger.debug("Failed to post account-link prompt to Slack", exc_info=True)
 
 
+def _build_channel_description_section(channel_info: dict[str, str]) -> str:
+    """Render the channel topic/purpose (and any repo links) as a prompt section."""
+    purpose = (channel_info.get("purpose") or "").strip()
+    topic = (channel_info.get("topic") or "").strip()
+    if not purpose and not topic:
+        return ""
+
+    lines = ["## Channel Description"]
+    if purpose:
+        lines.append(f"- Description: {purpose}")
+    if topic:
+        lines.append(f"- Topic: {topic}")
+
+    repo_links = extract_repo_links(f"{purpose}\n{topic}")
+    if repo_links:
+        rendered = ", ".join(link["url"] for link in repo_links)
+        lines.append(
+            f"This channel's description references these repositories: {rendered}. "
+            "Prefer one of these over the default repository hint unless the conversation "
+            "identifies a different repository."
+        )
+
+    return "\n".join(lines) + "\n\n"
+
+
 async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[str, str]) -> None:
     """Process a Slack app mention by creating a run or queuing a mid-run message."""
     channel_id = event_data.get("channel_id", "")
@@ -936,6 +980,7 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
     user_id = event_data.get("user_id", "")
     text = event_data.get("text", "")
     bot_user_id = event_data.get("bot_user_id", "")
+    channel_info = event_data.get("channel_info") or {}
 
     if not channel_id or not thread_ts or not event_ts:
         logger.warning(
@@ -1009,12 +1054,15 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
         context_messages, user_names_by_id
     )
 
+    channel_description_section = _build_channel_description_section(channel_info)
+
     prompt = (
         "You were mentioned in Slack.\n\n"
         "## Default Repository Hint\n"
         f"{repo_config.get('owner')}/{repo_config.get('name')}\n"
         "Use this only if the Slack conversation does not identify a different repository.\n\n"
-        f"## Triggered by\n{trigger_user}\n\n"
+        + channel_description_section
+        + f"## Triggered by\n{trigger_user}\n\n"
         f"## Slack Thread\n- Channel: {channel_id}\n- Thread TS: {thread_ts}\n"
         f"- Context starts at: {context_source}\n\n"
         f"## Conversation Context\n{context_text}\n\n"
@@ -1456,6 +1504,7 @@ async def slack_webhook(request: Request, background_tasks: BackgroundTasks) -> 
     if bot_user_id and user_id == bot_user_id:
         return {"status": "ignored", "reason": "Event from this bot user"}
 
+    channel_info = await fetch_slack_channel_info(channel_id)
     event_data = {
         "channel_id": channel_id,
         "thread_ts": thread_ts,
@@ -1463,8 +1512,11 @@ async def slack_webhook(request: Request, background_tasks: BackgroundTasks) -> 
         "user_id": user_id,
         "text": text,
         "bot_user_id": bot_user_id,
+        "channel_info": channel_info,
     }
-    repo_config = await get_slack_repo_config(channel_id, thread_ts, slack_user_id=user_id)
+    repo_config = await get_slack_repo_config(
+        channel_id, thread_ts, slack_user_id=user_id, channel_info=channel_info
+    )
 
     background_tasks.add_task(process_slack_mention, event_data, repo_config)
 
@@ -1526,7 +1578,10 @@ async def slack_interactivity(
     if not channel_id or not thread_ts or not event_ts or not user_id:
         return {"status": "ignored", "reason": "Missing Slack action context"}
 
-    repo_config = await get_slack_repo_config(channel_id, thread_ts, slack_user_id=user_id)
+    channel_info = await fetch_slack_channel_info(channel_id)
+    repo_config = await get_slack_repo_config(
+        channel_id, thread_ts, slack_user_id=user_id, channel_info=channel_info
+    )
     background_tasks.add_task(
         process_slack_mention,
         {
@@ -1536,6 +1591,7 @@ async def slack_interactivity(
             "user_id": user_id,
             "text": response,
             "bot_user_id": SLACK_BOT_USER_ID,
+            "channel_info": channel_info,
         },
         repo_config,
     )

--- a/tests/test_slack_context.py
+++ b/tests/test_slack_context.py
@@ -952,3 +952,102 @@ def test_process_slack_mention_bot_only_mode_runs_without_user_token(
 
     assert "run_create" in captured
     assert "prompt" not in captured
+
+
+def test_extract_repo_links_supported_hosts() -> None:
+    links = slack_utils.extract_repo_links(
+        "see https://github.com/acme/widgets and https://gitlab.com/foo/bar "
+        "plus https://codeberg.org/baz/qux"
+    )
+    assert [(link["host"], link["owner"], link["name"]) for link in links] == [
+        ("github.com", "acme", "widgets"),
+        ("gitlab.com", "foo", "bar"),
+        ("codeberg.org", "baz", "qux"),
+    ]
+
+
+def test_extract_repo_links_strips_git_suffix_and_deep_paths() -> None:
+    links = slack_utils.extract_repo_links(
+        "https://github.com/acme/widgets.git https://github.com/acme/widgets/tree/main/src"
+    )
+    assert len(links) == 1
+    assert links[0]["name"] == "widgets"
+    assert links[0]["url"] == "https://github.com/acme/widgets"
+
+
+def test_extract_repo_links_no_match() -> None:
+    assert slack_utils.extract_repo_links("no links here, just https://example.com") == []
+    assert slack_utils.extract_repo_links("") == []
+
+
+def test_get_slack_repo_config_uses_channel_description_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    monkeypatch.setattr(webapp, "SLACK_REPO_OWNER", "default-owner")
+    monkeypatch.setattr(webapp, "SLACK_REPO_NAME", "default-repo")
+    monkeypatch.setattr(webapp, "get_client", lambda url: _FakeClient(threads_client))
+
+    repo = asyncio.run(
+        webapp.get_slack_repo_config(
+            "C123",
+            "1.234",
+            channel_info={"purpose": "work on https://github.com/acme/widgets", "topic": ""},
+        )
+    )
+
+    assert repo == {"owner": "acme", "name": "widgets"}
+
+
+def test_get_slack_repo_config_thread_repo_beats_channel_description(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(
+        thread={"metadata": {"repo": {"owner": "saved-owner", "name": "saved-repo"}}}
+    )
+    monkeypatch.setattr(webapp, "get_client", lambda url: _FakeClient(threads_client))
+
+    repo = asyncio.run(
+        webapp.get_slack_repo_config(
+            "C123",
+            "1.234",
+            channel_info={"purpose": "https://github.com/acme/widgets", "topic": ""},
+        )
+    )
+
+    assert repo == {"owner": "saved-owner", "name": "saved-repo"}
+
+
+def test_get_slack_repo_config_ignores_non_github_channel_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    monkeypatch.setattr(webapp, "SLACK_REPO_OWNER", "default-owner")
+    monkeypatch.setattr(webapp, "SLACK_REPO_NAME", "default-repo")
+    monkeypatch.setattr(webapp, "get_client", lambda url: _FakeClient(threads_client))
+
+    repo = asyncio.run(
+        webapp.get_slack_repo_config(
+            "C123",
+            "1.234",
+            channel_info={"purpose": "https://gitlab.com/foo/bar", "topic": ""},
+        )
+    )
+
+    assert repo == {"owner": "default-owner", "name": "default-repo"}
+
+
+def test_build_channel_description_section_renders_fields_and_links() -> None:
+    section = webapp._build_channel_description_section(
+        {"purpose": "Repo: https://github.com/acme/widgets", "topic": "Standup chatter"}
+    )
+    assert "## Channel Description" in section
+    assert "- Description: Repo: https://github.com/acme/widgets" in section
+    assert "- Topic: Standup chatter" in section
+    assert "https://github.com/acme/widgets" in section
+    assert section.endswith("\n\n")
+
+
+def test_build_channel_description_section_empty() -> None:
+    assert webapp._build_channel_description_section({"purpose": "", "topic": ""}) == ""
+    assert webapp._build_channel_description_section({}) == ""


### PR DESCRIPTION
Pulls the Slack channel's description into the agent's context when it's mentioned, and uses any GitHub repo link found there to resolve the working repo.

## What changed
- `fetch_slack_channel_info` (`conversations.info`) returns the channel's topic and purpose (the UI "Description").
- `extract_repo_links` parses `github.com` / `gitlab.com` / `codeberg.org` repo URLs, stripping `.git` and deep paths, deduped.
- Both Slack entry points (`slack_webhook`, `slack_interactivity`) fetch channel info once and thread it into repo resolution and the prompt.
- New repo-resolution tier sits **below** thread metadata and **above** dashboard/team/env defaults. Only `github.com` links fill the owner/name hint; gitlab/codeberg links are surfaced in the prompt text but never override the hint (it's GitHub-shaped).
- The prompt gains a `## Channel Description` section rendering Description + Topic and listing any referenced repos.

## Test Plan
- [x] Unit tests for `extract_repo_links` (each host, `.git`/deep-path normalization, no-match) and the repo-override precedence in `get_slack_repo_config`, plus the prompt section builder
