### PR TITLE
perf: preload agent thread details

### DIFF
--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -1,143 +1,122 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react"
 
-import type { SessionUser } from "@/lib/api";
-import type { PendingPrompt } from "@/lib/agents/pendingPrompts";
-import type { AgentThread, Message } from "@/lib/agents/types";
-import type { ModelSelection } from "@/lib/agents/useModelOptions";
-import { AgentPromptBar } from "@/components/agents/AgentPromptBar";
-import { AgentsShell } from "@/components/agents/AgentsSidebar";
-import { MessageView } from "@/components/agents/ported";
-import { useCancelAgentThread, useSendAgentMessage } from "@/lib/agents/queries";
-import { dropPendingPrompts, getPendingPrompts } from "@/lib/agents/pendingPrompts";
-import { useAgentThreadStream } from "@/lib/agents/useThreadStream";
-import { useModelOptions } from "@/lib/agents/useModelOptions";
+import type { PendingPrompt } from "@/lib/agents/pendingPrompts"
+import type { AgentThread, Message } from "@/lib/agents/types"
+import type { ModelSelection } from "@/lib/agents/useModelOptions"
+import { AgentPromptBar } from "@/components/agents/AgentPromptBar"
+import { MessageView } from "@/components/agents/ported"
+import { useCancelAgentThread, useSendAgentMessage } from "@/lib/agents/queries"
+import {
+  dropPendingPrompts,
+  getPendingPrompts,
+} from "@/lib/agents/pendingPrompts"
+import { useAgentThreadStream } from "@/lib/agents/useThreadStream"
+import { useModelOptions } from "@/lib/agents/useModelOptions"
 
 interface AgentThreadViewProps {
-  user: SessionUser;
-  thread: AgentThread;
+  thread: AgentThread
 }
 
 function messageText(message: Message): string {
   return message.chunks
     .filter((chunk) => chunk.kind === "text")
     .map((chunk) => chunk.text)
-    .join("");
+    .join("")
 }
 
 function messageImageKey(message: Message): string {
   return message.chunks
     .filter((chunk) => chunk.kind === "image")
     .map((chunk) => `${chunk.mimeType}:${chunk.base64}`)
-    .join("\u0000");
+    .join("\u0000")
 }
 
 function pendingImageKey(entry: PendingPrompt): string {
   return (entry.images ?? [])
     .map((image) => `${image.mimeType}:${image.base64}`)
-    .join("\u0000");
+    .join("\u0000")
 }
 
-function isPendingPromptConfirmed(entry: PendingPrompt, messages: Array<Message>): boolean {
+function isPendingPromptConfirmed(
+  entry: PendingPrompt,
+  messages: Array<Message>
+): boolean {
   return messages.slice(entry.insertAt).some((message) => {
-    if (message.author !== "user") return false;
-    return messageText(message) === entry.prompt && messageImageKey(message) === pendingImageKey(entry);
-  });
+    if (message.author !== "user") return false
+    return (
+      messageText(message) === entry.prompt &&
+      messageImageKey(message) === pendingImageKey(entry)
+    )
+  })
 }
 
-export function AgentThreadView({ user, thread }: AgentThreadViewProps) {
-  const sendMessage = useSendAgentMessage(thread.id);
-  const cancelThread = useCancelAgentThread(thread.id);
-  useAgentThreadStream(thread.id, thread.status === "running");
-  const [pendingPrompts, setPendingPrompts] = useState<Array<PendingPrompt>>(() =>
-    getPendingPrompts(thread.id),
-  );
+export function AgentThreadView({ thread }: AgentThreadViewProps) {
+  const sendMessage = useSendAgentMessage(thread.id)
+  const cancelThread = useCancelAgentThread(thread.id)
+  useAgentThreadStream(thread.id, thread.status === "running")
+  const [pendingPrompts, setPendingPrompts] = useState<Array<PendingPrompt>>(
+    () => getPendingPrompts(thread.id)
+  )
 
-  const { models, defaultSelection } = useModelOptions();
+  const { models, defaultSelection } = useModelOptions()
   const threadSelection = useMemo<ModelSelection | null>(() => {
-    if (!thread.model || !thread.effort) return null;
+    if (!thread.model || !thread.effort) return null
     const supported = models.some(
-      (m) => m.id === thread.model && m.efforts.includes(thread.effort ?? ""),
-    );
-    if (!supported) return null;
-    return { modelId: thread.model, effort: thread.effort };
-  }, [models, thread.model, thread.effort]);
-  const [selection, setSelection] = useState<ModelSelection | null>(null);
-  const activeSelection = selection ?? threadSelection ?? defaultSelection;
+      (m) => m.id === thread.model && m.efforts.includes(thread.effort ?? "")
+    )
+    if (!supported) return null
+    return { modelId: thread.model, effort: thread.effort }
+  }, [models, thread.model, thread.effort])
+  const [selection, setSelection] = useState<ModelSelection | null>(null)
+  const activeSelection = selection ?? threadSelection ?? defaultSelection
 
   useEffect(() => {
     setPendingPrompts((prev) => {
-      if (prev.length === 0) return prev;
+      if (prev.length === 0) return prev
       const next = dropPendingPrompts(thread.id, (entry) =>
-        isPendingPromptConfirmed(entry, thread.messages),
-      );
-      return next.length === prev.length ? prev : next;
-    });
-  }, [thread.id, thread.messages]);
+        isPendingPromptConfirmed(entry, thread.messages)
+      )
+      return next.length === prev.length ? prev : next
+    })
+  }, [thread.id, thread.messages])
 
   const displayMessages = useMemo<Array<Message>>(() => {
-    if (pendingPrompts.length === 0) return thread.messages;
-    const baseTimestamp = new Date().toISOString();
-    const result = thread.messages.slice();
+    if (pendingPrompts.length === 0) return thread.messages
+    const baseTimestamp = new Date().toISOString()
+    const result = thread.messages.slice()
     pendingPrompts.forEach((entry, i) => {
-      const chunks: Message["chunks"] = [...(entry.images ?? [])];
-      if (entry.prompt) chunks.push({ kind: "text", text: entry.prompt });
+      const chunks: Message["chunks"] = [...(entry.images ?? [])]
+      if (entry.prompt) chunks.push({ kind: "text", text: entry.prompt })
       const synth: Message = {
         id: `pending-user-${i}`,
         author: "user",
         timestamp: baseTimestamp,
         chunks,
-      };
-      const at = Math.min(Math.max(entry.insertAt, 0), result.length);
-      result.splice(at, 0, synth);
-    });
-    return result;
-  }, [thread.messages, pendingPrompts]);
+      }
+      const at = Math.min(Math.max(entry.insertAt, 0), result.length)
+      result.splice(at, 0, synth)
+    })
+    return result
+  }, [thread.messages, pendingPrompts])
 
-  const hasMessages = displayMessages.length > 0;
-  const hasActiveRun = thread.status === "running";
-  const isStreaming = hasActiveRun || pendingPrompts.length > 0;
+  const hasMessages = displayMessages.length > 0
+  const hasActiveRun = thread.status === "running"
+  const isStreaming = hasActiveRun || pendingPrompts.length > 0
 
   return (
-    <AgentsShell user={user} activeThreadId={thread.id}>
-      <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex min-h-0 flex-1 flex-col">
-          {hasMessages ? (
-            <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-              <MessageView
-                messages={displayMessages}
-                isStreaming={isStreaming}
-                contentWidthClass="max-w-3xl"
-              />
-              <div className="shrink-0 px-4 pb-4">
-                <div className="mx-auto w-full min-w-0 max-w-3xl">
-                  <AgentPromptBar
-                    placeholder="Add a follow up"
-                    compact
-                    busy={hasActiveRun}
-                    disabled={sendMessage.isPending}
-                    onSubmit={(content, images) =>
-                      sendMessage.mutate({
-                        content,
-                        images,
-                        model_id: activeSelection?.modelId ?? null,
-                        effort: activeSelection?.effort ?? null,
-                      })
-                    }
-                    onStop={() => cancelThread.mutate()}
-                    stopping={cancelThread.isPending}
-                    models={models}
-                    selection={activeSelection}
-                    onSelectionChange={setSelection}
-                  />
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
-              <p className="text-sm text-[var(--ui-text-dim)]">This thread has no messages yet.</p>
-              <div className="w-full max-w-3xl">
+    <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
+        {hasMessages ? (
+          <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+            <MessageView
+              messages={displayMessages}
+              isStreaming={isStreaming}
+              contentWidthClass="max-w-3xl"
+            />
+            <div className="shrink-0 px-4 pb-4">
+              <div className="mx-auto w-full max-w-3xl min-w-0">
                 <AgentPromptBar
-                  placeholder="Send the first message"
+                  placeholder="Add a follow up"
                   compact
                   busy={hasActiveRun}
                   disabled={sendMessage.isPending}
@@ -157,9 +136,36 @@ export function AgentThreadView({ user, thread }: AgentThreadViewProps) {
                 />
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+            <p className="text-sm text-[var(--ui-text-dim)]">
+              This thread has no messages yet.
+            </p>
+            <div className="w-full max-w-3xl">
+              <AgentPromptBar
+                placeholder="Send the first message"
+                compact
+                busy={hasActiveRun}
+                disabled={sendMessage.isPending}
+                onSubmit={(content, images) =>
+                  sendMessage.mutate({
+                    content,
+                    images,
+                    model_id: activeSelection?.modelId ?? null,
+                    effort: activeSelection?.effort ?? null,
+                  })
+                }
+                onStop={() => cancelThread.mutate()}
+                stopping={cancelThread.isPending}
+                models={models}
+                selection={activeSelection}
+                onSelectionChange={setSelection}
+              />
+            </div>
+          </div>
+        )}
       </div>
-    </AgentsShell>
-  );
+    </div>
+  )
 }

--- a/ui/src/components/agents/AgentsSidebar.tsx
+++ b/ui/src/components/agents/AgentsSidebar.tsx
@@ -20,7 +20,11 @@ import {
   useSidebarLayout,
 } from "@/components/sidebar-layout"
 import { groupThreads } from "@/lib/agents/api"
-import { useAgentThreads, useDeleteAgentThread } from "@/lib/agents/queries"
+import {
+  useAgentThreads,
+  useDeleteAgentThread,
+  usePrefetchAgentThreadDetails,
+} from "@/lib/agents/queries"
 import { cn } from "@/lib/utils"
 
 type SourceIcon = ComponentType<SVGProps<SVGSVGElement>>
@@ -46,6 +50,7 @@ const NAV = [
 export function AgentsSidebar({ user, activeThreadId }: AgentsSidebarProps) {
   const threadsQuery = useAgentThreads()
   const threads = threadsQuery.data ?? []
+  usePrefetchAgentThreadDetails(threads, activeThreadId)
   const groups = groupThreads(threads)
   const layout = useSidebarLayout()
 

--- a/ui/src/lib/agents/queries.ts
+++ b/ui/src/lib/agents/queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
 
 import { agentsApi } from "./api"
 import { addPendingPrompt } from "./pendingPrompts"
@@ -13,6 +14,29 @@ export const agentThreadKeys = {
 
 export const agentScheduleKeys = {
   all: ["agent-schedules"] as const,
+}
+
+const PREFETCH_THREAD_DETAIL_LIMIT = 12
+
+export function usePrefetchAgentThreadDetails(
+  threads: Array<{ id: string }>,
+  activeThreadId?: string
+) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    const threadIds = threads
+      .map((thread) => thread.id)
+      .filter((threadId) => threadId !== activeThreadId)
+      .slice(0, PREFETCH_THREAD_DETAIL_LIMIT)
+
+    threadIds.forEach((threadId) => {
+      void queryClient.prefetchQuery({
+        queryKey: agentThreadKeys.detail(threadId),
+        queryFn: () => agentsApi.getThread(threadId),
+      })
+    })
+  }, [activeThreadId, queryClient, threads])
 }
 
 export function useAgentThreads() {

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -1,32 +1,46 @@
-import { Navigate, Outlet, createFileRoute } from "@tanstack/react-router";
+import {
+  Navigate,
+  Outlet,
+  createFileRoute,
+  useRouterState,
+} from "@tanstack/react-router"
 
-import { Skeleton } from "@/components/ui/skeleton";
-import agentsCss from "@/styles/agents.css?url";
-import { useSession } from "@/lib/session";
+import { AgentsShell } from "@/components/agents/AgentsSidebar"
+import { Skeleton } from "@/components/ui/skeleton"
+import agentsCss from "@/styles/agents.css?url"
+import { useSession } from "@/lib/session"
 
 export const Route = createFileRoute("/agents")({
   head: () => ({
     links: [{ rel: "stylesheet", href: agentsCss }],
   }),
   component: AgentsLayout,
-});
+})
 
 function AgentsLayout() {
-  const session = useSession();
+  const session = useSession()
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  })
+  const [, section, threadId] = pathname.split("/")
+  const activeThreadId =
+    section === "agents" && threadId && threadId !== "automations"
+      ? threadId
+      : undefined
 
   if (session.isLoading) {
     return (
       <main className="agents-ui flex h-svh items-center justify-center bg-[var(--ui-bg)] p-6">
         <Skeleton className="h-40 w-full max-w-md" />
       </main>
-    );
+    )
   }
 
-  if (!session.data) return <Navigate to="/login" />;
+  if (!session.data) return <Navigate to="/login" />
 
   return (
-    <div className="agents-ui h-svh overflow-hidden">
+    <AgentsShell user={session.data} activeThreadId={activeThreadId}>
       <Outlet />
-    </div>
-  );
+    </AgentsShell>
+  )
 }

--- a/ui/src/routes/agents/$threadId.tsx
+++ b/ui/src/routes/agents/$threadId.tsx
@@ -1,33 +1,36 @@
-import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { Navigate, createFileRoute } from "@tanstack/react-router"
 
-import { AgentThreadView } from "@/components/agents/AgentThreadView";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useAgentThread } from "@/lib/agents/queries";
-import { useSession } from "@/lib/session";
+import { AgentThreadView } from "@/components/agents/AgentThreadView"
+import { AgentsShell } from "@/components/agents/AgentsSidebar"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useAgentThread } from "@/lib/agents/queries"
+import { useSession } from "@/lib/session"
 
 export const Route = createFileRoute("/agents/$threadId")({
   component: AgentThreadPage,
-});
+})
 
 function AgentThreadPage() {
-  const { threadId } = Route.useParams();
-  const session = useSession();
-  const threadQuery = useAgentThread(threadId);
+  const { threadId } = Route.useParams()
+  const session = useSession()
+  const threadQuery = useAgentThread(threadId)
 
-  if (session.isLoading) return null;
-  if (!session.data) return <Navigate to="/login" />;
+  if (session.isLoading) return null
+  if (!session.data) return <Navigate to="/login" />
 
   if (threadQuery.isLoading) {
     return (
-      <main className="agents-ui flex h-svh items-center justify-center bg-[var(--ui-bg)] p-6">
-        <Skeleton className="h-40 w-full max-w-md" />
-      </main>
-    );
+      <AgentsShell user={session.data} activeThreadId={threadId}>
+        <main className="flex min-w-0 flex-1 items-center justify-center p-6">
+          <Skeleton className="h-40 w-full max-w-md" />
+        </main>
+      </AgentsShell>
+    )
   }
 
   if (threadQuery.isError || !threadQuery.data) {
-    return <Navigate to="/agents" />;
+    return <Navigate to="/agents" />
   }
 
-  return <AgentThreadView user={session.data} thread={threadQuery.data} />;
+  return <AgentThreadView user={session.data} thread={threadQuery.data} />
 }

--- a/ui/src/routes/agents/$threadId.tsx
+++ b/ui/src/routes/agents/$threadId.tsx
@@ -1,10 +1,8 @@
 import { Navigate, createFileRoute } from "@tanstack/react-router"
 
 import { AgentThreadView } from "@/components/agents/AgentThreadView"
-import { AgentsShell } from "@/components/agents/AgentsSidebar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useAgentThread } from "@/lib/agents/queries"
-import { useSession } from "@/lib/session"
 
 export const Route = createFileRoute("/agents/$threadId")({
   component: AgentThreadPage,
@@ -12,19 +10,13 @@ export const Route = createFileRoute("/agents/$threadId")({
 
 function AgentThreadPage() {
   const { threadId } = Route.useParams()
-  const session = useSession()
   const threadQuery = useAgentThread(threadId)
-
-  if (session.isLoading) return null
-  if (!session.data) return <Navigate to="/login" />
 
   if (threadQuery.isLoading) {
     return (
-      <AgentsShell user={session.data} activeThreadId={threadId}>
-        <main className="flex min-w-0 flex-1 items-center justify-center p-6">
-          <Skeleton className="h-40 w-full max-w-md" />
-        </main>
-      </AgentsShell>
+      <main className="flex min-w-0 flex-1 items-center justify-center p-6">
+        <Skeleton className="h-40 w-full max-w-md" />
+      </main>
     )
   }
 
@@ -32,5 +24,5 @@ function AgentThreadPage() {
     return <Navigate to="/agents" />
   }
 
-  return <AgentThreadView user={session.data} thread={threadQuery.data} />
+  return <AgentThreadView thread={threadQuery.data} />
 }

--- a/ui/src/routes/agents/automations/$scheduleId.tsx
+++ b/ui/src/routes/agents/automations/$scheduleId.tsx
@@ -1,46 +1,42 @@
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { Link, createFileRoute } from "@tanstack/react-router"
 
-import { AutomationEditor } from "@/components/agents/AutomationEditor";
-import { AgentsShell } from "@/components/agents/AgentsSidebar";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useAgentSchedules } from "@/lib/agents/queries";
-import { useSession } from "@/lib/session";
+import { AutomationEditor } from "@/components/agents/AutomationEditor"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useAgentSchedules } from "@/lib/agents/queries"
 
 export const Route = createFileRoute("/agents/automations/$scheduleId")({
   component: EditAutomationPage,
-});
+})
 
 function EditAutomationPage() {
-  const session = useSession();
-  const { scheduleId } = Route.useParams();
-  const schedulesQuery = useAgentSchedules();
+  const { scheduleId } = Route.useParams()
+  const schedulesQuery = useAgentSchedules()
+  const schedule = schedulesQuery.data?.find((s) => s.id === scheduleId)
 
-  if (!session.data) return null;
+  if (schedulesQuery.isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-6 py-10">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="mt-6 h-32 w-full" />
+      </div>
+    )
+  }
 
-  const schedule = schedulesQuery.data?.find((s) => s.id === scheduleId);
+  if (schedule) {
+    return <AutomationEditor mode="edit" schedule={schedule} />
+  }
 
   return (
-    <AgentsShell user={session.data}>
-      {schedulesQuery.isLoading ? (
-        <div className="mx-auto w-full max-w-3xl px-6 py-10">
-          <Skeleton className="h-9 w-64" />
-          <Skeleton className="mt-6 h-32 w-full" />
-        </div>
-      ) : schedule ? (
-        <AutomationEditor mode="edit" schedule={schedule} />
-      ) : (
-        <div className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
-          <p className="text-sm text-[var(--ui-text-muted)]">
-            This automation could not be found.
-          </p>
-          <Link
-            to="/agents/automations"
-            className="mt-3 inline-block text-sm text-[var(--ui-accent)] hover:underline"
-          >
-            Back to Automations
-          </Link>
-        </div>
-      )}
-    </AgentsShell>
-  );
+    <div className="mx-auto w-full max-w-3xl px-6 py-16 text-center">
+      <p className="text-sm text-[var(--ui-text-muted)]">
+        This automation could not be found.
+      </p>
+      <Link
+        to="/agents/automations"
+        className="mt-3 inline-block text-sm text-[var(--ui-accent)] hover:underline"
+      >
+        Back to Automations
+      </Link>
+    </div>
+  )
 }

--- a/ui/src/routes/agents/automations/index.tsx
+++ b/ui/src/routes/agents/automations/index.tsx
@@ -1,20 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router"
 
-import { AutomationsList } from "@/components/agents/AutomationsList";
-import { AgentsShell } from "@/components/agents/AgentsSidebar";
-import { useSession } from "@/lib/session";
+import { AutomationsList } from "@/components/agents/AutomationsList"
 
 export const Route = createFileRoute("/agents/automations/")({
   component: AutomationsIndexPage,
-});
+})
 
 function AutomationsIndexPage() {
-  const session = useSession();
-  if (!session.data) return null;
-
-  return (
-    <AgentsShell user={session.data}>
-      <AutomationsList />
-    </AgentsShell>
-  );
+  return <AutomationsList />
 }

--- a/ui/src/routes/agents/automations/new.tsx
+++ b/ui/src/routes/agents/automations/new.tsx
@@ -1,20 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router"
 
-import { AutomationEditor } from "@/components/agents/AutomationEditor";
-import { AgentsShell } from "@/components/agents/AgentsSidebar";
-import { useSession } from "@/lib/session";
+import { AutomationEditor } from "@/components/agents/AutomationEditor"
 
 export const Route = createFileRoute("/agents/automations/new")({
   component: NewAutomationPage,
-});
+})
 
 function NewAutomationPage() {
-  const session = useSession();
-  if (!session.data) return null;
-
-  return (
-    <AgentsShell user={session.data}>
-      <AutomationEditor mode="create" />
-    </AgentsShell>
-  );
+  return <AutomationEditor mode="create" />
 }

--- a/ui/src/routes/agents/index.tsx
+++ b/ui/src/routes/agents/index.tsx
@@ -1,20 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router"
 
-import { AgentsHome } from "@/components/agents/AgentsHome";
-import { AgentsShell } from "@/components/agents/AgentsSidebar";
-import { useSession } from "@/lib/session";
+import { AgentsHome } from "@/components/agents/AgentsHome"
 
 export const Route = createFileRoute("/agents/")({
   component: AgentsIndexPage,
-});
+})
 
 function AgentsIndexPage() {
-  const session = useSession();
-  if (!session.data) return null;
-
-  return (
-    <AgentsShell user={session.data}>
-      <AgentsHome />
-    </AgentsShell>
-  );
+  return <AgentsHome />
 }


### PR DESCRIPTION
## Description
Persists the agents shell at the `/agents` layout level so switching between conversations only remounts the thread content instead of the whole page/sidebar. Also preloads recent thread detail queries from the persistent sidebar so first-page thread switches can render from React Query cache.

## Release Note
none

## Test Plan
- [ ] Manually verify first-page agent thread switching no longer flashes the full-page loading state.

Made by [Open SWE](https://openswe.vercel.app)
