### PR TITLE
fix: reword reviewer feedback prompt

### DIFF
--- a/agent/reviewer_publish.py
+++ b/agent/reviewer_publish.py
@@ -103,7 +103,7 @@ def render_inline_comment_body(finding: Finding) -> str:
         *(Refers to lines X-Y)*
 
         ---
-        *Good catch or off base? React with 👍 or 👎 to help Open SWE learn.*
+        *Your feedback helps Open SWE learn. React with 👍 or 👎 to tell us if this review comment was useful.*
 
         ```suggestion
         <replacement>
@@ -132,7 +132,11 @@ def render_inline_comment_body(finding: Finding) -> str:
     if line_ref:
         body_parts.extend(["", line_ref])
     body_parts.extend(
-        ["", "---", "*Good catch or off base? React with 👍 or 👎 to help Open SWE learn.*"]
+        [
+            "",
+            "---",
+            "*Your feedback helps Open SWE learn. React with 👍 or 👎 to tell us if this review comment was useful.*",
+        ]
     )
     body = "\n".join(body_parts)
 

--- a/agent/reviewer_publish.py
+++ b/agent/reviewer_publish.py
@@ -103,7 +103,7 @@ def render_inline_comment_body(finding: Finding) -> str:
         *(Refers to lines X-Y)*
 
         ---
-        *Was this helpful? React with 👍 or 👎 to provide feedback.*
+        *Good catch or off base? React with 👍 or 👎 to help Open SWE learn.*
 
         ```suggestion
         <replacement>
@@ -131,7 +131,9 @@ def render_inline_comment_body(finding: Finding) -> str:
         body_parts.extend(["", detail])
     if line_ref:
         body_parts.extend(["", line_ref])
-    body_parts.extend(["", "---", "*Was this helpful? React with 👍 or 👎 to provide feedback.*"])
+    body_parts.extend(
+        ["", "---", "*Good catch or off base? React with 👍 or 👎 to help Open SWE learn.*"]
+    )
     body = "\n".join(body_parts)
 
     suggestion = finding.get("suggestion")

--- a/tests/test_reviewer_publish.py
+++ b/tests/test_reviewer_publish.py
@@ -65,9 +65,9 @@ def test_render_inline_comment_body_without_suggestion() -> None:
     assert "<!-- open-swe-review-comment" in body
     assert '"id":"f_' in body
     assert "just text" in body
-    assert "Good catch or off base?" in body
+    assert "Your feedback helps Open SWE learn." in body
     assert "👍 or 👎" in body
-    assert "help Open SWE learn" in body
+    assert "tell us if this review comment was useful" in body
 
 
 def test_render_inline_comment_body_with_suggestion_appends_block() -> None:

--- a/tests/test_reviewer_publish.py
+++ b/tests/test_reviewer_publish.py
@@ -65,8 +65,9 @@ def test_render_inline_comment_body_without_suggestion() -> None:
     assert "<!-- open-swe-review-comment" in body
     assert '"id":"f_' in body
     assert "just text" in body
-    assert "Was this helpful?" in body
+    assert "Good catch or off base?" in body
     assert "👍 or 👎" in body
+    assert "help Open SWE learn" in body
 
 
 def test_render_inline_comment_body_with_suggestion_appends_block() -> None:


### PR DESCRIPTION
## Description
Rewords the reviewer inline feedback prompt so it feels distinct and Open SWE-specific while keeping the reaction-based feedback flow.

## Release Note
Updated reviewer comment feedback copy.

## Test Plan
- [x] Rendered inline reviewer comment body includes the new feedback copy.

Made by [Open SWE](https://openswe.vercel.app)