### PR TITLE
fix: use pierre-dark theme for diff view in dark mode

### DIFF
--- a/ui/src/components/agents/utils/diffUtils.ts
+++ b/ui/src/components/agents/utils/diffUtils.ts
@@ -54,7 +54,8 @@ export const DIFF_UNSAFE_CSS = `
 `;
 
 export const diffOptions = {
-  theme: "pierre-light" as const,
+  theme: { light: "pierre-light", dark: "pierre-dark" } as const,
+  themeType: "system" as const,
   diffStyle: "unified" as const,
   overflow: "scroll" as const,
   disableFileHeader: true,


### PR DESCRIPTION
## Description
The Pierre diff view hardcoded the syntax-highlight theme to `pierre-light`, while the diff background follows the app theme (`--ui-panel`). In dark mode this rendered light-theme token colors on a dark background, causing poor contrast / unreadable text. The fix supplies both light and dark Pierre themes and lets the diff follow the document's `color-scheme` via `themeType: "system"` (the app already sets `color-scheme` on `<html>` for every theme mode).

## Release Note
Fixed poor text contrast in the Pierre diff view when using dark mode.

## Test Plan
- [ ] In dark mode, open a diff in the agents UI and confirm syntax-highlighted tokens are clearly legible against the dark background.
- [ ] Toggle to light mode and confirm the diff still renders correctly.

Made by [Open SWE](https://openswe.vercel.app)