### PR TITLE
fix: let usage table expand to fill available width

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -10,15 +10,23 @@ interface AppShellProps {
   title: string;
   description?: string;
   backTo?: { to: string; label: string };
+  maxWidthClassName?: string;
   children: ReactNode;
 }
 
-export function AppShell({ user, title, description, backTo, children }: AppShellProps) {
+export function AppShell({
+  user,
+  title,
+  description,
+  backTo,
+  maxWidthClassName = "max-w-3xl",
+  children,
+}: AppShellProps) {
   return (
     <div className="flex h-svh overflow-hidden bg-background text-foreground">
       <AppSidebar user={user} />
       <main className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-4 pt-14 pb-6 sm:px-8 sm:py-10">
+        <div className={`mx-auto ${maxWidthClassName} px-4 pt-14 pb-6 sm:px-8 sm:py-10`}>
           {backTo && (
             <Link
               to={backTo.to}

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -4,13 +4,14 @@ import type { ReactNode } from "react";
 
 import type { SessionUser } from "@/lib/api";
 import { AppSidebar } from "@/components/AppSidebar";
+import { cn } from "@/lib/utils";
 
 interface AppShellProps {
   user: SessionUser;
   title: string;
   description?: string;
   backTo?: { to: string; label: string };
-  maxWidthClassName?: string;
+  className?: string;
   children: ReactNode;
 }
 
@@ -19,14 +20,14 @@ export function AppShell({
   title,
   description,
   backTo,
-  maxWidthClassName = "max-w-3xl",
+  className,
   children,
 }: AppShellProps) {
   return (
     <div className="flex h-svh overflow-hidden bg-background text-foreground">
       <AppSidebar user={user} />
       <main className="flex-1 overflow-y-auto">
-        <div className={`mx-auto ${maxWidthClassName} px-4 pt-14 pb-6 sm:px-8 sm:py-10`}>
+        <div className={cn("mx-auto max-w-3xl px-4 pt-14 pb-6 sm:px-8 sm:py-10", className)}>
           {backTo && (
             <Link
               to={backTo.to}

--- a/ui/src/routes/usage.tsx
+++ b/ui/src/routes/usage.tsx
@@ -60,7 +60,7 @@ function UsagePage() {
   if (!session.data) return <Navigate to="/login" />
 
   return (
-    <AppShell user={session.data} title="Usage" maxWidthClassName="max-w-5xl">
+    <AppShell user={session.data} title="Usage" className="max-w-5xl">
       <SettingsSection
         title="Agent leaderboard"
         description="Ranked by agent lines of code, then PRs opened and agent runs."

--- a/ui/src/routes/usage.tsx
+++ b/ui/src/routes/usage.tsx
@@ -60,7 +60,7 @@ function UsagePage() {
   if (!session.data) return <Navigate to="/login" />
 
   return (
-    <AppShell user={session.data} title="Usage">
+    <AppShell user={session.data} title="Usage" maxWidthClassName="max-w-5xl">
       <SettingsSection
         title="Agent leaderboard"
         description="Ranked by agent lines of code, then PRs opened and agent runs."


### PR DESCRIPTION
## Description
The usage page content was capped at `max-w-3xl`, but the leaderboard table requires a ~760px minimum for its 7 columns, so it always overflowed and forced horizontal scrolling (with no scroll affordance). This adds an optional `maxWidthClassName` prop to `AppShell` and widens the usage page to `max-w-5xl`, so the table expands to fill available space while keeping `overflow-x-auto` as a fallback on narrow screens.

## Release Note
The usage leaderboard table now expands to fill available width instead of being forced to scroll horizontally.

## Test Plan
<img width="1512" height="798" alt="Screenshot 2026-06-09 at 11 12 48 AM" src="https://github.com/user-attachments/assets/f0f5d5d9-f87d-4251-bba1-a304f6b60b86" />
without horizontal scrolling.

Made by [Open SWE](https://openswe.vercel.app)