### PR TITLE
feat: add Claude Fable 5 as a supported model

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -15,6 +15,13 @@ class ModelOption(TypedDict):
 
 SUPPORTED_MODELS: list[ModelOption] = [
     {
+        "id": "anthropic:claude-fable-5",
+        "label": "Fable 5",
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "default_effort": "high",
+        "supports_images": True,
+    },
+    {
         "id": "anthropic:claude-opus-4-8",
         "label": "Opus 4.8",
         "efforts": ["low", "medium", "high", "xhigh", "max"],

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -15,15 +15,15 @@ class ModelOption(TypedDict):
 
 SUPPORTED_MODELS: list[ModelOption] = [
     {
-        "id": "anthropic:claude-fable-5",
-        "label": "Fable 5",
+        "id": "anthropic:claude-opus-4-8",
+        "label": "Opus 4.8",
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
         "supports_images": True,
     },
     {
-        "id": "anthropic:claude-opus-4-8",
-        "label": "Opus 4.8",
+        "id": "anthropic:claude-fable-5",
+        "label": "Fable 5",
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
         "supports_images": True,


### PR DESCRIPTION
## Description
Anthropic released Claude Fable 5 (Mythos-class, June 9 2026) — its most capable widely-available model. This adds the `anthropic:claude-fable-5` API model ID to `SUPPORTED_MODELS` so it can be selected in the profile editor. The existing `anthropic:`-prefix logic in `model.py` handles effort/adaptive-thinking, so no further wiring is needed.

## Release Note
Add Claude Fable 5 (`claude-fable-5`) as a selectable agent model.

## Test Plan
- [ ] Select Fable 5 in the profile editor and confirm a run starts on it

Made by [Open SWE](https://openswe.vercel.app)