### PR TITLE
feat: add pup Datadog CLI to sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG NODEJS_VERSION=22.22.0-1nodesource1
 ARG UV_VERSION=0.9.26
 ARG YARN_VERSION=4.12.0
 ARG GH_VERSION=2.83.1
+ARG PUP_VERSION=1.0.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -58,6 +59,20 @@ RUN set -eux; \
     install -m 0755 "/tmp/uv-${uv_arch}/uvx" /root/.local/bin/uvx; \
     rm -rf /tmp/uv.tar.gz "/tmp/uv-${uv_arch}"
 
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "${arch}" in \
+      amd64) pup_arch="Linux_x86_64"; pup_sha256="f672ee800cb48090df1336fe4fff0b923e6ea22ab7bacf81c60bf1fbe686fe0a" ;; \
+      arm64) pup_arch="Linux_arm64"; pup_sha256="2afa4e44b559072b1b871672c93cd4ba1f6913fae20a37bebf61950a946c041b" ;; \
+      *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/DataDog/pup/releases/download/v${PUP_VERSION}/pup_${PUP_VERSION}_${pup_arch}.tar.gz" -o /tmp/pup.tar.gz; \
+    echo "${pup_sha256}  /tmp/pup.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/pup.tar.gz -C /tmp pup; \
+    install -m 0755 -d /root/.local/bin; \
+    install -m 0755 /tmp/pup /root/.local/bin/pup; \
+    rm -rf /tmp/pup.tar.gz /tmp/pup
+
 ENV PATH=/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
@@ -84,4 +99,5 @@ RUN echo "=== Installed versions ===" \
     && go version \
     && docker --version \
     && git --version \
-    && gh --version
+    && gh --version \
+    && pup --version

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -208,7 +208,7 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="86400"
 
 `DEFAULT_SANDBOX_SNAPSHOT_ID` is required when `SANDBOX_TYPE=langsmith`. The server validates this at startup and refuses to boot if it's missing. The snapshot should include the GitHub CLI from the project Dockerfile; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
 
-The snapshot also bundles the [`pup`](https://github.com/DataDog/pup) Datadog CLI for read-only observability queries. `pup` reads `DD_SITE`, `DD_API_KEY`, and `DD_APP_KEY` from the environment. To enable it, set those variables in your deployment config (see the Datadog section in step 6); use a dedicated, read-only scoped Datadog Application key rather than reusing a personal key. If they're unset, `pup` is simply unavailable at runtime — no other functionality is affected.
+The snapshot also bundles the [`pup`](https://github.com/DataDog/pup) Datadog CLI for read-only observability queries. To enable it with the default LangSmith sandbox provider, set `DD_SITE`, `DD_API_KEY`, and `DD_APP_KEY` in your deployment config (see the Datadog section in step 6); Open SWE forwards those values into each sandbox command. Use a dedicated, read-only scoped Datadog Application key rather than reusing a personal key. If they're unset, `pup` is simply unavailable at runtime — no other functionality is affected.
 
 ## 5. Set up triggers
 
@@ -511,8 +511,8 @@ DEFAULT_SANDBOX_IDLE_TTL_SECONDS=""    # Auto-stop after N seconds idle (default
 DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS=""  # Delete N seconds after stop (default: 86400; 0 disables)
 
 # === Datadog (optional) ===
-# Enables the bundled `pup` Datadog CLI inside the sandbox for read-only
-# observability queries. All three must be set for `pup` to work.
+# Enables the bundled `pup` Datadog CLI inside LangSmith sandbox commands for
+# read-only observability queries. All three must be set for `pup` to work.
 # Use a dedicated, read-only scoped Datadog Application key (not a personal key).
 DD_SITE=""                             # e.g. datadoghq.com, us5.datadoghq.com
 DD_API_KEY=""                          # Datadog API key

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -208,6 +208,8 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="86400"
 
 `DEFAULT_SANDBOX_SNAPSHOT_ID` is required when `SANDBOX_TYPE=langsmith`. The server validates this at startup and refuses to boot if it's missing. The snapshot should include the GitHub CLI from the project Dockerfile; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
 
+The snapshot also bundles the [`pup`](https://github.com/DataDog/pup) Datadog CLI for read-only observability queries. `pup` reads `DD_SITE`, `DD_API_KEY`, and `DD_APP_KEY` from the environment. To enable it, set those variables in your deployment config (see the Datadog section in step 6); use a dedicated, read-only scoped Datadog Application key rather than reusing a personal key. If they're unset, `pup` is simply unavailable at runtime — no other functionality is affected.
+
 ## 5. Set up triggers
 
 Open SWE can be triggered from GitHub, Linear, and/or Slack. **Configure whichever surfaces your team uses — you don't need all of them.**
@@ -507,6 +509,14 @@ DEFAULT_SANDBOX_VCPUS=""               # vCPUs per sandbox (default: 4)
 DEFAULT_SANDBOX_MEM_BYTES=""           # Memory in bytes per sandbox (default: 15 GiB)
 DEFAULT_SANDBOX_IDLE_TTL_SECONDS=""    # Auto-stop after N seconds idle (default: 600; 0 disables)
 DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS=""  # Delete N seconds after stop (default: 86400; 0 disables)
+
+# === Datadog (optional) ===
+# Enables the bundled `pup` Datadog CLI inside the sandbox for read-only
+# observability queries. All three must be set for `pup` to work.
+# Use a dedicated, read-only scoped Datadog Application key (not a personal key).
+DD_SITE=""                             # e.g. datadoghq.com, us5.datadoghq.com
+DD_API_KEY=""                          # Datadog API key
+DD_APP_KEY=""                          # Datadog Application key (read-only scopes)
 
 # === Token Encryption ===
 TOKEN_ENCRYPTION_KEY=""                # Generate with: openssl rand -base64 32

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -33,6 +33,7 @@ PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
 PROXY_CONFIG_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+DATADOG_SANDBOX_ENV_VARS = ("DD_SITE", "DD_API_KEY", "DD_APP_KEY")
 
 
 def _get_langsmith_api_key() -> str | None:
@@ -60,6 +61,11 @@ def _execute_client_grace_seconds() -> int:
     before giving up and killing it. The server is meant to enforce the command
     timeout; this is the client-side backstop for when it doesn't."""
     return _parse_optional_int("SANDBOX_EXECUTE_CLIENT_GRACE_SECONDS", 30)
+
+
+def _get_datadog_sandbox_env() -> dict[str, str]:
+    """Get Datadog CLI env vars to forward into sandbox commands."""
+    return {name: value for name in DATADOG_SANDBOX_ENV_VARS if (value := os.environ.get(name))}
 
 
 def _get_sandbox_snapshot_config() -> tuple[str | None, int, int, int, int, int]:
@@ -288,6 +294,10 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         TypeError,
     )
 
+    def __init__(self, *args: Any, env: dict[str, str] | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._sandbox_env = env or {}
+
     def _deadline(self, effective_timeout: int) -> int:
         return effective_timeout + _execute_client_grace_seconds()
 
@@ -314,19 +324,31 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         except Exception:  # noqa: BLE001 - best-effort cleanup of a wedged command
             logger.warning("Failed to kill timed-out sandbox command", exc_info=True)
 
+    def _run_sandbox_command(self, command: str, *, timeout: int | None, wait: bool) -> Any:
+        kwargs: dict[str, Any] = {"timeout": timeout, "wait": wait}
+        sandbox_env = getattr(self, "_sandbox_env", None)
+        if sandbox_env:
+            kwargs["env"] = sandbox_env
+        return self._sandbox.run(command, **kwargs)
+
     def _base_execute(self, command: str, timeout: int | None) -> ExecuteResponse:
-        # WS path unavailable; the base wait=True path falls back to HTTP,
-        # which carries its own request deadline.
-        return LangSmithSandbox.execute(self, command, timeout=timeout)
+        effective = timeout if timeout is not None else self._default_timeout
+        try:
+            result = self._run_sandbox_command(command, timeout=effective, wait=True)
+        except CommandTimeoutError:
+            return self._timeout_response(
+                effective if effective is not None else 0, server_side=True
+            )
+        return self._result_to_response(result)
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         effective = timeout if timeout is not None else self._default_timeout
         if not effective:  # 0 / None: caller opted out of any deadline
-            return super().execute(command, timeout=timeout)
+            return self._base_execute(command, timeout)
         # run(wait=False) eagerly opens the WS and reads the "started" frame, so
         # connect/setup failures raise here — fall back to the base path.
         try:
-            handle = self._sandbox.run(command, timeout=effective, wait=False)
+            handle = self._run_sandbox_command(command, timeout=effective, wait=False)
         except (*self._WS_FALLBACK_ERRORS, TimeoutError):
             return self._base_execute(command, timeout)
         deadline = self._deadline(effective)
@@ -355,13 +377,13 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
     ) -> ExecuteResponse:
         effective = timeout if timeout is not None else self._default_timeout
         if not effective:
-            return await super().aexecute(command, timeout=timeout)
+            return await asyncio.to_thread(self._base_execute, command, timeout)
         # run(wait=False) eagerly opens the WS and reads the "started" frame
         # (blocking, bounded by the SDK connect timeout); connect/setup failures
         # raise here — fall back to the base path.
         try:
             handle = await asyncio.to_thread(
-                self._sandbox.run, command, timeout=effective, wait=False
+                self._run_sandbox_command, command, timeout=effective, wait=False
             )
         except (*self._WS_FALLBACK_ERRORS, TimeoutError):
             return await asyncio.to_thread(self._base_execute, command, timeout)
@@ -471,7 +493,7 @@ class LangSmithProvider(SandboxProvider):
             except Exception as e:
                 msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
                 raise RuntimeError(msg) from e
-            return TimeoutLangSmithSandbox(sandbox)
+            return TimeoutLangSmithSandbox(sandbox, env=_get_datadog_sandbox_env())
 
         if not snapshot_id:
             msg = "DEFAULT_SANDBOX_SNAPSHOT_ID must be set when SANDBOX_TYPE=langsmith"
@@ -491,7 +513,7 @@ class LangSmithProvider(SandboxProvider):
             msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
             raise RuntimeError(msg) from e
 
-        return TimeoutLangSmithSandbox(sandbox)
+        return TimeoutLangSmithSandbox(sandbox, env=_get_datadog_sandbox_env())
 
     def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:
         """Delete a LangSmith sandbox."""

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import base64
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from agent.integrations.langsmith import _configure_github_proxy
+from agent.integrations.langsmith import (
+    TimeoutLangSmithSandbox,
+    _configure_github_proxy,
+    _get_datadog_sandbox_env,
+)
 
 
 class TestSandboxFactoryLoading:
@@ -28,6 +33,38 @@ class TestSandboxFactoryLoading:
         assert sandbox.id == "local"
         mock_import_module.assert_called_once_with("agent.integrations.local")
         module.create_local_sandbox.assert_called_once_with("existing")
+
+
+class TestDatadogSandboxEnv:
+    def test_reads_configured_datadog_env_vars(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {"DD_SITE": "datadoghq.com", "DD_API_KEY": "api", "DD_APP_KEY": "app"},
+            clear=True,
+        ):
+            assert _get_datadog_sandbox_env() == {
+                "DD_SITE": "datadoghq.com",
+                "DD_API_KEY": "api",
+                "DD_APP_KEY": "app",
+            }
+
+    def test_execute_forwards_datadog_env_to_sandbox_run(self) -> None:
+        datadog_env = {"DD_SITE": "datadoghq.com", "DD_API_KEY": "api", "DD_APP_KEY": "app"}
+        sandbox = MagicMock()
+        sandbox.run.return_value = SimpleNamespace(
+            result=SimpleNamespace(stdout="ok", stderr="", exit_code=0)
+        )
+        backend = object.__new__(TimeoutLangSmithSandbox)
+        backend._sandbox = sandbox
+        backend._sandbox_env = datadog_env
+        backend._default_timeout = 30
+
+        response = backend.execute("pup --version")
+
+        assert response.output == "ok"
+        sandbox.run.assert_called_once_with(
+            "pup --version", timeout=30, wait=False, env=datadog_env
+        )
 
 
 class TestConfigureGithubProxy:


### PR DESCRIPTION
## Description
Bundles the [`pup`](https://github.com/DataDog/pup) Datadog CLI into the sandbox image. The LangSmith sandbox wrapper forwards configured `DD_SITE`, `DD_API_KEY`, and `DD_APP_KEY` values into each sandbox command so `pup` can authenticate without baking secrets into the image.

## Release Note
Sandbox images include `pup`; set `DD_SITE`, `DD_API_KEY`, and `DD_APP_KEY` to enable read-only Datadog access in LangSmith sandboxes.

## Test Plan
- [ ] Build the image for amd64 and arm64; confirm `pup --version` prints `pup 1.0.0` in the final stage.
- [ ] With `DD_SITE`/`DD_API_KEY`/`DD_APP_KEY` set, run a read-only `pup` command in a sandbox and confirm it authenticates.

Made by [Open SWE](https://openswe.vercel.app)
