### PR TITLE
fix: call reviewer-eval judge directly instead of via gateway

### DIFF
--- a/evals/reviewer/judge.py
+++ b/evals/reviewer/judge.py
@@ -13,6 +13,7 @@ directly comparable to martian's published numbers.
 from __future__ import annotations
 
 import json
+import os
 import threading
 from typing import Any
 from uuid import UUID
@@ -21,6 +22,11 @@ from langchain_anthropic import ChatAnthropic
 from langsmith.schemas import Example, Run
 
 JUDGE_MODEL = "claude-opus-4-5"
+
+# Call Anthropic directly. Without an explicit base_url the Anthropic SDK falls
+# back to ANTHROPIC_BASE_URL, which in dev shells points at the LangSmith
+# gateway and 403s for this model — silently nulling every judge score.
+JUDGE_BASE_URL = os.environ.get("JUDGE_ANTHROPIC_BASE_URL", "https://api.anthropic.com")
 
 JUDGE_SYSTEM = "You are a precise code review evaluator. Always respond with valid JSON."
 
@@ -48,7 +54,20 @@ _judge: ChatAnthropic | None = None
 def _get_judge() -> ChatAnthropic:
     global _judge
     if _judge is None:
-        _judge = ChatAnthropic(model=JUDGE_MODEL, temperature=0.0, max_tokens=512)
+        api_key = os.environ.get("JUDGE_ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "No Anthropic API key for the judge. Set JUDGE_ANTHROPIC_API_KEY or "
+                "ANTHROPIC_API_KEY (the judge calls Anthropic directly, not via a gateway)."
+            )
+        _judge = ChatAnthropic(
+            model=JUDGE_MODEL,
+            temperature=0.0,
+            max_tokens=512,
+            base_url=JUDGE_BASE_URL,
+            api_key=api_key,
+            max_retries=3,
+        )
     return _judge
 
 


### PR DESCRIPTION
The reviewer eval's F1 judge (`evals/reviewer/judge.py`, `ChatAnthropic("claude-opus-4-5")`) was constructed with no explicit `base_url`/`api_key`, so the Anthropic SDK fell back to `ANTHROPIC_BASE_URL` from the shell — which in dev points at the LangSmith gateway and returns `403 Forbidden` for this model. Every pairwise judge call failed, so `precision`/`recall`/`f1`/`tp`/`fp`/`fn` were recorded as null for ~28/30 runs (the error surfaced only as the feedback comment).

Surfaced in experiment `187fea60-e908-452b-a99d-0767e84b5693`.

## What changed
- Pass an explicit `base_url` (default `https://api.anthropic.com`, override via `JUDGE_ANTHROPIC_BASE_URL`) so the judge never silently inherits a gateway URL.
- Pass an explicit `api_key` from `JUDGE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`, and fail fast with a clear message if neither is set.
- `max_retries=3` so a transient blip doesn't null an example's metrics.

Verified the judge returns matches correctly even with the gateway `ANTHROPIC_BASE_URL` set in the environment.