### PR TITLE
fix: restore org-wide read access to agent threads

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -428,7 +428,7 @@ async def get_dashboard_thread(
         raise HTTPException(404, "thread not found") from exc
 
     metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
-    _assert_thread_owner(metadata, login, email)
+    is_owner = _user_owns_thread(metadata, login, email)
 
     messages: list[dict[str, Any]] = []
     try:
@@ -454,7 +454,7 @@ async def get_dashboard_thread(
             else None
         ),
     )
-    if mark_viewed and status != "running":
+    if mark_viewed and is_owner and status != "running":
         metadata = await _mark_thread_viewed(
             client,
             thread_id,

--- a/tests/test_dashboard_thread_api_activity.py
+++ b/tests/test_dashboard_thread_api_activity.py
@@ -83,6 +83,24 @@ async def test_get_dashboard_thread_marks_finished_thread_viewed(monkeypatch) ->
     assert client.threads.thread["metadata"]["last_viewed_run_id"] == "run-1"
 
 
+async def test_get_dashboard_thread_readable_by_non_owner(monkeypatch) -> None:
+    client = FakeClient(
+        {
+            "source": "slack",
+            "github_login": "octocat",
+            "latest_run_id": "run-1",
+            "latest_run_status": "success",
+        },
+        "success",
+    )
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: client)
+
+    result = await thread_api.get_dashboard_thread("tid", "someone-else")
+
+    assert result["status"] == "finished"
+    assert "last_viewed_run_id" not in client.threads.thread["metadata"]
+
+
 async def test_get_dashboard_thread_skips_mark_viewed_when_disabled(monkeypatch) -> None:
     client = FakeClient(
         {


### PR DESCRIPTION
## Description
PR #1441 (sidebar activity indicators) re-added `_assert_thread_owner` to `get_dashboard_thread`, regressing #1425 which made all surfaced threads (incl. Slack-triggered) readable by any org user. This removes the owner gate on reads again and only writes the viewed marker when the viewer owns the thread, so other users' views don't clear the owner's unread indicator. Writes (send/cancel/delete) remain owner-only.

## Release Note
Fix regression: agent threads (including Slack-triggered ones) are again viewable by any org user.

## Test Plan
- [ ] Non-owner org user can open another user's Slack-triggered thread; owner's unread indicator is unaffected

Made by [Open SWE](https://openswe.vercel.app)