### PR TITLE
fix: show submitted user message immediately in web chat

### DIFF
--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -97,7 +97,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
     (content: string, images: Array<ImageChunk>) => {
       setPendingPrompts((prev) => [
         ...prev,
-        { prompt: content, insertAt: thread.messages.length, images },
+        { prompt: content, insertAt: thread.messages.length + prev.length, images },
       ])
       sendMessage.mutate({
         content,

--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -8,6 +8,7 @@ import { AgentPromptBar } from "@/components/agents/AgentPromptBar"
 import { MessageView } from "@/components/agents/ported"
 import { agentThreadKeys, useSendAgentMessage } from "@/lib/agents/queries"
 import {
+  addPendingPrompt,
   dropPendingPrompts,
   getPendingPrompts,
 } from "@/lib/agents/pendingPrompts"
@@ -95,18 +96,42 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
 
   const handleSubmit = useCallback(
     (content: string, images: Array<ImageChunk>) => {
-      setPendingPrompts((prev) => [
-        ...prev,
-        { prompt: content, insertAt: thread.messages.length + prev.length, images },
-      ])
-      sendMessage.mutate({
-        content,
+      const entry: PendingPrompt = {
+        prompt: content,
+        insertAt: thread.messages.length + pendingPrompts.length,
         images,
-        model_id: activeSelection?.modelId ?? null,
-        effort: activeSelection?.effort ?? null,
-      })
+      }
+      addPendingPrompt(thread.id, entry.prompt, entry.insertAt, entry.images)
+      setPendingPrompts((prev) => [...prev, entry])
+      sendMessage.mutate(
+        {
+          content,
+          images,
+          model_id: activeSelection?.modelId ?? null,
+          effort: activeSelection?.effort ?? null,
+        },
+        {
+          onError: () => {
+            setPendingPrompts(
+              dropPendingPrompts(
+                thread.id,
+                (p) =>
+                  p.insertAt === entry.insertAt &&
+                  p.prompt === entry.prompt &&
+                  pendingImageKey(p) === pendingImageKey(entry)
+              )
+            )
+          },
+        }
+      )
     },
-    [sendMessage, thread.messages.length, activeSelection]
+    [
+      sendMessage,
+      thread.id,
+      thread.messages.length,
+      pendingPrompts.length,
+      activeSelection,
+    ]
   )
 
   const displayMessages = useMemo<Array<Message>>(() => {

--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 
 import type { PendingPrompt } from "@/lib/agents/pendingPrompts"
-import type { AgentThread, Message } from "@/lib/agents/types"
+import type { AgentThread, ImageChunk, Message } from "@/lib/agents/types"
 import type { ModelSelection } from "@/lib/agents/useModelOptions"
 import { AgentPromptBar } from "@/components/agents/AgentPromptBar"
 import { MessageView } from "@/components/agents/ported"
@@ -93,6 +93,22 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
     )
   }, [queryClient, thread])
 
+  const handleSubmit = useCallback(
+    (content: string, images: Array<ImageChunk>) => {
+      setPendingPrompts((prev) => [
+        ...prev,
+        { prompt: content, insertAt: thread.messages.length, images },
+      ])
+      sendMessage.mutate({
+        content,
+        images,
+        model_id: activeSelection?.modelId ?? null,
+        effort: activeSelection?.effort ?? null,
+      })
+    },
+    [sendMessage, thread.messages.length, activeSelection]
+  )
+
   const displayMessages = useMemo<Array<Message>>(() => {
     if (pendingPrompts.length === 0) return thread.messages
     const baseTimestamp = new Date().toISOString()
@@ -136,14 +152,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
                   compact
                   busy={isStreaming}
                   disabled={sendMessage.isPending}
-                  onSubmit={(content, images) =>
-                    sendMessage.mutate({
-                      content,
-                      images,
-                      model_id: activeSelection?.modelId ?? null,
-                      effort: activeSelection?.effort ?? null,
-                    })
-                  }
+                  onSubmit={handleSubmit}
                   models={models}
                   selection={activeSelection}
                   onSelectionChange={setSelection}
@@ -162,14 +171,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
                 compact
                 busy={isStreaming}
                 disabled={sendMessage.isPending}
-                onSubmit={(content, images) =>
-                  sendMessage.mutate({
-                    content,
-                    images,
-                    model_id: activeSelection?.modelId ?? null,
-                    effort: activeSelection?.effort ?? null,
-                  })
-                }
+                onSubmit={handleSubmit}
                 models={models}
                 selection={activeSelection}
                 onSelectionChange={setSelection}

--- a/ui/src/lib/agents/queries.ts
+++ b/ui/src/lib/agents/queries.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { useEffect } from "react"
 
 import { agentsApi } from "./api"
-import { addPendingPrompt } from "./pendingPrompts"
+import { addPendingPrompt, getPendingPrompts } from "./pendingPrompts"
 import type { ScheduleUpdateRequest } from "./api"
 import type { ImageChunk } from "./types"
 
@@ -148,9 +148,10 @@ export function useSendAgentMessage(threadId: string) {
       const cached = queryClient.getQueryData<{ messages?: Array<unknown> }>(
         agentThreadKeys.detail(threadId)
       )
-      const insertAt = Array.isArray(cached?.messages)
+      const baseLength = Array.isArray(cached?.messages)
         ? cached.messages.length
         : 0
+      const insertAt = baseLength + getPendingPrompts(threadId).length
       addPendingPrompt(threadId, vars.content, insertAt, vars.images)
     },
     onSuccess: (thread) => {

--- a/ui/src/lib/agents/queries.ts
+++ b/ui/src/lib/agents/queries.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { useEffect } from "react"
 
 import { agentsApi } from "./api"
-import { addPendingPrompt, getPendingPrompts } from "./pendingPrompts"
+import { addPendingPrompt } from "./pendingPrompts"
 import type { ScheduleUpdateRequest } from "./api"
 import type { ImageChunk } from "./types"
 
@@ -144,16 +144,6 @@ export function useSendAgentMessage(threadId: string) {
         model_id: vars.model_id,
         effort: vars.effort,
       }),
-    onMutate: (vars) => {
-      const cached = queryClient.getQueryData<{ messages?: Array<unknown> }>(
-        agentThreadKeys.detail(threadId)
-      )
-      const baseLength = Array.isArray(cached?.messages)
-        ? cached.messages.length
-        : 0
-      const insertAt = baseLength + getPendingPrompts(threadId).length
-      addPendingPrompt(threadId, vars.content, insertAt, vars.images)
-    },
     onSuccess: (thread) => {
       queryClient.setQueryData(
         agentThreadKeys.detail(threadId),


### PR DESCRIPTION
## Description
When submitting from the web UI, the optimistic user message was written to sessionStorage but never added to the component's local `pendingPrompts` state, so it didn't render until `thread.messages` refetched (after the agent responded). The submit handler now inserts the pending prompt into local state synchronously, so the message appears immediately.

## Release Note
Web UI now shows your submitted message in the chat immediately instead of waiting for the agent's response.

## Test Plan
- [ ] In the web UI, send a message in an agent thread and confirm it appears instantly, before the agent starts responding.

Made by [Open SWE](https://openswe.vercel.app)