### PR TITLE
fix: theme-aware syntax highlighting in chat code blocks

### DIFF
--- a/ui/src/components/agents/ported/CodeBlock.tsx
+++ b/ui/src/components/agents/ported/CodeBlock.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { getSingletonHighlighter, type ThemedToken } from "shiki";
+import { useResolvedTheme } from "@/lib/theme";
 
 interface CodeBlockProps {
   text: string;
   language?: string;
 }
+
+const SHIKI_THEME = { light: "github-light", dark: "github-dark" } as const;
 
 const TOKEN_CACHE = new Map<string, ThemedToken[][]>();
 
@@ -44,6 +47,8 @@ function languageLabel(language: string): string {
 export function CodeBlock({ text, language }: CodeBlockProps) {
   const [tokens, setTokens] = useState<ThemedToken[][] | null>(null);
   const [copied, setCopied] = useState(false);
+  const resolvedTheme = useResolvedTheme();
+  const shikiTheme = SHIKI_THEME[resolvedTheme];
   const normalizedLanguage = useMemo(() => normalizeLanguage(language), [language]);
   const displayLanguage = useMemo(() => languageLabel(normalizedLanguage), [normalizedLanguage]);
 
@@ -53,7 +58,7 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
 
     if (normalizedLanguage === "text") return;
 
-    const cacheKey = `${normalizedLanguage}::${text}`;
+    const cacheKey = `${shikiTheme}::${normalizedLanguage}::${text}`;
     const cached = TOKEN_CACHE.get(cacheKey);
     if (cached) {
       setTokens(cached);
@@ -61,7 +66,7 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
     }
 
     getSingletonHighlighter({
-      themes: ["github-dark"],
+      themes: [shikiTheme],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       langs: [normalizedLanguage as any],
     })
@@ -70,7 +75,7 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
         const result = highlighter.codeToTokens(text, {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           lang: normalizedLanguage as any,
-          theme: "github-dark",
+          theme: shikiTheme,
         });
         if (TOKEN_CACHE.size >= 500) TOKEN_CACHE.clear();
         TOKEN_CACHE.set(cacheKey, result.tokens);
@@ -86,7 +91,7 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
     return () => {
       cancelled = true;
     };
-  }, [text, normalizedLanguage]);
+  }, [text, normalizedLanguage, shikiTheme]);
 
   const handleCopy = async () => {
     try {

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -73,3 +73,27 @@ export function useTheme() {
 
   return { theme, resolvedTheme, setTheme, toggleTheme }
 }
+
+function readDomResolvedTheme(): ResolvedTheme {
+  if (typeof document === "undefined") return "light"
+  return document.documentElement.classList.contains("dark") ? "dark" : "light"
+}
+
+/** Reactive resolved theme that tracks the root `.dark` class set by `useTheme`. */
+export function useResolvedTheme(): ResolvedTheme {
+  const [resolved, setResolved] = useState<ResolvedTheme>(readDomResolvedTheme)
+
+  useEffect(() => {
+    setResolved(readDomResolvedTheme())
+    const observer = new MutationObserver(() =>
+      setResolved(readDomResolvedTheme())
+    )
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  return resolved
+}


### PR DESCRIPTION
## Description
Inline chat code blocks hardcoded the `github-dark` Shiki theme, so in light mode the pale dark-theme token colors rendered on a light bubble with very poor contrast. We now resolve the Shiki theme (`github-light` / `github-dark`) from the active mode, cache tokens per-theme, and add a reactive `useResolvedTheme` hook so blocks re-highlight live when the existing light/dark/system toggle flips. The pierre diff components were already theme-aware and are left unchanged, per the clarification that the contrast issue is in chat code blocks, not diffs.

## Release Note
Chat code blocks now use a light syntax theme in light mode for proper contrast.

## Test Plan
- [ ] In light mode, open a chat thread with a fenced code block and confirm syntax colors are high-contrast on the light bubble.
- [ ] Toggle between Light / Dark / System and confirm rendered code blocks update theme live.

Made by [Open SWE](https://openswe.vercel.app)