### PR TITLE
feat: prep reviewer repo at init and load repo skills

### DIFF
--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -69,6 +69,7 @@ from .utils.api_standards_skill import fetch_api_standards_skill
 from .utils.github_app import get_github_app_installation_token_with_expiry
 from .utils.github_token import cache_github_token_for_thread
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
+from .utils.repo_prep import discover_skill_sources, prepare_review_repo
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 
 REVIEWER_PROMPT_TEMPLATE = """You are a specialized code reviewer agent. Your job is to review one GitHub PR and publish a single review.
@@ -87,11 +88,16 @@ Re-review (user message says "A new commit has been pushed"):
 GH_TOKEN=dummy gh api repos/{repo_owner}/{repo_name}/compare/<last_reviewed_sha>...<head_sha> -H "Accept: application/vnd.github.v3.diff"
 ```
 
-Clone the repo so you can grep for full file context:
+The repo is normally already cloned and checked out at the PR head in
+`{working_dir}` — `cd` there and grep for full file context. If that directory
+is missing (prep can occasionally fail), clone it yourself:
 
 ```
 GH_TOKEN=dummy gh repo clone {repo_owner}/{repo_name} && cd {repo_name} && git checkout <head_sha>
 ```
+
+If a skills section appears below, the repo ships reviewer-relevant skills. Read
+the `SKILL.md` that matches the area you're reviewing and apply it.
 
 Tools: `add_finding`, `update_finding`, `list_findings`, `publish_review`,
 `resolve_finding_thread`, `reply_to_finding_thread`.
@@ -696,6 +702,23 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     repo_name = str(repo_config.get("name", ""))
     base_sha = str(config["configurable"].get("base_sha", "") or "")
     head_sha = str(config["configurable"].get("head_sha", "") or "")
+
+    # Prep the repo on the sandbox before the first model call so the LLM does
+    # not narrate `gh repo clone`, and so SkillsMiddleware can discover the
+    # repo's skills from disk at its one-shot scan.
+    repo_ready = await prepare_review_repo(
+        sandbox_backend,
+        work_dir=work_dir,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        head_sha=head_sha,
+    )
+    skill_sources: list[str] = []
+    if repo_ready and repo_name:
+        skill_sources = await discover_skill_sources(
+            sandbox_backend, repo_dir=f"{work_dir}/{repo_name}"
+        )
+
     pr_number = config["configurable"].get("pr_number")
     pr_url = str(config["configurable"].get("pr_url", "") or "")
     last_reviewed_sha = str(config["configurable"].get("last_reviewed_sha", "") or "")
@@ -945,6 +968,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         ],
         subagents=[_general_purpose_subagent(reviewer_subagent_model)],
         backend=sandbox_backend,
+        skills=skill_sources or None,
         middleware=[
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -69,7 +69,7 @@ from .utils.api_standards_skill import fetch_api_standards_skill
 from .utils.github_app import get_github_app_installation_token_with_expiry
 from .utils.github_token import cache_github_token_for_thread
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
-from .utils.repo_prep import discover_skill_sources, prepare_review_repo
+from .utils.repo_prep import materialize_trusted_skills, prepare_review_repo
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 
 REVIEWER_PROMPT_TEMPLATE = """You are a specialized code reviewer agent. Your job is to review one GitHub PR and publish a single review.
@@ -702,24 +702,27 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     repo_name = str(repo_config.get("name", ""))
     base_sha = str(config["configurable"].get("base_sha", "") or "")
     head_sha = str(config["configurable"].get("head_sha", "") or "")
+    pr_number = config["configurable"].get("pr_number")
 
     # Prep the repo on the sandbox before the first model call so the LLM does
     # not narrate `gh repo clone`, and so SkillsMiddleware can discover the
-    # repo's skills from disk at its one-shot scan.
+    # repo's skills at its one-shot scan. Skills are materialized from the PR
+    # base sha (trusted), never the PR head (author-controlled).
     repo_ready = await prepare_review_repo(
         sandbox_backend,
         work_dir=work_dir,
         repo_owner=repo_owner,
         repo_name=repo_name,
         head_sha=head_sha,
+        pr_number=pr_number if isinstance(pr_number, int) else None,
+        base_sha=base_sha,
     )
     skill_sources: list[str] = []
     if repo_ready and repo_name:
-        skill_sources = await discover_skill_sources(
-            sandbox_backend, repo_dir=f"{work_dir}/{repo_name}"
+        skill_sources = await materialize_trusted_skills(
+            sandbox_backend, repo_dir=f"{work_dir}/{repo_name}", trusted_ref=base_sha
         )
 
-    pr_number = config["configurable"].get("pr_number")
     pr_url = str(config["configurable"].get("pr_url", "") or "")
     last_reviewed_sha = str(config["configurable"].get("last_reviewed_sha", "") or "")
     is_re_review = bool(config["configurable"].get("re_review"))

--- a/agent/utils/repo_prep.py
+++ b/agent/utils/repo_prep.py
@@ -1,0 +1,121 @@
+"""Deterministic repo prep for the reviewer sandbox.
+
+The reviewer reviews a single PR, so we clone its repo and check out the PR
+head during agent init -- before the first model call -- instead of asking the
+LLM to narrate ``gh repo clone`` mid-run. Pre-cloning also lets ``SkillsMiddleware``
+discover the repo's ``.agents/skills`` / ``.claude/skills`` from the real
+sandbox filesystem at its one-shot ``before_agent`` scan.
+
+Best-effort: any failure leaves the sandbox usable (the review still works off
+the fetched diff) and returns ``False`` so callers can skip skill wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import posixpath
+import shlex
+from collections.abc import Sequence
+
+from deepagents.backends.protocol import SandboxBackendProtocol
+
+logger = logging.getLogger(__name__)
+
+CLONE_TIMEOUT_SECONDS = 240
+
+DEFAULT_SKILL_DIRS = (".agents/skills", ".claude/skills")
+
+
+def _prep_command(work_dir: str, repo_owner: str, repo_name: str, head_sha: str) -> str:
+    repo_dir = posixpath.join(work_dir, repo_name)
+    q_work_dir = shlex.quote(work_dir)
+    q_repo_dir = shlex.quote(repo_dir)
+    q_full_name = shlex.quote(f"{repo_owner}/{repo_name}")
+    q_repo_name = shlex.quote(repo_name)
+    q_head = shlex.quote(head_sha) if head_sha else ""
+
+    lines = [
+        "set -e",
+        f"if [ -d {q_repo_dir}/.git ]; then",
+        f"  cd {q_repo_dir} && GH_TOKEN=dummy git fetch --all --quiet",
+        "else",
+        f"  cd {q_work_dir} && GH_TOKEN=dummy gh repo clone {q_full_name} && cd {q_repo_name}",
+        "fi",
+    ]
+    if q_head:
+        # Fetch the head sha explicitly (covers same-repo PRs); fall back
+        # gracefully when it is not reachable (e.g. fork PRs) so skills still
+        # load from the default branch.
+        lines.append(f"GH_TOKEN=dummy git fetch origin {q_head} --quiet 2>/dev/null || true")
+        lines.append(f"git checkout {q_head} --quiet 2>/dev/null || true")
+    return "\n".join(lines)
+
+
+async def prepare_review_repo(
+    sandbox_backend: SandboxBackendProtocol,
+    *,
+    work_dir: str,
+    repo_owner: str,
+    repo_name: str,
+    head_sha: str,
+) -> bool:
+    """Clone-or-fetch the repo and check out ``head_sha`` in the sandbox.
+
+    Returns ``True`` when the repo is prepped at ``work_dir/repo_name``.
+    """
+    if not repo_owner or not repo_name:
+        return False
+
+    command = _prep_command(work_dir, repo_owner, repo_name, head_sha)
+    try:
+        result = await asyncio.to_thread(
+            sandbox_backend.execute, command, timeout=CLONE_TIMEOUT_SECONDS
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to prep review repo %s/%s", repo_owner, repo_name, exc_info=True)
+        return False
+
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (0, None):
+        logger.warning(
+            "Review repo prep for %s/%s exited %s: %s",
+            repo_owner,
+            repo_name,
+            exit_code,
+            getattr(result, "output", ""),
+        )
+        return False
+
+    logger.info(
+        "Prepped review repo %s/%s at %s (head=%s)",
+        repo_owner,
+        repo_name,
+        posixpath.join(work_dir, repo_name),
+        head_sha or "<none>",
+    )
+    return True
+
+
+async def discover_skill_sources(
+    sandbox_backend: SandboxBackendProtocol,
+    *,
+    repo_dir: str,
+    skill_dirs: Sequence[str] = DEFAULT_SKILL_DIRS,
+) -> list[str]:
+    """Return the skill source dirs that actually exist under ``repo_dir``.
+
+    Wiring SkillsMiddleware at a missing path produces noisy load warnings, so
+    only return directories present on disk (with a trailing slash, as the
+    middleware expects).
+    """
+    candidates = [posixpath.join(repo_dir, d) for d in skill_dirs]
+    test = " ".join(f"[ -d {shlex.quote(p)} ] && echo {shlex.quote(p)};" for p in candidates)
+    try:
+        result = await asyncio.to_thread(sandbox_backend.execute, test)
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to probe skill dirs under %s", repo_dir, exc_info=True)
+        return []
+    output = getattr(result, "output", "") or ""
+    found = {line.strip() for line in output.splitlines() if line.strip()}
+    return [f"{p}/" for p in candidates if p in found]

--- a/agent/utils/repo_prep.py
+++ b/agent/utils/repo_prep.py
@@ -3,8 +3,8 @@
 The reviewer reviews a single PR, so we clone its repo and check out the PR
 head during agent init -- before the first model call -- instead of asking the
 LLM to narrate ``gh repo clone`` mid-run. Pre-cloning also lets ``SkillsMiddleware``
-discover the repo's ``.agents/skills`` / ``.claude/skills`` from the real
-sandbox filesystem at its one-shot ``before_agent`` scan.
+discover the repo's ``.agents/skills`` / ``.claude/skills`` at its one-shot
+``before_agent`` scan.
 
 Best-effort: any failure leaves the sandbox usable (the review still works off
 the fetched diff) and returns ``False`` so callers can skip skill wiring.
@@ -26,8 +26,17 @@ CLONE_TIMEOUT_SECONDS = 240
 
 DEFAULT_SKILL_DIRS = (".agents/skills", ".claude/skills")
 
+TRUSTED_SKILLS_DIRNAME = ".review-skills"
 
-def _prep_command(work_dir: str, repo_owner: str, repo_name: str, head_sha: str) -> str:
+
+def _prep_command(
+    work_dir: str,
+    repo_owner: str,
+    repo_name: str,
+    head_sha: str,
+    pr_number: int | None,
+    base_sha: str,
+) -> str:
     repo_dir = posixpath.join(work_dir, repo_name)
     q_work_dir = shlex.quote(work_dir)
     q_repo_dir = shlex.quote(repo_dir)
@@ -43,12 +52,19 @@ def _prep_command(work_dir: str, repo_owner: str, repo_name: str, head_sha: str)
         f"  cd {q_work_dir} && GH_TOKEN=dummy gh repo clone {q_full_name} && cd {q_repo_name}",
         "fi",
     ]
+    if base_sha:
+        q_base = shlex.quote(base_sha)
+        lines.append(f"GH_TOKEN=dummy git fetch origin {q_base} --quiet 2>/dev/null || true")
     if q_head:
-        # Fetch the head sha explicitly (covers same-repo PRs); fall back
-        # gracefully when it is not reachable (e.g. fork PRs) so skills still
-        # load from the default branch.
+        # Direct sha fetch covers same-repo PRs; the pull ref covers fork PRs
+        # whose head commit is not reachable from origin's branches.
         lines.append(f"GH_TOKEN=dummy git fetch origin {q_head} --quiet 2>/dev/null || true")
-        lines.append(f"git checkout {q_head} --quiet 2>/dev/null || true")
+        if pr_number is not None:
+            pull_ref = shlex.quote(f"refs/pull/{pr_number}/head")
+            lines.append(f"GH_TOKEN=dummy git fetch origin {pull_ref} --quiet 2>/dev/null || true")
+        # Strict on purpose: a failed checkout must fail the prep so callers
+        # know the tree is NOT at the PR head.
+        lines.append(f"git checkout {q_head} --quiet")
     return "\n".join(lines)
 
 
@@ -59,15 +75,18 @@ async def prepare_review_repo(
     repo_owner: str,
     repo_name: str,
     head_sha: str,
+    pr_number: int | None = None,
+    base_sha: str = "",
 ) -> bool:
     """Clone-or-fetch the repo and check out ``head_sha`` in the sandbox.
 
-    Returns ``True`` when the repo is prepped at ``work_dir/repo_name``.
+    Returns ``True`` only when the repo is prepped at ``work_dir/repo_name``
+    and (when ``head_sha`` is given) actually checked out at the PR head.
     """
     if not repo_owner or not repo_name:
         return False
 
-    command = _prep_command(work_dir, repo_owner, repo_name, head_sha)
+    command = _prep_command(work_dir, repo_owner, repo_name, head_sha, pr_number, base_sha)
     try:
         result = await asyncio.to_thread(
             sandbox_backend.execute, command, timeout=CLONE_TIMEOUT_SECONDS
@@ -97,25 +116,47 @@ async def prepare_review_repo(
     return True
 
 
-async def discover_skill_sources(
+async def materialize_trusted_skills(
     sandbox_backend: SandboxBackendProtocol,
     *,
     repo_dir: str,
+    trusted_ref: str,
     skill_dirs: Sequence[str] = DEFAULT_SKILL_DIRS,
 ) -> list[str]:
-    """Return the skill source dirs that actually exist under ``repo_dir``.
+    """Extract skill dirs from ``trusted_ref`` into a path outside the checkout.
 
-    Wiring SkillsMiddleware at a missing path produces noisy load warnings, so
-    only return directories present on disk (with a trailing slash, as the
-    middleware expects).
+    Skills are sourced from the PR's base sha -- never the PR head, which the
+    PR author controls -- so a PR cannot inject instructions into the reviewer
+    prompt by adding or editing a ``SKILL.md``. Returns the extracted source
+    dirs (with a trailing slash, as SkillsMiddleware expects).
     """
-    candidates = [posixpath.join(repo_dir, d) for d in skill_dirs]
-    test = " ".join(f"[ -d {shlex.quote(p)} ] && echo {shlex.quote(p)};" for p in candidates)
-    try:
-        result = await asyncio.to_thread(sandbox_backend.execute, test)
-    except Exception:  # noqa: BLE001
-        logger.warning("Failed to probe skill dirs under %s", repo_dir, exc_info=True)
+    if not trusted_ref:
         return []
-    output = getattr(result, "output", "") or ""
-    found = {line.strip() for line in output.splitlines() if line.strip()}
-    return [f"{p}/" for p in candidates if p in found]
+    dest_root = posixpath.join(posixpath.dirname(repo_dir), TRUSTED_SKILLS_DIRNAME)
+    q_repo_dir = shlex.quote(repo_dir)
+    q_ref = shlex.quote(trusted_ref)
+
+    sources: list[str] = []
+    for skill_dir in skill_dirs:
+        dest = posixpath.join(dest_root, skill_dir)
+        q_dest = shlex.quote(dest)
+        q_dir = shlex.quote(skill_dir)
+        depth = len(skill_dir.split("/"))
+        command = (
+            f"cd {q_repo_dir} && "
+            f"git cat-file -e {q_ref}:{q_dir} 2>/dev/null && "
+            f"rm -rf {q_dest} && mkdir -p {q_dest} && "
+            f"git archive {q_ref} {q_dir} | tar -x --strip-components={depth} -C {q_dest} && "
+            f"echo {q_dest}"
+        )
+        try:
+            result = await asyncio.to_thread(sandbox_backend.execute, command)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to extract trusted skills %s from %s", skill_dir, trusted_ref, exc_info=True
+            )
+            continue
+        output = getattr(result, "output", "") or ""
+        if dest in output.splitlines():
+            sources.append(f"{dest}/")
+    return sources

--- a/agent/utils/repo_prep.py
+++ b/agent/utils/repo_prep.py
@@ -152,9 +152,7 @@ async def materialize_trusted_skills(
         try:
             result = await asyncio.to_thread(sandbox_backend.execute, command)
         except Exception:  # noqa: BLE001
-            logger.warning(
-                "Failed to extract trusted skills %s from %s", skill_dir, trusted_ref, exc_info=True
-            )
+            logger.warning("Failed to extract trusted skills %s", skill_dir, exc_info=True)
             continue
         output = getattr(result, "output", "") or ""
         if dest in output.splitlines():

--- a/tests/test_repo_prep.py
+++ b/tests/test_repo_prep.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from deepagents.backends.protocol import ExecuteResponse
 
-from agent.utils.repo_prep import discover_skill_sources, prepare_review_repo
+from agent.utils.repo_prep import materialize_trusted_skills, prepare_review_repo
 
 
 class _FakeSandboxBackend:
@@ -12,10 +12,12 @@ class _FakeSandboxBackend:
         exit_code: int = 0,
         raise_exc: bool = False,
         output: str = "",
+        outputs: list[str] | None = None,
     ) -> None:
         self._exit_code = exit_code
         self._raise = raise_exc
         self._output = output
+        self._outputs = outputs
         self.commands: list[str] = []
 
     @property
@@ -27,7 +29,10 @@ class _FakeSandboxBackend:
         if self._raise:
             raise RuntimeError("sandbox unreachable")
         self.commands.append(command)
-        return ExecuteResponse(output=self._output, exit_code=self._exit_code, truncated=False)
+        output = self._output
+        if self._outputs is not None:
+            output = self._outputs[len(self.commands) - 1]
+        return ExecuteResponse(output=output, exit_code=self._exit_code, truncated=False)
 
 
 async def test_prepare_review_repo_clones_and_checks_out_head() -> None:
@@ -38,13 +43,31 @@ async def test_prepare_review_repo_clones_and_checks_out_head() -> None:
         repo_owner="acme",
         repo_name="widget",
         head_sha="abc123",
+        pr_number=42,
+        base_sha="def456",
     )
     assert ok is True
     assert len(backend.commands) == 1
     cmd = backend.commands[0]
     assert "gh repo clone acme/widget" in cmd
     assert "/work/widget/.git" in cmd
-    assert "git checkout abc123" in cmd
+    assert "git fetch origin def456" in cmd
+    assert "git fetch origin refs/pull/42/head" in cmd
+    assert "git checkout abc123 --quiet" in cmd
+    assert "git checkout abc123 --quiet 2>/dev/null || true" not in cmd
+
+
+async def test_prepare_review_repo_skips_pull_ref_without_pr_number() -> None:
+    backend = _FakeSandboxBackend()
+    ok = await prepare_review_repo(
+        backend,
+        work_dir="/work",
+        repo_owner="acme",
+        repo_name="widget",
+        head_sha="abc123",
+    )
+    assert ok is True
+    assert "refs/pull" not in backend.commands[0]
 
 
 async def test_prepare_review_repo_skips_checkout_without_head() -> None:
@@ -85,19 +108,36 @@ async def test_prepare_review_repo_returns_false_on_exception() -> None:
     assert ok is False
 
 
-async def test_discover_skill_sources_returns_only_existing_dirs() -> None:
-    backend = _FakeSandboxBackend(output="/work/widget/.agents/skills\n")
-    sources = await discover_skill_sources(backend, repo_dir="/work/widget")
-    assert sources == ["/work/widget/.agents/skills/"]
+async def test_materialize_trusted_skills_extracts_from_trusted_ref() -> None:
+    backend = _FakeSandboxBackend(outputs=["/work/.review-skills/.agents/skills\n", ""])
+    sources = await materialize_trusted_skills(
+        backend, repo_dir="/work/widget", trusted_ref="def456"
+    )
+    assert sources == ["/work/.review-skills/.agents/skills/"]
+    assert len(backend.commands) == 2
+    for cmd in backend.commands:
+        assert "git cat-file -e def456:" in cmd
+        assert "git archive def456" in cmd
 
 
-async def test_discover_skill_sources_empty_when_none_exist() -> None:
+async def test_materialize_trusted_skills_empty_without_ref() -> None:
+    backend = _FakeSandboxBackend()
+    sources = await materialize_trusted_skills(backend, repo_dir="/work/widget", trusted_ref="")
+    assert sources == []
+    assert backend.commands == []
+
+
+async def test_materialize_trusted_skills_empty_when_none_exist() -> None:
     backend = _FakeSandboxBackend(output="")
-    sources = await discover_skill_sources(backend, repo_dir="/work/widget")
+    sources = await materialize_trusted_skills(
+        backend, repo_dir="/work/widget", trusted_ref="def456"
+    )
     assert sources == []
 
 
-async def test_discover_skill_sources_handles_exception() -> None:
+async def test_materialize_trusted_skills_handles_exception() -> None:
     backend = _FakeSandboxBackend(raise_exc=True)
-    sources = await discover_skill_sources(backend, repo_dir="/work/widget")
+    sources = await materialize_trusted_skills(
+        backend, repo_dir="/work/widget", trusted_ref="def456"
+    )
     assert sources == []

--- a/tests/test_repo_prep.py
+++ b/tests/test_repo_prep.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from deepagents.backends.protocol import ExecuteResponse
+
+from agent.utils.repo_prep import discover_skill_sources, prepare_review_repo
+
+
+class _FakeSandboxBackend:
+    def __init__(
+        self,
+        *,
+        exit_code: int = 0,
+        raise_exc: bool = False,
+        output: str = "",
+    ) -> None:
+        self._exit_code = exit_code
+        self._raise = raise_exc
+        self._output = output
+        self.commands: list[str] = []
+
+    @property
+    def id(self) -> str:
+        return "fake-sandbox"
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        del timeout
+        if self._raise:
+            raise RuntimeError("sandbox unreachable")
+        self.commands.append(command)
+        return ExecuteResponse(output=self._output, exit_code=self._exit_code, truncated=False)
+
+
+async def test_prepare_review_repo_clones_and_checks_out_head() -> None:
+    backend = _FakeSandboxBackend()
+    ok = await prepare_review_repo(
+        backend,
+        work_dir="/work",
+        repo_owner="acme",
+        repo_name="widget",
+        head_sha="abc123",
+    )
+    assert ok is True
+    assert len(backend.commands) == 1
+    cmd = backend.commands[0]
+    assert "gh repo clone acme/widget" in cmd
+    assert "/work/widget/.git" in cmd
+    assert "git checkout abc123" in cmd
+
+
+async def test_prepare_review_repo_skips_checkout_without_head() -> None:
+    backend = _FakeSandboxBackend()
+    ok = await prepare_review_repo(
+        backend,
+        work_dir="/work",
+        repo_owner="acme",
+        repo_name="widget",
+        head_sha="",
+    )
+    assert ok is True
+    assert "git checkout" not in backend.commands[0]
+
+
+async def test_prepare_review_repo_requires_owner_and_name() -> None:
+    backend = _FakeSandboxBackend()
+    ok = await prepare_review_repo(
+        backend, work_dir="/work", repo_owner="", repo_name="widget", head_sha="abc"
+    )
+    assert ok is False
+    assert backend.commands == []
+
+
+async def test_prepare_review_repo_returns_false_on_nonzero_exit() -> None:
+    backend = _FakeSandboxBackend(exit_code=1)
+    ok = await prepare_review_repo(
+        backend, work_dir="/work", repo_owner="acme", repo_name="widget", head_sha="abc"
+    )
+    assert ok is False
+
+
+async def test_prepare_review_repo_returns_false_on_exception() -> None:
+    backend = _FakeSandboxBackend(raise_exc=True)
+    ok = await prepare_review_repo(
+        backend, work_dir="/work", repo_owner="acme", repo_name="widget", head_sha="abc"
+    )
+    assert ok is False
+
+
+async def test_discover_skill_sources_returns_only_existing_dirs() -> None:
+    backend = _FakeSandboxBackend(output="/work/widget/.agents/skills\n")
+    sources = await discover_skill_sources(backend, repo_dir="/work/widget")
+    assert sources == ["/work/widget/.agents/skills/"]
+
+
+async def test_discover_skill_sources_empty_when_none_exist() -> None:
+    backend = _FakeSandboxBackend(output="")
+    sources = await discover_skill_sources(backend, repo_dir="/work/widget")
+    assert sources == []
+
+
+async def test_discover_skill_sources_handles_exception() -> None:
+    backend = _FakeSandboxBackend(raise_exc=True)
+    sources = await discover_skill_sources(backend, repo_dir="/work/widget")
+    assert sources == []


### PR DESCRIPTION
## Description
The reviewer is single-repo, so we now clone + checkout the PR head during agent init (before the first model call). This lets deepagents' `SkillsMiddleware` discover the repo's `.agents/skills` / `.claude/skills` from disk at its one-shot `before_agent` scan, so reviews honor repo-defined skills (e.g. `pr-creation`) instead of only default prompting. It also removes the mid-run `gh repo clone` narration. The core agent stays ad-hoc. Repo prep is best-effort; only skill dirs that exist on disk are wired so there are no spurious load warnings.

## Release Note
Code reviews now load and apply skills defined in the target repo (`.agents/skills`, `.claude/skills`).

## Test Plan
- [ ] On a PR in a repo with `.agents/skills/`, confirm the reviewer's prompt lists the skills and applies the relevant `SKILL.md`.
- [ ] On a repo without skill dirs, confirm the reviewer runs normally with no skill-load warnings.

Made by [Open SWE](https://openswe.vercel.app)