### PR TITLE
fix: stop eval modules leaking .env into the test process

### DIFF
--- a/evals/reviewer/build_dataset.py
+++ b/evals/reviewer/build_dataset.py
@@ -21,8 +21,6 @@ from pathlib import Path
 from dotenv import load_dotenv
 from langsmith import Client
 
-load_dotenv()
-
 GOLDENS_DIR = Path(__file__).parent / "golden_comments"
 PR_URL_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)")
 
@@ -115,6 +113,7 @@ def upload(dataset_name: str, examples: list[dict]) -> None:
 
 
 def main() -> None:
+    load_dotenv()
     ap = argparse.ArgumentParser()
     ap.add_argument("--dataset-name", default="openswe-reviewer-v1")
     ap.add_argument("--dry-run", action="store_true", help="Build examples but don't upload.")

--- a/evals/reviewer/run_eval.py
+++ b/evals/reviewer/run_eval.py
@@ -22,8 +22,6 @@ from langsmith.schemas import Example
 from evals.reviewer.judge import aggregate_pr, judge_match
 from evals.reviewer.target import drain_thread_ids, get_langgraph_url, review_pr
 
-load_dotenv()
-
 logger = logging.getLogger(__name__)
 
 CONFIG_PATH = Path(__file__).with_name("config.toml")
@@ -127,6 +125,7 @@ async def _cleanup_threads(thread_ids: Iterable[str]) -> None:
 
 
 async def main() -> None:
+    load_dotenv()
     config = _load_config()
     _apply_config_to_env(config)
 

--- a/evals/reviewer/target.py
+++ b/evals/reviewer/target.py
@@ -13,12 +13,9 @@ import os
 import threading
 from typing import Any, Literal, cast
 
-from dotenv import load_dotenv
 from langgraph_sdk import get_client
 
 from agent.reviewer_findings import Finding, Severity, filter_findings_for_publish
-
-load_dotenv()
 
 DEFAULT_REVIEWER_ASSISTANT_ID = "reviewer"
 DEFAULT_LANGGRAPH_URL = "http://localhost:2024"

--- a/tests/test_slack_context.py
+++ b/tests/test_slack_context.py
@@ -323,12 +323,17 @@ def test_get_slack_repo_config_uses_existing_thread_repo(
     assert not posted
 
 
+async def _no_team_default_repo() -> dict[str, str] | None:
+    return None
+
+
 def test_get_slack_repo_config_new_thread_uses_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     threads_client = _FakeThreadsClient(raise_not_found=True)
     monkeypatch.setattr(webapp, "SLACK_REPO_OWNER", "default-owner")
     monkeypatch.setattr(webapp, "SLACK_REPO_NAME", "default-repo")
+    monkeypatch.setattr(webapp, "get_team_default_repo", _no_team_default_repo)
 
     monkeypatch.setattr(webapp, "get_client", lambda url: _FakeClient(threads_client))
 
@@ -343,6 +348,7 @@ def test_get_slack_repo_config_existing_thread_without_repo_uses_default(
     threads_client = _FakeThreadsClient(thread={"metadata": {}})
     monkeypatch.setattr(webapp, "SLACK_REPO_OWNER", "default-owner")
     monkeypatch.setattr(webapp, "SLACK_REPO_NAME", "default-repo")
+    monkeypatch.setattr(webapp, "get_team_default_repo", _no_team_default_repo)
 
     monkeypatch.setattr(webapp, "get_client", lambda url: _FakeClient(threads_client))
 


### PR DESCRIPTION
## Description
The two `test_slack_context` default-repo tests failed in full-suite runs but passed in isolation. Cause: `evals/reviewer/{target,run_eval,build_dataset}` call `load_dotenv()` at import time, so the eval tests importing them injected the real `.env` (live `LANGGRAPH_URL`) into the pytest process — `get_slack_repo_config` then fell through to `get_team_default_repo()` against the real LangGraph store and returned the developer's actual team default repo.

Fix: move `load_dotenv()` into the CLI entrypoints (all env reads were already lazy), and patch `get_team_default_repo` in the two tests so they're hermetic regardless of environment.

## Test Plan
- `pytest tests/test_reviewer_eval_run.py tests/test_reviewer_eval_target.py tests/test_slack_context.py` (previously failing combination) passes
- Full `make test`: 720 passed