### PR TITLE
chore: hide Fable 5 model from supported options

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -22,13 +22,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": True,
     },
     {
-        "id": "anthropic:claude-fable-5",
-        "label": "Fable 5",
-        "efforts": ["low", "medium", "high", "xhigh", "max"],
-        "default_effort": "high",
-        "supports_images": True,
-    },
-    {
         "id": "openai:gpt-5.5",
         "label": "GPT-5.5",
         "efforts": ["none", "low", "medium", "high", "xhigh"],


### PR DESCRIPTION
## Description
Fable 5 is currently unusable with our API key, so it's removed from the selectable model list in `agent/dashboard/options.py`. It can be re-added later when re-activated.

## Release Note
none

## Test Plan
- [ ] Confirm Fable 5 no longer appears in the profile/model selector.

Made by [Open SWE](https://openswe.vercel.app)