### PR TITLE
fix: collapse tool calls when agent moves to next step

### DIFF
--- a/ui/src/components/agents/ported/MessageView.tsx
+++ b/ui/src/components/agents/ported/MessageView.tsx
@@ -475,45 +475,42 @@ function AgentMessage({
     [renderItems],
   );
   const hasExploredGroups = exploredGroupIds.length > 0;
+
+  // The agent's current step is the last render item while the message is still
+  // streaming. Tool groups stay expanded only while they are the active step and
+  // collapse once the agent moves on to the next process.
+  const activeItemKey = useMemo(() => {
+    if (!isStreaming || renderItems.length === 0) return null;
+    return renderItems[renderItems.length - 1].key;
+  }, [isStreaming, renderItems]);
+
   const [expandedExploredGroups, setExpandedExploredGroups] = useState<Record<string, boolean>>({});
-  const wasExplorationLiveRef = useRef(false);
+  const prevAutoExploredRef = useRef<Record<string, boolean>>({});
 
   useEffect(() => {
-    const isLive = !!isStreaming;
-
     if (!hasExploredGroups) {
       setExpandedExploredGroups({});
-      wasExplorationLiveRef.current = isLive;
+      prevAutoExploredRef.current = {};
       return;
     }
 
-    if (isLive) {
-      const next: Record<string, boolean> = {};
-      for (const id of exploredGroupIds) {
-        next[id] = true;
-      }
-      setExpandedExploredGroups(next);
-      wasExplorationLiveRef.current = true;
-      return;
-    }
-
-    const shouldAutoCollapse = wasExplorationLiveRef.current;
     setExpandedExploredGroups((prev) => {
       const next: Record<string, boolean> = {};
+      let changed = Object.keys(prev).length !== exploredGroupIds.length;
       for (const id of exploredGroupIds) {
-        next[id] = shouldAutoCollapse ? false : (prev[id] ?? false);
+        const autoExpanded = id === activeItemKey;
+        const prevAuto = prevAutoExploredRef.current[id];
+        // Follow the auto state when it flips; otherwise keep the user's choice.
+        next[id] = prevAuto !== autoExpanded ? autoExpanded : (prev[id] ?? autoExpanded);
+        if (next[id] !== prev[id]) changed = true;
       }
-
-      const prevKeys = Object.keys(prev);
-      const nextKeys = Object.keys(next);
-      if (prevKeys.length !== nextKeys.length) return next;
-      for (const key of nextKeys) {
-        if (prev[key] !== next[key]) return next;
-      }
-      return prev;
+      prevAutoExploredRef.current = exploredGroupIds.reduce<Record<string, boolean>>((acc, id) => {
+        acc[id] = id === activeItemKey;
+        return acc;
+      }, {});
+      return changed ? next : prev;
     });
-    wasExplorationLiveRef.current = false;
-  }, [hasExploredGroups, isStreaming, exploredGroupIds, message.id]);
+  }, [hasExploredGroups, activeItemKey, exploredGroupIds, message.id]);
 
   return (
     <div className="my-2 min-w-0 space-y-2">
@@ -521,7 +518,7 @@ function AgentMessage({
         switch (item.type) {
           case "explored-group": {
             const summary = summarizeExploration(item.chunks);
-            const isExpanded = expandedExploredGroups[item.id] ?? false;
+            const isExpanded = expandedExploredGroups[item.id] ?? (item.key === activeItemKey);
             return (
               <div key={item.key}>
                 <button
@@ -583,6 +580,7 @@ function AgentMessage({
                 <ShellCommand
                   chunk={item.chunk}
                   projectPath={projectPath}
+                  isActive={item.key === activeItemKey}
                 />
               </div>
             );

--- a/ui/src/components/agents/ported/ShellCommand.tsx
+++ b/ui/src/components/agents/ported/ShellCommand.tsx
@@ -1,9 +1,11 @@
-import { memo, useState, useRef, useCallback, useLayoutEffect } from "react";
+import { memo, useState, useRef, useCallback, useEffect, useLayoutEffect } from "react";
 import type { ToolExecutionChunk } from "@/lib/agents/types";
 
 interface ShellCommandProps {
   chunk: ToolExecutionChunk;
   projectPath?: string;
+  /** True while this command is the agent's current (last, streaming) step. */
+  isActive?: boolean;
 }
 
 function getHeaderText(chunk: ToolExecutionChunk): string {
@@ -11,14 +13,17 @@ function getHeaderText(chunk: ToolExecutionChunk): string {
   const truncated = cmd.length > 80 ? cmd.slice(0, 80) + "..." : cmd;
   if (chunk.status === "in_progress") return `Running ${truncated}`;
   if (chunk.status === "pending") return `Run ${truncated}`;
-  return `Background terminal finished with ${truncated}`;
+  return `Ran ${truncated}`;
 }
 
 export const ShellCommand = memo(function ShellCommand({
   chunk,
+  isActive = false,
 }: ShellCommandProps) {
   const isSettled = chunk.status === "completed" || chunk.status === "error";
-  const [expanded, setExpanded] = useState(!isSettled);
+  const autoExpanded = !isSettled || isActive;
+  const [expanded, setExpanded] = useState(autoExpanded);
+  const prevAutoExpandedRef = useRef(autoExpanded);
   const [scrolledFromTop, setScrolledFromTop] = useState(false);
   const [scrolledFromBottom, setScrolledFromBottom] = useState(true);
   const outputRef = useRef<HTMLDivElement>(null);
@@ -29,6 +34,15 @@ export const ShellCommand = memo(function ShellCommand({
     setScrolledFromTop(el.scrollTop > 0);
     setScrolledFromBottom(el.scrollTop < el.scrollHeight - el.clientHeight - 1);
   }, []);
+
+  // Follow the active step: expand while this command is the current process,
+  // collapse once the agent moves on. Manual toggles still win until that flips.
+  useEffect(() => {
+    if (prevAutoExpandedRef.current !== autoExpanded) {
+      setExpanded(autoExpanded);
+      prevAutoExpandedRef.current = autoExpanded;
+    }
+  }, [autoExpanded]);
 
   const command = (chunk.input?.command as string) || "";
   const output = chunk.output || "";


### PR DESCRIPTION
## Description
Completed shell commands kept the verbose `Background terminal finished with <full command>` header and stayed expanded, dominating the chat UI. Shell commands and explored groups now auto-expand only while they are the agent's active (last streaming) step and collapse once it moves on, while still honoring manual toggles. The settled shell header is shortened to `Ran <command>`.

## Release Note
Tool calls in the Agents chat now collapse once the agent moves to the next step, keeping the conversation compact.

## Test Plan
- [ ] Run a multi-step agent task and confirm each shell/explored group expands while active and collapses when the next step starts.
- [ ] Confirm manually expanding/collapsing a settled tool call sticks.

Made by [Open SWE](https://openswe.vercel.app)