### PR TITLE
fix: collapse git panel by default

### DIFF
--- a/ui/src/components/agents/AgentGitPanel.tsx
+++ b/ui/src/components/agents/AgentGitPanel.tsx
@@ -74,8 +74,8 @@ function readStoredPanelWidth(): number {
 }
 
 function readStoredPanelCollapsed(): boolean {
-  if (typeof window === "undefined") return false
-  return window.localStorage.getItem(PANEL_STORAGE_COLLAPSED) === "1"
+  if (typeof window === "undefined") return true
+  return window.localStorage.getItem(PANEL_STORAGE_COLLAPSED) !== "0"
 }
 
 function PanelResizeHandle({


### PR DESCRIPTION
Default the agent git panel to collapsed when no preference is stored. Expanding/collapsing still persists across threads via localStorage.