### PR TITLE
fix: malformed-origin 500s and stuck home prompt on failed submit

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -66,7 +66,10 @@ def _origin_of(url: str) -> str:
         return ""
     scheme = parsed.scheme.lower()
     host = parsed.hostname.lower()
-    port = parsed.port
+    try:
+        port = parsed.port
+    except ValueError:
+        return ""
     if port is None:
         return f"{scheme}://{host}"
     default_port = 443 if scheme == "https" else 80 if scheme == "http" else None

--- a/tests/test_dashboard_csrf.py
+++ b/tests/test_dashboard_csrf.py
@@ -93,6 +93,16 @@ async def test_require_same_origin_rejects_null_origin(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_require_same_origin_rejects_malformed_port(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+
+    with pytest.raises(HTTPException) as exc:
+        oauth.require_same_origin(_request(origin="https://dashboard.example:notaport"))
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_require_same_origin_rejects_unknown_origin(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
 

--- a/ui/src/components/agents/AgentsHome.tsx
+++ b/ui/src/components/agents/AgentsHome.tsx
@@ -87,10 +87,17 @@ export function AgentsHome() {
     if (repo) configurable.repo = repo
     if (repoOverride === null) configurable.repo_explicitly_none = true
 
-    void stream.submit(
-      { messages: [{ type: "human", content: promptContent(prompt, images) }] },
-      { config: { configurable } }
-    )
+    stream
+      .submit(
+        { messages: [{ type: "human", content: promptContent(prompt, images) }] },
+        { config: { configurable } }
+      )
+      .catch(() => {
+        // Submit failed before the SDK minted a thread id — re-enable the
+        // prompt instead of leaving it disabled until a reload.
+        draftRef.current = null
+        setSubmitting(false)
+      })
   }
 
   return (


### PR DESCRIPTION
Fixes two findings surfaced by review on #1498 (out-of-diff there).

- `_origin_of`: `urlparse(...).port` raises `ValueError` on a malformed port (e.g. `Origin: https://x:notaport`), turning CSRF rejections into 500s. Invalid ports now read as an invalid origin → 403. Added a regression test.
- `AgentsHome`: `stream.submit` was fire-and-forgotten; a rejection before the SDK mints a thread id left `submitting` stuck true and the prompt disabled until reload. Now caught, resetting the draft and prompt.