### PR TITLE
fix: gray code-box background for changed-files diff card

### DIFF
--- a/ui/src/components/agents/messages/TurnChangedFilesCard.tsx
+++ b/ui/src/components/agents/messages/TurnChangedFilesCard.tsx
@@ -106,7 +106,7 @@ export const TurnChangedFilesCard = memo(function TurnChangedFilesCard({
   }, []);
 
   return (
-    <div className="mt-3 rounded-xl bg-[var(--ui-accent-bubble)] overflow-hidden">
+    <div className="mt-3 rounded-xl bg-[var(--ui-code-bubble)] overflow-hidden">
       <div className="px-3 py-2 text-xs text-[color:var(--ui-text-muted)] border-b border-[var(--ui-border)] flex items-center gap-2">
         <span>{files.length} file{files.length === 1 ? "" : "s"} changed</span>
         <span className="text-green-400">+{totals.additions}</span>


### PR DESCRIPTION
## Description
The turn changed-files diff card (`TurnChangedFilesCard`) used `--ui-accent-bubble`, the blue color that matches user-message bubbles. Switched it to `--ui-code-bubble`, the gray background used by code blocks, so the diff reads as agent output rather than a user message.

## Release Note
none

## Test Plan
- [ ] Open a thread where the agent changes files; confirm the "N files changed" diff card now uses the gray code-box background.

Made by [Open SWE](https://openswe.vercel.app)