### PR TITLE
feat: persist git panel open/closed state to localStorage

### DIFF
--- a/ui/src/components/agents/AgentGitPanel.tsx
+++ b/ui/src/components/agents/AgentGitPanel.tsx
@@ -73,6 +73,8 @@ function commonDirPrefix(paths: Array<string>): string {
 
 const PANEL_STORAGE_WIDTH = "open-swe.gitpanel.width"
 const PANEL_STORAGE_COLLAPSED = "open-swe.gitpanel.collapsed"
+const COLLAPSED_STATE_TRUE = "1"
+const COLLAPSED_STATE_FALSE = "0"
 const PANEL_DEFAULT_WIDTH = 420
 const PANEL_MIN_WIDTH = 320
 const PANEL_MAX_WIDTH = 720
@@ -88,7 +90,9 @@ function readStoredPanelWidth(): number {
 function readStoredPanelCollapsed(): boolean {
   if (typeof window === "undefined") return true
   // Default to collapsed until the user opens it once.
-  return window.localStorage.getItem(PANEL_STORAGE_COLLAPSED) !== "0"
+  return (
+    window.localStorage.getItem(PANEL_STORAGE_COLLAPSED) !== COLLAPSED_STATE_FALSE
+  )
 }
 
 function PanelResizeHandle({
@@ -176,12 +180,15 @@ export function AgentGitPanel({ thread, messages }: AgentGitPanelProps) {
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
   const [fullScreen, setFullScreen] = useState(false)
 
-  const setCollapsed = useCallback((next: boolean) => {
+  const setCollapsed = (next: boolean) => {
     setCollapsedState(next)
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(PANEL_STORAGE_COLLAPSED, next ? "1" : "0")
+      window.localStorage.setItem(
+        PANEL_STORAGE_COLLAPSED,
+        next ? COLLAPSED_STATE_TRUE : COLLAPSED_STATE_FALSE
+      )
     }
-  }, [])
+  }
 
   const setWidth = useCallback((next: number) => {
     const clamped = Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, next))

--- a/ui/src/components/agents/AgentGitPanel.tsx
+++ b/ui/src/components/agents/AgentGitPanel.tsx
@@ -72,6 +72,7 @@ function commonDirPrefix(paths: Array<string>): string {
 }
 
 const PANEL_STORAGE_WIDTH = "open-swe.gitpanel.width"
+const PANEL_STORAGE_COLLAPSED = "open-swe.gitpanel.collapsed"
 const PANEL_DEFAULT_WIDTH = 420
 const PANEL_MIN_WIDTH = 320
 const PANEL_MAX_WIDTH = 720
@@ -82,6 +83,12 @@ function readStoredPanelWidth(): number {
   const parsed = raw ? Number(raw) : NaN
   if (!Number.isFinite(parsed)) return PANEL_DEFAULT_WIDTH
   return Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, parsed))
+}
+
+function readStoredPanelCollapsed(): boolean {
+  if (typeof window === "undefined") return true
+  // Default to collapsed until the user opens it once.
+  return window.localStorage.getItem(PANEL_STORAGE_COLLAPSED) !== "0"
 }
 
 function PanelResizeHandle({
@@ -163,9 +170,18 @@ export function treeThemeStyle(): React.CSSProperties {
 export function AgentGitPanel({ thread, messages }: AgentGitPanelProps) {
   const [topTab, setTopTab] = useState<"git" | "desktop" | "terminal">("git")
   const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
-  const [collapsed, setCollapsed] = useState(true)
+  const [collapsed, setCollapsedState] = useState(() =>
+    readStoredPanelCollapsed()
+  )
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
   const [fullScreen, setFullScreen] = useState(false)
+
+  const setCollapsed = useCallback((next: boolean) => {
+    setCollapsedState(next)
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(PANEL_STORAGE_COLLAPSED, next ? "1" : "0")
+    }
+  }, [])
 
   const setWidth = useCallback((next: number) => {
     const clamped = Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, next))
@@ -176,14 +192,13 @@ export function AgentGitPanel({ thread, messages }: AgentGitPanelProps) {
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const pr = thread.pr
 
-  // Always start collapsed; re-collapse when switching threads, and
-  // uncollapse when a PR lands mid-session.
+  // The open/closed state is persisted to localStorage, so it carries across
+  // threads and reloads. Still uncollapse when a PR lands mid-session.
   const [prSeen, setPrSeen] = useState<{ threadId: string; hadPr: boolean }>(
     () => ({ threadId: thread.id, hadPr: Boolean(pr) })
   )
   if (prSeen.threadId !== thread.id) {
     setPrSeen({ threadId: thread.id, hadPr: Boolean(pr) })
-    setCollapsed(true)
   } else if (pr && !prSeen.hadPr) {
     setPrSeen({ threadId: thread.id, hadPr: true })
     setCollapsed(false)


### PR DESCRIPTION
## Description
In the Agents UI, the git panel (right-hand sidebar in a thread) always started collapsed and force-re-collapsed on every thread switch. This persists its open/closed state to `localStorage` (mirroring how panel width is already stored), so it stays open if you left it open and closed if you left it closed — across thread navigation and page reloads. The "auto-expand when a PR lands mid-session" behavior is preserved.

## Release Note
The Agents chat git panel now remembers whether you left it open or closed across threads and reloads.

## Test Plan
- [ ] Open a thread, expand the git panel, switch to another thread / reload — panel stays open.
- [ ] Collapse the git panel, switch threads / reload — panel stays closed.

Made by [Open SWE](https://openswe.vercel.app)