### PR TITLE
fix: Reviews tab — anchored finding card, paginated list, file tree truncation

### DIFF
--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -170,6 +170,7 @@ def _thread_review_summary(thread: dict[str, Any]) -> dict[str, Any] | None:
         "url": pr.get("url") or f"https://github.com/{owner}/{name}/pull/{number}",
         "head_ref": pr.get("head_ref") or "",
         "base_ref": pr.get("base_ref") or "",
+        "author": pr.get("author") if isinstance(pr.get("author"), str) else "",
         "head_sha": metadata.get("head_sha") or "",
         "watch": bool(metadata.get("watch")),
         "status": _run_status(thread, metadata),
@@ -179,27 +180,35 @@ def _thread_review_summary(thread: dict[str, Any]) -> dict[str, Any] | None:
 
 
 async def list_reviews(
-    limit: int = 100,
+    limit: int = 20,
     *,
+    offset: int = 0,
+    author: str | None = None,
     is_accessible: Callable[[dict[str, Any]], Awaitable[bool]] | None = None,
     page_size: int = 100,
     max_scan: int = 1000,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], bool]:
     """List review summaries, newest first.
 
+    Returns ``(summaries, has_more)`` where the summaries are the page at
+    ``offset`` (counted in accessible, filter-matching records) and
+    ``has_more`` says whether at least one more record exists past it.
+
     When ``is_accessible`` is given, keeps paging through reviewer threads
-    until ``limit`` accessible summaries are collected (or ``max_scan``
-    threads have been examined), so inaccessible records don't crowd
-    accessible ones out of a single fixed-size page.
+    until enough accessible summaries are collected (or ``max_scan`` threads
+    have been examined), so inaccessible records don't crowd accessible ones
+    out of a single fixed-size page. ``author`` filters on the PR author's
+    GitHub login stored in thread metadata.
     """
     client = langgraph_client()
+    needed = offset + limit + 1
     summaries: list[dict[str, Any]] = []
-    offset = 0
-    while len(summaries) < limit and offset < max_scan:
+    scan_offset = 0
+    while len(summaries) < needed and scan_offset < max_scan:
         threads = await client.threads.search(
             metadata={"kind": REVIEWER_THREAD_KIND},
             limit=page_size,
-            offset=offset,
+            offset=scan_offset,
             sort_by="updated_at",
             sort_order="desc",
         )
@@ -211,15 +220,18 @@ async def list_reviews(
             summary = _thread_review_summary(thread)
             if not summary:
                 continue
+            if author is not None and summary["author"] != author:
+                continue
             if is_accessible is not None and not await is_accessible(summary):
                 continue
             summaries.append(summary)
-            if len(summaries) >= limit:
+            if len(summaries) >= needed:
                 break
         if len(threads) < page_size:
             break
-        offset += page_size
-    return summaries
+        scan_offset += page_size
+    page = summaries[offset : offset + limit]
+    return page, len(summaries) > offset + limit
 
 
 def _user_ref(value: Any) -> dict[str, Any] | None:

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -709,10 +709,15 @@ async def api_list_review_styles(
     return out
 
 
+REVIEWS_PAGE_SIZE = 20
+
+
 @router.get("/reviews")
 async def api_list_reviews(
+    page: int = 0,
+    mine: bool = True,
     session: dict[str, Any] = _SESSION_DEP,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     login = session["sub"]
     access_cache: dict[str, bool] = {}
 
@@ -728,7 +733,14 @@ async def api_list_reviews(
                 access_cache[full_name] = False
         return access_cache[full_name]
 
-    return await list_reviews(is_accessible=is_accessible)
+    page = max(page, 0)
+    reviews, has_more = await list_reviews(
+        REVIEWS_PAGE_SIZE,
+        offset=page * REVIEWS_PAGE_SIZE,
+        author=login if mine else None,
+        is_accessible=is_accessible,
+    )
+    return {"reviews": reviews, "page": page, "has_more": has_more}
 
 
 @router.get("/reviews/{owner}/{repo}/{pr_number}")

--- a/agent/reviewer_findings.py
+++ b/agent/reviewer_findings.py
@@ -171,6 +171,7 @@ class ReviewerPRMeta(TypedDict, total=False):
     title: str
     head_ref: str
     base_ref: str
+    author: str
 
 
 class ReviewerSlackThread(TypedDict, total=False):

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -1865,6 +1865,7 @@ async def trigger_pr_review_from_ref(
         "title": pr_title,
         "head_ref": branch_name,
         "base_ref": base_ref,
+        "author": (pr_metadata.get("user") or {}).get("login", ""),
     }
     slack_thread_meta: ReviewerSlackThread | None = None
     if slack_channel_id and slack_thread_ts:
@@ -2020,6 +2021,7 @@ async def _dispatch_first_review_from_pr_payload(payload: dict[str, Any], *, sou
         "title": pr_title,
         "head_ref": branch_name,
         "base_ref": base_ref,
+        "author": (pull_request.get("user") or {}).get("login", ""),
     }
     last_reviewed_sha = ""
     if payload.get("action") == "ready_for_review":
@@ -2496,6 +2498,7 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
         "title": pr_title,
         "head_ref": head_ref,
         "base_ref": base_ref,
+        "author": (pr.get("user") or {}).get("login", ""),
     }
     await set_reviewer_thread_metadata(thread_id, pr=pr_meta, watch=True, head_sha=head_sha)
 

--- a/ui/src/components/agents/ReviewSidebar.tsx
+++ b/ui/src/components/agents/ReviewSidebar.tsx
@@ -122,7 +122,9 @@ function ReviewFileTreeExplorer({
           {
             height: "100%",
             ...treeThemeStyle(),
-            "--trees-theme-sidebar-bg": "transparent",
+            // Must stay opaque: the tree's truncation marker ("…") paints
+            // this color behind itself to hide the overflowing filename.
+            "--trees-theme-sidebar-bg": "var(--ui-sidebar)",
           } as React.CSSProperties
         }
       />

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -311,12 +311,19 @@ export interface ReviewSummary {
   url: string;
   head_ref: string;
   base_ref: string;
+  author: string;
   head_sha: string;
   watch: boolean;
   status: "running" | "error" | "idle";
   counts: ReviewCounts;
   updated_at: string | null;
   full_name?: string;
+}
+
+export interface ReviewListPayload {
+  reviews: Array<ReviewSummary>;
+  page: number;
+  has_more: boolean;
 }
 
 export interface ReviewUserRef {
@@ -470,7 +477,8 @@ export const api = {
       `/admin/user-mappings/${encodeURIComponent(github_login)}`,
       { method: "DELETE" },
     ),
-  listReviews: () => request<Array<ReviewSummary>>("/reviews"),
+  listReviews: (page: number, mine: boolean) =>
+    request<ReviewListPayload>(`/reviews?page=${page}&mine=${mine}`),
   getReview: (owner: string, repo: string, number: number) =>
     request<ReviewDetail>(
       `/reviews/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${number}`,

--- a/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
+++ b/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
@@ -17,6 +17,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react"
 import { IoLogoGithub } from "react-icons/io5"
+import { Popover } from "@base-ui/react/popover"
 
 import type {
   ReviewCheckRun,
@@ -207,16 +208,13 @@ function ReviewBody({
 }) {
   const [sideTab, setSideTab] = useState<SideTab>("info")
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
-  const scrollRef = useRef<HTMLElement | null>(null)
   const fileRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const anchorRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const [expandedFiles, setExpandedFiles] = useState<Record<string, boolean>>(
     {}
   )
   const [focused, setFocused] = useState<ReviewFinding | null>(null)
-  const [cardPos, setCardPos] = useState<{ top: number; left: number | null }>(
-    { top: 96, left: null }
-  )
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
 
   const viewedStorageKey = `open-swe.review.viewed.${detail.owner}/${detail.repo}/${detail.number}.${detail.head_sha}`
   const [viewed, setViewed] = useState<Set<string>>(() => {
@@ -303,26 +301,12 @@ function ReviewBody({
     })
   }, [])
 
-  const updateCardPos = useCallback((finding: ReviewFinding) => {
-    const rect = anchorRefs.current[finding.id]?.getBoundingClientRect()
-    if (rect) {
-      // No vertical clamp: the card must move 1:1 with its anchor while
-      // scrolling (and scroll out of view with it) to stay visually attached.
-      setCardPos({
-        top: rect.top,
-        left: Math.min(rect.right + 12, window.innerWidth - 412 - 8),
-      })
-    } else {
-      setCardPos({ top: 96, left: null })
-    }
-  }, [])
-
   const openFinding = useCallback(
     (finding: ReviewFinding) => {
       markRead(finding.id)
       setFocused(finding)
       if (!isAnchored(finding)) {
-        setCardPos({ top: 96, left: null })
+        setAnchorEl(null)
         return
       }
       setExpandedFiles((prev) => ({ ...prev, [finding.file]: true }))
@@ -330,23 +314,11 @@ function ReviewBody({
         const node =
           anchorRefs.current[finding.id] ?? fileRefs.current[finding.file]
         node?.scrollIntoView({ block: "center" })
-        requestAnimationFrame(() => updateCardPos(finding))
+        setAnchorEl(anchorRefs.current[finding.id] ?? null)
       })
     },
-    [markRead, updateCardPos]
+    [markRead]
   )
-
-  useEffect(() => {
-    if (!focused || !isAnchored(focused)) return
-    const scroller = scrollRef.current
-    const onMove = () => updateCardPos(focused)
-    scroller?.addEventListener("scroll", onMove, { passive: true })
-    window.addEventListener("resize", onMove)
-    return () => {
-      scroller?.removeEventListener("scroll", onMove)
-      window.removeEventListener("resize", onMove)
-    }
-  }, [focused, updateCardPos])
 
   const closeFinding = useCallback(() => setFocused(null), [])
 
@@ -383,7 +355,7 @@ function ReviewBody({
 
   return (
     <div className="relative flex min-h-0 flex-1">
-      <main ref={scrollRef} className="min-w-0 flex-1 overflow-y-auto">
+      <main className="min-w-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl px-6 py-6">
           <PrHeader detail={detail} />
           <div className="mt-4 rounded-lg border border-border bg-card p-4">
@@ -469,15 +441,55 @@ function ReviewBody({
         onFindingClick={openFinding}
       />
 
-      {focused && (
-        <FindingFloatingCard
-          detail={detail}
-          finding={focused}
-          top={cardPos.top}
-          left={cardPos.left}
-          onClose={closeFinding}
-        />
-      )}
+      {focused &&
+        (isAnchored(focused) && anchorEl ? (
+          <Popover.Root
+            open
+            onOpenChange={(open) => {
+              if (!open) setFocused(null)
+            }}
+          >
+            <Popover.Portal>
+              <Popover.Positioner
+                anchor={anchorEl}
+                side="right"
+                align="start"
+                sideOffset={12}
+                collisionAvoidance={{
+                  side: "shift",
+                  align: "none",
+                  fallbackAxisSide: "none",
+                }}
+                className="z-50"
+              >
+                <Popover.Popup
+                  data-finding-card
+                  aria-label={focused.title}
+                  className={FINDING_CARD_CLASS}
+                >
+                  <FindingCardContent
+                    detail={detail}
+                    finding={focused}
+                    onClose={closeFinding}
+                  />
+                </Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        ) : (
+          <div
+            data-finding-card
+            role="dialog"
+            aria-label={focused.title}
+            className={cn(FINDING_CARD_CLASS, "fixed top-24 right-1 z-50")}
+          >
+            <FindingCardContent
+              detail={detail}
+              finding={focused}
+              onClose={closeFinding}
+            />
+          </div>
+        ))}
     </div>
   )
 }
@@ -732,17 +744,16 @@ function DiffLineRow({
   )
 }
 
-function FindingFloatingCard({
+const FINDING_CARD_CLASS =
+  "flex max-h-[70vh] w-[412px] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-2xl"
+
+function FindingCardContent({
   detail,
   finding,
-  top,
-  left,
   onClose,
 }: {
   detail: ReviewDetail
   finding: ReviewFinding
-  top: number
-  left: number | null
   onClose: () => void
 }) {
   const [copied, setCopied] = useState(false)
@@ -771,16 +782,7 @@ function FindingFloatingCard({
   }
 
   return (
-    <div
-      data-finding-card
-      className={cn(
-        "fixed z-50 flex max-h-[70vh] w-[412px] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-2xl",
-        left === null && "right-1"
-      )}
-      style={left === null ? { top } : { top, left }}
-      role="dialog"
-      aria-label={finding.title}
-    >
+    <>
       <div className="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs">
         <Icon className={cn("size-3.5", style.className)} />
         <span className={cn("font-medium", style.className)}>
@@ -832,7 +834,7 @@ function FindingFloatingCard({
           </a>
         )}
       </div>
-    </div>
+    </>
   )
 }
 

--- a/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
+++ b/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
@@ -1,6 +1,13 @@
 import { Link, Navigate, createFileRoute } from "@tanstack/react-router"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import {
   ArrowClockwiseIcon,
   ArrowLeftIcon,
@@ -17,7 +24,6 @@ import {
   XIcon,
 } from "@phosphor-icons/react"
 import { IoLogoGithub } from "react-icons/io5"
-import { Popover } from "@base-ui/react/popover"
 
 import type {
   ReviewCheckRun,
@@ -215,6 +221,7 @@ function ReviewBody({
   )
   const [focused, setFocused] = useState<ReviewFinding | null>(null)
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const viewedStorageKey = `open-swe.review.viewed.${detail.owner}/${detail.repo}/${detail.number}.${detail.head_sha}`
   const [viewed, setViewed] = useState<Set<string>>(() => {
@@ -354,8 +361,11 @@ function ReviewBody({
   }, [focused])
 
   return (
-    <div className="relative flex min-h-0 flex-1">
-      <main className="min-w-0 flex-1 overflow-y-auto">
+    <div
+      ref={scrollRef}
+      className="relative flex min-h-0 flex-1 overflow-y-auto"
+    >
+      <main className="min-w-0 flex-1">
         <div className="mx-auto max-w-6xl px-6 py-6">
           <PrHeader detail={detail} />
           <div className="mt-4 rounded-lg border border-border bg-card p-4">
@@ -409,8 +419,7 @@ function ReviewBody({
                       const next = !(
                         expandedFiles[file.path] ?? !viewed.has(file.path)
                       )
-                      if (!next && focused?.file === file.path)
-                        setFocused(null)
+                      if (!next && focused?.file === file.path) setFocused(null)
                       setExpandedFiles((prev) => ({
                         ...prev,
                         [file.path]: next,
@@ -443,39 +452,14 @@ function ReviewBody({
 
       {focused &&
         (isAnchored(focused) && anchorEl ? (
-          <Popover.Root
-            open
-            onOpenChange={(open) => {
-              if (!open) setFocused(null)
-            }}
-          >
-            <Popover.Portal>
-              <Popover.Positioner
-                anchor={anchorEl}
-                side="right"
-                align="start"
-                sideOffset={12}
-                collisionAvoidance={{
-                  side: "shift",
-                  align: "none",
-                  fallbackAxisSide: "none",
-                }}
-                className="z-50"
-              >
-                <Popover.Popup
-                  data-finding-card
-                  aria-label={focused.title}
-                  className={FINDING_CARD_CLASS}
-                >
-                  <FindingCardContent
-                    detail={detail}
-                    finding={focused}
-                    onClose={closeFinding}
-                  />
-                </Popover.Popup>
-              </Popover.Positioner>
-            </Popover.Portal>
-          </Popover.Root>
+          <AnchoredFindingCard
+            key={focused.id}
+            detail={detail}
+            finding={focused}
+            anchorEl={anchorEl}
+            scrollRef={scrollRef}
+            onClose={closeFinding}
+          />
         ) : (
           <div
             data-finding-card
@@ -744,8 +728,75 @@ function DiffLineRow({
   )
 }
 
+const FINDING_CARD_WIDTH = 412
+const FINDING_CARD_GAP = 12
+
 const FINDING_CARD_CLASS =
   "flex max-h-[70vh] w-[412px] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-2xl"
+
+// Positioned absolutely inside the scroll container so it scrolls natively
+// with the diff — no per-scroll JS repositioning, hence no lag. Position is
+// recomputed only when layout shifts (files expand/collapse, resize).
+function AnchoredFindingCard({
+  detail,
+  finding,
+  anchorEl,
+  scrollRef,
+  onClose,
+}: {
+  detail: ReviewDetail
+  finding: ReviewFinding
+  anchorEl: HTMLDivElement
+  scrollRef: React.RefObject<HTMLDivElement | null>
+  onClose: () => void
+}) {
+  const cardRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    const card = cardRef.current
+    const scroller = scrollRef.current
+    if (!card || !scroller) return
+
+    const position = () => {
+      if (!anchorEl.isConnected) return
+      const scrollerRect = scroller.getBoundingClientRect()
+      const anchorRect = anchorEl.getBoundingClientRect()
+      const top = anchorRect.top - scrollerRect.top + scroller.scrollTop
+      const left = Math.max(
+        FINDING_CARD_GAP,
+        Math.min(
+          anchorRect.right -
+            scrollerRect.left +
+            scroller.scrollLeft +
+            FINDING_CARD_GAP,
+          scroller.clientWidth - FINDING_CARD_WIDTH - FINDING_CARD_GAP
+        )
+      )
+      card.style.top = `${top}px`
+      card.style.left = `${left}px`
+    }
+
+    position()
+    const observer = new ResizeObserver(position)
+    observer.observe(scroller)
+    for (const child of scroller.children) {
+      if (child !== card) observer.observe(child)
+    }
+    return () => observer.disconnect()
+  }, [anchorEl, scrollRef])
+
+  return (
+    <div
+      ref={cardRef}
+      data-finding-card
+      role="dialog"
+      aria-label={finding.title}
+      className={cn(FINDING_CARD_CLASS, "absolute z-50")}
+    >
+      <FindingCardContent detail={detail} finding={finding} onClose={onClose} />
+    </div>
+  )
+}
 
 function FindingCardContent({
   detail,
@@ -881,7 +932,7 @@ function SidePanel({
   return (
     <aside
       className={cn(
-        "hidden w-[420px] shrink-0 flex-col overflow-y-auto border-l border-border transition-opacity xl:flex",
+        "sticky top-0 hidden h-full w-[420px] shrink-0 flex-col overflow-y-auto border-l border-border transition-opacity xl:flex",
         dimmed && "pointer-events-none opacity-30"
       )}
     >

--- a/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
+++ b/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
@@ -306,8 +306,10 @@ function ReviewBody({
   const updateCardPos = useCallback((finding: ReviewFinding) => {
     const rect = anchorRefs.current[finding.id]?.getBoundingClientRect()
     if (rect) {
+      // No vertical clamp: the card must move 1:1 with its anchor while
+      // scrolling (and scroll out of view with it) to stay visually attached.
       setCardPos({
-        top: Math.min(Math.max(rect.top, 64), window.innerHeight - 360),
+        top: rect.top,
         left: Math.min(rect.right + 12, window.innerWidth - 412 - 8),
       })
     } else {

--- a/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
+++ b/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
@@ -207,6 +207,7 @@ function ReviewBody({
 }) {
   const [sideTab, setSideTab] = useState<SideTab>("info")
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const scrollRef = useRef<HTMLElement | null>(null)
   const fileRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const anchorRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const [expandedFiles, setExpandedFiles] = useState<Record<string, boolean>>(
@@ -302,6 +303,18 @@ function ReviewBody({
     })
   }, [])
 
+  const updateCardPos = useCallback((finding: ReviewFinding) => {
+    const rect = anchorRefs.current[finding.id]?.getBoundingClientRect()
+    if (rect) {
+      setCardPos({
+        top: Math.min(Math.max(rect.top, 64), window.innerHeight - 360),
+        left: Math.min(rect.right + 12, window.innerWidth - 412 - 8),
+      })
+    } else {
+      setCardPos({ top: 96, left: null })
+    }
+  }, [])
+
   const openFinding = useCallback(
     (finding: ReviewFinding) => {
       markRead(finding.id)
@@ -315,24 +328,23 @@ function ReviewBody({
         const node =
           anchorRefs.current[finding.id] ?? fileRefs.current[finding.file]
         node?.scrollIntoView({ block: "center" })
-        requestAnimationFrame(() => {
-          const rect = anchorRefs.current[finding.id]?.getBoundingClientRect()
-          if (rect) {
-            setCardPos({
-              top: Math.min(
-                Math.max(rect.top, 64),
-                window.innerHeight - 360
-              ),
-              left: Math.min(rect.right + 12, window.innerWidth - 412 - 8),
-            })
-          } else {
-            setCardPos({ top: 96, left: null })
-          }
-        })
+        requestAnimationFrame(() => updateCardPos(finding))
       })
     },
-    [markRead]
+    [markRead, updateCardPos]
   )
+
+  useEffect(() => {
+    if (!focused || !isAnchored(focused)) return
+    const scroller = scrollRef.current
+    const onMove = () => updateCardPos(focused)
+    scroller?.addEventListener("scroll", onMove, { passive: true })
+    window.addEventListener("resize", onMove)
+    return () => {
+      scroller?.removeEventListener("scroll", onMove)
+      window.removeEventListener("resize", onMove)
+    }
+  }, [focused, updateCardPos])
 
   const closeFinding = useCallback(() => setFocused(null), [])
 
@@ -353,13 +365,23 @@ function ReviewBody({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setFocused(null)
     }
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (target instanceof Element && target.closest("[data-finding-card]"))
+        return
+      setFocused(null)
+    }
     window.addEventListener("keydown", onKeyDown)
-    return () => window.removeEventListener("keydown", onKeyDown)
+    window.addEventListener("pointerdown", onPointerDown)
+    return () => {
+      window.removeEventListener("keydown", onKeyDown)
+      window.removeEventListener("pointerdown", onPointerDown)
+    }
   }, [focused])
 
   return (
     <div className="relative flex min-h-0 flex-1">
-      <main className="min-w-0 flex-1 overflow-y-auto">
+      <main ref={scrollRef} className="min-w-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl px-6 py-6">
           <PrHeader detail={detail} />
           <div className="mt-4 rounded-lg border border-border bg-card p-4">
@@ -398,18 +420,28 @@ function ReviewBody({
                     findings={findingsByFile.get(file.path) ?? []}
                     focused={focused}
                     viewed={viewed.has(file.path)}
-                    onToggleViewed={() => toggleViewed(file.path)}
+                    onToggleViewed={() => {
+                      const collapses =
+                        !viewed.has(file.path) &&
+                        expandedFiles[file.path] === undefined
+                      if (collapses && focused?.file === file.path)
+                        setFocused(null)
+                      toggleViewed(file.path)
+                    }}
                     expanded={
                       expandedFiles[file.path] ?? !viewed.has(file.path)
                     }
-                    onToggleExpanded={() =>
+                    onToggleExpanded={() => {
+                      const next = !(
+                        expandedFiles[file.path] ?? !viewed.has(file.path)
+                      )
+                      if (!next && focused?.file === file.path)
+                        setFocused(null)
                       setExpandedFiles((prev) => ({
                         ...prev,
-                        [file.path]: !(
-                          prev[file.path] ?? !viewed.has(file.path)
-                        ),
+                        [file.path]: next,
                       }))
-                    }
+                    }}
                     onFindingClick={openFinding}
                     sectionRef={(node) => {
                       fileRefs.current[file.path] = node
@@ -738,6 +770,7 @@ function FindingFloatingCard({
 
   return (
     <div
+      data-finding-card
       className={cn(
         "fixed z-50 flex max-h-[70vh] w-[412px] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-2xl",
         left === null && "right-1"
@@ -1062,7 +1095,7 @@ function ChecksSection({ checks }: { checks: Array<ReviewCheckRun> }) {
       {checks.length === 0 ? (
         <p className="text-[11px] text-muted-foreground">No checks reported.</p>
       ) : (
-        <div className="space-y-1">
+        <div className="max-h-56 space-y-1 overflow-y-auto">
           {checks.map((check, index) =>
             check.url ? (
               <a

--- a/ui/src/routes/agents/reviews/index.tsx
+++ b/ui/src/routes/agents/reviews/index.tsx
@@ -1,5 +1,6 @@
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import { useState } from "react"
 import {
   BugBeetleIcon,
   FlagIcon,
@@ -7,6 +8,7 @@ import {
 } from "@phosphor-icons/react"
 
 import type { ReviewSummary } from "@/lib/api"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { api } from "@/lib/api"
 import { useSession } from "@/lib/session"
@@ -33,13 +35,20 @@ function statusBadge(review: ReviewSummary) {
 
 function ReviewsPage() {
   const session = useSession()
+  const [mine, setMine] = useState(true)
+  const [page, setPage] = useState(0)
   const reviews = useQuery({
-    queryKey: ["reviews"],
-    queryFn: api.listReviews,
+    queryKey: ["reviews", mine, page],
+    queryFn: () => api.listReviews(page, mine),
     enabled: !!session.data,
+    placeholderData: keepPreviousData,
     refetchInterval: (query) =>
-      query.state.data?.some((r) => r.status === "running") ? 5000 : false,
+      query.state.data?.reviews.some((r) => r.status === "running")
+        ? 5000
+        : false,
   })
+
+  const items = reviews.data?.reviews ?? []
 
   return (
     <main className="min-w-0 flex-1 overflow-y-auto">
@@ -52,7 +61,33 @@ function ReviewsPage() {
           analysis.
         </p>
 
-        <div className="mt-6 overflow-hidden rounded-lg border border-[var(--ui-border)] bg-[var(--ui-panel)]">
+        <div className="mt-6 flex items-center gap-1">
+          {(
+            [
+              [true, "My PRs"],
+              [false, "All"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => {
+                setMine(value)
+                setPage(0)
+              }}
+              className={cn(
+                "rounded-md px-2.5 py-1 text-xs transition-colors",
+                mine === value
+                  ? "bg-[var(--ui-sidebar-hover)] font-medium text-[var(--ui-text)]"
+                  : "text-[var(--ui-text-muted)] hover:bg-[var(--ui-sidebar-hover)]"
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-3 overflow-hidden rounded-lg border border-[var(--ui-border)] bg-[var(--ui-panel)]">
           {reviews.isLoading && (
             <div className="p-4">
               <Skeleton className="h-24 w-full" />
@@ -63,14 +98,15 @@ function ReviewsPage() {
               {reviews.error.message}
             </p>
           )}
-          {reviews.data && reviews.data.length === 0 && (
+          {reviews.data && items.length === 0 && (
             <p className="px-4 py-3 text-xs text-[var(--ui-text-muted)]">
-              No reviews yet. Enable repositories under Open SWE Review settings
-              and open a PR.
+              {mine
+                ? "No reviews on your PRs yet. Switch to All to see every review you have access to."
+                : "No reviews yet. Enable repositories under Open SWE Review settings and open a PR."}
             </p>
           )}
           <div className="divide-y divide-[var(--ui-border)]">
-            {(reviews.data ?? []).map((review) => (
+            {items.map((review) => (
               <Link
                 key={review.thread_id}
                 to="/agents/reviews/$owner/$repo/$number"
@@ -89,6 +125,9 @@ function ReviewsPage() {
                     </div>
                     <div className="mt-0.5 text-xs text-[var(--ui-text-muted)]">
                       {review.owner}/{review.repo}#{review.number}
+                      {review.author && !mine && (
+                        <span className="ml-2">by {review.author}</span>
+                      )}
                       {review.head_ref && (
                         <span className="ml-2 font-mono text-[11px]">
                           {review.head_ref}
@@ -118,6 +157,31 @@ function ReviewsPage() {
               </Link>
             ))}
           </div>
+          {(page > 0 || reviews.data?.has_more) && (
+            <div className="flex items-center justify-between gap-4 border-t border-[var(--ui-border)] px-4 py-2 text-xs">
+              <span className="text-[var(--ui-text-muted)]">
+                Page {page + 1}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                >
+                  Prev
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!reviews.data?.has_more}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </main>


### PR DESCRIPTION
Fixes a batch of Reviews tab issues.

- Finding card was `fixed`-positioned and froze in place while the diff scrolled; it now tracks its anchor line on scroll/resize (Devin-style attachment)
- Finding card auto-hides when its diff card is collapsed (including collapse via mark-as-viewed) and on click outside
- Checks section gets a max height and scrolls
- File tree truncation: the `…` marker overlapped filenames because we set the tree sidebar bg to `transparent` — the pierre trees marker paints that color behind itself to mask overflow. Now uses the opaque `--ui-sidebar` color
- `/reviews` is paginated (page size 20, `has_more`) instead of returning everything, and defaults to the current user's PRs with an All toggle. PR author login is now persisted in reviewer thread metadata (`ReviewerPRMeta.author`); pre-existing threads without it only appear under All