### PR TITLE
fix: capitalize Minimal reasoning effort label in model selector

### DIFF
--- a/ui/src/lib/agents/provider/useModelOptions.ts
+++ b/ui/src/lib/agents/provider/useModelOptions.ts
@@ -58,6 +58,7 @@ export function useModelOptions(): ModelOptionsResult {
 
 const EFFORT_LABELS: Record<string, string> = {
   none: "None",
+  minimal: "Minimal",
   low: "Low",
   medium: "Medium",
   high: "High",


### PR DESCRIPTION
## Description
The model selector showed "Gemini 3.5 Flash minimal" with a lowercase effort label because `EFFORT_LABELS` had no `minimal` entry and fell back to the raw value. Added the `minimal: "Minimal"` mapping so it's capitalized like the other efforts.

## Release Note
none

## Test Plan
- [ ] Open the model selector and confirm the minimal effort now displays as "Minimal".

Made by [Open SWE](https://openswe.vercel.app)