### PR TITLE
fix: add cursor-pointer to sidebar expand/collapse buttons

### DIFF
--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -75,7 +75,7 @@ export function SidebarFrame({
         type="button"
         aria-label="Expand sidebar"
         onClick={toggle}
-        className="fixed top-3 left-3 z-30 flex size-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm hover:bg-accent hover:text-foreground"
+        className="fixed top-3 left-3 z-30 flex size-7 cursor-pointer items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm hover:bg-accent hover:text-foreground"
       >
         <SidebarSimpleIcon className="size-4" />
       </button>
@@ -164,7 +164,7 @@ export function SidebarCollapseButton({ onToggle, className }: SidebarCollapseBu
       aria-label="Collapse sidebar"
       onClick={onToggle}
       className={cn(
-        "flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground",
+        "flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground",
         className,
       )}
     >


### PR DESCRIPTION
## Description
The sidebar expand and collapse toggle buttons were missing `cursor-pointer`, so hovering over them didn't show a pointer cursor. Added the class to both the collapsed-state expand button and the `SidebarCollapseButton`.

## Release Note
Sidebar expand/collapse buttons now show a pointer cursor on hover.

## Test Plan
- [ ] Hover over the sidebar expand icon (collapsed state) and the collapse icon (next to logo) and confirm the cursor becomes a pointer.

Made by [Open SWE](https://openswe.vercel.app)