### PR TITLE
feat: support pasting images from clipboard into prompt bar

### DIFF
--- a/ui/src/components/agents/ported/CloudPromptBar.tsx
+++ b/ui/src/components/agents/ported/CloudPromptBar.tsx
@@ -271,6 +271,24 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
     [addFiles]
   )
 
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const files: Array<File> = []
+      for (const item of Array.from(items)) {
+        if (item.kind === "file") {
+          const file = item.getAsFile()
+          if (file && SUPPORTED_IMAGE_TYPES.has(file.type)) files.push(file)
+        }
+      }
+      if (files.length === 0) return
+      e.preventDefault()
+      void addFiles(files)
+    },
+    [addFiles]
+  )
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey && canSubmit) {
       e.preventDefault()
@@ -359,6 +377,7 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           placeholder={busy ? "Send a message to queue next..." : placeholder}
           disabled={disabled}
           className={cn(


### PR DESCRIPTION
## Description
The prompt bar only attached images via drag-and-drop or the file picker; pasting an image from the clipboard inserted the file name as text. This adds an `onPaste` handler to the textarea that extracts image files from `clipboardData` and attaches them as pending images.

## Release Note
Images can now be pasted from the clipboard directly into the chat prompt bar.

## Test Plan
- [ ] Copy an image to the clipboard and paste it into the prompt bar; it should attach as an image preview rather than inserting the file name as text.

Made by [Open SWE](https://openswe.vercel.app)