### PR TITLE
docs: add HVTracker badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   <a href="https://github.com/langchain-ai/open-swe/stargazers" target="_blank"><img src="https://img.shields.io/github/stars/langchain-ai/open-swe" alt="GitHub Stars"></a>
   <a href="https://github.com/langchain-ai/langgraph" target="_blank"><img src="https://img.shields.io/badge/Built%20on-LangGraph-blue" alt="Built on LangGraph"></a>
   <a href="https://github.com/langchain-ai/deepagents" target="_blank"><img src="https://img.shields.io/badge/Built%20on-Deep%20Agents-blue" alt="Built on Deep Agents"></a>
+  <a href="https://hvtracker.net/agents/open-swe/" target="_blank"><img src="https://hvtracker.net/badge/open-swe.svg" alt="HVTrust"></a>
+  <a href="https://hvtracker.net/agents/open-swe/" target="_blank"><img src="https://hvtracker.net/badge/open-swe-grade.svg" alt="Evidence Grade"></a>
   <a href="https://x.com/langchain" target="_blank"><img src="https://img.shields.io/twitter/url/https/twitter.com/langchain.svg?style=social&label=Follow%20%40LangChain" alt="Twitter / X"></a>
 </div>
 


### PR DESCRIPTION
## Summary
- add the requested HVTracker trust badge to the README header
- add the matching evidence-grade badge next to the existing project badges
- link both badges to the live Open SWE HVTracker profile

Closes #1363

## Testing
- HTTP/2 200 
date: Fri, 12 Jun 2026 02:36:26 GMT
content-type: image/svg+xml
cache-control: public, max-age=14400
content-security-policy-report-only: default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:
- HTTP/2 200 
date: Fri, 12 Jun 2026 02:36:26 GMT
content-type: image/svg+xml
cache-control: public, max-age=14400
content-security-policy-report-only: default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:
- README assertions passed
