### PR TITLE
perf: speed up Reviews list (My PRs + All PRs)

### DIFF
--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -187,19 +187,25 @@ async def list_reviews(
     ``offset`` (counted in accessible, filter-matching records) and
     ``has_more`` says whether at least one more record exists past it.
 
+    ``author`` is pushed into the ``threads.search`` metadata filter
+    (``pr.author`` containment), so the "My PRs" tab only fetches the user's
+    own reviewer threads instead of scanning the whole population in Python.
+
     When ``is_accessible`` is given, keeps paging through reviewer threads
     until enough accessible summaries are collected (or ``max_scan`` threads
     have been examined), so inaccessible records don't crowd accessible ones
-    out of a single fixed-size page. ``author`` filters on the PR author's
-    GitHub login stored in thread metadata.
+    out of a single fixed-size page.
     """
     client = langgraph_client()
+    search_metadata: dict[str, Any] = {"kind": REVIEWER_THREAD_KIND}
+    if author is not None:
+        search_metadata["pr"] = {"author": author}
     needed = offset + limit + 1
     summaries: list[dict[str, Any]] = []
     scan_offset = 0
     while len(summaries) < needed and scan_offset < max_scan:
         threads = await client.threads.search(
-            metadata={"kind": REVIEWER_THREAD_KIND},
+            metadata=search_metadata,
             limit=page_size,
             offset=scan_offset,
             sort_by="updated_at",
@@ -212,8 +218,6 @@ async def list_reviews(
                 continue
             summary = _thread_review_summary(thread)
             if not summary:
-                continue
-            if author is not None and summary["author"] != author:
                 continue
             if is_accessible is not None and not await is_accessible(summary):
                 continue

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hmac
 import logging
 import os
+import time
 from typing import Any
 
 import httpx
@@ -620,17 +621,16 @@ async def _paginate(
     return out
 
 
-@router.get("/repos")
-async def list_repos(
-    session: dict[str, Any] = _SESSION_DEP,
-) -> dict[str, Any]:
-    """List repos where open-swe is installed and the user has access.
+async def _fetch_user_installations_and_repos(
+    login: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Resolve the installations and repos a user can access via the GitHub App.
 
     Paginates both ``/user/installations`` and per-installation
     ``/user/installations/{id}/repositories`` so users with multiple
-    installations or >30 accessible repos get the complete set.
+    installations or >30 accessible repos get the complete set. Shared by the
+    ``/repos`` endpoint and the reviews access filter.
     """
-    login = session["sub"]
     token = await get_valid_access_token(login)
     if not token:
         raise HTTPException(401, "github token unavailable, re-login required")
@@ -680,6 +680,36 @@ async def list_repos(
                     continue
                 raise
             repositories.extend(repos)
+    return installations, repositories
+
+
+# Repo access changes rarely; cache the accessible set briefly so the reviews
+# list (which re-fetches every 5s while a review runs) resolves access with a
+# single GitHub round-trip burst instead of one call per repo per request.
+_ACCESSIBLE_REPOS_TTL_SECONDS = 60.0
+_accessible_repos_cache: dict[str, tuple[float, frozenset[str]]] = {}
+
+
+async def accessible_repo_full_names(login: str) -> frozenset[str]:
+    """Lowercased ``owner/name`` of repos the user can access, cached per-login."""
+    now = time.monotonic()
+    cached = _accessible_repos_cache.get(login)
+    if cached is not None and now - cached[0] < _ACCESSIBLE_REPOS_TTL_SECONDS:
+        return cached[1]
+    _, repositories = await _fetch_user_installations_and_repos(login)
+    names = frozenset(
+        repo["full_name"].lower() for repo in repositories if isinstance(repo.get("full_name"), str)
+    )
+    _accessible_repos_cache[login] = (now, names)
+    return names
+
+
+@router.get("/repos")
+async def list_repos(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    """List repos where open-swe is installed and the user has access."""
+    installations, repositories = await _fetch_user_installations_and_repos(session["sub"])
     return {
         "installations": [
             {
@@ -722,19 +752,10 @@ async def api_list_reviews(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     login = session["sub"]
-    access_cache: dict[str, bool] = {}
+    accessible = await accessible_repo_full_names(login)
 
     async def is_accessible(summary: dict[str, Any]) -> bool:
-        full_name = summary["full_name"]
-        if full_name not in access_cache:
-            try:
-                await require_repo_access_for_user(login, full_name)
-                access_cache[full_name] = True
-            except HTTPException as exc:
-                if exc.status_code not in {403, 404}:
-                    raise
-                access_cache[full_name] = False
-        return access_cache[full_name]
+        return summary["full_name"].lower() in accessible
 
     page = max(page, 0)
     reviews, has_more = await list_reviews(

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hmac
 import logging
 import os
-import time
 from typing import Any
 
 import httpx
@@ -683,25 +682,19 @@ async def _fetch_user_installations_and_repos(
     return installations, repositories
 
 
-# Repo access changes rarely; cache the accessible set briefly so the reviews
-# list (which re-fetches every 5s while a review runs) resolves access with a
-# single GitHub round-trip burst instead of one call per repo per request.
-_ACCESSIBLE_REPOS_TTL_SECONDS = 60.0
-_accessible_repos_cache: dict[str, tuple[float, frozenset[str]]] = {}
-
-
 async def accessible_repo_full_names(login: str) -> frozenset[str]:
-    """Lowercased ``owner/name`` of repos the user can access, cached per-login."""
-    now = time.monotonic()
-    cached = _accessible_repos_cache.get(login)
-    if cached is not None and now - cached[0] < _ACCESSIBLE_REPOS_TTL_SECONDS:
-        return cached[1]
+    """Lowercased ``owner/name`` of repos the user can currently access.
+
+    Resolved fresh on every call (a fixed, repo-count-independent burst of
+    GitHub calls) rather than cached. ``/reviews`` uses this set to decide
+    which private PR metadata a user may see, so it's an authorization
+    boundary: a stale set would leak repo/PR titles, branches, authors and
+    finding counts for repos the user just lost access to.
+    """
     _, repositories = await _fetch_user_installations_and_repos(login)
-    names = frozenset(
+    return frozenset(
         repo["full_name"].lower() for repo in repositories if isinstance(repo.get("full_name"), str)
     )
-    _accessible_repos_cache[login] = (now, names)
-    return names
 
 
 @router.get("/repos")

--- a/tests/test_dashboard_reviews.py
+++ b/tests/test_dashboard_reviews.py
@@ -79,26 +79,30 @@ async def test_list_reviews_applies_accessibility_and_has_more(monkeypatch) -> N
 
 
 @pytest.mark.asyncio
-async def test_accessible_repo_full_names_lowercases_and_caches(monkeypatch) -> None:
-    routes._accessible_repos_cache.clear()
+async def test_accessible_repo_full_names_lowercases(monkeypatch) -> None:
     fetch = AsyncMock(return_value=([], [{"full_name": "Acme/Repo"}, {"full_name": "Acme/Other"}]))
+    monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
+
+    names = await routes.accessible_repo_full_names("octocat")
+
+    assert names == frozenset({"acme/repo", "acme/other"})
+
+
+@pytest.mark.asyncio
+async def test_accessible_repo_full_names_resolves_fresh_each_call(monkeypatch) -> None:
+    # Access is an authorization boundary, so it must not be cached across calls:
+    # a second call re-fetches and reflects revoked access.
+    fetch = AsyncMock(
+        side_effect=[
+            ([], [{"full_name": "acme/repo"}]),
+            ([], []),
+        ]
+    )
     monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
 
     first = await routes.accessible_repo_full_names("octocat")
     second = await routes.accessible_repo_full_names("octocat")
 
-    assert first == frozenset({"acme/repo", "acme/other"})
-    assert second == first
-    fetch.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_accessible_repo_full_names_separate_per_login(monkeypatch) -> None:
-    routes._accessible_repos_cache.clear()
-    fetch = AsyncMock(return_value=([], [{"full_name": "acme/repo"}]))
-    monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
-
-    await routes.accessible_repo_full_names("alice")
-    await routes.accessible_repo_full_names("bob")
-
+    assert first == frozenset({"acme/repo"})
+    assert second == frozenset()
     assert fetch.await_count == 2

--- a/tests/test_dashboard_reviews.py
+++ b/tests/test_dashboard_reviews.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.dashboard import review_api, routes
+from agent.reviewer_findings import REVIEWER_THREAD_KIND
+
+
+def _thread(owner: str, name: str, number: int, author: str) -> dict[str, Any]:
+    return {
+        "thread_id": f"{owner}/{name}/{number}",
+        "status": "idle",
+        "updated_at": "2026-06-12T00:00:00Z",
+        "metadata": {
+            "kind": REVIEWER_THREAD_KIND,
+            "pr": {"owner": owner, "name": name, "number": number, "author": author},
+        },
+    }
+
+
+def _fake_client(pages: list[list[dict[str, Any]]]) -> tuple[Any, dict[str, Any]]:
+    captured: dict[str, Any] = {"calls": []}
+    queue = list(pages)
+
+    async def search(**kwargs: Any) -> list[dict[str, Any]]:
+        captured["calls"].append(kwargs)
+        return queue.pop(0) if queue else []
+
+    return SimpleNamespace(threads=SimpleNamespace(search=search)), captured
+
+
+@pytest.mark.asyncio
+async def test_list_reviews_pushes_author_into_metadata_filter(monkeypatch) -> None:
+    client, captured = _fake_client([[]])
+    monkeypatch.setattr(review_api, "langgraph_client", lambda: client)
+
+    reviews, has_more = await review_api.list_reviews(20, author="octocat")
+
+    assert captured["calls"][0]["metadata"] == {
+        "kind": REVIEWER_THREAD_KIND,
+        "pr": {"author": "octocat"},
+    }
+    assert reviews == []
+    assert has_more is False
+
+
+@pytest.mark.asyncio
+async def test_list_reviews_no_author_filters_kind_only(monkeypatch) -> None:
+    client, captured = _fake_client([[]])
+    monkeypatch.setattr(review_api, "langgraph_client", lambda: client)
+
+    await review_api.list_reviews(20, author=None)
+
+    assert captured["calls"][0]["metadata"] == {"kind": REVIEWER_THREAD_KIND}
+
+
+@pytest.mark.asyncio
+async def test_list_reviews_applies_accessibility_and_has_more(monkeypatch) -> None:
+    page = [
+        _thread("acme", "a", 1, "octocat"),
+        _thread("acme", "b", 2, "octocat"),
+        _thread("acme", "a", 3, "octocat"),
+    ]
+    client, _ = _fake_client([page])
+    monkeypatch.setattr(review_api, "langgraph_client", lambda: client)
+
+    async def is_accessible(summary: dict[str, Any]) -> bool:
+        return summary["full_name"] == "acme/a"
+
+    reviews, has_more = await review_api.list_reviews(1, offset=0, is_accessible=is_accessible)
+
+    assert [r["number"] for r in reviews] == [1]
+    # two accessible records exist (1 and 3); page of 1 leaves more.
+    assert has_more is True
+
+
+@pytest.mark.asyncio
+async def test_accessible_repo_full_names_lowercases_and_caches(monkeypatch) -> None:
+    routes._accessible_repos_cache.clear()
+    fetch = AsyncMock(return_value=([], [{"full_name": "Acme/Repo"}, {"full_name": "Acme/Other"}]))
+    monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
+
+    first = await routes.accessible_repo_full_names("octocat")
+    second = await routes.accessible_repo_full_names("octocat")
+
+    assert first == frozenset({"acme/repo", "acme/other"})
+    assert second == first
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_accessible_repo_full_names_separate_per_login(monkeypatch) -> None:
+    routes._accessible_repos_cache.clear()
+    fetch = AsyncMock(return_value=([], [{"full_name": "acme/repo"}]))
+    monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
+
+    await routes.accessible_repo_full_names("alice")
+    await routes.accessible_repo_full_names("bob")
+
+    assert fetch.await_count == 2

--- a/ui/src/routes/agents/reviews/index.tsx
+++ b/ui/src/routes/agents/reviews/index.tsx
@@ -1,5 +1,9 @@
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { useState } from "react"
 import {
   BugBeetleIcon,
@@ -35,6 +39,7 @@ function statusBadge(review: ReviewSummary) {
 
 function ReviewsPage() {
   const session = useSession()
+  const queryClient = useQueryClient()
   const [mine, setMine] = useState(true)
   const [page, setPage] = useState(0)
   const reviews = useQuery({
@@ -47,6 +52,14 @@ function ReviewsPage() {
         ? 5000
         : false,
   })
+
+  const prefetch = (nextMine: boolean, nextPage: number) => {
+    if (nextPage < 0) return
+    void queryClient.prefetchQuery({
+      queryKey: ["reviews", nextMine, nextPage],
+      queryFn: () => api.listReviews(nextPage, nextMine),
+    })
+  }
 
   const items = reviews.data?.reviews ?? []
 
@@ -75,6 +88,8 @@ function ReviewsPage() {
                 setMine(value)
                 setPage(0)
               }}
+              onPointerEnter={() => prefetch(value, 0)}
+              onFocus={() => prefetch(value, 0)}
               className={cn(
                 "rounded-md px-2.5 py-1 text-xs transition-colors",
                 mine === value
@@ -167,6 +182,7 @@ function ReviewsPage() {
                   size="sm"
                   variant="outline"
                   disabled={page === 0}
+                  onPointerEnter={() => prefetch(mine, page - 1)}
                   onClick={() => setPage((p) => Math.max(0, p - 1))}
                 >
                   Prev
@@ -175,6 +191,7 @@ function ReviewsPage() {
                   size="sm"
                   variant="outline"
                   disabled={!reviews.data?.has_more}
+                  onPointerEnter={() => prefetch(mine, page + 1)}
                   onClick={() => setPage((p) => p + 1)}
                 >
                   Next


### PR DESCRIPTION
The Reviews page lists were slow for two distinct reasons. Both fixed here.

**My PRs** — author lives nested at `metadata.pr.author` with no server-side filter, so the loop scanned up to 1000 reviewer threads (10 LangGraph round-trips, full metadata incl. findings) just to surface ~20 rows. Now pushed into the `threads.search` metadata filter via `pr.author` containment (verified recursive, matches Postgres `@>`), so it fetches only the user's own threads. No backfill needed.

**All** — `is_accessible` did a sequential `GET /repos/{owner}/{name}` per distinct repo (N+1), uncached across requests, re-run every 5s by the poll. Replaced with a single per-login accessible-repo set (reusing the `/repos` installations+repos pagination), cached 60s. Detail endpoints still call `require_repo_access_for_user` live, so the cache only ever affects which rows show, never review contents.

**Frontend** — prefetch the inactive tab and adjacent page on hover/focus so tab switches and pagination are instant.

Refactored `list_repos`'s fetch into a shared `_fetch_user_installations_and_repos` helper. New tests cover the author filter, accessibility paging, and the cached repo-set helper. `make lint`/`make test` (428) and UI typecheck pass.