### PR TITLE
chore: remove Kimi K2.6 from model selector

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -43,13 +43,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": False,
     },
     {
-        "id": "fireworks:accounts/fireworks/models/kimi-k2p6",
-        "label": "Kimi K2.6",
-        "efforts": ["none", "low", "medium", "high"],
-        "default_effort": "high",
-        "supports_images": False,
-    },
-    {
         "id": "fireworks:accounts/fireworks/models/deepseek-v4-pro",
         "label": "DeepSeek V4 Pro",
         "efforts": ["none", "low", "medium", "high", "xhigh", "max"],

--- a/tests/test_fireworks_model.py
+++ b/tests/test_fireworks_model.py
@@ -17,7 +17,7 @@ def test_fireworks_reasoning_effort_maps_effort() -> None:
 
 def test_provider_model_kwargs_for_fireworks() -> None:
     kwargs = provider_model_kwargs(
-        "fireworks:accounts/fireworks/models/kimi-k2p6",
+        "fireworks:accounts/fireworks/models/kimi-k2p7-code",
         "high",
         max_tokens=16_000,
     )


### PR DESCRIPTION
## Description
Removes the Kimi K2.6 model option from the supported model selector, since Kimi K2.7 is its replacement. Updates the fireworks provider test to use K2.7 instead of K2.6.

## Release Note
Removed Kimi K2.6 from the model selector; use Kimi K2.7 instead.

## Test Plan
- [x] Verified `tests/test_fireworks_model.py` passes with the updated model list.

Made by [Open SWE](https://openswe.vercel.app)