### PR TITLE
fix: pad shell command card bottom before output streams

### DIFF
--- a/ui/src/components/agents/ported/ShellCommand.tsx
+++ b/ui/src/components/agents/ported/ShellCommand.tsx
@@ -65,7 +65,7 @@ export const ShellCommand = memo(function ShellCommand({
 
       {expanded && (
         <div className="rounded-xl border border-[var(--ui-border-subtle)] bg-[var(--ui-code-bubble)] mt-1 overflow-hidden max-h-[250px] flex flex-col">
-          <div className="px-3 pt-2 pb-1 font-mono text-xs shrink-0">
+          <div className={`px-3 pt-2 ${output ? "pb-1" : "pb-3"} font-mono text-xs shrink-0`}>
             <div className="flex items-center justify-between gap-2 mb-2">
               <span className="text-[color:var(--ui-accent-2)]">bash</span>
               {chunk.status === "in_progress" && (


### PR DESCRIPTION
## Description
The bash command card only had `pb-1` on its header block, so the content sat cramped against the card's bottom edge until output streamed in (which adds its own bottom padding). Apply `pb-3` while there is no output yet so the pending/in-progress card looks uniformly padded.

## Release Note
none

## Test Plan
- [ ] Trigger a shell command in the Agents UI and confirm the card has even padding before its output begins streaming.

Made by [Open SWE](https://openswe.vercel.app)