### PR TITLE
chore: commit generated route tree SSR-register block

### DIFF
--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -490,3 +490,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}


### PR DESCRIPTION
`ui/src/routeTree.gen.ts` shows up as modified after every `vite dev`/`vite build`. The TanStack route generator appends an `@tanstack/react-start` `Register` module-augmentation block, but the committed version on `main` predates it, so the file is perpetual uncommitted drift in everyone's working tree.

This commits the current generator output verbatim so local regeneration is a no-op. The block is type-only (`import type` + `declare module`) and the file is `// @ts-nocheck`, so there's no build or lint impact (Vercel builds green with it).

The only diff is the appended block:
```ts
import type { getRouter } from './router.tsx'
import type { createStart } from '@tanstack/react-start'
declare module '@tanstack/react-start' {
  interface Register {
    ssr: true
    router: Awaited<ReturnType<typeof getRouter>>
  }
}
```