### PR TITLE
feat: soften long user-message scroll indicator to a fade

### DIFF
--- a/ui/src/components/agents/messages/UserMessage.tsx
+++ b/ui/src/components/agents/messages/UserMessage.tsx
@@ -24,12 +24,14 @@ export function UserMessage({ message }: { message: Message }) {
     updateScrollIndicators();
   }, [text, updateScrollIndicators]);
 
-  const textEdgeShadows = [
-    scrolledFromTop ? "inset 0 12px 10px -10px rgba(42, 63, 95, 0.95)" : "",
-    scrolledFromBottom ? "inset 0 -12px 10px -10px rgba(42, 63, 95, 0.95)" : "",
-  ]
-    .filter(Boolean)
-    .join(", ");
+  const topStop = scrolledFromTop ? "transparent 0, black 24px" : "black 0";
+  const bottomStop = scrolledFromBottom
+    ? "black calc(100% - 24px), transparent 100%"
+    : "black 100%";
+  const textEdgeMask =
+    scrolledFromTop || scrolledFromBottom
+      ? `linear-gradient(to bottom, ${topStop}, ${bottomStop})`
+      : undefined;
 
   return (
     <div className="flex justify-end my-4">
@@ -54,7 +56,10 @@ export function UserMessage({ message }: { message: Message }) {
               ref={textRef}
               onScroll={updateScrollIndicators}
               className="max-h-[250px] overflow-auto px-3 py-1.5 text-[color:var(--ui-text)] text-[13px] whitespace-pre-wrap break-words"
-              style={{ boxShadow: textEdgeShadows || "none" }}
+              style={{
+                maskImage: textEdgeMask,
+                WebkitMaskImage: textEdgeMask,
+              }}
             >
               {text}
             </div>


### PR DESCRIPTION
## Description
Long user messages capped at `max-h-[250px]` showed a hard inset box-shadow at the scroll edges, which looked heavy. This swaps it for a `mask-image` gradient so the text softly fades out at the top/bottom scroll edges instead.

## Release Note
Long chat messages now fade softly at the scroll edges instead of showing a hard shadow.

## Test Plan
<img width="950" height="520" alt="Screenshot 2026-06-15 at 1 30 19 PM" src="https://github.com/user-attachments/assets/c0cf20cf-9b43-4ddf-b000-c2ed824058c5" />


Made by [Open SWE](https://openswe.vercel.app)