### PR TITLE
feat: soften bash tool output scroll indicator to a fade

### DIFF
--- a/ui/src/components/agents/ported/ShellCommand.tsx
+++ b/ui/src/components/agents/ported/ShellCommand.tsx
@@ -38,12 +38,14 @@ export const ShellCommand = memo(function ShellCommand({
     handleOutputScroll();
   }, [handleOutputScroll, output, expanded]);
 
-  const outputEdgeShadows = [
-    scrolledFromTop ? "inset 0 12px 10px -10px rgba(42, 63, 95, 0.95)" : "",
-    scrolledFromBottom ? "inset 0 -12px 10px -10px rgba(42, 63, 95, 0.95)" : "",
-  ]
-    .filter(Boolean)
-    .join(", ");
+  const topStop = scrolledFromTop ? "transparent 0, black 24px" : "black 0";
+  const bottomStop = scrolledFromBottom
+    ? "black calc(100% - 24px), transparent 100%"
+    : "black 100%";
+  const outputEdgeMask =
+    scrolledFromTop || scrolledFromBottom
+      ? `linear-gradient(to bottom, ${topStop}, ${bottomStop})`
+      : undefined;
 
   return (
     <div className="my-1">
@@ -93,7 +95,10 @@ export const ShellCommand = memo(function ShellCommand({
               ref={outputRef}
               onScroll={handleOutputScroll}
               className="min-h-0 flex-1 overflow-auto px-3 pb-2"
-              style={{ boxShadow: outputEdgeShadows || "none" }}
+              style={{
+                maskImage: outputEdgeMask,
+                WebkitMaskImage: outputEdgeMask,
+              }}
             >
               <pre className="mt-1 text-[color:var(--ui-text-muted)] whitespace-pre font-mono text-xs w-max min-w-full">
                 {output}


### PR DESCRIPTION
## Description
Follow-up to #1531. The bash/shell tool output panel (`ShellCommand.tsx`) used the same hard inset box-shadow scroll indicators. This swaps it for a `mask-image` gradient so the output softly fades at the top/bottom scroll edges, matching the user message bubble treatment.

## Release Note
Bash tool output now fades softly at the scroll edges instead of showing a hard shadow.

## Test Plan
- [ ] Expand a bash tool with enough output to scroll; confirm the top/bottom edges fade as you scroll instead of showing a shadow.

Made by [Open SWE](https://openswe.vercel.app)