### PR TITLE
fix: keep sidebar thread rows at fixed height on hover

### DIFF
--- a/ui/src/components/agents/AgentsSidebar.tsx
+++ b/ui/src/components/agents/AgentsSidebar.tsx
@@ -368,7 +368,7 @@ function ThreadRow({
               params={{ threadId: thread.id }}
               onClick={onNavigate}
               className={cn(
-                "group mb-0.5 flex items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors",
+                "group mb-0.5 flex h-8 items-center gap-2 rounded-lg px-2.5 transition-colors",
                 isActive
                   ? "bg-[var(--ui-accent-bubble)] text-[var(--ui-text)]"
                   : "text-[var(--ui-text-muted)] hover:bg-[var(--ui-sidebar-hover)]",


### PR DESCRIPTION


https://github.com/user-attachments/assets/864f599b-a224-4858-9129-6530d2139ea9

## Description
Sidebar thread rows jumped in height on hover because hovering swaps the PR icon/badge (the badge has its own padding) for the resolve/delete action buttons, changing the row's natural height. Pinning the row to a fixed height (`h-8`, replacing the `py-1.5` padding) keeps it stable across resting and hover states.

## Release Note
Sidebar thread rows no longer change height when hovered.

## Test Plan
- [ ] Hover over thread rows in the agents sidebar and confirm the row height stays constant.

Made by [Open SWE](https://openswe.vercel.app)