### PR TITLE
feat: add independent PR TLDR feature alongside code review

### DIFF
--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -336,7 +336,28 @@ async def get_review(owner: str, repo: str, pr_number: int) -> dict[str, Any]:
     for finding in findings:
         finding["group"] = classify_finding(finding)
 
-    return {**summary, "pr": details, "checks": checks, "findings": findings}
+    return {
+        **summary,
+        "pr": details,
+        "checks": checks,
+        "findings": findings,
+        "tldr": _tldr(metadata),
+    }
+
+
+def _tldr(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    """Serialize the stored PR TLDR (markdown + provenance), if present."""
+    tldr = metadata.get("pr_tldr")
+    if not isinstance(tldr, dict):
+        return None
+    markdown = tldr.get("markdown")
+    if not isinstance(markdown, str) or not markdown.strip():
+        return None
+    return {
+        "markdown": markdown,
+        "head_sha": tldr.get("head_sha") if isinstance(tldr.get("head_sha"), str) else "",
+        "updated_at": tldr.get("updated_at") if isinstance(tldr.get("updated_at"), str) else None,
+    }
 
 
 async def get_review_diff(owner: str, repo: str, pr_number: int) -> dict[str, Any]:

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -38,8 +38,17 @@ ORG_GUIDELINES_MAX_CHARS = 10_000
 class TeamSettingsUpdate(BaseModel):
     trigger_mode: TriggerMode = "every_push"
     review_draft_prs: bool = False
-    pr_summaries: bool = True
+    code_review: bool = True
+    pr_tldr: bool = True
     review_trace_links: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_pr_summaries(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "pr_tldr" not in data and "pr_summaries" in data:
+            data = {**data, "pr_tldr": data["pr_summaries"]}
+        return data
+
     autofix_mode: AutofixMode = "off"
     autofix_severity_threshold: AutofixMode = "medium"
     org_guidelines: str | None = None
@@ -125,7 +134,8 @@ def _default_settings() -> dict[str, Any]:
     return {
         "trigger_mode": "every_push",
         "review_draft_prs": False,
-        "pr_summaries": True,
+        "code_review": True,
+        "pr_tldr": True,
         "review_trace_links": True,
         "autofix_mode": "off",
         "autofix_severity_threshold": "medium",
@@ -158,6 +168,11 @@ async def get_team_settings() -> dict[str, Any]:
     # Skip None-valued model fields so legacy records (or PUTs that cleared the
     # selection) still surface the hardcoded default instead of a null.
     overlay = {k: v for k, v in value.items() if v is not None}
+    # Migrate the legacy ``pr_summaries`` key to ``pr_tldr`` for records written
+    # before the rename, so an existing toggle value is preserved.
+    if "pr_tldr" not in overlay and "pr_summaries" in overlay:
+        overlay["pr_tldr"] = overlay["pr_summaries"]
+    overlay.pop("pr_summaries", None)
     merged = {**defaults, **overlay}
     # Drop obsolete trigger mode values so a legacy record doesn't surface a
     # value the new TriggerMode literal would reject on the next PUT.
@@ -170,7 +185,8 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
     value: dict[str, Any] = {
         "trigger_mode": update.trigger_mode,
         "review_draft_prs": update.review_draft_prs,
-        "pr_summaries": update.pr_summaries,
+        "code_review": update.code_review,
+        "pr_tldr": update.pr_tldr,
         "review_trace_links": update.review_trace_links,
         "autofix_mode": update.autofix_mode,
         "autofix_severity_threshold": update.autofix_severity_threshold,
@@ -271,6 +287,17 @@ async def get_team_review_trace_links_enabled() -> bool:
     """Return whether GitHub review bodies should include a LangSmith trace link."""
     settings = await get_team_settings()
     return bool(settings.get("review_trace_links", True))
+
+
+async def get_review_feature_flags() -> tuple[bool, bool]:
+    """Return ``(code_review_enabled, pr_tldr_enabled)`` for the team.
+
+    The two features are independent: a PR run produces a code review when the
+    first is on and a reviewer-focused TLDR when the second is on. Both share
+    the same reviewer sandbox; either or both can run.
+    """
+    settings = await get_team_settings()
+    return bool(settings.get("code_review", True)), bool(settings.get("pr_tldr", True))
 
 
 async def get_org_review_guidelines() -> str | None:

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -61,6 +61,7 @@ from .tools import (
     fetch_url,
     http_request,
     list_findings,
+    publish_pr_tldr,
     publish_review,
     reply_to_finding_thread,
     resolve_finding_thread,
@@ -290,6 +291,60 @@ The dataset expects 1-5 comments per PR (mean ~2).
 """
 
 
+_TLDR_BAR = """The TLDR is for a reviewer deciding whether the design is sound — not a
+changelog. Lead with a one-line headline, then a few bullets. Surface only the
+decisions worth a review:
+
+- data-model / schema changes; new or changed API contracts (routes,
+  request/response shape, status codes, breaking changes); new system
+  assumptions or invariants the rest of the system now relies on.
+- caching (is it hit? what's the TTL? how is it invalidated?), concurrency /
+  locking, auth / permission boundaries, new external dependencies, and
+  migration / rollback risk.
+- for frontend-only or backend-only PRs: the high-level structure of the code
+  and its tradeoffs / implications.
+
+Do NOT restate variable names, formatting, or walk through files. Be succinct
+and exercise judgment — name the handful of things a senior reviewer would
+actually scrutinize, and skip the rest. Add a short "Worth a closer look" line
+when something deserves extra scrutiny."""
+
+
+REVIEWER_TLDR_APPENDIX = f"""
+# PR TLDR (also required this run)
+
+In addition to the review above, produce a concise, reviewer-focused TLDR of
+this PR and post it by calling `publish_pr_tldr` exactly once (after
+`publish_review`).
+
+{_TLDR_BAR}
+"""
+
+
+PR_TLDR_ONLY_PROMPT_TEMPLATE = (
+    """You are a specialized PR summarizer. Your job is to read one GitHub PR and post a single concise, reviewer-focused TLDR.
+
+Sandbox: `{working_dir}`. Invoke `gh` as `GH_TOKEN=dummy gh <command>`.
+
+Fetch the diff:
+
+```
+GH_TOKEN=dummy gh pr diff {pr_number} --repo {repo_owner}/{repo_name}
+```
+
+{repo_checkout_note}
+
+"""
+    + _TLDR_BAR
+    + """
+
+Tools: `publish_pr_tldr` (call it once at the very end), plus `web_search`,
+`fetch_url`, `http_request` for extra context. Read-only: do not file findings,
+commit, push, or post a GitHub review.
+"""
+)
+
+
 _REPO_READY_NOTE = """The repo is already cloned and checked out at the PR head in
 `{working_dir}` — `cd` there and grep for full file context."""
 
@@ -412,6 +467,32 @@ def _reviewer_system_prompt(
             f"{api_standards_skill}"
         )
     return prompt
+
+
+def _pr_tldr_only_system_prompt(
+    working_dir: str,
+    *,
+    repo_owner: str,
+    repo_name: str,
+    pr_number: int | str,
+    repo_ready: bool = True,
+    head_sha: str = "",
+) -> str:
+    """System prompt for a TLDR-only run (code review disabled)."""
+    return PR_TLDR_ONLY_PROMPT_TEMPLATE.format(
+        working_dir=working_dir,
+        repo_owner=repo_owner or "<owner>",
+        repo_name=repo_name or "<repo>",
+        pr_number=pr_number if pr_number != "" else "<pr_number>",
+        repo_checkout_note=_repo_checkout_note(
+            repo_ready=repo_ready,
+            working_dir=working_dir,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            pr_number=pr_number,
+            head_sha=head_sha,
+        ),
+    )
 
 
 def _format_pr_overview(pr_title: str, pr_body: str) -> str:
@@ -580,6 +661,40 @@ def _build_finding_reply_context(
         f"Use `reply_to_finding_thread` only when the user asked a direct "
         f"question or a concise clarification is necessary. Call `publish_review` "
         f"once at the end so pending GitHub thread state is reconciled."
+    )
+
+
+def _build_tldr_only_context(
+    *,
+    pr_url: str,
+    repo_owner: str,
+    repo_name: str,
+    pr_number: int,
+    base_sha: str,
+    head_sha: str,
+    is_update: bool,
+    pr_title: str = "",
+    pr_body: str = "",
+) -> str:
+    overview = _format_pr_overview(pr_title, pr_body)
+    overview_section = f"\n{overview}" if overview else ""
+    heading = (
+        "## A new commit has been pushed — refresh the TLDR"
+        if is_update
+        else "## Pull request to summarize"
+    )
+    return (
+        f"{heading}\n\n"
+        f"- repo: {repo_owner}/{repo_name}\n"
+        f"- pr_number: {pr_number}\n"
+        f"- url: {pr_url}\n"
+        f"- base_sha: {base_sha}\n"
+        f"- head_sha: {head_sha}\n"
+        f"{overview_section}\n"
+        f"Fetch the diff with "
+        f"`GH_TOKEN=dummy gh pr diff {pr_number} --repo {repo_owner}/{repo_name}`, "
+        f"then write a concise reviewer-focused TLDR and call `publish_pr_tldr` "
+        f"once. The comment is upserted in place, so just post the current TLDR."
     )
 
 
@@ -796,6 +911,16 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     is_re_review = bool(config["configurable"].get("re_review"))
     reviewer_event = str(config["configurable"].get("reviewer_event", "") or "")
 
+    # The reviewer run is the shared vehicle for two independent features:
+    # code review (findings + publish_review) and the reviewer-focused PR TLDR.
+    # Either or both may run; default to code-review-only to preserve behavior
+    # for manual/eval runs that don't set these flags.
+    code_review_enabled = config["configurable"].get("code_review_enabled", True) is not False
+    pr_tldr_enabled = config["configurable"].get("pr_tldr_enabled", False) is True
+    if not code_review_enabled and not pr_tldr_enabled:
+        code_review_enabled = True
+    tldr_only = pr_tldr_enabled and not code_review_enabled
+
     can_fetch_pr = (
         pr_number is not None
         and isinstance(pr_number, int)
@@ -915,7 +1040,19 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     config["configurable"]["diff_line_set"] = pr_diff_line_set
 
     review_context = ""
-    if pr_number is not None and isinstance(pr_number, int):
+    if pr_number is not None and isinstance(pr_number, int) and tldr_only:
+        review_context = _build_tldr_only_context(
+            pr_url=pr_url,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            pr_number=pr_number,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            is_update=is_re_review,
+            pr_title=pr_title,
+            pr_body=pr_body,
+        )
+    elif pr_number is not None and isinstance(pr_number, int):
         if reviewer_event == "finding_reply":
             existing_findings = await list_findings_async(thread_id)
             review_context = _build_finding_reply_context(
@@ -1007,28 +1144,32 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     github_api_token = None
     github_token = None
 
-    system_prompt = _reviewer_system_prompt(
-        f"{work_dir}/{repo_name}" if repo_name else work_dir,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        pr_number=pr_number if isinstance(pr_number, int) else "",
-        repo_ready=repo_ready,
-        head_sha=head_sha,
-        reviewer_eval=reviewer_eval,
-        org_guidelines=org_guidelines,
-        repo_style_prompt=repo_style_prompt,
-        agents_md_content=agents_md_content,
-        api_standards_skill=api_standards_skill,
-    )
-    if review_context:
-        system_prompt = f"{system_prompt}\n\n{review_context}"
-
-    reviewer_model = make_model(model_id, **model_kwargs)
-    reviewer_subagent_model = make_model(subagent_model_id, **subagent_model_kwargs)
-    return create_deep_agent(
-        model=reviewer_model,
-        system_prompt=system_prompt,
-        tools=[
+    agent_work_dir = f"{work_dir}/{repo_name}" if repo_name else work_dir
+    if tldr_only:
+        system_prompt = _pr_tldr_only_system_prompt(
+            agent_work_dir,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            pr_number=pr_number if isinstance(pr_number, int) else "",
+            repo_ready=repo_ready,
+            head_sha=head_sha,
+        )
+        reviewer_tools = [publish_pr_tldr, web_search, fetch_url, http_request]
+    else:
+        system_prompt = _reviewer_system_prompt(
+            agent_work_dir,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            pr_number=pr_number if isinstance(pr_number, int) else "",
+            repo_ready=repo_ready,
+            head_sha=head_sha,
+            reviewer_eval=reviewer_eval,
+            org_guidelines=org_guidelines,
+            repo_style_prompt=repo_style_prompt,
+            agents_md_content=agents_md_content,
+            api_standards_skill=api_standards_skill,
+        )
+        reviewer_tools = [
             add_finding,
             update_finding,
             list_findings,
@@ -1038,7 +1179,19 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             web_search,
             fetch_url,
             http_request,
-        ],
+        ]
+        if pr_tldr_enabled:
+            system_prompt = f"{system_prompt}\n{REVIEWER_TLDR_APPENDIX}"
+            reviewer_tools.insert(4, publish_pr_tldr)
+    if review_context:
+        system_prompt = f"{system_prompt}\n\n{review_context}"
+
+    reviewer_model = make_model(model_id, **model_kwargs)
+    reviewer_subagent_model = make_model(subagent_model_id, **subagent_model_kwargs)
+    return create_deep_agent(
+        model=reviewer_model,
+        system_prompt=system_prompt,
+        tools=reviewer_tools,
         subagents=[_general_purpose_subagent(reviewer_subagent_model)],
         backend=sandbox_backend,
         skills=skill_sources or None,

--- a/agent/reviewer_publish.py
+++ b/agent/reviewer_publish.py
@@ -426,6 +426,66 @@ async def clear_review_started_comment(
     await set_reviewer_thread_metadata(thread_id, extra={"status_comment_id": None})
 
 
+def pr_tldr_marker(pr_number: int) -> str:
+    """Hidden marker stamped on the single upserted PR TLDR comment."""
+    return f"<!-- open-swe-pr-tldr pr={pr_number} -->"
+
+
+def render_pr_tldr_comment(
+    *,
+    markdown: str,
+    pr_number: int,
+    thread_id: str | None = None,
+) -> str:
+    """Compose the PR TLDR comment body, stamped with its upsert marker."""
+    parts = ["## Open SWE TLDR", markdown.strip()]
+    ui_url = dashboard_thread_url(thread_id) if thread_id else None
+    if ui_url:
+        parts.append(f"[Open in Web]({ui_url})")
+    parts.append(pr_tldr_marker(pr_number))
+    return "\n\n".join(parts)
+
+
+async def upsert_pr_tldr_comment(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    body: str,
+    token: str,
+    existing_comment_id: int | None,
+) -> int | None:
+    """Update the tracked TLDR comment in place, or post a fresh one.
+
+    Keeps a single always-current TLDR comment on the PR: edits the tracked
+    comment when one exists, recreating it only if it has been deleted (404).
+    Returns the live comment id (or ``None`` on failure).
+    """
+    headers = _github_headers(token)
+    if isinstance(existing_comment_id, int):
+        patch_url = f"{_GITHUB_API_BASE}/repos/{owner}/{repo}/issues/comments/{existing_comment_id}"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.patch(
+                    patch_url, headers=headers, json={"body": body}, timeout=30
+                )
+                if response.status_code != 404:  # noqa: PLR2004
+                    response.raise_for_status()
+                    return existing_comment_id
+            except httpx.HTTPError:
+                logger.exception(
+                    "Failed to update TLDR comment %s on %s/%s#%s",
+                    existing_comment_id,
+                    owner,
+                    repo,
+                    pr_number,
+                )
+                return None
+    return await post_status_comment(
+        owner=owner, repo=repo, pr_number=pr_number, body=body, token=token
+    )
+
+
 async def settle_review_check_run(
     *,
     thread_id: str,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -10,6 +10,7 @@ from .linear_list_teams import linear_list_teams
 from .linear_update_issue import linear_update_issue
 from .list_findings import list_findings
 from .open_pull_request import open_pull_request
+from .publish_pr_tldr import publish_pr_tldr
 from .publish_review import publish_review
 from .reply_to_finding_thread import reply_to_finding_thread
 from .request_pr_review import request_pr_review
@@ -32,6 +33,7 @@ __all__ = [
     "linear_update_issue",
     "list_findings",
     "open_pull_request",
+    "publish_pr_tldr",
     "publish_review",
     "request_pr_review",
     "reply_to_finding_thread",

--- a/agent/tools/publish_pr_tldr.py
+++ b/agent/tools/publish_pr_tldr.py
@@ -1,0 +1,137 @@
+"""Tool: ``publish_pr_tldr``. Upsert a reviewer-focused TLDR comment on a PR."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..reviewer_findings import (
+    ReviewerThreadMissingError,
+    get_thread_id_from_runtime,
+    get_thread_metadata,
+    resolve_review_head_sha,
+    set_reviewer_thread_metadata,
+    thread_missing_tool_result,
+)
+from ..reviewer_publish import render_pr_tldr_comment, upsert_pr_tldr_comment
+from ..utils.github_token import (
+    GitHubAuthError,
+    get_github_token,
+    invalidate_cached_github_token,
+)
+
+# Keep the TLDR short enough to scan in the sidebar; longer text defeats the
+# point of a TLDR and is rejected so the agent re-summarizes instead.
+MAX_TLDR_CHARS = 4000
+
+
+def publish_pr_tldr(tldr: str) -> dict[str, Any]:
+    """Post (or update) the PR's reviewer-focused TLDR comment.
+
+    Call this once at the end of the run with a concise, decision-oriented
+    summary of what a reviewer needs to evaluate the PR (data-model/API changes,
+    new assumptions, caching/concurrency/auth decisions, notable tradeoffs).
+    Skip restating variable names or a file-by-file walkthrough. The comment is
+    upserted in place, so each run keeps a single always-current TLDR.
+
+    Args:
+        tldr: Markdown body of the TLDR (a 1-line headline plus a few bullets).
+
+    Returns:
+        Dictionary with ``success`` and, on success, ``comment_id``.
+    """
+    text = tldr.strip() if isinstance(tldr, str) else ""
+    if not text:
+        return {"success": False, "error": "tldr must be a non-empty string"}
+    if len(text) > MAX_TLDR_CHARS:
+        return {
+            "success": False,
+            "error": f"tldr too long ({len(text)} chars); keep it under {MAX_TLDR_CHARS}",
+        }
+
+    config = get_config()
+    raw_configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    configurable = raw_configurable if isinstance(raw_configurable, dict) else {}
+    repo_config = configurable.get("repo")
+    pr_number = configurable.get("pr_number")
+
+    if (
+        not isinstance(repo_config, dict)
+        or not repo_config.get("owner")
+        or not repo_config.get("name")
+    ):
+        return {"success": False, "error": "Missing repo info in run config"}
+    if not isinstance(pr_number, int):
+        return {"success": False, "error": "Missing pr_number in run config"}
+
+    if configurable.get("reviewer_eval") is True or configurable.get("eval") is True:
+        return {"success": True, "dry_run": True, "comment_id": None}
+
+    token = get_github_token()
+    if not token:
+        return {"success": False, "error": "No GitHub token available"}
+
+    try:
+        return asyncio.run(
+            _publish_pr_tldr_async(
+                owner=str(repo_config["owner"]),
+                repo=str(repo_config["name"]),
+                pr_number=pr_number,
+                tldr=text,
+                token=token,
+                configurable=configurable,
+            )
+        )
+    except ReviewerThreadMissingError as exc:
+        return thread_missing_tool_result(exc)
+    except GitHubAuthError as exc:
+        thread_id = get_thread_id_from_runtime()
+        if thread_id:
+            asyncio.run(invalidate_cached_github_token(thread_id))
+        return {
+            "success": False,
+            "error": "GitHub returned 401 — the cached token is invalid or revoked.",
+            "auth_error": str(exc),
+        }
+
+
+async def _publish_pr_tldr_async(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    tldr: str,
+    token: str,
+    configurable: dict[str, Any],
+) -> dict[str, Any]:
+    thread_id = get_thread_id_from_runtime()
+    metadata = await get_thread_metadata(thread_id)
+    existing = metadata.get("pr_tldr")
+    existing_comment_id = existing.get("comment_id") if isinstance(existing, dict) else None
+    body = render_pr_tldr_comment(markdown=tldr, pr_number=pr_number, thread_id=thread_id)
+    comment_id = await upsert_pr_tldr_comment(
+        owner=owner,
+        repo=repo,
+        pr_number=pr_number,
+        body=body,
+        token=token,
+        existing_comment_id=existing_comment_id if isinstance(existing_comment_id, int) else None,
+    )
+    if comment_id is None:
+        return {"success": False, "error": "Failed to post TLDR comment to GitHub"}
+    head_sha = await resolve_review_head_sha(thread_id, configurable)
+    await set_reviewer_thread_metadata(
+        thread_id,
+        extra={
+            "pr_tldr": {
+                "markdown": tldr,
+                "comment_id": comment_id,
+                "head_sha": head_sha,
+                "updated_at": datetime.now(UTC).isoformat(),
+            }
+        },
+    )
+    return {"success": True, "comment_id": comment_id}

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -31,6 +31,7 @@ from .dashboard.enabled_repos import is_review_repo_enabled
 from .dashboard.oauth import build_settings_url
 from .dashboard.profiles import get_profile, get_valid_access_token, has_access_token_record
 from .dashboard.team_settings import (
+    get_review_feature_flags,
     get_team_default_repo,
     get_team_settings,
     is_autofix_enabled,
@@ -1959,6 +1960,8 @@ def _build_reviewer_configurable(
     last_reviewed_sha: str = "",
     slack_channel_id: str = "",
     slack_thread_ts: str = "",
+    code_review_enabled: bool = True,
+    pr_tldr_enabled: bool = False,
 ) -> dict[str, Any]:
     """Assemble the runnable-config ``configurable`` dict for a reviewer run."""
     configurable: dict[str, Any] = {
@@ -1972,6 +1975,8 @@ def _build_reviewer_configurable(
         "head_sha": head_sha,
         "review_requested": True,
         "re_review": re_review,
+        "code_review_enabled": code_review_enabled,
+        "pr_tldr_enabled": pr_tldr_enabled,
     }
     if branch_name:
         configurable["branch_name"] = branch_name
@@ -2069,24 +2074,45 @@ async def _dispatch_first_review_from_pr_payload(payload: dict[str, Any], *, sou
         logger.warning("No GitHub App token available for reviewer dispatch")
         return
 
+    code_review_enabled, pr_tldr_enabled = await get_review_feature_flags()
+    if not code_review_enabled and not pr_tldr_enabled:
+        logger.info(
+            "Skipping reviewer dispatch for %s/%s#%s: both code review and PR TLDR are disabled",
+            repo_config.get("owner"),
+            repo_config.get("name"),
+            pr_number,
+        )
+        return
+
     langgraph_client = get_client(url=LANGGRAPH_URL)
     if not await _ensure_thread_exists_for_metadata(thread_id, langgraph_client):
         return
 
     await set_reviewer_thread_metadata(thread_id, pr=pr_meta, watch=True, head_sha=head_sha)
 
-    check_run_id = await create_review_check_run(
-        owner=repo_config.get("owner", ""),
-        repo=repo_config.get("name", ""),
-        head_sha=head_sha,
-        token=app_token,
-        details_url=dashboard_thread_url(thread_id),
-    )
-    if check_run_id is not None:
-        await set_reviewer_thread_metadata(thread_id, extra={"review_check_run_id": check_run_id})
+    # The review check run only represents the code review; a TLDR-only run
+    # posts a comment and shouldn't surface a "review" check on the PR.
+    if code_review_enabled:
+        check_run_id = await create_review_check_run(
+            owner=repo_config.get("owner", ""),
+            repo=repo_config.get("name", ""),
+            head_sha=head_sha,
+            token=app_token,
+            details_url=dashboard_thread_url(thread_id),
+        )
+        if check_run_id is not None:
+            await set_reviewer_thread_metadata(
+                thread_id, extra={"review_check_run_id": check_run_id}
+            )
 
     is_re_review = bool(last_reviewed_sha)
-    if is_re_review:
+    if not code_review_enabled:
+        prompt = (
+            f"{'A new commit has been pushed to' if is_re_review else 'Summarize'} "
+            f"PR #{pr_number} (HEAD {head_sha}). Write a concise reviewer-focused TLDR "
+            f"and call `publish_pr_tldr` once."
+        )
+    elif is_re_review:
         prompt = (
             f"PR #{pr_number} has been marked ready for review. The new HEAD is "
             f"{head_sha}. Reconcile existing findings against the new diff, add any "
@@ -2107,6 +2133,8 @@ async def _dispatch_first_review_from_pr_payload(payload: dict[str, Any], *, sou
         repo_private=repo_private,
         re_review=is_re_review,
         last_reviewed_sha=last_reviewed_sha,
+        code_review_enabled=code_review_enabled,
+        pr_tldr_enabled=pr_tldr_enabled,
     )
 
     thread_active = await is_thread_active(thread_id)
@@ -2382,6 +2410,16 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
         )
         return
 
+    code_review_enabled, pr_tldr_enabled = await get_review_feature_flags()
+    if not code_review_enabled and not pr_tldr_enabled:
+        logger.info(
+            "Push to %s/%s head=%s ignored: code review and PR TLDR both disabled",
+            repo_config["owner"],
+            repo_config["name"],
+            head_ref,
+        )
+        return
+
     app_token, app_token_expires_at = await _reviewer_token_for_repo(
         repo_config,
         repo_private=repo_private,
@@ -2524,22 +2562,31 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
     # GitHub only shows check runs on a PR's current head commit, so the check
     # created on the previous head disappears after a follow-up push. Create a
     # fresh in-progress check on the new head SHA so the review stays visible;
-    # publish (or the after-agent hook) settles this id.
-    check_run_id = await create_review_check_run(
-        owner=repo_config["owner"],
-        repo=repo_config["name"],
-        head_sha=head_sha,
-        token=app_token,
-        details_url=dashboard_thread_url(thread_id),
-    )
-    if check_run_id is not None:
-        await set_reviewer_thread_metadata(thread_id, extra={"review_check_run_id": check_run_id})
+    # publish (or the after-agent hook) settles this id. TLDR-only runs skip it.
+    if code_review_enabled:
+        check_run_id = await create_review_check_run(
+            owner=repo_config["owner"],
+            repo=repo_config["name"],
+            head_sha=head_sha,
+            token=app_token,
+            details_url=dashboard_thread_url(thread_id),
+        )
+        if check_run_id is not None:
+            await set_reviewer_thread_metadata(
+                thread_id, extra={"review_check_run_id": check_run_id}
+            )
 
-    re_review_prompt = (
-        f"A new commit has been pushed to PR #{pr_number}. The new HEAD is "
-        f"{head_sha}. Reconcile existing findings against the new diff, add any "
-        f"net-new findings, and call `publish_review` once you're done."
-    )
+    if not code_review_enabled:
+        re_review_prompt = (
+            f"A new commit has been pushed to PR #{pr_number} (HEAD {head_sha}). "
+            f"Refresh the reviewer-focused TLDR and call `publish_pr_tldr` once."
+        )
+    else:
+        re_review_prompt = (
+            f"A new commit has been pushed to PR #{pr_number}. The new HEAD is "
+            f"{head_sha}. Reconcile existing findings against the new diff, add any "
+            f"net-new findings, and call `publish_review` once you're done."
+        )
     configurable = _build_reviewer_configurable(
         source="github_push",
         github_login=payload.get("sender", {}).get("login", "") or "",
@@ -2553,6 +2600,8 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
         repo_private=repo_private,
         re_review=True,
         last_reviewed_sha=last_reviewed_sha if isinstance(last_reviewed_sha, str) else "",
+        code_review_enabled=code_review_enabled,
+        pr_tldr_enabled=pr_tldr_enabled,
     )
 
     if thread_active:

--- a/tests/test_pr_tldr.py
+++ b/tests/test_pr_tldr.py
@@ -1,0 +1,74 @@
+"""Tests for the PR TLDR feature: comment rendering and settings migration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.dashboard.team_settings import TeamSettingsUpdate
+from agent.reviewer_publish import (
+    pr_tldr_marker,
+    render_pr_tldr_comment,
+    upsert_pr_tldr_comment,
+)
+
+
+def test_pr_tldr_marker_is_pr_scoped():
+    assert pr_tldr_marker(42) == "<!-- open-swe-pr-tldr pr=42 -->"
+
+
+def test_render_pr_tldr_comment_includes_marker_and_body():
+    body = render_pr_tldr_comment(markdown="- caches user lookups (TTL 60s)", pr_number=7)
+    assert "## Open SWE TLDR" in body
+    assert "- caches user lookups (TTL 60s)" in body
+    assert body.endswith(pr_tldr_marker(7))
+
+
+def test_settings_migrate_legacy_pr_summaries_to_pr_tldr():
+    # A stored record written before the rename should preserve its toggle.
+    update = TeamSettingsUpdate.model_validate({"pr_summaries": False})
+    assert update.pr_tldr is False
+    assert update.code_review is True
+
+
+def test_settings_pr_tldr_wins_over_legacy_when_both_present():
+    update = TeamSettingsUpdate.model_validate({"pr_summaries": False, "pr_tldr": True})
+    assert update.pr_tldr is True
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_existing_comment_in_place():
+    response = AsyncMock()
+    response.status_code = 200
+    response.raise_for_status = lambda: None
+    client = AsyncMock()
+    client.patch.return_value = response
+    with patch("agent.reviewer_publish.httpx.AsyncClient") as mk:
+        mk.return_value.__aenter__.return_value = client
+        result = await upsert_pr_tldr_comment(
+            owner="o", repo="r", pr_number=1, body="b", token="t", existing_comment_id=99
+        )
+    assert result == 99
+    client.patch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_recreates_when_existing_comment_gone():
+    patch_response = AsyncMock()
+    patch_response.status_code = 404
+    client = AsyncMock()
+    client.patch.return_value = patch_response
+    with (
+        patch("agent.reviewer_publish.httpx.AsyncClient") as mk,
+        patch(
+            "agent.reviewer_publish.post_status_comment",
+            new=AsyncMock(return_value=123),
+        ) as post,
+    ):
+        mk.return_value.__aenter__.return_value = client
+        result = await upsert_pr_tldr_comment(
+            owner="o", repo="r", pr_number=1, body="b", token="t", existing_comment_id=99
+        )
+    assert result == 123
+    post.assert_awaited_once()

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -106,7 +106,8 @@ export type AutofixMode = "off" | "low" | "medium" | "high";
 export interface TeamSettings {
   trigger_mode: TriggerMode;
   review_draft_prs: boolean;
-  pr_summaries: boolean;
+  code_review: boolean;
+  pr_tldr: boolean;
   review_trace_links: boolean;
   autofix_mode: AutofixMode;
   autofix_severity_threshold: AutofixMode;
@@ -355,10 +356,17 @@ export interface ReviewPrDetails {
   labels: Array<{ name: string; color: string | null }>;
 }
 
+export interface ReviewTldr {
+  markdown: string;
+  head_sha: string;
+  updated_at: string | null;
+}
+
 export interface ReviewDetail extends ReviewSummary {
   pr: ReviewPrDetails;
   checks: Array<ReviewCheckRun>;
   findings: Array<ReviewFinding>;
+  tldr: ReviewTldr | null;
 }
 
 export interface ReviewDiffFile {

--- a/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
+++ b/ui/src/routes/agents/reviews/$owner.$repo.$number.tsx
@@ -49,7 +49,7 @@ export const Route = createFileRoute("/agents/reviews/$owner/$repo/$number")({
   component: ReviewDetailPage,
 })
 
-type SideTab = "info" | "chat"
+type SideTab = "info" | "tldr" | "chat"
 
 const GROUP_STYLES = {
   bug: { label: "Bug", className: "text-destructive", Icon: BugBeetleIcon },
@@ -868,6 +868,7 @@ function SidePanel({
         {(
           [
             ["info", "Info"],
+            ["tldr", "TLDR"],
             ["chat", "Chat"],
           ] as const
         ).map(([id, label]) => (
@@ -890,6 +891,19 @@ function SidePanel({
       {tab === "chat" ? (
         <div className="flex flex-1 items-center justify-center p-6 text-xs text-muted-foreground">
           Coming Soon
+        </div>
+      ) : tab === "tldr" ? (
+        <div className="p-3">
+          {detail.tldr ? (
+            <div className="rounded-md border border-border bg-card p-3 text-xs">
+              <Markdown content={detail.tldr.markdown} />
+            </div>
+          ) : (
+            <p className="p-3 text-xs text-muted-foreground">
+              No TLDR yet. It's generated when PR TLDR is enabled and refreshes
+              on each push.
+            </p>
+          )}
         </div>
       ) : (
         <div className="divide-y divide-border">

--- a/ui/src/routes/review.tsx
+++ b/ui/src/routes/review.tsx
@@ -50,7 +50,8 @@ const AUTOFIX_MODES: Array<{ value: AutofixMode; label: string }> = [
 const DEFAULT_SETTINGS: TeamSettings = {
   trigger_mode: "every_push",
   review_draft_prs: false,
-  pr_summaries: true,
+  code_review: true,
+  pr_tldr: true,
   review_trace_links: true,
   autofix_mode: "off",
   autofix_severity_threshold: "medium",
@@ -213,12 +214,23 @@ function ReviewPage() {
             }
           />
           <SettingsRow
-            label="PR Summaries"
-            description="Generate descriptions on pull requests"
+            label="Code Reviews"
+            description="File inline findings on pull requests for bugs and issues."
             control={
               <Switch
-                checked={current.pr_summaries}
-                onCheckedChange={(v) => persist({ pr_summaries: v })}
+                checked={current.code_review}
+                onCheckedChange={(v) => persist({ code_review: v })}
+                disabled={!canEdit}
+              />
+            }
+          />
+          <SettingsRow
+            label="PR TLDR"
+            description="Post a concise, reviewer-focused summary of each PR's key decisions, kept up to date on every push. Independent of code reviews."
+            control={
+              <Switch
+                checked={current.pr_tldr}
+                onCheckedChange={(v) => persist({ pr_tldr: v })}
                 disabled={!canEdit}
               />
             }


### PR DESCRIPTION
## Description
Adds a reviewer-focused **PR TLDR**: a concise, decision-oriented summary (data-model/API changes, new assumptions, caching/concurrency/auth choices, tradeoffs) that's upserted on the PR and refreshed on every push. It runs on the existing reviewer graph, reusing the same sandbox and diff. TLDR and code review are now **independent** team toggles — `pr_tldr` (replaces the unused `pr_summaries` flag, with legacy migration) and a new `code_review` flag — so a PR run can produce either or both. The reviewer prompt/tools are gated by these flags, and TLDR is surfaced in the review sidebar as a `TLDR` tab.

## Release Note
Add a PR TLDR that posts a succinct, reviewer-focused summary on pull requests (kept up to date on every push), toggleable independently from code reviews.

## Test Plan
- [ ] Enable only PR TLDR (code review off) and confirm a TLDR comment is posted with no review check run
- [ ] Push a new commit and confirm the same TLDR comment is updated in place
- [ ] Verify the TLDR renders in the review detail sidebar's TLDR tab

Made by [Open SWE](https://openswe.vercel.app)