### PR TITLE
feat: add GLM 5.2 model option

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -50,6 +50,13 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": False,
     },
     {
+        "id": "fireworks:accounts/fireworks/models/glm-5p2",
+        "label": "GLM 5.2",
+        "efforts": ["none", "low", "medium", "high"],
+        "default_effort": "high",
+        "supports_images": False,
+    },
+    {
         "id": "fireworks:accounts/fireworks/models/glm-5p1",
         "label": "GLM 5.1",
         "efforts": ["none", "low", "medium", "high"],

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -56,13 +56,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "default_effort": "high",
         "supports_images": False,
     },
-    {
-        "id": "fireworks:accounts/fireworks/models/glm-5p1",
-        "label": "GLM 5.1",
-        "efforts": ["none", "low", "medium", "high"],
-        "default_effort": "high",
-        "supports_images": False,
-    },
 ]
 
 SUPPORTED_MODEL_IDS: frozenset[str] = frozenset(m["id"] for m in SUPPORTED_MODELS)


### PR DESCRIPTION
## Description
Adds GLM 5.2 (`fireworks:accounts/fireworks/models/glm-5p2`) to the supported model list and removes GLM 5.1, so GLM 5.2 is selectable in the profile editor and as a team/per-thread model. Mirrors the previous GLM 5.1 config (same efforts, default effort, no image support).

The model id is confirmed against Fireworks' day-zero GLM 5.2 announcement (https://fireworks.ai/blog/glm-5p2), which lists `accounts/fireworks/models/glm-5p2` as the published id.

## Release Note
Add GLM 5.2 as a selectable agent model (replacing GLM 5.1).

## Test Plan
- [ ] Verify GLM 5.2 appears in the profile editor model dropdown and can be selected for a run.

Made by [Open SWE](https://openswe.vercel.app/agents/f4bf1ed4-5be9-fc49-dd0d-5de9b707c841)