### PR TITLE
feat: weight merged PRs above LOC in usage leaderboard sorting

### DIFF
--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -398,6 +398,7 @@ async def _build_usage_leaderboard_snapshot(period: Period) -> dict[str, Any]:
     sorted_users = sorted(
         users.values(),
         key=lambda item: (
+            -item["merged_prs"],
             -item["agent_loc"],
             -item["prs_opened"],
             -item["agent_runs"],

--- a/ui/src/routes/usage.tsx
+++ b/ui/src/routes/usage.tsx
@@ -63,7 +63,7 @@ function UsagePage() {
     <AppShell user={session.data} title="Usage" className="max-w-5xl">
       <SettingsSection
         title="Agent leaderboard"
-        description="Ranked by agent lines of code, then PRs opened and agent runs."
+        description="Ranked by merged PRs, then agent lines of code, PRs opened, and agent runs."
         action={
           <Select
             value={activePeriod}


### PR DESCRIPTION
## Description
Prioritize merged PRs as the primary sort key in the agent usage leaderboard, ahead of LOC. This better reflects actual impact — a merged PR is a stronger signal than raw lines of code.

## Release Note
Usage leaderboard now sorts by merged PRs first, then LOC.

## Test Plan
- [ ] Verify leaderboard ranks users with more merged PRs higher, even if another user has more LOC

Made by [Open SWE](https://openswe.vercel.app/agents/019ed6b3-70a9-778b-b06b-57dc6a3cbff0)
