### PR TITLE
fix: contain markdown render crashes with an error boundary

### DIFF
--- a/ui/src/components/agents/ported/Markdown.tsx
+++ b/ui/src/components/agents/ported/Markdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { Component, memo, useMemo } from "react";
 import { Streamdown } from "streamdown";
 import type { ReactNode } from "react";
 import "streamdown/styles.css";
@@ -76,6 +76,46 @@ const STREAMDOWN_COMPONENTS = {
 
 const SHIKI_THEME: ["github-light", "github-dark"] = ["github-light", "github-dark"];
 
+interface BoundaryProps {
+  content: string;
+  children: ReactNode;
+}
+
+interface BoundaryState {
+  failed: boolean;
+  key: string;
+}
+
+// Streamdown bundles Mermaid and renders ```mermaid blocks itself; a diagram it
+// can't parse throws during render and, with no boundary, white-screens the
+// whole page. Contain it and fall back to the raw markdown text.
+class MarkdownErrorBoundary extends Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { failed: false, key: this.props.content };
+
+  static getDerivedStateFromError(): Partial<BoundaryState> {
+    return { failed: true };
+  }
+
+  static getDerivedStateFromProps(
+    props: BoundaryProps,
+    state: BoundaryState
+  ): Partial<BoundaryState> | null {
+    if (props.content !== state.key) return { failed: false, key: props.content };
+    return null;
+  }
+
+  render(): ReactNode {
+    if (this.state.failed) {
+      return (
+        <pre className="whitespace-pre-wrap break-words [overflow-wrap:anywhere] font-sans text-[color:var(--ui-text)]">
+          {this.props.content}
+        </pre>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export const Markdown = memo(function Markdown({
   content,
   isLive = false,
@@ -99,17 +139,19 @@ export const Markdown = memo(function Markdown({
 
   return (
     <div className="min-w-0 max-w-full text-[13px] leading-6 break-words [overflow-wrap:anywhere] [&_.streamdown]:text-[color:var(--ui-text)]">
-      <Streamdown
-        mode={isLive ? "streaming" : "static"}
-        parseIncompleteMarkdown={isLive}
-        isAnimating={isLive}
-        animated={isLive ? STREAMDOWN_ANIMATED : false}
-        shikiTheme={SHIKI_THEME}
-        className="streamdown-agent min-w-0 max-w-full"
-        components={components}
-      >
-        {content}
-      </Streamdown>
+      <MarkdownErrorBoundary content={content}>
+        <Streamdown
+          mode={isLive ? "streaming" : "static"}
+          parseIncompleteMarkdown={isLive}
+          isAnimating={isLive}
+          animated={isLive ? STREAMDOWN_ANIMATED : false}
+          shikiTheme={SHIKI_THEME}
+          className="streamdown-agent min-w-0 max-w-full"
+          components={components}
+        >
+          {content}
+        </Streamdown>
+      </MarkdownErrorBoundary>
     </div>
   );
 });


### PR DESCRIPTION
Some review pages white-screened with `TypeError: Cannot read properties of null (reading 'length')` from the bundled Mermaid renderer.

Streamdown renders ` ```mermaid ` blocks itself, and a diagram it can't parse throws synchronously during render. With no error boundary in the UI, the throw bubbled to the router root and took down the whole page. Only PRs whose description contains a malformed mermaid block hit it.

## What changed

Wrap the markdown render in `Markdown.tsx` with an error boundary that falls back to the raw text. Since it's in the shared component, PR bodies, finding descriptions, and chat are all protected. Resets on content change so streaming chat / re-reviews recover.

Tradeoff: when a bad diagram trips the boundary, the whole description falls back to plain text (not just the diagram) — streamdown renders blocks internally, so isolating one diagram would mean the riskier `plugins` route, which drops the default shiki highlighter. No content is lost.
