### PR TITLE
fix: prevent reviews page crash on binary/large file diffs

### DIFF
--- a/ui/src/components/agents/utils/diffUtils.test.ts
+++ b/ui/src/components/agents/utils/diffUtils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { fileContentsCacheKey } from "./diffUtils"
+
+describe("fileContentsCacheKey", () => {
+  it("builds a stable key from string contents", () => {
+    const key = fileContentsCacheKey("src/a.ts", "new", "hello")
+    expect(key.startsWith("src/a.ts:new:5:")).toBe(true)
+    expect(fileContentsCacheKey("src/a.ts", "new", "hello")).toBe(key)
+  })
+
+  it("treats null contents as empty instead of crashing", () => {
+    // Binary/oversized/added/removed blobs arrive as null from the backend; the
+    // reviews page still computes this key in an unconditional useMemo.
+    expect(() => fileContentsCacheKey("bin.png", "old", null)).not.toThrow()
+    expect(fileContentsCacheKey("bin.png", "old", null)).toBe(
+      fileContentsCacheKey("bin.png", "old", "")
+    )
+  })
+
+  it("treats undefined contents as empty", () => {
+    expect(() =>
+      fileContentsCacheKey("bin.png", "new", undefined)
+    ).not.toThrow()
+    expect(fileContentsCacheKey("bin.png", "new", undefined)).toBe(
+      fileContentsCacheKey("bin.png", "new", "")
+    )
+  })
+})

--- a/ui/src/components/agents/utils/diffUtils.ts
+++ b/ui/src/components/agents/utils/diffUtils.ts
@@ -137,13 +137,16 @@ function hashFileContents(contents: string): string {
 }
 
 // Stable per-file content key so the worker pool dedupes highlight work across
-// re-renders instead of re-tokenizing identical content.
+// re-renders instead of re-tokenizing identical content. Added/removed/binary/
+// oversized blobs arrive as null (see pr_diff.py); coerce to "" so the key never
+// dereferences null — these files don't render a diff, so the exact key is moot.
 export function fileContentsCacheKey(
   path: string,
   side: "old" | "new",
-  contents: string
+  contents: string | null | undefined
 ): string {
-  return `${path}:${side}:${contents.length}:${hashFileContents(contents)}`
+  const text = contents ?? ""
+  return `${path}:${side}:${text.length}:${hashFileContents(text)}`
 }
 
 let highlighterWarmup: Promise<void> | null = null


### PR DESCRIPTION
## Description
The crash on `/agents/reviews/$owner/$repo/$number` was misdiagnosed as a Mermaid/markdown failure (PR #1586 added a markdown error boundary that never fires here). The real culprit is `fileContentsCacheKey` in `diffUtils.ts`: the reviews page builds a Pierre `FileContents` cache key for every file in an **unconditional** `useMemo`, but binary/oversized/added/removed blobs arrive with `null` content (`pr_diff.py` flags them `unrenderable`). The helper did `contents.length` → `Cannot read properties of null (reading 'length')`, which bubbled past the markdown boundary and white-screened the whole route. The minified `Sg` in the trace is this helper, bundled into the shared `mermaid-*` chunk — hence the confusing stack. Fix coerces `null`/`undefined` contents to `""`.

## Release Note
Fixed a crash on the PR review page when a pull request includes binary or oversized files.

## Test Plan
- [ ] Open a review for a PR that includes a binary/large file (e.g. an image) and confirm the page renders with a "Binary or large file — diff not shown." placeholder instead of white-screening.

Made by [Open SWE](https://openswe.vercel.app/agents/019ef5e0-20f1-745e-9a22-05bc8ad66692)