### PR TITLE
feat(open-swe): disable Request Changes until the plan has a comment

### DIFF
--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -89,10 +89,14 @@ test.describe("Plan review (HTTP comments)", () => {
       timeout: 30_000,
     });
     await expect(owner.getByTestId("approve-plan")).toBeVisible();
+    // "Request changes" is meaningless with no feedback → disabled until a
+    // comment exists.
+    await expect(owner.getByTestId("reject-plan")).toBeDisabled();
 
     // Owner leaves a comment.
     await addComment(owner, "Owner: looks solid, ship it.");
     await expect(owner.getByTestId("plan-comment")).toHaveCount(1);
+    await expect(owner.getByTestId("reject-plan")).toBeEnabled();
 
     // 4. A COLLABORATOR opens the same plan: sees it AND the owner's comment
     //    (fetched over HTTP), but has NO approve button.

--- a/ui/src/components/agents/PlanReview.tsx
+++ b/ui/src/components/agents/PlanReview.tsx
@@ -128,7 +128,14 @@ export function PlanReview({ plan }: { plan: PlanData }) {
           <Button
             data-testid="reject-plan"
             variant="secondary"
-            disabled={busy !== null || decision !== null}
+            // Requesting changes feeds the comments to the agent, so it's
+            // meaningless with none — disable until at least one is left.
+            disabled={busy !== null || decision !== null || comments.length === 0}
+            title={
+              comments.length === 0
+                ? "Leave a comment first to request changes"
+                : undefined
+            }
             onClick={() => void decide("reject")}
           >
             Request changes


### PR DESCRIPTION
## Description
"Request changes" on the plan-review page dispatches a follow-up run that feeds the reviewer comments to the agent — so it's meaningless with no comments. Disable the button until at least one comment exists.

- `reject-plan` is disabled when `comments.length === 0` (in addition to the existing busy/decided guards), with a tooltip ("Leave a comment first to request changes").
- **Approve** is unchanged — the owner can approve a plan as-is with no comments.

## Test Plan
- [x] Playwright E2E (`tests/e2e/tests/plan_review.spec.ts`) — asserts "Request changes" is disabled on open (0 comments) and becomes enabled after a comment is added; full Slack → plan → comment → approve → PR flow still green
- [x] UI `tsc --noEmit` + eslint clean
