### PR TITLE
feat(open-swe): copy plan as markdown + fix premature plan-ready banner

### DIFF
--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -75,7 +75,9 @@ test.describe("Plan review (HTTP comments)", () => {
 
     // 3. The OWNER opens the conversation, follows the "Review plan" banner, and
     //    sees the rendered plan.
-    const ownerCtx = await browser.newContext();
+    const ownerCtx = await browser.newContext({
+      permissions: ["clipboard-read", "clipboard-write"],
+    });
     await ownerCtx.request.post("/control/login", { data: OWNER });
     const owner = await ownerCtx.newPage();
     await owner.goto(`/agents/${threadId}`);
@@ -92,6 +94,13 @@ test.describe("Plan review (HTTP comments)", () => {
     // "Request changes" is meaningless with no feedback → disabled until a
     // comment exists.
     await expect(owner.getByTestId("reject-plan")).toBeDisabled();
+
+    // Copy the whole plan as markdown.
+    await owner.getByTestId("copy-plan").click();
+    await expect(owner.getByTestId("copy-plan")).toContainText("Copied!");
+    const clipboard = await owner.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("## Plan: Add greet() helper");
+    expect(clipboard).toContain("### Verification");
 
     // Owner leaves a comment.
     await addComment(owner, "Owner: looks solid, ship it.");

--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -81,9 +81,11 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
             >
               <span className="flex items-center gap-2">
                 <MapIcon className="size-3.5 text-[var(--ui-accent)]" />
-                {thread.planStatus === "revising"
-                  ? "The agent is revising the plan."
-                  : "A plan is ready for your review."}
+                {thread.planStatus === "ready"
+                  ? "A plan is ready for your review."
+                  : thread.planStatus === "revising"
+                    ? "The agent is revising the plan."
+                    : "The agent is writing a plan."}
               </span>
               <span className="font-medium text-[var(--ui-accent)]">
                 Review plan →

--- a/ui/src/components/agents/PlanReview.tsx
+++ b/ui/src/components/agents/PlanReview.tsx
@@ -14,6 +14,38 @@ import { useResolvedTheme } from "@/lib/theme"
 
 const POLL_MS = 4000
 
+// Copy text to the clipboard across browsers: prefer the async Clipboard API
+// (needs a secure context), and fall back to a hidden-textarea + execCommand
+// for older Safari/Firefox and non-HTTPS origins. Returns whether it copied.
+async function copyToClipboard(text: string): Promise<boolean> {
+  // The DOM types mark navigator.clipboard required, but it's absent in older
+  // browsers and non-secure origins — treat it as optional.
+  const nav = navigator as { clipboard?: Clipboard }
+  try {
+    if (window.isSecureContext && nav.clipboard) {
+      await nav.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    /* fall through to the legacy path */
+  }
+  try {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.top = "-9999px"
+    document.body.appendChild(textarea)
+    textarea.select()
+    textarea.setSelectionRange(0, text.length)
+    const ok = document.execCommand("copy")
+    document.body.removeChild(textarea)
+    return ok
+  } catch {
+    return false
+  }
+}
+
 export function PlanReview({ plan }: { plan: PlanData }) {
   const resolvedTheme = useResolvedTheme()
   const [comments, setComments] = useState<Array<PlanComment>>([])
@@ -22,6 +54,7 @@ export function PlanReview({ plan }: { plan: PlanData }) {
   const [decision, setDecision] = useState<string | null>(null)
   const [busy, setBusy] = useState<"approve" | "reject" | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
 
   // Poll so reviewers see each other's comments without a realtime transport.
   useEffect(() => {
@@ -91,6 +124,16 @@ export function PlanReview({ plan }: { plan: PlanData }) {
     [plan.threadId]
   )
 
+  const copyPlan = useCallback(async () => {
+    setError(null)
+    if (await copyToClipboard(plan.markdown)) {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } else {
+      setError("Couldn't copy the plan to the clipboard.")
+    }
+  }, [plan.markdown])
+
   return (
     <div
       data-testid="plan-review"
@@ -116,6 +159,14 @@ export function PlanReview({ plan }: { plan: PlanData }) {
               {decision}
             </span>
           )}
+          <Button
+            data-testid="copy-plan"
+            variant="secondary"
+            disabled={!plan.markdown.trim()}
+            onClick={() => void copyPlan()}
+          >
+            {copied ? "Copied!" : "Copy markdown"}
+          </Button>
           {plan.isOwner && (
             <Button
               data-testid="approve-plan"


### PR DESCRIPTION
## Description
Two plan-review UI changes:

**1. Copy plan as markdown.** Adds a "Copy markdown" button to the plan header that copies the entire plan document. Works across browsers:
- Async Clipboard API (`navigator.clipboard.writeText`) in secure contexts.
- Falls back to a hidden-textarea + `document.execCommand("copy")` for older Safari/Firefox and non-HTTPS origins.
- Shows a transient "Copied!" confirmation; disabled when the plan is empty.

**2. Fix premature "ready" banner.** The conversation banner showed *"A plan is ready for your review"* for every non-approved/cancelled plan status — including `planning`. Since the agent shares the plan link right after entering plan mode (so you can follow along), the banner claimed the plan was ready the instant planning began; clicking through then correctly showed "the agent is still writing the plan." The banner now matches the actual status: `planning` → "The agent is writing a plan.", `revising` → "The agent is revising the plan.", `ready` → "A plan is ready for your review."

## Test Plan
- [x] Playwright E2E (`tests/e2e/tests/plan_review.spec.ts`) — clicks "Copy markdown", asserts the "Copied!" state and reads the clipboard back to confirm the full plan markdown was copied; full plan flow still green
- [x] UI `tsc --noEmit` + eslint clean
