### PR TITLE
feat: credit johannes under logo

### DIFF
--- a/ui/src/components/agents/ported/Logo.tsx
+++ b/ui/src/components/agents/ported/Logo.tsx
@@ -9,16 +9,25 @@ export function Logo() {
     "          ░███                                                                     ",
     "          █████                                                                    ",
     "         ░░░░░                                                                     ",
-  ].join("\n");
+  ].join("\n")
 
   return (
-    <div className="w-full" style={{ containerType: "inline-size" }}>
+    <div
+      className="flex w-full flex-col items-center gap-2"
+      style={{ containerType: "inline-size" }}
+    >
       <pre
         className="m-0 w-full overflow-hidden text-center font-mono leading-none text-[#87CEEB]"
         style={{ fontSize: "min(7px, 1.9cqw)" }}
       >
         {ascii}
       </pre>
+      <div
+        className="font-heading font-medium tracking-tight text-[#87CEEB]"
+        style={{ fontSize: "min(12px, 2.8cqw)" }}
+      >
+        by johannes
+      </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Description
Adds a small “by johannes” credit directly under the main ASCII Open SWE logo using the logo’s blue color.

## Test Plan
- [ ] Visually confirm the logo credit sizing/placement in the agents empty state.

Made by [Open SWE](https://openswe.vercel.app/agents/14789237-9097-fbb3-3e86-9fbfa08d49a4)