### PR TITLE
fix(agent): handle recursive `fetch_url` conversion

### DIFF
--- a/agent/tools/fetch_url.py
+++ b/agent/tools/fetch_url.py
@@ -1,3 +1,4 @@
+from html.parser import HTMLParser
 from typing import Any
 
 import requests
@@ -6,6 +7,30 @@ from markdownify import markdownify
 from .http_request import _request_with_safe_redirects
 
 FETCH_URL_MAX_CHARS = 100_000
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        text = " ".join(data.split())
+        if text:
+            self.parts.append(text)
+
+    def get_text(self) -> str:
+        return "\n\n".join(self.parts)
+
+
+def _html_to_markdown_content(html: str) -> str:
+    try:
+        return markdownify(html)
+    except RecursionError:
+        parser = _TextExtractor()
+        parser.feed(html)
+        parser.close()
+        return parser.get_text()
 
 
 def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
@@ -49,8 +74,7 @@ def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
 
         response.raise_for_status()
 
-        # Convert HTML content to markdown
-        markdown_content = markdownify(response.text)
+        markdown_content = _html_to_markdown_content(response.text)
 
         if len(markdown_content) > FETCH_URL_MAX_CHARS:
             markdown_content = (

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -109,6 +109,33 @@ def test_fetch_url_blocks_redirects_to_private_ips(monkeypatch) -> None:
     assert "Request blocked" in result["error"]
 
 
+def test_fetch_url_falls_back_when_markdownify_recurses(monkeypatch) -> None:
+    def fake_request(
+        method: str, url: str, *, timeout: int, headers: dict[str, str]
+    ) -> tuple[FakeResponse, None]:
+        return (
+            FakeResponse(
+                status_code=200,
+                url=url,
+                text="<html><body><p>Hello <strong>world</strong></p><p>Second</p></body></html>",
+            ),
+            None,
+        )
+
+    def recursive_markdownify(_html: str) -> str:
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(fetch_url_tool, "_request_with_safe_redirects", fake_request)
+    monkeypatch.setattr(fetch_url_tool, "markdownify", recursive_markdownify)
+
+    result = fetch_url_tool.fetch_url("https://example.com/deep")
+
+    assert result["status_code"] == 200
+    assert "Hello" in result["markdown_content"]
+    assert "world" in result["markdown_content"]
+    assert "Second" in result["markdown_content"]
+
+
 class _FakeSocket:
     """Records connect() targets without performing real network I/O."""
 


### PR DESCRIPTION
## Description
`markdownify` can raise `RecursionError` on deeply nested pages, which bubbles out of `fetch_url`. This adds a stdlib text-extraction fallback so the tool returns usable page text instead of crashing.

## Release Note
`fetch_url` no longer crashes when HTML-to-markdown conversion exceeds recursion depth.

## Test Plan
- [ ] Recursion fallback is covered by `test_fetch_url_falls_back_when_markdownify_recurses`.

Made by [Open SWE](https://openswe.vercel.app/agents/79d44275-aab0-bf62-abde-8242f55e0648)