### PR TITLE
feat: editable plan mode + fix review-plan banner overlap

### DIFF
--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -24,12 +24,16 @@ from pydantic import BaseModel
 from .oauth import require_same_origin_for_mutations, require_session
 from .plan_store import (
     PLAN_STATUS_APPROVED,
+    PLAN_STATUS_CANCELLED,
+    PLAN_STATUS_READY,
     PLAN_STATUS_REVISING,
     add_plan_comment,
     delete_plan_comment,
     get_plan_content,
     list_plan_comments,
+    save_plan_content,
     set_plan_status,
+    write_plan_to_sandbox,
 )
 from .thread_api import (
     _repo_config_from_metadata,
@@ -50,6 +54,10 @@ _SESSION_DEP = Depends(require_session)
 
 class CommentBody(BaseModel):
     body: str
+
+
+class PlanUpdate(BaseModel):
+    markdown: str
 
 
 async def _thread_metadata(thread_id: str) -> dict[str, Any]:
@@ -84,6 +92,32 @@ async def get_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -> di
             "name": session.get("name") or login,
         },
     }
+
+
+@plan_router.put("/{thread_id}")
+async def update_plan(
+    thread_id: str, body: PlanUpdate, session: dict[str, Any] = _SESSION_DEP
+) -> dict[str, Any]:
+    """Owner-only manual edit of the plan markdown.
+
+    Re-publishes the edited plan as ``ready`` (and mirrors it into the sandbox
+    ``plan.md``) while preserving reviewer comments, so the owner can refine the
+    plan before approving it."""
+    metadata = await _thread_metadata(thread_id)
+    if not _user_owns_thread(metadata, session["sub"], session.get("email")):
+        raise HTTPException(403, "only the plan owner can edit the plan")
+    markdown = body.markdown.strip()
+    if not markdown:
+        raise HTTPException(422, "plan markdown cannot be empty")
+    content = await get_plan_content(thread_id) or {}
+    status = content.get("status") or metadata.get("plan_status") or "planning"
+    if status in (PLAN_STATUS_APPROVED, PLAN_STATUS_CANCELLED):
+        raise HTTPException(409, f"cannot edit a {status} plan")
+    await save_plan_content(
+        thread_id, markdown=markdown, status=PLAN_STATUS_READY, clear_comments=False
+    )
+    await write_plan_to_sandbox(thread_id, markdown)
+    return {"status": PLAN_STATUS_READY, "markdown": markdown}
 
 
 @plan_router.get("/{thread_id}/comments")
@@ -136,17 +170,24 @@ async def approve_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -
     metadata = await _thread_metadata(thread_id)
     if not _user_owns_thread(metadata, session["sub"], session.get("email")):
         raise HTTPException(403, "only the plan owner can approve")
-    # Read comments BEFORE mutating state: a store failure here aborts the
-    # decision (500) rather than dispatching the run without the feedback.
+    # Read the published plan + comments BEFORE mutating state: a store failure
+    # here aborts the decision (500) rather than dispatching without them. The
+    # published markdown may have been edited by the reviewer, so it is the
+    # source of truth handed to the agent (not its own stale history).
+    content = await get_plan_content(thread_id) or {}
+    plan_markdown = str(content.get("markdown", "")).strip()
     feedback = _format_comments(await list_plan_comments(thread_id, raise_on_error=True))
     await set_plan_status(thread_id, PLAN_STATUS_APPROVED, plan_mode=False)
-    if feedback:
+    if plan_markdown:
         text = (
-            "The plan has been approved. Implement it now, taking this reviewer "
-            f"feedback into account:\n\n{feedback}"
+            "The plan has been approved. Implement it now exactly as written "
+            "below (it may have been edited by the reviewer, so treat this as "
+            f"the source of truth):\n\n{plan_markdown}"
         )
     else:
         text = "The plan has been approved. Implement it now as described in the plan."
+    if feedback:
+        text += "\n\nAlso take this reviewer feedback into account:\n\n" + feedback
     await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
     return {"status": PLAN_STATUS_APPROVED}
 

--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -173,8 +173,9 @@ async def approve_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -
     # Read the published plan + comments BEFORE mutating state: a store failure
     # here aborts the decision (500) rather than dispatching without them. The
     # published markdown may have been edited by the reviewer, so it is the
-    # source of truth handed to the agent (not its own stale history).
-    content = await get_plan_content(thread_id) or {}
+    # source of truth handed to the agent (not its own stale history) — read it
+    # strictly so a transient failure can't silently drop the edit.
+    content = await get_plan_content(thread_id, raise_on_error=True) or {}
     plan_markdown = str(content.get("markdown", "")).strip()
     feedback = _format_comments(await list_plan_comments(thread_id, raise_on_error=True))
     await set_plan_status(thread_id, PLAN_STATUS_APPROVED, plan_mode=False)

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -88,11 +88,20 @@ async def write_plan_to_sandbox(thread_id: str, content: str) -> str:
         return PLAN_FILE_PATH
 
 
-async def get_plan_content(thread_id: str) -> dict[str, Any] | None:
+async def get_plan_content(
+    thread_id: str, *, raise_on_error: bool = False
+) -> dict[str, Any] | None:
+    """The published plan record, or ``None`` when none exists.
+
+    With ``raise_on_error=True`` a store failure propagates instead of resolving
+    to ``None``. Approve uses this so a transient failure aborts the decision
+    rather than dispatching the agent without the (possibly edited) plan."""
     client = _client()
     try:
         item = await client.store.get_item(PLAN_CONTENT_NAMESPACE, thread_id)
     except Exception:
+        if raise_on_error:
+            raise
         return None
     return _item_value(item)
 

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -12,14 +12,20 @@ store operations (no CRDT/WebSocket).
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, datetime
 from typing import Any
 
 from langgraph_sdk import get_client
 
+logger = logging.getLogger(__name__)
+
 PLAN_CONTENT_NAMESPACE = ["plan", "content"]
 PLAN_COMMENTS_NAMESPACE = ["plan", "comments"]
+
+# The plan is mirrored into the sandbox as a real file the agent can re-read.
+PLAN_FILE_PATH = "plan.md"
 
 # Plan lifecycle, stored on both the content record and the thread metadata.
 PLAN_STATUS_PLANNING = "planning"
@@ -41,25 +47,45 @@ def _item_value(item: Any) -> dict[str, Any] | None:
 
 
 async def save_plan_content(
-    thread_id: str, *, markdown: str, status: str = PLAN_STATUS_READY
+    thread_id: str,
+    *,
+    markdown: str,
+    status: str = PLAN_STATUS_READY,
+    clear_comments: bool = True,
 ) -> None:
     """Publish the plan markdown + status for the dashboard to render.
 
     A republished (revised) plan supersedes the prior revision, so comments left
     on it are cleared — otherwise stale feedback would resurface on the new plan
-    and be fed back to the agent on the next approve/reject."""
+    and be fed back to the agent on the next approve/reject. A manual owner edit
+    passes ``clear_comments=False`` so reviewer feedback survives the edit."""
     client = _client()
     await client.store.put_item(
         PLAN_CONTENT_NAMESPACE,
         thread_id,
         {"markdown": markdown, "status": status},
     )
-    try:
-        await clear_plan_comments(thread_id)
-    except Exception:
-        # Best-effort: a failed cleanup must not block publishing the new plan.
-        pass
+    if clear_comments:
+        try:
+            await clear_plan_comments(thread_id)
+        except Exception:
+            # Best-effort: a failed cleanup must not block publishing the new plan.
+            pass
     await _merge_thread_metadata(thread_id, {"plan_status": status, "plan_mode": True})
+
+
+async def write_plan_to_sandbox(thread_id: str, content: str) -> str:
+    """Write ``plan.md`` into the thread's sandbox. Best-effort: a missing sandbox
+    must not block publishing the plan to the review page."""
+    try:
+        from ..utils.sandbox_state import get_sandbox_backend
+
+        backend = await get_sandbox_backend(thread_id)
+        await backend.awrite(PLAN_FILE_PATH, content)
+        return PLAN_FILE_PATH
+    except Exception:
+        logger.warning("Could not write plan.md to sandbox for %s", thread_id, exc_info=True)
+        return PLAN_FILE_PATH
 
 
 async def get_plan_content(thread_id: str) -> dict[str, Any] | None:

--- a/agent/tools/save_plan.py
+++ b/agent/tools/save_plan.py
@@ -14,11 +14,13 @@ from typing import Any
 
 from langgraph.config import get_config
 
-from ..dashboard.plan_store import PLAN_STATUS_READY, save_plan_content
+from ..dashboard.plan_store import (
+    PLAN_STATUS_READY,
+    save_plan_content,
+    write_plan_to_sandbox,
+)
 
 logger = logging.getLogger(__name__)
-
-PLAN_FILE_PATH = "plan.md"
 
 
 def save_plan(plan_markdown: str) -> dict[str, Any]:
@@ -62,20 +64,6 @@ def save_plan(plan_markdown: str) -> dict[str, Any]:
 
 
 async def _save(thread_id: str, content: str) -> str:
-    sandbox_path = await _write_to_sandbox(thread_id, content)
+    sandbox_path = await write_plan_to_sandbox(thread_id, content)
     await save_plan_content(thread_id, markdown=content, status=PLAN_STATUS_READY)
     return sandbox_path
-
-
-async def _write_to_sandbox(thread_id: str, content: str) -> str:
-    """Write ``plan.md`` into the thread's sandbox. Best-effort: a missing sandbox
-    must not block publishing the plan to the review page."""
-    try:
-        from ..utils.sandbox_state import get_sandbox_backend
-
-        backend = await get_sandbox_backend(thread_id)
-        await backend.awrite(PLAN_FILE_PATH, content)
-        return PLAN_FILE_PATH
-    except Exception:
-        logger.warning("Could not write plan.md to sandbox for %s", thread_id, exc_info=True)
-        return PLAN_FILE_PATH

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -176,3 +176,175 @@ def test_plan_mode_middleware_self_activation_via_state() -> None:
     # After enter_plan_mode sets state: the next request is filtered.
     on = _FakeReq([{"name": "read_file"}, {"name": "write_file"}], {"plan_mode": True})
     assert _names(mw._filter(on)) == {"read_file"}
+
+
+# --- manual plan editing -------------------------------------------------
+
+
+async def test_save_plan_content_clear_comments_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent.dashboard import plan_store
+
+    cleared: list[str] = []
+
+    class _Store:
+        async def put_item(self, *a: Any, **k: Any) -> None:
+            return None
+
+    async def fake_clear(thread_id: str) -> None:
+        cleared.append(thread_id)
+
+    async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
+        return None
+
+    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(plan_store, "clear_plan_comments", fake_clear)
+    monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
+
+    # A manual edit keeps reviewer comments; the agent's republish clears them.
+    await plan_store.save_plan_content("t", markdown="x", clear_comments=False)
+    assert cleared == []
+    await plan_store.save_plan_content("t", markdown="x")
+    assert cleared == ["t"]
+
+
+def _patch_update_plan_deps(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    metadata: dict[str, Any],
+    owner: bool,
+    content: dict[str, Any],
+    saved: dict[str, Any],
+    sandbox: dict[str, Any],
+) -> None:
+    from agent.dashboard import plan_api
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return metadata
+
+    async def fake_get_content(thread_id: str) -> dict[str, Any]:
+        return content
+
+    async def fake_save(
+        thread_id: str, *, markdown: str, status: str, clear_comments: bool = True
+    ) -> None:
+        saved.update(markdown=markdown, status=status, clear_comments=clear_comments)
+
+    async def fake_write(thread_id: str, c: str) -> str:
+        sandbox["content"] = c
+        return "plan.md"
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+    monkeypatch.setattr(plan_api, "_user_owns_thread", lambda *a, **k: owner)
+    monkeypatch.setattr(plan_api, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(plan_api, "save_plan_content", fake_save)
+    monkeypatch.setattr(plan_api, "write_plan_to_sandbox", fake_write)
+
+
+async def test_update_plan_owner_saves_and_mirrors_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.dashboard import plan_api
+
+    saved: dict[str, Any] = {}
+    sandbox: dict[str, Any] = {}
+    _patch_update_plan_deps(
+        monkeypatch,
+        metadata={"plan_status": "ready"},
+        owner=True,
+        content={"markdown": "old", "status": "ready"},
+        saved=saved,
+        sandbox=sandbox,
+    )
+
+    result = await plan_api.update_plan(
+        "t1", plan_api.PlanUpdate(markdown="# New\n\ndo x"), session={"sub": "a", "email": None}
+    )
+    assert result == {"status": "ready", "markdown": "# New\n\ndo x"}
+    assert saved["status"] == "ready"
+    assert saved["clear_comments"] is False
+    assert sandbox["content"] == "# New\n\ndo x"
+
+
+async def test_update_plan_rejects_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    from agent.dashboard import plan_api
+
+    _patch_update_plan_deps(monkeypatch, metadata={}, owner=False, content={}, saved={}, sandbox={})
+    with pytest.raises(HTTPException) as exc:
+        await plan_api.update_plan(
+            "t1", plan_api.PlanUpdate(markdown="x"), session={"sub": "b", "email": None}
+        )
+    assert exc.value.status_code == 403
+
+
+async def test_update_plan_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    from agent.dashboard import plan_api
+
+    _patch_update_plan_deps(monkeypatch, metadata={}, owner=True, content={}, saved={}, sandbox={})
+    with pytest.raises(HTTPException) as exc:
+        await plan_api.update_plan(
+            "t1", plan_api.PlanUpdate(markdown="   "), session={"sub": "a", "email": None}
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_update_plan_blocked_once_approved(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    from agent.dashboard import plan_api
+
+    _patch_update_plan_deps(
+        monkeypatch,
+        metadata={"plan_status": "approved"},
+        owner=True,
+        content={"markdown": "old", "status": "approved"},
+        saved={},
+        sandbox={},
+    )
+    with pytest.raises(HTTPException) as exc:
+        await plan_api.update_plan(
+            "t1", plan_api.PlanUpdate(markdown="x"), session={"sub": "a", "email": None}
+        )
+    assert exc.value.status_code == 409
+
+
+async def test_approve_plan_dispatches_published_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.dashboard import plan_api
+
+    dispatched: dict[str, Any] = {}
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return {"plan_status": "ready"}
+
+    async def fake_get_content(thread_id: str) -> dict[str, Any]:
+        return {"markdown": "# Edited plan\n\nstep one", "status": "ready"}
+
+    async def fake_list(thread_id: str, *, raise_on_error: bool = False) -> list[dict[str, Any]]:
+        return [{"author": "bob", "body": "use snake_case"}]
+
+    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
+        return None
+
+    async def fake_dispatch(
+        thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
+    ) -> None:
+        dispatched.update(text=text, plan_mode=plan_mode)
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+    monkeypatch.setattr(plan_api, "_user_owns_thread", lambda *a, **k: True)
+    monkeypatch.setattr(plan_api, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(plan_api, "list_plan_comments", fake_list)
+    monkeypatch.setattr(plan_api, "set_plan_status", fake_set_status)
+    monkeypatch.setattr(plan_api, "_dispatch_followup", fake_dispatch)
+
+    result = await plan_api.approve_plan("t1", session={"sub": "a", "email": None})
+    assert result["status"] == "approved"
+    # The (possibly edited) published plan is the source of truth, plus feedback.
+    assert "# Edited plan" in dispatched["text"]
+    assert "use snake_case" in dispatched["text"]
+    assert dispatched["plan_mode"] is False

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -321,7 +321,7 @@ async def test_approve_plan_dispatches_published_markdown(
     async def fake_meta(thread_id: str) -> dict[str, Any]:
         return {"plan_status": "ready"}
 
-    async def fake_get_content(thread_id: str) -> dict[str, Any]:
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         return {"markdown": "# Edited plan\n\nstep one", "status": "ready"}
 
     async def fake_list(thread_id: str, *, raise_on_error: bool = False) -> list[dict[str, Any]]:
@@ -348,3 +348,35 @@ async def test_approve_plan_dispatches_published_markdown(
     assert "# Edited plan" in dispatched["text"]
     assert "use snake_case" in dispatched["text"]
     assert dispatched["plan_mode"] is False
+
+
+async def test_approve_plan_aborts_when_plan_read_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.dashboard import plan_api
+
+    dispatched: list[Any] = []
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return {"plan_status": "ready"}
+
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        # A transient store failure must abort approval, not silently drop the
+        # owner's edited plan and dispatch the generic fallback text.
+        raise RuntimeError("store down")
+
+    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
+        return None
+
+    async def fake_dispatch(*a: Any, **k: Any) -> None:
+        dispatched.append((a, k))
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+    monkeypatch.setattr(plan_api, "_user_owns_thread", lambda *a, **k: True)
+    monkeypatch.setattr(plan_api, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(plan_api, "set_plan_status", fake_set_status)
+    monkeypatch.setattr(plan_api, "_dispatch_followup", fake_dispatch)
+
+    with pytest.raises(RuntimeError):
+        await plan_api.approve_plan("t1", session={"sub": "a", "email": None})
+    assert dispatched == []

--- a/ui/src/components/agents/AgentGitPanel.tsx
+++ b/ui/src/components/agents/AgentGitPanel.tsx
@@ -42,6 +42,8 @@ import { cn } from "@/lib/utils"
 interface AgentGitPanelProps {
   thread: AgentThread
   messages: Array<Message>
+  collapsed: boolean
+  onCollapsedChange: (next: boolean) => void
 }
 
 interface PanelFile {
@@ -117,12 +119,20 @@ function readStoredPanelWidth(): number {
   return clampPanelWidth(parsed)
 }
 
-function readStoredPanelCollapsed(): boolean {
+export function readStoredPanelCollapsed(): boolean {
   if (typeof window === "undefined") return true
   // Default to collapsed until the user opens it once.
   return (
     window.localStorage.getItem(PANEL_STORAGE_COLLAPSED) !==
     COLLAPSED_STATE_FALSE
+  )
+}
+
+export function writeStoredPanelCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(
+    PANEL_STORAGE_COLLAPSED,
+    collapsed ? COLLAPSED_STATE_TRUE : COLLAPSED_STATE_FALSE
   )
 }
 
@@ -267,12 +277,14 @@ export function treeThemeStyle(): React.CSSProperties {
   } as React.CSSProperties
 }
 
-export function AgentGitPanel({ thread, messages }: AgentGitPanelProps) {
+export function AgentGitPanel({
+  thread,
+  messages,
+  collapsed,
+  onCollapsedChange,
+}: AgentGitPanelProps) {
   const [topTab, setTopTab] = useState<"git" | "desktop" | "terminal">("git")
   const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
-  const [collapsed, setCollapsedState] = useState(() =>
-    readStoredPanelCollapsed()
-  )
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
   const [fullScreen, setFullScreen] = useState(false)
   const isMobile = useIsMobile()
@@ -281,15 +293,9 @@ export function AgentGitPanel({ thread, messages }: AgentGitPanelProps) {
   const overlay = fullScreen || isMobile
   const panelRef = useRef<HTMLDivElement>(null)
 
-  const setCollapsed = (next: boolean) => {
-    setCollapsedState(next)
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(
-        PANEL_STORAGE_COLLAPSED,
-        next ? COLLAPSED_STATE_TRUE : COLLAPSED_STATE_FALSE
-      )
-    }
-  }
+  // Collapsed state is owned by the parent (so the plan banner can reserve space
+  // for the floating expand button); persistence to localStorage lives there too.
+  const setCollapsed = onCollapsedChange
 
   const applyWidth = useCallback(
     (next: number) => {

--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { Link } from "@tanstack/react-router"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { Map as MapIcon } from "lucide-react"
@@ -8,6 +8,8 @@ import type { ModelSelection } from "@/lib/agents/provider/useModelOptions"
 import {
   AgentGitPanel,
   PANEL_MIN_CHAT_WIDTH,
+  readStoredPanelCollapsed,
+  writeStoredPanelCollapsed,
 } from "@/components/agents/AgentGitPanel"
 import { AgentPromptBar } from "@/components/agents/AgentPromptBar"
 import { Messages } from "@/components/agents/messages"
@@ -15,6 +17,7 @@ import { streamMessagesToUi } from "@/lib/agents/streamMessagesToUi"
 import { useSubmitAgentMessage } from "@/lib/agents/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/lib/agents/provider/useModelOptions"
 import { useIsMobile } from "@/lib/useIsMobile"
+import { cn } from "@/lib/utils"
 
 interface AgentThreadViewProps {
   thread: AgentThread
@@ -40,6 +43,16 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   const activeSelection = selection ?? threadSelection ?? defaultSelection
   const [planMode, setPlanMode] = useState<boolean | null>(null)
   const activePlanMode = planMode ?? thread.planMode ?? false
+
+  // Own the git panel's collapsed state so the plan banner can reserve space for
+  // the floating expand button the panel renders while collapsed.
+  const [panelCollapsed, setPanelCollapsed] = useState(() =>
+    readStoredPanelCollapsed()
+  )
+  const handlePanelCollapsedChange = useCallback((next: boolean) => {
+    setPanelCollapsed(next)
+    writeStoredPanelCollapsed(next)
+  }, [])
 
   const baseMessages = useMemo<Array<Message>>(() => {
     const live = streamMessagesToUi(
@@ -77,7 +90,12 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
               to="/agents/$threadId/plan"
               params={{ threadId: thread.id }}
               data-testid="review-plan-link"
-              className="flex items-center justify-between gap-2 border-b border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-2 text-xs text-[var(--ui-text)] hover:bg-[var(--ui-panel-2)]"
+              className={cn(
+                "flex items-center justify-between gap-2 border-b border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-2 text-xs text-[var(--ui-text)] hover:bg-[var(--ui-panel-2)]",
+                // The collapsed panel floats a fixed expand button in the
+                // top-right corner; clear it so it never covers "Review plan →".
+                panelCollapsed && "pr-14"
+              )}
             >
               <span className="flex items-center gap-2">
                 <MapIcon className="size-3.5 text-[var(--ui-accent)]" />
@@ -156,7 +174,12 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
           </div>
         )}
       </div>
-      <AgentGitPanel thread={thread} messages={baseMessages} />
+      <AgentGitPanel
+        thread={thread}
+        messages={baseMessages}
+        collapsed={panelCollapsed}
+        onCollapsedChange={handlePanelCollapsedChange}
+      />
     </div>
   )
 }

--- a/ui/src/components/agents/PlanReview.tsx
+++ b/ui/src/components/agents/PlanReview.tsx
@@ -7,6 +7,7 @@ import {
   deletePlanComment,
   getPlanComments,
   rejectPlan,
+  updatePlan,
 } from "@/lib/plan"
 import { Button } from "@/components/ui/button"
 import { Markdown } from "@/components/agents/ported"
@@ -55,6 +56,50 @@ export function PlanReview({ plan }: { plan: PlanData }) {
   const [busy, setBusy] = useState<"approve" | "reject" | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  // Locally track the displayed markdown so a manual edit shows immediately; the
+  // route's query stops polling once a plan exists, so the prop won't refetch.
+  const [markdown, setMarkdown] = useState(plan.markdown)
+  const [editing, setEditing] = useState(false)
+  const [editDraft, setEditDraft] = useState(plan.markdown)
+  const [saving, setSaving] = useState(false)
+
+  // Reflect external plan updates (e.g. an agent revision) while not editing.
+  useEffect(() => {
+    if (!editing) setMarkdown(plan.markdown)
+  }, [plan.markdown, editing])
+
+  const canEdit =
+    plan.isOwner && plan.status !== "approved" && plan.status !== "cancelled"
+
+  const startEditing = useCallback(() => {
+    setEditDraft(markdown)
+    setEditing(true)
+    setError(null)
+  }, [markdown])
+
+  const cancelEditing = useCallback(() => {
+    setEditing(false)
+    setError(null)
+  }, [])
+
+  const saveEdit = useCallback(async () => {
+    const next = editDraft.trim()
+    if (!next) {
+      setError("The plan cannot be empty.")
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await updatePlan(plan.threadId, next)
+      setMarkdown(result.markdown)
+      setEditing(false)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }, [editDraft, plan.threadId])
 
   // Poll so reviewers see each other's comments without a realtime transport.
   useEffect(() => {
@@ -126,13 +171,13 @@ export function PlanReview({ plan }: { plan: PlanData }) {
 
   const copyPlan = useCallback(async () => {
     setError(null)
-    if (await copyToClipboard(plan.markdown)) {
+    if (await copyToClipboard(markdown)) {
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1500)
     } else {
       setError("Couldn't copy the plan to the clipboard.")
     }
-  }, [plan.markdown])
+  }, [markdown])
 
   return (
     <div
@@ -159,38 +204,72 @@ export function PlanReview({ plan }: { plan: PlanData }) {
               {decision}
             </span>
           )}
-          <Button
-            data-testid="copy-plan"
-            variant="secondary"
-            disabled={!plan.markdown.trim()}
-            onClick={() => void copyPlan()}
-          >
-            {copied ? "Copied!" : "Copy markdown"}
-          </Button>
-          {plan.isOwner && (
-            <Button
-              data-testid="approve-plan"
-              disabled={busy !== null || decision !== null}
-              onClick={() => void decide("approve")}
-            >
-              Approve
-            </Button>
+          {editing ? (
+            <>
+              <Button
+                data-testid="cancel-edit-plan"
+                variant="secondary"
+                disabled={saving}
+                onClick={cancelEditing}
+              >
+                Cancel
+              </Button>
+              <Button
+                data-testid="save-plan"
+                disabled={saving || !editDraft.trim()}
+                onClick={() => void saveEdit()}
+              >
+                {saving ? "Saving…" : "Save"}
+              </Button>
+            </>
+          ) : (
+            <>
+              {canEdit && (
+                <Button
+                  data-testid="edit-plan"
+                  variant="secondary"
+                  disabled={busy !== null || decision !== null}
+                  onClick={startEditing}
+                >
+                  Edit
+                </Button>
+              )}
+              <Button
+                data-testid="copy-plan"
+                variant="secondary"
+                disabled={!markdown.trim()}
+                onClick={() => void copyPlan()}
+              >
+                {copied ? "Copied!" : "Copy markdown"}
+              </Button>
+              {plan.isOwner && (
+                <Button
+                  data-testid="approve-plan"
+                  disabled={busy !== null || decision !== null}
+                  onClick={() => void decide("approve")}
+                >
+                  Approve
+                </Button>
+              )}
+              <Button
+                data-testid="reject-plan"
+                variant="secondary"
+                // Requesting changes feeds the comments to the agent, so it's
+                // meaningless with none — disable until at least one is left.
+                disabled={
+                  busy !== null || decision !== null || comments.length === 0
+                }
+                title={
+                  comments.length === 0
+                    ? "Leave a comment first to request changes"
+                    : undefined
+                }
+                onClick={() => void decide("reject")}
+              >
+                Request changes
+              </Button>
+            </>
           )}
-          <Button
-            data-testid="reject-plan"
-            variant="secondary"
-            // Requesting changes feeds the comments to the agent, so it's
-            // meaningless with none — disable until at least one is left.
-            disabled={busy !== null || decision !== null || comments.length === 0}
-            title={
-              comments.length === 0
-                ? "Leave a comment first to request changes"
-                : undefined
-            }
-            onClick={() => void decide("reject")}
-          >
-            Request changes
-          </Button>
         </div>
       </div>
 
@@ -200,8 +279,21 @@ export function PlanReview({ plan }: { plan: PlanData }) {
           data-testid="plan-document"
           data-color-scheme={resolvedTheme}
         >
-          {plan.markdown.trim() ? (
-            <Markdown content={plan.markdown} />
+          {editing ? (
+            <div className="flex h-full flex-col gap-2">
+              {error && (
+                <p className="text-xs text-[color:var(--ui-danger)]">{error}</p>
+              )}
+              <textarea
+                data-testid="plan-editor"
+                value={editDraft}
+                onChange={(e) => setEditDraft(e.target.value)}
+                spellCheck={false}
+                className="min-h-[20rem] w-full flex-1 resize-none rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg)] px-3 py-2 font-mono text-sm text-[var(--ui-text)] outline-none focus:border-[var(--ui-accent)]"
+              />
+            </div>
+          ) : markdown.trim() ? (
+            <Markdown content={markdown} />
           ) : (
             <p className="text-sm text-[var(--ui-text-dim)]">
               The plan hasn't been written yet.

--- a/ui/src/lib/plan.ts
+++ b/ui/src/lib/plan.ts
@@ -113,6 +113,16 @@ export function deletePlanComment(
   )
 }
 
+export function updatePlan(
+  threadId: string,
+  markdown: string
+): Promise<{ status: PlanStatus; markdown: string }> {
+  return req(`/plan/${encodeURIComponent(threadId)}`, {
+    method: "PUT",
+    body: JSON.stringify({ markdown }),
+  })
+}
+
 export function approvePlan(threadId: string): Promise<{ status: string }> {
   return req(`/plan/${encodeURIComponent(threadId)}/approve`, {
     method: "POST",


### PR DESCRIPTION
## Description
Plan mode was comment-only and the read-only plan banner was getting covered by the collapsed git-panel's floating expand button. This adds owner-only manual plan editing on the plan-review page (Edit → textarea → Save) backed by a new `PUT /dashboard/api/plan/{thread_id}` endpoint that re-publishes the plan and mirrors it into the sandbox `plan.md`; on approve the published (possibly edited) markdown is handed to the agent as the source of truth. It also fixes the overlap by lifting the panel's collapsed state up so the banner reserves space for the floating button.

## Release Note
Plan-review pages now let the thread owner edit the plan by hand before approving, and the "Review plan" banner no longer overlaps the expand-panel button.

## Test Plan
- [ ] Collapse the git panel on a thread with a pending plan; confirm the "Review plan →" label clears the floating expand button.
- [ ] As the plan owner, click Edit, modify the markdown, Save; confirm it renders and persists, then Approve and confirm the agent receives the edited plan.

Made by [Open SWE](https://openswe.vercel.app/agents/019effd1-efb8-73a4-9980-84eaa666a157)