### PR TITLE
chore: bake sfw binary into sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,15 @@ ARG NODEJS_VERSION=22.22.0-1nodesource1
 ARG UV_VERSION=0.9.26
 ARG YARN_VERSION=4.12.0
 ARG GH_VERSION=2.83.1
+ARG SFW_VERSION=2.0.6
 
 ENV DEBIAN_FRONTEND=noninteractive
+# Skip sfw's daily background update check at runtime. The check hits
+# api.github.com/repos/SocketDev/sfw-free, which the sandbox proxy authenticates
+# with the GitHub App installation token (no access to that repo), so it fails
+# and the wrapper can't fall back to a binary it never managed to fetch. The
+# initial download still runs at build time below, where egress is unrestricted.
+ENV SFW_SKIP_UPDATE_CHECK=1
 
 RUN apt-get update && apt-get install -y \
     git \
@@ -65,7 +72,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/* \
     && corepack enable \
     && corepack prepare "yarn@${YARN_VERSION}" --activate \
-    && npm i -g sfw
+    && npm i -g "sfw@${SFW_VERSION}" \
+    && sfw --version \
+    && test -e "$(npm root -g)/sfw/.sfw-cache/latest"
 
 ENV GO_VERSION=1.23.5
 


### PR DESCRIPTION
sfw only ships a launcher that fetches its real binary at first run and does a daily update check against `api.github.com/repos/SocketDev/sfw-free`. Both fail in the sandbox (restricted egress; the proxy injects the GitHub App installation token, which lacks access to that repo), so `sfw yarn install` errors with "could not fetch its binary".

Changes:
- Pin `sfw` to 2.0.6 (matches the other pinned tools).
- Warm + verify the binary cache at build time, where egress is open.
- Bake `SFW_SKIP_UPDATE_CHECK=1` so runs use the cached binary and skip the broken update check.

Requires rebuilding the default sandbox snapshot from this image and pointing `DEFAULT_SANDBOX_SNAPSHOT_ID` at it.