### PR TITLE
feat: add planner executor model split

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -102,6 +102,22 @@ If a task would genuinely benefit from a structured plan before any code — com
 
 Plan-review link for this conversation: {plan_review_url}"""
 
+PLANNER_EXECUTOR_SECTION = """---
+
+### Planner/Executor Mode
+
+Planner/executor mode is active for this run:
+
+- Planner model: `{planner_model_id}` (`{planner_effort}` effort)
+- Executor model: `{executor_model_id}` (`{executor_effort}` effort)
+
+You are the planner/coordinator. Use your stronger reasoning and vision support to understand the user's request, inspect context with read/search tools, convert any image input into precise textual requirements, and decide the implementation strategy.
+
+Delegate repository setup, shell commands, code edits, focused verification, commits, pushes, and PR updates to the `executor` subagent via the `task` tool. Include all relevant constraints in each delegation: repo, branch, commit identity, PR policy, source-channel rules, tests to run, and any image-derived details the executor cannot see. Do not perform mutating implementation work directly; your role is to plan, supervise, and synthesize the executor's result for the user.
+
+The executor may report blockers or safety concerns. If that happens, refine the plan or ask the user only when genuinely blocked. You own final user communication unless the user explicitly asked not to reply in a source channel."""
+
+
 PLAN_MODE_SECTION = """---
 
 ### Plan Mode (ACTIVE)
@@ -310,6 +326,7 @@ SYSTEM_PROMPT_TEMPLATE = (
     WORKING_ENV_SECTION
     + PLAN_MODE_GUIDANCE_SECTION
     + "{plan_mode_section}"
+    + "{planner_executor_section}"
     + SELF_AWARENESS_SECTION
     + "{default_prompt_section}"
     + REPO_SETUP_SECTION
@@ -336,6 +353,11 @@ def construct_system_prompt(
     repo_custom_instructions: str | None = None,
     thread_url: str | None = None,
     corridor_enabled: bool = False,
+    planner_executor_mode: bool = False,
+    planner_model_id: str | None = None,
+    planner_effort: str | None = None,
+    executor_model_id: str | None = None,
+    executor_effort: str | None = None,
 ) -> str:
     default_prompt_section = _load_default_prompt()
     if default_repo and default_repo.get("owner") and default_repo.get("name"):
@@ -360,6 +382,16 @@ def construct_system_prompt(
         plan_mode_section=(
             PLAN_MODE_SECTION.format(plan_url=plan_url or "(plan-review link unavailable)")
             if plan_mode
+            else ""
+        ),
+        planner_executor_section=(
+            PLANNER_EXECUTOR_SECTION.format(
+                planner_model_id=planner_model_id or "unknown",
+                planner_effort=planner_effort or "default",
+                executor_model_id=executor_model_id or "unknown",
+                executor_effort=executor_effort or "default",
+            )
+            if planner_executor_mode
             else ""
         ),
         default_prompt_section=default_prompt_section,

--- a/agent/server.py
+++ b/agent/server.py
@@ -26,7 +26,7 @@ warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarnin
 from deepagents import create_deep_agent
 from deepagents.backends import LangSmithSandbox
 from deepagents.backends.protocol import SandboxBackendProtocol
-from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
+from deepagents.middleware.subagents import SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain_core.language_models import BaseChatModel
 from langsmith.sandbox import SandboxClientError
@@ -54,6 +54,7 @@ from .integrations.langsmith import _configure_github_proxy
 from .integrations.langsmith_tools import load_langsmith_tools
 from .integrations.notion_mcp import load_notion_tools
 from .middleware import (
+    ExcludeToolsMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
     SandboxCircuitBreakerMiddleware,
@@ -534,8 +535,8 @@ MODEL_CALL_RECURSION_LIMIT = 5_000
 # discipline (no mutating commands) is instructed via the system prompt rather
 # than enforced. `http_request` is excluded because it can POST/PUT/PATCH/DELETE
 # to external services — read-only web research goes through `web_search` /
-# `fetch_url`. `task` is excluded because the general-purpose subagent is built
-# with its own filesystem/PR/Linear tools and does not inherit this exclusion, so
+# `fetch_url`. `task` is excluded because the executor subagent is built with its
+# own filesystem/PR/Linear tools and does not inherit this exclusion, so
 # delegating to it would bypass the read-only intent.
 PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
     {
@@ -551,12 +552,32 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
     }
 )
 
+PLANNER_EXECUTOR_EXCLUDED_TOOLS: frozenset[str] = frozenset(
+    {
+        "write_file",
+        "edit_file",
+        "execute",
+        "http_request",
+        "open_pull_request",
+        "linear_create_issue",
+        "linear_update_issue",
+        "linear_delete_issue",
+    }
+)
 
-def _general_purpose_subagent(model: BaseChatModel) -> SubAgent:
+EXECUTOR_SUBAGENT_PROMPT = """You are Open SWE's executor subagent. Your job is to carry out concrete implementation work delegated by the planner.
+
+Follow the planner's task description exactly, including any repository setup, branch, commit identity, test, PR, and source-channel constraints it passes along. Use tools to inspect files, edit code, run focused verification, commit, push, and open/update pull requests when the delegated task asks for it. Do not redo high-level planning unless the plan is blocked or unsafe; if blocked, explain the blocker and the smallest viable next step. Return a complete concise report with files changed, verification run, commit/PR status, and anything the planner must tell the user."""
+
+
+def _executor_subagent(model: BaseChatModel) -> SubAgent:
     return {
-        "name": GENERAL_PURPOSE_SUBAGENT["name"],
-        "description": GENERAL_PURPOSE_SUBAGENT["description"],
-        "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
+        "name": "executor",
+        "description": (
+            "Executes delegated repository work: setup, code changes, focused tests, "
+            "git commits, pushes, and PR updates from a concrete planner instruction."
+        ),
+        "system_prompt": EXECUTOR_SUBAGENT_PROMPT,
         "model": model,
     }
 
@@ -664,7 +685,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     (model_id, profile_effort), (subagent_model_id, subagent_effort) = team_defaults
     logger.info("Using team default agent model: model=%s effort=%s", model_id, profile_effort)
     logger.info(
-        "Using team default agent subagent model: model=%s effort=%s",
+        "Using team default agent executor model: model=%s effort=%s",
         subagent_model_id,
         subagent_effort,
     )
@@ -687,7 +708,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         )
         if overridden_subagent_model:
             logger.info(
-                "Applying dashboard profile subagent override for %s: model=%s effort=%s",
+                "Applying dashboard profile executor override for %s: model=%s effort=%s",
                 profile_login,
                 overridden_subagent_model,
                 overridden_subagent_effort,
@@ -713,9 +734,39 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         subagent_model_id = per_thread_model
         subagent_effort = per_thread_effort
 
+    per_thread_executor_model = configurable.get("agent_executor_model_id") or configurable.get(
+        "agent_subagent_model_id"
+    )
+    per_thread_executor_effort = configurable.get("agent_executor_effort") or configurable.get(
+        "agent_subagent_effort"
+    )
+    if (
+        isinstance(per_thread_executor_model, str)
+        and per_thread_executor_model in SUPPORTED_MODEL_IDS
+        and isinstance(per_thread_executor_effort, str)
+        and model_supports_effort(per_thread_executor_model, per_thread_executor_effort)
+    ):
+        logger.info(
+            "Applying per-thread executor override: model=%s effort=%s",
+            per_thread_executor_model,
+            per_thread_executor_effort,
+        )
+        subagent_model_id = per_thread_executor_model
+        subagent_effort = per_thread_executor_effort
+
     always_create_prs = profile_create_prs(profile)
     if always_create_prs:
         logger.info("Always Create PRs enabled by profile for %s", profile_login)
+
+    planner_executor_mode = (model_id, profile_effort) != (subagent_model_id, subagent_effort)
+    if planner_executor_mode:
+        logger.info(
+            "Planner/executor mode enabled: planner=%s/%s executor=%s/%s",
+            model_id,
+            profile_effort,
+            subagent_model_id,
+            subagent_effort,
+        )
 
     model_kwargs = provider_model_kwargs(
         model_id,
@@ -751,6 +802,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     plan_mode_middleware: list[Any] = [
         PlanModeMiddleware(excluded=PLAN_MODE_EXCLUDED_TOOLS, initial=plan_mode)
     ]
+    planner_executor_middleware: list[Any] = []
+    if planner_executor_mode and not plan_mode:
+        planner_executor_middleware.append(
+            ExcludeToolsMiddleware(excluded=PLANNER_EXECUTOR_EXCLUDED_TOOLS)
+        )
 
     source = (
         configurable.get("source") if isinstance(configurable.get("source"), str) else "dashboard"
@@ -764,6 +820,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 "agent_kind": "agent",
                 "model": model_id,
                 "effort": profile_effort,
+                "planner_model": model_id,
+                "planner_effort": profile_effort,
+                "executor_model": subagent_model_id,
+                "executor_effort": subagent_effort,
+                "planner_executor_mode": planner_executor_mode,
                 "source": source,
                 "plan_mode": plan_mode,
             },
@@ -817,6 +878,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             repo_custom_instructions=repo_custom_instructions,
             thread_url=dashboard_thread_url(thread_id),
             corridor_enabled=bool(corridor_tools),
+            planner_executor_mode=planner_executor_mode and not plan_mode,
+            planner_model_id=model_id,
+            planner_effort=profile_effort,
+            executor_model_id=subagent_model_id,
+            executor_effort=subagent_effort,
         ),
         tools=[
             http_request,
@@ -841,7 +907,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             *currents_tools,
             *notion_tools,
         ],
-        subagents=[_general_purpose_subagent(subagent_model)],
+        subagents=[_executor_subagent(subagent_model)],
         backend=backend_factory,
         middleware=[
             SanitizeToolInputsMiddleware(),
@@ -857,6 +923,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             SandboxCircuitBreakerMiddleware(),
             *fallback_middleware,
             *plan_mode_middleware,
+            *planner_executor_middleware,
             SanitizeThinkingBlocksMiddleware(),
         ],
     ).with_config(config)

--- a/tests/test_agent_subagent_models.py
+++ b/tests/test_agent_subagent_models.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langgraph.graph.state import RunnableConfig
 
-from agent.server import get_agent
+from agent.middleware.exclude_tools import ExcludeToolsMiddleware
+from agent.server import EXECUTOR_SUBAGENT_PROMPT, get_agent
 
 
 class _DummyAgent:
@@ -13,7 +14,7 @@ class _DummyAgent:
 
 
 @pytest.mark.asyncio
-async def test_agent_uses_profile_subagent_model_override() -> None:
+async def test_agent_uses_profile_executor_model_override() -> None:
     config: RunnableConfig = {
         "configurable": {
             "__is_for_execution__": True,
@@ -64,7 +65,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
         ),
         patch("agent.server.fallback_model_id_for", return_value=None),
         patch("agent.server.make_model", side_effect=[main_model, subagent_model]) as make_model,
-        patch("agent.server.construct_system_prompt", return_value="prompt"),
+        patch("agent.server.construct_system_prompt", return_value="prompt") as construct_prompt,
         patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await get_agent(config)
@@ -72,8 +73,15 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
     assert captured["model"] is main_model
     subagents = captured["subagents"]
     assert isinstance(subagents, list)
-    assert subagents[0]["name"] == "general-purpose"
+    assert subagents[0]["name"] == "executor"
+    assert subagents[0]["system_prompt"] == EXECUTOR_SUBAGENT_PROMPT
     assert subagents[0]["model"] is subagent_model
+    middleware = captured["middleware"]
+    assert any(isinstance(m, ExcludeToolsMiddleware) for m in middleware)
+    construct_prompt.assert_called_once()
+    assert construct_prompt.call_args.kwargs["planner_executor_mode"] is True
+    assert construct_prompt.call_args.kwargs["planner_model_id"] == "anthropic:claude-opus-4-8"
+    assert construct_prompt.call_args.kwargs["executor_model_id"] == "openai:gpt-5.5"
 
     main_call = make_model.call_args_list[0]
     assert main_call.args == ("anthropic:claude-opus-4-8",)
@@ -86,7 +94,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_subagent_inherits_profile_model_override_without_explicit_pair() -> None:
+async def test_agent_executor_inherits_profile_model_override_without_explicit_pair() -> None:
     config: RunnableConfig = {
         "configurable": {
             "__is_for_execution__": True,
@@ -135,14 +143,19 @@ async def test_agent_subagent_inherits_profile_model_override_without_explicit_p
         ),
         patch("agent.server.fallback_model_id_for", return_value=None),
         patch("agent.server.make_model", side_effect=[main_model, subagent_model]) as make_model,
-        patch("agent.server.construct_system_prompt", return_value="prompt"),
+        patch("agent.server.construct_system_prompt", return_value="prompt") as construct_prompt,
         patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await get_agent(config)
 
     subagents = captured["subagents"]
     assert isinstance(subagents, list)
+    assert subagents[0]["name"] == "executor"
     assert subagents[0]["model"] is subagent_model
+    middleware = captured["middleware"]
+    assert not any(isinstance(m, ExcludeToolsMiddleware) for m in middleware)
+    construct_prompt.assert_called_once()
+    assert construct_prompt.call_args.kwargs["planner_executor_mode"] is False
     assert make_model.call_args_list[0].args == ("anthropic:claude-opus-4-8",)
     assert make_model.call_args_list[1].args == ("anthropic:claude-opus-4-8",)
     assert make_model.call_args_list[1].kwargs["thinking"] == {

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -596,12 +596,12 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
   return (
     <SettingsSection
       title="Global defaults"
-      description="Workspace-wide model defaults. Per-user Cloud Agent selections override the agent defaults."
+      description="Workspace-wide planner/executor model defaults. Per-user Cloud Agent selections override the agent defaults."
     >
       <div className="divide-y divide-border">
         <RolePicker
-          label="Open SWE Agent"
-          description="Model used for code-writing runs triggered from Slack, Linear, GitHub, and the Open SWE Agent."
+          label="Open SWE Agent planner"
+          description="Top-level model used for reasoning, image understanding, delegation, and final coordination."
           models={models}
           model={settings.data?.default_agent_model ?? null}
           effort={settings.data?.default_agent_reasoning_effort ?? null}
@@ -616,8 +616,8 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
           disabled={!settings.data || save.isPending}
         />
         <RolePicker
-          label="Open SWE Agent subagents"
-          description="Model used by delegated main-agent tasks."
+          label="Open SWE Agent executor"
+          description="Model used for delegated repository setup, code changes, focused tests, commits, pushes, and PR updates."
           models={models}
           model={settings.data?.default_agent_subagent_model ?? null}
           effort={

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -142,13 +142,13 @@ function CloudAgentsPage() {
     <AppShell
       user={session.data}
       title="Open SWE Agent"
-      description="Configure how the Open SWE Agent picks a model, repository, and PR defaults."
+      description="Configure how the Open SWE Agent picks planner/executor models, repository, and PR defaults."
     >
       <SettingsSection title="Defaults">
         <div className="divide-y divide-border">
           <SettingsRow
-            label="Default Model"
-            description="Used when no model is specified"
+            label="Default Planner Model"
+            description="Top-level model used for reasoning, image understanding, and coordination"
             control={
               <Select value={modelId} onValueChange={(v) => v && setModelId(v)}>
                 <SelectTrigger className="w-40">
@@ -165,8 +165,8 @@ function CloudAgentsPage() {
             }
           />
           <SettingsRow
-            label="Reasoning Effort"
-            description="How hard the model thinks before answering"
+            label="Planner Reasoning Effort"
+            description="How hard the planner thinks before delegating and answering"
             control={
               <Select value={effort} onValueChange={(v) => v && setEffort(v)}>
                 <SelectTrigger className="w-32">
@@ -183,8 +183,8 @@ function CloudAgentsPage() {
             }
           />
           <SettingsRow
-            label="Default Subagent Model"
-            description="Used for delegated tasks launched by your agent"
+            label="Default Executor Model"
+            description="Used for delegated repository setup, code changes, tests, and PR work"
             control={
               <Select
                 value={subagentModelId}
@@ -204,8 +204,8 @@ function CloudAgentsPage() {
             }
           />
           <SettingsRow
-            label="Subagent Reasoning Effort"
-            description="How hard delegated subagents think before answering"
+            label="Executor Reasoning Effort"
+            description="How hard the executor thinks while carrying out delegated work"
             control={
               <Select
                 value={subagentEffort}


### PR DESCRIPTION
## Description
Adds an explicit executor subagent and planner/executor prompt mode so a vision-capable planner can coordinate while delegating repo mutations to a cheaper executor model. The top-level planner hides implementation-mutating tools whenever planner and executor model pairs differ, while preserving existing behavior when they match.

## Release Note
Self-hosted users can configure separate agent planner and executor models for cost/vision tradeoffs.

## Test Plan
- [ ] Verify GPT-5.5 planner + GLM 5.2 executor accepts image-backed tasks and delegates implementation.

Made by [Open SWE](https://openswe.vercel.app/agents/4f6940ee-ead8-a981-ace5-a00a86f34fd9)