### PR TITLE
fix: stop reviewer/chat agent factories from mutating the caller's RunnableConfig

### DIFF
--- a/agent/chat.py
+++ b/agent/chat.py
@@ -164,8 +164,15 @@ async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
 
 async def get_chat_agent(config: RunnableConfig) -> Pregel:
     """Get a read-only PR chat agent. No sandbox; PR context comes via config."""
+    # Treat the caller's RunnableConfig as read-only. The body below stashes
+    # run-scoped values (recursion limit, GitHub App token) into the config; without
+    # a copy those writes mutate the caller's dict and leak across runs that share a
+    # base config. Shallow-copy config and the one nested dict we write into. #1584.
+    config = {**config}
+    config["configurable"] = {**config.get("configurable", {})}
+
     thread_id = config["configurable"].get("thread_id")
-    config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
+    config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
 
     if thread_id is None or not graph_loaded_for_execution(config):
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -1206,9 +1206,15 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
 
 async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     """Get or create a reviewer agent with checkpointed run prep."""
+    # Caller's RunnableConfig is a per-run entrypoint arg; keep it read-only. We set
+    # recursion_limit on it below, so shallow-copy config (and the nested configurable
+    # dict) to avoid leaking run-scoped state across runs that share a base config. #1584
+    config = {**config}
+    config["configurable"] = {**config.get("configurable", {})}
+
     thread_id = config["configurable"].get("thread_id", None)
 
-    config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
+    config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
 
     if thread_id is None or not graph_loaded_for_execution(config):
         logger.info("No thread_id or not for execution, returning reviewer agent without sandbox")

--- a/tests/test_factory_config_isolation.py
+++ b/tests/test_factory_config_isolation.py
@@ -1,0 +1,69 @@
+"""Regression tests for #1584.
+
+The ``get_reviewer_agent`` / ``get_chat_agent`` factories must treat the caller's
+``RunnableConfig`` as read-only: per the langgraph.json entrypoint contract they
+derive a compiled graph from a per-run config and must not mutate the dict the
+caller passed in. Before the fix they wrote ``recursion_limit`` (and, further
+down, the PR diff / GitHub App token) straight onto the caller's dict, silently
+overriding a caller's explicit limit and leaking data across runs that share a
+base config.
+
+These exercise the offline early-return path (no ``thread_id``), which is enough
+to prove the top-of-factory defensive copy: the caller's dict is left untouched.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from agent.chat import get_chat_agent
+from agent.reviewer import get_reviewer_agent
+
+
+def _config(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {"configurable": {"some_key": "value"}}
+    base.update(overrides)
+    return base
+
+
+async def test_get_reviewer_agent_preserves_caller_config() -> None:
+    config = _config(recursion_limit=200)
+    snapshot = copy.deepcopy(config)
+
+    await get_reviewer_agent(config)
+
+    # An explicit recursion_limit must survive (setdefault, not overwrite), and
+    # nothing else may be written back onto the caller's dict.
+    assert config == snapshot
+
+
+async def test_get_chat_agent_preserves_caller_config() -> None:
+    config = _config(recursion_limit=200)
+    snapshot = copy.deepcopy(config)
+
+    await get_chat_agent(config)
+
+    assert config == snapshot
+
+
+async def test_get_reviewer_agent_does_not_inject_default_into_caller_config() -> None:
+    # When the caller sets no limit, the factory applies its default on its own
+    # copy without mutating the caller's dict.
+    config = _config()
+    snapshot = copy.deepcopy(config)
+
+    await get_reviewer_agent(config)
+
+    assert config == snapshot
+    assert "recursion_limit" not in config
+
+
+async def test_get_chat_agent_does_not_inject_default_into_caller_config() -> None:
+    config = _config()
+    snapshot = copy.deepcopy(config)
+
+    await get_chat_agent(config)
+
+    assert config == snapshot
+    assert "recursion_limit" not in config


### PR DESCRIPTION
## What

`get_reviewer_agent` (`agent/reviewer.py`) and `get_chat_agent` (`agent/chat.py`) are langgraph.json entrypoint factories — by contract they take a per-run `RunnableConfig` and return a compiled graph, treating the config as read-only. Both instead **mutate the caller's `config` dict in-place**:

| File | Mutation |
|---|---|
| `agent/reviewer.py` | `config["recursion_limit"] = DEFAULT_RECURSION_LIMIT` (always overwrites) |
| `agent/reviewer.py` | `config["configurable"]["diff_text"] = …` (multi-MB PR diff) |
| `agent/reviewer.py` | `config["configurable"]["diff_line_set"] = …` |
| `agent/chat.py` | `config["recursion_limit"] = DEFAULT_RECURSION_LIMIT` |
| `agent/chat.py` | `config["configurable"]["chat_github_token"] = token` (resolved App token) |

Closes #1584.

## Impact

1. **A caller's explicit `recursion_limit` is silently overwritten** — e.g. `threads.create(..., config={"recursion_limit": 200})` ends up at `9_999` with no warning.
2. **Run-scoped data leaks across runs that share a base config** — a webhook handler that overlays a few fields onto a tenant-default config leaks one run's PR diff (and a GitHub App token) into the next; two concurrent runs race on `diff_text`/`diff_line_set`.
3. Violates the LangGraph factory contract (the runtime treats `RunnableConfig` as immutable).

## Fix

Shallow-copy `config` and its nested `configurable` dict at the top of each factory, so every subsequent write lands on the copy that is bound to the returned agent via `.with_config(config)`. The diff / token still reach the agent at runtime (the agent is built from the copy), but the caller's dict is never touched. `recursion_limit` uses `setdefault` so an explicit caller value wins instead of being silently overwritten (still defaults to `DEFAULT_RECURSION_LIMIT` when unset).

All writes were verified to be at most two levels deep (`config[k]` / `config["configurable"][k]`), so a two-level shallow copy fully isolates the caller's dict — no `deepcopy` needed.

## Tests

- New `tests/test_factory_config_isolation.py` — both factories leave the caller's config untouched (explicit `recursion_limit` preserved; default not written back).
- Updated two tests in `tests/test_reviewer.py` that asserted the pre-fix in-place mutation; they now assert the diff is bound to the **agent's** config (what `add_finding` reads at runtime) and that the caller's input config is left unmutated.

```
tests/test_factory_config_isolation.py ....                         [ 4 passed ]
tests/test_reviewer.py (diff_line_set + diff-fetch-fails)           [ 2 passed ]
full suite: 1212 passed, 1 pre-existing unrelated failure
```

(The single remaining failure — `test_plan_review.py::test_plan_routes_registered` — fails on `main` without this change and is unrelated.)
