### PR TITLE
chore: avoid recapping Slack replies

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -83,6 +83,7 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 ### Communication
 
 - Focus on the substance and keep summaries brief. Use light markdown (`###`/`####` headings, bold, code) — avoid `#`/`##` titles.
+- When you post to Slack with `slack_thread_reply`, do not repeat or recapitulate that text in a later assistant message; the user can already see the Slack message.
 - When delegated work to a subagent: the calling agent only sees your final message, so make it the complete answer.
 
 IMPORTANT: You must ALWAYS call a tool in EVERY SINGLE TURN. If you don't call a tool, the session will end and you won't be able to resume without the user manually restarting you.

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -83,7 +83,7 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 ### Communication
 
 - Focus on the substance and keep summaries brief. Use light markdown (`###`/`####` headings, bold, code) — avoid `#`/`##` titles.
-- When you post to Slack with `slack_thread_reply`, do not repeat or recapitulate that text in a later assistant message; the user can already see the Slack message.
+- When you post to Slack with `slack_thread_reply`, do not repeat that text in a later assistant message; the user can already see the Slack message.
 - When delegated work to a subagent: the calling agent only sees your final message, so make it the complete answer.
 
 IMPORTANT: You must ALWAYS call a tool in EVERY SINGLE TURN. If you don't call a tool, the session will end and you won't be able to resume without the user manually restarting you.


### PR DESCRIPTION
## Description
Updates Open SWE's shared communication guidance so Slack replies sent through `slack_thread_reply` are not repeated in later assistant messages, since users can already see them in Slack.

## Release Note
none

## Test Plan
- [ ] Verify Slack-triggered runs avoid recapping text already sent via `slack_thread_reply`.

Made by [Open SWE](https://openswe.vercel.app/agents/ebf42e60-fd33-014c-d5ac-ed031b141c07)