### PR TITLE
fix: return to thread after plan approval

### DIFF
--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -126,10 +126,11 @@ test.describe("Plan review (HTTP comments)", () => {
     await addComment(collab, "Reviewer: please also add a docstring.");
     await expect(collab.getByTestId("plan-comment")).toHaveCount(2);
 
-    // 5. The owner sees the collaborator's comment (polled), then approves.
+    // 5. The owner sees the collaborator's comment (polled), then approves and
+    //    returns to the main conversation while implementation starts.
     await expect(owner.getByTestId("plan-comment")).toHaveCount(2, { timeout: 30_000 });
     await owner.getByTestId("approve-plan").click();
-    await expect(owner.getByTestId("plan-decision")).toContainText(/implementing/i);
+    await expect(owner).toHaveURL(new RegExp(`/agents/${threadId}$`));
 
     // 6. The agent implements, opens a PR, and links it back in the Slack thread,
     //    echoing the reviewers' feedback — which proves the comments were stored

--- a/ui/src/components/agents/PlanReview.tsx
+++ b/ui/src/components/agents/PlanReview.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
 
 import type { PlanComment, PlanData } from "@/lib/plan"
 import {
@@ -48,6 +49,7 @@ async function copyToClipboard(text: string): Promise<boolean> {
 }
 
 export function PlanReview({ plan }: { plan: PlanData }) {
+  const navigate = useNavigate()
   const resolvedTheme = useResolvedTheme()
   const [comments, setComments] = useState<Array<PlanComment>>([])
   const [draft, setDraft] = useState("")
@@ -153,20 +155,23 @@ export function PlanReview({ plan }: { plan: PlanData }) {
       setBusy(kind)
       setError(null)
       try {
-        if (kind === "approve") await approvePlan(plan.threadId)
-        else await rejectPlan(plan.threadId)
-        setDecision(
-          kind === "approve"
-            ? "Plan approved — the agent is implementing it."
-            : "Changes requested — the agent is revising the plan."
-        )
+        if (kind === "approve") {
+          await approvePlan(plan.threadId)
+          await navigate({
+            to: "/agents/$threadId",
+            params: { threadId: plan.threadId },
+          })
+          return
+        }
+        await rejectPlan(plan.threadId)
+        setDecision("Changes requested — the agent is revising the plan.")
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setBusy(null)
       }
     },
-    [plan.threadId]
+    [navigate, plan.threadId]
   )
 
   const copyPlan = useCallback(async () => {


### PR DESCRIPTION
## Description
Owners approving a plan from the dashboard now navigate back to the agent conversation once approval succeeds, while request-changes stays on the plan review page. The plan-review E2E expectation was updated for the redirect.

## Release Note
Plan approval in the dashboard returns to the main conversation after approval.

## Test Plan
- [x] `cd ui && npm run typecheck -- --pretty false`
- [x] `cd ui && npm run lint -- --no-color src/components/agents/PlanReview.tsx`

Made by [Open SWE](https://openswe.vercel.app/agents/356aca64-92a1-4607-4c8b-fa036959f1ea)