### PR TITLE
chore: require bun for ui agent work

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+This file applies to all work under `ui/`.
+
+## Package manager
+
+- Use **Bun** for dashboard dependency management and script execution.
+- `bun.lock` is the canonical lockfile for this directory.
+- Run UI scripts with `bun run <script>` (for example, `bun run typecheck`, `bun run lint`, `bun run test`, `bun run build`).
+- Install or update UI dependencies with `bun install` / `bun add` only.
+- Do **not** use npm in this directory: no `npm install`, `npm ci`, `npm run`, `npx`, or npm lockfile changes.
+- If a command must use npm, it belongs outside `ui/` in a subtree that explicitly owns npm configuration and lockfiles.


### PR DESCRIPTION
## Description
Adds UI-specific agent guidance so dashboard work uses Bun consistently and avoids npm commands in `ui/`, matching the canonical `bun.lock` convention.

## Release Note
none

## Test Plan
- [x] Reviewed `ui/AGENTS.md` scope and package-manager guidance.

Made by [Open SWE](https://openswe.vercel.app/agents/9af7a8c0-bc69-ecb1-5b5b-66870a1a5ef5)