### PR TITLE
fix: widen split review diffs

### DIFF
--- a/ui/src/components/agents/ReviewMainBody.tsx
+++ b/ui/src/components/agents/ReviewMainBody.tsx
@@ -1116,7 +1116,10 @@ function ReviewBodyInner({
             >
               <Virtualizer
                 className="relative min-h-0 flex-1 overflow-y-auto"
-                contentClassName="mx-auto w-full max-w-6xl px-6 py-6"
+                contentClassName={cn(
+                  "mx-auto w-full px-6 py-6",
+                  diffStyle === "split" ? "max-w-none" : "max-w-6xl"
+                )}
                 config={DIFF_VIRTUALIZER_CONFIG}
               >
                 <div ref={scrollerProbe} aria-hidden className="hidden" />


### PR DESCRIPTION
## Description
Widen split-mode Review diffs by removing the max-width cap only when split view is active.

## Release Note
none
## Test Plan
- [x] `git diff --check`; UI lint not run because `bun` is unavailable in the sandbox.

Made by [Open SWE](https://openswe.vercel.app/agents/d3d16026-b6a9-90fd-7237-348b1cd300cf)