### PR TITLE
chore: Disable React StrictMode

### DIFF
--- a/ui/src/client.tsx
+++ b/ui/src/client.tsx
@@ -1,5 +1,4 @@
 import { StartClient } from "@tanstack/react-start/client"
-import { StrictMode } from "react"
 import { hydrateRoot } from "react-dom/client"
 import { registerSW } from "virtual:pwa-register"
 
@@ -10,9 +9,4 @@ if (import.meta.env.PROD) {
   registerSW()
 }
 
-hydrateRoot(
-  document,
-  <StrictMode>
-    <StartClient />
-  </StrictMode>
-)
+hydrateRoot(document, <StartClient />)


### PR DESCRIPTION
Remove the `StrictMode` wrapper and import from `ui/src/client.tsx`, so `StartClient` is hydrated directly.