### PR TITLE
chore: opt-in tracemalloc to attribute unclosed aiohttp sessions

### DIFF
--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -129,6 +129,26 @@ from .utils.thread_ids import generate_thread_id_from_slack_thread
 logger = logging.getLogger(__name__)
 
 
+# Opt-in leak diagnostics. Bursts of aiohttp "Unclosed client session" warnings
+# (from a third-party SDK) leak fds + memory in prod, but the warning omits the
+# allocation site. With tracemalloc running, aiohttp appends an "Object allocated
+# at" traceback to each warning, naming the exact source. Inert unless the env
+# var is set, so this is safe to ship and flip on for one diagnostic run.
+if os.environ.get("DEBUG_TRACEMALLOC"):
+    import tracemalloc
+
+    try:
+        _tracemalloc_frames = int(os.environ.get("DEBUG_TRACEMALLOC_FRAMES") or "25")
+    except ValueError:
+        _tracemalloc_frames = 25
+    tracemalloc.start(_tracemalloc_frames)
+    logger.warning(
+        "DEBUG_TRACEMALLOC enabled: tracemalloc started (%d frames) to attribute "
+        "unclosed-session warnings",
+        _tracemalloc_frames,
+    )
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     from .utils.model import validate_local_dev_llm_config


### PR DESCRIPTION
## Summary

Prod logs show recurring bursts of `Unclosed client session: <aiohttp.client.ClientSession …>`, correlated with sandbox/reviewer activity — leaking fds + memory and contributing to `exceeded max attempts` pod recycles. Our own HTTP code uses `async with httpx…` and doesn't leak; the sessions come from a third-party SDK. aiohttp's warning omits the allocation site, so the source can't be pinned from current logs.

## What changed

When `DEBUG_TRACEMALLOC` is set, `agent/webapp.py` calls `tracemalloc.start()` at import. With tracemalloc active, aiohttp appends an **"Object allocated at"** traceback to each unclosed-session warning, naming the exact SDK + call site on the next prod burst. Frame depth tunable via `DEBUG_TRACEMALLOC_FRAMES` (default 25). **Inert when the env var is unset** — no production behavior change.

## Follow-up

Diagnostics only. Once prod names the source, a separate PR closes the session (shared long-lived session, or close on sandbox eviction in `agent/utils/sandbox_state.py`).

## Test

Verified: import with the flag unset does not trace; with `DEBUG_TRACEMALLOC=1` tracemalloc is active at 25 frames.