### PR TITLE
fix: don't attach loopback run-complete webhooks

### DIFF
--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 from langgraph_sdk import get_client
 from langgraph_sdk.client import LangGraphClient
@@ -26,21 +27,53 @@ logger = logging.getLogger(__name__)
 
 ContentBlocks = str | list[dict[str, Any]]
 
-# Same-server FastAPI route the platform POSTs run completion/failure to. A
-# relative URL loopback-posts into this app (no SSRF/loopback config needed);
-# override with an absolute URL via env for split deployments. The route is
-# fail-closed on RUN_COMPLETE_WEBHOOK_SECRET, so only register the webhook when
-# the secret is set, appending it as ?token= so the route can verify the call
-# came from us (completion.verify_run_complete_token). Unset → no webhook.
+# FastAPI route the platform POSTs run completion/failure to. The platform
+# rejects loopback webhooks (relative URLs / localhost) — they bypass auth via
+# the in-process ASGI transport — so a loopback URL would 422 *every* run at
+# create time. COMPLETION_WEBHOOK_URL must therefore be the deployment's
+# absolute https URL (…/webhooks/run-complete). The route is fail-closed on
+# RUN_COMPLETE_WEBHOOK_SECRET, so we only attach the webhook when the secret is
+# set, appending it as ?token= so the route can verify the call came from us
+# (completion.verify_run_complete_token). Secret unset, or URL relative/loopback
+# → no webhook attached (the completion reply is best-effort; it must never
+# break run creation).
 _COMPLETION_WEBHOOK_BASE = os.environ.get("COMPLETION_WEBHOOK_URL") or "/webhooks/run-complete"
 _RUN_COMPLETE_SECRET = os.environ.get("RUN_COMPLETE_WEBHOOK_SECRET")
-COMPLETION_WEBHOOK_URL: str | None
-if not _RUN_COMPLETE_SECRET:
-    COMPLETION_WEBHOOK_URL = None
-elif "?" in _COMPLETION_WEBHOOK_BASE:
-    COMPLETION_WEBHOOK_URL = _COMPLETION_WEBHOOK_BASE
-else:
-    COMPLETION_WEBHOOK_URL = f"{_COMPLETION_WEBHOOK_BASE}?token={_RUN_COMPLETE_SECRET}"
+
+
+def _is_loopback_webhook(url: str) -> bool:
+    """Whether a webhook URL is relative or points at localhost (platform-rejected)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return True  # relative / schemeless
+    return (parsed.hostname or "").lower() in {"localhost", "127.0.0.1", "::1"}
+
+
+def _resolve_completion_webhook_url(base: str, secret: str | None) -> str | None:
+    """Resolve the completion webhook URL, or None to attach no webhook.
+
+    Degrades to None (with a warning) for a relative/loopback URL rather than
+    letting a rejected webhook poison every ``runs.create``.
+    """
+    if not secret:
+        return None
+    if _is_loopback_webhook(base):
+        logger.warning(
+            "RUN_COMPLETE_WEBHOOK_SECRET is set but COMPLETION_WEBHOOK_URL (%r) is relative "
+            "or loopback; the platform rejects such webhooks, so run-completion replies are "
+            "disabled. Set COMPLETION_WEBHOOK_URL to the deployment's absolute https URL "
+            "ending in /webhooks/run-complete to enable them.",
+            base,
+        )
+        return None
+    if "?" in base:
+        return base
+    return f"{base}?token={secret}"
+
+
+COMPLETION_WEBHOOK_URL: str | None = _resolve_completion_webhook_url(
+    _COMPLETION_WEBHOOK_BASE, _RUN_COMPLETE_SECRET
+)
 
 
 def _langgraph_url() -> str:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+
+dispatch = importlib.import_module("agent.dispatch")
+
+_ABSOLUTE = "https://open-swe-v3-abc.us.langgraph.app/webhooks/run-complete"
+
+
+def test_is_loopback_webhook_relative() -> None:
+    assert dispatch._is_loopback_webhook("/webhooks/run-complete") is True
+
+
+def test_is_loopback_webhook_localhost() -> None:
+    assert dispatch._is_loopback_webhook("http://localhost:2024/webhooks/run-complete") is True
+    assert dispatch._is_loopback_webhook("http://127.0.0.1:8000/webhooks/run-complete") is True
+
+
+def test_is_loopback_webhook_absolute() -> None:
+    assert dispatch._is_loopback_webhook(_ABSOLUTE) is False
+
+
+def test_resolve_no_secret_attaches_nothing() -> None:
+    assert dispatch._resolve_completion_webhook_url(_ABSOLUTE, None) is None
+    assert dispatch._resolve_completion_webhook_url(_ABSOLUTE, "") is None
+
+
+def test_resolve_relative_url_degrades_to_none() -> None:
+    # Secret set but a loopback URL would 422 every run — attach nothing instead.
+    assert dispatch._resolve_completion_webhook_url("/webhooks/run-complete", "s3cret") is None
+
+
+def test_resolve_localhost_url_degrades_to_none() -> None:
+    assert dispatch._resolve_completion_webhook_url("http://localhost/x", "s3cret") is None
+
+
+def test_resolve_absolute_url_appends_token() -> None:
+    assert (
+        dispatch._resolve_completion_webhook_url(_ABSOLUTE, "s3cret") == f"{_ABSOLUTE}?token=s3cret"
+    )
+
+
+def test_resolve_absolute_url_with_existing_query_left_as_is() -> None:
+    url = f"{_ABSOLUTE}?token=preset"
+    assert dispatch._resolve_completion_webhook_url(url, "s3cret") == url


### PR DESCRIPTION
## Summary

Setting `RUN_COMPLETE_WEBHOOK_SECRET` in prod took the whole deployment down: `dispatch.py` attached the **relative** webhook `/webhooks/run-complete?token=…`, and LangGraph 0.10.0rc3 rejects loopback webhooks (relative URLs / localhost) with a **422**, failing *every* `runs.create` for both the agent and reviewer graphs. Immediate Slack errors, zero reviewer traces.

Root-cause log:
```
UnprocessableEntityError: Loopback webhooks (relative URLs and localhost) are disabled by
default. They bypass authentication via the in-process ASGI transport ...
```

## What changed

The completion reply is best-effort and must never break run creation. `dispatch.py` now resolves the webhook URL up front (`_resolve_completion_webhook_url`) and attaches **no** webhook — with a warning — when the URL is relative or loopback. The feature activates only with an absolute `https` URL via `COMPLETION_WEBHOOK_URL`; otherwise runs dispatch cleanly as before.

## Deploy note

To actually enable run-completion replies, set on the deployment:
```
COMPLETION_WEBHOOK_URL=https://<deployment-host>/webhooks/run-complete
```
(keep `RUN_COMPLETE_WEBHOOK_SECRET`; the `?token=` is appended automatically). Without it, the secret alone no longer breaks dispatch — it just leaves replies off.

## Test

`uv run pytest tests/test_dispatch.py` — 8 passed (loopback detection for relative/localhost/absolute; resolution degrades relative+loopback to None, appends token to absolute, preserves preset query).