### PR TITLE
fix: add top padding to sticky review block header

### DIFF
--- a/ui/src/components/agents/ReviewMainBody.tsx
+++ b/ui/src/components/agents/ReviewMainBody.tsx
@@ -1425,7 +1425,7 @@ function GroupHeader({ group }: { group: ResolvedGroup }) {
     [group.summary]
   )
   return (
-    <div className="sticky top-0 z-[5] border-b border-border bg-background pt-2 pb-2">
+    <div className="sticky top-0 z-[5] border-b border-border bg-background py-2">
       <div className="flex items-center gap-2">
         <span className="flex size-5 shrink-0 items-center justify-center rounded bg-[var(--ui-panel-2)] text-[11px] font-medium text-muted-foreground">
           {group.index}

--- a/ui/src/components/agents/ReviewMainBody.tsx
+++ b/ui/src/components/agents/ReviewMainBody.tsx
@@ -1425,7 +1425,7 @@ function GroupHeader({ group }: { group: ResolvedGroup }) {
     [group.summary]
   )
   return (
-    <div className="sticky top-0 z-[5] border-b border-border bg-background pb-2">
+    <div className="sticky top-0 z-[5] border-b border-border bg-background pt-2 pb-2">
       <div className="flex items-center gap-2">
         <span className="flex size-5 shrink-0 items-center justify-center rounded bg-[var(--ui-panel-2)] text-[11px] font-medium text-muted-foreground">
           {group.index}


### PR DESCRIPTION


## Description
The sticky per-block header on the reviews page had padding below (`pb-2`) but none above, so the block number badge was glued against the top edge when the header pins during scroll. Added matching top padding (`pt-2`) for a bit of breathing room.

## Release Note
Reviews page: the pinned per-block header no longer sits flush against the top edge.

## Test Plan
After:
<img width="990" height="783" alt="Screenshot 2026-07-01 at 12 46 47 PM" src="https://github.com/user-attachments/assets/724aa407-d233-47f3-a064-bb5f1fd3beff" />

Before
<img width="985" height="784" alt="Screenshot 2026-07-01 at 12 46 53 PM" src="https://github.com/user-attachments/assets/ae41c4b9-7175-45c9-8365-429d5c48d673" />
Made by [Open SWE](https://openswe.vercel.app/agents/019f1f29-1a2d-75bf-8fe6-1d4256c738fb)