### PR TITLE
fix: match sidebar filter popover border to settings popover

### DIFF
--- a/ui/src/components/agents/SidebarFilterMenu.tsx
+++ b/ui/src/components/agents/SidebarFilterMenu.tsx
@@ -21,15 +21,15 @@ import {
 import { cn } from "@/lib/utils"
 
 const POPUP_CLASS =
-  "z-50 min-w-[12rem] origin-(--transform-origin) overflow-hidden rounded-md border border-[var(--ui-border)] bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95"
+  "z-50 min-w-[12rem] origin-(--transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95"
 
 const ITEM_CLASS =
-  "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-[var(--ui-sidebar-hover)] data-disabled:pointer-events-none data-disabled:opacity-50"
+  "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
 
 const LABEL_CLASS =
-  "px-2 py-1 text-[10px] font-medium tracking-wide text-[var(--ui-text-dim)] uppercase"
+  "px-2 py-1 text-[10px] font-medium tracking-wide text-muted-foreground uppercase"
 
-const SEPARATOR_CLASS = "my-1 h-px bg-[var(--ui-border)]"
+const SEPARATOR_CLASS = "my-1 h-px bg-border"
 
 function Indicator() {
   return <CheckIcon className="size-3.5 shrink-0" weight="bold" />
@@ -38,7 +38,7 @@ function Indicator() {
 function CountBadge({ count }: { count: number }) {
   if (count <= 0) return null
   return (
-    <span className="ml-auto rounded bg-[var(--ui-panel-2)] px-1.5 py-0.5 text-[10px] text-[var(--ui-text-muted)]">
+    <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
       {count}
     </span>
   )


### PR DESCRIPTION
## Description
The sidebar filter popover (`SidebarFilterMenu`) showed a strong near-black border. It renders through base-ui's `Menu.Portal` into `document.body`, which is outside the `.agents-ui` container where the `--ui-*` design tokens are scoped — so `border-[var(--ui-border)]` resolved to an undefined variable and `border-color` fell back to `currentColor` (near-black). The theme/settings popover (`SidebarUserMenu`) looks correct because it uses global shadcn tokens defined at `:root`, which resolve everywhere including portals.

This is also the answer to "why the discrepancy": the two popovers are not a shared component (one is a hand-rolled div, the other a base-ui `Menu`), and they used different border tokens. This switches the portaled filter popup to the same global tokens the settings popover uses (`border-border`, `bg-border`, `bg-muted`, `text-muted-foreground`), which have identical values to the `--ui-*` tokens but resolve inside portals.

## Release Note
Fix the sidebar filter popover so its border and styling match the account/settings popover instead of showing a hard black border.

## Test Plan
- [ ] Open the agents sidebar, click the funnel filter next to your name, and confirm the popover border is a soft light/dark border matching the settings popover (in both light and dark themes).

Made by [Open SWE](https://openswe.vercel.app/agents/019f1f4a-075d-722e-bbc7-6a14068046cb)