### PR TITLE
feat: opt-in LangSmith LLM Gateway routing

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -193,6 +193,24 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     return create_deep_agent(model=model, ...)
 ```
 
+### Routing through the LangSmith LLM Gateway
+
+Model calls can be proxied through the [LangSmith LLM Gateway](https://docs.langchain.com/langsmith/llm-gateway) (private beta) instead of hitting providers directly. The gateway authenticates with your **LangSmith API key** (reusing the existing `LANGSMITH_API_KEY` / `LANGSMITH_API_KEY_PROD`) and resolves the real provider key from workspace Provider Secrets, so no provider API keys are needed at runtime — and it adds central spend limits, PII/secrets redaction, and tracing. Your org must have the gateway enabled with Provider Secrets configured.
+
+Routing is opt-in and off by default. Enable it either way:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `LANGSMITH_GATEWAY_ENABLED` | `false` | Deployment-level default for gateway routing. |
+| `LANGSMITH_GATEWAY_BASE_URL` | `https://gateway.smith.langchain.com` | Override for a regional or self-hosted gateway host. |
+| `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `false` | Keep the OpenAI Responses API through the gateway (see caveat). Only set if your gateway proxies `/v1/responses`. |
+
+The admin panel (**Admin → LLM Gateway**) exposes a per-workspace toggle stored in team settings; when set it overrides the `LANGSMITH_GATEWAY_ENABLED` env default (a `None`/unset team value inherits the env default).
+
+Routing is applied centrally in `make_model` (`agent/utils/model.py`), which resolves the effective on/off and delegates URL/key wiring to `agent/utils/gateway.py`. **OpenAI, Anthropic, and Fireworks** are routed (their LangChain integrations accept `base_url` + `api_key`); other providers (Google Gemini/Vertex) call the provider directly with a logged warning.
+
+**Caveat — OpenAI endpoint:** open-swe uses the OpenAI Responses API over a `wss://` base URL by default, which an HTTPS proxy can't carry. When the gateway is on, gateway-routed OpenAI falls back to **Chat Completions** (dropping the Responses API's visible reasoning summaries) unless `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=true`. Anthropic and Fireworks are unaffected.
+
 ---
 
 ## 3. Tools

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -207,7 +207,7 @@ Routing is opt-in and off by default. Enable it either way:
 
 The admin panel (**Admin → LLM Gateway**) exposes a per-workspace toggle stored in team settings; when set it overrides the `LANGSMITH_GATEWAY_ENABLED` env default (a `None`/unset team value inherits the env default).
 
-Routing is applied centrally in `make_model` (`agent/utils/model.py`), which resolves the effective on/off and delegates URL/key wiring to `agent/utils/gateway.py`. **OpenAI, Anthropic, and Fireworks** are routed (their LangChain integrations accept `base_url` + `api_key`); other providers (Google Gemini/Vertex) call the provider directly with a logged warning.
+Routing is applied centrally in `make_model` (`agent/utils/model.py`), which resolves the effective on/off and delegates URL/key wiring to `agent/utils/gateway.py`. **OpenAI, Anthropic, Fireworks, and Google Gemini** are routed (their LangChain integrations accept `base_url` + `api_key`); Google Vertex (service-account auth) and any other provider call the provider directly with a logged warning.
 
 **Caveat — OpenAI endpoint:** open-swe uses the OpenAI Responses API over a `wss://` base URL by default, which an HTTPS proxy can't carry. When the gateway is on, gateway-routed OpenAI falls back to **Chat Completions** (dropping the Responses API's visible reasoning summaries) unless `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=true`. Anthropic and Fireworks are unaffected.
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -29,6 +29,7 @@ from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.state import StateBackend
 from langchain.agents.middleware import ModelCallLimitMiddleware
 
+from .dashboard.team_settings import get_effective_gateway_enabled
 from .integrations.langsmith import _configure_github_proxy
 from .middleware import SanitizeToolInputsMiddleware, ToolErrorMiddleware
 from .review_style_guidance import REVIEWER_STYLE_THEMES
@@ -116,6 +117,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     backend = CompositeBackend(default=sandbox_backend, routes={SKILLS_ROUTE: StateBackend()})
 
     model_id = DEFAULT_LLM_MODEL_ID
+    use_gateway = await get_effective_gateway_enabled()
     model_kwargs = provider_model_kwargs(
         model_id,
         None,
@@ -135,7 +137,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     system_prompt = f"{system_prompt}\n\n{user_context}"
 
     return create_deep_agent(
-        model=make_model(model_id, **model_kwargs),
+        model=make_model(model_id, use_gateway=use_gateway, **model_kwargs),
         system_prompt=system_prompt,
         tools=[save_review_style_prompt, read_finding_outcomes],
         backend=backend,

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -29,7 +29,7 @@ from deepagents import create_deep_agent
 from langchain.agents.middleware import ModelCallLimitMiddleware
 
 from .dashboard.options import SUPPORTED_MODEL_IDS, model_supports_effort
-from .dashboard.team_settings import get_team_default_model
+from .dashboard.team_settings import get_effective_gateway_enabled, get_team_default_model
 from .middleware import (
     ExcludeToolsMiddleware,
     SanitizeThinkingBlocksMiddleware,
@@ -123,6 +123,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
         configurable["chat_github_token"] = token
 
     model_id, effort = await _resolve_chat_model(configurable)
+    use_gateway = await get_effective_gateway_enabled()
     model_kwargs = provider_model_kwargs(
         model_id,
         effort,
@@ -137,7 +138,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
     )
 
     return create_deep_agent(
-        model=make_model(model_id, **model_kwargs),
+        model=make_model(model_id, use_gateway=use_gateway, **model_kwargs),
         system_prompt=system_prompt,
         tools=[
             read_repo_file,

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 from langgraph_sdk import get_client
 from pydantic import BaseModel, field_validator, model_validator
 
+from ..utils.gateway import resolve_gateway_enabled
 from .options import (
     SUPPORTED_MODEL_IDS,
     default_model_pair,
@@ -37,6 +38,9 @@ class TeamSettingsUpdate(BaseModel):
     review_draft_prs: bool = False
     pr_summaries: bool = True
     review_trace_links: bool = True
+    # Tri-state LLM Gateway toggle: True/False is authoritative, None inherits the
+    # LANGSMITH_GATEWAY_ENABLED deployment default.
+    gateway_enabled: bool | None = None
     review_tracing_project: str | None = None
     org_guidelines: str | None = None
     default_agent_model: str | None = None
@@ -151,6 +155,7 @@ def _default_settings() -> dict[str, Any]:
         "review_draft_prs": False,
         "pr_summaries": True,
         "review_trace_links": True,
+        "gateway_enabled": None,
         "review_tracing_project": None,
         "org_guidelines": None,
         "default_agent_model": fallback_model,
@@ -205,6 +210,7 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "review_draft_prs": update.review_draft_prs,
         "pr_summaries": update.pr_summaries,
         "review_trace_links": update.review_trace_links,
+        "gateway_enabled": update.gateway_enabled,
         "review_tracing_project": update.review_tracing_project,
         "org_guidelines": update.org_guidelines,
         "default_agent_model": update.default_agent_model,
@@ -323,6 +329,18 @@ async def get_team_review_trace_links_enabled() -> bool:
     """Return whether GitHub review bodies should include a LangSmith trace link."""
     settings = await get_team_settings()
     return bool(settings.get("review_trace_links", True))
+
+
+async def get_team_gateway_enabled() -> bool | None:
+    """Return the stored LLM Gateway toggle (``None`` means inherit the env default)."""
+    settings = await get_team_settings()
+    value = settings.get("gateway_enabled")
+    return value if isinstance(value, bool) else None
+
+
+async def get_effective_gateway_enabled() -> bool:
+    """Resolve whether LLM Gateway routing is on: team setting, else env default."""
+    return resolve_gateway_enabled(await get_team_gateway_enabled())
 
 
 async def get_team_review_tracing_project() -> str | None:

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -34,6 +34,7 @@ from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from .dashboard.team_settings import (
+    get_effective_gateway_enabled,
     get_org_review_guidelines,
     get_team_default_grouping_model,
     get_team_default_model_pair,
@@ -800,7 +801,9 @@ def _on_background_task_done(task: asyncio.Task[None]) -> None:
         logger.warning("Background reviewer task failed: %s", exc)
 
 
-async def _resolve_grouping_model(configurable: dict[str, object]) -> BaseChatModel:
+async def _resolve_grouping_model(
+    configurable: dict[str, object], *, use_gateway: bool
+) -> BaseChatModel:
     """Resolve the model for the diff-grouping pass.
 
     Per-run override (``grouping_model_id``/``grouping_reasoning_effort``) wins;
@@ -820,7 +823,7 @@ async def _resolve_grouping_model(configurable: dict[str, object]) -> BaseChatMo
         max_tokens=DEFAULT_LLM_MAX_TOKENS,
         openai_reasoning_default=DEFAULT_LLM_REASONING,
     )
-    return make_model(model_id, **model_kwargs)
+    return make_model(model_id, use_gateway=use_gateway, **model_kwargs)
 
 
 async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
@@ -1147,8 +1150,11 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     if review_context:
         system_prompt = f"{system_prompt}\n\n{review_context}"
 
-    reviewer_model = make_model(model_id, **model_kwargs)
-    reviewer_subagent_model = make_model(subagent_model_id, **subagent_model_kwargs)
+    use_gateway = await get_effective_gateway_enabled()
+    reviewer_model = make_model(model_id, use_gateway=use_gateway, **model_kwargs)
+    reviewer_subagent_model = make_model(
+        subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs
+    )
 
     # Kick off the AI-sorted diff grouping pass at run start, concurrently with
     # the review, so it adds ~0 latency. First-review and re-review only — a
@@ -1156,7 +1162,9 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     # its own errors and the UI falls back to the folder view when groups are
     # absent.
     if reviewer_event != "finding_reply" and pr_diff_text and thread_id:
-        grouping_model = await _resolve_grouping_model(config["configurable"])
+        grouping_model = await _resolve_grouping_model(
+            config["configurable"], use_gateway=use_gateway
+        )
         grouping_task = asyncio.create_task(
             maybe_generate_and_store_diff_groups(
                 thread_id=thread_id,

--- a/agent/server.py
+++ b/agent/server.py
@@ -43,6 +43,7 @@ from .dashboard.agent_usage import record_agent_thread_usage
 from .dashboard.options import DEFAULT_MODEL_ID, SUPPORTED_MODEL_IDS, model_supports_effort
 from .dashboard.repo_snapshots import resolve_repo_snapshot_id
 from .dashboard.team_settings import (
+    get_effective_gateway_enabled,
     get_team_default_model_pair,
     get_team_default_repo,
 )
@@ -707,11 +708,13 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         ensure_sandbox_for_thread(thread_id, repo=prompt_default_repo)
     )
     team_defaults_task = asyncio.create_task(get_team_default_model_pair("agent"))
+    gateway_task = asyncio.create_task(get_effective_gateway_enabled())
     profile_task = asyncio.create_task(load_profile(profile_login)) if profile_login else None
-    triggering_user_identity, sandbox_backend, team_defaults = await asyncio.gather(
+    triggering_user_identity, sandbox_backend, team_defaults, use_gateway = await asyncio.gather(
         triggering_user_identity_task,
         sandbox_task,
         team_defaults_task,
+        gateway_task,
     )
     profile = await profile_task if profile_task is not None else None
     del github_token
@@ -799,7 +802,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         if fallback_model_id.startswith("openai:"):
             fallback_kwargs["reasoning"] = DEFAULT_LLM_REASONING
         fallback_middleware.append(
-            ModelFallbackMiddleware(make_model(fallback_model_id, **fallback_kwargs))
+            ModelFallbackMiddleware(
+                make_model(fallback_model_id, use_gateway=use_gateway, **fallback_kwargs)
+            )
         )
         logger.info("Configured model fallback %s -> %s", model_id, fallback_model_id)
 
@@ -866,8 +871,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             notion_tools = []
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)
-    main_model = make_model(model_id, **model_kwargs)
-    subagent_model = make_model(subagent_model_id, **subagent_model_kwargs)
+    main_model = make_model(model_id, use_gateway=use_gateway, **model_kwargs)
+    subagent_model = make_model(subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs)
     return create_deep_agent(
         model=main_model,
         system_prompt=construct_system_prompt(

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -18,16 +18,18 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_GATEWAY_BASE_URL = "https://gateway.smith.langchain.com"
 
-# Provider prefix -> base-URL suffix appended to the gateway host. Only providers
-# whose LangChain integration accepts ``base_url`` + ``api_key`` through
-# ``init_chat_model`` are routed. The suffix matches each SDK's own path handling:
-# the OpenAI/Fireworks SDKs append ``/chat/completions`` to a ``/v1`` base, while
-# the Anthropic SDK appends ``/v1/messages`` to a bare host. google_genai/vertex
-# are intentionally absent (langchain-google-genai has no clean base_url override).
+# Provider prefix -> base-URL suffix appended to the gateway host. Each suffix
+# matches the SDK's own path handling: the OpenAI/Fireworks SDKs append
+# ``/chat/completions`` to a ``/v1`` base, the Anthropic SDK appends
+# ``/v1/messages`` to a bare host, and the google-genai SDK appends
+# ``/<api_version>/models/...`` to a bare host. Vertex (``google_vertexai``, which
+# uses service-account auth rather than a bearer key) and any other provider are
+# not routed and call the provider directly.
 _GATEWAY_PROVIDER_PATHS: dict[str, str] = {
     "openai": "/openai/v1",
     "anthropic": "/anthropic",
     "fireworks": "/fireworks/v1",
+    "google_genai": "/gemini",
 }
 
 

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -1,0 +1,115 @@
+"""LangSmith LLM Gateway routing for model construction.
+
+The LLM Gateway (https://docs.langchain.com/langsmith/llm-gateway) proxies
+provider calls through LangSmith: the client authenticates with a LangSmith API
+key and the gateway resolves the real provider key from workspace Provider
+Secrets, enforcing spend/PII/secrets policies and tracing every call. Routing is
+opt-in via ``LANGSMITH_GATEWAY_ENABLED`` (deployment default) or the
+``gateway_enabled`` team setting, and is applied centrally in
+:func:`agent.utils.model.make_model`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GATEWAY_BASE_URL = "https://gateway.smith.langchain.com"
+
+# Provider prefix -> base-URL suffix appended to the gateway host. Only providers
+# whose LangChain integration accepts ``base_url`` + ``api_key`` through
+# ``init_chat_model`` are routed. The suffix matches each SDK's own path handling:
+# the OpenAI/Fireworks SDKs append ``/chat/completions`` to a ``/v1`` base, while
+# the Anthropic SDK appends ``/v1/messages`` to a bare host. google_genai/vertex
+# are intentionally absent (langchain-google-genai has no clean base_url override).
+_GATEWAY_PROVIDER_PATHS: dict[str, str] = {
+    "openai": "/openai/v1",
+    "anthropic": "/anthropic",
+    "fireworks": "/fireworks/v1",
+}
+
+
+def _env_bool(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _langsmith_api_key() -> str | None:
+    """LangSmith API key used to authenticate gateway calls.
+
+    Mirrors ``agent.integrations.langsmith._get_langsmith_api_key``:
+    ``LANGSMITH_API_KEY`` first, then ``LANGSMITH_API_KEY_PROD`` for LangGraph
+    Cloud deployments where ``LANGSMITH_API_KEY`` is reserved.
+    """
+    return os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGSMITH_API_KEY_PROD")
+
+
+def gateway_base_url() -> str:
+    """Gateway host, overridable via ``LANGSMITH_GATEWAY_BASE_URL`` (regional/self-hosted)."""
+    return (os.environ.get("LANGSMITH_GATEWAY_BASE_URL") or DEFAULT_GATEWAY_BASE_URL).rstrip("/")
+
+
+def gateway_env_default() -> bool:
+    """Deployment-level default for gateway routing (``LANGSMITH_GATEWAY_ENABLED``)."""
+    return _env_bool(os.environ.get("LANGSMITH_GATEWAY_ENABLED"))
+
+
+def gateway_openai_use_responses() -> bool:
+    """Whether gateway-routed OpenAI keeps the Responses API.
+
+    Defaults to ``False``: the gateway's documented OpenAI surface is Chat
+    Completions, and an HTTPS proxy can't carry open-swe's default ``wss://``
+    Responses stream. Set ``LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=true`` only if
+    the gateway proxies ``/v1/responses``.
+    """
+    return _env_bool(os.environ.get("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES"))
+
+
+def resolve_gateway_enabled(team_value: bool | None) -> bool:
+    """Combine the team-settings toggle with the env default.
+
+    A team value of ``True``/``False`` is authoritative; ``None`` inherits the
+    ``LANGSMITH_GATEWAY_ENABLED`` deployment default.
+    """
+    if team_value is None:
+        return gateway_env_default()
+    return team_value
+
+
+def _provider_of(model_id: str) -> str:
+    return model_id.split(":", 1)[0]
+
+
+def gateway_overrides(model_id: str) -> dict[str, object] | None:
+    """``init_chat_model`` kwargs that route ``model_id`` through the gateway.
+
+    Returns ``None`` (so the caller keeps talking to the provider directly) when
+    the provider isn't routable through the gateway or no LangSmith API key is
+    available — both cases are logged rather than raised, so a run never fails
+    just because gateway routing couldn't be applied.
+    """
+    provider = _provider_of(model_id)
+    path = _GATEWAY_PROVIDER_PATHS.get(provider)
+    if path is None:
+        logger.warning(
+            "LangSmith gateway enabled but provider %r is not routed; calling it directly",
+            provider,
+        )
+        return None
+    api_key = _langsmith_api_key()
+    if not api_key:
+        logger.warning(
+            "LangSmith gateway enabled but no LANGSMITH_API_KEY(_PROD) is set; "
+            "calling the provider directly"
+        )
+        return None
+    overrides: dict[str, object] = {
+        "base_url": f"{gateway_base_url()}{path}",
+        "api_key": api_key,
+    }
+    if provider == "openai":
+        # An HTTPS proxy can't carry the wss:// Responses stream make_model sets by
+        # default; route Chat Completions unless the deployment opts back in.
+        overrides["use_responses_api"] = gateway_openai_use_responses()
+    return overrides

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -58,7 +58,7 @@ def _coerce_openai_chat_completions_kwargs(model_kwargs: dict[str, object]) -> N
     reasoning = model_kwargs.pop("reasoning", None)
     if isinstance(reasoning, dict):
         effort = reasoning.get("effort")
-        if isinstance(effort, str) and effort != "none":
+        if isinstance(effort, str):
             model_kwargs.setdefault("reasoning_effort", effort)
 
 

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -40,6 +40,7 @@ class AnthropicThinking(TypedDict, total=False):
 class ModelKwargs(TypedDict, total=False):
     max_tokens: int | None
     reasoning: OpenAIReasoning | None
+    reasoning_effort: OpenAIReasoningEffort | None
     thinking: AnthropicThinking | None
     effort: AnthropicEffort | None
     thinking_level: GoogleThinkingLevel | None
@@ -49,6 +50,16 @@ class ModelKwargs(TypedDict, total=False):
 
 
 _ANTHROPIC_EFFORTS: set[AnthropicEffort] = {"low", "medium", "high", "xhigh", "max"}
+
+
+def _coerce_openai_chat_completions_kwargs(model_kwargs: dict[str, object]) -> None:
+    if model_kwargs.get("use_responses_api") is not False:
+        return
+    reasoning = model_kwargs.pop("reasoning", None)
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        if isinstance(effort, str) and effort != "none":
+            model_kwargs.setdefault("reasoning_effort", effort)
 
 
 def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpack[ModelKwargs]):
@@ -73,6 +84,9 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
         overrides = gateway_overrides(model_id)
         if overrides is not None:
             model_kwargs.update(overrides)
+
+    if model_id.startswith("openai:"):
+        _coerce_openai_chat_completions_kwargs(model_kwargs)
 
     return init_chat_model(model=model_id, **model_kwargs)
 

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -4,6 +4,7 @@ from typing import Literal, TypedDict, Unpack
 from langchain.chat_models import init_chat_model
 
 from ..dashboard.options import DEFAULT_MODEL_ID
+from .gateway import gateway_env_default, gateway_overrides
 
 OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 
@@ -50,13 +51,28 @@ class ModelKwargs(TypedDict, total=False):
 _ANTHROPIC_EFFORTS: set[AnthropicEffort] = {"low", "medium", "high", "xhigh", "max"}
 
 
-def make_model(model_id: str, **kwargs: Unpack[ModelKwargs]):
+def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpack[ModelKwargs]):
+    """Build a chat model, optionally routed through the LangSmith LLM Gateway.
+
+    ``use_gateway`` resolves the deployment default (``LANGSMITH_GATEWAY_ENABLED``)
+    when ``None``; async callers pass the team-settings-resolved value. When on,
+    gateway ``base_url``/``api_key``/``use_responses_api`` override the direct
+    provider defaults below (see :mod:`agent.utils.gateway`).
+    """
     model_kwargs: dict[str, object] = kwargs.copy()
     model_kwargs.setdefault("max_retries", DEFAULT_MAX_RETRIES)
 
     if model_id.startswith("openai:"):
+        # Direct-provider default: Responses API over the OpenAI websocket base.
+        # Gateway routing overrides this below (an HTTP(S) proxy can't carry wss).
         model_kwargs["base_url"] = OPENAI_RESPONSES_WS_BASE_URL
         model_kwargs["use_responses_api"] = True
+
+    enabled = gateway_env_default() if use_gateway is None else use_gateway
+    if enabled:
+        overrides = gateway_overrides(model_id)
+        if overrides is not None:
+            model_kwargs.update(overrides)
 
     return init_chat_model(model=model_id, **model_kwargs)
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -66,9 +66,19 @@ def test_fireworks_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     assert overrides["base_url"] == "https://gateway.smith.langchain.com/fireworks/v1"
 
 
+def test_google_genai_routes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    overrides = gateway.gateway_overrides("google_genai:gemini-3.5-flash")
+    assert overrides == {
+        "base_url": "https://gateway.smith.langchain.com/gemini",
+        "api_key": "ls-key",
+    }
+
+
 def test_unsupported_provider_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    assert gateway.gateway_overrides("google_genai:gemini-3.5-flash") is None
+    # Vertex authenticates with a service account, not a bearer key, so it isn't routed.
+    assert gateway.gateway_overrides("google_vertexai:gemini-2.5-pro") is None
 
 
 def test_missing_api_key_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -159,6 +159,36 @@ def test_make_model_gateway_openai_replaces_websocket(
     assert captured["api_key"] == "ls-key"
 
 
+def test_make_model_gateway_openai_converts_reasoning_for_chat_completions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model(
+            "openai:gpt-5.5",
+            use_gateway=True,
+            reasoning={"effort": "high", "summary": "auto"},
+        )
+    assert captured["use_responses_api"] is False
+    assert captured["reasoning_effort"] == "high"
+    assert "reasoning" not in captured
+
+
+def test_make_model_gateway_openai_responses_optin_keeps_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "true")
+    reasoning = {"effort": "high", "summary": "auto"}
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model("openai:gpt-5.5", use_gateway=True, reasoning=reasoning)
+    assert captured["use_responses_api"] is True
+    assert captured["reasoning"] == reasoning
+    assert "reasoning_effort" not in captured
+
+
 def test_make_model_gateway_follows_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
@@ -166,6 +196,15 @@ def test_make_model_gateway_follows_env_default(monkeypatch: pytest.MonkeyPatch)
     with patch.object(model, "init_chat_model", fake):
         model.make_model("anthropic:claude-opus-4-8")  # use_gateway=None -> env default
     assert captured["base_url"] == "https://gateway.smith.langchain.com/anthropic"
+    assert captured["api_key"] == "ls-key"
+
+
+def test_make_model_gateway_google_genai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model("google_genai:gemini-3.5-flash", use_gateway=True)
+    assert captured["base_url"] == "https://gateway.smith.langchain.com/gemini"
     assert captured["api_key"] == "ls-key"
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,171 @@
+"""Unit tests for LangSmith LLM Gateway routing (agent/utils/gateway.py + make_model)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent.utils import gateway, model
+
+_GATEWAY_ENV_VARS = (
+    "LANGSMITH_API_KEY",
+    "LANGSMITH_API_KEY_PROD",
+    "LANGSMITH_GATEWAY_ENABLED",
+    "LANGSMITH_GATEWAY_BASE_URL",
+    "LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_gateway_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from a known env: no key, gateway off, default base URL."""
+    for name in _GATEWAY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+# --- gateway_overrides --------------------------------------------------------
+
+
+def test_openai_overrides_use_chat_completions_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    overrides = gateway.gateway_overrides("openai:gpt-5.5")
+    assert overrides == {
+        "base_url": "https://gateway.smith.langchain.com/openai/v1",
+        "api_key": "ls-key",
+        "use_responses_api": False,
+    }
+
+
+def test_openai_overrides_responses_optin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "true")
+    overrides = gateway.gateway_overrides("openai:gpt-5.5")
+    assert overrides is not None
+    assert overrides["use_responses_api"] is True
+
+
+def test_anthropic_overrides_have_no_responses_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    assert overrides == {
+        "base_url": "https://gateway.smith.langchain.com/anthropic",
+        "api_key": "ls-key",
+    }
+
+
+def test_fireworks_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    overrides = gateway.gateway_overrides("fireworks:accounts/fireworks/models/glm-5p2")
+    assert overrides is not None
+    assert overrides["base_url"] == "https://gateway.smith.langchain.com/fireworks/v1"
+
+
+def test_unsupported_provider_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    assert gateway.gateway_overrides("google_genai:gemini-3.5-flash") is None
+
+
+def test_missing_api_key_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert gateway.gateway_overrides("openai:gpt-5.5") is None
+
+
+def test_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    assert overrides is not None
+    assert overrides["api_key"] == "ls-prod-key"
+
+
+def test_base_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_BASE_URL", "https://gw.internal.example.com/")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    assert overrides is not None
+    # Trailing slash is stripped, then the provider path is appended.
+    assert overrides["base_url"] == "https://gw.internal.example.com/anthropic"
+
+
+# --- resolve_gateway_enabled --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("team_value", "env_enabled", "expected"),
+    [
+        (True, False, True),  # team True wins over env off
+        (False, True, False),  # team False wins over env on
+        (None, True, True),  # unset inherits env on
+        (None, False, False),  # unset inherits env off
+    ],
+)
+def test_resolve_gateway_enabled_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    team_value: bool | None,
+    env_enabled: bool,
+    expected: bool,
+) -> None:
+    if env_enabled:
+        monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
+    assert gateway.resolve_gateway_enabled(team_value) is expected
+
+
+# --- make_model integration ---------------------------------------------------
+
+
+def _capture_init_chat_model() -> tuple[dict[str, Any], Any]:
+    """Patch init_chat_model to record the kwargs make_model builds."""
+    captured: dict[str, Any] = {}
+
+    def _fake(model: str, **kwargs: Any) -> str:
+        captured["model"] = model
+        captured.update(kwargs)
+        return "MODEL"
+
+    return captured, _fake
+
+
+def test_make_model_direct_openai_uses_responses_websocket() -> None:
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model("openai:gpt-5.5", use_gateway=False)
+    assert captured["base_url"] == model.OPENAI_RESPONSES_WS_BASE_URL
+    assert captured["use_responses_api"] is True
+
+
+def test_make_model_gateway_openai_replaces_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model("openai:gpt-5.5", use_gateway=True)
+    assert captured["base_url"] == "https://gateway.smith.langchain.com/openai/v1"
+    assert captured["use_responses_api"] is False
+    assert captured["api_key"] == "ls-key"
+
+
+def test_make_model_gateway_follows_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model("anthropic:claude-opus-4-8")  # use_gateway=None -> env default
+    assert captured["base_url"] == "https://gateway.smith.langchain.com/anthropic"
+    assert captured["api_key"] == "ls-key"
+
+
+def test_make_model_gateway_without_key_falls_back_direct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model("openai:gpt-5.5", use_gateway=True)  # no LangSmith key
+    # No key -> overrides skipped -> the direct-provider websocket base stands.
+    assert captured["base_url"] == model.OPENAI_RESPONSES_WS_BASE_URL
+    assert captured["use_responses_api"] is True
+    assert "api_key" not in captured

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -175,6 +175,22 @@ def test_make_model_gateway_openai_converts_reasoning_for_chat_completions(
     assert "reasoning" not in captured
 
 
+def test_make_model_gateway_openai_preserves_reasoning_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    captured, fake = _capture_init_chat_model()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model(
+            "openai:gpt-5.5",
+            use_gateway=True,
+            reasoning={"effort": "none"},
+        )
+    assert captured["use_responses_api"] is False
+    assert captured["reasoning_effort"] == "none"
+    assert "reasoning" not in captured
+
+
 def test_make_model_gateway_openai_responses_optin_keeps_reasoning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -164,6 +164,8 @@ export interface TeamSettings {
   review_draft_prs: boolean
   pr_summaries: boolean
   review_trace_links: boolean
+  /** Tri-state LLM Gateway toggle; null inherits the LANGSMITH_GATEWAY_ENABLED default. */
+  gateway_enabled?: boolean | null
   review_tracing_project?: string | null
   org_guidelines?: string | null
   default_agent_model?: string | null

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
 import { api } from "@/lib/api"
 import { useSession } from "@/lib/session"
 
@@ -53,6 +54,8 @@ function AdminPage() {
       description="Workspace-wide defaults and user mappings."
     >
       <GlobalDefaultsSection models={options.data?.models ?? []} />
+
+      <LLMGatewaySection />
 
       <TriggerReviewSection />
 
@@ -563,6 +566,51 @@ function PRTraceResolutionSection() {
                 Save
               </Button>
             </div>
+          }
+        />
+      </div>
+      {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
+    </SettingsSection>
+  )
+}
+
+function LLMGatewaySection() {
+  const qc = useQueryClient()
+  const settings = useQuery({
+    queryKey: ["teamSettings"],
+    queryFn: api.getTeamSettings,
+  })
+  const [error, setError] = useState<string | null>(null)
+
+  const save = useMutation({
+    mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
+    onSuccess: (saved) => {
+      qc.setQueryData(["teamSettings"], saved)
+      setError(null)
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  const enabled = settings.data?.gateway_enabled ?? false
+
+  return (
+    <SettingsSection
+      title="LLM Gateway"
+      description="Route agent and reviewer LLM calls through the LangSmith LLM Gateway. It authenticates with the workspace LangSmith API key and resolves provider keys from Provider Secrets, so no provider keys are needed at runtime. Requires the gateway (private beta) enabled for your organization."
+    >
+      <div className="divide-y divide-border">
+        <SettingsRow
+          label="Route through the gateway"
+          description="Overrides the LANGSMITH_GATEWAY_ENABLED deployment default. OpenAI, Anthropic, and Fireworks are routed; other providers call the provider directly."
+          control={
+            <Switch
+              checked={enabled}
+              onCheckedChange={(checked) =>
+                settings.data &&
+                save.mutate({ ...settings.data, gateway_enabled: checked })
+              }
+              disabled={!settings.data || save.isPending}
+            />
           }
         />
       </div>

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -22,7 +22,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Switch } from "@/components/ui/switch"
 import { api } from "@/lib/api"
 import { useSession } from "@/lib/session"
 
@@ -574,6 +573,20 @@ function PRTraceResolutionSection() {
   )
 }
 
+type GatewayMode = "inherit" | "enabled" | "disabled"
+
+function gatewayMode(value: boolean | null | undefined): GatewayMode {
+  if (value === true) return "enabled"
+  if (value === false) return "disabled"
+  return "inherit"
+}
+
+function gatewayModeValue(mode: GatewayMode): boolean | null {
+  if (mode === "enabled") return true
+  if (mode === "disabled") return false
+  return null
+}
+
 function LLMGatewaySection() {
   const qc = useQueryClient()
   const settings = useQuery({
@@ -591,7 +604,7 @@ function LLMGatewaySection() {
     onError: (e: Error) => setError(e.message),
   })
 
-  const enabled = settings.data?.gateway_enabled ?? false
+  const mode = gatewayMode(settings.data?.gateway_enabled)
 
   return (
     <SettingsSection
@@ -601,16 +614,28 @@ function LLMGatewaySection() {
       <div className="divide-y divide-border">
         <SettingsRow
           label="Route through the gateway"
-          description="Overrides the LANGSMITH_GATEWAY_ENABLED deployment default. OpenAI, Anthropic, Fireworks, and Google Gemini are routed; other providers call the provider directly."
+          description="Inherit uses the LANGSMITH_GATEWAY_ENABLED deployment default. OpenAI, Anthropic, Fireworks, and Google Gemini are routed; other providers call the provider directly."
           control={
-            <Switch
-              checked={enabled}
-              onCheckedChange={(checked) =>
+            <Select
+              value={mode}
+              onValueChange={(next) =>
                 settings.data &&
-                save.mutate({ ...settings.data, gateway_enabled: checked })
+                save.mutate({
+                  ...settings.data,
+                  gateway_enabled: gatewayModeValue(next as GatewayMode),
+                })
               }
               disabled={!settings.data || save.isPending}
-            />
+            >
+              <SelectTrigger className="w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="inherit">Inherit deployment default</SelectItem>
+                <SelectItem value="enabled">Enabled</SelectItem>
+                <SelectItem value="disabled">Disabled</SelectItem>
+              </SelectContent>
+            </Select>
           }
         />
       </div>

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -601,7 +601,7 @@ function LLMGatewaySection() {
       <div className="divide-y divide-border">
         <SettingsRow
           label="Route through the gateway"
-          description="Overrides the LANGSMITH_GATEWAY_ENABLED deployment default. OpenAI, Anthropic, and Fireworks are routed; other providers call the provider directly."
+          description="Overrides the LANGSMITH_GATEWAY_ENABLED deployment default. OpenAI, Anthropic, Fireworks, and Google Gemini are routed; other providers call the provider directly."
           control={
             <Switch
               checked={enabled}


### PR DESCRIPTION
Adds opt-in routing of agent/reviewer/chat/analyzer LLM calls through the [LangSmith LLM Gateway](https://docs.langchain.com/langsmith/llm-gateway). The client authenticates with the LangSmith API key (reuses `LANGSMITH_API_KEY`/`_PROD`) and provider keys stay in LangSmith Provider Secrets. Off by default.

Enable via `LANGSMITH_GATEWAY_ENABLED` (deployment default) or the admin panel **LLM Gateway** toggle, which overrides the env default per workspace when set.

## What changed
- `agent/utils/gateway.py` (new): gateway base URL / key / enablement helpers + per-provider routing.
- `make_model` gains `use_gateway`; gateway `base_url`/`api_key`/`use_responses_api` override the direct-provider defaults, threaded through server/reviewer/chat/analyzer.
- `gateway_enabled` tri-state team setting + admin toggle (`team_settings.py`, `api.ts`, `admin.tsx`).
- Routes OpenAI/Anthropic/Fireworks; Gemini/Vertex pass through with a warning.

## Caveat
Gateway-routed OpenAI uses Chat Completions (the documented gateway surface), dropping the Responses-API reasoning summaries, unless `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=true` (an HTTPS proxy can't carry the `wss://` Responses stream). Docs in CUSTOMIZATION.md.
