### PR TITLE
fix: Support dedicated LangSmith Gateway API key

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -195,13 +195,14 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
 ### Routing through the LangSmith LLM Gateway
 
-Model calls can be proxied through the [LangSmith LLM Gateway](https://docs.langchain.com/langsmith/llm-gateway) (private beta) instead of hitting providers directly. The gateway authenticates with your **LangSmith API key** (reusing the existing `LANGSMITH_API_KEY` / `LANGSMITH_API_KEY_PROD`) and resolves the real provider key from workspace Provider Secrets, so no provider API keys are needed at runtime — and it adds central spend limits, PII/secrets redaction, and tracing. Your org must have the gateway enabled with Provider Secrets configured.
+Model calls can be proxied through the [LangSmith LLM Gateway](https://docs.langchain.com/langsmith/llm-gateway) (private beta) instead of hitting providers directly. The gateway authenticates with a **LangSmith API key** that has the `gateway:invoke` permission and resolves the real provider key from workspace Provider Secrets, so no provider API keys are needed at runtime — and it adds central spend limits, PII/secrets redaction, and tracing. Your org must have the gateway enabled with Provider Secrets configured.
 
 Routing is opt-in and off by default. Enable it either way:
 
 | Env var | Default | Purpose |
 |---|---|---|
 | `LANGSMITH_GATEWAY_ENABLED` | `false` | Deployment-level default for gateway routing. |
+| `LANGSMITH_GATEWAY_API_KEY` | unset | Optional dedicated LangSmith key for Gateway calls. Prefer this in LangGraph Cloud if the platform-provided `LANGSMITH_API_KEY` lacks `gateway:invoke`. Falls back to `LANGSMITH_API_KEY_PROD`, then `LANGSMITH_API_KEY`. |
 | `LANGSMITH_GATEWAY_BASE_URL` | `https://gateway.smith.langchain.com` | Override for a regional or self-hosted gateway host. |
 | `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `false` | Keep the OpenAI Responses API through the gateway (see caveat). Only set if your gateway proxies `/v1/responses`. |
 

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -40,11 +40,15 @@ def _env_bool(value: str | None) -> bool:
 def _langsmith_api_key() -> str | None:
     """LangSmith API key used to authenticate gateway calls.
 
-    Mirrors ``agent.integrations.langsmith._get_langsmith_api_key``:
-    ``LANGSMITH_API_KEY`` first, then ``LANGSMITH_API_KEY_PROD`` for LangGraph
-    Cloud deployments where ``LANGSMITH_API_KEY`` is reserved.
+    Prefer a gateway-specific key, then the prod LangSmith key. LangGraph Cloud
+    may inject ``LANGSMITH_API_KEY`` for tracing/platform APIs, and that key can
+    lack the ``gateway:invoke`` permission required by the LLM Gateway.
     """
-    return os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGSMITH_API_KEY_PROD")
+    return (
+        os.environ.get("LANGSMITH_GATEWAY_API_KEY")
+        or os.environ.get("LANGSMITH_API_KEY_PROD")
+        or os.environ.get("LANGSMITH_API_KEY")
+    )
 
 
 def gateway_base_url() -> str:
@@ -102,7 +106,8 @@ def gateway_overrides(model_id: str) -> dict[str, object] | None:
     api_key = _langsmith_api_key()
     if not api_key:
         logger.warning(
-            "LangSmith gateway enabled but no LANGSMITH_API_KEY(_PROD) is set; "
+            "LangSmith gateway enabled but no LANGSMITH_GATEWAY_API_KEY or "
+            "LANGSMITH_API_KEY(_PROD) is set; "
             "calling the provider directly"
         )
         return None

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -12,6 +12,7 @@ from agent.utils import gateway, model
 _GATEWAY_ENV_VARS = (
     "LANGSMITH_API_KEY",
     "LANGSMITH_API_KEY_PROD",
+    "LANGSMITH_GATEWAY_API_KEY",
     "LANGSMITH_GATEWAY_ENABLED",
     "LANGSMITH_GATEWAY_BASE_URL",
     "LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES",
@@ -90,6 +91,23 @@ def test_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
     assert overrides is not None
     assert overrides["api_key"] == "ls-prod-key"
+
+
+def test_prod_key_preferred_over_platform_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-platform-key")
+    monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    assert overrides is not None
+    assert overrides["api_key"] == "ls-prod-key"
+
+
+def test_gateway_key_preferred_over_prod_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-platform-key")
+    monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "ls-gateway-key")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    assert overrides is not None
+    assert overrides["api_key"] == "ls-gateway-key"
 
 
 def test_base_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- prefer LANGSMITH_GATEWAY_API_KEY for LLM Gateway calls
- fall back to LANGSMITH_API_KEY_PROD, then LANGSMITH_API_KEY
- document the dedicated gateway key env var and cover precedence in tests

## Testing
- uv run pytest -vvv tests/test_gateway.py
- uv run ruff check agent/utils/gateway.py tests/test_gateway.py