### PR TITLE
Fix Fireworks Gateway base URL

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -204,13 +204,13 @@ Routing is opt-in and off by default. Enable it either way:
 | `LANGSMITH_GATEWAY_ENABLED` | `false` | Deployment-level default for gateway routing. |
 | `LANGSMITH_GATEWAY_API_KEY` | unset | Optional dedicated LangSmith key for Gateway calls. Prefer this in LangGraph Cloud if the platform-provided `LANGSMITH_API_KEY` lacks `gateway:invoke`. Falls back to `LANGSMITH_API_KEY_PROD`, then `LANGSMITH_API_KEY`. |
 | `LANGSMITH_GATEWAY_BASE_URL` | `https://gateway.smith.langchain.com` | Override for a regional or self-hosted gateway host. |
-| `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `false` | Keep the OpenAI Responses API through the gateway (see caveat). Only set if your gateway proxies `/v1/responses`. |
+| `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `true` | Use the OpenAI Responses API through the gateway. Set to `false` only to force Chat Completions for OpenAI models. |
 
 The admin panel (**Admin → LLM Gateway**) exposes a per-workspace toggle stored in team settings; when set it overrides the `LANGSMITH_GATEWAY_ENABLED` env default (a `None`/unset team value inherits the env default).
 
 Routing is applied centrally in `make_model` (`agent/utils/model.py`), which resolves the effective on/off and delegates URL/key wiring to `agent/utils/gateway.py`. **OpenAI, Anthropic, Fireworks, and Google Gemini** are routed (their LangChain integrations accept `base_url` + `api_key`); Google Vertex (service-account auth) and any other provider call the provider directly with a logged warning.
 
-**Caveat — OpenAI endpoint:** open-swe uses the OpenAI Responses API over a `wss://` base URL by default, which an HTTPS proxy can't carry. When the gateway is on, gateway-routed OpenAI falls back to **Chat Completions** (dropping the Responses API's visible reasoning summaries) unless `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=true`. Anthropic and Fireworks are unaffected.
+**Caveat — OpenAI endpoint:** open-swe uses the OpenAI Responses API by default because OpenAI reasoning models with function tools reject `reasoning_effort` on Chat Completions. Direct OpenAI calls use a `wss://` base URL; gateway-routed OpenAI uses the HTTPS gateway base URL with Responses enabled. Set `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=false` only if you need to force Chat Completions. Anthropic and Fireworks are unaffected.
 
 ---
 

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -32,6 +32,7 @@ from .dashboard.options import SUPPORTED_MODEL_IDS, model_supports_effort
 from .dashboard.team_settings import get_effective_gateway_enabled, get_team_default_model
 from .middleware import (
     ExcludeToolsMiddleware,
+    SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     ToolErrorMiddleware,
@@ -152,6 +153,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
             ModelCallLimitMiddleware(run_limit=CHAT_MODEL_CALL_LIMIT, exit_behavior="end"),
             ToolErrorMiddleware(),
             ExcludeToolsMiddleware(excluded=_EXCLUDED_TOOLS),
+            SanitizeFireworksMessagesMiddleware(),
             SanitizeThinkingBlocksMiddleware(),
         ],
     ).with_config(config)

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -8,6 +8,7 @@ from .refresh_github_proxy import refresh_github_proxy_before_model
 from .refresh_slack_status import SlackAssistantStatusMiddleware
 from .repair_orphaned_tool_calls import RepairOrphanedToolCallsMiddleware
 from .sandbox_circuit_breaker import SandboxCircuitBreakerMiddleware
+from .sanitize_fireworks_messages import SanitizeFireworksMessagesMiddleware
 from .sanitize_thinking_blocks import SanitizeThinkingBlocksMiddleware
 from .sanitize_tool_inputs import SanitizeToolInputsMiddleware
 from .settle_review_check import settle_review_check_on_exit
@@ -20,6 +21,7 @@ __all__ = [
     "ModelFallbackMiddleware",
     "PlanModeMiddleware",
     "RepairOrphanedToolCallsMiddleware",
+    "SanitizeFireworksMessagesMiddleware",
     "SanitizeThinkingBlocksMiddleware",
     "SanitizeToolInputsMiddleware",
     "ToolArtifactMiddleware",

--- a/agent/middleware/sanitize_fireworks_messages.py
+++ b/agent/middleware/sanitize_fireworks_messages.py
@@ -1,0 +1,82 @@
+"""Strip legacy ``function_call`` fields before Fireworks provider calls.
+
+The LangSmith LLM Gateway enforces strict request-schema validation and rejects
+messages carrying the legacy OpenAI ``function_call`` field
+(``Extra inputs are not permitted, field: 'messages[N].function_call'``).
+``langchain_fireworks`` forwards ``function_call`` from
+``AIMessage.additional_kwargs`` whenever it is present — even when the message
+also carries modern ``tool_calls`` — so a message that was originally produced
+by (or deserialized from) a provider that populated the legacy field will break
+every subsequent Fireworks turn once routed through the gateway.
+
+This middleware drops the redundant legacy field from assistant messages before
+they reach the Fireworks serializer, mirroring the thinking-block sanitizer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage
+
+try:
+    from langchain_fireworks.chat_models import ChatFireworks
+except ImportError:  # pragma: no cover
+    ChatFireworks = None  # type: ignore[assignment, misc]
+
+
+def _is_chat_fireworks(model: object) -> bool:
+    if ChatFireworks is None:
+        return False
+    seen: set[int] = set()
+    current = model
+    for _ in range(10):
+        if isinstance(current, ChatFireworks):
+            return True
+        current_id = id(current)
+        if current_id in seen:
+            return False
+        seen.add(current_id)
+        bound = getattr(current, "bound", None)
+        if bound is None or bound is current:
+            return False
+        current = bound
+    return False
+
+
+def _sanitize_messages(messages: list[Any]) -> None:
+    for message in messages:
+        if not isinstance(message, AIMessage):
+            continue
+        additional_kwargs = message.additional_kwargs
+        if not isinstance(additional_kwargs, dict) or "function_call" not in additional_kwargs:
+            continue
+        # Drop the legacy field; modern tool calls live in `tool_calls` /
+        # `additional_kwargs["tool_calls"]`, which the Fireworks serializer
+        # emits separately and the gateway accepts.
+        additional_kwargs.pop("function_call", None)
+
+
+class SanitizeFireworksMessagesMiddleware(AgentMiddleware):
+    """Drop legacy ``function_call`` fields before Fireworks provider calls."""
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        if _is_chat_fireworks(request.model):
+            _sanitize_messages(request.messages)
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> Any:
+        if _is_chat_fireworks(request.model):
+            _sanitize_messages(request.messages)
+        return await handler(request)

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -41,6 +41,7 @@ from .dashboard.team_settings import (
 )
 from .middleware import (
     RepairOrphanedToolCallsMiddleware,
+    SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     SlackAssistantStatusMiddleware,
@@ -1200,6 +1201,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             refresh_github_proxy_before_model,
             check_message_queue_before_model,
             SlackAssistantStatusMiddleware(),
+            SanitizeFireworksMessagesMiddleware(),
             SanitizeThinkingBlocksMiddleware(),
             RepairOrphanedToolCallsMiddleware(),
             settle_review_check_on_exit,

--- a/agent/server.py
+++ b/agent/server.py
@@ -59,6 +59,7 @@ from .middleware import (
     ModelFallbackMiddleware,
     PlanModeMiddleware,
     SandboxCircuitBreakerMiddleware,
+    SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     SlackAssistantStatusMiddleware,
@@ -932,6 +933,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             SandboxCircuitBreakerMiddleware(),
             *fallback_middleware,
             *plan_mode_middleware,
+            SanitizeFireworksMessagesMiddleware(),
             SanitizeThinkingBlocksMiddleware(),
         ],
     ).with_config(config)

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -19,16 +19,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_GATEWAY_BASE_URL = "https://gateway.smith.langchain.com"
 
 # Provider prefix -> base-URL suffix appended to the gateway host. Each suffix
-# matches the SDK's own path handling: the OpenAI/Fireworks SDKs append
-# ``/chat/completions`` to a ``/v1`` base, the Anthropic SDK appends
-# ``/v1/messages`` to a bare host, and the google-genai SDK appends
+# matches the SDK's own path handling: the OpenAI SDK appends
+# ``/chat/completions`` to a ``/v1`` base, Fireworks appends
+# ``/v1/chat/completions`` to a bare provider host, Anthropic appends
+# ``/v1/messages`` to a bare host, and google-genai appends
 # ``/<api_version>/models/...`` to a bare host. Vertex (``google_vertexai``, which
 # uses service-account auth rather than a bearer key) and any other provider are
 # not routed and call the provider directly.
 _GATEWAY_PROVIDER_PATHS: dict[str, str] = {
     "openai": "/openai/v1",
     "anthropic": "/anthropic",
-    "fireworks": "/fireworks/v1",
+    "fireworks": "/fireworks",
     "google_genai": "/gemini",
 }
 

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -65,12 +65,15 @@ def gateway_env_default() -> bool:
 def gateway_openai_use_responses() -> bool:
     """Whether gateway-routed OpenAI keeps the Responses API.
 
-    Defaults to ``False``: the gateway's documented OpenAI surface is Chat
-    Completions, and an HTTPS proxy can't carry open-swe's default ``wss://``
-    Responses stream. Set ``LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=true`` only if
-    the gateway proxies ``/v1/responses``.
+    Defaults to ``True`` because OpenAI reasoning models with tool calls reject
+    ``reasoning_effort`` on Chat Completions. Set
+    ``LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=false`` only for deployments that
+    need to force Chat Completions through the gateway.
     """
-    return _env_bool(os.environ.get("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES"))
+    raw = os.environ.get("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES")
+    if raw is None:
+        return True
+    return _env_bool(raw)
 
 
 def resolve_gateway_enabled(team_value: bool | None) -> bool:
@@ -117,7 +120,7 @@ def gateway_overrides(model_id: str) -> dict[str, object] | None:
         "api_key": api_key,
     }
     if provider == "openai":
-        # An HTTPS proxy can't carry the wss:// Responses stream make_model sets by
-        # default; route Chat Completions unless the deployment opts back in.
+        # Use HTTPS Responses through the gateway by default; tool-calling OpenAI
+        # reasoning models reject reasoning_effort on Chat Completions.
         overrides["use_responses_api"] = gateway_openai_use_responses()
     return overrides

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -64,7 +64,7 @@ def test_fireworks_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     overrides = gateway.gateway_overrides("fireworks:accounts/fireworks/models/glm-5p2")
     assert overrides is not None
-    assert overrides["base_url"] == "https://gateway.smith.langchain.com/fireworks/v1"
+    assert overrides["base_url"] == "https://gateway.smith.langchain.com/fireworks"
 
 
 def test_google_genai_routes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 from fireworks import AsyncFireworks
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 
 from agent.utils import gateway, model
@@ -72,9 +72,7 @@ async def test_openai_sdk_uses_gateway_responses_path() -> None:
                         "type": "message",
                         "role": "assistant",
                         "status": "completed",
-                        "content": [
-                            {"type": "output_text", "text": "ok", "annotations": []}
-                        ],
+                        "content": [{"type": "output_text", "text": "ok", "annotations": []}],
                     }
                 ],
                 "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
@@ -157,6 +155,87 @@ async def test_fireworks_sdk_uses_allowlisted_gateway_path() -> None:
 
     assert len(requests) == 1
     assert requests[0].url.path == "/fireworks/v1/chat/completions"
+
+
+async def test_fireworks_gateway_strips_legacy_function_call() -> None:
+    """The serializer must not emit ``function_call`` after sanitization.
+
+    Reproduces the production 400 — ``Extra inputs are not permitted, field:
+    'messages[N].function_call'`` — by routing an ``AIMessage`` that carries the
+    legacy ``function_call`` (alongside modern ``tool_calls``) through the
+    Fireworks serializer toward the gateway. Without the sanitizer middleware
+    the request body contains ``function_call``; with it, only ``tool_calls``
+    survives.
+    """
+    import json
+
+    from fireworks import AsyncFireworks
+    from langchain_fireworks.chat_models import ChatFireworks
+
+    from agent.middleware.sanitize_fireworks_messages import _sanitize_messages
+
+    captured_bodies: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "accounts/fireworks/models/glm-5p2",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        chat_model = ChatFireworks(
+            model="accounts/fireworks/models/glm-5p2",
+            api_key="dummy",
+            base_url="https://gateway.smith.langchain.com/fireworks",
+            max_retries=0,
+        )
+        # Inject a mock-transport client so no real network call is made.
+        mock_sdk = AsyncFireworks(
+            api_key="dummy",
+            base_url="https://gateway.smith.langchain.com/fireworks",
+            http_client=http_client,
+            max_retries=0,
+        )
+        chat_model._async_sdk_client = mock_sdk  # type: ignore[attr-defined]
+        chat_model.async_client = mock_sdk.chat.completions  # type: ignore[attr-defined]
+
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
+            additional_kwargs={"function_call": {"name": "read_file", "arguments": "{}"}},
+        )
+        messages = [HumanMessage(content="hi"), ai_message]
+
+        # Apply the sanitizer the same way the middleware stack does.
+        _sanitize_messages(messages)
+
+        await chat_model.ainvoke(messages)
+        await mock_sdk.close()
+    finally:
+        await http_client.aclose()
+
+    assert len(captured_bodies) == 1
+    body = captured_bodies[0]
+    for msg in body["messages"]:
+        assert "function_call" not in msg, msg
+    # The assistant message still carries tool_calls.
+    assistant_msgs = [m for m in body["messages"] if m["role"] == "assistant"]
+    assert assistant_msgs and "tool_calls" in assistant_msgs[0]
 
 
 def test_google_genai_routes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import pytest
+from fireworks import AsyncFireworks
 
 from agent.utils import gateway, model
 
@@ -65,6 +67,48 @@ def test_fireworks_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     overrides = gateway.gateway_overrides("fireworks:accounts/fireworks/models/glm-5p2")
     assert overrides is not None
     assert overrides["base_url"] == "https://gateway.smith.langchain.com/fireworks"
+
+
+async def test_fireworks_sdk_uses_allowlisted_gateway_path() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "accounts/fireworks/models/glm-5p2",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        client = AsyncFireworks(
+            api_key="dummy",
+            base_url="https://gateway.smith.langchain.com/fireworks",
+            http_client=http_client,
+            max_retries=0,
+        )
+        await client.chat.completions.create(
+            model="accounts/fireworks/models/glm-5p2",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    finally:
+        await http_client.aclose()
+
+    assert len(requests) == 1
+    assert requests[0].url.path == "/fireworks/v1/chat/completions"
 
 
 def test_google_genai_routes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 import httpx
 import pytest
 from fireworks import AsyncFireworks
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
 
 from agent.utils import gateway, model
 
@@ -31,7 +33,7 @@ def _clean_gateway_env(monkeypatch: pytest.MonkeyPatch) -> None:
 # --- gateway_overrides --------------------------------------------------------
 
 
-def test_openai_overrides_use_chat_completions_by_default(
+def test_openai_overrides_use_responses_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
@@ -39,16 +41,62 @@ def test_openai_overrides_use_chat_completions_by_default(
     assert overrides == {
         "base_url": "https://gateway.smith.langchain.com/openai/v1",
         "api_key": "ls-key",
-        "use_responses_api": False,
+        "use_responses_api": True,
     }
 
 
-def test_openai_overrides_responses_optin(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openai_overrides_chat_completions_optout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "false")
     overrides = gateway.gateway_overrides("openai:gpt-5.5")
     assert overrides is not None
-    assert overrides["use_responses_api"] is True
+    assert overrides["use_responses_api"] is False
+
+
+async def test_openai_sdk_uses_gateway_responses_path() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_test",
+                "object": "response",
+                "created_at": 0,
+                "status": "completed",
+                "model": "gpt-5.5",
+                "output": [
+                    {
+                        "id": "msg_test",
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [
+                            {"type": "output_text", "text": "ok", "annotations": []}
+                        ],
+                    }
+                ],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        chat_model = ChatOpenAI(
+            model="gpt-5.5",
+            api_key="dummy",
+            base_url="https://gateway.smith.langchain.com/openai/v1",
+            use_responses_api=True,
+            http_async_client=http_client,
+            max_retries=0,
+        )
+        await chat_model.ainvoke([HumanMessage(content="hi")])
+    finally:
+        await http_client.aclose()
+
+    assert len(requests) == 1
+    assert requests[0].url.path == "/openai/v1/responses"
 
 
 def test_anthropic_overrides_have_no_responses_flag(
@@ -217,14 +265,15 @@ def test_make_model_gateway_openai_replaces_websocket(
     with patch.object(model, "init_chat_model", fake):
         model.make_model("openai:gpt-5.5", use_gateway=True)
     assert captured["base_url"] == "https://gateway.smith.langchain.com/openai/v1"
-    assert captured["use_responses_api"] is False
+    assert captured["use_responses_api"] is True
     assert captured["api_key"] == "ls-key"
 
 
-def test_make_model_gateway_openai_converts_reasoning_for_chat_completions(
+def test_make_model_gateway_openai_chat_completions_optout_converts_reasoning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "false")
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
         model.make_model(
@@ -248,16 +297,15 @@ def test_make_model_gateway_openai_preserves_reasoning_none(
             use_gateway=True,
             reasoning={"effort": "none"},
         )
-    assert captured["use_responses_api"] is False
-    assert captured["reasoning_effort"] == "none"
-    assert "reasoning" not in captured
+    assert captured["use_responses_api"] is True
+    assert captured["reasoning"] == {"effort": "none"}
+    assert "reasoning_effort" not in captured
 
 
-def test_make_model_gateway_openai_responses_optin_keeps_reasoning(
+def test_make_model_gateway_openai_responses_keeps_reasoning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "true")
     reasoning = {"effort": "high", "summary": "auto"}
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):

--- a/tests/test_sanitize_fireworks_messages.py
+++ b/tests/test_sanitize_fireworks_messages.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from agent.middleware.sanitize_fireworks_messages import SanitizeFireworksMessagesMiddleware
+
+
+def _make_request(messages: list[object], model: object | None = None) -> MagicMock:
+    request = MagicMock()
+    request.model = model
+    request.messages = messages
+    return request
+
+
+def _fireworks_model() -> MagicMock:
+    """A mock that satisfies ``_is_chat_fireworks`` via spec'd ``ChatFireworks``."""
+    try:
+        from langchain_fireworks.chat_models import ChatFireworks
+    except ImportError:  # pragma: no cover
+        pytest.skip("langchain-fireworks not installed")
+    return MagicMock(spec=ChatFireworks)
+
+
+class TestSanitizeFireworksMessagesMiddleware:
+    def test_drops_legacy_function_call(self) -> None:
+        message = AIMessage(
+            content="",
+            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
+            additional_kwargs={"function_call": {"name": "read_file", "arguments": "{}"}},
+        )
+        request = _make_request([message], model=_fireworks_model())
+        response = MagicMock()
+
+        def handler(req: object) -> object:
+            assert req is request
+            return response
+
+        result = SanitizeFireworksMessagesMiddleware().wrap_model_call(request, handler)
+
+        assert result is response
+        assert "function_call" not in message.additional_kwargs
+        # tool_calls are untouched
+        assert len(message.tool_calls) == 1
+
+    def test_preserves_message_without_function_call(self) -> None:
+        message = AIMessage(
+            content="ok",
+            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
+        )
+        request = _make_request([message], model=_fireworks_model())
+
+        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
+
+        assert "function_call" not in message.additional_kwargs
+        assert len(message.tool_calls) == 1
+
+    def test_drops_function_call_with_no_tool_calls(self) -> None:
+        message = AIMessage(
+            content="",
+            additional_kwargs={"function_call": {"name": "search", "arguments": "{}"}},
+        )
+        request = _make_request([message], model=_fireworks_model())
+
+        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
+
+        assert "function_call" not in message.additional_kwargs
+
+    @pytest.mark.asyncio
+    async def test_async_drops_legacy_function_call(self) -> None:
+        tool_result = ToolMessage(content="result", tool_call_id="tc1")
+        message = AIMessage(
+            content="",
+            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
+            additional_kwargs={"function_call": {"name": "read_file", "arguments": "{}"}},
+        )
+        request = _make_request(
+            [HumanMessage(content="hi"), message, tool_result],
+            model=_fireworks_model(),
+        )
+        response = MagicMock()
+
+        async def handler(req: object) -> object:
+            assert req is request
+            return response
+
+        result = await SanitizeFireworksMessagesMiddleware().awrap_model_call(request, handler)
+
+        assert result is response
+        assert "function_call" not in message.additional_kwargs
+
+    def test_ignores_non_fireworks_models(self) -> None:
+        message = AIMessage(
+            content="",
+            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
+            additional_kwargs={"function_call": {"name": "read_file", "arguments": "{}"}},
+        )
+        # Non-Fireworks model (plain MagicMock, no ChatFireworks in its spec chain)
+        request = _make_request([message], model=MagicMock())
+
+        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
+
+        # function_call preserved for non-Fireworks providers
+        assert "function_call" in message.additional_kwargs
+
+    def test_skips_non_ai_messages(self) -> None:
+        messages = [
+            HumanMessage(content="hi"),
+            ToolMessage(content="result", tool_call_id="tc1"),
+        ]
+        request = _make_request(messages, model=_fireworks_model())
+
+        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
+
+        # No AIMessages to mutate — handler still called
+        assert all(not isinstance(m, AIMessage) for m in messages)


### PR DESCRIPTION
## Summary

This PR fixes several issues with routing provider calls through the LangSmith LLM Gateway.

### 1. Correct Fireworks gateway base URL
The gateway provider path for Fireworks must be bare (`/fireworks`) because the Fireworks SDK appends `/v1/chat/completions` itself. The previous path produced a malformed URL.

### 2. Use OpenAI Responses through the gateway by default
OpenAI reasoning models with tool calls reject `reasoning_effort` on Chat Completions, so gateway-routed OpenAI keeps the Responses API by default (opt out via `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=false`).

### 3. Strip legacy `function_call` before Fireworks gateway calls
The gateway enforces strict request-schema validation and rejects messages carrying the legacy OpenAI `function_call` field:

```
Extra inputs are not permitted, field: 'messages[8].function_call'
```

`langchain_fireworks` forwards `function_call` from `AIMessage.additional_kwargs` whenever it is present — even when the message also carries modern `tool_calls` — so a message deserialized from the checkpointer (or produced by another provider) breaks every subsequent Fireworks turn once routed through the gateway.

Added `SanitizeFireworksMessagesMiddleware` (`agent/middleware/sanitize_fireworks_messages.py`) that drops the redundant legacy field before Fireworks provider calls, mirroring the existing `SanitizeThinkingBlocksMiddleware` pattern (same bound-model detection, same in-place message mutation). Wired into the agent (`server.py`), reviewer (`reviewer.py`), and chat (`chat.py`) middleware stacks, right before `SanitizeThinkingBlocksMiddleware`.

## Testing
- `uv run pytest -vvv tests/test_gateway.py tests/test_sanitize_fireworks_messages.py`
- `uv run ruff check agent/ tests/`
- Verified the integration test reproduces the 400 without the sanitizer (`function_call` present in the request body) and passes with it.