### PR TITLE
fix: route Anthropic effort via output config

### DIFF
--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -37,12 +37,16 @@ class AnthropicThinking(TypedDict, total=False):
     display: AnthropicThinkingDisplay
 
 
+class AnthropicOutputConfig(TypedDict, total=False):
+    effort: AnthropicEffort
+
+
 class ModelKwargs(TypedDict, total=False):
     max_tokens: int | None
     reasoning: OpenAIReasoning | None
     reasoning_effort: OpenAIReasoningEffort | None
     thinking: AnthropicThinking | None
-    effort: AnthropicEffort | None
+    output_config: AnthropicOutputConfig | None
     thinking_level: GoogleThinkingLevel | None
     temperature: float | None
     max_retries: int | None
@@ -208,7 +212,7 @@ def provider_model_kwargs(
             kwargs["thinking"] = thinking
         effort = anthropic_effort_for(profile_effort)
         if effort is not None:
-            kwargs["effort"] = effort
+            kwargs["output_config"] = {"effort": effort}
     elif model_id.startswith("google_genai:") and is_gemini_3_family(model_id):
         thinking_level = google_thinking_level_for(profile_effort)
         if thinking_level is not None:

--- a/tests/test_agent_subagent_models.py
+++ b/tests/test_agent_subagent_models.py
@@ -78,7 +78,8 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
     main_call = make_model.call_args_list[0]
     assert main_call.args == ("anthropic:claude-opus-4-8",)
     assert main_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
-    assert main_call.kwargs["effort"] == "high"
+    assert main_call.kwargs["output_config"] == {"effort": "high"}
+    assert "effort" not in main_call.kwargs
 
     subagent_call = make_model.call_args_list[1]
     assert subagent_call.args == ("openai:gpt-5.5",)
@@ -149,4 +150,5 @@ async def test_agent_subagent_inherits_profile_model_override_without_explicit_p
         "type": "adaptive",
         "display": "summarized",
     }
-    assert make_model.call_args_list[1].kwargs["effort"] == "high"
+    assert make_model.call_args_list[1].kwargs["output_config"] == {"effort": "high"}
+    assert "effort" not in make_model.call_args_list[1].kwargs

--- a/tests/test_anthropic_model.py
+++ b/tests/test_anthropic_model.py
@@ -18,7 +18,8 @@ def test_sonnet_5_is_supported_with_documented_efforts() -> None:
 def test_sonnet_5_efforts_map_to_anthropic_kwargs(effort: str) -> None:
     kwargs = provider_model_kwargs(SONNET_5_ID, effort, max_tokens=16_000)
     assert kwargs["max_tokens"] == 16_000
-    assert kwargs["effort"] == effort
+    assert kwargs["output_config"] == {"effort": effort}
+    assert "effort" not in kwargs
     assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
 
 

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -346,7 +346,8 @@ async def test_reviewer_applies_eval_model_and_effort_overrides() -> None:
     main_model_call = make_model.call_args_list[0]
     assert main_model_call.args == ("anthropic:claude-opus-4-8",)
     assert main_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
-    assert main_model_call.kwargs["effort"] == "high"
+    assert main_model_call.kwargs["output_config"] == {"effort": "high"}
+    assert "effort" not in main_model_call.kwargs
     subagent_model_call = make_model.call_args_list[1]
     assert subagent_model_call.args == ("openai:gpt-5.5",)
     assert subagent_model_call.kwargs["reasoning"] == {"effort": "low", "summary": "auto"}
@@ -394,11 +395,13 @@ async def test_reviewer_subagent_inherits_eval_model_without_explicit_override()
     main_model_call = make_model.call_args_list[0]
     assert main_model_call.args == ("anthropic:claude-opus-4-8",)
     assert main_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
-    assert main_model_call.kwargs["effort"] == "high"
+    assert main_model_call.kwargs["output_config"] == {"effort": "high"}
+    assert "effort" not in main_model_call.kwargs
     subagent_model_call = make_model.call_args_list[1]
     assert subagent_model_call.args == ("anthropic:claude-opus-4-8",)
     assert subagent_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
-    assert subagent_model_call.kwargs["effort"] == "high"
+    assert subagent_model_call.kwargs["output_config"] == {"effort": "high"}
+    assert "effort" not in subagent_model_call.kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Routes Anthropic model effort through `output_config` instead of a top-level kwarg, matching Claude's Messages API and preventing Opus runs from crashing before the first response.

## Release Note
Fixes Claude Opus/Sonnet effort selection for self-hosted deployments.

## Test Plan
- [ ] Switch a local agent thread to Claude Opus 4.8 with low effort and confirm it responds.

Made by [Open SWE](https://openswe.vercel.app/agents/019f2412-222a-7370-9e96-fcc97867720c)