### PR TITLE
fix: submit plan comments with cmd enter

### DIFF
--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -25,8 +25,21 @@ async function botMessages(request: APIRequestContext): Promise<Array<string>> {
   return msgs.filter((m) => m.is_bot).map((m) => m.text);
 }
 
-async function addComment(page: Page, text: string) {
-  await page.getByTestId("comment-input").fill(text);
+async function addComment(
+  page: Page,
+  text: string,
+  shortcut?: "meta" | "control",
+) {
+  const input = page.getByTestId("comment-input");
+  await input.fill(text);
+  if (shortcut === "meta") {
+    await input.press("Meta+Enter");
+    return;
+  }
+  if (shortcut === "control") {
+    await input.press("Control+Enter");
+    return;
+  }
   await page.getByTestId("comment-submit").click();
 }
 
@@ -145,8 +158,8 @@ test.describe("Plan review (HTTP comments)", () => {
     expect(clipboard).toContain("## Plan: Add greet() helper");
     expect(clipboard).toContain("### Verification");
 
-    // Owner leaves a comment.
-    await addComment(owner, "Owner: looks solid, ship it.");
+    // Owner leaves a comment with Cmd+Enter.
+    await addComment(owner, "Owner: looks solid, ship it.", "meta");
     await expect(owner.getByTestId("plan-comment")).toHaveCount(1);
     await expect(owner.getByTestId("reject-plan")).toBeEnabled();
 
@@ -171,8 +184,8 @@ test.describe("Plan review (HTTP comments)", () => {
     await expect(collab.getByTestId("approve-plan")).toHaveCount(0);
     await expect(collab.getByTestId("reject-plan")).toBeVisible();
 
-    // Collaborator leaves feedback.
-    await addComment(collab, "Reviewer: please also add a docstring.");
+    // Collaborator leaves feedback with Ctrl+Enter.
+    await addComment(collab, "Reviewer: please also add a docstring.", "control");
     await expect(collab.getByTestId("plan-comment")).toHaveCount(2);
 
     // 6. The owner sees the collaborator's comment (polled), then approves and

--- a/ui/src/components/agents/PlanReview.tsx
+++ b/ui/src/components/agents/PlanReview.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
+import type { KeyboardEvent } from "react"
 
 import type { PlanComment, PlanData } from "@/lib/plan"
 import {
@@ -137,6 +138,16 @@ export function PlanReview({ plan }: { plan: PlanData }) {
       setPosting(false)
     }
   }, [draft, plan.threadId])
+
+  const handleCommentKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return
+      event.preventDefault()
+      if (posting || !draft.trim()) return
+      void submitComment()
+    },
+    [draft, posting, submitComment]
+  )
 
   const removeComment = useCallback(
     async (id: string) => {
@@ -357,6 +368,7 @@ export function PlanReview({ plan }: { plan: PlanData }) {
               data-testid="comment-input"
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={handleCommentKeyDown}
               placeholder="Leave a comment on the plan"
               rows={3}
               className="w-full resize-none rounded-md border border-[var(--ui-border)] bg-[var(--ui-bg)] px-2 py-1.5 text-sm text-[var(--ui-text)] outline-none focus:border-[var(--ui-accent)]"


### PR DESCRIPTION
## Description
Adds a Cmd/Ctrl+Enter shortcut for posting plan review comments while preserving normal multiline comment input. Playwright coverage now submits reviewer feedback through both shortcut paths.

## Release Note
Plan review comments can now be submitted with Cmd/Ctrl+Enter.

## Test Plan
- [x] `npm --prefix /workspace/open-swe/tests/e2e run test -- tests/plan_review.spec.ts --project=chromium --reporter=list`

Made by [Open SWE](https://openswe.vercel.app/agents/d1479647-7626-6cc2-9368-ec850409b91c)