### PR TITLE
chore: clarify question answering prompt

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -86,7 +86,7 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 - Focus on the substance and keep summaries brief. Use light markdown (`###`/`####` headings, bold, code) — avoid `#`/`##` titles.
 - In Slack, when a user asks to “break out,” “split out,” or “start a separate thread” for part of the work, summarize the requested aspect and relevant context into self-contained instructions, then call `slack_start_new_thread` instead of only replying in the current thread.
 - In Slack, when acknowledging a user follow-up while you continue working, prefer `slack_add_reaction` with the default `eyes` reaction over posting a perfunctory “Updating…” / “I’ll check…” confirmation reply.
-- When you post to Slack with `slack_thread_reply`, do not repeat that text in a later assistant message; the user can already see the Slack message.
+- For Slack-triggered information-only answers, post only a concise summary in the associated Slack thread with `slack_thread_reply`, then provide the complete answer inline in your final assistant response. For other Slack updates, keep thread replies brief and avoid duplicating the same text later.
 - When delegated work to a subagent: the calling agent only sees your final message, so make it the complete answer.
 
 IMPORTANT: You must ALWAYS call a tool in EVERY SINGLE TURN. If you don't call a tool, the session will end and you won't be able to resume without the user manually restarting you.
@@ -180,7 +180,7 @@ If a Slack- or GitHub-triggered request asks you to review a GitHub pull request
 
 **For code-change tasks:** Understand the task and explore relevant files first. Make focused, minimal changes — do not touch code outside the task's scope or add implementations in other languages/packages. Verify with linters and only the tests related to your changes. Then commit, push, and (when a PR is warranted) open/update the draft PR — see Committing below.
 
-**For information-only requests:** Gather what you need and answer in the source channel. Never leave a question unanswered. Do not commit, push, or open/update a PR unless the user then asks for changes."""
+**For information-only requests:** First identify any relevant git repositories and check them out before answering, so your response is grounded in current repo state. Gather what you need, answer fully inline, and, for Slack-triggered requests, post only a concise summary to the associated Slack thread. Never leave a question unanswered. Do not commit, push, or open/update a PR unless the user then asks for changes."""
 
 
 CORRIDOR_PROMPT = """---

--- a/tests/test_github_comment_prompts.py
+++ b/tests/test_github_comment_prompts.py
@@ -149,9 +149,19 @@ def test_construct_system_prompt_does_not_require_pr_for_questions() -> None:
 
     assert "Do not create commits, branches, or pull requests for questions" in prompt
     assert "For information-only requests" in prompt
+    assert "check them out before answering" in prompt
+    assert "answer fully inline" in prompt
     assert "open or update a draft PR when the user asks for one" in prompt
     assert "Always Create PRs Policy Override" not in prompt
     assert "Always push, open/update the draft PR" not in prompt
+
+
+def test_shared_base_summarizes_slack_information_answers() -> None:
+    from agent.prompt import OPEN_SWE_SHARED_BASE
+
+    assert "Slack-triggered information-only answers" in OPEN_SWE_SHARED_BASE
+    assert "post only a concise summary" in OPEN_SWE_SHARED_BASE
+    assert "complete answer inline" in OPEN_SWE_SHARED_BASE
 
 
 def test_construct_system_prompt_includes_always_create_prs_override() -> None:


### PR DESCRIPTION
## Description
Updates the agent prompt so information-only answers first check out relevant git repos, answer fully inline, and summarize Slack-triggered answers in the associated Slack thread.

## Release Note
none

## Test Plan
- [ ] Verify a Slack-triggered information-only run posts a summary in Slack while retaining a full inline response.

Made by [Open SWE](https://openswe.vercel.app/agents/80d1a3be-eea2-5e8d-8194-817aa3b222d6)