### PR TITLE
feat: open Linear-triggered PRs as the triggering user

### DIFF
--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -19,7 +19,7 @@ from ..utils.slack import get_slack_permalink
 logger = logging.getLogger(__name__)
 
 GITHUB_API = "https://api.github.com"
-_USER_TOKEN_SOURCES = ("slack", "dashboard")
+_USER_TOKEN_SOURCES = ("slack", "linear", "dashboard")
 _REFERENCES_HEADING = "## References"
 
 
@@ -27,10 +27,10 @@ async def _resolve_pr_author_token() -> tuple[str | None, str]:
     """Return ``(token, kind)`` for opening the PR.
 
     Prefers the triggering user's OAuth token (so the PR is created *as them*)
-    for Slack/dashboard runs with a mapped GitHub login, resolving it by login
-    from the dashboard OAuth store. Falls back to the GitHub App installation
-    token (creator = open-swe[bot]) for GitHub-triggered runs, unmapped users,
-    or bot-token-only deployments — preserving today's behavior.
+    for Slack/Linear/dashboard runs with a mapped GitHub login, resolving it by
+    login from the dashboard OAuth store. Falls back to the GitHub App
+    installation token (creator = open-swe[bot]) for GitHub-triggered runs,
+    unmapped users, or bot-token-only deployments — preserving today's behavior.
 
     The token is resolved by login rather than read from the shared thread
     metadata: Slack thread ids are shared across a conversation, so a cached

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -401,8 +401,10 @@ async def _resolve_bot_installation_token(thread_id: str) -> tuple[str, str | No
 async def resolve_github_token(config: RunnableConfig, thread_id: str) -> tuple[str, str | None]:
     """Resolve a GitHub token from the run config based on the source.
 
-    Routes to the correct auth method depending on whether the run was
-    triggered from GitHub (login-based) or Linear/Slack (email-based).
+    Routes to the correct auth method depending on the source. Sources that
+    carry a mapped GitHub login (Slack, Linear, dashboard, schedule) resolve a
+    per-user OAuth token from the dashboard store; GitHub runs are login-based;
+    otherwise resolution falls back to email-based auth.
 
     In bot-token-only mode (LANGSMITH_API_KEY_PROD set without
     X_SERVICE_AUTH_JWT_SECRET), the GitHub App installation token is used
@@ -420,10 +422,10 @@ async def resolve_github_token(config: RunnableConfig, thread_id: str) -> tuple[
     github_login = configurable.get("github_login")
 
     # Per-user OAuth from the dashboard store wins even in bot-token-only mode,
-    # for sources that carry a mapped GitHub login (Slack, dashboard). This is
-    # what lets the agent open PRs as the triggering user.
+    # for sources that carry a mapped GitHub login (Slack, Linear, dashboard).
+    # This is what lets the agent open PRs as the triggering user.
     if (
-        source in ("slack", "dashboard", "schedule")
+        source in ("slack", "linear", "dashboard", "schedule")
         and isinstance(github_login, str)
         and github_login.strip()
     ):

--- a/agent/webhooks/linear.py
+++ b/agent/webhooks/linear.py
@@ -163,13 +163,16 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         f"When you're done, commit and push your changes. {tag_instruction}"
     )
     content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]
+
+    # Resolve the GitHub login from the Linear email via the same user-mapping
+    # store Slack uses, so PRs open *as the triggering user* and the thread is
+    # tagged for the dashboard.
+    mapped_login = await webapp.resolve_login_from_email_async(user_email) if user_email else None
+
     image_model_override: tuple[str, str] | None = None
     if image_urls:
         image_urls = webapp.dedupe_urls(image_urls)
-        linear_login = (
-            await webapp.resolve_login_from_email_async(user_email) if user_email else None
-        )
-        resolved_model_id = await webapp.resolve_agent_model_id(linear_login)
+        resolved_model_id = await webapp.resolve_agent_model_id(mapped_login)
         if not webapp.model_supports_images(resolved_model_id):
             fallback_model_id, fallback_effort = webapp.default_vision_model_pair()
             webapp.logger.info(
@@ -212,6 +215,8 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         "user_email": user_email,
         "source": "linear",
     }
+    if mapped_login:
+        configurable["github_login"] = mapped_login
     if image_model_override:
         configurable["agent_model_id"] = image_model_override[0]
         configurable["agent_effort"] = image_model_override[1]
@@ -220,6 +225,7 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         thread_id,
         source="linear",
         repo_config=repo_config,
+        github_login=mapped_login or "",
         user_email=user_email or "",
         title=title or identifier or "Linear issue",
         source_context={"linear_issue": configurable["linear_issue"]},

--- a/tests/test_auth_sources.py
+++ b/tests/test_auth_sources.py
@@ -147,7 +147,55 @@ def test_resolve_github_token_slack_no_token_falls_back_to_bot_in_bot_only_mode(
     assert (token, expires_at) == ("bot-tok", None)
 
 
-@pytest.mark.parametrize("source", ["github", "linear"])
+def _linear_config(github_login: str | None = "mason-gh") -> dict:
+    configurable: dict = {
+        "source": "linear",
+        "user_email": "mason@example.com",
+        "thread_id": "t1",
+    }
+    if github_login is not None:
+        configurable["github_login"] = github_login
+    return {"configurable": configurable}
+
+
+def test_resolve_github_token_linear_uses_dashboard_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_dashboard_store(monkeypatch, token="user-tok")
+    monkeypatch.setattr(auth, "is_bot_token_only_mode", lambda: False)
+
+    token, expires_at = asyncio.run(auth.resolve_github_token(_linear_config(), "t1"))
+
+    assert token == "user-tok"
+    assert expires_at == "2099-01-01T00:00:00Z"
+
+
+def test_resolve_github_token_linear_no_token_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_dashboard_store(monkeypatch, token=None)
+    monkeypatch.setattr(auth, "is_bot_token_only_mode", lambda: False)
+
+    with pytest.raises(auth.GitHubUserAuthRequired):
+        asyncio.run(auth.resolve_github_token(_linear_config(), "t1"))
+
+
+def test_resolve_github_token_linear_no_token_falls_back_to_bot_in_bot_only_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_dashboard_store(monkeypatch, token=None)
+    monkeypatch.setattr(auth, "is_bot_token_only_mode", lambda: True)
+
+    async def fake_bot(thread_id: str):
+        return ("bot-tok", None)
+
+    monkeypatch.setattr(auth, "_resolve_bot_installation_token", fake_bot)
+
+    token, expires_at = asyncio.run(auth.resolve_github_token(_linear_config(), "t1"))
+    assert (token, expires_at) == ("bot-tok", None)
+
+
+@pytest.mark.parametrize("source", ["github"])
 def test_resolve_github_token_bot_only_mode_non_slack_uses_bot(
     monkeypatch: pytest.MonkeyPatch, source: str
 ) -> None:

--- a/tests/test_linear_webhook_author.py
+++ b/tests/test_linear_webhook_author.py
@@ -1,0 +1,116 @@
+"""Tests for Linear webhook PR author linking (reuse of the Slack user mapping)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from agent.webhooks import linear as linear_webhook
+
+
+def _full_issue(*, user_email: str | None = "zhen@example.com", user_name: str = "Zhen") -> dict:
+    return {
+        "id": "issue-1",
+        "title": "Link Linear PRs to author",
+        "description": "Do the thing",
+        "identifier": "OS-42",
+        "url": "https://linear.app/x/issue/OS-42",
+        "creator": {"email": user_email, "name": user_name},
+        "comments": {"nodes": []},
+    }
+
+
+def _issue_data(*, user_email: str | None, user_name: str = "Zhen") -> dict:
+    # linear_webhook attaches comment_author to the issue dict before dispatch.
+    data = _full_issue(user_email=user_email, user_name=user_name)
+    data["comment_author"] = {"email": user_email, "name": user_name}
+    return data
+
+
+def _run_process(issue_data: dict, repo_config: dict[str, str]) -> tuple[dict, dict, str | None]:
+    captured: dict[str, Any] = {}
+
+    async def fake_dispatch(
+        thread_id, content, configurable, *, source, metadata=None, client=None
+    ):
+        captured["configurable"] = configurable
+        return {"run_id": "run-1"}
+
+    async def fake_upsert(
+        thread_id,
+        *,
+        source,
+        repo_config=None,
+        github_login="",
+        user_email="",
+        title="",
+        source_context=None,
+    ):
+        captured["upsert"] = {"github_login": github_login, "user_email": user_email}
+        return None
+
+    async def fake_resolve_login(email):
+        captured["resolved_email"] = email
+        return "zhen" if email == "zhen@example.com" else None
+
+    with (
+        patch.object(linear_webhook.webapp, "react_to_linear_comment", new_callable=AsyncMock),
+        patch.object(
+            linear_webhook.webapp, "generate_thread_id_from_issue", return_value="thread-1"
+        ),
+        patch.object(
+            linear_webhook.webapp,
+            "fetch_linear_issue_details",
+            new_callable=AsyncMock,
+            return_value=_full_issue(user_email=issue_data.get("comment_author", {}).get("email")),
+        ),
+        patch.object(
+            linear_webhook.webapp, "resolve_login_from_email_async", side_effect=fake_resolve_login
+        ),
+        patch.object(linear_webhook.webapp, "dispatch_agent_run", side_effect=fake_dispatch),
+        patch.object(
+            linear_webhook.webapp, "upsert_agent_thread_owner_metadata", side_effect=fake_upsert
+        ),
+        patch.object(linear_webhook.webapp, "post_linear_trace_comment", new_callable=AsyncMock),
+    ):
+        asyncio.run(linear_webhook.process_linear_issue(issue_data, repo_config))
+
+    return (
+        captured.get("configurable", {}),
+        captured.get("upsert", {}),
+        captured.get("resolved_email"),
+    )
+
+
+def test_linear_configurable_carries_github_login() -> None:
+    configurable, _upsert, resolved_email = _run_process(
+        _issue_data(user_email="zhen@example.com"),
+        {"owner": "langchain-ai", "name": "open-swe"},
+    )
+
+    assert resolved_email == "zhen@example.com"
+    assert configurable["source"] == "linear"
+    assert configurable["github_login"] == "zhen"
+    assert configurable["user_email"] == "zhen@example.com"
+
+
+def test_linear_upsert_tags_thread_with_login() -> None:
+    _configurable, upsert, _email = _run_process(
+        _issue_data(user_email="zhen@example.com"),
+        {"owner": "langchain-ai", "name": "open-swe"},
+    )
+
+    assert upsert["github_login"] == "zhen"
+    assert upsert["user_email"] == "zhen@example.com"
+
+
+def test_linear_omits_login_when_unmapped() -> None:
+    configurable, upsert, resolved_email = _run_process(
+        _issue_data(user_email="nobody@example.com"),
+        {"owner": "langchain-ai", "name": "open-swe"},
+    )
+
+    assert resolved_email == "nobody@example.com"
+    assert "github_login" not in configurable
+    assert upsert["github_login"] == ""

--- a/tests/test_open_pull_request.py
+++ b/tests/test_open_pull_request.py
@@ -142,6 +142,40 @@ def test_uses_user_token_for_slack_with_login(monkeypatch: pytest.MonkeyPatch) -
     }
 
 
+def test_uses_user_token_for_linear_with_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_config(monkeypatch, {"source": "linear", "github_login": "johannes117"})
+
+    from agent.dashboard import profiles
+
+    async def fake_user_token(login: str, **_kw: Any) -> str | None:
+        assert login == "johannes117"
+        return "user-tok"
+
+    monkeypatch.setattr(profiles, "get_valid_access_token", fake_user_token)
+
+    async def fail_bot() -> str | None:
+        raise AssertionError("bot token should not be used when a user token exists")
+
+    monkeypatch.setattr(opr, "get_github_app_installation_token", fail_bot)
+
+    client = _FakeClient(
+        post=_FakeResponse(
+            201,
+            {"html_url": "https://x/pull/1", "number": 1, "user": {"login": "johannes117"}},
+        )
+    )
+    _install_client(monkeypatch, client)
+
+    result = _open()
+
+    assert result["success"] is True
+    assert result["created"] is True
+    assert result["url"] == "https://x/pull/1"
+    assert result["author"] == "johannes117"
+    assert result["token_kind"] == "user"
+    assert client.post_calls[0]["headers"]["Authorization"] == "Bearer user-tok"
+
+
 def test_falls_back_to_bot_for_github_source(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_config(monkeypatch, {"source": "github", "github_login": "johannes117"})
 


### PR DESCRIPTION
## Description
Linear-triggered PRs now open **as the triggering user**, matching Slack. The Linear webhook resolves the commenter's GitHub login from their work email via the same user-mapping store Slack uses (populated by dashboard OAuth), passes `github_login` into the run configurable, and tags the thread metadata. `open_pull_request` now treats `"linear"` as a user-token source, so it resolves the user's OAuth token and falls back to `open-swe[bot]` when the user is unmapped or in bot-token-only mode.

## Release Note
Linear-triggered PRs are now authored by the triggering user (when their GitHub account is linked via the dashboard), instead of `open-swe[bot]`.

## Test Plan
- [ ] `tests/test_open_pull_request.py::test_uses_user_token_for_linear_with_login` — Linear source opens the PR with the user's token.
- [ ] `tests/test_linear_webhook_author.py` — configurable carries `github_login`, upsert tags the thread, and unmapped users omit it.

Made by [Open SWE](https://openswe.vercel.app/agents/b977e475-4282-5667-4872-92b5bb21bcaf)