### PR TITLE
refactor: remove dead sync-interface compatibility code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ Webhooks compute deterministic thread ids so the same Linear issue / Slack threa
 - New sandbox providers: add a module under `agent/integrations/` and wire it into `SANDBOX_FACTORIES` in `agent/utils/sandbox.py`. See `CUSTOMIZATION.md`.
 - New tools: add to `agent/tools/`, export from `agent/tools/__init__.py`, add to the `tools=[...]` list in `server.py:get_agent` (or `reviewer.py` for reviewer-only tools).
 - New middleware: add to `agent/middleware/`, export from `agent/middleware/__init__.py`, add to the `middleware=[...]` list in `server.py:get_agent` — order is significant (see the stack above).
+- Async-only: this app runs exclusively async, so do not add sync/async dual implementations. Implement only the async variant (`awrap_*`, `_arun`, etc.); the sync counterpart is never invoked. Omit the sync method entirely when the interface allows it (e.g. `AgentMiddleware` already raises `NotImplementedError` on the sync path). Only when a type/ABC requires the sync method to exist (e.g. `BaseTool._run` is abstract), define it with a bare `raise NotImplementedError` rather than a real sync implementation.
 - New dashboard endpoints: add to `agent/dashboard/routes.py`. The router is auto-mounted on the FastAPI app.
 - New graphs: register the entrypoint in `langgraph.json` under `graphs`.
 - Minimal-to-no code comments — only when the *why* isn't obvious from the code.

--- a/agent/integrations/notion_mcp.py
+++ b/agent/integrations/notion_mcp.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -65,10 +64,6 @@ class _RefreshingNotionMCPTool(BaseTool):
     mcp_tool_name: str
 
     def _run(self, *args: Any, **kwargs: Any) -> Any:
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(self._arun(*args, **kwargs))
         raise RuntimeError("Notion MCP tools must be called asynchronously")
 
     async def _arun(self, *args: Any, **kwargs: Any) -> Any:

--- a/agent/middleware/exclude_tools.py
+++ b/agent/middleware/exclude_tools.py
@@ -50,13 +50,6 @@ class ExcludeToolsMiddleware(AgentMiddleware):
             return request
         return request.override(tools=filtered)
 
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelResponse:
-        return handler(self._filter(request))
-
     async def awrap_model_call(
         self,
         request: ModelRequest,

--- a/agent/middleware/model_fallback.py
+++ b/agent/middleware/model_fallback.py
@@ -19,7 +19,7 @@ from typing import Any
 import anthropic
 import openai
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 
@@ -96,28 +96,6 @@ class ModelFallbackMiddleware(AgentMiddleware):
     def __init__(self, fallback_model: BaseChatModel) -> None:
         super().__init__()
         self._fallback_model = fallback_model
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelCallResult:
-        try:
-            return handler(request)
-        except Exception as exc:
-            access_error_message = _provider_access_error_message(exc)
-            if access_error_message is not None:
-                logger.warning("Model access error surfaced to user: %s", type(exc).__name__)
-                return AIMessage(content=access_error_message)
-            if not _should_fallback(exc):
-                raise
-            logger.warning(
-                "Primary model failed (%s); falling back to %s",
-                type(exc).__name__,
-                getattr(self._fallback_model, "model_name", None)
-                or getattr(self._fallback_model, "model", "fallback"),
-            )
-            return handler(request.override(model=self._fallback_model))
 
     async def awrap_model_call(
         self,

--- a/agent/middleware/plan_mode.py
+++ b/agent/middleware/plan_mode.py
@@ -69,13 +69,6 @@ class PlanModeMiddleware(AgentMiddleware):
             return request
         return request.override(tools=filtered)
 
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelResponse:
-        return handler(self._filter(request))
-
     async def awrap_model_call(
         self,
         request: ModelRequest,

--- a/agent/middleware/refresh_slack_status.py
+++ b/agent/middleware/refresh_slack_status.py
@@ -173,20 +173,6 @@ class SlackAssistantStatusMiddleware(AgentMiddleware):
         status = _TOOL_STATUS.get(name or "", DEFAULT_ASSISTANT_STATUS)
         return await self._run_with_heartbeat(status, handler(request))
 
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelResponse:
-        return handler(request)
-
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command],
-    ) -> ToolMessage | Command:
-        return handler(request)
-
     async def _try_set(self, status: str) -> None:
         try:
             slack_thread = _slack_thread_from_config()

--- a/agent/middleware/repair_orphaned_tool_calls.py
+++ b/agent/middleware/repair_orphaned_tool_calls.py
@@ -21,7 +21,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, ToolMessage
 
 logger = logging.getLogger(__name__)
@@ -97,16 +97,6 @@ def _repair_messages(messages: list[Any]) -> list[Any] | None:
 
 class RepairOrphanedToolCallsMiddleware(AgentMiddleware):
     """Insert synthetic tool results for interrupted tool calls before model calls."""
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelCallResult:
-        repaired = _repair_messages(request.messages)
-        if repaired is not None:
-            request.messages[:] = repaired
-        return handler(request)
 
     async def awrap_model_call(
         self,

--- a/agent/middleware/sanitize_fireworks_messages.py
+++ b/agent/middleware/sanitize_fireworks_messages.py
@@ -19,7 +19,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage
 
 try:
@@ -62,15 +62,6 @@ def _sanitize_messages(messages: list[Any]) -> None:
 
 class SanitizeFireworksMessagesMiddleware(AgentMiddleware):
     """Drop legacy ``function_call`` fields before Fireworks provider calls."""
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelCallResult:
-        if _is_chat_fireworks(request.model):
-            _sanitize_messages(request.messages)
-        return handler(request)
 
     async def awrap_model_call(
         self,

--- a/agent/middleware/sanitize_openai_responses.py
+++ b/agent/middleware/sanitize_openai_responses.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage
 
 try:
@@ -65,15 +65,6 @@ def _sanitize_messages(messages: list[Any]) -> None:
 
 class SanitizeOpenAIResponsesMiddleware(AgentMiddleware):
     """Drop non-replayable OpenAI Responses reasoning item references."""
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelCallResult:
-        if _is_chat_openai(request.model):
-            _sanitize_messages(request.messages)
-        return handler(request)
 
     async def awrap_model_call(
         self,

--- a/agent/middleware/sanitize_thinking_blocks.py
+++ b/agent/middleware/sanitize_thinking_blocks.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage
 
@@ -47,15 +47,6 @@ def _sanitize_messages(messages: list[Any]) -> None:
 
 class SanitizeThinkingBlocksMiddleware(AgentMiddleware):
     """Drop empty Anthropic thinking blocks before provider validation."""
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ModelCallResult:
-        if _is_chat_anthropic(request.model):
-            _sanitize_messages(request.messages)
-        return handler(request)
 
     async def awrap_model_call(
         self,

--- a/agent/middleware/sanitize_tool_inputs.py
+++ b/agent/middleware/sanitize_tool_inputs.py
@@ -73,13 +73,6 @@ class SanitizeToolInputsMiddleware(AgentMiddleware):
         new_tool_call = {**tool_call, "args": sanitized_args}
         return request.override(tool_call=new_tool_call)
 
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command],
-    ) -> ToolMessage | Command:
-        return handler(self._sanitize_request(request))
-
     async def awrap_tool_call(
         self,
         request: ToolCallRequest,

--- a/agent/middleware/tool_artifact.py
+++ b/agent/middleware/tool_artifact.py
@@ -193,18 +193,6 @@ class ToolArtifactMiddleware(AgentMiddleware):
             return None
         return SANDBOX_BACKENDS.get(thread_id)
 
-    def _read_before_sync(self, request: ToolCallRequest) -> tuple[str | None, str | None]:
-        backend = self._backend(request)
-        file_path = _file_path(_tool_args(request))
-        if backend is None or file_path is None:
-            return None, "other"
-        try:
-            result = backend.read(file_path, offset=0, limit=_MAX_DIFF_LINES)
-        except Exception:
-            logger.debug("tool_artifact: read failed for %s", file_path, exc_info=True)
-            return None, "other"
-        return _classify_read(result)
-
     async def _read_before_async(self, request: ToolCallRequest) -> tuple[str | None, str | None]:
         backend = self._backend(request)
         file_path = _file_path(_tool_args(request))
@@ -216,19 +204,6 @@ class ToolArtifactMiddleware(AgentMiddleware):
             logger.debug("tool_artifact: aread failed for %s", file_path, exc_info=True)
             return None, "other"
         return _classify_read(result)
-
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command],
-    ) -> ToolMessage | Command:
-        name = _tool_name(request)
-        if name not in _DIFF_TOOLS:
-            return handler(request)
-        before, kind = self._read_before_sync(request)
-        result = handler(request)
-        _stamp(result, _build_diff_artifact(name, _tool_args(request), before, kind))
-        return result
 
     async def awrap_tool_call(
         self,

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -6,7 +6,6 @@ returned as error ToolMessages instead of crashing the agent run.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
@@ -124,16 +123,6 @@ async def _recreate_sandbox_for_thread(thread_id: str) -> str:
     return sandbox_backend.id
 
 
-def _recreate_sandbox_for_thread_sync(thread_id: str) -> str:
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(_recreate_sandbox_for_thread(thread_id))
-    raise RuntimeError(
-        "Cannot recreate sandbox from a sync tool call while an event loop is running"
-    )
-
-
 def _sandbox_recreated_tool_message(
     e: SandboxClientError,
     sandbox_id: str,
@@ -165,27 +154,6 @@ class ToolErrorMiddleware(AgentMiddleware):
     """
 
     state_schema = AgentState
-
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command],
-    ) -> ToolMessage | Command:
-        try:
-            return handler(request)
-        except SandboxClientError as e:
-            logger.exception("Sandbox error during tool call handling; request=%r", request)
-            thread_id = _get_thread_id(request)
-            if thread_id:
-                try:
-                    sandbox_id = _recreate_sandbox_for_thread_sync(thread_id)
-                    return _sandbox_recreated_tool_message(e, sandbox_id, request)
-                except Exception:
-                    logger.exception("Failed to recreate sandbox for thread %s", thread_id)
-            return _generic_error_tool_message(e, request)
-        except Exception as e:
-            logger.exception("Error during tool call handling; request=%r", request)
-            return _generic_error_tool_message(e, request)
 
     async def awrap_tool_call(
         self,

--- a/agent/middleware/workflow_push_guard.py
+++ b/agent/middleware/workflow_push_guard.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 import logging
 import re
 import shlex
-import threading
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -302,29 +300,6 @@ def _approval_url(thread_id: str | None, fingerprint: str) -> str | None:
     return dashboard_workflow_approval_url(thread_id, fingerprint)
 
 
-def _run_coroutine_sync(coro: Awaitable[ToolMessage | Command]) -> ToolMessage | Command:
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-
-    result: dict[str, ToolMessage | Command | BaseException] = {}
-
-    def target() -> None:
-        try:
-            result["value"] = asyncio.run(coro)
-        except BaseException as exc:  # noqa: BLE001
-            result["value"] = exc
-
-    thread = threading.Thread(target=target)
-    thread.start()
-    thread.join()
-    value = result["value"]
-    if isinstance(value, BaseException):
-        raise value
-    return value
-
-
 def _workflow_change_for_push(backend: Any, parsed: ParsedGitPush) -> WorkflowPushChange | None:
     root_result = _run_git(backend, parsed.repo_dir, "rev-parse --show-toplevel")
     if not root_result.ok:
@@ -598,22 +573,6 @@ class WorkflowPushGuardMiddleware(AgentMiddleware):
                 already_rejected=state == "rejected",
             ),
             request,
-        )
-
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command],
-    ) -> ToolMessage | Command:
-        change = self._change_for_request(request)
-        if change is None:
-            return handler(request)
-
-        async def run_handler() -> ToolMessage | Command:
-            return handler(request)
-
-        return _run_coroutine_sync(
-            self._handle_change_async(request, lambda _request: run_handler(), change)
         )
 
     async def awrap_tool_call(

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -176,8 +176,3 @@ async def get_sandbox_backend(thread_id: str) -> SandboxBackendProxy:
 
     sandbox_backend = await asyncio.to_thread(create_sandbox, sandbox_id)
     return set_sandbox_backend(thread_id, sandbox_backend)
-
-
-def get_sandbox_backend_sync(thread_id: str) -> SandboxBackendProxy:
-    """Sync wrapper for get_sandbox_backend."""
-    return asyncio.run(get_sandbox_backend(thread_id))

--- a/tests/test_model_fallback_middleware.py
+++ b/tests/test_model_fallback_middleware.py
@@ -141,22 +141,3 @@ class TestModelFallbackMiddleware:
             await middleware.awrap_model_call(_make_request(), handler)
 
         assert len(calls) == 2
-
-    def test_sync_falls_over_on_overloaded(self) -> None:
-        fallback_model = MagicMock(name="fallback_model")
-        middleware = ModelFallbackMiddleware(fallback_model)
-        calls: list[object] = []
-        good_response = MagicMock(result=[AIMessage(content="ok")])
-
-        def handler(req: object) -> object:
-            calls.append(req)
-            if len(calls) == 1:
-                raise _anthropic_overloaded()
-            return good_response
-
-        request = _make_request()
-        result = middleware.wrap_model_call(request, handler)
-
-        assert result is good_response
-        assert len(calls) == 2
-        request.override.assert_called_once_with(model=fallback_model)

--- a/tests/test_repair_orphaned_tool_calls.py
+++ b/tests/test_repair_orphaned_tool_calls.py
@@ -26,14 +26,22 @@ def _ai_with_tool_call(call_id: str, name: str = "execute") -> AIMessage:
     )
 
 
+async def _noop_handler(_req: object) -> object:
+    return MagicMock()
+
+
 class TestRepairOrphanedToolCallsMiddleware:
-    def test_inserts_synthetic_result_for_orphaned_tool_call(self) -> None:
+    @pytest.mark.asyncio
+    async def test_inserts_synthetic_result_for_orphaned_tool_call(self) -> None:
         ai = _ai_with_tool_call("call_1")
         follow_up = HumanMessage(content="continue")
         request = _make_request([HumanMessage(content="hi"), ai, follow_up])
         response = MagicMock()
 
-        result = RepairOrphanedToolCallsMiddleware().wrap_model_call(request, lambda req: response)
+        async def handler(_req: object) -> object:
+            return response
+
+        result = await RepairOrphanedToolCallsMiddleware().awrap_model_call(request, handler)
 
         assert result is response
         messages = request.messages
@@ -47,17 +55,19 @@ class TestRepairOrphanedToolCallsMiddleware:
         assert payload["recovery"] == INTERRUPTED_TOOL_RECOVERY
         assert payload["name"] == "execute"
 
-    def test_leaves_satisfied_tool_calls_untouched(self) -> None:
+    @pytest.mark.asyncio
+    async def test_leaves_satisfied_tool_calls_untouched(self) -> None:
         ai = _ai_with_tool_call("call_1")
         tool = ToolMessage(content="done", tool_call_id="call_1")
         original = [HumanMessage(content="hi"), ai, tool]
         request = _make_request(list(original))
 
-        RepairOrphanedToolCallsMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await RepairOrphanedToolCallsMiddleware().awrap_model_call(request, _noop_handler)
 
         assert request.messages == original
 
-    def test_repairs_multiple_orphans_on_one_message(self) -> None:
+    @pytest.mark.asyncio
+    async def test_repairs_multiple_orphans_on_one_message(self) -> None:
         ai = AIMessage(
             content="",
             tool_calls=[
@@ -67,13 +77,14 @@ class TestRepairOrphanedToolCallsMiddleware:
         )
         request = _make_request([ai])
 
-        RepairOrphanedToolCallsMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await RepairOrphanedToolCallsMiddleware().awrap_model_call(request, _noop_handler)
 
         messages = request.messages
         assert [getattr(m, "tool_call_id", None) for m in messages[1:]] == ["call_1", "call_2"]
         assert all(isinstance(m, ToolMessage) for m in messages[1:])
 
-    def test_partial_repair_keeps_existing_result(self) -> None:
+    @pytest.mark.asyncio
+    async def test_partial_repair_keeps_existing_result(self) -> None:
         ai = AIMessage(
             content="",
             tool_calls=[
@@ -84,7 +95,7 @@ class TestRepairOrphanedToolCallsMiddleware:
         tool = ToolMessage(content="done", tool_call_id="call_1")
         request = _make_request([ai, tool])
 
-        RepairOrphanedToolCallsMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await RepairOrphanedToolCallsMiddleware().awrap_model_call(request, _noop_handler)
 
         synthetic = [
             m for m in request.messages if isinstance(m, ToolMessage) and m.status == "error"

--- a/tests/test_sanitize_fireworks_messages.py
+++ b/tests/test_sanitize_fireworks_messages.py
@@ -24,52 +24,13 @@ def _fireworks_model() -> MagicMock:
     return MagicMock(spec=ChatFireworks)
 
 
+async def _noop_handler(_req: object) -> object:
+    return MagicMock()
+
+
 class TestSanitizeFireworksMessagesMiddleware:
-    def test_drops_legacy_function_call(self) -> None:
-        message = AIMessage(
-            content="",
-            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
-            additional_kwargs={"function_call": {"name": "read_file", "arguments": "{}"}},
-        )
-        request = _make_request([message], model=_fireworks_model())
-        response = MagicMock()
-
-        def handler(req: object) -> object:
-            assert req is request
-            return response
-
-        result = SanitizeFireworksMessagesMiddleware().wrap_model_call(request, handler)
-
-        assert result is response
-        assert "function_call" not in message.additional_kwargs
-        # tool_calls are untouched
-        assert len(message.tool_calls) == 1
-
-    def test_preserves_message_without_function_call(self) -> None:
-        message = AIMessage(
-            content="ok",
-            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
-        )
-        request = _make_request([message], model=_fireworks_model())
-
-        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
-
-        assert "function_call" not in message.additional_kwargs
-        assert len(message.tool_calls) == 1
-
-    def test_drops_function_call_with_no_tool_calls(self) -> None:
-        message = AIMessage(
-            content="",
-            additional_kwargs={"function_call": {"name": "search", "arguments": "{}"}},
-        )
-        request = _make_request([message], model=_fireworks_model())
-
-        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
-
-        assert "function_call" not in message.additional_kwargs
-
     @pytest.mark.asyncio
-    async def test_async_drops_legacy_function_call(self) -> None:
+    async def test_drops_legacy_function_call(self) -> None:
         tool_result = ToolMessage(content="result", tool_call_id="tc1")
         message = AIMessage(
             content="",
@@ -90,8 +51,36 @@ class TestSanitizeFireworksMessagesMiddleware:
 
         assert result is response
         assert "function_call" not in message.additional_kwargs
+        # tool_calls are untouched
+        assert len(message.tool_calls) == 1
 
-    def test_ignores_non_fireworks_models(self) -> None:
+    @pytest.mark.asyncio
+    async def test_preserves_message_without_function_call(self) -> None:
+        message = AIMessage(
+            content="ok",
+            tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
+        )
+        request = _make_request([message], model=_fireworks_model())
+
+        await SanitizeFireworksMessagesMiddleware().awrap_model_call(request, _noop_handler)
+
+        assert "function_call" not in message.additional_kwargs
+        assert len(message.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_drops_function_call_with_no_tool_calls(self) -> None:
+        message = AIMessage(
+            content="",
+            additional_kwargs={"function_call": {"name": "search", "arguments": "{}"}},
+        )
+        request = _make_request([message], model=_fireworks_model())
+
+        await SanitizeFireworksMessagesMiddleware().awrap_model_call(request, _noop_handler)
+
+        assert "function_call" not in message.additional_kwargs
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_fireworks_models(self) -> None:
         message = AIMessage(
             content="",
             tool_calls=[{"name": "read_file", "args": {"file_path": "/x"}, "id": "tc1"}],
@@ -100,19 +89,20 @@ class TestSanitizeFireworksMessagesMiddleware:
         # Non-Fireworks model (plain MagicMock, no ChatFireworks in its spec chain)
         request = _make_request([message], model=MagicMock())
 
-        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await SanitizeFireworksMessagesMiddleware().awrap_model_call(request, _noop_handler)
 
         # function_call preserved for non-Fireworks providers
         assert "function_call" in message.additional_kwargs
 
-    def test_skips_non_ai_messages(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skips_non_ai_messages(self) -> None:
         messages = [
             HumanMessage(content="hi"),
             ToolMessage(content="result", tool_call_id="tc1"),
         ]
         request = _make_request(messages, model=_fireworks_model())
 
-        SanitizeFireworksMessagesMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await SanitizeFireworksMessagesMiddleware().awrap_model_call(request, _noop_handler)
 
         # No AIMessages to mutate — handler still called
         assert all(not isinstance(m, AIMessage) for m in messages)

--- a/tests/test_sanitize_thinking_blocks.py
+++ b/tests/test_sanitize_thinking_blocks.py
@@ -16,8 +16,13 @@ def _make_request(messages: list[object], model: object | None = None) -> MagicM
     return request
 
 
+async def _noop_handler(_req: object) -> object:
+    return MagicMock()
+
+
 class TestSanitizeThinkingBlocksMiddleware:
-    def test_drops_empty_thinking_block_for_anthropic(self) -> None:
+    @pytest.mark.asyncio
+    async def test_drops_empty_thinking_block_for_anthropic(self) -> None:
         message = AIMessage(
             content=[
                 {"type": "thinking", "signature": "abc", "thinking": ""},
@@ -27,22 +32,23 @@ class TestSanitizeThinkingBlocksMiddleware:
         request = _make_request([message])
         response = MagicMock()
 
-        def handler(req: object) -> object:
+        async def handler(req: object) -> object:
             assert req is request
             return response
 
-        result = SanitizeThinkingBlocksMiddleware().wrap_model_call(request, handler)
+        result = await SanitizeThinkingBlocksMiddleware().awrap_model_call(request, handler)
 
         assert result is response
         assert message.content == [{"type": "text", "text": "ok"}]
 
-    def test_preserves_non_empty_thinking_block_for_anthropic(self) -> None:
+    @pytest.mark.asyncio
+    async def test_preserves_non_empty_thinking_block_for_anthropic(self) -> None:
         thinking_block = {"type": "thinking", "signature": "abc", "thinking": "reasoning"}
         text_block = {"type": "text", "text": "ok"}
         message = AIMessage(content=[thinking_block, text_block])
         request = _make_request([message])
 
-        SanitizeThinkingBlocksMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await SanitizeThinkingBlocksMiddleware().awrap_model_call(request, _noop_handler)
 
         assert message.content == [thinking_block, text_block]
 
@@ -66,11 +72,12 @@ class TestSanitizeThinkingBlocksMiddleware:
         assert result is response
         assert message.content == [{"type": "text", "text": "ok"}]
 
-    def test_ignores_non_anthropic_models(self) -> None:
+    @pytest.mark.asyncio
+    async def test_ignores_non_anthropic_models(self) -> None:
         thinking_block = {"type": "thinking", "signature": "abc", "thinking": ""}
         message = AIMessage(content=[thinking_block, {"type": "text", "text": "ok"}])
         request = _make_request([message], model=MagicMock())
 
-        SanitizeThinkingBlocksMiddleware().wrap_model_call(request, lambda req: MagicMock())
+        await SanitizeThinkingBlocksMiddleware().awrap_model_call(request, _noop_handler)
 
         assert message.content == [thinking_block, {"type": "text", "text": "ok"}]


### PR DESCRIPTION
The agent runs async-only, so the sync halves of the middleware and tool interfaces are never invoked. This rips out the sync `wrap_*` / `_run` shims and the sync-only helpers that existed purely to satisfy those interfaces.

## What changed
- **Middleware**: deleted the sync `wrap_tool_call` / `wrap_model_call` overrides across `sanitize_tool_inputs`, `sanitize_fireworks_messages`, `sanitize_thinking_blocks`, `sanitize_openai_responses`, `plan_mode`, `tool_artifact`, `exclude_tools`, `model_fallback`, `tool_error_handler`, `workflow_push_guard`, `repair_orphaned_tool_calls`. Only the `awrap_*` variants run; the base `AgentMiddleware` already raises `NotImplementedError` on the sync path if it were ever hit.
- **Dead helpers**: removed `get_sandbox_backend_sync` (zero callers), `_recreate_sandbox_for_thread_sync`, `_run_coroutine_sync`, and `tool_artifact._read_before_sync`, plus the now-unused `asyncio` / `threading` imports.
- **notion_mcp**: `BaseTool._run` is abstract so it must stay, but its body is now just a `raise` — these tools are async-only.
- **Tests**: converted sync-path tests to their async equivalents and dropped now-redundant sync duplicates.

Left `langsmith._update_thread_sandbox_metadata` untouched — its `asyncio.run` branch is the live path when provisioning runs off-loop via `asyncio.to_thread`, not a dead shim. (A follow-up to make provisioning natively async via `AsyncSandboxClient` is tracked separately.)

## Test Plan
- [x] `make lint` (ruff check + format) clean
- [x] `make test` — 1309 passed