### PR TITLE
refactor(open-swe): provision LangSmith sandboxes natively async

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -12,7 +12,6 @@ on public repos even when the GitHub App is not installed on them.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import warnings
@@ -85,7 +84,7 @@ async def _configure_sandbox_github_proxy(
     if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
         return
     backend = unwrap_sandbox_backend(sandbox_backend)
-    await asyncio.to_thread(_configure_github_proxy, backend.id, github_token)
+    await _configure_github_proxy(backend.id, github_token)
 
 
 async def get_analyzer(config: RunnableConfig) -> Pregel:

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1679,7 +1679,7 @@ async def get_dashboard_thread_recovery_patch(
         raise HTTPException(404, "thread has no recoverable sandbox")
 
     try:
-        sandbox = await asyncio.to_thread(create_sandbox, sandbox_id)
+        sandbox = await create_sandbox(sandbox_id)
     except Exception as exc:  # noqa: BLE001
         logger.debug("Could not connect to sandbox %s for recovery", sandbox_id, exc_info=True)
         raise HTTPException(502, "could not connect to thread sandbox") from exc

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import logging
 import os
-import time
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeout
@@ -16,8 +15,8 @@ import httpx
 from deepagents.backends import LangSmithSandbox
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from langsmith.sandbox import (
+    AsyncSandboxClient,
     CommandTimeoutError,
-    SandboxClient,
     SandboxConnectionError,
     SandboxServerReloadError,
 )
@@ -134,7 +133,7 @@ def _is_retryable_proxy_config_error(exc: BaseException) -> bool:
     return isinstance(exc, httpx.TransportError)
 
 
-def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
+async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
     """Configure sandbox proxy to inject GitHub auth for GitHub traffic.
 
     Uses the LangSmith proxy-config API to set up header injection so that
@@ -152,10 +151,10 @@ def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
     langsmith_endpoint = os.environ.get("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
     url = f"{langsmith_endpoint}/v2/sandboxes/boxes/{sandbox_name}"
     payload = {"proxy_config": {"rules": _github_proxy_rules(github_token)}}
-    with httpx.Client(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:
+    async with httpx.AsyncClient(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:
         for attempt in range(PROXY_CONFIG_MAX_ATTEMPTS):
             try:
-                response = client.patch(
+                response = await client.patch(
                     url,
                     json=payload,
                     headers={"X-API-Key": api_key},
@@ -184,11 +183,16 @@ def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
                     type(exc).__name__,
                     delay,
                 )
-                time.sleep(delay)
+                await asyncio.sleep(delay)
     logger.info("Configured GitHub proxy for sandbox %s", sandbox_name)
 
 
-def create_langsmith_sandbox(
+def get_async_sandbox_client() -> AsyncSandboxClient:
+    """Build an ``AsyncSandboxClient`` from the resolved LangSmith API key."""
+    return AsyncSandboxClient(api_key=_get_langsmith_api_key())
+
+
+async def create_langsmith_sandbox(
     sandbox_id: str | None = None,
     github_token: str | None = None,
     *,
@@ -224,7 +228,7 @@ def create_langsmith_sandbox(
     effective_snapshot_id = snapshot_id or default_snapshot_id
 
     provider = LangSmithProvider(api_key=api_key)
-    backend = provider.get_or_create(
+    backend = await provider.get_or_create(
         sandbox_id=sandbox_id,
         snapshot_id=effective_snapshot_id,
         fs_capacity_bytes=fs_capacity_bytes,
@@ -233,19 +237,17 @@ def create_langsmith_sandbox(
         idle_ttl_seconds=idle_ttl_seconds,
         delete_after_stop_seconds=delete_after_stop_seconds,
     )
-    _update_thread_sandbox_metadata(backend.id)
+    await _update_thread_sandbox_metadata(backend.id)
 
     if sandbox_id is None and github_token:
-        _configure_github_proxy(backend.id, github_token)
+        await _configure_github_proxy(backend.id, github_token)
 
     return backend
 
 
-def _update_thread_sandbox_metadata(sandbox_id: str) -> None:
+async def _update_thread_sandbox_metadata(sandbox_id: str) -> None:
     """Update thread metadata with sandbox_id."""
     try:
-        import asyncio
-
         from langgraph.config import get_config
         from langgraph_sdk import get_client
 
@@ -254,19 +256,10 @@ def _update_thread_sandbox_metadata(sandbox_id: str) -> None:
         if not thread_id:
             return
         client = get_client()
-
-        async def _update() -> None:
-            await client.threads.update(
-                thread_id=thread_id,
-                metadata={"sandbox_id": sandbox_id},
-            )
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(_update())
-        else:
-            loop.create_task(_update())
+        await client.threads.update(
+            thread_id=thread_id,
+            metadata={"sandbox_id": sandbox_id},
+        )
     except Exception:
         pass
 
@@ -390,7 +383,7 @@ class SandboxProvider(ABC):
     """Interface for creating and deleting sandbox backends."""
 
     @abstractmethod
-    def get_or_create(
+    async def get_or_create(
         self,
         *,
         sandbox_id: str | None = None,
@@ -400,7 +393,7 @@ class SandboxProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def delete(
+    async def delete(
         self,
         *,
         sandbox_id: str,
@@ -414,13 +407,10 @@ class LangSmithProvider(SandboxProvider):
     """LangSmith sandbox provider implementation."""
 
     def __init__(self, api_key: str | None = None) -> None:
-        from langsmith import sandbox
-
         self._api_key = api_key or _get_langsmith_api_key()
         if not self._api_key:
             msg = "LANGSMITH_API_KEY (or LANGSMITH_API_KEY_PROD) not set"
             raise ValueError(msg)
-        self._client: SandboxClient = sandbox.SandboxClient(api_key=self._api_key)
 
     @classmethod
     def validate_startup_config(cls) -> None:
@@ -454,7 +444,7 @@ class LangSmithProvider(SandboxProvider):
                 msg = f"{name} must be >= 0, got {value}"
                 raise ValueError(msg)
 
-    def get_or_create(
+    async def get_or_create(
         self,
         *,
         sandbox_id: str | None = None,
@@ -467,38 +457,46 @@ class LangSmithProvider(SandboxProvider):
         delete_after_stop_seconds: int | None = None,
         **kwargs: Any,
     ) -> SandboxBackendProtocol:
-        """Get existing or create new LangSmith sandbox."""
+        """Get existing or create new LangSmith sandbox.
+
+        Provisioning runs natively async via ``AsyncSandboxClient``. The
+        resulting ``AsyncSandbox`` is converted to a sync ``Sandbox`` via
+        ``to_sync()`` so it satisfies the deepagents sync ``SandboxBackendProtocol``
+        that ``TimeoutLangSmithSandbox`` and the agent's file/execute tools expect.
+        """
         if kwargs:
             msg = f"Received unsupported arguments: {list(kwargs.keys())}"
             raise TypeError(msg)
-        if sandbox_id:
+        async with AsyncSandboxClient(api_key=self._api_key) as client:
+            if sandbox_id:
+                try:
+                    sandbox = await client.get_sandbox(name=sandbox_id)
+                except Exception as e:
+                    msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
+                    raise RuntimeError(msg) from e
+                return TimeoutLangSmithSandbox(sandbox.to_sync())
+
+            if not snapshot_id:
+                msg = "DEFAULT_SANDBOX_SNAPSHOT_ID must be set when SANDBOX_TYPE=langsmith"
+                raise ValueError(msg)
+
             try:
-                sandbox = self._client.get_sandbox(name=sandbox_id)
+                sandbox = await client.create_sandbox(
+                    snapshot_id=snapshot_id,
+                    fs_capacity_bytes=fs_capacity_bytes,
+                    vcpus=vcpus,
+                    mem_bytes=mem_bytes,
+                    idle_ttl_seconds=idle_ttl_seconds,
+                    delete_after_stop_seconds=delete_after_stop_seconds,
+                    timeout=timeout,
+                )
             except Exception as e:
-                msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
+                msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
                 raise RuntimeError(msg) from e
-            return TimeoutLangSmithSandbox(sandbox)
 
-        if not snapshot_id:
-            msg = "DEFAULT_SANDBOX_SNAPSHOT_ID must be set when SANDBOX_TYPE=langsmith"
-            raise ValueError(msg)
+            return TimeoutLangSmithSandbox(sandbox.to_sync())
 
-        try:
-            sandbox = self._client.create_sandbox(
-                snapshot_id=snapshot_id,
-                fs_capacity_bytes=fs_capacity_bytes,
-                vcpus=vcpus,
-                mem_bytes=mem_bytes,
-                idle_ttl_seconds=idle_ttl_seconds,
-                delete_after_stop_seconds=delete_after_stop_seconds,
-                timeout=timeout,
-            )
-        except Exception as e:
-            msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
-            raise RuntimeError(msg) from e
-
-        return TimeoutLangSmithSandbox(sandbox)
-
-    def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:
+    async def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:
         """Delete a LangSmith sandbox."""
-        self._client.delete_sandbox(sandbox_id)
+        async with AsyncSandboxClient(api_key=self._api_key) as client:
+            await client.delete_sandbox(sandbox_id)

--- a/agent/server.py
+++ b/agent/server.py
@@ -51,7 +51,7 @@ from .dashboard.user_mappings import email_for_login
 from .integrations.corridor_mcp import load_corridor_tools
 from .integrations.currents_tools import load_currents_tools
 from .integrations.datadog_mcp import load_datadog_tools
-from .integrations.langsmith import _configure_github_proxy
+from .integrations.langsmith import _configure_github_proxy, get_async_sandbox_client
 from .integrations.langsmith_tools import load_langsmith_tools
 from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
@@ -174,20 +174,21 @@ async def _start_langsmith_sandbox_if_needed(sandbox_backend: SandboxBackendProt
     if not isinstance(current_backend, LangSmithSandbox):
         return
 
-    sandbox = current_backend._sandbox  # noqa: SLF001
-    status = await asyncio.to_thread(sandbox._client.get_sandbox_status, sandbox.name)  # noqa: SLF001
-    status_name = getattr(status, "status", status)
-    status_name = getattr(status_name, "value", status_name)
-    status_text = str(status_name or "").lower()
-    if status_text in {"running", "ready"}:
-        return
+    name = current_backend.id
+    async with get_async_sandbox_client() as client:
+        status = await client.get_sandbox_status(name)
+        status_name = getattr(status, "status", status)
+        status_name = getattr(status_name, "value", status_name)
+        status_text = str(status_name or "").lower()
+        if status_text in {"running", "ready"}:
+            return
 
-    logger.info(
-        "Starting LangSmith sandbox %s before proxy refresh (status=%s)",
-        current_backend.id,
-        status_text or "unknown",
-    )
-    await asyncio.to_thread(sandbox.start)
+        logger.info(
+            "Starting LangSmith sandbox %s before proxy refresh (status=%s)",
+            name,
+            status_text or "unknown",
+        )
+        await client.start_sandbox(name)
 
 
 async def _resolve_proxy_token(
@@ -242,7 +243,7 @@ async def _create_sandbox_with_proxy(
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
     snapshot_id = await _resolve_snapshot_id_for_repo(repo)
-    sandbox_backend = await asyncio.to_thread(create_sandbox, snapshot_id=snapshot_id)
+    sandbox_backend = await create_sandbox(snapshot_id=snapshot_id)
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     if sandbox_type == "langsmith":
@@ -252,7 +253,7 @@ async def _create_sandbox_with_proxy(
             logger.error(msg)
             raise ValueError(msg)
         await _start_langsmith_sandbox_if_needed(sandbox_backend)
-        await asyncio.to_thread(_configure_github_proxy, sandbox_backend.id, token)
+        await _configure_github_proxy(sandbox_backend.id, token)
         record_proxy_token_expiry(
             thread_id,
             expires_at,
@@ -284,7 +285,7 @@ async def _refresh_github_proxy(
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
     await _start_langsmith_sandbox_if_needed(current_backend)
-    await asyncio.to_thread(_configure_github_proxy, current_backend.id, token)
+    await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
         thread_id,
         expires_at,
@@ -503,7 +504,7 @@ async def ensure_sandbox_for_thread(
         logger.info("Connecting to existing sandbox %s", sandbox_id)
         created_replacement_sandbox = False
         try:
-            sandbox_backend = await asyncio.to_thread(create_sandbox, sandbox_id)
+            sandbox_backend = await create_sandbox(sandbox_id)
         except Exception:
             logger.warning("Failed to connect to existing sandbox %s, creating new one", sandbox_id)
             await client.threads.update(thread_id=thread_id, metadata=_creating_metadata())

--- a/agent/utils/github_proxy.py
+++ b/agent/utils/github_proxy.py
@@ -9,7 +9,6 @@ before-model middleware re-configure the proxy before it goes stale.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 from collections.abc import Sequence
@@ -144,7 +143,7 @@ async def refresh_proxy_token(
     from ..integrations.langsmith import _configure_github_proxy
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
-    await asyncio.to_thread(_configure_github_proxy, current_backend.id, token)
+    await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
         thread_id,
         expires_at,

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -1,10 +1,12 @@
+import asyncio
 import os
 from collections.abc import Callable
 from importlib import import_module
+from typing import Any
 
 from deepagents.backends.protocol import SandboxBackendProtocol
 
-SandboxFactory = Callable[[str | None], SandboxBackendProtocol]
+SandboxFactory = Callable[..., Any]
 
 SANDBOX_FACTORIES: dict[str, tuple[str, str]] = {
     "langsmith": ("agent.integrations.langsmith", "create_langsmith_sandbox"),
@@ -27,7 +29,7 @@ def _load_sandbox_factory(sandbox_type: str) -> SandboxFactory:
     return factory
 
 
-def create_sandbox(
+async def create_sandbox(
     sandbox_id: str | None = None,
     *,
     snapshot_id: str | None = None,
@@ -36,6 +38,9 @@ def create_sandbox(
 
     The provider is selected via the SANDBOX_TYPE environment variable.
     Supported values: langsmith (default), daytona, modal, runloop, local.
+
+    The langsmith provider provisions natively async; the other providers wrap
+    sync SDKs and are bridged onto the event loop with ``asyncio.to_thread``.
 
     Args:
         sandbox_id: Optional existing sandbox ID to reconnect to.
@@ -48,9 +53,11 @@ def create_sandbox(
     """
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     factory = _load_sandbox_factory(sandbox_type)
-    if sandbox_type == "langsmith" and snapshot_id is not None:
-        return factory(sandbox_id, snapshot_id=snapshot_id)
-    return factory(sandbox_id)
+    if sandbox_type == "langsmith":
+        if snapshot_id is not None:
+            return await factory(sandbox_id, snapshot_id=snapshot_id)
+        return await factory(sandbox_id)
+    return await asyncio.to_thread(factory, sandbox_id)
 
 
 def validate_sandbox_startup_config() -> None:

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from deepagents.backends.protocol import (
@@ -174,10 +173,5 @@ async def get_sandbox_backend(thread_id: str) -> SandboxBackendProxy:
     if not sandbox_id:
         raise ValueError(f"Missing sandbox_id in thread metadata for {thread_id}")
 
-    sandbox_backend = await asyncio.to_thread(create_sandbox, sandbox_id)
+    sandbox_backend = await create_sandbox(sandbox_id)
     return set_sandbox_backend(thread_id, sandbox_backend)
-
-
-def get_sandbox_backend_sync(thread_id: str) -> SandboxBackendProxy:
-    """Sync wrapper for get_sandbox_backend."""
-    return asyncio.run(get_sandbox_backend(thread_id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "markdownify>=1.2.2",
     "langchain-anthropic>=1.4.6",
     "langgraph-cli[inmem]>=0.4.27",
-    "langsmith==0.9.3",
+    "langsmith==0.9.7",
     "langchain-openai>=1.2.2",
     "langchain-fireworks>=1.4.2",
     # langchain-fireworks 1.4.2 pins a pre-release fireworks-ai; opt in explicitly so uv resolves it.

--- a/tests/test_dashboard_thread_api.py
+++ b/tests/test_dashboard_thread_api.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
@@ -372,7 +373,7 @@ async def test_recovery_patch_downloads_generated_patch(monkeypatch) -> None:
             return [SimpleNamespace(content=b"patch bytes")]
 
     monkeypatch.setattr(thread_api, "_authorized_thread", fake_authorized_thread)
-    monkeypatch.setattr(thread_api, "create_sandbox", lambda sandbox_id: FakeSandbox())
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=FakeSandbox()))
 
     content, filename = await thread_api.get_dashboard_thread_recovery_patch("tid", "octocat")
 
@@ -392,7 +393,7 @@ async def test_recovery_patch_rejects_empty_patch(monkeypatch) -> None:
             )
 
     monkeypatch.setattr(thread_api, "_authorized_thread", fake_authorized_thread)
-    monkeypatch.setattr(thread_api, "create_sandbox", lambda sandbox_id: FakeSandbox())
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=FakeSandbox()))
 
     with pytest.raises(HTTPException) as exc_info:
         await thread_api.get_dashboard_thread_recovery_patch("tid", "octocat")
@@ -419,7 +420,7 @@ async def test_recovery_patch_enforces_size_limit(monkeypatch) -> None:
             )
 
     monkeypatch.setattr(thread_api, "_authorized_thread", fake_authorized_thread)
-    monkeypatch.setattr(thread_api, "create_sandbox", lambda sandbox_id: FakeSandbox())
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=FakeSandbox()))
 
     with pytest.raises(HTTPException) as exc_info:
         await thread_api.get_dashboard_thread_recovery_patch("tid", "octocat")

--- a/tests/test_github_proxy_refresh.py
+++ b/tests/test_github_proxy_refresh.py
@@ -99,7 +99,10 @@ class TestMaybeRefreshProxyToken:
                 "agent.utils.github_proxy.get_github_app_installation_token_with_expiry",
                 new=AsyncMock(return_value=("ghs_new", new_expiry)),
             ),
-            patch("agent.integrations.langsmith._configure_github_proxy") as mock_configure,
+            patch(
+                "agent.integrations.langsmith._configure_github_proxy",
+                new_callable=AsyncMock,
+            ) as mock_configure,
         ):
             result = await maybe_refresh_proxy_token("thread-1", now=now)
 
@@ -123,7 +126,10 @@ class TestMaybeRefreshProxyToken:
                 "agent.utils.github_proxy.get_github_app_installation_token_with_expiry",
                 new=token_mock,
             ),
-            patch("agent.integrations.langsmith._configure_github_proxy"),
+            patch(
+                "agent.integrations.langsmith._configure_github_proxy",
+                new_callable=AsyncMock,
+            ),
         ):
             result = await maybe_refresh_proxy_token("thread-1", now=now)
 

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -15,8 +15,15 @@ from agent.utils.github_app import (
 )
 
 
+def _mock_async_client(mock_client_cls: MagicMock, inner: MagicMock) -> None:
+    """Wire an ``httpx.AsyncClient`` mock class to yield ``inner`` from its
+    async context manager."""
+    mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=inner)
+    mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+
 class TestSandboxFactoryLoading:
-    def test_create_sandbox_loads_only_selected_provider(self) -> None:
+    async def test_create_sandbox_loads_only_selected_provider(self) -> None:
         with (
             patch("agent.utils.sandbox.import_module") as mock_import_module,
             patch.dict("os.environ", {"SANDBOX_TYPE": "local"}),
@@ -27,7 +34,7 @@ class TestSandboxFactoryLoading:
 
             from agent.utils.sandbox import create_sandbox
 
-            sandbox = create_sandbox("existing")
+            sandbox = await create_sandbox("existing")
 
         assert sandbox.id == "local"
         mock_import_module.assert_called_once_with("agent.integrations.local")
@@ -37,23 +44,22 @@ class TestSandboxFactoryLoading:
 class TestConfigureGithubProxy:
     """Tests for _configure_github_proxy payload shape and error handling."""
 
-    def test_sends_correct_payload_shape(self) -> None:
+    async def test_sends_correct_payload_shape(self) -> None:
         """Verify the PATCH request uses opaque headers with correct structure."""
         token = "ghs_testtoken123"
         expected_basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
 
         with (
-            patch("agent.integrations.langsmith.httpx.Client") as mock_client_cls,
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
             patch.dict("os.environ", {"LANGSMITH_API_KEY": "ls-api-key"}),
         ):
             mock_client = MagicMock()
             mock_response = MagicMock()
             mock_response.raise_for_status = MagicMock()
-            mock_client.patch.return_value = mock_response
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            _mock_async_client(mock_client_cls, mock_client)
 
-            _configure_github_proxy("sandbox-abc123", token)
+            await _configure_github_proxy("sandbox-abc123", token)
 
             mock_client.patch.assert_called_once()
             call_kwargs = mock_client.patch.call_args
@@ -82,10 +88,10 @@ class TestConfigureGithubProxy:
             assert headers[0]["type"] == "opaque"
             assert headers[0]["value"] == f"Basic {expected_basic}"
 
-    def test_sends_to_correct_url(self) -> None:
+    async def test_sends_to_correct_url(self) -> None:
         """Verify the PATCH hits the right endpoint."""
         with (
-            patch("agent.integrations.langsmith.httpx.Client") as mock_client_cls,
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
             patch.dict(
                 "os.environ",
                 {
@@ -97,34 +103,32 @@ class TestConfigureGithubProxy:
             mock_client = MagicMock()
             mock_response = MagicMock()
             mock_response.raise_for_status = MagicMock()
-            mock_client.patch.return_value = mock_response
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            _mock_async_client(mock_client_cls, mock_client)
 
-            _configure_github_proxy("sandbox-xyz", "token")
+            await _configure_github_proxy("sandbox-xyz", "token")
 
             url = mock_client.patch.call_args.args[0]
             assert url == "https://test.api.smith.langchain.com/v2/sandboxes/boxes/sandbox-xyz"
 
-    def test_sends_api_key_header(self) -> None:
+    async def test_sends_api_key_header(self) -> None:
         """Verify the PATCH includes the LangSmith API key."""
         with (
-            patch("agent.integrations.langsmith.httpx.Client") as mock_client_cls,
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
             patch.dict("os.environ", {"LANGSMITH_API_KEY": "my-api-key"}),
         ):
             mock_client = MagicMock()
             mock_response = MagicMock()
             mock_response.raise_for_status = MagicMock()
-            mock_client.patch.return_value = mock_response
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            _mock_async_client(mock_client_cls, mock_client)
 
-            _configure_github_proxy("sandbox-abc", "token")
+            await _configure_github_proxy("sandbox-abc", "token")
 
             headers = mock_client.patch.call_args.kwargs["headers"]
             assert headers == {"X-API-Key": "my-api-key"}
 
-    def test_retries_transient_http_error(self) -> None:
+    async def test_retries_transient_http_error(self) -> None:
         """Transient proxy API errors should be retried on the same sandbox."""
         request = httpx.Request(
             "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
@@ -136,8 +140,10 @@ class TestConfigureGithubProxy:
             response=response,
         )
         with (
-            patch("agent.integrations.langsmith.httpx.Client") as mock_client_cls,
-            patch("agent.integrations.langsmith.time.sleep") as mock_sleep,
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
             patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
         ):
             mock_client = MagicMock()
@@ -145,16 +151,15 @@ class TestConfigureGithubProxy:
             failed_response.raise_for_status.side_effect = transient_error
             successful_response = MagicMock()
             successful_response.raise_for_status = MagicMock()
-            mock_client.patch.side_effect = [failed_response, successful_response]
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.patch = AsyncMock(side_effect=[failed_response, successful_response])
+            _mock_async_client(mock_client_cls, mock_client)
 
-            _configure_github_proxy("sandbox-abc", "token")
+            await _configure_github_proxy("sandbox-abc", "token")
 
             assert mock_client.patch.call_count == 2
             mock_sleep.assert_called_once()
 
-    def test_raises_on_non_retryable_http_error(self) -> None:
+    async def test_raises_on_non_retryable_http_error(self) -> None:
         """Non-retryable HTTP errors should propagate without retrying."""
         request = httpx.Request(
             "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
@@ -162,19 +167,20 @@ class TestConfigureGithubProxy:
         response = httpx.Response(400, request=request)
         error = httpx.HTTPStatusError("Bad request", request=request, response=response)
         with (
-            patch("agent.integrations.langsmith.httpx.Client") as mock_client_cls,
-            patch("agent.integrations.langsmith.time.sleep") as mock_sleep,
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
             patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
         ):
             mock_client = MagicMock()
             failed_response = MagicMock()
             failed_response.raise_for_status.side_effect = error
-            mock_client.patch.return_value = failed_response
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.patch = AsyncMock(return_value=failed_response)
+            _mock_async_client(mock_client_cls, mock_client)
 
             with pytest.raises(httpx.HTTPStatusError):
-                _configure_github_proxy("sandbox-abc", "token")
+                await _configure_github_proxy("sandbox-abc", "token")
 
             mock_client.patch.assert_called_once()
             mock_sleep.assert_not_called()
@@ -192,8 +198,8 @@ class TestCreateSandboxWithProxy:
                 new_callable=AsyncMock,
                 return_value=("ghs_install", None),
             ) as mock_get_token,
-            patch("agent.server.create_sandbox") as mock_create,
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "LANGSMITH_API_KEY": "ls-key"}),
         ):
             mock_create.return_value = MagicMock(id="sandbox-123")
@@ -217,8 +223,8 @@ class TestCreateSandboxWithProxy:
                 new_callable=AsyncMock,
                 side_effect=[(None, None), ("ghs_install", "expires")],
             ) as mock_get_token,
-            patch("agent.server.create_sandbox") as mock_create,
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch("agent.server.record_proxy_token_expiry") as mock_record,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "LANGSMITH_API_KEY": "ls-key"}),
         ):
@@ -247,8 +253,8 @@ class TestCreateSandboxWithProxy:
     async def test_skips_proxy_for_non_langsmith(self) -> None:
         """Non-langsmith sandboxes should skip proxy configuration."""
         with (
-            patch("agent.server.create_sandbox") as mock_create,
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch.dict("os.environ", {"SANDBOX_TYPE": "daytona"}),
         ):
             mock_create.return_value = MagicMock(id="sandbox-456")
@@ -264,7 +270,7 @@ class TestCreateSandboxWithProxy:
     async def test_raises_when_no_installation_token_for_langsmith(self) -> None:
         """Should raise ValueError when installation token is unavailable for langsmith."""
         with (
-            patch("agent.server.create_sandbox") as mock_create,
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
             patch(
                 "agent.server.get_github_app_installation_token_with_expiry",
                 new_callable=AsyncMock,
@@ -299,6 +305,19 @@ class TestRefreshProxyOnSandboxReuse:
             "metadata": {},
         }
 
+    @staticmethod
+    def _async_client_mock(status: str) -> MagicMock:
+        """Build an ``httpx``-style async-context-manager mock for the sandbox
+        client whose status/start methods are awaitable."""
+        inner = MagicMock()
+        inner.get_sandbox_status = AsyncMock(return_value=MagicMock(status=status))
+        inner.start_sandbox = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=inner)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cm._inner = inner
+        return cm
+
     @pytest.mark.asyncio
     async def test_refreshes_proxy_for_cached_langsmith_sandbox(self) -> None:
         """Cached sandboxes should get a fresh proxy token before git operations."""
@@ -321,7 +340,7 @@ class TestRefreshProxyOnSandboxReuse:
                 new_callable=AsyncMock,
                 return_value=("ghs_fresh", None),
             ),
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch(
                 "agent.server.aresolve_sandbox_work_dir",
                 new_callable=AsyncMock,
@@ -365,13 +384,17 @@ class TestRefreshProxyOnSandboxReuse:
                 new_callable=AsyncMock,
                 return_value="sandbox-existing",
             ),
-            patch("agent.server.create_sandbox", return_value=mock_sandbox) as mock_create,
+            patch(
+                "agent.server.create_sandbox",
+                new_callable=AsyncMock,
+                return_value=mock_sandbox,
+            ) as mock_create,
             patch(
                 "agent.server.get_github_app_installation_token_with_expiry",
                 new_callable=AsyncMock,
                 return_value=("ghs_fresh", None),
             ),
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch(
                 "agent.server.aresolve_sandbox_work_dir",
                 new_callable=AsyncMock,
@@ -408,6 +431,7 @@ class TestRefreshProxyOnSandboxReuse:
             ),
             patch(
                 "agent.server._configure_github_proxy",
+                new_callable=AsyncMock,
                 side_effect=httpx.HTTPStatusError(
                     "Bad request",
                     request=request,
@@ -439,7 +463,7 @@ class TestRefreshProxyOnSandboxReuse:
         """Proxy config requires a running LangSmith sandbox."""
         inner_sandbox = MagicMock(name="sandbox-stopped")
         inner_sandbox.name = "sandbox-stopped"
-        inner_sandbox._client.get_sandbox_status.return_value = MagicMock(status="stopped")
+        client_cm = self._async_client_mock("stopped")
 
         with (
             patch(
@@ -447,7 +471,8 @@ class TestRefreshProxyOnSandboxReuse:
                 new_callable=AsyncMock,
                 return_value=("ghs_fresh", None),
             ),
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
+            patch("agent.server.get_async_sandbox_client", return_value=client_cm),
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
             from agent.server import LangSmithSandbox, _refresh_github_proxy
@@ -457,8 +482,8 @@ class TestRefreshProxyOnSandboxReuse:
 
             await _refresh_github_proxy(sandbox_backend)
 
-            inner_sandbox._client.get_sandbox_status.assert_called_once_with("sandbox-stopped")
-            inner_sandbox.start.assert_called_once_with()
+            client_cm._inner.get_sandbox_status.assert_awaited_once_with("sandbox-stopped")
+            client_cm._inner.start_sandbox.assert_awaited_once_with("sandbox-stopped")
             mock_proxy.assert_called_once_with("sandbox-stopped", "ghs_fresh")
 
     @pytest.mark.asyncio
@@ -466,7 +491,7 @@ class TestRefreshProxyOnSandboxReuse:
         """Ready sandboxes can be patched without starting again."""
         inner_sandbox = MagicMock(name="sandbox-ready")
         inner_sandbox.name = "sandbox-ready"
-        inner_sandbox._client.get_sandbox_status.return_value = MagicMock(status="ready")
+        client_cm = self._async_client_mock("ready")
 
         with (
             patch(
@@ -474,7 +499,8 @@ class TestRefreshProxyOnSandboxReuse:
                 new_callable=AsyncMock,
                 return_value=("ghs_fresh", None),
             ),
-            patch("agent.server._configure_github_proxy") as mock_proxy,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
+            patch("agent.server.get_async_sandbox_client", return_value=client_cm),
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
             from agent.server import LangSmithSandbox, _refresh_github_proxy
@@ -484,6 +510,6 @@ class TestRefreshProxyOnSandboxReuse:
 
             await _refresh_github_proxy(sandbox_backend)
 
-            inner_sandbox._client.get_sandbox_status.assert_called_once_with("sandbox-ready")
-            inner_sandbox.start.assert_not_called()
+            client_cm._inner.get_sandbox_status.assert_awaited_once_with("sandbox-ready")
+            client_cm._inner.start_sandbox.assert_not_called()
             mock_proxy.assert_called_once_with("sandbox-ready", "ghs_fresh")

--- a/tests/test_repo_snapshots.py
+++ b/tests/test_repo_snapshots.py
@@ -275,37 +275,37 @@ async def test_run_snapshot_build_failure_marks_failed() -> None:
     assert statuses[-1] == "failed"
 
 
-def test_create_langsmith_sandbox_uses_repo_snapshot_override() -> None:
+async def test_create_langsmith_sandbox_uses_repo_snapshot_override() -> None:
     from agent.integrations import langsmith
 
     fake_backend = MagicMock()
     fake_backend.id = "box-1"
     provider = MagicMock()
-    provider.get_or_create.return_value = fake_backend
+    provider.get_or_create = AsyncMock(return_value=fake_backend)
 
     with (
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-default"}, clear=True),
         patch.object(langsmith, "LangSmithProvider", return_value=provider),
-        patch.object(langsmith, "_update_thread_sandbox_metadata"),
+        patch.object(langsmith, "_update_thread_sandbox_metadata", new_callable=AsyncMock),
     ):
-        langsmith.create_langsmith_sandbox(snapshot_id="repo-snap")
+        await langsmith.create_langsmith_sandbox(snapshot_id="repo-snap")
 
     assert provider.get_or_create.call_args.kwargs["snapshot_id"] == "repo-snap"
 
 
-def test_create_langsmith_sandbox_falls_back_to_default() -> None:
+async def test_create_langsmith_sandbox_falls_back_to_default() -> None:
     from agent.integrations import langsmith
 
     fake_backend = MagicMock()
     fake_backend.id = "box-2"
     provider = MagicMock()
-    provider.get_or_create.return_value = fake_backend
+    provider.get_or_create = AsyncMock(return_value=fake_backend)
 
     with (
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-default"}, clear=True),
         patch.object(langsmith, "LangSmithProvider", return_value=provider),
-        patch.object(langsmith, "_update_thread_sandbox_metadata"),
+        patch.object(langsmith, "_update_thread_sandbox_metadata", new_callable=AsyncMock),
     ):
-        langsmith.create_langsmith_sandbox()
+        await langsmith.create_langsmith_sandbox()
 
     assert provider.get_or_create.call_args.kwargs["snapshot_id"] == "env-default"

--- a/tests/test_stale_sandbox_creating.py
+++ b/tests/test_stale_sandbox_creating.py
@@ -84,7 +84,11 @@ async def test_fresh_sandbox_creating_waits_for_other_worker() -> None:
         ),
         patch("agent.server.client.threads.get", new_callable=AsyncMock, side_effect=threads),
         patch("agent.server.asyncio.sleep", new_callable=AsyncMock),
-        patch("agent.server.create_sandbox", return_value=existing_backend) as connect_sandbox,
+        patch(
+            "agent.server.create_sandbox",
+            new_callable=AsyncMock,
+            return_value=existing_backend,
+        ) as connect_sandbox,
         patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as create_sandbox,
         patch("agent.server.check_or_recreate_sandbox", side_effect=passthrough),
         patch("agent.server._refresh_github_proxy_or_recreate", side_effect=passthrough),

--- a/uv.lock
+++ b/uv.lock
@@ -1696,7 +1696,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.3"
+version = "0.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1714,9 +1714,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/b7/43f80940a758ceb48714ccc10c7acb9564be4f0d4786e8ed5d46deb0be39/langsmith-0.9.3.tar.gz", hash = "sha256:868a007b3ecda002914b21212a953c77fcb1d71a8a09a94562c3b57941d3df3a", size = 4577380, upload-time = "2026-06-26T15:56:30.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/8b/a56b97a3b8a94f850fe2ec42351d4c508cc6bd7ca96644906c311e32ec5b/langsmith-0.9.7.tar.gz", hash = "sha256:40f8a66a466a7abd991a9df1b50de0a9d30c48ee0d3da46ce00516b68e41c9d7", size = 4711142, upload-time = "2026-07-02T20:11:09.619Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/fb/dc9f70b5581371fba7b01ba0704fe859bfcd12c4dad82b42ec12bd4160b1/langsmith-0.9.3-py3-none-any.whl", hash = "sha256:aac85686868a7e61d77858b880230e510583c61ea48ac0a197e6ceff64ffb22b", size = 619927, upload-time = "2026-06-26T15:56:28.301Z" },
+    { url = "https://files.pythonhosted.org/packages/54/95/0abb8647123c9ebbb31162bcdba3183f5f3d3bb2f752ef3d777ab715e88c/langsmith-0.9.7-py3-none-any.whl", hash = "sha256:a5ff9179b77eb0c3a0129294d30924eab13e51e2720f374372dbbc014c892911", size = 671052, upload-time = "2026-07-02T20:11:07.702Z" },
 ]
 
 [package.optional-dependencies]
@@ -2047,7 +2047,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.1.10" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.27" },
     { name = "langgraph-sdk", specifier = ">=0.4.2" },
-    { name = "langsmith", specifier = "==0.9.3" },
+    { name = "langsmith", specifier = "==0.9.7" },
     { name = "markdownify", specifier = ">=1.2.2" },
     { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.1" },


### PR DESCRIPTION
## Summary

Sandbox **provisioning** (create / get / delete, GitHub-proxy config, thread-metadata update) previously ran on the blocking sync `langsmith.sandbox.SandboxClient`, bridged onto the event loop with `asyncio.to_thread`. This migrates it to the SDK's native `AsyncSandboxClient`, so provisioning is natively async and the `to_thread` bridges collapse into direct `await`s.

- `LangSmithProvider.get_or_create`/`delete`, `_configure_github_proxy` (now `httpx.AsyncClient`), `_update_thread_sandbox_metadata`, and `create_langsmith_sandbox` are now `async`. `SandboxProvider` is async-only.
- deepagents' backend still needs a sync `Sandbox`, so the provisioned `AsyncSandbox` is converted via `.to_sync()`. **Execution is unchanged** — it stays on the sync backend, so the `TimeoutLangSmithSandbox` deadline wrapper is kept as-is.
- Other providers (modal/daytona/runloop/local) wrap genuinely-sync SDKs and don't use the ABC; they're bridged with `to_thread` inside `create_sandbox` and otherwise untouched.
- `_start_langsmith_sandbox_if_needed` now uses the async client for status/start. Removed the dead `get_sandbox_backend_sync` wrapper.
- Bumps `langsmith` 0.9.3 → 0.9.7.

## Test Plan

- [x] `make lint` clean (ruff check + format)
- [x] `make test` — 1311 passed
- [x] none