### PR TITLE
fix: checkpoint per-run graph setup

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -102,6 +102,19 @@ class PrepareAnalyzerRunMiddleware(BasePrepareRunMiddleware):
         self._thread_id = thread_id
         self._config = config
 
+    def _prepare_config_fingerprint(self) -> object:
+        configurable = self._config.get("configurable", {})
+        return {
+            "prepare_run_id": configurable.get("prepare_run_id")
+            if isinstance(configurable, dict)
+            else None,
+            "thread_id": self._thread_id,
+            "full_name": configurable.get("review_style_full_name")
+            if isinstance(configurable, dict)
+            else None,
+            "mode": configurable.get("analyzer_mode") if isinstance(configurable, dict) else None,
+        }
+
     async def _prepare(self, state: dict, runtime: object) -> dict:  # noqa: ARG002
         sandbox_backend = await ensure_sandbox_for_thread(self._thread_id)
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -30,17 +30,19 @@ from langchain.agents.middleware import ModelCallLimitMiddleware
 
 from .dashboard.team_settings import get_effective_gateway_enabled
 from .integrations.langsmith import _configure_github_proxy
-from .middleware import SanitizeToolInputsMiddleware, ToolErrorMiddleware
+from .middleware import BasePrepareRunMiddleware, SanitizeToolInputsMiddleware, ToolErrorMiddleware
 from .review_style_guidance import REVIEWER_STYLE_THEMES
 from .server import (
     DEFAULT_LLM_MAX_TOKENS,
     DEFAULT_LLM_MODEL_ID,
     DEFAULT_RECURSION_LIMIT,
+    _get_cached_sandbox_backend,
     ensure_sandbox_for_thread,
     graph_loaded_for_execution,
 )
 from .tools.read_finding_outcomes import read_finding_outcomes
 from .tools.save_review_style import save_review_style_prompt
+from .utils import ttl_cache
 from .utils.analyzer_skills import SKILLS_ROUTE, skill_path_for_mode
 from .utils.github_app import get_github_app_installation_token
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
@@ -87,6 +89,47 @@ async def _configure_sandbox_github_proxy(
     await _configure_github_proxy(backend.id, github_token)
 
 
+async def _cached_gateway_enabled() -> bool:
+    return await ttl_cache.cached(
+        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        60,
+        get_effective_gateway_enabled,
+    )
+
+
+class PrepareAnalyzerRunMiddleware(BasePrepareRunMiddleware):
+    def __init__(self, *, thread_id: str, config: RunnableConfig) -> None:
+        self._thread_id = thread_id
+        self._config = config
+
+    async def _prepare(self, state: dict, runtime: object) -> dict:  # noqa: ARG002
+        sandbox_backend = await ensure_sandbox_for_thread(self._thread_id)
+        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+        configurable = self._config["configurable"]
+        full_name = str(configurable.get("review_style_full_name") or "owner/repo")
+        owner, _, name = full_name.partition("/")
+        samples_text = str(configurable.get("review_style_samples_text") or "")
+        mode = str(configurable.get("analyzer_mode") or "bootstrap")
+        github_token = configurable.get("review_style_github_token")
+        if not (isinstance(github_token, str) and github_token):
+            github_token = await get_github_app_installation_token()
+        if isinstance(github_token, str) and github_token:
+            await _configure_sandbox_github_proxy(sandbox_backend, github_token)
+        system_prompt = STYLE_ANALYZER_PROMPT.format(
+            repo_owner=owner or "<owner>",
+            repo_name=name or "<repo>",
+            working_dir=work_dir,
+            mode=mode,
+            skill_path=skill_path_for_mode(mode),
+            reviewer_themes=REVIEWER_STYLE_THEMES.strip(),
+        )
+        user_context = f"Repository: `{full_name}`\n\n{samples_text}".strip()
+        return {
+            "work_dir": work_dir,
+            "rendered_system_prompt": f"{system_prompt}\n\n{user_context}",
+        }
+
+
 async def get_analyzer(config: RunnableConfig) -> Pregel:
     thread_id = config["configurable"].get("thread_id")
     config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
@@ -94,29 +137,15 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     if thread_id is None or not graph_loaded_for_execution(config):
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)
 
-    sandbox_backend = await ensure_sandbox_for_thread(thread_id)
-    work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
-
-    configurable = config["configurable"]
-    full_name = str(configurable.get("review_style_full_name") or "owner/repo")
-    owner, _, name = full_name.partition("/")
-    samples_text = str(configurable.get("review_style_samples_text") or "")
-    mode = str(configurable.get("analyzer_mode") or "bootstrap")
-
-    github_token = configurable.get("review_style_github_token")
-    if not (isinstance(github_token, str) and github_token):
-        # Nightly continual runs have no fresh dashboard OAuth token; fall back to
-        # the GitHub App installation token so `gh` still works through the proxy.
-        github_token = await get_github_app_installation_token()
-    if isinstance(github_token, str) and github_token:
-        await _configure_sandbox_github_proxy(sandbox_backend, github_token)
-
-    # Skills are served from a virtual StateBackend route; gh/clone/execute stay on
-    # the sandbox. SKILL.md files are seeded into the `files` channel at invoke time.
-    backend = CompositeBackend(default=sandbox_backend, routes={SKILLS_ROUTE: StateBackend()})
+    def backend_factory(_runtime: object, _thread_id: str = thread_id):
+        try:
+            default_backend = _get_cached_sandbox_backend(_thread_id)
+        except RuntimeError:
+            default_backend = StateBackend()
+        return CompositeBackend(default=default_backend, routes={SKILLS_ROUTE: StateBackend()})
 
     model_id = DEFAULT_LLM_MODEL_ID
-    use_gateway = await get_effective_gateway_enabled()
+    use_gateway = await _cached_gateway_enabled()
     model_kwargs = provider_model_kwargs(
         model_id,
         None,
@@ -124,24 +153,14 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
         openai_reasoning_default=DEFAULT_LLM_REASONING,
     )
 
-    system_prompt = STYLE_ANALYZER_PROMPT.format(
-        repo_owner=owner or "<owner>",
-        repo_name=name or "<repo>",
-        working_dir=work_dir,
-        mode=mode,
-        skill_path=skill_path_for_mode(mode),
-        reviewer_themes=REVIEWER_STYLE_THEMES.strip(),
-    )
-    user_context = f"Repository: `{full_name}`\n\n{samples_text}".strip()
-    system_prompt = f"{system_prompt}\n\n{user_context}"
-
     return create_deep_agent(
         model=make_model(model_id, use_gateway=use_gateway, **model_kwargs),
-        system_prompt=system_prompt,
+        system_prompt="",
         tools=[save_review_style_prompt, read_finding_outcomes],
-        backend=backend,
+        backend=backend_factory,
         skills=[SKILLS_ROUTE],
         middleware=[
+            PrepareAnalyzerRunMiddleware(thread_id=thread_id, config=config),
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(
                 run_limit=STYLE_ANALYZER_MODEL_CALL_LIMIT,

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -31,6 +31,7 @@ from langchain.agents.middleware import ModelCallLimitMiddleware
 from .dashboard.options import SUPPORTED_MODEL_IDS, model_supports_effort
 from .dashboard.team_settings import get_effective_gateway_enabled, get_team_default_model
 from .middleware import (
+    BasePrepareRunMiddleware,
     ExcludeToolsMiddleware,
     SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
@@ -49,6 +50,7 @@ from .tools import (
     search_repo_code,
     web_search,
 )
+from .utils import ttl_cache
 from .utils.github_app import get_github_app_installation_token
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
 from .utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
@@ -90,6 +92,45 @@ Guidance:
 """
 
 
+async def _cached_gateway_enabled() -> bool:
+    return await ttl_cache.cached(
+        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        60,
+        get_effective_gateway_enabled,
+    )
+
+
+async def _cached_team_chat_model() -> tuple[str, str]:
+    return await ttl_cache.cached(
+        f"team-default-model:chat:{id(get_team_default_model)}",
+        60,
+        lambda: get_team_default_model("chat"),
+    )
+
+
+class PrepareChatRunMiddleware(BasePrepareRunMiddleware):
+    def __init__(self, *, config: RunnableConfig) -> None:
+        self._config = config
+
+    async def _prepare(self, state: dict, runtime: object) -> dict:  # noqa: ARG002
+        configurable = self._config["configurable"]
+        repo_owner = str(configurable.get("chat_repo_owner") or "")
+        repo_name = str(configurable.get("chat_repo_name") or "")
+        pr_number = configurable.get("chat_pr_number")
+        token = await get_github_app_installation_token(
+            repositories=[repo_name] if repo_name else None
+        )
+        if isinstance(token, str) and token:
+            configurable["chat_github_token"] = token
+        return {
+            "rendered_system_prompt": CHAT_PROMPT.format(
+                repo_owner=repo_owner or "<owner>",
+                repo_name=repo_name or "<repo>",
+                pr_number=pr_number if isinstance(pr_number, int) else "?",
+            )
+        }
+
+
 async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
     model_id = configurable.get("chat_model_id")
     effort = configurable.get("chat_effort")
@@ -101,7 +142,7 @@ async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
     ):
         return model_id, effort
     # Team review-chat default, which itself inherits the Agent default if unset.
-    return await get_team_default_model("chat")
+    return await _cached_team_chat_model()
 
 
 async def get_chat_agent(config: RunnableConfig) -> Pregel:
@@ -113,18 +154,8 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)
 
     configurable = config["configurable"]
-    repo_owner = str(configurable.get("chat_repo_owner") or "")
-    repo_name = str(configurable.get("chat_repo_name") or "")
-    pr_number = configurable.get("chat_pr_number")
-
-    # Resolve a repo-scoped, read-only App token in-graph so a user credential is
-    # never passed through the run config. Tools read it from configurable.
-    token = await get_github_app_installation_token(repositories=[repo_name] if repo_name else None)
-    if isinstance(token, str) and token:
-        configurable["chat_github_token"] = token
-
     model_id, effort = await _resolve_chat_model(configurable)
-    use_gateway = await get_effective_gateway_enabled()
+    use_gateway = await _cached_gateway_enabled()
     model_kwargs = provider_model_kwargs(
         model_id,
         effort,
@@ -132,15 +163,9 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
         openai_reasoning_default=DEFAULT_LLM_REASONING,
     )
 
-    system_prompt = CHAT_PROMPT.format(
-        repo_owner=repo_owner or "<owner>",
-        repo_name=repo_name or "<repo>",
-        pr_number=pr_number if isinstance(pr_number, int) else "?",
-    )
-
     return create_deep_agent(
         model=make_model(model_id, use_gateway=use_gateway, **model_kwargs),
-        system_prompt=system_prompt,
+        system_prompt="",
         tools=[
             read_repo_file,
             search_repo_code,
@@ -149,6 +174,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
             fetch_url,
         ],
         middleware=[
+            PrepareChatRunMiddleware(config=config),
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(run_limit=CHAT_MODEL_CALL_LIMIT, exit_behavior="end"),
             ToolErrorMiddleware(),

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -112,6 +112,23 @@ class PrepareChatRunMiddleware(BasePrepareRunMiddleware):
     def __init__(self, *, config: RunnableConfig) -> None:
         self._config = config
 
+    def _prepare_config_fingerprint(self) -> object:
+        configurable = self._config.get("configurable", {})
+        return {
+            "prepare_run_id": configurable.get("prepare_run_id")
+            if isinstance(configurable, dict)
+            else None,
+            "repo_owner": configurable.get("chat_repo_owner")
+            if isinstance(configurable, dict)
+            else None,
+            "repo_name": configurable.get("chat_repo_name")
+            if isinstance(configurable, dict)
+            else None,
+            "pr_number": configurable.get("chat_pr_number")
+            if isinstance(configurable, dict)
+            else None,
+        }
+
     async def _prepare(self, state: dict, runtime: object) -> dict:  # noqa: ARG002
         configurable = self._config["configurable"]
         repo_owner = str(configurable.get("chat_repo_owner") or "")

--- a/agent/dashboard/review_style_jobs.py
+++ b/agent/dashboard/review_style_jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from typing import Any
 
 from langgraph_sdk import get_client
@@ -139,7 +140,7 @@ async def start_bootstrap_analysis(
                 ],
                 "files": build_skill_files(),
             },
-            config={"configurable": configurable},
+            config={"configurable": {**configurable, "prepare_run_id": str(uuid.uuid4())}},
             if_not_exists="create",
         )
         run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)
@@ -172,7 +173,7 @@ async def start_continual_run(
             thread_id,
             _ASSISTANT_ID,
             input=build_continual_run_input(full_name),
-            config={"configurable": configurable},
+            config={"configurable": {**configurable, "prepare_run_id": str(uuid.uuid4())}},
             if_not_exists="create",
         )
         run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -382,6 +382,7 @@ def _agent_run_config(record: dict[str, Any], thread_id: str) -> dict[str, Any]:
         "github_login": record.get("created_by"),
         "user_email": record.get("user_email"),
         "schedule_id": record["id"],
+        "prepare_run_id": str(uuid.uuid4()),
     }
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
     if repo and repo.get("owner") and repo.get("name"):

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from typing import Any
 from urllib.parse import urlparse
 
@@ -103,6 +104,7 @@ async def dispatch_agent_run(
     the graph (``"agent"`` or ``"reviewer"``).
     """
     client = client or dispatch_client()
+    configurable = {**configurable, "prepare_run_id": str(uuid.uuid4())}
     run = await client.runs.create(
         thread_id,
         assistant_id,

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -4,6 +4,7 @@ from .exclude_tools import ExcludeToolsMiddleware
 from .model_fallback import ModelFallbackMiddleware
 from .notify_step_limit import notify_step_limit_reached
 from .plan_mode import PlanModeMiddleware
+from .prepare_run import BasePrepareRunMiddleware, PrepareRunState
 from .refresh_github_proxy import refresh_github_proxy_before_model
 from .refresh_slack_status import SlackAssistantStatusMiddleware
 from .repair_orphaned_tool_calls import RepairOrphanedToolCallsMiddleware
@@ -20,7 +21,9 @@ from .workflow_push_guard import WorkflowPushGuardMiddleware
 __all__ = [
     "ExcludeToolsMiddleware",
     "ModelFallbackMiddleware",
+    "BasePrepareRunMiddleware",
     "PlanModeMiddleware",
+    "PrepareRunState",
     "RepairOrphanedToolCallsMiddleware",
     "SanitizeFireworksMessagesMiddleware",
     "SanitizeOpenAIResponsesMiddleware",

--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, NotRequired
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import SystemMessage
+from langgraph.runtime import Runtime
+
+
+class PrepareRunState(AgentState):
+    run_prepared: NotRequired[bool]
+    work_dir: NotRequired[str | None]
+    rendered_system_prompt: NotRequired[str | None]
+
+
+class BasePrepareRunMiddleware(AgentMiddleware):
+    """Checkpointed per-run setup.
+
+    Subclasses must keep `_prepare` idempotent. LangGraph checkpoints the
+    `run_prepared` latch after this before-agent node, so resumed runs skip
+    completed setup; if a run fails before that checkpoint, setup may execute
+    again and every operation it calls must tolerate that.
+    """
+
+    state_schema = PrepareRunState
+
+    async def abefore_agent(
+        self,
+        state: PrepareRunState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        if state.get("run_prepared"):
+            return None
+        updates = await self._prepare(state, runtime)
+        return {"run_prepared": True, **updates}
+
+    async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        rendered = request.state.get("rendered_system_prompt")
+        if isinstance(rendered, str) and rendered:
+            existing = request.system_message.text if request.system_message is not None else ""
+            content = f"{rendered}\n\n{existing}" if existing else rendered
+            request = request.override(system_message=SystemMessage(content=content))
+        return await handler(request)

--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Awaitable, Callable
 from typing import Any, NotRequired
 
@@ -15,17 +17,36 @@ from langgraph.runtime import Runtime
 
 class PrepareRunState(AgentState):
     run_prepared: NotRequired[bool]
+    run_prepared_for: NotRequired[str]
     work_dir: NotRequired[str | None]
     rendered_system_prompt: NotRequired[str | None]
+
+
+def _latest_message_fingerprint(state: dict[str, Any]) -> str | None:
+    messages = state.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return None
+    latest = messages[-1]
+    message_id = getattr(latest, "id", None)
+    content = getattr(latest, "content", latest)
+    payload = {
+        "type": latest.__class__.__name__,
+        "id": message_id,
+        "content": content,
+    }
+    encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 class BasePrepareRunMiddleware(AgentMiddleware):
     """Checkpointed per-run setup.
 
     Subclasses must keep `_prepare` idempotent. LangGraph checkpoints the
-    `run_prepared` latch after this before-agent node, so resumed runs skip
-    completed setup; if a run fails before that checkpoint, setup may execute
-    again and every operation it calls must tolerate that.
+    `run_prepared_for` latch after this before-agent node, so resumed attempts
+    of the same invocation skip completed setup while later invocations on the
+    same thread re-prepare fresh tokens, prompts, and diff context. If a run
+    fails before that checkpoint, setup may execute again and every operation it
+    calls must tolerate that.
     """
 
     state_schema = PrepareRunState
@@ -35,10 +56,23 @@ class BasePrepareRunMiddleware(AgentMiddleware):
         state: PrepareRunState,
         runtime: Runtime,
     ) -> dict[str, Any] | None:
-        if state.get("run_prepared"):
+        fingerprint = self._prepare_fingerprint(state, runtime)
+        if state.get("run_prepared") and state.get("run_prepared_for") == fingerprint:
             return None
         updates = await self._prepare(state, runtime)
-        return {"run_prepared": True, **updates}
+        return {"run_prepared": True, "run_prepared_for": fingerprint, **updates}
+
+    def _prepare_fingerprint(self, state: PrepareRunState, runtime: Runtime) -> str:  # noqa: ARG002
+        payload = {
+            "middleware": self.__class__.__name__,
+            "message": _latest_message_fingerprint(state),
+            "config": self._prepare_config_fingerprint(),
+        }
+        encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def _prepare_config_fingerprint(self) -> Any:
+        return None
 
     async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:
         raise NotImplementedError

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -20,6 +20,7 @@ import logging
 import posixpath
 import re
 import warnings
+from typing import Any, NotRequired
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 from deepagents import create_deep_agent
+from deepagents.middleware.skills import SkillsMiddleware
 from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain_core.language_models.chat_models import BaseChatModel
 
@@ -40,6 +42,8 @@ from .dashboard.team_settings import (
     get_team_default_model_pair,
 )
 from .middleware import (
+    BasePrepareRunMiddleware,
+    PrepareRunState,
     RepairOrphanedToolCallsMiddleware,
     SanitizeFireworksMessagesMiddleware,
     SanitizeOpenAIResponsesMiddleware,
@@ -68,6 +72,7 @@ from .server import (
     DEFAULT_RECURSION_LIMIT,
     MODEL_CALL_RECURSION_LIMIT,
     _general_purpose_subagent,
+    _get_cached_sandbox_backend,
     ensure_sandbox_for_thread,
     graph_loaded_for_execution,
 )
@@ -82,6 +87,7 @@ from .tools import (
     update_finding,
     web_search,
 )
+from .utils import ttl_cache
 from .utils.agents_md import fetch_agents_md
 from .utils.api_standards_skill import fetch_api_standards_skill
 from .utils.github_app import get_github_app_installation_token_with_expiry
@@ -828,8 +834,341 @@ async def _resolve_grouping_model(
     return make_model(model_id, use_gateway=use_gateway, **model_kwargs)
 
 
+async def _cached_reviewer_team_defaults():
+    return await ttl_cache.cached(
+        f"team-default-model-pair:reviewer:{id(get_team_default_model_pair)}",
+        60,
+        lambda: get_team_default_model_pair("reviewer"),
+    )
+
+
+async def _cached_gateway_enabled() -> bool:
+    return await ttl_cache.cached(
+        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        60,
+        get_effective_gateway_enabled,
+    )
+
+
+async def _cached_org_review_guidelines() -> str | None:
+    return await ttl_cache.cached(
+        f"reviewer:org-guidelines:{id(get_org_review_guidelines)}",
+        300,
+        get_org_review_guidelines,
+    )
+
+
+async def _cached_api_standards_skill() -> str | None:
+    return await ttl_cache.cached(
+        f"reviewer:api-standards-skill:{id(fetch_api_standards_skill)}",
+        300,
+        fetch_api_standards_skill,
+    )
+
+
+class PrepareReviewerRunState(PrepareRunState):
+    diff_text: NotRequired[str]
+    diff_line_set: NotRequired[dict[str, dict[str, set[int]]] | None]
+
+
+class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
+    state_schema = PrepareReviewerRunState
+
+    def __init__(
+        self,
+        *,
+        thread_id: str,
+        config: RunnableConfig,
+        use_gateway: bool,
+    ) -> None:
+        self._thread_id = thread_id
+        self._config = config
+        self._use_gateway = use_gateway
+
+    async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:
+        configurable = self._config["configurable"]
+        repo_config = configurable.get("repo") or {}
+        github_token: str | None = None
+        if configurable.get("source"):
+            repo_name_for_token = str(repo_config.get("name") or "")
+            github_token, expires_at = await get_github_app_installation_token_with_expiry(
+                repositories=[repo_name_for_token] if repo_name_for_token else None
+            )
+            if not github_token:
+                raise RuntimeError(
+                    f"GitHub App installation token unavailable for reviewer thread {self._thread_id}"
+                )
+            cache_github_token_for_thread(self._thread_id, github_token, expires_at=expires_at)
+
+        repo_name_for_scope = str(repo_config.get("name") or "")
+        repo_for_snapshot = (
+            {"owner": str(repo_config["owner"]), "name": str(repo_config["name"])}
+            if repo_config.get("owner") and repo_config.get("name")
+            else None
+        )
+        sandbox_backend = await ensure_sandbox_for_thread(
+            self._thread_id,
+            github_proxy_token=github_token,
+            github_proxy_repositories=[repo_name_for_scope] if repo_name_for_scope else None,
+            repo=repo_for_snapshot,
+        )
+        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+
+        repo_owner = str(repo_config.get("owner", ""))
+        repo_name = str(repo_config.get("name", ""))
+        base_sha = str(configurable.get("base_sha", "") or "")
+        head_sha = str(configurable.get("head_sha", "") or "")
+        pr_number = configurable.get("pr_number")
+
+        repo_ready = await prepare_review_repo(
+            sandbox_backend,
+            work_dir=work_dir,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            head_sha=head_sha,
+            pr_number=pr_number if isinstance(pr_number, int) else None,
+            base_sha=base_sha,
+        )
+        skill_sources: list[str] = []
+        if repo_ready and repo_name:
+            skill_sources = await materialize_trusted_skills(
+                sandbox_backend, repo_dir=f"{work_dir}/{repo_name}", trusted_ref=base_sha
+            )
+
+        pr_url = str(configurable.get("pr_url", "") or "")
+        last_reviewed_sha = str(configurable.get("last_reviewed_sha", "") or "")
+        is_re_review = bool(configurable.get("re_review"))
+        reviewer_event = str(configurable.get("reviewer_event", "") or "")
+        can_fetch_pr = (
+            pr_number is not None
+            and isinstance(pr_number, int)
+            and bool(repo_owner)
+            and bool(repo_name)
+            and bool(github_token)
+        )
+
+        async def _fetch_diff_context() -> tuple[str, dict[str, dict[str, set[int]]] | None]:
+            if not can_fetch_pr or github_token is None or not isinstance(pr_number, int):
+                return "", None
+            fetched_diff = await fetch_pr_diff(
+                owner=repo_owner,
+                repo=repo_name,
+                pr_number=pr_number,
+                token=github_token,
+            )
+            if fetched_diff is None:
+                return "", None
+            return fetched_diff, compute_diff_line_set(fetched_diff)
+
+        async def _fetch_pr_overview() -> tuple[str, str]:
+            if not can_fetch_pr or github_token is None or not isinstance(pr_number, int):
+                return "", ""
+            metadata = await fetch_pr_metadata(
+                owner=repo_owner,
+                repo=repo_name,
+                pr_number=pr_number,
+                token=github_token,
+            )
+            return metadata if metadata is not None else ("", "")
+
+        async def _fetch_existing_threads_block() -> str:
+            if not can_fetch_pr or github_token is None or not isinstance(pr_number, int):
+                return ""
+            try:
+                threads = await fetch_pr_review_threads(
+                    owner=repo_owner,
+                    repo=repo_name,
+                    pr_number=pr_number,
+                    token=github_token,
+                )
+                await reconcile_findings_with_review_threads(self._thread_id, threads)
+                block = _format_pr_review_threads(threads)
+                if block:
+                    logger.info(
+                        "Loaded %d existing PR review thread(s) into reviewer context for %s/%s#%s",
+                        len(threads),
+                        repo_owner,
+                        repo_name,
+                        pr_number,
+                    )
+                return block
+            except Exception:
+                logger.exception(
+                    "Failed to load existing PR review threads for %s/%s#%s; continuing without comment-awareness context",
+                    repo_owner,
+                    repo_name,
+                    pr_number,
+                )
+                return ""
+
+        async def _fetch_repo_style_prompt() -> str | None:
+            if not repo_owner or not repo_name:
+                return None
+            from .dashboard.review_styles import get_repo_custom_prompt
+
+            return await get_repo_custom_prompt(repo_owner, repo_name)
+
+        async def _fetch_agents_md_context() -> str | None:
+            if not repo_owner or not repo_name or not base_sha:
+                return None
+            content = await fetch_agents_md(repo_owner, repo_name, base_sha, token=github_token)
+            if content:
+                logger.info(
+                    "Loaded AGENTS.md (%d chars) from %s/%s@%s into reviewer prompt",
+                    len(content),
+                    repo_owner,
+                    repo_name,
+                    base_sha,
+                )
+            return content
+
+        async def _prepare_pr_trace_context() -> PRTraceContext | None:
+            try:
+                return await prepare_pr_trace_context(
+                    configurable=configurable,
+                    sandbox_backend=sandbox_backend,
+                    work_dir=work_dir,
+                )
+            except Exception:
+                logger.exception("Failed to prepare PR trace context; continuing without it")
+                return None
+
+        (
+            diff_context,
+            pr_overview,
+            existing_threads_block,
+            repo_style_prompt,
+            agents_md_content,
+            org_guidelines,
+            api_standards_skill,
+            pr_trace_context,
+        ) = await asyncio.gather(
+            _fetch_diff_context(),
+            _fetch_pr_overview(),
+            _fetch_existing_threads_block(),
+            _fetch_repo_style_prompt(),
+            _fetch_agents_md_context(),
+            _cached_org_review_guidelines(),
+            _cached_api_standards_skill(),
+            _prepare_pr_trace_context(),
+        )
+        pr_diff_text, pr_diff_line_set = diff_context
+        pr_title, pr_body = pr_overview
+
+        review_context = ""
+        if pr_number is not None and isinstance(pr_number, int):
+            if reviewer_event == "finding_reply":
+                existing_findings = await list_findings_async(self._thread_id)
+                review_context = _build_finding_reply_context(
+                    pr_url=pr_url,
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    pr_number=pr_number,
+                    finding_id=str(configurable.get("finding_reply_id", "") or ""),
+                    reply_author=str(configurable.get("finding_reply_author", "") or ""),
+                    reply_body=str(configurable.get("finding_reply_body", "") or ""),
+                    existing_findings_block=_format_existing_findings(existing_findings),
+                    pr_title=pr_title,
+                    pr_body=pr_body,
+                    existing_threads_block=existing_threads_block,
+                )
+            elif is_re_review and last_reviewed_sha:
+                existing_findings = await list_findings_async(self._thread_id)
+                review_context = _build_re_review_context(
+                    pr_url=pr_url,
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    pr_number=pr_number,
+                    last_reviewed_sha=last_reviewed_sha,
+                    head_sha=head_sha,
+                    existing_findings_block=_format_existing_findings(existing_findings),
+                    pr_title=pr_title,
+                    pr_body=pr_body,
+                    existing_threads_block=existing_threads_block,
+                )
+            else:
+                review_context = _build_first_review_context(
+                    pr_url=pr_url,
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    pr_number=pr_number,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    pr_title=pr_title,
+                    pr_body=pr_body,
+                    existing_threads_block=existing_threads_block,
+                )
+
+        reviewer_eval = (
+            configurable.get("reviewer_eval") is True or configurable.get("eval") is True
+        )
+        system_prompt = _reviewer_system_prompt(
+            f"{work_dir}/{repo_name}" if repo_name else work_dir,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            pr_number=pr_number if isinstance(pr_number, int) else "",
+            repo_ready=repo_ready,
+            head_sha=head_sha,
+            reviewer_eval=reviewer_eval,
+            org_guidelines=org_guidelines,
+            repo_style_prompt=repo_style_prompt,
+            agents_md_content=agents_md_content,
+            api_standards_skill=api_standards_skill,
+        )
+        trace_context_prompt = format_pr_trace_context_prompt(pr_trace_context)
+        if trace_context_prompt:
+            system_prompt = f"{system_prompt}\n\n{trace_context_prompt}"
+        if review_context:
+            system_prompt = f"{system_prompt}\n\n{review_context}"
+        if skill_sources:
+            skill_middleware = SkillsMiddleware(backend=sandbox_backend, sources=skill_sources)
+            skill_update = await skill_middleware.abefore_agent({}, runtime, self._config) or {}
+            skill_request_state = {
+                "skills_metadata": skill_update.get("skills_metadata", []),
+                "skills_load_errors": skill_update.get("skills_load_errors", []),
+            }
+            skills_locations = skill_middleware._format_skills_locations()
+            skills_list = skill_middleware._format_skills_list(
+                skill_request_state["skills_metadata"]
+            )
+            skills_load_warnings = skill_middleware._format_skills_load_warnings(
+                skill_request_state["skills_load_errors"]
+            )
+            if skill_middleware.system_prompt_template:
+                system_prompt = (
+                    f"{system_prompt}\n\n"
+                    + skill_middleware.system_prompt_template.format(
+                        skills_locations=skills_locations,
+                        skills_load_warnings=skills_load_warnings,
+                        skills_list=skills_list,
+                    )
+                )
+
+        if reviewer_event != "finding_reply" and pr_diff_text and self._thread_id:
+            grouping_model = await _resolve_grouping_model(
+                configurable, use_gateway=self._use_gateway
+            )
+            grouping_task = asyncio.create_task(
+                maybe_generate_and_store_diff_groups(
+                    thread_id=self._thread_id,
+                    head_sha=head_sha,
+                    diff_text=pr_diff_text,
+                    model=grouping_model,
+                )
+            )
+            _BACKGROUND_TASKS.add(grouping_task)
+            grouping_task.add_done_callback(_on_background_task_done)
+
+        return {
+            "work_dir": work_dir,
+            "rendered_system_prompt": system_prompt,
+            "diff_text": pr_diff_text,
+            "diff_line_set": pr_diff_line_set,
+        }
+
+
 async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
-    """Get or create a reviewer agent with a sandbox + prepped repo."""
+    """Get or create a reviewer agent with checkpointed run prep."""
     thread_id = config["configurable"].get("thread_id", None)
 
     config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
@@ -838,254 +1177,9 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         logger.info("No thread_id or not for execution, returning reviewer agent without sandbox")
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)
 
-    repo_config = config["configurable"].get("repo") or {}
-    github_token: str | None = None
-    if config["configurable"].get("source"):
-        # Reviewer runs always act as the GitHub App (open-swe[bot]). Resolve the
-        # installation token in this process at run start rather than relying on a
-        # token cached by the webhook handler, which runs in a separate process. The
-        # App token also bypasses org SAML enforcement that blocks user OAuth tokens.
-        repo_name = str(repo_config.get("name") or "")
-        github_token, expires_at = await get_github_app_installation_token_with_expiry(
-            repositories=[repo_name] if repo_name else None
-        )
-        if not github_token:
-            raise RuntimeError(
-                f"GitHub App installation token unavailable for reviewer thread {thread_id}"
-            )
-        # Cache in-process so reviewer tools and the sandbox proxy can read it this run.
-        cache_github_token_for_thread(thread_id, github_token, expires_at=expires_at)
-
-    github_proxy_token = github_token
-    github_api_token = github_token
-    repo_name_for_scope = str(repo_config.get("name") or "")
-    repo_for_snapshot = (
-        {"owner": str(repo_config["owner"]), "name": str(repo_config["name"])}
-        if repo_config.get("owner") and repo_config.get("name")
-        else None
-    )
-    sandbox_backend = await ensure_sandbox_for_thread(
-        thread_id,
-        github_proxy_token=github_proxy_token,
-        github_proxy_repositories=[repo_name_for_scope] if repo_name_for_scope else None,
-        repo=repo_for_snapshot,
-    )
-
-    work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
-
-    repo_owner = str(repo_config.get("owner", ""))
-    repo_name = str(repo_config.get("name", ""))
-    base_sha = str(config["configurable"].get("base_sha", "") or "")
-    head_sha = str(config["configurable"].get("head_sha", "") or "")
-    pr_number = config["configurable"].get("pr_number")
-
-    # Prep the repo on the sandbox before the first model call so the LLM does
-    # not narrate `gh repo clone`, and so SkillsMiddleware can discover the
-    # repo's skills at its one-shot scan. Skills are materialized from the PR
-    # base sha (trusted), never the PR head (author-controlled).
-    repo_ready = await prepare_review_repo(
-        sandbox_backend,
-        work_dir=work_dir,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        head_sha=head_sha,
-        pr_number=pr_number if isinstance(pr_number, int) else None,
-        base_sha=base_sha,
-    )
-    skill_sources: list[str] = []
-    if repo_ready and repo_name:
-        skill_sources = await materialize_trusted_skills(
-            sandbox_backend, repo_dir=f"{work_dir}/{repo_name}", trusted_ref=base_sha
-        )
-
-    pr_url = str(config["configurable"].get("pr_url", "") or "")
-    last_reviewed_sha = str(config["configurable"].get("last_reviewed_sha", "") or "")
-    is_re_review = bool(config["configurable"].get("re_review"))
-    reviewer_event = str(config["configurable"].get("reviewer_event", "") or "")
-
-    can_fetch_pr = (
-        pr_number is not None
-        and isinstance(pr_number, int)
-        and bool(repo_owner)
-        and bool(repo_name)
-        and bool(github_api_token)
-    )
-
-    async def _fetch_diff_context() -> tuple[str, dict[str, dict[str, set[int]]] | None]:
-        """Return (diff, line_set).
-
-        The reviewer model has a large context window and reviews the full diff;
-        it is not truncated. The line set is computed from the same diff so
-        findings on any changed line are accepted.
-        """
-        if not can_fetch_pr or github_api_token is None or not isinstance(pr_number, int):
-            return "", None
-        fetched_diff = await fetch_pr_diff(
-            owner=repo_owner,
-            repo=repo_name,
-            pr_number=pr_number,
-            token=github_api_token,
-        )
-        if fetched_diff is None:
-            return "", None
-        return fetched_diff, compute_diff_line_set(fetched_diff)
-
-    async def _fetch_pr_overview() -> tuple[str, str]:
-        if not can_fetch_pr or github_api_token is None or not isinstance(pr_number, int):
-            return "", ""
-        metadata = await fetch_pr_metadata(
-            owner=repo_owner,
-            repo=repo_name,
-            pr_number=pr_number,
-            token=github_api_token,
-        )
-        return metadata if metadata is not None else ("", "")
-
-    async def _fetch_existing_threads_block() -> str:
-        if not can_fetch_pr or github_api_token is None or not isinstance(pr_number, int):
-            return ""
-        try:
-            threads = await fetch_pr_review_threads(
-                owner=repo_owner,
-                repo=repo_name,
-                pr_number=pr_number,
-                token=github_api_token,
-            )
-            await reconcile_findings_with_review_threads(thread_id, threads)
-            block = _format_pr_review_threads(threads)
-            if block:
-                logger.info(
-                    "Loaded %d existing PR review thread(s) into reviewer context for %s/%s#%s",
-                    len(threads),
-                    repo_owner,
-                    repo_name,
-                    pr_number,
-                )
-            return block
-        except Exception:  # noqa: BLE001
-            logger.exception(
-                "Failed to load existing PR review threads for %s/%s#%s; "
-                "continuing without comment-awareness context",
-                repo_owner,
-                repo_name,
-                pr_number,
-            )
-            return ""
-
-    async def _fetch_repo_style_prompt() -> str | None:
-        if not repo_owner or not repo_name:
-            return None
-        from .dashboard.review_styles import get_repo_custom_prompt
-
-        return await get_repo_custom_prompt(repo_owner, repo_name)
-
-    async def _fetch_org_guidelines() -> str | None:
-        try:
-            return await get_org_review_guidelines()
-        except Exception:  # noqa: BLE001
-            logger.exception("Failed to load org-wide review guidelines; continuing without them")
-            return None
-
-    async def _fetch_agents_md_context() -> str | None:
-        if not repo_owner or not repo_name or not base_sha:
-            return None
-        content = await fetch_agents_md(
-            repo_owner,
-            repo_name,
-            base_sha,
-            token=github_api_token,
-        )
-        if content:
-            logger.info(
-                "Loaded AGENTS.md (%d chars) from %s/%s@%s into reviewer prompt",
-                len(content),
-                repo_owner,
-                repo_name,
-                base_sha,
-            )
-        return content
-
-    async def _prepare_pr_trace_context() -> PRTraceContext | None:
-        try:
-            return await prepare_pr_trace_context(
-                configurable=config["configurable"],
-                sandbox_backend=sandbox_backend,
-                work_dir=work_dir,
-            )
-        except Exception:  # noqa: BLE001
-            logger.exception("Failed to prepare PR trace context; continuing without it")
-            return None
-
-    (
-        diff_context,
-        pr_overview,
-        existing_threads_block,
-        repo_style_prompt,
-        agents_md_content,
-        org_guidelines,
-        api_standards_skill,
-        pr_trace_context,
-    ) = await asyncio.gather(
-        _fetch_diff_context(),
-        _fetch_pr_overview(),
-        _fetch_existing_threads_block(),
-        _fetch_repo_style_prompt(),
-        _fetch_agents_md_context(),
-        _fetch_org_guidelines(),
-        fetch_api_standards_skill(),
-        _prepare_pr_trace_context(),
-    )
-    pr_diff_text, pr_diff_line_set = diff_context
-    pr_title, pr_body = pr_overview
-    config["configurable"]["diff_text"] = pr_diff_text
-    config["configurable"]["diff_line_set"] = pr_diff_line_set
-
-    review_context = ""
-    if pr_number is not None and isinstance(pr_number, int):
-        if reviewer_event == "finding_reply":
-            existing_findings = await list_findings_async(thread_id)
-            review_context = _build_finding_reply_context(
-                pr_url=pr_url,
-                repo_owner=repo_owner,
-                repo_name=repo_name,
-                pr_number=pr_number,
-                finding_id=str(config["configurable"].get("finding_reply_id", "") or ""),
-                reply_author=str(config["configurable"].get("finding_reply_author", "") or ""),
-                reply_body=str(config["configurable"].get("finding_reply_body", "") or ""),
-                existing_findings_block=_format_existing_findings(existing_findings),
-                pr_title=pr_title,
-                pr_body=pr_body,
-                existing_threads_block=existing_threads_block,
-            )
-        elif is_re_review and last_reviewed_sha:
-            existing_findings = await list_findings_async(thread_id)
-            review_context = _build_re_review_context(
-                pr_url=pr_url,
-                repo_owner=repo_owner,
-                repo_name=repo_name,
-                pr_number=pr_number,
-                last_reviewed_sha=last_reviewed_sha,
-                head_sha=head_sha,
-                existing_findings_block=_format_existing_findings(existing_findings),
-                pr_title=pr_title,
-                pr_body=pr_body,
-                existing_threads_block=existing_threads_block,
-            )
-        else:
-            review_context = _build_first_review_context(
-                pr_url=pr_url,
-                repo_owner=repo_owner,
-                repo_name=repo_name,
-                pr_number=pr_number,
-                base_sha=base_sha,
-                head_sha=head_sha,
-                pr_title=pr_title,
-                pr_body=pr_body,
-                existing_threads_block=existing_threads_block,
-            )
-
-    configured_model_id = config["configurable"].get("reviewer_model_id")
-    configured_effort = config["configurable"].get("reviewer_reasoning_effort")
+    configurable = config["configurable"]
+    configured_model_id = configurable.get("reviewer_model_id")
+    configured_effort = configurable.get("reviewer_reasoning_effort")
     if isinstance(configured_model_id, str) and configured_model_id:
         model_id = configured_model_id
         reasoning_effort = configured_effort if isinstance(configured_effort, str) else None
@@ -1095,7 +1189,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         (
             (model_id, reasoning_effort),
             (subagent_model_id, subagent_effort),
-        ) = await get_team_default_model_pair("reviewer")
+        ) = await _cached_reviewer_team_defaults()
         logger.info(
             "Using team default reviewer model: model=%s effort=%s",
             model_id,
@@ -1106,8 +1200,8 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id,
             subagent_effort,
         )
-    configured_subagent_model_id = config["configurable"].get("reviewer_subagent_model_id")
-    configured_subagent_effort = config["configurable"].get("reviewer_subagent_reasoning_effort")
+    configured_subagent_model_id = configurable.get("reviewer_subagent_model_id")
+    configured_subagent_effort = configurable.get("reviewer_subagent_reasoning_effort")
     if isinstance(configured_subagent_model_id, str) and configured_subagent_model_id:
         subagent_model_id = configured_subagent_model_id
         subagent_effort = (
@@ -1126,61 +1220,18 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         openai_reasoning_default=DEFAULT_LLM_REASONING,
     )
 
-    reviewer_eval = (
-        config["configurable"].get("reviewer_eval") is True
-        or config["configurable"].get("eval") is True
-    )
-    github_api_token = None
-    github_token = None
-
-    system_prompt = _reviewer_system_prompt(
-        f"{work_dir}/{repo_name}" if repo_name else work_dir,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        pr_number=pr_number if isinstance(pr_number, int) else "",
-        repo_ready=repo_ready,
-        head_sha=head_sha,
-        reviewer_eval=reviewer_eval,
-        org_guidelines=org_guidelines,
-        repo_style_prompt=repo_style_prompt,
-        agents_md_content=agents_md_content,
-        api_standards_skill=api_standards_skill,
-    )
-    trace_context_prompt = format_pr_trace_context_prompt(pr_trace_context)
-    if trace_context_prompt:
-        system_prompt = f"{system_prompt}\n\n{trace_context_prompt}"
-    if review_context:
-        system_prompt = f"{system_prompt}\n\n{review_context}"
-
-    use_gateway = await get_effective_gateway_enabled()
+    use_gateway = await _cached_gateway_enabled()
     reviewer_model = make_model(model_id, use_gateway=use_gateway, **model_kwargs)
     reviewer_subagent_model = make_model(
         subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs
     )
 
-    # Kick off the AI-sorted diff grouping pass at run start, concurrently with
-    # the review, so it adds ~0 latency. First-review and re-review only — a
-    # finding_reply run doesn't change the diff. Best-effort: the task swallows
-    # its own errors and the UI falls back to the folder view when groups are
-    # absent.
-    if reviewer_event != "finding_reply" and pr_diff_text and thread_id:
-        grouping_model = await _resolve_grouping_model(
-            config["configurable"], use_gateway=use_gateway
-        )
-        grouping_task = asyncio.create_task(
-            maybe_generate_and_store_diff_groups(
-                thread_id=thread_id,
-                head_sha=head_sha,
-                diff_text=pr_diff_text,
-                model=grouping_model,
-            )
-        )
-        _BACKGROUND_TASKS.add(grouping_task)
-        grouping_task.add_done_callback(_on_background_task_done)
+    def backend_factory(_runtime: object, _thread_id: str = thread_id):
+        return _get_cached_sandbox_backend(_thread_id)
 
     return create_deep_agent(
         model=reviewer_model,
-        system_prompt=system_prompt,
+        system_prompt="",
         tools=[
             add_finding,
             update_finding,
@@ -1193,9 +1244,13 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             http_request,
         ],
         subagents=[_general_purpose_subagent(reviewer_subagent_model)],
-        backend=sandbox_backend,
-        skills=skill_sources or None,
+        backend=backend_factory,
         middleware=[
+            PrepareReviewerRunMiddleware(
+                thread_id=thread_id,
+                config=config,
+                use_gateway=use_gateway,
+            ),
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
             ToolErrorMiddleware(),

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -885,6 +885,29 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
         self._config = config
         self._use_gateway = use_gateway
 
+    def _prepare_config_fingerprint(self) -> Any:
+        configurable = self._config.get("configurable", {})
+        repo_config = configurable.get("repo") if isinstance(configurable, dict) else None
+        return {
+            "prepare_run_id": configurable.get("prepare_run_id")
+            if isinstance(configurable, dict)
+            else None,
+            "thread_id": self._thread_id,
+            "repo": repo_config,
+            "pr_number": configurable.get("pr_number") if isinstance(configurable, dict) else None,
+            "base_sha": configurable.get("base_sha") if isinstance(configurable, dict) else None,
+            "head_sha": configurable.get("head_sha") if isinstance(configurable, dict) else None,
+            "last_reviewed_sha": configurable.get("last_reviewed_sha")
+            if isinstance(configurable, dict)
+            else None,
+            "reviewer_event": configurable.get("reviewer_event")
+            if isinstance(configurable, dict)
+            else None,
+            "finding_reply_id": configurable.get("finding_reply_id")
+            if isinstance(configurable, dict)
+            else None,
+        }
+
     async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:
         configurable = self._config["configurable"]
         repo_config = configurable.get("repo") or {}

--- a/agent/server.py
+++ b/agent/server.py
@@ -747,6 +747,18 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         self._plan_mode = plan_mode
         self._corridor_enabled = corridor_enabled
 
+    def _prepare_config_fingerprint(self) -> Any:
+        configurable = (self._config or {}).get("configurable") or {}
+        return {
+            "prepare_run_id": configurable.get("prepare_run_id"),
+            "thread_id": self._thread_id,
+            "source": self._source,
+            "repo": configurable.get("repo"),
+            "plan_mode": self._plan_mode,
+            "model": self._model_id,
+            "effort": self._effort,
+        }
+
     async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:  # noqa: ARG002
         github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
         configurable = (self._config or {}).get("configurable") or {}

--- a/agent/server.py
+++ b/agent/server.py
@@ -56,6 +56,7 @@ from .integrations.langsmith_tools import load_langsmith_tools
 from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
 from .middleware import (
+    BasePrepareRunMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
     SandboxCircuitBreakerMiddleware,
@@ -94,6 +95,7 @@ from .tools import (
     slack_thread_reply,
     web_search,
 )
+from .utils import ttl_cache
 from .utils.auth import resolve_github_token
 from .utils.authorship import (
     OPEN_SWE_BOT_EMAIL,
@@ -657,6 +659,14 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
     )
 
 
+async def _cached_tool_loader(key: str, ttl_seconds: float, loader: Any) -> list[Any]:
+    try:
+        return await ttl_cache.cached(key, ttl_seconds, loader)
+    except Exception:
+        logger.warning("Failed to load cached tools for %s", key, exc_info=True)
+        return []
+
+
 async def _load_observability_tools(authorized: bool) -> list[Any]:
     """Datadog (MCP) + LangSmith read tools when the team has connected them.
 
@@ -667,24 +677,134 @@ async def _load_observability_tools(authorized: bool) -> list[Any]:
     """
     if not authorized:
         return []
-    try:
-        datadog_tools, langsmith_tools = await asyncio.gather(
-            load_datadog_tools(),
-            load_langsmith_tools(),
-        )
-    except Exception:
-        logger.warning("Failed to load observability tools", exc_info=True)
-        return []
+    datadog_tools, langsmith_tools = await asyncio.gather(
+        _cached_tool_loader(f"tools:datadog:{id(load_datadog_tools)}", 600, load_datadog_tools),
+        _cached_tool_loader(
+            f"tools:langsmith:{id(load_langsmith_tools)}", 600, load_langsmith_tools
+        ),
+    )
     return [*datadog_tools, *langsmith_tools]
 
 
 async def _load_corridor_mcp_tools() -> list[Any]:
     """Corridor MCP tools when the deployment environment has configured them."""
-    try:
-        return await load_corridor_tools()
-    except Exception:
-        logger.warning("Failed to load Corridor MCP tools", exc_info=True)
-        return []
+    return await _cached_tool_loader(
+        f"tools:corridor:{id(load_corridor_tools)}", 600, load_corridor_tools
+    )
+
+
+async def _cached_team_default_model_pair(kind: str):
+    return await ttl_cache.cached(
+        f"team-default-model-pair:{kind}:{id(get_team_default_model_pair)}",
+        60,
+        lambda: get_team_default_model_pair(kind),
+    )
+
+
+async def _cached_gateway_enabled() -> bool:
+    return await ttl_cache.cached(
+        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        60,
+        get_effective_gateway_enabled,
+    )
+
+
+async def _cached_profile(profile_login: str | None):
+    if not profile_login:
+        return None
+    return await ttl_cache.cached(
+        f"profile:{profile_login}:{id(load_profile)}", 30, lambda: load_profile(profile_login)
+    )
+
+
+class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
+    def __init__(
+        self,
+        *,
+        thread_id: str,
+        config: RunnableConfig,
+        profile_login: str | None,
+        model_id: str,
+        effort: str | None,
+        source: str,
+        user_email: str,
+        linear_project_id: str,
+        linear_issue_number: str,
+        create_prs: bool,
+        plan_mode: bool,
+        corridor_enabled: bool,
+    ) -> None:
+        self._thread_id = thread_id
+        self._config = config
+        self._profile_login = profile_login
+        self._model_id = model_id
+        self._effort = effort
+        self._source = source
+        self._user_email = user_email
+        self._linear_project_id = linear_project_id
+        self._linear_issue_number = linear_issue_number
+        self._create_prs = create_prs
+        self._plan_mode = plan_mode
+        self._corridor_enabled = corridor_enabled
+
+    async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:  # noqa: ARG002
+        github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
+        configurable = (self._config or {}).get("configurable") or {}
+        prompt_default_repo = await _resolve_prompt_default_repo(configurable)
+        triggering_user_identity_task = asyncio.create_task(
+            asyncio.to_thread(resolve_triggering_user_identity, self._config, github_token)
+        )
+        sandbox_task = asyncio.create_task(
+            ensure_sandbox_for_thread(self._thread_id, repo=prompt_default_repo)
+        )
+        triggering_user_identity, sandbox_backend = await asyncio.gather(
+            triggering_user_identity_task,
+            sandbox_task,
+        )
+        del github_token
+        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+        repo_custom_instructions = await _resolve_repo_custom_instructions(prompt_default_repo)
+
+        try:
+            await client.threads.update(
+                thread_id=self._thread_id,
+                metadata={
+                    "agent_kind": "agent",
+                    "model": self._model_id,
+                    "effort": self._effort,
+                    "source": self._source,
+                    "plan_mode": self._plan_mode,
+                },
+            )
+            await record_agent_thread_usage(
+                thread_id=self._thread_id,
+                github_login=self._profile_login,
+                user_email=self._user_email,
+                model_id=self._model_id,
+                effort=self._effort,
+                source=self._source,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to record agent usage for thread %s", self._thread_id, exc_info=True
+            )
+
+        return {
+            "work_dir": work_dir,
+            "rendered_system_prompt": construct_system_prompt(
+                working_dir=work_dir,
+                linear_project_id=self._linear_project_id,
+                linear_issue_number=self._linear_issue_number,
+                triggering_user_identity=triggering_user_identity,
+                create_prs=self._create_prs,
+                default_repo=prompt_default_repo,
+                plan_mode=self._plan_mode,
+                plan_url=dashboard_plan_url(self._thread_id),
+                repo_custom_instructions=repo_custom_instructions,
+                thread_url=dashboard_thread_url(self._thread_id),
+                corridor_enabled=self._corridor_enabled,
+            ),
+        }
 
 
 async def get_agent(config: RunnableConfig) -> Pregel:
@@ -700,33 +820,19 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             tools=[],
         ).with_config(config)
 
-    github_token, _expires_at = await resolve_github_token(config, thread_id)
     profile_login = resolve_github_login(config)
     configurable = (config or {}).get("configurable") or {}
-    prompt_default_repo = await _resolve_prompt_default_repo(configurable)
-    triggering_user_identity_task = asyncio.create_task(
-        asyncio.to_thread(resolve_triggering_user_identity, config, github_token)
+    # Team/profile settings are accepted stale for a short TTL so graph factories
+    # stay off the critical path during worker load and retry storms.
+    team_defaults, use_gateway, profile = await asyncio.gather(
+        _cached_team_default_model_pair("agent"),
+        _cached_gateway_enabled(),
+        _cached_profile(profile_login),
     )
-    sandbox_task = asyncio.create_task(
-        ensure_sandbox_for_thread(thread_id, repo=prompt_default_repo)
-    )
-    team_defaults_task = asyncio.create_task(get_team_default_model_pair("agent"))
-    gateway_task = asyncio.create_task(get_effective_gateway_enabled())
-    profile_task = asyncio.create_task(load_profile(profile_login)) if profile_login else None
-    triggering_user_identity, sandbox_backend, team_defaults, use_gateway = await asyncio.gather(
-        triggering_user_identity_task,
-        sandbox_task,
-        team_defaults_task,
-        gateway_task,
-    )
-    profile = await profile_task if profile_task is not None else None
-    del github_token
 
     linear_issue = config["configurable"].get("linear_issue", {})
     linear_project_id = linear_issue.get("linear_project_id", "")
     linear_issue_number = linear_issue.get("linear_issue_number", "")
-
-    work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
 
     def backend_factory(_runtime: object, _thread_id: str = thread_id) -> SandboxBackendProtocol:
         return _get_cached_sandbox_backend(_thread_id)
@@ -829,29 +935,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     )
     user_email = configurable.get("user_email")
     user_email = user_email if isinstance(user_email, str) else ""
-    try:
-        await client.threads.update(
-            thread_id=thread_id,
-            metadata={
-                "agent_kind": "agent",
-                "model": model_id,
-                "effort": profile_effort,
-                "source": source,
-                "plan_mode": plan_mode,
-            },
-        )
-        await record_agent_thread_usage(
-            thread_id=thread_id,
-            github_login=profile_login,
-            user_email=user_email,
-            model_id=model_id,
-            effort=profile_effort,
-            source=source,
-        )
-    except Exception:
-        logger.debug("Failed to record agent usage for thread %s", thread_id, exc_info=True)
-
-    repo_custom_instructions = await _resolve_repo_custom_instructions(prompt_default_repo)
 
     observability_tools = await _load_observability_tools(
         await _observability_authorized(config, profile_login)
@@ -862,35 +945,25 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
     if profile_login:
-        try:
-            currents_tools = await load_currents_tools(profile_login)
-        except Exception:
-            logger.warning("Failed to load Currents tools", exc_info=True)
-            currents_tools = []
-        try:
-            notion_tools = await load_notion_tools(profile_login)
-        except Exception:
-            logger.warning("Failed to load Notion tools", exc_info=True)
-            notion_tools = []
+        currents_tools, notion_tools = await asyncio.gather(
+            _cached_tool_loader(
+                f"tools:currents:{profile_login}:{id(load_currents_tools)}",
+                300,
+                lambda: load_currents_tools(profile_login),
+            ),
+            _cached_tool_loader(
+                f"tools:notion:{profile_login}:{id(load_notion_tools)}",
+                300,
+                lambda: load_notion_tools(profile_login),
+            ),
+        )
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)
     main_model = make_model(model_id, use_gateway=use_gateway, **model_kwargs)
     subagent_model = make_model(subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs)
     return create_deep_agent(
         model=main_model,
-        system_prompt=construct_system_prompt(
-            working_dir=work_dir,
-            linear_project_id=linear_project_id,
-            linear_issue_number=linear_issue_number,
-            triggering_user_identity=triggering_user_identity,
-            create_prs=always_create_prs,
-            default_repo=prompt_default_repo,
-            plan_mode=plan_mode,
-            plan_url=dashboard_plan_url(thread_id),
-            repo_custom_instructions=repo_custom_instructions,
-            thread_url=dashboard_thread_url(thread_id),
-            corridor_enabled=bool(corridor_tools),
-        ),
+        system_prompt="",
         tools=[
             http_request,
             fetch_url,
@@ -922,6 +995,20 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         ],
         backend=backend_factory,
         middleware=[
+            PrepareAgentRunMiddleware(
+                thread_id=thread_id,
+                config=config,
+                profile_login=profile_login,
+                model_id=model_id,
+                effort=profile_effort,
+                source=source,
+                user_email=user_email,
+                linear_project_id=linear_project_id,
+                linear_issue_number=linear_issue_number,
+                create_prs=always_create_prs,
+                plan_mode=plan_mode,
+                corridor_enabled=bool(corridor_tools),
+            ),
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
             ToolErrorMiddleware(),

--- a/agent/tools/add_finding.py
+++ b/agent/tools/add_finding.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from langgraph.config import get_config
+from langgraph.prebuilt import InjectedState
 
-from ..reviewer_diff import is_range_in_diff
+from ..reviewer_diff import compute_diff_line_set, fetch_pr_diff, is_range_in_diff
 from ..reviewer_findings import (
     DEFAULT_FINDING_TITLE,
     MAX_SUGGESTION_LINES,
@@ -23,6 +24,7 @@ from ..reviewer_findings import (
     resolve_review_head_sha,
     thread_missing_tool_result,
 )
+from ..utils.github_token import get_github_token
 
 
 async def add_finding(
@@ -36,6 +38,7 @@ async def add_finding(
     end_line: int | None = None,
     suggestion: str | None = None,
     side: str = "RIGHT",
+    state: Annotated[dict[str, Any] | None, InjectedState] = None,
 ) -> dict[str, Any]:
     """Record a review finding on the reviewer thread.
 
@@ -114,8 +117,7 @@ async def add_finding(
 
     config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
-    diff_line_set = configurable.get("diff_line_set") if isinstance(configurable, dict) else None
-    diff_text = configurable.get("diff_text", "") if isinstance(configurable, dict) else ""
+    diff_line_set, diff_text = await _resolve_diff_context(state, configurable)
 
     in_diff = not isinstance(diff_line_set, dict) or is_range_in_diff(
         diff_line_set, file, start_line, end_line, side=_cast_side(side)
@@ -174,6 +176,41 @@ async def add_finding(
             "include `suggestion` for small, obvious fixes."
         )
     return result
+
+
+async def _resolve_diff_context(
+    state: dict[str, Any] | None,
+    configurable: dict[str, Any] | Any,
+) -> tuple[dict[str, Any] | None, str]:
+    if isinstance(state, dict):
+        state_line_set = state.get("diff_line_set")
+        state_diff_text = state.get("diff_text")
+        if isinstance(state_line_set, dict):
+            return state_line_set, state_diff_text if isinstance(state_diff_text, str) else ""
+    if isinstance(configurable, dict):
+        config_line_set = configurable.get("diff_line_set")
+        config_diff_text = configurable.get("diff_text")
+        if isinstance(config_line_set, dict):
+            return config_line_set, config_diff_text if isinstance(config_diff_text, str) else ""
+        repo_config = configurable.get("repo")
+        pr_number = configurable.get("pr_number")
+        token = get_github_token()
+        if (
+            isinstance(repo_config, dict)
+            and isinstance(repo_config.get("owner"), str)
+            and isinstance(repo_config.get("name"), str)
+            and isinstance(pr_number, int)
+            and token
+        ):
+            diff_text = await fetch_pr_diff(
+                owner=repo_config["owner"],
+                repo=repo_config["name"],
+                pr_number=pr_number,
+                token=token,
+            )
+            if diff_text is not None:
+                return compute_diff_line_set(diff_text), diff_text
+    return None, ""
 
 
 def _cast_severity(value: str) -> Severity:

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from langgraph.config import get_config
+from langgraph.prebuilt import InjectedState
 
 from ..dashboard.team_settings import get_team_review_trace_links_enabled
 from ..reviewer_diff import compute_diff_line_set, fetch_pr_diff, is_range_in_diff
@@ -58,6 +59,7 @@ from ..utils.tracing import REVIEW_TRACING_PROJECT
 async def publish_review(
     severity_threshold: str = "medium",
     cap: int = 4,
+    state: Annotated[dict[str, Any] | None, InjectedState] = None,
 ) -> dict[str, Any]:
     """Post all current findings to the PR as a GitHub Review.
 
@@ -145,6 +147,7 @@ async def publish_review(
             is_re_review=is_re_review,
             langgraph_run_id=_current_run_id(config),
             trace_link_config_override=configurable.get("review_trace_link_enabled"),
+            state=state,
         )
     except ReviewerThreadMissingError as exc:
         return thread_missing_tool_result(exc)
@@ -228,6 +231,7 @@ async def _publish_review_async(
     is_re_review: bool,
     langgraph_run_id: str | None = None,
     trace_link_config_override: object = None,
+    state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     thread_id = get_thread_id_from_runtime()
     # The run config's head_sha is frozen at run creation; a push that arrived
@@ -362,6 +366,7 @@ async def _publish_review_async(
             repo=repo,
             pr_number=pr_number,
             token=token,
+            state=state,
         )
         if dropped_ids and valid_with_payload:
             retry_inline = [p for _, p in valid_with_payload]
@@ -762,6 +767,7 @@ async def _resolve_diff_line_set(
     repo: str,
     pr_number: int,
     token: str,
+    state: dict[str, Any] | None = None,
 ) -> dict[str, set[int]] | None:
     """Return the new-side line set for the PR diff, fetching it if needed.
 
@@ -772,6 +778,10 @@ async def _resolve_diff_line_set(
     fly. Returns ``None`` if the fetch fails — caller treats that as "we
     can't tell which finding is bad, don't retry blindly".
     """
+    if isinstance(state, dict):
+        state_cached = state.get("diff_line_set")
+        if isinstance(state_cached, dict):
+            return state_cached
     config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
     cached = configurable.get("diff_line_set") if isinstance(configurable, dict) else None
@@ -791,6 +801,7 @@ async def _filter_against_pr_diff(
     repo: str,
     pr_number: int,
     token: str,
+    state: dict[str, Any] | None = None,
 ) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], list[str]]:
     """Drop findings whose path/line range is not in the current PR diff.
 
@@ -800,7 +811,7 @@ async def _filter_against_pr_diff(
     original error rather than retry blindly.
     """
     diff_line_set = await _resolve_diff_line_set(
-        owner=owner, repo=repo, pr_number=pr_number, token=token
+        owner=owner, repo=repo, pr_number=pr_number, token=token, state=state
     )
     if diff_line_set is None:
         return list(eligible_with_payload), []

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -1,5 +1,6 @@
+import asyncio
 import os
-from typing import Literal, TypedDict, Unpack
+from typing import Any, Literal, TypedDict, Unpack
 
 from langchain.chat_models import init_chat_model
 
@@ -11,6 +12,37 @@ OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 # Anthropic SDK default is 2; a 529 burst can outlive that. Bump to give the
 # primary provider a fair chance before the fallback middleware kicks in.
 DEFAULT_MAX_RETRIES = 6
+
+_MODEL_CACHE: dict[
+    tuple[str, bool | None, int | None, tuple[tuple[str, str], ...], int | None], Any
+] = {}
+
+
+def _loop_cache_key() -> int | None:
+    try:
+        return id(asyncio.get_running_loop())
+    except RuntimeError:
+        return None
+
+
+def _freeze_model_kwargs(kwargs: dict[str, object]) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted((key, repr(value)) for key, value in kwargs.items()))
+
+
+async def close_cached_models() -> None:
+    models = list(_MODEL_CACHE.values())
+    _MODEL_CACHE.clear()
+    for model in models:
+        close = getattr(model, "aclose", None)
+        if callable(close):
+            await close()
+            continue
+        close = getattr(model, "close", None)
+        if callable(close):
+            result = close()
+            if asyncio.iscoroutine(result):
+                await result
+
 
 OpenAIReasoningEffort = Literal["none", "low", "medium", "high", "xhigh"]
 # OpenAI's Responses API only returns human-readable reasoning text when a
@@ -102,7 +134,19 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
         _configure_openai_responses_kwargs(model_kwargs)
         _coerce_openai_chat_completions_kwargs(model_kwargs)
 
-    return init_chat_model(model=model_id, **model_kwargs)
+    key = (
+        model_id,
+        use_gateway,
+        model_kwargs.get("max_tokens") if isinstance(model_kwargs.get("max_tokens"), int) else None,
+        _freeze_model_kwargs(model_kwargs),
+        _loop_cache_key(),
+    )
+    cached = _MODEL_CACHE.get(key)
+    if cached is not None:
+        return cached
+    model = init_chat_model(model=model_id, **model_kwargs)
+    _MODEL_CACHE[key] = model
+    return model
 
 
 def fallback_model_id_for(primary_model_id: str) -> str | None:

--- a/agent/utils/ttl_cache.py
+++ b/agent/utils/ttl_cache.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_CACHE: dict[str, tuple[object, float]] = {}
+_LOCKS: dict[tuple[str, int], asyncio.Lock] = {}
+
+
+def _now() -> float:
+    return asyncio.get_running_loop().time()
+
+
+def _lock_for(key: str) -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock_key = (key, id(loop))
+    lock = _LOCKS.get(lock_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _LOCKS[lock_key] = lock
+    return lock
+
+
+async def cached(key: str, ttl_seconds: float, loader: Callable[[], Awaitable[T]]) -> T:
+    now = _now()
+    entry = _CACHE.get(key)
+    if entry is not None:
+        value, expires_at = entry
+        if expires_at > now:
+            return value  # type: ignore[return-value]
+
+    async with _lock_for(key):
+        now = _now()
+        entry = _CACHE.get(key)
+        if entry is not None:
+            value, expires_at = entry
+            if expires_at > now:
+                return value  # type: ignore[return-value]
+
+        stale = entry[0] if entry is not None else None
+        has_stale = entry is not None
+        try:
+            value = await loader()
+        except Exception:
+            if has_stale:
+                logger.warning(
+                    "TTL cache loader failed for %s; serving stale value", key, exc_info=True
+                )
+                return stale  # type: ignore[return-value]
+            raise
+        _CACHE[key] = (value, now + ttl_seconds)
+        return value
+
+
+def set_cached(key: str, value: object, ttl_seconds: float) -> None:
+    try:
+        expires_at = _now() + ttl_seconds
+    except RuntimeError:
+        expires_at = float("inf")
+    _CACHE[key] = (value, expires_at)
+
+
+def invalidate(key: str) -> None:
+    _CACHE.pop(key, None)
+
+
+def clear() -> None:
+    _CACHE.clear()
+    _LOCKS.clear()

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -151,12 +151,15 @@ if os.environ.get("DEBUG_TRACEMALLOC"):
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    from .utils.model import validate_local_dev_llm_config
+    from .utils.model import close_cached_models, validate_local_dev_llm_config
     from .utils.sandbox import validate_sandbox_startup_config
 
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
-    yield
+    try:
+        yield
+    finally:
+        await close_cached_models()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/tests/test_corridor_mcp.py
+++ b/tests/test_corridor_mcp.py
@@ -119,7 +119,11 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
         "metadata": {},
     }
 
-    def fake_create_deep_agent(**_kwargs):
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        captured.update(kwargs)
+
         class _DummyAgent:
             def with_config(self, _config):
                 return self
@@ -174,6 +178,8 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
             patch.object(server, "create_deep_agent", side_effect=fake_create_deep_agent),
         ):
             await server.get_agent(config)
+            prepare = captured["middleware"][0]
+            await prepare.abefore_agent({}, None)
         return bool(prompt.call_args.kwargs["corridor_enabled"])
 
     assert await run_with_corridor_tools([]) is False

--- a/tests/test_prepare_run_middleware.py
+++ b/tests/test_prepare_run_middleware.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from agent.middleware.prepare_run import BasePrepareRunMiddleware
+from agent.utils import ttl_cache
+
+
+class DummyPrepareMiddleware(BasePrepareRunMiddleware):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def _prepare(self, state, runtime):
+        self.calls += 1
+        return {"work_dir": "/tmp/work", "rendered_system_prompt": "prepared prompt"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_latch_skips_second_call():
+    middleware = DummyPrepareMiddleware()
+
+    update = await middleware.abefore_agent({}, None)
+    assert update == {
+        "run_prepared": True,
+        "work_dir": "/tmp/work",
+        "rendered_system_prompt": "prepared prompt",
+    }
+    assert await middleware.abefore_agent({"run_prepared": True}, None) is None
+    assert middleware.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_prompt_injection():
+    middleware = DummyPrepareMiddleware()
+    seen = {}
+
+    async def handler(request):
+        seen["system_prompt"] = request.system_prompt
+        return None
+
+    request = type(
+        "Request",
+        (),
+        {
+            "state": {
+                "rendered_system_prompt": "prepared prompt",
+                "messages": [HumanMessage("hi")],
+            },
+            "system_message": None,
+            "override": lambda self, **kwargs: type(
+                "Request",
+                (),
+                {
+                    "state": self.state,
+                    "system_prompt": kwargs["system_message"].text,
+                    "override": self.override,
+                },
+            )(),
+        },
+    )()
+    await middleware.awrap_model_call(request, handler)
+    assert seen["system_prompt"] == "prepared prompt"
+
+
+@pytest.mark.asyncio
+async def test_ttl_cache_single_flight_and_stale_while_error():
+    ttl_cache.clear()
+    calls = 0
+
+    async def loader():
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return calls
+
+    results = await asyncio.gather(*(ttl_cache.cached("k", 60, loader) for _ in range(10)))
+    assert results == [1] * 10
+    assert calls == 1
+
+    ttl_cache.set_cached("k", "stale", -1)
+
+    async def failing_loader():
+        raise RuntimeError("boom")
+
+    assert await ttl_cache.cached("k", 60, failing_loader) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_ttl_cache_exception_without_stale_is_not_cached():
+    ttl_cache.clear()
+    calls = 0
+
+    async def failing_loader():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await ttl_cache.cached("k", 60, failing_loader)
+    with pytest.raises(RuntimeError):
+        await ttl_cache.cached("k", 60, failing_loader)
+    assert calls == 2

--- a/tests/test_prepare_run_middleware.py
+++ b/tests/test_prepare_run_middleware.py
@@ -23,12 +23,27 @@ async def test_prepare_latch_skips_second_call():
     middleware = DummyPrepareMiddleware()
 
     update = await middleware.abefore_agent({}, None)
+    fingerprint = update.pop("run_prepared_for")
+    assert isinstance(fingerprint, str)
     assert update == {
         "run_prepared": True,
         "work_dir": "/tmp/work",
         "rendered_system_prompt": "prepared prompt",
     }
-    assert await middleware.abefore_agent({"run_prepared": True}, None) is None
+    assert (
+        await middleware.abefore_agent(
+            {"run_prepared": True, "run_prepared_for": fingerprint}, None
+        )
+        is None
+    )
+    assert middleware.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_latch_reruns_when_fingerprint_changes():
+    middleware = DummyPrepareMiddleware()
+
+    assert await middleware.abefore_agent({"run_prepared": True, "run_prepared_for": "stale"}, None)
     assert middleware.calls == 1
 
 

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -323,6 +323,11 @@ class TestRefreshProxyOnSandboxReuse:
         """Cached sandboxes should get a fresh proxy token before git operations."""
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-cached")
+        captured: dict[str, object] = {}
+
+        def fake_create_deep_agent(**kwargs):
+            captured.update(kwargs)
+            return _DummyAgent()
 
         with (
             patch(
@@ -353,7 +358,7 @@ class TestRefreshProxyOnSandboxReuse:
             ),
             patch("agent.server.make_model", return_value=MagicMock()),
             patch("agent.server.construct_system_prompt", return_value="prompt"),
-            patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
+            patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
             patch.dict(
                 "agent.server.SANDBOX_BACKENDS",
                 {"thread-123": mock_sandbox},
@@ -364,6 +369,8 @@ class TestRefreshProxyOnSandboxReuse:
             from agent.server import get_agent
 
             await get_agent(config)
+            prepare = captured["middleware"][0]
+            await prepare.abefore_agent({}, None)
 
             mock_proxy.assert_called_once_with("sandbox-cached", "ghs_fresh")
 
@@ -372,6 +379,11 @@ class TestRefreshProxyOnSandboxReuse:
         """Reconnected sandboxes should also get a fresh proxy token."""
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-existing")
+        captured: dict[str, object] = {}
+
+        def fake_create_deep_agent(**kwargs):
+            captured.update(kwargs)
+            return _DummyAgent()
 
         with (
             patch(
@@ -402,13 +414,15 @@ class TestRefreshProxyOnSandboxReuse:
             ),
             patch("agent.server.make_model", return_value=MagicMock()),
             patch("agent.server.construct_system_prompt", return_value="prompt"),
-            patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
+            patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
             patch.dict("agent.server.SANDBOX_BACKENDS", {}, clear=True),
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
             from agent.server import get_agent
 
             await get_agent(config)
+            prepare = captured["middleware"][0]
+            await prepare.abefore_agent({}, None)
 
             mock_create.assert_called_once_with("sandbox-existing")
             mock_proxy.assert_called_once_with("sandbox-existing", "ghs_fresh")

--- a/tests/test_repo_extraction.py
+++ b/tests/test_repo_extraction.py
@@ -19,11 +19,13 @@ class TestExtractRepoFromText:
         assert result == {"owner": "langchain-ai", "name": "langchainjs"}
 
     def test_repo_colon_name_only_uses_default_owner(self) -> None:
-        result = extract_repo_from_text("fix bug in repo:langchainplus")
+        result = extract_repo_from_text(
+            "fix bug in repo:langchainplus", default_owner="langchain-ai"
+        )
         assert result == {"owner": "langchain-ai", "name": "langchainplus"}
 
     def test_repo_space_name_only_uses_default_owner(self) -> None:
-        result = extract_repo_from_text("fix bug in repo open-swe")
+        result = extract_repo_from_text("fix bug in repo open-swe", default_owner="langchain-ai")
         assert result == {"owner": "langchain-ai", "name": "open-swe"}
 
     def test_repo_name_only_custom_default_owner(self) -> None:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -298,6 +298,7 @@ async def test_reviewer_raises_when_app_installation_token_unavailable() -> None
             new_callable=AsyncMock,
             return_value=MagicMock(),
         ) as mock_sandbox,
+        patch("agent.reviewer.make_model", return_value=MagicMock()),
         patch("agent.reviewer.create_deep_agent", return_value=_DummyAgent()) as create_agent,
     ):
         await reviewer.get_reviewer_agent(config)

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -208,6 +208,8 @@ async def test_reviewer_resolves_app_installation_token_at_run_start() -> None:
         patch("agent.reviewer.create_deep_agent", return_value=dummy_agent) as create_agent,
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = create_agent.call_args.kwargs["middleware"][0]
+        await prepare.abefore_agent({}, None)
 
     metadata = config["metadata"]
     assert isinstance(metadata, dict)
@@ -259,9 +261,11 @@ async def test_reviewer_reuses_app_token_for_sandbox_proxy() -> None:
         ),
         patch("agent.reviewer.fetch_agents_md", new_callable=AsyncMock, return_value=None),
         patch("agent.reviewer.make_model", return_value=MagicMock()),
-        patch("agent.reviewer.create_deep_agent", return_value=_DummyAgent()),
+        patch("agent.reviewer.create_deep_agent", return_value=_DummyAgent()) as create_agent,
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = create_agent.call_args.kwargs["middleware"][0]
+        await prepare.abefore_agent({}, None)
 
     mock_sandbox.assert_awaited_once_with(
         "reviewer-thread-id",
@@ -294,10 +298,12 @@ async def test_reviewer_raises_when_app_installation_token_unavailable() -> None
             new_callable=AsyncMock,
             return_value=MagicMock(),
         ) as mock_sandbox,
-        patch("agent.reviewer.create_deep_agent", return_value=_DummyAgent()),
+        patch("agent.reviewer.create_deep_agent", return_value=_DummyAgent()) as create_agent,
     ):
+        await reviewer.get_reviewer_agent(config)
+        prepare = create_agent.call_args.kwargs["middleware"][0]
         with pytest.raises(RuntimeError, match="installation token unavailable"):
-            await reviewer.get_reviewer_agent(config)
+            await prepare.abefore_agent({}, None)
 
     mock_sandbox.assert_not_awaited()
 
@@ -421,6 +427,7 @@ async def test_reviewer_injects_repo_style_during_eval() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -448,6 +455,9 @@ async def test_reviewer_injects_repo_style_during_eval() -> None:
         ),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     assert "Repository-specific review style" in captured["system_prompt"]
     assert "Flag table rerender regressions" in captured["system_prompt"]
@@ -472,6 +482,7 @@ async def test_reviewer_inlines_org_guidelines_into_system_prompt() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -509,6 +520,9 @@ async def test_reviewer_inlines_org_guidelines_into_system_prompt() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     assert "Organization-wide review guidelines" in captured["system_prompt"]
     assert "disables a CI gate" in captured["system_prompt"]
@@ -547,6 +561,7 @@ async def test_reviewer_inlines_agents_md_into_system_prompt() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -574,6 +589,9 @@ async def test_reviewer_inlines_agents_md_into_system_prompt() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     mock_fetch_agents_md.assert_awaited_once_with("acme", "repo", "base-sha-xyz", token="gh-token")
     assert "Repository conventions (AGENTS.md / CLAUDE.md)" in captured["system_prompt"]
@@ -599,6 +617,7 @@ async def test_reviewer_inlines_claude_md_when_agents_md_absent() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -626,6 +645,9 @@ async def test_reviewer_inlines_claude_md_when_agents_md_absent() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     mock_fetch_agents_md.assert_awaited_once_with("acme", "repo", "base-sha-xyz", token="gh-token")
     assert "Repository conventions (AGENTS.md / CLAUDE.md)" in captured["system_prompt"]
@@ -937,6 +959,7 @@ async def test_reviewer_injects_pr_review_threads_into_first_review_context() ->
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     fake_threads = [
@@ -991,6 +1014,9 @@ async def test_reviewer_injects_pr_review_threads_into_first_review_context() ->
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     mock_fetch_threads.assert_awaited_once()
     assert "Pre-existing PR review threads" in captured["system_prompt"]
@@ -1019,6 +1045,7 @@ async def test_reviewer_injects_pr_review_threads_into_re_review_context() -> No
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     fake_threads = [
@@ -1067,6 +1094,9 @@ async def test_reviewer_injects_pr_review_threads_into_re_review_context() -> No
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     assert "A new commit has been pushed" in captured["system_prompt"]
     assert "Pre-existing PR review threads" in captured["system_prompt"]
@@ -1093,6 +1123,7 @@ async def test_reviewer_omits_threads_block_when_fetch_returns_empty() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -1125,6 +1156,9 @@ async def test_reviewer_omits_threads_block_when_fetch_returns_empty() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     # The rule text mentions the wrapper tag, but the actual rendered XML
     # data block (which always has a `</pr_review_threads>` closer and a
@@ -1152,6 +1186,7 @@ async def test_reviewer_continues_when_thread_fetch_raises() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -1184,6 +1219,9 @@ async def test_reviewer_continues_when_thread_fetch_raises() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     # The reviewer must still produce a usable prompt even if the thread
     # fetch fails; the first-review user-message context should still appear.
@@ -1218,7 +1256,10 @@ async def test_reviewer_populates_diff_line_set_from_github_api() -> None:
         "+touched\n"
     )
 
+    captured: dict[str, object] = {}
+
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -1256,12 +1297,14 @@ async def test_reviewer_populates_diff_line_set_from_github_api() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
 
     mock_fetch_diff.assert_awaited_once_with(
         owner="acme", repo="repo", pr_number=42, token="gh-token"
     )
-    assert config["configurable"]["diff_text"] == pr_diff
-    assert config["configurable"]["diff_line_set"] == {"in_diff.py": {"RIGHT": {10}, "LEFT": {1}}}
+    assert updates["diff_text"] == pr_diff
+    assert updates["diff_line_set"] == {"in_diff.py": {"RIGHT": {10}, "LEFT": {1}}}
 
 
 @pytest.mark.asyncio
@@ -1283,7 +1326,10 @@ async def test_reviewer_leaves_validation_disabled_when_diff_fetch_fails() -> No
         "metadata": {},
     }
 
+    captured: dict[str, object] = {}
+
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -1321,9 +1367,11 @@ async def test_reviewer_leaves_validation_disabled_when_diff_fetch_fails() -> No
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
 
-    assert config["configurable"]["diff_text"] == ""
-    assert config["configurable"]["diff_line_set"] is None
+    assert updates["diff_text"] == ""
+    assert updates["diff_line_set"] is None
 
 
 @pytest.mark.asyncio
@@ -1345,6 +1393,7 @@ async def test_reviewer_injects_pr_title_and_body_into_context() -> None:
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
+        captured["middleware"] = kwargs["middleware"]
         return _DummyAgent()
 
     with (
@@ -1387,6 +1436,9 @@ async def test_reviewer_injects_pr_title_and_body_into_context() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
+        prepare = captured["middleware"][0]
+        updates = await prepare.abefore_agent({}, None)
+        captured["system_prompt"] = updates["rendered_system_prompt"]
 
     mock_fetch_metadata.assert_awaited_once_with(
         owner="acme", repo="repo", pr_number=42, token="gh-token"

--- a/tests/test_slack_context.py
+++ b/tests/test_slack_context.py
@@ -636,6 +636,7 @@ def test_process_slack_mention_unmapped_user_blocked_and_prompted(
     monkeypatch.setattr(webapp, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webapp, "login_for_email", fake_login_for_email)
     monkeypatch.setattr(webapp, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webapp, "is_bot_token_only_mode", lambda: False)
 
     asyncio.run(
         webapp.process_slack_mention(
@@ -686,6 +687,7 @@ def test_process_slack_mention_mapped_user_no_token_record_prompts_setup(
     monkeypatch.setattr(webapp, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(webapp, "has_access_token_record", fake_has_token_record)
     monkeypatch.setattr(webapp, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webapp, "is_bot_token_only_mode", lambda: False)
 
     asyncio.run(
         webapp.process_slack_mention(
@@ -732,6 +734,7 @@ def test_process_slack_mention_mapped_user_unusable_token_prompts_revoked(
     monkeypatch.setattr(webapp, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(webapp, "has_access_token_record", fake_has_token_record)
     monkeypatch.setattr(webapp, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webapp, "is_bot_token_only_mode", lambda: False)
 
     asyncio.run(
         webapp.process_slack_mention(


### PR DESCRIPTION
## Summary
- Add checkpointed prepare-run middleware plus async TTL/model caches and shutdown cleanup.
- Move agent, reviewer, analyzer, and chat sandbox/token/prompt setup into prepare hooks so warm graph factories avoid network/sandbox setup work.
- Checkpoint reviewer diff context in state and update finding/publish tools to prefer injected state with legacy/on-demand fallbacks.
- Cache integration tool/model/team-setting/profile loaders and update tests for prepare-time setup.

## Verification
- make lint
- make test

## Notes
- deepagents 0.6.8 inserts SkillsMiddleware before user middleware and runs its skills scan as before_agent; reviewer trusted repo skills are therefore materialized during prepare and appended to the prepared reviewer prompt rather than relying on the built-in one-shot scan.
- Diff context storage choice: store full diff_text and diff_line_set in checkpointed reviewer state, with configurable and on-demand fetch fallback for compatibility.