### PR TITLE
fix: reconnect sandbox backend on resumed runs

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -150,11 +150,11 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     if thread_id is None or not graph_loaded_for_execution(config):
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)
 
+    async def reconnect_backend(_thread_id: str = thread_id):
+        return await ensure_sandbox_for_thread(_thread_id)
+
     def backend_factory(_runtime: object, _thread_id: str = thread_id):
-        try:
-            default_backend = _get_cached_sandbox_backend(_thread_id)
-        except RuntimeError:
-            default_backend = StateBackend()
+        default_backend = _get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)
         return CompositeBackend(default=default_backend, routes={SKILLS_ROUTE: StateBackend()})
 
     model_id = DEFAULT_LLM_MODEL_ID

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -31,6 +31,7 @@ warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 from deepagents import create_deep_agent
+from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.middleware.skills import SkillsMiddleware
 from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -871,6 +872,40 @@ class PrepareReviewerRunState(PrepareRunState):
     diff_line_set: NotRequired[dict[str, dict[str, set[int]]] | None]
 
 
+async def _ensure_reviewer_sandbox_for_thread(
+    thread_id: str,
+    configurable: dict[str, Any],
+) -> tuple[SandboxBackendProtocol, str | None]:
+    repo_config = configurable.get("repo") or {}
+    github_token: str | None = None
+    if configurable.get("source"):
+        repo_name_for_token = str(repo_config.get("name") or "")
+        github_token, expires_at = await get_github_app_installation_token_with_expiry(
+            repositories=[repo_name_for_token] if repo_name_for_token else None
+        )
+        if not github_token:
+            raise RuntimeError(
+                f"GitHub App installation token unavailable for reviewer thread {thread_id}"
+            )
+        cache_github_token_for_thread(thread_id, github_token, expires_at=expires_at)
+
+    repo_name_for_scope = str(repo_config.get("name") or "")
+    repo_for_snapshot = (
+        {"owner": str(repo_config["owner"]), "name": str(repo_config["name"])}
+        if repo_config.get("owner") and repo_config.get("name")
+        else None
+    )
+    return (
+        await ensure_sandbox_for_thread(
+            thread_id,
+            github_proxy_token=github_token,
+            github_proxy_repositories=[repo_name_for_scope] if repo_name_for_scope else None,
+            repo=repo_for_snapshot,
+        ),
+        github_token,
+    )
+
+
 class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
     state_schema = PrepareReviewerRunState
 
@@ -911,29 +946,8 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
     async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:
         configurable = self._config["configurable"]
         repo_config = configurable.get("repo") or {}
-        github_token: str | None = None
-        if configurable.get("source"):
-            repo_name_for_token = str(repo_config.get("name") or "")
-            github_token, expires_at = await get_github_app_installation_token_with_expiry(
-                repositories=[repo_name_for_token] if repo_name_for_token else None
-            )
-            if not github_token:
-                raise RuntimeError(
-                    f"GitHub App installation token unavailable for reviewer thread {self._thread_id}"
-                )
-            cache_github_token_for_thread(self._thread_id, github_token, expires_at=expires_at)
-
-        repo_name_for_scope = str(repo_config.get("name") or "")
-        repo_for_snapshot = (
-            {"owner": str(repo_config["owner"]), "name": str(repo_config["name"])}
-            if repo_config.get("owner") and repo_config.get("name")
-            else None
-        )
-        sandbox_backend = await ensure_sandbox_for_thread(
-            self._thread_id,
-            github_proxy_token=github_token,
-            github_proxy_repositories=[repo_name_for_scope] if repo_name_for_scope else None,
-            repo=repo_for_snapshot,
+        sandbox_backend, github_token = await _ensure_reviewer_sandbox_for_thread(
+            self._thread_id, configurable
         )
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
 
@@ -1249,8 +1263,17 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs
     )
 
+    async def reconnect_backend(
+        _thread_id: str = thread_id,
+        _configurable: dict[str, Any] = configurable,
+    ) -> SandboxBackendProtocol:
+        sandbox_backend, _github_token = await _ensure_reviewer_sandbox_for_thread(
+            _thread_id, _configurable
+        )
+        return sandbox_backend
+
     def backend_factory(_runtime: object, _thread_id: str = thread_id):
-        return _get_cached_sandbox_backend(_thread_id)
+        return _get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)
 
     return create_deep_agent(
         model=reviewer_model,

--- a/agent/server.py
+++ b/agent/server.py
@@ -129,6 +129,7 @@ SANDBOX_POLL_INTERVAL = 1.0
 
 from .utils.sandbox_state import (
     SANDBOX_BACKENDS,
+    get_or_create_sandbox_backend_proxy,
     get_sandbox_id_from_metadata,
     set_sandbox_backend,
     unwrap_sandbox_backend,
@@ -632,10 +633,7 @@ def _browser_subagent(model: BaseChatModel, tools: list[Any]) -> SubAgent:
 
 
 def _get_cached_sandbox_backend(thread_id: str) -> SandboxBackendProtocol:
-    sandbox_backend = SANDBOX_BACKENDS.get(thread_id)
-    if sandbox_backend is None:
-        raise RuntimeError(f"No sandbox backend cached for thread {thread_id}")
-    return sandbox_backend
+    return get_or_create_sandbox_backend_proxy(thread_id)
 
 
 async def _observability_authorized(config: RunnableConfig, profile_login: str | None) -> bool:

--- a/agent/server.py
+++ b/agent/server.py
@@ -7,7 +7,7 @@ import logging
 import os
 import time
 import warnings
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -469,6 +469,8 @@ async def ensure_sandbox_for_thread(
     first creation/reconnect for this thread initializes git identity.
     """
     sandbox_backend = SANDBOX_BACKENDS.get(thread_id)
+    if sandbox_backend is not None and not sandbox_backend.has_backend:
+        sandbox_backend = None
     sandbox_id = await get_sandbox_id_from_metadata(thread_id)
 
     if sandbox_id == SANDBOX_CREATING and not sandbox_backend:
@@ -632,8 +634,12 @@ def _browser_subagent(model: BaseChatModel, tools: list[Any]) -> SubAgent:
     }
 
 
-def _get_cached_sandbox_backend(thread_id: str) -> SandboxBackendProtocol:
-    return get_or_create_sandbox_backend_proxy(thread_id)
+def _get_cached_sandbox_backend(
+    thread_id: str,
+    *,
+    reconnect: Callable[[], Awaitable[SandboxBackendProtocol]] | None = None,
+) -> SandboxBackendProtocol:
+    return get_or_create_sandbox_backend_proxy(thread_id, reconnect=reconnect)
 
 
 async def _observability_authorized(config: RunnableConfig, profile_login: str | None) -> bool:
@@ -844,8 +850,15 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     linear_project_id = linear_issue.get("linear_project_id", "")
     linear_issue_number = linear_issue.get("linear_issue_number", "")
 
+    async def reconnect_backend(
+        _thread_id: str = thread_id,
+        _configurable: dict[str, Any] = configurable,
+    ) -> SandboxBackendProtocol:
+        prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
+        return await ensure_sandbox_for_thread(_thread_id, repo=prompt_default_repo)
+
     def backend_factory(_runtime: object, _thread_id: str = thread_id) -> SandboxBackendProtocol:
-        return _get_cached_sandbox_backend(_thread_id)
+        return _get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)
 
     (model_id, profile_effort), (subagent_model_id, subagent_effort) = team_defaults
     logger.info("Using team default agent model: model=%s effort=%s", model_id, profile_effort)

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 
 from deepagents.backends.protocol import (
     EditResult,
@@ -33,9 +34,11 @@ class SandboxBackendProxy(SandboxBackendProtocol):
         backend: SandboxBackendProtocol | None = None,
         *,
         thread_id: str | None = None,
+        reconnect: Callable[[], Awaitable[SandboxBackendProtocol]] | None = None,
     ) -> None:
         self._backend = backend
         self._thread_id = thread_id
+        self._reconnect = reconnect
         self._lock: asyncio.Lock | None = None
 
     @property
@@ -48,6 +51,16 @@ class SandboxBackendProxy(SandboxBackendProtocol):
 
     def replace_backend(self, backend: SandboxBackendProtocol) -> None:
         self._backend = backend
+
+    @property
+    def has_backend(self) -> bool:
+        return self._backend is not None
+
+    def set_reconnect(
+        self,
+        reconnect: Callable[[], Awaitable[SandboxBackendProtocol]] | None,
+    ) -> None:
+        self._reconnect = reconnect
 
     def _get_backend(self) -> SandboxBackendProtocol:
         if self._backend is None:
@@ -68,6 +81,12 @@ class SandboxBackendProxy(SandboxBackendProtocol):
 
         async with self._get_lock():
             if self._backend is not None:
+                return self._backend
+
+            if self._reconnect is not None:
+                logger.info("Reconnecting sandbox backend for thread %s", self._thread_id)
+                sandbox_backend = await self._reconnect()
+                self._backend = unwrap_sandbox_backend(sandbox_backend)
                 return self._backend
 
             sandbox_id = await get_sandbox_id_from_metadata(self._thread_id)
@@ -186,12 +205,17 @@ def set_sandbox_backend(
     return proxy
 
 
-def get_or_create_sandbox_backend_proxy(thread_id: str) -> SandboxBackendProxy:
+def get_or_create_sandbox_backend_proxy(
+    thread_id: str,
+    *,
+    reconnect: Callable[[], Awaitable[SandboxBackendProtocol]] | None = None,
+) -> SandboxBackendProxy:
     sandbox_backend = SANDBOX_BACKENDS.get(thread_id)
     if sandbox_backend:
+        sandbox_backend.set_reconnect(reconnect)
         return sandbox_backend
 
-    sandbox_backend = SandboxBackendProxy(thread_id=thread_id)
+    sandbox_backend = SandboxBackendProxy(thread_id=thread_id, reconnect=reconnect)
     SANDBOX_BACKENDS[thread_id] = sandbox_backend
     return sandbox_backend
 
@@ -230,7 +254,7 @@ async def get_sandbox_id_from_metadata(thread_id: str) -> str | None:
 async def get_sandbox_backend(thread_id: str) -> SandboxBackendProxy:
     """Get sandbox backend from cache, or connect using thread metadata."""
     sandbox_backend = SANDBOX_BACKENDS.get(thread_id)
-    if sandbox_backend:
+    if sandbox_backend and sandbox_backend.has_backend:
         return sandbox_backend
 
     sandbox_id = await get_sandbox_id_from_metadata(thread_id)

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from deepagents.backends.protocol import (
@@ -17,6 +18,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from langgraph.config import get_config
+from langgraph_sdk import get_client
 
 from .sandbox import create_sandbox
 
@@ -26,31 +28,68 @@ logger = logging.getLogger(__name__)
 class SandboxBackendProxy(SandboxBackendProtocol):
     """Stable per-thread backend handle whose target can be replaced."""
 
-    def __init__(self, backend: SandboxBackendProtocol) -> None:
+    def __init__(
+        self,
+        backend: SandboxBackendProtocol | None = None,
+        *,
+        thread_id: str | None = None,
+    ) -> None:
         self._backend = backend
+        self._thread_id = thread_id
+        self._lock: asyncio.Lock | None = None
 
     @property
     def current(self) -> SandboxBackendProtocol:
-        return self._backend
+        return self._get_backend()
 
     @property
     def id(self) -> str:
-        return self._backend.id
+        return self._get_backend().id
 
     def replace_backend(self, backend: SandboxBackendProtocol) -> None:
         self._backend = backend
 
+    def _get_backend(self) -> SandboxBackendProtocol:
+        if self._backend is None:
+            suffix = f" for thread {self._thread_id}" if self._thread_id else ""
+            raise RuntimeError(f"No sandbox backend cached{suffix}")
+        return self._backend
+
+    def _get_lock(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    async def _aget_backend(self) -> SandboxBackendProtocol:
+        if self._backend is not None:
+            return self._backend
+        if not self._thread_id:
+            raise RuntimeError("No sandbox backend cached")
+
+        async with self._get_lock():
+            if self._backend is not None:
+                return self._backend
+
+            sandbox_id = await get_sandbox_id_from_metadata(self._thread_id)
+            if not sandbox_id:
+                raise ValueError(f"Missing sandbox_id in thread metadata for {self._thread_id}")
+
+            logger.info("Reconnecting sandbox backend for thread %s from metadata", self._thread_id)
+            self._backend = await create_sandbox(sandbox_id)
+            SANDBOX_BACKENDS[self._thread_id] = self
+            return self._backend
+
     def ls(self, path: str) -> LsResult:
-        return self._backend.ls(path)
+        return self._get_backend().ls(path)
 
     async def als(self, path: str) -> LsResult:
-        return await self._backend.als(path)
+        return await (await self._aget_backend()).als(path)
 
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
-        return self._backend.read(file_path, offset, limit)
+        return self._get_backend().read(file_path, offset, limit)
 
     async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
-        return await self._backend.aread(file_path, offset, limit)
+        return await (await self._aget_backend()).aread(file_path, offset, limit)
 
     def grep(
         self,
@@ -58,7 +97,7 @@ class SandboxBackendProxy(SandboxBackendProtocol):
         path: str | None = None,
         glob: str | None = None,
     ) -> GrepResult:
-        return self._backend.grep(pattern, path, glob)
+        return self._get_backend().grep(pattern, path, glob)
 
     async def agrep(
         self,
@@ -66,19 +105,19 @@ class SandboxBackendProxy(SandboxBackendProtocol):
         path: str | None = None,
         glob: str | None = None,
     ) -> GrepResult:
-        return await self._backend.agrep(pattern, path, glob)
+        return await (await self._aget_backend()).agrep(pattern, path, glob)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
-        return self._backend.glob(pattern, path)
+        return self._get_backend().glob(pattern, path)
 
     async def aglob(self, pattern: str, path: str = "/") -> GlobResult:
-        return await self._backend.aglob(pattern, path)
+        return await (await self._aget_backend()).aglob(pattern, path)
 
     def write(self, file_path: str, content: str) -> WriteResult:
-        return self._backend.write(file_path, content)
+        return self._get_backend().write(file_path, content)
 
     async def awrite(self, file_path: str, content: str) -> WriteResult:
-        return await self._backend.awrite(file_path, content)
+        return await (await self._aget_backend()).awrite(file_path, content)
 
     def edit(
         self,
@@ -87,7 +126,7 @@ class SandboxBackendProxy(SandboxBackendProtocol):
         new_string: str,
         replace_all: bool = False,
     ) -> EditResult:
-        return self._backend.edit(file_path, old_string, new_string, replace_all)
+        return self._get_backend().edit(file_path, old_string, new_string, replace_all)
 
     async def aedit(
         self,
@@ -96,25 +135,27 @@ class SandboxBackendProxy(SandboxBackendProtocol):
         new_string: str,
         replace_all: bool = False,
     ) -> EditResult:
-        return await self._backend.aedit(file_path, old_string, new_string, replace_all)
+        return await (await self._aget_backend()).aedit(
+            file_path, old_string, new_string, replace_all
+        )
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        return self._backend.upload_files(files)
+        return self._get_backend().upload_files(files)
 
     async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        return await self._backend.aupload_files(files)
+        return await (await self._aget_backend()).aupload_files(files)
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        return self._backend.download_files(paths)
+        return self._get_backend().download_files(paths)
 
     async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        return await self._backend.adownload_files(paths)
+        return await (await self._aget_backend()).adownload_files(paths)
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
-        return self._backend.execute(command, timeout=timeout)
+        return self._get_backend().execute(command, timeout=timeout)
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
-        return await self._backend.aexecute(command, timeout=timeout)
+        return await (await self._aget_backend()).aexecute(command, timeout=timeout)
 
 
 # Thread ID -> stable SandboxBackendProxy, shared between server.py and middleware.
@@ -140,9 +181,19 @@ def set_sandbox_backend(
         existing.replace_backend(sandbox_backend)
         return existing
 
-    proxy = SandboxBackendProxy(sandbox_backend)
+    proxy = SandboxBackendProxy(sandbox_backend, thread_id=thread_id)
     SANDBOX_BACKENDS[thread_id] = proxy
     return proxy
+
+
+def get_or_create_sandbox_backend_proxy(thread_id: str) -> SandboxBackendProxy:
+    sandbox_backend = SANDBOX_BACKENDS.get(thread_id)
+    if sandbox_backend:
+        return sandbox_backend
+
+    sandbox_backend = SandboxBackendProxy(thread_id=thread_id)
+    SANDBOX_BACKENDS[thread_id] = sandbox_backend
+    return sandbox_backend
 
 
 def clear_sandbox_backend(thread_id: str) -> None:
@@ -153,13 +204,26 @@ async def get_sandbox_id_from_metadata(thread_id: str) -> str | None:
     """Fetch sandbox_id from thread metadata."""
     try:
         config = get_config()
+        metadata = config.get("metadata", {})
+        if isinstance(metadata, dict):
+            sandbox_id = metadata.get("sandbox_id")
+            if isinstance(sandbox_id, str):
+                return sandbox_id
     except Exception:
-        logger.exception("Failed to read thread metadata for sandbox")
+        logger.debug(
+            "Failed to read inline thread metadata for sandbox; falling back to live lookup",
+            exc_info=True,
+        )
+
+    try:
+        client = get_client()
+        thread = await client.threads.get(thread_id)
+    except Exception:
+        logger.exception("Failed to fetch live thread metadata for sandbox")
         return None
-    metadata = config.get("metadata", {})
-    if not isinstance(metadata, dict):
-        return None
-    sandbox_id = metadata.get("sandbox_id")
+
+    metadata = thread.get("metadata", {}) if isinstance(thread, dict) else {}
+    sandbox_id = metadata.get("sandbox_id") if isinstance(metadata, dict) else None
     return sandbox_id if isinstance(sandbox_id, str) else None
 
 

--- a/tests/test_sandbox_state.py
+++ b/tests/test_sandbox_state.py
@@ -61,6 +61,38 @@ async def test_sandbox_proxy_reconnects_from_metadata_once(monkeypatch: pytest.M
 
 
 @pytest.mark.asyncio
+async def test_sandbox_proxy_uses_registered_reconnect_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    thread_id = "thread-1"
+    clear_sandbox_backend(thread_id)
+    reconnected: list[str] = []
+
+    async def reconnect():
+        reconnected.append(thread_id)
+        await asyncio.sleep(0)
+        return _FakeSandboxBackend()
+
+    async def create_sandbox(sandbox_id: str):
+        raise AssertionError(f"unexpected direct reconnect to {sandbox_id}")
+
+    monkeypatch.setattr("agent.utils.sandbox_state.create_sandbox", create_sandbox)
+
+    proxy = get_or_create_sandbox_backend_proxy(thread_id, reconnect=reconnect)
+    results = await asyncio.gather(*(proxy.aexecute(f"cmd-{idx}") for idx in range(5)))
+
+    assert reconnected == [thread_id]
+    assert [result.output for result in results] == [
+        "sandbox-1: cmd-0: None",
+        "sandbox-1: cmd-1: None",
+        "sandbox-1: cmd-2: None",
+        "sandbox-1: cmd-3: None",
+        "sandbox-1: cmd-4: None",
+    ]
+    clear_sandbox_backend(thread_id)
+
+
+@pytest.mark.asyncio
 async def test_sandbox_id_metadata_falls_back_to_live_thread(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sandbox_state.py
+++ b/tests/test_sandbox_state.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from deepagents.backends.protocol import ExecuteResponse
+
+from agent.utils.sandbox_state import (
+    SANDBOX_BACKENDS,
+    clear_sandbox_backend,
+    get_or_create_sandbox_backend_proxy,
+    get_sandbox_id_from_metadata,
+)
+
+
+class _FakeSandboxBackend:
+    id = "sandbox-1"
+
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        return ExecuteResponse(output=f"{self.id}: {command}: {timeout}", exit_code=0)
+
+
+@pytest.mark.asyncio
+async def test_sandbox_proxy_reconnects_from_metadata_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    thread_id = "thread-1"
+    clear_sandbox_backend(thread_id)
+    created: list[str] = []
+
+    async def get_sandbox_id_from_metadata(requested_thread_id: str) -> str:
+        assert requested_thread_id == thread_id
+        return "sandbox-1"
+
+    async def create_sandbox(sandbox_id: str):
+        created.append(sandbox_id)
+        await asyncio.sleep(0)
+        return _FakeSandboxBackend()
+
+    monkeypatch.setattr(
+        "agent.utils.sandbox_state.get_sandbox_id_from_metadata",
+        get_sandbox_id_from_metadata,
+    )
+    monkeypatch.setattr("agent.utils.sandbox_state.create_sandbox", create_sandbox)
+
+    proxy = get_or_create_sandbox_backend_proxy(thread_id)
+    assert SANDBOX_BACKENDS[thread_id] is proxy
+
+    results = await asyncio.gather(*(proxy.aexecute(f"cmd-{idx}") for idx in range(5)))
+
+    assert created == ["sandbox-1"]
+    assert [result.output for result in results] == [
+        "sandbox-1: cmd-0: None",
+        "sandbox-1: cmd-1: None",
+        "sandbox-1: cmd-2: None",
+        "sandbox-1: cmd-3: None",
+        "sandbox-1: cmd-4: None",
+    ]
+    assert proxy.current.id == "sandbox-1"
+    clear_sandbox_backend(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_sandbox_id_metadata_falls_back_to_live_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads = SimpleNamespace(
+        get=AsyncMock(return_value={"metadata": {"sandbox_id": "sandbox-live"}})
+    )
+
+    monkeypatch.setattr(
+        "agent.utils.sandbox_state.get_config",
+        lambda: {"metadata": {}},
+    )
+    monkeypatch.setattr(
+        "agent.utils.sandbox_state.get_client",
+        lambda: SimpleNamespace(threads=threads),
+    )
+
+    assert await get_sandbox_id_from_metadata("thread-1") == "sandbox-live"
+    threads.get.assert_awaited_once_with("thread-1")

--- a/tests/test_stale_sandbox_creating.py
+++ b/tests/test_stale_sandbox_creating.py
@@ -8,6 +8,7 @@ from agent.server import (
     SANDBOX_CREATION_TIMEOUT,
     ensure_sandbox_for_thread,
 )
+from agent.utils.sandbox_state import get_or_create_sandbox_backend_proxy
 
 
 @pytest.mark.asyncio
@@ -106,4 +107,55 @@ async def test_fresh_sandbox_creating_waits_for_other_worker() -> None:
         assert call.kwargs["metadata"] != {"sandbox_id": None, "sandbox_creating_at": None}
 
     assert SANDBOX_CREATION_TIMEOUT > 0
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_ensure_sandbox_resolves_unresolved_backend_proxy() -> None:
+    thread_id = "thread-unresolved-proxy"
+    SANDBOX_BACKENDS.clear()
+    proxy = get_or_create_sandbox_backend_proxy(thread_id)
+    existing_backend = MagicMock()
+    existing_backend.id = "sandbox-existing"
+
+    async def passthrough(
+        sandbox_backend,
+        _thread_id,
+        _github_proxy_token=None,
+        _github_proxy_repositories=None,
+        _repo=None,
+    ):
+        return sandbox_backend
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-existing",
+        ),
+        patch(
+            "agent.server.create_sandbox",
+            new_callable=AsyncMock,
+            return_value=existing_backend,
+        ) as connect_sandbox,
+        patch(
+            "agent.server.check_or_recreate_sandbox",
+            new_callable=AsyncMock,
+            side_effect=passthrough,
+        ),
+        patch(
+            "agent.server._refresh_github_proxy_or_recreate",
+            new_callable=AsyncMock,
+            side_effect=passthrough,
+        ) as refresh_proxy,
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", new_callable=AsyncMock) as update_thread,
+    ):
+        result = await ensure_sandbox_for_thread(thread_id)
+
+    assert result is proxy
+    assert proxy.current is existing_backend
+    connect_sandbox.assert_awaited_once_with("sandbox-existing")
+    assert refresh_proxy.await_count == 1
+    update_thread.assert_not_awaited()
     SANDBOX_BACKENDS.clear()


### PR DESCRIPTION
## Summary
- Return a stable sandbox backend proxy from graph backend factories so resumed runs do not fail when process-local cache is cold.
- Lazily reconnect async sandbox operations from persisted thread metadata, with a live metadata fallback when inline run config is stale.
- Add regression coverage for fresh-worker reconnects and live metadata lookup.

## Test plan
- uv run ruff check agent/utils/sandbox_state.py agent/server.py tests/test_sandbox_state.py
- uv run pytest -vvv tests/test_sandbox_state.py tests/test_prepare_run_middleware.py tests/middleware/test_sandbox_recovery.py tests/test_proxy_auth.py tests/test_stale_sandbox_creating.py
- uv run pytest -vvv tests/test_proxy_auth.py tests/test_stale_sandbox_creating.py tests/test_reviewer.py