### PR TITLE
fix: fall back on model stream transport errors

### DIFF
--- a/agent/middleware/model_fallback.py
+++ b/agent/middleware/model_fallback.py
@@ -17,6 +17,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import anthropic
+import httpx
 import openai
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
@@ -36,6 +37,7 @@ _TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     openai.APITimeoutError,
     openai.RateLimitError,
     openai.InternalServerError,
+    httpx.TransportError,
 )
 
 

--- a/tests/test_model_fallback_middleware.py
+++ b/tests/test_model_fallback_middleware.py
@@ -67,6 +67,12 @@ class TestShouldFallback:
         exc = anthropic.RateLimitError("rate", response=response, body={})
         assert _should_fallback(exc) is True
 
+    def test_httpx_remote_protocol_error_falls_back(self) -> None:
+        exc = httpx.RemoteProtocolError(
+            "peer closed connection without sending complete message body (incomplete chunked read)"
+        )
+        assert _should_fallback(exc) is True
+
     def test_anthropic_400_does_not_fall_back(self) -> None:
         request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
         response = httpx.Response(400, request=request, json={"error": {}})
@@ -90,6 +96,31 @@ class TestModelFallbackMiddleware:
             calls.append(req)
             if len(calls) == 1:
                 raise _anthropic_overloaded()
+            return good_response
+
+        request = _make_request()
+        result = await middleware.awrap_model_call(request, handler)
+
+        assert result is good_response
+        assert len(calls) == 2
+        request.override.assert_called_once_with(model=fallback_model)
+        assert calls[1] is request.override.return_value
+
+    @pytest.mark.asyncio
+    async def test_async_falls_over_on_stream_transport_error(self) -> None:
+        fallback_model = MagicMock(name="fallback_model")
+        middleware = ModelFallbackMiddleware(fallback_model)
+
+        calls: list[object] = []
+        good_response = MagicMock(result=[AIMessage(content="ok from fallback")])
+
+        async def handler(req: object) -> object:
+            calls.append(req)
+            if len(calls) == 1:
+                raise httpx.RemoteProtocolError(
+                    "peer closed connection without sending complete message body "
+                    "(incomplete chunked read)"
+                )
             return good_response
 
         request = _make_request()

--- a/uv.lock
+++ b/uv.lock
@@ -1491,9 +1491,9 @@ dependencies = [
     { name = "deepagents" },
     { name = "e2b" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/1a/ab8db1288a70b25bfb2489327fae0d3a82ea07231d446083a2dcb0bfc174/langchain_e2b-0.0.4.tar.gz", hash = "sha256:bf543ad7394b83c3f097c9914adfc59bb3af3af9837dea9ada5064abcf4666d2", size = 207862, upload-time = "2026-06-17T21:25:25.478320Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/1a/ab8db1288a70b25bfb2489327fae0d3a82ea07231d446083a2dcb0bfc174/langchain_e2b-0.0.4.tar.gz", hash = "sha256:bf543ad7394b83c3f097c9914adfc59bb3af3af9837dea9ada5064abcf4666d2", size = 207862, upload-time = "2026-06-17T21:25:25.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/6f/4e2263f5372019bd05fc8c7fe50674b041cc6b22df3faf3037897587413f/langchain_e2b-0.0.4-py3-none-any.whl", hash = "sha256:6cf20f155ebf6b1a8f36d69dec4b5925c242dfcf779209c94ccb18fda3296419", size = 7482, upload-time = "2026-06-17T21:25:24.025124Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6f/4e2263f5372019bd05fc8c7fe50674b041cc6b22df3faf3037897587413f/langchain_e2b-0.0.4-py3-none-any.whl", hash = "sha256:6cf20f155ebf6b1a8f36d69dec4b5925c242dfcf779209c94ccb18fda3296419", size = 7482, upload-time = "2026-06-17T21:25:24.025Z" },
 ]
 
 [[package]]
@@ -2080,7 +2080,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.3.9" },
     { name = "langchain-anthropic", specifier = ">=1.4.6" },
     { name = "langchain-daytona", specifier = ">=0.0.5" },
-    { name = "langchain-e2b", specifier = ">=0.0.4" },
+    { name = "langchain-e2b", specifier = "==0.0.4" },
     { name = "langchain-fireworks", specifier = ">=1.4.2" },
     { name = "langchain-google-genai", specifier = ">=4.2.4" },
     { name = "langchain-mcp-adapters", specifier = ">=0.2.2" },


### PR DESCRIPTION
## Summary
- Treat raw `httpx.TransportError` failures from streamed model responses as transient in `ModelFallbackMiddleware`.
- Cover the observed OpenAI incomplete chunked read path so runs retry against the fallback model instead of cancelling.

## Test plan
- `uv run pytest -vvv tests/test_model_fallback_middleware.py`
- `uv run ruff check agent/middleware/model_fallback.py tests/test_model_fallback_middleware.py`