### PR TITLE
fix: Harden durable agent runs

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import warnings
+from typing import Any
 
 from langgraph.graph.state import RunnableConfig
 from langgraph.pregel import Pregel
@@ -27,10 +28,16 @@ from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.state import StateBackend
 from langchain.agents.middleware import ModelCallLimitMiddleware
+from langchain_core.language_models import BaseChatModel
 
 from .dashboard.team_settings import get_effective_gateway_enabled
 from .integrations.langsmith import _configure_github_proxy
-from .middleware import BasePrepareRunMiddleware, SanitizeToolInputsMiddleware, ToolErrorMiddleware
+from .middleware import (
+    BasePrepareRunMiddleware,
+    SanitizeToolInputsMiddleware,
+    TimeoutWrapupMiddleware,
+    ToolErrorMiddleware,
+)
 from .review_style_guidance import REVIEWER_STYLE_THEMES
 from .server import (
     DEFAULT_LLM_MAX_TOKENS,
@@ -44,6 +51,7 @@ from .tools.read_finding_outcomes import read_finding_outcomes
 from .tools.save_review_style import save_review_style_prompt
 from .utils import ttl_cache
 from .utils.analyzer_skills import SKILLS_ROUTE, skill_path_for_mode
+from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import get_github_app_installation_token
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
@@ -95,6 +103,14 @@ async def _cached_gateway_enabled() -> bool:
         60,
         get_effective_gateway_enabled,
     )
+
+
+def _make_model_or_defer(model_id: str, *, use_gateway: bool, **kwargs: Any) -> BaseChatModel:
+    try:
+        return make_model(model_id, use_gateway=use_gateway, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Deferring analyzer model setup failure for %s", model_id, exc_info=True)
+        return make_deferred_error_model(e, model_id=model_id)
 
 
 class PrepareAnalyzerRunMiddleware(BasePrepareRunMiddleware):
@@ -167,7 +183,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     )
 
     return create_deep_agent(
-        model=make_model(model_id, use_gateway=use_gateway, **model_kwargs),
+        model=_make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs),
         system_prompt="",
         tools=[save_review_style_prompt, read_finding_outcomes],
         backend=backend_factory,
@@ -180,6 +196,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
                 exit_behavior="end",
             ),
             ToolErrorMiddleware(),
+            TimeoutWrapupMiddleware(),
         ],
     ).with_config(config)
 

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from typing import Any
 
 from langgraph.graph.state import RunnableConfig
 from langgraph.pregel import Pregel
@@ -27,6 +28,7 @@ warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarnin
 
 from deepagents import create_deep_agent
 from langchain.agents.middleware import ModelCallLimitMiddleware
+from langchain_core.language_models import BaseChatModel
 
 from .dashboard.options import SUPPORTED_MODEL_IDS, model_supports_effort
 from .dashboard.team_settings import get_effective_gateway_enabled, get_team_default_model
@@ -51,6 +53,7 @@ from .tools import (
     web_search,
 )
 from .utils import ttl_cache
+from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import get_github_app_installation_token
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
 from .utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
@@ -106,6 +109,14 @@ async def _cached_team_chat_model() -> tuple[str, str]:
         60,
         lambda: get_team_default_model("chat"),
     )
+
+
+def _make_model_or_defer(model_id: str, *, use_gateway: bool, **kwargs: Any) -> BaseChatModel:
+    try:
+        return make_model(model_id, use_gateway=use_gateway, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Deferring chat model setup failure for %s", model_id, exc_info=True)
+        return make_deferred_error_model(e, model_id=model_id)
 
 
 class PrepareChatRunMiddleware(BasePrepareRunMiddleware):
@@ -181,7 +192,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
     )
 
     return create_deep_agent(
-        model=make_model(model_id, use_gateway=use_gateway, **model_kwargs),
+        model=_make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs),
         system_prompt="",
         tools=[
             read_repo_file,

--- a/agent/completion.py
+++ b/agent/completion.py
@@ -2,13 +2,14 @@
 
 The platform POSTs a run-completion payload to ``/webhooks/run-complete`` (wired
 as the ``webhook`` on every dispatched run, see ``agent.dispatch``). When a run
-ends in a failure state (``error`` / ``timeout`` / ``interrupted``) we post a
+ends in a failure state (``error`` / ``timeout``) we post a
 short failure reply to the originating channel, so a run that died on a server
 recycle or hit a limit never leaves the user in silence.
 
 This decouples "the user gets an answer" from "the agent remembered to reply."
-The reply is idempotent per run: thread metadata records which run ids already
-posted a failure reply, so platform webhook retries do not duplicate messages.
+The reply is idempotent per run when the webhook includes a run id. Older or
+manual payloads without a run id fall back to legacy thread-level idempotence so
+missing ids degrade dedupe instead of silencing failure replies.
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
 # follow-up halts the prior run (status "interrupted") while its replacement
 # carries on — that's healthy, not a failure worth a "couldn't finish" reply.
 _TERMINAL_FAILURE_STATUSES = frozenset({"error", "timeout"})
+_FAILURE_REPLY_FLAG = "failure_reply_posted"
 _FAILURE_REPLY_RUN_ID = "failure_reply_posted_run_id"
 _FAILURE_REPLY_RUN_IDS = "failure_reply_posted_run_ids"
 _MAX_FAILURE_REPLY_RUN_IDS = 20
@@ -127,7 +129,9 @@ def _posted_failure_run_ids(metadata: dict[str, Any]) -> list[str]:
     return ids
 
 
-def _failure_reply_metadata(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
+def _failure_reply_metadata(metadata: dict[str, Any], run_id: str | None) -> dict[str, Any]:
+    if run_id is None:
+        return {_FAILURE_REPLY_FLAG: True}
     ids = [item for item in _posted_failure_run_ids(metadata) if item != run_id]
     ids.append(run_id)
     return {
@@ -144,11 +148,10 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     """
     status = payload.get("status")
     thread_id = payload.get("thread_id")
-    run_id = payload.get("run_id")
+    raw_run_id = payload.get("run_id")
+    run_id = raw_run_id if isinstance(raw_run_id, str) and raw_run_id else None
     if not isinstance(thread_id, str) or not thread_id:
         return {"status": "ignored", "reason": "missing thread_id"}
-    if not isinstance(run_id, str) or not run_id:
-        return {"status": "ignored", "reason": "missing run_id"}
     if status not in _TERMINAL_FAILURE_STATUSES:
         return {"status": "ignored", "reason": f"non-failure status: {status}"}
 
@@ -161,7 +164,12 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
 
     metadata = thread.get("metadata") if isinstance(thread, dict) else None
     metadata = metadata if isinstance(metadata, dict) else {}
-    if run_id in _posted_failure_run_ids(metadata):
+    if run_id is None:
+        # Payloads without run ids fall back to the old per-thread flag; run-scoped
+        # dedupe intentionally does not read it so future runs can still report.
+        if metadata.get(_FAILURE_REPLY_FLAG):
+            return {"status": "ignored", "reason": "failure reply already posted"}
+    elif run_id in _posted_failure_run_ids(metadata):
         return {"status": "ignored", "reason": "failure reply already posted for run"}
 
     posted = await _post_failure_reply(thread_id, metadata, status)

--- a/agent/completion.py
+++ b/agent/completion.py
@@ -7,8 +7,8 @@ short failure reply to the originating channel, so a run that died on a server
 recycle or hit a limit never leaves the user in silence.
 
 This decouples "the user gets an answer" from "the agent remembered to reply."
-The reply is idempotent: a per-thread metadata flag prevents double-posting when
-the platform retries the webhook or a checkpoint replays.
+The reply is idempotent per run: thread metadata records which run ids already
+posted a failure reply, so platform webhook retries do not duplicate messages.
 """
 
 from __future__ import annotations
@@ -32,7 +32,9 @@ logger = logging.getLogger(__name__)
 # follow-up halts the prior run (status "interrupted") while its replacement
 # carries on — that's healthy, not a failure worth a "couldn't finish" reply.
 _TERMINAL_FAILURE_STATUSES = frozenset({"error", "timeout"})
-_FAILURE_REPLY_FLAG = "failure_reply_posted"
+_FAILURE_REPLY_RUN_ID = "failure_reply_posted_run_id"
+_FAILURE_REPLY_RUN_IDS = "failure_reply_posted_run_ids"
+_MAX_FAILURE_REPLY_RUN_IDS = 20
 
 # Shared-secret bearer token proving a /webhooks/run-complete call came from our
 # own dispatch (which appends ?token= when this is set) rather than from an
@@ -116,6 +118,24 @@ async def _post_failure_reply(thread_id: str, metadata: dict[str, Any], status: 
     return False
 
 
+def _posted_failure_run_ids(metadata: dict[str, Any]) -> list[str]:
+    raw = metadata.get(_FAILURE_REPLY_RUN_IDS)
+    ids = [item for item in raw if isinstance(item, str) and item] if isinstance(raw, list) else []
+    latest = metadata.get(_FAILURE_REPLY_RUN_ID)
+    if isinstance(latest, str) and latest and latest not in ids:
+        ids.append(latest)
+    return ids
+
+
+def _failure_reply_metadata(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
+    ids = [item for item in _posted_failure_run_ids(metadata) if item != run_id]
+    ids.append(run_id)
+    return {
+        _FAILURE_REPLY_RUN_ID: run_id,
+        _FAILURE_REPLY_RUN_IDS: ids[-_MAX_FAILURE_REPLY_RUN_IDS:],
+    }
+
+
 async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     """Handle a platform run-completion webhook POST.
 
@@ -124,8 +144,11 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     """
     status = payload.get("status")
     thread_id = payload.get("thread_id")
+    run_id = payload.get("run_id")
     if not isinstance(thread_id, str) or not thread_id:
         return {"status": "ignored", "reason": "missing thread_id"}
+    if not isinstance(run_id, str) or not run_id:
+        return {"status": "ignored", "reason": "missing run_id"}
     if status not in _TERMINAL_FAILURE_STATUSES:
         return {"status": "ignored", "reason": f"non-failure status: {status}"}
 
@@ -138,15 +161,18 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
 
     metadata = thread.get("metadata") if isinstance(thread, dict) else None
     metadata = metadata if isinstance(metadata, dict) else {}
-    if metadata.get(_FAILURE_REPLY_FLAG):
-        return {"status": "ignored", "reason": "failure reply already posted"}
+    if run_id in _posted_failure_run_ids(metadata):
+        return {"status": "ignored", "reason": "failure reply already posted for run"}
 
     posted = await _post_failure_reply(thread_id, metadata, status)
     if not posted:
         return {"status": "ignored", "reason": "no reply posted"}
 
     try:
-        await client.threads.update(thread_id=thread_id, metadata={_FAILURE_REPLY_FLAG: True})
+        await client.threads.update(
+            thread_id=thread_id,
+            metadata=_failure_reply_metadata(metadata, run_id),
+        )
     except Exception:  # noqa: BLE001
         logger.warning("run-complete: could not flag thread %s", thread_id, exc_info=True)
     logger.info("Posted failure reply for thread %s (status=%s)", thread_id, status)

--- a/agent/dashboard/review_style_jobs.py
+++ b/agent/dashboard/review_style_jobs.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from langgraph_sdk import get_client
 
+from ..dispatch import create_durable_run
 from ..review_style_collector import (
     collect_review_samples,
     format_samples_for_analyzer,
@@ -123,7 +124,7 @@ async def start_bootstrap_analysis(
     )
 
     try:
-        run = await client.runs.create(
+        run = await create_durable_run(
             thread_id,
             _ASSISTANT_ID,
             input={
@@ -140,8 +141,9 @@ async def start_bootstrap_analysis(
                 ],
                 "files": build_skill_files(),
             },
+            source="review-style-bootstrap",
             config={"configurable": {**configurable, "prepare_run_id": str(uuid.uuid4())}},
-            if_not_exists="create",
+            client=client,
         )
         run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)
         record = await update_review_style(
@@ -169,12 +171,14 @@ async def start_continual_run(
     configurable = build_continual_run_configurable(full_name)
     thread_id = configurable["thread_id"]
     try:
-        run = await _client().runs.create(
+        client = _client()
+        run = await create_durable_run(
             thread_id,
             _ASSISTANT_ID,
             input=build_continual_run_input(full_name),
+            source="review-style-continual",
             config={"configurable": {**configurable, "prepare_run_id": str(uuid.uuid4())}},
-            if_not_exists="create",
+            client=client,
         )
         run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)
         return await update_review_style(

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, field_validator
 
+from ..dispatch import create_durable_run
 from ..utils.thread_ops import langgraph_client
 from .options import SUPPORTED_MODEL_IDS, model_supports_effort
 from .profiles import get_profile, get_valid_access_token
@@ -435,12 +436,13 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
     client = _client()
     await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
     await client.threads.update(thread_id=thread_id, metadata=metadata)
-    run = await client.runs.create(
+    run = await create_durable_run(
         thread_id,
         _AGENT_ASSISTANT_ID,
         input={"messages": [{"role": "user", "content": record["prompt"]}]},
+        source="schedule",
         config=_agent_run_config(record, thread_id),
-        if_not_exists="create",
+        client=client,
         stream_mode=["values", "updates", "messages-tuple"],
         stream_resumable=True,
     )

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -27,6 +27,8 @@ from langgraph_sdk.client import LangGraphClient
 logger = logging.getLogger(__name__)
 
 ContentBlocks = str | list[dict[str, Any]]
+RunInput = dict[str, Any]
+RunConfig = dict[str, Any]
 
 # FastAPI route the platform POSTs run completion/failure to. The platform
 # rejects loopback webhooks (relative URLs / localhost) — they bypass auth via
@@ -87,6 +89,65 @@ def dispatch_client() -> LangGraphClient:
     return get_client(url=_langgraph_url())
 
 
+def _config_with_prepare_run_id(
+    config: RunConfig | None,
+    metadata: dict[str, Any] | None,
+) -> RunConfig:
+    run_config = dict(config or {})
+    configurable = run_config.get("configurable")
+    configurable = dict(configurable) if isinstance(configurable, dict) else {}
+    configurable.setdefault("prepare_run_id", str(uuid.uuid4()))
+    run_config["configurable"] = configurable
+    if metadata is not None:
+        run_config["metadata"] = metadata
+    return run_config
+
+
+async def create_durable_run(
+    thread_id: str,
+    assistant_id: str,
+    *,
+    input: RunInput,
+    source: str,
+    config: RunConfig | None = None,
+    metadata: dict[str, Any] | None = None,
+    client: LangGraphClient | None = None,
+    multitask_strategy: str = "interrupt",
+    durability: str = "sync",
+    if_not_exists: str = "create",
+    stream_mode: Any | None = None,
+    stream_resumable: bool | None = None,
+    after_seconds: int | float | None = None,
+) -> dict[str, Any]:
+    """Create a run with Open SWE's durable LangGraph defaults."""
+    client = client or dispatch_client()
+    create_kwargs: dict[str, Any] = {
+        "input": input,
+        "config": _config_with_prepare_run_id(config, metadata),
+        "multitask_strategy": multitask_strategy,
+        "durability": durability,
+        "if_not_exists": if_not_exists,
+    }
+    if COMPLETION_WEBHOOK_URL:
+        create_kwargs["webhook"] = COMPLETION_WEBHOOK_URL
+    if stream_mode is not None:
+        create_kwargs["stream_mode"] = stream_mode
+    if stream_resumable is not None:
+        create_kwargs["stream_resumable"] = stream_resumable
+    if after_seconds is not None:
+        create_kwargs["after_seconds"] = after_seconds
+
+    run = await client.runs.create(thread_id, assistant_id, **create_kwargs)
+    logger.info(
+        "Dispatched %s run on thread %s (source=%s, run=%s)",
+        assistant_id,
+        thread_id,
+        source,
+        run.get("run_id") if isinstance(run, dict) else None,
+    )
+    return run
+
+
 async def dispatch_agent_run(
     thread_id: str,
     content: ContentBlocks,
@@ -103,23 +164,12 @@ async def dispatch_agent_run(
     contract. ``source`` is for logging/metadata only; ``assistant_id`` selects
     the graph (``"agent"`` or ``"reviewer"``).
     """
-    client = client or dispatch_client()
-    configurable = {**configurable, "prepare_run_id": str(uuid.uuid4())}
-    run = await client.runs.create(
+    return await create_durable_run(
         thread_id,
         assistant_id,
         input={"messages": [{"role": "user", "content": content}]},
-        config={"configurable": configurable, "metadata": metadata or {}},
-        multitask_strategy="interrupt",
-        durability="sync",
-        webhook=COMPLETION_WEBHOOK_URL,
-        if_not_exists="create",
+        config={"configurable": configurable},
+        metadata=metadata or {},
+        source=source,
+        client=client or dispatch_client(),
     )
-    logger.info(
-        "Dispatched %s run on thread %s (source=%s, run=%s)",
-        assistant_id,
-        thread_id,
-        source,
-        run.get("run_id") if isinstance(run, dict) else None,
-    )
-    return run

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -23,11 +23,23 @@ from langsmith.sandbox import (
 
 logger = logging.getLogger(__name__)
 
+try:
+    from langsmith.sandbox import SandboxNotReadyError
+except ImportError:  # pragma: no cover - depends on langsmith SDK version
+    SANDBOX_NOT_READY_ERRORS: tuple[type[BaseException], ...] = ()
+else:
+    SANDBOX_NOT_READY_ERRORS = (SandboxNotReadyError,)
+
 DEFAULT_SNAPSHOT_FS_CAPACITY_BYTES = 32 * 1024**3
 DEFAULT_SANDBOX_VCPUS = 2
 DEFAULT_SANDBOX_MEM_BYTES = 7936 * 1024**2  # 7936 MiB ("large" tier cap)
 DEFAULT_SANDBOX_IDLE_TTL_SECONDS = 2 * 60 * 60  # 2 hours
 DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS = 24 * 60 * 60  # 24 hours
+SANDBOX_CREATE_MAX_ATTEMPTS = 3
+SANDBOX_CREATE_RETRY_DELAYS_SECONDS = (1.0, 3.0)
+SANDBOX_CREATE_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+SANDBOX_READY_STATUSES = frozenset({"ready", "running"})
+SANDBOX_RECONNECT_STARTABLE_STATUSES = frozenset({"stopped", "paused", "idle"})
 PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
@@ -131,6 +143,64 @@ def _is_retryable_proxy_config_error(exc: BaseException) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in PROXY_CONFIG_RETRYABLE_STATUS_CODES
     return isinstance(exc, httpx.TransportError)
+
+
+def _status_text(sandbox_or_status: Any) -> str:
+    status = getattr(sandbox_or_status, "status", sandbox_or_status)
+    status = getattr(status, "value", status)
+    return str(status or "").lower()
+
+
+def _is_retryable_sandbox_create_error(exc: BaseException) -> bool:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None) or getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code in SANDBOX_CREATE_RETRYABLE_STATUS_CODES
+    return exc.__class__.__name__ in {
+        "ResourceCreationError",
+        "SandboxAPIError",
+        "SandboxConnectionError",
+        "SandboxNotReadyError",
+    }
+
+
+async def _create_sandbox_with_retry(
+    client: AsyncSandboxClient,
+    *,
+    snapshot_id: str,
+    fs_capacity_bytes: int | None,
+    vcpus: int | None,
+    mem_bytes: int | None,
+    idle_ttl_seconds: int | None,
+    delete_after_stop_seconds: int | None,
+    timeout: int,
+) -> Any:
+    for attempt in range(SANDBOX_CREATE_MAX_ATTEMPTS):
+        try:
+            return await client.create_sandbox(
+                snapshot_id=snapshot_id,
+                fs_capacity_bytes=fs_capacity_bytes,
+                vcpus=vcpus,
+                mem_bytes=mem_bytes,
+                idle_ttl_seconds=idle_ttl_seconds,
+                delete_after_stop_seconds=delete_after_stop_seconds,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            if attempt == SANDBOX_CREATE_MAX_ATTEMPTS - 1 or not _is_retryable_sandbox_create_error(
+                exc
+            ):
+                raise
+            delay = SANDBOX_CREATE_RETRY_DELAYS_SECONDS[
+                min(attempt, len(SANDBOX_CREATE_RETRY_DELAYS_SECONDS) - 1)
+            ]
+            logger.warning(
+                "Failed to create LangSmith sandbox (%s); retrying in %.1fs",
+                type(exc).__name__,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    raise RuntimeError("unreachable sandbox retry state")
 
 
 async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
@@ -326,7 +396,7 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         # connect/setup failures raise here — fall back to the base path.
         try:
             handle = self._sandbox.run(command, timeout=effective, wait=False)
-        except (*self._WS_FALLBACK_ERRORS, TimeoutError):
+        except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS, TimeoutError):
             return self._base_execute(command, timeout)
         deadline = self._deadline(effective)
         pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sbx-exec")
@@ -339,7 +409,7 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
                 return self._timeout_response(deadline, server_side=False)
             except CommandTimeoutError:
                 return self._timeout_response(effective, server_side=True)
-            except self._WS_FALLBACK_ERRORS:
+            except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS):
                 return self._base_execute(command, timeout)
             return self._result_to_response(result)
         finally:
@@ -362,7 +432,7 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
             handle = await asyncio.to_thread(
                 self._sandbox.run, command, timeout=effective, wait=False
             )
-        except (*self._WS_FALLBACK_ERRORS, TimeoutError):
+        except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS, TimeoutError):
             return await asyncio.to_thread(self._base_execute, command, timeout)
         deadline = self._deadline(effective)
         try:
@@ -374,7 +444,7 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
             return self._timeout_response(deadline, server_side=False)
         except CommandTimeoutError:
             return self._timeout_response(effective, server_side=True)
-        except self._WS_FALLBACK_ERRORS:
+        except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS):
             return await asyncio.to_thread(self._base_execute, command, timeout)
         return self._result_to_response(result)
 
@@ -474,6 +544,24 @@ class LangSmithProvider(SandboxProvider):
                 except Exception as e:
                     msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
                     raise RuntimeError(msg) from e
+                status = _status_text(sandbox)
+                if status and status not in SANDBOX_READY_STATUSES:
+                    if status in SANDBOX_RECONNECT_STARTABLE_STATUSES:
+                        try:
+                            logger.info(
+                                "Starting LangSmith sandbox %s before reconnect (status=%s)",
+                                sandbox_id,
+                                status,
+                            )
+                            await client.start_sandbox(sandbox_id)
+                            sandbox = await client.get_sandbox(name=sandbox_id)
+                            status = _status_text(sandbox)
+                        except Exception as e:
+                            msg = f"Failed to start existing sandbox '{sandbox_id}' ({status})"
+                            raise RuntimeError(msg) from e
+                    if status not in SANDBOX_READY_STATUSES:
+                        msg = f"Existing sandbox '{sandbox_id}' is {status or 'unknown'}, not reusable"
+                        raise RuntimeError(msg)
                 return TimeoutLangSmithSandbox(sandbox.to_sync())
 
             if not snapshot_id:
@@ -481,7 +569,8 @@ class LangSmithProvider(SandboxProvider):
                 raise ValueError(msg)
 
             try:
-                sandbox = await client.create_sandbox(
+                sandbox = await _create_sandbox_with_retry(
+                    client,
                     snapshot_id=snapshot_id,
                     fs_capacity_bytes=fs_capacity_bytes,
                     vcpus=vcpus,

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -40,6 +40,9 @@ SANDBOX_CREATE_RETRY_DELAYS_SECONDS = (1.0, 3.0)
 SANDBOX_CREATE_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
 SANDBOX_READY_STATUSES = frozenset({"ready", "running"})
 SANDBOX_RECONNECT_STARTABLE_STATUSES = frozenset({"stopped", "paused", "idle"})
+SANDBOX_RECONNECT_PENDING_STATUSES = frozenset({"creating", "pending", "starting", "resuming"})
+SANDBOX_RECONNECT_READY_TIMEOUT_SECONDS = 30.0
+SANDBOX_RECONNECT_READY_POLL_SECONDS = 2.0
 PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
@@ -162,6 +165,27 @@ def _is_retryable_sandbox_create_error(exc: BaseException) -> bool:
         "SandboxConnectionError",
         "SandboxNotReadyError",
     }
+
+
+async def _wait_for_reconnected_sandbox(
+    client: AsyncSandboxClient,
+    sandbox_id: str,
+    *,
+    timeout_seconds: float = SANDBOX_RECONNECT_READY_TIMEOUT_SECONDS,
+    poll_seconds: float = SANDBOX_RECONNECT_READY_POLL_SECONDS,
+) -> Any:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    last_sandbox = await client.get_sandbox(name=sandbox_id)
+    while True:
+        status = _status_text(last_sandbox)
+        if status in SANDBOX_READY_STATUSES or status not in SANDBOX_RECONNECT_PENDING_STATUSES:
+            return last_sandbox
+        if asyncio.get_running_loop().time() >= deadline:
+            return last_sandbox
+        await asyncio.sleep(
+            min(poll_seconds, max(deadline - asyncio.get_running_loop().time(), 0.0))
+        )
+        last_sandbox = await client.get_sandbox(name=sandbox_id)
 
 
 async def _create_sandbox_with_retry(
@@ -554,7 +578,7 @@ class LangSmithProvider(SandboxProvider):
                                 status,
                             )
                             await client.start_sandbox(sandbox_id)
-                            sandbox = await client.get_sandbox(name=sandbox_id)
+                            sandbox = await _wait_for_reconnected_sandbox(client, sandbox_id)
                             status = _status_text(sandbox)
                         except Exception as e:
                             msg = f"Failed to start existing sandbox '{sandbox_id}' ({status})"

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -14,6 +14,8 @@ from .sanitize_openai_responses import SanitizeOpenAIResponsesMiddleware
 from .sanitize_thinking_blocks import SanitizeThinkingBlocksMiddleware
 from .sanitize_tool_inputs import SanitizeToolInputsMiddleware
 from .settle_review_check import settle_review_check_on_exit
+from .task_retry import task_on_failure, task_retry_on
+from .timeout_wrapup import TimeoutWrapupMiddleware
 from .tool_artifact import ToolArtifactMiddleware
 from .tool_error_handler import ToolErrorMiddleware
 from .workflow_push_guard import WorkflowPushGuardMiddleware
@@ -31,6 +33,7 @@ __all__ = [
     "SanitizeToolInputsMiddleware",
     "ToolArtifactMiddleware",
     "ToolErrorMiddleware",
+    "TimeoutWrapupMiddleware",
     "WorkflowPushGuardMiddleware",
     "SandboxCircuitBreakerMiddleware",
     "SlackAssistantStatusMiddleware",
@@ -39,4 +42,6 @@ __all__ = [
     "notify_step_limit_reached",
     "refresh_github_proxy_before_model",
     "settle_review_check_on_exit",
+    "task_on_failure",
+    "task_retry_on",
 ]

--- a/agent/middleware/task_retry.py
+++ b/agent/middleware/task_retry.py
@@ -4,7 +4,7 @@ import json
 
 _RETURN_TO_MODEL_CODES = frozenset({"invalid_prompt", "context_length_exceeded"})
 _RETURN_TO_MODEL_STATUS_CODES = frozenset({400, 422})
-_RETRY_HTTP_STATUS_CODES = frozenset({429})
+_RETRY_HTTP_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
 _TRANSIENT_ERROR_NAMES = frozenset(
     {
         "APIConnectionError",
@@ -49,11 +49,19 @@ def _error_fields(exc: Exception) -> dict[str, object]:
     return out
 
 
+def _is_httpx_transport_error(exc: Exception) -> bool:
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - dependency is declared in production
+        return False
+    return isinstance(exc, httpx.TransportError)
+
+
 def task_retry_on(exc: Exception) -> bool:
     status = _status_code(exc)
     if isinstance(status, int) and (status in _RETRY_HTTP_STATUS_CODES or status >= 500):
         return True
-    return exc.__class__.__name__ in _TRANSIENT_ERROR_NAMES
+    return exc.__class__.__name__ in _TRANSIENT_ERROR_NAMES or _is_httpx_transport_error(exc)
 
 
 def task_on_failure(exc: Exception) -> str:

--- a/agent/middleware/task_retry.py
+++ b/agent/middleware/task_retry.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+
+_RETURN_TO_MODEL_CODES = frozenset({"invalid_prompt", "context_length_exceeded"})
+_RETURN_TO_MODEL_STATUS_CODES = frozenset({400, 422})
+_RETRY_HTTP_STATUS_CODES = frozenset({429})
+_TRANSIENT_ERROR_NAMES = frozenset(
+    {
+        "APIConnectionError",
+        "APITimeoutError",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "TimeoutException",
+        "TransportError",
+    }
+)
+
+
+def _error_body(exc: Exception) -> dict[str, object]:
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        nested = body.get("error")
+        return nested if isinstance(nested, dict) else body
+    return {}
+
+
+def _status_code(exc: Exception) -> int | None:
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def _error_fields(exc: Exception) -> dict[str, object]:
+    body = _error_body(exc)
+    out: dict[str, object] = {}
+    status = _status_code(exc)
+    if status is not None:
+        out["status_code"] = status
+    for key in ("type", "code", "message"):
+        value = body.get(key)
+        if not isinstance(value, str) or not value:
+            value = getattr(exc, key, None)
+        if isinstance(value, str) and value:
+            out[key] = value
+    return out
+
+
+def task_retry_on(exc: Exception) -> bool:
+    status = _status_code(exc)
+    if isinstance(status, int) and (status in _RETRY_HTTP_STATUS_CODES or status >= 500):
+        return True
+    return exc.__class__.__name__ in _TRANSIENT_ERROR_NAMES
+
+
+def task_on_failure(exc: Exception) -> str:
+    error = _error_fields(exc)
+    code = error.get("code")
+    status = error.get("status_code")
+    returnable = code in _RETURN_TO_MODEL_CODES or (
+        code is None
+        and error.get("type") == "invalid_request_error"
+        and isinstance(status, int)
+        and status in _RETURN_TO_MODEL_STATUS_CODES
+    )
+    if not returnable:
+        raise exc
+    return json.dumps(
+        {"status": "failed", "source": "subagent", "error": error},
+        sort_keys=True,
+    )

--- a/agent/middleware/timeout_wrapup.py
+++ b/agent/middleware/timeout_wrapup.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Awaitable, Callable
 
 from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
-from langchain_core.messages import SystemMessage
+from langchain_core.messages import BaseMessage, SystemMessage
 
 _DEFAULT_TIMEOUT_SECONDS = 45 * 60
 _WRAPUP_INSTRUCTION = """
@@ -28,20 +28,32 @@ def _configured_timeout_seconds() -> int:
     return value if value > 0 else _DEFAULT_TIMEOUT_SECONDS
 
 
+def _content_with_instruction(message: BaseMessage | None, instruction: str) -> str | list[object]:
+    if message is None:
+        return instruction
+    content = message.content
+    if isinstance(content, list):
+        return [*content, {"type": "text", "text": instruction}]
+    return f"{content}\n\n{instruction}" if content else instruction
+
+
 class TimeoutWrapupMiddleware(AgentMiddleware):
     def __init__(self, timeout_seconds: int | None = None) -> None:
         super().__init__()
         self._timeout_seconds = timeout_seconds or _configured_timeout_seconds()
-        self._start = time.monotonic()
+        # Graph construction should create one middleware instance per run; start
+        # lazily so construction-time caching cannot age the run clock.
+        self._start: float | None = None
 
     def _should_wrapup(self) -> bool:
+        if self._start is None:
+            self._start = time.monotonic()
         return (time.monotonic() - self._start) >= self._timeout_seconds
 
     def _apply(self, request: ModelRequest) -> ModelRequest:
         if not self._should_wrapup():
             return request
-        existing = request.system_message.text if request.system_message is not None else ""
-        content = f"{existing}\n\n{_WRAPUP_INSTRUCTION}" if existing else _WRAPUP_INSTRUCTION
+        content = _content_with_instruction(request.system_message, _WRAPUP_INSTRUCTION)
         return request.override(system_message=SystemMessage(content=content))
 
     async def awrap_model_call(

--- a/agent/middleware/timeout_wrapup.py
+++ b/agent/middleware/timeout_wrapup.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import SystemMessage
+
+_DEFAULT_TIMEOUT_SECONDS = 45 * 60
+_WRAPUP_INSTRUCTION = """
+<time_limit_warning>
+You have been running for a long time. Wrap up immediately: finish the current
+step, save or report useful state, avoid starting new investigations, and end
+your turn with the best available result.
+</time_limit_warning>
+"""
+
+
+def _configured_timeout_seconds() -> int:
+    raw = os.environ.get("OPEN_SWE_WRAPUP_TIMEOUT_SECONDS")
+    if not raw:
+        return _DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_TIMEOUT_SECONDS
+    return value if value > 0 else _DEFAULT_TIMEOUT_SECONDS
+
+
+class TimeoutWrapupMiddleware(AgentMiddleware):
+    def __init__(self, timeout_seconds: int | None = None) -> None:
+        super().__init__()
+        self._timeout_seconds = timeout_seconds or _configured_timeout_seconds()
+        self._start = time.monotonic()
+
+    def _should_wrapup(self) -> bool:
+        return (time.monotonic() - self._start) >= self._timeout_seconds
+
+    def _apply(self, request: ModelRequest) -> ModelRequest:
+        if not self._should_wrapup():
+            return request
+        existing = request.system_message.text if request.system_message is not None else ""
+        content = f"{existing}\n\n{_WRAPUP_INSTRUCTION}" if existing else _WRAPUP_INSTRUCTION
+        return request.override(system_message=SystemMessage(content=content))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        return await handler(self._apply(request))

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -51,6 +51,7 @@ from .middleware import (
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     SlackAssistantStatusMiddleware,
+    TimeoutWrapupMiddleware,
     ToolErrorMiddleware,
     check_message_queue_before_model,
     refresh_github_proxy_before_model,
@@ -91,6 +92,7 @@ from .tools import (
 from .utils import ttl_cache
 from .utils.agents_md import fetch_agents_md
 from .utils.api_standards_skill import fetch_api_standards_skill
+from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import get_github_app_installation_token_with_expiry
 from .utils.github_token import cache_github_token_for_thread
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
@@ -801,6 +803,19 @@ def _format_existing_findings(findings: list[dict]) -> str:
 _BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
 
 
+def _make_model_or_defer(
+    model_id: str,
+    *,
+    use_gateway: bool,
+    **kwargs: Any,
+) -> BaseChatModel:
+    try:
+        return make_model(model_id, use_gateway=use_gateway, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Deferring reviewer model setup failure for %s", model_id, exc_info=True)
+        return make_deferred_error_model(e, model_id=model_id)
+
+
 def _on_background_task_done(task: asyncio.Task[None]) -> None:
     _BACKGROUND_TASKS.discard(task)
     if task.cancelled():
@@ -832,7 +847,7 @@ async def _resolve_grouping_model(
         max_tokens=DEFAULT_LLM_MAX_TOKENS,
         openai_reasoning_default=DEFAULT_LLM_REASONING,
     )
-    return make_model(model_id, use_gateway=use_gateway, **model_kwargs)
+    return _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
 
 
 async def _cached_reviewer_team_defaults():
@@ -1258,8 +1273,8 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     )
 
     use_gateway = await _cached_gateway_enabled()
-    reviewer_model = make_model(model_id, use_gateway=use_gateway, **model_kwargs)
-    reviewer_subagent_model = make_model(
+    reviewer_model = _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
+    reviewer_subagent_model = _make_model_or_defer(
         subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs
     )
 
@@ -1303,6 +1318,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             refresh_github_proxy_before_model,
             check_message_queue_before_model,
             SlackAssistantStatusMiddleware(),
+            TimeoutWrapupMiddleware(),
             SanitizeOpenAIResponsesMiddleware(),
             SanitizeFireworksMessagesMiddleware(),
             SanitizeThinkingBlocksMiddleware(),

--- a/agent/server.py
+++ b/agent/server.py
@@ -31,7 +31,7 @@ from deepagents import create_deep_agent
 from deepagents.backends import LangSmithSandbox
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
-from langchain.agents.middleware import ModelCallLimitMiddleware
+from langchain.agents.middleware import ModelCallLimitMiddleware, ToolRetryMiddleware
 from langchain_core.language_models import BaseChatModel
 from langsmith.sandbox import SandboxClientError
 
@@ -68,12 +68,15 @@ from .middleware import (
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     SlackAssistantStatusMiddleware,
+    TimeoutWrapupMiddleware,
     ToolArtifactMiddleware,
     ToolErrorMiddleware,
     WorkflowPushGuardMiddleware,
     check_message_queue_before_model,
     notify_step_limit_reached,
     refresh_github_proxy_before_model,
+    task_on_failure,
+    task_retry_on,
 )
 from .prompt import construct_system_prompt
 from .tools import (
@@ -105,6 +108,7 @@ from .utils.authorship import (
     resolve_triggering_user_identity,
 )
 from .utils.dashboard_links import dashboard_plan_url, dashboard_thread_url
+from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import (
     BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
     RUNTIME_PROXY_TOKEN_PERMISSIONS,
@@ -648,6 +652,19 @@ async def _cached_profile(profile_login: str | None):
     )
 
 
+def _make_model_or_defer(
+    model_id: str,
+    *,
+    use_gateway: bool,
+    **kwargs: Any,
+) -> BaseChatModel:
+    try:
+        return make_model(model_id, use_gateway=use_gateway, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Deferring model setup failure for %s", model_id, exc_info=True)
+        return make_deferred_error_model(e, model_id=model_id)
+
+
 class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
     def __init__(
         self,
@@ -857,7 +874,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             fallback_kwargs["reasoning"] = DEFAULT_LLM_REASONING
         fallback_middleware.append(
             ModelFallbackMiddleware(
-                make_model(fallback_model_id, use_gateway=use_gateway, **fallback_kwargs)
+                _make_model_or_defer(fallback_model_id, use_gateway=use_gateway, **fallback_kwargs)
             )
         )
         logger.info("Configured model fallback %s -> %s", model_id, fallback_model_id)
@@ -904,8 +921,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         )
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)
-    main_model = make_model(model_id, use_gateway=use_gateway, **model_kwargs)
-    subagent_model = make_model(subagent_model_id, use_gateway=use_gateway, **subagent_model_kwargs)
+    main_model = _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
+    subagent_model = _make_model_or_defer(
+        subagent_model_id,
+        use_gateway=use_gateway,
+        **subagent_model_kwargs,
+    )
     return create_deep_agent(
         model=main_model,
         system_prompt="",
@@ -956,12 +977,21 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             ),
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
+            ToolRetryMiddleware(
+                max_retries=2,
+                tools=["task"],
+                retry_on=task_retry_on,
+                on_failure=task_on_failure,
+                initial_delay=1.0,
+                max_delay=10.0,
+            ),
             ToolErrorMiddleware(),
             ToolArtifactMiddleware(),
             WorkflowPushGuardMiddleware(),
             refresh_github_proxy_before_model,
             check_message_queue_before_model,
             SlackAssistantStatusMiddleware(),
+            TimeoutWrapupMiddleware(),
             notify_step_limit_reached,
             *fallback_middleware,
             *plan_mode_middleware,

--- a/agent/server.py
+++ b/agent/server.py
@@ -977,6 +977,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             ),
             SanitizeToolInputsMiddleware(),
             ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
+            ToolErrorMiddleware(),
             ToolRetryMiddleware(
                 max_retries=2,
                 tools=["task"],
@@ -985,7 +986,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 initial_delay=1.0,
                 max_delay=10.0,
             ),
-            ToolErrorMiddleware(),
             ToolArtifactMiddleware(),
             WorkflowPushGuardMiddleware(),
             refresh_github_proxy_before_model,

--- a/agent/utils/deferred_model.py
+++ b/agent/utils/deferred_model.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+
+
+class DeferredErrorModel(BaseChatModel):
+    """Model placeholder that raises a stored setup error on first invocation."""
+
+    error_message: str
+    model_id: str | None = None
+
+    @property
+    def _llm_type(self) -> str:
+        return "deferred-error"
+
+    def _get_ls_params(self, stop: Any = None, **kwargs: Any) -> dict[str, Any]:
+        params = super()._get_ls_params(stop=stop, **kwargs)
+        if self.model_id:
+            params["ls_model_name"] = self.model_id
+            if ":" in self.model_id:
+                params["ls_provider"] = self.model_id.split(":", 1)[0]
+        return params
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> DeferredErrorModel:
+        return self
+
+    def _generate(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any):
+        raise ValueError(self.error_message)
+
+
+def make_deferred_error_model(
+    error: BaseException, *, model_id: str | None = None
+) -> BaseChatModel:
+    return DeferredErrorModel(error_message=str(error), model_id=model_id)

--- a/agent/utils/deferred_model.py
+++ b/agent/utils/deferred_model.py
@@ -33,4 +33,4 @@ class DeferredErrorModel(BaseChatModel):
 def make_deferred_error_model(
     error: BaseException, *, model_id: str | None = None
 ) -> BaseChatModel:
-    return DeferredErrorModel(error_message=str(error), model_id=model_id)
+    return DeferredErrorModel(error_message=f"{type(error).__name__}: {error}", model_id=model_id)

--- a/tests/test_agent_assembly_context.py
+++ b/tests/test_agent_assembly_context.py
@@ -101,3 +101,13 @@ async def test_agent_keeps_message_queue_and_step_limit_middleware() -> None:
     present = {type(m).__name__ for m in middleware}
     assert "check_message_queue_before_model" in present
     assert "notify_step_limit_reached" in present
+
+
+@pytest.mark.asyncio
+async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
+    captured = await _capture_create_deep_agent_kwargs()
+    middleware = captured["middleware"]
+    assert isinstance(middleware, list)
+    names = [type(m).__name__ for m in middleware]
+
+    assert names.index("ToolErrorMiddleware") < names.index("ToolRetryMiddleware")

--- a/tests/test_agent_schedules.py
+++ b/tests/test_agent_schedules.py
@@ -368,6 +368,9 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(fake_client,
     assert run["thread_id"] == thread_id
     assert run["assistant_id"] == "agent"
     assert run["input"]["messages"][0]["content"] == record["prompt"]
+    assert run["durability"] == "sync"
+    assert run["multitask_strategy"] == "interrupt"
+    assert run["if_not_exists"] == "create"
     assert run["config"]["configurable"]["source"] == "schedule"
     assert run["config"]["configurable"]["repo"] == record["repo"]
 

--- a/tests/test_completion_webhook.py
+++ b/tests/test_completion_webhook.py
@@ -42,7 +42,9 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
         completion, "dashboard_thread_url", lambda thread_id: f"https://ui/{thread_id}"
     )
 
-    result = await completion.handle_run_completion({"thread_id": "t1", "status": "error"})
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "error"}
+    )
 
     assert result["status"] == "ok"
     reply.assert_awaited_once()
@@ -50,7 +52,9 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
     assert args[0] == "C1"
     assert args[1] == "123.45"
     assert "<https://ui/t1|Open SWE Web>" in args[2]
-    assert client.threads.updates == [{"failure_reply_posted": True}]
+    assert client.threads.updates == [
+        {"failure_reply_posted_run_id": "run-1", "failure_reply_posted_run_ids": ["run-1"]}
+    ]
 
 
 @pytest.mark.asyncio
@@ -60,7 +64,9 @@ async def test_success_status_is_ignored(monkeypatch: pytest.MonkeyPatch) -> Non
     reply = AsyncMock(return_value=True)
     monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
 
-    result = await completion.handle_run_completion({"thread_id": "t1", "status": "success"})
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "success"}
+    )
 
     assert result["status"] == "ignored"
     reply.assert_not_called()
@@ -69,17 +75,44 @@ async def test_success_status_is_ignored(monkeypatch: pytest.MonkeyPatch) -> Non
 @pytest.mark.asyncio
 async def test_idempotent_when_already_replied(monkeypatch: pytest.MonkeyPatch) -> None:
     metadata = _slack_metadata()
-    metadata["failure_reply_posted"] = True
+    metadata["failure_reply_posted_run_ids"] = ["run-1"]
     client = _FakeClient(metadata)
     monkeypatch.setattr(completion, "langgraph_client", lambda: client)
     reply = AsyncMock(return_value=True)
     monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
 
-    result = await completion.handle_run_completion({"thread_id": "t1", "status": "timeout"})
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "timeout"}
+    )
 
     assert result["status"] == "ignored"
     reply.assert_not_called()
     assert client.threads.updates == []
+
+
+@pytest.mark.asyncio
+async def test_later_failed_run_posts_even_if_prior_run_replied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _slack_metadata()
+    metadata["failure_reply_posted_run_ids"] = ["run-1"]
+    client = _FakeClient(metadata)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
+
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-2", "status": "timeout"}
+    )
+
+    assert result["status"] == "ok"
+    reply.assert_awaited_once()
+    assert client.threads.updates == [
+        {
+            "failure_reply_posted_run_id": "run-2",
+            "failure_reply_posted_run_ids": ["run-1", "run-2"],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -89,7 +122,9 @@ async def test_linear_source_comments_on_issue(monkeypatch: pytest.MonkeyPatch) 
     comment = AsyncMock(return_value=True)
     monkeypatch.setattr(completion, "comment_on_linear_issue", comment)
 
-    result = await completion.handle_run_completion({"thread_id": "t1", "status": "timeout"})
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "timeout"}
+    )
 
     assert result["status"] == "ok"
     comment.assert_awaited_once()
@@ -98,7 +133,13 @@ async def test_linear_source_comments_on_issue(monkeypatch: pytest.MonkeyPatch) 
 
 @pytest.mark.asyncio
 async def test_missing_thread_id_is_ignored() -> None:
-    result = await completion.handle_run_completion({"status": "error"})
+    result = await completion.handle_run_completion({"run_id": "run-1", "status": "error"})
+    assert result["status"] == "ignored"
+
+
+@pytest.mark.asyncio
+async def test_missing_run_id_is_ignored() -> None:
+    result = await completion.handle_run_completion({"thread_id": "t1", "status": "error"})
     assert result["status"] == "ignored"
 
 
@@ -107,7 +148,9 @@ async def test_no_reply_channel_does_not_flag(monkeypatch: pytest.MonkeyPatch) -
     client = _FakeClient({"source": "schedule"})
     monkeypatch.setattr(completion, "langgraph_client", lambda: client)
 
-    result = await completion.handle_run_completion({"thread_id": "t1", "status": "error"})
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "error"}
+    )
 
     assert result["status"] == "ignored"
     assert client.threads.updates == []
@@ -122,7 +165,9 @@ async def test_interrupted_status_is_ignored(monkeypatch: pytest.MonkeyPatch) ->
     reply = AsyncMock(return_value=True)
     monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
 
-    result = await completion.handle_run_completion({"thread_id": "t1", "status": "interrupted"})
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "interrupted"}
+    )
 
     assert result["status"] == "ignored"
     reply.assert_not_called()

--- a/tests/test_completion_webhook.py
+++ b/tests/test_completion_webhook.py
@@ -138,9 +138,37 @@ async def test_missing_thread_id_is_ignored() -> None:
 
 
 @pytest.mark.asyncio
-async def test_missing_run_id_is_ignored() -> None:
+async def test_missing_run_id_falls_back_to_thread_level_dedupe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient(_slack_metadata())
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
+
     result = await completion.handle_run_completion({"thread_id": "t1", "status": "error"})
+
+    assert result["status"] == "ok"
+    reply.assert_awaited_once()
+    assert client.threads.updates == [{"failure_reply_posted": True}]
+
+
+@pytest.mark.asyncio
+async def test_missing_run_id_respects_thread_level_dedupe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _slack_metadata()
+    metadata["failure_reply_posted"] = True
+    client = _FakeClient(metadata)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
+
+    result = await completion.handle_run_completion({"thread_id": "t1", "status": "error"})
+
     assert result["status"] == "ignored"
+    reply.assert_not_called()
+    assert client.threads.updates == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_deferred_model.py
+++ b/tests/test_deferred_model.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from agent.utils.deferred_model import DeferredErrorModel, make_deferred_error_model
+
+
+def test_deferred_error_model_binds_tools_without_raising() -> None:
+    model = DeferredErrorModel(error_message="missing key", model_id="openai:gpt-5")
+
+    assert model.bind_tools([]) is model
+    assert model._get_ls_params()["ls_model_name"] == "openai:gpt-5"
+
+
+def test_deferred_error_model_raises_on_first_call() -> None:
+    model = make_deferred_error_model(RuntimeError("missing key"), model_id="openai:gpt-5")
+
+    with pytest.raises(ValueError, match="missing key"):
+        model.invoke([HumanMessage(content="hello")])

--- a/tests/test_deferred_model.py
+++ b/tests/test_deferred_model.py
@@ -16,5 +16,5 @@ def test_deferred_error_model_binds_tools_without_raising() -> None:
 def test_deferred_error_model_raises_on_first_call() -> None:
     model = make_deferred_error_model(RuntimeError("missing key"), model_id="openai:gpt-5")
 
-    with pytest.raises(ValueError, match="missing key"):
+    with pytest.raises(ValueError, match="RuntimeError: missing key"):
         model.invoke([HumanMessage(content="hello")])

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import importlib
+from typing import Any
+
+import pytest
 
 dispatch = importlib.import_module("agent.dispatch")
 
@@ -43,3 +46,67 @@ def test_resolve_absolute_url_appends_token() -> None:
 def test_resolve_absolute_url_with_existing_query_left_as_is() -> None:
     url = f"{_ABSOLUTE}?token=preset"
     assert dispatch._resolve_completion_webhook_url(url, "s3cret") == url
+
+
+class _FakeRuns:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    async def create(self, thread_id: str, assistant_id: str, **kwargs: Any) -> dict[str, str]:
+        self.created.append({"thread_id": thread_id, "assistant_id": assistant_id, **kwargs})
+        return {"run_id": "run-1"}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.runs = _FakeRuns()
+
+
+@pytest.mark.asyncio
+async def test_create_durable_run_applies_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(dispatch, "COMPLETION_WEBHOOK_URL", "https://app/webhooks/run-complete")
+
+    run = await dispatch.create_durable_run(
+        "thread-1",
+        "agent",
+        input={"messages": [{"role": "user", "content": "hi"}]},
+        source="test",
+        config={"configurable": {"thread_id": "thread-1"}, "metadata": {"kind": "test"}},
+        client=client,
+    )
+
+    assert run == {"run_id": "run-1"}
+    created = client.runs.created[0]
+    assert created["durability"] == "sync"
+    assert created["multitask_strategy"] == "interrupt"
+    assert created["if_not_exists"] == "create"
+    assert created["webhook"] == "https://app/webhooks/run-complete"
+    assert created["config"]["metadata"] == {"kind": "test"}
+    assert created["config"]["configurable"]["thread_id"] == "thread-1"
+    assert isinstance(created["config"]["configurable"]["prepare_run_id"], str)
+
+
+@pytest.mark.asyncio
+async def test_create_durable_run_preserves_existing_prepare_id_and_stream_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(dispatch, "COMPLETION_WEBHOOK_URL", None)
+
+    await dispatch.create_durable_run(
+        "thread-1",
+        "agent",
+        input={"messages": []},
+        source="schedule",
+        config={"configurable": {"prepare_run_id": "existing"}},
+        stream_mode=["values"],
+        stream_resumable=True,
+        client=client,
+    )
+
+    created = client.runs.created[0]
+    assert "webhook" not in created
+    assert created["stream_mode"] == ["values"]
+    assert created["stream_resumable"] is True
+    assert created["config"]["configurable"]["prepare_run_id"] == "existing"

--- a/tests/test_langsmith_sandbox_config.py
+++ b/tests/test_langsmith_sandbox_config.py
@@ -13,6 +13,7 @@ from agent.integrations.langsmith import (
     LangSmithProvider,
     _create_sandbox_with_retry,
     _get_sandbox_snapshot_config,
+    _wait_for_reconnected_sandbox,
 )
 
 
@@ -116,6 +117,22 @@ class _FakeSandboxClient:
         return {"sandbox": kwargs["snapshot_id"]}
 
 
+class _FakeStatusSandbox:
+    def __init__(self, status: str) -> None:
+        self.status = status
+
+
+class _FakeReconnectClient:
+    def __init__(self, statuses: list[str]) -> None:
+        self.statuses = statuses
+        self.calls = 0
+
+    async def get_sandbox(self, *, name: str) -> _FakeStatusSandbox:
+        self.calls += 1
+        status = self.statuses[min(self.calls - 1, len(self.statuses) - 1)]
+        return _FakeStatusSandbox(status)
+
+
 @pytest.mark.asyncio
 async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -> None:  # noqa: ANN001
     client = _FakeSandboxClient(failures=2)
@@ -134,3 +151,21 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
 
     assert result == {"sandbox": "snap-1"}
     assert client.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_wait_for_reconnected_sandbox_polls_until_ready(monkeypatch) -> None:  # noqa: ANN001
+    client = _FakeReconnectClient(["starting", "starting", "running"])
+    sleep = AsyncMock()
+    monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", sleep)
+
+    sandbox = await _wait_for_reconnected_sandbox(
+        client,
+        "sandbox-1",
+        timeout_seconds=30,
+        poll_seconds=2,
+    )
+
+    assert sandbox.status == "running"
+    assert client.calls == 3
+    assert sleep.await_count == 2

--- a/tests/test_langsmith_sandbox_config.py
+++ b/tests/test_langsmith_sandbox_config.py
@@ -1,6 +1,6 @@
 """Tests for LangSmith sandbox env-var configuration parsing."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -11,6 +11,7 @@ from agent.integrations.langsmith import (
     DEFAULT_SANDBOX_VCPUS,
     DEFAULT_SNAPSHOT_FS_CAPACITY_BYTES,
     LangSmithProvider,
+    _create_sandbox_with_retry,
     _get_sandbox_snapshot_config,
 )
 
@@ -97,3 +98,39 @@ def test_validate_startup_accepts_valid_config() -> None:
         clear=True,
     ):
         LangSmithProvider.validate_startup_config()
+
+
+class _RetryableCreateError(Exception):
+    status_code = 503
+
+
+class _FakeSandboxClient:
+    def __init__(self, failures: int) -> None:
+        self.failures = failures
+        self.calls = 0
+
+    async def create_sandbox(self, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise _RetryableCreateError("try again")
+        return {"sandbox": kwargs["snapshot_id"]}
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -> None:  # noqa: ANN001
+    client = _FakeSandboxClient(failures=2)
+    monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", AsyncMock())
+
+    result = await _create_sandbox_with_retry(
+        client,
+        snapshot_id="snap-1",
+        fs_capacity_bytes=None,
+        vcpus=None,
+        mem_bytes=None,
+        idle_ttl_seconds=None,
+        delete_after_stop_seconds=None,
+        timeout=180,
+    )
+
+    assert result == {"sandbox": "snap-1"}
+    assert client.calls == 3

--- a/tests/test_task_retry.py
+++ b/tests/test_task_retry.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.middleware.task_retry import task_on_failure, task_retry_on
+
+
+class _HTTPError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+
+
+class _InvalidPromptError(Exception):
+    body = {"error": {"type": "invalid_request_error", "code": "invalid_prompt"}}
+
+
+def test_task_retry_on_transient_status() -> None:
+    assert task_retry_on(_HTTPError(429)) is True
+    assert task_retry_on(_HTTPError(503)) is True
+    assert task_retry_on(_HTTPError(400)) is False
+
+
+def test_task_on_failure_returns_model_fixable_error() -> None:
+    payload = json.loads(task_on_failure(_InvalidPromptError("bad prompt")))
+
+    assert payload["status"] == "failed"
+    assert payload["source"] == "subagent"
+    assert payload["error"]["code"] == "invalid_prompt"
+
+
+def test_task_on_failure_reraises_unrecoverable_error() -> None:
+    exc = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        task_on_failure(exc)

--- a/tests/test_task_retry.py
+++ b/tests/test_task_retry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
 
 from agent.middleware.task_retry import task_on_failure, task_retry_on
@@ -18,9 +19,18 @@ class _InvalidPromptError(Exception):
 
 
 def test_task_retry_on_transient_status() -> None:
+    assert task_retry_on(_HTTPError(408)) is True
+    assert task_retry_on(_HTTPError(409)) is True
+    assert task_retry_on(_HTTPError(425)) is True
     assert task_retry_on(_HTTPError(429)) is True
     assert task_retry_on(_HTTPError(503)) is True
+    assert task_retry_on(_HTTPError(529)) is True
     assert task_retry_on(_HTTPError(400)) is False
+
+
+def test_task_retry_on_httpx_transport_subclasses() -> None:
+    assert task_retry_on(httpx.RemoteProtocolError("stream dropped")) is True
+    assert task_retry_on(httpx.ConnectError("connect failed")) is True
 
 
 def test_task_on_failure_returns_model_fixable_error() -> None:

--- a/tests/test_timeout_wrapup.py
+++ b/tests/test_timeout_wrapup.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, SystemMessage
+
+from agent.middleware.timeout_wrapup import TimeoutWrapupMiddleware
+
+
+@pytest.mark.asyncio
+async def test_timeout_wrapup_starts_clock_lazily(monkeypatch: pytest.MonkeyPatch) -> None:
+    times = [100.0, 105.0, 111.0]
+
+    def monotonic() -> float:
+        return times.pop(0) if times else 111.0
+
+    monkeypatch.setattr("agent.middleware.timeout_wrapup.time.monotonic", monotonic)
+    middleware = TimeoutWrapupMiddleware(timeout_seconds=10)
+    seen: list[ModelRequest] = []
+
+    async def handler(request: ModelRequest) -> ModelResponse:
+        seen.append(request)
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    request = ModelRequest(model=None, messages=[], system_message=SystemMessage(content="base"))
+
+    await middleware.awrap_model_call(request, handler)
+    await middleware.awrap_model_call(request, handler)
+
+    assert seen[0].system_message.content == "base"
+    assert "time_limit_warning" in seen[1].system_message.content
+
+
+@pytest.mark.asyncio
+async def test_timeout_wrapup_preserves_structured_system_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agent.middleware.timeout_wrapup.time.monotonic", lambda: 100.0)
+    middleware = TimeoutWrapupMiddleware(timeout_seconds=0.1)
+    middleware._start = 99.0
+    seen: list[ModelRequest] = []
+
+    async def handler(request: ModelRequest) -> ModelResponse:
+        seen.append(request)
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    request = ModelRequest(
+        model=None,
+        messages=[],
+        system_message=SystemMessage(
+            content=[{"type": "text", "text": "base", "cache_control": {"type": "ephemeral"}}]
+        ),
+    )
+
+    await middleware.awrap_model_call(request, handler)
+
+    content = seen[0].system_message.content
+    assert content[0] == {"type": "text", "text": "base", "cache_control": {"type": "ephemeral"}}
+    assert content[1]["type"] == "text"
+    assert "time_limit_warning" in content[1]["text"]


### PR DESCRIPTION
## Description
Route Open SWE run creation through a durable helper with sync checkpointing, completion webhooks, and prepare-run ids. Harden failure recovery by keeping completion replies best-effort without run ids, retrying real httpx transport failures, polling restarted LangSmith sandboxes before reconnecting, preserving structured timeout-wrapup prompts, and surfacing deferred error types. Subagent output-cap/timeout wrappers were intentionally left out in favor of retry-only hardening to avoid brittle internals.

## Release Note
Durable agent runs now recover more reliably from transient model, webhook, and LangSmith sandbox failures.

## Test Plan
- [x] `make lint`
- [x] `uv run pytest -vvv tests/test_dispatch.py tests/test_completion_webhook.py tests/test_agent_schedules.py tests/test_langsmith_sandbox_config.py tests/test_deferred_model.py tests/test_task_retry.py tests/test_reviewer.py tests/test_review_style_sync.py tests/test_pr_ready_auto_review.py tests/test_reviewer_watch.py tests/test_timeout_wrapup.py`

Made by [Open SWE](https://openswe.vercel.app/agents/019f3e08-daa0-74fa-8026-f3c5d077d41f)
