### PR TITLE
fix: Reduce graph import and loader startup latency

### DIFF
--- a/agent/dashboard/__init__.py
+++ b/agent/dashboard/__init__.py
@@ -15,5 +15,6 @@ def __getattr__(name: str) -> Any:
     if name == "router":
         from .routes import router
 
+        globals()[name] = router
         return router
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/agent/dashboard/__init__.py
+++ b/agent/dashboard/__init__.py
@@ -1,5 +1,19 @@
-"""Dashboard backend: OAuth, profiles, and admin endpoints for the open-swe UI."""
+"""Dashboard backend: OAuth, profiles, and admin endpoints for the open-swe UI.
 
-from .routes import router
+``router`` is loaded lazily (PEP 562): importing any dashboard submodule
+(e.g. ``agent.dashboard.options`` from middleware) executes this __init__,
+and it must NOT drag in routes.py + FastAPI + every API/job module. Only the
+webapp, which actually mounts the router, pays that cost.
+"""
+
+from typing import Any
 
 __all__ = ["router"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "router":
+        from .routes import router
+
+        return router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/agent/dashboard/review_chat_api.py
+++ b/agent/dashboard/review_chat_api.py
@@ -17,7 +17,6 @@ from datetime import UTC, datetime
 from typing import Any
 
 import httpx
-from deepagents.backends.utils import create_file_data
 from fastapi import HTTPException
 
 from ..reviewer_diff import fetch_pr_diff
@@ -223,6 +222,9 @@ async def _build_pr_context(
     Accepts an already-fetched ``review`` to avoid re-fetching it when the caller
     has just read it to decide whether a reseed is needed.
     """
+    # deferred: pulls deepagents -> langchain_anthropic -> anthropic at import time
+    from deepagents.backends.utils import create_file_data
+
     if review is None:
         review = await get_review(owner, repo, pr_number)
     findings = review.get("findings") if isinstance(review.get("findings"), list) else []

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -19,7 +19,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from ..utils.dashboard_handoff import DASHBOARD_HANDOFF_INSTRUCTION
 from ..utils.langsmith import get_langsmith_trace_url
-from ..utils.sandbox import create_sandbox
 from ..utils.slack import lookup_slack_thread_run_mapping, update_slack_trace_reply_for_web_handoff
 from ..utils.thread_ops import (
     get_thread_active_status,
@@ -66,6 +65,13 @@ _SURFACED_SOURCES: tuple[str, ...] = ("dashboard", "github", "slack", "linear", 
 _PR_STATES: frozenset[str] = frozenset({"draft", "open", "merged", "closed"})
 _RECOVERY_PATCH_LIMIT_BYTES = 25 * 1024 * 1024
 _RECOVERY_PATCH_TIMEOUT_SECONDS = 120
+
+
+async def create_sandbox(*args: Any, **kwargs: Any) -> Any:
+    # deferred: pulls deepagents -> langchain_anthropic -> anthropic at import time
+    from ..utils.sandbox import create_sandbox as _create_sandbox
+
+    return await _create_sandbox(*args, **kwargs)
 
 
 def _agent_version_metadata() -> dict[str, str]:

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -1,22 +1,27 @@
-from .check_message_queue import check_message_queue_before_model
-from .ensure_no_empty_msg import ensure_no_empty_msg
-from .exclude_tools import ExcludeToolsMiddleware
-from .model_fallback import ModelFallbackMiddleware
-from .notify_step_limit import notify_step_limit_reached
-from .plan_mode import PlanModeMiddleware
-from .prepare_run import BasePrepareRunMiddleware, PrepareRunState
-from .refresh_github_proxy import refresh_github_proxy_before_model
-from .refresh_slack_status import SlackAssistantStatusMiddleware
-from .repair_orphaned_tool_calls import RepairOrphanedToolCallsMiddleware
-from .sandbox_circuit_breaker import SandboxCircuitBreakerMiddleware
-from .sanitize_fireworks_messages import SanitizeFireworksMessagesMiddleware
-from .sanitize_openai_responses import SanitizeOpenAIResponsesMiddleware
-from .sanitize_thinking_blocks import SanitizeThinkingBlocksMiddleware
-from .sanitize_tool_inputs import SanitizeToolInputsMiddleware
-from .settle_review_check import settle_review_check_on_exit
-from .tool_artifact import ToolArtifactMiddleware
-from .tool_error_handler import ToolErrorMiddleware
-from .workflow_push_guard import WorkflowPushGuardMiddleware
+from typing import TYPE_CHECKING, Any
+
+_MIDDLEWARE_MODULES = {
+    "check_message_queue_before_model": ".check_message_queue",
+    "ensure_no_empty_msg": ".ensure_no_empty_msg",
+    "ExcludeToolsMiddleware": ".exclude_tools",
+    "ModelFallbackMiddleware": ".model_fallback",
+    "notify_step_limit_reached": ".notify_step_limit",
+    "PlanModeMiddleware": ".plan_mode",
+    "BasePrepareRunMiddleware": ".prepare_run",
+    "PrepareRunState": ".prepare_run",
+    "refresh_github_proxy_before_model": ".refresh_github_proxy",
+    "SlackAssistantStatusMiddleware": ".refresh_slack_status",
+    "RepairOrphanedToolCallsMiddleware": ".repair_orphaned_tool_calls",
+    "SandboxCircuitBreakerMiddleware": ".sandbox_circuit_breaker",
+    "SanitizeFireworksMessagesMiddleware": ".sanitize_fireworks_messages",
+    "SanitizeOpenAIResponsesMiddleware": ".sanitize_openai_responses",
+    "SanitizeThinkingBlocksMiddleware": ".sanitize_thinking_blocks",
+    "SanitizeToolInputsMiddleware": ".sanitize_tool_inputs",
+    "settle_review_check_on_exit": ".settle_review_check",
+    "ToolArtifactMiddleware": ".tool_artifact",
+    "ToolErrorMiddleware": ".tool_error_handler",
+    "WorkflowPushGuardMiddleware": ".workflow_push_guard",
+}
 
 __all__ = [
     "ExcludeToolsMiddleware",
@@ -40,3 +45,33 @@ __all__ = [
     "refresh_github_proxy_before_model",
     "settle_review_check_on_exit",
 ]
+
+if TYPE_CHECKING:
+    from .check_message_queue import check_message_queue_before_model
+    from .ensure_no_empty_msg import ensure_no_empty_msg
+    from .exclude_tools import ExcludeToolsMiddleware
+    from .model_fallback import ModelFallbackMiddleware
+    from .notify_step_limit import notify_step_limit_reached
+    from .plan_mode import PlanModeMiddleware
+    from .prepare_run import BasePrepareRunMiddleware, PrepareRunState
+    from .refresh_github_proxy import refresh_github_proxy_before_model
+    from .refresh_slack_status import SlackAssistantStatusMiddleware
+    from .repair_orphaned_tool_calls import RepairOrphanedToolCallsMiddleware
+    from .sandbox_circuit_breaker import SandboxCircuitBreakerMiddleware
+    from .sanitize_fireworks_messages import SanitizeFireworksMessagesMiddleware
+    from .sanitize_openai_responses import SanitizeOpenAIResponsesMiddleware
+    from .sanitize_thinking_blocks import SanitizeThinkingBlocksMiddleware
+    from .sanitize_tool_inputs import SanitizeToolInputsMiddleware
+    from .settle_review_check import settle_review_check_on_exit
+    from .tool_artifact import ToolArtifactMiddleware
+    from .tool_error_handler import ToolErrorMiddleware
+    from .workflow_push_guard import WorkflowPushGuardMiddleware
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _MIDDLEWARE_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    return getattr(import_module(module_name, __name__), name)

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -1,3 +1,5 @@
+import sys
+from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
 _MIDDLEWARE_MODULES = {
@@ -68,10 +70,30 @@ if TYPE_CHECKING:
     from .workflow_push_guard import WorkflowPushGuardMiddleware
 
 
-def __getattr__(name: str) -> Any:
+def _load_export(name: str) -> Any:
     module_name = _MIDDLEWARE_MODULES.get(name)
     if module_name is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     from importlib import import_module
 
-    return getattr(import_module(module_name, __name__), name)
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value
+
+
+class _LazyMiddlewareModule(ModuleType):
+    def __getattribute__(self, name: str) -> Any:
+        module_map = ModuleType.__getattribute__(self, "__dict__").get("_MIDDLEWARE_MODULES", {})
+        if name not in module_map:
+            return ModuleType.__getattribute__(self, name)
+        existing = ModuleType.__getattribute__(self, "__dict__").get(name)
+        if existing is not None and not isinstance(existing, ModuleType):
+            return existing
+        return _load_export(name)
+
+
+def __getattr__(name: str) -> Any:
+    return _load_export(name)
+
+
+sys.modules[__name__].__class__ = _LazyMiddlewareModule

--- a/agent/server.py
+++ b/agent/server.py
@@ -132,6 +132,23 @@ from .utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
 
 client = get_client()
 
+DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS = 5.0
+
+
+def _tool_loader_timeout_seconds() -> float:
+    raw_timeout = os.environ.get("TOOL_LOADER_TIMEOUT_SECONDS")
+    if not raw_timeout:
+        return DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw_timeout)
+    except ValueError:
+        logger.warning("Invalid TOOL_LOADER_TIMEOUT_SECONDS=%r; using default", raw_timeout)
+        return DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS
+    if timeout <= 0:
+        logger.warning("TOOL_LOADER_TIMEOUT_SECONDS must be positive; using default")
+        return DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS
+    return timeout
+
 
 async def _resolve_prompt_default_repo(configurable: dict[str, Any]) -> dict[str, str] | None:
     repo_config = configurable.get("repo")
@@ -591,8 +608,14 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
 
 
 async def _cached_tool_loader(key: str, ttl_seconds: float, loader: Any) -> list[Any]:
+    async def load_with_timeout() -> list[Any]:
+        return await asyncio.wait_for(loader(), timeout=_tool_loader_timeout_seconds())
+
     try:
-        return await ttl_cache.cached(key, ttl_seconds, loader)
+        return await ttl_cache.cached_stale_while_revalidate(key, ttl_seconds, load_with_timeout)
+    except TimeoutError:
+        logger.warning("Timed out loading cached tools for %s", key, exc_info=True)
+        return []
     except Exception:
         logger.warning("Failed to load cached tools for %s", key, exc_info=True)
         return []
@@ -622,6 +645,18 @@ async def _load_corridor_mcp_tools() -> list[Any]:
     return await _cached_tool_loader(
         f"tools:corridor:{id(load_corridor_tools)}", 600, load_corridor_tools
     )
+
+
+async def warm_deployment_tool_caches() -> None:
+    """Best-effort warmup for deployment-scoped optional tool loaders."""
+    results = await asyncio.gather(
+        _load_corridor_mcp_tools(),
+        _load_observability_tools(True),
+        return_exceptions=True,
+    )
+    for result in results:
+        if isinstance(result, Exception):
+            logger.debug("Deployment tool cache warmup failed", exc_info=result)
 
 
 async def _cached_team_default_model_pair(kind: str):

--- a/agent/server.py
+++ b/agent/server.py
@@ -647,18 +647,6 @@ async def _load_corridor_mcp_tools() -> list[Any]:
     )
 
 
-async def warm_deployment_tool_caches() -> None:
-    """Best-effort warmup for deployment-scoped optional tool loaders."""
-    results = await asyncio.gather(
-        _load_corridor_mcp_tools(),
-        _load_observability_tools(True),
-        return_exceptions=True,
-    )
-    for result in results:
-        if isinstance(result, Exception):
-            logger.debug("Deployment tool cache warmup failed", exc_info=result)
-
-
 async def _cached_team_default_model_pair(kind: str):
     return await ttl_cache.cached(
         f"team-default-model-pair:{kind}:{id(get_team_default_model_pair)}",

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -1,31 +1,37 @@
-from .add_finding import add_finding
-from .enter_plan_mode import enter_plan_mode
-from .fetch_url import fetch_url
-from .http_request import http_request
-from .linear_comment import linear_comment
-from .linear_create_issue import linear_create_issue
-from .linear_delete_issue import linear_delete_issue
-from .linear_get_issue import linear_get_issue
-from .linear_get_issue_comments import linear_get_issue_comments
-from .linear_list_teams import linear_list_teams
-from .linear_update_issue import linear_update_issue
-from .list_findings import list_findings
-from .list_review_findings import list_review_findings
-from .open_pull_request import open_pull_request
-from .publish_review import publish_review
-from .read_repo_file import read_repo_file
-from .reply_to_finding_thread import reply_to_finding_thread
-from .request_pr_review import request_pr_review
-from .resolve_finding_thread import resolve_finding_thread
-from .save_plan import save_plan
-from .schedule_thread_wakeup import schedule_thread_wakeup
-from .search_repo_code import search_repo_code
-from .slack_add_reaction import slack_add_reaction
-from .slack_read_thread_messages import slack_read_thread_messages
-from .slack_start_new_thread import slack_start_new_thread
-from .slack_thread_reply import slack_thread_reply
-from .update_finding import update_finding
-from .web_search import web_search
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+_TOOL_MODULES = {
+    "add_finding": ".add_finding",
+    "enter_plan_mode": ".enter_plan_mode",
+    "fetch_url": ".fetch_url",
+    "http_request": ".http_request",
+    "linear_comment": ".linear_comment",
+    "linear_create_issue": ".linear_create_issue",
+    "linear_delete_issue": ".linear_delete_issue",
+    "linear_get_issue": ".linear_get_issue",
+    "linear_get_issue_comments": ".linear_get_issue_comments",
+    "linear_list_teams": ".linear_list_teams",
+    "linear_update_issue": ".linear_update_issue",
+    "list_findings": ".list_findings",
+    "list_review_findings": ".list_review_findings",
+    "open_pull_request": ".open_pull_request",
+    "publish_review": ".publish_review",
+    "read_repo_file": ".read_repo_file",
+    "request_pr_review": ".request_pr_review",
+    "reply_to_finding_thread": ".reply_to_finding_thread",
+    "resolve_finding_thread": ".resolve_finding_thread",
+    "save_plan": ".save_plan",
+    "schedule_thread_wakeup": ".schedule_thread_wakeup",
+    "search_repo_code": ".search_repo_code",
+    "slack_add_reaction": ".slack_add_reaction",
+    "slack_read_thread_messages": ".slack_read_thread_messages",
+    "slack_start_new_thread": ".slack_start_new_thread",
+    "slack_thread_reply": ".slack_thread_reply",
+    "update_finding": ".update_finding",
+    "web_search": ".web_search",
+}
 
 __all__ = [
     "add_finding",
@@ -57,3 +63,62 @@ __all__ = [
     "update_finding",
     "web_search",
 ]
+
+if TYPE_CHECKING:
+    from .add_finding import add_finding
+    from .enter_plan_mode import enter_plan_mode
+    from .fetch_url import fetch_url
+    from .http_request import http_request
+    from .linear_comment import linear_comment
+    from .linear_create_issue import linear_create_issue
+    from .linear_delete_issue import linear_delete_issue
+    from .linear_get_issue import linear_get_issue
+    from .linear_get_issue_comments import linear_get_issue_comments
+    from .linear_list_teams import linear_list_teams
+    from .linear_update_issue import linear_update_issue
+    from .list_findings import list_findings
+    from .list_review_findings import list_review_findings
+    from .open_pull_request import open_pull_request
+    from .publish_review import publish_review
+    from .read_repo_file import read_repo_file
+    from .reply_to_finding_thread import reply_to_finding_thread
+    from .request_pr_review import request_pr_review
+    from .resolve_finding_thread import resolve_finding_thread
+    from .save_plan import save_plan
+    from .schedule_thread_wakeup import schedule_thread_wakeup
+    from .search_repo_code import search_repo_code
+    from .slack_add_reaction import slack_add_reaction
+    from .slack_read_thread_messages import slack_read_thread_messages
+    from .slack_start_new_thread import slack_start_new_thread
+    from .slack_thread_reply import slack_thread_reply
+    from .update_finding import update_finding
+    from .web_search import web_search
+
+
+def _load_export(name: str) -> Any:
+    module_name = _TOOL_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value
+
+
+class _LazyToolsModule(ModuleType):
+    def __getattribute__(self, name: str) -> Any:
+        module_map = ModuleType.__getattribute__(self, "__dict__").get("_TOOL_MODULES", {})
+        if name not in module_map:
+            return ModuleType.__getattribute__(self, name)
+        existing = ModuleType.__getattribute__(self, "__dict__").get(name)
+        if existing is not None and not isinstance(existing, ModuleType):
+            return existing
+        return _load_export(name)
+
+
+def __getattr__(name: str) -> Any:
+    return _load_export(name)
+
+
+sys.modules[__name__].__class__ = _LazyToolsModule

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -111,6 +111,7 @@ class _LazyToolsModule(ModuleType):
         module_map = ModuleType.__getattribute__(self, "__dict__").get("_TOOL_MODULES", {})
         if name not in module_map:
             return ModuleType.__getattribute__(self, name)
+        # Prefer public exports over same-named submodule attributes set by importlib.
         existing = ModuleType.__getattribute__(self, "__dict__").get(name)
         if existing is not None and not isinstance(existing, ModuleType):
             return existing

--- a/agent/tools/request_pr_review.py
+++ b/agent/tools/request_pr_review.py
@@ -2,8 +2,28 @@ from typing import Any
 
 from langgraph.config import get_config
 
-from agent.utils.slack import parse_github_pr_url
-from agent.webapp import trigger_pr_review_from_ref
+from agent.utils.slack import GitHubPrRef, parse_github_pr_url
+
+
+async def trigger_pr_review_from_ref(
+    pr_ref: GitHubPrRef,
+    *,
+    source: str,
+    github_login: str = "",
+    github_user_id: int | None = None,
+    slack_channel_id: str = "",
+    slack_thread_ts: str = "",
+) -> dict[str, Any]:
+    from agent.webapp import trigger_pr_review_from_ref as _trigger_pr_review_from_ref
+
+    return await _trigger_pr_review_from_ref(
+        pr_ref,
+        source=source,
+        github_login=github_login,
+        github_user_id=github_user_id,
+        slack_channel_id=slack_channel_id,
+        slack_thread_ts=slack_thread_ts,
+    )
 
 
 async def request_pr_review(pr_url: str) -> dict[str, Any]:

--- a/agent/tools/web_search.py
+++ b/agent/tools/web_search.py
@@ -3,8 +3,6 @@ import logging
 import os
 from typing import Any
 
-from exa_py import Exa
-
 logger = logging.getLogger(__name__)
 
 
@@ -38,6 +36,8 @@ async def web_search(
         }
 
     async def _search() -> dict[str, Any]:
+        from exa_py import Exa  # deferred: heavy import
+
         client = Exa(api_key=api_key)
         if include_contents:
             result = await asyncio.to_thread(

--- a/agent/utils/analyzer_skills.py
+++ b/agent/utils/analyzer_skills.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from deepagents.backends.utils import create_file_data
-
 SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
 SKILLS_ROUTE = "/skills/"
 
@@ -41,6 +39,9 @@ def build_skill_files() -> dict[str, Any]:
     can serve them. Keys omit the ``/skills`` prefix (stripped by the composite
     route); values are ``FileData`` v2 entries.
     """
+    # deferred: pulls deepagents -> langchain_anthropic -> anthropic at import time
+    from deepagents.backends.utils import create_file_data
+
     files: dict[str, Any] = {}
     for skill in ANALYZER_MODES.values():
         skill_md = SKILLS_DIR / skill / "SKILL.md"

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -2,9 +2,10 @@ import asyncio
 import os
 from collections.abc import Callable
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from deepagents.backends.protocol import SandboxBackendProtocol
+if TYPE_CHECKING:
+    from deepagents.backends.protocol import SandboxBackendProtocol
 
 SandboxFactory = Callable[..., Any]
 
@@ -34,7 +35,7 @@ async def create_sandbox(
     sandbox_id: str | None = None,
     *,
     snapshot_id: str | None = None,
-) -> SandboxBackendProtocol:
+) -> "SandboxBackendProtocol":
     """Create or reconnect to a sandbox using the configured provider.
 
     The provider is selected via the SANDBOX_TYPE environment variable.

--- a/agent/utils/ttl_cache.py
+++ b/agent/utils/ttl_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
@@ -11,6 +11,7 @@ T = TypeVar("T")
 
 _CACHE: dict[str, tuple[object, float]] = {}
 _LOCKS: dict[tuple[str, int], asyncio.Lock] = {}
+_REFRESH_TASKS: dict[tuple[str, int], asyncio.Task[None]] = {}
 
 
 def _now() -> float:
@@ -33,7 +34,7 @@ async def cached(key: str, ttl_seconds: float, loader: Callable[[], Awaitable[T]
     if entry is not None:
         value, expires_at = entry
         if expires_at > now:
-            return value  # type: ignore[return-value]
+            return cast(T, value)
 
     async with _lock_for(key):
         now = _now()
@@ -41,7 +42,7 @@ async def cached(key: str, ttl_seconds: float, loader: Callable[[], Awaitable[T]
         if entry is not None:
             value, expires_at = entry
             if expires_at > now:
-                return value  # type: ignore[return-value]
+                return cast(T, value)
 
         stale = entry[0] if entry is not None else None
         has_stale = entry is not None
@@ -52,10 +53,52 @@ async def cached(key: str, ttl_seconds: float, loader: Callable[[], Awaitable[T]
                 logger.warning(
                     "TTL cache loader failed for %s; serving stale value", key, exc_info=True
                 )
-                return stale  # type: ignore[return-value]
+                return cast(T, stale)
             raise
         _CACHE[key] = (value, now + ttl_seconds)
         return value
+
+
+async def _refresh_stale_entry(
+    key: str, ttl_seconds: float, loader: Callable[[], Awaitable[object]]
+) -> None:
+    async with _lock_for(key):
+        try:
+            value = await loader()
+        except Exception:
+            logger.warning("TTL cache background refresh failed for %s", key, exc_info=True)
+            return
+        _CACHE[key] = (value, _now() + ttl_seconds)
+
+
+def _schedule_refresh(
+    key: str, ttl_seconds: float, loader: Callable[[], Awaitable[object]]
+) -> None:
+    loop = asyncio.get_running_loop()
+    task_key = (key, id(loop))
+    existing = _REFRESH_TASKS.get(task_key)
+    if existing is not None and not existing.done():
+        return
+
+    task = asyncio.create_task(_refresh_stale_entry(key, ttl_seconds, loader))
+    _REFRESH_TASKS[task_key] = task
+    task.add_done_callback(lambda _task: _REFRESH_TASKS.pop(task_key, None))
+
+
+async def cached_stale_while_revalidate(
+    key: str,
+    ttl_seconds: float,
+    loader: Callable[[], Awaitable[T]],
+) -> T:
+    now = _now()
+    entry = _CACHE.get(key)
+    if entry is not None:
+        value, expires_at = entry
+        if expires_at > now:
+            return cast(T, value)
+        _schedule_refresh(key, ttl_seconds, loader)
+        return cast(T, value)
+    return await cached(key, ttl_seconds, loader)
 
 
 def set_cached(key: str, value: object, ttl_seconds: float) -> None:
@@ -73,3 +116,6 @@ def invalidate(key: str) -> None:
 def clear() -> None:
     _CACHE.clear()
     _LOCKS.clear()
+    for task in _REFRESH_TASKS.values():
+        task.cancel()
+    _REFRESH_TASKS.clear()

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -1,5 +1,6 @@
 """Custom FastAPI routes for LangGraph server."""
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -7,7 +8,7 @@ import logging
 import os
 import uuid
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import parse_qs, quote
@@ -149,6 +150,15 @@ if os.environ.get("DEBUG_TRACEMALLOC"):
     )
 
 
+async def _warm_deployment_tool_caches() -> None:
+    try:
+        from .server import warm_deployment_tool_caches
+
+        await warm_deployment_tool_caches()
+    except Exception:
+        logger.debug("Deployment tool cache warmup failed", exc_info=True)
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     from .utils.model import close_cached_models, validate_local_dev_llm_config
@@ -156,9 +166,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
+    warmup_task = asyncio.create_task(_warm_deployment_tool_caches())
     try:
         yield
     finally:
+        if not warmup_task.done():
+            warmup_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await warmup_task
         await close_cached_models()
 
 

--- a/agent/webapp.py
+++ b/agent/webapp.py
@@ -1,6 +1,5 @@
 """Custom FastAPI routes for LangGraph server."""
 
-import asyncio
 import hashlib
 import hmac
 import json
@@ -8,7 +7,7 @@ import logging
 import os
 import uuid
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import parse_qs, quote
@@ -150,15 +149,6 @@ if os.environ.get("DEBUG_TRACEMALLOC"):
     )
 
 
-async def _warm_deployment_tool_caches() -> None:
-    try:
-        from .server import warm_deployment_tool_caches
-
-        await warm_deployment_tool_caches()
-    except Exception:
-        logger.debug("Deployment tool cache warmup failed", exc_info=True)
-
-
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     from .utils.model import close_cached_models, validate_local_dev_llm_config
@@ -166,14 +156,9 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
-    warmup_task = asyncio.create_task(_warm_deployment_tool_caches())
     try:
         yield
     finally:
-        if not warmup_task.done():
-            warmup_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await warmup_task
         await close_cached_models()
 
 

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -1,0 +1,52 @@
+"""Guardrails against import-graph regressions.
+
+Slow imports of agent.webapp delay pod readiness on LangGraph Cloud and have
+caused runs to fail with "exceeded max attempts". These tests pin which heavy
+modules are allowed in each entrypoint's transitive import closure.
+"""
+
+import json
+import subprocess
+import sys
+
+
+def _closure_check(entry: str, forbidden: list[str]) -> dict[str, bool]:
+    code = (
+        "import importlib, json, sys; "
+        f"importlib.import_module({entry!r}); "
+        f"print(json.dumps({{m: (m in sys.modules) for m in {forbidden!r}}}))"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def test_webapp_does_not_import_agent_stack() -> None:
+    loaded = _closure_check(
+        "agent.webapp",
+        [
+            "deepagents",
+            "anthropic",
+            "langchain_anthropic",
+            "openai",
+            "exa_py",
+            "agent.server",
+            "agent.middleware",
+            "agent.tools",
+        ],
+    )
+    assert not any(loaded.values()), f"forbidden modules imported by agent.webapp: {loaded}"
+
+
+def test_server_does_not_import_exa_or_dashboard_routes() -> None:
+    loaded = _closure_check("agent.server", ["exa_py"])
+    assert not any(loaded.values()), f"forbidden modules imported by agent.server: {loaded}"
+
+
+def test_lazy_names_all_resolve() -> None:
+    code = (
+        "import agent.tools, agent.middleware, agent.dashboard;"
+        "[getattr(agent.tools, n) for n in agent.tools.__all__];"
+        "[getattr(agent.middleware, n) for n in agent.middleware.__all__];"
+        "agent.dashboard.router"
+    )
+    subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -38,15 +38,26 @@ def test_webapp_does_not_import_agent_stack() -> None:
 
 
 def test_server_does_not_import_exa_or_dashboard_routes() -> None:
-    loaded = _closure_check("agent.server", ["exa_py"])
+    loaded = _closure_check("agent.server", ["exa_py", "agent.dashboard.routes", "agent.webapp"])
     assert not any(loaded.values()), f"forbidden modules imported by agent.server: {loaded}"
 
 
 def test_lazy_names_all_resolve() -> None:
-    code = (
-        "import agent.tools, agent.middleware, agent.dashboard;"
-        "[getattr(agent.tools, n) for n in agent.tools.__all__];"
-        "[getattr(agent.middleware, n) for n in agent.middleware.__all__];"
-        "agent.dashboard.router"
-    )
+    code = """
+import importlib
+import types
+
+for package_name in ("agent.tools", "agent.middleware"):
+    package = importlib.import_module(package_name)
+    for name in package.__all__:
+        namespace = {}
+        exec(f"from {package_name} import {name} as value", namespace)
+        if isinstance(namespace["value"], types.ModuleType):
+            raise AssertionError(f"{package_name}.{name} resolved to a module")
+
+namespace = {}
+exec("from agent.dashboard import router as value", namespace)
+if isinstance(namespace["value"], types.ModuleType):
+    raise AssertionError("agent.dashboard.router resolved to a module")
+"""
     subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)

--- a/tests/test_prepare_run_middleware.py
+++ b/tests/test_prepare_run_middleware.py
@@ -104,6 +104,34 @@ async def test_ttl_cache_single_flight_and_stale_while_error():
 
 
 @pytest.mark.asyncio
+async def test_ttl_cache_stale_while_revalidate_refreshes_in_background():
+    ttl_cache.clear()
+    ttl_cache.set_cached("k", "stale", -1)
+    refresh_started = asyncio.Event()
+    allow_refresh = asyncio.Event()
+    calls = 0
+
+    async def loader():
+        nonlocal calls
+        calls += 1
+        refresh_started.set()
+        await allow_refresh.wait()
+        return "fresh"
+
+    assert await ttl_cache.cached_stale_while_revalidate("k", 60, loader) == "stale"
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    assert calls == 1
+
+    allow_refresh.set()
+    for _ in range(20):
+        if await ttl_cache.cached_stale_while_revalidate("k", 60, loader) == "fresh":
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise AssertionError("stale cache entry was not refreshed")
+
+
+@pytest.mark.asyncio
 async def test_ttl_cache_exception_without_stale_is_not_cached():
     ttl_cache.clear()
     calls = 0


### PR DESCRIPTION
## Summary
- Lazily resolves dashboard, tool, and middleware package exports so webapp imports do not drag in the agent graph stack.
- Defers heavy `deepagents`, `exa_py`, and PR-review webapp imports to their call sites and adds subprocess import-hygiene guardrails.
- Adds timeout-bounded stale-while-revalidate caching for optional tool loaders while keeping loading on demand, avoiding webapp lifespan warmup contention.

## Import Time
| Entrypoint | Before | After |
|---|---:|---:|
| `agent.webapp` | ~1.53s local | ~0.72s local |
| `agent.server` | ~2.78s local | ~1.09s local |

## Closure Removals
- `agent.webapp`: `deepagents`, `anthropic`, `langchain_anthropic`, `openai`, `exa_py`, `agent.server`, `agent.middleware`, `agent.tools` are absent from the checked import closure.
- `agent.server`: `exa_py`, `agent.dashboard.routes`, and `agent.webapp` are absent from the checked import closure.

## Test Plan
- [x] `uv run pytest tests/test_import_hygiene.py -vvv`
- [x] `uv run pytest tests/test_github_issue_webhook.py::test_request_pr_review_tool_uses_shared_trigger tests/test_prepare_run_middleware.py::test_ttl_cache_stale_while_revalidate_refreshes_in_background -q`
- [x] `make lint`
- [x] `uv run pytest tests/ -x -q`
- [x] `uv run python -X importtime -c "import agent.webapp"`
- [x] `uv run python -X importtime -c "import agent.server"`

## Merge Note
If #1696 lands before this PR, reconcile its middleware exports into the lazy map: `TimeoutWrapupMiddleware -> .timeout_wrapup` and `task_on_failure` / `task_retry_on -> .task_retry`, plus `TYPE_CHECKING` and `__all__`. Re-run `tests/test_import_hygiene.py` after either merge order.

## Post-Deploy Validation
- [ ] `load_custom_app elapsed_seconds` in deployment logs drops from 6-9s to <= ~4s.
- [ ] "Slow graph load" warnings become rare and bounded by the new timeout/SWR behavior.
- [ ] `Run ... exceeded max attempts (6)` frequency drops. If it doesn't, check pod-level restart reasons and memory metrics; that is out of scope for this PR.