### PR TITLE
fix: fall back to core GitHub App scope when optional grants missing

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -119,8 +119,7 @@ from .utils.authorship import (
 from .utils.dashboard_links import dashboard_plan_url, dashboard_thread_url
 from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import (
-    BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
-    RUNTIME_PROXY_TOKEN_PERMISSIONS,
+    PROXY_TOKEN_PERMISSION_LADDER,
     PermissionMap,
     get_github_app_installation_token_with_expiry,
 )
@@ -235,18 +234,24 @@ async def _resolve_proxy_token(
         )
         return token, expires_at, permissions
 
-    token, expires_at = await get_github_app_installation_token_with_expiry(
-        permissions=RUNTIME_PROXY_TOKEN_PERMISSIONS,
-        log_errors=False,
-    )
-    if token:
-        return token, expires_at, RUNTIME_PROXY_TOKEN_PERMISSIONS
-
-    logger.warning("Retrying GitHub proxy token mint without optional Actions read permission")
-    token, expires_at = await get_github_app_installation_token_with_expiry(
-        permissions=BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS
-    )
-    return token, expires_at, BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS if token else None
+    # Walk from the richest scope to the guaranteed core so an installation that
+    # hasn't granted workflows:write / actions:read degrades instead of failing.
+    ladder = PROXY_TOKEN_PERMISSION_LADDER
+    last = len(ladder) - 1
+    for index, scope in enumerate(ladder):
+        token, expires_at = await get_github_app_installation_token_with_expiry(
+            permissions=scope,
+            log_errors=index == last,
+        )
+        if token:
+            if index:
+                logger.warning(
+                    "GitHub proxy token minted with reduced scope %s; installation is "
+                    "missing higher-privilege grants",
+                    sorted(scope),
+                )
+            return token, expires_at, scope
+    return None, None, None
 
 
 async def _resolve_snapshot_id_for_repo(repo: dict[str, str] | None) -> str | None:

--- a/agent/server.py
+++ b/agent/server.py
@@ -243,14 +243,15 @@ async def _resolve_proxy_token(
             permissions=scope,
             log_errors=index == last,
         )
-        if token:
-            if index:
-                logger.warning(
-                    "GitHub proxy token minted with reduced scope %s; installation is "
-                    "missing higher-privilege grants",
-                    sorted(scope),
-                )
-            return token, expires_at, scope
+        if not token:
+            continue
+        if index:
+            logger.warning(
+                "GitHub proxy token minted with reduced scope %s; installation is "
+                "missing higher-privilege grants",
+                sorted(scope),
+            )
+        return token, expires_at, scope
     return None, None, None
 
 

--- a/agent/utils/github_app.py
+++ b/agent/utils/github_app.py
@@ -26,17 +26,32 @@ GITHUB_APP_INSTALLATION_ID = os.environ.get("GITHUB_APP_INSTALLATION_ID", "")
 # 5-minute refresh window (``github_proxy.PROXY_TOKEN_REFRESH_WINDOW``) so a
 # near-expiry proxy refresh still mints a genuinely fresh token.
 _TOKEN_CACHE_MARGIN = timedelta(minutes=10)
-BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS: dict[str, str] = {
+# Granted on every installation at install time, so a token scoped to these
+# always mints — the terminal rung of the fallback ladder.
+CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS: dict[str, str] = {
     "contents": "write",
     "pull_requests": "write",
     "issues": "write",
     "checks": "write",
+}
+# `workflows:write` (workflow-file pushes) and `actions:read` (CI log reads) are
+# later additions an installation may not have accepted. GitHub 422s a mint that
+# requests an ungranted permission, so ``_resolve_proxy_token`` walks
+# ``PROXY_TOKEN_PERMISSION_LADDER`` high→low and degrades to what is granted
+# instead of failing the whole run.
+BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS: dict[str, str] = {
+    **CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
     "workflows": "write",
 }
 RUNTIME_PROXY_TOKEN_PERMISSIONS: dict[str, str] = {
     **BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
     "actions": "read",
 }
+PROXY_TOKEN_PERMISSION_LADDER: tuple[dict[str, str], ...] = (
+    RUNTIME_PROXY_TOKEN_PERMISSIONS,
+    BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+    CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+)
 
 PermissionMap = Mapping[str, str]
 PermissionKey = tuple[tuple[str, str], ...]

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -155,6 +155,27 @@ def test_runtime_proxy_token_permissions_include_workflows_and_optional_actions(
     assert github_app.RUNTIME_PROXY_TOKEN_PERMISSIONS.get("actions") != "write"
 
 
+def test_core_proxy_token_permissions_exclude_optional_grants() -> None:
+    """The terminal ladder rung must only ask for install-time permissions."""
+    core = github_app.CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS
+    assert "workflows" not in core
+    assert "actions" not in core
+    assert core["contents"] == "write"
+
+
+def test_proxy_token_ladder_descends_to_core() -> None:
+    """Ladder goes most→least privileged so a missing grant degrades gracefully."""
+    ladder = github_app.PROXY_TOKEN_PERMISSION_LADDER
+    assert ladder == (
+        github_app.RUNTIME_PROXY_TOKEN_PERMISSIONS,
+        github_app.BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+        github_app.CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+    )
+    assert [len(scope) for scope in ladder] == sorted(
+        (len(scope) for scope in ladder), reverse=True
+    )
+
+
 @pytest.mark.asyncio
 async def test_installation_token_includes_permissions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(github_app, "GITHUB_APP_ID", "1")

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -11,6 +11,8 @@ import pytest
 from agent.integrations.langsmith import _configure_github_proxy
 from agent.utils.github_app import (
     BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+    CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+    PROXY_TOKEN_PERMISSION_LADDER,
     RUNTIME_PROXY_TOKEN_PERMISSIONS,
 )
 
@@ -249,6 +251,59 @@ class TestCreateSandboxWithProxy:
                 repositories=None,
                 permissions=BASE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
             )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_core_when_workflows_grant_missing(self) -> None:
+        """An install lacking workflows:write must still mint a core-scoped token."""
+        with (
+            patch(
+                "agent.server.get_github_app_installation_token_with_expiry",
+                new_callable=AsyncMock,
+                side_effect=[(None, None), (None, None), ("ghs_install", "expires")],
+            ) as mock_get_token,
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
+            patch("agent.server.record_proxy_token_expiry") as mock_record,
+            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "LANGSMITH_API_KEY": "ls-key"}),
+        ):
+            mock_create.return_value = MagicMock(id="sandbox-123")
+
+            from agent.server import _create_sandbox_with_proxy
+
+            await _create_sandbox_with_proxy(thread_id="thread-123")
+
+            scopes = [call.kwargs["permissions"] for call in mock_get_token.await_args_list]
+            assert scopes == list(PROXY_TOKEN_PERMISSION_LADDER)
+            assert "workflows" not in scopes[-1]
+            mock_proxy.assert_called_once_with("sandbox-123", "ghs_install")
+            mock_record.assert_called_once_with(
+                "thread-123",
+                "expires",
+                repositories=None,
+                permissions=CORE_RUNTIME_PROXY_TOKEN_PERMISSIONS,
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_only_when_even_core_scope_fails(self) -> None:
+        """A hard failure requires every ladder rung — including core — to fail."""
+        with (
+            patch(
+                "agent.server.get_github_app_installation_token_with_expiry",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ) as mock_get_token,
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
+            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "LANGSMITH_API_KEY": "ls-key"}),
+        ):
+            mock_create.return_value = MagicMock(id="sandbox-123")
+
+            from agent.server import _create_sandbox_with_proxy
+
+            with pytest.raises(ValueError, match="installation token is unavailable"):
+                await _create_sandbox_with_proxy(thread_id="thread-123")
+
+            assert mock_get_token.await_count == len(PROXY_TOKEN_PERMISSION_LADDER)
 
     @pytest.mark.asyncio
     async def test_skips_proxy_for_non_langsmith(self) -> None:


### PR DESCRIPTION
## What

Proxy-token minting requested `workflows:write` (and `actions:read`) in the permission set used for **every** sandbox. GitHub returns 422 for a token request that asks for a permission the installation hasn't granted, so any installation without `workflows:write` failed to mint a token and **every run died in before-agent setup** with `Cannot configure proxy: GitHub App installation token is unavailable`.

`_resolve_proxy_token` now walks a permission ladder — `full → +workflows → core` — and returns the first scope that mints, recording the *granted* scope so hourly proxy refreshes stay consistent. A missing optional grant degrades to the install-time core scope (`contents`/`pull_requests`/`issues`/`checks`) instead of failing the run. It self-corrects: once an install grants `Workflows: write`, the top rung succeeds again with no redeploy.

## Tradeoff

On installs without `workflows:write`, the agent runs fully; only workflow-file HITL pushes fail at push time (`WorkflowPushGuardMiddleware`), which is the correct degradation given the permission genuinely isn't there.

## Test Plan

- [x] `uv run pytest tests/test_proxy_auth.py tests/test_github_app.py` — added ladder-descent, core-fallback, and all-rungs-fail cases
- [x] `make lint`