### PR TITLE
fix: link issue PRs and prompt repo conventions

### DIFF
--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -560,6 +560,15 @@ async def _build_source_reference_lines(configurable: dict[str, Any]) -> list[st
             lines.append(f"- Linear ticket: [{identifier or url}]({url})")
         elif identifier:
             lines.append(f"- Linear ticket: {identifier}")
+    elif source in ("github", "github_issue"):
+        github_issue = configurable.get("github_issue") or {}
+        url = github_issue.get("url")
+        number = github_issue.get("number")
+        if url:
+            label = f"#{number}" if number else url
+            lines.append(f"- GitHub issue: [{label}]({url})")
+        elif number:
+            lines.append(f"- GitHub issue: #{number}")
 
     return lines
 

--- a/agent/webhooks/github.py
+++ b/agent/webhooks/github.py
@@ -24,9 +24,11 @@ def build_github_issue_prompt(
     *,
     github_login: str,
     issue_author: str = "",
+    issue_url: str = "",
 ) -> str:
     """Build the user prompt for a GitHub issue-triggered run."""
     triggered_by_line = f"## Triggered by: {github_login}\n\n" if github_login else ""
+    issue_url_line = f"## Issue URL: {issue_url}\n\n" if issue_url else ""
     comments_text = webapp._build_github_issue_comments_text(comments)
     sanitized_title = webapp.sanitize_github_comment_body(title)
     formatted_body = webapp.format_github_comment_body_for_prompt(
@@ -37,10 +39,15 @@ def build_github_issue_prompt(
         f"## Repository: {repo_config.get('owner')}/{repo_config.get('name')}\n\n"
         f"{triggered_by_line}"
         f"## GitHub Issue: #{issue_number} - Issue ID: {issue_id}\n\n"
+        f"{issue_url_line}"
         f"## Title: {sanitized_title}\n\n"
         f"## Description:\n{formatted_body}\n"
         f"{comments_text}\n\n"
         "Please analyze this issue and implement the necessary changes. "
+        "If you open a PR for this issue, make sure the PR description links back to "
+        "this issue and follows this repository's PR conventions for the title, body, "
+        "release note, and/or changelog. Inspect AGENTS.md, PR templates, "
+        ".changelog/README.md, and nearby docs before choosing the PR title/body format. "
         "When you need to communicate on GitHub, use `GH_TOKEN=dummy gh issue comment` "
         "with the issue number."
     )
@@ -977,6 +984,7 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
             comments,
             github_login=github_login,
             issue_author=issue_author,
+            issue_url=issue_url,
         )
     configurable: dict[str, Any] = {
         "source": "github",

--- a/agent/webhooks/linear.py
+++ b/agent/webhooks/linear.py
@@ -144,6 +144,8 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         )
 
     identifier = full_issue.get("identifier", "") or issue_data.get("identifier", "")
+    ticket_url = full_issue.get("url", "") or issue_data.get("url", "")
+    ticket_url_line = f"## Linear Ticket URL: {ticket_url}\n\n" if ticket_url else ""
 
     triggered_by_line = f"## Triggered by: {user_name}\n\n" if user_name else ""
     tag_instruction = (
@@ -157,9 +159,14 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         f"## Title: {title}\n\n"
         f"{triggered_by_line}"
         f"## Linear Ticket: {identifier} - Ticket ID: {issue_id}\n\n"
+        f"{ticket_url_line}"
         f"## Description:\n{description}\n"
         f"{comments_text}\n\n"
-        f"Please analyze this issue and implement the necessary changes. "
+        "Please analyze this issue and implement the necessary changes. "
+        "If you open a PR for this issue, make sure the PR description links back to "
+        "this Linear ticket and follows this repository's PR conventions for the title, body, "
+        "release note, and/or changelog. Inspect AGENTS.md, PR templates, "
+        ".changelog/README.md, and nearby docs before choosing the PR title/body format. "
         f"When you're done, commit and push your changes. {tag_instruction}"
     )
     content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]

--- a/tests/test_github_issue_webhook.py
+++ b/tests/test_github_issue_webhook.py
@@ -77,11 +77,15 @@ def test_build_github_issue_prompt_includes_issue_context() -> None:
         "The test is failing intermittently.",
         [{"author": "octocat", "body": "Please take a look", "created_at": "2026-03-09T00:00:00Z"}],
         github_login="octocat",
+        issue_url="https://github.com/langchain-ai/open-swe/issues/42",
     )
 
     assert "Fix the flaky test" in prompt
     assert "The test is failing intermittently." in prompt
     assert "Please take a look" in prompt
+    assert "https://github.com/langchain-ai/open-swe/issues/42" in prompt
+    assert "PR description links back to this issue" in prompt
+    assert "repository's PR conventions" in prompt
     assert "GH_TOKEN=dummy gh issue comment" in prompt
 
 

--- a/tests/test_linear_webhook_author.py
+++ b/tests/test_linear_webhook_author.py
@@ -28,12 +28,15 @@ def _issue_data(*, user_email: str | None, user_name: str = "Zhen") -> dict:
     return data
 
 
-def _run_process(issue_data: dict, repo_config: dict[str, str]) -> tuple[dict, dict, str | None]:
+def _run_process(
+    issue_data: dict, repo_config: dict[str, str]
+) -> tuple[dict, dict, str | None, object]:
     captured: dict[str, Any] = {}
 
     async def fake_dispatch(
         thread_id, content, configurable, *, source, metadata=None, client=None
     ):
+        captured["content"] = content
         captured["configurable"] = configurable
         return {"run_id": "run-1"}
 
@@ -80,11 +83,12 @@ def _run_process(issue_data: dict, repo_config: dict[str, str]) -> tuple[dict, d
         captured.get("configurable", {}),
         captured.get("upsert", {}),
         captured.get("resolved_email"),
+        captured.get("content"),
     )
 
 
 def test_linear_configurable_carries_github_login() -> None:
-    configurable, _upsert, resolved_email = _run_process(
+    configurable, _upsert, resolved_email, _content = _run_process(
         _issue_data(user_email="zhen@example.com"),
         {"owner": "langchain-ai", "name": "open-swe"},
     )
@@ -96,7 +100,7 @@ def test_linear_configurable_carries_github_login() -> None:
 
 
 def test_linear_upsert_tags_thread_with_login() -> None:
-    _configurable, upsert, _email = _run_process(
+    _configurable, upsert, _email, _content = _run_process(
         _issue_data(user_email="zhen@example.com"),
         {"owner": "langchain-ai", "name": "open-swe"},
     )
@@ -106,7 +110,7 @@ def test_linear_upsert_tags_thread_with_login() -> None:
 
 
 def test_linear_omits_login_when_unmapped() -> None:
-    configurable, upsert, resolved_email = _run_process(
+    configurable, upsert, resolved_email, _content = _run_process(
         _issue_data(user_email="nobody@example.com"),
         {"owner": "langchain-ai", "name": "open-swe"},
     )
@@ -114,3 +118,16 @@ def test_linear_omits_login_when_unmapped() -> None:
     assert resolved_email == "nobody@example.com"
     assert "github_login" not in configurable
     assert upsert["github_login"] == ""
+
+
+def test_linear_issue_prompt_mentions_pr_references_and_conventions() -> None:
+    _configurable, _upsert, _email, content = _run_process(
+        _issue_data(user_email="zhen@example.com"),
+        {"owner": "langchain-ai", "name": "open-swe"},
+    )
+
+    prompt = content[0]["text"]
+    assert "https://linear.app/x/issue/OS-42" in prompt
+    assert "PR description links back to this Linear ticket" in prompt
+    assert "repository's PR conventions" in prompt
+    assert ".changelog/README.md" in prompt

--- a/tests/test_open_pull_request.py
+++ b/tests/test_open_pull_request.py
@@ -552,6 +552,31 @@ def test_appends_linear_reference_for_private_repo(monkeypatch: pytest.MonkeyPat
     assert "- Linear ticket: [AB-12](https://linear.app/x/AB-12)" in sent_body
 
 
+def test_appends_github_issue_reference_for_private_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_config(
+        monkeypatch,
+        {
+            "source": "github",
+            "github_issue": {
+                "url": "https://github.com/langchain-ai/open-swe/issues/42",
+                "number": 42,
+            },
+        },
+    )
+    _stub_token(monkeypatch)
+
+    client = _RoutingClient(
+        post=_FakeResponse(201, {"html_url": "u", "number": 1, "user": {}}),
+        get_routes={"/repos/langchain-ai/open-swe": _FakeResponse(200, {"private": True})},
+    )
+    _install_client(monkeypatch, client)
+
+    _open_with_body("body")
+
+    sent_body = client.post_calls[0]["json"]["body"]
+    assert "- GitHub issue: [#42](https://github.com/langchain-ai/open-swe/issues/42)" in sent_body
+
+
 def test_skips_append_when_no_source_context(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_config(monkeypatch, {"source": "slack"})
     _stub_token(monkeypatch)


### PR DESCRIPTION
## Description
Issue-triggered runs now explicitly tell the agent to link PRs back to the source issue and follow repository PR/changelog conventions. GitHub issue sources are also appended to PR References for private repos, matching Linear/Slack behavior.

## Test Plan
- [x] `uv run --project /workspace/open-swe pytest -q /workspace/open-swe/tests/test_github_issue_webhook.py::test_build_github_issue_prompt_includes_issue_context /workspace/open-swe/tests/test_linear_webhook_author.py /workspace/open-swe/tests/test_open_pull_request.py::test_appends_linear_reference_for_private_repo /workspace/open-swe/tests/test_open_pull_request.py::test_appends_github_issue_reference_for_private_repo --no-header --no-summary`
- [x] `uv run --project /workspace/open-swe pytest -q /workspace/open-swe/tests/test_github_comment_prompts.py::test_build_github_issue_prompt_only_wraps_external_comments --no-header --no-summary`
- [x] `make -C /workspace/open-swe lint`

Made by [Open SWE](https://openswe.vercel.app/agents/e60eb684-117f-3de1-b3b0-18f746deef4d)