### PR TITLE
fix: drop orphaned function_call when stale reasoning is stripped

### DIFF
--- a/agent/middleware/sanitize_openai_responses.py
+++ b/agent/middleware/sanitize_openai_responses.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, ToolMessage
 
 try:
     from langchain_openai import ChatOpenAI
@@ -46,21 +46,65 @@ def _is_stale_reasoning_reference(block: dict[str, Any]) -> bool:
     return isinstance(block_id, str) and block_id.startswith("rs_")
 
 
+def _sanitize_ai_message(message: AIMessage) -> tuple[int, set[str]]:
+    """Drop stale reasoning blocks and their dependent function_call blocks.
+
+    The Responses API requires a function_call item to be immediately preceded
+    by the reasoning item that produced it. If that reasoning item can't be
+    replayed (no encrypted_content to resume from), the function_call item
+    must be dropped too, or the request is rejected as malformed. Returns the
+    number of reasoning blocks removed and the set of ``call_id`` values for
+    any function_call blocks dropped this way, so their corresponding
+    ToolMessages can be removed as well.
+    """
+    content = []
+    removed_reasoning = 0
+    dropped_call_ids: set[str] = set()
+    dropping = False
+    for block in message.content:
+        if isinstance(block, dict) and _is_stale_reasoning_reference(block):
+            dropping = True
+            removed_reasoning += 1
+            continue
+        if dropping and isinstance(block, dict) and block.get("type") == "function_call":
+            call_id = block.get("call_id")
+            if isinstance(call_id, str):
+                dropped_call_ids.add(call_id)
+            continue
+        dropping = False
+        content.append(block)
+    if len(content) != len(message.content):
+        message.content = content
+    if dropped_call_ids and message.tool_calls:
+        message.tool_calls = [
+            tool_call
+            for tool_call in message.tool_calls
+            if tool_call.get("id") not in dropped_call_ids
+        ]
+    return removed_reasoning, dropped_call_ids
+
+
 def _sanitize_messages(messages: list[Any]) -> None:
-    removed = 0
+    removed_reasoning = 0
+    dropped_call_ids: set[str] = set()
     for message in messages:
         if not isinstance(message, AIMessage) or not isinstance(message.content, list):
             continue
-        content = []
-        for block in message.content:
-            if isinstance(block, dict) and _is_stale_reasoning_reference(block):
-                removed += 1
-                continue
-            content.append(block)
-        if len(content) != len(message.content):
-            message.content = content
-    if removed:
-        logger.warning("Removed %d stale OpenAI Responses reasoning reference(s)", removed)
+        message_removed, message_dropped = _sanitize_ai_message(message)
+        removed_reasoning += message_removed
+        dropped_call_ids |= message_dropped
+    if dropped_call_ids:
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if isinstance(message, ToolMessage) and message.tool_call_id in dropped_call_ids:
+                del messages[index]
+    if removed_reasoning:
+        logger.warning(
+            "Removed %d stale OpenAI Responses reasoning reference(s) and %d "
+            "dependent function_call/tool result(s)",
+            removed_reasoning,
+            len(dropped_call_ids),
+        )
 
 
 class SanitizeOpenAIResponsesMiddleware(AgentMiddleware):

--- a/tests/test_sanitize_openai_responses.py
+++ b/tests/test_sanitize_openai_responses.py
@@ -1,9 +1,9 @@
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from agent.middleware.sanitize_openai_responses import _sanitize_messages
 
 
-def test_sanitize_messages_drops_stale_reasoning_references() -> None:
+def test_sanitize_messages_drops_stale_reasoning_and_dependent_function_call() -> None:
     messages = [
         HumanMessage(content="review this"),
         AIMessage(
@@ -30,14 +30,16 @@ def test_sanitize_messages_drops_stale_reasoning_references() -> None:
                 }
             ],
         ),
+        ToolMessage(content="file contents", tool_call_id="call_123", name="read_file"),
     ]
 
     _sanitize_messages(messages)
 
     content = messages[1].content
     assert isinstance(content, list)
-    assert [block["type"] for block in content] == ["function_call"]
-    assert messages[1].tool_calls[0]["id"] == "call_123"
+    assert content == []
+    assert messages[1].tool_calls == []
+    assert len(messages) == 2
 
 
 def test_sanitize_messages_preserves_encrypted_reasoning() -> None:


### PR DESCRIPTION
## Description
`SanitizeOpenAIResponsesMiddleware` dropped stale (non-encrypted) `reasoning` blocks from replayed `AIMessage.content` but left the paired `function_call` block and `tool_calls` entry in place, orphaning it — OpenAI's Responses API then rejects the request with `Item 'fc_...' of type 'function_call' was provided without its required 'reasoning' item`. This reproduces intermittently on reviewer/agent runs using OpenAI reasoning models. Fix drops the dependent `function_call` block(s), the matching `tool_calls` entries, and any `ToolMessage` referencing the dropped call id, whenever a stale reasoning item is removed.

## Release Note
Fix intermittent 400 errors from OpenAI's Responses API caused by orphaned function_call items after reasoning-item cleanup.

## Test Plan
- [x] Updated `tests/test_sanitize_openai_responses.py` to assert the function_call block, tool_calls entry, and matching ToolMessage are all removed together with the stale reasoning item.
- [x] `pytest tests/test_sanitize_openai_responses.py tests/test_gateway.py`

Made by [Open SWE](https://openswe.vercel.app/agents/019f4298-34a7-7539-b6e4-00fbe534834d)