### PR TITLE
fix: collapse pasted text in history

### DIFF
--- a/ui/src/components/agents/messages/CollapsedUserText.test.ts
+++ b/ui/src/components/agents/messages/CollapsedUserText.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { collapsedUserTextSegments } from "./collapsedUserTextSegments"
+
+describe("collapsedUserTextSegments", () => {
+  it("leaves short text unchanged", () => {
+    expect(collapsedUserTextSegments("small prompt")).toEqual([
+      { type: "text", text: "small prompt" },
+    ])
+  })
+
+  it("collapses long single-block text", () => {
+    const text = "x".repeat(1_250)
+
+    expect(collapsedUserTextSegments(text)).toEqual([
+      { type: "pasted", text, label: "[Pasted 1.3k chars]" },
+    ])
+  })
+
+  it("preserves a short prompt prefix before collapsed text", () => {
+    const pasted = Array.from(
+      { length: 25 },
+      (_, index) => `line ${index}`
+    ).join("\n")
+    const text = `Please inspect this:\n${pasted}`
+
+    expect(collapsedUserTextSegments(text)).toEqual([
+      { type: "text", text: "Please inspect this:\n" },
+      { type: "pasted", text: pasted, label: "[Pasted 25 lines]" },
+    ])
+  })
+})

--- a/ui/src/components/agents/messages/CollapsedUserText.tsx
+++ b/ui/src/components/agents/messages/CollapsedUserText.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from "react"
+
+import { collapsedUserTextSegments } from "./collapsedUserTextSegments"
+
+export function CollapsedUserText({
+  text,
+  className,
+}: {
+  text: string
+  className?: string
+}) {
+  const segments = useMemo(() => collapsedUserTextSegments(text), [text])
+
+  return (
+    <div className={className}>
+      {segments.map((segment, index) =>
+        segment.type === "text" ? (
+          <span key={`${index}-text`}>{segment.text}</span>
+        ) : (
+          <span
+            key={`${index}-pasted`}
+            aria-label={`${segment.label} collapsed in message history`}
+            title="Pasted content is collapsed in message history"
+            className="inline-flex max-w-full items-center rounded-md border border-[var(--ui-border)] bg-[var(--ui-panel-2)] px-1.5 py-0.5 align-baseline font-mono text-[11px] leading-4 text-[color:var(--ui-text-muted)]"
+          >
+            {segment.label}
+          </span>
+        )
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/agents/messages/Messages.tsx
+++ b/ui/src/components/agents/messages/Messages.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { ChevronDown } from "lucide-react";
 
 import { AgentMessage } from "./AgentMessage";
+import { CollapsedUserText } from "./CollapsedUserText";
 import { ThinkingSpinner } from "./ThinkingSpinner";
 import { UserMessage } from "./UserMessage";
 import type { MessagesProps } from "./types";
@@ -32,7 +33,12 @@ function QueuedMessages({
               </span>
               <span className="h-1.5 w-1.5 rounded-full bg-[var(--ui-accent)]" />
             </div>
-            {message.content && <div className="whitespace-pre-wrap break-words">{message.content}</div>}
+            {message.content && (
+              <CollapsedUserText
+                text={message.content}
+                className="whitespace-pre-wrap break-words"
+              />
+            )}
             {imageCount > 0 && (
               <div className="mt-1 text-xs text-[color:var(--ui-text-muted)]">
                 {imageCount} image{imageCount === 1 ? "" : "s"} attached

--- a/ui/src/components/agents/messages/UserMessage.tsx
+++ b/ui/src/components/agents/messages/UserMessage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
+import { CollapsedUserText } from "./CollapsedUserText";
 import { MessageTimestamp } from "./MessageTimestamp";
 import type { Message } from "@/lib/agents/types";
 
@@ -60,7 +61,7 @@ export function UserMessage({ message }: { message: Message }) {
                 WebkitMaskImage: textEdgeMask,
               }}
             >
-              {text}
+              <CollapsedUserText text={text} />
             </div>
           </div>
         )}

--- a/ui/src/components/agents/messages/collapsedUserTextSegments.ts
+++ b/ui/src/components/agents/messages/collapsedUserTextSegments.ts
@@ -1,0 +1,75 @@
+const COLLAPSE_CHAR_THRESHOLD = 1_200
+const COLLAPSE_LINE_THRESHOLD = 24
+const LEADING_CONTEXT_CHAR_LIMIT = 240
+
+interface TextSegment {
+  type: "text"
+  text: string
+}
+
+interface PastedSegment {
+  type: "pasted"
+  text: string
+  label: string
+}
+
+type CollapsedUserTextSegment = TextSegment | PastedSegment
+
+function lineCount(text: string): number {
+  if (!text) return 0
+  return text.split(/\r\n|\r|\n/).length
+}
+
+function shouldCollapse(text: string): boolean {
+  return (
+    text.length >= COLLAPSE_CHAR_THRESHOLD ||
+    lineCount(text) >= COLLAPSE_LINE_THRESHOLD
+  )
+}
+
+function compactNumber(value: number): string {
+  if (value < 1_000) return String(value)
+  const rounded = Math.round(value / 100) / 10
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}k`
+}
+
+function pastedLabel(text: string): string {
+  const lines = lineCount(text)
+  if (lines >= COLLAPSE_LINE_THRESHOLD) {
+    return `[Pasted ${compactNumber(lines)} lines]`
+  }
+  return `[Pasted ${compactNumber(text.length)} chars]`
+}
+
+function leadingContextLength(text: string): number {
+  const paragraphBreak = /\n\s*\n/.exec(text)
+  if (
+    paragraphBreak?.index &&
+    paragraphBreak.index <= LEADING_CONTEXT_CHAR_LIMIT
+  ) {
+    return paragraphBreak.index + paragraphBreak[0].length
+  }
+
+  const firstNewline = text.indexOf("\n")
+  if (firstNewline > 0 && firstNewline <= LEADING_CONTEXT_CHAR_LIMIT) {
+    return firstNewline + 1
+  }
+
+  return 0
+}
+
+export function collapsedUserTextSegments(
+  text: string
+): Array<CollapsedUserTextSegment> {
+  if (!shouldCollapse(text)) return [{ type: "text", text }]
+
+  const prefixLength = leadingContextLength(text)
+  const prefix = text.slice(0, prefixLength)
+  const pasted = text.slice(prefixLength).trim()
+  if (!pasted) return [{ type: "text", text }]
+
+  return [
+    ...(prefix ? [{ type: "text" as const, text: prefix }] : []),
+    { type: "pasted" as const, text: pasted, label: pastedLabel(pasted) },
+  ]
+}


### PR DESCRIPTION
## Description
Collapses large pasted user-message text in thread history and queued previews into `[Pasted …]` chips while preserving short lead-in text. Adds a shared segmentation helper and focused unit coverage.

## Release Note
none

## Test Plan
- [x] `pnpm --dir /workspace/open-swe/ui exec vitest run src/components/agents/messages/CollapsedUserText.test.ts --no-color`
- [x] `pnpm --dir /workspace/open-swe/ui run typecheck`
- [ ] `pnpm --dir /workspace/open-swe/ui run lint` (blocked: `eslint` not found after install)

Made by [Open SWE](https://openswe.vercel.app/agents/88623171-b000-d848-f5b6-1d07aa609081)