### PR TITLE
feat: add GPT-5.6 OpenAI models

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -135,14 +135,14 @@ See `deepagents.backends.LangSmithSandbox` and `agent/integrations/langsmith.py`
 
 ## 2. Model
 
-The model is configured in the `get_agent()` function in `agent/server.py`. By default it uses `openai:gpt-5.5` with medium reasoning effort, but you can override the model with the `LLM_MODEL_ID` environment variable:
+The model is configured in the `get_agent()` function in `agent/server.py`. By default it uses `openai:gpt-5.6-sol` with medium reasoning effort, but you can override the model with the `LLM_MODEL_ID` environment variable:
 
 ```bash
 # Set the model via environment variable (uses provider:model format)
 LLM_MODEL_ID="anthropic:claude-sonnet-5"
 ```
 
-If `LLM_MODEL_ID` is not set, the default model (`openai:gpt-5.5`) is used.
+If `LLM_MODEL_ID` is not set, the default model (`openai:gpt-5.6-sol`) is used.
 
 `max_tokens` is a maximum completion/output token budget, not the model's total context window. For OpenAI reasoning models, this budget can include both internal reasoning tokens and final response tokens.
 
@@ -155,7 +155,7 @@ Use the `provider:model` format:
 model=make_model("anthropic:claude-sonnet-5", temperature=0, max_tokens=16_000)
 
 # OpenAI (uses Responses API by default)
-model=make_model("openai:gpt-5.5", max_tokens=128_000, reasoning={"effort": "medium"})
+model=make_model("openai:gpt-5.6-sol", max_tokens=128_000, reasoning={"effort": "medium"})
 
 # Google
 model=make_model("google_genai:gemini-2.5-pro", temperature=0, max_tokens=16_000)
@@ -187,7 +187,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         model = make_model("anthropic:claude-sonnet-5", temperature=0, max_tokens=16_000)
     else:
         # Full model for code changes from Linear
-        model = make_model("openai:gpt-5.5", max_tokens=128_000, reasoning={"effort": "medium"})
+        model = make_model("openai:gpt-5.6-sol", max_tokens=128_000, reasoning={"effort": "medium"})
     
     return create_deep_agent(model=model, ...)
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Rather than forking an existing agent or building from scratch, Open SWE **compo
 
 ```python
 create_deep_agent(
-    model="openai:gpt-5.5",
+    model="openai:gpt-5.6-sol",
     system_prompt=construct_system_prompt(...),
     tools=[http_request, fetch_url, linear_comment, slack_thread_reply],
     backend=sandbox_backend,

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -36,8 +36,22 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": True,
     },
     {
-        "id": "openai:gpt-5.5",
-        "label": "GPT-5.5",
+        "id": "openai:gpt-5.6-sol",
+        "label": "GPT-5.6 Sol",
+        "efforts": ["none", "low", "medium", "high", "xhigh"],
+        "default_effort": "xhigh",
+        "supports_images": True,
+    },
+    {
+        "id": "openai:gpt-5.6-terra",
+        "label": "GPT-5.6 Terra",
+        "efforts": ["none", "low", "medium", "high", "xhigh"],
+        "default_effort": "xhigh",
+        "supports_images": True,
+    },
+    {
+        "id": "openai:gpt-5.6-luna",
+        "label": "GPT-5.6 Luna",
         "efforts": ["none", "low", "medium", "high", "xhigh"],
         "default_effort": "xhigh",
         "supports_images": True,
@@ -101,7 +115,7 @@ def gate_fable_model(
     return model_id, effort
 
 
-DEFAULT_MODEL_ID: str = "openai:gpt-5.5"
+DEFAULT_MODEL_ID: str = "openai:gpt-5.6-sol"
 DEFAULT_MODEL_EFFORT: str = "medium"
 
 

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import httpx
 from langgraph_sdk import get_client
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, model_validator
 
 from ..encryption import decrypt_token, encrypt_token
 from .oauth import (
@@ -27,7 +27,7 @@ from .oauth import (
     is_unrecoverable_refresh_error,
     refresh_user_access_token,
 )
-from .options import SUPPORTED_MODEL_IDS, model_supports_effort
+from .options import SUPPORTED_MODEL_IDS, model_supports_effort, provider_fallback_pair
 
 logger = logging.getLogger(__name__)
 
@@ -47,12 +47,20 @@ class ProfileUpdate(BaseModel):
     create_prs: bool = False
     review_draft_prs: bool | None = None
 
-    @field_validator("default_model")
-    @classmethod
-    def _model_supported(cls, v: str) -> str:
-        if v not in SUPPORTED_MODEL_IDS:
-            raise ValueError(f"unsupported model: {v}")
-        return v
+    @model_validator(mode="after")
+    def _normalize_stale_model_pairs(self) -> ProfileUpdate:
+        self.default_model, self.reasoning_effort = _normalize_stale_model_pair(
+            self.default_model,
+            self.reasoning_effort,
+        )
+        if self.default_subagent_model is not None:
+            self.default_subagent_model, self.subagent_reasoning_effort = (
+                _normalize_stale_model_pair(
+                    self.default_subagent_model,
+                    self.subagent_reasoning_effort,
+                )
+            )
+        return self
 
     def validate_pairing(self) -> None:
         if not model_supports_effort(self.default_model, self.reasoning_effort):
@@ -73,6 +81,36 @@ class ProfileUpdate(BaseModel):
                 f"effort {self.subagent_reasoning_effort!r} not supported by "
                 f"{self.default_subagent_model!r}"
             )
+
+
+def _normalize_stale_model_pair(model: str, effort: str | None) -> tuple[str, str | None]:
+    if model in SUPPORTED_MODEL_IDS or effort is None:
+        return model, effort
+    fallback = provider_fallback_pair(model, effort)
+    if fallback is None:
+        return model, effort
+    return fallback
+
+
+def normalize_profile_for_response(profile: dict[str, Any]) -> dict[str, Any]:
+    value = dict(profile)
+    model = value.get("default_model")
+    effort = value.get("reasoning_effort")
+    if isinstance(model, str):
+        value["default_model"], value["reasoning_effort"] = _normalize_stale_model_pair(
+            model,
+            effort if isinstance(effort, str) else None,
+        )
+    subagent_model = value.get("default_subagent_model")
+    subagent_effort = value.get("subagent_reasoning_effort")
+    if isinstance(subagent_model, str):
+        value["default_subagent_model"], value["subagent_reasoning_effort"] = (
+            _normalize_stale_model_pair(
+                subagent_model,
+                subagent_effort if isinstance(subagent_effort, str) else None,
+            )
+        )
+    return value
 
 
 def _client():

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -64,6 +64,7 @@ from .profiles import (
     ProfileUpdate,
     get_profile,
     get_valid_access_token,
+    normalize_profile_for_response,
     upsert_access_token_from_github_response,
     upsert_profile,
 )
@@ -454,7 +455,9 @@ async def get_my_profile(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     profile = await get_profile(session["sub"])
-    return profile or {}
+    if not profile:
+        return {}
+    return normalize_profile_for_response(profile)
 
 
 @router.put("/profile")

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -157,7 +157,7 @@ def fallback_model_id_for(primary_model_id: str) -> str | None:
     local, or self-hosted providers we don't want to silently route off-host).
     """
     if primary_model_id.startswith("anthropic:"):
-        return "openai:gpt-5.5"
+        return "openai:gpt-5.6-sol"
     if primary_model_id.startswith("openai:"):
         return "anthropic:claude-opus-4-8"
     return None

--- a/evals/reviewer/config.toml
+++ b/evals/reviewer/config.toml
@@ -9,7 +9,7 @@ langsmith_project = "open-swe-evals"
 # Leave blank to use LANGGRAPH_URL or local dev.
 langgraph_url = ""
 assistant_id = "reviewer"
-# models: openai:gpt-5.5, anthropic:claude-opus-4-8, google_genai:gemini-3.5-flash
+# models: openai:gpt-5.6-sol, anthropic:claude-opus-4-8, google_genai:gemini-3.5-flash
 model_id = "google_genai:gemini-3.5-flash"
 reasoning_effort = "medium"
 

--- a/tests/test_agent_assembly_context.py
+++ b/tests/test_agent_assembly_context.py
@@ -61,7 +61,7 @@ async def _capture_create_deep_agent_kwargs() -> dict[str, object]:
         patch(
             "agent.server.get_team_default_model_pair",
             new_callable=AsyncMock,
-            return_value=(("openai:gpt-5.5", "medium"), ("openai:gpt-5.5", "low")),
+            return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
         ),
         patch("agent.server.load_profile", new_callable=AsyncMock, return_value=None),
         patch("agent.server.fallback_model_id_for", return_value=None),

--- a/tests/test_agent_subagent_models.py
+++ b/tests/test_agent_subagent_models.py
@@ -50,7 +50,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
         patch(
             "agent.server.get_team_default_model_pair",
             new_callable=AsyncMock,
-            return_value=(("openai:gpt-5.5", "medium"), ("openai:gpt-5.5", "low")),
+            return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
         ),
         patch(
             "agent.server.load_profile",
@@ -58,7 +58,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
             return_value={
                 "default_model": "anthropic:claude-opus-4-8",
                 "reasoning_effort": "high",
-                "default_subagent_model": "openai:gpt-5.5",
+                "default_subagent_model": "openai:gpt-5.6-sol",
                 "subagent_reasoning_effort": "xhigh",
             },
         ),
@@ -81,7 +81,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
     assert main_call.kwargs["effort"] == "high"
 
     subagent_call = make_model.call_args_list[1]
-    assert subagent_call.args == ("openai:gpt-5.5",)
+    assert subagent_call.args == ("openai:gpt-5.6-sol",)
     assert subagent_call.kwargs["reasoning"] == {"effort": "xhigh", "summary": "auto"}
 
 
@@ -123,7 +123,7 @@ async def test_agent_subagent_inherits_profile_model_override_without_explicit_p
         patch(
             "agent.server.get_team_default_model_pair",
             new_callable=AsyncMock,
-            return_value=(("openai:gpt-5.5", "medium"), ("openai:gpt-5.5", "low")),
+            return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
         ),
         patch(
             "agent.server.load_profile",
@@ -188,7 +188,7 @@ async def test_agent_gate_swaps_disabled_fable_profile_to_opus() -> None:
         patch(
             "agent.server.get_team_default_model_pair",
             new_callable=AsyncMock,
-            return_value=(("openai:gpt-5.5", "medium"), ("openai:gpt-5.5", "low")),
+            return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
         ),
         # Profile selected Fable back when it was allowed; it's now disabled.
         patch(

--- a/tests/test_check_message_queue.py
+++ b/tests/test_check_message_queue.py
@@ -106,7 +106,7 @@ async def test_build_blocks_skips_images_for_text_only_model() -> None:
 @pytest.mark.asyncio
 async def test_build_blocks_includes_images_for_vision_model() -> None:
     payload: dict[str, Any] = {"text": "see this", "image_urls": []}
-    blocks = await _build_blocks_from_payload(payload, model_id="openai:gpt-5.5")
+    blocks = await _build_blocks_from_payload(payload, model_id="openai:gpt-5.6-sol")
     assert blocks == [{"type": "text", "text": "see this"}]
 
 

--- a/tests/test_corridor_mcp.py
+++ b/tests/test_corridor_mcp.py
@@ -155,7 +155,7 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
                 server,
                 "get_team_default_model_pair",
                 new_callable=AsyncMock,
-                return_value=(("openai:gpt-5.5", "medium"), ("openai:gpt-5.5", "low")),
+                return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
             ),
             patch.object(server, "fallback_model_id_for", return_value=None),
             patch.object(server, "make_model", return_value=MagicMock()),

--- a/tests/test_dashboard_thread_api.py
+++ b/tests/test_dashboard_thread_api.py
@@ -11,9 +11,9 @@ from agent.dashboard.agent_overrides import resolve_agent_model_id
 from agent.dashboard.options import model_supports_images
 
 _TEXT_ONLY_MODEL = "fireworks:accounts/fireworks/models/deepseek-v4-pro"
-_VISION_MODEL = "openai:gpt-5.5"
+_VISION_MODEL = "openai:gpt-5.6-sol"
 _FABLE = "anthropic:claude-fable-5"
-_PAIR = ("openai:gpt-5.5", "medium")
+_PAIR = ("openai:gpt-5.6-sol", "medium")
 
 
 def _image() -> thread_api.DashboardImageBody:

--- a/tests/test_dashboard_thread_api.py
+++ b/tests/test_dashboard_thread_api.py
@@ -1431,6 +1431,26 @@ async def test_status_filter_refreshes_threads_missing_run_status(monkeypatch) -
 
 
 @pytest.mark.asyncio
+async def test_get_my_profile_normalizes_stale_openai_models() -> None:
+    with patch(
+        "agent.dashboard.routes.get_profile",
+        new_callable=AsyncMock,
+        return_value={
+            "default_model": "openai:gpt-5.5",
+            "reasoning_effort": "medium",
+            "default_subagent_model": "openai:gpt-5.5",
+            "subagent_reasoning_effort": "low",
+        },
+    ):
+        payload = await routes.get_my_profile({"sub": "octocat"})
+
+    assert payload["default_model"] == "openai:gpt-5.6-sol"
+    assert payload["reasoning_effort"] == "medium"
+    assert payload["default_subagent_model"] == "openai:gpt-5.6-sol"
+    assert payload["subagent_reasoning_effort"] == "low"
+
+
+@pytest.mark.asyncio
 async def test_options_omits_fable_when_disabled() -> None:
     with (
         patch(

--- a/tests/test_dashboard_web_handoff.py
+++ b/tests/test_dashboard_web_handoff.py
@@ -282,7 +282,7 @@ async def test_dashboard_followup_on_busy_thread_queues_images(
     metadata = {
         "source": "dashboard",
         "github_login": "octocat",
-        "resolved_model": "openai:gpt-5.5",
+        "resolved_model": "openai:gpt-5.6-sol",
     }
     client = _FakeClient(metadata)
     queued_messages: list[object] = []
@@ -345,7 +345,7 @@ async def test_dashboard_followup_on_busy_text_only_thread_rejects_images(
             thread_api.ThreadMessageBody(
                 content="continue in web",
                 images=[thread_api.DashboardImageBody(base64="aW1hZ2U=", mimeType="image/png")],
-                model_id="openai:gpt-5.5",
+                model_id="openai:gpt-5.6-sol",
                 effort="medium",
             ),
         )

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -37,7 +37,7 @@ def test_openai_overrides_use_responses_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    overrides = gateway.gateway_overrides("openai:gpt-5.5")
+    overrides = gateway.gateway_overrides("openai:gpt-5.6-sol")
     assert overrides == {
         "base_url": "https://gateway.smith.langchain.com/openai/v1",
         "api_key": "ls-key",
@@ -48,7 +48,7 @@ def test_openai_overrides_use_responses_by_default(
 def test_openai_overrides_chat_completions_optout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     monkeypatch.setenv("LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES", "false")
-    overrides = gateway.gateway_overrides("openai:gpt-5.5")
+    overrides = gateway.gateway_overrides("openai:gpt-5.6-sol")
     assert overrides is not None
     assert overrides["use_responses_api"] is False
 
@@ -65,7 +65,7 @@ async def test_openai_sdk_uses_gateway_responses_path() -> None:
                 "object": "response",
                 "created_at": 0,
                 "status": "completed",
-                "model": "gpt-5.5",
+                "model": "gpt-5.6-sol",
                 "output": [
                     {
                         "id": "msg_test",
@@ -82,7 +82,7 @@ async def test_openai_sdk_uses_gateway_responses_path() -> None:
     http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     try:
         chat_model = ChatOpenAI(
-            model="gpt-5.5",
+            model="gpt-5.6-sol",
             api_key="dummy",
             base_url="https://gateway.smith.langchain.com/openai/v1",
             use_responses_api=True,
@@ -254,7 +254,7 @@ def test_unsupported_provider_passes_through(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_missing_api_key_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
-    assert gateway.gateway_overrides("openai:gpt-5.5") is None
+    assert gateway.gateway_overrides("openai:gpt-5.6-sol") is None
 
 
 def test_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -331,7 +331,7 @@ def _capture_init_chat_model() -> tuple[dict[str, Any], Any]:
 def test_make_model_direct_openai_uses_responses_websocket() -> None:
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("openai:gpt-5.5", use_gateway=False)
+        model.make_model("openai:gpt-5.6-sol", use_gateway=False)
     assert captured["base_url"] == model.OPENAI_RESPONSES_WS_BASE_URL
     assert captured["use_responses_api"] is True
     assert captured["store"] is False
@@ -344,7 +344,7 @@ def test_make_model_gateway_openai_replaces_websocket(
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("openai:gpt-5.5", use_gateway=True)
+        model.make_model("openai:gpt-5.6-sol", use_gateway=True)
     assert captured["base_url"] == "https://gateway.smith.langchain.com/openai/v1"
     assert captured["use_responses_api"] is True
     assert captured["store"] is False
@@ -360,7 +360,7 @@ def test_make_model_gateway_openai_chat_completions_optout_converts_reasoning(
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
         model.make_model(
-            "openai:gpt-5.5",
+            "openai:gpt-5.6-sol",
             use_gateway=True,
             reasoning={"effort": "high", "summary": "auto"},
         )
@@ -378,7 +378,7 @@ def test_make_model_gateway_openai_preserves_reasoning_none(
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
         model.make_model(
-            "openai:gpt-5.5",
+            "openai:gpt-5.6-sol",
             use_gateway=True,
             reasoning={"effort": "none"},
         )
@@ -396,7 +396,7 @@ def test_make_model_gateway_openai_responses_keeps_reasoning(
     reasoning = {"effort": "high", "summary": "auto"}
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("openai:gpt-5.5", use_gateway=True, reasoning=reasoning)
+        model.make_model("openai:gpt-5.6-sol", use_gateway=True, reasoning=reasoning)
     assert captured["use_responses_api"] is True
     assert captured["store"] is False
     assert captured["include"] == ["reasoning.encrypted_content"]
@@ -428,7 +428,7 @@ def test_make_model_gateway_without_key_falls_back_direct(
 ) -> None:
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("openai:gpt-5.5", use_gateway=True)  # no LangSmith key
+        model.make_model("openai:gpt-5.6-sol", use_gateway=True)  # no LangSmith key
     # No key -> overrides skipped -> the direct-provider websocket base stands.
     assert captured["base_url"] == model.OPENAI_RESPONSES_WS_BASE_URL
     assert captured["use_responses_api"] is True

--- a/tests/test_model_fallback_resolution.py
+++ b/tests/test_model_fallback_resolution.py
@@ -6,6 +6,8 @@ from agent.dashboard.agent_overrides import normalize_profile_overrides
 from agent.dashboard.options import (
     DEFAULT_MODEL_ID,
     FABLE_MODEL_IDS,
+    SUPPORTED_MODEL_IDS,
+    SUPPORTED_MODELS,
     default_model_pair,
     fable_disabled_fallback,
     gate_fable_model,
@@ -28,8 +30,18 @@ def test_provider_fallback_uses_default_effort_when_unsupported() -> None:
 
 def test_provider_fallback_resolves_openai_within_provider() -> None:
     model, effort = provider_fallback_pair("openai:gpt-5-legacy", "low")
-    assert model.startswith("openai:")
+    assert model == "openai:gpt-5.6-sol"
     assert effort == "low"
+
+
+def test_supported_openai_models_replace_gpt_5_5() -> None:
+    assert "openai:gpt-5.5" not in SUPPORTED_MODEL_IDS
+    openai_options = [model for model in SUPPORTED_MODELS if model["id"].startswith("openai:")]
+    assert [(model["id"], model["label"]) for model in openai_options] == [
+        ("openai:gpt-5.6-sol", "GPT-5.6 Sol"),
+        ("openai:gpt-5.6-terra", "GPT-5.6 Terra"),
+        ("openai:gpt-5.6-luna", "GPT-5.6 Luna"),
+    ]
 
 
 @pytest.mark.parametrize("model_id", ["unknown:model", "no-colon", "", None, 123])
@@ -99,8 +111,8 @@ def test_gate_fable_swaps_to_opus_when_disabled() -> None:
 
 
 def test_gate_fable_leaves_non_fable_ids_alone() -> None:
-    assert gate_fable_model("openai:gpt-5.5", "high", fable_enabled=False) == (
-        "openai:gpt-5.5",
+    assert gate_fable_model("openai:gpt-5.6-sol", "high", fable_enabled=False) == (
+        "openai:gpt-5.6-sol",
         "high",
     )
 

--- a/tests/test_model_fallback_resolution.py
+++ b/tests/test_model_fallback_resolution.py
@@ -13,6 +13,7 @@ from agent.dashboard.options import (
     gate_fable_model,
     provider_fallback_pair,
 )
+from agent.dashboard.profiles import ProfileUpdate, normalize_profile_for_response
 from agent.dashboard.team_settings import get_team_default_model
 
 STALE_ANTHROPIC = "anthropic:claude-opus-4-7"
@@ -80,6 +81,46 @@ async def test_team_default_unknown_provider_falls_back_to_global() -> None:
 def test_profile_stale_anthropic_upgrades_to_supported() -> None:
     profile = {"default_model": STALE_ANTHROPIC, "reasoning_effort": "high"}
     assert normalize_profile_overrides(profile) == (SUPPORTED_ANTHROPIC, "high")
+
+
+def test_profile_update_normalizes_stale_openai_model() -> None:
+    update = ProfileUpdate(default_model="openai:gpt-5.5", reasoning_effort="medium")
+    update.validate_pairing()
+    assert update.default_model == "openai:gpt-5.6-sol"
+    assert update.reasoning_effort == "medium"
+
+
+def test_profile_update_normalizes_stale_openai_subagent_model() -> None:
+    update = ProfileUpdate(
+        default_model="openai:gpt-5.6-terra",
+        reasoning_effort="high",
+        default_subagent_model="openai:gpt-5.5",
+        subagent_reasoning_effort="low",
+    )
+    update.validate_pairing()
+    assert update.default_subagent_model == "openai:gpt-5.6-sol"
+    assert update.subagent_reasoning_effort == "low"
+
+
+def test_profile_response_normalizes_stale_openai_models() -> None:
+    profile = normalize_profile_for_response(
+        {
+            "default_model": "openai:gpt-5.5",
+            "reasoning_effort": "medium",
+            "default_subagent_model": "openai:gpt-5.5",
+            "subagent_reasoning_effort": "low",
+        }
+    )
+    assert profile["default_model"] == "openai:gpt-5.6-sol"
+    assert profile["reasoning_effort"] == "medium"
+    assert profile["default_subagent_model"] == "openai:gpt-5.6-sol"
+    assert profile["subagent_reasoning_effort"] == "low"
+
+
+def test_profile_update_rejects_unknown_provider() -> None:
+    update = ProfileUpdate(default_model="mystery:model", reasoning_effort="high")
+    with pytest.raises(ValueError, match="not supported"):
+        update.validate_pairing()
 
 
 def test_profile_without_model_defers_to_team_default() -> None:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -322,7 +322,7 @@ async def test_reviewer_applies_eval_model_and_effort_overrides() -> None:
             "head_sha": "head",
             "reviewer_model_id": "anthropic:claude-opus-4-8",
             "reviewer_reasoning_effort": "high",
-            "reviewer_subagent_model_id": "openai:gpt-5.5",
+            "reviewer_subagent_model_id": "openai:gpt-5.6-sol",
             "reviewer_subagent_reasoning_effort": "low",
         },
         "metadata": {},
@@ -355,7 +355,7 @@ async def test_reviewer_applies_eval_model_and_effort_overrides() -> None:
     assert main_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert main_model_call.kwargs["effort"] == "high"
     subagent_model_call = make_model.call_args_list[1]
-    assert subagent_model_call.args == ("openai:gpt-5.5",)
+    assert subagent_model_call.args == ("openai:gpt-5.6-sol",)
     assert subagent_model_call.kwargs["reasoning"] == {"effort": "low", "summary": "auto"}
 
 

--- a/tests/test_reviewer_eval_run.py
+++ b/tests/test_reviewer_eval_run.py
@@ -111,7 +111,7 @@ def test_load_env_config_reads_all_supported_keys() -> None:
         "LANGGRAPH_URL": "https://lg.env",
         "LANGSMITH_PROJECT": "project-env",
         "REVIEWER_ASSISTANT_ID": "reviewer-env",
-        "REVIEWER_EVAL_MODEL_ID": "openai:gpt-5.5",
+        "REVIEWER_EVAL_MODEL_ID": "openai:gpt-5.6-sol",
         "REVIEWER_EVAL_REASONING_EFFORT": "xhigh",
         "REVIEWER_EVAL_SCORE_MODE": "surfaced_findings",
         "REVIEWER_EVAL_SEVERITY_THRESHOLD": "critical",
@@ -125,7 +125,7 @@ def test_load_env_config_reads_all_supported_keys() -> None:
         "langgraph_url": "https://lg.env",
         "langsmith_project": "project-env",
         "assistant_id": "reviewer-env",
-        "model_id": "openai:gpt-5.5",
+        "model_id": "openai:gpt-5.6-sol",
         "reasoning_effort": "xhigh",
         "score_mode": "surfaced_findings",
         "severity_threshold": "critical",
@@ -159,13 +159,13 @@ def test_resolve_config_prefers_cli_then_env_then_toml() -> None:
         config = _resolve_config(
             {
                 "experiment_prefix": "experiment-cli",
-                "model_id": "openai:gpt-5.5",
+                "model_id": "openai:gpt-5.6-sol",
                 "reasoning_effort": "xhigh",
             }
         )
 
     assert config["dataset_name"] == "dataset-config"
     assert config["experiment_prefix"] == "experiment-cli"
-    assert config["model_id"] == "openai:gpt-5.5"
+    assert config["model_id"] == "openai:gpt-5.6-sol"
     assert config["reasoning_effort"] == "xhigh"
     assert config["langsmith_project"] == "project-env"

--- a/tests/test_team_settings_fable.py
+++ b/tests/test_team_settings_fable.py
@@ -105,10 +105,10 @@ def test_disable_transition_coerces_all_fable_defaults() -> None:
 def test_update_leaves_non_fable_defaults_untouched_when_disabled() -> None:
     # Coercion only rewrites Fable ids; other selections pass through unchanged.
     update = TeamSettingsUpdate(
-        default_agent_model="openai:gpt-5.5",
+        default_agent_model="openai:gpt-5.6-sol",
         default_agent_reasoning_effort="medium",
     )
-    assert update.default_agent_model == "openai:gpt-5.5"
+    assert update.default_agent_model == "openai:gpt-5.6-sol"
     assert update.default_agent_reasoning_effort == "medium"
 
 

--- a/tests/test_team_settings_grouping.py
+++ b/tests/test_team_settings_grouping.py
@@ -10,7 +10,7 @@ from agent.dashboard.team_settings import (
     get_team_default_grouping_model,
 )
 
-_REVIEWER_SUBAGENT_PAIR = ("openai:gpt-5.5", "low")
+_REVIEWER_SUBAGENT_PAIR = ("openai:gpt-5.6-sol", "low")
 _GROUPING_PAIR = ("google_genai:gemini-3.5-flash", "low")
 
 


### PR DESCRIPTION
## Description
Adds GPT-5.6 Sol, Terra, and Luna to the supported OpenAI model options, replacing the retired GPT-5.5 defaults and fallbacks across docs and tests. Stale saved GPT-5.5 profile selections are normalized on read/save so users can update unrelated settings after the model retirement.

## Release Note
OpenAI model options now use GPT-5.6 Sol/Terra/Luna instead of GPT-5.5.

## Test Plan
- [ ] Verify GPT-5.6 Sol, Terra, and Luna appear in dashboard model selectors.
- [ ] Verify a profile previously saved with GPT-5.5 can save unrelated settings and is shown as GPT-5.6 Sol.

Made by [Open SWE](https://openswe.vercel.app/agents/019f47e0-f0bc-772f-a46f-8ab5738b063e)