### PR TITLE
fix: stale admin model defaults after model upgrades

### DIFF
--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -95,6 +95,39 @@ class TeamSettingsUpdate(BaseModel):
 
     @model_validator(mode="after")
     def _validate_model_pairs(self) -> TeamSettingsUpdate:
+        self.default_agent_model, self.default_agent_reasoning_effort = _normalize_stale_model_pair(
+            self.default_agent_model,
+            self.default_agent_reasoning_effort,
+        )
+        self.default_agent_subagent_model, self.default_agent_subagent_reasoning_effort = (
+            _normalize_stale_model_pair(
+                self.default_agent_subagent_model,
+                self.default_agent_subagent_reasoning_effort,
+            )
+        )
+        self.default_reviewer_model, self.default_reviewer_reasoning_effort = (
+            _normalize_stale_model_pair(
+                self.default_reviewer_model,
+                self.default_reviewer_reasoning_effort,
+            )
+        )
+        (
+            self.default_reviewer_subagent_model,
+            self.default_reviewer_subagent_reasoning_effort,
+        ) = _normalize_stale_model_pair(
+            self.default_reviewer_subagent_model,
+            self.default_reviewer_subagent_reasoning_effort,
+        )
+        self.default_grouping_model, self.default_grouping_reasoning_effort = (
+            _normalize_stale_model_pair(
+                self.default_grouping_model,
+                self.default_grouping_reasoning_effort,
+            )
+        )
+        self.default_chat_model, self.default_chat_reasoning_effort = _normalize_stale_model_pair(
+            self.default_chat_model,
+            self.default_chat_reasoning_effort,
+        )
         _validate_model_effort_pair(
             self.default_agent_model, self.default_agent_reasoning_effort, "agent"
         )
@@ -151,6 +184,37 @@ def _validate_model_effort_pair(model: str | None, effort: str | None, role: str
         raise ValueError(f"unsupported {role} model: {model}")
     if effort is None or not model_supports_effort(model, effort):
         raise ValueError(f"effort {effort!r} not supported by {role} model {model!r}")
+
+
+def _normalize_stale_model_pair(
+    model: str | None, effort: str | None
+) -> tuple[str | None, str | None]:
+    if model is None or model in SUPPORTED_MODEL_IDS or effort is None:
+        return model, effort
+    return provider_fallback_pair(model, effort) or (model, effort)
+
+
+_MODEL_PAIR_FIELDS: tuple[tuple[str, str], ...] = (
+    ("default_agent_model", "default_agent_reasoning_effort"),
+    ("default_agent_subagent_model", "default_agent_subagent_reasoning_effort"),
+    ("default_reviewer_model", "default_reviewer_reasoning_effort"),
+    ("default_reviewer_subagent_model", "default_reviewer_subagent_reasoning_effort"),
+    ("default_grouping_model", "default_grouping_reasoning_effort"),
+    ("default_chat_model", "default_chat_reasoning_effort"),
+)
+
+
+def normalize_team_settings_for_response(settings: dict[str, Any]) -> dict[str, Any]:
+    value = dict(settings)
+    for model_field, effort_field in _MODEL_PAIR_FIELDS:
+        model = value.get(model_field)
+        effort = value.get(effort_field)
+        if isinstance(model, str):
+            value[model_field], value[effort_field] = _normalize_stale_model_pair(
+                model,
+                effort if isinstance(effort, str) else None,
+            )
+    return value
 
 
 def _client():
@@ -226,7 +290,7 @@ async def get_team_settings() -> dict[str, Any]:
         "review_author_context_enabled",
     ):
         merged.pop(stale_field, None)
-    return merged
+    return normalize_team_settings_for_response(merged)
 
 
 async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -186,12 +186,17 @@ def _validate_model_effort_pair(model: str | None, effort: str | None, role: str
         raise ValueError(f"effort {effort!r} not supported by {role} model {model!r}")
 
 
+_RETIRED_MODEL_REPLACEMENTS: dict[str, str] = {
+    "openai:gpt-5.5": "openai:gpt-5.6-sol",
+}
+
+
 def _normalize_stale_model_pair(
     model: str | None, effort: str | None
 ) -> tuple[str | None, str | None]:
-    if model is None or model in SUPPORTED_MODEL_IDS or effort is None:
+    if model is None:
         return model, effort
-    return provider_fallback_pair(model, effort) or (model, effort)
+    return _RETIRED_MODEL_REPLACEMENTS.get(model, model), effort
 
 
 _MODEL_PAIR_FIELDS: tuple[tuple[str, str], ...] = (

--- a/tests/test_model_fallback_resolution.py
+++ b/tests/test_model_fallback_resolution.py
@@ -14,7 +14,11 @@ from agent.dashboard.options import (
     provider_fallback_pair,
 )
 from agent.dashboard.profiles import ProfileUpdate, normalize_profile_for_response
-from agent.dashboard.team_settings import get_team_default_model
+from agent.dashboard.team_settings import (
+    TeamSettingsUpdate,
+    get_team_default_model,
+    normalize_team_settings_for_response,
+)
 
 STALE_ANTHROPIC = "anthropic:claude-opus-4-7"
 SUPPORTED_ANTHROPIC = "anthropic:claude-opus-4-8"
@@ -115,6 +119,40 @@ def test_profile_response_normalizes_stale_openai_models() -> None:
     assert profile["reasoning_effort"] == "medium"
     assert profile["default_subagent_model"] == "openai:gpt-5.6-sol"
     assert profile["subagent_reasoning_effort"] == "low"
+
+
+def test_team_settings_update_normalizes_stale_openai_models() -> None:
+    update = TeamSettingsUpdate(
+        default_agent_model="openai:gpt-5.6-sol",
+        default_agent_reasoning_effort="medium",
+        default_agent_subagent_model="openai:gpt-5.5",
+        default_agent_subagent_reasoning_effort="medium",
+        default_reviewer_model="openai:gpt-5.5",
+        default_reviewer_reasoning_effort="medium",
+        default_reviewer_subagent_model="openai:gpt-5.5",
+        default_reviewer_subagent_reasoning_effort="low",
+    )
+
+    assert update.default_agent_subagent_model == "openai:gpt-5.6-sol"
+    assert update.default_reviewer_model == "openai:gpt-5.6-sol"
+    assert update.default_reviewer_subagent_model == "openai:gpt-5.6-sol"
+
+
+def test_team_settings_response_normalizes_stale_openai_models() -> None:
+    settings = normalize_team_settings_for_response(
+        {
+            "default_agent_subagent_model": "openai:gpt-5.5",
+            "default_agent_subagent_reasoning_effort": "medium",
+            "default_reviewer_model": "openai:gpt-5.5",
+            "default_reviewer_reasoning_effort": "medium",
+            "default_reviewer_subagent_model": "openai:gpt-5.5",
+            "default_reviewer_subagent_reasoning_effort": "low",
+        }
+    )
+
+    assert settings["default_agent_subagent_model"] == "openai:gpt-5.6-sol"
+    assert settings["default_reviewer_model"] == "openai:gpt-5.6-sol"
+    assert settings["default_reviewer_subagent_model"] == "openai:gpt-5.6-sol"
 
 
 def test_profile_update_rejects_unknown_provider() -> None:

--- a/tests/test_model_fallback_resolution.py
+++ b/tests/test_model_fallback_resolution.py
@@ -138,6 +138,22 @@ def test_team_settings_update_normalizes_stale_openai_models() -> None:
     assert update.default_reviewer_subagent_model == "openai:gpt-5.6-sol"
 
 
+def test_team_settings_update_rejects_unknown_openai_model() -> None:
+    with pytest.raises(ValueError, match="unsupported agent model"):
+        TeamSettingsUpdate(
+            default_agent_model="openai:gpt-5.6-slo",
+            default_agent_reasoning_effort="medium",
+        )
+
+
+def test_team_settings_update_rejects_invalid_effort_for_retired_model() -> None:
+    with pytest.raises(ValueError, match="effort 'bogus' not supported"):
+        TeamSettingsUpdate(
+            default_agent_model="openai:gpt-5.5",
+            default_agent_reasoning_effort="bogus",
+        )
+
+
 def test_team_settings_response_normalizes_stale_openai_models() -> None:
     settings = normalize_team_settings_for_response(
         {


### PR DESCRIPTION
## Summary
- normalize retired team model IDs to supported same-provider fallbacks before validation
- return normalized team settings so the admin page always submits a valid payload
- cover stale GPT-5.5 admin defaults in regression tests

## Test plan
- [x] `uv run pytest -q tests/`
- [x] `uv run ruff check agent/dashboard/team_settings.py tests/test_model_fallback_resolution.py`