### PR TITLE
feat: keep agent todos above chat input

### DIFF
--- a/ui/src/components/agents/AgentThreadView.tsx
+++ b/ui/src/components/agents/AgentThreadView.tsx
@@ -18,7 +18,9 @@ import {
 import { AgentPromptBar } from "@/components/agents/AgentPromptBar"
 import { WorkflowApprovalCard } from "@/components/agents/WorkflowApprovalCard"
 import { Messages } from "@/components/agents/messages"
+import { TodoList } from "@/components/agents/ported/TodoList"
 import { streamMessagesToUi } from "@/lib/agents/streamMessagesToUi"
+import { todosFromState } from "@/lib/agents/todos"
 import { messageArrivalTimestamp } from "@/lib/agents/messageTimestamps"
 import { useSubmitAgentMessage } from "@/lib/agents/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/lib/agents/provider/useModelOptions"
@@ -27,6 +29,10 @@ import { cn } from "@/lib/utils"
 
 interface AgentThreadViewProps {
   thread: AgentThread
+}
+
+interface AgentThreadState {
+  todos?: unknown
 }
 
 function messageText(message: Message): string {
@@ -71,7 +77,7 @@ function visibleQueuedMessages(
 // survives the home → thread navigation), so this view only consumes it.
 export function AgentThreadView({ thread }: AgentThreadViewProps) {
   const sendMessage = useSubmitAgentMessage(thread.id)
-  const stream = useAgentThreadStream()
+  const stream = useAgentThreadStream<AgentThreadState>()
   const isMobile = useIsMobile()
 
   const { models, defaultSelection } = useModelOptions()
@@ -113,6 +119,10 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
     if (thread.messages.length > 0) return thread.messages
     return live
   }, [stream.messages, stream.toolCalls, stream.subagents, thread.messages])
+  const todos = useMemo(
+    () => todosFromState(stream.values.todos),
+    [stream.values.todos]
+  )
 
   const isStreaming = thread.status === "running" || stream.isLoading
   const queuedMessages = useMemo(
@@ -185,11 +195,23 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
               settingUpSandbox={settingUpSandbox}
               contentWidthClass="max-w-3xl"
             />
+            {todos.length > 0 && (
+              <div className="shrink-0 px-4">
+                <div className="mx-auto -mb-2 w-full max-w-3xl min-w-0">
+                  <TodoList
+                    todos={todos}
+                    runActive={isStreaming}
+                    className="rounded-t-xl rounded-b-none pb-2"
+                  />
+                </div>
+              </div>
+            )}
             <div className="shrink-0 px-4 pb-4">
               <div className="mx-auto w-full max-w-3xl min-w-0">
                 <AgentPromptBar
                   placeholder="Add a follow up"
                   compact
+                  connectedTop={todos.length > 0}
                   busy={isStreaming}
                   onSubmit={(content, images) =>
                     sendMessage.mutateAsync({

--- a/ui/src/components/agents/ported/CloudPromptBar.tsx
+++ b/ui/src/components/agents/ported/CloudPromptBar.tsx
@@ -129,6 +129,7 @@ export interface CloudPromptBarProps {
   /** When provided, a Plan mode toggle is shown. Plan mode researches read-only and proposes a plan before editing. */
   planMode?: boolean
   onPlanModeChange?: (next: boolean) => void
+  connectedTop?: boolean
 }
 
 function fileToImageChunk(file: File): Promise<ImageChunk | null> {
@@ -172,6 +173,7 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
   onRepoChange,
   planMode = false,
   onPlanModeChange,
+  connectedTop = false,
 }: CloudPromptBarProps) {
   const [value, setValue] = useState("")
   const [pendingImages, setPendingImages] = useState<Array<ImageChunk>>([])
@@ -364,6 +366,7 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
         className={cn(
           "relative flex min-h-[106px] flex-col rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2.5 shadow-sm",
           compact && "min-h-[88px]",
+          connectedTop && "-mt-px rounded-t-none border-t-0",
           isDragOver && "border-[var(--ui-accent)]"
         )}
       >

--- a/ui/src/components/agents/ported/TodoList.tsx
+++ b/ui/src/components/agents/ported/TodoList.tsx
@@ -29,12 +29,14 @@ function StatusIcon({ status }: { status: TodoItem["status"] }) {
 const MAX_HEIGHT = 160;
 
 export function TodoList({ todos, className = "", runActive = false }: TodoListProps) {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(!runActive);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevRunActiveRef = useRef(runActive);
 
   useEffect(() => {
-    if (prevRunActiveRef.current && !runActive) {
+    if (!prevRunActiveRef.current && runActive) {
+      setCollapsed(false);
+    } else if (prevRunActiveRef.current && !runActive) {
       setCollapsed(true);
     }
     prevRunActiveRef.current = runActive;

--- a/ui/src/lib/agents/streamMessagesToUi.test.ts
+++ b/ui/src/lib/agents/streamMessagesToUi.test.ts
@@ -1,0 +1,22 @@
+import { AIMessage } from "@langchain/core/messages"
+import { expect, it } from "vitest"
+
+import { streamMessagesToUi } from "./streamMessagesToUi"
+
+it("omits write_todos calls from transcript work", () => {
+  const message = new AIMessage({
+    content: "",
+    tool_calls: [
+      {
+        id: "tool-todos",
+        name: "write_todos",
+        args: {
+          todos: [{ content: "Render todos", status: "in_progress" }],
+        },
+        type: "tool_call",
+      },
+    ],
+  })
+
+  expect(streamMessagesToUi([message])).toEqual([])
+})

--- a/ui/src/lib/agents/streamMessagesToUi.ts
+++ b/ui/src/lib/agents/streamMessagesToUi.ts
@@ -378,7 +378,7 @@ export function streamMessagesToUi(
 
       for (const toolCall of raw.tool_calls ?? []) {
         const name = toolCall.name || "tool";
-        if (INTERNAL_TOOLS.has(name)) continue;
+        if (INTERNAL_TOOLS.has(name) || name.toLowerCase() === "write_todos") continue;
         const toolCallId = toolCall.id || `tool-${index}-${chunks.length}`;
         const args = parseToolArgs(toolCall.args);
         const assembled = toolCallsById.get(toolCallId);

--- a/ui/src/lib/agents/todos.test.ts
+++ b/ui/src/lib/agents/todos.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { todosFromState } from "./todos"
+
+describe("todosFromState", () => {
+  it("returns validated todo state", () => {
+    expect(
+      todosFromState([
+        { content: "Inspect the UI", status: "completed" },
+        { content: "Render todos", status: "in_progress" },
+      ])
+    ).toEqual([
+      { content: "Inspect the UI", status: "completed" },
+      { content: "Render todos", status: "in_progress" },
+    ])
+  })
+
+  it("rejects malformed todo state", () => {
+    expect(todosFromState([{ content: "Broken", status: "unknown" }])).toEqual(
+      []
+    )
+    expect(todosFromState({ todos: [] })).toEqual([])
+  })
+})

--- a/ui/src/lib/agents/todos.ts
+++ b/ui/src/lib/agents/todos.ts
@@ -1,0 +1,22 @@
+import type { TodoItem } from "./types"
+
+export function todosFromState(value: unknown): Array<TodoItem> {
+  if (!Array.isArray(value)) return []
+
+  const todos: Array<TodoItem> = []
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return []
+    const { content, status } = item as Record<string, unknown>
+    if (
+      typeof content !== "string" ||
+      !content.trim() ||
+      (status !== "pending" &&
+        status !== "in_progress" &&
+        status !== "completed")
+    ) {
+      return []
+    }
+    todos.push({ content: content.trim(), status })
+  }
+  return todos
+}


### PR DESCRIPTION
## Description
Render authoritative `stream.values.todos` in a persistent panel above the chat input, with active/finished collapse behavior. Hide `write_todos` calls from collapsed transcript work and strictly validate todo state before rendering.
## Release Note
Agent todos now remain visible above the dashboard chat input.
## Test Plan
- [x] `pnpm run typecheck`
- [x] Focused Vitest (3 tests; exit 0 with Vite shutdown warnings); `git diff --check`
- [ ] `pnpm run lint` unavailable because the installed tree has no `eslint` binary

Made by [Open SWE](https://openswe.vercel.app/agents/ba2baec6-27cb-4b99-43a7-7c2a2208f509)