### PR TITLE
feat: add agent observability with Monocle

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -135,6 +135,9 @@ from .utils.sandbox_state import (
 )
 from .utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
 
+from monocle_apptrace import setup_monocle_telemetry
+setup_monocle_telemetry(workflow_name="open-swe", monocle_exporters_list="file")
+
 client = get_client()
 
 DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS = 5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "langchain-google-genai>=4.2.4",
     "langchain-mcp-adapters>=0.2.2",
     "stagehand>=3.21.0",
+    "monocle_apptrace",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds Monocle observability to the agent. Monocle is an OpenTelemetry-based tracer for LLM applications. With it enabled, each run is recorded as a structured trace: the agent and graph invocations, tool calls, LLM inferences, token usage, and timings. The change is additive and does not alter application logic.

## What this adds

Instrumentation is one setup call plus one dependency:

- `pyproject.toml`: adds `monocle_apptrace`.
- `agent/server.py`: calls `setup_monocle_telemetry(workflow_name="open-swe", monocle_exporters_list="file")` at startup.

That call auto-instruments the frameworks already in use (LangGraph and the LLM clients), so there is no per-tool or per-call wiring to maintain. Traces are written to `.monocle/` by default.

## What you get

Each run produces a trace of all the agents and tools that were triggered: which agents ran, which tools were called (`read_file`, `search_repo_code`, `web_search`), and what LLM inferences happened. In effect, it's the path the agent took to answer a given request. This is useful for developers building the agent, since they can see how it actually behaved on a run. The same traces are also a good basis for a behavioral test suite, an integration test that asserts on that behavior, and I've opened a companion PR that shows how that works: [behavioral test suite](https://github.com/langchain-ai/open-swe/pull/1716). You can open the trace files directly, view them in the [Monocle VS Code extension](https://marketplace.visualstudio.com/items?itemName=OkahuAI.monocle-apptrace), or send them to [Okahu](https://www.okahu.ai) for analysis across many runs.


---

## Example trace (Okahu VS Code Extension)

Open SWE's LangGraph agent reading and searching the repo (`read_file`, `search_repo_code`, `web_search`) captured as trace spans.

<img width="1710" height="1076" alt="image" src="https://github.com/user-attachments/assets/b29c313f-f564-4fc8-916e-113f39abea2e" />





---

PS: if Monocle looks useful, a ⭐ helps the project (https://github.com/monocle2ai/monocle). And if you want to turn these traces into tests, that's the companion PR (#1716).
