### PR TITLE
fix: sanitize orphaned OpenAI tool results

### DIFF
--- a/agent/middleware/sanitize_openai_responses.py
+++ b/agent/middleware/sanitize_openai_responses.py
@@ -1,4 +1,4 @@
-"""Middleware that removes stale OpenAI Responses reasoning references."""
+"""Middleware that sanitizes replayed OpenAI Responses history."""
 
 from __future__ import annotations
 
@@ -46,6 +46,20 @@ def _is_stale_reasoning_reference(block: dict[str, Any]) -> bool:
     return isinstance(block_id, str) and block_id.startswith("rs_")
 
 
+def _content_tool_call(block: dict[str, Any]) -> tuple[bool, str | None]:
+    """Return whether a content block is a tool call and its call ID."""
+    if block.get("type") == "non_standard" and isinstance(block.get("value"), dict):
+        block = block["value"]
+    block_type = block.get("type")
+    if block_type == "tool_call":
+        call_id = block.get("id")
+    elif block_type in ("function_call", "custom_tool_call", "computer_call"):
+        call_id = block.get("call_id")
+    else:
+        return False, None
+    return True, call_id if isinstance(call_id, str) else None
+
+
 def _sanitize_ai_message(message: AIMessage) -> tuple[int, set[str]]:
     """Drop stale reasoning blocks and their dependent function_call blocks.
 
@@ -66,38 +80,82 @@ def _sanitize_ai_message(message: AIMessage) -> tuple[int, set[str]]:
             dropping = True
             removed_reasoning += 1
             continue
-        if dropping and isinstance(block, dict) and block.get("type") == "function_call":
-            call_id = block.get("call_id")
-            if isinstance(call_id, str):
-                dropped_call_ids.add(call_id)
-            continue
+        if dropping and isinstance(block, dict):
+            is_tool_call, call_id = _content_tool_call(block)
+            if is_tool_call:
+                if call_id is not None:
+                    dropped_call_ids.add(call_id)
+                continue
         dropping = False
         content.append(block)
     if len(content) != len(message.content):
         message.content = content
+    if removed_reasoning:
+        content_call_ids: set[str] = set()
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            _, call_id = _content_tool_call(block)
+            if call_id is not None:
+                content_call_ids.add(call_id)
+        dropped_call_ids.update(
+            call_id
+            for tool_call in (*message.tool_calls, *message.invalid_tool_calls)
+            if isinstance(call_id := tool_call.get("id"), str) and call_id not in content_call_ids
+        )
     if dropped_call_ids and message.tool_calls:
         message.tool_calls = [
             tool_call
             for tool_call in message.tool_calls
             if tool_call.get("id") not in dropped_call_ids
         ]
+    if dropped_call_ids and message.invalid_tool_calls:
+        message.invalid_tool_calls = [
+            tool_call
+            for tool_call in message.invalid_tool_calls
+            if tool_call.get("id") not in dropped_call_ids
+        ]
     return removed_reasoning, dropped_call_ids
+
+
+def _assistant_tool_call_ids(message: AIMessage) -> set[str]:
+    """Return every tool call ID that the Responses API can replay."""
+    call_ids = {
+        call_id
+        for tool_call in (*message.tool_calls, *message.invalid_tool_calls)
+        if isinstance(call_id := tool_call.get("id"), str)
+    }
+    if isinstance(message.content, list):
+        for block in message.content:
+            if not isinstance(block, dict):
+                continue
+            _, call_id = _content_tool_call(block)
+            if call_id is not None:
+                call_ids.add(call_id)
+    return call_ids
 
 
 def _sanitize_messages(messages: list[Any]) -> None:
     removed_reasoning = 0
     dropped_call_ids: set[str] = set()
+    valid_call_ids: set[str] = set()
+    sanitized_messages = []
+    removed_orphans = 0
     for message in messages:
-        if not isinstance(message, AIMessage) or not isinstance(message.content, list):
+        if isinstance(message, AIMessage):
+            if isinstance(message.content, list):
+                message_removed, message_dropped = _sanitize_ai_message(message)
+                removed_reasoning += message_removed
+                dropped_call_ids |= message_dropped
+            valid_call_ids |= _assistant_tool_call_ids(message)
+        elif isinstance(message, ToolMessage) and message.tool_call_id not in valid_call_ids:
+            removed_orphans += 1
             continue
-        message_removed, message_dropped = _sanitize_ai_message(message)
-        removed_reasoning += message_removed
-        dropped_call_ids |= message_dropped
-    if dropped_call_ids:
-        for index in range(len(messages) - 1, -1, -1):
-            message = messages[index]
-            if isinstance(message, ToolMessage) and message.tool_call_id in dropped_call_ids:
-                del messages[index]
+        sanitized_messages.append(message)
+
+    if removed_orphans:
+        messages[:] = sanitized_messages
+
     if removed_reasoning:
         logger.warning(
             "Removed %d stale OpenAI Responses reasoning reference(s) and %d "
@@ -105,10 +163,15 @@ def _sanitize_messages(messages: list[Any]) -> None:
             removed_reasoning,
             len(dropped_call_ids),
         )
+    if removed_orphans:
+        logger.warning(
+            "Removed %d OpenAI tool result(s) without matching function calls",
+            removed_orphans,
+        )
 
 
 class SanitizeOpenAIResponsesMiddleware(AgentMiddleware):
-    """Drop non-replayable OpenAI Responses reasoning item references."""
+    """Drop non-replayable reasoning references and orphaned tool results."""
 
     async def awrap_model_call(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "langchain-anthropic>=1.4.6",
     "langgraph-cli[inmem]>=0.4.30",
     "langsmith==0.9.8",
-    "langchain-openai>=1.3.3",
+    "langchain-openai>=1.3.4",
     "langchain-fireworks>=1.4.4",
     # langchain-fireworks 1.4.2 pins a pre-release fireworks-ai; opt in explicitly so uv resolves it.
     "fireworks-ai>=1.2.0a86",

--- a/tests/test_sanitize_openai_responses.py
+++ b/tests/test_sanitize_openai_responses.py
@@ -42,6 +42,145 @@ def test_sanitize_messages_drops_stale_reasoning_and_dependent_function_call() -
     assert len(messages) == 2
 
 
+def test_sanitize_messages_drops_stale_reasoning_and_invalid_tool_call() -> None:
+    messages = [
+        HumanMessage(content="review this"),
+        AIMessage(
+            content=[
+                {"type": "reasoning", "id": "rs_123", "summary": [], "content": []},
+                {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_invalid",
+                    "name": "read_file",
+                    "arguments": "{",
+                },
+            ],
+            invalid_tool_calls=[
+                {
+                    "name": "read_file",
+                    "args": "{",
+                    "id": "call_invalid",
+                    "error": "invalid JSON",
+                    "type": "invalid_tool_call",
+                }
+            ],
+        ),
+        ToolMessage(content="tool error", tool_call_id="call_invalid", name="read_file"),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert messages[1].content == []
+    assert messages[1].invalid_tool_calls == []
+    assert len(messages) == 2
+
+
+def test_sanitize_messages_drops_stale_reasoning_and_tool_calls_only() -> None:
+    messages = [
+        AIMessage(
+            content=[{"type": "reasoning", "id": "rs_123", "summary": [], "content": []}],
+            tool_calls=[{"name": "read_file", "args": {}, "id": "call_tool_only"}],
+        ),
+        ToolMessage(
+            content="file contents",
+            tool_call_id="call_tool_only",
+            name="read_file",
+        ),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert messages[0].content == []
+    assert messages[0].tool_calls == []
+    assert len(messages) == 1
+
+
+def test_sanitize_messages_drops_stale_reasoning_and_invalid_tool_calls_only() -> None:
+    messages = [
+        AIMessage(
+            content=[{"type": "reasoning", "id": "rs_123", "summary": [], "content": []}],
+            invalid_tool_calls=[
+                {
+                    "name": "read_file",
+                    "args": "{",
+                    "id": "call_invalid_only",
+                    "error": "invalid JSON",
+                    "type": "invalid_tool_call",
+                }
+            ],
+        ),
+        ToolMessage(
+            content="tool error",
+            tool_call_id="call_invalid_only",
+            name="read_file",
+        ),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert messages[0].content == []
+    assert messages[0].invalid_tool_calls == []
+    assert len(messages) == 1
+
+
+def test_sanitize_messages_drops_stale_reasoning_and_v1_tool_call() -> None:
+    messages = [
+        HumanMessage(content="review this"),
+        AIMessage(
+            content=[
+                {"type": "reasoning", "id": "rs_123", "summary": [], "content": []},
+                {
+                    "type": "tool_call",
+                    "id": "call_v1",
+                    "name": "read_file",
+                    "args": {},
+                },
+            ],
+            tool_calls=[{"name": "read_file", "args": {}, "id": "call_v1"}],
+        ),
+        ToolMessage(content="file contents", tool_call_id="call_v1", name="read_file"),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert messages[1].content == []
+    assert messages[1].tool_calls == []
+    assert len(messages) == 2
+
+
+def test_sanitize_messages_drops_stale_reasoning_and_non_standard_call() -> None:
+    messages = [
+        HumanMessage(content="review this"),
+        AIMessage(
+            content=[
+                {"type": "reasoning", "id": "rs_123", "summary": [], "content": []},
+                {
+                    "type": "non_standard",
+                    "value": {
+                        "type": "function_call",
+                        "call_id": "call_non_standard",
+                        "name": "read_file",
+                        "arguments": "{}",
+                    },
+                },
+            ],
+            tool_calls=[{"name": "read_file", "args": {}, "id": "call_non_standard"}],
+        ),
+        ToolMessage(
+            content="file contents",
+            tool_call_id="call_non_standard",
+            name="read_file",
+        ),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert messages[1].content == []
+    assert messages[1].tool_calls == []
+    assert len(messages) == 2
+
+
 def test_sanitize_messages_preserves_encrypted_reasoning() -> None:
     reasoning = {
         "type": "reasoning",
@@ -55,3 +194,123 @@ def test_sanitize_messages_preserves_encrypted_reasoning() -> None:
     _sanitize_messages(messages)
 
     assert messages[0].content == [reasoning]
+
+
+def test_sanitize_messages_drops_reverse_orphaned_tool_result() -> None:
+    messages = [
+        HumanMessage(content="continue"),
+        ToolMessage(content="orphaned result", tool_call_id="call_orphan", name="grep"),
+        HumanMessage(content="pick up where you left off"),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert messages == [
+        HumanMessage(content="continue"),
+        HumanMessage(content="pick up where you left off"),
+    ]
+
+
+def test_sanitize_messages_preserves_matched_tool_result() -> None:
+    messages = [
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "grep", "args": {}, "id": "call_matched"}],
+        ),
+        ToolMessage(content="matched result", tool_call_id="call_matched", name="grep"),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert len(messages) == 2
+    assert isinstance(messages[1], ToolMessage)
+
+
+def test_sanitize_messages_recognizes_responses_function_call_blocks() -> None:
+    messages = [
+        AIMessage(
+            content=[
+                {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_content_block",
+                    "name": "grep",
+                    "arguments": "{}",
+                }
+            ]
+        ),
+        ToolMessage(
+            content="matched result",
+            tool_call_id="call_content_block",
+            name="grep",
+        ),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert len(messages) == 2
+    assert isinstance(messages[1], ToolMessage)
+
+
+def test_sanitize_messages_recognizes_v1_tool_call_blocks() -> None:
+    messages = [
+        AIMessage(
+            content=[
+                {
+                    "type": "tool_call",
+                    "id": "call_v1",
+                    "name": "grep",
+                    "args": {},
+                }
+            ]
+        ),
+        ToolMessage(content="matched result", tool_call_id="call_v1", name="grep"),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert len(messages) == 2
+    assert isinstance(messages[1], ToolMessage)
+
+
+def test_sanitize_messages_recognizes_non_standard_function_call_blocks() -> None:
+    messages = [
+        AIMessage(
+            content=[
+                {
+                    "type": "non_standard",
+                    "value": {
+                        "type": "function_call",
+                        "call_id": "call_non_standard",
+                        "name": "grep",
+                        "arguments": "{}",
+                    },
+                }
+            ]
+        ),
+        ToolMessage(
+            content="matched result",
+            tool_call_id="call_non_standard",
+            name="grep",
+        ),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert len(messages) == 2
+    assert isinstance(messages[1], ToolMessage)
+
+
+def test_sanitize_messages_requires_tool_call_to_precede_result() -> None:
+    messages = [
+        ToolMessage(content="early result", tool_call_id="call_late", name="grep"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "grep", "args": {}, "id": "call_late"}],
+        ),
+    ]
+
+    _sanitize_messages(messages)
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], AIMessage)

--- a/uv.lock
+++ b/uv.lock
@@ -1452,7 +1452,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.4.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1465,9 +1465,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/b9/e937d0a90b26540bff07e7a7c64349f3b29c2dcc36257cd1cd3fdce17f2a/langchain_core-1.4.9.tar.gz", hash = "sha256:f8078901145bed0466755277500a5a22822a7b628808c4c0a28d4fc88895fcf2", size = 967294, upload-time = "2026-07-08T20:06:54.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
+    { url = "https://files.pythonhosted.org/packages/84/70/ade2fada52772798ef815b6352b59e71b116aa0c32c3aef5be3dc2cbed12/langchain_core-1.4.9-py3-none-any.whl", hash = "sha256:28e3909e2a10cc81504952d795ac0a9e014c0018121ef89d48dd396fa09ec624", size = 558293, upload-time = "2026-07-08T20:06:52.382Z" },
 ]
 
 [[package]]
@@ -1556,16 +1556,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.3.3"
+version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/f3/b38e052f943a75ba0e6762c0a50b6f1d6bcd52a9ce63386d8803c2ff506e/langchain_openai-1.3.3.tar.gz", hash = "sha256:143769bf943820b80db769e47ca8fd0aac08ed18714519333b044c4431e9aa67", size = 3256559, upload-time = "2026-06-22T22:54:05.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/fe/cfd11b9ebc54f7667e3c8f847f64246fad169ad998b8a08d7c3c9d9bccaf/langchain_openai-1.3.4.tar.gz", hash = "sha256:d888d5f39c2a8c3d0d8aa88f5cf50e58a8e7d242f3f15e39422add520eec8e31", size = 3258207, upload-time = "2026-07-08T22:59:50.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/4b/7520114de1ce36bb17cbc98d0fcda048a9f755bedaeb73b92137aeaaf1db/langchain_openai-1.3.3-py3-none-any.whl", hash = "sha256:e469659862c8aabba4f6653df973206e7be54f98cf2275c86be7f06b7abe20d7", size = 120437, upload-time = "2026-06-22T22:54:03.8Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6e/f8f47f2c6976a4520b5416eaeeaee5e6aa7dd906b39685dc1ad4ef6d1ba2/langchain_openai-1.3.4-py3-none-any.whl", hash = "sha256:3241b8392b29c1af233b902b7d9a84bfc5fe26ccb210a7febdfc3972af7e5771", size = 120529, upload-time = "2026-07-08T22:59:49.451Z" },
 ]
 
 [[package]]
@@ -2085,7 +2085,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.2.4" },
     { name = "langchain-mcp-adapters", specifier = ">=0.3.0" },
     { name = "langchain-modal", specifier = ">=0.0.5" },
-    { name = "langchain-openai", specifier = ">=1.3.3" },
+    { name = "langchain-openai", specifier = ">=1.3.4" },
     { name = "langchain-runloop", specifier = ">=0.0.6" },
     { name = "langgraph", specifier = ">=1.1.10" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.30" },


### PR DESCRIPTION
## Description
Upgrade `langchain-openai` to 1.3.4 for upstream stateless reasoning replay handling, then remove tool results without a preceding surviving call before OpenAI Responses requests.

## Release Note
Prevents resumed OpenAI threads from crashing on orphaned tool results.

## Test Plan
- [x] Cover stale reasoning and reverse-orphan histories across supported message formats.

Made by [Open SWE](https://openswe.vercel.app/agents/1cd376a8-96ab-7d50-8c04-bb52decbcc56)