### PR TITLE
chore: include ripgrep in sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     openssh-client \
     jq \
+    ripgrep \
     unzip \
     zip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description
Install the Debian `ripgrep` package in the base Open SWE image so sandbox agents can use `rg` for fast repository searches.

## Release Note
Open SWE sandbox images now include ripgrep.

## Test Plan
- [x] Confirmed the Dockerfile diff adds `ripgrep` to the existing apt package list and passes `git diff --check`.

Made by [Open SWE](https://openswe.vercel.app/agents/0faa346a-f41d-e967-5845-6f0cf34c2b8f)