### PR TITLE
feat: include Cargo in sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     lsb-release \
     build-essential \
+    cargo \
     openssh-client \
     jq \
     unzip \
@@ -100,6 +101,7 @@ RUN echo "=== Installed versions ===" \
     && yarn --version \
     && sfw --version \
     && go version \
+    && cargo --version \
     && docker --version \
     && git --version \
     && gh --version


### PR DESCRIPTION
## Description
Install Cargo from Debian alongside the existing sandbox build tools and verify it in the image's version smoke check.

## Release Note
Sandbox images now include Cargo for Rust projects.

## Test Plan
- [ ] Build the image and confirm `cargo --version` succeeds (Docker daemon unavailable locally).

Made by [Open SWE](https://openswe.vercel.app/agents/d32f27b5-343a-3abe-97ee-fcc93baa11ac)