### PR TITLE
fix: let admins interrupt runaway agents

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -153,6 +153,7 @@ from .team_settings import (
 from .thread_api import (
     ThreadMessageBody,
     ThreadResolveBody,
+    admin_cancel_dashboard_thread,
     cancel_dashboard_thread,
     delete_dashboard_thread,
     get_dashboard_thread,
@@ -1637,6 +1638,14 @@ async def api_cancel_thread(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     return await cancel_dashboard_thread(thread_id, session["sub"], email=session.get("email"))
+
+
+@router.post("/admin/threads/{thread_id}/cancel")
+async def admin_cancel_thread(
+    thread_id: str,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    return await admin_cancel_dashboard_thread(thread_id)
 
 
 @router.delete("/threads/{thread_id}")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1405,6 +1405,32 @@ async def cancel_dashboard_thread(
     )
 
 
+async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
+    client = langgraph_client()
+    try:
+        thread = await client.threads.get(thread_id)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(404, "thread not found") from exc
+
+    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    try:
+        await client.runs.cancel_many(thread_id=thread_id, status="all", action="interrupt")
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to cancel active runs for thread %s", thread_id)
+        raise HTTPException(502, "failed to request thread cancellation") from exc
+
+    await client.threads.update(
+        thread_id=thread_id,
+        metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
+    )
+    updated_thread = await client.threads.get(thread_id)
+    return _thread_summary(
+        updated_thread
+        if isinstance(updated_thread, dict)
+        else {"thread_id": thread_id, "metadata": metadata}
+    )
+
+
 async def delete_dashboard_thread(thread_id: str, login: str, *, email: str | None = None) -> None:
     client = langgraph_client()
     try:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1526,3 +1526,94 @@ async def test_options_gates_stale_fable_default_when_disabled() -> None:
     assert payload["default_agent_subagent_model"] != _FABLE
     assert payload["default_agent_model"] in model_ids
     assert payload["default_agent_subagent_model"] in model_ids
+
+
+async def test_admin_cancel_dashboard_thread_interrupts_all_active_runs(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+    thread = {
+        "thread_id": "thread-1",
+        "status": "busy",
+        "metadata": {
+            "title": "Runaway thread",
+            "latest_run_status": "running",
+            "updated_at_ms": 1,
+        },
+    }
+
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            assert thread_id == "thread-1"
+            return thread
+
+        async def update(self, **kwargs: object) -> None:
+            calls.append(("update", kwargs))
+            metadata = kwargs["metadata"]
+            assert isinstance(metadata, dict)
+            thread["metadata"].update(metadata)
+
+    class FakeRuns:
+        async def cancel_many(self, **kwargs: object) -> None:
+            calls.append(("cancel_many", kwargs))
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    result = await thread_api.admin_cancel_dashboard_thread("thread-1")
+
+    assert calls[0] == (
+        "cancel_many",
+        {"thread_id": "thread-1", "status": "all", "action": "interrupt"},
+    )
+    assert calls[1][0] == "update"
+    assert thread["metadata"]["latest_run_status"] == "interrupted"
+    assert result["id"] == "thread-1"
+
+
+async def test_admin_cancel_dashboard_thread_does_not_update_on_cancel_failure(monkeypatch) -> None:
+    updated = False
+
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {"thread_id": thread_id, "status": "busy", "metadata": {}}
+
+        async def update(self, **kwargs: object) -> None:
+            nonlocal updated
+            updated = True
+
+    class FakeRuns:
+        async def cancel_many(self, **kwargs: object) -> None:
+            raise RuntimeError("runtime unavailable")
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.admin_cancel_dashboard_thread("thread-1")
+
+    assert exc_info.value.status_code == 502
+    assert updated is False
+
+
+async def test_admin_cancel_thread_route_delegates_without_owner_identity(monkeypatch) -> None:
+    cancel = AsyncMock(return_value={"id": "thread-1", "status": "interrupted"})
+    monkeypatch.setattr(routes, "admin_cancel_dashboard_thread", cancel)
+
+    result = await routes.admin_cancel_thread("thread-1", _admin={"sub": "admin"})
+
+    assert result == {"id": "thread-1", "status": "interrupted"}
+    cancel.assert_awaited_once_with("thread-1")
+
+
+def test_admin_cancel_thread_dependency_rejects_non_admin(monkeypatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin")
+
+    with pytest.raises(HTTPException) as exc_info:
+        routes._require_admin({"sub": "not-admin", "email": "user@example.com"})
+
+    assert exc_info.value.status_code == 403

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -72,6 +72,7 @@ export interface ThreadRecoveryPatch {
 export interface ThreadsPageParams {
   limit?: number
   offset?: number
+  all?: boolean
   resolved?: boolean
   viewed?: boolean
   source?: string
@@ -173,6 +174,7 @@ function buildThreadsPageQuery(params: ThreadsPageParams): string {
   const search = new URLSearchParams()
   if (params.limit != null) search.set("limit", String(params.limit))
   if (params.offset != null) search.set("offset", String(params.offset))
+  if (params.all != null) search.set("all", String(params.all))
   if (params.resolved != null) search.set("resolved", String(params.resolved))
   if (params.viewed != null) search.set("viewed", String(params.viewed))
   if (params.source) search.set("source", params.source)
@@ -265,6 +267,13 @@ export const agentsApi = {
   cancelThread: (threadId: string) =>
     agentsRequest<AgentThread>(
       `/threads/${encodeURIComponent(threadId)}/cancel`,
+      {
+        method: "POST",
+      }
+    ),
+  adminCancelThread: (threadId: string) =>
+    agentsRequest<AgentThread>(
+      `/admin/threads/${encodeURIComponent(threadId)}/cancel`,
       {
         method: "POST",
       }

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -284,6 +284,18 @@ export function useCancelAgentThread(threadId: string) {
   })
 }
 
+export function useAdminCancelAgentThread() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (threadId: string) => agentsApi.adminCancelThread(threadId),
+    onSuccess: (thread) => {
+      queryClient.setQueryData(agentThreadKeys.detail(thread.id), thread)
+      invalidateAgentThreadLists(queryClient)
+    },
+  })
+}
+
 export function useDeleteAgentThread() {
   const queryClient = useQueryClient()
   const navigate = useNavigate()

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -24,6 +24,10 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { api } from "@/lib/api"
+import {
+  useAdminCancelAgentThread,
+  useThreadsPage,
+} from "@/features/agents/lib/queries"
 import { RequireLogin } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
 
@@ -62,6 +66,8 @@ function AdminPage() {
 
       <TriggerReviewSection />
 
+      <RunningAgentsSection />
+
       <SettingsSection title="Evals">
         <Link
           to="/admin/evals"
@@ -86,6 +92,97 @@ function AdminPage() {
 
       <UserMappingsSection enabled={!!session.data.is_admin} />
     </AppShell>
+  )
+}
+
+function RunningAgentsSection() {
+  const threads = useThreadsPage({
+    all: true,
+    status: "running",
+    limit: 50,
+  })
+  const cancel = useAdminCancelAgentThread()
+  const [message, setMessage] = useState<string | null>(null)
+
+  return (
+    <SettingsSection
+      title="Running agents"
+      description="Workspace-wide active threads. Killing a thread requests interruption of all pending and running runs without deleting its history."
+    >
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {threads.data?.items.length ?? 0} running
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void threads.refetch()}
+            disabled={threads.isFetching}
+          >
+            {threads.isFetching ? "Refreshing…" : "Refresh"}
+          </Button>
+        </div>
+
+        {threads.isLoading ? (
+          <Skeleton className="h-20" />
+        ) : threads.data?.items.length ? (
+          <div className="flex flex-col">
+            {threads.data.items.map((thread) => {
+              const isCancelling =
+                cancel.isPending && cancel.variables === thread.id
+              return (
+                <div
+                  key={thread.id}
+                  className="flex items-center justify-between gap-3 border-b border-border py-2 last:border-b-0"
+                >
+                  <Link
+                    to="/agents/$threadId"
+                    params={{ threadId: thread.id }}
+                    className="min-w-0 flex-1 hover:underline"
+                  >
+                    <p className="truncate text-xs font-medium text-foreground">
+                      {thread.title}
+                    </p>
+                    <p className="truncate font-mono text-[11px] text-muted-foreground">
+                      {thread.repoFullName || "no repo"} · {thread.id}
+                    </p>
+                  </Link>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    disabled={cancel.isPending}
+                    onClick={() => {
+                      setMessage(null)
+                      cancel.mutate(thread.id, {
+                        onSuccess: () =>
+                          setMessage(`Interruption requested for ${thread.title}.`),
+                        onError: (error: Error) => setMessage(error.message),
+                      })
+                    }}
+                  >
+                    {isCancelling ? "Killing…" : "Kill"}
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">No running agents.</p>
+        )}
+
+        {threads.error && (
+          <p className="text-xs text-destructive">{threads.error.message}</p>
+        )}
+        {message && (
+          <p
+            className={`text-xs ${cancel.isError ? "text-destructive" : "text-muted-foreground"}`}
+          >
+            {message}
+          </p>
+        )}
+      </div>
+    </SettingsSection>
   )
 }
 


### PR DESCRIPTION
## Summary
- add an admin-only endpoint that interrupts all active runs for a thread without deleting history
- show workspace-wide running agents and kill controls in the admin panel
- cover bulk cancellation, failure handling, and admin authorization

## Test plan
- [x] `uv run pytest -q tests/dashboard/test_dashboard_thread_api.py`
- [x] Ruff check and format validation
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (existing warnings only)