### PR TITLE
fix: disable todos by default

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -17,10 +17,18 @@ from .utils.github_comments import UNTRUSTED_GITHUB_COMMENT_OPEN_TAG
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROMPT_PATH = os.environ.get("DEFAULT_PROMPT_PATH")
+ENABLE_TODOS_ENV_VAR = "OPEN_SWE_ENABLE_TODOS"
 
-# Tools stripped from the agent regardless of run state (none today: plan-mode
-# tool stripping is dynamic and handled by PlanModeMiddleware, not the profile).
-HARNESS_EXCLUDED_TOOLS: frozenset[str] = frozenset()
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _harness_excluded_tools() -> frozenset[str]:
+    return frozenset() if _env_flag(ENABLE_TODOS_ENV_VAR) else frozenset({"write_todos"})
+
+
+HARNESS_EXCLUDED_TOOLS: frozenset[str] = _harness_excluded_tools()
 
 # Provider keys the harness profile is registered under. deepagents resolves a
 # pre-built model's profile by `provider:identifier` then a provider-only

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -5,6 +5,7 @@ from importlib import resources
 from pathlib import Path
 
 from deepagents import HarnessProfile, register_harness_profile
+from langchain.agents.middleware import TodoListMiddleware
 
 from .utils.authorship import (
     OPEN_SWE_BOT_EMAIL,
@@ -28,7 +29,12 @@ def _harness_excluded_tools() -> frozenset[str]:
     return frozenset() if _env_flag(ENABLE_TODOS_ENV_VAR) else frozenset({"write_todos"})
 
 
+def _harness_excluded_middleware() -> frozenset[type[TodoListMiddleware]]:
+    return frozenset() if _env_flag(ENABLE_TODOS_ENV_VAR) else frozenset({TodoListMiddleware})
+
+
 HARNESS_EXCLUDED_TOOLS: frozenset[str] = _harness_excluded_tools()
+HARNESS_EXCLUDED_MIDDLEWARE: frozenset[type[TodoListMiddleware]] = _harness_excluded_middleware()
 
 # Provider keys the harness profile is registered under. deepagents resolves a
 # pre-built model's profile by `provider:identifier` then a provider-only
@@ -407,6 +413,7 @@ def register_open_swe_harness_profile() -> None:
     profile = HarnessProfile(
         base_system_prompt=OPEN_SWE_SHARED_BASE,
         excluded_tools=HARNESS_EXCLUDED_TOOLS,
+        excluded_middleware=HARNESS_EXCLUDED_MIDDLEWARE,
     )
     for key in HARNESS_PROFILE_KEYS:
         register_harness_profile(key, profile)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -462,6 +462,10 @@ ALLOWED_GITHUB_REPOS=""                # e.g. "some-user/their-repo,another-org/
 DEFAULT_REPO_OWNER=""                  # Default GitHub org (e.g. "my-org")
 DEFAULT_REPO_NAME=""                   # Default GitHub repo (e.g. "my-repo")
 
+# === Agent Behavior (optional) ===
+# Todos are hidden from the agent by default. Set true to re-enable the write_todos tool.
+OPEN_SWE_ENABLE_TODOS=""
+
 # === Dashboard (required to run the web dashboard) ===
 # Public URL that browsers use for /dashboard/api/* and OAuth callbacks.
 # Use the FastAPI backend URL for local/cross-origin direct API calls.

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-import sys
 from typing import Any
 
 from langchain_core.language_models import BaseChatModel
@@ -191,65 +187,6 @@ def test_todo_tool_and_prompt_are_hidden_from_model_request_by_default() -> None
     system_text = "\n".join(_content_text(message.content) for message in model.captured_messages)
     assert "write_todos" not in tool_names
     assert "You have access to the `write_todos` tool" not in system_text
-
-
-def test_enable_todos_env_restores_todo_tool_and_prompt() -> None:
-    code = """
-import json
-from typing import Any
-from deepagents import create_deep_agent
-from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage
-from langchain_core.outputs import ChatGeneration, ChatResult
-import agent.prompt
-
-class CaptureRequestModel(BaseChatModel):
-    captured_messages: Any = None
-    captured_tools: Any = None
-
-    @property
-    def _llm_type(self) -> str:
-        return "capture-request"
-
-    def _get_ls_params(self, *args: Any, **kwargs: Any) -> dict[str, str]:
-        return {"ls_provider": "openai"}
-
-    def bind_tools(self, tools: Any, **kwargs: Any) -> "CaptureRequestModel":
-        self.captured_tools = tools
-        return self
-
-    def _generate(self, messages: list[Any], **kwargs: Any) -> ChatResult:
-        self.captured_messages = messages
-        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="done"))])
-
-def content_text(content: Any) -> str:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return "\\n".join(item.get("text", "") if isinstance(item, dict) else str(item) for item in content)
-    return str(content)
-
-model = CaptureRequestModel()
-graph = create_deep_agent(model=model, tools=[])
-graph.invoke({"messages": [{"role": "user", "content": "hi"}]}, config={"recursion_limit": 5})
-system_text = "\\n".join(content_text(message.content) for message in model.captured_messages)
-print(json.dumps({
-    "tools": [getattr(tool, "name", None) for tool in model.captured_tools],
-    "has_todo_prompt": "You have access to the `write_todos` tool" in system_text,
-}))
-"""
-    env = {**os.environ, "OPEN_SWE_ENABLE_TODOS": "true"}
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        check=True,
-        env=env,
-    )
-
-    payload = json.loads(result.stdout)
-    assert "write_todos" in payload["tools"]
-    assert payload["has_todo_prompt"] is True
 
 
 def test_shared_base_is_neutral_for_read_only_agents() -> None:

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
 from agent.dashboard.agent_overrides import profile_create_prs
 from agent.prompt import construct_system_prompt
 from agent.utils import github_comments
@@ -13,6 +23,36 @@ from agent.utils.authorship import (
 from agent.webhooks import github as github_webhooks
 
 _BOT_TRAILER = f"Co-authored-by: {OPEN_SWE_BOT_NAME} <{OPEN_SWE_BOT_EMAIL}>"
+
+
+class _CaptureRequestModel(BaseChatModel):
+    captured_messages: Any = None
+    captured_tools: Any = None
+
+    @property
+    def _llm_type(self) -> str:
+        return "capture-request"
+
+    def _get_ls_params(self, *args: Any, **kwargs: Any) -> dict[str, str]:
+        return {"ls_provider": "openai"}
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> _CaptureRequestModel:
+        self.captured_tools = tools
+        return self
+
+    def _generate(self, messages: list[Any], **kwargs: Any) -> ChatResult:
+        self.captured_messages = messages
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="done"))])
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            item.get("text", "") if isinstance(item, dict) else str(item) for item in content
+        )
+    return str(content)
 
 
 def test_build_pr_prompt_wraps_external_comments_without_trust_section() -> None:
@@ -108,20 +148,26 @@ def test_harness_profile_replaces_deepagents_base_for_supported_providers() -> N
     import deepagents.profiles.harness.harness_profiles as hp
 
     import agent.prompt  # noqa: F401  (registers the profile on import)
-    from agent.prompt import HARNESS_EXCLUDED_TOOLS, HARNESS_PROFILE_KEYS, OPEN_SWE_SHARED_BASE
+    from agent.prompt import (
+        HARNESS_EXCLUDED_MIDDLEWARE,
+        HARNESS_EXCLUDED_TOOLS,
+        HARNESS_PROFILE_KEYS,
+        OPEN_SWE_SHARED_BASE,
+    )
 
     hp._ensure_harness_profiles_loaded()
     assert set(HARNESS_PROFILE_KEYS) >= {"anthropic", "openai", "google_genai", "fireworks"}
     assert "write_todos" in HARNESS_EXCLUDED_TOOLS
+    assert HARNESS_EXCLUDED_MIDDLEWARE
     for key in HARNESS_PROFILE_KEYS:
         profile = hp._HARNESS_PROFILES.get(key)
         assert profile is not None, f"no harness profile registered for {key!r}"
         assert profile.base_system_prompt == OPEN_SWE_SHARED_BASE
         assert HARNESS_EXCLUDED_TOOLS <= profile.excluded_tools
-        assert not profile.excluded_middleware
+        assert HARNESS_EXCLUDED_MIDDLEWARE <= profile.excluded_middleware
     resolved_profile = hp._get_harness_profile("openai:gpt-5.6-sol")
     assert "write_todos" in resolved_profile.excluded_tools
-    assert not resolved_profile.excluded_middleware
+    assert HARNESS_EXCLUDED_MIDDLEWARE <= resolved_profile.excluded_middleware
 
 
 def test_enable_todos_env_clears_harness_exclusions(monkeypatch) -> None:
@@ -130,6 +176,80 @@ def test_enable_todos_env_clears_harness_exclusions(monkeypatch) -> None:
     monkeypatch.setenv(prompt_module.ENABLE_TODOS_ENV_VAR, "true")
 
     assert prompt_module._harness_excluded_tools() == frozenset()
+    assert prompt_module._harness_excluded_middleware() == frozenset()
+
+
+def test_todo_tool_and_prompt_are_hidden_from_model_request_by_default() -> None:
+    from deepagents import create_deep_agent
+
+    model = _CaptureRequestModel()
+    graph = create_deep_agent(model=model, tools=[])
+
+    graph.invoke({"messages": [{"role": "user", "content": "hi"}]}, config={"recursion_limit": 5})
+
+    tool_names = {getattr(tool, "name", None) for tool in model.captured_tools}
+    system_text = "\n".join(_content_text(message.content) for message in model.captured_messages)
+    assert "write_todos" not in tool_names
+    assert "You have access to the `write_todos` tool" not in system_text
+
+
+def test_enable_todos_env_restores_todo_tool_and_prompt() -> None:
+    code = """
+import json
+from typing import Any
+from deepagents import create_deep_agent
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+import agent.prompt
+
+class CaptureRequestModel(BaseChatModel):
+    captured_messages: Any = None
+    captured_tools: Any = None
+
+    @property
+    def _llm_type(self) -> str:
+        return "capture-request"
+
+    def _get_ls_params(self, *args: Any, **kwargs: Any) -> dict[str, str]:
+        return {"ls_provider": "openai"}
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "CaptureRequestModel":
+        self.captured_tools = tools
+        return self
+
+    def _generate(self, messages: list[Any], **kwargs: Any) -> ChatResult:
+        self.captured_messages = messages
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="done"))])
+
+def content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\\n".join(item.get("text", "") if isinstance(item, dict) else str(item) for item in content)
+    return str(content)
+
+model = CaptureRequestModel()
+graph = create_deep_agent(model=model, tools=[])
+graph.invoke({"messages": [{"role": "user", "content": "hi"}]}, config={"recursion_limit": 5})
+system_text = "\\n".join(content_text(message.content) for message in model.captured_messages)
+print(json.dumps({
+    "tools": [getattr(tool, "name", None) for tool in model.captured_tools],
+    "has_todo_prompt": "You have access to the `write_todos` tool" in system_text,
+}))
+"""
+    env = {**os.environ, "OPEN_SWE_ENABLE_TODOS": "true"}
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+
+    payload = json.loads(result.stdout)
+    assert "write_todos" in payload["tools"]
+    assert payload["has_todo_prompt"] is True
 
 
 def test_shared_base_is_neutral_for_read_only_agents() -> None:

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -108,16 +108,28 @@ def test_harness_profile_replaces_deepagents_base_for_supported_providers() -> N
     import deepagents.profiles.harness.harness_profiles as hp
 
     import agent.prompt  # noqa: F401  (registers the profile on import)
-    from agent.prompt import HARNESS_PROFILE_KEYS, OPEN_SWE_SHARED_BASE
+    from agent.prompt import HARNESS_EXCLUDED_TOOLS, HARNESS_PROFILE_KEYS, OPEN_SWE_SHARED_BASE
 
     hp._ensure_harness_profiles_loaded()
     assert set(HARNESS_PROFILE_KEYS) >= {"anthropic", "openai", "google_genai", "fireworks"}
+    assert "write_todos" in HARNESS_EXCLUDED_TOOLS
     for key in HARNESS_PROFILE_KEYS:
         profile = hp._HARNESS_PROFILES.get(key)
         assert profile is not None, f"no harness profile registered for {key!r}"
         assert profile.base_system_prompt == OPEN_SWE_SHARED_BASE
+        assert HARNESS_EXCLUDED_TOOLS <= profile.excluded_tools
         assert not profile.excluded_middleware
-    assert not hp._get_harness_profile("openai:gpt-5.6-sol").excluded_middleware
+    resolved_profile = hp._get_harness_profile("openai:gpt-5.6-sol")
+    assert "write_todos" in resolved_profile.excluded_tools
+    assert not resolved_profile.excluded_middleware
+
+
+def test_enable_todos_env_clears_harness_exclusions(monkeypatch) -> None:
+    from agent import prompt as prompt_module
+
+    monkeypatch.setenv(prompt_module.ENABLE_TODOS_ENV_VAR, "true")
+
+    assert prompt_module._harness_excluded_tools() == frozenset()
 
 
 def test_shared_base_is_neutral_for_read_only_agents() -> None:


### PR DESCRIPTION
## Description
Hide `write_todos` through the Open SWE harness profile so todos are unavailable by default across Open SWE agents. Set `OPEN_SWE_ENABLE_TODOS=true` to re-enable the tool.

## Release Note
Todos are disabled by default; set `OPEN_SWE_ENABLE_TODOS=true` to restore the todo tool.

## Test Plan
- [x] `make format && make lint`
- [x] `uv run pytest -vvv tests/github/test_github_comment_prompts.py tests/agent/test_agent_assembly_context.py`
- [x] `OPEN_SWE_ENABLE_TODOS=true uv run python ...` verifies clean env import re-enables todos.

Made by [Open SWE](https://openswe.vercel.app/agents/cd081d4a-6103-f7b5-3f56-fa766454dc64)