### PR TITLE
fix: handle Slack DMs as mentions

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -183,6 +183,8 @@ def select_slack_context_messages(
     current_message_ts: str,
     bot_user_id: str,
     bot_username: str = "",
+    *,
+    treat_all_messages_as_mentions: bool = False,
 ) -> tuple[list[dict[str, Any]], str]:
     """Select context from thread start or previous bot mention."""
     if not messages:
@@ -199,13 +201,24 @@ def select_slack_context_messages(
         mention_tokens.append(f"<@{bot_user_id}>")
     if bot_username:
         mention_tokens.append(f"@{bot_username}")
-    if not mention_tokens:
+    if not mention_tokens and not treat_all_messages_as_mentions:
         return up_to_current, "thread_start"
 
     last_mention_index = -1
     for index, message in enumerate(up_to_current[:-1]):
         text = message.get("text", "")
-        if isinstance(text, str) and any(token in text for token in mention_tokens):
+        is_explicit_mention = isinstance(text, str) and any(
+            token in text for token in mention_tokens
+        )
+        user_id = message.get("user")
+        is_user_message = (
+            isinstance(user_id, str)
+            and bool(user_id)
+            and user_id != bot_user_id
+            and not message.get("bot_id")
+            and not message.get("bot_profile")
+        )
+        if is_explicit_mention or (treat_all_messages_as_mentions and is_user_message):
             last_mention_index = index
 
     if last_mention_index >= 0:

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -278,8 +278,13 @@ async def _process_slack_mention_impl(
     if not any(str(message.get("ts")) == str(event_ts) for message in thread_messages):
         thread_messages.append({"ts": event_ts, "text": text, "user": user_id})
 
+    treat_all_messages_as_mentions = bool(event_data.get("treat_all_messages_as_mentions"))
     context_messages, context_mode = common.select_slack_context_messages(
-        thread_messages, event_ts, bot_user_id, common.SLACK_BOT_USERNAME
+        thread_messages,
+        event_ts,
+        bot_user_id,
+        common.SLACK_BOT_USERNAME,
+        treat_all_messages_as_mentions=treat_all_messages_as_mentions,
     )
     context_user_ids = [
         value
@@ -295,11 +300,13 @@ async def _process_slack_mention_impl(
         bot_user_id=bot_user_id,
         bot_username=common.SLACK_BOT_USERNAME,
     )
-    context_source = (
-        "the previous message where I was tagged"
-        if context_mode == "last_mention"
-        else "the beginning of the thread"
-    )
+    context_source = "the beginning of the thread"
+    if context_mode == "last_mention":
+        context_source = (
+            "the previous direct message"
+            if treat_all_messages_as_mentions
+            else "the previous message where I was tagged"
+        )
     clean_text = (
         common.strip_bot_mention(text, bot_user_id, bot_username=common.SLACK_BOT_USERNAME)
         or "(no text in mention)"

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -59,6 +59,11 @@ async def slack_webhook(
             return {"status": "accepted", "message": "Reaction removal queued"}
         return {"status": "ignored", "reason": "Reaction not tracked for feedback"}
 
+    is_direct_message = (
+        event.get("type") == "message"
+        and event.get("channel_type") == "im"
+        and bool(event.get("user"))
+    )
     if event.get("type") != "app_mention":
         message_text = event.get("text", "")
         has_username_mention = bool(
@@ -73,14 +78,18 @@ async def slack_webhook(
         )
         is_ready_plan_reply = bool(
             event.get("type") == "message"
+            and not is_direct_message
             and await service._slack_user_can_reply_to_ready_plan(
                 str(event.get("channel") or ""),
                 str(event.get("thread_ts") or ""),
                 str(event.get("user") or ""),
             )
         )
-        if not (has_username_mention or has_id_mention or is_ready_plan_reply):
-            return {"status": "ignored", "reason": "Not an app mention or plan reply"}
+        should_handle_message = any(
+            (has_username_mention, has_id_mention, is_ready_plan_reply, is_direct_message)
+        )
+        if not should_handle_message:
+            return {"status": "ignored", "reason": "Not an app mention, DM, or plan reply"}
 
     if event.get("subtype") == "bot_message" or event.get("bot_id"):
         return {"status": "ignored", "reason": "Event from a bot"}
@@ -129,6 +138,7 @@ async def slack_webhook(
         "user_id": user_id,
         "text": text,
         "bot_user_id": bot_user_id,
+        "treat_all_messages_as_mentions": is_direct_message,
     }
     repo_config = await common.get_slack_repo_config(
         channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -76,6 +76,7 @@ fakes.seed_bare_remote()
 @app.post("/control/reset")
 async def control_reset() -> JSONResponse:
     fakes.reset()
+    CURRENT_THREAD["channel"] = DEMO_CHANNEL
     CURRENT_THREAD["thread_ts"] = None
     return JSONResponse({"ok": True})
 
@@ -94,27 +95,32 @@ async def slack_send(request: Request) -> JSONResponse:
     form = await request.json()
     text = str(form.get("text", ""))
     mention_bot = bool(form.get("mention_bot", True))
+    channel_type = str(form.get("channel_type") or "")
     # Sender defaults to the first test user (Alice) — the canonical owner the
     # automated tests log in as; the mock UI passes the chosen test user.
     user_id = str(form.get("user") or TEST_USERS[0]["slack_id"])
-    channel = DEMO_CHANNEL
+    channel = str(form.get("channel") or ("D_DEMO" if channel_type == "im" else DEMO_CHANNEL))
 
     ts = fakes.new_thread_ts()
+    CURRENT_THREAD["channel"] = channel
     CURRENT_THREAD["thread_ts"] = ts
     fakes.add_slack_message(channel, ts, user=user_id, text=text, is_bot=False)
 
+    event = {
+        "type": "app_mention" if mention_bot else "message",
+        "channel": channel,
+        "user": user_id,
+        "text": text,
+        "ts": ts,
+        "thread_ts": ts,
+    }
+    if channel_type:
+        event["channel_type"] = channel_type
     payload = {
         "type": "event_callback",
         "event_id": f"Ev{ts}",
         "authorizations": [{"user_id": BOT_USER_ID}],
-        "event": {
-            "type": "app_mention" if mention_bot else "message",
-            "channel": channel,
-            "user": user_id,
-            "text": text,
-            "ts": ts,
-            "thread_ts": ts,
-        },
+        "event": event,
     }
     raw = json.dumps(payload).encode()
     req_ts = str(int(time.time()))

--- a/tests/e2e/tests/full_flow.spec.ts
+++ b/tests/e2e/tests/full_flow.spec.ts
@@ -37,6 +37,27 @@ test.describe("Open SWE full flow", () => {
     await expect(page.locator('.pr[data-pr="1"]')).toContainText("greet.py");
   });
 
+  test("Slack DM request without a bot mention still starts a run", async ({ page, request }) => {
+    const send = await request.post("/mock/slack/send", {
+      data: {
+        text: "please add a greet() helper and open a PR",
+        mention_bot: false,
+        channel_type: "im",
+      },
+    });
+    const sent = await send.json();
+    expect(sent.webhook).toMatchObject({ status: "accepted", message: "Slack mention queued" });
+
+    await expect(page.locator(".msg").filter({ hasText: "add a greet() helper" })).toBeVisible();
+    const reply = page.locator(".msg.bot").filter({ hasText: "Add greet() helper" });
+    await expect(reply).toBeVisible();
+    await expect(reply.locator('a[href*="/pull/"]')).toBeVisible();
+
+    await page.goto("/mock/github");
+    await expect(page.locator('.pr[data-pr="1"]')).toContainText("Add greet() helper");
+    await expect(page.locator('.pr[data-pr="1"]')).toContainText("greet.py");
+  });
+
   test("Slack breakout request starts a new top-level Open SWE thread", async ({ page }) => {
     await page.locator("#text").fill("<@U0BOT> please break out adding a greet() helper into a separate thread");
     await page.locator("#send").click();

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -891,6 +891,64 @@ def test_slack_webhook_threaded_followup_uses_parent_thread_ts(monkeypatch) -> N
     assert event_data["event_ts"] == "1700000000.000200"
 
 
+def test_slack_webhook_accepts_unmentioned_direct_message(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_get_slack_repo_config(
+        channel_id: str,
+        thread_ts: str,
+        slack_user_id: str | None = None,
+        **kwargs: object,
+    ) -> dict[str, str]:
+        captured["repo_config_request"] = {
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "slack_user_id": slack_user_id,
+        }
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    async def fake_process_slack_mention(
+        event_data: dict[str, object], repo_config: dict[str, str]
+    ) -> None:
+        captured["event_data"] = event_data
+        captured["repo_config"] = repo_config
+
+    monkeypatch.setattr(webhook_common, "SLACK_SIGNING_SECRET", _TEST_SLACK_SECRET)
+    monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "UBOT")
+    monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "open-swe")
+    monkeypatch.setattr(slack_utils.time, "time", lambda: 1700000000)
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", fake_get_slack_repo_config)
+    monkeypatch.setattr(slack_webhooks, "process_slack_mention", fake_process_slack_mention)
+
+    response = _post_slack_webhook(
+        TestClient(app),
+        {
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "channel": "D123",
+                "ts": "1700000000.000200",
+                "user": "U123",
+                "text": "please check my branch",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Slack mention queued"
+    assert captured["repo_config"] == {"owner": "langchain-ai", "name": "open-swe"}
+    assert captured["repo_config_request"] == {
+        "channel_id": "D123",
+        "thread_ts": "1700000000.000200",
+        "slack_user_id": "U123",
+    }
+    event_data = captured["event_data"]
+    assert isinstance(event_data, dict)
+    assert event_data["text"] == "please check my branch"
+    assert event_data["treat_all_messages_as_mentions"] is True
+
+
 def test_slack_webhook_accepts_unmentioned_ready_plan_reply(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -965,7 +1023,7 @@ def test_slack_webhook_ignores_unmentioned_non_plan_reply(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.json() == {
         "status": "ignored",
-        "reason": "Not an app mention or plan reply",
+        "reason": "Not an app mention, DM, or plan reply",
     }
 
 

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -96,6 +96,27 @@ def test_select_slack_context_messages_ignores_messages_after_current_event() ->
     assert [item["ts"] for item in selected] == ["1.0", "2.0", "3.0"]
 
 
+def test_select_slack_context_messages_treats_direct_user_messages_as_mentions() -> None:
+    bot_user_id = "UBOT"
+    messages = [
+        {"ts": "1.0", "text": "first request", "user": "U1"},
+        {"ts": "2.0", "text": "agent response", "user": "UBOT", "bot_id": "B1"},
+        {"ts": "3.0", "text": "follow up", "user": "U1"},
+        {"ts": "3.5", "text": "agent response", "user": "UBOT", "bot_id": "B1"},
+        {"ts": "4.0", "text": "latest", "user": "U1"},
+    ]
+
+    selected, mode = select_slack_context_messages(
+        messages,
+        "4.0",
+        bot_user_id,
+        treat_all_messages_as_mentions=True,
+    )
+
+    assert mode == "last_mention"
+    assert [item["ts"] for item in selected] == ["3.0", "3.5", "4.0"]
+
+
 def test_strip_bot_mention_removes_bot_tag() -> None:
     assert strip_bot_mention("<@UBOT> please check", "UBOT") == "please check"
 
@@ -573,6 +594,62 @@ def test_process_slack_mention_creates_thread_first_run_with_trace_reply(
     assert prompt_block["text"].count("## Slack Thread") == 1
     assert f"Thread TS: {thread_ts}" in prompt_block["text"]
     assert "## Latest Mention Request\ncontinue on the branch" in prompt_block["text"]
+
+
+def test_process_slack_mention_treats_direct_message_as_implicit_mention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    _setup_slack_mention_fakes(monkeypatch, captured)
+
+    async def fake_thread_exists(thread_id: str) -> bool:
+        return True
+
+    async def fake_fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[dict]:
+        captured["fetch_thread"] = {"channel_id": channel_id, "thread_ts": thread_ts}
+        return [
+            {"ts": "1700000000.000100", "text": "first request", "user": "U123"},
+            {
+                "ts": "1700000000.000150",
+                "text": "agent response",
+                "user": "UBOT",
+                "bot_id": "B1",
+            },
+            {"ts": "1700000000.000200", "text": "continue on the branch", "user": "U123"},
+        ]
+
+    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(
+        webhook_common, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages
+    )
+
+    asyncio.run(
+        slack_webhooks.process_slack_mention(
+            {
+                "channel_id": "D123",
+                "thread_ts": "1700000000.000100",
+                "event_ts": "1700000000.000200",
+                "user_id": "U123",
+                "text": "continue on the branch",
+                "bot_user_id": "UBOT",
+                "treat_all_messages_as_mentions": True,
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    run_create = captured["run_create"]
+    assert isinstance(run_create, dict)
+    prompt_block = run_create["kwargs"]["input"]["messages"][0]["content"][0]
+    assert "Context starts at: the previous direct message" in prompt_block["text"]
+    assert "## Latest Mention Request\ncontinue on the branch" in prompt_block["text"]
+    context_messages = captured["context_messages"]
+    assert isinstance(context_messages, list)
+    assert [message["ts"] for message in context_messages] == [
+        "1700000000.000100",
+        "1700000000.000150",
+        "1700000000.000200",
+    ]
 
 
 def test_process_slack_mention_skips_trace_reply_on_followup_mention(


### PR DESCRIPTION
## Description
Slack direct-message events now pass through the webhook without an explicit bot tag and carry a flag that treats prior DM user messages as mention boundaries. Added Slack simulator Playwright coverage for the DM path while preserving non-DM ignore behavior.

## Release Note
Slack DMs to Open SWE no longer require tagging the bot.

## Test Plan
- [x] `make -C "/workspace/open-swe" format && make -C "/workspace/open-swe" lint`
- [x] `uv run --directory "/workspace/open-swe" pytest -vvv tests/slack/test_slack_context.py tests/github/test_github_issue_webhook.py -q --no-header --disable-warnings`
- [x] `npm --prefix "/workspace/open-swe/tests/e2e" exec -- playwright test --config "/workspace/open-swe/tests/e2e/playwright.config.ts" tests/full_flow.spec.ts -g "Slack DM request without a bot mention still starts a run"`

Made by [Open SWE](https://openswe.vercel.app/agents/c361f11b-2f06-ea2c-f329-7b2508419a0d)