### PR TITLE
feat(open-swe): untagged two-party Slack replies + debounced interrupts

### DIFF
--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -157,14 +157,12 @@ async def dispatch_agent_run(
     assistant_id: str = "agent",
     metadata: dict[str, Any] | None = None,
     client: LangGraphClient | None = None,
-    after_seconds: int | float | None = None,
 ) -> dict[str, Any]:
     """Create (or interrupt-and-resume) a run for ``thread_id``.
 
     Routes every Slack / Linear / GitHub / dashboard trigger through one
     contract. ``source`` is for logging/metadata only; ``assistant_id`` selects
-    the graph (``"agent"`` or ``"reviewer"``). ``after_seconds`` delays the run's
-    start (used to debounce rapid interrupts of a busy thread).
+    the graph (``"agent"`` or ``"reviewer"``).
     """
     return await create_durable_run(
         thread_id,
@@ -174,5 +172,4 @@ async def dispatch_agent_run(
         metadata=metadata or {},
         source=source,
         client=client or dispatch_client(),
-        after_seconds=after_seconds,
     )

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -157,12 +157,14 @@ async def dispatch_agent_run(
     assistant_id: str = "agent",
     metadata: dict[str, Any] | None = None,
     client: LangGraphClient | None = None,
+    after_seconds: int | float | None = None,
 ) -> dict[str, Any]:
     """Create (or interrupt-and-resume) a run for ``thread_id``.
 
     Routes every Slack / Linear / GitHub / dashboard trigger through one
     contract. ``source`` is for logging/metadata only; ``assistant_id`` selects
-    the graph (``"agent"`` or ``"reviewer"``).
+    the graph (``"agent"`` or ``"reviewer"``). ``after_seconds`` delays the run's
+    start (used to debounce rapid interrupts of a busy thread).
     """
     return await create_durable_run(
         thread_id,
@@ -172,4 +174,5 @@ async def dispatch_agent_run(
         metadata=metadata or {},
         source=source,
         client=client or dispatch_client(),
+        after_seconds=after_seconds,
     )

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -120,6 +120,7 @@ from ..utils.slack_feedback import (
     process_slack_reaction_removed,
 )
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
+from ..utils.thread_ops import queue_message_for_thread  # noqa: F401
 
 __all__ = [
     "Any",
@@ -233,6 +234,7 @@ __all__ = [
     "post_slack_trace_reply",
     "process_slack_reaction_added",
     "process_slack_reaction_removed",
+    "queue_message_for_thread",
     "react_to_github_comment",
     "react_to_linear_comment",
     "reconcile_findings_with_review_threads",
@@ -281,6 +283,8 @@ GITHUB_WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
 SLACK_SIGNING_SECRET = os.environ.get("SLACK_SIGNING_SECRET", "")
 SLACK_BOT_USER_ID = os.environ.get("SLACK_BOT_USER_ID", "")
 SLACK_BOT_USERNAME = os.environ.get("SLACK_BOT_USERNAME", "")
+# Quiet window (seconds) to coalesce rapid follow-ups into one interrupt of a busy thread.
+SLACK_INTERRUPT_DEBOUNCE_SECONDS = float(os.environ.get("SLACK_INTERRUPT_DEBOUNCE_SECONDS", "15"))
 DEFAULT_REPO_OWNER = os.environ.get("DEFAULT_REPO_OWNER", "langchain-ai")
 DEFAULT_REPO_NAME = os.environ.get("DEFAULT_REPO_NAME", "")
 SLACK_REPO_OWNER = os.environ.get("SLACK_REPO_OWNER", "") or DEFAULT_REPO_OWNER

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -120,6 +120,7 @@ from ..utils.slack_feedback import (
     process_slack_reaction_removed,
 )
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
+from ..utils.thread_ops import queue_message_for_thread  # noqa: F401
 
 __all__ = [
     "Any",
@@ -233,6 +234,7 @@ __all__ = [
     "post_slack_trace_reply",
     "process_slack_reaction_added",
     "process_slack_reaction_removed",
+    "queue_message_for_thread",
     "react_to_github_comment",
     "react_to_linear_comment",
     "reconcile_findings_with_review_threads",
@@ -281,12 +283,6 @@ GITHUB_WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
 SLACK_SIGNING_SECRET = os.environ.get("SLACK_SIGNING_SECRET", "")
 SLACK_BOT_USER_ID = os.environ.get("SLACK_BOT_USER_ID", "")
 SLACK_BOT_USERNAME = os.environ.get("SLACK_BOT_USERNAME", "")
-# Quiet window (seconds) to coalesce rapid follow-ups into one interrupt of a busy thread.
-SLACK_INTERRUPT_DEBOUNCE_SECONDS = float(os.environ.get("SLACK_INTERRUPT_DEBOUNCE_SECONDS", "15"))
-# Cap on accumulated content blocks carried by a debounced interrupt (abuse guard).
-SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS = int(
-    os.environ.get("SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", "200")
-)
 DEFAULT_REPO_OWNER = os.environ.get("DEFAULT_REPO_OWNER", "langchain-ai")
 DEFAULT_REPO_NAME = os.environ.get("DEFAULT_REPO_NAME", "")
 SLACK_REPO_OWNER = os.environ.get("SLACK_REPO_OWNER", "") or DEFAULT_REPO_OWNER

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -120,7 +120,6 @@ from ..utils.slack_feedback import (
     process_slack_reaction_removed,
 )
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
-from ..utils.thread_ops import queue_message_for_thread  # noqa: F401
 
 __all__ = [
     "Any",
@@ -234,7 +233,6 @@ __all__ = [
     "post_slack_trace_reply",
     "process_slack_reaction_added",
     "process_slack_reaction_removed",
-    "queue_message_for_thread",
     "react_to_github_comment",
     "react_to_linear_comment",
     "reconcile_findings_with_review_threads",
@@ -285,6 +283,10 @@ SLACK_BOT_USER_ID = os.environ.get("SLACK_BOT_USER_ID", "")
 SLACK_BOT_USERNAME = os.environ.get("SLACK_BOT_USERNAME", "")
 # Quiet window (seconds) to coalesce rapid follow-ups into one interrupt of a busy thread.
 SLACK_INTERRUPT_DEBOUNCE_SECONDS = float(os.environ.get("SLACK_INTERRUPT_DEBOUNCE_SECONDS", "15"))
+# Cap on accumulated content blocks carried by a debounced interrupt (abuse guard).
+SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS = int(
+    os.environ.get("SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", "200")
+)
 DEFAULT_REPO_OWNER = os.environ.get("DEFAULT_REPO_OWNER", "langchain-ai")
 DEFAULT_REPO_NAME = os.environ.get("DEFAULT_REPO_NAME", "")
 SLACK_REPO_OWNER = os.environ.get("SLACK_REPO_OWNER", "") or DEFAULT_REPO_OWNER

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -122,16 +122,23 @@ async def _dispatch_or_queue_slack_run(
     thread_id: str,
     content_blocks: list[dict[str, Any]],
     configurable: dict[str, Any],
+    *,
     is_first_mention: bool,
+    explicitly_tagged: bool,
 ) -> dict[str, Any] | None:
     """Start a run, or coalesce onto the thread queue if one is already in flight.
 
-    Debounces interrupts: while the agent is busy, rapid follow-ups are parked on
-    the store queue and picked up together at its next model call (via
-    ``check_message_queue_before_model``) instead of each halting and resuming the
-    active run. Returns the run dict, or ``None`` when the message was queued.
+    An explicit @-mention always interrupts immediately (the active run halts and
+    resumes with the new message). Only untagged follow-ups are debounced: while
+    the agent is busy they are parked on the store queue and picked up together at
+    its next model call (via ``check_message_queue_before_model``). Returns the run
+    dict, or ``None`` when the message was queued.
     """
-    if not is_first_mention and await _slack_thread_is_busy(client, thread_id):
+    if (
+        not explicitly_tagged
+        and not is_first_mention
+        and await _slack_thread_is_busy(client, thread_id)
+    ):
         await common.queue_message_for_thread(thread_id, content_blocks)
         return None
     return await common.dispatch_agent_run(
@@ -537,8 +544,17 @@ async def _process_slack_mention_impl(
         source_context={"slack_thread": configurable["slack_thread"]},
     )
 
+    explicitly_tagged = bool(
+        (bot_user_id and f"<@{bot_user_id}>" in text)
+        or (common.SLACK_BOT_USERNAME and f"@{common.SLACK_BOT_USERNAME}" in text)
+    )
     run = await _dispatch_or_queue_slack_run(
-        langgraph_client, thread_id, content_blocks, configurable, is_first_mention
+        langgraph_client,
+        thread_id,
+        content_blocks,
+        configurable,
+        is_first_mention=is_first_mention,
+        explicitly_tagged=explicitly_tagged,
     )
     if run is None:
         common.logger.info("Coalesced Slack follow-up onto the queue for busy thread %s", thread_id)

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -6,6 +6,7 @@ object (``common.X``) so tests that monkeypatch them keep working.
 
 import asyncio
 import re
+import time
 from datetime import UTC, datetime
 from typing import Any
 
@@ -100,6 +101,47 @@ async def _slack_thread_allows_untagged_reply(
             humans.add(author)
 
     return bot_participated and len(humans) == 1
+
+
+async def _slack_thread_is_busy(client: Any, thread_id: str) -> bool:
+    try:
+        thread = await client.threads.get(thread_id)
+    except Exception:  # noqa: BLE001
+        common.logger.debug(
+            "Could not read Slack thread status for %s; treating as idle", thread_id, exc_info=True
+        )
+        return False
+    status = thread.get("status") if isinstance(thread, dict) else None
+    return status == "busy"
+
+
+async def _claim_slack_interrupt_debounce(client: Any, thread_id: str, now: float) -> bool:
+    """Claim the debounce slot for a busy thread.
+
+    Returns True when this message is the leader that should schedule the single
+    delayed interrupt; False when an interrupt is already pending within the
+    quiet window, in which case the caller should coalesce onto the store queue.
+    """
+    namespace = ("slack_debounce", thread_id)
+    key = "claim"
+    try:
+        existing = await client.store.get_item(namespace, key)
+        deadline = None
+        if existing and isinstance(existing.get("value"), dict):
+            deadline = existing["value"].get("deadline")
+        if isinstance(deadline, (int, float)) and deadline > now:
+            return False
+        await client.store.put_item(
+            namespace, key, {"deadline": now + common.SLACK_INTERRUPT_DEBOUNCE_SECONDS}
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        common.logger.warning(
+            "Slack debounce bookkeeping failed for %s; scheduling interrupt anyway",
+            thread_id,
+            exc_info=True,
+        )
+        return True
 
 
 async def _slack_user_can_reply_to_ready_plan(
@@ -490,6 +532,22 @@ async def _process_slack_mention_impl(
         source_context={"slack_thread": configurable["slack_thread"]},
     )
 
+    # Debounce interrupts: when the thread is already working, hold the interrupt
+    # for a quiet window and coalesce rapid follow-ups. The leader schedules one
+    # delayed interrupt (carrying its own message); followers within the window
+    # drop onto the store queue, which the run drains at its next model call.
+    after_seconds: float | None = None
+    if not is_first_mention and await _slack_thread_is_busy(langgraph_client, thread_id):
+        if await _claim_slack_interrupt_debounce(langgraph_client, thread_id, time.time()):
+            after_seconds = common.SLACK_INTERRUPT_DEBOUNCE_SECONDS
+        else:
+            await common.queue_message_for_thread(thread_id, content_blocks)
+            common.logger.info(
+                "Coalesced Slack follow-up onto pending debounced interrupt for thread %s",
+                thread_id,
+            )
+            return
+
     run = await common.dispatch_agent_run(
         thread_id,
         content_blocks,
@@ -497,6 +555,7 @@ async def _process_slack_mention_impl(
         source="slack",
         metadata=common._AGENT_VERSION_METADATA,
         client=langgraph_client,
+        after_seconds=after_seconds,
     )
     common.logger.info(
         "Slack LangGraph run %s dispatched for thread %s",

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -115,33 +115,69 @@ async def _slack_thread_is_busy(client: Any, thread_id: str) -> bool:
     return status == "busy"
 
 
-async def _claim_slack_interrupt_debounce(client: Any, thread_id: str, now: float) -> bool:
-    """Claim the debounce slot for a busy thread.
+async def _schedule_debounced_slack_interrupt(
+    client: Any,
+    thread_id: str,
+    content_blocks: list[dict[str, Any]],
+    configurable: dict[str, Any],
+    now: float,
+) -> dict[str, Any]:
+    """Schedule (or reschedule) a single delayed interrupt of a busy thread.
 
-    Returns True when this message is the leader that should schedule the single
-    delayed interrupt; False when an interrupt is already pending within the
-    quiet window, in which case the caller should coalesce onto the store queue.
+    Trailing-edge debounce: the quiet window restarts on every follow-up. The
+    first message of a burst is the anchor carried as the eventual run input;
+    each later message is coalesced onto the store queue (drained by the run at
+    its first model call) and resets the timer by cancelling the still-pending
+    interrupt and rescheduling it ``window`` seconds out.
     """
     namespace = ("slack_debounce", thread_id)
     key = "claim"
+    anchor = content_blocks
+
     try:
         existing = await client.store.get_item(namespace, key)
-        deadline = None
-        if existing and isinstance(existing.get("value"), dict):
-            deadline = existing["value"].get("deadline")
-        if isinstance(deadline, (int, float)) and deadline > now:
-            return False
-        await client.store.put_item(
-            namespace, key, {"deadline": now + common.SLACK_INTERRUPT_DEBOUNCE_SECONDS}
-        )
-        return True
+        value = existing.get("value") if isinstance(existing, dict) else None
     except Exception:  # noqa: BLE001
-        common.logger.warning(
-            "Slack debounce bookkeeping failed for %s; scheduling interrupt anyway",
-            thread_id,
-            exc_info=True,
+        common.logger.warning("Slack debounce read failed for %s", thread_id, exc_info=True)
+        value = None
+
+    deadline = value.get("deadline") if isinstance(value, dict) else None
+    if isinstance(deadline, (int, float)) and deadline > now:
+        anchor = value.get("anchor") or content_blocks
+        await common.queue_message_for_thread(thread_id, content_blocks)
+        pending_run_id = value.get("run_id")
+        if isinstance(pending_run_id, str) and pending_run_id:
+            try:
+                await client.runs.cancel(thread_id, pending_run_id, action="rollback")
+            except Exception:  # noqa: BLE001
+                common.logger.debug(
+                    "Could not cancel pending Slack interrupt %s", pending_run_id, exc_info=True
+                )
+        common.logger.info("Extended debounced Slack interrupt window for thread %s", thread_id)
+
+    run = await common.dispatch_agent_run(
+        thread_id,
+        anchor,
+        configurable,
+        source="slack",
+        metadata=common._AGENT_VERSION_METADATA,
+        client=client,
+        after_seconds=common.SLACK_INTERRUPT_DEBOUNCE_SECONDS,
+    )
+    run_id = run.get("run_id") if isinstance(run, dict) else None
+    try:
+        await client.store.put_item(
+            namespace,
+            key,
+            {
+                "deadline": now + common.SLACK_INTERRUPT_DEBOUNCE_SECONDS,
+                "run_id": run_id,
+                "anchor": anchor,
+            },
         )
-        return True
+    except Exception:  # noqa: BLE001
+        common.logger.warning("Slack debounce write failed for %s", thread_id, exc_info=True)
+    return run
 
 
 async def _slack_user_can_reply_to_ready_plan(
@@ -532,31 +568,21 @@ async def _process_slack_mention_impl(
         source_context={"slack_thread": configurable["slack_thread"]},
     )
 
-    # Debounce interrupts: when the thread is already working, hold the interrupt
-    # for a quiet window and coalesce rapid follow-ups. The leader schedules one
-    # delayed interrupt (carrying its own message); followers within the window
-    # drop onto the store queue, which the run drains at its next model call.
-    after_seconds: float | None = None
+    # When the thread is already working, debounce the interrupt: coalesce rapid
+    # follow-ups and only interrupt once the burst goes quiet (see the scheduler).
     if not is_first_mention and await _slack_thread_is_busy(langgraph_client, thread_id):
-        if await _claim_slack_interrupt_debounce(langgraph_client, thread_id, time.time()):
-            after_seconds = common.SLACK_INTERRUPT_DEBOUNCE_SECONDS
-        else:
-            await common.queue_message_for_thread(thread_id, content_blocks)
-            common.logger.info(
-                "Coalesced Slack follow-up onto pending debounced interrupt for thread %s",
-                thread_id,
-            )
-            return
-
-    run = await common.dispatch_agent_run(
-        thread_id,
-        content_blocks,
-        configurable,
-        source="slack",
-        metadata=common._AGENT_VERSION_METADATA,
-        client=langgraph_client,
-        after_seconds=after_seconds,
-    )
+        run = await _schedule_debounced_slack_interrupt(
+            langgraph_client, thread_id, content_blocks, configurable, time.time()
+        )
+    else:
+        run = await common.dispatch_agent_run(
+            thread_id,
+            content_blocks,
+            configurable,
+            source="slack",
+            metadata=common._AGENT_VERSION_METADATA,
+            client=langgraph_client,
+        )
     common.logger.info(
         "Slack LangGraph run %s dispatched for thread %s",
         common._run_id_for_logging(run),

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -94,8 +94,11 @@ async def _slack_thread_allows_untagged_reply(
     humans: set[str] = set()
     for message in messages:
         author = message.get("user")
-        if author == bot_user_id or message.get("bot_id"):
+        if author == bot_user_id:
             bot_participated = True
+            continue
+        # Skip other apps (GitHub/CI bots) — they are neither Open SWE nor a human participant.
+        if message.get("bot_id"):
             continue
         if isinstance(author, str) and author:
             humans.add(author)

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -128,14 +128,14 @@ async def _schedule_debounced_slack_interrupt(
     """Schedule (or reschedule) a single delayed interrupt of a busy thread.
 
     Trailing-edge debounce: the quiet window restarts on every follow-up. The
-    first message of a burst is the anchor carried as the eventual run input;
-    each later message is coalesced onto the store queue (drained by the run at
-    its first model call) and resets the timer by cancelling the still-pending
-    interrupt and rescheduling it ``window`` seconds out.
+    whole burst is accumulated in debounce-specific storage (never the thread's
+    normal message queue, which the *active* run would drain mid-window) and
+    carried, in arrival order, as the eventual interrupt run's input. Each
+    follow-up appends its blocks, cancels the still-pending interrupt, and
+    reschedules it a full window out.
     """
     namespace = ("slack_debounce", thread_id)
-    key = "claim"
-    anchor = content_blocks
+    key = "burst"
 
     try:
         existing = await client.store.get_item(namespace, key)
@@ -146,8 +146,8 @@ async def _schedule_debounced_slack_interrupt(
 
     deadline = value.get("deadline") if isinstance(value, dict) else None
     if isinstance(deadline, (int, float)) and deadline > now:
-        anchor = value.get("anchor") or content_blocks
-        await common.queue_message_for_thread(thread_id, content_blocks)
+        prior = value.get("blocks") if isinstance(value.get("blocks"), list) else []
+        blocks = [*prior, *content_blocks]
         pending_run_id = value.get("run_id")
         if isinstance(pending_run_id, str) and pending_run_id:
             try:
@@ -157,10 +157,15 @@ async def _schedule_debounced_slack_interrupt(
                     "Could not cancel pending Slack interrupt %s", pending_run_id, exc_info=True
                 )
         common.logger.info("Extended debounced Slack interrupt window for thread %s", thread_id)
+    else:
+        blocks = list(content_blocks)
+
+    if len(blocks) > common.SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS:
+        blocks = blocks[-common.SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS :]
 
     run = await common.dispatch_agent_run(
         thread_id,
-        anchor,
+        blocks,
         configurable,
         source="slack",
         metadata=common._AGENT_VERSION_METADATA,
@@ -175,7 +180,7 @@ async def _schedule_debounced_slack_interrupt(
             {
                 "deadline": now + common.SLACK_INTERRUPT_DEBOUNCE_SECONDS,
                 "run_id": run_id,
-                "anchor": anchor,
+                "blocks": blocks,
             },
         )
     except Exception:  # noqa: BLE001

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -6,7 +6,6 @@ object (``common.X``) so tests that monkeypatch them keep working.
 
 import asyncio
 import re
-import time
 from datetime import UTC, datetime
 from typing import Any
 
@@ -85,7 +84,7 @@ async def _slack_thread_allows_untagged_reply(
     if not channel_id or not thread_ts or not bot_user_id:
         return False
 
-    mentioned = set(re.findall(r"<@([A-Z0-9]+)>", text or ""))
+    mentioned = set(re.findall(r"<@([A-Z0-9_]+)", text or ""))
     if any(user_id != bot_user_id for user_id in mentioned):
         return False
 
@@ -118,74 +117,31 @@ async def _slack_thread_is_busy(client: Any, thread_id: str) -> bool:
     return status == "busy"
 
 
-async def _schedule_debounced_slack_interrupt(
+async def _dispatch_or_queue_slack_run(
     client: Any,
     thread_id: str,
     content_blocks: list[dict[str, Any]],
     configurable: dict[str, Any],
-    now: float,
-) -> dict[str, Any]:
-    """Schedule (or reschedule) a single delayed interrupt of a busy thread.
+    is_first_mention: bool,
+) -> dict[str, Any] | None:
+    """Start a run, or coalesce onto the thread queue if one is already in flight.
 
-    Trailing-edge debounce: the quiet window restarts on every follow-up. The
-    whole burst is accumulated in debounce-specific storage (never the thread's
-    normal message queue, which the *active* run would drain mid-window) and
-    carried, in arrival order, as the eventual interrupt run's input. Each
-    follow-up appends its blocks, cancels the still-pending interrupt, and
-    reschedules it a full window out.
+    Debounces interrupts: while the agent is busy, rapid follow-ups are parked on
+    the store queue and picked up together at its next model call (via
+    ``check_message_queue_before_model``) instead of each halting and resuming the
+    active run. Returns the run dict, or ``None`` when the message was queued.
     """
-    namespace = ("slack_debounce", thread_id)
-    key = "burst"
-
-    try:
-        existing = await client.store.get_item(namespace, key)
-        value = existing.get("value") if isinstance(existing, dict) else None
-    except Exception:  # noqa: BLE001
-        common.logger.warning("Slack debounce read failed for %s", thread_id, exc_info=True)
-        value = None
-
-    deadline = value.get("deadline") if isinstance(value, dict) else None
-    if isinstance(deadline, (int, float)) and deadline > now:
-        prior = value.get("blocks") if isinstance(value.get("blocks"), list) else []
-        blocks = [*prior, *content_blocks]
-        pending_run_id = value.get("run_id")
-        if isinstance(pending_run_id, str) and pending_run_id:
-            try:
-                await client.runs.cancel(thread_id, pending_run_id, action="rollback")
-            except Exception:  # noqa: BLE001
-                common.logger.debug(
-                    "Could not cancel pending Slack interrupt %s", pending_run_id, exc_info=True
-                )
-        common.logger.info("Extended debounced Slack interrupt window for thread %s", thread_id)
-    else:
-        blocks = list(content_blocks)
-
-    if len(blocks) > common.SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS:
-        blocks = blocks[-common.SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS :]
-
-    run = await common.dispatch_agent_run(
+    if not is_first_mention and await _slack_thread_is_busy(client, thread_id):
+        await common.queue_message_for_thread(thread_id, content_blocks)
+        return None
+    return await common.dispatch_agent_run(
         thread_id,
-        blocks,
+        content_blocks,
         configurable,
         source="slack",
         metadata=common._AGENT_VERSION_METADATA,
         client=client,
-        after_seconds=common.SLACK_INTERRUPT_DEBOUNCE_SECONDS,
     )
-    run_id = run.get("run_id") if isinstance(run, dict) else None
-    try:
-        await client.store.put_item(
-            namespace,
-            key,
-            {
-                "deadline": now + common.SLACK_INTERRUPT_DEBOUNCE_SECONDS,
-                "run_id": run_id,
-                "blocks": blocks,
-            },
-        )
-    except Exception:  # noqa: BLE001
-        common.logger.warning("Slack debounce write failed for %s", thread_id, exc_info=True)
-    return run
 
 
 async def _slack_user_can_reply_to_ready_plan(
@@ -196,7 +152,12 @@ async def _slack_user_can_reply_to_ready_plan(
     from agent.dashboard.plan_api import _thread_metadata
 
     thread_id = common.generate_thread_id_from_slack_thread(channel_id, thread_ts)
-    metadata = await _thread_metadata(thread_id)
+    try:
+        metadata = await _thread_metadata(thread_id)
+    except Exception:  # noqa: BLE001
+        # A brand-new thread has no metadata (_thread_metadata raises 404); an
+        # untagged message there simply isn't a plan reply — don't abort the gate.
+        return False
     return (
         metadata.get("plan_mode") is True
         and metadata.get("plan_status") == "ready"
@@ -576,21 +537,12 @@ async def _process_slack_mention_impl(
         source_context={"slack_thread": configurable["slack_thread"]},
     )
 
-    # When the thread is already working, debounce the interrupt: coalesce rapid
-    # follow-ups and only interrupt once the burst goes quiet (see the scheduler).
-    if not is_first_mention and await _slack_thread_is_busy(langgraph_client, thread_id):
-        run = await _schedule_debounced_slack_interrupt(
-            langgraph_client, thread_id, content_blocks, configurable, time.time()
-        )
-    else:
-        run = await common.dispatch_agent_run(
-            thread_id,
-            content_blocks,
-            configurable,
-            source="slack",
-            metadata=common._AGENT_VERSION_METADATA,
-            client=langgraph_client,
-        )
+    run = await _dispatch_or_queue_slack_run(
+        langgraph_client, thread_id, content_blocks, configurable, is_first_mention
+    )
+    if run is None:
+        common.logger.info("Coalesced Slack follow-up onto the queue for busy thread %s", thread_id)
+        return
     common.logger.info(
         "Slack LangGraph run %s dispatched for thread %s",
         common._run_id_for_logging(run),

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -73,6 +73,35 @@ def _is_natural_language_plan_approval(text: str) -> bool:
     return any(f" {phrase} " in padded for phrase in _PLAN_APPROVAL_PHRASES)
 
 
+async def _slack_thread_allows_untagged_reply(
+    channel_id: str, thread_ts: str, text: str, bot_user_id: str
+) -> bool:
+    """Allow an untagged follow-up when Open SWE and exactly one human share the thread.
+
+    Skipped when the message mentions any user other than Open SWE, so tagging a
+    different person still hands the turn to them rather than the agent.
+    """
+    if not channel_id or not thread_ts or not bot_user_id:
+        return False
+
+    mentioned = set(re.findall(r"<@([A-Z0-9]+)>", text or ""))
+    if any(user_id != bot_user_id for user_id in mentioned):
+        return False
+
+    messages = await common.fetch_slack_thread_messages(channel_id, thread_ts)
+    bot_participated = False
+    humans: set[str] = set()
+    for message in messages:
+        author = message.get("user")
+        if author == bot_user_id or message.get("bot_id"):
+            bot_participated = True
+            continue
+        if isinstance(author, str) and author:
+            humans.add(author)
+
+    return bot_participated and len(humans) == 1
+
+
 async def _slack_user_can_reply_to_ready_plan(
     channel_id: str, thread_ts: str, slack_user_id: str
 ) -> bool:

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -102,6 +102,7 @@ async def slack_webhook(
         is_untagged_two_party_reply = bool(
             event.get("type") == "message"
             and not event.get("subtype")
+            and not is_direct_message
             and await service._slack_thread_allows_untagged_reply(
                 str(event.get("channel") or ""),
                 str(event.get("thread_ts") or ""),

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -59,6 +59,20 @@ async def slack_webhook(
             return {"status": "accepted", "message": "Reaction removal queued"}
         return {"status": "ignored", "reason": "Reaction not tracked for feedback"}
 
+    bot_user_id = common.SLACK_BOT_USER_ID
+    if not bot_user_id:
+        authorizations = payload.get("authorizations", [])
+        if isinstance(authorizations, list) and authorizations:
+            auth_user_id = authorizations[0].get("user_id")
+            if isinstance(auth_user_id, str):
+                bot_user_id = auth_user_id
+    if not bot_user_id:
+        authed_users = payload.get("authed_users", [])
+        if isinstance(authed_users, list) and authed_users:
+            first_user = authed_users[0]
+            if isinstance(first_user, str):
+                bot_user_id = first_user
+
     if event.get("type") != "app_mention":
         message_text = event.get("text", "")
         has_username_mention = bool(
@@ -79,7 +93,22 @@ async def slack_webhook(
                 str(event.get("user") or ""),
             )
         )
-        if not (has_username_mention or has_id_mention or is_ready_plan_reply):
+        is_untagged_two_party_reply = bool(
+            event.get("type") == "message"
+            and not event.get("subtype")
+            and await service._slack_thread_allows_untagged_reply(
+                str(event.get("channel") or ""),
+                str(event.get("thread_ts") or ""),
+                message_text,
+                bot_user_id,
+            )
+        )
+        if not (
+            has_username_mention
+            or has_id_mention
+            or is_ready_plan_reply
+            or is_untagged_two_party_reply
+        ):
             return {"status": "ignored", "reason": "Not an app mention or plan reply"}
 
     if event.get("subtype") == "bot_message" or event.get("bot_id"):
@@ -92,20 +121,6 @@ async def slack_webhook(
     text = event.get("text", "")
     if not channel_id or not event_ts or not thread_ts:
         return {"status": "ignored", "reason": "Missing channel/thread timestamp"}
-
-    bot_user_id = common.SLACK_BOT_USER_ID
-    if not bot_user_id:
-        authorizations = payload.get("authorizations", [])
-        if isinstance(authorizations, list) and authorizations:
-            auth_user_id = authorizations[0].get("user_id")
-            if isinstance(auth_user_id, str):
-                bot_user_id = auth_user_id
-    if not bot_user_id:
-        authed_users = payload.get("authed_users", [])
-        if isinstance(authed_users, list) and authed_users:
-            first_user = authed_users[0]
-            if isinstance(first_user, str):
-                bot_user_id = first_user
 
     if bot_user_id and user_id == bot_user_id:
         return {"status": "ignored", "reason": "Event from this bot user"}

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -9,6 +9,7 @@ the preceding tool result, exactly as a real model would.
 
 from __future__ import annotations
 
+import os
 import re
 import time
 from collections.abc import Callable
@@ -405,5 +406,11 @@ class FakeScriptedChatModel(BaseChatModel):
             (i for i, m in enumerate(messages) if isinstance(m, HumanMessage)), default=-1
         )
         step_index = sum(1 for m in messages[last_human + 1 :] if isinstance(m, AIMessage))
+
+        # Keep a run busy on demand so E2E can land follow-ups mid-run (exercising
+        # the interrupt-debounce path). Only the triggering message carries the
+        # marker, and only the first model call of that run blocks.
+        if step_index == 0 and "E2E_BUSY_HOLD" in context.last_text:
+            time.sleep(float(os.environ.get("E2E_BUSY_HOLD_SECONDS", "10")))
         step = script[step_index] if step_index < len(script) else SCRIPT_LIBRARY["followup"][0]
         return ChatResult(generations=[ChatGeneration(message=_render_step(step, messages))])

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -87,6 +87,26 @@ async def control_state() -> JSONResponse:
     )
 
 
+@app.get("/control/queued")
+async def control_queued(thread_id: str = "") -> JSONResponse:
+    """Count the follow-ups parked on a busy thread's message queue.
+
+    While the agent is busy, debounced follow-ups accumulate here (namespace
+    ``("queue", thread_id)``) until the active run drains them together at its
+    next model call. Lets the E2E assert coalescing instead of per-message runs."""
+    from langgraph_sdk import get_client
+
+    value: Any = None
+    try:
+        client = get_client(url=os.environ["LANGGRAPH_URL"])
+        item = await client.store.get_item(("queue", thread_id), key="pending_messages")
+        value = item.get("value") if item else None
+    except Exception:  # noqa: BLE001
+        value = None
+    messages = value.get("messages") if isinstance(value, dict) else None
+    return JSONResponse({"queued_count": len(messages) if isinstance(messages, list) else 0})
+
+
 @app.post("/mock/slack/send")
 async def slack_send(request: Request) -> JSONResponse:
     """Simulate a user posting in Slack: store the message, then deliver the
@@ -99,21 +119,29 @@ async def slack_send(request: Request) -> JSONResponse:
     user_id = str(form.get("user") or TEST_USERS[0]["slack_id"])
     channel = DEMO_CHANNEL
 
-    ts = fakes.new_thread_ts()
-    CURRENT_THREAD["thread_ts"] = ts
-    fakes.add_slack_message(channel, ts, user=user_id, text=text, is_bot=False)
+    # ``thread_ts`` replies into an existing thread (a distinct message ts under
+    # the same thread); omitting it opens a fresh thread, as the mock UI does.
+    reply_thread_ts = str(form.get("thread_ts") or "")
+    if reply_thread_ts:
+        thread_ts = reply_thread_ts
+        event_ts = fakes.add_slack_message(channel, thread_ts, user=user_id, text=text)
+    else:
+        thread_ts = fakes.new_thread_ts()
+        CURRENT_THREAD["thread_ts"] = thread_ts
+        fakes.add_slack_message(channel, thread_ts, user=user_id, text=text)
+        event_ts = thread_ts
 
     payload = {
         "type": "event_callback",
-        "event_id": f"Ev{ts}",
+        "event_id": f"Ev{event_ts}",
         "authorizations": [{"user_id": BOT_USER_ID}],
         "event": {
             "type": "app_mention" if mention_bot else "message",
             "channel": channel,
             "user": user_id,
             "text": text,
-            "ts": ts,
-            "thread_ts": ts,
+            "ts": event_ts,
+            "thread_ts": thread_ts,
         },
     }
     raw = json.dumps(payload).encode()
@@ -134,8 +162,8 @@ async def slack_send(request: Request) -> JSONResponse:
         )
     return JSONResponse(
         {
-            "thread_ts": ts,
-            "thread_id": generate_thread_id_from_slack_thread(channel, ts),
+            "thread_ts": thread_ts,
+            "thread_id": generate_thread_id_from_slack_thread(channel, thread_ts),
             "webhook_status": resp.status_code,
             "webhook": resp.json(),
         }

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -40,5 +40,8 @@ export default defineConfig({
     url: `${baseURL}/mock/github/data`,
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,
+    // Deterministic busy window for the interrupt-debounce spec: the fake LLM
+    // holds the first run open this long so follow-ups reliably land mid-run.
+    env: { ...process.env, E2E_BUSY_HOLD_SECONDS: "20" },
   },
 });

--- a/tests/e2e/tests/slack_debounce.spec.ts
+++ b/tests/e2e/tests/slack_debounce.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect, type APIRequestContext } from "@playwright/test";
 
-// Feature: while Open SWE is busy on a thread, rapid follow-ups are debounced —
+// Feature: while Open SWE is busy, *untagged* follow-ups are debounced —
 // coalesced onto the thread's message queue (for the active run to drain at its
-// next model call) instead of each halting and resuming the run. Driven through
-// the real webhook + real agent; the LLM is faked and holds the first run open
-// so follow-ups land mid-run.
+// next model call) instead of each halting and resuming the run. An explicit
+// @-mention is NOT debounced (it keeps interrupting immediately). Driven through
+// the real webhook + real agent; the LLM is faked and holds a run open so
+// follow-ups land mid-run.
 
 type SendResult = {
   thread_ts: string;
@@ -18,6 +19,15 @@ async function send(
 ): Promise<SendResult> {
   const res = await request.post("/mock/slack/send", { data });
   return (await res.json()) as SendResult;
+}
+
+async function botTexts(request: APIRequestContext): Promise<string> {
+  const res = await request.get("/mock/slack/messages");
+  const msgs = (await res.json()) as Array<{ text: string; is_bot: boolean }>;
+  return msgs
+    .filter((m) => m.is_bot)
+    .map((m) => m.text)
+    .join("\n");
 }
 
 async function threadStatus(
@@ -41,42 +51,43 @@ async function queuedCount(
   return body.queued_count;
 }
 
-async function runCount(
-  request: APIRequestContext,
-  threadId: string,
-): Promise<number> {
-  const res = await request.get(`/threads/${threadId}/runs`);
-  if (!res.ok()) return -1;
-  const runs = (await res.json()) as unknown[];
-  return Array.isArray(runs) ? runs.length : -1;
-}
-
 test.describe("Slack busy-thread interrupt debounce", () => {
-  test("rapid follow-ups coalesce onto the queue without new runs", async ({
+  test("untagged follow-ups on a busy thread coalesce onto the queue", async ({
     request,
   }) => {
     await request.post("/control/reset");
 
-    // 1. Start a run that holds the thread busy (the fake LLM sleeps on the
-    //    E2E_BUSY_HOLD marker), so follow-ups arrive mid-run.
+    // Phase 1: open a two-party thread so Open SWE has participated (a
+    // prerequisite for untagged follow-ups to be accepted).
     const opened = await send(request, {
-      text: "<@U0BOT> please add a greet() helper and open a PR E2E_BUSY_HOLD",
+      text: "<@U0BOT> please add a greet() helper and open a PR",
       mention_bot: true,
     });
     const threadId = opened.thread_id;
     const threadTs = opened.thread_ts;
-    expect(opened.webhook.status).toBe("accepted");
+    await expect
+      .poll(() => botTexts(request), { timeout: 60_000 })
+      .toContain("/pull/");
+    await expect
+      .poll(() => threadStatus(request, threadId), { timeout: 30_000 })
+      .not.toBe("busy");
 
-    // 2. Wait until the run is actually busy before firing follow-ups.
+    // Phase 2: start a run that holds the thread busy (fake LLM sleeps on the
+    // marker). This one IS tagged, so it dispatches immediately.
+    const busy = await send(request, {
+      text: "<@U0BOT> now also tweak it E2E_BUSY_HOLD",
+      mention_bot: true,
+      thread_ts: threadTs,
+    });
+    expect(busy.webhook.status).toBe("accepted");
     await expect
       .poll(() => threadStatus(request, threadId), { timeout: 30_000 })
       .toBe("busy");
-    const runsWhileBusy = await runCount(request, threadId);
 
-    // 3. First follow-up while busy → parked on the queue, no new run.
+    // 3. First UNTAGGED follow-up while busy → parked on the queue, no interrupt.
     const b = await send(request, {
-      text: "<@U0BOT> also rename it to hello()",
-      mention_bot: true,
+      text: "also rename it to hello()",
+      mention_bot: false,
       thread_ts: threadTs,
     });
     expect(b.webhook.status).toBe("accepted");
@@ -84,10 +95,10 @@ test.describe("Slack busy-thread interrupt debounce", () => {
       .poll(() => queuedCount(request, threadId), { timeout: 30_000 })
       .toBe(1);
 
-    // 4. Second follow-up while still busy → coalesced onto the SAME queue.
+    // 4. Second UNTAGGED follow-up while still busy → coalesced onto the queue.
     const c = await send(request, {
-      text: "<@U0BOT> and add a type hint",
-      mention_bot: true,
+      text: "and add a type hint",
+      mention_bot: false,
       thread_ts: threadTs,
     });
     expect(c.webhook.status).toBe("accepted");
@@ -95,8 +106,7 @@ test.describe("Slack busy-thread interrupt debounce", () => {
       .poll(() => queuedCount(request, threadId), { timeout: 30_000 })
       .toBe(2);
 
-    // 5. Neither follow-up spawned its own run — the active run absorbs both.
+    // The run is still busy — the untagged follow-ups did not interrupt it.
     expect(await threadStatus(request, threadId)).toBe("busy");
-    expect(await runCount(request, threadId)).toBe(runsWhileBusy);
   });
 });

--- a/tests/e2e/tests/slack_debounce.spec.ts
+++ b/tests/e2e/tests/slack_debounce.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+// Feature: while Open SWE is busy on a thread, rapid follow-ups are debounced —
+// coalesced onto the thread's message queue (for the active run to drain at its
+// next model call) instead of each halting and resuming the run. Driven through
+// the real webhook + real agent; the LLM is faked and holds the first run open
+// so follow-ups land mid-run.
+
+type SendResult = {
+  thread_ts: string;
+  thread_id: string;
+  webhook: { status: string };
+};
+
+async function send(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+): Promise<SendResult> {
+  const res = await request.post("/mock/slack/send", { data });
+  return (await res.json()) as SendResult;
+}
+
+async function threadStatus(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<string> {
+  const res = await request.get(`/threads/${threadId}`);
+  if (!res.ok()) return "";
+  const thread = (await res.json()) as { status?: string };
+  return thread.status ?? "";
+}
+
+async function queuedCount(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<number> {
+  const res = await request.get(
+    `/control/queued?thread_id=${encodeURIComponent(threadId)}`,
+  );
+  const body = (await res.json()) as { queued_count: number };
+  return body.queued_count;
+}
+
+async function runCount(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<number> {
+  const res = await request.get(`/threads/${threadId}/runs`);
+  if (!res.ok()) return -1;
+  const runs = (await res.json()) as unknown[];
+  return Array.isArray(runs) ? runs.length : -1;
+}
+
+test.describe("Slack busy-thread interrupt debounce", () => {
+  test("rapid follow-ups coalesce onto the queue without new runs", async ({
+    request,
+  }) => {
+    await request.post("/control/reset");
+
+    // 1. Start a run that holds the thread busy (the fake LLM sleeps on the
+    //    E2E_BUSY_HOLD marker), so follow-ups arrive mid-run.
+    const opened = await send(request, {
+      text: "<@U0BOT> please add a greet() helper and open a PR E2E_BUSY_HOLD",
+      mention_bot: true,
+    });
+    const threadId = opened.thread_id;
+    const threadTs = opened.thread_ts;
+    expect(opened.webhook.status).toBe("accepted");
+
+    // 2. Wait until the run is actually busy before firing follow-ups.
+    await expect
+      .poll(() => threadStatus(request, threadId), { timeout: 30_000 })
+      .toBe("busy");
+    const runsWhileBusy = await runCount(request, threadId);
+
+    // 3. First follow-up while busy → parked on the queue, no new run.
+    const b = await send(request, {
+      text: "<@U0BOT> also rename it to hello()",
+      mention_bot: true,
+      thread_ts: threadTs,
+    });
+    expect(b.webhook.status).toBe("accepted");
+    await expect
+      .poll(() => queuedCount(request, threadId), { timeout: 30_000 })
+      .toBe(1);
+
+    // 4. Second follow-up while still busy → coalesced onto the SAME queue.
+    const c = await send(request, {
+      text: "<@U0BOT> and add a type hint",
+      mention_bot: true,
+      thread_ts: threadTs,
+    });
+    expect(c.webhook.status).toBe("accepted");
+    await expect
+      .poll(() => queuedCount(request, threadId), { timeout: 30_000 })
+      .toBe(2);
+
+    // 5. Neither follow-up spawned its own run — the active run absorbs both.
+    expect(await threadStatus(request, threadId)).toBe("busy");
+    expect(await runCount(request, threadId)).toBe(runsWhileBusy);
+  });
+});

--- a/tests/e2e/tests/slack_untagged_reply.spec.ts
+++ b/tests/e2e/tests/slack_untagged_reply.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+// Feature: in a Slack thread whose only participants are Open SWE and one human,
+// a follow-up no longer needs to @-mention the bot — UNLESS it tags a different
+// user. Driven through the real webhook + real agent; only the LLM is faked.
+
+type SendResult = {
+  thread_ts: string;
+  thread_id: string;
+  webhook: { status: string; reason?: string };
+};
+
+async function send(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+): Promise<SendResult> {
+  const res = await request.post("/mock/slack/send", { data });
+  return (await res.json()) as SendResult;
+}
+
+async function botTexts(request: APIRequestContext): Promise<string[]> {
+  const res = await request.get("/mock/slack/messages");
+  const msgs = (await res.json()) as Array<{ text: string; is_bot: boolean }>;
+  return msgs.filter((m) => m.is_bot).map((m) => m.text);
+}
+
+async function threadStatus(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<string> {
+  const res = await request.get(`/threads/${threadId}`);
+  if (!res.ok()) return "";
+  const thread = (await res.json()) as { status?: string };
+  return thread.status ?? "";
+}
+
+async function stateText(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<string> {
+  const res = await request.get(`/threads/${threadId}/state`);
+  const state = (await res.json()) as {
+    values?: { messages?: Array<{ content?: unknown }> };
+  };
+  return (state.values?.messages ?? [])
+    .map((m) =>
+      typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+    )
+    .join("\n");
+}
+
+// Open a two-party thread: Alice @-mentions the bot, the agent implements and
+// replies, so the thread now holds exactly Alice + Open SWE.
+async function openTwoPartyThread(
+  request: APIRequestContext,
+): Promise<SendResult> {
+  await request.post("/control/reset");
+  const opened = await send(request, {
+    text: "<@U0BOT> please add a greet() helper and open a PR",
+    mention_bot: true,
+  });
+  expect(opened.webhook.status).toBe("accepted");
+  await expect
+    .poll(async () => (await botTexts(request)).join("\n"), { timeout: 60_000 })
+    .toContain("/pull/");
+  // Let the opening run settle so a follow-up dispatches immediately rather than
+  // queueing behind an about-to-finish run.
+  await expect
+    .poll(() => threadStatus(request, opened.thread_id), { timeout: 30_000 })
+    .not.toBe("busy");
+  return opened;
+}
+
+test.describe("Slack untagged two-party replies", () => {
+  test("an untagged follow-up triggers a run once Open SWE is in the thread", async ({
+    request,
+  }) => {
+    const { thread_ts, thread_id } = await openTwoPartyThread(request);
+
+    // A plain message (no @-mention) in the two-party thread is accepted…
+    const followUp = await send(request, {
+      text: "actually, can you also add a docstring?",
+      mention_bot: false,
+      thread_ts,
+    });
+    expect(followUp.webhook.status).toBe("accepted");
+
+    // …and the agent actually runs on it (its follow-up reply lands in state).
+    await expect
+      .poll(async () => stateText(request, thread_id), { timeout: 60_000 })
+      .toContain("anything else you'd like changed");
+  });
+
+  test("an untagged message tagging another user is ignored", async ({
+    request,
+  }) => {
+    const { thread_ts } = await openTwoPartyThread(request);
+
+    // Tagging Bob (a different, non-bot user) hands the turn to him, not the agent.
+    const toSomeoneElse = await send(request, {
+      text: "<@U_BOB> could you take a look at this one?",
+      mention_bot: false,
+      thread_ts,
+    });
+    expect(toSomeoneElse.webhook.status).toBe("ignored");
+  });
+
+  test("an untagged message in a brand-new thread is ignored", async ({
+    request,
+  }) => {
+    await request.post("/control/reset");
+    // No prior Open SWE participation → the bot must be @-mentioned to engage.
+    const fresh = await send(request, {
+      text: "just chatting with the team, nothing for the bot",
+      mention_bot: false,
+    });
+    expect(fresh.webhook.status).toBe("ignored");
+  });
+});

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -247,6 +247,15 @@ class _FakeStore:
         self.puts.append(value)
 
 
+class _FakeRuns:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.cancelled: list[tuple[str, str]] = []
+
+    async def cancel(self, thread_id: str, run_id: str, *, action: str = "interrupt") -> None:
+        self.cancelled.append((run_id, action))
+
+
 class _FakeStoreClient:
     class _Threads:
         def __init__(self, status: str) -> None:
@@ -258,6 +267,7 @@ class _FakeStoreClient:
     def __init__(self, status: str = "busy", item: dict[str, Any] | None = None) -> None:
         self.store = _FakeStore(item)
         self.threads = _FakeStoreClient._Threads(status)
+        self.runs = _FakeRuns()
 
 
 @pytest.mark.asyncio
@@ -267,21 +277,76 @@ async def test_slack_thread_is_busy_reflects_status() -> None:
 
 
 @pytest.mark.asyncio
-async def test_debounce_leader_claims_slot_when_none_pending() -> None:
+async def test_debounce_first_message_schedules_delayed_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _FakeStoreClient(item=None)
-    assert await slack_webhook._claim_slack_interrupt_debounce(client, "t1", now=100.0) is True
-    assert client.store.puts and client.store.puts[0]["deadline"] > 100.0
+    dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    queue = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
+    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
+
+    blocks = [{"type": "text", "text": "first"}]
+    run = await slack_webhook._schedule_debounced_slack_interrupt(
+        client, "t1", blocks, {}, now=100.0
+    )
+
+    assert run == {"run_id": "run-1"}
+    # First message is the anchor input, not queued, and schedules a delayed interrupt.
+    queue.assert_not_awaited()
+    assert dispatch.await_args.args[1] == blocks
+    assert dispatch.await_args.kwargs["after_seconds"] == 15.0
+    stored = client.store.puts[-1]
+    assert (
+        stored["deadline"] == 115.0 and stored["run_id"] == "run-1" and stored["anchor"] == blocks
+    )
 
 
 @pytest.mark.asyncio
-async def test_debounce_follower_when_claim_still_active() -> None:
-    client = _FakeStoreClient(item={"value": {"deadline": 200.0}})
-    assert await slack_webhook._claim_slack_interrupt_debounce(client, "t1", now=100.0) is False
-    assert client.store.puts == []
+async def test_debounce_follow_up_extends_window_and_keeps_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    anchor = [{"type": "text", "text": "first"}]
+    client = _FakeStoreClient(
+        item={"value": {"deadline": 110.0, "run_id": "run-1", "anchor": anchor}}
+    )
+    dispatch = AsyncMock(return_value={"run_id": "run-2"})
+    queue = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
+    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
+
+    later = [{"type": "text", "text": "second"}]
+    await slack_webhook._schedule_debounced_slack_interrupt(client, "t1", later, {}, now=105.0)
+
+    # Later message is coalesced onto the queue; the pending interrupt is cancelled.
+    queue.assert_awaited_once_with("t1", later)
+    assert client.runs.cancelled == [("run-1", "rollback")]
+    # The rescheduled run still carries the original anchor and a fresh deadline.
+    assert dispatch.await_args.args[1] == anchor
+    stored = client.store.puts[-1]
+    assert (
+        stored["deadline"] == 120.0 and stored["run_id"] == "run-2" and stored["anchor"] == anchor
+    )
 
 
 @pytest.mark.asyncio
-async def test_debounce_leader_when_prior_claim_expired() -> None:
-    client = _FakeStoreClient(item={"value": {"deadline": 50.0}})
-    assert await slack_webhook._claim_slack_interrupt_debounce(client, "t1", now=100.0) is True
-    assert client.store.puts
+async def test_debounce_expired_claim_starts_fresh_burst(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeStoreClient(item={"value": {"deadline": 50.0, "run_id": "old", "anchor": ["x"]}})
+    dispatch = AsyncMock(return_value={"run_id": "run-3"})
+    queue = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
+    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
+
+    blocks = [{"type": "text", "text": "new burst"}]
+    await slack_webhook._schedule_debounced_slack_interrupt(client, "t1", blocks, {}, now=100.0)
+
+    # Expired claim: treat as a fresh burst — no queue, no cancel, new anchor.
+    queue.assert_not_awaited()
+    assert client.runs.cancelled == []
+    assert dispatch.await_args.args[1] == blocks
+    assert client.store.puts[-1]["anchor"] == blocks

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -253,115 +253,78 @@ async def test_untagged_reply_blocked_when_only_third_party_bot_present(
     )
 
 
-class _FakeStore:
-    def __init__(self, item: dict[str, Any] | None = None) -> None:
-        self.item = item
-        self.puts: list[dict[str, Any]] = []
+class _FakeThreadsStatus:
+    def __init__(self, status: str) -> None:
+        self._status = status
 
-    async def get_item(self, namespace: tuple[str, ...], key: str) -> dict[str, Any] | None:
-        return self.item
-
-    async def put_item(self, namespace: tuple[str, ...], key: str, value: dict[str, Any]) -> None:
-        self.item = {"value": value}
-        self.puts.append(value)
+    async def get(self, thread_id: str) -> dict[str, str]:
+        return {"status": self._status}
 
 
-class _FakeRuns:
-    def __init__(self) -> None:
-        self.created: list[dict[str, Any]] = []
-        self.cancelled: list[tuple[str, str]] = []
-
-    async def cancel(self, thread_id: str, run_id: str, *, action: str = "interrupt") -> None:
-        self.cancelled.append((run_id, action))
-
-
-class _FakeStoreClient:
-    class _Threads:
-        def __init__(self, status: str) -> None:
-            self._status = status
-
-        async def get(self, thread_id: str) -> dict[str, str]:
-            return {"status": self._status}
-
-    def __init__(self, status: str = "busy", item: dict[str, Any] | None = None) -> None:
-        self.store = _FakeStore(item)
-        self.threads = _FakeStoreClient._Threads(status)
-        self.runs = _FakeRuns()
+class _FakeStatusClient:
+    def __init__(self, status: str = "busy") -> None:
+        self.threads = _FakeThreadsStatus(status)
 
 
 @pytest.mark.asyncio
 async def test_slack_thread_is_busy_reflects_status() -> None:
-    assert await slack_webhook._slack_thread_is_busy(_FakeStoreClient("busy"), "t1") is True
-    assert await slack_webhook._slack_thread_is_busy(_FakeStoreClient("idle"), "t1") is False
+    assert await slack_webhook._slack_thread_is_busy(_FakeStatusClient("busy"), "t1") is True
+    assert await slack_webhook._slack_thread_is_busy(_FakeStatusClient("idle"), "t1") is False
 
 
 @pytest.mark.asyncio
-async def test_debounce_first_message_schedules_delayed_interrupt(
+async def test_dispatch_or_queue_dispatches_when_idle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = _FakeStoreClient(item=None)
     dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    queue = AsyncMock(return_value=True)
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
-    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
-    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", 200)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
 
-    blocks = [{"type": "text", "text": "first"}]
-    run = await slack_webhook._schedule_debounced_slack_interrupt(
-        client, "t1", blocks, {}, now=100.0
+    blocks = [{"type": "text", "text": "hi"}]
+    run = await slack_webhook._dispatch_or_queue_slack_run(
+        _FakeStatusClient("idle"), "t1", blocks, {}, is_first_mention=False
     )
 
     assert run == {"run_id": "run-1"}
-    # First message becomes the burst input and schedules a delayed interrupt.
+    queue.assert_not_awaited()
     assert dispatch.await_args.args[1] == blocks
-    assert dispatch.await_args.kwargs["after_seconds"] == 15.0
-    stored = client.store.puts[-1]
-    assert (
-        stored["deadline"] == 115.0 and stored["run_id"] == "run-1" and stored["blocks"] == blocks
-    )
 
 
 @pytest.mark.asyncio
-async def test_debounce_follow_up_accumulates_burst_and_resets_timer(
+async def test_dispatch_or_queue_dispatches_on_first_mention_without_status_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    first = [{"type": "text", "text": "first"}]
-    client = _FakeStoreClient(
-        item={"value": {"deadline": 110.0, "run_id": "run-1", "blocks": first}}
-    )
-    dispatch = AsyncMock(return_value={"run_id": "run-2"})
+    dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    queue = AsyncMock(return_value=True)
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
-    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
-    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", 200)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
 
-    later = [{"type": "text", "text": "second"}]
-    await slack_webhook._schedule_debounced_slack_interrupt(client, "t1", later, {}, now=105.0)
-
-    # The still-pending interrupt is cancelled and rescheduled; no shared queue involved.
-    assert client.runs.cancelled == [("run-1", "rollback")]
-    # The rescheduled run carries the whole burst in arrival order with a fresh deadline.
-    assert dispatch.await_args.args[1] == [*first, *later]
-    stored = client.store.puts[-1]
-    assert (
-        stored["deadline"] == 120.0
-        and stored["run_id"] == "run-2"
-        and stored["blocks"] == [*first, *later]
+    # A brand-new thread can't be busy — dispatch straight away (status "busy"
+    # here proves the first-mention short-circuit skips the check).
+    run = await slack_webhook._dispatch_or_queue_slack_run(
+        _FakeStatusClient("busy"), "t1", [{"type": "text", "text": "hi"}], {}, is_first_mention=True
     )
+
+    assert run == {"run_id": "run-1"}
+    queue.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_debounce_expired_claim_starts_fresh_burst(
+async def test_dispatch_or_queue_coalesces_onto_queue_when_busy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = _FakeStoreClient(item={"value": {"deadline": 50.0, "run_id": "old", "blocks": ["x"]}})
-    dispatch = AsyncMock(return_value={"run_id": "run-3"})
+    dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    queue = AsyncMock(return_value=True)
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
-    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
-    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", 200)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
 
-    blocks = [{"type": "text", "text": "new burst"}]
-    await slack_webhook._schedule_debounced_slack_interrupt(client, "t1", blocks, {}, now=100.0)
+    blocks = [{"type": "text", "text": "follow up"}]
+    run = await slack_webhook._dispatch_or_queue_slack_run(
+        _FakeStatusClient("busy"), "t1", blocks, {}, is_first_mention=False
+    )
 
-    # Expired claim: fresh burst — no cancel, the stale burst is dropped.
-    assert client.runs.cancelled == []
-    assert dispatch.await_args.args[1] == blocks
-    assert client.store.puts[-1]["blocks"] == blocks
+    # Busy → parked on the queue for the active run to drain; no new run started.
+    assert run is None
+    dispatch.assert_not_awaited()
+    queue.assert_awaited_once_with("t1", blocks)

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -234,6 +234,25 @@ async def test_untagged_reply_blocked_when_bot_absent(
     )
 
 
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_when_only_third_party_bot_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # One human + a GitHub/CI bot reply, but no Open SWE message: not a two-party
+    # Open SWE thread, so an untagged follow-up must not start a run.
+    messages = [
+        {"ts": "1.0", "user": "UHUMAN"},
+        {"ts": "1.1", "user": "UGH", "bot_id": "BGITHUB"},
+    ]
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "keep going", "BOT"
+    )
+
+
 class _FakeStore:
     def __init__(self, item: dict[str, Any] | None = None) -> None:
         self.item = item

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -301,10 +301,9 @@ async def test_debounce_first_message_schedules_delayed_interrupt(
 ) -> None:
     client = _FakeStoreClient(item=None)
     dispatch = AsyncMock(return_value={"run_id": "run-1"})
-    queue = AsyncMock(return_value=True)
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
-    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
     monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
+    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", 200)
 
     blocks = [{"type": "text", "text": "first"}]
     run = await slack_webhook._schedule_debounced_slack_interrupt(
@@ -312,41 +311,40 @@ async def test_debounce_first_message_schedules_delayed_interrupt(
     )
 
     assert run == {"run_id": "run-1"}
-    # First message is the anchor input, not queued, and schedules a delayed interrupt.
-    queue.assert_not_awaited()
+    # First message becomes the burst input and schedules a delayed interrupt.
     assert dispatch.await_args.args[1] == blocks
     assert dispatch.await_args.kwargs["after_seconds"] == 15.0
     stored = client.store.puts[-1]
     assert (
-        stored["deadline"] == 115.0 and stored["run_id"] == "run-1" and stored["anchor"] == blocks
+        stored["deadline"] == 115.0 and stored["run_id"] == "run-1" and stored["blocks"] == blocks
     )
 
 
 @pytest.mark.asyncio
-async def test_debounce_follow_up_extends_window_and_keeps_anchor(
+async def test_debounce_follow_up_accumulates_burst_and_resets_timer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    anchor = [{"type": "text", "text": "first"}]
+    first = [{"type": "text", "text": "first"}]
     client = _FakeStoreClient(
-        item={"value": {"deadline": 110.0, "run_id": "run-1", "anchor": anchor}}
+        item={"value": {"deadline": 110.0, "run_id": "run-1", "blocks": first}}
     )
     dispatch = AsyncMock(return_value={"run_id": "run-2"})
-    queue = AsyncMock(return_value=True)
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
-    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
     monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
+    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", 200)
 
     later = [{"type": "text", "text": "second"}]
     await slack_webhook._schedule_debounced_slack_interrupt(client, "t1", later, {}, now=105.0)
 
-    # Later message is coalesced onto the queue; the pending interrupt is cancelled.
-    queue.assert_awaited_once_with("t1", later)
+    # The still-pending interrupt is cancelled and rescheduled; no shared queue involved.
     assert client.runs.cancelled == [("run-1", "rollback")]
-    # The rescheduled run still carries the original anchor and a fresh deadline.
-    assert dispatch.await_args.args[1] == anchor
+    # The rescheduled run carries the whole burst in arrival order with a fresh deadline.
+    assert dispatch.await_args.args[1] == [*first, *later]
     stored = client.store.puts[-1]
     assert (
-        stored["deadline"] == 120.0 and stored["run_id"] == "run-2" and stored["anchor"] == anchor
+        stored["deadline"] == 120.0
+        and stored["run_id"] == "run-2"
+        and stored["blocks"] == [*first, *later]
     )
 
 
@@ -354,18 +352,16 @@ async def test_debounce_follow_up_extends_window_and_keeps_anchor(
 async def test_debounce_expired_claim_starts_fresh_burst(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = _FakeStoreClient(item={"value": {"deadline": 50.0, "run_id": "old", "anchor": ["x"]}})
+    client = _FakeStoreClient(item={"value": {"deadline": 50.0, "run_id": "old", "blocks": ["x"]}})
     dispatch = AsyncMock(return_value={"run_id": "run-3"})
-    queue = AsyncMock(return_value=True)
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
-    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
     monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_SECONDS", 15.0)
+    monkeypatch.setattr(slack_webhook.common, "SLACK_INTERRUPT_DEBOUNCE_MAX_BLOCKS", 200)
 
     blocks = [{"type": "text", "text": "new burst"}]
     await slack_webhook._schedule_debounced_slack_interrupt(client, "t1", blocks, {}, now=100.0)
 
-    # Expired claim: treat as a fresh burst — no queue, no cancel, new anchor.
-    queue.assert_not_awaited()
+    # Expired claim: fresh burst — no cancel, the stale burst is dropped.
     assert client.runs.cancelled == []
     assert dispatch.await_args.args[1] == blocks
-    assert client.store.puts[-1]["anchor"] == blocks
+    assert client.store.puts[-1]["blocks"] == blocks

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -158,3 +158,77 @@ async def test_plan_revision_reply_does_not_trigger_approval(
 
     assert handled is False
     is_owner.assert_not_awaited()
+
+
+def _thread(*users: str) -> list[dict[str, Any]]:
+    return [{"ts": f"1.{i}", "user": user} for i, user in enumerate(users)]
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_allowed_for_two_party_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = _thread("UHUMAN", "BOT", "UHUMAN")
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "no worries, keep going", "BOT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_when_mentioning_other_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = _thread("UHUMAN", "BOT")
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "hey <@UOTHER> can you look?", "BOT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_mentioning_only_bot_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = _thread("UHUMAN", "BOT")
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "<@BOT> keep going", "BOT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_for_three_party_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = _thread("UHUMAN", "BOT", "USECOND")
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "keep going", "BOT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_when_bot_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = _thread("UHUMAN", "UHUMAN")
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "keep going", "BOT"
+    )

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -232,3 +232,56 @@ async def test_untagged_reply_blocked_when_bot_absent(
     assert not await slack_webhook._slack_thread_allows_untagged_reply(
         "C1", "123.45", "keep going", "BOT"
     )
+
+
+class _FakeStore:
+    def __init__(self, item: dict[str, Any] | None = None) -> None:
+        self.item = item
+        self.puts: list[dict[str, Any]] = []
+
+    async def get_item(self, namespace: tuple[str, ...], key: str) -> dict[str, Any] | None:
+        return self.item
+
+    async def put_item(self, namespace: tuple[str, ...], key: str, value: dict[str, Any]) -> None:
+        self.item = {"value": value}
+        self.puts.append(value)
+
+
+class _FakeStoreClient:
+    class _Threads:
+        def __init__(self, status: str) -> None:
+            self._status = status
+
+        async def get(self, thread_id: str) -> dict[str, str]:
+            return {"status": self._status}
+
+    def __init__(self, status: str = "busy", item: dict[str, Any] | None = None) -> None:
+        self.store = _FakeStore(item)
+        self.threads = _FakeStoreClient._Threads(status)
+
+
+@pytest.mark.asyncio
+async def test_slack_thread_is_busy_reflects_status() -> None:
+    assert await slack_webhook._slack_thread_is_busy(_FakeStoreClient("busy"), "t1") is True
+    assert await slack_webhook._slack_thread_is_busy(_FakeStoreClient("idle"), "t1") is False
+
+
+@pytest.mark.asyncio
+async def test_debounce_leader_claims_slot_when_none_pending() -> None:
+    client = _FakeStoreClient(item=None)
+    assert await slack_webhook._claim_slack_interrupt_debounce(client, "t1", now=100.0) is True
+    assert client.store.puts and client.store.puts[0]["deadline"] > 100.0
+
+
+@pytest.mark.asyncio
+async def test_debounce_follower_when_claim_still_active() -> None:
+    client = _FakeStoreClient(item={"value": {"deadline": 200.0}})
+    assert await slack_webhook._claim_slack_interrupt_debounce(client, "t1", now=100.0) is False
+    assert client.store.puts == []
+
+
+@pytest.mark.asyncio
+async def test_debounce_leader_when_prior_claim_expired() -> None:
+    client = _FakeStoreClient(item={"value": {"deadline": 50.0}})
+    assert await slack_webhook._claim_slack_interrupt_debounce(client, "t1", now=100.0) is True
+    assert client.store.puts

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -283,7 +283,12 @@ async def test_dispatch_or_queue_dispatches_when_idle(
 
     blocks = [{"type": "text", "text": "hi"}]
     run = await slack_webhook._dispatch_or_queue_slack_run(
-        _FakeStatusClient("idle"), "t1", blocks, {}, is_first_mention=False
+        _FakeStatusClient("idle"),
+        "t1",
+        blocks,
+        {},
+        is_first_mention=False,
+        explicitly_tagged=False,
     )
 
     assert run == {"run_id": "run-1"}
@@ -303,7 +308,12 @@ async def test_dispatch_or_queue_dispatches_on_first_mention_without_status_chec
     # A brand-new thread can't be busy — dispatch straight away (status "busy"
     # here proves the first-mention short-circuit skips the check).
     run = await slack_webhook._dispatch_or_queue_slack_run(
-        _FakeStatusClient("busy"), "t1", [{"type": "text", "text": "hi"}], {}, is_first_mention=True
+        _FakeStatusClient("busy"),
+        "t1",
+        [{"type": "text", "text": "hi"}],
+        {},
+        is_first_mention=True,
+        explicitly_tagged=True,
     )
 
     assert run == {"run_id": "run-1"}
@@ -311,7 +321,7 @@ async def test_dispatch_or_queue_dispatches_on_first_mention_without_status_chec
 
 
 @pytest.mark.asyncio
-async def test_dispatch_or_queue_coalesces_onto_queue_when_busy(
+async def test_dispatch_or_queue_coalesces_untagged_follow_up_when_busy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dispatch = AsyncMock(return_value={"run_id": "run-1"})
@@ -321,10 +331,39 @@ async def test_dispatch_or_queue_coalesces_onto_queue_when_busy(
 
     blocks = [{"type": "text", "text": "follow up"}]
     run = await slack_webhook._dispatch_or_queue_slack_run(
-        _FakeStatusClient("busy"), "t1", blocks, {}, is_first_mention=False
+        _FakeStatusClient("busy"),
+        "t1",
+        blocks,
+        {},
+        is_first_mention=False,
+        explicitly_tagged=False,
     )
 
-    # Busy → parked on the queue for the active run to drain; no new run started.
+    # Untagged + busy → parked on the queue for the active run to drain.
     assert run is None
     dispatch.assert_not_awaited()
     queue.assert_awaited_once_with("t1", blocks)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_or_queue_tagged_message_interrupts_even_when_busy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    queue = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
+    monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
+
+    # An explicit @-mention keeps the old immediate-interrupt behavior.
+    run = await slack_webhook._dispatch_or_queue_slack_run(
+        _FakeStatusClient("busy"),
+        "t1",
+        [{"type": "text", "text": "<@BOT> stop and do this instead"}],
+        {},
+        is_first_mention=False,
+        explicitly_tagged=True,
+    )
+
+    assert run == {"run_id": "run-1"}
+    queue.assert_not_awaited()
+    dispatch.assert_awaited_once()


### PR DESCRIPTION
## Summary

Two Slack-triggering improvements, plus end-to-end Playwright coverage for both.

**1. Untagged replies in two-party threads.** Drops the explicit `@open-swe` requirement for a follow-up when the thread has only Open SWE and exactly one human (Open SWE must already have participated) **and** the message doesn't `<@mention>` any user other than Open SWE. Tagging a third party, or a thread with a second human, still requires an explicit mention. New pass condition (`_slack_thread_allows_untagged_reply`) in the webhook gate.

**2. Debounce interrupts to a busy thread — for untagged follow-ups only.** An explicit `@open-swe` mention keeps the old behavior: it interrupts the running agent immediately. But an *untagged* follow-up (feature 1) that arrives while the agent is busy is **coalesced onto the thread's message queue** and drained together by the active run at its next model call (`check_message_queue_before_model`) — no per-message interrupt. Idle threads dispatch immediately as before.

> Note: an earlier iteration tried to schedule a single *delayed* interrupt (`after_seconds`). E2E proved that doesn't work — LangGraph cancels the active run at interrupt-run **creation** time, so `after_seconds` only delays the resume, not the halt. The queue-coalesce approach is version-independent and never prematurely halts the run.

**Also fixed (surfaced by the e2e):** the other-user mention regex missed underscored Slack ids; and a brand-new untagged message 500'd the webhook because the ready-plan check raised on a nonexistent thread.

## Tests

- Unit: untagged-reply gate (two-party allow, bot-only mention allow, other-user block, three-party block, bot-absent block, third-party-bot block); `_slack_thread_is_busy`; `_dispatch_or_queue_slack_run` (idle dispatch, first-mention dispatch, untagged-busy→queue, tagged-busy→interrupt).
- **Playwright e2e** (real webhook + real agent, only the LLM faked): `slack_untagged_reply` (follow-up triggers a run; tagging another user / brand-new thread ignored) and `slack_debounce` (untagged follow-ups on a busy thread coalesce onto the queue). Harness gains same-thread replies, a `/control/queued` probe, and a fake-LLM busy-hold.

## Test Plan

- [x] `make test` (full suite) + `make lint`
- [x] `cd tests/e2e && npx playwright test slack_untagged_reply slack_debounce` — 4/4 green