### PR TITLE
fix: bound reviewer diff fetching

### DIFF
--- a/agent/review/diff.py
+++ b/agent/review/diff.py
@@ -430,6 +430,9 @@ def _stdout_from_result(result: object) -> str:
     stdout = getattr(result, "stdout", None)
     if isinstance(stdout, str):
         return stdout
+    output = getattr(result, "output", None)
+    if isinstance(output, str):
+        return output
     text = getattr(result, "text", None)
     if isinstance(text, str):
         return text

--- a/agent/review/diff.py
+++ b/agent/review/diff.py
@@ -15,6 +15,7 @@ The reviewer needs three things from a PR diff:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import re
 from dataclasses import dataclass
@@ -33,6 +34,17 @@ _HUNK_HEADER_RE = re.compile(
     r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? "
     r"\+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
 )
+_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+@dataclass(frozen=True)
+class MaterializedReviewDiff:
+    path: str
+    diff_text: str
+    base_ref: str
+    head_ref: str
+    merge_base: bool
+    cached: bool
 
 
 @dataclass(frozen=True)
@@ -270,6 +282,102 @@ async def fetch_pr_metadata(
     title = payload.get("title")
     body = payload.get("body")
     return (title if isinstance(title, str) else "", body if isinstance(body, str) else "")
+
+
+def review_diff_range(
+    *,
+    base_sha: str,
+    head_sha: str,
+    last_reviewed_sha: str = "",
+    re_review: bool = False,
+) -> tuple[str, str, bool]:
+    """Resolve the trusted commit range for the current review invocation."""
+    base_ref = last_reviewed_sha if re_review and last_reviewed_sha else base_sha
+    if not _GIT_SHA_RE.fullmatch(base_ref) or not _GIT_SHA_RE.fullmatch(head_sha):
+        raise ValueError("review diff requires valid Git commit SHAs")
+    return base_ref.lower(), head_sha.lower(), not re_review
+
+
+def review_diff_path(work_dir: str, base_ref: str, head_ref: str, merge_base: bool) -> str:
+    """Return a deterministic sandbox path for one review diff range."""
+    operator = "..." if merge_base else ".."
+    digest = hashlib.sha256(f"{base_ref}{operator}{head_ref}".encode()).hexdigest()[:16]
+    return f"{work_dir.rstrip('/')}/review-diff-{digest}.patch"
+
+
+async def materialize_review_diff(
+    sandbox_backend: SandboxBackendProtocol,
+    *,
+    work_dir: str,
+    base_ref: str,
+    head_ref: str,
+    merge_base: bool,
+    diff_text: str | None = None,
+) -> MaterializedReviewDiff:
+    """Idempotently write a review diff to the sandbox."""
+    path = review_diff_path(work_dir, base_ref, head_ref, merge_base)
+    if diff_text is None:
+        responses = await sandbox_backend.adownload_files([path])
+        response = responses[0] if responses else None
+        cached_content = _download_content(response)
+        if cached_content is not None:
+            return MaterializedReviewDiff(
+                path=path,
+                diff_text=cached_content,
+                base_ref=base_ref,
+                head_ref=head_ref,
+                merge_base=merge_base,
+                cached=True,
+            )
+        diff_text = await compute_diff_in_sandbox(
+            sandbox_backend,
+            work_dir,
+            base_ref,
+            head_ref,
+            merge_base=merge_base,
+        )
+
+    responses = await sandbox_backend.aupload_files([(path, diff_text.encode())])
+    response = responses[0] if responses else None
+    error = (
+        response.get("error") if isinstance(response, dict) else getattr(response, "error", None)
+    )
+    if error:
+        raise RuntimeError(f"failed to materialize review diff: {error}")
+    return MaterializedReviewDiff(
+        path=path,
+        diff_text=diff_text,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        merge_base=merge_base,
+        cached=False,
+    )
+
+
+def changed_files(diff_text: str) -> list[str]:
+    """Return changed paths from a unified diff without exposing its body."""
+    paths = (
+        match.group("b")
+        for line in diff_text.splitlines()
+        if (match := _DIFF_FILE_HEADER_RE.match(line))
+    )
+    return list(dict.fromkeys(paths))
+
+
+def _download_content(response: object) -> str | None:
+    if response is None:
+        return None
+    if isinstance(response, dict):
+        content = response.get("content")
+        error = response.get("error")
+    else:
+        content = getattr(response, "content", None)
+        error = getattr(response, "error", None)
+    if error or content is None:
+        return None
+    if isinstance(content, bytes):
+        return content.decode(errors="replace")
+    return content if isinstance(content, str) else None
 
 
 async def compute_diff_in_sandbox(

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -1046,7 +1046,7 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
                 )
                 materialized = await materialize_review_diff(
                     sandbox_backend,
-                    work_dir=work_dir,
+                    work_dir=f"{work_dir}/{repo_name}",
                     base_ref=diff_base,
                     head_ref=diff_head,
                     merge_base=merge_base,

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -59,7 +59,13 @@ from .middleware import (
     refresh_github_proxy_before_model,
     settle_review_check_on_exit,
 )
-from .review.diff import compute_diff_line_set, fetch_pr_diff, fetch_pr_metadata
+from .review.diff import (
+    compute_diff_line_set,
+    fetch_pr_diff,
+    fetch_pr_metadata,
+    materialize_review_diff,
+    review_diff_range,
+)
 from .review.findings import (
     REVIEW_FINDING_CAP,
 )
@@ -84,6 +90,7 @@ from .runtime import (
 )
 from .tools import (
     add_finding,
+    fetch_review_diff,
     fetch_url,
     http_request,
     list_findings,
@@ -113,27 +120,20 @@ HISTORICAL_REVIEW_GUIDANCE = """- **Anything that overlaps an existing PR review
 
 REVIEWER_PROMPT_TEMPLATE = """You are a specialized code reviewer agent. Your job is to review one GitHub PR and publish a single review.
 
-Sandbox: `{working_dir}`. Invoke `gh` as `GH_TOKEN=dummy gh <command>`.
+Sandbox: `{working_dir}`. Review target: `{repo_owner}/{repo_name}#{pr_number}`.
+Invoke `gh` as `GH_TOKEN=dummy gh <command>`.
 
-Fetch the diff:
-
-```
-GH_TOKEN=dummy gh pr diff {pr_number} --repo {repo_owner}/{repo_name}
-```
-
-Re-review (user message says "A new commit has been pushed"):
-
-```
-GH_TOKEN=dummy gh api repos/{repo_owner}/{repo_name}/compare/<last_reviewed_sha>...<head_sha> -H "Accept: application/vnd.github.v3.diff"
-```
+Call `fetch_review_diff` to materialize the current review range in the sandbox.
+It returns only the file path and bounded metadata. Inspect that file with `grep`
+and paginated `read_file` calls; never fetch a full diff through `execute` or `gh`.
 
 {repo_checkout_note}
 
 If a skills section appears below, the repo ships reviewer-relevant skills. Read
 the `SKILL.md` that matches the area you're reviewing and apply it.
 
-Tools: `add_finding`, `update_finding`, `list_findings`, `publish_review`,
-`resolve_finding_thread`, `reply_to_finding_thread`.
+Tools: `fetch_review_diff`, `add_finding`, `update_finding`, `list_findings`,
+`publish_review`, `resolve_finding_thread`, `reply_to_finding_thread`.
 Call `publish_review` once at the end.
 
 Delegate at most one review pass. Give the reviewer subagent an explicit,
@@ -559,9 +559,8 @@ def _build_first_review_context(
         f"- head_sha: {head_sha}\n"
         f"{overview_section}"
         f"{prior_section}\n"
-        f"Fetch the diff yourself with "
-        f"`GH_TOKEN=dummy gh pr diff {pr_number} --repo {repo_owner}/{repo_name}`, "
-        f"then review using the ordered passes (mechanical grep → diff-line audit "
+        f"Call `fetch_review_diff`, then inspect its sandbox file with `grep` and "
+        f"paginated `read_file` calls. Review using the ordered passes (mechanical grep → diff-line audit "
         f"→ security/auth if applicable → pipeline sweep → deep flow).\n\n"
         f"This is a first review — there are no existing findings recorded by "
         f"you.{historical_guidance} Record net-new issues with `add_finding`, "
@@ -600,10 +599,9 @@ def _build_re_review_context(
         f"{overview_section}"
         f"## Existing findings\n\n{existing_findings_block}\n\n"
         f"{prior_threads_section}"
-        f"Fetch the diff since the previous reviewed SHA yourself with "
-        f"`GH_TOKEN=dummy gh api repos/{repo_owner}/{repo_name}/compare/"
-        f'{last_reviewed_sha}...{head_sha} -H "Accept: application/vnd.github.v3.diff"`, '
-        f"then review only what's in that diff.\n\n"
+        f"Call `fetch_review_diff` to materialize the changes since the previous reviewed "
+        f"SHA, then inspect its sandbox file with `grep` and paginated `read_file` calls. "
+        f"Review only what's in that diff.\n\n"
         f"For each open finding above, decide whether the new commits resolved "
         f'it (`update_finding(id, status="resolved", note="<full reply body>")`), left it unchanged '
         f"(no action), or changed it materially (`update_finding` with new "
@@ -1029,15 +1027,38 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
         async def _fetch_diff_context() -> tuple[str, dict[str, dict[str, set[int]]] | None]:
             if not can_fetch_pr or github_token is None or not isinstance(pr_number, int):
                 return "", None
-            fetched_diff = await fetch_pr_diff(
-                owner=repo_owner,
-                repo=repo_name,
-                pr_number=pr_number,
-                token=github_token,
-            )
-            if fetched_diff is None:
-                return "", None
-            return fetched_diff, compute_diff_line_set(fetched_diff)
+            fetched_diff: str | None = None
+            if not (is_re_review and last_reviewed_sha):
+                fetched_diff = await fetch_pr_diff(
+                    owner=repo_owner,
+                    repo=repo_name,
+                    pr_number=pr_number,
+                    token=github_token,
+                )
+                if fetched_diff is None:
+                    return "", None
+            try:
+                diff_base, diff_head, merge_base = review_diff_range(
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    last_reviewed_sha=last_reviewed_sha,
+                    re_review=is_re_review,
+                )
+                materialized = await materialize_review_diff(
+                    sandbox_backend,
+                    work_dir=work_dir,
+                    base_ref=diff_base,
+                    head_ref=diff_head,
+                    merge_base=merge_base,
+                    diff_text=fetched_diff,
+                )
+                diff_text = materialized.diff_text
+            except (RuntimeError, ValueError):
+                logger.exception("Failed to materialize review diff")
+                if fetched_diff is None:
+                    return "", None
+                diff_text = fetched_diff
+            return diff_text, compute_diff_line_set(diff_text)
 
         async def _fetch_pr_overview() -> tuple[str, str]:
             if not can_fetch_pr or github_token is None or not isinstance(pr_number, int):
@@ -1331,6 +1352,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         model=reviewer_model,
         system_prompt="",
         tools=[
+            fetch_review_diff,
             add_finding,
             update_finding,
             list_findings,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 _TOOL_MODULES = {
     "add_finding": ".add_finding",
     "enter_plan_mode": ".enter_plan_mode",
+    "fetch_review_diff": ".fetch_review_diff",
     "fetch_url": ".fetch_url",
     "http_request": ".http_request",
     "linear_comment": ".linear_comment",
@@ -37,6 +38,7 @@ _TOOL_MODULES = {
 __all__ = [
     "add_finding",
     "enter_plan_mode",
+    "fetch_review_diff",
     "fetch_url",
     "http_request",
     "linear_comment",
@@ -69,6 +71,7 @@ __all__ = [
 if TYPE_CHECKING:
     from .add_finding import add_finding
     from .enter_plan_mode import enter_plan_mode
+    from .fetch_review_diff import fetch_review_diff
     from .fetch_url import fetch_url
     from .http_request import http_request
     from .linear_comment import linear_comment

--- a/agent/tools/fetch_review_diff.py
+++ b/agent/tools/fetch_review_diff.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from langgraph.config import get_config
@@ -11,6 +12,7 @@ from ..runtime import get_cached_sandbox_backend
 from ..utils.sandbox_paths import aresolve_sandbox_work_dir
 
 _MAX_CHANGED_FILES = 200
+_REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 async def fetch_review_diff() -> dict[str, Any]:
@@ -23,6 +25,10 @@ async def fetch_review_diff() -> dict[str, Any]:
     thread_id = configurable.get("thread_id")
     if not isinstance(thread_id, str) or not thread_id:
         return {"success": False, "error": "review thread unavailable"}
+    repo = configurable.get("repo")
+    repo_name = repo.get("name") if isinstance(repo, dict) else None
+    if not isinstance(repo_name, str) or not _REPO_NAME_RE.fullmatch(repo_name):
+        return {"success": False, "error": "review repository unavailable"}
 
     try:
         base_ref, head_ref, merge_base = review_diff_range(
@@ -35,7 +41,7 @@ async def fetch_review_diff() -> dict[str, Any]:
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
         materialized = await materialize_review_diff(
             sandbox_backend,
-            work_dir=work_dir,
+            work_dir=f"{work_dir}/{repo_name}",
             base_ref=base_ref,
             head_ref=head_ref,
             merge_base=merge_base,

--- a/agent/tools/fetch_review_diff.py
+++ b/agent/tools/fetch_review_diff.py
@@ -1,0 +1,58 @@
+"""Tool: materialize the current reviewer diff in the sandbox."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..review.diff import changed_files, materialize_review_diff, review_diff_range
+from ..runtime import get_cached_sandbox_backend
+from ..utils.sandbox_paths import aresolve_sandbox_work_dir
+
+_MAX_CHANGED_FILES = 200
+
+
+async def fetch_review_diff() -> dict[str, Any]:
+    """Write the current review diff to a file and return bounded metadata."""
+    config = get_config()
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    if not isinstance(configurable, dict):
+        return {"success": False, "error": "review context unavailable"}
+
+    thread_id = configurable.get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        return {"success": False, "error": "review thread unavailable"}
+
+    try:
+        base_ref, head_ref, merge_base = review_diff_range(
+            base_sha=str(configurable.get("base_sha", "") or ""),
+            head_sha=str(configurable.get("head_sha", "") or ""),
+            last_reviewed_sha=str(configurable.get("last_reviewed_sha", "") or ""),
+            re_review=bool(configurable.get("re_review")),
+        )
+        sandbox_backend = get_cached_sandbox_backend(thread_id)
+        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+        materialized = await materialize_review_diff(
+            sandbox_backend,
+            work_dir=work_dir,
+            base_ref=base_ref,
+            head_ref=head_ref,
+            merge_base=merge_base,
+        )
+    except (RuntimeError, ValueError) as exc:
+        return {"success": False, "error": str(exc)}
+
+    all_files = changed_files(materialized.diff_text)
+    files = all_files[:_MAX_CHANGED_FILES]
+    return {
+        "success": True,
+        "path": materialized.path,
+        "bytes": len(materialized.diff_text.encode()),
+        "files": files,
+        "file_count": len(all_files),
+        "files_truncated": len(all_files) > len(files),
+        "base_sha": materialized.base_ref,
+        "head_sha": materialized.head_ref,
+        "cached": materialized.cached,
+    }

--- a/tests/reviewer/test_fetch_review_diff_tool.py
+++ b/tests/reviewer/test_fetch_review_diff_tool.py
@@ -22,6 +22,7 @@ async def test_fetch_review_diff_returns_metadata_without_diff_body() -> None:
     config = {
         "configurable": {
             "thread_id": "thread-1",
+            "repo": {"owner": "acme", "name": "repo"},
             "base_sha": "a" * 40,
             "head_sha": "b" * 40,
         }
@@ -55,6 +56,7 @@ async def test_fetch_review_diff_returns_metadata_without_diff_body() -> None:
         "cached": True,
     }
     assert diff_text not in str(result)
+    assert mock_materialize.await_args.kwargs["work_dir"] == "/workspace/repo"
     assert mock_materialize.await_args.kwargs["merge_base"] is True
 
 
@@ -63,6 +65,7 @@ async def test_fetch_review_diff_uses_incremental_range_for_re_review() -> None:
     config = {
         "configurable": {
             "thread_id": "thread-1",
+            "repo": {"owner": "acme", "name": "repo"},
             "base_sha": "a" * 40,
             "last_reviewed_sha": "b" * 40,
             "head_sha": "c" * 40,
@@ -96,7 +99,7 @@ async def test_fetch_review_diff_uses_incremental_range_for_re_review() -> None:
 
     assert result["base_sha"] == "b" * 40
     assert mock_materialize.await_args.kwargs == {
-        "work_dir": "/workspace",
+        "work_dir": "/workspace/repo",
         "base_ref": "b" * 40,
         "head_ref": "c" * 40,
         "merge_base": False,

--- a/tests/reviewer/test_fetch_review_diff_tool.py
+++ b/tests/reviewer/test_fetch_review_diff_tool.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.review.diff import MaterializedReviewDiff
+from agent.tools.fetch_review_diff import fetch_review_diff
+
+
+@pytest.mark.asyncio
+async def test_fetch_review_diff_returns_metadata_without_diff_body() -> None:
+    diff_text = "diff --git a/app.py b/app.py\n@@ -1 +1 @@\n-old\n+new\n"
+    materialized = MaterializedReviewDiff(
+        path="/workspace/review-diff.patch",
+        diff_text=diff_text,
+        base_ref="a" * 40,
+        head_ref="b" * 40,
+        merge_base=True,
+        cached=True,
+    )
+    config = {
+        "configurable": {
+            "thread_id": "thread-1",
+            "base_sha": "a" * 40,
+            "head_sha": "b" * 40,
+        }
+    }
+
+    with (
+        patch("agent.tools.fetch_review_diff.get_config", return_value=config),
+        patch("agent.tools.fetch_review_diff.get_cached_sandbox_backend", return_value=MagicMock()),
+        patch(
+            "agent.tools.fetch_review_diff.aresolve_sandbox_work_dir",
+            new_callable=AsyncMock,
+            return_value="/workspace",
+        ),
+        patch(
+            "agent.tools.fetch_review_diff.materialize_review_diff",
+            new_callable=AsyncMock,
+            return_value=materialized,
+        ) as mock_materialize,
+    ):
+        result = await fetch_review_diff()
+
+    assert result == {
+        "success": True,
+        "path": "/workspace/review-diff.patch",
+        "bytes": len(diff_text.encode()),
+        "files": ["app.py"],
+        "file_count": 1,
+        "files_truncated": False,
+        "base_sha": "a" * 40,
+        "head_sha": "b" * 40,
+        "cached": True,
+    }
+    assert diff_text not in str(result)
+    assert mock_materialize.await_args.kwargs["merge_base"] is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_review_diff_uses_incremental_range_for_re_review() -> None:
+    config = {
+        "configurable": {
+            "thread_id": "thread-1",
+            "base_sha": "a" * 40,
+            "last_reviewed_sha": "b" * 40,
+            "head_sha": "c" * 40,
+            "re_review": True,
+        }
+    }
+    materialized = MaterializedReviewDiff(
+        path="/workspace/review-diff.patch",
+        diff_text="",
+        base_ref="b" * 40,
+        head_ref="c" * 40,
+        merge_base=False,
+        cached=False,
+    )
+
+    with (
+        patch("agent.tools.fetch_review_diff.get_config", return_value=config),
+        patch("agent.tools.fetch_review_diff.get_cached_sandbox_backend", return_value=MagicMock()),
+        patch(
+            "agent.tools.fetch_review_diff.aresolve_sandbox_work_dir",
+            new_callable=AsyncMock,
+            return_value="/workspace",
+        ),
+        patch(
+            "agent.tools.fetch_review_diff.materialize_review_diff",
+            new_callable=AsyncMock,
+            return_value=materialized,
+        ) as mock_materialize,
+    ):
+        result = await fetch_review_diff()
+
+    assert result["base_sha"] == "b" * 40
+    assert mock_materialize.await_args.kwargs == {
+        "work_dir": "/workspace",
+        "base_ref": "b" * 40,
+        "head_ref": "c" * 40,
+        "merge_base": False,
+    }

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -25,6 +25,9 @@ def test_reviewer_system_prompt_formats_without_keyerror() -> None:
     assert "wrong identifier/value/key" in prompt
     assert "Keep at most 6 findings" in prompt
     assert "Delegate at most one review pass" in prompt
+    assert "fetch_review_diff" in prompt
+    assert "gh pr diff" not in prompt
+    assert "gh api repos/" not in prompt
 
 
 def test_reviewer_eval_prompt_omits_historical_and_benchmark_gaming() -> None:

--- a/tests/reviewer/test_reviewer_diff.py
+++ b/tests/reviewer/test_reviewer_diff.py
@@ -179,6 +179,24 @@ async def test_compute_diff_in_sandbox_uses_three_dot_for_merge_base() -> None:
 
 
 @pytest.mark.asyncio
+async def test_compute_diff_in_sandbox_reads_execute_response_output() -> None:
+    from unittest.mock import MagicMock
+
+    from deepagents.backends.protocol import ExecuteResponse
+
+    from agent.review.diff import compute_diff_in_sandbox
+
+    backend = MagicMock()
+    backend.execute = MagicMock(return_value=ExecuteResponse(output=_TWO_FILE_DIFF, exit_code=0))
+
+    result = await compute_diff_in_sandbox(
+        backend, work_dir="/w/repo", base_ref="base", head_ref="head"
+    )
+
+    assert result == _TWO_FILE_DIFF
+
+
+@pytest.mark.asyncio
 async def test_compute_diff_in_sandbox_uses_two_dot_by_default() -> None:
     """Re-review delta path passes merge_base=False so we use base..head."""
     from unittest.mock import MagicMock

--- a/tests/reviewer/test_reviewer_diff.py
+++ b/tests/reviewer/test_reviewer_diff.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import pytest
 
 from agent.review.diff import (
+    changed_files,
     compute_diff_line_set,
     extract_diff_hunk,
     is_range_in_diff,
+    materialize_review_diff,
     parse_unified_diff,
+    review_diff_range,
 )
 
 _TWO_FILE_DIFF = """diff --git a/foo.py b/foo.py
@@ -96,6 +99,64 @@ def test_extract_diff_hunk_supports_single_line_and_range(start: int, end: int) 
     hunk = extract_diff_hunk(_TWO_FILE_DIFF, "bar.py", start, end)
     assert hunk is not None
     assert "import sys" in hunk
+
+
+def test_review_diff_range_uses_previous_head_for_re_review() -> None:
+    assert review_diff_range(
+        base_sha="a" * 40,
+        head_sha="c" * 40,
+        last_reviewed_sha="b" * 40,
+        re_review=True,
+    ) == ("b" * 40, "c" * 40, False)
+
+
+def test_changed_files_returns_bounded_path_list() -> None:
+    assert changed_files(_TWO_FILE_DIFF) == ["foo.py", "bar.py"]
+
+
+@pytest.mark.asyncio
+async def test_materialize_review_diff_reuses_existing_file() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    backend = MagicMock()
+    backend.adownload_files = AsyncMock(return_value=[{"content": _TWO_FILE_DIFF.encode()}])
+    backend.aupload_files = AsyncMock()
+
+    result = await materialize_review_diff(
+        backend,
+        work_dir="/workspace",
+        base_ref="a" * 40,
+        head_ref="b" * 40,
+        merge_base=True,
+    )
+
+    assert result.cached is True
+    assert result.diff_text == _TWO_FILE_DIFF
+    backend.aupload_files.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_materialize_review_diff_writes_supplied_diff() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    backend = MagicMock()
+    backend.adownload_files = AsyncMock()
+    backend.aupload_files = AsyncMock(return_value=[{"error": None}])
+
+    result = await materialize_review_diff(
+        backend,
+        work_dir="/workspace",
+        base_ref="a" * 40,
+        head_ref="b" * 40,
+        merge_base=True,
+        diff_text=_TWO_FILE_DIFF,
+    )
+
+    assert result.cached is False
+    uploaded_path, uploaded_content = backend.aupload_files.await_args.args[0][0]
+    assert uploaded_path == result.path
+    assert uploaded_content == _TWO_FILE_DIFF.encode()
+    backend.adownload_files.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Prevents large PR diffs from being injected through uncapped `gh` output. The reviewer now materializes a trusted, content-addressed diff file and receives only bounded metadata for paginated inspection, including incremental re-review ranges.

## Release Note
Reviewer diffs are now fetched safely through sandbox files instead of model context.

## Test Plan
- [x] Verify first-review and re-review ranges, cache reuse, bounded tool output, and safe prompt guidance.

Made by [Open SWE](https://openswe.vercel.app/agents/f4da0475-f2a3-b943-b14f-1ae1384f1c9e)