### PR TITLE
fix: validate and scope dashboard repositories

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -36,6 +36,7 @@ from .options import (
 )
 from .pr_diff import build_pr_diff_files
 from .profiles import get_profile, get_valid_access_token
+from .repo_access import repo_config_for_user
 from .team_settings import get_team_default_model, get_team_fable_enabled
 from .user_mappings import email_for_login
 
@@ -193,6 +194,14 @@ def _parse_repo(full_name: str | None) -> dict[str, str] | None:
     if not owner or not name:
         return None
     return {"owner": owner, "name": name}
+
+
+async def _validate_dashboard_repo(login: str, repo_config: dict[str, str]) -> dict[str, str]:
+    owner = repo_config.get("owner")
+    name = repo_config.get("name")
+    if not owner or not name:
+        return {}
+    return await repo_config_for_user(login, f"{owner}/{name}") or {}
 
 
 def _decode_dashboard_image(image: DashboardImageBody) -> bytes:
@@ -1200,10 +1209,15 @@ async def _enrich_run_start_command(
         # forwarded to LangGraph. The repo hint rides in the client
         # configurable; it never reaches the run config (which is rebuilt from
         # the stamped metadata below).
+        repo_hint = client_configurable.get("repo")
+        requested_repo = _parse_repo(repo_hint)
+        if repo_hint is not None and requested_repo is None:
+            raise HTTPException(422, "repository must use owner/name format")
+        validated_repo = await _validate_dashboard_repo(login, requested_repo or {})
         thread = await _create_dashboard_thread_record(
             thread_id,
             login=login,
-            repo_config=_parse_repo(client_configurable.get("repo")) or {},
+            repo_config=validated_repo,
             repo_explicitly_none=client_configurable.get("repo_explicitly_none") is True,
             prompt=_command_prompt_text(content),
             images=command_images,
@@ -1222,6 +1236,8 @@ async def _enrich_run_start_command(
             overrides["agent_model_id"] = chosen_model
             overrides["agent_effort"] = chosen_effort
     else:
+        if _thread_source(metadata) == _DASHBOARD_SOURCE:
+            await _validate_dashboard_repo(login, _repo_config_from_metadata(metadata))
         run_model = chosen_model or _metadata_model_id(metadata)
         run_effort = chosen_effort
         if not run_effort:

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -37,7 +37,7 @@ from .options import (
 from .pr_diff import build_pr_diff_files
 from .profiles import get_profile, get_valid_access_token
 from .repo_access import repo_config_for_user
-from .team_settings import get_team_default_model, get_team_fable_enabled
+from .team_settings import get_team_default_model, get_team_default_repo, get_team_fable_enabled
 from .user_mappings import email_for_login
 
 logger = logging.getLogger(__name__)
@@ -1209,16 +1209,19 @@ async def _enrich_run_start_command(
         # forwarded to LangGraph. The repo hint rides in the client
         # configurable; it never reaches the run config (which is rebuilt from
         # the stamped metadata below).
+        repo_explicitly_none = client_configurable.get("repo_explicitly_none") is True
         repo_hint = client_configurable.get("repo")
         requested_repo = _parse_repo(repo_hint)
         if repo_hint is not None and requested_repo is None:
             raise HTTPException(422, "repository must use owner/name format")
+        if requested_repo is None and not repo_explicitly_none:
+            requested_repo = await get_team_default_repo()
         validated_repo = await _validate_dashboard_repo(login, requested_repo or {})
         thread = await _create_dashboard_thread_record(
             thread_id,
             login=login,
             repo_config=validated_repo,
-            repo_explicitly_none=client_configurable.get("repo_explicitly_none") is True,
+            repo_explicitly_none=repo_explicitly_none,
             prompt=_command_prompt_text(content),
             images=command_images,
             model_id=client_configurable.get("agent_model_id"),

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -90,7 +90,7 @@ def _get_tool_call_id(request: ToolCallRequest) -> str | None:
     return None
 
 
-def _get_thread_id(request: ToolCallRequest) -> str | None:
+def _get_configurable(request: ToolCallRequest) -> Mapping[str, Any]:
     runtime_config = getattr(getattr(request, "runtime", None), "config", None)
     config: Mapping[str, Any] | None = (
         runtime_config if isinstance(runtime_config, Mapping) else None
@@ -100,23 +100,41 @@ def _get_thread_id(request: ToolCallRequest) -> str | None:
             maybe_config = get_config()
         except Exception:
             logger.exception("Failed to read runnable config while handling sandbox error")
-            return None
+            return {}
         config = maybe_config if isinstance(maybe_config, Mapping) else None
     if config is None:
-        return None
+        return {}
 
     configurable = config.get("configurable", {})
-    if not isinstance(configurable, Mapping):
-        return None
+    return configurable if isinstance(configurable, Mapping) else {}
+
+
+def _get_thread_id(configurable: Mapping[str, Any]) -> str | None:
     thread_id = configurable.get("thread_id")
     return thread_id if isinstance(thread_id, str) and thread_id else None
 
 
-async def _recreate_sandbox_for_thread(thread_id: str) -> str:
+async def _recreate_sandbox_for_thread(thread_id: str, configurable: Mapping[str, Any]) -> str:
     from agent.server import _configure_git_identity, _recreate_sandbox, client
+    from agent.utils.auth import resolve_github_token
     from agent.utils.sandbox_state import set_sandbox_backend
 
-    sandbox_backend = await _recreate_sandbox(thread_id)
+    repo = configurable.get("repo")
+    repo_config = repo if isinstance(repo, dict) else None
+    proxy_repositories = (
+        [repo_config["name"]] if repo_config and isinstance(repo_config.get("name"), str) else None
+    )
+    proxy_token = None
+    if configurable.get("source") == "dashboard" and repo_config is None:
+        proxy_token, _expires_at = await resolve_github_token(
+            {"configurable": dict(configurable)}, thread_id
+        )
+    sandbox_backend = await _recreate_sandbox(
+        thread_id,
+        github_proxy_token=proxy_token,
+        github_proxy_repositories=proxy_repositories,
+        repo=repo_config,
+    )
     sandbox_backend = set_sandbox_backend(thread_id, sandbox_backend)
     await client.threads.update(thread_id=thread_id, metadata={"sandbox_id": sandbox_backend.id})
     await _configure_git_identity(sandbox_backend)
@@ -164,10 +182,11 @@ class ToolErrorMiddleware(AgentMiddleware):
             return await handler(request)
         except SandboxClientError as e:
             logger.exception("Sandbox error during tool call handling; request=%r", request)
-            thread_id = _get_thread_id(request)
+            configurable = _get_configurable(request)
+            thread_id = _get_thread_id(configurable)
             if thread_id:
                 try:
-                    sandbox_id = await _recreate_sandbox_for_thread(thread_id)
+                    sandbox_id = await _recreate_sandbox_for_thread(thread_id, configurable)
                     return _sandbox_recreated_tool_message(e, sandbox_id, request)
                 except Exception:
                     logger.exception("Failed to recreate sandbox for thread %s", thread_id)

--- a/agent/server.py
+++ b/agent/server.py
@@ -230,6 +230,7 @@ async def _start_langsmith_sandbox_if_needed(sandbox_backend: SandboxBackendProt
 async def _resolve_proxy_token(
     github_proxy_token: str | None,
     *,
+    repositories: Sequence[str] | None = None,
     permissions: PermissionMap | None = None,
 ) -> tuple[str | None, str | None, PermissionMap | None]:
     """Resolve the proxy token, its expiry, and the effective permission scope."""
@@ -237,7 +238,8 @@ async def _resolve_proxy_token(
         return github_proxy_token, None, None
     if permissions is not None:
         token, expires_at = await get_github_app_installation_token_with_expiry(
-            permissions=permissions
+            repositories=repositories,
+            permissions=permissions,
         )
         return token, expires_at, permissions
 
@@ -247,6 +249,7 @@ async def _resolve_proxy_token(
     last = len(ladder) - 1
     for index, scope in enumerate(ladder):
         token, expires_at = await get_github_app_installation_token_with_expiry(
+            repositories=repositories,
             permissions=scope,
             log_errors=index == last,
         )
@@ -290,7 +293,10 @@ async def _create_sandbox_with_proxy(
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     if sandbox_type == "langsmith":
-        token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
+        token, expires_at, permissions = await _resolve_proxy_token(
+            github_proxy_token,
+            repositories=github_proxy_repositories,
+        )
         if not token:
             msg = "Cannot configure proxy: GitHub App installation token is unavailable"
             logger.error(msg)
@@ -318,7 +324,10 @@ async def _refresh_github_proxy(
     if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
         return
 
-    token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
+    token, expires_at, permissions = await _resolve_proxy_token(
+        github_proxy_token,
+        repositories=github_proxy_repositories,
+    )
     if not token:
         logger.warning(
             "Skipping GitHub proxy refresh for sandbox %s: installation token unavailable",
@@ -754,8 +763,17 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         triggering_user_identity_task = asyncio.create_task(
             asyncio.to_thread(resolve_triggering_user_identity, self._config, github_token)
         )
+        proxy_repositories = (
+            [prompt_default_repo["name"]]
+            if prompt_default_repo and prompt_default_repo.get("name")
+            else None
+        )
         sandbox_task = asyncio.create_task(
-            ensure_sandbox_for_thread(self._thread_id, repo=prompt_default_repo)
+            ensure_sandbox_for_thread(
+                self._thread_id,
+                github_proxy_repositories=proxy_repositories,
+                repo=prompt_default_repo,
+            )
         )
         triggering_user_identity, sandbox_backend = await asyncio.gather(
             triggering_user_identity_task,
@@ -840,7 +858,16 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         _configurable: dict[str, Any] = configurable,
     ) -> SandboxBackendProtocol:
         prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
-        return await ensure_sandbox_for_thread(_thread_id, repo=prompt_default_repo)
+        proxy_repositories = (
+            [prompt_default_repo["name"]]
+            if prompt_default_repo and prompt_default_repo.get("name")
+            else None
+        )
+        return await ensure_sandbox_for_thread(
+            _thread_id,
+            github_proxy_repositories=proxy_repositories,
+            repo=prompt_default_repo,
+        )
 
     def backend_factory(_runtime: object, _thread_id: str = thread_id) -> SandboxBackendProtocol:
         return _get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)

--- a/agent/server.py
+++ b/agent/server.py
@@ -187,6 +187,18 @@ async def _resolve_prompt_default_repo(configurable: dict[str, Any]) -> dict[str
         return None
 
 
+def _sandbox_proxy_auth(
+    source: str,
+    repo: dict[str, str] | None,
+    user_token: str | None = None,
+) -> tuple[str | None, list[str] | None]:
+    if repo and repo.get("name"):
+        return None, [repo["name"]]
+    if source == "dashboard":
+        return user_token, None
+    return None, None
+
+
 async def _resolve_repo_custom_instructions(
     default_repo: dict[str, str] | None,
 ) -> str | None:
@@ -763,14 +775,13 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         triggering_user_identity_task = asyncio.create_task(
             asyncio.to_thread(resolve_triggering_user_identity, self._config, github_token)
         )
-        proxy_repositories = (
-            [prompt_default_repo["name"]]
-            if prompt_default_repo and prompt_default_repo.get("name")
-            else None
+        proxy_token, proxy_repositories = _sandbox_proxy_auth(
+            self._source, prompt_default_repo, github_token
         )
         sandbox_task = asyncio.create_task(
             ensure_sandbox_for_thread(
                 self._thread_id,
+                github_proxy_token=proxy_token,
                 github_proxy_repositories=proxy_repositories,
                 repo=prompt_default_repo,
             )
@@ -858,13 +869,16 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         _configurable: dict[str, Any] = configurable,
     ) -> SandboxBackendProtocol:
         prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
-        proxy_repositories = (
-            [prompt_default_repo["name"]]
-            if prompt_default_repo and prompt_default_repo.get("name")
-            else None
+        source = str(_configurable.get("source") or "")
+        proxy_token = None
+        if source == "dashboard" and prompt_default_repo is None:
+            proxy_token, _expires_at = await resolve_github_token(config, _thread_id)
+        proxy_token, proxy_repositories = _sandbox_proxy_auth(
+            source, prompt_default_repo, proxy_token
         )
         return await ensure_sandbox_for_thread(
             _thread_id,
+            github_proxy_token=proxy_token,
             github_proxy_repositories=proxy_repositories,
             repo=prompt_default_repo,
         )

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -162,11 +162,15 @@ def _patch_new_thread_deps(monkeypatch, *, profile: dict[str, object]) -> None:
         owner, name = full_name.split("/", 1)
         return {"owner": owner, "name": name}
 
+    async def fake_team_default_repo() -> None:
+        return None
+
     monkeypatch.setattr(thread_api, "get_profile", fake_profile)
     monkeypatch.setattr(thread_api, "get_team_default_model", fake_team_default)
     monkeypatch.setattr(thread_api, "_ensure_dashboard_github_token", fake_ensure_token)
     monkeypatch.setattr(thread_api, "_resolve_run_email", fake_resolve_email)
     monkeypatch.setattr(thread_api, "repo_config_for_user", fake_repo_config)
+    monkeypatch.setattr(thread_api, "get_team_default_repo", fake_team_default_repo)
 
 
 async def test_enrich_run_start_command_creates_and_stamps_new_thread(monkeypatch) -> None:
@@ -213,6 +217,37 @@ async def test_enrich_run_start_command_creates_and_stamps_new_thread(monkeypatc
     # Dashboard-only creation hints must not leak into the run config.
     assert "repo_explicitly_none" not in configurable
     assert enriched["params"]["assistant_id"] == "agent"
+
+
+async def test_enrich_run_start_command_validates_implicit_team_default_repo(
+    monkeypatch,
+) -> None:
+    created: dict[str, object] = {}
+    _patch_new_thread_deps(monkeypatch, profile={})
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: _new_thread_client(created))
+    checked: list[tuple[str, str]] = []
+
+    async def team_default_repo() -> dict[str, str]:
+        return {"owner": "team", "name": "default"}
+
+    async def validate_repo(login: str, full_name: str) -> dict[str, str]:
+        checked.append((login, full_name))
+        return {"owner": "team", "name": "default"}
+
+    monkeypatch.setattr(thread_api, "get_team_default_repo", team_default_repo)
+    monkeypatch.setattr(thread_api, "repo_config_for_user", validate_repo)
+    command = {
+        "method": "run.start",
+        "params": {"input": {"messages": [{"type": "human", "content": "Fix it"}]}},
+    }
+
+    await thread_api._enrich_run_start_command(
+        "new-tid", "octocat", command, metadata={}, creating=True
+    )
+
+    assert checked == [("octocat", "team/default")]
+    assert created["metadata"]["repo_owner"] == "team"
+    assert created["metadata"]["repo_name"] == "default"
 
 
 async def test_enrich_run_start_command_rejects_inaccessible_repo_before_stamping(

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -158,10 +158,15 @@ def _patch_new_thread_deps(monkeypatch, *, profile: dict[str, object]) -> None:
     async def fake_resolve_email(login: str, prof: dict[str, object]) -> str:
         return f"{login}@example.com"
 
+    async def fake_repo_config(login: str, full_name: str) -> dict[str, str]:
+        owner, name = full_name.split("/", 1)
+        return {"owner": owner, "name": name}
+
     monkeypatch.setattr(thread_api, "get_profile", fake_profile)
     monkeypatch.setattr(thread_api, "get_team_default_model", fake_team_default)
     monkeypatch.setattr(thread_api, "_ensure_dashboard_github_token", fake_ensure_token)
     monkeypatch.setattr(thread_api, "_resolve_run_email", fake_resolve_email)
+    monkeypatch.setattr(thread_api, "repo_config_for_user", fake_repo_config)
 
 
 async def test_enrich_run_start_command_creates_and_stamps_new_thread(monkeypatch) -> None:
@@ -208,6 +213,59 @@ async def test_enrich_run_start_command_creates_and_stamps_new_thread(monkeypatc
     # Dashboard-only creation hints must not leak into the run config.
     assert "repo_explicitly_none" not in configurable
     assert enriched["params"]["assistant_id"] == "agent"
+
+
+async def test_enrich_run_start_command_rejects_inaccessible_repo_before_stamping(
+    monkeypatch,
+) -> None:
+    created: dict[str, object] = {}
+    _patch_new_thread_deps(monkeypatch, profile={})
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: _new_thread_client(created))
+
+    async def deny_repo(login: str, full_name: str) -> dict[str, str]:
+        raise HTTPException(403, "no access to this private repository")
+
+    monkeypatch.setattr(thread_api, "repo_config_for_user", deny_repo)
+    command = {
+        "method": "run.start",
+        "params": {
+            "input": {"messages": [{"type": "human", "content": "Read secrets"}]},
+            "config": {"configurable": {"repo": "private/target"}},
+        },
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api._enrich_run_start_command(
+            "new-tid",
+            "attacker",
+            command,
+            metadata={},
+            creating=True,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert created == {}
+
+
+async def test_enrich_run_start_command_rejects_malformed_repo_hint(monkeypatch) -> None:
+    created: dict[str, object] = {}
+    _patch_new_thread_deps(monkeypatch, profile={})
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: _new_thread_client(created))
+    command = {
+        "method": "run.start",
+        "params": {
+            "input": {"messages": [{"type": "human", "content": "Fix it"}]},
+            "config": {"configurable": {"repo": {"owner": "private", "name": "target"}}},
+        },
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api._enrich_run_start_command(
+            "new-tid", "attacker", command, metadata={}, creating=True
+        )
+
+    assert exc_info.value.status_code == 422
+    assert created == {}
 
 
 async def test_enrich_run_start_command_uses_vision_fallback_for_text_only_model(
@@ -666,10 +724,16 @@ async def test_enrich_run_start_command_allowlists_client_configurable(monkeypat
         assert login == "octocat"
         return "octocat@example.com"
 
+    async def fake_repo_config(login: str, full_name: str) -> dict[str, str]:
+        assert login == "octocat"
+        assert full_name == "octo/repo"
+        return {"owner": "octo", "name": "repo"}
+
     monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
     monkeypatch.setattr(thread_api, "get_profile", fake_get_profile)
     monkeypatch.setattr(thread_api, "_ensure_dashboard_github_token", fake_ensure_token)
     monkeypatch.setattr(thread_api, "_resolve_run_email", fake_resolve_email)
+    monkeypatch.setattr(thread_api, "repo_config_for_user", fake_repo_config)
 
     command = {
         "method": "run.start",

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -208,10 +208,11 @@ class TestCreateSandboxWithProxy:
 
             from agent.server import _create_sandbox_with_proxy
 
-            await _create_sandbox_with_proxy()
+            await _create_sandbox_with_proxy(github_proxy_repositories=["open-swe"])
 
             mock_create.assert_called_once_with(snapshot_id=None)
             mock_proxy.assert_called_once_with("sandbox-123", "ghs_install")
+            assert mock_get_token.await_args.kwargs["repositories"] == ["open-swe"]
             assert (
                 mock_get_token.await_args.kwargs["permissions"] == RUNTIME_PROXY_TOKEN_PERMISSIONS
             )

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -22,8 +22,10 @@ class FakeSandboxBackend(SandboxBackendProtocol):
         return ExecuteResponse(output=f"{self.id}: {command}: {timeout}", exit_code=0)
 
 
-def _tool_request(thread_id: str = "thread-1") -> ToolCallRequest:
-    runtime = MagicMock(config={"configurable": {"thread_id": thread_id}})
+def _tool_request(
+    thread_id: str = "thread-1", configurable: dict[str, object] | None = None
+) -> ToolCallRequest:
+    runtime = MagicMock(config={"configurable": {"thread_id": thread_id, **(configurable or {})}})
     return ToolCallRequest(
         tool_call={"name": "ls", "args": {"path": "/"}, "id": "tc1"},
         tool=MagicMock(),
@@ -70,7 +72,12 @@ async def test_sandbox_client_error_recreates_sandbox() -> None:
             result = await middleware.awrap_tool_call(request, handler)
 
         assert isinstance(result, ToolMessage)
-        mock_recreate.assert_awaited_once_with("thread-1")
+        mock_recreate.assert_awaited_once_with(
+            "thread-1",
+            github_proxy_token=None,
+            github_proxy_repositories=None,
+            repo=None,
+        )
         mock_client.threads.update.assert_awaited_once_with(
             thread_id="thread-1",
             metadata={"sandbox_id": "sb-new"},
@@ -88,6 +95,70 @@ async def test_sandbox_client_error_recreates_sandbox() -> None:
         assert "sb-new" in payload["error"]
     finally:
         clear_sandbox_backend("thread-1")
+
+
+@pytest.mark.asyncio
+async def test_sandbox_recovery_preserves_repository_scope() -> None:
+    middleware = ToolErrorMiddleware()
+    request = _tool_request(
+        configurable={
+            "source": "dashboard",
+            "repo": {"owner": "langchain-ai", "name": "open-swe"},
+        }
+    )
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        raise SandboxClientError("Sandbox request timed out: sb-dead")
+
+    with (
+        patch("agent.server._recreate_sandbox", new_callable=AsyncMock) as mock_recreate,
+        patch("agent.server.client") as mock_client,
+    ):
+        mock_recreate.return_value = FakeSandboxBackend()
+        mock_client.threads.update = AsyncMock()
+        await middleware.awrap_tool_call(request, handler)
+
+    mock_recreate.assert_awaited_once_with(
+        "thread-1",
+        github_proxy_token=None,
+        github_proxy_repositories=["open-swe"],
+        repo={"owner": "langchain-ai", "name": "open-swe"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repo_less_dashboard_recovery_uses_user_token() -> None:
+    middleware = ToolErrorMiddleware()
+    request = _tool_request(
+        configurable={
+            "source": "dashboard",
+            "github_login": "octocat",
+            "repo_explicitly_none": True,
+        }
+    )
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        raise SandboxClientError("Sandbox request timed out: sb-dead")
+
+    with (
+        patch("agent.server._recreate_sandbox", new_callable=AsyncMock) as mock_recreate,
+        patch("agent.server.client") as mock_client,
+        patch(
+            "agent.utils.auth.resolve_github_token",
+            new_callable=AsyncMock,
+            return_value=("user-token", None),
+        ),
+    ):
+        mock_recreate.return_value = FakeSandboxBackend()
+        mock_client.threads.update = AsyncMock()
+        await middleware.awrap_tool_call(request, handler)
+
+    mock_recreate.assert_awaited_once_with(
+        "thread-1",
+        github_proxy_token="user-token",
+        github_proxy_repositories=None,
+        repo=None,
+    )
 
 
 def test_repeated_sandbox_errors_trigger_circuit_breaker_once() -> None:


### PR DESCRIPTION
## Description
Validate dashboard-selected repositories with the logged-in user’s OAuth token before stamping or resuming runs. Restrict sandbox GitHub App proxy tokens to the validated repository throughout creation and refresh.

## Release Note
Prevent dashboard runs from using GitHub App access for unauthorized repositories.

## Test Plan
- [x] Verify inaccessible and malformed dashboard repositories fail before thread creation
- [x] Verify proxy token minting retains repository scope across lifecycle paths

Made by [Open SWE](https://openswe.vercel.app/agents/f538015e-e216-aa5d-54ec-954aa02712df)