### PR TITLE
fix: defensive copy in get_reviewer_agent and get_chat_agent [closes #1584]

### DIFF
--- a/agent/chat.py
+++ b/agent/chat.py
@@ -16,6 +16,7 @@ GitHub-backed tools never receive a user credential.
 
 from __future__ import annotations
 
+import copy
 import logging
 import warnings
 from typing import Any
@@ -183,8 +184,9 @@ async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
 
 async def get_chat_agent(config: RunnableConfig) -> Pregel:
     """Get a read-only PR chat agent. No sandbox; PR context comes via config."""
+    config = copy.deepcopy(config)
+    config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
     thread_id = config["configurable"].get("thread_id")
-    config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
 
     if thread_id is None or not graph_loaded_for_execution(config):
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -16,7 +16,6 @@ GitHub-backed tools never receive a user credential.
 
 from __future__ import annotations
 
-import copy
 import logging
 import warnings
 from typing import Any
@@ -184,7 +183,8 @@ async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
 
 async def get_chat_agent(config: RunnableConfig) -> Pregel:
     """Get a read-only PR chat agent. No sandbox; PR context comes via config."""
-    config = copy.deepcopy(config)
+    config = config.copy()
+    config["configurable"] = config["configurable"].copy()
     config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
     thread_id = config["configurable"].get("thread_id")
 

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -16,6 +16,7 @@ agent for code review only:
 # ruff: noqa: E402
 
 import asyncio
+import copy
 import logging
 import posixpath
 import re
@@ -1274,9 +1275,9 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
 
 async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     """Get or create a reviewer agent with checkpointed run prep."""
+    config = copy.deepcopy(config)
+    config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
     thread_id = config["configurable"].get("thread_id", None)
-
-    config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
 
     if thread_id is None or not graph_loaded_for_execution(config):
         logger.info("No thread_id or not for execution, returning reviewer agent without sandbox")

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -16,7 +16,6 @@ agent for code review only:
 # ruff: noqa: E402
 
 import asyncio
-import copy
 import logging
 import posixpath
 import re
@@ -1275,7 +1274,8 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
 
 async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     """Get or create a reviewer agent with checkpointed run prep."""
-    config = copy.deepcopy(config)
+    config = config.copy()
+    config["configurable"] = config["configurable"].copy()
     config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
     thread_id = config["configurable"].get("thread_id", None)
 

--- a/tests/reviewer/test_factory_config_isolation.py
+++ b/tests/reviewer/test_factory_config_isolation.py
@@ -1,0 +1,112 @@
+"""Tests that get_reviewer_agent and get_chat_agent do not mutate the caller's config."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langgraph.graph.state import RunnableConfig
+
+
+def _make_config(recursion_limit: int = 25) -> RunnableConfig:
+    return {
+        "configurable": {"thread_id": None},
+        "recursion_limit": recursion_limit,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_reviewer_agent_does_not_mutate_caller_config() -> None:
+    """get_reviewer_agent must not overwrite the caller's recursion_limit."""
+    from agent import reviewer
+
+    config = _make_config(recursion_limit=25)
+    original_limit = config["recursion_limit"]
+
+    fake_pregel = MagicMock()
+    fake_pregel.with_config = MagicMock(return_value=fake_pregel)
+
+    with patch("agent.reviewer.create_deep_agent", return_value=fake_pregel):
+        await reviewer.get_reviewer_agent(config)
+
+    assert config["recursion_limit"] == original_limit, (
+        f"get_reviewer_agent mutated caller's recursion_limit: "
+        f"expected {original_limit}, got {config['recursion_limit']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_reviewer_agent_applies_default_when_limit_unset() -> None:
+    """get_reviewer_agent should apply DEFAULT_RECURSION_LIMIT when the caller didn't set one."""
+    from agent import reviewer
+
+    config: RunnableConfig = {"configurable": {"thread_id": None}}
+
+    fake_pregel = MagicMock()
+    fake_pregel.with_config = MagicMock(return_value=fake_pregel)
+
+    with patch("agent.reviewer.create_deep_agent", return_value=fake_pregel):
+        await reviewer.get_reviewer_agent(config)
+
+    # The original config must still be unchanged (no recursion_limit key added)
+    assert "recursion_limit" not in config
+
+
+@pytest.mark.asyncio
+async def test_get_chat_agent_does_not_mutate_caller_config() -> None:
+    """get_chat_agent must not overwrite the caller's recursion_limit."""
+    from agent import chat
+
+    config = _make_config(recursion_limit=50)
+    original_limit = config["recursion_limit"]
+
+    fake_pregel = MagicMock()
+    fake_pregel.with_config = MagicMock(return_value=fake_pregel)
+
+    with patch("agent.chat.create_deep_agent", return_value=fake_pregel):
+        await chat.get_chat_agent(config)
+
+    assert config["recursion_limit"] == original_limit, (
+        f"get_chat_agent mutated caller's recursion_limit: "
+        f"expected {original_limit}, got {config['recursion_limit']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_chat_agent_applies_default_when_limit_unset() -> None:
+    """get_chat_agent should apply DEFAULT_RECURSION_LIMIT when the caller didn't set one."""
+    from agent import chat
+
+    config: RunnableConfig = {"configurable": {"thread_id": None}}
+
+    fake_pregel = MagicMock()
+    fake_pregel.with_config = MagicMock(return_value=fake_pregel)
+
+    with patch("agent.chat.create_deep_agent", return_value=fake_pregel):
+        await chat.get_chat_agent(config)
+
+    assert "recursion_limit" not in config
+
+
+@pytest.mark.asyncio
+async def test_get_reviewer_agent_configurable_isolation() -> None:
+    """get_reviewer_agent must not mutate the caller's configurable sub-dict."""
+    from agent import reviewer
+
+    config: RunnableConfig = {
+        "configurable": {"thread_id": None, "custom_key": "sentinel"},
+    }
+    original_configurable_id = id(config["configurable"])
+
+    fake_pregel = MagicMock()
+    fake_pregel.with_config = MagicMock(return_value=fake_pregel)
+
+    with patch("agent.reviewer.create_deep_agent", return_value=fake_pregel):
+        await reviewer.get_reviewer_agent(config)
+
+    assert id(config["configurable"]) == original_configurable_id, (
+        "get_reviewer_agent replaced the caller's configurable dict"
+    )
+    assert config["configurable"]["custom_key"] == "sentinel", (
+        "get_reviewer_agent mutated the caller's configurable dict"
+    )

--- a/tests/reviewer/test_factory_config_isolation.py
+++ b/tests/reviewer/test_factory_config_isolation.py
@@ -48,7 +48,6 @@ async def test_get_reviewer_agent_applies_default_when_limit_unset() -> None:
     with patch("agent.reviewer.create_deep_agent", return_value=fake_pregel):
         await reviewer.get_reviewer_agent(config)
 
-    # The original config must still be unchanged (no recursion_limit key added)
     assert "recursion_limit" not in config
 
 
@@ -88,25 +87,36 @@ async def test_get_chat_agent_applies_default_when_limit_unset() -> None:
     assert "recursion_limit" not in config
 
 
+@pytest.mark.parametrize(
+    ("module_name", "factory_name"),
+    [("agent.reviewer", "get_reviewer_agent"), ("agent.chat", "get_chat_agent")],
+)
 @pytest.mark.asyncio
-async def test_get_reviewer_agent_configurable_isolation() -> None:
-    """get_reviewer_agent must not mutate the caller's configurable sub-dict."""
-    from agent import reviewer
-
+async def test_factory_copies_config_dicts_but_preserves_runtime_objects(
+    module_name: str, factory_name: str
+) -> None:
+    """Factory config isolation must preserve callback and configurable value identities."""
+    module = __import__(module_name, fromlist=[factory_name])
+    factory = getattr(module, factory_name)
+    callback = object()
+    configurable_value = object()
+    callbacks = [callback]
     config: RunnableConfig = {
-        "configurable": {"thread_id": None, "custom_key": "sentinel"},
+        "configurable": {"thread_id": None, "custom_key": configurable_value},
+        "callbacks": callbacks,
     }
-    original_configurable_id = id(config["configurable"])
 
     fake_pregel = MagicMock()
     fake_pregel.with_config = MagicMock(return_value=fake_pregel)
 
-    with patch("agent.reviewer.create_deep_agent", return_value=fake_pregel):
-        await reviewer.get_reviewer_agent(config)
+    with patch(f"{module_name}.create_deep_agent", return_value=fake_pregel):
+        await factory(config)
 
-    assert id(config["configurable"]) == original_configurable_id, (
-        "get_reviewer_agent replaced the caller's configurable dict"
-    )
-    assert config["configurable"]["custom_key"] == "sentinel", (
-        "get_reviewer_agent mutated the caller's configurable dict"
-    )
+    bound_config = fake_pregel.with_config.call_args.args[0]
+    assert bound_config is not config
+    assert bound_config["configurable"] is not config["configurable"]
+    assert bound_config["configurable"]["custom_key"] is configurable_value
+    assert bound_config["callbacks"] is callbacks
+    assert bound_config["callbacks"][0] is callback
+    assert "recursion_limit" not in config
+    assert config["configurable"] == {"thread_id": None, "custom_key": configurable_value}


### PR DESCRIPTION
## Description
Avoid mutating caller-owned `RunnableConfig` dictionaries while preserving runtime objects such as callback handlers by identity through shallow, targeted copies. Explicit recursion limits continue to win over the default.
## Release Note
Preserve caller callback identity and recursion limits in reviewer and PR chat graph factories.
## Test Plan
- [x] Added focused factory-isolation tests for both agents; ran Ruff format/lint and the focused test file.

Made by [Open SWE](https://openswe.vercel.app/agents/019f6274-a8a1-717b-824e-f04e43f4798b)