### PR TITLE
chore: upgrade deepagents to 0.7.0a7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ A separate **reviewer** graph runs read-only code reviews on PRs, and a **review
 Dependencies are managed with **uv**. Tests use pytest (`asyncio_mode = "auto"`). Lint/format is **ruff** (line-length 100, target py311). `requires-python = ">=3.11"`; `langgraph.json` pins the runtime to 3.12.
 
 ```bash
-make install            # uv pip install -e .
+make install            # uv sync
 make dev                # uv run langgraph dev — serves all three graphs + the FastAPI app from langgraph.json
 make run                # uvicorn agent.webapp:app --reload --port 8000 (FastAPI only, no LangGraph runtime)
 make test               # uv run pytest -vvv tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ A separate **reviewer** graph runs read-only code reviews on PRs, and a **review
 Dependencies are managed with **uv**. Tests use pytest (`asyncio_mode = "auto"`). Lint/format is **ruff** (line-length 100, target py311). `requires-python = ">=3.11"`; `langgraph.json` pins the runtime to 3.12.
 
 ```bash
-make install            # uv pip install -e .
+make install            # uv sync
 make dev                # uv run langgraph dev — serves all three graphs + the FastAPI app from langgraph.json
 make run                # uvicorn agent.webapp:app --reload --port 8000 (FastAPI only, no LangGraph runtime)
 make test               # uv run pytest -vvv tests/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run:
 	uv run uvicorn agent.webapp:app --reload --port 8000
 
 install:
-	uv pip install -e .
+	uv sync
 
 ######################
 # TESTING

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "deepagents==0.6.12",
+    "deepagents==0.7.0a7",
     "fastapi>=0.139.0",
     "uvicorn>=0.50.2",
     "httpx>=0.28.1",
@@ -40,6 +40,13 @@ dev = [
     "ruff>=0.15.20",
     "Pygments>=2.20.0",
 ]
+
+[tool.uv]
+# The langchain-{e2b,daytona,modal,runloop} sandbox integrations still declare a
+# conservative `deepagents<0.7.0` upper bound, but the 0.7.0 alpha keeps the
+# public API they rely on (SandboxBackendProtocol / BaseSandbox) backward
+# compatible. Override the transitive bound so we can track the latest alpha.
+override-dependencies = ["deepagents==0.7.0a7"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+overrides = [{ name = "deepagents", specifier = "==0.7.0a7" }]
+
 [[package]]
 name = "aiofiles"
 version = "24.1.0"
@@ -662,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.6.12"
+version = "0.7.0a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -672,9 +675,9 @@ dependencies = [
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/db/a6acdc72a9e90c3f07ed10de35c951734a02d4facb693bb59684ad368801/deepagents-0.6.12.tar.gz", hash = "sha256:1f281c0bc5a63132f62e2ee345c1dc593b23188da6e23016401f6879fbe54b5f", size = 211364, upload-time = "2026-06-25T17:26:52.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/0f/728afa9f34868657cd282624d96eb4afb5b1882826d19ee7795887a1a985/deepagents-0.7.0a7.tar.gz", hash = "sha256:023dbf08c7161215a274c69c0cf084c4b8a47eed1d156f71ac3ef4a87d1ac156", size = 271948, upload-time = "2026-07-14T04:49:10.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/49/af7219b3c13520fee047bb807cfaefba17f8e4584c551d946773589a4f08/deepagents-0.6.12-py3-none-any.whl", hash = "sha256:28b8fa0119ca0a689e3e18e288c4634e4046062acfc87a1cb34289d3af3a1c88", size = 236120, upload-time = "2026-06-25T17:26:51.736Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f0/39e7a327baf4f597624ce024d3d59968d7068f0216f0e8469e952fc8a574/deepagents-0.7.0a7-py3-none-any.whl", hash = "sha256:5c2080e3f630c200abed416748fd9fa3e12bc954d5052ea14ba84fee76d5698b", size = 297251, upload-time = "2026-07-14T04:49:09.569Z" },
 ]
 
 [[package]]
@@ -1424,16 +1427,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload-time = "2026-06-22T23:00:33.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/33/fd716d0273c8495482953bd63461bf02f71f3a8f4a2fe6c0a70a0e6ff799/langchain-1.3.13.tar.gz", hash = "sha256:bcf874680f31e9970f0db2264509df5bc2115d9680e9d651d537eb49bf1a7d8a", size = 642868, upload-time = "2026-07-10T23:06:08.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload-time = "2026-06-22T23:00:31.619Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c6/dc676c632f3d20c88789b0726c43ad5e039c25338cc3bb7090fc247d1522/langchain-1.3.13-py3-none-any.whl", hash = "sha256:20a8fe4b1dea7db74356f7d2b5455c4970099b9f7f53c2122ea97f115c907fbd", size = 136911, upload-time = "2026-07-10T23:06:07.012Z" },
 ]
 
 [[package]]
@@ -2072,7 +2075,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=49.0.0" },
-    { name = "deepagents", specifier = "==0.6.12" },
+    { name = "deepagents", specifier = "==0.7.0a7" },
     { name = "exa-py", specifier = ">=2.16.0" },
     { name = "fastapi", specifier = ">=0.139.0" },
     { name = "fireworks-ai", specifier = ">=1.2.0a86" },


### PR DESCRIPTION
Upgrade the Deep Agents SDK to the 0.7.0 alpha (`0.7.0a7`).

---

Bumps `deepagents` from `0.6.12` to the latest `0.7.0` alpha (`0.7.0a7`). The public API the codebase relies on — `create_deep_agent`, `SubAgent`/`GENERAL_PURPOSE_SUBAGENT`, `HarnessProfile`/`register_harness_profile`, `SkillsMiddleware`, `CompositeBackend`/`StateBackend`, `SandboxBackendProtocol`/`BaseSandbox`/`LangSmithSandbox`, `create_file_data` — is unchanged (0.7 is purely additive: `SystemPromptConfig`, `DeleteResult`, offload/delete methods), so no source changes are required. The `langchain-{e2b,daytona,modal,runloop}` sandbox integrations still declare a conservative `deepagents<0.7.0` upper bound with no compatible release available, so a `uv` `override-dependencies` entry forces the alpha past that transitive bound. `uv lock` also pulled `langchain` `1.3.11 → 1.3.13` transitively.

Note: with the alpha, `agent/chat.py`'s trivial stub agent (`create_deep_agent(model=None, ...)`) now emits a `model=None` deprecation warning (slated for removal in `deepagents==1.0.0`). Left as-is intentionally — that stub is only returned when not executing, to avoid resolving model credentials.

Made by [Open SWE](https://openswe.vercel.app/agents/7117a4b5-2ef0-9c94-a9bc-2ab43f2230f5)