### PR TITLE
chore: point basedpyright at uv's .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 
 # misc
 .DS_Store
+.vscode/
 *.pem
 *.key
 *.crt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "cSpell.words": [
-    "DAYTONA",
-    "helicunate"
-  ]
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,8 @@ ignore = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.basedpyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.11"


### PR DESCRIPTION
## Summary
- Adds `[tool.basedpyright]` in `pyproject.toml` so basedpyright/Cursor resolves imports from the project `.venv` created by `uv sync`
- Stops tracking `.vscode/settings.json` and gitignores `.vscode/` so personal editor prefs (interpreter path, etc.) stay local
- Fixes false `reportMissingImports` for packages like FastAPI when the IDE interpreter picker doesn't wire into basedpyright

## Notes
- `.venv` stays gitignored; only the type-checker config is committed (same idea as `[tool.ruff]` / `[tool.pytest]`)
- Existing local `.vscode/settings.json` is preserved on disk after untrack

## Test plan
- [ ] Open `agent/api/app.py` in Cursor with basedpyright
- [ ] Confirm `from fastapi.middleware.cors import CORSMiddleware` no longer reports missing import after reload / basedpyright restart
- [ ] Confirm `uv run basedpyright agent/api/app.py` still has no missing-import errors
- [ ] Confirm `.vscode/settings.json` is no longer tracked (`git status` after editing it should not show it)