### PR TITLE
fix: add trace link to error banner

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -139,6 +139,19 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
           <div className="border-b border-[var(--ui-border)] bg-[var(--ui-danger)]/10 px-4 py-2 text-xs text-[var(--ui-danger)]">
             The last run hit an error before it could finish. Send another
             message to retry.
+            {thread.traceUrl && (
+              <>
+                {" "}
+                <a
+                  href={thread.traceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium underline underline-offset-2"
+                >
+                  Open trace
+                </a>
+              </>
+            )}
           </div>
         )}
         <WorkflowApprovalCard


### PR DESCRIPTION
## Description
Adds an inline trace link to the agent thread error banner when a trace URL is available, so users can inspect failures even on threads they cannot access through the sidebar actions.

## Release Note
Dashboard error banners now link to the run trace when available.

## Test Plan
- [ ] Open an errored agent thread with a trace URL and confirm the banner includes an Open trace link.

Made by [Open SWE](https://openswe.vercel.app/agents/1d4d148b-34d7-a8c5-2f5e-dba87b2e9f4a)