### PR TITLE
fix: patch 5 PyJWT security alerts

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2670,11 +2670,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Security Alert Patch

Resolves all 5 open Dependabot security alerts by updating the locked PyJWT version from 2.12.1 to 2.13.0, the minimum patched release.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| PyJWT | `>=2.12.1` (locked at 2.12.1) | `>=2.12.1` (locked at 2.13.0) | lockfile-only (A-lockfile) | published | CVE-2026-48526, CVE-2026-48522, CVE-2026-48525, CVE-2026-48523, CVE-2026-48524 |

The published constraint remains unchanged because production JWT decoding uses explicit single-family algorithm allowlists. Updating the lockfile protects deployed Open SWE instances without unnecessarily raising the package floor for downstream users.

### CVE Details

- [CVE-2026-48526 / GHSA-xgmm-8j9v-c9wx](https://github.com/advisories/GHSA-xgmm-8j9v-c9wx) — public-key JWK accepted as an HMAC secret when mixed algorithm families are allowed
- [CVE-2026-48522 / GHSA-993g-76c3-p5m4](https://github.com/advisories/GHSA-993g-76c3-p5m4) — PyJWKClient scheme allowlist bypass enabling SSRF and token forgery
- [CVE-2026-48525 / GHSA-w7vc-732c-9m39](https://github.com/advisories/GHSA-w7vc-732c-9m39) — denial of service through unbounded Base64URL decoding
- [CVE-2026-48523 / GHSA-jq35-7prp-9v3f](https://github.com/advisories/GHSA-jq35-7prp-9v3f) — algorithm allowlist bypass with PyJWK and PyJWKClient keys
- [CVE-2026-48524 / GHSA-fhv5-28vv-h8m8](https://github.com/advisories/GHSA-fhv5-28vv-h8m8) — unbounded JWKS requests from attacker-controlled key IDs

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] Lockfile regenerated with PyJWT 2.13.0
- [x] `ruff check .`
- [x] `ruff format . --check`
- [x] 1,537 tests passed

🤖 Submitted by langster-ops patch workflow