### PR TITLE
fix: recover reviewer auth at publish boundary

### DIFF
--- a/agent/review/auth.py
+++ b/agent/review/auth.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from ..utils.github_app import (
+    get_github_app_installation_token_with_expiry,
+    invalidate_cached_app_token,
+)
+from ..utils.github_token import cache_github_token_for_thread
+from .findings import (
+    REVIEWER_THREAD_KIND,
+    ReviewerThreadMissingError,
+    get_thread_metadata_strict,
+    get_thread_pr_meta,
+)
+
+logger = logging.getLogger(__name__)
+
+REVIEWER_GITHUB_TOKEN_PERMISSIONS = {
+    "checks": "write",
+    "contents": "read",
+    "pull_requests": "write",
+}
+_MAX_TOKEN_MINT_ATTEMPTS = 3
+_TOKEN_MINT_INITIAL_DELAY_SECONDS = 0.25
+
+
+class ReviewerPublicationContextError(Exception):
+    """Raised when durable reviewer metadata does not match the publish target."""
+
+
+class ReviewerPublicationContextUnavailableError(Exception):
+    """Raised when durable reviewer context cannot be verified transiently."""
+
+
+class ReviewerTokenUnavailableError(Exception):
+    """Raised when a reviewer GitHub App token cannot be provisioned."""
+
+
+async def mint_reviewer_github_token(
+    *,
+    thread_id: str,
+    repo: str,
+    attempts: int = 1,
+) -> str | None:
+    """Mint and process-cache a least-privilege reviewer token."""
+    if not repo:
+        return None
+    bounded_attempts = max(1, min(attempts, _MAX_TOKEN_MINT_ATTEMPTS))
+    for attempt in range(bounded_attempts):
+        token, expires_at = await get_github_app_installation_token_with_expiry(
+            repositories=[repo],
+            permissions=REVIEWER_GITHUB_TOKEN_PERMISSIONS,
+        )
+        if token:
+            cache_github_token_for_thread(
+                thread_id,
+                token,
+                expires_at=expires_at,
+                is_bot_token=True,
+            )
+            return token
+        if attempt + 1 < bounded_attempts:
+            await asyncio.sleep(_TOKEN_MINT_INITIAL_DELAY_SECONDS * (2**attempt))
+    return None
+
+
+def invalidate_reviewer_github_token(repo: str) -> None:
+    """Invalidate the exact reviewer App-token scope after a 401."""
+    invalidate_cached_app_token(
+        repositories=[repo],
+        permissions=REVIEWER_GITHUB_TOKEN_PERMISSIONS,
+    )
+
+
+async def recover_reviewer_github_token(
+    *,
+    run_config: Mapping[str, Any],
+    thread_id: str,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    run_id: str | None,
+) -> str:
+    """Recover reviewer auth at the publish boundary after a durable resume."""
+    configurable = run_config.get("configurable", {})
+    configured_thread_id = (
+        configurable.get("thread_id") if isinstance(configurable, Mapping) else None
+    )
+    if configured_thread_id != thread_id:
+        raise ReviewerPublicationContextError("reviewer thread context mismatch")
+
+    try:
+        metadata = await get_thread_metadata_strict(thread_id)
+    except ReviewerThreadMissingError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Reviewer publication context unavailable for thread %s",
+            thread_id,
+            exc_info=True,
+        )
+        raise ReviewerPublicationContextUnavailableError(
+            "reviewer publication context unavailable"
+        ) from exc
+    pr = get_thread_pr_meta(metadata)
+    if (
+        metadata.get("kind") != REVIEWER_THREAD_KIND
+        or pr is None
+        or str(pr.get("owner", "")).casefold() != owner.casefold()
+        or str(pr.get("name", "")).casefold() != repo.casefold()
+        or pr.get("number") != pr_number
+    ):
+        logger.warning(
+            "Refusing reviewer token recovery after publication context mismatch for thread %s",
+            thread_id,
+        )
+        raise ReviewerPublicationContextError("reviewer publication context mismatch")
+
+    current_run_id = metadata.get("current_reviewer_run_id")
+    if not isinstance(current_run_id, str) or not current_run_id:
+        logger.warning(
+            "Refusing reviewer token recovery without an active run for thread %s",
+            thread_id,
+        )
+        raise ReviewerPublicationContextUnavailableError("active reviewer run unavailable")
+    if run_id and current_run_id != run_id:
+        logger.warning(
+            "Refusing reviewer token recovery for stale run on thread %s",
+            thread_id,
+        )
+        raise ReviewerPublicationContextError("reviewer run is not current")
+
+    token = await mint_reviewer_github_token(
+        thread_id=thread_id,
+        repo=repo,
+        attempts=_MAX_TOKEN_MINT_ATTEMPTS,
+    )
+    if not token:
+        logger.error(
+            "Reviewer token recovery failed for thread %s repo %s/%s PR %s",
+            thread_id,
+            owner,
+            repo,
+            pr_number,
+        )
+        raise ReviewerTokenUnavailableError("GitHub App installation token unavailable")
+
+    logger.info(
+        "Recovered reviewer GitHub App token for thread %s repo %s/%s PR %s",
+        thread_id,
+        owner,
+        repo,
+        pr_number,
+    )
+    return token

--- a/agent/review/findings.py
+++ b/agent/review/findings.py
@@ -349,6 +349,11 @@ async def get_thread_metadata(thread_id: str) -> dict[str, Any]:
         return {}
 
 
+async def get_thread_metadata_strict(thread_id: str) -> dict[str, Any]:
+    """Fetch reviewer metadata without swallowing transient failures."""
+    return await _get_thread_metadata_strict(thread_id)
+
+
 async def _get_thread_metadata_strict(thread_id: str) -> dict[str, Any]:
     client = get_client()
     try:

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -59,6 +59,7 @@ from .middleware import (
     refresh_github_proxy_before_model,
     settle_review_check_on_exit,
 )
+from .review.auth import REVIEWER_GITHUB_TOKEN_PERMISSIONS
 from .review.diff import (
     compute_diff_line_set,
     fetch_pr_diff,
@@ -913,8 +914,11 @@ async def _ensure_reviewer_sandbox_for_thread(
     github_token: str | None = None
     if configurable.get("source"):
         repo_name_for_token = str(repo_config.get("name") or "")
+        if not repo_name_for_token:
+            raise RuntimeError(f"Repository unavailable for reviewer thread {thread_id}")
         github_token, expires_at = await get_github_app_installation_token_with_expiry(
-            repositories=[repo_name_for_token] if repo_name_for_token else None
+            repositories=[repo_name_for_token],
+            permissions=REVIEWER_GITHUB_TOKEN_PERMISSIONS,
         )
         if not github_token:
             raise RuntimeError(

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
+from uuid import UUID
 
 from langgraph.config import get_config
 from langgraph.prebuilt import InjectedState
 
 from ..dashboard.team_settings import get_team_review_trace_links_enabled
+from ..review.auth import (
+    ReviewerPublicationContextError,
+    ReviewerPublicationContextUnavailableError,
+    ReviewerTokenUnavailableError,
+    invalidate_reviewer_github_token,
+    recover_reviewer_github_token,
+)
 from ..review.diff import compute_diff_line_set, fetch_pr_diff, is_range_in_diff
 from ..review.findings import (
     REVIEW_FINDING_CAP,
@@ -48,14 +57,12 @@ from ..review.publish import (
 from ..review.reconcile import reconcile_findings_with_review_threads
 from ..utils.dashboard_links import dashboard_review_url
 from ..utils.github_checks import review_check_conclusion
-from ..utils.github_token import (
-    GitHubAuthError,
-    get_github_token,
-    invalidate_cached_github_token,
-)
+from ..utils.github_token import GitHubAuthError, invalidate_cached_github_token
 from ..utils.langsmith import get_langsmith_trace_url
 from ..utils.slack import post_slack_thread_reply
 from ..utils.tracing import REVIEW_TRACING_PROJECT
+
+logger = logging.getLogger(__name__)
 
 
 async def publish_review(
@@ -141,38 +148,174 @@ async def publish_review(
         except ReviewerThreadMissingError as exc:
             return thread_missing_tool_result(exc)
 
-    token = get_github_token()
-    if not token:
-        return {"success": False, "error": "No GitHub token available"}
+    owner = str(repo_config["owner"])
+    repo = str(repo_config["name"])
+    run_id = _current_run_id(config)
+    try:
+        thread_id = get_thread_id_from_runtime()
+        token = await recover_reviewer_github_token(
+            run_config=config,
+            thread_id=thread_id,
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            run_id=run_id,
+        )
+    except ReviewerThreadMissingError as exc:
+        return thread_missing_tool_result(exc)
+    except ReviewerPublicationContextUnavailableError:
+        return {
+            "success": False,
+            "error": "Reviewer publication context is temporarily unavailable",
+            "error_code": "publication_context_unavailable",
+            "retryable": True,
+            "publication_pending": False,
+        }
+    except ReviewerPublicationContextError:
+        return {
+            "success": False,
+            "error": "Reviewer publication context validation failed",
+            "error_code": "publication_context_mismatch",
+            "retryable": False,
+        }
+    except ReviewerTokenUnavailableError:
+        try:
+            await _record_review_publication_pending(
+                thread_id=thread_id,
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                severity_threshold=_cast_severity(severity_threshold),
+                run_id=run_id,
+                error_code="github_app_token_unavailable",
+            )
+        except ReviewerThreadMissingError as exc:
+            return thread_missing_tool_result(exc)
+        except Exception:
+            logger.exception(
+                "Failed to record token-recovery publication state for thread %s",
+                thread_id,
+            )
+            return {
+                "success": False,
+                "error": "GitHub App token unavailable; findings remain stored on the thread",
+                "error_code": "github_app_token_unavailable",
+                "retryable": True,
+                "publication_pending": False,
+            }
+        return {
+            "success": False,
+            "error": "GitHub App token unavailable; findings were preserved for retry",
+            "error_code": "github_app_token_unavailable",
+            "retryable": True,
+            "publication_pending": True,
+        }
 
     try:
-        return await _publish_review_async(
-            owner=str(repo_config["owner"]),
-            repo=str(repo_config["name"]),
+        result = await _publish_review_async(
+            owner=owner,
+            repo=repo,
             pr_number=pr_number,
             head_sha=head_sha,
             token=token,
             severity_threshold=_cast_severity(severity_threshold),
             cap=REVIEW_FINDING_CAP,
             is_re_review=is_re_review,
-            langgraph_run_id=_current_run_id(config),
+            langgraph_run_id=run_id,
             trace_link_config_override=configurable.get("review_trace_link_enabled"),
             state=state,
         )
+        if result.get("success"):
+            try:
+                await set_reviewer_thread_metadata(
+                    thread_id,
+                    extra={"review_publication_pending": None},
+                )
+            except Exception:
+                logger.exception(
+                    "Published review but failed to clear pending state for thread %s",
+                    thread_id,
+                )
+        return result
     except ReviewerThreadMissingError as exc:
         return thread_missing_tool_result(exc)
     except GitHubAuthError as exc:
-        thread_id = get_thread_id_from_runtime()
-        if thread_id:
-            await invalidate_cached_github_token(thread_id)
+        await invalidate_cached_github_token(thread_id)
+        invalidate_reviewer_github_token(repo)
+        publication_pending = True
+        try:
+            await _record_review_publication_pending(
+                thread_id=thread_id,
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                severity_threshold=_cast_severity(severity_threshold),
+                run_id=run_id,
+                error_code="github_token_rejected",
+            )
+        except Exception:
+            publication_pending = False
+            logger.exception(
+                "Failed to record rejected-token publication state for thread %s",
+                thread_id,
+            )
         return {
             "success": False,
             "error": (
-                "GitHub returned 401 — the cached OAuth token is invalid or revoked. "
-                "Please re-authenticate and trigger the review again."
+                "GitHub returned 401 — the cached reviewer token was rejected. "
+                "Retry publish_review to provision a fresh GitHub App token."
             ),
             "auth_error": str(exc),
+            "error_code": "github_token_rejected",
+            "retryable": True,
+            "publication_pending": publication_pending,
         }
+
+
+async def _record_review_publication_pending(
+    *,
+    thread_id: str,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    severity_threshold: Severity,
+    run_id: str | None,
+    error_code: str,
+) -> None:
+    """Persist sanitized state for a later publication retry."""
+    metadata = await get_thread_metadata(thread_id)
+    findings = await list_findings_async(thread_id)
+    previous = metadata.get("review_publication_pending")
+    previous_attempts = previous.get("attempt_count") if isinstance(previous, dict) else 0
+    attempt_count = (
+        previous_attempts + 1
+        if isinstance(previous_attempts, int) and not isinstance(previous_attempts, bool)
+        else 1
+    )
+    finding_ids = [
+        finding["id"]
+        for finding in findings
+        if isinstance(finding.get("id"), str)
+        and finding.get("status", "open") == "open"
+        and not isinstance(finding.get("github_review_comment_id"), int)
+    ]
+    pending: dict[str, Any] = {
+        "target": {"owner": owner, "repo": repo, "pr_number": pr_number},
+        "head_sha": head_sha,
+        "severity_threshold": severity_threshold,
+        "finding_ids": finding_ids,
+        "attempt_count": attempt_count,
+        "error_code": error_code,
+    }
+    if run_id:
+        pending["run_id"] = run_id
+    await set_reviewer_thread_metadata(
+        thread_id,
+        extra={"review_publication_pending": pending},
+    )
 
 
 def _cast_severity(value: str) -> Severity:
@@ -1062,7 +1205,12 @@ def _current_run_id(config: dict[str, Any]) -> str | None:
     configurable = config.get("configurable")
     if isinstance(configurable, dict):
         candidates.append(configurable.get("run_id"))
+    metadata = config.get("metadata")
+    if isinstance(metadata, dict):
+        candidates.append(metadata.get("run_id"))
     for candidate in candidates:
         if isinstance(candidate, str) and candidate:
             return candidate
+        if isinstance(candidate, UUID):
+            return str(candidate)
     return None

--- a/agent/utils/github_app.py
+++ b/agent/utils/github_app.py
@@ -111,6 +111,16 @@ def clear_app_token_cache() -> None:
     _TOKEN_CACHE.clear()
 
 
+def invalidate_cached_app_token(
+    *,
+    repository_ids: Sequence[int] | None = None,
+    repositories: Sequence[str] | None = None,
+    permissions: PermissionMap | None = None,
+) -> None:
+    """Drop one cached installation-token scope."""
+    _TOKEN_CACHE.pop(_scope_key(repository_ids, repositories, permissions), None)
+
+
 def _generate_app_jwt() -> str:
     """Generate a short-lived JWT signed with the GitHub App private key."""
     now = int(time.time())

--- a/tests/github/test_github_app.py
+++ b/tests/github/test_github_app.py
@@ -112,6 +112,36 @@ async def test_cache_is_scoped_per_repository_set(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.asyncio
+async def test_invalidating_one_scope_forces_only_that_scope_to_remint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+    class Client(_CountingClient):
+        posts = 0
+        expires_at = future
+
+    _configure(monkeypatch, Client)
+    permissions = {"contents": "read", "pull_requests": "write"}
+
+    await github_app.get_github_app_installation_token_with_expiry(
+        repositories=["a"], permissions=permissions
+    )
+    await github_app.get_github_app_installation_token_with_expiry(
+        repositories=["b"], permissions=permissions
+    )
+    github_app.invalidate_cached_app_token(repositories=["a"], permissions=permissions)
+    await github_app.get_github_app_installation_token_with_expiry(
+        repositories=["a"], permissions=permissions
+    )
+    await github_app.get_github_app_installation_token_with_expiry(
+        repositories=["b"], permissions=permissions
+    )
+
+    assert Client.posts == 3
+
+
+@pytest.mark.asyncio
 async def test_near_expiry_token_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     soon = (datetime.now(UTC) + timedelta(minutes=2)).isoformat()
 

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -238,7 +238,10 @@ async def test_reviewer_resolves_app_installation_token_at_run_start() -> None:
     assert "github_token_encrypted" not in metadata
     # Token is resolved in this process at run start (scoped to the repo), not read
     # from a cache the webhook handler populated in a different process.
-    mock_app_token.assert_awaited_once_with(repositories=["repo"])
+    mock_app_token.assert_awaited_once_with(
+        repositories=["repo"],
+        permissions=reviewer.REVIEWER_GITHUB_TOKEN_PERMISSIONS,
+    )
     mock_cache_token.assert_called_once_with(
         "reviewer-thread-id", "app-token", expires_at=None, is_bot_token=True
     )

--- a/tests/reviewer/test_reviewer_auth.py
+++ b/tests/reviewer/test_reviewer_auth.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.review.auth import (
+    REVIEWER_GITHUB_TOKEN_PERMISSIONS,
+    ReviewerPublicationContextError,
+    ReviewerPublicationContextUnavailableError,
+    ReviewerTokenUnavailableError,
+    invalidate_reviewer_github_token,
+    mint_reviewer_github_token,
+    recover_reviewer_github_token,
+)
+
+
+async def test_mint_reviewer_token_is_repo_scoped_and_least_privilege() -> None:
+    mint = AsyncMock(return_value=("token", "expiry"))
+    cache = MagicMock()
+    with (
+        patch("agent.review.auth.get_github_app_installation_token_with_expiry", mint),
+        patch("agent.review.auth.cache_github_token_for_thread", cache),
+    ):
+        token = await mint_reviewer_github_token(thread_id="thread", repo="repo")
+
+    assert token == "token"
+    mint.assert_awaited_once_with(
+        repositories=["repo"],
+        permissions=REVIEWER_GITHUB_TOKEN_PERMISSIONS,
+    )
+    cache.assert_called_once_with(
+        "thread",
+        "token",
+        expires_at="expiry",
+        is_bot_token=True,
+    )
+
+
+async def test_mint_reviewer_token_retries_only_token_acquisition() -> None:
+    mint = AsyncMock(side_effect=[(None, None), (None, None), ("token", "expiry")])
+    sleep = AsyncMock()
+    with (
+        patch("agent.review.auth.get_github_app_installation_token_with_expiry", mint),
+        patch("agent.review.auth.cache_github_token_for_thread"),
+        patch("agent.review.auth.asyncio.sleep", sleep),
+    ):
+        token = await mint_reviewer_github_token(
+            thread_id="thread",
+            repo="repo",
+            attempts=3,
+        )
+
+    assert token == "token"
+    assert mint.await_count == 3
+    assert sleep.await_count == 2
+
+
+def test_invalidate_reviewer_token_targets_exact_scope() -> None:
+    with patch("agent.review.auth.invalidate_cached_app_token") as invalidate:
+        invalidate_reviewer_github_token("repo")
+
+    invalidate.assert_called_once_with(
+        repositories=["repo"],
+        permissions=REVIEWER_GITHUB_TOKEN_PERMISSIONS,
+    )
+
+
+async def test_recover_reviewer_token_always_derives_scoped_app_token() -> None:
+    config = {"configurable": {"thread_id": "thread"}}
+    metadata = {
+        "kind": "reviewer",
+        "pr": {"owner": "acme", "name": "repo", "number": 7},
+        "current_reviewer_run_id": "run-1",
+    }
+    mint = AsyncMock(return_value="scoped-app-token")
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch("agent.review.auth.mint_reviewer_github_token", mint),
+    ):
+        token = await recover_reviewer_github_token(
+            run_config=config,
+            thread_id="thread",
+            owner="acme",
+            repo="repo",
+            pr_number=7,
+            run_id="run-1",
+        )
+
+    assert token == "scoped-app-token"
+    mint.assert_awaited_once_with(thread_id="thread", repo="repo", attempts=3)
+
+
+async def test_recover_reviewer_token_after_durable_resume() -> None:
+    config = {"configurable": {"thread_id": "thread"}}
+    metadata = {
+        "kind": "reviewer",
+        "pr": {"owner": "acme", "name": "repo", "number": 7},
+        "current_reviewer_run_id": "run-1",
+    }
+    mint = AsyncMock(return_value="recovered")
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch("agent.review.auth.mint_reviewer_github_token", mint),
+    ):
+        token = await recover_reviewer_github_token(
+            run_config=config,
+            thread_id="thread",
+            owner="acme",
+            repo="repo",
+            pr_number=7,
+            run_id="run-1",
+        )
+
+    assert token == "recovered"
+    mint.assert_awaited_once_with(thread_id="thread", repo="repo", attempts=3)
+
+
+async def test_recover_reviewer_token_when_retry_attempt_omits_runtime_run_id() -> None:
+    metadata = {
+        "kind": "reviewer",
+        "pr": {"owner": "acme", "name": "repo", "number": 7},
+        "current_reviewer_run_id": "run-1",
+    }
+    mint = AsyncMock(return_value="recovered")
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch("agent.review.auth.mint_reviewer_github_token", mint),
+    ):
+        token = await recover_reviewer_github_token(
+            run_config={"configurable": {"thread_id": "thread"}},
+            thread_id="thread",
+            owner="acme",
+            repo="repo",
+            pr_number=7,
+            run_id=None,
+        )
+
+    assert token == "recovered"
+    mint.assert_awaited_once_with(thread_id="thread", repo="repo", attempts=3)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"kind": "agent", "pr": {"owner": "acme", "name": "repo", "number": 7}},
+        {"kind": "reviewer", "pr": {"owner": "other", "name": "repo", "number": 7}},
+        {"kind": "reviewer", "pr": {"owner": "acme", "name": "other", "number": 7}},
+        {"kind": "reviewer", "pr": {"owner": "acme", "name": "repo", "number": 8}},
+    ],
+)
+async def test_recover_reviewer_token_rejects_context_mismatch(
+    metadata: dict[str, object],
+) -> None:
+    mint = AsyncMock()
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch("agent.review.auth.mint_reviewer_github_token", mint),
+    ):
+        with pytest.raises(ReviewerPublicationContextError):
+            await recover_reviewer_github_token(
+                run_config={"configurable": {"thread_id": "thread"}},
+                thread_id="thread",
+                owner="acme",
+                repo="repo",
+                pr_number=7,
+                run_id="run-1",
+            )
+
+    mint.assert_not_awaited()
+
+
+async def test_recover_reviewer_token_rejects_stale_run() -> None:
+    metadata = {
+        "kind": "reviewer",
+        "pr": {"owner": "acme", "name": "repo", "number": 7},
+        "current_reviewer_run_id": "run-2",
+    }
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch("agent.review.auth.mint_reviewer_github_token", new_callable=AsyncMock) as mint,
+    ):
+        with pytest.raises(ReviewerPublicationContextError):
+            await recover_reviewer_github_token(
+                run_config={"configurable": {"thread_id": "thread"}},
+                thread_id="thread",
+                owner="acme",
+                repo="repo",
+                pr_number=7,
+                run_id="run-1",
+            )
+
+    mint.assert_not_awaited()
+
+
+async def test_recover_reviewer_token_reports_transient_metadata_failure() -> None:
+    with patch(
+        "agent.review.auth.get_thread_metadata_strict",
+        AsyncMock(side_effect=TimeoutError("metadata unavailable")),
+    ):
+        with pytest.raises(ReviewerPublicationContextUnavailableError):
+            await recover_reviewer_github_token(
+                run_config={"configurable": {"thread_id": "thread"}},
+                thread_id="thread",
+                owner="acme",
+                repo="repo",
+                pr_number=7,
+                run_id=None,
+            )
+
+
+async def test_recover_reviewer_token_retries_missing_active_run_context() -> None:
+    run_id = "run-1"
+    current_run_id = None
+    metadata = {
+        "kind": "reviewer",
+        "pr": {"owner": "acme", "name": "repo", "number": 7},
+        "current_reviewer_run_id": current_run_id,
+    }
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch("agent.review.auth.mint_reviewer_github_token", new_callable=AsyncMock) as mint,
+    ):
+        with pytest.raises(ReviewerPublicationContextUnavailableError):
+            await recover_reviewer_github_token(
+                run_config={"configurable": {"thread_id": "thread"}},
+                thread_id="thread",
+                owner="acme",
+                repo="repo",
+                pr_number=7,
+                run_id=run_id,
+            )
+
+    mint.assert_not_awaited()
+
+
+async def test_recover_reviewer_token_raises_after_bounded_mint_failure() -> None:
+    metadata = {
+        "kind": "reviewer",
+        "pr": {"owner": "acme", "name": "repo", "number": 7},
+        "current_reviewer_run_id": "run-1",
+    }
+    with (
+        patch("agent.review.auth.get_thread_metadata_strict", AsyncMock(return_value=metadata)),
+        patch(
+            "agent.review.auth.mint_reviewer_github_token",
+            AsyncMock(return_value=None),
+        ) as mint,
+    ):
+        with pytest.raises(ReviewerTokenUnavailableError):
+            await recover_reviewer_github_token(
+                run_config={"configurable": {"thread_id": "thread"}},
+                thread_id="thread",
+                owner="acme",
+                repo="repo",
+                pr_number=7,
+                run_id="run-1",
+            )
+
+    mint.assert_awaited_once_with(thread_id="thread", repo="repo", attempts=3)

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -407,7 +407,10 @@ async def test_publish_review_eval_mode_does_not_call_github() -> None:
         patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="tid"),
         patch("agent.tools.publish_review.list_findings_async", AsyncMock(return_value=findings)),
         patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()) as set_meta,
-        patch("agent.tools.publish_review.get_github_token") as get_token,
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            new_callable=AsyncMock,
+        ) as recover_token,
         patch("agent.tools.publish_review.post_pull_request_review", AsyncMock()) as post_review,
     ):
         result = await publish_review()
@@ -416,7 +419,7 @@ async def test_publish_review_eval_mode_does_not_call_github() -> None:
     assert result["dry_run"] is True
     assert result["surfaced_count"] == 1
     assert result["hidden_count"] == 1
-    get_token.assert_not_called()
+    recover_token.assert_not_awaited()
     post_review.assert_not_called()
     set_meta.assert_awaited_once_with(
         "tid",
@@ -529,13 +532,309 @@ async def test_publish_review_forwards_trace_link_config_override() -> None:
                 "metadata": {},
             },
         ),
-        patch("agent.tools.publish_review.get_github_token", return_value="token"),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(return_value="token"),
+        ),
         patch("agent.tools.publish_review._publish_review_async", publish_async),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()),
     ):
         result = await publish_review()
 
     assert result == {"success": True}
     assert publish_async.call_args.kwargs["trace_link_config_override"] is False
+
+
+def test_current_run_id_accepts_runnable_config_uuid() -> None:
+    from uuid import UUID
+
+    from agent.tools.publish_review import _current_run_id
+
+    run_id = UUID("12345678-1234-5678-1234-567812345678")
+    assert _current_run_id({"run_id": run_id}) == str(run_id)
+    assert _current_run_id({"metadata": {"run_id": run_id}}) == str(run_id)
+
+
+async def test_publish_review_recovers_token_after_durable_resume() -> None:
+    from agent.tools.publish_review import publish_review
+
+    config = {
+        "configurable": {
+            "thread_id": "reviewer-thread-id",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "head_sha": "sha",
+            "run_id": "run-1",
+        },
+        "metadata": {},
+    }
+    recover = AsyncMock(return_value="recovered-token")
+    publish_async = AsyncMock(return_value={"success": True, "review_id": 42})
+    set_metadata = AsyncMock()
+    with (
+        patch("agent.tools.publish_review.get_config", return_value=config),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch("agent.tools.publish_review.recover_reviewer_github_token", recover),
+        patch("agent.tools.publish_review._publish_review_async", publish_async),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", set_metadata),
+    ):
+        result = await publish_review()
+
+    assert result == {"success": True, "review_id": 42}
+    recover.assert_awaited_once_with(
+        run_config=config,
+        thread_id="thread",
+        owner="o",
+        repo="r",
+        pr_number=7,
+        run_id="run-1",
+    )
+    assert publish_async.await_count == 1
+    assert publish_async.await_args.kwargs["token"] == "recovered-token"
+    set_metadata.assert_awaited_once_with(
+        "thread",
+        extra={"review_publication_pending": None},
+    )
+
+
+async def test_publish_review_returns_retryable_context_unavailable() -> None:
+    from agent.review.auth import ReviewerPublicationContextUnavailableError
+    from agent.tools.publish_review import publish_review
+
+    config = {
+        "configurable": {
+            "thread_id": "thread",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "head_sha": "sha",
+        },
+        "metadata": {},
+    }
+    with (
+        patch("agent.tools.publish_review.get_config", return_value=config),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(side_effect=ReviewerPublicationContextUnavailableError),
+        ),
+    ):
+        result = await publish_review()
+
+    assert result == {
+        "success": False,
+        "error": "Reviewer publication context is temporarily unavailable",
+        "error_code": "publication_context_unavailable",
+        "retryable": True,
+        "publication_pending": False,
+    }
+
+
+async def test_publish_review_does_not_retry_after_pending_cleanup_failure() -> None:
+    from agent.tools.publish_review import publish_review
+
+    config = {
+        "configurable": {
+            "thread_id": "thread",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "head_sha": "sha",
+        },
+        "metadata": {},
+    }
+    publish_async = AsyncMock(return_value={"success": True, "review_id": 42})
+    with (
+        patch("agent.tools.publish_review.get_config", return_value=config),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(return_value="token"),
+        ),
+        patch("agent.tools.publish_review._publish_review_async", publish_async),
+        patch(
+            "agent.tools.publish_review.set_reviewer_thread_metadata",
+            AsyncMock(side_effect=RuntimeError("metadata unavailable")),
+        ),
+    ):
+        result = await publish_review()
+
+    assert result == {"success": True, "review_id": 42}
+    assert publish_async.await_count == 1
+
+
+async def test_publish_review_preserves_pending_state_when_token_recovery_fails() -> None:
+    from agent.review.auth import ReviewerTokenUnavailableError
+    from agent.tools.publish_review import publish_review
+
+    config = {
+        "configurable": {
+            "thread_id": "thread",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "head_sha": "sha",
+        },
+        "metadata": {},
+    }
+    record_pending = AsyncMock()
+    publish_async = AsyncMock()
+    with (
+        patch("agent.tools.publish_review.get_config", return_value=config),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(side_effect=ReviewerTokenUnavailableError),
+        ),
+        patch("agent.tools.publish_review._record_review_publication_pending", record_pending),
+        patch("agent.tools.publish_review._publish_review_async", publish_async),
+    ):
+        result = await publish_review()
+
+    assert result == {
+        "success": False,
+        "error": "GitHub App token unavailable; findings were preserved for retry",
+        "error_code": "github_app_token_unavailable",
+        "retryable": True,
+        "publication_pending": True,
+    }
+    record_pending.assert_awaited_once_with(
+        thread_id="thread",
+        owner="o",
+        repo="r",
+        pr_number=7,
+        head_sha="sha",
+        severity_threshold="medium",
+        run_id=None,
+        error_code="github_app_token_unavailable",
+    )
+    publish_async.assert_not_awaited()
+
+
+async def test_publish_review_invalidates_exact_app_scope_after_401() -> None:
+    from agent.tools.publish_review import GitHubAuthError, publish_review
+
+    config = {
+        "configurable": {
+            "thread_id": "thread",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "head_sha": "sha",
+        },
+        "metadata": {},
+    }
+    invalidate_thread = AsyncMock()
+    invalidate_app = MagicMock()
+    record_pending = AsyncMock()
+    with (
+        patch("agent.tools.publish_review.get_config", return_value=config),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(return_value="token"),
+        ),
+        patch(
+            "agent.tools.publish_review._publish_review_async",
+            AsyncMock(side_effect=GitHubAuthError("rejected")),
+        ),
+        patch(
+            "agent.tools.publish_review.invalidate_cached_github_token",
+            invalidate_thread,
+        ),
+        patch("agent.tools.publish_review.invalidate_reviewer_github_token", invalidate_app),
+        patch("agent.tools.publish_review._record_review_publication_pending", record_pending),
+    ):
+        result = await publish_review()
+
+    assert result["error_code"] == "github_token_rejected"
+    assert result["retryable"] is True
+    invalidate_thread.assert_awaited_once_with("thread")
+    invalidate_app.assert_called_once_with("r")
+    record_pending.assert_awaited_once()
+
+
+async def test_publish_review_keeps_structured_error_when_pending_write_fails() -> None:
+    from agent.review.auth import ReviewerTokenUnavailableError
+    from agent.tools.publish_review import publish_review
+
+    config = {
+        "configurable": {
+            "thread_id": "thread",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "head_sha": "sha",
+        },
+        "metadata": {},
+    }
+    with (
+        patch("agent.tools.publish_review.get_config", return_value=config),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(side_effect=ReviewerTokenUnavailableError),
+        ),
+        patch(
+            "agent.tools.publish_review._record_review_publication_pending",
+            AsyncMock(side_effect=RuntimeError("metadata unavailable")),
+        ),
+    ):
+        result = await publish_review()
+
+    assert result == {
+        "success": False,
+        "error": "GitHub App token unavailable; findings remain stored on the thread",
+        "error_code": "github_app_token_unavailable",
+        "retryable": True,
+        "publication_pending": False,
+    }
+
+
+async def test_pending_publication_metadata_contains_no_finding_bodies() -> None:
+    from agent.tools.publish_review import _record_review_publication_pending
+
+    findings = [
+        {
+            "id": "f_open",
+            "status": "open",
+            "description": "sensitive finding body",
+            "github_review_comment_id": None,
+        },
+        {
+            "id": "f_posted",
+            "status": "open",
+            "description": "already posted",
+            "github_review_comment_id": 12,
+        },
+    ]
+    set_metadata = AsyncMock()
+    with (
+        patch(
+            "agent.tools.publish_review.get_thread_metadata",
+            AsyncMock(return_value={"review_publication_pending": {"attempt_count": 2}}),
+        ),
+        patch("agent.tools.publish_review.list_findings_async", AsyncMock(return_value=findings)),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", set_metadata),
+    ):
+        await _record_review_publication_pending(
+            thread_id="thread",
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="sha",
+            severity_threshold="high",
+            run_id="run-1",
+            error_code="github_app_token_unavailable",
+        )
+
+    pending = set_metadata.await_args.kwargs["extra"]["review_publication_pending"]
+    assert pending == {
+        "target": {"owner": "o", "repo": "r", "pr_number": 7},
+        "head_sha": "sha",
+        "severity_threshold": "high",
+        "finding_ids": ["f_open"],
+        "attempt_count": 3,
+        "error_code": "github_app_token_unavailable",
+        "run_id": "run-1",
+    }
+    assert "sensitive finding body" not in repr(pending)
 
 
 @pytest.mark.asyncio
@@ -2261,8 +2560,13 @@ async def test_publish_review_tool_returns_structured_error_when_thread_missing(
                 "metadata": {},
             },
         ),
-        patch("agent.tools.publish_review.get_github_token", return_value="token"),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="thread"),
+        patch(
+            "agent.tools.publish_review.recover_reviewer_github_token",
+            AsyncMock(return_value="token"),
+        ),
         patch("agent.tools.publish_review._publish_review_async", publish_async),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()),
     ):
         result = await publish_review()
 


### PR DESCRIPTION
## Description
Reviewer publication now securely re-derives a repo-scoped, least-privilege GitHub App token after durable worker resumes. Recovery validates durable thread/PR/run context, retries only token minting, records sanitized pending state, and evicts rejected scoped tokens without replaying side effects.

## Release Note
Reviewer findings no longer get dropped when a resumed worker loses its process-local GitHub token.

## Test Plan
- [x] Simulated cold-cache durable resume, transient context failures, scoped-token rejection, and pending-state recovery.

Made by [Open SWE](https://openswe.vercel.app/agents/f6d83e32-ab92-5497-e3a2-ba9bbd0ff22a)

## References
- Plan: https://openswe.vercel.app/agents/f6d83e32-ab92-5497-e3a2-ba9bbd0ff22a/plan