### PR TITLE
feat: inject extra JSON fields into sandbox create via env var

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -99,6 +100,43 @@ def _get_sandbox_snapshot_config() -> tuple[str | None, int, int, int, int, int]
         idle_ttl_seconds,
         delete_after_stop_seconds,
     )
+
+
+def _get_sandbox_create_extra_fields() -> dict[str, Any]:
+    """Parse SANDBOX_CREATE_EXTRA_JSON into extra fields merged into the
+    sandbox-create request body, e.g. ``{"_internal_runtime": "v2"}``."""
+    raw = os.environ.get("SANDBOX_CREATE_EXTRA_JSON")
+    if not raw or not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        msg = f"SANDBOX_CREATE_EXTRA_JSON must be valid JSON, got {raw!r}"
+        raise ValueError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"SANDBOX_CREATE_EXTRA_JSON must be a JSON object, got {type(parsed).__name__}"
+        raise ValueError(msg)
+    return parsed
+
+
+def _install_create_extra_fields(client: AsyncSandboxClient, extra: dict[str, Any]) -> None:
+    """Merge ``extra`` into the JSON body of the sandbox-create request.
+
+    The SDK's ``create_sandbox`` builds a fixed payload with no passthrough, so
+    wrap the HTTP client's ``post`` to inject the fields on the ``POST /boxes``
+    request only (other endpoints post to ``/boxes/{name}/...``).
+    """
+    if not extra:
+        return
+    original_post = client._http.post
+
+    async def post_with_extra(url: Any, *args: Any, **kwargs: Any) -> Any:
+        payload = kwargs.get("json")
+        if str(url).endswith("/boxes") and isinstance(payload, dict):
+            kwargs["json"] = {**payload, **extra}
+        return await original_post(url, *args, **kwargs)
+
+    client._http.post = post_with_extra
 
 
 def _github_proxy_rules(github_token: str) -> list[dict[str, Any]]:
@@ -537,6 +575,7 @@ class LangSmithProvider(SandboxProvider):
             ):
                 msg = f"{name} must be >= 0, got {value}"
                 raise ValueError(msg)
+        _get_sandbox_create_extra_fields()
 
     async def get_or_create(
         self,
@@ -591,6 +630,8 @@ class LangSmithProvider(SandboxProvider):
             if not snapshot_id:
                 msg = "DEFAULT_SANDBOX_SNAPSHOT_ID must be set when SANDBOX_TYPE=langsmith"
                 raise ValueError(msg)
+
+            _install_create_extra_fields(client, _get_sandbox_create_extra_fields())
 
             try:
                 sandbox = await _create_sandbox_with_retry(

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -12,7 +12,9 @@ from agent.integrations.langsmith import (
     DEFAULT_SNAPSHOT_FS_CAPACITY_BYTES,
     LangSmithProvider,
     _create_sandbox_with_retry,
+    _get_sandbox_create_extra_fields,
     _get_sandbox_snapshot_config,
+    _install_create_extra_fields,
     _wait_for_reconnected_sandbox,
 )
 
@@ -169,3 +171,69 @@ async def test_wait_for_reconnected_sandbox_polls_until_ready(monkeypatch) -> No
     assert sandbox.status == "running"
     assert client.calls == 3
     assert sleep.await_count == 2
+
+
+def test_extra_fields_unset_is_empty() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        assert _get_sandbox_create_extra_fields() == {}
+    with patch.dict("os.environ", {"SANDBOX_CREATE_EXTRA_JSON": "  "}, clear=True):
+        assert _get_sandbox_create_extra_fields() == {}
+
+
+def test_extra_fields_parsed() -> None:
+    with patch.dict(
+        "os.environ",
+        {"SANDBOX_CREATE_EXTRA_JSON": '{"_internal_runtime": "v2"}'},
+        clear=True,
+    ):
+        assert _get_sandbox_create_extra_fields() == {"_internal_runtime": "v2"}
+
+
+def test_extra_fields_rejects_invalid_json() -> None:
+    with patch.dict("os.environ", {"SANDBOX_CREATE_EXTRA_JSON": "{not json"}, clear=True):
+        with pytest.raises(ValueError, match="valid JSON"):
+            _get_sandbox_create_extra_fields()
+
+
+def test_extra_fields_rejects_non_object() -> None:
+    with patch.dict("os.environ", {"SANDBOX_CREATE_EXTRA_JSON": "[1, 2]"}, clear=True):
+        with pytest.raises(ValueError, match="JSON object"):
+            _get_sandbox_create_extra_fields()
+
+
+@pytest.mark.asyncio
+async def test_install_create_extra_fields_merges_only_boxes_post() -> None:
+    calls: list[tuple[str, dict]] = []
+
+    class _FakeHttp:
+        async def post(self, url, **kwargs):  # noqa: ANN001, ANN003
+            calls.append((url, kwargs.get("json")))
+            return "ok"
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self._http = _FakeHttp()
+
+    client = _FakeClient()
+    _install_create_extra_fields(client, {"_internal_runtime": "v2"})
+
+    await client._http.post("https://api/v2/sandboxes/boxes", json={"snapshot_id": "s"})
+    await client._http.post("https://api/v2/sandboxes/boxes/abc/start", json={"foo": "bar"})
+
+    assert calls[0][1] == {"snapshot_id": "s", "_internal_runtime": "v2"}
+    assert calls[1][1] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_install_create_extra_fields_noop_when_empty() -> None:
+    class _FakeHttp:
+        def __init__(self) -> None:
+            self.post = "sentinel"
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self._http = _FakeHttp()
+
+    client = _FakeClient()
+    _install_create_extra_fields(client, {})
+    assert client._http.post == "sentinel"


### PR DESCRIPTION
## What

Adds `SANDBOX_CREATE_EXTRA_JSON` — a JSON object whose fields are merged into the LangSmith sandbox-create request body. Motivating use: `SANDBOX_CREATE_EXTRA_JSON={"_internal_runtime":"v2"}`.

## How

The langsmith SDK's `create_sandbox` builds a fixed payload with no passthrough for extra fields. So we wrap the client's `_http.post` to merge the configured fields into the `json` body of the `POST /boxes` request only — reconnect/start/service-url calls (which post to `/boxes/{name}/...`) are untouched. Malformed JSON (or a non-object) fails at startup via `validate_startup_config`.

Caveat: this rides on the SDK internal `client._http`; if the SDK renames it or switches away from `_http.post(...)`, the injection silently stops. The clean long-term fix is an `extra_body` param in the langsmith SDK itself.

Only the langsmith provider is wired up (the default). Other providers are unaffected.

## Test Plan

- [x] `_get_sandbox_create_extra_fields` parsing: unset/blank → `{}`, valid object parsed, invalid JSON and non-object rejected
- [x] `_install_create_extra_fields` merges into `POST /boxes` only, leaves `/boxes/{name}/start` untouched, and is a no-op when empty
- [x] `make lint` (ruff check + format) clean on changed files