### PR TITLE
fix: clear basedpyright standard-mode type errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,10 @@ A separate **reviewer** graph runs read-only code reviews on PRs, and a **review
 
 ## Commands
 
-Dependencies are managed with **uv**. Tests use pytest (`asyncio_mode = "auto"`). Lint/format is **ruff** (line-length 100, target py311). `requires-python = ">=3.11"`; `langgraph.json` pins the runtime to 3.12.
+Dependencies are managed with **uv**. Tests use pytest (`asyncio_mode = "auto"`). Lint/format is **ruff** (line-length 100, target py311). Type checking is **basedpyright** (`typeCheckingMode = "standard"`). `requires-python = ">=3.11"`; `langgraph.json` pins the runtime to 3.12.
 
 ```bash
-make install            # uv sync
+make install            # uv sync --extra dev (pytest, ruff, …)
 make dev                # uv run langgraph dev — serves all three graphs + the FastAPI app from langgraph.json
 make run                # uvicorn agent.webapp:app --reload --port 8000 (FastAPI only, no LangGraph runtime)
 make test               # uv run pytest -vvv tests/
@@ -21,6 +21,7 @@ make test TEST_FILE=tests/github/test_open_pull_request.py    # single test file
 uv run pytest -vvv tests/github/test_open_pull_request.py::test_name  # single test
 make lint               # ruff check + ruff format --diff
 make format             # ruff format + ruff check --fix
+make typecheck          # basedpyright agent tests
 ```
 
 `langgraph.json` declares three graph entrypoints and the FastAPI app, all served together by `langgraph dev`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ A separate **reviewer** graph runs read-only code reviews on PRs, and a **review
 
 ## Commands
 
-Dependencies are managed with **uv**. Tests use pytest (`asyncio_mode = "auto"`). Lint/format is **ruff** (line-length 100, target py311). `requires-python = ">=3.11"`; `langgraph.json` pins the runtime to 3.12.
+Dependencies are managed with **uv**. Tests use pytest (`asyncio_mode = "auto"`). Lint/format is **ruff** (line-length 100, target py311). Type checking is **basedpyright** (`typeCheckingMode = "standard"`). `requires-python = ">=3.11"`; `langgraph.json` pins the runtime to 3.12.
 
 ```bash
-make install            # uv sync
+make install            # uv sync --extra dev (pytest, ruff, …)
 make dev                # uv run langgraph dev — serves all three graphs + the FastAPI app from langgraph.json
 make run                # uvicorn agent.webapp:app --reload --port 8000 (FastAPI only, no LangGraph runtime)
 make test               # uv run pytest -vvv tests/
@@ -21,6 +21,7 @@ make test TEST_FILE=tests/github/test_open_pull_request.py    # single test file
 uv run pytest -vvv tests/github/test_open_pull_request.py::test_name  # single test
 make lint               # ruff check + ruff format --diff
 make format             # ruff format + ruff check --fix
+make typecheck          # basedpyright agent tests
 ```
 
 `langgraph.json` declares three graph entrypoints and the FastAPI app, all served together by `langgraph dev`:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint test tests integration_tests help run dev
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -14,7 +14,7 @@ run:
 	uv run uvicorn agent.webapp:app --reload --port 8000
 
 install:
-	uv sync
+	uv sync --extra dev
 
 ######################
 # TESTING
@@ -53,6 +53,9 @@ format:
 format-check:
 	uv run ruff format $(PYTHON_FILES) --check
 
+typecheck:
+	npx --yes basedpyright agent tests
+
 ######################
 # HELP
 ######################
@@ -61,8 +64,10 @@ help:
 	@echo '----'
 	@echo 'dev                          - run LangGraph dev server'
 	@echo 'run                          - run webhook server'
-	@echo 'install                      - install dependencies'
+	@echo 'install                      - install dependencies (incl. dev extras)'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
+	@echo 'typecheck                    - run basedpyright on agent/ and tests/'
 	@echo 'test                         - run unit tests'
 	@echo 'integration_tests            - run integration tests'
+	@echo '----'

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import Any
+from typing import Any, cast
 
 from langgraph.graph.state import RunnableConfig
 from langgraph.pregel import Pregel
+from langgraph.runtime import Runtime
 
 warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
@@ -28,12 +29,14 @@ from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.state import StateBackend
 from langchain.agents.middleware import ModelCallLimitMiddleware
+from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
 
 from .dashboard.team_settings import get_effective_gateway_enabled
 from .integrations.langsmith import _configure_github_proxy
 from .middleware import (
     BasePrepareRunMiddleware,
+    PrepareRunState,
     SanitizeToolInputsMiddleware,
     TimeoutWrapupMiddleware,
     ToolErrorMiddleware,
@@ -131,10 +134,10 @@ class PrepareAnalyzerRunMiddleware(BasePrepareRunMiddleware):
             "mode": configurable.get("analyzer_mode") if isinstance(configurable, dict) else None,
         }
 
-    async def _prepare(self, state: dict, runtime: object) -> dict:  # noqa: ARG002
+    async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
         sandbox_backend = await ensure_sandbox_for_thread(self._thread_id)
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
-        configurable = self._config["configurable"]
+        configurable = self._config.get("configurable") or {}
         full_name = str(configurable.get("review_style_full_name") or "owner/repo")
         owner, _, name = full_name.partition("/")
         samples_text = str(configurable.get("review_style_samples_text") or "")
@@ -160,7 +163,8 @@ class PrepareAnalyzerRunMiddleware(BasePrepareRunMiddleware):
 
 
 async def get_analyzer(config: RunnableConfig) -> Pregel:
-    thread_id = config["configurable"].get("thread_id")
+    configurable = config.get("configurable") or {}
+    thread_id = configurable.get("thread_id")
     config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
 
     if thread_id is None or not graph_loaded_for_execution(config):
@@ -188,16 +192,19 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
         tools=[save_review_style_prompt, read_finding_outcomes],
         backend=backend_factory,
         skills=[SKILLS_ROUTE],
-        middleware=[
-            PrepareAnalyzerRunMiddleware(thread_id=thread_id, config=config),
-            SanitizeToolInputsMiddleware(),
-            ModelCallLimitMiddleware(
-                run_limit=STYLE_ANALYZER_MODEL_CALL_LIMIT,
-                exit_behavior="end",
-            ),
-            ToolErrorMiddleware(),
-            TimeoutWrapupMiddleware(),
-        ],
+        middleware=cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [
+                PrepareAnalyzerRunMiddleware(thread_id=thread_id, config=config),
+                SanitizeToolInputsMiddleware(),
+                ModelCallLimitMiddleware(
+                    run_limit=STYLE_ANALYZER_MODEL_CALL_LIMIT,
+                    exit_behavior="end",
+                ),
+                ToolErrorMiddleware(),
+                TimeoutWrapupMiddleware(),
+            ],
+        ),
     ).with_config(config)
 
 

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -18,16 +18,18 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import Any
+from typing import Any, cast
 
 from langgraph.graph.state import RunnableConfig
 from langgraph.pregel import Pregel
+from langgraph.runtime import Runtime
 
 warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 from deepagents import create_deep_agent
 from langchain.agents.middleware import ModelCallLimitMiddleware
+from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
 
 from .dashboard.options import (
@@ -48,6 +50,7 @@ from .middleware import (
     SanitizeToolInputsMiddleware,
     ToolErrorMiddleware,
 )
+from .middleware.prepare_run import PrepareRunState
 from .runtime import (
     DEFAULT_LLM_MAX_TOKENS,
     DEFAULT_RECURSION_LIMIT,
@@ -148,8 +151,8 @@ class PrepareChatRunMiddleware(BasePrepareRunMiddleware):
             else None,
         }
 
-    async def _prepare(self, state: dict, runtime: object) -> dict:  # noqa: ARG002
-        configurable = self._config["configurable"]
+    async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
+        configurable = self._config.get("configurable") or {}
         repo_owner = str(configurable.get("chat_repo_owner") or "")
         repo_name = str(configurable.get("chat_repo_name") or "")
         pr_number = configurable.get("chat_pr_number")
@@ -167,7 +170,7 @@ class PrepareChatRunMiddleware(BasePrepareRunMiddleware):
         }
 
 
-async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
+async def _resolve_chat_model(configurable: dict[str, Any]) -> tuple[str, str]:
     model_id = configurable.get("chat_model_id")
     effort = configurable.get("chat_effort")
     if (
@@ -184,14 +187,14 @@ async def _resolve_chat_model(configurable: dict) -> tuple[str, str]:
 async def get_chat_agent(config: RunnableConfig) -> Pregel:
     """Get a read-only PR chat agent. No sandbox; PR context comes via config."""
     config = config.copy()
-    config["configurable"] = config["configurable"].copy()
+    configurable = dict(config.get("configurable") or {})
+    config["configurable"] = configurable
     config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
-    thread_id = config["configurable"].get("thread_id")
+    thread_id = configurable.get("thread_id")
 
     if thread_id is None or not graph_loaded_for_execution(config):
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)
 
-    configurable = config["configurable"]
     model_id, effort = await _resolve_chat_model(configurable)
     model_id, effort = gate_fable_model(
         model_id, effort, fable_enabled=await get_team_fable_enabled()
@@ -214,15 +217,18 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
             web_search,
             fetch_url,
         ],
-        middleware=[
-            PrepareChatRunMiddleware(config=config),
-            SanitizeToolInputsMiddleware(),
-            ModelCallLimitMiddleware(run_limit=CHAT_MODEL_CALL_LIMIT, exit_behavior="end"),
-            ToolErrorMiddleware(),
-            ExcludeToolsMiddleware(excluded=_EXCLUDED_TOOLS),
-            SanitizeFireworksMessagesMiddleware(),
-            SanitizeThinkingBlocksMiddleware(),
-        ],
+        middleware=cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [
+                PrepareChatRunMiddleware(config=config),
+                SanitizeToolInputsMiddleware(),
+                ModelCallLimitMiddleware(run_limit=CHAT_MODEL_CALL_LIMIT, exit_behavior="end"),
+                ToolErrorMiddleware(),
+                ExcludeToolsMiddleware(excluded=_EXCLUDED_TOOLS),
+                SanitizeFireworksMessagesMiddleware(),
+                SanitizeThinkingBlocksMiddleware(),
+            ],
+        ),
     ).with_config(config)
 
 

--- a/agent/dashboard/__init__.py
+++ b/agent/dashboard/__init__.py
@@ -6,9 +6,12 @@ and it must NOT drag in routes.py + FastAPI + every API/job module. Only the
 webapp, which actually mounts the router, pays that cost.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 __all__ = ["router"]
+
+if TYPE_CHECKING:
+    from .routes import router
 
 
 def __getattr__(name: str) -> Any:

--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -14,6 +14,7 @@ from langgraph_sdk import get_client
 
 from ..review.findings import REVIEWER_THREAD_KIND
 from ..utils.github_app import get_github_app_installation_token
+from ..utils.json_types import ThreadLike, as_json_object, thread_metadata
 
 USAGE_THREAD_NAMESPACE: list[str] = ["agent_usage", "threads"]
 USAGE_PR_NAMESPACE: list[str] = ["agent_usage", "prs"]
@@ -50,7 +51,11 @@ def _period_cutoff_ms(period: str) -> int | None:
 
 
 def _normalize_period(period: str | None) -> Period:
-    return period if period in {"7d", "30d", "all"} else "30d"
+    if period == "7d":
+        return "7d"
+    if period == "all":
+        return "all"
+    return "30d"
 
 
 def _record_from_item(item: Any) -> dict[str, Any] | None:
@@ -424,7 +429,7 @@ async def refresh_usage_leaderboard_cache(period: str | None = "30d") -> dict[st
 
 
 def _is_finding_surfaced(finding: dict[str, Any]) -> bool:
-    surface = finding.get("surface") if isinstance(finding.get("surface"), dict) else {}
+    surface = as_json_object(finding.get("surface"))
     state = surface.get("state")
     if state in {"surfaced", "resolve_pending", "resolved"}:
         return True
@@ -440,7 +445,7 @@ def _is_finding_surfaced(finding: dict[str, Any]) -> bool:
 def _is_finding_resolved_by_us(finding: dict[str, Any]) -> bool:
     if finding.get("status") != "resolved" or not _is_finding_surfaced(finding):
         return False
-    surface = finding.get("surface") if isinstance(finding.get("surface"), dict) else {}
+    surface = as_json_object(finding.get("surface"))
     return bool(
         surface.get("state") == "resolved"
         or finding.get("github_thread_resolved")
@@ -449,7 +454,7 @@ def _is_finding_resolved_by_us(finding: dict[str, Any]) -> bool:
     )
 
 
-def _thread_created_at_ms(thread: dict[str, Any], metadata: dict[str, Any]) -> int:
+def _thread_created_at_ms(thread: ThreadLike, metadata: dict[str, Any]) -> int:
     timestamp = _thread_explicit_created_at_ms(thread, metadata)
     if timestamp:
         return timestamp
@@ -465,7 +470,7 @@ def _thread_created_at_ms(thread: dict[str, Any], metadata: dict[str, Any]) -> i
     return _now_ms()
 
 
-def _thread_explicit_created_at_ms(thread: dict[str, Any], metadata: dict[str, Any]) -> int:
+def _thread_explicit_created_at_ms(thread: ThreadLike, metadata: dict[str, Any]) -> int:
     for source in (
         metadata.get("created_at_ms"),
         metadata.get("created_at"),
@@ -502,8 +507,8 @@ async def _iter_reviewer_thread_pages(cutoff_ms: int | None):
             last_thread = next(
                 (thread for thread in reversed(page) if isinstance(thread, dict)), None
             )
-            metadata = last_thread.get("metadata") if isinstance(last_thread, dict) else None
-            if isinstance(metadata, dict):
+            if last_thread is not None:
+                metadata = thread_metadata(last_thread)
                 last_created_at_ms = _thread_explicit_created_at_ms(last_thread, metadata)
                 if last_created_at_ms and last_created_at_ms < cutoff_ms:
                     return
@@ -528,7 +533,7 @@ async def _build_reviewer_stats_snapshot(period: Period) -> dict[str, Any]:
         for thread in page:
             if not isinstance(thread, dict):
                 continue
-            metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+            metadata = thread_metadata(thread)
             if cutoff_ms is not None and _thread_created_at_ms(thread, metadata) < cutoff_ms:
                 continue
 

--- a/agent/dashboard/notion_oauth.py
+++ b/agent/dashboard/notion_oauth.py
@@ -259,8 +259,15 @@ async def exchange_notion_code(code: str, flow: dict[str, Any]) -> dict[str, Any
     client_id = flow.get("client_id")
     redirect_uri = flow.get("redirect_uri")
     code_verifier = flow.get("code_verifier")
-    if not all(
-        isinstance(v, str) and v for v in (token_endpoint, client_id, redirect_uri, code_verifier)
+    if (
+        not isinstance(token_endpoint, str)
+        or not token_endpoint
+        or not isinstance(client_id, str)
+        or not client_id
+        or not isinstance(redirect_uri, str)
+        or not redirect_uri
+        or not isinstance(code_verifier, str)
+        or not code_verifier
     ):
         raise NotionOAuthError(400, "stored Notion OAuth flow is incomplete")
     _require_notion_https_url(token_endpoint, "token endpoint")

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -49,10 +49,13 @@ class ProfileUpdate(BaseModel):
 
     @model_validator(mode="after")
     def _normalize_stale_model_pairs(self) -> ProfileUpdate:
-        self.default_model, self.reasoning_effort = _normalize_stale_model_pair(
+        model, effort = _normalize_stale_model_pair(
             self.default_model,
             self.reasoning_effort,
         )
+        self.default_model = model
+        if effort is not None:
+            self.reasoning_effort = effort
         if self.default_subagent_model is not None:
             self.default_subagent_model, self.subagent_reasoning_effort = (
                 _normalize_stale_model_pair(
@@ -289,7 +292,8 @@ async def _refresh_stored_token(login: str, record: dict[str, Any]) -> tuple[str
     except Exception as exc:  # noqa: BLE001
         logger.warning("GitHub token refresh failed for %s", login, exc_info=True)
         return None, is_unrecoverable_refresh_error(exc)
-    email = record.get("email") if isinstance(record.get("email"), str) else ""
+    email_value = record.get("email")
+    email = email_value if isinstance(email_value, str) else ""
     await upsert_access_token_from_github_response(login, email, data)
     access_token = data.get("access_token")
     return (access_token if isinstance(access_token, str) else None), False

--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -22,7 +22,10 @@ from fastapi import HTTPException, Response
 from ..review.findings import REVIEWER_THREAD_KIND
 from ..utils.github_app import get_github_app_installation_token
 from ..utils.github_checks import github_headers
+from ..utils.json_types import ThreadLike, as_json_object, thread_metadata
 from ..utils.thread_ops import langgraph_client
+from ..webhooks.common import fetch_github_pr_metadata
+from ..webhooks.github import trigger_pr_review_from_ref
 from .pr_diff import build_pr_diff_files
 
 logger = logging.getLogger(__name__)
@@ -212,7 +215,7 @@ def _finding_counts(findings: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
-def _run_status(thread: dict[str, Any], metadata: dict[str, Any]) -> str:
+def _run_status(thread: ThreadLike, metadata: dict[str, Any]) -> str:
     if thread.get("status") == "busy":
         return "running"
     latest = metadata.get("latest_run_status")
@@ -223,8 +226,8 @@ def _run_status(thread: dict[str, Any], metadata: dict[str, Any]) -> str:
     return "idle"
 
 
-def _thread_review_summary(thread: dict[str, Any]) -> dict[str, Any] | None:
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+def _thread_review_summary(thread: ThreadLike) -> dict[str, Any] | None:
+    metadata = thread_metadata(thread)
     pr = metadata.get("pr")
     if not isinstance(pr, dict):
         return None
@@ -455,8 +458,9 @@ def _clean_comment_body(body: str) -> str:
 
 
 def _normalize_review_comment(item: dict[str, Any]) -> dict[str, Any]:
-    body = item.get("body") if isinstance(item.get("body"), str) else ""
-    user = item.get("user") if isinstance(item.get("user"), dict) else {}
+    raw_body = item.get("body")
+    body = raw_body if isinstance(raw_body, str) else ""
+    user = as_json_object(item.get("user"))
     line = item.get("line")
     if not isinstance(line, int):
         original = item.get("original_line")
@@ -519,7 +523,7 @@ async def get_review(owner: str, repo: str, pr_number: int) -> dict[str, Any]:
         raise HTTPException(404, "review not found") from exc
     if not isinstance(thread, dict):
         raise HTTPException(404, "review not found")
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     summary = _thread_review_summary(thread)
     if not summary:
         raise HTTPException(404, "review not found")
@@ -697,7 +701,6 @@ async def proxy_pr_image(owner: str, repo: str, pr_number: int, url: str) -> Res
 
 async def trigger_re_review(owner: str, repo: str, pr_number: int, login: str) -> dict[str, Any]:
     from ..utils.slack import GitHubPrRef
-    from ..webapp import trigger_pr_review_from_ref
 
     pr_ref = GitHubPrRef(
         owner=owner,
@@ -718,7 +721,6 @@ async def dry_run_trace_resolution(owner: str, repo: str, pr_number: int) -> dic
     from ..review.trace_context import resolve_pr_trace
     from ..utils.github_app import get_github_app_installation_token_with_expiry
     from ..utils.slack import GitHubPrRef
-    from ..webapp import fetch_github_pr_metadata
 
     pr_ref = GitHubPrRef(
         owner=owner,

--- a/agent/dashboard/review_chat_api.py
+++ b/agent/dashboard/review_chat_api.py
@@ -22,6 +22,7 @@ from fastapi import HTTPException
 from ..review.diff import fetch_pr_diff
 from ..review.findings import REVIEWER_THREAD_KIND
 from ..utils.github_app import get_github_app_installation_token
+from ..utils.json_types import as_json_object
 from ..utils.thread_ops import langgraph_client, langgraph_url
 from .options import SUPPORTED_MODEL_IDS, model_supports_effort
 from .review_api import classify_finding, get_pr_head_sha, get_review, reviewer_thread_id
@@ -99,7 +100,7 @@ async def list_review_chat_threads(
     for thread in threads or []:
         if not isinstance(thread, dict):
             continue
-        metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+        metadata = as_json_object(thread.get("metadata"))
         thread_id = thread.get("thread_id") or thread.get("id")
         if not isinstance(thread_id, str):
             continue
@@ -154,7 +155,7 @@ def _derive_title(params: dict[str, Any]) -> str:
 
 
 def _render_overview(review: dict[str, Any]) -> str:
-    pr = review.get("pr") if isinstance(review.get("pr"), dict) else {}
+    pr = as_json_object(review.get("pr"))
     lines = [
         f"# {review.get('title') or 'Pull request'} (#{review.get('number')})",
         "",
@@ -205,7 +206,7 @@ def _render_findings(findings: list[dict[str, Any]]) -> str:
 
 
 def _review_head_sha(review: dict[str, Any]) -> str:
-    pr = review.get("pr") if isinstance(review.get("pr"), dict) else {}
+    pr = as_json_object(review.get("pr"))
     return str(pr.get("head_sha") or review.get("head_sha") or "")
 
 
@@ -227,7 +228,12 @@ async def _build_pr_context(
 
     if review is None:
         review = await get_review(owner, repo, pr_number)
-    findings = review.get("findings") if isinstance(review.get("findings"), list) else []
+    raw_findings = review.get("findings")
+    findings = (
+        [finding for finding in raw_findings if isinstance(finding, dict)]
+        if isinstance(raw_findings, list)
+        else []
+    )
     head_sha = _review_head_sha(review)
     diff = await fetch_pr_diff(owner=owner, repo=repo, pr_number=pr_number, token=token) or ""
     if len(diff) > _MAX_DIFF_CHARS:
@@ -246,7 +252,7 @@ async def _get_chat_thread_metadata(thread_id: str) -> dict[str, Any] | None:
         thread = await client.threads.get(thread_id)
     except Exception:  # noqa: BLE001
         return None
-    return thread.get("metadata") if isinstance(thread, dict) else None
+    return as_json_object(thread.get("metadata")) if isinstance(thread, dict) else None
 
 
 async def assert_chat_thread_access(

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -251,7 +251,7 @@ def _frontend_base_url() -> str:
     return v
 
 
-def _cookie_security() -> tuple[bool, str]:
+def _cookie_security() -> tuple[bool, Literal["lax", "none"]]:
     """Cookie ``secure``/``samesite`` flags derived from the API scheme.
 
     Production serves the API over HTTPS and the dashboard is a separate

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import HTTPException
+from langgraph_sdk.schema import Config
 from pydantic import BaseModel, Field, field_validator
 
 from ..dispatch import create_durable_run
@@ -223,12 +224,11 @@ async def _ensure_dashboard_github_token(login: str) -> None:
         raise HTTPException(401, "github token unavailable, re-login required")
 
 
-def _build_cron_config(record: dict[str, Any]) -> dict[str, Any]:
+def _build_cron_config(record: dict[str, Any]) -> Config:
     return {
         "configurable": {
             "schedule_id": record["id"],
         },
-        "metadata": _agent_version_metadata(),
     }
 
 
@@ -242,6 +242,7 @@ async def _create_cron(record: dict[str, Any]) -> str:
             "kind": "agent_schedule",
             "schedule_id": record["id"],
             "github_login": record.get("created_by"),
+            **_agent_version_metadata(),
         },
     )
     cron_id = cron.get("cron_id") if isinstance(cron, dict) else getattr(cron, "cron_id", None)

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -8,16 +8,23 @@ import binascii
 import json
 import logging
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime
 from typing import Any
 
 import httpx
 from fastapi import HTTPException
-from langchain_core.messages.content import create_image_block
+from langchain_core.messages.content import ImageContentBlock, create_image_block
 from pydantic import BaseModel, ConfigDict, Field
 
 from ..utils.dashboard_handoff import DASHBOARD_HANDOFF_INSTRUCTION
+from ..utils.json_types import (
+    JsonObject,
+    ThreadLike,
+    as_json_object,
+    as_thread_dict,
+    thread_metadata,
+)
 from ..utils.langsmith import get_langsmith_trace_url
 from ..utils.slack import lookup_slack_thread_run_mapping, update_slack_trace_reply_for_web_handoff
 from ..utils.thread_ops import (
@@ -102,7 +109,7 @@ def _langgraph_proxy_headers(
     return headers
 
 
-def _thread_is_busy(thread: dict[str, Any]) -> bool:
+def _thread_is_busy(thread: ThreadLike) -> bool:
     return thread.get("status") == "busy"
 
 
@@ -163,6 +170,8 @@ async def _resolve_agent_model_choice(
     resolved_model, resolved_effort = gate_fable_model(
         resolved_model, resolved_effort, fable_enabled=await get_team_fable_enabled()
     )
+    if not isinstance(resolved_effort, str):
+        raise ValueError("team default model must include a reasoning effort")
     return resolved_model, resolved_effort
 
 
@@ -209,7 +218,7 @@ def _decode_dashboard_image(image: DashboardImageBody) -> bytes:
 
 def _image_blocks(
     images: list[DashboardImageBody], *, model_id: str | None
-) -> list[dict[str, Any]]:
+) -> list[ImageContentBlock]:
     if len(images) > _MAX_DASHBOARD_IMAGES:
         raise HTTPException(422, f"at most {_MAX_DASHBOARD_IMAGES} images are supported")
     if images and (not model_id or not model_supports_images(model_id)):
@@ -226,7 +235,7 @@ def _image_blocks(
 
 def _user_message_content(
     prompt: str, images: list[DashboardImageBody], *, model_id: str | None = None
-) -> str | list[dict[str, Any]]:
+) -> str | list[ImageContentBlock | dict[str, str]]:
     text = prompt.strip()
     if not text and not images:
         raise HTTPException(422, "prompt or image required")
@@ -244,22 +253,22 @@ async def _ensure_dashboard_github_token(login: str) -> None:
         raise HTTPException(401, "github token unavailable, re-login required")
 
 
-def _thread_owner_login(metadata: dict[str, Any]) -> str | None:
+def _thread_owner_login(metadata: Mapping[str, Any]) -> str | None:
     login = metadata.get("github_login")
     return login.strip() if isinstance(login, str) and login.strip() else None
 
 
-def _thread_owner_email(metadata: dict[str, Any]) -> str | None:
+def _thread_owner_email(metadata: Mapping[str, Any]) -> str | None:
     email = metadata.get("triggering_user_email")
     return email.strip().lower() if isinstance(email, str) and email.strip() else None
 
 
-def _thread_source(metadata: dict[str, Any]) -> str:
+def _thread_source(metadata: Mapping[str, Any]) -> str:
     source = metadata.get("source")
     return source if isinstance(source, str) and source else _DASHBOARD_SOURCE
 
 
-def _metadata_model_id(metadata: dict[str, Any]) -> str | None:
+def _metadata_model_id(metadata: Mapping[str, Any]) -> str | None:
     for key in ("resolved_model", "model"):
         model = metadata.get(key)
         if isinstance(model, str) and model in SUPPORTED_MODEL_IDS:
@@ -267,7 +276,7 @@ def _metadata_model_id(metadata: dict[str, Any]) -> str | None:
     return None
 
 
-def _user_owns_thread(metadata: dict[str, Any], login: str, email: str | None) -> bool:
+def _user_owns_thread(metadata: Mapping[str, Any], login: str, email: str | None) -> bool:
     if _thread_source(metadata) not in _SURFACED_SOURCES:
         return False
     if _thread_owner_login(metadata) == login:
@@ -277,12 +286,12 @@ def _user_owns_thread(metadata: dict[str, Any], login: str, email: str | None) -
     return False
 
 
-def _assert_thread_owner(metadata: dict[str, Any], login: str, email: str | None = None) -> None:
+def _assert_thread_owner(metadata: Mapping[str, Any], login: str, email: str | None = None) -> None:
     if not _user_owns_thread(metadata, login, email):
         raise HTTPException(404, "thread not found")
 
 
-def _attribution_prefix(metadata: dict[str, Any], login: str, email: str | None) -> str:
+def _attribution_prefix(metadata: Mapping[str, Any], login: str, email: str | None) -> str:
     """Attribution prefix for a message; empty when the poster owns the thread.
 
     Teammates can post into any surfaced-source thread (read access is already
@@ -294,7 +303,7 @@ def _attribution_prefix(metadata: dict[str, Any], login: str, email: str | None)
     return f"@{login}: "
 
 
-def _thread_is_readable(metadata: dict[str, Any]) -> bool:
+def _thread_is_readable(metadata: Mapping[str, Any]) -> bool:
     """Any surfaced-source thread is readable by authenticated users.
 
     Dashboard login is already gated by ``ALLOWED_GITHUB_ORGS`` (see
@@ -305,12 +314,12 @@ def _thread_is_readable(metadata: dict[str, Any]) -> bool:
     return _thread_source(metadata) in _SURFACED_SOURCES
 
 
-def _assert_thread_readable(metadata: dict[str, Any]) -> None:
+def _assert_thread_readable(metadata: Mapping[str, Any]) -> None:
     if not _thread_is_readable(metadata):
         raise HTTPException(404, "thread not found")
 
 
-def _metadata_repo(metadata: dict[str, Any]) -> tuple[str, str, str]:
+def _metadata_repo(metadata: Mapping[str, Any]) -> tuple[str, str, str]:
     owner = metadata.get("repo_owner")
     name = metadata.get("repo_name")
     if isinstance(owner, str) and isinstance(name, str) and owner and name:
@@ -334,14 +343,14 @@ def _run_status_to_agent_status(thread_status: str | None, run_status: str | Non
     return "idle"
 
 
-def _thread_run_id(metadata: dict[str, Any], latest_run_id: str | None) -> str | None:
+def _thread_run_id(metadata: Mapping[str, Any], latest_run_id: str | None) -> str | None:
     if latest_run_id:
         return latest_run_id
     run_id = metadata.get("latest_run_id")
     return run_id if isinstance(run_id, str) and run_id else None
 
 
-def _is_thread_viewed(metadata: dict[str, Any], latest_run_id: str | None) -> bool:
+def _is_thread_viewed(metadata: Mapping[str, Any], latest_run_id: str | None) -> bool:
     viewed_at = metadata.get("last_viewed_at_ms")
     viewed_run_id = metadata.get("last_viewed_run_id")
     run_id = _thread_run_id(metadata, latest_run_id)
@@ -350,19 +359,19 @@ def _is_thread_viewed(metadata: dict[str, Any], latest_run_id: str | None) -> bo
     return isinstance(viewed_at, (int, float))
 
 
-def _is_thread_resolved(metadata: dict[str, Any]) -> bool:
+def _is_thread_resolved(metadata: Mapping[str, Any]) -> bool:
     return metadata.get("resolved") is True
 
 
 def _thread_summary(
-    thread: dict[str, Any],
+    thread: ThreadLike,
     *,
     latest_run_status: str | None = None,
     latest_run_id: str | None = None,
     owner_login: str | None = None,
     owner_email: str | None = None,
 ) -> dict[str, Any]:
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     owner, name, full_name = _metadata_repo(metadata)
     created_at = metadata.get("created_at_ms")
     updated_at = metadata.get("updated_at_ms")
@@ -431,8 +440,8 @@ def _thread_summary(
             "baseRef": metadata.get("base_branch") or "main",
             "url": pr_url,
         }
-    diff_stats = metadata.get("diff_stats")
-    if isinstance(diff_stats, dict):
+    diff_stats = as_json_object(metadata.get("diff_stats"))
+    if diff_stats:
         summary["diffStats"] = {
             "files": int(diff_stats.get("files") or 0),
             "additions": int(diff_stats.get("additions") or 0),
@@ -470,13 +479,13 @@ async def _latest_run_status(thread_id: str) -> str | None:
 
 
 async def _refresh_latest_run_metadata(
-    client: Any, thread: dict[str, Any]
-) -> tuple[dict[str, Any], str | None, str | None]:
+    client: Any, thread: ThreadLike
+) -> tuple[ThreadLike, str | None, str | None]:
     thread_id = thread.get("thread_id") or thread.get("id")
     if not isinstance(thread_id, str) or not thread_id:
         return thread, None, None
     latest_run_status, latest_run_id = await _latest_run_info(client, thread_id)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     metadata_update: dict[str, Any] = {}
     if latest_run_status and latest_run_status != metadata.get("latest_run_status"):
         metadata_update["latest_run_status"] = latest_run_status
@@ -488,7 +497,7 @@ async def _refresh_latest_run_metadata(
         except Exception:  # noqa: BLE001
             logger.debug("Could not persist latest run metadata for %s", thread_id, exc_info=True)
         else:
-            thread = {**thread, "metadata": {**metadata, **metadata_update}}
+            thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
     return thread, latest_run_status, latest_run_id
 
 
@@ -499,13 +508,13 @@ _RUN_REFRESH_CONCURRENCY = 8
 _RUNNING_METADATA_STATUSES = {"pending", "running"}
 
 
-def _thread_id(thread: dict[str, Any]) -> str | None:
+def _thread_id(thread: ThreadLike) -> str | None:
     thread_id = thread.get("thread_id") or thread.get("id")
     return thread_id if isinstance(thread_id, str) and thread_id else None
 
 
-def _thread_metadata(thread: dict[str, Any]) -> dict[str, Any]:
-    return thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+def _thread_metadata(thread: ThreadLike) -> JsonObject:
+    return thread_metadata(thread)
 
 
 def _owner_search_filters(
@@ -531,8 +540,8 @@ def _search_metadata_filter(
 
 
 async def _search_threads_batch(
-    client: Any, metadata: dict[str, Any], *, limit: int, offset: int
-) -> list[dict[str, Any]]:
+    client: Any, metadata: JsonObject, *, limit: int, offset: int
+) -> list[ThreadLike]:
     batch = await client.threads.search(
         metadata=metadata,
         limit=limit,
@@ -541,10 +550,10 @@ async def _search_threads_batch(
         sort_order="desc",
         select=_THREAD_LIST_SELECT,
     )
-    return [thread for thread in batch or [] if isinstance(thread, dict)]
+    return [thread for thread in batch or [] if isinstance(thread, Mapping)]
 
 
-def _thread_updated_ms(thread: dict[str, Any]) -> int:
+def _thread_updated_ms(thread: ThreadLike) -> int:
     metadata = _thread_metadata(thread)
     value = metadata.get("updated_at_ms")
     if isinstance(value, (int, float)):
@@ -560,7 +569,7 @@ def _thread_updated_ms(thread: dict[str, Any]) -> int:
 
 
 def _metadata_matches_filters(
-    metadata: dict[str, Any],
+    metadata: Mapping[str, Any],
     *,
     resolved: bool | None,
     source: str | None,
@@ -603,7 +612,7 @@ def _summary_matches_filters(
     return True
 
 
-def _should_refresh_latest_run(thread: dict[str, Any]) -> bool:
+def _should_refresh_latest_run(thread: ThreadLike) -> bool:
     metadata = _thread_metadata(thread)
     metadata_status = metadata.get("latest_run_status")
     thread_status = thread.get("status")
@@ -616,7 +625,7 @@ def _should_refresh_latest_run(thread: dict[str, Any]) -> bool:
 
 async def _summarize_thread(
     client: Any,
-    thread: dict[str, Any],
+    thread: ThreadLike,
     *,
     owner_login: str | None = None,
     owner_email: str | None = None,
@@ -638,14 +647,14 @@ async def _summarize_thread(
 
 async def _summarize_threads(
     client: Any,
-    threads: list[dict[str, Any]],
+    threads: list[ThreadLike],
     *,
     owner_login: str | None = None,
     owner_email: str | None = None,
 ) -> list[dict[str, Any]]:
     semaphore = asyncio.Semaphore(_RUN_REFRESH_CONCURRENCY)
 
-    async def summarize(thread: dict[str, Any]) -> dict[str, Any]:
+    async def summarize(thread: ThreadLike) -> dict[str, Any]:
         if not _should_refresh_latest_run(thread):
             return await _summarize_thread(
                 client,
@@ -676,8 +685,8 @@ async def _collect_thread_candidates(
     source: str | None = None,
     query: str | None = None,
     target_per_search: int | None = None,
-) -> list[dict[str, Any]]:
-    seen: dict[str, dict[str, Any]] = {}
+) -> list[ThreadLike]:
+    seen: dict[str, ThreadLike] = {}
     for owner_filter in searches:
         matched_for_search = 0
         offset = 0
@@ -742,8 +751,8 @@ async def list_dashboard_threads_sidebar(
     safe_resolved_limit = min(max(resolved_limit, 1), 100)
     active_target = safe_active_limit + 1
     resolved_target = safe_resolved_limit + 1
-    active: dict[str, dict[str, Any]] = {}
-    resolved_threads: dict[str, dict[str, Any]] = {}
+    active: dict[str, ThreadLike] = {}
+    resolved_threads: dict[str, ThreadLike] = {}
 
     for owner_filter in searches:
         local_active = 0
@@ -906,7 +915,7 @@ async def get_dashboard_thread(
         logger.debug("Thread lookup failed for %s", thread_id, exc_info=True)
         raise HTTPException(404, "thread not found") from exc
 
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_readable(metadata)
     is_owner = _user_owns_thread(metadata, login, email)
 
@@ -914,7 +923,7 @@ async def get_dashboard_thread(
     # `GET …/state` → `stream.messages`), so the detail endpoint returns
     # metadata only — no server-side message conversion.
     thread, latest_run_status, latest_run_id = await _refresh_latest_run_metadata(client, thread)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else metadata
+    metadata = thread_metadata(thread)
     status = _run_status_to_agent_status(
         thread.get("status") if isinstance(thread.get("status"), str) else "idle",
         latest_run_status
@@ -931,7 +940,7 @@ async def get_dashboard_thread(
             metadata,
             latest_run_id=latest_run_id,
         )
-        thread = {**thread, "metadata": metadata}
+        thread = {**as_thread_dict(thread), "metadata": metadata}
 
     return _thread_summary(
         thread,
@@ -1002,10 +1011,10 @@ async def _create_dashboard_thread_record(
     await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
     await client.threads.update(thread_id=thread_id, metadata=metadata)
     thread = await client.threads.get(thread_id)
-    return thread if isinstance(thread, dict) else {"thread_id": thread_id, "metadata": metadata}
+    return as_thread_dict(thread)
 
 
-def _repo_config_from_metadata(metadata: dict[str, Any]) -> dict[str, str]:
+def _repo_config_from_metadata(metadata: Mapping[str, Any]) -> dict[str, str]:
     owner, name, _ = _metadata_repo(metadata)
     if owner and name:
         return {"owner": owner, "name": name}
@@ -1015,7 +1024,7 @@ def _repo_config_from_metadata(metadata: dict[str, Any]) -> dict[str, str]:
 async def _build_dashboard_configurable(
     thread_id: str,
     login: str,
-    metadata: dict[str, Any],
+    metadata: Mapping[str, Any],
     *,
     profile: dict[str, Any] | None = None,
     overrides: dict[str, Any] | None = None,
@@ -1139,8 +1148,8 @@ def _dashboard_images_from_content(content: Any) -> list[DashboardImageBody]:
         images.append(
             DashboardImageBody(
                 base64=data,
-                mime_type=mime,
-                file_name=file_name if isinstance(file_name, str) else None,
+                mimeType=mime,
+                fileName=file_name if isinstance(file_name, str) else None,
             )
         )
     return images
@@ -1211,7 +1220,7 @@ async def _enrich_run_start_command(
             effort=client_configurable.get("agent_effort"),
             plan_mode=plan_mode_requested,
         )
-        metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else metadata
+        metadata = thread_metadata(thread)
         if command_images:
             resolved_model = metadata.get("resolved_model")
             resolved_effort = metadata.get("resolved_effort")
@@ -1281,7 +1290,7 @@ async def _enrich_run_start_command(
     return command
 
 
-def _slack_thread_context(metadata: dict[str, Any]) -> dict[str, Any] | None:
+def _slack_thread_context(metadata: Mapping[str, Any]) -> JsonObject | None:
     source_context = metadata.get("source_context")
     if not isinstance(source_context, dict):
         return None
@@ -1289,7 +1298,9 @@ def _slack_thread_context(metadata: dict[str, Any]) -> dict[str, Any] | None:
     return slack_thread if isinstance(slack_thread, dict) else None
 
 
-async def _notify_slack_web_handoff(thread_id: str, metadata: dict[str, Any], client: Any) -> None:
+async def _notify_slack_web_handoff(
+    thread_id: str, metadata: Mapping[str, Any], client: Any
+) -> None:
     if metadata.get("source") != "slack":
         return
     slack_thread = _slack_thread_context(metadata)
@@ -1327,7 +1338,7 @@ async def send_dashboard_message(
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
 
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_readable(metadata)
 
     prompt = f"{_attribution_prefix(metadata, login, email)}{body.content.strip()}"
@@ -1371,9 +1382,7 @@ async def send_dashboard_message(
     except Exception:
         logger.exception("Failed to update Slack message for dashboard handoff on %s", thread_id)
     thread = await client.threads.get(thread_id)
-    return _thread_summary(
-        thread if isinstance(thread, dict) else {"thread_id": thread_id, "metadata": metadata}
-    )
+    return _thread_summary(thread)
 
 
 async def cancel_dashboard_thread(
@@ -1385,7 +1394,7 @@ async def cancel_dashboard_thread(
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
 
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_owner(metadata, login, email)
 
     run_id = metadata.get("latest_run_id")
@@ -1400,19 +1409,16 @@ async def cancel_dashboard_thread(
         metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
     )
     thread = await client.threads.get(thread_id)
-    return _thread_summary(
-        thread if isinstance(thread, dict) else {"thread_id": thread_id, "metadata": metadata}
-    )
+    return _thread_summary(thread)
 
 
 async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
     client = langgraph_client()
     try:
-        thread = await client.threads.get(thread_id)
+        await client.threads.get(thread_id)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
 
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
     try:
         await client.runs.cancel_many(thread_id=thread_id, status="all", action="interrupt")
     except Exception as exc:  # noqa: BLE001
@@ -1424,11 +1430,7 @@ async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
         metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
     )
     updated_thread = await client.threads.get(thread_id)
-    return _thread_summary(
-        updated_thread
-        if isinstance(updated_thread, dict)
-        else {"thread_id": thread_id, "metadata": metadata}
-    )
+    return _thread_summary(updated_thread)
 
 
 async def delete_dashboard_thread(thread_id: str, login: str, *, email: str | None = None) -> None:
@@ -1438,7 +1440,7 @@ async def delete_dashboard_thread(thread_id: str, login: str, *, email: str | No
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
 
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_owner(metadata, login, email)
 
     run_id = metadata.get("latest_run_id")
@@ -1457,7 +1459,7 @@ async def resolve_dashboard_thread(
     """Mark a thread resolved/unresolved via thread metadata."""
     client = langgraph_client()
     thread = await _authorized_thread(thread_id, login, email=email)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     metadata_update: dict[str, Any] = {
         "resolved": resolved,
         "resolved_at_ms": _now_ms() if resolved else None,
@@ -1467,7 +1469,7 @@ async def resolve_dashboard_thread(
     except Exception as exc:  # noqa: BLE001
         logger.debug("Could not update resolved state for thread %s", thread_id, exc_info=True)
         raise HTTPException(502, "failed to update thread") from exc
-    thread = {**thread, "metadata": {**metadata, **metadata_update}}
+    thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
     return _thread_summary(thread)
 
 
@@ -1475,25 +1477,23 @@ async def _authorized_thread_metadata(
     thread_id: str, login: str, *, email: str | None = None
 ) -> dict[str, Any]:
     thread = await _authorized_thread(thread_id, login, email=email)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     return metadata
 
 
-async def _authorized_thread(
-    thread_id: str, login: str, *, email: str | None = None
-) -> dict[str, Any]:
+async def _authorized_thread(thread_id: str, login: str, *, email: str | None = None) -> ThreadLike:
     try:
         thread = await langgraph_client().threads.get(thread_id)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_owner(metadata, login, email)
     return thread
 
 
 async def _readable_thread(
     thread_id: str, *, login: str | None = None, email: str | None = None
-) -> dict[str, Any]:
+) -> ThreadLike:
     """Fetch a thread and assert it is readable by the requesting user.
 
     Read access is granted to any authenticated org member for surfaced-source
@@ -1503,7 +1503,7 @@ async def _readable_thread(
         thread = await langgraph_client().threads.get(thread_id)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_readable(metadata)
     return thread
 
@@ -1512,7 +1512,7 @@ async def _readable_thread_metadata(
     thread_id: str, *, login: str | None = None, email: str | None = None
 ) -> dict[str, Any]:
     thread = await _readable_thread(thread_id, login=login, email=email)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     return metadata
 
 
@@ -1520,9 +1520,9 @@ async def get_dashboard_thread_state(
     thread_id: str, login: str, *, email: str | None = None
 ) -> dict[str, Any]:
     thread = await _readable_thread(thread_id, login=login, email=email)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     state = await langgraph_client().threads.get_state(thread_id)
-    result = state if isinstance(state, dict) else dict(state)
+    result = as_json_object(state)
     # The SDK's `useStream` opens its live event subscription only when the
     # hydrated `getState()` looks active (`next` non-empty / absent). When a
     # run was just started out-of-band (our REST run-create), the latest
@@ -1576,7 +1576,7 @@ def _download_content(result: Any) -> bytes | None:
     return None
 
 
-def _recovery_patch_command(metadata: dict[str, Any], thread_id: str) -> str:
+def _recovery_patch_command(metadata: Mapping[str, Any], thread_id: str) -> str:
     _, name, _ = _metadata_repo(metadata)
     payload = {
         "repo_name": name,
@@ -1718,7 +1718,7 @@ async def get_dashboard_thread_recovery_patch(
     thread_id: str, login: str, *, email: str | None = None
 ) -> tuple[bytes, str]:
     thread = await _authorized_thread(thread_id, login, email=email)
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     sandbox_id = metadata.get("sandbox_id")
     if not isinstance(sandbox_id, str) or not sandbox_id:
         raise HTTPException(404, "thread has no recoverable sandbox")
@@ -1890,7 +1890,7 @@ async def proxy_dashboard_thread_commands(
         metadata: dict[str, Any] = {}
         thread_busy = False
     else:
-        metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+        metadata = thread_metadata(thread)
         if method == "run.start":
             _assert_thread_readable(metadata)
         else:
@@ -2010,7 +2010,7 @@ async def stream_dashboard_thread(
         thread = await langgraph_client().threads.get(thread_id)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(404, "thread not found") from exc
-    metadata = thread.get("metadata") if isinstance(thread.get("metadata"), dict) else {}
+    metadata = thread_metadata(thread)
     _assert_thread_readable(metadata)
 
     stream = await langgraph_client().threads.join_stream(

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 
 from langgraph_sdk import get_client
 from langgraph_sdk.client import LangGraphClient
+from langgraph_sdk.schema import Run
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +119,7 @@ async def create_durable_run(
     stream_mode: Any | None = None,
     stream_resumable: bool | None = None,
     after_seconds: int | float | None = None,
-) -> dict[str, Any]:
+) -> Run:
     """Create a run with Open SWE's durable LangGraph defaults."""
     client = client or dispatch_client()
     create_kwargs: dict[str, Any] = {
@@ -157,7 +158,7 @@ async def dispatch_agent_run(
     assistant_id: str = "agent",
     metadata: dict[str, Any] | None = None,
     client: LangGraphClient | None = None,
-) -> dict[str, Any]:
+) -> Run:
     """Create (or interrupt-and-resume) a run for ``thread_id``.
 
     Routes every Slack / Linear / GitHub / dashboard trigger through one

--- a/agent/integrations/corridor_mcp.py
+++ b/agent/integrations/corridor_mcp.py
@@ -11,6 +11,7 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Any, cast
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from langchain_core.tools import BaseTool
@@ -89,16 +90,19 @@ async def _build_mcp_tools(config: CorridorMCPConfig) -> list[BaseTool]:
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
     client = MultiServerMCPClient(
-        {
-            "corridor": {
-                "transport": "http",
-                "url": config.url,
-                "headers": {
-                    "Authorization": f"Bearer {config.token}",
-                },
-                "timeout": timedelta(seconds=_MCP_TIMEOUT_SECONDS),
-            }
-        }
+        cast(
+            Any,
+            {
+                "corridor": {
+                    "transport": "http",
+                    "url": config.url,
+                    "headers": {
+                        "Authorization": f"Bearer {config.token}",
+                    },
+                    "timeout": timedelta(seconds=_MCP_TIMEOUT_SECONDS),
+                }
+            },
+        )
     )
     return await client.get_tools()
 

--- a/agent/integrations/modal.py
+++ b/agent/integrations/modal.py
@@ -16,11 +16,10 @@ def create_modal_sandbox(sandbox_id: str | None = None):
     Returns:
         ModalSandbox instance implementing SandboxBackendProtocol.
     """
-    app = modal.App.lookup(MODAL_APP_NAME)
-
     if sandbox_id:
-        sandbox = modal.Sandbox.from_id(sandbox_id, app=app)
+        sandbox = modal.Sandbox.from_id(sandbox_id)
     else:
+        app = modal.App.lookup(MODAL_APP_NAME)
         sandbox = modal.Sandbox.create(app=app)
 
     return ModalSandbox(sandbox=sandbox)

--- a/agent/integrations/runloop.py
+++ b/agent/integrations/runloop.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, cast
 
 from langchain_runloop import RunloopSandbox
 from runloop_api_client import Client
@@ -27,4 +28,4 @@ def create_runloop_sandbox(sandbox_id: str | None = None):
     else:
         devbox = client.devboxes.create()
 
-    return RunloopSandbox(devbox=devbox)
+    return RunloopSandbox(devbox=cast(Any, devbox))

--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -8,7 +8,7 @@ human messages before the next model call.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from langchain.agents.middleware import AgentState, before_model
@@ -81,7 +81,7 @@ async def _build_blocks_from_payload(
         for image_url in image_urls:
             image_block = await fetch_image_block(image_url, client)
             if image_block:
-                blocks.append(image_block)
+                blocks.append(cast(dict[str, Any], image_block))
     return blocks
 
 

--- a/agent/middleware/ensure_no_empty_msg.py
+++ b/agent/middleware/ensure_no_empty_msg.py
@@ -2,7 +2,7 @@ from typing import Any
 from uuid import uuid4
 
 from langchain.agents.middleware import AgentState, after_model
-from langchain_core.messages import AnyMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
 from langgraph.config import get_config
 from langgraph.runtime import Runtime
 
@@ -77,6 +77,8 @@ def _is_dashboard_source() -> bool:
 @after_model
 def ensure_no_empty_msg(state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
     last_msg = state["messages"][-1]
+    if not isinstance(last_msg, AIMessage):
+        return None
     has_contents = bool(last_msg.text)
     has_tool_calls = bool(last_msg.tool_calls)
     if not has_tool_calls and not has_contents:

--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Awaitable, Callable
-from typing import Any, NotRequired
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, NotRequired, cast
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -22,7 +22,7 @@ class PrepareRunState(AgentState):
     rendered_system_prompt: NotRequired[str | None]
 
 
-def _latest_message_fingerprint(state: dict[str, Any]) -> str | None:
+def _latest_message_fingerprint(state: Mapping[str, Any]) -> str | None:
     messages = state.get("messages")
     if not isinstance(messages, list) or not messages:
         return None
@@ -53,13 +53,17 @@ class BasePrepareRunMiddleware(AgentMiddleware):
 
     async def abefore_agent(
         self,
-        state: PrepareRunState,
+        state: AgentState,
         runtime: Runtime,
     ) -> dict[str, Any] | None:
-        fingerprint = self._prepare_fingerprint(state, runtime)
-        if state.get("run_prepared") and state.get("run_prepared_for") == fingerprint:
+        prepared_state = cast(PrepareRunState, state)
+        fingerprint = self._prepare_fingerprint(prepared_state, runtime)
+        if (
+            prepared_state.get("run_prepared")
+            and prepared_state.get("run_prepared_for") == fingerprint
+        ):
             return None
-        updates = await self._prepare(state, runtime)
+        updates = await self._prepare(prepared_state, runtime)
         return {"run_prepared": True, "run_prepared_for": fingerprint, **updates}
 
     def _prepare_fingerprint(self, state: PrepareRunState, runtime: Runtime) -> str:  # noqa: ARG002

--- a/agent/middleware/sanitize_tool_inputs.py
+++ b/agent/middleware/sanitize_tool_inputs.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import ToolCall, ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
@@ -38,7 +39,7 @@ def _coerce_int(value: object) -> int | None:
     return None
 
 
-def _sanitize_read_file_args(args: dict) -> dict:
+def _sanitize_read_file_args(args: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of *args* with integer fields coerced where needed."""
     sanitized = dict(args)
     for field in _READ_FILE_INT_FIELDS:
@@ -67,10 +68,12 @@ class SanitizeToolInputsMiddleware(AgentMiddleware):
         if not isinstance(tool_call, dict) or tool_call.get("name") != "read_file":
             return request
         args = tool_call.get("args", {})
+        if not isinstance(args, dict):
+            return request
         sanitized_args = _sanitize_read_file_args(args)
         if sanitized_args is args:
             return request
-        new_tool_call = {**tool_call, "args": sanitized_args}
+        new_tool_call = cast(ToolCall, {**tool_call, "args": sanitized_args})
         return request.override(tool_call=new_tool_call)
 
     async def awrap_tool_call(

--- a/agent/middleware/subdir_agents.py
+++ b/agent/middleware/subdir_agents.py
@@ -133,8 +133,8 @@ def _can_append_reminder(result: ToolMessage | Command) -> bool:
 
 
 def _append_reminder(result: ToolMessage | Command, reminder: str | None) -> ToolMessage | Command:
-    if reminder is not None and _can_append_reminder(result):
-        result.content = f"{result.content}\n\n{reminder}"
+    if reminder is not None and isinstance(result, ToolMessage) and _can_append_reminder(result):
+        return result.model_copy(update={"content": f"{result.content}\n\n{reminder}"})
     return result
 
 

--- a/agent/middleware/timeout_wrapup.py
+++ b/agent/middleware/timeout_wrapup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
 from langchain_core.messages import BaseMessage, SystemMessage
@@ -28,7 +29,9 @@ def _configured_timeout_seconds() -> int:
     return value if value > 0 else _DEFAULT_TIMEOUT_SECONDS
 
 
-def _content_with_instruction(message: BaseMessage | None, instruction: str) -> str | list[object]:
+def _content_with_instruction(
+    message: BaseMessage | None, instruction: str
+) -> str | list[str | dict[Any, Any]]:
     if message is None:
         return instruction
     content = message.content

--- a/agent/middleware/workflow_push_guard.py
+++ b/agent/middleware/workflow_push_guard.py
@@ -9,10 +9,10 @@ import re
 import shlex
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import ToolCall, ToolMessage
 from langgraph.config import get_config
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
@@ -421,8 +421,7 @@ def _blocked_message(
 
 
 def _tool_message_for_request(message: ToolMessage, request: ToolCallRequest) -> ToolMessage:
-    message.tool_call_id = _tool_call_id(request)
-    return message
+    return message.model_copy(update={"tool_call_id": _tool_call_id(request)})
 
 
 def _override_execute_command(request: ToolCallRequest, command: str) -> ToolCallRequest:
@@ -431,7 +430,7 @@ def _override_execute_command(request: ToolCallRequest, command: str) -> ToolCal
         return request
     args = dict(_tool_args(request))
     args["command"] = command
-    return request.override(tool_call={**dict(tool_call), "args": args})
+    return request.override(tool_call=cast(ToolCall, {**dict(tool_call), "args": args}))
 
 
 def _approval_slack_message(change: WorkflowPushChange, approval_url: str | None = None) -> str:

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -3,9 +3,11 @@ import os
 import shlex
 from importlib import resources
 from pathlib import Path
+from typing import Any, cast
 
 from deepagents import HarnessProfile, register_harness_profile
 from langchain.agents.middleware import TodoListMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
 
 from .utils.authorship import (
     OPEN_SWE_BOT_EMAIL,
@@ -414,7 +416,10 @@ def register_open_swe_harness_profile() -> None:
     profile = HarnessProfile(
         base_system_prompt=OPEN_SWE_SHARED_BASE,
         excluded_tools=HARNESS_EXCLUDED_TOOLS,
-        excluded_middleware=HARNESS_EXCLUDED_MIDDLEWARE,
+        excluded_middleware=cast(
+            frozenset[type[AgentMiddleware[AgentState[Any], None, Any]] | str],
+            HARNESS_EXCLUDED_MIDDLEWARE,
+        ),
     )
     for key in HARNESS_PROFILE_KEYS:
         register_harness_profile(key, profile)

--- a/agent/review/findings.py
+++ b/agent/review/findings.py
@@ -19,7 +19,7 @@ import logging
 import uuid
 import weakref
 from collections.abc import Callable
-from typing import Any, Literal, NotRequired, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
 from langgraph.config import get_config
 from langgraph_sdk import get_client
@@ -110,7 +110,7 @@ class Finding(TypedDict):
     severity: Severity
     confidence: Confidence
     category: str
-    title: NotRequired[str]
+    title: str
     file: str
     start_line: int | None
     end_line: int | None
@@ -121,25 +121,25 @@ class Finding(TypedDict):
     status: FindingStatus
     first_seen_sha: str
     last_confirmed_sha: str
-    github_review_id: NotRequired[int | None]
-    github_review_comment_id: NotRequired[int | None]
-    github_review_comment_ids: NotRequired[list[int]]
-    github_review_thread_id: NotRequired[str | None]
-    github_review_thread_ids: NotRequired[list[str]]
-    github_review_run_id: NotRequired[str | None]
-    github_thread_resolved: NotRequired[bool]
-    github_resolved_thread_ids: NotRequired[list[str]]
-    github_posted_resolution_comment_ids: NotRequired[list[int]]
-    last_human_reply_at: NotRequired[str | None]
-    last_human_reply_author: NotRequired[str | None]
-    last_human_reply_body: NotRequired[str | None]
-    last_reconciliation_note: NotRequired[str | None]
-    resolution_note: NotRequired[str | None]
-    diff_hunk: NotRequired[str | None]
+    github_review_id: int | None
+    github_review_comment_id: int | None
+    github_review_comment_ids: list[int]
+    github_review_thread_id: str | None
+    github_review_thread_ids: list[str]
+    github_review_run_id: str | None
+    github_thread_resolved: bool
+    github_resolved_thread_ids: list[str]
+    github_posted_resolution_comment_ids: list[int]
+    last_human_reply_at: str | None
+    last_human_reply_author: str | None
+    last_human_reply_body: str | None
+    last_reconciliation_note: str | None
+    resolution_note: str | None
+    diff_hunk: str | None
     fingerprint: str
-    anchor: NotRequired[FindingAnchor]
-    surface: NotRequired[FindingSurface]
-    interactions: NotRequired[list[FindingInteraction]]
+    anchor: FindingAnchor | None
+    surface: FindingSurface | None
+    interactions: list[FindingInteraction]
 
 
 class AppendFindingResult(TypedDict):
@@ -248,6 +248,7 @@ def new_finding(
         "severity": severity,
         "confidence": confidence,
         "category": category,
+        "title": normalize_finding_title(title, description),
         "file": file,
         "start_line": start_line,
         "end_line": end_line,
@@ -278,8 +279,6 @@ def new_finding(
         "surface": surface,
         "interactions": [],
     }
-    if title is not None:
-        finding["title"] = normalize_finding_title(title)
     return finding
 
 
@@ -499,7 +498,7 @@ async def update_finding_fields(
     def _apply(findings: list[Finding]) -> bool:
         for finding in findings:
             if finding.get("id") == finding_id:
-                finding.update(updates)
+                finding.update(cast(Finding, updates))
                 captured["finding"] = finding
                 return True
         return False
@@ -521,7 +520,7 @@ async def update_finding_surface(
             if finding.get("id") != finding_id:
                 continue
             surface = _coerce_surface(finding, finding_id)
-            surface.update(updates)
+            surface.update(cast(FindingSurface, updates))
             finding["surface"] = surface
             _sync_legacy_surface_fields(finding, surface)
             captured["finding"] = finding
@@ -565,6 +564,7 @@ async def append_finding_interaction(
 
 def _coerce_surface(finding: Finding, finding_id: str) -> FindingSurface:
     surface = finding.get("surface")
+    coerced: FindingSurface
     if isinstance(surface, dict):
         coerced = cast(FindingSurface, dict(surface))
     else:
@@ -576,13 +576,20 @@ def _coerce_surface(finding: Finding, finding_id: str) -> FindingSurface:
             coerced["state"] = "surfaced"
         else:
             coerced["state"] = "not_surfaced"
-    coerced.setdefault("github_review_id", finding.get("github_review_id"))
-    coerced.setdefault("github_review_comment_id", finding.get("github_review_comment_id"))
-    coerced.setdefault("github_review_thread_id", finding.get("github_review_thread_id"))
-    coerced.setdefault("severity_threshold_at_publish", None)
-    coerced.setdefault("surfaced_at_sha", None)
-    coerced.setdefault("last_github_sync_at", None)
-    coerced.setdefault("last_error", None)
+    if "github_review_id" not in coerced:
+        coerced["github_review_id"] = finding.get("github_review_id")
+    if "github_review_comment_id" not in coerced:
+        coerced["github_review_comment_id"] = finding.get("github_review_comment_id")
+    if "github_review_thread_id" not in coerced:
+        coerced["github_review_thread_id"] = finding.get("github_review_thread_id")
+    if "severity_threshold_at_publish" not in coerced:
+        coerced["severity_threshold_at_publish"] = None
+    if "surfaced_at_sha" not in coerced:
+        coerced["surfaced_at_sha"] = None
+    if "last_github_sync_at" not in coerced:
+        coerced["last_github_sync_at"] = None
+    if "last_error" not in coerced:
+        coerced["last_error"] = None
     return coerced
 
 

--- a/agent/review/reconcile.py
+++ b/agent/review/reconcile.py
@@ -210,14 +210,17 @@ def _sync_latest_human_reply(
         return False
 
     latest = replies[-1]
-    body = latest.get("body") if isinstance(latest.get("body"), str) else ""
+    raw_body = latest.get("body")
+    body = raw_body if isinstance(raw_body, str) else ""
     if len(body) > 1000:
         body = body[:1000] + "\n...[truncated]"
-    created_at = latest.get("created_at") if isinstance(latest.get("created_at"), str) else ""
+    raw_created_at = latest.get("created_at")
+    created_at = raw_created_at if isinstance(raw_created_at, str) else ""
     if finding.get("last_human_reply_at") == created_at:
         return False
 
-    author = latest.get("author") if isinstance(latest.get("author"), str) else ""
+    raw_author = latest.get("author")
+    author = raw_author if isinstance(raw_author, str) else ""
     finding["last_human_reply_at"] = created_at
     finding["last_human_reply_author"] = author
     finding["last_human_reply_body"] = body

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -20,21 +20,23 @@ import logging
 import posixpath
 import re
 import warnings
-from typing import Any, NotRequired
+from typing import Any, NotRequired, cast
 
 logger = logging.getLogger(__name__)
 
 from langgraph.graph.state import RunnableConfig
 from langgraph.pregel import Pregel
+from langgraph.runtime import Runtime
 
 warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 from deepagents import create_deep_agent
 from deepagents.backends.protocol import SandboxBackendProtocol
-from deepagents.middleware.skills import SkillsMiddleware
+from deepagents.middleware.skills import SkillsMiddleware, SkillsState
 from deepagents.middleware.subagents import SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware
+from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from .dashboard.options import gate_fable_model
@@ -47,7 +49,6 @@ from .dashboard.team_settings import (
 )
 from .middleware import (
     BasePrepareRunMiddleware,
-    PrepareRunState,
     RepairOrphanedToolCallsMiddleware,
     SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
@@ -59,6 +60,7 @@ from .middleware import (
     refresh_github_proxy_before_model,
     settle_review_check_on_exit,
 )
+from .middleware.prepare_run import PrepareRunState
 from .review.diff import (
     compute_diff_line_set,
     fetch_pr_diff,
@@ -68,6 +70,7 @@ from .review.diff import (
 )
 from .review.findings import (
     REVIEW_FINDING_CAP,
+    Finding,
 )
 from .review.findings import (
     list_findings as list_findings_async,
@@ -788,23 +791,23 @@ def _format_pr_review_threads(threads: list[dict]) -> str:
     return "\n".join(out)
 
 
-def _format_existing_findings(findings: list[dict]) -> str:
+def _format_existing_findings(findings: list[Finding]) -> str:
     if not findings:
         return "_(none)_"
     lines: list[str] = []
     for f in findings:
         if f.get("status") != "open":
             continue
-        location = f.get("file", "<unknown>")
-        start = f.get("start_line")
-        end = f.get("end_line")
+        location = f["file"]
+        start = f["start_line"]
+        end = f["end_line"]
         if start is not None and end is not None:
             location += f":{start}" if start == end else f":{start}-{end}"
         title = f.get("title")
         title_prefix = f"{title}: " if isinstance(title, str) and title.strip() else ""
         lines.append(
-            f"- [{f.get('id')}] ({f.get('severity')}, {f.get('category')}) "
-            f"{location} — {title_prefix}{f.get('description', '').strip()}"
+            f"- [{f['id']}] ({f['severity']}, {f['category']}) "
+            f"{location} — {title_prefix}{f['description'].strip()}"
         )
         human_reply = f.get("last_human_reply_body")
         if isinstance(human_reply, str) and human_reply:
@@ -982,8 +985,8 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
             else None,
         }
 
-    async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:
-        configurable = self._config["configurable"]
+    async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:
+        configurable = self._config.get("configurable") or {}
         repo_config = configurable.get("repo") or {}
         sandbox_backend, github_token = await _ensure_reviewer_sandbox_for_thread(
             self._thread_id, configurable
@@ -1140,25 +1143,22 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
                 logger.exception("Failed to prepare PR trace context; continuing without it")
                 return None
 
-        (
-            diff_context,
-            pr_overview,
-            existing_threads_block,
-            repo_style_prompt,
-            agents_md_content,
-            org_guidelines,
-            api_standards_skill,
-            pr_trace_context,
-        ) = await asyncio.gather(
-            _fetch_diff_context(),
-            _fetch_pr_overview(),
-            _fetch_existing_threads_block(),
-            _fetch_repo_style_prompt(),
-            _fetch_agents_md_context(),
-            _cached_org_review_guidelines(),
-            _cached_api_standards_skill(),
-            _prepare_pr_trace_context(),
-        )
+        diff_context_task = asyncio.create_task(_fetch_diff_context())
+        pr_overview_task = asyncio.create_task(_fetch_pr_overview())
+        existing_threads_task = asyncio.create_task(_fetch_existing_threads_block())
+        repo_style_task = asyncio.create_task(_fetch_repo_style_prompt())
+        agents_md_task = asyncio.create_task(_fetch_agents_md_context())
+        org_guidelines_task = asyncio.create_task(_cached_org_review_guidelines())
+        api_standards_task = asyncio.create_task(_cached_api_standards_skill())
+        pr_trace_context_task = asyncio.create_task(_prepare_pr_trace_context())
+        diff_context = await diff_context_task
+        pr_overview = await pr_overview_task
+        existing_threads_block = await existing_threads_task
+        repo_style_prompt = await repo_style_task
+        agents_md_content = await agents_md_task
+        org_guidelines = await org_guidelines_task
+        api_standards_skill = await api_standards_task
+        pr_trace_context = await pr_trace_context_task
         pr_diff_text, pr_diff_line_set = diff_context
         pr_title, pr_body = pr_overview
 
@@ -1227,7 +1227,14 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
             system_prompt = f"{system_prompt}\n\n{review_context}"
         if skill_sources:
             skill_middleware = SkillsMiddleware(backend=sandbox_backend, sources=skill_sources)
-            skill_update = await skill_middleware.abefore_agent({}, runtime, self._config) or {}
+            skill_update = (
+                await skill_middleware.abefore_agent(
+                    cast(SkillsState, {}),
+                    cast(Runtime[None], runtime),
+                    self._config,
+                )
+                or {}
+            )
             skill_request_state = {
                 "skills_metadata": skill_update.get("skills_metadata", []),
                 "skills_load_errors": skill_update.get("skills_load_errors", []),
@@ -1275,15 +1282,15 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
 async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     """Get or create a reviewer agent with checkpointed run prep."""
     config = config.copy()
-    config["configurable"] = config["configurable"].copy()
+    configurable = dict(config.get("configurable") or {})
+    config["configurable"] = configurable
     config.setdefault("recursion_limit", DEFAULT_RECURSION_LIMIT)
-    thread_id = config["configurable"].get("thread_id", None)
+    thread_id = configurable.get("thread_id")
 
     if thread_id is None or not graph_loaded_for_execution(config):
         logger.info("No thread_id or not for execution, returning reviewer agent without sandbox")
         return create_deep_agent(system_prompt="", tools=[]).with_config(config)
 
-    configurable = config["configurable"]
     configured_model_id = configurable.get("reviewer_model_id")
     configured_effort = configurable.get("reviewer_reasoning_effort")
     if isinstance(configured_model_id, str) and configured_model_id:
@@ -1368,24 +1375,27 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         ],
         subagents=[_reviewer_subagent(reviewer_subagent_model)],
         backend=backend_factory,
-        middleware=[
-            PrepareReviewerRunMiddleware(
-                thread_id=thread_id,
-                config=config,
-                use_gateway=use_gateway,
-            ),
-            SanitizeToolInputsMiddleware(),
-            ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
-            ToolErrorMiddleware(),
-            refresh_github_proxy_before_model,
-            check_message_queue_before_model,
-            SlackAssistantStatusMiddleware(),
-            TimeoutWrapupMiddleware(),
-            SanitizeFireworksMessagesMiddleware(),
-            SanitizeThinkingBlocksMiddleware(),
-            RepairOrphanedToolCallsMiddleware(),
-            settle_review_check_on_exit,
-        ],
+        middleware=cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [
+                PrepareReviewerRunMiddleware(
+                    thread_id=thread_id,
+                    config=config,
+                    use_gateway=use_gateway,
+                ),
+                SanitizeToolInputsMiddleware(),
+                ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
+                ToolErrorMiddleware(),
+                refresh_github_proxy_before_model,
+                check_message_queue_before_model,
+                SlackAssistantStatusMiddleware(),
+                TimeoutWrapupMiddleware(),
+                SanitizeFireworksMessagesMiddleware(),
+                SanitizeThinkingBlocksMiddleware(),
+                RepairOrphanedToolCallsMiddleware(),
+                settle_review_check_on_exit,
+            ],
+        ),
     ).with_config(config)
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -12,12 +12,13 @@ import logging
 import os
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any
+from typing import Any, Literal, cast
 
 logger = logging.getLogger(__name__)
 
 from langgraph.graph.state import RunnableConfig
 from langgraph.pregel import Pregel
+from langgraph.runtime import Runtime
 from langgraph_sdk import get_client
 
 warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
@@ -32,6 +33,7 @@ from deepagents.backends import LangSmithSandbox
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolRetryMiddleware
+from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
 from langsmith.sandbox import SandboxClientError
 
@@ -84,6 +86,7 @@ from .middleware import (
     task_on_failure,
     task_retry_on,
 )
+from .middleware.prepare_run import PrepareRunState
 from .prompt import construct_system_prompt
 from .runtime.constants import (
     DEFAULT_LLM_MAX_TOKENS,
@@ -132,6 +135,7 @@ from .utils.github_app import (
     get_github_app_installation_token_with_expiry,
 )
 from .utils.github_proxy import record_proxy_token_expiry
+from .utils.json_types import as_json_object
 from .utils.model import (
     DEFAULT_LLM_REASONING,
     ModelKwargs,
@@ -661,7 +665,7 @@ async def _load_corridor_mcp_tools() -> list[Any]:
     )
 
 
-async def _cached_team_default_model_pair(kind: str):
+async def _cached_team_default_model_pair(kind: Literal["agent", "reviewer"]):
     return await ttl_cache.cached(
         f"team-default-model-pair:{kind}:{id(get_team_default_model_pair)}",
         60,
@@ -748,12 +752,14 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             "effort": self._effort,
         }
 
-    async def _prepare(self, state: dict[str, Any], runtime: object) -> dict[str, Any]:  # noqa: ARG002
+    async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
         github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
         configurable = (self._config or {}).get("configurable") or {}
         prompt_default_repo = await _resolve_prompt_default_repo(configurable)
         triggering_user_identity_task = asyncio.create_task(
-            asyncio.to_thread(resolve_triggering_user_identity, self._config, github_token)
+            asyncio.to_thread(
+                resolve_triggering_user_identity, as_json_object(self._config), github_token
+            )
         )
         sandbox_task = asyncio.create_task(
             ensure_sandbox_for_thread(self._thread_id, repo=prompt_default_repo)
@@ -810,7 +816,8 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
 
 async def get_agent(config: RunnableConfig) -> Pregel:
     """Get or create an agent with a sandbox for the given thread."""
-    thread_id = config["configurable"].get("thread_id", None)
+    configurable = config.get("configurable") or {}
+    thread_id = configurable.get("thread_id")
 
     config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
 
@@ -821,8 +828,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             tools=[],
         ).with_config(config)
 
-    profile_login = resolve_github_login(config)
-    configurable = (config or {}).get("configurable") or {}
+    profile_login = resolve_github_login(as_json_object(config))
     # Team/profile settings are accepted stale for a short TTL so graph factories
     # stay off the critical path during worker load and retry storms.
     team_defaults, use_gateway, profile, fable_enabled = await asyncio.gather(
@@ -832,7 +838,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         _cached_fable_enabled(),
     )
 
-    linear_issue = config["configurable"].get("linear_issue", {})
+    linear_issue = as_json_object(configurable.get("linear_issue"))
     linear_project_id = linear_issue.get("linear_project_id", "")
     linear_issue_number = linear_issue.get("linear_issue_number", "")
 
@@ -928,9 +934,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         )
         logger.info("Configured model fallback %s -> %s", model_id, fallback_model_id)
 
-    source = (
-        configurable.get("source") if isinstance(configurable.get("source"), str) else "dashboard"
-    )
+    source_value = configurable.get("source")
+    source = source_value if isinstance(source_value, str) else "dashboard"
     user_email = configurable.get("user_email")
     user_email = user_email if isinstance(user_email, str) else ""
 
@@ -1011,46 +1016,49 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             *([_browser_subagent(subagent_model, browser_tools)] if browser_tools else []),
         ],
         backend=backend_factory,
-        middleware=[
-            PrepareAgentRunMiddleware(
-                thread_id=thread_id,
-                config=config,
-                profile_login=profile_login,
-                model_id=model_id,
-                effort=profile_effort,
-                source=source,
-                user_email=user_email,
-                linear_project_id=linear_project_id,
-                linear_issue_number=linear_issue_number,
-                create_prs=always_create_prs,
-                plan_mode=plan_mode,
-                corridor_enabled=bool(corridor_tools),
-            ),
-            SanitizeToolInputsMiddleware(),
-            ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
-            ToolErrorMiddleware(),
-            SubdirAgentsReadMiddleware(),
-            ToolRetryMiddleware(
-                max_retries=2,
-                tools=["task"],
-                retry_on=task_retry_on,
-                on_failure=task_on_failure,
-                initial_delay=1.0,
-                max_delay=10.0,
-            ),
-            ToolArtifactMiddleware(),
-            PullRequestCreationGuardMiddleware(),
-            WorkflowPushGuardMiddleware(),
-            refresh_github_proxy_before_model,
-            check_message_queue_before_model,
-            SlackAssistantStatusMiddleware(),
-            TimeoutWrapupMiddleware(),
-            notify_step_limit_reached,
-            *fallback_middleware,
-            *plan_mode_middleware,
-            SanitizeFireworksMessagesMiddleware(),
-            SanitizeThinkingBlocksMiddleware(),
-        ],
+        middleware=cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [
+                PrepareAgentRunMiddleware(
+                    thread_id=thread_id,
+                    config=config,
+                    profile_login=profile_login,
+                    model_id=model_id,
+                    effort=profile_effort,
+                    source=source,
+                    user_email=user_email,
+                    linear_project_id=linear_project_id,
+                    linear_issue_number=linear_issue_number,
+                    create_prs=always_create_prs,
+                    plan_mode=plan_mode,
+                    corridor_enabled=bool(corridor_tools),
+                ),
+                SanitizeToolInputsMiddleware(),
+                ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
+                ToolErrorMiddleware(),
+                SubdirAgentsReadMiddleware(),
+                ToolRetryMiddleware(
+                    max_retries=2,
+                    tools=["task"],
+                    retry_on=task_retry_on,
+                    on_failure=task_on_failure,
+                    initial_delay=1.0,
+                    max_delay=10.0,
+                ),
+                ToolArtifactMiddleware(),
+                PullRequestCreationGuardMiddleware(),
+                WorkflowPushGuardMiddleware(),
+                refresh_github_proxy_before_model,
+                check_message_queue_before_model,
+                SlackAssistantStatusMiddleware(),
+                TimeoutWrapupMiddleware(),
+                notify_step_limit_reached,
+                *fallback_middleware,
+                *plan_mode_middleware,
+                SanitizeFireworksMessagesMiddleware(),
+                SanitizeThinkingBlocksMiddleware(),
+            ],
+        ),
     ).with_config(config)
 
 

--- a/agent/tools/fetch_url.py
+++ b/agent/tools/fetch_url.py
@@ -47,6 +47,8 @@ async def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
                     "status_code": blocked["status_code"],
                     "url": blocked["url"],
                 }
+            if response is None:
+                return {"error": "Fetch URL error: no response received", "url": url}
 
             response.raise_for_status()
 

--- a/agent/tools/http_request.py
+++ b/agent/tools/http_request.py
@@ -64,6 +64,14 @@ async def http_request(
             )
         if blocked:
             return blocked
+        if response is None:
+            return {
+                "success": False,
+                "status_code": 0,
+                "headers": {},
+                "content": "Request completed without a response",
+                "url": url,
+            }
 
         try:
             content = response.json()

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -477,11 +477,12 @@ async def _record_pr_telemetry(
         merged = bool(details.get("merged"))
         is_draft = bool(details.get("draft", pr.get("draft")))
         state = details.get("state") if isinstance(details.get("state"), str) else "open"
-        additions = details.get("additions") if isinstance(details.get("additions"), int) else 0
-        deletions = details.get("deletions") if isinstance(details.get("deletions"), int) else 0
-        changed_files = (
-            details.get("changed_files") if isinstance(details.get("changed_files"), int) else 0
-        )
+        additions_value = details.get("additions")
+        additions = additions_value if isinstance(additions_value, int) else 0
+        deletions_value = details.get("deletions")
+        deletions = deletions_value if isinstance(deletions_value, int) else 0
+        changed_files_value = details.get("changed_files")
+        changed_files = changed_files_value if isinstance(changed_files_value, int) else 0
         await record_agent_pr_usage(
             thread_id=thread_id if isinstance(thread_id, str) else None,
             github_login=github_login,

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Annotated, Any
 
 from langgraph.config import get_config
@@ -304,13 +305,13 @@ async def _publish_review_async(
     )
 
     inline_comments: list[dict[str, Any]] = []
-    eligible_with_payload: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    eligible_with_payload: list[tuple[Finding, dict[str, Any]]] = []
     for finding in eligible:
         payload = render_inline_comment_payload(finding)
         if payload is None:
             continue
         inline_comments.append(payload)
-        eligible_with_payload.append((dict(finding), payload))
+        eligible_with_payload.append((finding, payload))
 
     # With nothing new to surface, skip the "no issues found" summary if Open
     # SWE has already reviewed this PR — the user already saw the previous
@@ -603,7 +604,7 @@ def _str_list(value: Any) -> list[str]:
     return [item for item in value if isinstance(item, str) and item]
 
 
-def _comment_ids_for_finding(finding: dict[str, Any]) -> list[int]:
+def _comment_ids_for_finding(finding: Finding) -> list[int]:
     comment_ids = _int_list(finding.get("github_review_comment_ids"))
     comment_id = finding.get("github_review_comment_id")
     if isinstance(comment_id, int) and comment_id not in comment_ids:
@@ -611,7 +612,7 @@ def _comment_ids_for_finding(finding: dict[str, Any]) -> list[int]:
     return comment_ids
 
 
-def _thread_ids_for_finding(finding: dict[str, Any]) -> list[str]:
+def _thread_ids_for_finding(finding: Finding) -> list[str]:
     thread_ids = _str_list(finding.get("github_review_thread_ids"))
     thread_id = finding.get("github_review_thread_id")
     if isinstance(thread_id, str) and thread_id and thread_id not in thread_ids:
@@ -643,7 +644,7 @@ async def _backfill_findings_from_pr_threads(
 
 def _missing_comment_ids_for_published_findings(
     findings: list[Finding],
-    eligible_with_payload: list[tuple[dict[str, Any], dict[str, Any]]],
+    eligible_with_payload: list[tuple[Finding, dict[str, Any]]],
 ) -> bool:
     finding_ids = {
         finding.get("id")
@@ -710,7 +711,7 @@ def _apply_comment_ids(
 
 
 def _comment_id_by_finding_id(
-    eligible_with_payload: list[tuple[dict[str, Any], dict[str, Any]]],
+    eligible_with_payload: list[tuple[Finding, dict[str, Any]]],
     comment_records: list[dict[str, Any]],
 ) -> dict[str, int]:
     """Map each surfaced finding id to its GitHub comment id via the marker.
@@ -746,7 +747,7 @@ async def _record_review_publication(
     *,
     thread_id: str,
     review_id: int,
-    inline_with_payload: list[tuple[dict[str, Any], dict[str, Any]]],
+    inline_with_payload: list[tuple[Finding, dict[str, Any]]],
     comment_records: list[dict[str, Any]],
     langgraph_run_id: str | None,
 ) -> None:
@@ -789,7 +790,7 @@ async def _resolve_diff_line_set(
     pr_number: int,
     token: str,
     state: dict[str, Any] | None = None,
-) -> dict[str, set[int]] | None:
+) -> dict[str, dict[str, set[int]]] | None:
     """Return the new-side line set for the PR diff, fetching it if needed.
 
     Reviewer runs clear ``configurable['diff_line_set']`` before the agent
@@ -816,14 +817,14 @@ async def _resolve_diff_line_set(
 
 
 async def _filter_against_pr_diff(
-    eligible_with_payload: list[tuple[dict[str, Any], dict[str, Any]]],
+    eligible_with_payload: list[tuple[Finding, dict[str, Any]]],
     *,
     owner: str,
     repo: str,
     pr_number: int,
     token: str,
     state: dict[str, Any] | None = None,
-) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], list[str]]:
+) -> tuple[list[tuple[Finding, dict[str, Any]]], list[str]]:
     """Drop findings whose path/line range is not in the current PR diff.
 
     Returns ``(valid_with_payload, dropped_finding_ids)``. When the diff
@@ -837,7 +838,7 @@ async def _filter_against_pr_diff(
     if diff_line_set is None:
         return list(eligible_with_payload), []
 
-    valid: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    valid: list[tuple[Finding, dict[str, Any]]] = []
     dropped: list[str] = []
     for finding, payload in eligible_with_payload:
         path = payload.get("path")
@@ -881,6 +882,10 @@ async def _maybe_post_slack_completion_reply(
     slack_ref = get_thread_slack_ref(metadata)
     if slack_ref is None:
         return
+    channel_id = slack_ref.get("channel_id")
+    thread_ts = slack_ref.get("thread_ts")
+    if not isinstance(channel_id, str) or not isinstance(thread_ts, str):
+        return
 
     if surfaced_count == 0:
         headline = "*Open SWE Review*: No issues found."
@@ -893,7 +898,7 @@ async def _maybe_post_slack_completion_reply(
         review_url = f"{review_url}#pullrequestreview-{review_id}"
     text = f"{headline} <{review_url}|View review>"
 
-    await post_slack_thread_reply(slack_ref["channel_id"], slack_ref["thread_ts"], text)
+    await post_slack_thread_reply(channel_id, thread_ts, text)
 
 
 async def _store_thread_ids_on_findings(
@@ -965,7 +970,7 @@ async def _resolve_threads_for_resolved_findings(
     repo: str,
     pr_number: int,
     token: str,
-    findings: list[dict[str, Any]],
+    findings: list[Finding],
 ) -> int:
     """Resolve GitHub review threads for findings that just transitioned to resolved.
 
@@ -1057,7 +1062,7 @@ async def _resolve_threads_for_resolved_findings(
     return resolved_count
 
 
-def _current_run_id(config: dict[str, Any]) -> str | None:
+def _current_run_id(config: Mapping[str, Any]) -> str | None:
     candidates = [config.get("run_id")]
     configurable = config.get("configurable")
     if isinstance(configurable, dict):

--- a/agent/tools/resolve_finding_thread.py
+++ b/agent/tools/resolve_finding_thread.py
@@ -224,7 +224,7 @@ def _str_list(value: Any) -> list[str]:
     return [item for item in value if isinstance(item, str) and item]
 
 
-def _comment_ids_for_finding(finding: dict[str, Any]) -> list[int]:
+def _comment_ids_for_finding(finding: Finding) -> list[int]:
     comment_ids = _int_list(finding.get("github_review_comment_ids"))
     comment_id = finding.get("github_review_comment_id")
     if isinstance(comment_id, int) and comment_id not in comment_ids:
@@ -232,7 +232,7 @@ def _comment_ids_for_finding(finding: dict[str, Any]) -> list[int]:
     return comment_ids
 
 
-def _thread_ids_for_finding(finding: dict[str, Any]) -> list[str]:
+def _thread_ids_for_finding(finding: Finding) -> list[str]:
     thread_ids = _str_list(finding.get("github_review_thread_ids"))
     thread_id = finding.get("github_review_thread_id")
     if isinstance(thread_id, str) and thread_id and thread_id not in thread_ids:

--- a/agent/tools/schedule_thread_wakeup.py
+++ b/agent/tools/schedule_thread_wakeup.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from langgraph.config import get_config
 from langgraph_sdk import get_client
+from langgraph_sdk.schema import Config
 
 from ..utils.thread_ops import langgraph_url
 
@@ -124,7 +125,7 @@ async def _create_wakeup_cron(
     client = get_client(url=langgraph_url())
     schedule = _build_one_shot_cron(fire_time)
     end_time = fire_time + timedelta(seconds=_END_TIME_PADDING_SECONDS)
-    run_config: dict[str, Any] = {"configurable": configurable}
+    run_config: Config = {"configurable": configurable}
     cron = await client.crons.create_for_thread(
         thread_id,
         _AGENT_ASSISTANT_ID,

--- a/agent/tools/slack_read_thread_messages.py
+++ b/agent/tools/slack_read_thread_messages.py
@@ -15,7 +15,7 @@ async def _fetch_and_format(channel_id: str, message_ts: str) -> dict[str, Any]:
         return {"success": False, "messages": []}
 
     user_ids = [
-        msg.get("user") for msg in messages if isinstance(msg.get("user"), str) and msg.get("user")
+        user_id for msg in messages if isinstance(user_id := msg.get("user"), str) and user_id
     ]
     user_names = await get_slack_user_names(user_ids) if user_ids else {}
 

--- a/agent/tools/update_finding.py
+++ b/agent/tools/update_finding.py
@@ -178,7 +178,7 @@ async def update_finding(
         from .resolve_finding_thread import resolve_finding_thread
 
         resolve_result = await resolve_finding_thread(
-            finding_id, status=status, note=normalized_note
+            finding_id, status=status, note=normalized_note or ""
         )
         if not resolve_result.get("success"):
             return {

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
@@ -424,7 +425,9 @@ async def _resolve_bot_installation_token(thread_id: str) -> tuple[str, str | No
     )
 
 
-async def resolve_github_token(config: RunnableConfig, thread_id: str) -> tuple[str, str | None]:
+async def resolve_github_token(
+    config: Mapping[str, Any] | RunnableConfig, thread_id: str
+) -> tuple[str, str | None]:
     """Resolve a GitHub token from the run config based on the source.
 
     Routes to the correct auth method depending on the source. Sources that
@@ -439,7 +442,9 @@ async def resolve_github_token(config: RunnableConfig, thread_id: str) -> tuple[
     Raises:
         RuntimeError: If source is missing or token resolution fails.
     """
-    configurable = config["configurable"]
+    configurable = config.get("configurable")
+    if not isinstance(configurable, Mapping):
+        raise RuntimeError(f"GitHub auth failed for thread {thread_id}: missing configurable state")
     source = configurable.get("source")
     if not source:
         logger.error("Missing source for thread %s; cannot route auth failure responses", thread_id)

--- a/agent/utils/deferred_model.py
+++ b/agent/utils/deferred_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models.base import LangSmithParams
 
 
 class DeferredErrorModel(BaseChatModel):
@@ -15,7 +16,7 @@ class DeferredErrorModel(BaseChatModel):
     def _llm_type(self) -> str:
         return "deferred-error"
 
-    def _get_ls_params(self, stop: Any = None, **kwargs: Any) -> dict[str, Any]:
+    def _get_ls_params(self, stop: list[str] | None = None, **kwargs: Any) -> LangSmithParams:
         params = super()._get_ls_params(stop=stop, **kwargs)
         if self.model_id:
             params["ls_model_name"] = self.model_id

--- a/agent/utils/github_feedback.py
+++ b/agent/utils/github_feedback.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import uuid
+from collections.abc import Mapping
 from typing import Any
 
 from langgraph_sdk import get_client
@@ -34,7 +35,7 @@ def _reviewer_thread_id(owner: str, repo: str, pr_number: int) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_URL, f"{owner}/{repo}/pr/{pr_number}/reviewer"))
 
 
-def _read_active_reactions(item: dict[str, Any] | None) -> set[str]:
+def _read_active_reactions(item: Mapping[str, Any] | None) -> set[str]:
     if not item:
         return set()
     value = item.get("value")

--- a/agent/utils/json_types.py
+++ b/agent/utils/json_types.py
@@ -1,0 +1,33 @@
+"""Helpers for LangGraph SDK / store JSON values that type as ``dict | None``."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeAlias, cast
+
+from langgraph_sdk.schema import Run, Thread, ThreadState
+
+JsonObject: TypeAlias = dict[str, Any]
+ThreadLike: TypeAlias = Thread | Mapping[str, Any]
+RunLike: TypeAlias = Run | Mapping[str, Any]
+ThreadStateLike: TypeAlias = ThreadState | Mapping[str, Any]
+
+
+def as_json_object(value: Any) -> JsonObject:
+    """Return ``value`` if it is a ``dict``, otherwise ``{}``."""
+    return value if isinstance(value, dict) else {}
+
+
+def thread_metadata(thread: ThreadLike) -> JsonObject:
+    return as_json_object(thread.get("metadata") if isinstance(thread, Mapping) else None)
+
+
+def run_metadata(run: RunLike) -> JsonObject:
+    return as_json_object(run.get("metadata") if isinstance(run, Mapping) else None)
+
+
+def as_thread_dict(thread: ThreadLike) -> JsonObject:
+    """Normalize a SDK ``Thread`` (TypedDict) to a plain ``dict`` for helpers."""
+    if isinstance(thread, dict):
+        return cast(JsonObject, thread)
+    return dict(thread)

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import Any, Literal, TypedDict, Unpack
+from typing import Any, Literal, TypedDict, Unpack, cast
 
 from langchain.chat_models import init_chat_model
 
@@ -35,7 +35,9 @@ async def close_cached_models() -> None:
     for model in models:
         close = getattr(model, "aclose", None)
         if callable(close):
-            await close()
+            result = close()
+            if asyncio.iscoroutine(result):
+                await result
             continue
         close = getattr(model, "close", None)
         if callable(close):
@@ -117,7 +119,7 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
     gateway ``base_url``/``api_key``/``use_responses_api`` override the direct
     provider defaults below (see :mod:`agent.utils.gateway`).
     """
-    model_kwargs: dict[str, object] = kwargs.copy()
+    model_kwargs: dict[str, object] = dict(kwargs)
     model_kwargs.setdefault("max_retries", DEFAULT_MAX_RETRIES)
 
     if model_id.startswith("openai:"):
@@ -136,17 +138,19 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
         _configure_openai_responses_kwargs(model_kwargs)
         _coerce_openai_chat_completions_kwargs(model_kwargs)
 
+    max_tokens = model_kwargs.get("max_tokens")
+    max_tokens_key = max_tokens if type(max_tokens) is int else None
     key = (
         model_id,
         use_gateway,
-        model_kwargs.get("max_tokens") if isinstance(model_kwargs.get("max_tokens"), int) else None,
+        max_tokens_key,
         _freeze_model_kwargs(model_kwargs),
         _loop_cache_key(),
     )
     cached = _MODEL_CACHE.get(key)
     if cached is not None:
         return cached
-    model = init_chat_model(model=model_id, **model_kwargs)
+    model = init_chat_model(model=model_id, **cast(dict[str, Any], model_kwargs))
     _MODEL_CACHE[key] = model
     return model
 

--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -7,11 +7,10 @@ import logging
 import mimetypes
 import os
 import re
-from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from langchain_core.messages.content import create_image_block
+from langchain_core.messages.content import ImageContentBlock, create_image_block
 
 from .url_safety import request_with_safe_redirects
 
@@ -83,7 +82,7 @@ def _image_auth_headers_for_url(original_url: str, current_url: str) -> dict[str
 async def fetch_image_block(
     image_url: str,
     client: httpx.AsyncClient,
-) -> dict[str, Any] | None:
+) -> ImageContentBlock | None:
     """Fetch image bytes and build an image content block."""
     try:
         logger.debug("Fetching image from %s", image_url)
@@ -97,6 +96,8 @@ async def fetch_image_block(
             logger.warning(
                 "Refusing to fetch image (SSRF guard) %s: %s", image_url, blocked["content"]
             )
+            return None
+        if response is None:
             return None
         response.raise_for_status()
         content_type = response.headers.get("Content-Type", "").split(";")[0].strip()

--- a/agent/utils/reviewer_outcomes.py
+++ b/agent/utils/reviewer_outcomes.py
@@ -20,6 +20,8 @@ from typing import Any
 
 from langsmith import Client as LangSmithClient
 
+from ..review.findings import Finding
+
 logger = logging.getLogger(__name__)
 
 OUTCOMES_DATASET_NAME = os.environ.get("REVIEWER_OUTCOMES_DATASET", "openswe-reviewer-outcomes")
@@ -126,7 +128,7 @@ def _create_or_update_example(
 
 
 def upsert_finding_outcome(
-    finding: dict[str, Any],
+    finding: Finding,
     *,
     label: str,
     label_source: str,
@@ -247,7 +249,7 @@ def repo_full_name_from_config(configurable: dict[str, Any]) -> str:
 
 
 def emit_finding_status_outcome(
-    finding: dict[str, Any],
+    finding: Finding,
     status: str,
     *,
     configurable: dict[str, Any],

--- a/agent/utils/sandbox_paths.py
+++ b/agent/utils/sandbox_paths.py
@@ -110,7 +110,8 @@ def _call_path_method(provider: Any, method_name: str) -> str | None:
         return None
 
     try:
-        return _normalize_path(method())
+        value = method()
+        return _normalize_path(value if isinstance(value, str) else None)
     except Exception:
         logger.debug("Failed to call %s on %s", method_name, type(provider).__name__, exc_info=True)
         return None

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -115,21 +115,25 @@ class SandboxBackendProxy(SandboxBackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
-        return self._get_backend().grep(pattern, path, glob)
+        return self._get_backend().grep(pattern, path, glob, max_count=max_count)
 
     async def agrep(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
-        return await (await self._aget_backend()).agrep(pattern, path, glob)
+        return await (await self._aget_backend()).agrep(pattern, path, glob, max_count=max_count)
 
-    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
         return self._get_backend().glob(pattern, path)
 
-    async def aglob(self, pattern: str, path: str = "/") -> GlobResult:
+    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
         return await (await self._aget_backend()).aglob(pattern, path)
 
     def write(self, file_path: str, content: str) -> WriteResult:

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -422,7 +423,9 @@ def _with_slack_web_link_context_block(
             context_block,
         ]
     updated_blocks = copy.deepcopy(blocks)
-    if any(_block_contains_text(block, dashboard_url) for block in updated_blocks):
+    if dashboard_url and any(
+        _block_contains_text(block, dashboard_url) for block in updated_blocks
+    ):
         return updated_blocks
     updated_blocks.append(context_block)
     return updated_blocks
@@ -1101,7 +1104,7 @@ _THREAD_RUN_KEY_PREFIX = "thread:"
 _MESSAGE_RUN_KEY_PREFIX = "message:"
 
 
-def _extract_run_id_from_store_item(item: dict[str, Any] | None) -> str | None:
+def _extract_run_id_from_store_item(item: Mapping[str, Any] | None) -> str | None:
     if not item:
         return None
     value = item.get("value")

--- a/agent/utils/slack_feedback.py
+++ b/agent/utils/slack_feedback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any
 
 from langgraph_sdk import get_client
@@ -32,7 +33,7 @@ _REACTION_STATE_NAMESPACE = "slack_reaction_state"
 _REACTION_EVENT_NAMESPACE = "slack_reaction_events"
 
 
-def _read_active_reactions(item: dict[str, Any] | None) -> set[str]:
+def _read_active_reactions(item: Mapping[str, Any] | None) -> set[str]:
     if not item:
         return set()
     value = item.get("value")

--- a/agent/utils/url_safety.py
+++ b/agent/utils/url_safety.py
@@ -113,6 +113,7 @@ async def request_with_safe_redirects(
     request_kwargs = dict(kwargs)
     caller_headers = dict(request_kwargs.pop("headers", None) or {})
     caller_extensions = dict(request_kwargs.pop("extensions", None) or {})
+    response: httpx.Response | None = None
 
     for redirect_count in range(_MAX_REDIRECTS + 1):
         is_safe, reason, hostname, addr_infos = resolve_and_validate(current_url)
@@ -140,6 +141,8 @@ async def request_with_safe_redirects(
                 if address_index == len(pinned_ips) - 1:
                     raise
 
+        if response is None:
+            raise httpx.ConnectError("No response received from pinned address")
         if response.status_code not in _REDIRECT_CODES:
             return response, None
 

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -85,6 +85,7 @@ from ..utils.github_token import (
     invalidate_cached_github_token,
 )
 from ..utils.http import DEFAULT_HTTP_TIMEOUT
+from ..utils.json_types import ThreadLike, as_thread_dict
 from ..utils.linear import post_linear_trace_comment  # noqa: F401
 from ..utils.linear_team_repo_map import LINEAR_TEAM_TO_REPO
 from ..utils.multimodal import (
@@ -345,13 +346,15 @@ def get_repo_config_from_team_mapping(
     if "owner" in config and "name" in config:
         return config
 
-    if "projects" in config and project_name:
-        project_config = config["projects"].get(project_name)
-        if project_config:
+    projects = config.get("projects")
+    if isinstance(projects, dict) and project_name:
+        project_config = projects.get(project_name)
+        if isinstance(project_config, dict):
             return project_config
 
-    if "default" in config:
-        return config["default"]
+    default = config.get("default")
+    if isinstance(default, dict):
+        return default
 
     return fallback
 
@@ -497,8 +500,9 @@ def generate_reviewer_thread_id(owner: str, repo: str, pr_number: int) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_URL, stable_key))
 
 
-def _extract_repo_config_from_thread(thread: dict[str, Any]) -> dict[str, str] | None:
+def _extract_repo_config_from_thread(thread: ThreadLike) -> dict[str, str] | None:
     """Extract repo config from persisted thread data."""
+    thread = as_thread_dict(thread)
     metadata = thread.get("metadata")
     if not isinstance(metadata, dict):
         return None
@@ -697,10 +701,9 @@ async def upsert_agent_thread_owner_metadata(
             logger.exception("Failed to read thread %s for owner metadata", thread_id)
         existing = None
 
+    existing_dict = as_thread_dict(existing) if existing is not None else {}
     existing_meta = (
-        existing.get("metadata")
-        if isinstance(existing, dict) and isinstance(existing.get("metadata"), dict)
-        else {}
+        existing_dict["metadata"] if isinstance(existing_dict.get("metadata"), dict) else {}
     )
     if existing_meta.get("created_at_ms") is None:
         metadata["created_at_ms"] = now_ms

--- a/agent/webhooks/github.py
+++ b/agent/webhooks/github.py
@@ -805,18 +805,18 @@ async def process_github_review_finding_reply(payload: dict[str, Any]) -> None:
     comment = payload.get("comment", {})
     if not isinstance(comment, dict):
         return
-    reply_body = comment.get("body") if isinstance(comment.get("body"), str) else ""
+    raw_reply_body = comment.get("body")
+    reply_body = raw_reply_body if isinstance(raw_reply_body, str) else ""
     reply_author = sender_login if isinstance(sender_login, str) else "unknown"
     reply_comment_id = comment.get("id") if isinstance(comment.get("id"), int) else None
+    raw_created_at = comment.get("created_at")
     interaction: FindingInteraction = {
         "kind": "human_reply",
         "github_comment_id": reply_comment_id,
         "github_parent_comment_id": parent_comment_id,
         "author": reply_author,
         "body": reply_body,
-        "created_at": comment.get("created_at")
-        if isinstance(comment.get("created_at"), str)
-        else "",
+        "created_at": raw_created_at if isinstance(raw_created_at, str) else "",
         "needs_reassessment": True,
     }
     await common.append_finding_interaction(thread_id, finding_id, interaction)

--- a/agent/webhooks/linear.py
+++ b/agent/webhooks/linear.py
@@ -4,7 +4,7 @@ Helpers and constants stay in common.py; they are accessed through the module
 object (``common.X``) so tests that monkeypatch them keep working.
 """
 
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from langchain_core.messages.content import create_text_block
@@ -169,7 +169,7 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         ".changelog/README.md, and nearby docs before choosing the PR title/body format. "
         f"When you're done, commit and push your changes. {tag_instruction}"
     )
-    content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]
+    content_blocks: list[dict[str, Any]] = [cast(dict[str, Any], create_text_block(prompt))]
 
     # Resolve the GitHub login from the Linear email via the same user-mapping
     # store Slack uses, so PRs open *as the triggering user* and the thread is
@@ -198,7 +198,7 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
             for image_url in image_urls:
                 image_block = await common.fetch_image_block(image_url, client)
                 if image_block:
-                    content_blocks.append(image_block)
+                    content_blocks.append(cast(dict[str, Any], image_block))
         common.logger.info("Built %d content block(s) for prompt", len(content_blocks))
 
     linear_project_id = ""

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -7,11 +7,12 @@ object (``common.X``) so tests that monkeypatch them keep working.
 import asyncio
 import re
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from langchain_core.messages.content import create_text_block
 
+from agent.utils.json_types import as_json_object
 from agent.utils.langsmith import get_langsmith_trace_url
 
 from . import common
@@ -143,13 +144,15 @@ async def _dispatch_or_queue_slack_run(
     ):
         await common.queue_message_for_thread(thread_id, content_blocks)
         return None
-    return await common.dispatch_agent_run(
-        thread_id,
-        content_blocks,
-        configurable,
-        source="slack",
-        metadata=common._AGENT_VERSION_METADATA,
-        client=client,
+    return as_json_object(
+        await common.dispatch_agent_run(
+            thread_id,
+            content_blocks,
+            configurable,
+            source="slack",
+            metadata=common._AGENT_VERSION_METADATA,
+            client=client,
+        )
     )
 
 
@@ -439,7 +442,7 @@ async def _process_slack_mention_impl(
         "Use `slack_read_thread_messages` to read any Slack messages by providing channel_id "
         "and message_ts."
     )
-    content_blocks: list[dict[str, Any]] = [create_text_block(prompt)]
+    content_blocks: list[dict[str, Any]] = [cast(dict[str, Any], create_text_block(prompt))]
 
     image_urls = common.dedupe_urls(
         [url for msg in context_messages for url in common.extract_image_urls(msg.get("text", ""))]
@@ -477,7 +480,7 @@ async def _process_slack_mention_impl(
             for image_url in image_urls:
                 image_block = await common.fetch_image_block(image_url, http_client)
                 if image_block:
-                    content_blocks.append(image_block)
+                    content_blocks.append(cast(dict[str, Any], image_block))
 
     # Open SWE opens PRs as the triggering user, so a run only proceeds when we
     # have a valid user GitHub token. Users who have never signed in with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,7 @@ testpaths = ["tests"]
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+typeCheckingMode = "standard"
+include = ["agent", "tests"]
+exclude = ["**/node_modules", "**/__pycache__", ".venv", "ui", "**/.*"]
+reportMissingTypeStubs = false

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -97,6 +97,7 @@ async def test_agent_does_not_add_custom_repair_middleware() -> None:
 async def test_agent_keeps_message_queue_and_step_limit_middleware() -> None:
     captured = await _capture_create_deep_agent_kwargs()
     middleware = captured["middleware"]
+    assert isinstance(middleware, list)
     # The dashboard depends on check_message_queue_before_model; the step-limit
     # notifier must still fire when the lowered run budget is hit.
     present = {type(m).__name__ for m in middleware}

--- a/tests/agent/test_agent_thread_pr_state.py
+++ b/tests/agent/test_agent_thread_pr_state.py
@@ -61,8 +61,10 @@ async def test_update_agent_thread_pr_state_updates_matching_thread() -> None:
 
     fake_client.threads.search.assert_awaited_once()
     fake_client.threads.update.assert_awaited_once()
-    assert fake_client.threads.update.await_args.kwargs["thread_id"] == "t1"
-    assert fake_client.threads.update.await_args.kwargs["metadata"] == {"pr_state": "closed"}
+    call_args = fake_client.threads.update.await_args
+    assert call_args is not None
+    assert call_args.kwargs["thread_id"] == "t1"
+    assert call_args.kwargs["metadata"] == {"pr_state": "closed"}
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_multimodal.py
+++ b/tests/agent/test_multimodal.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import socket
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import httpx
@@ -148,7 +148,11 @@ class FakeImageResponse:
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
-            raise httpx.HTTPStatusError(f"{self.status_code} error", request=None, response=None)
+            raise httpx.HTTPStatusError(
+                f"{self.status_code} error",
+                request=httpx.Request("GET", self.url),
+                response=httpx.Response(self.status_code, request=httpx.Request("GET", self.url)),
+            )
 
 
 class FakeImageClient:
@@ -187,7 +191,9 @@ async def test_fetch_image_block_blocks_redirect_to_internal_url(monkeypatch: An
 
     client = FakeImageClient(responder)
 
-    result = await fetch_image_block("https://example.com/start.png", client)
+    result = await fetch_image_block(
+        "https://example.com/start.png", cast(httpx.AsyncClient, client)
+    )
 
     assert result is None
     assert len(client.calls) == 1
@@ -218,7 +224,9 @@ async def test_fetch_image_block_tries_each_validated_address(monkeypatch: Any) 
 
     client = FakeImageClient(responder)
 
-    result = await fetch_image_block("https://example.com/image.png", client)
+    result = await fetch_image_block(
+        "https://example.com/image.png", cast(httpx.AsyncClient, client)
+    )
 
     assert result == {"base64": "cG5n", "mime_type": "image/png"}
     assert [urlparse(call["url"]).hostname for call in client.calls] == [
@@ -251,7 +259,9 @@ async def test_fetch_image_block_does_not_forward_slack_auth_to_redirect_host(
 
     client = FakeImageClient(responder)
 
-    result = await fetch_image_block("https://files.slack.com/image.png", client)
+    result = await fetch_image_block(
+        "https://files.slack.com/image.png", cast(httpx.AsyncClient, client)
+    )
 
     assert result == {"base64": "cG5n", "mime_type": "image/png"}
     assert len(client.calls) == 2
@@ -283,7 +293,9 @@ async def test_fetch_image_block_does_not_add_slack_auth_after_untrusted_redirec
 
     client = FakeImageClient(responder)
 
-    result = await fetch_image_block("https://example.com/start.png", client)
+    result = await fetch_image_block(
+        "https://example.com/start.png", cast(httpx.AsyncClient, client)
+    )
 
     assert result == {"base64": "cG5n", "mime_type": "image/png"}
     assert len(client.calls) == 2
@@ -311,7 +323,9 @@ async def test_fetch_image_block_keeps_auth_within_slack_host_family(monkeypatch
 
     client = FakeImageClient(responder)
 
-    result = await fetch_image_block("https://files.slack.com/image.png", client)
+    result = await fetch_image_block(
+        "https://files.slack.com/image.png", cast(httpx.AsyncClient, client)
+    )
 
     assert result == {"base64": "cG5n", "mime_type": "image/png"}
     assert len(client.calls) == 2

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -183,6 +183,7 @@ async def test_enter_plan_mode_tool_returns_command() -> None:
         {"name": "enter_plan_mode", "args": {}, "id": "call-1", "type": "tool_call"}
     )
     assert isinstance(result, Command)
+    assert result.update is not None
     assert result.update["plan_mode"] is True
     messages = result.update["messages"]
     assert len(messages) == 1

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -418,7 +418,7 @@ def test_plan_mode_middleware_initial_always_filters() -> None:
 
     mw = PlanModeMiddleware(excluded=frozenset({"write_file"}), initial=True)
     req = _FakeReq([{"name": "read_file"}, {"name": "write_file"}], {})
-    assert _names(mw._filter(req)) == {"read_file"}
+    assert _names(cast(_FakeReq, mw._filter(cast(Any, req)))) == {"read_file"}
 
 
 def test_plan_mode_middleware_self_activation_via_state() -> None:
@@ -427,10 +427,10 @@ def test_plan_mode_middleware_self_activation_via_state() -> None:
     mw = PlanModeMiddleware(excluded=frozenset({"write_file"}), initial=False)
     # Plan mode not yet active: nothing filtered.
     off = _FakeReq([{"name": "read_file"}, {"name": "write_file"}], {})
-    assert _names(mw._filter(off)) == {"read_file", "write_file"}
+    assert _names(cast(_FakeReq, mw._filter(cast(Any, off)))) == {"read_file", "write_file"}
     # After enter_plan_mode sets state: the next request is filtered.
     on = _FakeReq([{"name": "read_file"}, {"name": "write_file"}], {"plan_mode": True})
-    assert _names(mw._filter(on)) == {"read_file"}
+    assert _names(cast(_FakeReq, mw._filter(cast(Any, on)))) == {"read_file"}
 
 
 # --- manual plan editing -------------------------------------------------

--- a/tests/agent/test_repo_prep.py
+++ b/tests/agent/test_repo_prep.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from deepagents.backends.protocol import ExecuteResponse
+from typing import cast
+
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
 from agent.utils.repo_prep import materialize_trusted_skills, prepare_review_repo
 
@@ -38,7 +40,7 @@ class _FakeSandboxBackend:
 async def test_prepare_review_repo_clones_and_checks_out_head() -> None:
     backend = _FakeSandboxBackend()
     ok = await prepare_review_repo(
-        backend,
+        cast(SandboxBackendProtocol, backend),
         work_dir="/work",
         repo_owner="acme",
         repo_name="widget",
@@ -62,7 +64,7 @@ async def test_prepare_review_repo_clones_and_checks_out_head() -> None:
 async def test_prepare_review_repo_skips_pull_ref_without_pr_number() -> None:
     backend = _FakeSandboxBackend()
     ok = await prepare_review_repo(
-        backend,
+        cast(SandboxBackendProtocol, backend),
         work_dir="/work",
         repo_owner="acme",
         repo_name="widget",
@@ -75,7 +77,7 @@ async def test_prepare_review_repo_skips_pull_ref_without_pr_number() -> None:
 async def test_prepare_review_repo_skips_checkout_without_head() -> None:
     backend = _FakeSandboxBackend()
     ok = await prepare_review_repo(
-        backend,
+        cast(SandboxBackendProtocol, backend),
         work_dir="/work",
         repo_owner="acme",
         repo_name="widget",
@@ -88,7 +90,11 @@ async def test_prepare_review_repo_skips_checkout_without_head() -> None:
 async def test_prepare_review_repo_requires_owner_and_name() -> None:
     backend = _FakeSandboxBackend()
     ok = await prepare_review_repo(
-        backend, work_dir="/work", repo_owner="", repo_name="widget", head_sha="abc"
+        cast(SandboxBackendProtocol, backend),
+        work_dir="/work",
+        repo_owner="",
+        repo_name="widget",
+        head_sha="abc",
     )
     assert ok is False
     assert backend.commands == []
@@ -97,7 +103,11 @@ async def test_prepare_review_repo_requires_owner_and_name() -> None:
 async def test_prepare_review_repo_returns_false_on_nonzero_exit() -> None:
     backend = _FakeSandboxBackend(exit_code=1)
     ok = await prepare_review_repo(
-        backend, work_dir="/work", repo_owner="acme", repo_name="widget", head_sha="abc"
+        cast(SandboxBackendProtocol, backend),
+        work_dir="/work",
+        repo_owner="acme",
+        repo_name="widget",
+        head_sha="abc",
     )
     assert ok is False
 
@@ -105,7 +115,11 @@ async def test_prepare_review_repo_returns_false_on_nonzero_exit() -> None:
 async def test_prepare_review_repo_returns_false_on_exception() -> None:
     backend = _FakeSandboxBackend(raise_exc=True)
     ok = await prepare_review_repo(
-        backend, work_dir="/work", repo_owner="acme", repo_name="widget", head_sha="abc"
+        cast(SandboxBackendProtocol, backend),
+        work_dir="/work",
+        repo_owner="acme",
+        repo_name="widget",
+        head_sha="abc",
     )
     assert ok is False
 
@@ -113,7 +127,7 @@ async def test_prepare_review_repo_returns_false_on_exception() -> None:
 async def test_materialize_trusted_skills_extracts_from_trusted_ref() -> None:
     backend = _FakeSandboxBackend(outputs=["/work/.review-skills/.agents/skills\n", ""])
     sources = await materialize_trusted_skills(
-        backend, repo_dir="/work/widget", trusted_ref="def456"
+        cast(SandboxBackendProtocol, backend), repo_dir="/work/widget", trusted_ref="def456"
     )
     assert sources == ["/work/.review-skills/.agents/skills/"]
     assert len(backend.commands) == 2
@@ -124,7 +138,9 @@ async def test_materialize_trusted_skills_extracts_from_trusted_ref() -> None:
 
 async def test_materialize_trusted_skills_empty_without_ref() -> None:
     backend = _FakeSandboxBackend()
-    sources = await materialize_trusted_skills(backend, repo_dir="/work/widget", trusted_ref="")
+    sources = await materialize_trusted_skills(
+        cast(SandboxBackendProtocol, backend), repo_dir="/work/widget", trusted_ref=""
+    )
     assert sources == []
     assert backend.commands == []
 
@@ -132,7 +148,7 @@ async def test_materialize_trusted_skills_empty_without_ref() -> None:
 async def test_materialize_trusted_skills_empty_when_none_exist() -> None:
     backend = _FakeSandboxBackend(output="")
     sources = await materialize_trusted_skills(
-        backend, repo_dir="/work/widget", trusted_ref="def456"
+        cast(SandboxBackendProtocol, backend), repo_dir="/work/widget", trusted_ref="def456"
     )
     assert sources == []
 
@@ -140,6 +156,6 @@ async def test_materialize_trusted_skills_empty_when_none_exist() -> None:
 async def test_materialize_trusted_skills_handles_exception() -> None:
     backend = _FakeSandboxBackend(raise_exc=True)
     sources = await materialize_trusted_skills(
-        backend, repo_dir="/work/widget", trusted_ref="def456"
+        cast(SandboxBackendProtocol, backend), repo_dir="/work/widget", trusted_ref="def456"
     )
     assert sources == []

--- a/tests/agent/test_timeout_wrapup.py
+++ b/tests/agent/test_timeout_wrapup.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 
 from agent.middleware.timeout_wrapup import TimeoutWrapupMiddleware
@@ -22,12 +25,19 @@ async def test_timeout_wrapup_starts_clock_lazily(monkeypatch: pytest.MonkeyPatc
         seen.append(request)
         return ModelResponse(result=[AIMessage(content="ok")])
 
-    request = ModelRequest(model=None, messages=[], system_message=SystemMessage(content="base"))
+    request = ModelRequest(
+        model=cast(BaseChatModel, object()),
+        messages=[],
+        system_message=SystemMessage(content="base"),
+    )
 
     await middleware.awrap_model_call(request, handler)
     await middleware.awrap_model_call(request, handler)
 
+    assert seen[0].system_message is not None
+    assert seen[1].system_message is not None
     assert seen[0].system_message.content == "base"
+    assert isinstance(seen[1].system_message.content, str)
     assert "time_limit_warning" in seen[1].system_message.content
 
 
@@ -36,7 +46,7 @@ async def test_timeout_wrapup_preserves_structured_system_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("agent.middleware.timeout_wrapup.time.monotonic", lambda: 100.0)
-    middleware = TimeoutWrapupMiddleware(timeout_seconds=0.1)
+    middleware = TimeoutWrapupMiddleware(timeout_seconds=1)
     middleware._start = 99.0
     seen: list[ModelRequest] = []
 
@@ -45,7 +55,7 @@ async def test_timeout_wrapup_preserves_structured_system_content(
         return ModelResponse(result=[AIMessage(content="ok")])
 
     request = ModelRequest(
-        model=None,
+        model=cast(BaseChatModel, object()),
         messages=[],
         system_message=SystemMessage(
             content=[{"type": "text", "text": "base", "cache_control": {"type": "ephemeral"}}]
@@ -54,7 +64,11 @@ async def test_timeout_wrapup_preserves_structured_system_content(
 
     await middleware.awrap_model_call(request, handler)
 
+    assert seen[0].system_message is not None
     content = seen[0].system_message.content
+    assert isinstance(content, list)
     assert content[0] == {"type": "text", "text": "base", "cache_control": {"type": "ephemeral"}}
-    assert content[1]["type"] == "text"
-    assert "time_limit_warning" in content[1]["text"]
+    warning_block = content[1]
+    assert isinstance(warning_block, dict)
+    assert warning_block["type"] == "text"
+    assert "time_limit_warning" in warning_block["text"]

--- a/tests/agent/test_workflow_push_guard.py
+++ b/tests/agent/test_workflow_push_guard.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from deepagents.backends.protocol import SandboxBackendProtocol
+from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import ToolMessage
 
 from agent.middleware import workflow_push_guard as guard
+from agent.utils.sandbox_state import SandboxBackendProxy
 
 
 class _Response:
@@ -182,7 +185,9 @@ def test_workflow_change_for_push_rejects_non_current_refspec() -> None:
 async def test_unapproved_workflow_push_blocks_and_posts_slack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    guard.SANDBOX_BACKENDS["thread-1"] = _Backend()
+    guard.SANDBOX_BACKENDS["thread-1"] = SandboxBackendProxy(
+        cast(SandboxBackendProtocol, _Backend()), thread_id="thread-1"
+    )
     posted: dict[str, Any] = {}
 
     async def fake_approved(thread_id: str, fingerprint: str) -> bool:
@@ -217,7 +222,9 @@ async def test_unapproved_workflow_push_blocks_and_posts_slack(
         called = True
         return ToolMessage(content="pushed", tool_call_id="call-1")
 
-    result = await guard.WorkflowPushGuardMiddleware().awrap_tool_call(_Request(), handler)
+    result = await guard.WorkflowPushGuardMiddleware().awrap_tool_call(
+        cast(ToolCallRequest, _Request()), handler
+    )
 
     assert called is False
     assert isinstance(result, ToolMessage)
@@ -238,7 +245,9 @@ async def test_unapproved_workflow_push_blocks_and_posts_slack(
 async def test_approved_workflow_push_runs_fixed_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    guard.SANDBOX_BACKENDS["thread-1"] = _Backend()
+    guard.SANDBOX_BACKENDS["thread-1"] = SandboxBackendProxy(
+        cast(SandboxBackendProtocol, _Backend()), thread_id="thread-1"
+    )
 
     async def fake_approved(thread_id: str, fingerprint: str) -> bool:
         return True
@@ -252,7 +261,9 @@ async def test_approved_workflow_push_runs_fixed_command(
         pushed_command = request.tool_call["args"]["command"]
         return ToolMessage(content="pushed", tool_call_id="call-1")
 
-    result = await guard.WorkflowPushGuardMiddleware().awrap_tool_call(_Request(), handler)
+    result = await guard.WorkflowPushGuardMiddleware().awrap_tool_call(
+        cast(ToolCallRequest, _Request()), handler
+    )
 
     assert isinstance(result, ToolMessage)
     assert result.content == "pushed"
@@ -263,7 +274,9 @@ async def test_approved_workflow_push_runs_fixed_command(
 
 
 async def test_non_workflow_push_runs_without_approval(monkeypatch: pytest.MonkeyPatch) -> None:
-    guard.SANDBOX_BACKENDS["thread-1"] = _Backend(workflow_files="")
+    guard.SANDBOX_BACKENDS["thread-1"] = SandboxBackendProxy(
+        cast(SandboxBackendProtocol, _Backend(workflow_files="")), thread_id="thread-1"
+    )
     called = False
 
     async def fail_approval(*args: Any, **kwargs: Any) -> bool:
@@ -276,7 +289,9 @@ async def test_non_workflow_push_runs_without_approval(monkeypatch: pytest.Monke
         called = True
         return ToolMessage(content="pushed", tool_call_id="call-1")
 
-    result = await guard.WorkflowPushGuardMiddleware().awrap_tool_call(_Request(), handler)
+    result = await guard.WorkflowPushGuardMiddleware().awrap_tool_call(
+        cast(ToolCallRequest, _Request()), handler
+    )
 
     assert called is True
     assert isinstance(result, ToolMessage)

--- a/tests/analyzer/test_analyzer_skills.py
+++ b/tests/analyzer/test_analyzer_skills.py
@@ -39,6 +39,7 @@ def test_bundled_skill_md_parse() -> None:
     for skill in ANALYZER_MODES.values():
         path = SKILLS_DIR / skill / "SKILL.md"
         meta = _parse_skill_metadata(path.read_text(), str(path), path.parent.name)
+        assert meta is not None
         assert meta["name"] == skill
         assert meta["description"].strip()
 

--- a/tests/dashboard/test_account_link.py
+++ b/tests/dashboard/test_account_link.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 import pytest
 
 from agent.webhooks import common as webhook_common
+
+
+class _Reply(TypedDict):
+    channel_id: str
+    thread_ts: str
+    text: str
 
 
 @pytest.fixture(autouse=True)
@@ -19,9 +27,9 @@ def test_account_link_prompt_posts_generic_token_free_link(
     import asyncio
 
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://app.example.com")
-    calls: dict[str, object] = {}
+    calls: dict[str, _Reply] = {}
 
-    async def fake_reply(channel_id, thread_ts, text):
+    async def fake_reply(channel_id: str, thread_ts: str, text: str) -> bool:
         calls["reply"] = {"channel_id": channel_id, "thread_ts": thread_ts, "text": text}
         return True
 
@@ -30,20 +38,21 @@ def test_account_link_prompt_posts_generic_token_free_link(
     asyncio.run(
         webhook_common._post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="unlinked")
     )
-    assert calls["reply"]["channel_id"] == "C1"
-    assert calls["reply"]["thread_ts"] == "1.1"
-    assert "https://app.example.com/my-settings" in calls["reply"]["text"]
+    reply = calls["reply"]
+    assert reply["channel_id"] == "C1"
+    assert reply["thread_ts"] == "1.1"
+    assert "https://app.example.com/my-settings" in reply["text"]
     # No signed account-link token may appear in the public thread.
-    assert "link=" not in calls["reply"]["text"]
+    assert "link=" not in reply["text"]
 
 
 def test_account_link_prompt_revoked_wording(monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://app.example.com")
-    calls: dict[str, object] = {}
+    calls: dict[str, str] = {}
 
-    async def fake_reply(channel_id, thread_ts, text):
+    async def fake_reply(channel_id: str, thread_ts: str, text: str) -> bool:
         calls["text"] = text
         return True
 
@@ -52,8 +61,9 @@ def test_account_link_prompt_revoked_wording(monkeypatch: pytest.MonkeyPatch) ->
     asyncio.run(
         webhook_common._post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="revoked")
     )
-    assert "no longer valid" in calls["text"]
-    assert "link=" not in calls["text"]
+    text = calls["text"]
+    assert "no longer valid" in text
+    assert "link=" not in text
 
 
 def test_account_link_prompt_skips_when_dashboard_url_unset(
@@ -64,7 +74,7 @@ def test_account_link_prompt_skips_when_dashboard_url_unset(
     monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
     posted = False
 
-    async def fake_reply(channel_id, thread_ts, text):
+    async def fake_reply(channel_id: str, thread_ts: str, text: str) -> bool:
         nonlocal posted
         posted = True
         return True

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -732,7 +733,8 @@ async def test_proxy_run_start_from_slack_thread_updates_trace_reply(monkeypatch
             }
 
         async def update(self, *, thread_id: str, metadata: dict[str, object]) -> None:
-            captured.setdefault("updates", []).append(metadata)
+            updates = cast(list[dict[str, object]], captured.setdefault("updates", []))
+            updates.append(metadata)
 
     class FakeClient:
         threads = FakeThreads()
@@ -1003,7 +1005,8 @@ async def test_send_dashboard_message_attributes_non_owner(monkeypatch) -> None:
         thread_api.ThreadMessageBody(content="ship it"),
     )
 
-    assert captured["payload"]["text"] == "@teammate: ship it"
+    payload = cast(dict[str, object], captured["payload"])
+    assert payload["text"] == "@teammate: ship it"
 
 
 async def test_send_dashboard_message_does_not_attribute_owner(monkeypatch) -> None:
@@ -1039,7 +1042,8 @@ async def test_send_dashboard_message_does_not_attribute_owner(monkeypatch) -> N
         thread_api.ThreadMessageBody(content="ship it"),
     )
 
-    assert captured["payload"]["text"] == "ship it"
+    payload = cast(dict[str, object], captured["payload"])
+    assert payload["text"] == "ship it"
 
 
 def test_thread_summary_exposes_resolved_state() -> None:
@@ -1287,7 +1291,7 @@ async def test_list_dashboard_threads_page_pages_beyond_first_search_batch(monke
     page_size = thread_api._THREADS_SEARCH_PAGE
     threads = _make_threads(page_size + 50, resolved_before=page_size)
     for thread in threads:
-        thread["metadata"]["latest_run_status"] = "success"
+        cast(dict[str, object], thread["metadata"])["latest_run_status"] = "success"
     offsets: list[int] = []
     run_list_calls = 0
 
@@ -1360,9 +1364,9 @@ async def test_list_dashboard_threads_sidebar_fills_buckets_with_one_endpoint(mo
 
 async def test_list_dashboard_threads_page_refreshes_only_unsettled_threads(monkeypatch) -> None:
     threads = _make_threads(3, resolved_before=0)
-    threads[0]["metadata"]["latest_run_status"] = "success"
-    threads[1]["metadata"]["latest_run_status"] = "pending"
-    threads[2]["metadata"]["latest_run_status"] = "error"
+    cast(dict[str, object], threads[0]["metadata"])["latest_run_status"] = "success"
+    cast(dict[str, object], threads[1]["metadata"])["latest_run_status"] = "pending"
+    cast(dict[str, object], threads[2]["metadata"])["latest_run_status"] = "error"
     run_list_thread_ids: list[str] = []
     updates: list[dict[str, object]] = []
 
@@ -1399,7 +1403,7 @@ async def test_list_dashboard_threads_page_refreshes_only_unsettled_threads(monk
 async def test_status_filter_refreshes_threads_missing_run_status(monkeypatch) -> None:
     threads = _make_threads(2, resolved_before=0)
     for thread in threads:
-        thread["metadata"]["source"] = "slack"
+        cast(dict[str, object], thread["metadata"])["source"] = "slack"
     run_statuses = {"t0": "success", "t1": "error"}
     run_list_thread_ids: list[str] = []
 

--- a/tests/dashboard/test_public_repo_org_gate.py
+++ b/tests/dashboard/test_public_repo_org_gate.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from typing import Any, cast
 
 import pytest
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from agent.api.app import app
 from agent.webhooks import common as webhook_common
@@ -21,16 +23,19 @@ def _sign_body(body: bytes, secret: str = _TEST_WEBHOOK_SECRET) -> str:
     return f"sha256={sig}"
 
 
-def _post_github_webhook(client: TestClient, event_type: str, payload: dict) -> object:
+def _post_github_webhook(client: TestClient, event_type: str, payload: dict[str, Any]) -> Response:
     body = json.dumps(payload, separators=(",", ":")).encode()
-    return client.post(
-        "/webhooks/github",
-        content=body,
-        headers={
-            "X-GitHub-Event": event_type,
-            "X-Hub-Signature-256": _sign_body(body),
-            "Content-Type": "application/json",
-        },
+    return cast(
+        Response,
+        client.post(
+            "/webhooks/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": event_type,
+                "X-Hub-Signature-256": _sign_body(body),
+                "Content-Type": "application/json",
+            },
+        ),
     )
 
 

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -362,7 +362,9 @@ async def mock_users() -> JSONResponse:
 
 @app.get("/mock/slack/messages")
 async def slack_messages() -> JSONResponse:
-    msgs = fakes.slack_messages(CURRENT_THREAD["channel"])
+    channel = CURRENT_THREAD["channel"]
+    assert channel is not None
+    msgs = fakes.slack_messages(channel)
     return JSONResponse(
         [
             {

--- a/tests/e2e/patches.py
+++ b/tests/e2e/patches.py
@@ -61,10 +61,10 @@ def apply() -> None:
         return "dummy-installation-token"
 
     auth.get_github_app_installation_token_with_expiry = _dummy_install_token_with_expiry
-    opr.get_github_app_installation_token = _dummy_install_token
+    opr.__dict__["get_github_app_installation_token"] = _dummy_install_token
 
     # Point the real PR/Slack code at the in-process fakes.
-    opr.GITHUB_API = FAKE_GITHUB_API
+    opr.__dict__["GITHUB_API"] = FAKE_GITHUB_API
     slack_utils.SLACK_API_BASE_URL = FAKE_SLACK_API
 
     # Keep the triggering-user identity lookup offline; the real fallback to

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage
+from langchain_core.language_models.base import LangSmithParams
+from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
 from agent.dashboard.agent_overrides import profile_create_prs
@@ -29,14 +31,20 @@ class _CaptureRequestModel(BaseChatModel):
     def _llm_type(self) -> str:
         return "capture-request"
 
-    def _get_ls_params(self, *args: Any, **kwargs: Any) -> dict[str, str]:
-        return {"ls_provider": "openai"}
+    def _get_ls_params(self, stop: list[str] | None = None, **kwargs: Any) -> LangSmithParams:
+        return LangSmithParams(ls_provider="openai")
 
     def bind_tools(self, tools: Any, **kwargs: Any) -> _CaptureRequestModel:
         self.captured_tools = tools
         return self
 
-    def _generate(self, messages: list[Any], **kwargs: Any) -> ChatResult:
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
         self.captured_messages = messages
         return ChatResult(generations=[ChatGeneration(message=AIMessage(content="done"))])
 
@@ -164,6 +172,7 @@ def test_harness_profile_replaces_deepagents_base_for_supported_providers() -> N
         assert HARNESS_EXCLUDED_TOOLS <= profile.excluded_tools
         assert HARNESS_EXCLUDED_MIDDLEWARE <= profile.excluded_middleware
     resolved_profile = hp._get_harness_profile("openai:gpt-5.6-sol")
+    assert resolved_profile is not None
     assert "write_todos" in resolved_profile.excluded_tools
     assert HARNESS_EXCLUDED_MIDDLEWARE <= resolved_profile.excluded_middleware
 

--- a/tests/github/test_github_feedback.py
+++ b/tests/github/test_github_feedback.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from fastapi import BackgroundTasks, Request
 
 from agent.utils import github_feedback
 from agent.utils.github_feedback import (
@@ -179,7 +180,9 @@ async def test_github_webhook_ignores_reaction_event(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(webhook_common, "verify_github_signature", lambda *args, **kwargs: True)
 
-    response = await github_routes.github_webhook(_FakeRequest(payload), background_tasks)
+    response = await github_routes.github_webhook(
+        cast(Request, _FakeRequest(payload)), cast(BackgroundTasks, background_tasks)
+    )
 
     assert response == {"status": "ignored", "reason": "Unsupported event type: reaction"}
     assert background_tasks.tasks == []

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -6,8 +6,10 @@ import hmac
 import importlib
 import json
 import logging
+from typing import cast
 
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from agent.api.app import app
 from agent.tools import request_pr_review as request_pr_review_tool
@@ -29,7 +31,9 @@ def _sign_body(body: bytes, secret: str = _TEST_WEBHOOK_SECRET) -> str:
     return f"sha256={sig}"
 
 
-def _post_github_webhook(client: TestClient, event_type: str, payload: dict) -> object:
+def _post_github_webhook(
+    client: TestClient, event_type: str, payload: dict[object, object]
+) -> Response:
     """Send a signed GitHub webhook POST request."""
     body = json.dumps(payload, separators=(",", ":")).encode()
     return client.post(
@@ -49,7 +53,7 @@ def _sign_slack_body(body: bytes, timestamp: str = "1700000000") -> str:
     return f"v0={sig}"
 
 
-def _post_slack_webhook(client: TestClient, payload: dict) -> object:
+def _post_slack_webhook(client: TestClient, payload: dict[object, object]) -> Response:
     body = json.dumps(payload, separators=(",", ":")).encode()
     timestamp = "1700000000"
     return client.post(
@@ -991,7 +995,8 @@ def test_slack_webhook_accepts_unmentioned_ready_plan_reply(monkeypatch) -> None
     assert response.status_code == 200
     assert response.json()["message"] == "Slack mention queued"
     assert captured["plan_reply_check"] == ("C123", "1700000000.000100", "U123")
-    assert captured["event_data"]["text"] == "looks good, go ahead"
+    event_data = cast(dict[str, object], captured["event_data"])
+    assert event_data["text"] == "looks good, go ahead"
 
 
 def test_slack_webhook_ignores_unmentioned_non_plan_reply(monkeypatch) -> None:
@@ -1093,9 +1098,10 @@ def test_process_github_pr_ready_creates_reviewer_run(monkeypatch) -> None:
         )
     )
 
-    kwargs = captured["kwargs"]
-    prompt = kwargs["input"]["messages"][0]["content"]
-    config = kwargs["config"]["configurable"]
+    kwargs = cast(dict[str, object], captured["kwargs"])
+    input_data = cast(dict[str, object], kwargs["input"])
+    prompt = cast(list[dict[str, str]], input_data["messages"])[0]["content"]
+    config = cast(dict[str, object], cast(dict[str, object], kwargs["config"])["configurable"])
 
     assert captured["graph"] == "reviewer"
     assert captured["thread_create_kwargs"] == {
@@ -1199,9 +1205,10 @@ def test_trigger_pr_review_from_ref_creates_reviewer_run(monkeypatch) -> None:
         )
     )
 
-    kwargs = captured["kwargs"]
-    prompt = kwargs["input"]["messages"][0]["content"]
-    config = kwargs["config"]["configurable"]
+    kwargs = cast(dict[str, object], captured["kwargs"])
+    input_data = cast(dict[str, object], kwargs["input"])
+    prompt = cast(list[dict[str, str]], input_data["messages"])[0]["content"]
+    config = cast(dict[str, object], cast(dict[str, object], kwargs["config"])["configurable"])
     assert result["success"] is True
     assert auto_review_checked is False
     assert captured["graph"] == "reviewer"
@@ -1222,9 +1229,11 @@ def test_trigger_pr_review_from_ref_creates_reviewer_run(monkeypatch) -> None:
     }
     # The live head must be persisted to metadata so resolve_review_head_sha
     # doesn't return a stale head left by a prior push/ready dispatch.
-    assert captured["set_metadata_kwargs"]["head_sha"] == "head-sha"
+    metadata_kwargs = cast(dict[str, object], captured["set_metadata_kwargs"])
+    assert metadata_kwargs["head_sha"] == "head-sha"
     # A live status comment is posted on dispatch so the PR shows "reviewing".
-    assert captured["status_comment_kwargs"]["pr_number"] == 1244
+    status_comment_kwargs = cast(dict[str, object], captured["status_comment_kwargs"])
+    assert status_comment_kwargs["pr_number"] == 1244
 
 
 async def test_request_pr_review_tool_uses_shared_trigger(monkeypatch) -> None:
@@ -1489,7 +1498,8 @@ def test_process_github_issue_existing_thread_uses_followup_prompt(monkeypatch) 
     )
 
     assert captured["prompt"] == "**octocat:**\n@openswe please handle this"
-    assert "## Repository" not in captured["prompt"]
+    prompt = cast(str, captured["prompt"])
+    assert "## Repository" not in prompt
 
 
 def test_github_webhook_routes_pr_comment_review_to_agent(monkeypatch) -> None:

--- a/tests/github/test_github_proxy_refresh.py
+++ b/tests/github/test_github_proxy_refresh.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware import AgentState
 
 from agent.utils import github_proxy
 from agent.utils.github_proxy import (
@@ -18,7 +21,7 @@ from agent.utils.github_proxy import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_state() -> None:
+def _clear_state() -> Generator[None, None, None]:
     github_proxy._PROXY_TOKEN_EXPIRY.clear()
     yield
     github_proxy._PROXY_TOKEN_EXPIRY.clear()
@@ -49,7 +52,7 @@ class TestProxyTokenNeedsRefresh:
     def test_fallback_ttl_when_expiry_unknown(self) -> None:
         now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
         record_proxy_token_expiry("thread-1", None)
-        github_proxy._PROXY_TOKEN_EXPIRY["thread-1"] = (None, now, None)
+        github_proxy._PROXY_TOKEN_EXPIRY["thread-1"] = (None, now, None, ())
         assert proxy_token_needs_refresh("thread-1", now=now) is False
         later = now + PROXY_TOKEN_FALLBACK_TTL
         assert proxy_token_needs_refresh("thread-1", now=later) is True
@@ -175,7 +178,9 @@ class TestRefreshGithubProxyMiddleware:
                 new=AsyncMock(return_value=True),
             ) as mock_refresh,
         ):
-            result = await refresh_github_proxy_before_model.abefore_model({}, MagicMock())
+            result = await refresh_github_proxy_before_model.abefore_model(
+                cast(AgentState, {}), MagicMock()
+            )
 
         assert result is None
         mock_refresh.assert_awaited_once_with("thread-9")
@@ -194,7 +199,9 @@ class TestRefreshGithubProxyMiddleware:
                 new=AsyncMock(),
             ) as mock_refresh,
         ):
-            result = await refresh_github_proxy_before_model.abefore_model({}, MagicMock())
+            result = await refresh_github_proxy_before_model.abefore_model(
+                cast(AgentState, {}), MagicMock()
+            )
 
         assert result is None
         mock_refresh.assert_not_called()
@@ -213,6 +220,8 @@ class TestRefreshGithubProxyMiddleware:
                 new=AsyncMock(side_effect=RuntimeError("boom")),
             ),
         ):
-            result = await refresh_github_proxy_before_model.abefore_model({}, MagicMock())
+            result = await refresh_github_proxy_before_model.abefore_model(
+                cast(AgentState, {}), MagicMock()
+            )
 
         assert result is None

--- a/tests/github/test_pr_creation_guard.py
+++ b/tests/github/test_pr_creation_guard.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 
+from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import ToolMessage
 
 from agent.middleware.pr_creation_guard import (
@@ -55,7 +56,7 @@ async def test_middleware_blocks_execute_pr_creation_fallbacks() -> None:
         "curl -X POST https://api.github.com/repos/langchain-ai/open-swe/pulls -d '{}'",
     ):
         result = await PullRequestCreationGuardMiddleware().awrap_tool_call(
-            _Request(command), _handler
+            cast(ToolCallRequest, _Request(command)), _handler
         )
 
         assert isinstance(result, ToolMessage)
@@ -69,7 +70,7 @@ async def test_middleware_blocks_execute_pr_creation_fallbacks() -> None:
 
 async def test_middleware_allows_safe_pr_view() -> None:
     result = await PullRequestCreationGuardMiddleware().awrap_tool_call(
-        _Request("GH_TOKEN=dummy gh pr view 1 --json url"), _handler
+        cast(ToolCallRequest, _Request("GH_TOKEN=dummy gh pr view 1 --json url")), _handler
     )
 
     assert isinstance(result, ToolMessage)

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from agent.middleware.check_message_queue import (
     DASHBOARD_HANDOFF_MARKER,
+    LinearNotifyState,
     _build_blocks_from_payload,
     check_message_queue_before_model,
 )
@@ -49,7 +50,9 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         ),
         patch("agent.middleware.check_message_queue.get_store", return_value=store),
     ):
-        result = await check_message_queue_before_model.abefore_model({}, MagicMock())
+        result = await check_message_queue_before_model.abefore_model(
+            cast(LinearNotifyState, {"messages": []}), MagicMock()
+        )
 
     assert result is not None
     message = result["messages"][0]
@@ -77,7 +80,9 @@ async def test_check_message_queue_injects_pending_autofix_event() -> None:
         ),
         patch("agent.middleware.check_message_queue.get_store", return_value=store),
     ):
-        result = await check_message_queue_before_model.abefore_model({}, MagicMock())
+        result = await check_message_queue_before_model.abefore_model(
+            cast(LinearNotifyState, {"messages": []}), MagicMock()
+        )
 
     assert result is not None
     message = result["messages"][0]

--- a/tests/middleware/test_ensure_no_empty_msg.py
+++ b/tests/middleware/test_ensure_no_empty_msg.py
@@ -1,6 +1,8 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain.agents.middleware import AgentState
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 
 from agent.middleware.check_message_queue import DASHBOARD_HANDOFF_INSTRUCTION
 from agent.middleware.ensure_no_empty_msg import (
@@ -13,7 +15,7 @@ from agent.middleware.ensure_no_empty_msg import (
 
 class TestGetEveryMessageSinceLastHuman:
     def test_returns_messages_after_last_human(self) -> None:
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="first human"),
                 AIMessage(content="ai response"),
@@ -28,7 +30,7 @@ class TestGetEveryMessageSinceLastHuman:
         assert result[0].content == "final ai"
 
     def test_returns_all_messages_when_no_human(self) -> None:
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 AIMessage(content="ai 1"),
                 AIMessage(content="ai 2"),
@@ -42,7 +44,7 @@ class TestGetEveryMessageSinceLastHuman:
         assert result[1].content == "ai 2"
 
     def test_returns_empty_when_human_is_last(self) -> None:
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 AIMessage(content="ai response"),
                 HumanMessage(content="human last"),
@@ -54,7 +56,7 @@ class TestGetEveryMessageSinceLastHuman:
         assert len(result) == 0
 
     def test_returns_multiple_messages_after_human(self) -> None:
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="human"),
                 AIMessage(content="ai 1"),
@@ -73,21 +75,21 @@ class TestGetEveryMessageSinceLastHuman:
 
 class TestCheckIfModelMessagedUser:
     def test_returns_true_for_slack_thread_reply(self) -> None:
-        messages = [
+        messages: list[AnyMessage] = [
             ToolMessage(content="sent", tool_call_id="123", name="slack_thread_reply"),
         ]
 
         assert check_if_model_messaged_user(messages) is True
 
     def test_returns_true_for_linear_comment(self) -> None:
-        messages = [
+        messages: list[AnyMessage] = [
             ToolMessage(content="commented", tool_call_id="123", name="linear_comment"),
         ]
 
         assert check_if_model_messaged_user(messages) is True
 
     def test_returns_false_for_other_tools(self) -> None:
-        messages = [
+        messages: list[AnyMessage] = [
             ToolMessage(content="result", tool_call_id="123", name="bash"),
             ToolMessage(content="result", tool_call_id="456", name="read_file"),
         ]
@@ -100,14 +102,14 @@ class TestCheckIfModelMessagedUser:
 
 class TestCheckIfConfirmingCompletion:
     def test_returns_true_when_confirming_completion_called(self) -> None:
-        messages = [
+        messages: list[AnyMessage] = [
             ToolMessage(content="confirmed", tool_call_id="123", name="confirming_completion"),
         ]
 
         assert check_if_confirming_completion(messages) is True
 
     def test_returns_false_for_other_tools(self) -> None:
-        messages = [
+        messages: list[AnyMessage] = [
             ToolMessage(content="result", tool_call_id="123", name="bash"),
         ]
 
@@ -133,7 +135,7 @@ class TestEnsureNoEmptyMsgNotify:
 
     def test_returns_none_when_user_messaged(self) -> None:
         empty_ai = AIMessage(content="")
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="fix the bug"),
                 ToolMessage(content="message sent", tool_call_id="1", name="slack_thread_reply"),
@@ -147,7 +149,7 @@ class TestEnsureNoEmptyMsgNotify:
 
     def test_returns_none_with_linear_comment(self) -> None:
         empty_ai = AIMessage(content="")
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="fix the bug"),
                 ToolMessage(content="commented", tool_call_id="1", name="linear_comment"),
@@ -161,7 +163,7 @@ class TestEnsureNoEmptyMsgNotify:
 
     def test_injects_no_op_when_user_not_messaged(self) -> None:
         empty_ai = AIMessage(content="")
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="fix the bug"),
                 ToolMessage(content="result", tool_call_id="1", name="bash"),
@@ -177,7 +179,7 @@ class TestEnsureNoEmptyMsgNotify:
 
     def test_returns_none_when_only_user_messaged(self) -> None:
         empty_ai = AIMessage(content="")
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="fix the bug"),
                 ToolMessage(content="message sent", tool_call_id="1", name="slack_thread_reply"),
@@ -191,7 +193,7 @@ class TestEnsureNoEmptyMsgNotify:
 
     def test_skips_confirming_completion_for_dashboard_source(self) -> None:
         ai = AIMessage(content="Hi! How can I help?")
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(content="hello"),
                 ai,
@@ -209,7 +211,7 @@ class TestEnsureNoEmptyMsgNotify:
 
     def test_skips_confirming_completion_for_dashboard_handoff(self) -> None:
         ai = AIMessage(content="Done in web.")
-        state = {
+        state: AgentState[Any] = {
             "messages": [
                 HumanMessage(
                     content=[

--- a/tests/middleware/test_model_fallback_middleware.py
+++ b/tests/middleware/test_model_fallback_middleware.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import anthropic
 import httpx
 import openai
 import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage
 
 from agent.middleware.model_fallback import (
@@ -48,10 +50,10 @@ def _anthropic_model_not_available_error() -> anthropic.BadRequestError:
     return anthropic.BadRequestError("model unavailable", response=response, body=body)
 
 
-def _make_request() -> MagicMock:
+def _make_request() -> ModelRequest[None]:
     request = MagicMock()
     request.override = MagicMock(return_value=MagicMock(name="overridden_request"))
-    return request
+    return cast(ModelRequest[None], request)
 
 
 class TestShouldFallback:
@@ -92,19 +94,20 @@ class TestModelFallbackMiddleware:
         calls: list[object] = []
         good_response = MagicMock(result=[AIMessage(content="ok from fallback")])
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             calls.append(req)
             if len(calls) == 1:
                 raise _anthropic_overloaded()
-            return good_response
+            return cast(ModelResponse[Any], good_response)
 
         request = _make_request()
         result = await middleware.awrap_model_call(request, handler)
 
         assert result is good_response
         assert len(calls) == 2
-        request.override.assert_called_once_with(model=fallback_model)
-        assert calls[1] is request.override.return_value
+        override = cast(MagicMock, request.override)
+        override.assert_called_once_with(model=fallback_model)
+        assert calls[1] is override.return_value
 
     @pytest.mark.asyncio
     async def test_async_falls_over_on_stream_transport_error(self) -> None:
@@ -114,29 +117,30 @@ class TestModelFallbackMiddleware:
         calls: list[object] = []
         good_response = MagicMock(result=[AIMessage(content="ok from fallback")])
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             calls.append(req)
             if len(calls) == 1:
                 raise httpx.RemoteProtocolError(
                     "peer closed connection without sending complete message body "
                     "(incomplete chunked read)"
                 )
-            return good_response
+            return cast(ModelResponse[Any], good_response)
 
         request = _make_request()
         result = await middleware.awrap_model_call(request, handler)
 
         assert result is good_response
         assert len(calls) == 2
-        request.override.assert_called_once_with(model=fallback_model)
-        assert calls[1] is request.override.return_value
+        override = cast(MagicMock, request.override)
+        override.assert_called_once_with(model=fallback_model)
+        assert calls[1] is override.return_value
 
     @pytest.mark.asyncio
     async def test_async_propagates_non_transient_error(self) -> None:
         middleware = ModelFallbackMiddleware(MagicMock())
         calls: list[object] = []
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             calls.append(req)
             raise ValueError("not transient")
 
@@ -149,7 +153,7 @@ class TestModelFallbackMiddleware:
     async def test_async_surfaces_model_unavailable_error(self) -> None:
         middleware = ModelFallbackMiddleware(MagicMock())
 
-        async def handler(_req: object) -> object:
+        async def handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
             raise _anthropic_model_not_available_error()
 
         result = await middleware.awrap_model_call(_make_request(), handler)
@@ -166,11 +170,11 @@ class TestModelFallbackMiddleware:
         calls: list[object] = []
         good_response = MagicMock(result=[AIMessage(content="ok from primary retry")])
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             calls.append(req)
             if len(calls) <= 2:  # primary fails, then fallback fails
                 raise _openai_5xx()
-            return good_response
+            return cast(ModelResponse[Any], good_response)
 
         request = _make_request()
         result = await middleware.awrap_model_call(request, handler)
@@ -179,7 +183,7 @@ class TestModelFallbackMiddleware:
         assert len(calls) == 3
         # Attempts alternate primary -> fallback -> primary.
         assert calls[0] is request
-        assert calls[1] is request.override.return_value
+        assert calls[1] is cast(MagicMock, request.override).return_value
         assert calls[2] is request
 
     @pytest.mark.asyncio
@@ -188,7 +192,7 @@ class TestModelFallbackMiddleware:
         middleware = ModelFallbackMiddleware(MagicMock(), backoff_schedule=(0.0, 0.0))
         calls: list[object] = []
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             calls.append(req)
             raise _openai_5xx()
 
@@ -205,7 +209,7 @@ class TestModelFallbackMiddleware:
         )
         calls: list[object] = []
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             calls.append(req)
             raise _openai_5xx()
 

--- a/tests/middleware/test_notify_step_limit_middleware.py
+++ b/tests/middleware/test_notify_step_limit_middleware.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware import AgentState
 from langchain_core.messages import AIMessage, HumanMessage
 
 from agent.middleware.notify_step_limit import notify_step_limit_reached
@@ -12,7 +13,9 @@ class TestNotifyStepLimitReached:
 
     @pytest.mark.asyncio
     async def test_posts_slack_reply_when_limit_marker_present(self) -> None:
-        state = {"messages": [AIMessage(content="Model call limits exceeded: run limit reached")]}
+        state: AgentState = {
+            "messages": [AIMessage(content="Model call limits exceeded: run limit reached")]
+        }
 
         with (
             patch(
@@ -30,12 +33,14 @@ class TestNotifyStepLimitReached:
 
         assert result is None
         mock_post.assert_awaited_once()
-        assert mock_post.await_args.args[0:2] == ("C123", "171.123")
-        assert "maximum step limit" in mock_post.await_args.args[2]
+        call_args = mock_post.await_args
+        assert call_args is not None
+        assert call_args.args[0:2] == ("C123", "171.123")
+        assert "maximum step limit" in call_args.args[2]
 
     @pytest.mark.asyncio
     async def test_posts_slack_reply_for_list_content_with_limit_marker(self) -> None:
-        state = {
+        state: AgentState = {
             "messages": [
                 AIMessage(
                     content=[
@@ -65,7 +70,7 @@ class TestNotifyStepLimitReached:
 
     @pytest.mark.asyncio
     async def test_skips_when_limit_marker_absent(self) -> None:
-        state = {"messages": [HumanMessage(content="keep going")]}
+        state: AgentState = {"messages": [HumanMessage(content="keep going")]}
 
         with patch(
             "agent.middleware.notify_step_limit.post_slack_thread_reply",
@@ -78,7 +83,9 @@ class TestNotifyStepLimitReached:
 
     @pytest.mark.asyncio
     async def test_skips_when_slack_thread_config_missing(self) -> None:
-        state = {"messages": [AIMessage(content="Model call limits exceeded: run limit reached")]}
+        state: AgentState = {
+            "messages": [AIMessage(content="Model call limits exceeded: run limit reached")]
+        }
 
         with (
             patch(

--- a/tests/middleware/test_prepare_run_middleware.py
+++ b/tests/middleware/test_prepare_run_middleware.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents.middleware import AgentState
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import HumanMessage
+from langgraph.runtime import Runtime
 
 from agent.middleware.prepare_run import BasePrepareRunMiddleware
 from agent.utils import ttl_cache
@@ -22,7 +27,10 @@ class DummyPrepareMiddleware(BasePrepareRunMiddleware):
 async def test_prepare_latch_skips_second_call():
     middleware = DummyPrepareMiddleware()
 
-    update = await middleware.abefore_agent({}, None)
+    update = await middleware.abefore_agent(
+        cast(AgentState, {"messages": []}), cast(Runtime[None], MagicMock())
+    )
+    assert update is not None
     fingerprint = update.pop("run_prepared_for")
     assert isinstance(fingerprint, str)
     assert update == {
@@ -32,7 +40,10 @@ async def test_prepare_latch_skips_second_call():
     }
     assert (
         await middleware.abefore_agent(
-            {"run_prepared": True, "run_prepared_for": fingerprint}, None
+            cast(
+                AgentState, {"messages": [], "run_prepared": True, "run_prepared_for": fingerprint}
+            ),
+            cast(Runtime[None], MagicMock()),
         )
         is None
     )
@@ -43,7 +54,10 @@ async def test_prepare_latch_skips_second_call():
 async def test_prepare_latch_reruns_when_fingerprint_changes():
     middleware = DummyPrepareMiddleware()
 
-    assert await middleware.abefore_agent({"run_prepared": True, "run_prepared_for": "stale"}, None)
+    assert await middleware.abefore_agent(
+        cast(AgentState, {"messages": [], "run_prepared": True, "run_prepared_for": "stale"}),
+        cast(Runtime[None], MagicMock()),
+    )
     assert middleware.calls == 1
 
 
@@ -52,9 +66,9 @@ async def test_prepare_prompt_injection():
     middleware = DummyPrepareMiddleware()
     seen = {}
 
-    async def handler(request):
+    async def handler(request: ModelRequest[None]) -> ModelResponse[Any]:
         seen["system_prompt"] = request.system_prompt
-        return None
+        return cast(ModelResponse[Any], MagicMock())
 
     request = type(
         "Request",
@@ -76,7 +90,7 @@ async def test_prepare_prompt_injection():
             )(),
         },
     )()
-    await middleware.awrap_model_call(request, handler)
+    await middleware.awrap_model_call(cast(ModelRequest[None], request), handler)
     assert seen["system_prompt"] == "prepared prompt"
 
 

--- a/tests/middleware/test_repair_orphaned_tool_calls.py
+++ b/tests/middleware/test_repair_orphaned_tool_calls.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from agent.middleware.repair_orphaned_tool_calls import (
@@ -12,11 +14,11 @@ from agent.middleware.repair_orphaned_tool_calls import (
 )
 
 
-def _make_request(messages: list[object]) -> MagicMock:
+def _make_request(messages: list[object]) -> ModelRequest[None]:
     request = MagicMock()
     request.model = MagicMock()
     request.messages = messages
-    return request
+    return cast(ModelRequest[None], request)
 
 
 def _ai_with_tool_call(call_id: str, name: str = "execute") -> AIMessage:
@@ -26,8 +28,8 @@ def _ai_with_tool_call(call_id: str, name: str = "execute") -> AIMessage:
     )
 
 
-async def _noop_handler(_req: object) -> object:
-    return MagicMock()
+async def _noop_handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
+    return cast(ModelResponse[Any], MagicMock())
 
 
 class TestRepairOrphanedToolCallsMiddleware:
@@ -38,8 +40,8 @@ class TestRepairOrphanedToolCallsMiddleware:
         request = _make_request([HumanMessage(content="hi"), ai, follow_up])
         response = MagicMock()
 
-        async def handler(_req: object) -> object:
-            return response
+        async def handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
+            return cast(ModelResponse[Any], response)
 
         result = await RepairOrphanedToolCallsMiddleware().awrap_model_call(request, handler)
 
@@ -51,6 +53,7 @@ class TestRepairOrphanedToolCallsMiddleware:
         assert synthetic.tool_call_id == "call_1"
         assert synthetic.status == "error"
         assert messages[3] is follow_up
+        assert isinstance(synthetic.content, str)
         payload = json.loads(synthetic.content)
         assert payload["recovery"] == INTERRUPTED_TOOL_RECOVERY
         assert payload["name"] == "execute"
@@ -109,9 +112,9 @@ class TestRepairOrphanedToolCallsMiddleware:
         request = _make_request([ai, HumanMessage(content="hi")])
         response = MagicMock()
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             assert req is request
-            return response
+            return cast(ModelResponse[Any], response)
 
         result = await RepairOrphanedToolCallsMiddleware().awrap_model_call(request, handler)
 

--- a/tests/middleware/test_sanitize_fireworks_messages.py
+++ b/tests/middleware/test_sanitize_fireworks_messages.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from agent.middleware.sanitize_fireworks_messages import SanitizeFireworksMessagesMiddleware
 
 
-def _make_request(messages: list[object], model: object | None = None) -> MagicMock:
+def _make_request(messages: list[object], model: object | None = None) -> ModelRequest[None]:
     request = MagicMock()
     request.model = model
     request.messages = messages
-    return request
+    return cast(ModelRequest[None], request)
 
 
 def _fireworks_model() -> MagicMock:
@@ -24,8 +26,8 @@ def _fireworks_model() -> MagicMock:
     return MagicMock(spec=ChatFireworks)
 
 
-async def _noop_handler(_req: object) -> object:
-    return MagicMock()
+async def _noop_handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
+    return cast(ModelResponse[Any], MagicMock())
 
 
 class TestSanitizeFireworksMessagesMiddleware:
@@ -43,9 +45,9 @@ class TestSanitizeFireworksMessagesMiddleware:
         )
         response = MagicMock()
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             assert req is request
-            return response
+            return cast(ModelResponse[Any], response)
 
         result = await SanitizeFireworksMessagesMiddleware().awrap_model_call(request, handler)
 

--- a/tests/middleware/test_sanitize_thinking_blocks.py
+++ b/tests/middleware/test_sanitize_thinking_blocks.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage, HumanMessage
 
 from agent.middleware.sanitize_thinking_blocks import SanitizeThinkingBlocksMiddleware
 
 
-def _make_request(messages: list[object], model: object | None = None) -> MagicMock:
+def _make_request(messages: list[object], model: object | None = None) -> ModelRequest[None]:
     request = MagicMock()
     request.model = model or MagicMock(spec=ChatAnthropic)
     request.messages = messages
-    return request
+    return cast(ModelRequest[None], request)
 
 
-async def _noop_handler(_req: object) -> object:
-    return MagicMock()
+async def _noop_handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
+    return cast(ModelResponse[Any], MagicMock())
 
 
 class TestSanitizeThinkingBlocksMiddleware:
@@ -32,9 +34,9 @@ class TestSanitizeThinkingBlocksMiddleware:
         request = _make_request([message])
         response = MagicMock()
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             assert req is request
-            return response
+            return cast(ModelResponse[Any], response)
 
         result = await SanitizeThinkingBlocksMiddleware().awrap_model_call(request, handler)
 
@@ -63,9 +65,9 @@ class TestSanitizeThinkingBlocksMiddleware:
         request = _make_request([HumanMessage(content="hi"), message])
         response = MagicMock()
 
-        async def handler(req: object) -> object:
+        async def handler(req: ModelRequest[None]) -> ModelResponse[Any]:
             assert req is request
-            return response
+            return cast(ModelResponse[Any], response)
 
         result = await SanitizeThinkingBlocksMiddleware().awrap_model_call(request, handler)
 

--- a/tests/middleware/test_subdir_agents_middleware.py
+++ b/tests/middleware/test_subdir_agents_middleware.py
@@ -46,6 +46,11 @@ def _ok(name: str, content: str = "file content") -> ToolMessage:
     return ToolMessage(content=content, tool_call_id="call-1", status="success", name=name)
 
 
+def _tool_result(result: object) -> ToolMessage:
+    assert isinstance(result, ToolMessage)
+    return result
+
+
 @pytest.fixture
 def register_backend():
     registered: list[str] = []
@@ -73,7 +78,7 @@ async def test_read_file_appends_applicable_agents_in_root_to_leaf_order(registe
     async def handler(_req: Any) -> ToolMessage:
         return _ok("read_file")
 
-    result = await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler)
+    result = _tool_result(await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler))
 
     assert isinstance(result.content, str)
     assert "<system-reminder>" in result.content
@@ -98,11 +103,15 @@ async def test_read_file_does_not_reload_same_agents_file(register_backend) -> N
     async def handler(_req: Any) -> ToolMessage:
         return _ok("read_file")
 
-    first = await middleware.awrap_tool_call(
-        _request("read_file", {"file_path": "/repo/pkg/a.py"}), handler
+    first = _tool_result(
+        await middleware.awrap_tool_call(
+            _request("read_file", {"file_path": "/repo/pkg/a.py"}), handler
+        )
     )
-    second = await middleware.awrap_tool_call(
-        _request("read_file", {"file_path": "/repo/pkg/b.py"}), handler
+    second = _tool_result(
+        await middleware.awrap_tool_call(
+            _request("read_file", {"file_path": "/repo/pkg/b.py"}), handler
+        )
     )
 
     assert isinstance(first.content, str)
@@ -120,7 +129,7 @@ async def test_reading_agents_md_directly_does_not_append_reminder(register_back
     async def handler(_req: Any) -> ToolMessage:
         return _ok("read_file", "pkg rules")
 
-    result = await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler)
+    result = _tool_result(await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler))
 
     assert result.content == "pkg rules"
     assert backend.reads == []
@@ -134,7 +143,7 @@ async def test_non_read_file_tool_is_untouched(register_backend) -> None:
     async def handler(_req: Any) -> ToolMessage:
         return _ok("edit_file")
 
-    result = await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler)
+    result = _tool_result(await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler))
 
     assert result.content == "file content"
     assert backend.reads == []
@@ -146,7 +155,7 @@ async def test_missing_backend_is_graceful() -> None:
     async def handler(_req: Any) -> ToolMessage:
         return _ok("read_file")
 
-    result = await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler)
+    result = _tool_result(await SubdirAgentsReadMiddleware().awrap_tool_call(request, handler))
 
     assert result.content == "file content"
 

--- a/tests/middleware/test_tool_artifact_middleware.py
+++ b/tests/middleware/test_tool_artifact_middleware.py
@@ -75,6 +75,7 @@ async def test_edit_file_stamps_full_file_diff(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact == {
         "diff": {
             "filePath": "/repo/a.py",
@@ -99,6 +100,7 @@ async def test_edit_file_replace_all(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact["diff"]["newContent"] == "y y y"
 
 
@@ -114,6 +116,7 @@ async def test_edit_file_missing_old_string_skips(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact is None
 
 
@@ -127,6 +130,7 @@ async def test_write_file_new_file(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact == {
         "diff": {
             "filePath": "/repo/new.py",
@@ -147,6 +151,7 @@ async def test_write_file_overwrite(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact["diff"]["originalContent"] == "old content\n"
     assert result.artifact["diff"]["newContent"] == "new content\n"
     assert result.artifact["diff"]["isNewFile"] is False
@@ -162,6 +167,7 @@ async def test_non_edit_tool_is_untouched(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact is None
     assert backend.reads == []
 
@@ -178,6 +184,7 @@ async def test_error_result_is_not_stamped(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact is None
 
 
@@ -193,6 +200,7 @@ async def test_missing_backend_is_graceful() -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact is None
 
 
@@ -208,6 +216,7 @@ async def test_binary_read_skips(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact is None
 
 
@@ -225,5 +234,6 @@ async def test_existing_artifact_is_merged(register_backend) -> None:
 
     result = await ToolArtifactMiddleware().awrap_tool_call(request, handler)
 
+    assert isinstance(result, ToolMessage)
     assert result.artifact["existing"] == "kept"
     assert result.artifact["diff"]["newContent"] == "NEW\n"

--- a/tests/models/test_anthropic_model.py
+++ b/tests/models/test_anthropic_model.py
@@ -9,18 +9,18 @@ FABLE_5_ID = "anthropic:claude-fable-5"
 
 def test_sonnet_5_is_supported_with_documented_efforts() -> None:
     sonnet = next(m for m in SUPPORTED_MODELS if m["id"] == SONNET_5_ID)
-    assert sonnet["label"] == "Sonnet 5"
-    assert sonnet["efforts"] == ["low", "medium", "high", "xhigh", "max"]
-    assert sonnet["default_effort"] == "high"
+    assert sonnet.get("label") == "Sonnet 5"
+    assert sonnet.get("efforts") == ["low", "medium", "high", "xhigh", "max"]
+    assert sonnet.get("default_effort") == "high"
     assert sonnet["supports_images"] is True
 
 
 @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
 def test_sonnet_5_efforts_map_to_anthropic_kwargs(effort: str) -> None:
     kwargs = provider_model_kwargs(SONNET_5_ID, effort, max_tokens=16_000)
-    assert kwargs["max_tokens"] == 16_000
-    assert kwargs["effort"] == effort
-    assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert kwargs.get("max_tokens") == 16_000
+    assert kwargs.get("effort") == effort
+    assert kwargs.get("thinking") == {"type": "adaptive", "display": "summarized"}
 
 
 def test_sonnet_46_fallback_uses_sonnet_5() -> None:
@@ -39,15 +39,15 @@ def test_opus_fallback_stays_on_opus_family() -> None:
 
 def test_fable_5_is_supported_with_documented_efforts() -> None:
     fable = next(m for m in SUPPORTED_MODELS if m["id"] == FABLE_5_ID)
-    assert fable["label"] == "Fable 5"
-    assert fable["efforts"] == ["low", "medium", "high", "xhigh", "max"]
-    assert fable["default_effort"] == "high"
+    assert fable.get("label") == "Fable 5"
+    assert fable.get("efforts") == ["low", "medium", "high", "xhigh", "max"]
+    assert fable.get("default_effort") == "high"
     assert fable["supports_images"] is True
 
 
 @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
 def test_fable_5_efforts_map_to_anthropic_kwargs(effort: str) -> None:
     kwargs = provider_model_kwargs(FABLE_5_ID, effort, max_tokens=16_000)
-    assert kwargs["max_tokens"] == 16_000
-    assert kwargs["effort"] == effort
-    assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert kwargs.get("max_tokens") == 16_000
+    assert kwargs.get("effort") == effort
+    assert kwargs.get("thinking") == {"type": "adaptive", "display": "summarized"}

--- a/tests/models/test_deferred_model.py
+++ b/tests/models/test_deferred_model.py
@@ -10,7 +10,7 @@ def test_deferred_error_model_binds_tools_without_raising() -> None:
     model = DeferredErrorModel(error_message="missing key", model_id="openai:gpt-5")
 
     assert model.bind_tools([]) is model
-    assert model._get_ls_params()["ls_model_name"] == "openai:gpt-5"
+    assert model._get_ls_params().get("ls_model_name") == "openai:gpt-5"
 
 
 def test_deferred_error_model_raises_on_first_call() -> None:

--- a/tests/models/test_fireworks_model.py
+++ b/tests/models/test_fireworks_model.py
@@ -21,8 +21,8 @@ def test_provider_model_kwargs_for_fireworks() -> None:
         "high",
         max_tokens=16_000,
     )
-    assert kwargs["max_tokens"] == 16_000
-    assert kwargs["model_kwargs"] == {"reasoning_effort": "high"}
+    assert kwargs.get("max_tokens") == 16_000
+    assert kwargs.get("model_kwargs") == {"reasoning_effort": "high"}
 
 
 def test_kimi_k2p7_is_supported() -> None:
@@ -31,11 +31,13 @@ def test_kimi_k2p7_is_supported() -> None:
         None,
     )
     assert kimi_k2p7 is not None
-    assert kimi_k2p7["efforts"] == ["low", "medium", "high"]
-    assert "none" not in kimi_k2p7["efforts"]
-    assert kimi_k2p7["default_effort"] == "high"
-    kwargs = provider_model_kwargs(kimi_k2p7["id"], "high", max_tokens=16_000)
-    assert kwargs["model_kwargs"] == {"reasoning_effort": "high"}
+    assert kimi_k2p7.get("efforts") == ["low", "medium", "high"]
+    assert "none" not in kimi_k2p7.get("efforts", [])
+    assert kimi_k2p7.get("default_effort") == "high"
+    model_id = kimi_k2p7.get("id")
+    assert isinstance(model_id, str)
+    kwargs = provider_model_kwargs(model_id, "high", max_tokens=16_000)
+    assert kwargs.get("model_kwargs") == {"reasoning_effort": "high"}
 
 
 def test_provider_model_kwargs_for_fireworks_none_disables_reasoning() -> None:
@@ -44,7 +46,7 @@ def test_provider_model_kwargs_for_fireworks_none_disables_reasoning() -> None:
         "none",
         max_tokens=16_000,
     )
-    assert kwargs["model_kwargs"] == {"reasoning_effort": "none"}
+    assert kwargs.get("model_kwargs") == {"reasoning_effort": "none"}
 
 
 def test_provider_model_kwargs_for_fireworks_unknown_effort_omits_reasoning() -> None:

--- a/tests/models/test_google_model.py
+++ b/tests/models/test_google_model.py
@@ -46,5 +46,5 @@ def test_provider_model_kwargs_for_google() -> None:
         "high",
         max_tokens=16_000,
     )
-    assert kwargs["max_tokens"] == 16_000
-    assert kwargs["thinking_level"] == "high"
+    assert kwargs.get("max_tokens") == 16_000
+    assert kwargs.get("thinking_level") == "high"

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -34,7 +34,9 @@ def test_provider_fallback_uses_default_effort_when_unsupported() -> None:
 
 
 def test_provider_fallback_resolves_openai_within_provider() -> None:
-    model, effort = provider_fallback_pair("openai:gpt-5-legacy", "low")
+    fallback = provider_fallback_pair("openai:gpt-5-legacy", "low")
+    assert fallback is not None
+    model, effort = fallback
     assert model == "openai:gpt-5.5"
     assert effort == "low"
 

--- a/tests/reviewer/test_factory_config_isolation.py
+++ b/tests/reviewer/test_factory_config_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,7 +22,8 @@ async def test_get_reviewer_agent_does_not_mutate_caller_config() -> None:
     from agent import reviewer
 
     config = _make_config(recursion_limit=25)
-    original_limit = config["recursion_limit"]
+    original_limit = config.get("recursion_limit")
+    assert original_limit is not None
 
     fake_pregel = MagicMock()
     fake_pregel.with_config = MagicMock(return_value=fake_pregel)
@@ -29,9 +31,9 @@ async def test_get_reviewer_agent_does_not_mutate_caller_config() -> None:
     with patch("agent.reviewer.create_deep_agent", return_value=fake_pregel):
         await reviewer.get_reviewer_agent(config)
 
-    assert config["recursion_limit"] == original_limit, (
+    assert config.get("recursion_limit") == original_limit, (
         f"get_reviewer_agent mutated caller's recursion_limit: "
-        f"expected {original_limit}, got {config['recursion_limit']}"
+        f"expected {original_limit}, got {config.get('recursion_limit')}"
     )
 
 
@@ -57,7 +59,8 @@ async def test_get_chat_agent_does_not_mutate_caller_config() -> None:
     from agent import chat
 
     config = _make_config(recursion_limit=50)
-    original_limit = config["recursion_limit"]
+    original_limit = config.get("recursion_limit")
+    assert original_limit is not None
 
     fake_pregel = MagicMock()
     fake_pregel.with_config = MagicMock(return_value=fake_pregel)
@@ -65,9 +68,9 @@ async def test_get_chat_agent_does_not_mutate_caller_config() -> None:
     with patch("agent.chat.create_deep_agent", return_value=fake_pregel):
         await chat.get_chat_agent(config)
 
-    assert config["recursion_limit"] == original_limit, (
+    assert config.get("recursion_limit") == original_limit, (
         f"get_chat_agent mutated caller's recursion_limit: "
-        f"expected {original_limit}, got {config['recursion_limit']}"
+        f"expected {original_limit}, got {config.get('recursion_limit')}"
     )
 
 
@@ -101,10 +104,13 @@ async def test_factory_copies_config_dicts_but_preserves_runtime_objects(
     callback = object()
     configurable_value = object()
     callbacks = [callback]
-    config: RunnableConfig = {
-        "configurable": {"thread_id": None, "custom_key": configurable_value},
-        "callbacks": callbacks,
-    }
+    config = cast(
+        RunnableConfig,
+        {
+            "configurable": {"thread_id": None, "custom_key": configurable_value},
+            "callbacks": callbacks,
+        },
+    )
 
     fake_pregel = MagicMock()
     fake_pregel.with_config = MagicMock(return_value=fake_pregel)
@@ -112,11 +118,15 @@ async def test_factory_copies_config_dicts_but_preserves_runtime_objects(
     with patch(f"{module_name}.create_deep_agent", return_value=fake_pregel):
         await factory(config)
 
-    bound_config = fake_pregel.with_config.call_args.args[0]
+    assert fake_pregel.with_config.call_args is not None
+    bound_config = cast(dict[str, object], fake_pregel.with_config.call_args.args[0])
+    configurable = cast(dict[str, object], bound_config["configurable"])
+    original_configurable = config.get("configurable")
+    assert isinstance(original_configurable, dict)
     assert bound_config is not config
-    assert bound_config["configurable"] is not config["configurable"]
-    assert bound_config["configurable"]["custom_key"] is configurable_value
+    assert configurable is not original_configurable
+    assert configurable["custom_key"] is configurable_value
     assert bound_config["callbacks"] is callbacks
-    assert bound_config["callbacks"][0] is callback
+    assert cast(list[object], bound_config["callbacks"])[0] is callback
     assert "recursion_limit" not in config
-    assert config["configurable"] == {"thread_id": None, "custom_key": configurable_value}
+    assert config.get("configurable") == {"thread_id": None, "custom_key": configurable_value}

--- a/tests/reviewer/test_fetch_review_diff_tool.py
+++ b/tests/reviewer/test_fetch_review_diff_tool.py
@@ -56,6 +56,7 @@ async def test_fetch_review_diff_returns_metadata_without_diff_body() -> None:
         "cached": True,
     }
     assert diff_text not in str(result)
+    assert mock_materialize.await_args is not None
     assert mock_materialize.await_args.kwargs["work_dir"] == "/workspace/repo"
     assert mock_materialize.await_args.kwargs["merge_base"] is True
 
@@ -98,6 +99,7 @@ async def test_fetch_review_diff_uses_incremental_range_for_re_review() -> None:
         result = await fetch_review_diff()
 
     assert result["base_sha"] == "b" * 40
+    assert mock_materialize.await_args is not None
     assert mock_materialize.await_args.kwargs == {
         "work_dir": "/workspace/repo",
         "base_ref": "b" * 40,

--- a/tests/reviewer/test_pr_ready_auto_review.py
+++ b/tests/reviewer/test_pr_ready_auto_review.py
@@ -37,7 +37,7 @@ def _pr_payload(
     }
 
 
-def _patch_dispatch_deps(monkeypatch: pytest.MonkeyPatch, fake_client: Any) -> None:
+def _patch_dispatch_deps(monkeypatch: pytest.MonkeyPatch, fake_client: MagicMock) -> AsyncMock:
     monkeypatch.setattr(
         webhook_common,
         "get_github_app_installation_token_with_expiry",
@@ -47,8 +47,10 @@ def _patch_dispatch_deps(monkeypatch: pytest.MonkeyPatch, fake_client: Any) -> N
         webhook_common, "_ensure_thread_exists_for_metadata", AsyncMock(return_value=True)
     )
     monkeypatch.setattr(webhook_common, "cache_github_token_for_thread", MagicMock())
-    monkeypatch.setattr(webhook_common, "set_reviewer_thread_metadata", AsyncMock())
+    set_metadata = AsyncMock()
+    monkeypatch.setattr(webhook_common, "set_reviewer_thread_metadata", set_metadata)
     monkeypatch.setattr(webhook_common, "get_client", lambda url: fake_client)
+    return set_metadata
 
 
 @pytest.mark.asyncio
@@ -62,6 +64,7 @@ async def test_pr_ready_non_draft_triggers_run(monkeypatch: pytest.MonkeyPatch) 
     await github_webhooks.process_github_pr_ready(_pr_payload(action="opened", draft=False))
 
     fake_client.runs.create.assert_awaited_once()
+    assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["source"] == "github"
     assert kwargs["config"]["configurable"]["pr_number"] == 7
@@ -90,6 +93,7 @@ async def test_pr_ready_public_repo_uses_scoped_reviewer_token(
     )
 
     get_token.assert_awaited_once_with(repository_ids=[123])
+    assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is False
 
@@ -116,6 +120,7 @@ async def test_pr_ready_private_repo_uses_full_reviewer_token(
     )
 
     get_token.assert_awaited_once_with()
+    assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is True
 
@@ -168,6 +173,7 @@ async def test_pr_ready_for_review_skips_when_head_already_reviewed(
     fake_client.runs.create.assert_not_called()
     get_token.assert_not_awaited()
     set_metadata.assert_awaited_once()
+    assert set_metadata.await_args is not None
     assert set_metadata.await_args.kwargs["watch"] is True
 
 
@@ -177,7 +183,7 @@ async def test_pr_ready_for_review_uses_re_review_after_previous_review(
 ) -> None:
     fake_client = MagicMock()
     fake_client.runs.create = AsyncMock()
-    _patch_dispatch_deps(monkeypatch, fake_client)
+    set_metadata = _patch_dispatch_deps(monkeypatch, fake_client)
     monkeypatch.setattr(
         webhook_common,
         "_get_thread_metadata_safe",
@@ -197,6 +203,7 @@ async def test_pr_ready_for_review_uses_re_review_after_previous_review(
     )
 
     fake_client.runs.create.assert_awaited_once()
+    assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     configurable = kwargs["config"]["configurable"]
     assert configurable["re_review"] is True
@@ -205,7 +212,7 @@ async def test_pr_ready_for_review_uses_re_review_after_previous_review(
     assert "marked ready for review" in kwargs["input"]["messages"][0]["content"]
     head_sha_writes = [
         c.kwargs.get("head_sha")
-        for c in webhook_common.set_reviewer_thread_metadata.await_args_list
+        for c in set_metadata.await_args_list
         if c.kwargs.get("head_sha") is not None
     ]
     assert "headsha" in head_sha_writes

--- a/tests/reviewer/test_reconcile_sweep.py
+++ b/tests/reviewer/test_reconcile_sweep.py
@@ -76,6 +76,7 @@ async def test_cancels_only_stale_pending_runs(monkeypatch: pytest.MonkeyPatch) 
 
     assert counts == {"threads_checked": 1, "stale_runs": 2, "cancelled": 2}
     runs.cancel_many.assert_awaited_once()
+    assert runs.cancel_many.await_args is not None
     kwargs = runs.cancel_many.await_args.kwargs
     assert kwargs["thread_id"] == "t1"
     assert sorted(kwargs["run_ids"]) == ["old1", "old2"]
@@ -109,6 +110,7 @@ async def test_bad_thread_does_not_abort_sweep(monkeypatch: pytest.MonkeyPatch) 
     # Both threads counted; the good thread is still reconciled despite the bad one.
     assert counts == {"threads_checked": 2, "stale_runs": 1, "cancelled": 1}
     runs.cancel_many.assert_awaited_once()
+    assert runs.cancel_many.await_args is not None
     assert runs.cancel_many.await_args.kwargs["thread_id"] == "good"
     assert runs.cancel_many.await_args.kwargs["run_ids"] == ["old1"]
 
@@ -155,4 +157,5 @@ async def test_unparseable_created_at_is_skipped(monkeypatch: pytest.MonkeyPatch
     counts = await reconcile.reconcile_stale_runs(max_age_seconds=1800)
 
     assert counts == {"threads_checked": 1, "stale_runs": 1, "cancelled": 1}
+    assert runs.cancel_many.await_args is not None
     assert runs.cancel_many.await_args.kwargs["run_ids"] == ["old"]

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware import AgentMiddleware, AgentState
 from langgraph.graph.state import RunnableConfig
+from langgraph.runtime import Runtime
 
 from agent import reviewer
 
@@ -193,6 +196,14 @@ class _DummyAgent:
     def with_config(self, config: dict[str, object]) -> _DummyAgent:
         self.config = config
         return self
+
+
+async def _run_prepare(prepare: AgentMiddleware) -> dict[str, object]:
+    updates = await prepare.abefore_agent(
+        cast(AgentState, {"messages": []}), cast(Runtime[None], MagicMock())
+    )
+    assert updates is not None
+    return cast(dict[str, object], updates)
 
 
 @pytest.mark.asyncio
@@ -452,7 +463,7 @@ async def test_reviewer_injects_repo_style_during_eval() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -493,9 +504,11 @@ async def test_reviewer_injects_repo_style_during_eval() -> None:
         ),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     assert "Repository-specific review style" in captured["system_prompt"]
     assert "Flag table rerender regressions" in captured["system_prompt"]
@@ -518,7 +531,7 @@ async def test_reviewer_inlines_org_guidelines_into_system_prompt() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -560,9 +573,11 @@ async def test_reviewer_inlines_org_guidelines_into_system_prompt() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     assert "Organization-wide review guidelines" in captured["system_prompt"]
     assert "disables a CI gate" in captured["system_prompt"]
@@ -597,7 +612,7 @@ async def test_reviewer_inlines_agents_md_into_system_prompt() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -629,9 +644,11 @@ async def test_reviewer_inlines_agents_md_into_system_prompt() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     mock_fetch_agents_md.assert_awaited_once_with("acme", "repo", "base-sha-xyz", token="gh-token")
     assert "Repository conventions (AGENTS.md / CLAUDE.md)" in captured["system_prompt"]
@@ -653,7 +670,7 @@ async def test_reviewer_inlines_claude_md_when_agents_md_absent() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -685,9 +702,11 @@ async def test_reviewer_inlines_claude_md_when_agents_md_absent() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     mock_fetch_agents_md.assert_awaited_once_with("acme", "repo", "base-sha-xyz", token="gh-token")
     assert "Repository conventions (AGENTS.md / CLAUDE.md)" in captured["system_prompt"]
@@ -995,7 +1014,7 @@ async def test_reviewer_injects_pr_review_threads_into_first_review_context() ->
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -1054,9 +1073,11 @@ async def test_reviewer_injects_pr_review_threads_into_first_review_context() ->
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     mock_fetch_threads.assert_awaited_once()
     assert "Pre-existing PR review threads" in captured["system_prompt"]
@@ -1081,7 +1102,7 @@ async def test_reviewer_injects_pr_review_threads_into_re_review_context() -> No
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -1134,9 +1155,11 @@ async def test_reviewer_injects_pr_review_threads_into_re_review_context() -> No
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     assert "A new commit has been pushed" in captured["system_prompt"]
     assert "Pre-existing PR review threads" in captured["system_prompt"]
@@ -1159,7 +1182,7 @@ async def test_reviewer_omits_threads_block_when_fetch_returns_empty() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -1196,9 +1219,11 @@ async def test_reviewer_omits_threads_block_when_fetch_returns_empty() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     # The rule text mentions the wrapper tag, but the actual rendered XML
     # data block (which always has a `</pr_review_threads>` closer and a
@@ -1222,7 +1247,7 @@ async def test_reviewer_continues_when_thread_fetch_raises() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -1259,9 +1284,11 @@ async def test_reviewer_continues_when_thread_fetch_raises() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     # The reviewer must still produce a usable prompt even if the thread
     # fetch fails; the first-review user-message context should still appear.
@@ -1337,8 +1364,10 @@ async def test_reviewer_populates_diff_line_set_from_github_api() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
 
     mock_fetch_diff.assert_awaited_once_with(
         owner="acme", repo="repo", pr_number=42, token="gh-token"
@@ -1407,8 +1436,10 @@ async def test_reviewer_leaves_validation_disabled_when_diff_fetch_fails() -> No
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
 
     assert updates["diff_text"] == ""
     assert updates["diff_line_set"] is None
@@ -1429,7 +1460,7 @@ async def test_reviewer_injects_pr_title_and_body_into_context() -> None:
         },
         "metadata": {},
     }
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
@@ -1476,9 +1507,11 @@ async def test_reviewer_injects_pr_title_and_body_into_context() -> None:
         patch("agent.reviewer.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
         await reviewer.get_reviewer_agent(config)
-        prepare = captured["middleware"][0]
-        updates = await prepare.abefore_agent({}, None)
-        captured["system_prompt"] = updates["rendered_system_prompt"]
+        middleware = captured["middleware"]
+        assert isinstance(middleware, list)
+        prepare = cast(AgentMiddleware, middleware[0])
+        updates = await _run_prepare(prepare)
+        captured["system_prompt"] = cast(str, updates["rendered_system_prompt"])
 
     mock_fetch_metadata.assert_awaited_once_with(
         owner="acme", repo="repo", pr_number=42, token="gh-token"

--- a/tests/reviewer/test_reviewer_eval_judge.py
+++ b/tests/reviewer/test_reviewer_eval_judge.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
+
+from langsmith.schemas import Example, Run
 
 from evals.reviewer import judge
 
@@ -64,7 +67,7 @@ def test_judge_match_deduplicates_and_persists_full_matrix() -> None:
         return _result(golden.get("comment") == "first" and candidate.get("file") == "a.py", 0.8)
 
     with patch("evals.reviewer.judge._judge_pair", side_effect=_pair):
-        result = judge.judge_match(run, example)
+        result = judge.judge_match(cast(Run, run), cast(Example, example))
 
     by_key = {item["key"]: item for item in result["results"]}
     assert len(calls) == 4
@@ -102,8 +105,8 @@ def test_aggregate_pr_reports_synthetic_and_medium_plus_metrics() -> None:
         "medium_plus_recall": 1.0,
         "medium_plus_f1": 1.0,
     }
-    judge._record_counts(uuid4(), {**base, "is_synthetic": False})
-    judge._record_counts(uuid4(), {**base, "is_synthetic": True})
+    judge._record_counts(uuid4(), cast(judge.ExampleCounts, {**base, "is_synthetic": False}))
+    judge._record_counts(uuid4(), cast(judge.ExampleCounts, {**base, "is_synthetic": True}))
 
     result = judge.aggregate_pr([], [])
 

--- a/tests/reviewer/test_reviewer_eval_run.py
+++ b/tests/reviewer/test_reviewer_eval_run.py
@@ -164,8 +164,8 @@ def test_resolve_config_prefers_cli_then_env_then_toml() -> None:
             }
         )
 
-    assert config["dataset_name"] == "dataset-config"
-    assert config["experiment_prefix"] == "experiment-cli"
-    assert config["model_id"] == "openai:gpt-5.6-sol"
-    assert config["reasoning_effort"] == "xhigh"
-    assert config["langsmith_project"] == "project-env"
+    assert config.get("dataset_name") == "dataset-config"
+    assert config.get("experiment_prefix") == "experiment-cli"
+    assert config.get("model_id") == "openai:gpt-5.6-sol"
+    assert config.get("reasoning_effort") == "xhigh"
+    assert config.get("langsmith_project") == "project-env"

--- a/tests/reviewer/test_reviewer_groups.py
+++ b/tests/reviewer/test_reviewer_groups.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.language_models import BaseChatModel
 
 from agent.review.groups import (
     _build_prompt,
@@ -57,7 +58,9 @@ async def test_generate_diff_groups_partitions() -> None:
             _DiffGroupModel(title="Bar change", summary="Edits bar", files=["bar.py"]),
         ]
     )
-    groups = await generate_diff_groups(diff_text=_DIFF, model=_FakeModel(result))
+    groups = await generate_diff_groups(
+        diff_text=_DIFF, model=cast(BaseChatModel, _FakeModel(result))
+    )
     assert groups == [
         {"title": "Foo change", "summary": "Edits foo", "files": ["foo.py"]},
         {"title": "Bar change", "summary": "Edits bar", "files": ["bar.py"]},
@@ -77,7 +80,9 @@ async def test_generate_diff_groups_dedupes_and_drops_unknown() -> None:
             _DiffGroupModel(title="", summary="ignored", files=["bar.py"]),
         ]
     )
-    groups = await generate_diff_groups(diff_text=_DIFF, model=_FakeModel(result))
+    groups = await generate_diff_groups(
+        diff_text=_DIFF, model=cast(BaseChatModel, _FakeModel(result))
+    )
     # foo.py only in the first group, bar.py only in the second; the untitled
     # group and the unknown path are dropped.
     assert groups == [
@@ -88,12 +93,16 @@ async def test_generate_diff_groups_dedupes_and_drops_unknown() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_diff_groups_empty_diff_returns_empty() -> None:
-    assert await generate_diff_groups(diff_text="", model=_FakeModel(None)) == []
+    assert (
+        await generate_diff_groups(diff_text="", model=cast(BaseChatModel, _FakeModel(None))) == []
+    )
 
 
 @pytest.mark.asyncio
 async def test_generate_diff_groups_llm_failure_returns_none() -> None:
-    groups = await generate_diff_groups(diff_text=_DIFF, model=_FakeModel(None, raises=True))
+    groups = await generate_diff_groups(
+        diff_text=_DIFF, model=cast(BaseChatModel, _FakeModel(None, raises=True))
+    )
     assert groups is None
 
 

--- a/tests/reviewer/test_reviewer_outcomes.py
+++ b/tests/reviewer/test_reviewer_outcomes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
+from agent.review.findings import Finding
 from agent.utils import reviewer_outcomes
 from agent.utils.reviewer_outcomes import (
     FALSE_POSITIVE,
@@ -76,23 +77,26 @@ class _FakeClient:
         self.updated.append(kwargs)
 
 
-def _finding() -> dict[str, Any]:
-    return {
-        "id": "f_abc",
-        "file": "app/x.rb",
-        "start_line": 10,
-        "end_line": 12,
-        "side": "RIGHT",
-        "diff_hunk": "@@ -1 +1 @@\n-foo\n+bar",
-        "title": "NoMethodError on nil",
-        "description": "body",
-        "severity": "high",
-        "confidence": "high",
-        "category": "correctness",
-        "first_seen_sha": "aaa",
-        "github_review_run_id": "run_1",
-        "resolution_note": "fixed in def",
-    }
+def _finding() -> Finding:
+    return cast(
+        Finding,
+        {
+            "id": "f_abc",
+            "file": "app/x.rb",
+            "start_line": 10,
+            "end_line": 12,
+            "side": "RIGHT",
+            "diff_hunk": "@@ -1 +1 @@\n-foo\n+bar",
+            "title": "NoMethodError on nil",
+            "description": "body",
+            "severity": "high",
+            "confidence": "high",
+            "category": "correctness",
+            "first_seen_sha": "aaa",
+            "github_review_run_id": "run_1",
+            "resolution_note": "fixed in def",
+        },
+    )
 
 
 def test_upsert_finding_outcome_builds_payload(monkeypatch) -> None:  # noqa: ANN001

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -29,18 +29,44 @@ from agent.review.publish import (
 
 
 def _f(**overrides: Any) -> Finding:
-    base = new_finding(
-        severity="high",
-        confidence="high",
-        category="correctness",
-        file="src/foo.py",
-        start_line=10,
-        end_line=10,
-        description="boom",
-        sha="abc",
-    )
-    base.update(overrides)  # type: ignore[arg-type]
-    return base
+    construct_keys = {
+        "severity",
+        "confidence",
+        "category",
+        "file",
+        "start_line",
+        "end_line",
+        "description",
+        "sha",
+        "title",
+        "side",
+        "suggestion",
+        "diff_hunk",
+        "finding_id",
+        "in_diff",
+    }
+    kwargs: dict[str, Any] = {
+        "severity": "high",
+        "confidence": "high",
+        "category": "correctness",
+        "file": "src/foo.py",
+        "start_line": 10,
+        "end_line": 10,
+        "description": "boom",
+        "sha": "abc",
+    }
+    rest: dict[str, Any] = {}
+    for key, value in overrides.items():
+        if key == "id":
+            kwargs["finding_id"] = value
+        elif key in construct_keys:
+            kwargs[key] = value
+        else:
+            rest[key] = value
+    finding = new_finding(**kwargs)
+    if rest:
+        finding.update(rest)  # type: ignore[typeddict-item]
+    return finding
 
 
 @pytest.fixture(autouse=True)
@@ -310,6 +336,7 @@ async def test_post_review_started_comment_deletes_lingering_before_reposting() 
         )
     assert cid == 500
     delete.assert_awaited_once()
+    assert delete.await_args is not None
     assert delete.await_args.kwargs["comment_id"] == 99
 
 
@@ -327,6 +354,7 @@ async def test_clear_review_started_comment_deletes_and_clears_metadata() -> Non
     ):
         await clear_review_started_comment(thread_id="tid", owner="o", repo="r", token="t")
     delete.assert_awaited_once()
+    assert delete.await_args is not None
     assert delete.await_args.kwargs["comment_id"] == 99
     set_meta.assert_awaited_once_with("tid", extra={"status_comment_id": None})
 
@@ -461,6 +489,7 @@ async def test_publish_review_eval_mode_uses_configured_cap() -> None:
         result = await publish_review()
 
     assert result["surfaced_count"] == 1
+    assert set_meta.await_args is not None
     publication = set_meta.await_args.kwargs["extra"]["reviewer_eval_publication"]
     assert publication["cap"] == 1
     assert publication["finding_ids"] == ["f_first"]
@@ -506,6 +535,7 @@ async def test_publish_review_surfaces_additional_findings_count_in_body() -> No
 
     assert result["success"] is True
     assert result["surfaced_count"] == 0
+    assert post_review.await_args is not None
     posted_body = post_review.await_args.kwargs["body"]
     assert "No issues found" in posted_body
     assert "2 additional findings can be viewed in the web app." in posted_body
@@ -535,6 +565,7 @@ async def test_publish_review_forwards_trace_link_config_override() -> None:
         result = await publish_review()
 
     assert result == {"success": True}
+    assert publish_async.call_args is not None
     assert publish_async.call_args.kwargs["trace_link_config_override"] is False
 
 
@@ -722,6 +753,7 @@ async def test_publish_review_skips_findings_already_published() -> None:
 
     assert result["success"] is True
     assert result["surfaced_count"] == 1
+    assert post_review.await_args is not None
     posted = post_review.await_args.kwargs["inline_comments"]
     paths = {c["path"] for c in posted}
     assert paths == {"b.py"}
@@ -939,6 +971,7 @@ async def test_publish_review_uses_resolved_head_sha_for_commit_and_last_reviewe
         )
 
     assert result["success"] is True
+    assert post_review.await_args is not None
     assert post_review.await_args.kwargs["head_sha"] == "freshhead"
     final = set_metadata.await_args_list[-1]
     assert final.args[0] == "tid"
@@ -1365,6 +1398,7 @@ async def test_re_review_only_posts_current_head_unpublished_findings() -> None:
 
     assert result["success"] is True
     assert result["surfaced_count"] == 1
+    assert post_review.await_args is not None
     inline_comments = post_review.await_args.kwargs["inline_comments"]
     assert [comment["path"] for comment in inline_comments] == ["new.py"]
     assert old["github_review_id"] is None
@@ -1525,6 +1559,7 @@ async def test_publish_review_posts_summary_when_no_findings() -> None:
     assert result["surfaced_count"] == 0
     assert result["review_id"] == 555
     post_review.assert_awaited_once()
+    assert post_review.await_args is not None
     posted_body = post_review.await_args.kwargs["body"]
     posted_inline = post_review.await_args.kwargs["inline_comments"]
     assert posted_inline == []
@@ -1575,6 +1610,7 @@ async def test_publish_review_posts_slack_reply_on_first_review_with_slack_ref()
         )
 
     slack_post.assert_awaited_once()
+    assert slack_post.await_args is not None
     args = slack_post.await_args.args
     assert args[0] == "C1"
     assert args[1] == "1234.5"
@@ -1630,6 +1666,7 @@ async def test_publish_review_uses_plural_findings_in_slack_reply() -> None:
         )
 
     slack_post.assert_awaited_once()
+    assert slack_post.await_args is not None
     text = slack_post.await_args.args[2]
     assert "found 2 potential issues" in text
 

--- a/tests/reviewer/test_reviewer_reconcile.py
+++ b/tests/reviewer/test_reviewer_reconcile.py
@@ -293,5 +293,7 @@ async def test_reconcile_records_latest_human_reply_after_bot_comment() -> None:
 
     assert result[0]["github_review_thread_id"] == "THREAD_1"
     assert result[0]["last_human_reply_author"] == "human"
-    assert "not valid" in result[0]["last_human_reply_body"]
+    reply_body = result[0]["last_human_reply_body"]
+    assert isinstance(reply_body, str)
+    assert "not valid" in reply_body
     replace.assert_awaited_once()

--- a/tests/reviewer/test_reviewer_tools.py
+++ b/tests/reviewer/test_reviewer_tools.py
@@ -337,6 +337,7 @@ async def test_resolve_finding_thread_resolves_all_known_threads() -> None:
     assert all(
         call.kwargs["body"] == "Fixed in the latest commit" for call in reply.await_args_list
     )
+    assert update.await_args is not None
     updates = update.await_args.args[2]
     assert updates["github_thread_resolved"] is True
     assert updates["github_resolved_thread_ids"] == ["THREAD_1", "THREAD_2"]

--- a/tests/reviewer/test_reviewer_watch.py
+++ b/tests/reviewer/test_reviewer_watch.py
@@ -157,12 +157,15 @@ async def test_push_event_skips_when_pr_diff_unchanged_since_last_review() -> No
 
     fake_client.runs.create.assert_not_called()
     set_metadata.assert_awaited_once()
+    assert set_metadata.await_args is not None
     assert set_metadata.await_args.kwargs["last_reviewed_sha"] == "newsha"
     # Even without a re-review, a settled check lands on the new head so the
     # review stays visible after the head moves.
     create_check.assert_awaited_once()
+    assert create_check.await_args is not None
     assert create_check.await_args.kwargs["head_sha"] == "newsha"
     complete_check.assert_awaited_once()
+    assert complete_check.await_args is not None
     assert complete_check.await_args.kwargs["check_run_id"] == 42
     assert complete_check.await_args.kwargs["conclusion"] == "success"
 
@@ -235,6 +238,7 @@ async def test_push_event_triggers_re_review_run_when_watching() -> None:
         await github_webhooks.process_github_push_event(payload)
 
     fake_client.runs.create.assert_awaited_once()
+    assert fake_client.runs.create.await_args is not None
     args, kwargs = fake_client.runs.create.await_args
     assert args[1] == "reviewer"
     configurable = kwargs["config"]["configurable"]
@@ -252,6 +256,7 @@ async def test_push_event_triggers_re_review_run_when_watching() -> None:
     # A fresh check run is created on the new head SHA (GitHub only shows
     # checks on the current head), and its id is persisted for settling.
     create_check.assert_awaited_once()
+    assert create_check.await_args is not None
     assert create_check.await_args.kwargs["head_sha"] == "newsha"
     check_id_writes = [
         c.kwargs.get("extra", {}).get("review_check_run_id")
@@ -396,6 +401,7 @@ async def test_push_event_public_repo_uses_scoped_token() -> None:
         await github_webhooks.process_github_push_event(payload)
 
     get_token.assert_awaited_once_with(repository_ids=[123])
+    assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is False
 
@@ -450,6 +456,7 @@ async def test_push_event_rescopes_token_when_pr_metadata_reveals_public() -> No
         await github_webhooks.process_github_push_event(payload)
 
     assert get_token.await_args_list == [call(), call(repository_ids=[456])]
+    assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is False
 

--- a/tests/sandbox/test_daytona_integration.py
+++ b/tests/sandbox/test_daytona_integration.py
@@ -23,12 +23,12 @@ class _FakeDaytonaSandbox:
 
 def _load_daytona_module(monkeypatch):
     fake_daytona = types.ModuleType("daytona")
-    fake_daytona.CreateSandboxFromSnapshotParams = _FakeCreateSandboxFromSnapshotParams
-    fake_daytona.DaytonaConfig = _FakeDaytonaConfig
-    fake_daytona.Daytona = object
+    fake_daytona.__dict__["CreateSandboxFromSnapshotParams"] = _FakeCreateSandboxFromSnapshotParams
+    fake_daytona.__dict__["DaytonaConfig"] = _FakeDaytonaConfig
+    fake_daytona.__dict__["Daytona"] = object
 
     fake_langchain_daytona = types.ModuleType("langchain_daytona")
-    fake_langchain_daytona.DaytonaSandbox = _FakeDaytonaSandbox
+    fake_langchain_daytona.__dict__["DaytonaSandbox"] = _FakeDaytonaSandbox
 
     monkeypatch.setitem(sys.modules, "daytona", fake_daytona)
     monkeypatch.setitem(sys.modules, "langchain_daytona", fake_langchain_daytona)

--- a/tests/sandbox/test_e2b_integration.py
+++ b/tests/sandbox/test_e2b_integration.py
@@ -34,10 +34,10 @@ def _load_e2b_module(monkeypatch):
     _FakeSandbox.connect_calls = []
 
     fake_e2b = types.ModuleType("e2b")
-    fake_e2b.Sandbox = _FakeSandbox
+    fake_e2b.__dict__["Sandbox"] = _FakeSandbox
 
     fake_langchain_e2b = types.ModuleType("langchain_e2b")
-    fake_langchain_e2b.E2BSandbox = _FakeE2BSandbox
+    fake_langchain_e2b.__dict__["E2BSandbox"] = _FakeE2BSandbox
 
     monkeypatch.setitem(sys.modules, "e2b", fake_e2b)
     monkeypatch.setitem(sys.modules, "langchain_e2b", fake_langchain_e2b)

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import httpx
@@ -10,8 +10,10 @@ import pytest
 from fireworks import AsyncFireworks
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
+from pydantic import SecretStr
 
 from agent.utils import gateway, model
+from agent.utils.model import OpenAIReasoning
 
 _GATEWAY_ENV_VARS = (
     "LANGSMITH_API_KEY",
@@ -83,7 +85,7 @@ async def test_openai_sdk_uses_gateway_responses_path() -> None:
     try:
         chat_model = ChatOpenAI(
             model="gpt-5.6-sol",
-            api_key="dummy",
+            api_key=SecretStr("dummy"),
             base_url="https://gateway.smith.langchain.com/openai/v1",
             use_responses_api=True,
             http_async_client=http_client,
@@ -200,7 +202,7 @@ async def test_fireworks_gateway_strips_legacy_function_call() -> None:
     try:
         chat_model = ChatFireworks(
             model="accounts/fireworks/models/glm-5p2",
-            api_key="dummy",
+            api_key=SecretStr("dummy"),
             base_url="https://gateway.smith.langchain.com/fireworks",
             max_retries=0,
         )
@@ -364,7 +366,7 @@ def test_make_model_gateway_openai_chat_completions_optout_converts_reasoning(
         model.make_model(
             "openai:gpt-5.6-sol",
             use_gateway=True,
-            reasoning={"effort": "high", "summary": "auto"},
+            reasoning=cast(OpenAIReasoning, {"effort": "high", "summary": "auto"}),
         )
     assert captured["use_responses_api"] is False
     assert captured["reasoning_effort"] == "high"
@@ -395,7 +397,7 @@ def test_make_model_gateway_openai_responses_keeps_reasoning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    reasoning = {"effort": "high", "summary": "auto"}
+    reasoning = cast(OpenAIReasoning, {"effort": "high", "summary": "auto"})
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
         model.make_model("openai:gpt-5.6-sol", use_gateway=True, reasoning=reasoning)

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -1,8 +1,10 @@
 """Tests for LangSmith sandbox env-var configuration parsing."""
 
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from langsmith.sandbox import AsyncSandboxClient
 
 from agent.integrations.langsmith import (
     DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS,
@@ -139,7 +141,7 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
     monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", AsyncMock())
 
     result = await _create_sandbox_with_retry(
-        client,
+        cast(AsyncSandboxClient, client),
         snapshot_id="snap-1",
         fs_capacity_bytes=None,
         vcpus=None,
@@ -160,7 +162,7 @@ async def test_wait_for_reconnected_sandbox_polls_until_ready(monkeypatch) -> No
     monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", sleep)
 
     sandbox = await _wait_for_reconnected_sandbox(
-        client,
+        cast(AsyncSandboxClient, client),
         "sandbox-1",
         timeout_seconds=30,
         poll_seconds=2,

--- a/tests/sandbox/test_langsmith_sandbox_timeout.py
+++ b/tests/sandbox/test_langsmith_sandbox_timeout.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from langsmith.sandbox import CommandTimeoutError, SandboxConnectionError
@@ -48,7 +48,7 @@ def _backend(
     handle: _FakeHandle, *, run_raises: Exception | None = None
 ) -> TimeoutLangSmithSandbox:
     sb = TimeoutLangSmithSandbox.__new__(TimeoutLangSmithSandbox)
-    sb._sandbox = _FakeSandbox(handle, run_raises=run_raises)
+    object.__setattr__(sb, "_sandbox", _FakeSandbox(handle, run_raises=run_raises))
     sb._default_timeout = 30 * 60
     return sb
 
@@ -67,7 +67,8 @@ async def test_aexecute_kills_on_client_timeout() -> None:
     assert resp.exit_code == 124
     assert "killed" in resp.output
     assert handle.killed
-    assert sb._sandbox.run_calls[0]["wait"] is False
+    sandbox = cast(_FakeSandbox, sb._sandbox)
+    assert sandbox.run_calls[0]["wait"] is False
 
 
 async def test_aexecute_success_combines_streams() -> None:

--- a/tests/sandbox/test_local_integration.py
+++ b/tests/sandbox/test_local_integration.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import agent.integrations.local as local_mod
 
 
@@ -16,9 +18,10 @@ def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
     backend = local_mod.create_local_sandbox()
 
     assert root.is_dir()
-    assert backend.root_dir == str(root)
-    assert backend.virtual_mode is True
-    assert backend.inherit_env is True
+    stub = cast(_StubLocalShellBackend, backend)
+    assert stub.root_dir == str(root)
+    assert stub.virtual_mode is True
+    assert stub.inherit_env is True
 
 
 def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
@@ -28,5 +31,6 @@ def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
 
     backend = local_mod.create_local_sandbox()
 
-    assert backend.root_dir == str(tmp_path)
-    assert backend.virtual_mode is True
+    stub = cast(_StubLocalShellBackend, backend)
+    assert stub.root_dir == str(tmp_path)
+    assert stub.virtual_mode is True

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import base64
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_core.runnables import RunnableConfig
+from langgraph.runtime import Runtime
 
 from agent.integrations.langsmith import _configure_github_proxy
 from agent.utils.github_app import (
@@ -212,9 +216,9 @@ class TestCreateSandboxWithProxy:
 
             mock_create.assert_called_once_with(snapshot_id=None)
             mock_proxy.assert_called_once_with("sandbox-123", "ghs_install")
-            assert (
-                mock_get_token.await_args.kwargs["permissions"] == RUNTIME_PROXY_TOKEN_PERMISSIONS
-            )
+            await_args = mock_get_token.await_args
+            assert await_args is not None
+            assert await_args.kwargs["permissions"] == RUNTIME_PROXY_TOKEN_PERMISSIONS
 
     @pytest.mark.asyncio
     async def test_falls_back_when_optional_actions_permission_is_unavailable(self) -> None:
@@ -351,15 +355,18 @@ class TestRefreshProxyOnSandboxReuse:
     """Tests for refreshing GitHub proxy auth on sandbox reuse."""
 
     @staticmethod
-    def _execution_config() -> dict:
-        return {
-            "configurable": {
-                "__is_for_execution__": True,
-                "thread_id": "thread-123",
-                "repo": {"owner": "langchain-ai", "name": "open-swe"},
+    def _execution_config() -> RunnableConfig:
+        return cast(
+            RunnableConfig,
+            {
+                "configurable": {
+                    "__is_for_execution__": True,
+                    "thread_id": "thread-123",
+                    "repo": {"owner": "langchain-ai", "name": "open-swe"},
+                },
+                "metadata": {},
             },
-            "metadata": {},
-        }
+        )
 
     @staticmethod
     def _async_client_mock(status: str) -> MagicMock:
@@ -425,8 +432,11 @@ class TestRefreshProxyOnSandboxReuse:
             from agent.server import get_agent
 
             await get_agent(config)
-            prepare = captured["middleware"][0]
-            await prepare.abefore_agent({}, None)
+            prepare = cast(AgentMiddleware, cast(list[object], captured["middleware"])[0])
+            await prepare.abefore_agent(
+                cast(AgentState[object], {"messages": []}),
+                cast(Runtime[None], MagicMock()),
+            )
 
             mock_proxy.assert_called_once_with("sandbox-cached", "ghs_fresh")
 
@@ -477,8 +487,11 @@ class TestRefreshProxyOnSandboxReuse:
             from agent.server import get_agent
 
             await get_agent(config)
-            prepare = captured["middleware"][0]
-            await prepare.abefore_agent({}, None)
+            prepare = cast(AgentMiddleware, cast(list[object], captured["middleware"])[0])
+            await prepare.abefore_agent(
+                cast(AgentState[object], {"messages": []}),
+                cast(Runtime[None], MagicMock()),
+            )
 
             mock_create.assert_called_once_with("sandbox-existing")
             mock_proxy.assert_called_once_with("sandbox-existing", "ghs_fresh")

--- a/tests/sandbox/test_repo_snapshots.py
+++ b/tests/sandbox/test_repo_snapshots.py
@@ -248,7 +248,9 @@ async def test_run_snapshot_build_success_marks_ready() -> None:
         await run_snapshot_build("acme/repo")
 
     assert statuses[-1][0] == "ready"
-    assert statuses[-1][1]["snapshot_id"] == "snap-new"
+    extra = statuses[-1][1]
+    assert extra is not None
+    assert extra["snapshot_id"] == "snap-new"
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_sandbox_paths.py
+++ b/tests/sandbox/test_sandbox_paths.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import shlex
+from typing import cast
 
-from deepagents.backends.protocol import ExecuteResponse
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
 from agent.utils.sandbox_paths import (
     aresolve_repo_dir,
@@ -69,7 +70,7 @@ def test_resolve_repo_dir_uses_provider_work_dir() -> None:
         writable_dirs={"/workspace"},
     )
 
-    repo_dir = resolve_repo_dir(backend, "open-swe")
+    repo_dir = resolve_repo_dir(cast(SandboxBackendProtocol, backend), "open-swe")
 
     assert repo_dir == "/workspace/open-swe"
     assert backend.commands == ["test -d /workspace && test -w /workspace"]
@@ -85,7 +86,7 @@ def test_resolve_sandbox_work_dir_falls_back_to_home_when_work_dir_is_not_writab
         writable_dirs={"/home/daytona"},
     )
 
-    work_dir = resolve_sandbox_work_dir(backend)
+    work_dir = resolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
 
     assert work_dir == "/home/daytona"
     assert backend.commands == [
@@ -101,8 +102,8 @@ def test_resolve_sandbox_work_dir_caches_the_result() -> None:
         writable_dirs={"/workspace"},
     )
 
-    first = resolve_sandbox_work_dir(backend)
-    second = resolve_sandbox_work_dir(backend)
+    first = resolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
+    second = resolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
 
     assert first == "/workspace"
     assert second == "/workspace"
@@ -115,7 +116,7 @@ async def test_aresolve_repo_dir_offloads_sync_resolution() -> None:
         writable_dirs={"/home/daytona"},
     )
 
-    repo_dir = await aresolve_repo_dir(backend, "open-swe")
+    repo_dir = await aresolve_repo_dir(cast(SandboxBackendProtocol, backend), "open-swe")
 
     assert repo_dir == "/home/daytona/open-swe"
     assert backend.commands == ["test -d /home/daytona && test -w /home/daytona"]

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -1,8 +1,10 @@
 import json
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+from langchain.agents.middleware import AgentState
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langsmith.sandbox import SandboxClientError
@@ -16,7 +18,12 @@ from agent.utils.sandbox_state import SANDBOX_BACKENDS, clear_sandbox_backend, s
 
 
 class FakeSandboxBackend(SandboxBackendProtocol):
-    id = "sb-new"
+    def __init__(self, sandbox_id: str = "sb-new") -> None:
+        self._sandbox_id = sandbox_id
+
+    @property
+    def id(self) -> str:
+        return self._sandbox_id
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         return ExecuteResponse(output=f"{self.id}: {command}: {timeout}", exit_code=0)
@@ -50,10 +57,8 @@ def _sandbox_error_message(tool_call_id: str, sandbox_id: str = "sb-dead") -> To
 async def test_sandbox_client_error_recreates_sandbox() -> None:
     middleware = ToolErrorMiddleware()
     request = _tool_request()
-    old_backend = FakeSandboxBackend()
-    backend = FakeSandboxBackend()
-    old_backend.id = "sb-old"
-    backend.id = "sb-new"
+    old_backend = FakeSandboxBackend("sb-old")
+    backend = FakeSandboxBackend("sb-new")
     proxy = set_sandbox_backend("thread-1", old_backend)
 
     async def handler(_request: ToolCallRequest) -> ToolMessage:
@@ -80,6 +85,7 @@ async def test_sandbox_client_error_recreates_sandbox() -> None:
         assert proxy.id == "sb-new"
         assert proxy.execute("echo ok").output == "sb-new: echo ok: None"
 
+        assert isinstance(result.content, str)
         payload = json.loads(result.content)
         assert payload["status"] == "error"
         assert payload["error_type"] == "SandboxClientError"
@@ -208,7 +214,7 @@ async def test_circuit_breaker_posts_one_user_notification() -> None:
             new_callable=AsyncMock,
         ) as mock_github,
     ):
-        result = await middleware.aafter_agent(state, MagicMock())
+        result = await middleware.aafter_agent(cast(AgentState[Any], state), MagicMock())
 
     assert result is None
     mock_slack.assert_awaited_once_with("C123", "171.123", SANDBOX_UNRECOVERABLE_MESSAGE)

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
-from deepagents.backends.protocol import ExecuteResponse
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
 from agent.utils.sandbox_state import (
     SANDBOX_BACKENDS,
@@ -78,7 +80,10 @@ async def test_sandbox_proxy_uses_registered_reconnect_once(
 
     monkeypatch.setattr("agent.utils.sandbox_state.create_sandbox", create_sandbox)
 
-    proxy = get_or_create_sandbox_backend_proxy(thread_id, reconnect=reconnect)
+    proxy = get_or_create_sandbox_backend_proxy(
+        thread_id,
+        reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
+    )
     results = await asyncio.gather(*(proxy.aexecute(f"cmd-{idx}") for idx in range(5)))
 
     assert reconnected == [thread_id]

--- a/tests/slack/test_refresh_slack_status_middleware.py
+++ b/tests/slack/test_refresh_slack_status_middleware.py
@@ -34,8 +34,10 @@ class TestSlackAssistantStatusMiddleware:
 
         assert result is None
         mock_set.assert_awaited_once()
-        args = mock_set.await_args.args
-        kwargs = mock_set.await_args.kwargs
+        await_args = mock_set.await_args
+        assert await_args is not None
+        args = await_args.args
+        kwargs = await_args.kwargs
         assert args == ("C1", "1.0")
         assert kwargs["status"] == DEFAULT_ASSISTANT_STATUS
         assert kwargs["loading_messages"] == list(DEFAULT_LOADING_MESSAGES)
@@ -53,8 +55,10 @@ class TestSlackAssistantStatusMiddleware:
             result = await middleware.aafter_agent({"messages": []}, self._runtime())
 
         assert result is None
-        assert mock_set.await_args.kwargs["status"] == ""
-        assert mock_set.await_args.kwargs["loading_messages"] is None
+        await_args = mock_set.await_args
+        assert await_args is not None
+        assert await_args.kwargs["status"] == ""
+        assert await_args.kwargs["loading_messages"] is None
 
     @pytest.mark.asyncio
     async def test_model_call_uses_contextual_status_from_last_tool_call(self) -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import cast
 
 import pytest
 
@@ -910,7 +911,10 @@ def test_process_slack_mention_mapped_user_with_token_runs_as_user(
     )
 
     run_create = captured["run_create"]
-    configurable = run_create["kwargs"]["config"]["configurable"]
+    run_create_data = cast(dict[str, object], run_create)
+    kwargs = cast(dict[str, object], run_create_data["kwargs"])
+    config = cast(dict[str, object], kwargs["config"])
+    configurable = cast(dict[str, object], config["configurable"])
     assert configurable["github_login"] == "mason-gh"
     # The thread is tagged with the login resolved from the Slack user id, so it
     # surfaces in the web Agents UI even when the Slack profile email does not

--- a/tests/slack/test_slack_feedback.py
+++ b/tests/slack/test_slack_feedback.py
@@ -1,7 +1,9 @@
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from fastapi import BackgroundTasks
+from starlette.requests import Request
 
 from agent.utils import slack_feedback
 from agent.utils.slack_feedback import (
@@ -224,7 +226,10 @@ async def test_slack_webhook_queues_reaction_added(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
 
-    response = await slack_routes.slack_webhook(_FakeRequest(payload), background_tasks)
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload)),
+        cast(BackgroundTasks, background_tasks),
+    )
 
     assert response == {"status": "accepted", "message": "Reaction feedback queued"}
     assert background_tasks.tasks == [(webhook_common.process_slack_reaction_added, (event, "Ev1"))]
@@ -238,7 +243,10 @@ async def test_slack_webhook_queues_reaction_removed(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
 
-    response = await slack_routes.slack_webhook(_FakeRequest(payload), background_tasks)
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload)),
+        cast(BackgroundTasks, background_tasks),
+    )
 
     assert response == {"status": "accepted", "message": "Reaction removal queued"}
     assert background_tasks.tasks == [
@@ -254,7 +262,10 @@ async def test_slack_webhook_ignores_untracked_reaction(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
 
-    response = await slack_routes.slack_webhook(_FakeRequest(payload), background_tasks)
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload)),
+        cast(BackgroundTasks, background_tasks),
+    )
 
     assert response == {"status": "ignored", "reason": "Reaction not tracked for feedback"}
     assert background_tasks.tasks == []

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -69,8 +69,10 @@ async def test_slack_processing_error_posts_dashboard_link(
     assert isinstance(update["metadata"]["updated_at_ms"], int)
     set_status.assert_awaited_once_with("C1", "123.45", status="")
     post_reply.assert_awaited_once()
-    assert post_reply.await_args.args[:2] == ("C1", "123.45")
-    assert "<https://ui/t1|Open SWE Web>" in post_reply.await_args.args[2]
+    await_args = post_reply.await_args
+    assert await_args is not None
+    assert await_args.args[:2] == ("C1", "123.45")
+    assert "<https://ui/t1|Open SWE Web>" in await_args.args[2]
 
 
 async def test_natural_language_plan_approval_uses_shared_approval_flow(
@@ -293,7 +295,9 @@ async def test_dispatch_or_queue_dispatches_when_idle(
 
     assert run == {"run_id": "run-1"}
     queue.assert_not_awaited()
-    assert dispatch.await_args.args[1] == blocks
+    await_args = dispatch.await_args
+    assert await_args is not None
+    assert await_args.args[1] == blocks
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_responses_replay.py
+++ b/tests/test_openai_responses_replay.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_openai import ChatOpenAI
+from pydantic import SecretStr
 
 
 def test_stateless_responses_replay_preserves_tool_history_without_mutation() -> None:
@@ -42,7 +43,7 @@ def test_stateless_responses_replay_preserves_tool_history_without_mutation() ->
     original_messages = deepcopy(messages)
     model = ChatOpenAI(
         model="gpt-5.6-sol",
-        api_key="test",
+        api_key=SecretStr("test"),
         use_responses_api=True,
         store=False,
         include=["reasoning.encrypted_content"],

--- a/tests/tools/test_corridor_mcp.py
+++ b/tests/tools/test_corridor_mcp.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_core.runnables import RunnableConfig
+from langgraph.runtime import Runtime
 
 from agent import server
 from agent.integrations import corridor_mcp
@@ -177,9 +181,12 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
             patch.object(server, "construct_system_prompt", return_value="prompt") as prompt,
             patch.object(server, "create_deep_agent", side_effect=fake_create_deep_agent),
         ):
-            await server.get_agent(config)
-            prepare = captured["middleware"][0]
-            await prepare.abefore_agent({}, None)
+            await server.get_agent(cast(RunnableConfig, config))
+            prepare = cast(AgentMiddleware, cast(list[object], captured["middleware"])[0])
+            await prepare.abefore_agent(
+                cast(AgentState[object], {"messages": []}),
+                cast(Runtime[None], MagicMock()),
+            )
         return bool(prompt.call_args.kwargs["corridor_enabled"])
 
     assert await run_with_corridor_tools([]) is False

--- a/tests/tools/test_http_security.py
+++ b/tests/tools/test_http_security.py
@@ -5,6 +5,7 @@ import json
 import socket as real_socket
 import sys
 import types
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -12,7 +13,7 @@ import httpx
 import pytest
 
 exa_py_stub = types.ModuleType("exa_py")
-exa_py_stub.Exa = object
+exa_py_stub.__dict__["Exa"] = object
 sys.modules.setdefault("exa_py", exa_py_stub)
 
 importlib.import_module("agent.tools.fetch_url")
@@ -57,7 +58,11 @@ class FakeResponse:
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
-            raise httpx.HTTPStatusError(f"{self.status_code} error", request=None, response=None)
+            request = httpx.Request("GET", self.url)
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"{self.status_code} error", request=request, response=response
+            )
 
 
 class FakeAsyncClient:
@@ -85,7 +90,11 @@ class FakeAsyncClient:
         return self._responder(method, url, **kwargs)
 
 
-def _install_client(monkeypatch, module, responder) -> type:
+def _install_client(
+    monkeypatch: pytest.MonkeyPatch,
+    module: types.ModuleType,
+    responder: Callable[..., FakeResponse],
+) -> Callable[..., FakeAsyncClient]:
     def factory(*args: Any, **kwargs: Any) -> FakeAsyncClient:
         return FakeAsyncClient(responder, *args, **kwargs)
 

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import StructuredTool
 
 from agent import server
@@ -222,8 +223,8 @@ async def test_observability_authorized_gates_on_admin(monkeypatch: pytest.Monke
     monkeypatch.delenv("OBSERVABILITY_AUTHORIZED_EMAILS", raising=False)
     monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
 
-    admin_config = {"configurable": {"user_email": "admin@example.com"}}
-    other_config = {"configurable": {"user_email": "attacker@example.com"}}
+    admin_config = cast(RunnableConfig, {"configurable": {"user_email": "admin@example.com"}})
+    other_config = cast(RunnableConfig, {"configurable": {"user_email": "attacker@example.com"}})
 
     assert await server._observability_authorized(admin_config, None) is True
     assert await server._observability_authorized(other_config, None) is False
@@ -235,7 +236,7 @@ async def test_observability_authorized_allowlist(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv("OBSERVABILITY_AUTHORIZED_EMAILS", "trusted@example.com")
     monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
 
-    config = {"configurable": {"user_email": "trusted@example.com"}}
+    config = cast(RunnableConfig, {"configurable": {"user_email": "trusted@example.com"}})
     assert await server._observability_authorized(config, None) is True
 
 
@@ -251,7 +252,7 @@ async def test_observability_authorized_resolves_login_email(
         AsyncMock(side_effect=lambda login: "dev@example.com" if login else None),
     )
 
-    config = {"configurable": {"github_login": "dev"}}
+    config = cast(RunnableConfig, {"configurable": {"github_login": "dev"}})
     assert await server._observability_authorized(config, "dev") is True
 
 
@@ -263,5 +264,5 @@ async def test_observability_authorized_accepts_admin_login(
     monkeypatch.delenv("OBSERVABILITY_AUTHORIZED_EMAILS", raising=False)
     monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
 
-    config = {"configurable": {"github_login": "dev"}}
+    config = cast(RunnableConfig, {"configurable": {"github_login": "dev"}})
     assert await server._observability_authorized(config, "dev") is True

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -48,7 +48,9 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
 
     assert result["status"] == "ok"
     reply.assert_awaited_once()
-    args = reply.await_args.args
+    await_args = reply.await_args
+    assert await_args is not None
+    args = await_args.args
     assert args[0] == "C1"
     assert args[1] == "123.45"
     assert "<https://ui/t1|Open SWE Web>" in args[2]
@@ -128,7 +130,9 @@ async def test_linear_source_comments_on_issue(monkeypatch: pytest.MonkeyPatch) 
 
     assert result["status"] == "ok"
     comment.assert_awaited_once()
-    assert comment.await_args.args[0] == "iss_1"
+    await_args = comment.await_args
+    assert await_args is not None
+    assert await_args.args[0] == "iss_1"
 
 
 @pytest.mark.asyncio

--- a/tests/webhooks/test_linear_webhook_author.py
+++ b/tests/webhooks/test_linear_webhook_author.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 from agent.webhooks import linear as linear_webhook
@@ -126,7 +126,9 @@ def test_linear_issue_prompt_mentions_pr_references_and_conventions() -> None:
         {"owner": "langchain-ai", "name": "open-swe"},
     )
 
-    prompt = content[0]["text"]
+    blocks = cast(list[object], content)
+    block = cast(dict[str, object], blocks[0])
+    prompt = cast(str, block["text"])
     assert "https://linear.app/x/issue/OS-42" in prompt
     assert "PR description links back to this Linear ticket" in prompt
     assert "repository's PR conventions" in prompt


### PR DESCRIPTION
## Summary
- Set `typeCheckingMode = "standard"` for basedpyright and clear all errors across `agent/` + `tests/` (710 → 0).
- Normalize LangGraph SDK `Thread`/`Run` metadata via `agent/utils/json_types.py`, fix prepare-run override signatures, middleware invariance casts, and `asyncio.gather` typing.
- Add `make typecheck` and install `dev` extras via `make install` so pytest/ruff resolve for the checker.

## Test plan
- [x] `npx basedpyright agent tests` → 0 errors, 0 warnings
- [x] `make lint` → pass
- [x] `make test` → 1537 passed
- [ ] CI green on this PR