### PR TITLE
feat: optional separate LangSmith key/endpoint for sandboxes

### DIFF
--- a/agent/dashboard/repo_snapshots.py
+++ b/agent/dashboard/repo_snapshots.py
@@ -342,7 +342,7 @@ def _build_snapshot_sync(record: dict[str, Any], snapshot_name: str) -> tuple[st
     """
     from langsmith.sandbox import SandboxClient
 
-    from agent.integrations.langsmith import _get_sandbox_api_key, _get_sandbox_endpoint
+    from agent.integrations.langsmith import _get_sandbox_api_endpoint, _get_sandbox_api_key
 
     api_key = _get_sandbox_api_key()
     if not api_key:
@@ -356,7 +356,7 @@ def _build_snapshot_sync(record: dict[str, Any], snapshot_name: str) -> tuple[st
     timeout = int(
         os.environ.get("REPO_SNAPSHOT_BUILD_TIMEOUT_SECONDS", DEFAULT_BUILD_TIMEOUT_SECONDS)
     )
-    client = SandboxClient(api_key=api_key, api_endpoint=_get_sandbox_endpoint())
+    client = SandboxClient(api_key=api_key, api_endpoint=_get_sandbox_api_endpoint())
     try:
         with tempfile.TemporaryDirectory(prefix="openswe-snapshot-") as context_dir:
             dockerfile_path = Path(context_dir) / "Dockerfile"

--- a/agent/dashboard/repo_snapshots.py
+++ b/agent/dashboard/repo_snapshots.py
@@ -342,9 +342,9 @@ def _build_snapshot_sync(record: dict[str, Any], snapshot_name: str) -> tuple[st
     """
     from langsmith.sandbox import SandboxClient
 
-    from agent.integrations.langsmith import _get_langsmith_api_key
+    from agent.integrations.langsmith import _get_sandbox_api_key, _get_sandbox_endpoint
 
-    api_key = _get_langsmith_api_key()
+    api_key = _get_sandbox_api_key()
     if not api_key:
         raise RuntimeError("LANGSMITH_API_KEY is not configured")
 
@@ -356,7 +356,7 @@ def _build_snapshot_sync(record: dict[str, Any], snapshot_name: str) -> tuple[st
     timeout = int(
         os.environ.get("REPO_SNAPSHOT_BUILD_TIMEOUT_SECONDS", DEFAULT_BUILD_TIMEOUT_SECONDS)
     )
-    client = SandboxClient(api_key=api_key)
+    client = SandboxClient(api_key=api_key, api_endpoint=_get_sandbox_endpoint())
     try:
         with tempfile.TemporaryDirectory(prefix="openswe-snapshot-") as context_dir:
             dockerfile_path = Path(context_dir) / "Dockerfile"

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import logging
 import os
+import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeout
@@ -79,6 +80,33 @@ def _get_sandbox_endpoint() -> str:
         or os.environ.get("LANGSMITH_ENDPOINT")
         or "https://api.smith.langchain.com"
     )
+
+
+def _current_thread_id() -> str | None:
+    """The LangGraph thread id for the active run, if any."""
+    try:
+        from langgraph.config import get_config
+
+        return get_config().get("configurable", {}).get("thread_id")
+    except Exception:
+        return None
+
+
+def _sandbox_name_for_thread(thread_id: str | None) -> str | None:
+    """Deterministic, thread-traceable sandbox name: ``openswe-<b32(thread uuid)>``.
+
+    The thread id (a UUID) is base32-encoded lowercase without padding so the
+    name is a compact, hyphen-free token that maps back to the thread. Returns
+    None when the thread id is missing or not a UUID, leaving the name unset.
+    """
+    if not thread_id:
+        return None
+    try:
+        raw = uuid.UUID(thread_id).bytes
+    except ValueError:
+        return None
+    encoded = base64.b32encode(raw).decode("ascii").rstrip("=").lower()
+    return f"openswe-{encoded}"
 
 
 def _parse_optional_int(name: str, default: int) -> int:
@@ -215,6 +243,7 @@ async def _create_sandbox_with_retry(
     client: AsyncSandboxClient,
     *,
     snapshot_id: str,
+    name: str | None,
     fs_capacity_bytes: int | None,
     vcpus: int | None,
     mem_bytes: int | None,
@@ -226,6 +255,7 @@ async def _create_sandbox_with_retry(
         try:
             return await client.create_sandbox(
                 snapshot_id=snapshot_id,
+                name=name,
                 fs_capacity_bytes=fs_capacity_bytes,
                 vcpus=vcpus,
                 mem_bytes=mem_bytes,
@@ -348,6 +378,7 @@ async def create_langsmith_sandbox(
     backend = await provider.get_or_create(
         sandbox_id=sandbox_id,
         snapshot_id=effective_snapshot_id,
+        name=_sandbox_name_for_thread(_current_thread_id()),
         fs_capacity_bytes=fs_capacity_bytes,
         vcpus=vcpus,
         mem_bytes=mem_bytes,
@@ -365,11 +396,9 @@ async def create_langsmith_sandbox(
 async def _update_thread_sandbox_metadata(sandbox_id: str) -> None:
     """Update thread metadata with sandbox_id."""
     try:
-        from langgraph.config import get_config
         from langgraph_sdk import get_client
 
-        config = get_config()
-        thread_id = config.get("configurable", {}).get("thread_id")
+        thread_id = _current_thread_id()
         if not thread_id:
             return
         client = get_client()
@@ -568,6 +597,7 @@ class LangSmithProvider(SandboxProvider):
         sandbox_id: str | None = None,
         timeout: int = 180,
         snapshot_id: str | None = None,
+        name: str | None = None,
         fs_capacity_bytes: int | None = None,
         vcpus: int | None = None,
         mem_bytes: int | None = None,
@@ -622,6 +652,7 @@ class LangSmithProvider(SandboxProvider):
                 sandbox = await _create_sandbox_with_retry(
                     client,
                     snapshot_id=snapshot_id,
+                    name=name,
                     fs_capacity_bytes=fs_capacity_bytes,
                     vcpus=vcpus,
                     mem_bytes=mem_bytes,

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -58,6 +58,29 @@ def _get_langsmith_api_key() -> str | None:
     return os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGSMITH_API_KEY_PROD")
 
 
+def _get_sandbox_api_key() -> str | None:
+    """LangSmith API key for sandbox operations.
+
+    ``SANDBOX_LANGSMITH_API_KEY`` lets sandboxes run against a different
+    LangSmith workspace than the one used for tracing/other API calls; falls
+    back to the standard key.
+    """
+    return os.environ.get("SANDBOX_LANGSMITH_API_KEY") or _get_langsmith_api_key()
+
+
+def _get_sandbox_endpoint() -> str:
+    """LangSmith API endpoint for sandbox operations.
+
+    Overridable via ``SANDBOX_LANGSMITH_ENDPOINT`` to pair with
+    ``SANDBOX_LANGSMITH_API_KEY``; falls back to ``LANGSMITH_ENDPOINT``.
+    """
+    return (
+        os.environ.get("SANDBOX_LANGSMITH_ENDPOINT")
+        or os.environ.get("LANGSMITH_ENDPOINT")
+        or "https://api.smith.langchain.com"
+    )
+
+
 def _parse_optional_int(name: str, default: int) -> int:
     raw = os.environ.get(name)
     if not raw:
@@ -238,11 +261,11 @@ async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
         sandbox_name: The sandbox name/ID returned by the LangSmith API.
         github_token: GitHub token to inject as Authorization header.
     """
-    api_key = _get_langsmith_api_key()
+    api_key = _get_sandbox_api_key()
     if not api_key:
         logger.warning("No LangSmith API key found, skipping GitHub proxy configuration")
         return
-    langsmith_endpoint = os.environ.get("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+    langsmith_endpoint = _get_sandbox_endpoint()
     url = f"{langsmith_endpoint}/v2/sandboxes/boxes/{sandbox_name}"
     payload = {"proxy_config": {"rules": _github_proxy_rules(github_token)}}
     async with httpx.AsyncClient(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:
@@ -282,8 +305,8 @@ async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
 
 
 def get_async_sandbox_client() -> AsyncSandboxClient:
-    """Build an ``AsyncSandboxClient`` from the resolved LangSmith API key."""
-    return AsyncSandboxClient(api_key=_get_langsmith_api_key())
+    """Build an ``AsyncSandboxClient`` from the resolved sandbox LangSmith credentials."""
+    return AsyncSandboxClient(api_key=_get_sandbox_api_key(), api_endpoint=_get_sandbox_endpoint())
 
 
 async def create_langsmith_sandbox(
@@ -309,7 +332,7 @@ async def create_langsmith_sandbox(
     Returns:
         SandboxBackendProtocol instance
     """
-    api_key = _get_langsmith_api_key()
+    api_key = _get_sandbox_api_key()
     (
         default_snapshot_id,
         fs_capacity_bytes,
@@ -501,7 +524,8 @@ class LangSmithProvider(SandboxProvider):
     """LangSmith sandbox provider implementation."""
 
     def __init__(self, api_key: str | None = None) -> None:
-        self._api_key = api_key or _get_langsmith_api_key()
+        self._api_key = api_key or _get_sandbox_api_key()
+        self._api_endpoint = _get_sandbox_endpoint()
         if not self._api_key:
             msg = "LANGSMITH_API_KEY (or LANGSMITH_API_KEY_PROD) not set"
             raise ValueError(msg)
@@ -561,7 +585,9 @@ class LangSmithProvider(SandboxProvider):
         if kwargs:
             msg = f"Received unsupported arguments: {list(kwargs.keys())}"
             raise TypeError(msg)
-        async with AsyncSandboxClient(api_key=self._api_key) as client:
+        async with AsyncSandboxClient(
+            api_key=self._api_key, api_endpoint=self._api_endpoint
+        ) as client:
             if sandbox_id:
                 try:
                     sandbox = await client.get_sandbox(name=sandbox_id)
@@ -611,5 +637,7 @@ class LangSmithProvider(SandboxProvider):
 
     async def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:
         """Delete a LangSmith sandbox."""
-        async with AsyncSandboxClient(api_key=self._api_key) as client:
+        async with AsyncSandboxClient(
+            api_key=self._api_key, api_endpoint=self._api_endpoint
+        ) as client:
             await client.delete_sandbox(sandbox_id)

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -70,16 +70,29 @@ def _get_sandbox_api_key() -> str | None:
 
 
 def _get_sandbox_endpoint() -> str:
-    """LangSmith API endpoint for sandbox operations.
+    """LangSmith API **root** for sandbox operations.
 
     Overridable via ``SANDBOX_LANGSMITH_ENDPOINT`` to pair with
-    ``SANDBOX_LANGSMITH_API_KEY``; falls back to ``LANGSMITH_ENDPOINT``.
+    ``SANDBOX_LANGSMITH_API_KEY``; falls back to ``LANGSMITH_ENDPOINT``. This is
+    the bare root (e.g. ``https://api.smith.langchain.com``) used to build the
+    proxy-config URL; the SDK clients take :func:`_get_sandbox_api_endpoint`.
     """
     return (
         os.environ.get("SANDBOX_LANGSMITH_ENDPOINT")
         or os.environ.get("LANGSMITH_ENDPOINT")
         or "https://api.smith.langchain.com"
     )
+
+
+def _get_sandbox_api_endpoint() -> str:
+    """Sandbox API base URL for the langsmith SDK clients.
+
+    The SDK's ``api_endpoint`` is the sandbox base (root + ``/v2/sandboxes``),
+    not the API root, and its methods append ``/boxes``, ``/snapshots``, etc.
+    """
+    root = _get_sandbox_endpoint().rstrip("/")
+    suffix = "/v2/sandboxes"
+    return root if root.endswith(suffix) else f"{root}{suffix}"
 
 
 def _current_thread_id() -> str | None:
@@ -336,7 +349,9 @@ async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
 
 def get_async_sandbox_client() -> AsyncSandboxClient:
     """Build an ``AsyncSandboxClient`` from the resolved sandbox LangSmith credentials."""
-    return AsyncSandboxClient(api_key=_get_sandbox_api_key(), api_endpoint=_get_sandbox_endpoint())
+    return AsyncSandboxClient(
+        api_key=_get_sandbox_api_key(), api_endpoint=_get_sandbox_api_endpoint()
+    )
 
 
 async def create_langsmith_sandbox(
@@ -554,7 +569,7 @@ class LangSmithProvider(SandboxProvider):
 
     def __init__(self, api_key: str | None = None) -> None:
         self._api_key = api_key or _get_sandbox_api_key()
-        self._api_endpoint = _get_sandbox_endpoint()
+        self._api_endpoint = _get_sandbox_api_endpoint()
         if not self._api_key:
             msg = "LANGSMITH_API_KEY (or LANGSMITH_API_KEY_PROD) not set"
             raise ValueError(msg)

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -69,6 +69,8 @@ Set the `SANDBOX_TYPE` environment variable to switch providers. Each provider h
 
 > **Warning**: `local` runs commands directly on your host with no sandboxing. Only use for local development with human-in-the-loop enabled.
 
+For `langsmith`, sandboxes default to the same LangSmith credentials as tracing. To run sandboxes against a **different** LangSmith workspace, set `SANDBOX_LANGSMITH_API_KEY` (falls back to `LANGSMITH_API_KEY` / `LANGSMITH_API_KEY_PROD`) and optionally `SANDBOX_LANGSMITH_ENDPOINT` (falls back to `LANGSMITH_ENDPOINT`). These apply to sandbox create/connect/delete, the GitHub proxy config, and repo snapshot builds — the `DEFAULT_SANDBOX_SNAPSHOT_ID` must exist in whichever workspace these credentials point at.
+
 ### Adding a new sandbox provider
 
 1. **Create an integration file** at `agent/integrations/my_provider.py` with a factory function matching this signature:

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -1,5 +1,7 @@
 """Tests for LangSmith sandbox env-var configuration parsing."""
 
+import base64
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,8 +15,27 @@ from agent.integrations.langsmith import (
     LangSmithProvider,
     _create_sandbox_with_retry,
     _get_sandbox_snapshot_config,
+    _sandbox_name_for_thread,
     _wait_for_reconnected_sandbox,
 )
+
+
+def test_sandbox_name_for_thread_encodes_uuid() -> None:
+    thread_id = "12345678-1234-5678-1234-567812345678"
+    name = _sandbox_name_for_thread(thread_id)
+    assert name is not None
+    prefix, _, encoded = name.partition("-")
+    assert prefix == "openswe"
+    assert encoded == encoded.lower()
+    assert "=" not in encoded and "-" not in encoded
+    # Round-trips back to the original UUID.
+    padded = encoded.upper() + "=" * (-len(encoded) % 8)
+    assert uuid.UUID(bytes=base64.b32decode(padded)) == uuid.UUID(thread_id)
+
+
+def test_sandbox_name_for_thread_none_or_invalid() -> None:
+    assert _sandbox_name_for_thread(None) is None
+    assert _sandbox_name_for_thread("not-a-uuid") is None
 
 
 def test_defaults_when_env_unset() -> None:
@@ -112,6 +133,7 @@ class _FakeSandboxClient:
 
     async def create_sandbox(self, **kwargs):
         self.calls += 1
+        self.last_kwargs = kwargs
         if self.calls <= self.failures:
             raise _RetryableCreateError("try again")
         return {"sandbox": kwargs["snapshot_id"]}
@@ -141,6 +163,7 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
     result = await _create_sandbox_with_retry(
         client,
         snapshot_id="snap-1",
+        name="openswe-abc",
         fs_capacity_bytes=None,
         vcpus=None,
         mem_bytes=None,
@@ -151,6 +174,7 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
 
     assert result == {"sandbox": "snap-1"}
     assert client.calls == 3
+    assert client.last_kwargs["name"] == "openswe-abc"
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -14,10 +14,24 @@ from agent.integrations.langsmith import (
     DEFAULT_SNAPSHOT_FS_CAPACITY_BYTES,
     LangSmithProvider,
     _create_sandbox_with_retry,
+    _get_sandbox_api_endpoint,
     _get_sandbox_snapshot_config,
     _sandbox_name_for_thread,
     _wait_for_reconnected_sandbox,
 )
+
+
+def test_sandbox_api_endpoint_appends_v2_sandboxes() -> None:
+    with patch.dict("os.environ", {"LANGSMITH_ENDPOINT": "https://eu.smith.langchain.com"}):
+        assert _get_sandbox_api_endpoint() == "https://eu.smith.langchain.com/v2/sandboxes"
+
+
+def test_sandbox_api_endpoint_no_double_suffix() -> None:
+    with patch.dict(
+        "os.environ",
+        {"SANDBOX_LANGSMITH_ENDPOINT": "https://x.smith.langchain.com/v2/sandboxes"},
+    ):
+        assert _get_sandbox_api_endpoint() == "https://x.smith.langchain.com/v2/sandboxes"
 
 
 def test_sandbox_name_for_thread_encodes_uuid() -> None:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -130,6 +130,34 @@ class TestConfigureGithubProxy:
             headers = mock_client.patch.call_args.kwargs["headers"]
             assert headers == {"X-API-Key": "my-api-key"}
 
+    async def test_sandbox_overrides_take_precedence(self) -> None:
+        """SANDBOX_LANGSMITH_* override the shared key/endpoint for the proxy call."""
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch.dict(
+                "os.environ",
+                {
+                    "LANGSMITH_API_KEY": "shared-key",
+                    "LANGSMITH_ENDPOINT": "https://shared.smith.langchain.com",
+                    "SANDBOX_LANGSMITH_API_KEY": "sandbox-key",
+                    "SANDBOX_LANGSMITH_ENDPOINT": "https://sandbox.smith.langchain.com",
+                },
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            await _configure_github_proxy("sandbox-abc", "token")
+
+            assert (
+                mock_client.patch.call_args.args[0]
+                == "https://sandbox.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
+            )
+            assert mock_client.patch.call_args.kwargs["headers"] == {"X-API-Key": "sandbox-key"}
+
     async def test_retries_transient_http_error(self) -> None:
         """Transient proxy API errors should be retried on the same sandbox."""
         request = httpx.Request(


### PR DESCRIPTION
## What

Two changes to the LangSmith sandbox integration:

**1. Optional separate LangSmith workspace for sandboxes.** Sandboxes can authenticate against a different LangSmith workspace than the deployment uses for tracing and other API calls, via two new optional env vars:

| Env var | Falls back to |
|---|---|
| `SANDBOX_LANGSMITH_API_KEY` | `LANGSMITH_API_KEY` → `LANGSMITH_API_KEY_PROD` |
| `SANDBOX_LANGSMITH_ENDPOINT` | `LANGSMITH_ENDPOINT` → `https://api.smith.langchain.com` |

Both are optional; when unset, resolution is identical to today (no-op for existing deployments).

**2. Thread-traceable sandbox names.** New sandboxes are named `openswe-<b32(thread id)>` — the LangGraph thread id (a UUID) base32-encoded lowercase without padding, e.g. `openswe-ci2fm6asgrlhqerukz4bencwpa`. This ties each sandbox back to its thread in the LangSmith UI. The name is cosmetic: reconnect/delete still key off the server-assigned sandbox id, so a repeated thread simply gets a fresh id under the same name. Falls back to an unset name when no thread id is present or it isn't a UUID.

## Why

Sandbox compute and app tracing can belong to separate LangSmith workspaces/regions (e.g. running sandboxes under a dedicated billing or capacity account while tracing flows to the primary workspace). Sandbox creation was previously hard-wired to the same key/endpoint as everything else. The credential override mirrors the existing `LANGSMITH_GATEWAY_API_KEY` pattern of a purpose-scoped credential.

Deterministic names make it possible to find the sandbox for a given thread (and vice-versa) without going through thread metadata.

## How

Credential resolvers `_get_sandbox_api_key` / `_get_sandbox_endpoint` in `agent/integrations/langsmith.py` centralize the fallback logic and are wired into every call that hits the sandbox workspace:

- `get_async_sandbox_client()` and `LangSmithProvider` — create / connect / delete (client now gets an explicit `api_endpoint`)
- `_configure_github_proxy()` — `X-API-Key` header and the proxy-config PATCH URL
- `create_langsmith_sandbox()`
- `agent/dashboard/repo_snapshots.py` — snapshot builds via `SandboxClient`

The name is computed by `_sandbox_name_for_thread()` from the active thread id (`_current_thread_id()`, reused for the existing metadata write) and passed through `get_or_create` → `_create_sandbox_with_retry` → `client.create_sandbox(name=...)`.

Keys are read from env only and never logged.

**Operational note:** `DEFAULT_SANDBOX_SNAPSHOT_ID` (and any repo snapshots) must exist in whichever workspace these credentials point at. Documented in `docs/CUSTOMIZATION.md`.

## Test Plan

- [x] Unit tests for the name encoder (UUID round-trip, hyphen/pad-free, None/invalid → unset) and that the name is forwarded to `create_sandbox`
- [x] Precedence test asserting the credential overrides win over the shared key/endpoint in the proxy-config call
- [x] Full `tests/sandbox/` suite passes
- [x] `make lint` clean
