### PR TITLE
fix: capitalize dashboard tool labels

### DIFF
--- a/ui/src/features/agents/components/chat/ToolExecution.test.ts
+++ b/ui/src/features/agents/components/chat/ToolExecution.test.ts
@@ -37,13 +37,13 @@ describe("formatToolDisplay", () => {
     expect(formatToolDisplay("write todos", "other", {}, projectPath)).toBe("Update todos");
   });
 
-  it("title-cases raw tool names", () => {
+  it("sentence-cases raw tool names", () => {
     expect(formatToolDisplay("enter_plan_mode", "other", {}, projectPath)).toBe(
-      "Enter Plan Mode",
+      "Enter plan mode",
     );
-    expect(formatToolDisplay("save_plan", "other", {}, projectPath)).toBe("Save Plan");
+    expect(formatToolDisplay("save_plan", "other", {}, projectPath)).toBe("Save plan");
     expect(formatToolDisplay("slack_thread_reply", "other", {}, projectPath)).toBe(
-      "Slack Thread Reply",
+      "Slack thread reply",
     );
   });
 });

--- a/ui/src/features/agents/components/chat/ToolExecution.test.ts
+++ b/ui/src/features/agents/components/chat/ToolExecution.test.ts
@@ -36,4 +36,14 @@ describe("formatToolDisplay", () => {
   it("normalizes write_todos", () => {
     expect(formatToolDisplay("write todos", "other", {}, projectPath)).toBe("Update todos");
   });
+
+  it("title-cases raw tool names", () => {
+    expect(formatToolDisplay("enter_plan_mode", "other", {}, projectPath)).toBe(
+      "Enter Plan Mode",
+    );
+    expect(formatToolDisplay("save_plan", "other", {}, projectPath)).toBe("Save Plan");
+    expect(formatToolDisplay("slack_thread_reply", "other", {}, projectPath)).toBe(
+      "Slack Thread Reply",
+    );
+  });
 });

--- a/ui/src/features/agents/components/chat/toolExecutionDisplay.ts
+++ b/ui/src/features/agents/components/chat/toolExecutionDisplay.ts
@@ -1,3 +1,4 @@
+import { humanizeToolName } from "@/features/agents/lib/toolNames";
 import type { AcpToolKind } from "@/features/agents/lib/types";
 
 function stripProjectPath(path: string, projectPath?: string): string {
@@ -27,7 +28,15 @@ function normalizedToolName(title: string): string {
 }
 
 function humanizeToolTitle(title: string): string {
-  return title.replace(/_/g, " ").trim() || "Tool";
+  const trimmed = title.trim();
+  if (!trimmed) return "Tool";
+
+  const [name, ...rest] = trimmed.split(/\s+/);
+  const suffix = rest.join(" ");
+  if (name && suffix && /^(?:[./~]|[a-z]+:\/\/)/i.test(suffix)) {
+    return `${humanizeToolName(name)} ${suffix}`;
+  }
+  return humanizeToolName(trimmed);
 }
 
 export function formatToolDisplay(

--- a/ui/src/features/agents/components/subagents/SubagentActivity.tsx
+++ b/ui/src/features/agents/components/subagents/SubagentActivity.tsx
@@ -1,9 +1,7 @@
 import { useStreamContext as useAgentThreadStream, useToolCalls } from "@langchain/react"
 import { Check, Loader2, X } from "lucide-react"
 
-function humanizeToolName(name: string): string {
-  return name.replace(/_/g, " ").trim() || "tool"
-}
+import { humanizeToolName } from "@/features/agents/lib/toolNames"
 
 /**
  * Live status for a single subagent, read straight from the SDK's scoped

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -1,5 +1,6 @@
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { messageArrivalTimestamp } from "./messageTimestamps";
+import { humanizeToolName } from "./toolNames";
 import type { BaseMessage, ContentBlock } from "@langchain/core/messages";
 import type { AssembledToolCall, SubagentDiscoverySnapshot } from "@langchain/react";
 
@@ -39,7 +40,7 @@ function toolTitle(name: string, args: Record<string, unknown>): string {
   if (typeof command === "string" && command.trim()) {
     return command.trim().split("\n")[0]?.slice(0, 120) ?? "";
   }
-  return name.replace(/_/g, " ").trim() || "Tool";
+  return humanizeToolName(name);
 }
 
 function parseToolArgs(raw: unknown): Record<string, unknown> {

--- a/ui/src/features/agents/lib/toolNames.ts
+++ b/ui/src/features/agents/lib/toolNames.ts
@@ -1,30 +1,10 @@
-const TOOL_NAME_WORDS: Record<string, string> = {
-  api: "API",
-  ci: "CI",
-  cli: "CLI",
-  github: "GitHub",
-  http: "HTTP",
-  id: "ID",
-  ids: "IDs",
-  oauth: "OAuth",
-  pr: "PR",
-  ui: "UI",
-  uri: "URI",
-  url: "URL",
-  urls: "URLs",
-}
-
-function titleCaseWord(word: string): string {
-  const lower = word.toLowerCase()
-  return (
-    TOOL_NAME_WORDS[lower] ??
-    `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`
-  )
-}
-
 export function humanizeToolName(name: string, fallback = "Tool"): string {
-  const words = name.replace(/[_-]+/g, " ").trim().split(/\s+/).filter(Boolean)
+  const normalized = name
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase()
 
-  if (!words.length) return fallback
-  return words.map(titleCaseWord).join(" ")
+  if (!normalized) return fallback
+  return `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
 }

--- a/ui/src/features/agents/lib/toolNames.ts
+++ b/ui/src/features/agents/lib/toolNames.ts
@@ -1,0 +1,30 @@
+const TOOL_NAME_WORDS: Record<string, string> = {
+  api: "API",
+  ci: "CI",
+  cli: "CLI",
+  github: "GitHub",
+  http: "HTTP",
+  id: "ID",
+  ids: "IDs",
+  oauth: "OAuth",
+  pr: "PR",
+  ui: "UI",
+  uri: "URI",
+  url: "URL",
+  urls: "URLs",
+}
+
+function titleCaseWord(word: string): string {
+  const lower = word.toLowerCase()
+  return (
+    TOOL_NAME_WORDS[lower] ??
+    `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`
+  )
+}
+
+export function humanizeToolName(name: string, fallback = "Tool"): string {
+  const words = name.replace(/[_-]+/g, " ").trim().split(/\s+/).filter(Boolean)
+
+  if (!words.length) return fallback
+  return words.map(titleCaseWord).join(" ")
+}


### PR DESCRIPTION
## Description
Capitalizes raw dashboard tool-call labels using sentence case so entries like `enter_plan_mode`, `save_plan`, and `slack_thread_reply` render as readable labels across main and subagent activity UI.

## Test Plan
- [ ] Verify the new tool-label casing in the agent transcript UI.

Made by [Open SWE](https://openswe.vercel.app/agents/3d2c19f4-e639-8d47-a39f-23dac9bf4318)