### PR TITLE
feat: Expose more specific AGENTS.md context to Open SWE reviewer

### DIFF
--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -62,6 +62,7 @@ from .middleware import (
 )
 from .middleware.prepare_run import PrepareRunState
 from .review.diff import (
+    changed_files,
     compute_diff_line_set,
     fetch_pr_diff,
     fetch_pr_metadata,
@@ -104,7 +105,7 @@ from .tools import (
     web_search,
 )
 from .utils import ttl_cache
-from .utils.agents_md import fetch_agents_md
+from .utils.agents_md import fetch_agents_md, fetch_scoped_agents_md
 from .utils.api_standards_skill import fetch_api_standards_skill
 from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import get_github_app_installation_token_with_expiry
@@ -410,6 +411,7 @@ def _reviewer_system_prompt(
     org_guidelines: str | None = None,
     repo_style_prompt: str | None = None,
     agents_md_content: str | None = None,
+    scoped_agents_md: dict[str, str] | None = None,
     api_standards_skill: str | None = None,
 ) -> str:
     prompt = REVIEWER_PROMPT_TEMPLATE.format(
@@ -450,12 +452,22 @@ def _reviewer_system_prompt(
             "they refine tone, severity, and what this team typically flags.\n\n"
             f"{repo_style_prompt}"
         )
-    if agents_md_content:
+    if agents_md_content or scoped_agents_md:
+        instruction_sections: list[str] = []
+        if agents_md_content:
+            instruction_sections.append(
+                f"## Root instructions (scope: entire repository)\n\n```\n{agents_md_content}\n```"
+            )
+        for path, content in (scoped_agents_md or {}).items():
+            scope = posixpath.dirname(path)
+            instruction_sections.append(
+                f"## Instructions from `{path}` (scope: `{scope}/`)\n\n```\n{content}\n```"
+            )
         prompt = (
             f"{prompt}\n\n"
             "# Repository conventions (AGENTS.md / CLAUDE.md)\n\n"
-            "The following is the `AGENTS.md` or `CLAUDE.md` file from the target "
-            "branch (the PR's base), not from the PR head. It documents the "
+            "The following files come from the target branch (the PR's base), "
+            "not from the PR head. They document the "
             "project's conventions, architecture, and rules. These rules are "
             "**mandatory** — the project enforces them on every contributor and "
             "they are not optional style preferences. When a changed line "
@@ -475,9 +487,9 @@ def _reviewer_system_prompt(
             "- **Process / CI rules** — if the repo requires tests, changelog "
             "entries, or specific CI steps for certain changes and the PR skips "
             "them, that is a finding.\n\n"
-            "```\n"
-            f"{agents_md_content}\n"
-            "```"
+            "Each scoped `AGENTS.md` applies only to changed files under its "
+            "listed directory. When instructions conflict, the most deeply "
+            "nested applicable file takes precedence.\n\n" + "\n\n".join(instruction_sections)
         )
     if api_standards_skill:
         prompt = (
@@ -1152,14 +1164,24 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
         api_standards_task = asyncio.create_task(_cached_api_standards_skill())
         pr_trace_context_task = asyncio.create_task(_prepare_pr_trace_context())
         diff_context = await diff_context_task
+        pr_diff_text, pr_diff_line_set = diff_context
+        scoped_agents_md_task = asyncio.create_task(
+            fetch_scoped_agents_md(
+                repo_owner,
+                repo_name,
+                base_sha,
+                changed_files(pr_diff_text),
+                token=github_token,
+            )
+        )
         pr_overview = await pr_overview_task
         existing_threads_block = await existing_threads_task
         repo_style_prompt = await repo_style_task
         agents_md_content = await agents_md_task
+        scoped_agents_md = await scoped_agents_md_task
         org_guidelines = await org_guidelines_task
         api_standards_skill = await api_standards_task
         pr_trace_context = await pr_trace_context_task
-        pr_diff_text, pr_diff_line_set = diff_context
         pr_title, pr_body = pr_overview
 
         review_context = ""
@@ -1218,6 +1240,7 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
             org_guidelines=org_guidelines,
             repo_style_prompt=repo_style_prompt,
             agents_md_content=agents_md_content,
+            scoped_agents_md=scoped_agents_md,
             api_standards_skill=api_standards_skill,
         )
         trace_context_prompt = format_pr_trace_context_prompt(pr_trace_context)

--- a/agent/utils/agents_md.py
+++ b/agent/utils/agents_md.py
@@ -149,39 +149,43 @@ async def fetch_scoped_agents_md(
     semaphore = asyncio.Semaphore(_SCOPED_FETCH_CONCURRENCY)
     async with httpx.AsyncClient(timeout=timeout) as client:
 
-        async def _fetch(path: str) -> tuple[str, str] | None:
-            url_path = quote(path, safe="/")
-            url = f"https://api.github.com/repos/{owner}/{repo}/contents/{url_path}"
-            try:
-                async with semaphore:
-                    response = await client.get(url, headers=headers, params={"ref": ref})
-            except httpx.HTTPError:
-                logger.exception("Failed to fetch %s from %s/%s@%s", path, owner, repo, ref)
-                return None
-            if response.status_code == 404:
-                return None
-            if response.status_code != 200:
-                logger.warning(
-                    "Unexpected status %s fetching %s from %s/%s@%s",
-                    response.status_code,
-                    path,
-                    owner,
-                    repo,
-                    ref,
-                )
-                return None
-            content = response.text
-            if len(content.encode("utf-8")) > _MAX_AGENTS_MD_BYTES:
-                logger.info(
-                    "%s in %s/%s@%s exceeds %d bytes; skipping inline",
-                    path,
-                    owner,
-                    repo,
-                    ref,
-                    _MAX_AGENTS_MD_BYTES,
-                )
-                return None
-            return path, content
+        async def _fetch(candidate: str) -> tuple[str, str] | None:
+            directory = posixpath.dirname(candidate)
+            for filename in _AGENT_DOC_FILENAMES:
+                path = posixpath.join(directory, filename)
+                url_path = quote(path, safe="/")
+                url = f"https://api.github.com/repos/{owner}/{repo}/contents/{url_path}"
+                try:
+                    async with semaphore:
+                        response = await client.get(url, headers=headers, params={"ref": ref})
+                except httpx.HTTPError:
+                    logger.exception("Failed to fetch %s from %s/%s@%s", path, owner, repo, ref)
+                    return None
+                if response.status_code == 404:
+                    continue
+                if response.status_code != 200:
+                    logger.warning(
+                        "Unexpected status %s fetching %s from %s/%s@%s",
+                        response.status_code,
+                        path,
+                        owner,
+                        repo,
+                        ref,
+                    )
+                    return None
+                content = response.text
+                if len(content.encode("utf-8")) > _MAX_AGENTS_MD_BYTES:
+                    logger.info(
+                        "%s in %s/%s@%s exceeds %d bytes; skipping inline",
+                        path,
+                        owner,
+                        repo,
+                        ref,
+                        _MAX_AGENTS_MD_BYTES,
+                    )
+                    return None
+                return path, content
+            return None
 
         fetched = await asyncio.gather(*(_fetch(path) for path in candidates))
 

--- a/agent/utils/agents_md.py
+++ b/agent/utils/agents_md.py
@@ -6,7 +6,11 @@ without the model having to clone the repo and read the file itself.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import posixpath
+from collections.abc import Iterable
+from urllib.parse import quote
 
 import httpx
 
@@ -20,6 +24,25 @@ _MAX_AGENTS_MD_BYTES = 64 * 1024
 # Filenames tried in order of preference. AGENTS.md is the cross-tool standard;
 # CLAUDE.md is the legacy Anthropic-specific filename still used by many repos.
 _AGENT_DOC_FILENAMES = ("AGENTS.md", "CLAUDE.md")
+_SCOPED_FETCH_CONCURRENCY = 8
+
+
+def applicable_agents_md_paths(changed_files: Iterable[str]) -> list[str]:
+    """Return repo-relative ancestor ``AGENTS.md`` paths for changed files.
+
+    The root file is loaded separately (with the ``CLAUDE.md`` fallback), so
+    this only returns directory-scoped files. Paths are ordered from shallowest
+    to deepest so later instructions can take precedence in the prompt.
+    """
+    candidates: set[str] = set()
+    for raw_path in changed_files:
+        path = posixpath.normpath(raw_path.strip())
+        if not raw_path.strip() or path in {".", ".."} or path.startswith(("/", "../")):
+            continue
+        parts = path.split("/")
+        for depth in range(1, len(parts)):
+            candidates.add("/".join((*parts[:depth], "AGENTS.md")))
+    return sorted(candidates, key=lambda path: (path.count("/"), path))
 
 
 async def fetch_agents_md(
@@ -93,3 +116,78 @@ async def fetch_agents_md(
             return content
 
     return None
+
+
+async def fetch_scoped_agents_md(
+    owner: str,
+    repo: str,
+    ref: str,
+    changed_files: Iterable[str],
+    *,
+    token: str | None,
+    timeout: float = 10.0,
+) -> dict[str, str]:
+    """Fetch applicable directory-scoped ``AGENTS.md`` files at ``ref``.
+
+    Each candidate is an ancestor of at least one changed file. Missing,
+    oversized, or unavailable files are skipped independently so one bad path
+    does not hide valid instructions in another changed subtree.
+    """
+    if not owner or not repo or not ref:
+        return {}
+    candidates = applicable_agents_md_paths(changed_files)
+    if not candidates:
+        return {}
+
+    headers = {
+        "Accept": "application/vnd.github.raw",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    semaphore = asyncio.Semaphore(_SCOPED_FETCH_CONCURRENCY)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+
+        async def _fetch(path: str) -> tuple[str, str] | None:
+            url_path = quote(path, safe="/")
+            url = f"https://api.github.com/repos/{owner}/{repo}/contents/{url_path}"
+            try:
+                async with semaphore:
+                    response = await client.get(url, headers=headers, params={"ref": ref})
+            except httpx.HTTPError:
+                logger.exception("Failed to fetch %s from %s/%s@%s", path, owner, repo, ref)
+                return None
+            if response.status_code == 404:
+                return None
+            if response.status_code != 200:
+                logger.warning(
+                    "Unexpected status %s fetching %s from %s/%s@%s",
+                    response.status_code,
+                    path,
+                    owner,
+                    repo,
+                    ref,
+                )
+                return None
+            content = response.text
+            if len(content.encode("utf-8")) > _MAX_AGENTS_MD_BYTES:
+                logger.info(
+                    "%s in %s/%s@%s exceeds %d bytes; skipping inline",
+                    path,
+                    owner,
+                    repo,
+                    ref,
+                    _MAX_AGENTS_MD_BYTES,
+                )
+                return None
+            return path, content
+
+        fetched = await asyncio.gather(*(_fetch(path) for path in candidates))
+
+    result: dict[str, str] = {}
+    for item in fetched:
+        if item is not None:
+            path, content = item
+            result[path] = content
+    return result

--- a/tests/agent/test_agents_md.py
+++ b/tests/agent/test_agents_md.py
@@ -108,3 +108,35 @@ async def test_fetch_agents_md_returns_none_for_missing_params() -> None:
     assert result is None
     result = await agents_md.fetch_agents_md("acme", "repo", "", token="tok")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_scoped_agents_md_falls_back_to_claude_md() -> None:
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        client = MagicMock()
+        client.get = AsyncMock(
+            side_effect=[
+                _make_response(404),
+                _make_response(200, "# CLAUDE.md\nrules"),
+            ]
+        )
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+        result = await agents_md.fetch_scoped_agents_md(
+            "acme", "repo", "main", ["ui/app.py"], token="tok"
+        )
+    assert result == {"ui/CLAUDE.md": "# CLAUDE.md\nrules"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_scoped_agents_md_prefers_agents_md() -> None:
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        client = MagicMock()
+        client.get = AsyncMock(return_value=_make_response(200, "# AGENTS.md\nrules"))
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+        result = await agents_md.fetch_scoped_agents_md(
+            "acme", "repo", "main", ["ui/app.py"], token="tok"
+        )
+    assert result == {"ui/AGENTS.md": "# AGENTS.md\nrules"}
+    assert client.get.await_count == 1


### PR DESCRIPTION
## Expose more specific AGENTS.md context to Open SWE reviewer

Right now, Open SWE reviewer only loads up the root AGENTS.md file, but what we really want is for the reviewer to load up all the relevant agent rules from all the files touched in the PR. This PR solves that problem to give Open SWE reviewer the best context possible to review (ie. will load up smith-frontend/AGENTS.md for any frontend files changed)

Made by [Open SWE](https://openswe.vercel.app/agents/019f70fd-1f8b-75a2-8230-06c84f2000b7)