### PR TITLE
feat: define stackability review artifact

### DIFF
--- a/agent/review/__init__.py
+++ b/agent/review/__init__.py
@@ -3,9 +3,27 @@ from agent.review.findings import (
     REVIEWER_THREAD_KIND,
     Finding,
 )
+from agent.review.stackability import (
+    HARNESS_PROMPT_REQUIREMENTS,
+    STACKABILITY_REVIEW_RUBRIC,
+    StackabilityConfidence,
+    StackabilityPublishingMode,
+    StackabilityReview,
+    StackabilityVerdict,
+    StackStep,
+    validate_stackability_review,
+)
 
 __all__ = [
     "Finding",
     "REVIEWER_THREAD_KIND",
     "REVIEW_FINDING_CAP",
+    "HARNESS_PROMPT_REQUIREMENTS",
+    "STACKABILITY_REVIEW_RUBRIC",
+    "StackStep",
+    "StackabilityConfidence",
+    "StackabilityPublishingMode",
+    "StackabilityReview",
+    "StackabilityVerdict",
+    "validate_stackability_review",
 ]

--- a/agent/review/stackability.py
+++ b/agent/review/stackability.py
@@ -124,12 +124,11 @@ def _validate_stack_step(
 
     title = value.get("title")
     title_is_valid = _validate_non_empty_string(title, f"{path}.title", errors)
+    normalized_title: str | None = None
     if title_is_valid and isinstance(title, str):
         normalized_title = title.strip().casefold()
         if normalized_title in seen_titles:
             errors.append(f"{path}.title: must be unique within proposed_stack")
-        else:
-            seen_titles.add(normalized_title)
 
     _validate_non_empty_string(value.get("purpose"), f"{path}.purpose", errors)
     _validate_string_list(value.get("include"), f"{path}.include", errors, require_non_empty=True)
@@ -140,6 +139,11 @@ def _validate_stack_step(
         errors.append(f"{path}.depends_on: must be a string or null")
     elif isinstance(depends_on, str) and not depends_on.strip():
         errors.append(f"{path}.depends_on: must be a non-empty string or null")
+    elif isinstance(depends_on, str) and depends_on.strip().casefold() not in seen_titles:
+        errors.append(f"{path}.depends_on: must reference an earlier step title")
+
+    if normalized_title is not None:
+        seen_titles.add(normalized_title)
 
     _validate_non_empty_string(
         value.get("independently_testable_because"),

--- a/agent/review/stackability.py
+++ b/agent/review/stackability.py
@@ -1,0 +1,201 @@
+from typing import Literal, TypedDict
+
+StackabilityVerdict = Literal[
+    "split_recommended",
+    "not_worth_splitting",
+    "needs_human_context",
+]
+StackabilityConfidence = Literal["low", "medium", "high"]
+StackabilityPublishingMode = Literal["manual_advisory", "automatic_advisory", "blocking"]
+
+
+class StackStep(TypedDict):
+    title: str
+    purpose: str
+    include: list[str]
+    exclude_or_defer: list[str]
+    depends_on: str | None
+    independently_testable_because: str
+    suggested_checks: list[str]
+
+
+class StackabilityReview(TypedDict):
+    verdict: StackabilityVerdict
+    confidence: StackabilityConfidence
+    rationale: str
+    proposed_stack: list[StackStep]
+    harness_prompt: str
+    risks_or_human_decisions: list[str]
+
+
+STACKABILITY_REVIEW_RUBRIC = """
+Assess whether splitting the pull request creates a meaningfully safer or easier review and landing
+sequence. This is not a line-count warning and is separate from bug findings, which require a
+concrete, diff-anchored failure mode.
+
+Verdicts:
+- split_recommended: propose two or more ordered, independently testable steps when separation
+  improves reviewer comprehension, safe landing order, accidental-coupling control, or
+  codeowner/domain ownership clarity.
+- not_worth_splitting: use for a cohesive change whose implementation, tests, generated artifacts,
+  or mechanical edits are best reviewed and landed together, even when the pull request is large.
+- needs_human_context: use when an ownership, rollout, compatibility, or product decision prevents a
+  responsible recommendation. State each concrete question or decision needed.
+
+Confidence:
+- high: the dependency boundaries and checks are directly supported by the pull request.
+- medium: the split is useful but some boundary or landing detail requires a reasonable assumption.
+- low: important repository, rollout, or ownership context is missing.
+
+For each proposed step, identify its purpose, included paths or scopes, deferred work, dependency on
+earlier steps, why it is independently testable, and checks that demonstrate that independence.
+Avoid splits that merely distribute line count, break an atomic refactor, separate tests from their
+behavior, create temporary broken states, or add review and merge overhead without a clearer unit.
+
+Publication modes are manual_advisory (requested, non-blocking), automatic_advisory (triggered,
+non-blocking), and blocking (opt-in and appropriate only for an actionable split or a specific human
+context question). A stackability review must never be represented as a normal bug finding.
+""".strip()
+
+
+HARNESS_PROMPT_REQUIREMENTS = """
+The harness prompt must preserve the source pull request's repository, base branch, head branch, and
+relevant commit context; describe the ordered branches and pull requests to create and the dependency
+between each; assign included paths or scopes and explicitly deferred changes to every step; list the
+checks that establish independent testability; and carry forward unresolved risks, decisions, and
+questions. It must instruct the harness to preserve user work and avoid force-pushing or otherwise
+rewriting the source branch. The resulting stack should be created on new branches unless the user
+explicitly authorizes another approach.
+""".strip()
+
+
+_VERDICTS = {"split_recommended", "not_worth_splitting", "needs_human_context"}
+_CONFIDENCES = {"low", "medium", "high"}
+_REVIEW_FIELDS = (
+    "verdict",
+    "confidence",
+    "rationale",
+    "proposed_stack",
+    "harness_prompt",
+    "risks_or_human_decisions",
+)
+_STEP_FIELDS = (
+    "title",
+    "purpose",
+    "include",
+    "exclude_or_defer",
+    "depends_on",
+    "independently_testable_because",
+    "suggested_checks",
+)
+
+
+def _validate_non_empty_string(value: object, path: str, errors: list[str]) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{path}: must be a non-empty string")
+        return False
+    return True
+
+
+def _validate_string_list(
+    value: object, path: str, errors: list[str], *, require_non_empty: bool = False
+) -> bool:
+    if not isinstance(value, list):
+        errors.append(f"{path}: must be a list of strings")
+        return False
+    if require_non_empty and not value:
+        errors.append(f"{path}: must contain at least one string")
+    for index, item in enumerate(value):
+        _validate_non_empty_string(item, f"{path}[{index}]", errors)
+    return True
+
+
+def _validate_stack_step(
+    value: object, index: int, errors: list[str], seen_titles: set[str]
+) -> None:
+    path = f"proposed_stack[{index}]"
+    if not isinstance(value, dict):
+        errors.append(f"{path}: must be an object")
+        return
+
+    for field in _STEP_FIELDS:
+        if field not in value:
+            errors.append(f"{path}.{field}: field is required")
+
+    title = value.get("title")
+    title_is_valid = _validate_non_empty_string(title, f"{path}.title", errors)
+    if title_is_valid and isinstance(title, str):
+        normalized_title = title.strip().casefold()
+        if normalized_title in seen_titles:
+            errors.append(f"{path}.title: must be unique within proposed_stack")
+        else:
+            seen_titles.add(normalized_title)
+
+    _validate_non_empty_string(value.get("purpose"), f"{path}.purpose", errors)
+    _validate_string_list(value.get("include"), f"{path}.include", errors, require_non_empty=True)
+    _validate_string_list(value.get("exclude_or_defer"), f"{path}.exclude_or_defer", errors)
+
+    depends_on = value.get("depends_on")
+    if depends_on is not None and not isinstance(depends_on, str):
+        errors.append(f"{path}.depends_on: must be a string or null")
+    elif isinstance(depends_on, str) and not depends_on.strip():
+        errors.append(f"{path}.depends_on: must be a non-empty string or null")
+
+    _validate_non_empty_string(
+        value.get("independently_testable_because"),
+        f"{path}.independently_testable_because",
+        errors,
+    )
+    _validate_string_list(
+        value.get("suggested_checks"),
+        f"{path}.suggested_checks",
+        errors,
+        require_non_empty=True,
+    )
+
+
+def validate_stackability_review(value: object) -> list[str]:
+    """Return all field-addressed schema errors without modifying ``value``."""
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return ["review: must be an object"]
+
+    for field in _REVIEW_FIELDS:
+        if field not in value:
+            errors.append(f"{field}: field is required")
+
+    verdict = value.get("verdict")
+    if not isinstance(verdict, str) or verdict not in _VERDICTS:
+        errors.append(f"verdict: must be one of {', '.join(sorted(_VERDICTS))}")
+
+    confidence = value.get("confidence")
+    if not isinstance(confidence, str) or confidence not in _CONFIDENCES:
+        errors.append(f"confidence: must be one of {', '.join(sorted(_CONFIDENCES))}")
+
+    _validate_non_empty_string(value.get("rationale"), "rationale", errors)
+    _validate_non_empty_string(value.get("harness_prompt"), "harness_prompt", errors)
+    risks_are_list = _validate_string_list(
+        value.get("risks_or_human_decisions"), "risks_or_human_decisions", errors
+    )
+
+    proposed_stack = value.get("proposed_stack")
+    if not isinstance(proposed_stack, list):
+        errors.append("proposed_stack: must be a list")
+    else:
+        seen_titles: set[str] = set()
+        for index, step in enumerate(proposed_stack):
+            _validate_stack_step(step, index, errors, seen_titles)
+
+        if verdict == "split_recommended" and len(proposed_stack) < 2:
+            errors.append("proposed_stack: split_recommended requires at least two steps")
+        if verdict == "not_worth_splitting" and proposed_stack:
+            errors.append("proposed_stack: not_worth_splitting requires no proposed steps")
+
+    risks = value.get("risks_or_human_decisions")
+    if verdict == "needs_human_context" and risks_are_list and not risks:
+        errors.append(
+            "risks_or_human_decisions: needs_human_context requires at least one explicit risk, "
+            "decision, or question"
+        )
+
+    return errors

--- a/tests/reviewer/test_stackability.py
+++ b/tests/reviewer/test_stackability.py
@@ -1,0 +1,183 @@
+from copy import deepcopy
+
+import pytest
+
+from agent.review.stackability import validate_stackability_review
+
+
+def _split_review() -> dict[str, object]:
+    return {
+        "verdict": "split_recommended",
+        "confidence": "high",
+        "rationale": "The migration and its consumers can land and be tested independently.",
+        "proposed_stack": [
+            {
+                "title": "Add the storage migration",
+                "purpose": "Introduce the schema used by the new feature.",
+                "include": ["migrations/", "tests/migrations/"],
+                "exclude_or_defer": ["agent/feature.py"],
+                "depends_on": None,
+                "independently_testable_because": "Migration tests exercise the schema alone.",
+                "suggested_checks": ["uv run pytest tests/migrations"],
+            },
+            {
+                "title": "Adopt the migrated schema",
+                "purpose": "Move application reads and writes to the new schema.",
+                "include": ["agent/feature.py", "tests/test_feature.py"],
+                "exclude_or_defer": [],
+                "depends_on": "Add the storage migration",
+                "independently_testable_because": "Feature tests cover the application behavior.",
+                "suggested_checks": ["uv run pytest tests/test_feature.py"],
+            },
+        ],
+        "harness_prompt": "Create the two ordered PRs above without force-pushing the source branch.",
+        "risks_or_human_decisions": ["Confirm the migration can precede the application rollout."],
+    }
+
+
+def test_valid_split_recommended_review() -> None:
+    assert validate_stackability_review(_split_review()) == []
+
+
+def test_valid_not_worth_splitting_review() -> None:
+    review = _split_review()
+    review.update(
+        verdict="not_worth_splitting",
+        confidence="medium",
+        proposed_stack=[],
+        rationale="The implementation and tests form one cohesive behavior change.",
+    )
+
+    assert validate_stackability_review(review) == []
+
+
+def test_valid_needs_human_context_review_with_question() -> None:
+    review = _split_review()
+    review.update(
+        verdict="needs_human_context",
+        confidence="low",
+        proposed_stack=[],
+        risks_or_human_decisions=[
+            "Should the migration be deployed before this feature is enabled?"
+        ],
+    )
+
+    assert validate_stackability_review(review) == []
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_error"),
+    [
+        ({"verdict": "maybe"}, "verdict: must be one of"),
+        ({"verdict": []}, "verdict: must be one of"),
+        ({"confidence": "certain"}, "confidence: must be one of"),
+        ({"rationale": "  "}, "rationale: must be a non-empty string"),
+        ({"harness_prompt": None}, "harness_prompt: must be a non-empty string"),
+        ({"risks_or_human_decisions": "none"}, "risks_or_human_decisions: must be a list"),
+        ({"proposed_stack": {}}, "proposed_stack: must be a list"),
+    ],
+)
+def test_invalid_top_level_fields(updates: dict[str, object], expected_error: str) -> None:
+    review = _split_review()
+    review.update(updates)
+
+    assert any(error.startswith(expected_error) for error in validate_stackability_review(review))
+
+
+def test_missing_required_fields_are_reported() -> None:
+    errors = validate_stackability_review({})
+
+    for field in (
+        "verdict",
+        "confidence",
+        "rationale",
+        "proposed_stack",
+        "harness_prompt",
+        "risks_or_human_decisions",
+    ):
+        assert any(error.startswith(f"{field}:") for error in errors)
+
+
+def test_malformed_step_fields_are_all_reported() -> None:
+    review = _split_review()
+    review["proposed_stack"] = [
+        {
+            "title": " ",
+            "purpose": 3,
+            "include": ["agent/", 4],
+            "exclude_or_defer": "later",
+            "depends_on": 1,
+            "independently_testable_because": "",
+            "suggested_checks": [],
+        },
+        "not a step",
+    ]
+
+    errors = validate_stackability_review(review)
+
+    expected_paths = (
+        "proposed_stack[0].title",
+        "proposed_stack[0].purpose",
+        "proposed_stack[0].include[1]",
+        "proposed_stack[0].exclude_or_defer",
+        "proposed_stack[0].depends_on",
+        "proposed_stack[0].independently_testable_because",
+        "proposed_stack[0].suggested_checks",
+        "proposed_stack[1]",
+    )
+    for path in expected_paths:
+        assert any(error.startswith(f"{path}:") for error in errors)
+
+
+def test_duplicate_step_titles_are_rejected_after_trimming() -> None:
+    review = _split_review()
+    stack = review["proposed_stack"]
+    assert isinstance(stack, list)
+    assert isinstance(stack[1], dict)
+    stack[1]["title"] = "  Add the storage migration  "
+
+    assert any(
+        error.startswith("proposed_stack[1].title: must be unique")
+        for error in validate_stackability_review(review)
+    )
+
+
+def test_split_recommended_requires_at_least_two_steps() -> None:
+    review = _split_review()
+    stack = review["proposed_stack"]
+    assert isinstance(stack, list)
+    review["proposed_stack"] = stack[:1]
+
+    assert (
+        "proposed_stack: split_recommended requires at least two steps"
+        in validate_stackability_review(review)
+    )
+
+
+def test_not_worth_splitting_rejects_proposed_steps() -> None:
+    review = _split_review()
+    review["verdict"] = "not_worth_splitting"
+
+    assert (
+        "proposed_stack: not_worth_splitting requires no proposed steps"
+        in validate_stackability_review(review)
+    )
+
+
+def test_needs_human_context_requires_an_explicit_item() -> None:
+    review = _split_review()
+    review.update(verdict="needs_human_context", proposed_stack=[], risks_or_human_decisions=[])
+
+    assert (
+        "risks_or_human_decisions: needs_human_context requires at least one explicit risk, "
+        "decision, or question"
+    ) in validate_stackability_review(review)
+
+
+def test_validation_does_not_mutate_input() -> None:
+    review = _split_review()
+    original = deepcopy(review)
+
+    validate_stackability_review(review)
+
+    assert review == original

--- a/tests/reviewer/test_stackability.py
+++ b/tests/reviewer/test_stackability.py
@@ -142,6 +142,37 @@ def test_duplicate_step_titles_are_rejected_after_trimming() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("step_index", "depends_on"),
+    [
+        (1, "Missing step"),
+        (0, "Adopt the migrated schema"),
+        (0, "Add the storage migration"),
+    ],
+)
+def test_step_dependencies_must_reference_an_earlier_step(step_index: int, depends_on: str) -> None:
+    review = _split_review()
+    stack = review["proposed_stack"]
+    assert isinstance(stack, list)
+    assert isinstance(stack[step_index], dict)
+    stack[step_index]["depends_on"] = depends_on
+
+    assert (
+        f"proposed_stack[{step_index}].depends_on: must reference an earlier step title"
+        in validate_stackability_review(review)
+    )
+
+
+def test_step_dependencies_match_titles_after_normalization() -> None:
+    review = _split_review()
+    stack = review["proposed_stack"]
+    assert isinstance(stack, list)
+    assert isinstance(stack[1], dict)
+    stack[1]["depends_on"] = "  ADD THE STORAGE MIGRATION  "
+
+    assert validate_stackability_review(review) == []
+
+
 def test_split_recommended_requires_at_least_two_steps() -> None:
     review = _split_review()
     stack = review["proposed_stack"]


### PR DESCRIPTION
## Summary

- define JSON-compatible typed stackability review and stack-step schemas
- add reusable reviewer rubric and harness prompt requirements
- validate artifacts with non-mutating, field-addressed runtime errors
- expose the stackability types and validator through the review-domain API
- cover valid verdicts, malformed inputs, cross-field constraints, and input preservation

## Testing

- `uv run pytest -vvv tests/reviewer/test_stackability.py`
- `make lint`
- targeted basedpyright: 0 errors
- `make test` (1567 passed)

Full `make typecheck` retains three unrelated pre-existing errors in `tests/sandbox/test_langsmith_sandbox_config.py`.