### PR TITLE
fix: tighten sandbox config test types

### DIFF
--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -266,7 +266,9 @@ async def test_install_create_extra_fields_merges_only_boxes_post() -> None:
 
     class _FakeHttp:
         async def post(self, url, **kwargs):  # noqa: ANN001, ANN003
-            calls.append((url, kwargs.get("json")))
+            payload = kwargs.get("json")
+            assert isinstance(payload, dict)
+            calls.append((url, payload))
             return "ok"
 
     class _FakeClient:
@@ -274,7 +276,7 @@ async def test_install_create_extra_fields_merges_only_boxes_post() -> None:
             self._http = _FakeHttp()
 
     client = _FakeClient()
-    _install_create_extra_fields(client, {"_internal_runtime": "v2"})
+    _install_create_extra_fields(cast(AsyncSandboxClient, client), {"_internal_runtime": "v2"})
 
     await client._http.post("https://api/v2/sandboxes/boxes", json={"snapshot_id": "s"})
     await client._http.post("https://api/v2/sandboxes/boxes/abc/start", json={"foo": "bar"})
@@ -294,5 +296,5 @@ async def test_install_create_extra_fields_noop_when_empty() -> None:
             self._http = _FakeHttp()
 
     client = _FakeClient()
-    _install_create_extra_fields(client, {})
+    _install_create_extra_fields(cast(AsyncSandboxClient, client), {})
     assert client._http.post == "sentinel"


### PR DESCRIPTION
## Summary

- narrow captured sandbox request JSON to a dictionary in the test double
- explicitly cast minimal fake clients at the AsyncSandboxClient boundary
- leave production sandbox behavior unchanged

## Verification

- make lint
- make typecheck
- make test (1579 passed)