### PR TITLE
feat: add stackability review tool

### DIFF
--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -100,6 +100,7 @@ from .tools import (
     publish_review,
     reply_to_finding_thread,
     resolve_finding_thread,
+    set_stackability_review,
     update_finding,
     web_search,
 )
@@ -1369,6 +1370,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             publish_review,
             resolve_finding_thread,
             reply_to_finding_thread,
+            set_stackability_review,
             web_search,
             fetch_url,
             http_request,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -28,6 +28,7 @@ _TOOL_MODULES = {
     "save_plan": ".save_plan",
     "schedule_thread_wakeup": ".schedule_thread_wakeup",
     "search_repo_code": ".search_repo_code",
+    "set_stackability_review": ".set_stackability_review",
     "slack_add_reaction": ".slack_add_reaction",
     "slack_read_thread_messages": ".slack_read_thread_messages",
     "slack_start_new_thread": ".slack_start_new_thread",
@@ -62,6 +63,7 @@ __all__ = [
     "save_plan",
     "schedule_thread_wakeup",
     "search_repo_code",
+    "set_stackability_review",
     "slack_add_reaction",
     "slack_read_thread_messages",
     "slack_start_new_thread",
@@ -96,6 +98,7 @@ if TYPE_CHECKING:
     from .save_plan import save_plan
     from .schedule_thread_wakeup import schedule_thread_wakeup
     from .search_repo_code import search_repo_code
+    from .set_stackability_review import set_stackability_review
     from .slack_add_reaction import slack_add_reaction
     from .slack_read_thread_messages import slack_read_thread_messages
     from .slack_start_new_thread import slack_start_new_thread

--- a/agent/tools/set_stackability_review.py
+++ b/agent/tools/set_stackability_review.py
@@ -1,0 +1,76 @@
+"""Tool: ``set_stackability_review``. Records a stackability artifact."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..review.findings import (
+    ReviewerThreadMissingError,
+    resolve_review_head_sha,
+    thread_missing_tool_result,
+)
+from ..review.stackability import (
+    new_stackability_review_record,
+    validate_stackability_review,
+)
+from ..review.stackability import (
+    set_stackability_review as persist_stackability_review,
+)
+
+
+async def set_stackability_review(
+    verdict: str,
+    confidence: str,
+    rationale: str,
+    proposed_stack: list[dict[str, Any]],
+    harness_prompt: str,
+    risks_or_human_decisions: list[str],
+) -> dict[str, Any]:
+    """Validate and record a stackability review without publishing it.
+
+    The current pull request head is resolved by the system so the stored
+    artifact can be recognized as stale after a later push.
+    """
+    review = {
+        "verdict": verdict,
+        "confidence": confidence,
+        "rationale": rationale,
+        "proposed_stack": proposed_stack,
+        "harness_prompt": harness_prompt,
+        "risks_or_human_decisions": risks_or_human_decisions,
+    }
+    errors = validate_stackability_review(review)
+    if errors:
+        return {
+            "success": False,
+            "error": "invalid_stackability_review",
+            "errors": errors,
+        }
+
+    config = get_config()
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
+    if not isinstance(thread_id, str) or not thread_id:
+        return {"success": False, "error": "reviewer_thread_unavailable"}
+
+    try:
+        reviewed_head_sha = await resolve_review_head_sha(thread_id, configurable)
+    except ReviewerThreadMissingError as exc:
+        return thread_missing_tool_result(exc)
+    if not reviewed_head_sha:
+        return {"success": False, "error": "review_head_unavailable"}
+
+    record = new_stackability_review_record(reviewed_head_sha, review)
+    try:
+        await persist_stackability_review(thread_id, record)
+    except ReviewerThreadMissingError as exc:
+        return thread_missing_tool_result(exc)
+
+    return {
+        "success": True,
+        "verdict": verdict,
+        "reviewed_head_sha": reviewed_head_sha,
+        "proposed_step_count": len(proposed_stack),
+    }

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -116,6 +116,16 @@ async def test_agent_includes_report_platform_issue_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_excludes_stackability_review_tool() -> None:
+    from agent.tools import set_stackability_review
+
+    captured = await _capture_create_deep_agent_kwargs()
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+    assert set_stackability_review not in tools
+
+
+@pytest.mark.asyncio
 async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
     captured = await _capture_create_deep_agent_kwargs()
     middleware = captured["middleware"]

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -468,6 +468,7 @@ async def test_reviewer_injects_repo_style_during_eval() -> None:
     def fake_create_deep_agent(*, system_prompt: str, **kwargs: object) -> _DummyAgent:
         captured["system_prompt"] = system_prompt
         captured["middleware"] = kwargs["middleware"]
+        captured["tools"] = kwargs["tools"]
         return _DummyAgent()
 
     fetch_threads = AsyncMock(return_value=[])
@@ -513,6 +514,9 @@ async def test_reviewer_injects_repo_style_during_eval() -> None:
     assert "Repository-specific review style" in captured["system_prompt"]
     assert "Flag table rerender regressions" in captured["system_prompt"]
     assert "Pre-existing PR review threads" not in captured["system_prompt"]
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+    assert reviewer.set_stackability_review in tools
     fetch_threads.assert_not_awaited()
 
 

--- a/tests/reviewer/test_stackability_tool.py
+++ b/tests/reviewer/test_stackability_tool.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.review.findings import ReviewerThreadMissingError
+
+stackability_tool = importlib.import_module("agent.tools.set_stackability_review")
+
+
+def _step(title: str, *, depends_on: str | None = None) -> dict[str, object]:
+    return {
+        "title": title,
+        "purpose": f"Land {title}",
+        "include": [f"src/{title}.py"],
+        "exclude_or_defer": [],
+        "depends_on": depends_on,
+        "independently_testable_because": "Its unit tests exercise the isolated behavior.",
+        "suggested_checks": [f"pytest tests/{title}"],
+    }
+
+
+def _arguments(**overrides: object) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "verdict": "split_recommended",
+        "confidence": "high",
+        "rationale": "The two changes have independent behavior and test boundaries.",
+        "proposed_stack": [_step("foundation"), _step("feature", depends_on="foundation")],
+        "harness_prompt": "Create two ordered pull requests on new branches.",
+        "risks_or_human_decisions": [],
+    }
+    arguments.update(overrides)
+    return arguments
+
+
+@pytest.mark.asyncio
+async def test_set_stackability_review_persists_live_head(monkeypatch) -> None:
+    persist = AsyncMock()
+    monkeypatch.setattr(
+        stackability_tool,
+        "get_config",
+        lambda: {"configurable": {"thread_id": "reviewer-1", "head_sha": "frozen-head"}},
+    )
+    monkeypatch.setattr(
+        stackability_tool,
+        "resolve_review_head_sha",
+        AsyncMock(return_value="live-head"),
+    )
+    monkeypatch.setattr(stackability_tool, "persist_stackability_review", persist)
+
+    result = await stackability_tool.set_stackability_review(**_arguments())
+
+    assert result == {
+        "success": True,
+        "verdict": "split_recommended",
+        "reviewed_head_sha": "live-head",
+        "proposed_step_count": 2,
+    }
+    call = persist.await_args
+    assert call is not None
+    record = call.args[1]
+    assert record["reviewed_head_sha"] == "live-head"
+    assert record["publication"] == {
+        "mode": None,
+        "state": "unpublished",
+        "github_comment_id": None,
+        "github_review_id": None,
+        "github_review_thread_id": None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "error_prefix"),
+    [
+        ({"verdict": "maybe"}, "verdict:"),
+        ({"rationale": ""}, "rationale:"),
+        ({"proposed_stack": [_step("only")]}, "proposed_stack:"),
+    ],
+)
+async def test_set_stackability_review_returns_validation_errors(
+    monkeypatch, overrides: dict[str, object], error_prefix: str
+) -> None:
+    persist = AsyncMock()
+    resolve_head = AsyncMock()
+    monkeypatch.setattr(stackability_tool, "persist_stackability_review", persist)
+    monkeypatch.setattr(stackability_tool, "resolve_review_head_sha", resolve_head)
+
+    result = await stackability_tool.set_stackability_review(**_arguments(**overrides))
+
+    assert result["success"] is False
+    assert result["error"] == "invalid_stackability_review"
+    assert any(error.startswith(error_prefix) for error in result["errors"])
+    resolve_head.assert_not_awaited()
+    persist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_stackability_review_rejects_unavailable_head(monkeypatch) -> None:
+    persist = AsyncMock()
+    monkeypatch.setattr(
+        stackability_tool,
+        "get_config",
+        lambda: {"configurable": {"thread_id": "reviewer-1"}},
+    )
+    monkeypatch.setattr(
+        stackability_tool,
+        "resolve_review_head_sha",
+        AsyncMock(return_value=""),
+    )
+    monkeypatch.setattr(stackability_tool, "persist_stackability_review", persist)
+
+    result = await stackability_tool.set_stackability_review(**_arguments())
+
+    assert result == {"success": False, "error": "review_head_unavailable"}
+    persist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_stackability_review_handles_missing_reviewer_thread(monkeypatch) -> None:
+    monkeypatch.setattr(
+        stackability_tool,
+        "get_config",
+        lambda: {"configurable": {"thread_id": "missing-reviewer"}},
+    )
+    monkeypatch.setattr(
+        stackability_tool,
+        "resolve_review_head_sha",
+        AsyncMock(side_effect=ReviewerThreadMissingError("missing-reviewer", RuntimeError())),
+    )
+
+    result = await stackability_tool.set_stackability_review(**_arguments())
+
+    assert result["success"] is False
+    assert result["error"] == "thread_not_found"
+    assert result["thread_id"] == "missing-reviewer"
+
+
+@pytest.mark.asyncio
+async def test_set_stackability_review_requires_reviewer_thread_config(monkeypatch) -> None:
+    monkeypatch.setattr(stackability_tool, "get_config", lambda: {"configurable": {}})
+
+    result = await stackability_tool.set_stackability_review(**_arguments())
+
+    assert result == {"success": False, "error": "reviewer_thread_unavailable"}


### PR DESCRIPTION
## Summary
- add a reviewer-only `set_stackability_review` tool
- validate and persist unpublished artifacts with the live PR head SHA
- return structured validation and unavailable-thread/head errors
- keep the tool out of the main agent and publication flow

## Testing
- `make lint`
- `make typecheck`
- `make test` (1,587 passed)