### PR TITLE
feat: connect automations to Slack channels

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -85,8 +85,8 @@ async def _post_failure_reply(thread_id: str, metadata: dict[str, Any], status: 
     ctx = ctx if isinstance(ctx, dict) else {}
     text = _failure_text(status)
 
-    if source == "slack":
-        slack_thread = ctx.get("slack_thread")
+    slack_thread = ctx.get("slack_thread")
+    if source == "slack" or isinstance(slack_thread, dict):
         if isinstance(slack_thread, dict):
             channel_id = slack_thread.get("channel_id")
             thread_ts = slack_thread.get("thread_ts")

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -21,6 +21,7 @@ from .profiles import get_profile, get_valid_access_token
 from .repo_access import repo_config_for_user, require_repo_access_for_user
 from .team_settings import get_team_fable_enabled
 from .thread_api import _agent_version_metadata, _now_ms, _resolve_run_email
+from .user_mappings import slack_id_for_login
 
 logger = logging.getLogger(__name__)
 
@@ -510,6 +511,10 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
             "channel_id": slack_channel_id,
             "thread_ts": message_ts,
             "triggering_event_ts": message_ts,
+            "triggering_user_id": await slack_id_for_login(
+                record.get("created_by") if isinstance(record.get("created_by"), str) else None
+            )
+            or "",
             "triggering_user_email": record.get("user_email") or "",
         }
         thread_id = generate_thread_id_from_slack_thread(slack_channel_id, message_ts)

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -12,6 +13,8 @@ from langgraph_sdk.schema import Config
 from pydantic import BaseModel, Field, field_validator
 
 from ..dispatch import create_durable_run
+from ..utils.slack import post_slack_top_level_message_with_ts, store_slack_run_mapping
+from ..utils.thread_ids import generate_thread_id_from_slack_thread
 from ..utils.thread_ops import langgraph_client
 from .options import SUPPORTED_MODEL_IDS, gate_fable_model, model_supports_effort
 from .profiles import get_profile, get_valid_access_token
@@ -25,6 +28,16 @@ SCHEDULES_NAMESPACE: list[str] = ["agent_schedules"]
 _AGENT_ASSISTANT_ID = "agent"
 _SCHEDULER_ASSISTANT_ID = "scheduler"
 _CRON_FIELD_RANGES = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
+_SLACK_CHANNEL_ID_RE = re.compile(r"^[CG][A-Z0-9]{8,}$")
+
+
+def _normalize_slack_channel_id(value: str | None) -> str | None:
+    channel_id = value.strip().upper() if isinstance(value, str) else ""
+    if not channel_id:
+        return None
+    if not _SLACK_CHANNEL_ID_RE.fullmatch(channel_id):
+        raise ValueError("slack_channel_id must be a Slack channel ID starting with C or G")
+    return channel_id
 
 
 class ScheduleCreateBody(BaseModel):
@@ -34,11 +47,17 @@ class ScheduleCreateBody(BaseModel):
     repo: str | None = None
     model_id: str | None = None
     effort: str | None = None
+    slack_channel_id: str | None = None
 
     @field_validator("schedule")
     @classmethod
     def _valid_schedule(cls, value: str) -> str:
         return normalize_cron_schedule(value)
+
+    @field_validator("slack_channel_id")
+    @classmethod
+    def _valid_slack_channel_id(cls, value: str | None) -> str | None:
+        return _normalize_slack_channel_id(value)
 
 
 class ScheduleUpdateBody(BaseModel):
@@ -49,11 +68,17 @@ class ScheduleUpdateBody(BaseModel):
     model_id: str | None = None
     effort: str | None = None
     enabled: bool | None = None
+    slack_channel_id: str | None = None
 
     @field_validator("schedule")
     @classmethod
     def _valid_schedule(cls, value: str | None) -> str | None:
         return normalize_cron_schedule(value) if value is not None else None
+
+    @field_validator("slack_channel_id")
+    @classmethod
+    def _valid_slack_channel_id(cls, value: str | None) -> str | None:
+        return _normalize_slack_channel_id(value)
 
 
 def _client():
@@ -132,6 +157,7 @@ def _schedule_summary(record: dict[str, Any]) -> dict[str, Any]:
         "prompt": record.get("prompt"),
         "schedule": record.get("schedule"),
         "repo": _repo_full_name(repo),
+        "slackChannelId": record.get("slack_channel_id"),
         "model": record.get("model"),
         "effort": record.get("effort"),
         "enabled": bool(record.get("enabled")),
@@ -275,6 +301,7 @@ async def create_agent_schedule(
         "prompt": body.prompt.strip(),
         "schedule": body.schedule,
         "repo": repo,
+        "slack_channel_id": body.slack_channel_id,
         "model": chosen_model or profile.get("default_model") or "Default",
         "effort": chosen_effort or profile.get("reasoning_effort"),
         "base_branch": profile.get("base_branch") or "main",
@@ -325,6 +352,8 @@ async def update_agent_schedule(
             patch["effort"] = effort
     if body.enabled is not None:
         patch["enabled"] = body.enabled
+    if "slack_channel_id" in body.model_fields_set:
+        patch["slack_channel_id"] = body.slack_channel_id
 
     updated = {**existing, **patch}
     schedule_changed = updated.get("schedule") != existing.get("schedule")
@@ -355,7 +384,29 @@ async def delete_agent_schedule(schedule_id: str, login: str, *, email: str | No
     await _client().store.delete_item(SCHEDULES_NAMESPACE, schedule_id)
 
 
-def _agent_run_metadata(record: dict[str, Any], thread_id: str) -> dict[str, Any]:
+def _slack_root_message(record: dict[str, Any]) -> str:
+    repo = _repo_full_name(record.get("repo") if isinstance(record.get("repo"), dict) else None)
+    repo_line = f"\n*Repository:* `{repo}`" if repo else ""
+    return (
+        f"*Open SWE automation:* {record.get('name') or 'Scheduled agent'}{repo_line}\n\n"
+        "A scheduled run started. Reply in this thread to follow up with the agent."
+    )
+
+
+def _scheduled_prompt(record: dict[str, Any], slack_thread: dict[str, Any] | None) -> str:
+    prompt = str(record["prompt"])
+    if not slack_thread:
+        return prompt
+    return (
+        f"{prompt}\n\n"
+        "Use `slack_thread_reply` for clarifying questions, essential progress updates, "
+        "the pull request link, and the final outcome in the connected Slack thread."
+    )
+
+
+def _agent_run_metadata(
+    record: dict[str, Any], thread_id: str, slack_thread: dict[str, Any] | None = None
+) -> dict[str, Any]:
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
     now_ms = _now_ms()
     metadata: dict[str, Any] = {
@@ -375,10 +426,14 @@ def _agent_run_metadata(record: dict[str, Any], thread_id: str) -> dict[str, Any
     if repo and repo.get("owner") and repo.get("name"):
         metadata["repo_owner"] = repo["owner"]
         metadata["repo_name"] = repo["name"]
+    if slack_thread:
+        metadata["source_context"] = {"slack_thread": slack_thread}
     return metadata
 
 
-async def _agent_run_config(record: dict[str, Any], thread_id: str) -> dict[str, Any]:
+async def _agent_run_config(
+    record: dict[str, Any], thread_id: str, slack_thread: dict[str, Any] | None = None
+) -> dict[str, Any]:
     configurable: dict[str, Any] = {
         "thread_id": thread_id,
         "source": "schedule",
@@ -390,6 +445,8 @@ async def _agent_run_config(record: dict[str, Any], thread_id: str) -> dict[str,
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
     if repo and repo.get("owner") and repo.get("name"):
         configurable["repo"] = repo
+    if slack_thread:
+        configurable["slack_thread"] = slack_thread
     model, effort = _normalize_model_choice(record.get("model"), record.get("effort"))
     if model and effort:
         model, effort = gate_fable_model(
@@ -436,22 +493,52 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
             )
             return {"status": "unauthorized", "schedule_id": schedule_id, "error": exc.detail}
 
-    thread_id = str(uuid.uuid4())
-    metadata = _agent_run_metadata(record, thread_id)
+    slack_thread: dict[str, Any] | None = None
+    slack_channel_id = record.get("slack_channel_id")
+    if isinstance(slack_channel_id, str) and slack_channel_id:
+        message_ts, slack_error = await post_slack_top_level_message_with_ts(
+            slack_channel_id,
+            _slack_root_message(record),
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+        if not message_ts:
+            error = f"Slack post failed: {slack_error or 'unknown error'}"
+            await _put_value({**record, "last_error": error, "last_error_at": _now_iso()})
+            return {"status": "error", "schedule_id": schedule_id, "error": error}
+        slack_thread = {
+            "channel_id": slack_channel_id,
+            "thread_ts": message_ts,
+            "triggering_event_ts": message_ts,
+            "triggering_user_email": record.get("user_email") or "",
+        }
+        thread_id = generate_thread_id_from_slack_thread(slack_channel_id, message_ts)
+    else:
+        thread_id = str(uuid.uuid4())
+
+    metadata = _agent_run_metadata(record, thread_id, slack_thread)
     client = _client()
     await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
     await client.threads.update(thread_id=thread_id, metadata=metadata)
     run = await create_durable_run(
         thread_id,
         _AGENT_ASSISTANT_ID,
-        input={"messages": [{"role": "user", "content": record["prompt"]}]},
+        input={"messages": [{"role": "user", "content": _scheduled_prompt(record, slack_thread)}]},
         source="schedule",
-        config=await _agent_run_config(record, thread_id),
+        config=await _agent_run_config(record, thread_id, slack_thread),
         client=client,
         stream_mode=["values", "updates", "messages-tuple"],
         stream_resumable=True,
     )
     run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)
+    if slack_thread and isinstance(run_id, str) and run_id:
+        await store_slack_run_mapping(
+            client,
+            slack_thread["channel_id"],
+            slack_thread["thread_ts"],
+            run_id,
+            message_ts=slack_thread["thread_ts"],
+        )
     now_ms = _now_ms()
     await client.threads.update(
         thread_id=thread_id,

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -136,6 +136,18 @@ def cached_email_for_login(login: str | None) -> str | None:
     return email or None
 
 
+def cached_slack_id_for_login(login: str | None) -> str | None:
+    norm = _norm_login(login)
+    if not norm:
+        return None
+    with _cache_lock:
+        record = _by_login.get(norm.lower())
+    if not record or record.get("status", "active") != "active":
+        return None
+    slack_id = _norm_slack_id(record.get("slack_user_id"))
+    return slack_id or None
+
+
 def cached_login_for_email(email: str | None) -> str | None:
     norm = _norm_email(email)
     if not norm:
@@ -235,6 +247,15 @@ async def email_for_login(login: str | None) -> str | None:
         return cached
     await _ensure_cache_loaded()
     return cached_email_for_login(login)
+
+
+async def slack_id_for_login(login: str | None) -> str | None:
+    """Async login→Slack ID with cache fallthrough to the Store."""
+    cached = cached_slack_id_for_login(login)
+    if cached is not None:
+        return cached
+    await _ensure_cache_loaded()
+    return cached_slack_id_for_login(login)
 
 
 async def login_for_email(email: str | None) -> str | None:

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -116,6 +116,9 @@ def auth(monkeypatch) -> None:  # noqa: ANN001
     async def fake_require_repo_access_for_user(login: str, full_name: str) -> str:
         return "gho_token"
 
+    async def fake_slack_id_for_login(login: str | None) -> str | None:
+        return "UALICE" if login == "alice" else None
+
     monkeypatch.setattr(schedules, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(schedules, "get_profile", fake_get_profile)
     monkeypatch.setattr(schedules, "_resolve_run_email", fake_resolve_run_email)
@@ -123,6 +126,7 @@ def auth(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setattr(
         schedules, "require_repo_access_for_user", fake_require_repo_access_for_user
     )
+    monkeypatch.setattr(schedules, "slack_id_for_login", fake_slack_id_for_login)
 
 
 def test_cron_validation_rejects_non_five_field_expression() -> None:
@@ -462,6 +466,7 @@ async def test_launch_scheduled_agent_run_connects_slack_thread(
     slack_thread = metadata["source_context"]["slack_thread"]
     assert slack_thread["channel_id"] == "C0123456789"
     assert slack_thread["thread_ts"] == "1784302353.900029"
+    assert slack_thread["triggering_user_id"] == "UALICE"
     run = fake_client.runs.created[0]
     assert run["config"]["configurable"]["slack_thread"] == slack_thread
     assert "slack_thread_reply" in run["input"]["messages"][0]["content"]

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -136,18 +136,30 @@ def test_cron_validation_accepts_steps_ranges_and_lists() -> None:
     assert body.schedule == "*/15 9-17 * * 1,3,5"
 
 
+def test_slack_channel_validation_normalizes_ids() -> None:
+    body = ScheduleCreateBody(
+        prompt="hello", schedule="0 9 * * *", slack_channel_id=" c0123456789 "
+    )
+
+    assert body.slack_channel_id == "C0123456789"
+    with pytest.raises(ValidationError):
+        ScheduleCreateBody(prompt="hello", schedule="0 9 * * *", slack_channel_id="#general")
+
+
 async def test_create_agent_schedule_registers_scheduler_cron(fake_client, auth) -> None:  # noqa: ANN001, ARG001
     body = ScheduleCreateBody(
         name="Daily report",
         prompt="Summarize merged PRs",
         schedule="0 9 * * 1-5",
         repo="langchain-ai/open-swe",
+        slack_channel_id="C0123456789",
     )
 
     result = await schedules.create_agent_schedule("alice", body, email="alice@example.com")
 
     assert result["name"] == "Daily report"
     assert result["enabled"] is True
+    assert result["slackChannelId"] == "C0123456789"
     assert result["cronId"] == "cron_1"
     created = fake_client.crons.created[0]
     assert created["assistant_id"] == "scheduler"
@@ -269,6 +281,35 @@ async def test_update_agent_schedule_rechecks_repo_access(fake_client, auth, mon
     assert result["repo"] == "langchain-ai/open-swe"
 
 
+async def test_update_agent_schedule_clears_slack_channel(fake_client) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Daily",
+        "prompt": "Run daily",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "slack_channel_id": "C0123456789",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_old",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    result = await schedules.update_agent_schedule(
+        "sched_1",
+        "alice",
+        ScheduleUpdateBody(slack_channel_id=None),
+        email="alice@example.com",
+    )
+
+    assert result["slackChannelId"] is None
+
+
 async def test_update_agent_schedule_pause_deletes_cron(fake_client) -> None:  # noqa: ANN001
     record = {
         "id": "sched_1",
@@ -377,3 +418,93 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(fake_client,
     stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
     assert stored["last_thread_id"] == thread_id
     assert stored["last_run_id"] == "run_123"
+
+
+async def test_launch_scheduled_agent_run_connects_slack_thread(
+    fake_client, auth, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    record = {
+        "id": "sched_1",
+        "name": "Linear queue",
+        "prompt": "Work the next Linear issue",
+        "schedule": "*/15 * * * *",
+        "repo": {"owner": "langchain-ai", "name": "open-swe"},
+        "slack_channel_id": "C0123456789",
+        "model": "Default",
+        "effort": None,
+        "base_branch": "main",
+        "branch_prefix": "open-swe",
+        "enabled": True,
+        "cron_id": "cron_1",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+    posted: dict[str, Any] = {}
+
+    async def fake_post(channel_id: str, text: str, **kwargs: Any) -> tuple[str, None]:
+        posted.update({"channel_id": channel_id, "text": text, "kwargs": kwargs})
+        return "1784302353.900029", None
+
+    monkeypatch.setattr(schedules, "post_slack_top_level_message_with_ts", fake_post)
+
+    result = await schedules.launch_scheduled_agent_run("sched_1")
+
+    expected_thread_id = schedules.generate_thread_id_from_slack_thread(
+        "C0123456789", "1784302353.900029"
+    )
+    assert result["thread_id"] == expected_thread_id
+    assert posted["channel_id"] == "C0123456789"
+    assert "Linear queue" in posted["text"]
+    metadata = fake_client.threads.created[0]["metadata"]
+    slack_thread = metadata["source_context"]["slack_thread"]
+    assert slack_thread["channel_id"] == "C0123456789"
+    assert slack_thread["thread_ts"] == "1784302353.900029"
+    run = fake_client.runs.created[0]
+    assert run["config"]["configurable"]["slack_thread"] == slack_thread
+    assert "slack_thread_reply" in run["input"]["messages"][0]["content"]
+    mapping = fake_client.store.items[
+        (("slack_run_map", "C0123456789"), "thread:1784302353.900029")
+    ]
+    assert mapping["run_id"] == "run_123"
+
+
+async def test_launch_scheduled_agent_run_stops_when_slack_post_fails(
+    fake_client, auth, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    record = {
+        "id": "sched_1",
+        "name": "Linear queue",
+        "prompt": "Work the next Linear issue",
+        "schedule": "*/15 * * * *",
+        "repo": None,
+        "slack_channel_id": "C0123456789",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_1",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    async def fake_post(*args: Any, **kwargs: Any) -> tuple[None, str]:
+        return None, "not_in_channel"
+
+    monkeypatch.setattr(schedules, "post_slack_top_level_message_with_ts", fake_post)
+
+    result = await schedules.launch_scheduled_agent_run("sched_1")
+
+    assert result == {
+        "status": "error",
+        "schedule_id": "sched_1",
+        "error": "Slack post failed: not_in_channel",
+    }
+    assert fake_client.threads.created == []
+    assert fake_client.runs.created == []
+    stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
+    assert stored["last_error"] == "Slack post failed: not_in_channel"

--- a/tests/dashboard/test_user_mappings.py
+++ b/tests/dashboard/test_user_mappings.py
@@ -51,6 +51,7 @@ async def test_upsert_and_bidirectional_lookup(fake_store: _FakeStore) -> None:
     )
     # Login lookups are case-insensitive; email is normalized to lowercase.
     assert await um.email_for_login("octocat") == "octo@example.com"
+    assert await um.slack_id_for_login("octocat") == "U123"
     assert await um.login_for_email("octo@example.com") == "Octocat"
     assert await um.login_for_slack_id("U123") == "Octocat"
 
@@ -72,6 +73,7 @@ async def test_pending_status_not_trusted(fake_store: _FakeStore) -> None:
     um.clear_cache()
     await um.refresh_cache()
     assert um.is_login_mapped("newbie") is False
+    assert await um.slack_id_for_login("newbie") is None
 
 
 @pytest.mark.asyncio

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -60,6 +60,25 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
+async def test_schedule_source_with_slack_context_posts_failure_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _slack_metadata()
+    metadata["source"] = "schedule"
+    client = _FakeClient(metadata)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
+
+    result = await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "error"}
+    )
+
+    assert result["status"] == "ok"
+    reply.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_success_status_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
     client = _FakeClient(_slack_metadata())
     monkeypatch.setattr(completion, "langgraph_client", lambda: client)

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -31,6 +31,7 @@ export interface ScheduleCreateRequest {
   schedule: string
   name?: string | null
   repo?: string | null
+  slack_channel_id?: string | null
   model_id?: string | null
   effort?: string | null
 }
@@ -40,6 +41,7 @@ export interface ScheduleUpdateRequest {
   schedule?: string | null
   name?: string | null
   repo?: string | null
+  slack_channel_id?: string | null
   model_id?: string | null
   effort?: string | null
   enabled?: boolean | null

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -162,6 +162,7 @@ export interface AgentSchedule {
   prompt: string
   schedule: string
   repo: string | null
+  slackChannelId?: string | null
   model: string
   effort?: string | null
   enabled: boolean

--- a/ui/src/features/automations/components/AutomationEditor.tsx
+++ b/ui/src/features/automations/components/AutomationEditor.tsx
@@ -72,6 +72,9 @@ export function AutomationEditor({
     initialCron ? !isDescribableCron(initialCron) : false
   )
   const [repo, setRepo] = useState<string | null>(schedule?.repo ?? null)
+  const [slackChannelId, setSlackChannelId] = useState(
+    schedule?.slackChannelId ?? ""
+  )
   const [enabled, setEnabled] = useState(schedule?.enabled ?? true)
   // undefined = untouched (derive from the schedule / default as models load).
   const [selectionOverride, setSelectionOverride] = useState<
@@ -113,6 +116,7 @@ export function AutomationEditor({
           prompt: prompt.trim(),
           schedule: cron.trim(),
           repo,
+          slack_channel_id: slackChannelId.trim() || null,
           model_id: modelId,
           effort,
         },
@@ -129,6 +133,7 @@ export function AutomationEditor({
           prompt: prompt.trim(),
           schedule: cron.trim(),
           repo: repo ?? "",
+          slack_channel_id: slackChannelId.trim() || null,
           model_id: modelId,
           effort,
           enabled,
@@ -244,6 +249,21 @@ export function AutomationEditor({
             onSelect={onPickTrigger}
             triggerLabel={cron ? "Change trigger" : "Add Trigger"}
           />
+        </div>
+
+        <SectionLabel>Slack destination</SectionLabel>
+        <div className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-3">
+          <input
+            value={slackChannelId}
+            onChange={(e) => setSlackChannelId(e.target.value)}
+            placeholder="C0123456789"
+            spellCheck={false}
+            className="w-full bg-transparent font-mono text-sm text-[var(--ui-text)] outline-none placeholder:text-[var(--ui-text-dim)]"
+          />
+          <p className="mt-2 text-xs text-[var(--ui-text-dim)]">
+            Optional Slack channel ID. Each run starts a new thread there; the
+            Open SWE bot must be a member of the channel.
+          </p>
         </div>
 
         <SectionLabel>Agent Instructions</SectionLabel>

--- a/ui/src/features/automations/components/AutomationsList.tsx
+++ b/ui/src/features/automations/components/AutomationsList.tsx
@@ -186,6 +186,7 @@ function AutomationRow({ schedule }: { schedule: AgentSchedule }) {
             {describeCron(schedule.schedule)}
           </span>
           {schedule.repo && <span>{schedule.repo}</span>}
+          {schedule.slackChannelId && <span>{schedule.slackChannelId}</span>}
           <span>Last run: {formatDate(schedule.lastTriggeredAt)}</span>
         </div>
       </div>


### PR DESCRIPTION
## Description
Let users attach an optional Slack channel ID to an automation. Each scheduled run creates a fresh Slack thread, uses its deterministic agent thread ID, and routes questions, PR links, follow-ups, and failures there.

## Release Note
Automations can now create interactive per-run threads in a configured Slack channel.

## Test Plan
- [x] Verify schedule persistence, Slack thread dispatch/mapping, failures, Python checks, and UI typecheck; UI lint is blocked because the existing package does not install an `eslint` binary.

Made by [Open SWE](https://openswe.vercel.app/agents/909eb325-d071-d0af-1adf-7cad7f86354c)