### PR TITLE
feat: add explicit plan approval tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ There is intentionally no after-agent safety net that opens a PR for the agent. 
 All tools live in `agent/tools/` and are flat-imported via `agent/tools/__init__.py`. The set is intentionally small and curated — see README "Tools — Curated, Not Accumulated".
 
 Wired into `get_agent`:
-`http_request`, `fetch_url`, `web_search`, `linear_comment`, `linear_create_issue`, `linear_delete_issue`, `linear_get_issue`, `linear_get_issue_comments`, `linear_list_teams`, `linear_search_issues`, `linear_update_issue`, `request_pr_review`, `schedule_thread_wakeup`, `slack_add_reaction`, `slack_read_thread_messages`, `slack_thread_reply`.
+`http_request`, `fetch_url`, `web_search`, `approve_plan`, `enter_plan_mode`, `save_plan`, `linear_comment`, `linear_create_issue`, `linear_delete_issue`, `linear_get_issue`, `linear_get_issue_comments`, `linear_list_teams`, `linear_search_issues`, `linear_update_issue`, `open_pull_request`, `request_pr_review`, `report_platform_issue`, `schedule_thread_wakeup`, `slack_add_reaction`, `slack_read_thread_messages`, `slack_start_new_thread`, `slack_thread_reply`.
 
 Reviewer-only tools (in `agent/reviewer.py`): `add_finding`, `update_finding`, `list_findings`, `publish_review`. The review-style analyzer uses `save_review_style` (exported as `save_review_style_prompt`).
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1369,7 +1369,11 @@ async def send_dashboard_message(
     active_model = _metadata_model_id(metadata) if body.images else None
     content = _user_message_content(prompt, body.images, model_id=active_model)
     await client.threads.update(thread_id=thread_id, metadata=metadata_update)
-    queue_payload: dict[str, Any] = {"text": prompt, "source": _DASHBOARD_SOURCE}
+    queue_payload: dict[str, Any] = {
+        "text": prompt,
+        "source": _DASHBOARD_SOURCE,
+        "from_owner": _user_owns_thread(metadata, login, email),
+    }
     if isinstance(content, list):
         queue_payload["images"] = [
             block for block in content if isinstance(block, dict) and block.get("type") != "text"

--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -8,7 +8,7 @@ human messages before the next model call.
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any, NotRequired, cast
 
 import httpx
 from langchain.agents.middleware import AgentState, before_model
@@ -32,6 +32,7 @@ class LinearNotifyState(AgentState):
     """Extended agent state for tracking Linear notifications."""
 
     linear_messages_sent_count: int
+    plan_approval_blocked: NotRequired[bool]
 
 
 async def _resolve_thread_model_id(thread_id: str) -> str | None:
@@ -89,7 +90,16 @@ def _is_dashboard_queued_message(content: object) -> bool:
     return isinstance(content, dict) and content.get("source") == "dashboard"
 
 
-def _message_update(content_blocks: list[dict[str, Any]], thread_id: str) -> dict[str, Any] | None:
+def _dashboard_queued_message_from_owner(content: object) -> bool:
+    return isinstance(content, dict) and content.get("from_owner") is True
+
+
+def _message_update(
+    content_blocks: list[dict[str, Any]],
+    thread_id: str,
+    *,
+    plan_approval_blocked: bool | None = None,
+) -> dict[str, Any] | None:
     if not content_blocks:
         return None
     logger.info(
@@ -97,7 +107,10 @@ def _message_update(content_blocks: list[dict[str, Any]], thread_id: str) -> dic
         len(content_blocks),
         thread_id,
     )
-    return {"messages": [{"role": "user", "content": content_blocks}]}
+    update: dict[str, Any] = {"messages": [{"role": "user", "content": content_blocks}]}
+    if plan_approval_blocked is not None:
+        update["plan_approval_blocked"] = plan_approval_blocked
+    return update
 
 
 async def _consume_pending_autofix_event(store: BaseStore, thread_id: str) -> str | None:
@@ -164,6 +177,7 @@ async def check_message_queue_before_model(  # noqa: PLR0911
             return None
 
         content_blocks: list[dict[str, Any]] = []
+        plan_approval_blocked: bool | None = None
         pending_autofix = await _consume_pending_autofix_event(store, thread_id)
         if pending_autofix:
             content_blocks.append({"type": "text", "text": pending_autofix})
@@ -207,6 +221,10 @@ async def check_message_queue_before_model(  # noqa: PLR0911
             content = msg.get("content")
             if _is_dashboard_queued_message(content):
                 content_blocks.append({"type": "text", "text": DASHBOARD_HANDOFF_INSTRUCTION})
+                if _dashboard_queued_message_from_owner(content):
+                    plan_approval_blocked = False
+                elif plan_approval_blocked is None:
+                    plan_approval_blocked = True
             if isinstance(content, dict) and (
                 "text" in content or "image_urls" in content or "images" in content
             ):
@@ -222,7 +240,9 @@ async def check_message_queue_before_model(  # noqa: PLR0911
                 logger.debug("Queued message contains text content")
                 content_blocks.append({"type": "text", "text": content})
 
-        return _message_update(content_blocks, thread_id)  # noqa: TRY300
+        return _message_update(
+            content_blocks, thread_id, plan_approval_blocked=plan_approval_blocked
+        )  # noqa: TRY300
     except Exception:
         logger.exception("Error in check_message_queue_before_model")
     return None

--- a/agent/middleware/plan_mode.py
+++ b/agent/middleware/plan_mode.py
@@ -54,12 +54,16 @@ class PlanModeMiddleware(AgentMiddleware):
         return {"plan_mode": self._initial}
 
     def _active(self, request: ModelRequest) -> bool:
-        if self._initial:
-            return True
         state = getattr(request, "state", None)
         if isinstance(state, dict):
-            return state.get("plan_mode") is True
-        return getattr(state, "plan_mode", None) is True
+            value = state.get("plan_mode")
+            if isinstance(value, bool):
+                return value
+        else:
+            value = getattr(state, "plan_mode", None)
+            if isinstance(value, bool):
+                return value
+        return self._initial
 
     def _filter(self, request: ModelRequest) -> ModelRequest:
         if not self._excluded or not self._active(request):

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -126,7 +126,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply naturally in the thread to approve the plan or request changes; do not send plan-approval buttons.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply naturally in the thread to approve the plan or request changes; do not send plan-approval buttons. Only call `approve_plan` when the latest user message explicitly asks you to approve the plan, exit plan mode, or begin implementation.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -134,17 +134,17 @@ PLAN_MODE_SECTION = """---
 
 ### Plan Mode (ACTIVE)
 
-**Plan mode is enabled for this run. This supersedes any instruction telling you to edit code, commit, push, or open a pull request.**
+**Plan mode is enabled for this run unless `approve_plan` succeeds after an explicit owner request. Until then, this supersedes any instruction telling you to edit code, commit, push, or open a pull request.**
 
 You are in a read-only research-and-planning phase for the target repo. Your single deliverable is a clear, reviewable implementation plan saved as a Markdown file outside any repo and published with `save_plan` — NOT code changes. Share the plan-review link below with the user right after entering plan mode and again when the plan is ready.
 
 **Plan-review link:** {plan_url}
 
-**You MUST NOT** edit/create/delete files inside the target repo, run state-changing `execute` commands except creating `/workspace/plans` (no `git commit`/`push`/`checkout -b`, installs, code generators, or file-rewriting formatters), commit, push, open/update a PR, call `request_pr_review`, or mutate Linear/external systems. The `task` subagent is disabled here (subagents wouldn't inherit these restrictions) — research directly.
+Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside the target repo, run state-changing `execute` commands except creating `/workspace/plans` (no `git commit`/`push`/`checkout -b`, installs, code generators, or file-rewriting formatters), commit, push, open/update a PR, call `request_pr_review`, or mutate Linear/external systems. The `task` subagent is disabled here (subagents wouldn't inherit these restrictions) — research directly.
 
 **You MAY:** clone and read the repo (`read_file`, `ls`, `glob`, `grep`, read-only `execute` like `git clone`/`status`/`log`/`diff`, `cat`, `rg`), research with `web_search`/`fetch_url`, ask clarifying questions via `slack_thread_reply` / `linear_comment`, use `execute` only if needed to create `/workspace/plans`, and use `write_file` / `edit_file` only to create or revise the plan file outside any repo under `/workspace/plans/`.
 
-**Workflow:** explore the relevant code enough to choose a sound approach, clarify ambiguity, choose a dated, descriptive plan path like `/workspace/plans/YYYY-MM-DD-short-task-slug.md`, create it with ONE recommended plan, refine it with normal file-editing tools if needed, then publish it with `save_plan` by passing that exact `plan_file_path`. Keep it high level: focus on desired behavior, architecture boundaries, product decisions, tradeoffs, rollout/migration concerns, and verification. Avoid file/function-level details and exhaustive file lists unless a specific implementation detail is unusually tricky, risky, or controversial. Aim for about one page or less unless the task truly requires more. Use this structure:
+**Workflow:** explore the relevant code enough to choose a sound approach, clarify ambiguity, choose a dated, descriptive plan path like `/workspace/plans/YYYY-MM-DD-short-task-slug.md`, create it with ONE recommended plan, refine it with normal file-editing tools if needed, then publish it with `save_plan` by passing that exact `plan_file_path`. Keep it high level: focus on desired behavior, architecture boundaries, product decisions, tradeoffs, rollout/migration concerns, and verification. Avoid file/function-level details and exhaustive file lists unless a specific implementation detail is unusually tricky, risky, or controversial. Aim for about one page or less unless the task truly requires more. If the plan owner explicitly asks you to approve the current plan, exit plan mode, or implement the plan, call `approve_plan` with their exact request before any implementation; do not infer approval from vague praise, silence, or your own judgment. After `approve_plan` succeeds, plan mode is inactive for this run and you should implement the approved plan. Use this structure:
 
 ```
 ## Plan: <short title>

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -126,7 +126,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply naturally in the thread to approve the plan or request changes; do not send plan-approval buttons. Only call `approve_plan` when the latest user message explicitly asks you to approve the plan, exit plan mode, or begin implementation.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply naturally in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -134,7 +134,7 @@ PLAN_MODE_SECTION = """---
 
 ### Plan Mode (ACTIVE)
 
-**Plan mode is enabled for this run unless `approve_plan` succeeds after an explicit owner request. Until then, this supersedes any instruction telling you to edit code, commit, push, or open a pull request.**
+**Plan mode is enabled for this run unless `approve_plan` succeeds. Until then, this supersedes any instruction telling you to edit code, commit, push, or open a pull request.**
 
 You are in a read-only research-and-planning phase for the target repo. Your single deliverable is a clear, reviewable implementation plan saved as a Markdown file outside any repo and published with `save_plan` — NOT code changes. Share the plan-review link below with the user right after entering plan mode and again when the plan is ready.
 
@@ -144,7 +144,7 @@ Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside 
 
 **You MAY:** clone and read the repo (`read_file`, `ls`, `glob`, `grep`, read-only `execute` like `git clone`/`status`/`log`/`diff`, `cat`, `rg`), research with `web_search`/`fetch_url`, ask clarifying questions via `slack_thread_reply` / `linear_comment`, use `execute` only if needed to create `/workspace/plans`, and use `write_file` / `edit_file` only to create or revise the plan file outside any repo under `/workspace/plans/`.
 
-**Workflow:** explore the relevant code enough to choose a sound approach, clarify ambiguity, choose a dated, descriptive plan path like `/workspace/plans/YYYY-MM-DD-short-task-slug.md`, create it with ONE recommended plan, refine it with normal file-editing tools if needed, then publish it with `save_plan` by passing that exact `plan_file_path`. Keep it high level: focus on desired behavior, architecture boundaries, product decisions, tradeoffs, rollout/migration concerns, and verification. Avoid file/function-level details and exhaustive file lists unless a specific implementation detail is unusually tricky, risky, or controversial. Aim for about one page or less unless the task truly requires more. If the plan owner explicitly asks you to approve the current plan, exit plan mode, or implement the plan, call `approve_plan` with their exact request before any implementation; do not infer approval from vague praise, silence, or your own judgment. After `approve_plan` succeeds, plan mode is inactive for this run and you should implement the approved plan. Use this structure:
+**Workflow:** explore the relevant code enough to choose a sound approach, clarify ambiguity, choose a dated, descriptive plan path like `/workspace/plans/YYYY-MM-DD-short-task-slug.md`, create it with ONE recommended plan, refine it with normal file-editing tools if needed, then publish it with `save_plan` by passing that exact `plan_file_path`. Keep it high level: focus on desired behavior, architecture boundaries, product decisions, tradeoffs, rollout/migration concerns, and verification. Avoid file/function-level details and exhaustive file lists unless a specific implementation detail is unusually tricky, risky, or controversial. Aim for about one page or less unless the task truly requires more. If the user approves the current plan, asks to exit plan mode, or asks to implement the plan, call `approve_plan` before implementation. After `approve_plan` succeeds, plan mode is inactive for this run and you should implement the approved plan. Use this structure:
 
 ```
 ## Plan: <short title>

--- a/agent/server.py
+++ b/agent/server.py
@@ -97,6 +97,7 @@ from .runtime.constants import (
 )
 from .runtime.execution import graph_loaded_for_execution
 from .tools import (
+    approve_plan,
     enter_plan_mode,
     fetch_url,
     http_request,
@@ -958,6 +959,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             http_request,
             fetch_url,
             web_search,
+            approve_plan,
             enter_plan_mode,
             save_plan,
             linear_comment,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 _TOOL_MODULES = {
     "add_finding": ".add_finding",
+    "approve_plan": ".approve_plan",
     "enter_plan_mode": ".enter_plan_mode",
     "fetch_review_diff": ".fetch_review_diff",
     "fetch_url": ".fetch_url",
@@ -38,6 +39,7 @@ _TOOL_MODULES = {
 
 __all__ = [
     "add_finding",
+    "approve_plan",
     "enter_plan_mode",
     "fetch_review_diff",
     "fetch_url",
@@ -72,6 +74,7 @@ __all__ = [
 
 if TYPE_CHECKING:
     from .add_finding import add_finding
+    from .approve_plan import approve_plan
     from .enter_plan_mode import enter_plan_mode
     from .fetch_review_diff import fetch_review_diff
     from .fetch_url import fetch_url

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Annotated, Any
+from typing import Annotated, Any, TypedDict
 
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import InjectedToolCallId
@@ -25,8 +25,13 @@ from ..dashboard.thread_api import _user_owns_thread
 logger = logging.getLogger(__name__)
 
 
+class ApprovePlanState(TypedDict, total=False):
+    plan_mode: bool
+    plan_approval_blocked: bool
+
+
 async def approve_plan(
-    state: Annotated[dict[str, Any] | None, InjectedState] = None,
+    state: Annotated[ApprovePlanState | None, InjectedState] = None,
     tool_call_id: Annotated[str, InjectedToolCallId] = "",
 ) -> Command | dict[str, Any]:
     """Approve the current plan and exit plan mode.
@@ -47,6 +52,11 @@ async def approve_plan(
         metadata = await _thread_metadata(str(thread_id))
         if not _active_plan_mode(state, configurable, metadata):
             return {"success": False, "error": "plan mode is not active for this thread"}
+        if isinstance(state, dict) and state.get("plan_approval_blocked") is True:
+            return {
+                "success": False,
+                "error": "a non-owner dashboard follow-up cannot approve the plan",
+            }
         if not _current_user_owns_thread(metadata, configurable):
             return {"success": False, "error": "only the plan owner can approve the plan"}
         content = await get_plan_content(str(thread_id), raise_on_error=True) or {}
@@ -82,7 +92,7 @@ async def _thread_metadata(thread_id: str) -> dict[str, Any]:
 
 
 def _active_plan_mode(
-    state: dict[str, Any] | None, configurable: Any, metadata: Mapping[str, Any]
+    state: Mapping[str, Any] | None, configurable: Any, metadata: Mapping[str, Any]
 ) -> bool:
     if isinstance(state, dict) and "plan_mode" in state:
         return state.get("plan_mode") is True

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -1,0 +1,199 @@
+"""Tool: ``approve_plan``. Approve a reviewed plan and exit plan mode."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from typing import Annotated, Any
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import InjectedToolCallId
+from langgraph.config import get_config
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from langgraph_sdk import get_client
+
+from ..dashboard.plan_store import (
+    PLAN_STATUS_APPROVED,
+    PLAN_STATUS_SHARED,
+    get_plan_content,
+    list_plan_comments,
+    set_plan_status,
+)
+from ..dashboard.thread_api import _user_owns_thread
+
+logger = logging.getLogger(__name__)
+
+_EXPLICIT_APPROVAL_PHRASES = (
+    "approve",
+    "approve it",
+    "approve plan",
+    "approve the plan",
+    "approved",
+    "exit plan mode",
+    "leave plan mode",
+    "get out of plan mode",
+    "turn off plan mode",
+    "disable plan mode",
+    "implement now",
+    "implement the plan",
+    "start implementation",
+    "proceed with implementation",
+    "continue implementation",
+    "continue with implementation",
+    "go ahead and implement",
+    "go ahead and implement it",
+)
+_EXPLICIT_APPROVAL_NEGATIONS = (
+    "cancel",
+    "change",
+    "changes",
+    "deny",
+    "denied",
+    "do not",
+    "don t",
+    "dont",
+    "hasn t",
+    "hasnt",
+    "haven t",
+    "havent",
+    "hold",
+    "no",
+    "not",
+    "reject",
+    "revise",
+    "stop",
+    "wait",
+)
+
+
+async def approve_plan(
+    approval_request: str,
+    state: Annotated[dict[str, Any] | None, InjectedState] = None,
+    tool_call_id: Annotated[str, InjectedToolCallId] = "",
+) -> Command | dict[str, Any]:
+    """Approve the current plan and exit plan mode only when explicitly asked.
+
+    Call this only when the latest user message explicitly asks you to approve the
+    current plan, exit/disable plan mode, or begin implementation of the plan. Do
+    not call it for vague approval, praise, silence, or your own judgment. Pass
+    the exact user request that explicitly authorizes approval.
+    """
+    if not isinstance(approval_request, str) or not approval_request.strip():
+        return {"success": False, "error": "approval_request must quote the explicit user ask"}
+    if not _is_explicit_plan_approval_request(approval_request):
+        return {
+            "success": False,
+            "error": "approval_request is not an explicit request to approve or exit plan mode",
+        }
+
+    try:
+        config = get_config()
+    except Exception:
+        config = {}
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
+    if not thread_id:
+        return {"success": False, "error": "no thread_id in run config"}
+
+    try:
+        metadata = await _thread_metadata(str(thread_id))
+        if not _active_plan_mode(state, configurable, metadata):
+            return {"success": False, "error": "plan mode is not active for this thread"}
+        if not _current_user_owns_thread(metadata, configurable):
+            return {"success": False, "error": "only the plan owner can approve the plan"}
+        content = await get_plan_content(str(thread_id), raise_on_error=True) or {}
+        if content.get("status") == PLAN_STATUS_SHARED:
+            return {"success": False, "error": "shared content is not an implementation plan"}
+        plan_markdown = str(content.get("markdown", "")).strip()
+        comments = await list_plan_comments(str(thread_id), raise_on_error=True)
+        feedback = _format_comments(comments)
+        await set_plan_status(str(thread_id), PLAN_STATUS_APPROVED, plan_mode=False)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("approve_plan failed for thread %s", thread_id)
+        return {"success": False, "error": f"failed to approve plan: {exc}"}
+
+    return Command(
+        update={
+            "plan_mode": False,
+            "messages": [
+                ToolMessage(
+                    content=_approved_message(plan_markdown, feedback),
+                    tool_call_id=tool_call_id,
+                )
+            ],
+        }
+    )
+
+
+def _is_explicit_plan_approval_request(text: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+    if not normalized:
+        return False
+    padded = f" {normalized} "
+    if any(f" {phrase} " in padded for phrase in _EXPLICIT_APPROVAL_NEGATIONS):
+        return False
+    return any(f" {phrase} " in padded for phrase in _EXPLICIT_APPROVAL_PHRASES)
+
+
+async def _thread_metadata(thread_id: str) -> dict[str, Any]:
+    thread = await get_client().threads.get(thread_id)
+    metadata = (
+        thread.get("metadata") if isinstance(thread, dict) else getattr(thread, "metadata", None)
+    )
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _active_plan_mode(
+    state: dict[str, Any] | None, configurable: Any, metadata: Mapping[str, Any]
+) -> bool:
+    if isinstance(state, dict) and "plan_mode" in state:
+        return state.get("plan_mode") is True
+    if isinstance(configurable, dict) and configurable.get("plan_mode") is True:
+        return True
+    return metadata.get("plan_mode") is True
+
+
+def _current_user_owns_thread(metadata: Mapping[str, Any], configurable: Any) -> bool:
+    if not isinstance(configurable, dict):
+        return False
+    login = configurable.get("github_login")
+    login = login.strip() if isinstance(login, str) else ""
+    email = configurable.get("user_email")
+    if not isinstance(email, str):
+        slack_thread = configurable.get("slack_thread")
+        if isinstance(slack_thread, dict):
+            email = slack_thread.get("triggering_user_email")
+    email = email.strip().lower() if isinstance(email, str) else None
+    return bool(login or email) and _user_owns_thread(metadata, login, email)
+
+
+def _format_comments(comments: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    index = 1
+    for comment in comments:
+        body = str(comment.get("body", "")).strip()
+        if not body:
+            continue
+        author = str(comment.get("author") or "reviewer").strip()
+        lines.append(f"{index}. {author}: {body}")
+        index += 1
+    return "\n".join(lines)
+
+
+def _approved_message(plan_markdown: str, feedback: str) -> str:
+    if plan_markdown:
+        message = (
+            "Plan mode is now inactive because the plan owner explicitly approved it. "
+            "Implement the approved plan now. Treat this published plan as the source of truth:\n\n"
+            f"{plan_markdown}"
+        )
+    else:
+        message = (
+            "Plan mode is now inactive because the plan owner explicitly approved it. "
+            "Implement now as described in the approved plan."
+        )
+    if feedback:
+        message += "\n\nAlso take this reviewer feedback into account:\n\n" + feedback
+    return message

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Mapping
 from typing import Annotated, Any
 
@@ -25,69 +24,16 @@ from ..dashboard.thread_api import _user_owns_thread
 
 logger = logging.getLogger(__name__)
 
-_EXPLICIT_APPROVAL_PHRASES = (
-    "approve",
-    "approve it",
-    "approve plan",
-    "approve the plan",
-    "approved",
-    "exit plan mode",
-    "leave plan mode",
-    "get out of plan mode",
-    "turn off plan mode",
-    "disable plan mode",
-    "implement now",
-    "implement the plan",
-    "start implementation",
-    "proceed with implementation",
-    "continue implementation",
-    "continue with implementation",
-    "go ahead and implement",
-    "go ahead and implement it",
-)
-_EXPLICIT_APPROVAL_NEGATIONS = (
-    "cancel",
-    "change",
-    "changes",
-    "deny",
-    "denied",
-    "do not",
-    "don t",
-    "dont",
-    "hasn t",
-    "hasnt",
-    "haven t",
-    "havent",
-    "hold",
-    "no",
-    "not",
-    "reject",
-    "revise",
-    "stop",
-    "wait",
-)
-
 
 async def approve_plan(
-    approval_request: str,
     state: Annotated[dict[str, Any] | None, InjectedState] = None,
     tool_call_id: Annotated[str, InjectedToolCallId] = "",
 ) -> Command | dict[str, Any]:
-    """Approve the current plan and exit plan mode only when explicitly asked.
+    """Approve the current plan and exit plan mode.
 
-    Call this only when the latest user message explicitly asks you to approve the
-    current plan, exit/disable plan mode, or begin implementation of the plan. Do
-    not call it for vague approval, praise, silence, or your own judgment. Pass
-    the exact user request that explicitly authorizes approval.
+    Call this when the user approves the plan, asks to leave plan mode, or asks to
+    start implementing the approved plan.
     """
-    if not isinstance(approval_request, str) or not approval_request.strip():
-        return {"success": False, "error": "approval_request must quote the explicit user ask"}
-    if not _is_explicit_plan_approval_request(approval_request):
-        return {
-            "success": False,
-            "error": "approval_request is not an explicit request to approve or exit plan mode",
-        }
-
     try:
         config = get_config()
     except Exception:
@@ -125,16 +71,6 @@ async def approve_plan(
             ],
         }
     )
-
-
-def _is_explicit_plan_approval_request(text: str) -> bool:
-    normalized = re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
-    if not normalized:
-        return False
-    padded = f" {normalized} "
-    if any(f" {phrase} " in padded for phrase in _EXPLICIT_APPROVAL_NEGATIONS):
-        return False
-    return any(f" {phrase} " in padded for phrase in _EXPLICIT_APPROVAL_PHRASES)
 
 
 async def _thread_metadata(thread_id: str) -> dict[str, Any]:
@@ -185,13 +121,13 @@ def _format_comments(comments: list[dict[str, Any]]) -> str:
 def _approved_message(plan_markdown: str, feedback: str) -> str:
     if plan_markdown:
         message = (
-            "Plan mode is now inactive because the plan owner explicitly approved it. "
+            "Plan mode is now inactive because the plan was approved. "
             "Implement the approved plan now. Treat this published plan as the source of truth:\n\n"
             f"{plan_markdown}"
         )
     else:
         message = (
-            "Plan mode is now inactive because the plan owner explicitly approved it. "
+            "Plan mode is now inactive because the plan was approved. "
             "Implement now as described in the approved plan."
         )
     if feedback:

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -33,7 +33,8 @@ def test_plan_mode_excluded_tools_cover_mutating_tools() -> None:
         "linear_delete_issue",
     ):
         assert tool in excluded
-    # Read-only tools and plan-file editing tools must stay available.
+    # Read-only tools, plan-file editing tools, and explicit plan approval stay available.
+    assert "approve_plan" not in excluded
     assert "read_file" not in excluded
     assert "write_file" not in excluded
     assert "edit_file" not in excluded
@@ -195,6 +196,132 @@ def test_enter_plan_mode_exported() -> None:
     from agent.tools import enter_plan_mode
 
     assert callable(enter_plan_mode)
+
+
+async def test_approve_plan_tool_rejects_implicit_request() -> None:
+    from agent.tools.approve_plan import approve_plan
+
+    result = await approve_plan(
+        "looks good to me",
+        state={"plan_mode": True},
+        tool_call_id="call-1",
+    )
+
+    assert isinstance(result, dict)
+    assert result["success"] is False
+    assert "explicit request" in result["error"]
+
+
+async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    from langchain_core.messages import ToolMessage
+    from langgraph.types import Command
+
+    from agent.tools import approve_plan as approve_plan_export
+
+    approve_plan_tool = importlib.import_module("agent.tools.approve_plan")
+
+    assert callable(approve_plan_export)
+
+    saved: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        approve_plan_tool,
+        "get_config",
+        lambda: {
+            "configurable": {
+                "thread_id": "t1",
+                "github_login": "octo",
+                "user_email": "octo@example.com",
+                "plan_mode": True,
+            }
+        },
+    )
+
+    async def fake_thread_metadata(thread_id: str) -> dict[str, Any]:
+        assert thread_id == "t1"
+        return {
+            "source": "dashboard",
+            "github_login": "octo",
+            "triggering_user_email": "octo@example.com",
+            "plan_mode": True,
+            "plan_status": "ready",
+        }
+
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        assert raise_on_error is True
+        return {"markdown": "# Plan\n\nDo it", "status": "ready"}
+
+    async def fake_list_comments(
+        thread_id: str, *, raise_on_error: bool = False
+    ) -> list[dict[str, Any]]:
+        assert raise_on_error is True
+        return [{"author": "Alice", "body": "add tests"}]
+
+    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
+        saved.update(thread_id=thread_id, status=status, plan_mode=plan_mode)
+
+    monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
+    monkeypatch.setattr(approve_plan_tool, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(approve_plan_tool, "list_plan_comments", fake_list_comments)
+    monkeypatch.setattr(approve_plan_tool, "set_plan_status", fake_set_status)
+
+    result = await approve_plan_tool.approve_plan(
+        "approve the plan",
+        state={"plan_mode": True},
+        tool_call_id="call-1",
+    )
+
+    assert isinstance(result, Command)
+    assert result.update is not None
+    assert result.update["plan_mode"] is False
+    assert saved == {"thread_id": "t1", "status": "approved", "plan_mode": False}
+    messages = result.update["messages"]
+    assert len(messages) == 1
+    assert isinstance(messages[0], ToolMessage)
+    assert messages[0].tool_call_id == "call-1"
+    assert "# Plan" in messages[0].content
+    assert "add tests" in messages[0].content
+
+
+async def test_approve_plan_tool_rejects_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    approve_plan_tool = importlib.import_module("agent.tools.approve_plan")
+
+    monkeypatch.setattr(
+        approve_plan_tool,
+        "get_config",
+        lambda: {
+            "configurable": {
+                "thread_id": "t1",
+                "github_login": "other",
+                "user_email": "other@example.com",
+                "plan_mode": True,
+            }
+        },
+    )
+
+    async def fake_thread_metadata(thread_id: str) -> dict[str, Any]:
+        return {
+            "source": "dashboard",
+            "github_login": "octo",
+            "triggering_user_email": "octo@example.com",
+            "plan_mode": True,
+        }
+
+    monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
+
+    result = await approve_plan_tool.approve_plan(
+        "approve the plan",
+        state={"plan_mode": True},
+        tool_call_id="call-1",
+    )
+
+    assert isinstance(result, dict)
+    assert result["success"] is False
+    assert "owner" in result["error"]
 
 
 @pytest.mark.parametrize(

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -198,20 +198,6 @@ def test_enter_plan_mode_exported() -> None:
     assert callable(enter_plan_mode)
 
 
-async def test_approve_plan_tool_rejects_implicit_request() -> None:
-    from agent.tools.approve_plan import approve_plan
-
-    result = await approve_plan(
-        "looks good to me",
-        state={"plan_mode": True},
-        tool_call_id="call-1",
-    )
-
-    assert isinstance(result, dict)
-    assert result["success"] is False
-    assert "explicit request" in result["error"]
-
-
 async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     import importlib
 
@@ -268,7 +254,6 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(approve_plan_tool, "set_plan_status", fake_set_status)
 
     result = await approve_plan_tool.approve_plan(
-        "approve the plan",
         state={"plan_mode": True},
         tool_call_id="call-1",
     )
@@ -314,7 +299,6 @@ async def test_approve_plan_tool_rejects_non_owner(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
 
     result = await approve_plan_tool.approve_plan(
-        "approve the plan",
         state={"plan_mode": True},
         tool_call_id="call-1",
     )

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -270,6 +270,46 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
     assert "add tests" in messages[0].content
 
 
+async def test_approve_plan_tool_rejects_non_owner_followup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    approve_plan_tool = importlib.import_module("agent.tools.approve_plan")
+
+    monkeypatch.setattr(
+        approve_plan_tool,
+        "get_config",
+        lambda: {
+            "configurable": {
+                "thread_id": "t1",
+                "github_login": "octo",
+                "user_email": "octo@example.com",
+                "plan_mode": True,
+            }
+        },
+    )
+
+    async def fake_thread_metadata(thread_id: str) -> dict[str, Any]:
+        return {
+            "source": "dashboard",
+            "github_login": "octo",
+            "triggering_user_email": "octo@example.com",
+            "plan_mode": True,
+        }
+
+    monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
+
+    result = await approve_plan_tool.approve_plan(
+        state={"plan_mode": True, "plan_approval_blocked": True},
+        tool_call_id="call-1",
+    )
+
+    assert isinstance(result, dict)
+    assert result["success"] is False
+    assert "non-owner" in result["error"]
+
+
 async def test_approve_plan_tool_rejects_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
     import importlib
 

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -433,6 +433,14 @@ def test_plan_mode_middleware_self_activation_via_state() -> None:
     assert _names(cast(_FakeReq, mw._filter(cast(Any, on)))) == {"read_file"}
 
 
+def test_plan_mode_middleware_self_deactivation_via_state() -> None:
+    from agent.middleware import PlanModeMiddleware
+
+    mw = PlanModeMiddleware(excluded=frozenset({"write_file"}), initial=True)
+    off = _FakeReq([{"name": "read_file"}, {"name": "write_file"}], {"plan_mode": False})
+    assert _names(cast(_FakeReq, mw._filter(cast(Any, off)))) == {"read_file", "write_file"}
+
+
 # --- manual plan editing -------------------------------------------------
 
 

--- a/tests/dashboard/test_dashboard_web_handoff.py
+++ b/tests/dashboard/test_dashboard_web_handoff.py
@@ -174,7 +174,9 @@ async def test_dashboard_followup_on_busy_thread_queues_dashboard_handoff(
     )
 
     assert client.threads.updates[0]["source"] == "dashboard"
-    assert queued_messages == [{"text": "continue in web", "source": "dashboard"}]
+    assert queued_messages == [
+        {"text": "continue in web", "source": "dashboard", "from_owner": True}
+    ]
 
 
 @pytest.mark.asyncio
@@ -221,7 +223,9 @@ async def test_dashboard_followup_on_busy_slack_thread_updates_trace_reply(
         email="octocat@example.com",
     )
 
-    assert queued_messages == [{"text": "continue in web", "source": "dashboard"}]
+    assert queued_messages == [
+        {"text": "continue in web", "source": "dashboard", "from_owner": True}
+    ]
     assert handoff_updates == [
         {"channel_id": "C1", "message_ts": "123.46", "thread_id": "thread-1"}
     ]
@@ -313,6 +317,7 @@ async def test_dashboard_followup_on_busy_thread_queues_images(
         {
             "text": "continue in web",
             "source": "dashboard",
+            "from_owner": True,
             "images": [{"type": "image", "data": "aW1hZ2U=", "mime_type": "image/png"}],
         }
     ]

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -59,7 +59,36 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
     assert message["role"] == "user"
     assert DASHBOARD_HANDOFF_MARKER in message["content"][0]["text"]
     assert message["content"][1] == {"type": "text", "text": "continue in web"}
+    assert result["plan_approval_blocked"] is True
     assert store.deleted == [(("queue", "thread-1"), "pending_messages")]
+
+
+@pytest.mark.asyncio
+async def test_check_message_queue_allows_owner_dashboard_approval() -> None:
+    store = _FakeStore(
+        {
+            (("queue", "thread-1"), "pending_messages"): {
+                "messages": [
+                    {"content": {"text": "go ahead", "source": "dashboard", "from_owner": True}},
+                ]
+            }
+        }
+    )
+
+    with (
+        patch(
+            "agent.middleware.check_message_queue.get_config",
+            return_value={"configurable": {"thread_id": "thread-1"}},
+        ),
+        patch("agent.middleware.check_message_queue.get_store", return_value=store),
+    ):
+        result = await check_message_queue_before_model.abefore_model(
+            cast(LinearNotifyState, {"messages": []}), MagicMock()
+        )
+
+    assert result is not None
+    assert result["plan_approval_blocked"] is False
+    assert result["messages"][0]["content"][1] == {"type": "text", "text": "go ahead"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Adds a zero-argument `approve_plan` tool that lets the agent approve the current plan and deactivate plan mode within the same run. The backend still checks active plan mode and thread ownership before mutating state, then returns the approved plan/feedback as tool context and updates plan-mode gating.

## Release Note
none

## Test Plan
- [ ] Verify an owner can approve/exit plan mode and continue implementation from the same run.

Made by [Open SWE](https://openswe.vercel.app/agents/b9273ea7-6604-a124-793d-5e1ff23f0309)