### PR TITLE
feat: link originating Slack threads

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -364,6 +364,8 @@ def _is_thread_resolved(metadata: Mapping[str, Any]) -> bool:
 
 
 def _thread_source_url(metadata: Mapping[str, Any]) -> str | None:
+    if metadata.get("repo_private") is not True:
+        return None
     source_context = metadata.get("source_context")
     if not isinstance(source_context, dict):
         return None

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -363,6 +363,17 @@ def _is_thread_resolved(metadata: Mapping[str, Any]) -> bool:
     return metadata.get("resolved") is True
 
 
+def _thread_source_url(metadata: Mapping[str, Any]) -> str | None:
+    source_context = metadata.get("source_context")
+    if not isinstance(source_context, dict):
+        return None
+    slack_thread = source_context.get("slack_thread")
+    if not isinstance(slack_thread, dict):
+        return None
+    permalink = slack_thread.get("permalink")
+    return permalink.strip() if isinstance(permalink, str) and permalink.strip() else None
+
+
 def _thread_summary(
     thread: ThreadLike,
     *,
@@ -429,6 +440,7 @@ def _thread_summary(
         "updatedAt": int(updated_at) if isinstance(updated_at, (int, float)) else _now_ms(),
         "isOwner": (_user_owns_thread(metadata, owner_login, owner_email) if owner_login else True),
         "traceUrl": trace_url,
+        "sourceUrl": _thread_source_url(metadata),
         "sandboxId": sandbox_id,
     }
     if isinstance(pr_number, int) and isinstance(pr_url, str):

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -264,7 +264,7 @@ Steps, in order:
    ## Test Plan
    - [ ] <new/novel verification steps only — not "run existing tests">
    ```
-   For private repos, `open_pull_request` appends a `## References` section automatically; for public repos, don't reference private repos or PR/issue numbers. Commit messages: concise, focused on the "why"; default to the PR title.
+   `open_pull_request` appends a `## References` section automatically for plans and originating Slack threads when available; Linear/GitHub source references are appended only for private repos. For public repos, don't manually reference private repos or PR/issue numbers. Commit messages: concise, focused on the "why"; default to the PR title.
 
 3. **Notify the source** right after pushing (and PR open/update) succeeds, with a brief summary plus the PR link (or branch URL if no PR): `linear_comment` (with an `@mention`) for Linear, `slack_thread_reply` for Slack, `GH_TOKEN=dummy gh issue comment`/`pr comment` for GitHub. Skip if there is no known source channel.
 

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -264,7 +264,7 @@ Steps, in order:
    ## Test Plan
    - [ ] <new/novel verification steps only — not "run existing tests">
    ```
-   `open_pull_request` appends a `## References` section automatically for plans and originating Slack threads when available; Linear/GitHub source references are appended only for private repos. For public repos, don't manually reference private repos or PR/issue numbers. Commit messages: concise, focused on the "why"; default to the PR title.
+   `open_pull_request` appends a `## References` section automatically for plans, and for originating Slack/Linear/GitHub source references only on private repos. For public repos, don't manually reference private repos, Slack threads, or PR/issue numbers. Commit messages: concise, focused on the "why"; default to the PR title.
 
 3. **Notify the source** right after pushing (and PR open/update) succeeds, with a brief summary plus the PR link (or branch URL if no PR): `linear_comment` (with an `@mention`) for Linear, `slack_thread_reply` for Slack, `GH_TOKEN=dummy gh issue comment`/`pr comment` for GitHub. Skip if there is no known source channel.
 

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -549,10 +549,13 @@ async def _build_source_reference_lines(configurable: dict[str, Any]) -> list[st
         slack_thread = configurable.get("slack_thread") or {}
         channel_id = slack_thread.get("channel_id")
         thread_ts = slack_thread.get("thread_ts")
-        if channel_id and thread_ts:
-            permalink = await get_slack_permalink(channel_id, thread_ts)
-            if permalink:
-                lines.append(f"- Slack thread: {permalink}")
+        permalink = slack_thread.get("permalink")
+        if not isinstance(permalink, str) or not permalink.strip():
+            permalink = None
+            if channel_id and thread_ts:
+                permalink = await get_slack_permalink(channel_id, thread_ts)
+        if isinstance(permalink, str) and permalink.strip():
+            lines.append(f"- Slack thread: {permalink.strip()}")
     elif source == "linear":
         linear_issue = configurable.get("linear_issue") or {}
         url = linear_issue.get("url")
@@ -599,8 +602,11 @@ async def _maybe_append_references(
             lines.append(plan_line)
         try:
             source_lines = await _build_source_reference_lines(configurable)
-            if source_lines and await _is_private_repo(client, token, owner, repo):
-                lines.extend(source_lines)
+            if source_lines:
+                if configurable.get("source") == "slack" or await _is_private_repo(
+                    client, token, owner, repo
+                ):
+                    lines.extend(source_lines)
         except Exception:
             logger.debug("Failed to append source references to PR body", exc_info=True)
         if not lines:

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -500,23 +500,27 @@ async def _record_pr_telemetry(
             merged=merged,
         )
         if isinstance(thread_id, str) and thread_id:
-            await get_client().threads.update(
-                thread_id=thread_id,
-                metadata={
-                    "agent_kind": "agent",
-                    "pr_url": pr_url if isinstance(pr_url, str) else "",
-                    "pr_number": pr_number,
-                    "pr_state": derive_pr_state(state=state, merged=merged, draft=is_draft),
-                    "pr_title": details.get("title") or pr.get("title"),
-                    "branch_name": head,
-                    "base_branch": base,
-                    "diff_stats": {
-                        "files": changed_files,
-                        "additions": additions,
-                        "deletions": deletions,
-                    },
+            repo_private = None
+            base_repo = details.get("base", {}).get("repo")
+            if isinstance(base_repo, dict) and isinstance(base_repo.get("private"), bool):
+                repo_private = base_repo["private"]
+            metadata: dict[str, Any] = {
+                "agent_kind": "agent",
+                "pr_url": pr_url if isinstance(pr_url, str) else "",
+                "pr_number": pr_number,
+                "pr_state": derive_pr_state(state=state, merged=merged, draft=is_draft),
+                "pr_title": details.get("title") or pr.get("title"),
+                "branch_name": head,
+                "base_branch": base,
+                "diff_stats": {
+                    "files": changed_files,
+                    "additions": additions,
+                    "deletions": deletions,
                 },
-            )
+            }
+            if repo_private is not None:
+                metadata["repo_private"] = repo_private
+            await get_client().threads.update(thread_id=thread_id, metadata=metadata)
     except Exception:
         logger.debug(
             "Failed to record PR usage for %s/%s#%s", owner, repo, pr_number, exc_info=True
@@ -602,11 +606,8 @@ async def _maybe_append_references(
             lines.append(plan_line)
         try:
             source_lines = await _build_source_reference_lines(configurable)
-            if source_lines:
-                if configurable.get("source") == "slack" or await _is_private_repo(
-                    client, token, owner, repo
-                ):
-                    lines.extend(source_lines)
+            if source_lines and await _is_private_repo(client, token, owner, repo):
+                lines.extend(source_lines)
         except Exception:
             logger.debug("Failed to append source references to PR body", exc_info=True)
         if not lines:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -662,8 +662,24 @@ async def _upsert_slack_thread_repo_metadata(
         )
 
 
+def _existing_slack_permalink(
+    existing_metadata: dict[str, Any], channel_id: str, thread_ts: str
+) -> str | None:
+    source_context = existing_metadata.get("source_context")
+    if not isinstance(source_context, dict):
+        return None
+    slack_thread = source_context.get("slack_thread")
+    if not isinstance(slack_thread, dict):
+        return None
+    if slack_thread.get("channel_id") != channel_id or slack_thread.get("thread_ts") != thread_ts:
+        return None
+    permalink = slack_thread.get("permalink")
+    return permalink.strip() if isinstance(permalink, str) and permalink.strip() else None
+
+
 async def _source_context_with_slack_permalink(
     source_context: dict[str, Any],
+    existing_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     enriched = dict(source_context)
     slack_thread = enriched.get("slack_thread")
@@ -684,11 +700,17 @@ async def _source_context_with_slack_permalink(
     if not isinstance(thread_ts, str) or not thread_ts.strip():
         return enriched
 
+    normalized_channel_id = channel_id.strip()
+    normalized_thread_ts = thread_ts.strip()
     try:
-        permalink = await get_slack_permalink(channel_id.strip(), thread_ts.strip())
+        permalink = await get_slack_permalink(normalized_channel_id, normalized_thread_ts)
     except Exception:  # noqa: BLE001
         logger.debug("Failed to resolve Slack permalink for thread metadata", exc_info=True)
         permalink = None
+    if not permalink and existing_metadata:
+        permalink = _existing_slack_permalink(
+            existing_metadata, normalized_channel_id, normalized_thread_ts
+        )
     if permalink:
         enriched_slack_thread["permalink"] = permalink
         enriched["slack_thread"] = enriched_slack_thread
@@ -724,8 +746,6 @@ async def upsert_agent_thread_owner_metadata(
         metadata["triggering_user_email"] = user_email.strip().lower()
     if title:
         metadata["title"] = title[:80]
-    if source_context:
-        metadata["source_context"] = await _source_context_with_slack_permalink(source_context)
 
     langgraph_client = get_client(url=LANGGRAPH_URL)
     try:
@@ -739,6 +759,10 @@ async def upsert_agent_thread_owner_metadata(
     existing_meta = (
         existing_dict["metadata"] if isinstance(existing_dict.get("metadata"), dict) else {}
     )
+    if source_context:
+        metadata["source_context"] = await _source_context_with_slack_permalink(
+            source_context, existing_meta
+        )
     if existing_meta.get("created_at_ms") is None:
         metadata["created_at_ms"] = now_ms
     if existing_meta.get("title") and "title" in metadata:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -103,6 +103,7 @@ from ..utils.slack import (
     get_slack_channel_context_description,
     get_slack_channel_description,
     get_slack_channel_info,
+    get_slack_permalink,
     get_slack_user_info,
     get_slack_user_names,  # noqa: F401
     is_slack_channel_named,
@@ -661,6 +662,39 @@ async def _upsert_slack_thread_repo_metadata(
         )
 
 
+async def _source_context_with_slack_permalink(
+    source_context: dict[str, Any],
+) -> dict[str, Any]:
+    enriched = dict(source_context)
+    slack_thread = enriched.get("slack_thread")
+    if not isinstance(slack_thread, dict):
+        return enriched
+
+    enriched_slack_thread = dict(slack_thread)
+    permalink = enriched_slack_thread.get("permalink")
+    if isinstance(permalink, str) and permalink.strip():
+        enriched_slack_thread["permalink"] = permalink.strip()
+        enriched["slack_thread"] = enriched_slack_thread
+        return enriched
+
+    channel_id = enriched_slack_thread.get("channel_id")
+    thread_ts = enriched_slack_thread.get("thread_ts")
+    if not isinstance(channel_id, str) or not channel_id.strip():
+        return enriched
+    if not isinstance(thread_ts, str) or not thread_ts.strip():
+        return enriched
+
+    try:
+        permalink = await get_slack_permalink(channel_id.strip(), thread_ts.strip())
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to resolve Slack permalink for thread metadata", exc_info=True)
+        permalink = None
+    if permalink:
+        enriched_slack_thread["permalink"] = permalink
+        enriched["slack_thread"] = enriched_slack_thread
+    return enriched
+
+
 async def upsert_agent_thread_owner_metadata(
     thread_id: str,
     *,
@@ -691,7 +725,7 @@ async def upsert_agent_thread_owner_metadata(
     if title:
         metadata["title"] = title[:80]
     if source_context:
-        metadata["source_context"] = source_context
+        metadata["source_context"] = await _source_context_with_slack_permalink(source_context)
 
     langgraph_client = get_client(url=LANGGRAPH_URL)
     try:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -328,6 +328,19 @@ def test_thread_summary_hides_creating_sandbox_sentinel() -> None:
     assert summary["sandboxId"] is None
 
 
+def test_thread_summary_includes_slack_source_url() -> None:
+    summary = thread_api._thread_summary(
+        _thread_with_metadata(
+            {
+                "source": "slack",
+                "source_context": {"slack_thread": {"permalink": "https://slack.example/thread"}},
+            }
+        )
+    )
+
+    assert summary["sourceUrl"] == "https://slack.example/thread"
+
+
 async def test_recovery_patch_requires_thread_owner(monkeypatch) -> None:
     class FakeThreads:
         async def get(self, thread_id: str) -> dict[str, object]:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -328,17 +328,32 @@ def test_thread_summary_hides_creating_sandbox_sentinel() -> None:
     assert summary["sandboxId"] is None
 
 
-def test_thread_summary_includes_slack_source_url() -> None:
+def test_thread_summary_includes_slack_source_url_for_private_repo() -> None:
     summary = thread_api._thread_summary(
         _thread_with_metadata(
             {
                 "source": "slack",
+                "repo_private": True,
                 "source_context": {"slack_thread": {"permalink": "https://slack.example/thread"}},
             }
         )
     )
 
     assert summary["sourceUrl"] == "https://slack.example/thread"
+
+
+def test_thread_summary_omits_slack_source_url_for_public_repo() -> None:
+    summary = thread_api._thread_summary(
+        _thread_with_metadata(
+            {
+                "source": "slack",
+                "repo_private": False,
+                "source_context": {"slack_thread": {"permalink": "https://slack.example/thread"}},
+            }
+        )
+    )
+
+    assert summary["sourceUrl"] is None
 
 
 async def test_recovery_patch_requires_thread_owner(monkeypatch) -> None:

--- a/tests/e2e/fakes.py
+++ b/tests/e2e/fakes.py
@@ -69,6 +69,7 @@ def slack_messages(channel: str) -> list[dict[str, Any]]:
 
 # --- GitHub ----------------------------------------------------------------
 PULLS: list[dict[str, Any]] = []
+REPO_PRIVATE = [False]
 _pr_seq = [0]
 
 
@@ -163,8 +164,17 @@ def find_pull(number: int) -> dict[str, Any] | None:
     return next((p for p in PULLS if p["number"] == number), None)
 
 
+def set_repo_private(value: bool) -> None:
+    REPO_PRIVATE[0] = value
+
+
+def repo_private() -> bool:
+    return REPO_PRIVATE[0]
+
+
 def reset() -> None:
     SLACK_MESSAGES.clear()
     PULLS.clear()
+    REPO_PRIVATE[0] = False
     _pr_seq[0] = 0
     seed_bare_remote()

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -88,6 +88,14 @@ async def control_state() -> JSONResponse:
     )
 
 
+@app.post("/control/repo-private")
+async def control_repo_private(request: Request) -> JSONResponse:
+    body = await request.json()
+    value = bool(body.get("private", False))
+    fakes.set_repo_private(value)
+    return JSONResponse({"ok": True, "private": value})
+
+
 @app.get("/control/queued")
 async def control_queued(thread_id: str = "") -> JSONResponse:
     """Count the follow-ups parked on a busy thread's message queue.
@@ -454,7 +462,7 @@ def _gh_pr_json(pr: dict[str, Any]) -> dict[str, Any]:
         "body": pr["body"],
         "user": {"login": pr["author"]},
         "head": {"ref": pr["head"]},
-        "base": {"ref": pr["base"]},
+        "base": {"ref": pr["base"], "repo": {"private": fakes.repo_private()}},
         "additions": pr["additions"],
         "deletions": pr["deletions"],
         "changed_files": len(pr["files"]),
@@ -463,7 +471,7 @@ def _gh_pr_json(pr: dict[str, Any]) -> dict[str, Any]:
 
 @app.get("/fake-gh/repos/{owner}/{repo}")
 async def gh_get_repo(owner: str, repo: str) -> JSONResponse:
-    return JSONResponse({"full_name": f"{owner}/{repo}", "private": False})
+    return JSONResponse({"full_name": f"{owner}/{repo}", "private": fakes.repo_private()})
 
 
 @app.get("/fake-gh/repos/{owner}/{repo}/branches/{branch:path}")

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -10,6 +10,13 @@ async function loginAs(page: Page, user: { login: string; email: string }) {
   expect(res.ok()).toBeTruthy();
 }
 
+async function setRepoPrivate(page: Page, value: boolean) {
+  const res = await page.request.post("/control/repo-private", {
+    data: { private: value },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
 async function openRunningThreadViaSlackLink(page: Page) {
   await page.goto("/mock/slack");
   await page.locator("#reset").click();
@@ -27,9 +34,15 @@ async function openRunningThreadViaSlackLink(page: Page) {
 
 // Run the Slack flow so a thread + PR exist, then click the bot's real
 // "Open in Web" link, landing on the actual dashboard app.
-async function openThreadViaSlackLink(page: Page) {
+async function openThreadViaSlackLink(
+  page: Page,
+  options: { repoPrivate?: boolean } = {},
+) {
   await page.goto("/mock/slack");
   await page.locator("#reset").click();
+  if (options.repoPrivate) {
+    await setRepoPrivate(page, true);
+  }
   await expect(page.locator("#thread")).toContainText("No messages yet");
   await page
     .locator("#text")
@@ -54,6 +67,14 @@ async function expectTranscriptVisible(page: Page) {
       page.getByRole("link", { name: "Add greet() helper" }).first(),
     ).toBeVisible({ timeout: 8000 });
   }).toPass({ timeout: 60000 });
+}
+
+async function latestPrBody(page: Page): Promise<string> {
+  const res = await page.request.get("/mock/github/data");
+  expect(res.ok()).toBeTruthy();
+  const prs = (await res.json()) as Array<{ body?: string }>;
+  expect(prs.length).toBeGreaterThan(0);
+  return prs[prs.length - 1]?.body ?? "";
 }
 
 test.describe("Slack → web handoff (real dashboard UI)", () => {
@@ -92,6 +113,32 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect(
       page.getByRole("link", { name: "Add greet() helper" }).first(),
     ).toBeVisible();
+  });
+
+  test("does not expose the originating Slack thread for public repos", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page);
+
+    await expect(
+      page.getByRole("link", { name: /Originating Slack thread/ }),
+    ).toHaveCount(0);
+    await expect.poll(() => latestPrBody(page)).not.toContain("Slack thread");
+  });
+
+  test("exposes the originating Slack thread for private repos", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page, { repoPrivate: true });
+
+    const sourceLink = page.getByRole("link", {
+      name: /Originating Slack thread/,
+    });
+    await expect(sourceLink).toBeVisible();
+    await expect(sourceLink).toHaveAttribute("href", /\/mock\/slack/);
+    await expect.poll(() => latestPrBody(page)).toContain("Slack thread");
   });
 
   test("shows follow-ups queued while the agent is still running", async ({

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -77,6 +77,18 @@ async function latestPrBody(page: Page): Promise<string> {
   return prs[prs.length - 1]?.body ?? "";
 }
 
+async function openThreadActionsMenu(page: Page) {
+  await page
+    .getByRole("link", { name: /please add a greet/ })
+    .first()
+    .hover();
+  const actionsButton = page
+    .getByRole("button", { name: "Thread actions" })
+    .first();
+  await expect(actionsButton).toBeVisible();
+  await actionsButton.click();
+}
+
 test.describe("Slack → web handoff (real dashboard UI)", () => {
   test("the SAME user continues the conversation in the web app", async ({
     page,
@@ -121,9 +133,8 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await loginAs(page, SAME_USER);
     await openThreadViaSlackLink(page);
 
-    await expect(
-      page.getByRole("link", { name: /Originating Slack thread/ }),
-    ).toHaveCount(0);
+    await openThreadActionsMenu(page);
+    await expect(page.getByText("Open Slack thread")).toHaveCount(0);
     await expect.poll(() => latestPrBody(page)).not.toContain("Slack thread");
   });
 
@@ -133,11 +144,13 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await loginAs(page, SAME_USER);
     await openThreadViaSlackLink(page, { repoPrivate: true });
 
-    const sourceLink = page.getByRole("link", {
-      name: /Originating Slack thread/,
-    });
-    await expect(sourceLink).toBeVisible();
-    await expect(sourceLink).toHaveAttribute("href", /\/mock\/slack/);
+    await openThreadActionsMenu(page);
+    const sourceItem = page.getByText("Open Slack thread");
+    await expect(sourceItem).toBeVisible();
+    const popupPromise = page.waitForEvent("popup");
+    await sourceItem.click();
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL(/\/mock\/slack/);
     await expect.poll(() => latestPrBody(page)).toContain("Slack thread");
   });
 

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -380,6 +380,35 @@ def test_appends_slack_reference_for_private_repo(monkeypatch: pytest.MonkeyPatc
     assert "- Slack thread: https://slack.example/p1" in sent_body
 
 
+def test_uses_stored_slack_permalink_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_config(
+        monkeypatch,
+        {
+            "source": "slack",
+            "slack_thread": {
+                "channel_id": "C123",
+                "thread_ts": "1700000000.000100",
+                "permalink": "https://slack.example/stored",
+            },
+        },
+    )
+    _stub_token(monkeypatch)
+
+    async def fail_permalink(*_args: Any, **_kwargs: Any) -> str:
+        raise AssertionError("stored permalink should be used")
+
+    monkeypatch.setattr(opr, "get_slack_permalink", fail_permalink)
+    client = _RoutingClient(
+        post=_FakeResponse(201, {"html_url": "u", "number": 1, "user": {}}),
+        get_routes={"/repos/langchain-ai/open-swe": _FakeResponse(200, {"private": False})},
+    )
+    _install_client(monkeypatch, client)
+
+    _open_with_body("body")
+
+    assert "- Slack thread: https://slack.example/stored" in client.post_calls[0]["json"]["body"]
+
+
 def test_appends_plan_reference_from_thread_id(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
     _set_config(monkeypatch, {"source": "dashboard", "thread_id": "thread-1"})
@@ -475,7 +504,7 @@ def test_plan_reference_survives_source_reference_failure(
     assert client.post_calls
 
 
-def test_no_reference_for_public_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_appends_slack_reference_for_public_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_config(
         monkeypatch,
         {
@@ -496,10 +525,12 @@ def test_no_reference_for_public_repo(monkeypatch: pytest.MonkeyPatch) -> None:
 
     _open_with_body("original body")
 
-    assert client.post_calls[0]["json"]["body"] == "original body"
+    assert client.post_calls[0]["json"]["body"] == (
+        "original body\n\n## References\n- Slack thread: https://slack.example/p1"
+    )
 
 
-def test_public_repo_appends_plan_but_not_source_reference(
+def test_public_repo_appends_plan_and_slack_reference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
@@ -527,7 +558,7 @@ def test_public_repo_appends_plan_but_not_source_reference(
 
     sent_body = client.post_calls[0]["json"]["body"]
     assert "- Plan: https://dashboard.example/agents/thread-1/plan" in sent_body
-    assert "Slack thread" not in sent_body
+    assert "- Slack thread: https://slack.example/p1" in sent_body
 
 
 def test_appends_linear_reference_for_private_repo(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -400,7 +400,7 @@ def test_uses_stored_slack_permalink_reference(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(opr, "get_slack_permalink", fail_permalink)
     client = _RoutingClient(
         post=_FakeResponse(201, {"html_url": "u", "number": 1, "user": {}}),
-        get_routes={"/repos/langchain-ai/open-swe": _FakeResponse(200, {"private": False})},
+        get_routes={"/repos/langchain-ai/open-swe": _FakeResponse(200, {"private": True})},
     )
     _install_client(monkeypatch, client)
 
@@ -504,7 +504,7 @@ def test_plan_reference_survives_source_reference_failure(
     assert client.post_calls
 
 
-def test_appends_slack_reference_for_public_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_omits_slack_reference_for_public_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_config(
         monkeypatch,
         {
@@ -525,12 +525,10 @@ def test_appends_slack_reference_for_public_repo(monkeypatch: pytest.MonkeyPatch
 
     _open_with_body("original body")
 
-    assert client.post_calls[0]["json"]["body"] == (
-        "original body\n\n## References\n- Slack thread: https://slack.example/p1"
-    )
+    assert client.post_calls[0]["json"]["body"] == "original body"
 
 
-def test_public_repo_appends_plan_and_slack_reference(
+def test_public_repo_appends_plan_but_not_slack_reference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
@@ -558,7 +556,7 @@ def test_public_repo_appends_plan_and_slack_reference(
 
     sent_body = client.post_calls[0]["json"]["body"]
     assert "- Plan: https://dashboard.example/agents/thread-1/plan" in sent_body
-    assert "- Slack thread: https://slack.example/p1" in sent_body
+    assert "Slack thread" not in sent_body
 
 
 def test_appends_linear_reference_for_private_repo(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -52,6 +52,62 @@ def test_generate_thread_id_from_slack_thread_is_deterministic() -> None:
     assert len(first) == 36
 
 
+def test_source_context_preserves_existing_slack_permalink_on_lookup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_slack_permalink(channel_id: str, thread_ts: str) -> str | None:
+        assert channel_id == "C123"
+        assert thread_ts == "1700000000.000100"
+        return None
+
+    monkeypatch.setattr(webhook_common, "get_slack_permalink", fake_get_slack_permalink)
+
+    enriched = asyncio.run(
+        webhook_common._source_context_with_slack_permalink(
+            {"slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"}},
+            {
+                "source_context": {
+                    "slack_thread": {
+                        "channel_id": "C123",
+                        "thread_ts": "1700000000.000100",
+                        "permalink": "https://slack.example/existing",
+                    }
+                }
+            },
+        )
+    )
+
+    slack_thread = cast(dict[str, object], enriched["slack_thread"])
+    assert slack_thread["permalink"] == "https://slack.example/existing"
+
+
+def test_source_context_does_not_reuse_permalink_for_different_slack_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_slack_permalink(_channel_id: str, _thread_ts: str) -> str | None:
+        return None
+
+    monkeypatch.setattr(webhook_common, "get_slack_permalink", fake_get_slack_permalink)
+
+    enriched = asyncio.run(
+        webhook_common._source_context_with_slack_permalink(
+            {"slack_thread": {"channel_id": "C999", "thread_ts": "1700000000.000999"}},
+            {
+                "source_context": {
+                    "slack_thread": {
+                        "channel_id": "C123",
+                        "thread_ts": "1700000000.000100",
+                        "permalink": "https://slack.example/existing",
+                    }
+                }
+            },
+        )
+    )
+
+    slack_thread = cast(dict[str, object], enriched["slack_thread"])
+    assert "permalink" not in slack_thread
+
+
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:
     bot_user_id = "UBOT"
     messages = [

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react"
 import { Link } from "@tanstack/react-router"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { Map as MapIcon } from "lucide-react"
+import { IoLogoSlack } from "react-icons/io5"
 
 import type {
   AgentThread,
@@ -161,6 +162,20 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
               </>
             )}
           </div>
+        )}
+        {thread.sourceUrl && (
+          <a
+            href={thread.sourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center justify-between gap-2 border-b border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-2 text-xs text-[var(--ui-text)] hover:bg-[var(--ui-panel-2)]"
+          >
+            <span className="flex items-center gap-2">
+              <IoLogoSlack className="size-3.5 text-[var(--ui-text-dim)]" />
+              Originating Slack thread
+            </span>
+            <span className="font-medium text-[var(--ui-accent)]">Open →</span>
+          </a>
         )}
         <WorkflowApprovalCard
           threadId={thread.id}

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from "react"
 import { Link } from "@tanstack/react-router"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { Map as MapIcon } from "lucide-react"
-import { IoLogoSlack } from "react-icons/io5"
 
 import type {
   AgentThread,
@@ -162,20 +161,6 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
               </>
             )}
           </div>
-        )}
-        {thread.sourceUrl && (
-          <a
-            href={thread.sourceUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="flex items-center justify-between gap-2 border-b border-[var(--ui-border)] bg-[var(--ui-panel)] px-4 py-2 text-xs text-[var(--ui-text)] hover:bg-[var(--ui-panel-2)]"
-          >
-            <span className="flex items-center gap-2">
-              <IoLogoSlack className="size-3.5 text-[var(--ui-text-dim)]" />
-              Originating Slack thread
-            </span>
-            <span className="font-medium text-[var(--ui-accent)]">Open →</span>
-          </a>
         )}
         <WorkflowApprovalCard
           threadId={thread.id}

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -397,6 +397,11 @@ function ThreadRow({
     window.open(thread.traceUrl, "_blank", "noopener,noreferrer")
   }
 
+  const openSource = () => {
+    if (!thread.sourceUrl) return
+    window.open(thread.sourceUrl, "_blank", "noopener,noreferrer")
+  }
+
   const copySandboxId = () => {
     if (!thread.sandboxId) return
     void navigator.clipboard.writeText(thread.sandboxId)
@@ -493,6 +498,15 @@ function ThreadRow({
                   <TreeStructureIcon className="size-3.5" />
                   Open trace
                 </Menu.Item>
+                {thread.sourceUrl && (
+                  <Menu.Item
+                    onClick={openSource}
+                    className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
+                  >
+                    <IoLogoSlack className="size-3.5" />
+                    Open Slack thread
+                  </Menu.Item>
+                )}
                 <Menu.Item
                   disabled={!thread.sandboxId}
                   onClick={copySandboxId}

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -234,6 +234,7 @@ export interface AgentThread {
   createdAt: number
   updatedAt: number
   traceUrl?: string | null
+  sourceUrl?: string | null
   sandboxId?: string | null
   messages: Array<Message>
   queuedMessages?: Array<QueuedThreadMessage>


### PR DESCRIPTION
## Description
Expose originating Slack thread links only for private repositories, tucked into the sidebar thread actions menu instead of the main conversation header. Adds Playwright coverage for public/private repo behavior and the sidebar action.

## Release Note
Adds private-repo-only originating Slack thread links in the dashboard sidebar menu and generated PR references.

## Test Plan
- [x] Verify public/private Slack thread link behavior with targeted Playwright E2E coverage.
- [x] Verify the Slack thread link appears in the sidebar thread actions menu.

Made by [Open SWE](https://openswe.vercel.app/agents/666ef39f-3ab4-c5d8-0277-00ca482f49aa)