### PR TITLE
fix: derive model context windows from LangChain profiles

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cache, lru_cache
 from importlib import import_module
 from typing import NotRequired, TypedDict, cast
@@ -103,29 +103,32 @@ FABLE_MODEL_IDS: frozenset[str] = frozenset(
     m["id"] for m in SUPPORTED_MODELS if m["id"].startswith("anthropic:claude-fable")
 )
 
-ProfileRegistry = Mapping[str, Mapping[str, object]]
+ProfileLoader = Callable[[str], Mapping[str, object]]
 
-_PROFILE_DATA_MODULES: dict[str, str] = {
-    "anthropic": "langchain_anthropic.data._profiles",
-    "fireworks": "langchain_fireworks.data._profiles",
-    "google_genai": "langchain_google_genai.data._profiles",
-    "openai": "langchain_openai.data._profiles",
+# LangChain partner packages expose ``_get_default_model_profile`` — the same
+# accessor that populates ``ChatModel.profile`` from bundled models.dev data —
+# so context windows come from LangChain profiles instead of hardcoded numbers.
+_PROFILE_LOADER_MODULES: dict[str, str] = {
+    "anthropic": "langchain_anthropic.chat_models",
+    "fireworks": "langchain_fireworks.chat_models",
+    "google_genai": "langchain_google_genai.chat_models",
+    "openai": "langchain_openai.chat_models.base",
 }
 
 
 @cache
-def _profile_registry(provider: str) -> ProfileRegistry | None:
-    module_path = _PROFILE_DATA_MODULES.get(provider)
+def _profile_loader(provider: str) -> ProfileLoader | None:
+    module_path = _PROFILE_LOADER_MODULES.get(provider)
     if module_path is None:
         return None
     try:
         module = import_module(module_path)
     except ImportError:
         return None
-    profiles = getattr(module, "_PROFILES", None)
-    if not isinstance(profiles, Mapping):
+    loader = getattr(module, "_get_default_model_profile", None)
+    if not callable(loader):
         return None
-    return cast(ProfileRegistry, profiles)
+    return cast(ProfileLoader, loader)
 
 
 @lru_cache(maxsize=512)
@@ -133,12 +136,10 @@ def model_profile_context_window(model_id: str) -> int | None:
     provider, _, model_name = model_id.partition(":")
     if not provider or not model_name:
         return None
-    registry = _profile_registry(provider)
-    if registry is None:
+    loader = _profile_loader(provider)
+    if loader is None:
         return None
-    profile = registry.get(model_name)
-    if profile is None:
-        return None
+    profile = loader(model_name)
     context_window = profile.get("max_input_tokens")
     if isinstance(context_window, int) and context_window > 0:
         return context_window

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import NotRequired, TypedDict
+from collections.abc import Mapping, Sequence
+from functools import cache, lru_cache
+from importlib import import_module
+from typing import NotRequired, TypedDict, cast
 
 
 class ModelOption(TypedDict):
@@ -21,7 +24,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
         "supports_images": True,
-        "context_window": 200_000,
     },
     {
         "id": "anthropic:claude-sonnet-5",
@@ -29,7 +31,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
         "supports_images": True,
-        "context_window": 200_000,
     },
     {
         "id": "anthropic:claude-fable-5",
@@ -37,7 +38,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
         "supports_images": True,
-        "context_window": 200_000,
     },
     {
         "id": "openai:gpt-5.5",
@@ -45,7 +45,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["none", "low", "medium", "high", "xhigh"],
         "default_effort": "xhigh",
         "supports_images": True,
-        "context_window": 128_000,
     },
     {
         "id": "openai:gpt-5.6-sol",
@@ -53,7 +52,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["none", "low", "medium", "high", "xhigh"],
         "default_effort": "xhigh",
         "supports_images": True,
-        "context_window": 128_000,
     },
     {
         "id": "openai:gpt-5.6-terra",
@@ -61,7 +59,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["none", "low", "medium", "high", "xhigh"],
         "default_effort": "xhigh",
         "supports_images": True,
-        "context_window": 128_000,
     },
     {
         "id": "openai:gpt-5.6-luna",
@@ -69,7 +66,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["none", "low", "medium", "high", "xhigh"],
         "default_effort": "xhigh",
         "supports_images": True,
-        "context_window": 128_000,
     },
     {
         "id": "google_genai:gemini-3.5-flash",
@@ -77,7 +73,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["minimal", "low", "medium", "high"],
         "default_effort": "medium",
         "supports_images": True,
-        "context_window": 1_000_000,
     },
     {
         "id": "fireworks:accounts/fireworks/models/kimi-k2p7-code",
@@ -85,7 +80,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["low", "medium", "high"],
         "default_effort": "high",
         "supports_images": False,
-        "context_window": 256_000,
     },
     {
         "id": "fireworks:accounts/fireworks/models/deepseek-v4-pro",
@@ -93,7 +87,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
         "supports_images": False,
-        "context_window": 128_000,
     },
     {
         "id": "fireworks:accounts/fireworks/models/glm-5p2",
@@ -101,7 +94,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "efforts": ["none", "high", "max"],
         "default_effort": "high",
         "supports_images": False,
-        "context_window": 128_000,
     },
 ]
 
@@ -110,6 +102,64 @@ SUPPORTED_MODEL_IDS: frozenset[str] = frozenset(m["id"] for m in SUPPORTED_MODEL
 FABLE_MODEL_IDS: frozenset[str] = frozenset(
     m["id"] for m in SUPPORTED_MODELS if m["id"].startswith("anthropic:claude-fable")
 )
+
+ProfileRegistry = Mapping[str, Mapping[str, object]]
+
+_PROFILE_DATA_MODULES: dict[str, str] = {
+    "anthropic": "langchain_anthropic.data._profiles",
+    "fireworks": "langchain_fireworks.data._profiles",
+    "google_genai": "langchain_google_genai.data._profiles",
+    "openai": "langchain_openai.data._profiles",
+}
+
+
+@cache
+def _profile_registry(provider: str) -> ProfileRegistry | None:
+    module_path = _PROFILE_DATA_MODULES.get(provider)
+    if module_path is None:
+        return None
+    try:
+        module = import_module(module_path)
+    except ImportError:
+        return None
+    profiles = getattr(module, "_PROFILES", None)
+    if not isinstance(profiles, Mapping):
+        return None
+    return cast(ProfileRegistry, profiles)
+
+
+@lru_cache(maxsize=512)
+def model_profile_context_window(model_id: str) -> int | None:
+    provider, _, model_name = model_id.partition(":")
+    if not provider or not model_name:
+        return None
+    registry = _profile_registry(provider)
+    if registry is None:
+        return None
+    profile = registry.get(model_name)
+    if profile is None:
+        return None
+    context_window = profile.get("max_input_tokens")
+    if isinstance(context_window, int) and context_window > 0:
+        return context_window
+    return None
+
+
+def models_with_profile_context_windows(models: Sequence[ModelOption]) -> list[ModelOption]:
+    enriched: list[ModelOption] = []
+    for model in models:
+        option: ModelOption = {
+            "id": model["id"],
+            "label": model["label"],
+            "efforts": model["efforts"],
+            "default_effort": model["default_effort"],
+            "supports_images": model["supports_images"],
+        }
+        context_window = model_profile_context_window(model["id"])
+        if context_window is not None:
+            option["context_window"] = context_window
+        enriched.append(option)
+    return enriched
 
 
 def fable_disabled_fallback(effort: object = None) -> tuple[str, str]:

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -59,7 +59,12 @@ from .oauth import (
     require_session,
     sanitize_redirect_to,
 )
-from .options import FABLE_MODEL_IDS, SUPPORTED_MODELS, gate_fable_model
+from .options import (
+    FABLE_MODEL_IDS,
+    SUPPORTED_MODELS,
+    gate_fable_model,
+    models_with_profile_context_windows,
+)
 from .profiles import (
     ProfileUpdate,
     get_profile,
@@ -443,7 +448,7 @@ async def options() -> dict[str, Any]:
         else [m for m in SUPPORTED_MODELS if m["id"] not in FABLE_MODEL_IDS]
     )
     return {
-        "models": models,
+        "models": models_with_profile_context_windows(models),
         "default_agent_model": agent_model,
         "default_agent_reasoning_effort": agent_effort,
         "default_agent_subagent_model": subagent_model,

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1498,6 +1498,8 @@ async def test_options_includes_fable_when_enabled() -> None:
     ):
         payload = await routes.options()
     assert _FABLE in [m["id"] for m in payload["models"]]
+    gpt_5_5 = next(m for m in payload["models"] if m["id"] == _VISION_MODEL)
+    assert gpt_5_5["context_window"] == 1_050_000
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -11,6 +11,8 @@ from agent.dashboard.options import (
     default_model_pair,
     fable_disabled_fallback,
     gate_fable_model,
+    model_profile_context_window,
+    models_with_profile_context_windows,
     provider_fallback_pair,
 )
 from agent.dashboard.profiles import ProfileUpdate, normalize_profile_for_response
@@ -50,6 +52,26 @@ def test_supported_openai_models_include_gpt_5_5_and_gpt_5_6() -> None:
         ("openai:gpt-5.6-terra", "GPT-5.6 Terra"),
         ("openai:gpt-5.6-luna", "GPT-5.6 Luna"),
     ]
+
+
+def test_supported_models_do_not_hardcode_context_windows() -> None:
+    assert all("context_window" not in model for model in SUPPORTED_MODELS)
+
+
+def test_model_profile_context_window_uses_langchain_profile() -> None:
+    assert model_profile_context_window("openai:gpt-5.5") == 1_050_000
+
+
+def test_models_with_profile_context_windows_enriches_copies() -> None:
+    openai_models = [model for model in SUPPORTED_MODELS if model["id"].startswith("openai:")]
+    enriched = models_with_profile_context_windows(openai_models)
+    assert all("context_window" not in model for model in openai_models)
+    assert {model["id"]: model.get("context_window") for model in enriched} == {
+        "openai:gpt-5.5": 1_050_000,
+        "openai:gpt-5.6-sol": 1_050_000,
+        "openai:gpt-5.6-terra": 1_050_000,
+        "openai:gpt-5.6-luna": 1_050_000,
+    }
 
 
 @pytest.mark.parametrize("model_id", ["unknown:model", "no-colon", "", None, 123])

--- a/uv.lock
+++ b/uv.lock
@@ -1559,16 +1559,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/fe/cfd11b9ebc54f7667e3c8f847f64246fad169ad998b8a08d7c3c9d9bccaf/langchain_openai-1.3.4.tar.gz", hash = "sha256:d888d5f39c2a8c3d0d8aa88f5cf50e58a8e7d242f3f15e39422add520eec8e31", size = 3258207, upload-time = "2026-07-08T22:59:50.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/7e/43eef3f8fae2668f52e2222fdc26b6de58acf158bcb580e32e88a299260d/langchain_openai-1.3.5.tar.gz", hash = "sha256:c1db2256a42ac46e8e7b0564c5ccb478b9f58dc047a58935da33c82e6e1f9a07", size = 3261548, upload-time = "2026-07-10T18:58:29.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/6e/f8f47f2c6976a4520b5416eaeeaee5e6aa7dd906b39685dc1ad4ef6d1ba2/langchain_openai-1.3.4-py3-none-any.whl", hash = "sha256:3241b8392b29c1af233b902b7d9a84bfc5fe26ccb210a7febdfc3972af7e5771", size = 120529, upload-time = "2026-07-08T22:59:49.451Z" },
+    { url = "https://files.pythonhosted.org/packages/61/64/4e0918cb96ff2b49e06acd9c11c250297d727d2fcce9e012d62efb73b4d6/langchain_openai-1.3.5-py3-none-any.whl", hash = "sha256:f586263b884bceb3d426ec84d3bfbd27051c3c92ae668da6175629e3f44dcec5", size = 121601, upload-time = "2026-07-10T18:58:28.327Z" },
 ]
 
 [[package]]
@@ -2107,7 +2107,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "openai"
-version = "2.33.0"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2119,9 +2119,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
The Agents UI showed GPT-5.5 as `128.0K context` because `agent/dashboard/options.py` hardcoded a `context_window` per model (and GPT-5.5's value was the max *output* tokens, not its context window). This removes those hardcoded defaults and instead derives each model's context window from LangChain model profiles — the partner packages' `_get_default_model_profile` accessor (the same data, sourced from models.dev, that populates `ChatModel.profile`). `/options` now enriches each supported model with `max_input_tokens` when a profile is available, so GPT-5.5 correctly reports ~1.05M. Also bumps `langchain-openai` to 1.3.5 so the GPT-5.6 profiles resolve.

## Release Note
Model context windows shown in the Agents UI are now sourced from LangChain model profiles instead of hardcoded values, fixing an incorrect GPT-5.5 context size.

## Test Plan
- [ ] `/options` returns `context_window` sourced from LangChain profiles (e.g. GPT-5.5 ≈ 1,050,000); models without a profile omit the field.

Made by [Open SWE](https://openswe.vercel.app/agents/6dd310ce-ca25-6f45-8d95-0c8d972558fd)