### PR TITLE
chore: clarify shared response image guidance

### DIFF
--- a/agent/tools/save_plan.py
+++ b/agent/tools/save_plan.py
@@ -43,7 +43,10 @@ async def save_plan(
     shared content.
 
     Write the content in standard Markdown — headings, bullet/numbered lists, and
-    fenced code blocks all render.
+    fenced code blocks all render. Shared responses persist Markdown text only;
+    they do not upload or serve sandbox-local or relative image files. If images
+    or screenshots are needed for a Slack response, post them directly in Slack
+    instead of relying on the shared response page.
 
     Args:
         plan_file_path: Path to the Markdown plan file in the sandbox.

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -369,6 +369,14 @@ def test_save_plan_exported_and_wired() -> None:
     assert callable(save_plan)
 
 
+def test_save_plan_description_warns_about_slack_images() -> None:
+    from agent.tools import save_plan
+
+    description = save_plan.__doc__ or ""
+    assert "persist Markdown text only" in description
+    assert "post them directly in Slack" in description
+
+
 def test_plan_status_constants() -> None:
     from agent.dashboard import plan_store
 


### PR DESCRIPTION
## Description
Clarifies the `save_plan` tool description so agents know shared responses persist Markdown text only and should post needed Slack images/screenshots directly instead of relying on local image embeds.

## Release Note
none

## Test Plan
- [x] `uv run pytest -vvv tests/agent/test_plan_review.py::test_save_plan_description_warns_about_slack_images`
- [x] `make format && make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/ffbf9588-c9af-7bb6-dbb5-3bbaa0e81ed9)