### PR TITLE
fix: Harden Stagehand browser URL handling

### DIFF
--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -31,6 +31,7 @@ operate on the same live page. Always finish with ``browser_close``.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 from typing import Any
@@ -46,6 +47,10 @@ _DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
 # thread_id -> (client, session)
 _SESSIONS: dict[str, tuple[Any, Any]] = {}
 _LOCK = asyncio.Lock()
+
+
+class BrowserNavigationBlocked(RuntimeError):
+    pass
 
 
 def _is_local() -> bool:
@@ -129,6 +134,142 @@ def _browserbase_session_create_params() -> dict[str, Any]:
     return {"project_id": project_id} if project_id else {}
 
 
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _safe_attr(obj: Any, name: str) -> Any:
+    try:
+        return getattr(obj, name)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _callable_attr(obj: Any, name: str) -> Any:
+    value = _safe_attr(obj, name)
+    return value if callable(value) else None
+
+
+def _request_url(route: Any, request: Any | None = None) -> str | None:
+    request = request or _safe_attr(route, "request")
+    if callable(request):
+        request = request()
+    url = _safe_attr(request, "url") if request is not None else None
+    if isinstance(url, str) and url:
+        return url
+    url = _safe_attr(route, "url")
+    return url if isinstance(url, str) and url else None
+
+
+async def _continue_route(route: Any) -> None:
+    continue_ = _callable_attr(route, "continue_") or _callable_attr(route, "fallback")
+    if continue_ is not None:
+        await _maybe_await(continue_())
+
+
+async def _abort_route(route: Any) -> None:
+    abort = _callable_attr(route, "abort")
+    if abort is not None:
+        await _maybe_await(abort())
+
+
+def _mark_blocked_request(session: Any, url: str, reason: str) -> None:
+    try:
+        session._open_swe_blocked_request = (url, reason)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _clear_blocked_request(session: Any) -> None:
+    try:
+        if hasattr(session, "_open_swe_blocked_request"):
+            delattr(session, "_open_swe_blocked_request")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _blocked_request_error(session: Any) -> str | None:
+    blocked = _safe_attr(session, "_open_swe_blocked_request")
+    if isinstance(blocked, tuple) and len(blocked) == 2:
+        url, reason = blocked
+        return f"blocked browser request to {url}: {reason}"
+    return None
+
+
+def _guard_targets(session: Any) -> list[Any]:
+    targets: list[Any] = []
+    for candidate in (
+        session,
+        _safe_attr(session, "page"),
+        _safe_attr(session, "context"),
+        _safe_attr(session, "browser_context"),
+        _safe_attr(_safe_attr(session, "data"), "page"),
+        _safe_attr(_safe_attr(session, "data"), "context"),
+        _safe_attr(_safe_attr(session, "data"), "browser_context"),
+    ):
+        if candidate is None or any(candidate is target for target in targets):
+            continue
+        targets.append(candidate)
+    return targets
+
+
+async def _install_browser_url_guard(session: Any) -> None:
+    async def guarded_route(route: Any, request: Any | None = None) -> None:
+        url = _request_url(route, request)
+        if not url:
+            await _continue_route(route)
+            return
+        safe, reason = is_url_safe(url)
+        if safe:
+            await _continue_route(route)
+            return
+        _mark_blocked_request(session, url, reason)
+        logger.warning("Blocked unsafe browser request to %s: %s", url, reason)
+        await _abort_route(route)
+
+    installed = False
+    for target in _guard_targets(session):
+        if _safe_attr(target, "_open_swe_url_guard_installed"):
+            installed = True
+            continue
+        route = _callable_attr(target, "route")
+        if route is None:
+            continue
+        try:
+            await _maybe_await(route("**/*", guarded_route))
+            target._open_swe_url_guard_installed = True
+            installed = True
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to install browser URL guard on %r", target, exc_info=True)
+    if not installed:
+        logger.warning("Stagehand session does not expose a browser request hook for URL guarding")
+
+
+def _current_page_url(session: Any) -> str | None:
+    for target in _guard_targets(session):
+        url = _safe_attr(target, "url")
+        if isinstance(url, str) and url and url != "about:blank":
+            return url
+    return None
+
+
+async def _raise_if_browser_blocked(session: Any, operation: str) -> None:
+    blocked_error = _blocked_request_error(session)
+    if blocked_error:
+        await browser_close()
+        raise BrowserNavigationBlocked(f"{operation} blocked: {blocked_error}")
+
+    current_url = _current_page_url(session)
+    if not current_url:
+        return
+    safe, reason = is_url_safe(current_url)
+    if not safe:
+        await browser_close()
+        raise BrowserNavigationBlocked(f"{operation} blocked after navigation: {reason}")
+
+
 async def _get_session(create: bool = True) -> Any:
     """Return the live Stagehand session for this thread, creating one if needed."""
     thread_id = _thread_id()
@@ -144,6 +285,7 @@ async def _get_session(create: bool = True) -> Any:
         if browserbase_session_create_params:
             session_kwargs["browserbase_session_create_params"] = browserbase_session_create_params
         session = await client.sessions.start(**session_kwargs)
+        await _install_browser_url_guard(session)
         _SESSIONS[thread_id] = (client, session)
         logger.info("Started Stagehand session %s for thread %s", session.id, thread_id)
         return session
@@ -175,8 +317,12 @@ async def browser_navigate(url: str) -> dict[str, Any]:
         if not safe:
             return {"success": False, "error": f"browser_navigate blocked: {reason}"}
         session = await _get_session()
+        _clear_blocked_request(session)
         await session.navigate(url=url)
+        await _raise_if_browser_blocked(session, "browser_navigate")
         return {"success": True, "url": url, **_session_meta(session)}
+    except BrowserNavigationBlocked as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:  # noqa: BLE001
         return {"success": False, "error": f"browser_navigate failed: {e!s}"}
 
@@ -198,8 +344,12 @@ async def browser_act(action: str) -> dict[str, Any]:
         session = await _get_session(create=False)
         if session is None:
             return {"success": False, "error": "No active browser. Call browser_navigate first."}
+        _clear_blocked_request(session)
         result = await session.act(input=action)
+        await _raise_if_browser_blocked(session, "browser_act")
         return {"success": True, "result": _unwrap_result(_to_jsonable(result))}
+    except BrowserNavigationBlocked as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:  # noqa: BLE001
         return {"success": False, "error": f"browser_act failed: {e!s}"}
 

--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -31,7 +31,9 @@ operate on the same live page. Always finish with ``browser_close``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
+import json
 import logging
 import os
 from typing import Any
@@ -198,6 +200,231 @@ def _blocked_request_error(session: Any) -> str | None:
     return None
 
 
+def _set_current_page_url(session: Any, url: str) -> None:
+    if not url or url == "about:blank":
+        return
+    try:
+        session._open_swe_current_page_url = url
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _cdp_url(session: Any) -> str | None:
+    url = _safe_attr(_safe_attr(session, "data"), "cdp_url")
+    return url if isinstance(url, str) and url else None
+
+
+async def _connect_cdp_websocket(cdp_url: str) -> Any:
+    import websockets
+
+    return await websockets.connect(cdp_url)
+
+
+class _CDPBrowserURLGuard:
+    def __init__(self, session: Any, cdp_url: str) -> None:
+        self._session = session
+        self._cdp_url = cdp_url
+        self._ws: Any | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._send_lock = asyncio.Lock()
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future[Any]] = {}
+        self._attached_sessions: set[str] = set()
+
+    async def start(self) -> None:
+        self._ws = await _connect_cdp_websocket(self._cdp_url)
+        self._task = asyncio.create_task(self._run())
+        await self._send(
+            "Target.setAutoAttach",
+            {
+                "autoAttach": True,
+                "waitForDebuggerOnStart": False,
+                "flatten": True,
+            },
+        )
+        await self._send("Target.setDiscoverTargets", {"discover": True})
+        targets = await self._send("Target.getTargets")
+        if isinstance(targets, dict):
+            for target_info in targets.get("targetInfos", []):
+                if isinstance(target_info, dict):
+                    await self._attach_to_target(target_info)
+
+    async def close(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        if self._ws is not None:
+            close = _callable_attr(self._ws, "close")
+            if close is not None:
+                await _maybe_await(close())
+        for future in self._pending.values():
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+
+    async def _send(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> Any:
+        if self._ws is None:
+            return None
+        self._next_id += 1
+        message_id = self._next_id
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[Any] = loop.create_future()
+        self._pending[message_id] = future
+        await self._send_message(message_id, method, params, session_id=session_id)
+        try:
+            return await asyncio.wait_for(future, timeout=10)
+        finally:
+            self._pending.pop(message_id, None)
+
+    async def _send_fire_and_forget(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        if self._ws is None:
+            return
+        self._next_id += 1
+        await self._send_message(self._next_id, method, params, session_id=session_id)
+
+    async def _send_message(
+        self,
+        message_id: int,
+        method: str,
+        params: dict[str, Any] | None,
+        *,
+        session_id: str | None,
+    ) -> None:
+        message: dict[str, Any] = {"id": message_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        if session_id is not None:
+            message["sessionId"] = session_id
+        async with self._send_lock:
+            await self._ws.send(json.dumps(message))
+
+    async def _run(self) -> None:
+        assert self._ws is not None
+        try:
+            async for raw_message in self._ws:
+                try:
+                    message = json.loads(raw_message)
+                except Exception:  # noqa: BLE001
+                    logger.debug("Ignoring malformed CDP message", exc_info=True)
+                    continue
+                message_id = message.get("id")
+                if isinstance(message_id, int):
+                    future = self._pending.pop(message_id, None)
+                    if future is not None and not future.done():
+                        if "error" in message:
+                            future.set_exception(RuntimeError(str(message["error"])))
+                        else:
+                            future.set_result(message.get("result"))
+                    continue
+                await self._handle_event(message)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            logger.debug("CDP browser URL guard stopped", exc_info=True)
+            for future in self._pending.values():
+                if not future.done():
+                    future.set_exception(e)
+
+    async def _handle_event(self, message: dict[str, Any]) -> None:
+        method = message.get("method")
+        params = message.get("params")
+        if not isinstance(params, dict):
+            return
+        if method == "Target.attachedToTarget":
+            session_id = params.get("sessionId")
+            target_info = params.get("targetInfo")
+            if isinstance(session_id, str) and isinstance(target_info, dict):
+                url = target_info.get("url")
+                if isinstance(url, str):
+                    _set_current_page_url(self._session, url)
+                target_type = target_info.get("type")
+                if target_type in {"page", "iframe", "webview"}:
+                    await self._enable_fetch(session_id)
+            return
+        if method == "Target.targetCreated":
+            target_info = params.get("targetInfo")
+            if isinstance(target_info, dict):
+                await self._attach_to_target(target_info)
+            return
+        if method == "Target.targetInfoChanged":
+            target_info = params.get("targetInfo")
+            if isinstance(target_info, dict):
+                url = target_info.get("url")
+                if isinstance(url, str):
+                    _set_current_page_url(self._session, url)
+            return
+        if method == "Page.frameNavigated":
+            frame = params.get("frame")
+            if isinstance(frame, dict):
+                url = frame.get("url")
+                if isinstance(url, str):
+                    _set_current_page_url(self._session, url)
+            return
+        if method == "Fetch.requestPaused":
+            session_id = message.get("sessionId")
+            if isinstance(session_id, str):
+                await self._handle_paused_request(session_id, params)
+
+    async def _attach_to_target(self, target_info: dict[str, Any]) -> None:
+        target_type = target_info.get("type")
+        target_id = target_info.get("targetId")
+        url = target_info.get("url")
+        if isinstance(url, str):
+            _set_current_page_url(self._session, url)
+        if target_type not in {"page", "iframe", "webview"} or not isinstance(target_id, str):
+            return
+        await self._send_fire_and_forget(
+            "Target.attachToTarget",
+            {"targetId": target_id, "flatten": True},
+        )
+
+    async def _enable_fetch(self, session_id: str) -> None:
+        if session_id in self._attached_sessions:
+            return
+        self._attached_sessions.add(session_id)
+        await self._send_fire_and_forget("Page.enable", session_id=session_id)
+        await self._send_fire_and_forget(
+            "Fetch.enable",
+            {"patterns": [{"urlPattern": "*"}]},
+            session_id=session_id,
+        )
+
+    async def _handle_paused_request(self, session_id: str, params: dict[str, Any]) -> None:
+        request_id = params.get("requestId")
+        request = params.get("request")
+        url = request.get("url") if isinstance(request, dict) else None
+        if not isinstance(request_id, str) or not isinstance(url, str):
+            return
+        safe, reason = is_url_safe(url)
+        if safe:
+            await self._send_fire_and_forget(
+                "Fetch.continueRequest",
+                {"requestId": request_id},
+                session_id=session_id,
+            )
+            return
+        _mark_blocked_request(self._session, url, reason)
+        logger.warning("Blocked unsafe browser request to %s: %s", url, reason)
+        await self._send_fire_and_forget(
+            "Fetch.failRequest",
+            {"requestId": request_id, "errorReason": "Aborted"},
+            session_id=session_id,
+        )
+
+
 def _guard_targets(session: Any) -> list[Any]:
     targets: list[Any] = []
     for candidate in (
@@ -216,6 +443,17 @@ def _guard_targets(session: Any) -> list[Any]:
 
 
 async def _install_browser_url_guard(session: Any) -> None:
+    installed = False
+    cdp_url = _cdp_url(session)
+    if cdp_url is not None and not _safe_attr(session, "_open_swe_cdp_guard"):
+        try:
+            cdp_guard = _CDPBrowserURLGuard(session, cdp_url)
+            await cdp_guard.start()
+            session._open_swe_cdp_guard = cdp_guard
+            installed = True
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to install CDP browser URL guard", exc_info=True)
+
     async def guarded_route(route: Any, request: Any | None = None) -> None:
         url = _request_url(route, request)
         if not url:
@@ -229,7 +467,6 @@ async def _install_browser_url_guard(session: Any) -> None:
         logger.warning("Blocked unsafe browser request to %s: %s", url, reason)
         await _abort_route(route)
 
-    installed = False
     for target in _guard_targets(session):
         if _safe_attr(target, "_open_swe_url_guard_installed"):
             installed = True
@@ -248,6 +485,9 @@ async def _install_browser_url_guard(session: Any) -> None:
 
 
 def _current_page_url(session: Any) -> str | None:
+    cdp_url = _safe_attr(session, "_open_swe_current_page_url")
+    if isinstance(cdp_url, str) and cdp_url and cdp_url != "about:blank":
+        return cdp_url
     for target in _guard_targets(session):
         url = _safe_attr(target, "url")
         if isinstance(url, str) and url and url != "about:blank":
@@ -268,6 +508,11 @@ async def _raise_if_browser_blocked(session: Any, operation: str) -> None:
     if not safe:
         await browser_close()
         raise BrowserNavigationBlocked(f"{operation} blocked after navigation: {reason}")
+
+
+async def _prepare_browser_operation(session: Any, operation: str) -> None:
+    await _raise_if_browser_blocked(session, operation)
+    _clear_blocked_request(session)
 
 
 async def _get_session(create: bool = True) -> Any:
@@ -317,7 +562,7 @@ async def browser_navigate(url: str) -> dict[str, Any]:
         if not safe:
             return {"success": False, "error": f"browser_navigate blocked: {reason}"}
         session = await _get_session()
-        _clear_blocked_request(session)
+        await _prepare_browser_operation(session, "browser_navigate")
         await session.navigate(url=url)
         await _raise_if_browser_blocked(session, "browser_navigate")
         return {"success": True, "url": url, **_session_meta(session)}
@@ -344,7 +589,7 @@ async def browser_act(action: str) -> dict[str, Any]:
         session = await _get_session(create=False)
         if session is None:
             return {"success": False, "error": "No active browser. Call browser_navigate first."}
-        _clear_blocked_request(session)
+        await _prepare_browser_operation(session, "browser_act")
         result = await session.act(input=action)
         await _raise_if_browser_blocked(session, "browser_act")
         return {"success": True, "result": _unwrap_result(_to_jsonable(result))}
@@ -370,8 +615,12 @@ async def browser_observe(instruction: str) -> dict[str, Any]:
         session = await _get_session(create=False)
         if session is None:
             return {"success": False, "error": "No active browser. Call browser_navigate first."}
+        await _prepare_browser_operation(session, "browser_observe")
         result = await session.observe(instruction=instruction)
+        await _raise_if_browser_blocked(session, "browser_observe")
         return {"success": True, "observations": _unwrap_result(_to_jsonable(result))}
+    except BrowserNavigationBlocked as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:  # noqa: BLE001
         return {"success": False, "error": f"browser_observe failed: {e!s}"}
 
@@ -391,11 +640,15 @@ async def browser_extract(instruction: str, schema: dict[str, Any] | None = None
         session = await _get_session(create=False)
         if session is None:
             return {"success": False, "error": "No active browser. Call browser_navigate first."}
+        await _prepare_browser_operation(session, "browser_extract")
         if schema is not None:
             result = await session.extract(instruction=instruction, schema=schema)
         else:
             result = await session.extract(instruction=instruction)
+        await _raise_if_browser_blocked(session, "browser_extract")
         return {"success": True, "data": _unwrap_result(_to_jsonable(result))}
+    except BrowserNavigationBlocked as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:  # noqa: BLE001
         return {"success": False, "error": f"browser_extract failed: {e!s}"}
 
@@ -412,6 +665,10 @@ async def browser_close() -> dict[str, Any]:
     if entry is None:
         return {"success": True, "closed": False}
     client, session = entry
+    cdp_guard = _safe_attr(session, "_open_swe_cdp_guard")
+    close_cdp_guard = _callable_attr(cdp_guard, "close") if cdp_guard is not None else None
+    if close_cdp_guard is not None:
+        await _maybe_await(close_cdp_guard())
     try:
         await session.end()
     except Exception:  # noqa: BLE001

--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -230,26 +230,40 @@ class _CDPBrowserURLGuard:
         self._next_id = 0
         self._pending: dict[int, asyncio.Future[Any]] = {}
         self._attached_sessions: set[str] = set()
+        self._protected_target_ids: set[str] = set()
+        self._configuration_tasks: set[asyncio.Task[None]] = set()
+        self._fetch_tasks: dict[str, asyncio.Task[None]] = {}
+        self._failure: BaseException | None = None
 
     async def start(self) -> None:
-        self._ws = await _connect_cdp_websocket(self._cdp_url)
-        self._task = asyncio.create_task(self._run())
-        await self._send(
-            "Target.setAutoAttach",
-            {
-                "autoAttach": True,
-                "waitForDebuggerOnStart": False,
-                "flatten": True,
-            },
-        )
-        await self._send("Target.setDiscoverTargets", {"discover": True})
-        targets = await self._send("Target.getTargets")
-        if isinstance(targets, dict):
-            for target_info in targets.get("targetInfos", []):
-                if isinstance(target_info, dict):
-                    await self._attach_to_target(target_info, wait_for_fetch=True)
+        try:
+            self._ws = await _connect_cdp_websocket(self._cdp_url)
+            self._task = asyncio.create_task(self._run())
+            await self._send(
+                "Target.setAutoAttach",
+                {
+                    "autoAttach": True,
+                    "waitForDebuggerOnStart": True,
+                    "flatten": True,
+                },
+            )
+            await self._send("Target.setDiscoverTargets", {"discover": True})
+            await self._protect_initial_targets()
+        except BaseException:
+            await self.close()
+            raise
 
     async def close(self) -> None:
+        for task in self._configuration_tasks:
+            task.cancel()
+        for task in self._fetch_tasks.values():
+            task.cancel()
+        if self._configuration_tasks:
+            await asyncio.gather(*self._configuration_tasks, return_exceptions=True)
+        if self._fetch_tasks:
+            await asyncio.gather(*self._fetch_tasks.values(), return_exceptions=True)
+        self._configuration_tasks.clear()
+        self._fetch_tasks.clear()
         if self._task is not None:
             self._task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -303,13 +317,16 @@ class _CDPBrowserURLGuard:
         *,
         session_id: str | None,
     ) -> None:
+        websocket = self._ws
+        if websocket is None:
+            raise RuntimeError("CDP websocket is not connected")
         message: dict[str, Any] = {"id": message_id, "method": method}
         if params is not None:
             message["params"] = params
         if session_id is not None:
             message["sessionId"] = session_id
         async with self._send_lock:
-            await self._ws.send(json.dumps(message))
+            await websocket.send(json.dumps(message))
 
     async def _run(self) -> None:
         assert self._ws is not None
@@ -333,6 +350,7 @@ class _CDPBrowserURLGuard:
         except asyncio.CancelledError:
             raise
         except Exception as e:  # noqa: BLE001
+            self._failure = e
             logger.debug("CDP browser URL guard stopped", exc_info=True)
             for future in self._pending.values():
                 if not future.done():
@@ -351,13 +369,13 @@ class _CDPBrowserURLGuard:
                 if isinstance(url, str):
                     _set_current_page_url(self._session, url)
                 target_type = target_info.get("type")
-                if target_type in {"page", "iframe", "webview"}:
-                    await self._enable_fetch(session_id)
-            return
-        if method == "Target.targetCreated":
-            target_info = params.get("targetInfo")
-            if isinstance(target_info, dict):
-                await self._attach_to_target(target_info)
+                waiting_for_debugger = params.get("waitingForDebugger") is True
+                if target_type in {"page", "iframe", "webview"} or waiting_for_debugger:
+                    self._schedule_target_configuration(
+                        session_id,
+                        target_info,
+                        waiting_for_debugger=waiting_for_debugger,
+                    )
             return
         if method == "Target.targetInfoChanged":
             target_info = params.get("targetInfo")
@@ -378,9 +396,49 @@ class _CDPBrowserURLGuard:
             if isinstance(session_id, str):
                 await self._handle_paused_request(session_id, params)
 
-    async def _attach_to_target(
-        self, target_info: dict[str, Any], *, wait_for_fetch: bool = False
-    ) -> None:
+    async def _protect_initial_targets(self) -> None:
+        targets = await self._target_infos()
+        for target_info in targets:
+            try:
+                await self._attach_to_target(target_info)
+            except Exception:  # noqa: BLE001
+                logger.debug("Initial CDP target disappeared before attachment", exc_info=True)
+        await self._wait_for_configuration_tasks()
+        self._raise_if_failed()
+
+        current_targets = await self._target_infos()
+        for target_info in current_targets:
+            target_id = target_info.get("targetId")
+            if not isinstance(target_id, str) or target_id in self._protected_target_ids:
+                continue
+            try:
+                await self._attach_to_target(target_info)
+            except Exception:  # noqa: BLE001
+                logger.debug("CDP target could not be protected", exc_info=True)
+        await self._wait_for_configuration_tasks()
+        self._raise_if_failed()
+
+        unprotected = {
+            target_info["targetId"]
+            for target_info in current_targets
+            if isinstance(target_info.get("targetId"), str)
+            and target_info["targetId"] not in self._protected_target_ids
+        }
+        if not self._attached_sessions or unprotected:
+            raise RuntimeError("CDP URL guard did not protect every live browser target")
+
+    async def _target_infos(self) -> list[dict[str, Any]]:
+        targets = await self._send("Target.getTargets")
+        if not isinstance(targets, dict):
+            return []
+        return [
+            target_info
+            for target_info in targets.get("targetInfos", [])
+            if isinstance(target_info, dict)
+            and target_info.get("type") in {"page", "iframe", "webview"}
+        ]
+
+    async def _attach_to_target(self, target_info: dict[str, Any]) -> None:
         target_type = target_info.get("type")
         target_id = target_info.get("targetId")
         url = target_info.get("url")
@@ -388,31 +446,29 @@ class _CDPBrowserURLGuard:
             _set_current_page_url(self._session, url)
         if target_type not in {"page", "iframe", "webview"} or not isinstance(target_id, str):
             return
-        if not wait_for_fetch:
-            await self._send_fire_and_forget(
-                "Target.attachToTarget",
-                {"targetId": target_id, "flatten": True},
-            )
-            return
         result = await self._send(
             "Target.attachToTarget",
             {"targetId": target_id, "flatten": True},
         )
         session_id = result.get("sessionId") if isinstance(result, dict) else None
         if isinstance(session_id, str):
-            await self._enable_fetch(session_id, wait=True)
+            await self._enable_fetch(session_id)
+            self._protected_target_ids.add(target_id)
 
-    async def _enable_fetch(self, session_id: str, *, wait: bool = False) -> None:
+    async def _enable_fetch(self, session_id: str) -> None:
         if session_id in self._attached_sessions:
             return
-        if not wait:
-            await self._send_fire_and_forget("Page.enable", session_id=session_id)
-            await self._send_fire_and_forget(
-                "Fetch.enable",
-                {"patterns": [{"urlPattern": "*"}]},
-                session_id=session_id,
-            )
-            return
+        task = self._fetch_tasks.get(session_id)
+        if task is None:
+            task = asyncio.create_task(self._enable_fetch_commands(session_id))
+            self._fetch_tasks[session_id] = task
+        try:
+            await asyncio.shield(task)
+        finally:
+            if task.done():
+                self._fetch_tasks.pop(session_id, None)
+
+    async def _enable_fetch_commands(self, session_id: str) -> None:
         await self._send("Page.enable", session_id=session_id)
         await self._send(
             "Fetch.enable",
@@ -420,6 +476,61 @@ class _CDPBrowserURLGuard:
             session_id=session_id,
         )
         self._attached_sessions.add(session_id)
+
+    def _schedule_target_configuration(
+        self,
+        session_id: str,
+        target_info: dict[str, Any],
+        *,
+        waiting_for_debugger: bool,
+    ) -> None:
+        task = asyncio.create_task(
+            self._configure_attached_target(
+                session_id,
+                target_info,
+                waiting_for_debugger=waiting_for_debugger,
+            )
+        )
+        self._configuration_tasks.add(task)
+        task.add_done_callback(self._configuration_finished)
+
+    async def _configure_attached_target(
+        self,
+        session_id: str,
+        target_info: dict[str, Any],
+        *,
+        waiting_for_debugger: bool,
+    ) -> None:
+        if target_info.get("type") in {"page", "iframe", "webview"}:
+            await self._enable_fetch(session_id)
+            target_id = target_info.get("targetId")
+            if isinstance(target_id, str):
+                self._protected_target_ids.add(target_id)
+        if waiting_for_debugger:
+            await self._send("Runtime.runIfWaitingForDebugger", session_id=session_id)
+
+    def _configuration_finished(self, task: asyncio.Task[None]) -> None:
+        self._configuration_tasks.discard(task)
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            self._failure = error
+
+    async def _wait_for_configuration_tasks(self) -> None:
+        while self._configuration_tasks:
+            await asyncio.gather(*tuple(self._configuration_tasks), return_exceptions=True)
+
+    def _raise_if_failed(self) -> None:
+        if self._failure is not None:
+            raise RuntimeError("CDP URL guard failed") from self._failure
+
+    def failure(self) -> BaseException | None:
+        if self._failure is not None:
+            return self._failure
+        if self._task is not None and self._task.done() and not self._task.cancelled():
+            return self._task.exception() or RuntimeError("CDP URL guard stopped")
+        return None
 
     async def _handle_paused_request(self, session_id: str, params: dict[str, Any]) -> None:
         request_id = params.get("requestId")
@@ -465,12 +576,15 @@ async def _install_browser_url_guard(session: Any) -> None:
     installed = False
     cdp_url = _cdp_url(session)
     if cdp_url is not None and not _safe_attr(session, "_open_swe_cdp_guard"):
+        cdp_guard: _CDPBrowserURLGuard | None = None
         try:
             cdp_guard = _CDPBrowserURLGuard(session, cdp_url)
             await cdp_guard.start()
             session._open_swe_cdp_guard = cdp_guard
             installed = True
         except Exception:  # noqa: BLE001
+            if cdp_guard is not None:
+                await cdp_guard.close()
             logger.warning("Failed to install CDP browser URL guard", exc_info=True)
 
     async def guarded_route(route: Any, request: Any | None = None) -> None:
@@ -500,7 +614,9 @@ async def _install_browser_url_guard(session: Any) -> None:
         except Exception:  # noqa: BLE001
             logger.debug("Failed to install browser URL guard on %r", target, exc_info=True)
     if not installed:
-        logger.warning("Stagehand session does not expose a browser request hook for URL guarding")
+        raise BrowserNavigationBlocked(
+            "Stagehand session does not expose a working browser request hook for URL guarding"
+        )
 
 
 def _current_page_url(session: Any) -> str | None:
@@ -515,6 +631,12 @@ def _current_page_url(session: Any) -> str | None:
 
 
 async def _raise_if_browser_blocked(session: Any, operation: str) -> None:
+    cdp_guard = _safe_attr(session, "_open_swe_cdp_guard")
+    guard_failure = cdp_guard.failure() if isinstance(cdp_guard, _CDPBrowserURLGuard) else None
+    if guard_failure is not None:
+        await browser_close()
+        raise BrowserNavigationBlocked(f"{operation} blocked: browser URL guard failed")
+
     blocked_error = _blocked_request_error(session)
     if blocked_error:
         await browser_close()
@@ -549,7 +671,14 @@ async def _get_session(create: bool = True) -> Any:
         if browserbase_session_create_params:
             session_kwargs["browserbase_session_create_params"] = browserbase_session_create_params
         session = await client.sessions.start(**session_kwargs)
-        await _install_browser_url_guard(session)
+        try:
+            await _install_browser_url_guard(session)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await session.end()
+            with contextlib.suppress(Exception):
+                await client.close()
+            raise
         _SESSIONS[thread_id] = (client, session)
         logger.info("Started Stagehand session %s for thread %s", session.id, thread_id)
         return session

--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -247,7 +247,7 @@ class _CDPBrowserURLGuard:
         if isinstance(targets, dict):
             for target_info in targets.get("targetInfos", []):
                 if isinstance(target_info, dict):
-                    await self._attach_to_target(target_info)
+                    await self._attach_to_target(target_info, wait_for_fetch=True)
 
     async def close(self) -> None:
         if self._task is not None:
@@ -378,7 +378,9 @@ class _CDPBrowserURLGuard:
             if isinstance(session_id, str):
                 await self._handle_paused_request(session_id, params)
 
-    async def _attach_to_target(self, target_info: dict[str, Any]) -> None:
+    async def _attach_to_target(
+        self, target_info: dict[str, Any], *, wait_for_fetch: bool = False
+    ) -> None:
         target_type = target_info.get("type")
         target_id = target_info.get("targetId")
         url = target_info.get("url")
@@ -386,21 +388,38 @@ class _CDPBrowserURLGuard:
             _set_current_page_url(self._session, url)
         if target_type not in {"page", "iframe", "webview"} or not isinstance(target_id, str):
             return
-        await self._send_fire_and_forget(
+        if not wait_for_fetch:
+            await self._send_fire_and_forget(
+                "Target.attachToTarget",
+                {"targetId": target_id, "flatten": True},
+            )
+            return
+        result = await self._send(
             "Target.attachToTarget",
             {"targetId": target_id, "flatten": True},
         )
+        session_id = result.get("sessionId") if isinstance(result, dict) else None
+        if isinstance(session_id, str):
+            await self._enable_fetch(session_id, wait=True)
 
-    async def _enable_fetch(self, session_id: str) -> None:
+    async def _enable_fetch(self, session_id: str, *, wait: bool = False) -> None:
         if session_id in self._attached_sessions:
             return
-        self._attached_sessions.add(session_id)
-        await self._send_fire_and_forget("Page.enable", session_id=session_id)
-        await self._send_fire_and_forget(
+        if not wait:
+            await self._send_fire_and_forget("Page.enable", session_id=session_id)
+            await self._send_fire_and_forget(
+                "Fetch.enable",
+                {"patterns": [{"urlPattern": "*"}]},
+                session_id=session_id,
+            )
+            return
+        await self._send("Page.enable", session_id=session_id)
+        await self._send(
             "Fetch.enable",
             {"patterns": [{"urlPattern": "*"}]},
             session_id=session_id,
         )
+        self._attached_sessions.add(session_id)
 
     async def _handle_paused_request(self, session_id: str, params: dict[str, Any]) -> None:
         request_id = params.get("requestId")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "langchain-google-genai>=4.2.4",
     "langchain-mcp-adapters>=0.3.0",
     "stagehand>=3.21.0",
+    "websockets>=15.0.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/tools/test_stagehand_browser.py
+++ b/tests/tools/test_stagehand_browser.py
@@ -116,6 +116,8 @@ class FakeCDPWebSocket:
     def __init__(self) -> None:
         self.sent: list[dict[str, object]] = []
         self.incoming: asyncio.Queue[str | None] = asyncio.Queue()
+        self.responses: dict[str, dict[str, object]] = {}
+        self.held_methods: set[str] = set()
         self.closed = False
 
     def __aiter__(self) -> "FakeCDPWebSocket":
@@ -130,9 +132,25 @@ class FakeCDPWebSocket:
     async def send(self, message: str) -> None:
         parsed = json.loads(message)
         self.sent.append(parsed)
+        method = parsed.get("method")
+        if isinstance(method, str) and method in self.held_methods:
+            return
+        await self.respond(parsed)
+
+    async def respond(self, parsed: dict[str, object]) -> None:
+        method = parsed.get("method")
         message_id = parsed.get("id")
-        if isinstance(message_id, int):
-            await self.incoming.put(json.dumps({"id": message_id, "result": {}}))
+        if not isinstance(message_id, int):
+            return
+        result = self.responses.get(method, {}) if isinstance(method, str) else {}
+        await self.incoming.put(json.dumps({"id": message_id, "result": result}))
+
+    async def respond_to_method(self, method: str) -> None:
+        for message in self.sent:
+            if message.get("method") == method:
+                await self.respond(message)
+                return
+        raise AssertionError(f"No CDP message sent for {method}")
 
     async def close(self) -> None:
         self.closed = True
@@ -193,6 +211,49 @@ async def test_cdp_browser_url_guard_blocks_real_stagehand_requests(
     assert stagehand_browser._blocked_request_error(session) is not None
     assert any(message["method"] == "Fetch.enable" for message in websocket.sent)
     assert any(message["method"] == "Fetch.failRequest" for message in websocket.sent)
+
+    await session._open_swe_cdp_guard.close()
+
+
+@pytest.mark.asyncio
+async def test_cdp_browser_url_guard_waits_for_initial_fetch_enable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
+    del session.page
+    websocket = FakeCDPWebSocket()
+    websocket.responses["Target.getTargets"] = {
+        "targetInfos": [
+            {
+                "targetId": "target-1",
+                "type": "page",
+                "url": "about:blank",
+            }
+        ]
+    }
+    websocket.responses["Target.attachToTarget"] = {"sessionId": "cdp-session-1"}
+    websocket.held_methods.add("Fetch.enable")
+
+    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
+        return websocket
+
+    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
+
+    install_task = asyncio.create_task(stagehand_browser._install_browser_url_guard(session))
+    for _ in range(100):
+        if any(message["method"] == "Fetch.enable" for message in websocket.sent):
+            break
+        await asyncio.sleep(0.01)
+
+    assert install_task.done() is False
+    assert any(message["method"] == "Fetch.enable" for message in websocket.sent)
+
+    websocket.held_methods.remove("Fetch.enable")
+    await websocket.respond_to_method("Fetch.enable")
+    await install_task
+
+    assert "cdp-session-1" in session._open_swe_cdp_guard._attached_sessions
 
     await session._open_swe_cdp_guard.close()
 

--- a/tests/tools/test_stagehand_browser.py
+++ b/tests/tools/test_stagehand_browser.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from collections.abc import Awaitable, Callable
 
 import pytest
 
@@ -68,9 +69,11 @@ class FakeRoute:
 class FakePage:
     def __init__(self) -> None:
         self.url = "about:blank"
-        self.handler = None
+        self.handler: Callable[[FakeRoute, FakeRequest], Awaitable[None]] | None = None
 
-    async def route(self, pattern: str, handler: object) -> None:
+    async def route(
+        self, pattern: str, handler: Callable[[FakeRoute, FakeRequest], Awaitable[None]]
+    ) -> None:
         self.pattern = pattern
         self.handler = handler
 
@@ -82,11 +85,12 @@ class FakePage:
 
 
 class FakeData:
-    cdp_url = None
+    cdp_url: str | None = None
 
 
 class FakeSession:
     id = "session-123"
+    _open_swe_cdp_guard: stagehand_browser._CDPBrowserURLGuard
 
     def __init__(self) -> None:
         self.data = FakeData()
@@ -117,6 +121,10 @@ class FakeCDPWebSocket:
         self.sent: list[dict[str, object]] = []
         self.incoming: asyncio.Queue[str | None] = asyncio.Queue()
         self.responses: dict[str, dict[str, object]] = {}
+        self.response_sequences: dict[str, list[dict[str, object]]] = {}
+        self.method_errors: dict[str, dict[str, object]] = {}
+        self.target_errors: dict[str, dict[str, object]] = {}
+        self.target_responses: dict[str, dict[str, object]] = {}
         self.held_methods: set[str] = set()
         self.closed = False
 
@@ -142,7 +150,25 @@ class FakeCDPWebSocket:
         message_id = parsed.get("id")
         if not isinstance(message_id, int):
             return
-        result = self.responses.get(method, {}) if isinstance(method, str) else {}
+        if isinstance(method, str) and method in self.method_errors:
+            await self.incoming.put(
+                json.dumps({"id": message_id, "error": self.method_errors[method]})
+            )
+            return
+        params = parsed.get("params")
+        target_id = params.get("targetId") if isinstance(params, dict) else None
+        if method == "Target.attachToTarget" and isinstance(target_id, str):
+            error = self.target_errors.get(target_id)
+            if error is not None:
+                await self.incoming.put(json.dumps({"id": message_id, "error": error}))
+                return
+            result = self.target_responses.get(
+                target_id, self.responses.get("Target.attachToTarget", {})
+            )
+        elif isinstance(method, str) and self.response_sequences.get(method):
+            result = self.response_sequences[method].pop(0)
+        else:
+            result = self.responses.get(method, {}) if isinstance(method, str) else {}
         await self.incoming.put(json.dumps({"id": message_id, "result": result}))
 
     async def respond_to_method(self, method: str) -> None:
@@ -180,6 +206,16 @@ async def test_cdp_browser_url_guard_blocks_real_stagehand_requests(
     session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
     del session.page
     websocket = FakeCDPWebSocket()
+    websocket.responses["Target.getTargets"] = {
+        "targetInfos": [
+            {
+                "targetId": "initial-target",
+                "type": "page",
+                "url": "about:blank",
+            }
+        ]
+    }
+    websocket.target_responses["initial-target"] = {"sessionId": "cdp-session-initial"}
 
     async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
         return websocket
@@ -192,10 +228,19 @@ async def test_cdp_browser_url_guard_blocks_real_stagehand_requests(
             "method": "Target.attachedToTarget",
             "params": {
                 "sessionId": "cdp-session-1",
-                "targetInfo": {"type": "page", "url": "https://example.com/"},
+                "targetInfo": {
+                    "targetId": "new-target",
+                    "type": "page",
+                    "url": "https://example.com/",
+                },
+                "waitingForDebugger": True,
             },
         }
     )
+    for _ in range(100):
+        if "cdp-session-1" in session._open_swe_cdp_guard._attached_sessions:
+            break
+        await asyncio.sleep(0.01)
     await websocket.emit(
         {
             "method": "Fetch.requestPaused",
@@ -256,6 +301,91 @@ async def test_cdp_browser_url_guard_waits_for_initial_fetch_enable(
     assert "cdp-session-1" in session._open_swe_cdp_guard._attached_sessions
 
     await session._open_swe_cdp_guard.close()
+
+
+@pytest.mark.asyncio
+async def test_cdp_browser_url_guard_ignores_stale_initial_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
+    del session.page
+    websocket = FakeCDPWebSocket()
+    stale_target = {"targetId": "stale-target", "type": "page", "url": "about:blank"}
+    live_target = {"targetId": "live-target", "type": "page", "url": "about:blank"}
+    websocket.response_sequences["Target.getTargets"] = [
+        {"targetInfos": [stale_target, live_target]},
+        {"targetInfos": [live_target]},
+    ]
+    websocket.target_errors["stale-target"] = {
+        "code": -32602,
+        "message": "No target with given id found",
+    }
+    websocket.target_responses["live-target"] = {"sessionId": "cdp-session-live"}
+
+    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
+        return websocket
+
+    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
+
+    await stagehand_browser._install_browser_url_guard(session)
+
+    guard = session._open_swe_cdp_guard
+    assert guard._protected_target_ids == {"live-target"}
+    assert "cdp-session-live" in guard._attached_sessions
+    assert any(
+        message["method"] == "Target.setAutoAttach"
+        and isinstance((params := message.get("params")), dict)
+        and params.get("waitForDebuggerOnStart") is True
+        for message in websocket.sent
+    )
+
+    await guard.close()
+
+
+@pytest.mark.asyncio
+async def test_get_session_fails_closed_when_fetch_interception_cannot_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
+    del session.page
+    websocket = FakeCDPWebSocket()
+    live_target = {"targetId": "live-target", "type": "page", "url": "about:blank"}
+    websocket.responses["Target.getTargets"] = {"targetInfos": [live_target]}
+    websocket.target_responses["live-target"] = {"sessionId": "cdp-session-live"}
+    websocket.method_errors["Fetch.enable"] = {
+        "code": -32000,
+        "message": "Fetch interception unavailable",
+    }
+
+    class FakeSessions:
+        async def start(self, **_kwargs: object) -> FakeSession:
+            return session
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.sessions = FakeSessions()
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    client = FakeClient()
+
+    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
+        return websocket
+
+    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
+    monkeypatch.setattr(stagehand_browser, "_build_client", lambda: client)
+
+    with pytest.raises(stagehand_browser.BrowserNavigationBlocked):
+        await stagehand_browser._get_session()
+
+    assert session.ended is True
+    assert client.closed is True
+    assert websocket.closed is True
+    assert stagehand_browser._SESSIONS == {}
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_stagehand_browser.py
+++ b/tests/tools/test_stagehand_browser.py
@@ -1,3 +1,6 @@
+import asyncio
+import json
+
 import pytest
 
 from agent.integrations import stagehand_browser
@@ -78,10 +81,15 @@ class FakePage:
         return route
 
 
+class FakeData:
+    cdp_url = None
+
+
 class FakeSession:
     id = "session-123"
 
     def __init__(self) -> None:
+        self.data = FakeData()
         self.page = FakePage()
         self.ended = False
 
@@ -92,8 +100,46 @@ class FakeSession:
         self.page.url = input
         return {"result": "ok"}
 
+    async def observe(self, instruction: str) -> dict[str, object]:
+        return {"result": instruction}
+
+    async def extract(
+        self, instruction: str, schema: dict[str, object] | None = None
+    ) -> dict[str, object]:
+        return {"result": {"instruction": instruction, "schema": schema}}
+
     async def end(self) -> None:
         self.ended = True
+
+
+class FakeCDPWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.incoming: asyncio.Queue[str | None] = asyncio.Queue()
+        self.closed = False
+
+    def __aiter__(self) -> "FakeCDPWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        message = await self.incoming.get()
+        if message is None:
+            raise StopAsyncIteration
+        return message
+
+    async def send(self, message: str) -> None:
+        parsed = json.loads(message)
+        self.sent.append(parsed)
+        message_id = parsed.get("id")
+        if isinstance(message_id, int):
+            await self.incoming.put(json.dumps({"id": message_id, "result": {}}))
+
+    async def close(self) -> None:
+        self.closed = True
+        await self.incoming.put(None)
+
+    async def emit(self, message: dict[str, object]) -> None:
+        await self.incoming.put(json.dumps(message))
 
 
 @pytest.mark.asyncio
@@ -106,6 +152,49 @@ async def test_browser_url_guard_aborts_internal_browser_requests() -> None:
     assert route.aborted is True
     assert route.continued is False
     assert stagehand_browser._blocked_request_error(session) is not None
+
+
+@pytest.mark.asyncio
+async def test_cdp_browser_url_guard_blocks_real_stagehand_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
+    del session.page
+    websocket = FakeCDPWebSocket()
+
+    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
+        return websocket
+
+    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
+
+    await stagehand_browser._install_browser_url_guard(session)
+    await websocket.emit(
+        {
+            "method": "Target.attachedToTarget",
+            "params": {
+                "sessionId": "cdp-session-1",
+                "targetInfo": {"type": "page", "url": "https://example.com/"},
+            },
+        }
+    )
+    await websocket.emit(
+        {
+            "method": "Fetch.requestPaused",
+            "sessionId": "cdp-session-1",
+            "params": {
+                "requestId": "request-1",
+                "request": {"url": "http://169.254.169.254/latest/meta-data/"},
+            },
+        }
+    )
+    await asyncio.sleep(0)
+
+    assert stagehand_browser._blocked_request_error(session) is not None
+    assert any(message["method"] == "Fetch.enable" for message in websocket.sent)
+    assert any(message["method"] == "Fetch.failRequest" for message in websocket.sent)
+
+    await session._open_swe_cdp_guard.close()
 
 
 @pytest.mark.asyncio
@@ -168,4 +257,26 @@ async def test_browser_act_reports_unsafe_final_url(monkeypatch: pytest.MonkeyPa
 
     assert result["success"] is False
     assert "blocked after navigation" in result["error"]
+    assert session.ended is True
+
+
+@pytest.mark.asyncio
+async def test_browser_act_fails_on_existing_blocked_background_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    stagehand_browser._mark_blocked_request(
+        session, "http://169.254.169.254/latest/meta-data/", "metadata endpoint"
+    )
+
+    async def get_session(*_args: object, **_kwargs: object) -> FakeSession:
+        return session
+
+    monkeypatch.setattr(stagehand_browser, "_get_session", get_session)
+    stagehand_browser._SESSIONS["default"] = (object(), session)
+
+    result = await stagehand_browser.browser_act("click continue")
+
+    assert result["success"] is False
+    assert "blocked browser request" in result["error"]
     assert session.ended is True

--- a/tests/tools/test_stagehand_browser.py
+++ b/tests/tools/test_stagehand_browser.py
@@ -3,6 +3,11 @@ import pytest
 from agent.integrations import stagehand_browser
 
 
+@pytest.fixture(autouse=True)
+def clear_stagehand_sessions() -> None:
+    stagehand_browser._SESSIONS.clear()
+
+
 @pytest.mark.asyncio
 async def test_browser_navigate_blocks_internal_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fail_get_session(*_args: object, **_kwargs: object) -> object:
@@ -37,3 +42,130 @@ def test_browserbase_project_id_is_forwarded_when_set(monkeypatch: pytest.Monkey
     monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "project-123")
 
     assert stagehand_browser._browserbase_session_create_params() == {"project_id": "project-123"}
+
+
+class FakeRequest:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class FakeRoute:
+    def __init__(self, url: str) -> None:
+        self.request = FakeRequest(url)
+        self.aborted = False
+        self.continued = False
+
+    async def abort(self) -> None:
+        self.aborted = True
+
+    async def continue_(self) -> None:
+        self.continued = True
+
+
+class FakePage:
+    def __init__(self) -> None:
+        self.url = "about:blank"
+        self.handler = None
+
+    async def route(self, pattern: str, handler: object) -> None:
+        self.pattern = pattern
+        self.handler = handler
+
+    async def request(self, url: str) -> FakeRoute:
+        assert self.handler is not None
+        route = FakeRoute(url)
+        await self.handler(route, route.request)
+        return route
+
+
+class FakeSession:
+    id = "session-123"
+
+    def __init__(self) -> None:
+        self.page = FakePage()
+        self.ended = False
+
+    async def navigate(self, url: str) -> None:
+        self.page.url = url
+
+    async def act(self, input: str) -> dict[str, object]:
+        self.page.url = input
+        return {"result": "ok"}
+
+    async def end(self) -> None:
+        self.ended = True
+
+
+@pytest.mark.asyncio
+async def test_browser_url_guard_aborts_internal_browser_requests() -> None:
+    session = FakeSession()
+    await stagehand_browser._install_browser_url_guard(session)
+
+    route = await session.page.request("http://169.254.169.254/latest/meta-data/")
+
+    assert route.aborted is True
+    assert route.continued is False
+    assert stagehand_browser._blocked_request_error(session) is not None
+
+
+@pytest.mark.asyncio
+async def test_browser_url_guard_allows_public_browser_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(stagehand_browser, "is_url_safe", lambda _url: (True, ""))
+    session = FakeSession()
+    await stagehand_browser._install_browser_url_guard(session)
+
+    route = await session.page.request("https://example.com/")
+
+    assert route.continued is True
+    assert route.aborted is False
+    assert stagehand_browser._blocked_request_error(session) is None
+
+
+@pytest.mark.asyncio
+async def test_browser_navigate_reports_blocked_redirect_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    await stagehand_browser._install_browser_url_guard(session)
+
+    async def get_session(*_args: object, **_kwargs: object) -> FakeSession:
+        return session
+
+    async def navigate_with_redirect(url: str) -> None:
+        session.page.url = url
+        await session.page.request("http://169.254.169.254/latest/meta-data/")
+
+    def fake_is_url_safe(url: str) -> tuple[bool, str]:
+        if "169.254.169.254" in url:
+            return False, "metadata endpoint"
+        return True, ""
+
+    monkeypatch.setattr(stagehand_browser, "_get_session", get_session)
+    monkeypatch.setattr(stagehand_browser, "is_url_safe", fake_is_url_safe)
+    monkeypatch.setattr(session, "navigate", navigate_with_redirect)
+    stagehand_browser._SESSIONS["default"] = (object(), session)
+
+    result = await stagehand_browser.browser_navigate("https://example.com/")
+
+    assert result["success"] is False
+    assert "169.254.169.254" in result["error"]
+    assert session.ended is True
+
+
+@pytest.mark.asyncio
+async def test_browser_act_reports_unsafe_final_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = FakeSession()
+
+    async def get_session(*_args: object, **_kwargs: object) -> FakeSession:
+        return session
+
+    monkeypatch.setattr(stagehand_browser, "_get_session", get_session)
+    stagehand_browser._SESSIONS["default"] = (object(), session)
+
+    result = await stagehand_browser.browser_act("http://169.254.169.254/latest/meta-data/")
+
+    assert result["success"] is False
+    assert "blocked after navigation" in result["error"]
+    assert session.ended is True

--- a/uv.lock
+++ b/uv.lock
@@ -2062,6 +2062,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "stagehand" },
     { name = "uvicorn" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -2102,6 +2103,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20" },
     { name = "stagehand", specifier = ">=3.21.0" },
     { name = "uvicorn", specifier = ">=0.50.2" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- install a per-session CDP browser request guard using Stagehand's `cdp_url`, with Playwright-style route hooks kept as a compatibility fallback
- wait for initial CDP page attachment and `Fetch.enable` before the first navigation can run, so fresh-session redirects/subresources are covered
- block unsafe browser requests using the existing `is_url_safe` policy and close/reset the session when a blocked request or unsafe final URL is detected
- preserve blocked background-request signals across tool calls so the next browser operation fails closed instead of clearing them
- add regression coverage for CDP-request blocking, initial `Fetch.enable` readiness, metadata endpoint requests, redirect-style blocked requests, `browser_act` final URL blocking, stale background-request markers, and normal public requests

## Validation
- `uv run --project /tmp/open-swe --extra dev ruff format /tmp/open-swe/agent/integrations/stagehand_browser.py /tmp/open-swe/tests/tools/test_stagehand_browser.py`
- `uv run --project /tmp/open-swe --extra dev ruff check /tmp/open-swe/agent/integrations/stagehand_browser.py /tmp/open-swe/tests/tools/test_stagehand_browser.py`
- `uv run --project /tmp/open-swe --extra dev pytest -q /tmp/open-swe/tests/tools/test_stagehand_browser.py`

## Notes
- This is scoped to the open Corridor SSRF findings for Stagehand browser navigation/action paths.
- The guard is intentionally session-level so it applies to browser actions beyond explicit `browser_navigate` calls.