### PR TITLE
feat: optional blocking conclusion for the Open SWE Review check

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -23,6 +23,7 @@ from .review.findings import REVIEWER_THREAD_KIND
 from .review.publish import settle_review_check_run
 from .utils.dashboard_links import dashboard_thread_url
 from .utils.github_app import get_github_app_installation_token
+from .utils.github_checks import incomplete_review_check_result
 from .utils.github_comments import post_github_comment
 from .utils.linear import comment_on_linear_issue
 from .utils.slack import post_slack_thread_reply
@@ -108,12 +109,7 @@ async def _settle_failed_reviewer_check(thread_id: str, metadata: dict[str, Any]
             title = str(pending.get("title") or "Review completed")
             summary = str(pending.get("summary") or "")
         else:
-            conclusion = "neutral"
-            title = "Review did not complete"
-            summary = (
-                "The Open SWE review run ended without publishing a review. "
-                "Re-trigger the review by pushing a commit or re-requesting it."
-            )
+            conclusion, title, summary = incomplete_review_check_result()
         await settle_review_check_run(
             thread_id=thread_id,
             owner=owner,

--- a/agent/middleware/settle_review_check.py
+++ b/agent/middleware/settle_review_check.py
@@ -3,14 +3,14 @@
 ``publish_review`` normally completes the ``Open SWE Review`` check run and
 clears ``review_check_run_id`` from reviewer thread metadata. If the run ends
 without ever publishing (crash, model-call limit, sandbox failure), the check
-would hang "in progress" on the PR forever. This hook closes it as neutral —
-the review not completing is reviewer infrastructure failing, not the PR.
+would hang "in progress" on the PR forever. This hook closes it as neutral by
+default, or as failure when blocking review checks are enabled.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast, get_args
 
 from langchain.agents.middleware import AgentState, after_agent
 from langgraph.config import get_config
@@ -18,6 +18,7 @@ from langgraph.runtime import Runtime
 
 from ..review.findings import get_thread_metadata
 from ..review.publish import settle_review_check_run
+from ..utils.github_checks import CheckConclusion, incomplete_review_check_result
 from ..utils.github_token import get_github_token
 
 logger = logging.getLogger(__name__)
@@ -54,23 +55,12 @@ async def settle_review_check_on_exit(
         # PATCH failed transiently — retry with the real conclusion instead of
         # misreporting a published review as failed.
         pending = metadata.get("review_check_pending_result")
-        if isinstance(pending, dict) and pending.get("conclusion") in {
-            "success",
-            "neutral",
-            "failure",
-        }:
-            conclusion = pending["conclusion"]
+        if isinstance(pending, dict) and pending.get("conclusion") in get_args(CheckConclusion):
+            conclusion = cast(CheckConclusion, pending["conclusion"])
             title = str(pending.get("title") or "Review completed")
             summary = str(pending.get("summary") or "")
         else:
-            # Neutral, not failure: an incomplete review is a reviewer-infra
-            # problem, and a red X on the PR misreads as a code problem.
-            conclusion = "neutral"
-            title = "Review did not complete"
-            summary = (
-                "The Open SWE review run ended without publishing a review. "
-                "Re-trigger the review by pushing a commit or re-requesting it."
-            )
+            conclusion, title, summary = incomplete_review_check_result()
         await settle_review_check_run(
             thread_id=thread_id,
             owner=owner,

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -48,7 +48,7 @@ from ..review.publish import (
 )
 from ..review.reconcile import reconcile_findings_with_review_threads
 from ..utils.dashboard_links import dashboard_review_url
-from ..utils.github_checks import review_check_conclusion
+from ..utils.github_checks import review_check_blocking_enabled, review_check_conclusion
 from ..utils.github_token import (
     GitHubAuthError,
     get_github_token,
@@ -192,6 +192,20 @@ async def _resolve_review_trace_url(thread_id: str, config_override: object) -> 
 
 def _is_reviewer_eval_mode(configurable: dict[str, Any]) -> bool:
     return configurable.get("reviewer_eval") is True or configurable.get("eval") is True
+
+
+async def _review_check_finding_count(thread_id: str, newly_posted_count: int) -> int:
+    # Blocking checks count all standing findings; informational checks preserve publish-time count.
+    if not review_check_blocking_enabled():
+        return newly_posted_count
+    findings = await list_findings_async(thread_id)
+    return sum(
+        1
+        for finding in findings
+        if finding.get("status", "open") == "open"
+        and isinstance((surface := finding.get("surface")), dict)
+        and surface.get("state") in {"surfaced", "resolve_pending"}
+    )
 
 
 async def _publish_review_eval_dry_run_async(
@@ -340,7 +354,8 @@ async def _publish_review_async(
         )
         await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
         await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
-        conclusion, check_title, check_summary = review_check_conclusion(0)
+        check_finding_count = await _review_check_finding_count(thread_id, 0)
+        conclusion, check_title, check_summary = review_check_conclusion(check_finding_count)
         await settle_review_check_run(
             thread_id=thread_id,
             owner=owner,
@@ -526,7 +541,8 @@ async def _publish_review_async(
 
     await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
     await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
-    conclusion, check_title, check_summary = review_check_conclusion(len(inline_comments))
+    check_finding_count = await _review_check_finding_count(thread_id, len(inline_comments))
+    conclusion, check_title, check_summary = review_check_conclusion(check_finding_count)
     await settle_review_check_run(
         thread_id=thread_id,
         owner=owner,

--- a/agent/utils/github_checks.py
+++ b/agent/utils/github_checks.py
@@ -12,6 +12,7 @@ break review dispatch or publish.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -153,18 +154,36 @@ async def post_autofix_status_check(
     return True
 
 
-def review_check_conclusion(surfaced_count: int) -> tuple[CheckConclusion, str, str]:
-    """Map a publish result to (conclusion, title, summary).
+def review_check_blocking_enabled() -> bool:
+    """Return whether surfaced findings should fail the review check.
 
-    Always ``success`` so the check is informational and non-blocking, and so
-    GitHub groups it under "successful checks" rather than a confusing
-    "neutral check". The finding count is surfaced in the title; the findings
-    themselves are posted as PR comments.
+    Deliberately env-scoped (deployment-level merge policy) rather than a team
+    setting: whoever operates branch protection owns this toggle.
     """
+    return os.getenv("REVIEW_CHECK_BLOCKING", "").lower() in {"1", "true", "yes"}
+
+
+def incomplete_review_check_result() -> tuple[CheckConclusion, str, str]:
+    """Conclusion for a review run that ended without publishing.
+
+    Shared by every settle path (after-agent middleware and the run-completion
+    handler) so an unfinished review cannot satisfy a blocking check through
+    one path while failing it through another.
+    """
+    return (
+        "failure" if review_check_blocking_enabled() else "neutral",
+        "Review did not complete",
+        "The Open SWE review run ended without publishing a review. "
+        "Re-trigger the review by pushing a commit or re-requesting it.",
+    )
+
+
+def review_check_conclusion(surfaced_count: int) -> tuple[CheckConclusion, str, str]:
+    """Map a publish result to (conclusion, title, summary)."""
     if surfaced_count > 0:
         issue_word = "issue" if surfaced_count == 1 else "issues"
         return (
-            "success",
+            "failure" if review_check_blocking_enabled() else "success",
             f"Found {surfaced_count} potential {issue_word}",
             f"Open SWE surfaced {surfaced_count} potential {issue_word} on this pull request.",
         )

--- a/tests/github/test_github_checks.py
+++ b/tests/github/test_github_checks.py
@@ -146,18 +146,85 @@ async def test_post_autofix_status_check_completes_neutral(
     assert body["details_url"] == "https://example.com/thread"
 
 
-def test_review_check_conclusion_mapping() -> None:
-    conclusion, title, _ = github_checks.review_check_conclusion(0)
-    assert conclusion == "success"
-    assert title == "No issues found"
+@pytest.mark.parametrize(
+    ("flag", "surfaced_count", "expected"),
+    [
+        (
+            None,
+            0,
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+        (
+            None,
+            3,
+            (
+                "success",
+                "Found 3 potential issues",
+                "Open SWE surfaced 3 potential issues on this pull request.",
+            ),
+        ),
+        (
+            "true",
+            0,
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+        (
+            "true",
+            1,
+            (
+                "failure",
+                "Found 1 potential issue",
+                "Open SWE surfaced 1 potential issue on this pull request.",
+            ),
+        ),
+        (
+            "TRUE",
+            2,
+            (
+                "failure",
+                "Found 2 potential issues",
+                "Open SWE surfaced 2 potential issues on this pull request.",
+            ),
+        ),
+        (
+            "false",
+            2,
+            (
+                "success",
+                "Found 2 potential issues",
+                "Open SWE surfaced 2 potential issues on this pull request.",
+            ),
+        ),
+    ],
+    ids=[
+        "flag-unset-zero-findings-success",
+        "flag-unset-three-findings-success",
+        "flag-true-zero-findings-success",
+        "flag-true-one-finding-failure",
+        "flag-uppercase-true-two-findings-failure",
+        "flag-false-two-findings-success",
+    ],
+)
+def test_review_check_conclusion_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str | None,
+    surfaced_count: int,
+    expected: tuple[str, str, str],
+) -> None:
+    if flag is None:
+        monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
+    else:
+        monkeypatch.setenv("REVIEW_CHECK_BLOCKING", flag)
 
-    conclusion, title, _ = github_checks.review_check_conclusion(1)
-    assert conclusion == "success"
-    assert "1 potential issue" in title
-
-    conclusion, title, _ = github_checks.review_check_conclusion(3)
-    assert conclusion == "success"
-    assert "3 potential issues" in title
+    assert github_checks.review_check_conclusion(surfaced_count) == expected
 
 
 async def test_settle_review_check_run_noop_without_tracked_id(

--- a/tests/middleware/test_settle_review_check.py
+++ b/tests/middleware/test_settle_review_check.py
@@ -1,0 +1,78 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain.agents.middleware import AgentState
+
+from agent.middleware.settle_review_check import settle_review_check_on_exit
+
+
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [
+        (
+            None,
+            (
+                "neutral",
+                "Review did not complete",
+                "The Open SWE review run ended without publishing a review. "
+                "Re-trigger the review by pushing a commit or re-requesting it.",
+            ),
+        ),
+        (
+            "true",
+            (
+                "failure",
+                "Review did not complete",
+                "The Open SWE review run ended without publishing a review. "
+                "Re-trigger the review by pushing a commit or re-requesting it.",
+            ),
+        ),
+    ],
+    ids=["flag-unset-neutral", "flag-true-failure"],
+)
+async def test_unpublished_review_settle_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str | None,
+    expected: tuple[str, str, str],
+) -> None:
+    if flag is None:
+        monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
+    else:
+        monkeypatch.setenv("REVIEW_CHECK_BLOCKING", flag)
+
+    state: AgentState = {"messages": []}
+    with (
+        patch(
+            "agent.middleware.settle_review_check.get_config",
+            return_value={
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "repo": {"owner": "acme", "name": "widgets"},
+                }
+            },
+        ),
+        patch(
+            "agent.middleware.settle_review_check.get_thread_metadata",
+            new_callable=AsyncMock,
+            return_value={"review_check_run_id": 42},
+        ),
+        patch(
+            "agent.middleware.settle_review_check.get_github_token",
+            return_value="token",
+        ),
+        patch(
+            "agent.middleware.settle_review_check.settle_review_check_run",
+            new_callable=AsyncMock,
+        ) as settle,
+    ):
+        result = await settle_review_check_on_exit.aafter_agent(state, MagicMock())
+
+    assert result is None
+    settle.assert_awaited_once()
+    call = settle.await_args
+    assert call is not None
+    assert (
+        call.kwargs["conclusion"],
+        call.kwargs["title"],
+        call.kwargs["summary"],
+    ) == expected

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -824,6 +824,112 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
     assert result["skipped_empty_re_review"] is True
 
 
+@pytest.mark.parametrize(
+    ("status", "flag", "expected"),
+    [
+        (
+            "open",
+            "true",
+            (
+                "failure",
+                "Found 1 potential issue",
+                "Open SWE surfaced 1 potential issue on this pull request.",
+            ),
+        ),
+        (
+            "resolved",
+            "true",
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+        (
+            "open",
+            None,
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+    ],
+    ids=[
+        "standing-open-surfaced-blocking-fails",
+        "standing-resolved-blocking-succeeds",
+        "standing-open-surfaced-informational-unchanged",
+    ],
+)
+async def test_publish_review_check_counts_standing_findings(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    flag: str | None,
+    expected: tuple[str, str, str],
+) -> None:
+    from agent.tools.publish_review import _publish_review_async
+
+    if flag is None:
+        monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
+    else:
+        monkeypatch.setenv("REVIEW_CHECK_BLOCKING", flag)
+
+    finding = _f(
+        id="f_standing",
+        status=status,
+        github_review_comment_id=100,
+    )
+    surface = finding["surface"]
+    assert surface is not None
+    surface["state"] = "surfaced"
+    settle = AsyncMock()
+    post_review = AsyncMock()
+
+    with (
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="tid"),
+        patch(
+            "agent.tools.publish_review.list_findings_async",
+            AsyncMock(return_value=[finding]),
+        ),
+        patch(
+            "agent.tools.publish_review._open_swe_already_reviewed",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review._resolve_threads_for_resolved_findings",
+            AsyncMock(return_value=0),
+        ),
+        patch("agent.tools.publish_review.post_pull_request_review", post_review),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()),
+        patch("agent.tools.publish_review.settle_review_check_run", settle),
+        patch(
+            "agent.tools.publish_review._resolve_review_trace_url",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await _publish_review_async(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="newsha",
+            token="t",
+            severity_threshold="medium",
+            cap=15,
+            is_re_review=True,
+        )
+
+    post_review.assert_not_called()
+    settle.assert_awaited_once()
+    call = settle.await_args
+    assert call is not None
+    assert (
+        call.kwargs["conclusion"],
+        call.kwargs["title"],
+        call.kwargs["summary"],
+    ) == expected
+    assert result["surfaced_count"] == 0
+
+
 @pytest.mark.asyncio
 async def test_publish_review_does_not_surface_out_of_diff_finding() -> None:
     """Out-of-diff findings are disabled: a finding anchored outside the diff is

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -61,6 +61,7 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
 
 @pytest.mark.asyncio
 async def test_reviewer_error_settles_tracked_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
     metadata = {
         "kind": "reviewer",
         "review_check_run_id": 42,
@@ -92,6 +93,35 @@ async def test_reviewer_error_settles_tracked_check(monkeypatch: pytest.MonkeyPa
             "Re-trigger the review by pushing a commit or re-requesting it."
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_reviewer_error_settles_failure_when_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REVIEW_CHECK_BLOCKING", "true")
+    metadata = {
+        "kind": "reviewer",
+        "review_check_run_id": 42,
+        "pr": {"owner": "acme", "name": "widgets"},
+        "source": "schedule",
+    }
+    client = _FakeClient(metadata)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    monkeypatch.setattr(
+        completion, "get_github_app_installation_token", AsyncMock(return_value="token")
+    )
+    settle = AsyncMock()
+    monkeypatch.setattr(completion, "settle_review_check_run", settle)
+
+    await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "error"}
+    )
+
+    # A crashed reviewer must not satisfy a blocking (required) check.
+    settle_args = settle.await_args
+    assert settle_args is not None
+    assert settle_args.kwargs["conclusion"] == "failure"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Adds an opt-in **merge-on-clean** mode for the `Open SWE Review` check run. When the `REVIEW_CHECK_BLOCKING` env var is set, the check concludes as `failure` while findings are open, so branch protection / auto-merge can gate on review cleanliness. Three behaviors change together, all behind the flag:

- **Surfaced findings fail the check** instead of concluding `success` with a count.
- **Blocking checks count all standing surfaced findings**, not just newly posted ones — a re-review that surfaces nothing new can't flip a dirty PR green.
- **Unfinished reviews fail instead of settling neutral.** Both settle paths — the after-agent middleware and the run-completion handler from #1779 — now share one conclusion helper (`incomplete_review_check_result`), so a crashed or timed-out reviewer can't satisfy a required check through the completion path (`neutral` passes required checks).

**Default off:** without the env var, every conclusion is byte-identical to today's informational behavior (covered by tests).

The toggle is deliberately env-scoped (deployment-level merge policy) rather than a team setting: whoever operates branch protection owns it.

## Why

We run Open SWE with required-check gating (auto-merge blocked until the review is clean). The informational check can't express "this PR has open findings" to branch protection. This is the minimal seam that makes the existing check usable as a merge gate.

## Test Plan

- [x] Full suite passes (1598); `ruff check`, `ruff format --diff`, `basedpyright` clean
- [x] Flag-off conclusions byte-identical (literal-tuple tests in `tests/github/test_github_checks.py`)
- [x] Blocking mode: surfaced findings → `failure`; standing-findings count on re-review (`tests/reviewer/test_reviewer_publish.py`)
- [x] Crash settle: middleware and completion-handler paths both conclude `failure` under the flag (`tests/middleware/test_settle_review_check.py`, `tests/webhooks/test_completion_webhook.py` — the completion test would have settled `neutral` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)