### PR TITLE
feat: dispatch auto-fix runs from surfaced review findings

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -23,6 +23,7 @@ from .review.findings import REVIEWER_THREAD_KIND
 from .review.publish import settle_review_check_run
 from .utils.dashboard_links import dashboard_thread_url
 from .utils.github_app import get_github_app_installation_token
+from .utils.github_checks import incomplete_review_check_result
 from .utils.github_comments import post_github_comment
 from .utils.linear import comment_on_linear_issue
 from .utils.slack import post_slack_thread_reply
@@ -108,12 +109,7 @@ async def _settle_failed_reviewer_check(thread_id: str, metadata: dict[str, Any]
             title = str(pending.get("title") or "Review completed")
             summary = str(pending.get("summary") or "")
         else:
-            conclusion = "neutral"
-            title = "Review did not complete"
-            summary = (
-                "The Open SWE review run ended without publishing a review. "
-                "Re-trigger the review by pushing a commit or re-requesting it."
-            )
+            conclusion, title, summary = incomplete_review_check_result()
         await settle_review_check_run(
             thread_id=thread_id,
             owner=owner,

--- a/agent/dashboard/autofix_state.py
+++ b/agent/dashboard/autofix_state.py
@@ -28,18 +28,28 @@ def _key(owner: str, repo: str, pr_number: int) -> str:
 
 
 async def is_pr_autofix_disabled(owner: str, repo: str, pr_number: int) -> bool:
-    """Return whether auto-fix has been turned off for a specific PR."""
-    try:
-        item = await _client().store.get_item(
-            AUTOFIX_PR_STATE_NAMESPACE, _key(owner, repo, pr_number)
-        )
-    except Exception as e:  # noqa: BLE001
-        logger.debug("autofix PR state lookup failed: %s", e)
-        return False
+    """Return whether auto-fix has been turned off for a specific PR.
+
+    Lookup errors propagate: an explicit opt-out is a safety control, so a
+    store failure must abort automatic dispatch rather than read as opted-in.
+    """
+    item = await _client().store.get_item(AUTOFIX_PR_STATE_NAMESPACE, _key(owner, repo, pr_number))
     if item is None:
         return False
     value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
     return bool(value.get("disabled")) if isinstance(value, dict) else False
+
+
+async def get_pr_autofix_cycle_count(owner: str, repo: str, pr_number: int) -> int:
+    """Return the number of review auto-fix cycles dispatched for a PR."""
+    item = await _client().store.get_item(
+        AUTOFIX_PR_STATE_NAMESPACE,
+        f"{_key(owner, repo, pr_number)}:review_autofix_cycles",
+    )
+    if item is None:
+        return 0
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return int(value.get("cycle_count", 0)) if isinstance(value, dict) else 0
 
 
 async def set_pr_autofix_disabled(owner: str, repo: str, pr_number: int, disabled: bool) -> None:
@@ -48,4 +58,15 @@ async def set_pr_autofix_disabled(owner: str, repo: str, pr_number: int, disable
         AUTOFIX_PR_STATE_NAMESPACE,
         _key(owner, repo, pr_number),
         {"disabled": disabled, "updated_at": datetime.now(UTC).isoformat()},
+    )
+
+
+async def set_pr_autofix_cycle_count(
+    owner: str, repo: str, pr_number: int, cycle_count: int
+) -> None:
+    """Persist the review auto-fix cycle count for a PR."""
+    await _client().store.put_item(
+        AUTOFIX_PR_STATE_NAMESPACE,
+        f"{_key(owner, repo, pr_number)}:review_autofix_cycles",
+        {"cycle_count": cycle_count, "updated_at": datetime.now(UTC).isoformat()},
     )

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -293,11 +293,12 @@ async def get_team_settings() -> dict[str, Any]:
     # selection) still surface the hardcoded default instead of a null.
     overlay = {k: v for k, v in value.items() if v is not None}
     merged = {**defaults, **overlay}
+    # autofix_enabled / autofix_severity_threshold were in this stale-field
+    # purge from an older settings shape; they are supported typed settings
+    # again (review auto-fix opt-in) and must survive the response.
     for stale_field in (
         "trigger_mode",
         "autofix_mode",
-        "autofix_severity_threshold",
-        "autofix_enabled",
         "review_author_context_enabled",
     ):
         merged.pop(stale_field, None)

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -43,6 +43,11 @@ class TeamSettingsUpdate(BaseModel):
     # Tri-state LLM Gateway toggle: True/False is authoritative, None inherits the
     # LANGSMITH_GATEWAY_ENABLED deployment default.
     gateway_enabled: bool | None = None
+    # Review auto-fix opt-in. Tri-state like gateway_enabled: None preserves the
+    # stored value, so a client that doesn't render these fields cannot silently
+    # erase the opt-in by saving unrelated settings.
+    autofix_enabled: bool | None = None
+    autofix_severity_threshold: Literal["low", "medium", "high", "critical"] | None = None
     fable_enabled: bool = False
     review_tracing_project: str | None = None
     org_guidelines: str | None = None
@@ -246,6 +251,8 @@ def _default_settings() -> dict[str, Any]:
         "pr_summaries": True,
         "review_trace_links": True,
         "gateway_enabled": None,
+        "autofix_enabled": False,
+        "autofix_severity_threshold": "medium",
         "fable_enabled": False,
         "review_tracing_project": None,
         "org_guidelines": None,
@@ -269,18 +276,19 @@ def _default_settings() -> dict[str, Any]:
     }
 
 
-async def get_team_settings() -> dict[str, Any]:
-    defaults = _default_settings()
+async def _get_stored_team_settings() -> dict[str, Any]:
     try:
         item = await _client().store.get_item(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY)
     except Exception as e:
         logger.debug("team settings lookup failed: %s", e)
-        return defaults
-    if item is None:
-        return defaults
+        return {}
     value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    if not isinstance(value, dict):
-        return defaults
+    return value if isinstance(value, dict) else {}
+
+
+async def get_team_settings() -> dict[str, Any]:
+    defaults = _default_settings()
+    value = await _get_stored_team_settings()
     # Skip None-valued model fields so legacy records (or PUTs that cleared the
     # selection) still surface the hardcoded default instead of a null.
     overlay = {k: v for k, v in value.items() if v is not None}
@@ -297,11 +305,24 @@ async def get_team_settings() -> dict[str, Any]:
 
 
 async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
+    stored = await _get_stored_team_settings()
     value: dict[str, Any] = {
         "review_draft_prs": update.review_draft_prs,
         "pr_summaries": update.pr_summaries,
         "review_trace_links": update.review_trace_links,
         "gateway_enabled": update.gateway_enabled,
+        # None preserves the stored opt-in: saving unrelated settings from a
+        # client that doesn't send these fields must not disable auto-fix.
+        "autofix_enabled": (
+            update.autofix_enabled
+            if update.autofix_enabled is not None
+            else stored.get("autofix_enabled")
+        ),
+        "autofix_severity_threshold": (
+            update.autofix_severity_threshold
+            if update.autofix_severity_threshold is not None
+            else stored.get("autofix_severity_threshold")
+        ),
         "fable_enabled": update.fable_enabled,
         "review_tracing_project": update.review_tracing_project,
         "org_guidelines": update.org_guidelines,
@@ -415,6 +436,15 @@ async def get_team_default_grouping_model() -> tuple[str, str]:
         settings.get("default_reviewer_subagent_model"),
         settings.get("default_reviewer_subagent_reasoning_effort"),
     )
+
+
+async def get_team_autofix_settings() -> tuple[bool, str]:
+    """Return the review auto-fix enabled flag and severity threshold."""
+    settings = await get_team_settings()
+    threshold = settings.get("autofix_severity_threshold")
+    if threshold not in ("low", "medium", "high", "critical"):
+        threshold = "medium"
+    return settings.get("autofix_enabled") is True, threshold
 
 
 async def get_team_review_trace_links_enabled() -> bool:

--- a/agent/middleware/settle_review_check.py
+++ b/agent/middleware/settle_review_check.py
@@ -3,14 +3,14 @@
 ``publish_review`` normally completes the ``Open SWE Review`` check run and
 clears ``review_check_run_id`` from reviewer thread metadata. If the run ends
 without ever publishing (crash, model-call limit, sandbox failure), the check
-would hang "in progress" on the PR forever. This hook closes it as neutral —
-the review not completing is reviewer infrastructure failing, not the PR.
+would hang "in progress" on the PR forever. This hook closes it as neutral by
+default, or as failure when blocking review checks are enabled.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast, get_args
 
 from langchain.agents.middleware import AgentState, after_agent
 from langgraph.config import get_config
@@ -18,6 +18,7 @@ from langgraph.runtime import Runtime
 
 from ..review.findings import get_thread_metadata
 from ..review.publish import settle_review_check_run
+from ..utils.github_checks import CheckConclusion, incomplete_review_check_result
 from ..utils.github_token import get_github_token
 
 logger = logging.getLogger(__name__)
@@ -54,23 +55,12 @@ async def settle_review_check_on_exit(
         # PATCH failed transiently — retry with the real conclusion instead of
         # misreporting a published review as failed.
         pending = metadata.get("review_check_pending_result")
-        if isinstance(pending, dict) and pending.get("conclusion") in {
-            "success",
-            "neutral",
-            "failure",
-        }:
-            conclusion = pending["conclusion"]
+        if isinstance(pending, dict) and pending.get("conclusion") in get_args(CheckConclusion):
+            conclusion = cast(CheckConclusion, pending["conclusion"])
             title = str(pending.get("title") or "Review completed")
             summary = str(pending.get("summary") or "")
         else:
-            # Neutral, not failure: an incomplete review is a reviewer-infra
-            # problem, and a red X on the PR misreads as a code problem.
-            conclusion = "neutral"
-            title = "Review did not complete"
-            summary = (
-                "The Open SWE review run ended without publishing a review. "
-                "Re-trigger the review by pushing a commit or re-requesting it."
-            )
+            conclusion, title, summary = incomplete_review_check_result()
         await settle_review_check_run(
             thread_id=thread_id,
             owner=owner,

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -616,6 +616,46 @@ def _review_autofix_finding_detail(finding: Finding) -> str:
     return f"[{severity}] {file_path}:{line if isinstance(line, int) else '?'} — {title}: {description}"
 
 
+async def _verify_pr_head_is_local_branch(
+    *, owner: str, repo: str, pr_number: int, branch_name: str, token: str
+) -> None:
+    """Require the PR's head to be ``branch_name`` in ``owner/repo`` itself.
+
+    Branch names are only unique within one repository, so the thread-metadata
+    branch check in ``_thread_matches_review_pr`` is meaningful only when this
+    PR's head actually lives in the enrolled repository. A fork can carry any
+    branch name — including a copy of another thread's — so fork-headed PRs
+    never dispatch auto-fix (implementation threads always push their branches
+    to the enrolled repository). Raises on mismatch and on any fetch failure:
+    an unverifiable head fails closed.
+    """
+    from ..utils.github_http import GITHUB_API_BASE, github_client, github_request
+
+    url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}/pulls/{pr_number}"
+    async with github_client(token=token) as client:
+        response = await github_request(client, "GET", url)
+        response.raise_for_status()
+        payload = response.json()
+    head_raw = payload.get("head") if isinstance(payload, dict) else None
+    head: dict[str, Any] = head_raw if isinstance(head_raw, dict) else {}
+    repo_raw = head.get("repo")
+    head_repo: dict[str, Any] = repo_raw if isinstance(repo_raw, dict) else {}
+    head_repo_full_name = head_repo.get("full_name")
+    if not (
+        isinstance(head_repo_full_name, str)
+        and head_repo_full_name.lower() == f"{owner}/{repo}".lower()
+    ):
+        raise RuntimeError(
+            f"PR #{pr_number} head repo {head_repo_full_name!r} is not {owner}/{repo}; "
+            "refusing auto-fix dispatch for fork-headed pull requests"
+        )
+    if head.get("ref") != branch_name:
+        raise RuntimeError(
+            f"PR #{pr_number} head ref {head.get('ref')!r} does not match branch "
+            f"{branch_name!r}; refusing auto-fix dispatch"
+        )
+
+
 def _thread_matches_review_pr(
     thread: Mapping[str, Any], owner: str, repo: str, branch_name: str
 ) -> bool:
@@ -690,6 +730,9 @@ async def _maybe_dispatch_review_autofix(
             return
         if await is_pr_autofix_disabled(owner, repo, pr_number):
             return
+        await _verify_pr_head_is_local_branch(
+            owner=owner, repo=repo, pr_number=pr_number, branch_name=branch_name, token=token
+        )
         client = dispatch_client()
         implementation_thread_id, thread = await _resolve_review_autofix_thread(
             client, owner, repo, branch_name

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -48,7 +48,7 @@ from ..review.publish import (
 )
 from ..review.reconcile import reconcile_findings_with_review_threads
 from ..utils.dashboard_links import dashboard_review_url
-from ..utils.github_checks import review_check_conclusion
+from ..utils.github_checks import review_check_blocking_enabled, review_check_conclusion
 from ..utils.github_token import (
     GitHubAuthError,
     get_github_token,
@@ -192,6 +192,20 @@ async def _resolve_review_trace_url(thread_id: str, config_override: object) -> 
 
 def _is_reviewer_eval_mode(configurable: dict[str, Any]) -> bool:
     return configurable.get("reviewer_eval") is True or configurable.get("eval") is True
+
+
+async def _review_check_finding_count(thread_id: str, newly_posted_count: int) -> int:
+    # Blocking checks count all standing findings; informational checks preserve publish-time count.
+    if not review_check_blocking_enabled():
+        return newly_posted_count
+    findings = await list_findings_async(thread_id)
+    return sum(
+        1
+        for finding in findings
+        if finding.get("status", "open") == "open"
+        and isinstance((surface := finding.get("surface")), dict)
+        and surface.get("state") in {"surfaced", "resolve_pending"}
+    )
 
 
 async def _publish_review_eval_dry_run_async(
@@ -340,7 +354,8 @@ async def _publish_review_async(
         )
         await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
         await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
-        conclusion, check_title, check_summary = review_check_conclusion(0)
+        check_finding_count = await _review_check_finding_count(thread_id, 0)
+        conclusion, check_title, check_summary = review_check_conclusion(check_finding_count)
         await settle_review_check_run(
             thread_id=thread_id,
             owner=owner,
@@ -526,7 +541,8 @@ async def _publish_review_async(
 
     await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
     await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
-    conclusion, check_title, check_summary = review_check_conclusion(len(inline_comments))
+    check_finding_count = await _review_check_finding_count(thread_id, len(inline_comments))
+    conclusion, check_title, check_summary = review_check_conclusion(check_finding_count)
     await settle_review_check_run(
         thread_id=thread_id,
         owner=owner,

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -2,17 +2,31 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import Annotated, Any
 
-from langgraph.config import get_config
+from langgraph.config import get_config, get_store
 from langgraph.prebuilt import InjectedState
 
-from ..dashboard.team_settings import get_team_review_trace_links_enabled
+from ..dashboard.agent_overrides import load_profile
+from ..dashboard.autofix_state import (
+    get_pr_autofix_cycle_count,
+    is_pr_autofix_disabled,
+    set_pr_autofix_cycle_count,
+)
+from ..dashboard.enabled_repos import is_review_repo_enabled
+from ..dashboard.team_settings import (
+    get_team_autofix_settings,
+    get_team_review_trace_links_enabled,
+)
+from ..dispatch import dispatch_agent_run, dispatch_client
 from ..review.diff import compute_diff_line_set, fetch_pr_diff, is_range_in_diff
 from ..review.findings import (
+    DEFAULT_FINDING_TITLE,
     REVIEW_FINDING_CAP,
     REVIEWER_EVAL_PUBLICATION_KEY,
+    REVIEWER_THREAD_KIND,
     SEVERITY_ORDER,
     Finding,
     ReviewerThreadMissingError,
@@ -47,8 +61,13 @@ from ..review.publish import (
     settle_review_check_run,
 )
 from ..review.reconcile import reconcile_findings_with_review_threads
-from ..utils.dashboard_links import dashboard_review_url
-from ..utils.github_checks import review_check_blocking_enabled, review_check_conclusion
+from ..utils.dashboard_links import dashboard_review_url, dashboard_thread_url
+from ..utils.github_checks import (
+    post_autofix_status_check,
+    review_check_blocking_enabled,
+    review_check_conclusion,
+)
+from ..utils.github_comments import get_thread_id_from_branch
 from ..utils.github_token import (
     GitHubAuthError,
     get_github_token,
@@ -57,6 +76,11 @@ from ..utils.github_token import (
 from ..utils.langsmith import get_langsmith_trace_url
 from ..utils.slack import post_slack_thread_reply
 from ..utils.tracing import REVIEW_TRACING_PROJECT
+
+logger = logging.getLogger(__name__)
+
+_AUTOFIX_MAX_CYCLES = 2
+_AUTOFIX_NUDGE = "Process the pending Open SWE review auto-fix event for this pull request."
 
 
 async def publish_review(
@@ -109,6 +133,8 @@ async def publish_review(
     pr_number = configurable.get("pr_number")
     head_sha = configurable.get("head_sha")
     is_re_review = bool(configurable.get("re_review"))
+    raw_branch_name = configurable.get("branch_name")
+    branch_name = raw_branch_name if isinstance(raw_branch_name, str) else ""
 
     if (
         not isinstance(repo_config, dict)
@@ -156,6 +182,7 @@ async def publish_review(
             severity_threshold=_cast_severity(severity_threshold),
             cap=REVIEW_FINDING_CAP,
             is_re_review=is_re_review,
+            branch_name=branch_name,
             langgraph_run_id=_current_run_id(config),
             trace_link_config_override=configurable.get("review_trace_link_enabled"),
             state=state,
@@ -268,6 +295,7 @@ async def _publish_review_async(
     severity_threshold: Severity,
     cap: int,
     is_re_review: bool,
+    branch_name: str = "",
     langgraph_run_id: str | None = None,
     trace_link_config_override: object = None,
     state: dict[str, Any] | None = None,
@@ -552,6 +580,16 @@ async def _publish_review_async(
         title=check_title,
         summary=check_summary,
     )
+    if review_id is not None and eligible_with_payload:
+        await _maybe_dispatch_review_autofix(
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            branch_name=branch_name,
+            token=token,
+            surfaced_findings=[finding for finding, _payload in eligible_with_payload],
+        )
 
     result: dict[str, Any] = {
         "success": True,
@@ -567,6 +605,200 @@ async def _publish_review_async(
             "call update_finding to fix or resolve them."
         )
     return result
+
+
+def _review_autofix_finding_detail(finding: Finding) -> str:
+    severity = str(finding.get("severity") or "medium").upper()
+    file_path = str(finding.get("file") or "unknown file")
+    line = finding.get("end_line")
+    title = str(finding.get("title") or DEFAULT_FINDING_TITLE)
+    description = str(finding.get("description") or "").strip()
+    return f"[{severity}] {file_path}:{line if isinstance(line, int) else '?'} — {title}: {description}"
+
+
+def _thread_matches_review_pr(
+    thread: Mapping[str, Any], owner: str, repo: str, branch_name: str
+) -> bool:
+    """Reject threads that did not produce this PR's branch.
+
+    Agent thread UUIDs are embedded in branch names, and branch names are
+    author-controlled, so the UUID alone must never select a dispatch target:
+    the resolved thread's own persisted metadata has to point back at the same
+    branch (and repository, when the thread recorded one).
+    """
+    metadata = thread.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+    if metadata.get("kind") == REVIEWER_THREAD_KIND:
+        return False
+    if metadata.get("branch_name") != branch_name:
+        return False
+    repo_config = metadata.get("repo")
+    if isinstance(repo_config, Mapping) and (
+        str(repo_config.get("owner", "")).lower() != owner.lower()
+        or str(repo_config.get("name", "")).lower() != repo.lower()
+    ):
+        return False
+    return True
+
+
+async def _resolve_review_autofix_thread(
+    client: Any, owner: str, repo: str, branch_name: str
+) -> tuple[str, dict[str, Any]]:
+    thread_id = get_thread_id_from_branch(branch_name)
+    if thread_id:
+        thread = await client.threads.get(thread_id)
+        if not _thread_matches_review_pr(thread, owner, repo, branch_name):
+            raise RuntimeError(
+                f"thread {thread_id} does not match {owner}/{repo} branch {branch_name!r}; "
+                "refusing auto-fix dispatch"
+            )
+        return thread_id, thread
+    threads = await client.threads.search(metadata={"branch_name": branch_name}, limit=10)
+    for thread in threads:
+        if _thread_matches_review_pr(thread, owner, repo, branch_name):
+            return thread["thread_id"], thread
+    raise RuntimeError(f"could not resolve implementation thread from branch {branch_name!r}")
+
+
+async def _maybe_dispatch_review_autofix(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    branch_name: str,
+    token: str,
+    surfaced_findings: list[Finding],
+) -> None:
+    enabled, threshold = await get_team_autofix_settings()
+    if not enabled:
+        return
+    severity_rank = SEVERITY_ORDER[_cast_severity(threshold)]
+    qualifying_findings = [
+        finding
+        for finding in surfaced_findings
+        if SEVERITY_ORDER.get(finding.get("severity", "low"), 0) >= severity_rank
+    ]
+    if not qualifying_findings:
+        return
+
+    implementation_thread_id: str | None = None
+    pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_number}"
+    try:
+        if not await is_review_repo_enabled(owner, repo):
+            return
+        if await is_pr_autofix_disabled(owner, repo, pr_number):
+            return
+        client = dispatch_client()
+        implementation_thread_id, thread = await _resolve_review_autofix_thread(
+            client, owner, repo, branch_name
+        )
+        metadata = thread["metadata"]
+        github_login = metadata.get("github_login")
+        if github_login:
+            profile = await load_profile(github_login)
+            if isinstance(profile, dict) and profile.get("auto_fix_ci") is False:
+                return
+        source = metadata.get("source")
+        if not source:
+            raise RuntimeError(
+                f"implementation thread {implementation_thread_id} has no source metadata"
+            )
+        configurable: dict[str, Any] = {
+            "thread_id": implementation_thread_id,
+            "source": source,
+            "repo": {"owner": owner, "name": repo},
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "head_sha": head_sha,
+        }
+        for metadata_key, configurable_key in (
+            ("github_login", "github_login"),
+            ("triggering_user_email", "user_email"),
+        ):
+            value = metadata.get(metadata_key)
+            if value is not None:
+                configurable[configurable_key] = value
+        source_context = metadata.get("source_context")
+        if isinstance(source_context, dict):
+            for key in ("slack_thread", "linear_issue", "github_issue"):
+                value = source_context.get(key)
+                if isinstance(value, dict):
+                    configurable[key] = value
+
+        cycle_count = await get_pr_autofix_cycle_count(owner, repo, pr_number)
+        if cycle_count >= _AUTOFIX_MAX_CYCLES:
+            await post_autofix_status_check(
+                owner=owner,
+                repo=repo,
+                head_sha=head_sha,
+                token=token,
+                title="Auto-fix cycle limit reached",
+                summary=(
+                    "Open SWE did not dispatch another fix run because this pull request "
+                    f"has reached the {_AUTOFIX_MAX_CYCLES}-cycle limit."
+                ),
+                details_url=dashboard_thread_url(implementation_thread_id),
+            )
+            return
+
+        details = [
+            f"PR: {pr_url}",
+            f"Head SHA: {head_sha}",
+            *[_review_autofix_finding_detail(finding) for finding in qualifying_findings],
+        ]
+        store = get_store()
+        pending_namespace = ("autofix", implementation_thread_id)
+        await store.aput(
+            pending_namespace,
+            "pending_event",
+            {"reason": "Open SWE Review surfaced findings for auto-fix.", "details": details},
+        )
+        next_cycle = cycle_count + 1
+        try:
+            await dispatch_agent_run(
+                implementation_thread_id,
+                _AUTOFIX_NUDGE,
+                configurable,
+                source="review_autofix",
+                client=client,
+            )
+        except BaseException:
+            # Accepted runs may outlive cancellation; pending_event is best-effort PR context.
+            await store.adelete(pending_namespace, "pending_event")
+            raise
+        # Deliberate ordering: count the cycle only after dispatch succeeds, so a
+        # transient dispatch failure never burns the small cycle budget. The
+        # opposite race (dispatch accepted, count write fails) at worst allows one
+        # extra cycle, and while the store is down later publishes fail closed on
+        # the cycle read anyway.
+        await set_pr_autofix_cycle_count(owner, repo, pr_number, next_cycle)
+        await post_autofix_status_check(
+            owner=owner,
+            repo=repo,
+            head_sha=head_sha,
+            token=token,
+            title=f"Auto-fix cycle {next_cycle} dispatched",
+            summary=(
+                f"Open SWE dispatched auto-fix cycle {next_cycle} of {_AUTOFIX_MAX_CYCLES} "
+                f"for {len(qualifying_findings)} newly surfaced review finding(s)."
+            ),
+            details_url=dashboard_thread_url(implementation_thread_id),
+        )
+    except Exception as exc:
+        logger.exception("Review auto-fix producer failed for %s/%s#%s", owner, repo, pr_number)
+        await post_autofix_status_check(
+            owner=owner,
+            repo=repo,
+            head_sha=head_sha,
+            token=token,
+            title="Auto-fix dispatch failed",
+            summary=f"Open SWE could not dispatch auto-fix for {pr_url}: {type(exc).__name__}",
+            details_url=(
+                dashboard_thread_url(implementation_thread_id) if implementation_thread_id else None
+            ),
+        )
 
 
 async def _open_swe_already_reviewed(

--- a/agent/utils/github_checks.py
+++ b/agent/utils/github_checks.py
@@ -12,6 +12,7 @@ break review dispatch or publish.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -153,18 +154,36 @@ async def post_autofix_status_check(
     return True
 
 
-def review_check_conclusion(surfaced_count: int) -> tuple[CheckConclusion, str, str]:
-    """Map a publish result to (conclusion, title, summary).
+def review_check_blocking_enabled() -> bool:
+    """Return whether surfaced findings should fail the review check.
 
-    Always ``success`` so the check is informational and non-blocking, and so
-    GitHub groups it under "successful checks" rather than a confusing
-    "neutral check". The finding count is surfaced in the title; the findings
-    themselves are posted as PR comments.
+    Deliberately env-scoped (deployment-level merge policy) rather than a team
+    setting: whoever operates branch protection owns this toggle.
     """
+    return os.getenv("REVIEW_CHECK_BLOCKING", "").lower() in {"1", "true", "yes"}
+
+
+def incomplete_review_check_result() -> tuple[CheckConclusion, str, str]:
+    """Conclusion for a review run that ended without publishing.
+
+    Shared by every settle path (after-agent middleware and the run-completion
+    handler) so an unfinished review cannot satisfy a blocking check through
+    one path while failing it through another.
+    """
+    return (
+        "failure" if review_check_blocking_enabled() else "neutral",
+        "Review did not complete",
+        "The Open SWE review run ended without publishing a review. "
+        "Re-trigger the review by pushing a commit or re-requesting it.",
+    )
+
+
+def review_check_conclusion(surfaced_count: int) -> tuple[CheckConclusion, str, str]:
+    """Map a publish result to (conclusion, title, summary)."""
     if surfaced_count > 0:
         issue_word = "issue" if surfaced_count == 1 else "issues"
         return (
-            "success",
+            "failure" if review_check_blocking_enabled() else "success",
             f"Found {surfaced_count} potential {issue_word}",
             f"Open SWE surfaced {surfaced_count} potential {issue_word} on this pull request.",
         )

--- a/tests/dashboard/test_autofix_state.py
+++ b/tests/dashboard/test_autofix_state.py
@@ -11,7 +11,7 @@ from agent.dashboard import autofix_state
 
 
 @pytest.mark.asyncio
-async def test_set_and_check_pr_disabled() -> None:
+async def test_pr_cycle_count_uses_sibling_state_record() -> None:
     store: dict[tuple[Any, ...], Any] = {}
     client = MagicMock()
 
@@ -27,7 +27,12 @@ async def test_set_and_check_pr_disabled() -> None:
 
     with patch.object(autofix_state, "get_client", return_value=client):
         assert await autofix_state.is_pr_autofix_disabled("O", "R", 5) is False
+        assert await autofix_state.get_pr_autofix_cycle_count("O", "R", 5) == 0
         await autofix_state.set_pr_autofix_disabled("O", "R", 5, True)
+        await autofix_state.set_pr_autofix_cycle_count("O", "R", 5, 1)
         assert await autofix_state.is_pr_autofix_disabled("o", "r", 5) is True
-        await autofix_state.set_pr_autofix_disabled("o", "r", 5, False)
-        assert await autofix_state.is_pr_autofix_disabled("o", "r", 5) is False
+        assert await autofix_state.get_pr_autofix_cycle_count("o", "r", 5) == 1
+
+    namespace = ("autofix_pr_state",)
+    assert store[(namespace, "o/r#5")]["disabled"] is True
+    assert store[(namespace, "o/r#5:review_autofix_cycles")]["cycle_count"] == 1

--- a/tests/dashboard/test_team_settings_autofix.py
+++ b/tests/dashboard/test_team_settings_autofix.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.dashboard.team_settings import (
+    TeamSettingsUpdate,
+    get_team_autofix_settings,
+    upsert_team_settings,
+)
+
+# --- accessor: get_team_autofix_settings (async, patched settings) ---
+
+
+@pytest.mark.asyncio
+async def test_autofix_defaults_off_when_absent() -> None:
+    # Legacy record with no autofix keys -> disabled, medium threshold.
+    with patch(
+        "agent.dashboard.team_settings.get_team_settings",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        assert await get_team_autofix_settings() == (False, "medium")
+
+
+@pytest.mark.asyncio
+async def test_autofix_enabled_with_threshold() -> None:
+    with patch(
+        "agent.dashboard.team_settings.get_team_settings",
+        new_callable=AsyncMock,
+        return_value={"autofix_enabled": True, "autofix_severity_threshold": "high"},
+    ):
+        assert await get_team_autofix_settings() == (True, "high")
+
+
+@pytest.mark.asyncio
+async def test_autofix_invalid_values_fail_closed() -> None:
+    # Fail-closed: non-bool enabled reads as off, unknown threshold as medium.
+    with patch(
+        "agent.dashboard.team_settings.get_team_settings",
+        new_callable=AsyncMock,
+        return_value={"autofix_enabled": "true", "autofix_severity_threshold": "extreme"},
+    ):
+        assert await get_team_autofix_settings() == (False, "medium")
+
+
+# --- upsert: unrelated saves must not erase the opt-in ---
+
+
+def _put_capture() -> tuple[MagicMock, AsyncMock]:
+    client = MagicMock()
+    put = AsyncMock()
+    client.store.put_item = put
+    return client, put
+
+
+@pytest.mark.asyncio
+async def test_upsert_without_autofix_fields_preserves_stored_opt_in() -> None:
+    client, put = _put_capture()
+    with (
+        patch(
+            "agent.dashboard.team_settings._get_stored_team_settings",
+            new_callable=AsyncMock,
+            return_value={"autofix_enabled": True, "autofix_severity_threshold": "high"},
+        ),
+        patch("agent.dashboard.team_settings._client", return_value=client),
+    ):
+        value = await upsert_team_settings(TeamSettingsUpdate())
+
+    put.assert_awaited_once()
+    assert value["autofix_enabled"] is True
+    assert value["autofix_severity_threshold"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_upsert_sets_autofix_fields_explicitly() -> None:
+    client, put = _put_capture()
+    with (
+        patch(
+            "agent.dashboard.team_settings._get_stored_team_settings",
+            new_callable=AsyncMock,
+            return_value={"autofix_enabled": True, "autofix_severity_threshold": "high"},
+        ),
+        patch("agent.dashboard.team_settings._client", return_value=client),
+    ):
+        value = await upsert_team_settings(
+            TeamSettingsUpdate(autofix_enabled=False, autofix_severity_threshold="low")
+        )
+
+    put.assert_awaited_once()
+    assert value["autofix_enabled"] is False
+    assert value["autofix_severity_threshold"] == "low"
+
+
+def test_update_rejects_unknown_threshold() -> None:
+    with pytest.raises(ValueError):
+        TeamSettingsUpdate(autofix_severity_threshold="extreme")  # type: ignore[arg-type]

--- a/tests/dashboard/test_team_settings_autofix.py
+++ b/tests/dashboard/test_team_settings_autofix.py
@@ -45,6 +45,20 @@ async def test_autofix_invalid_values_fail_closed() -> None:
         assert await get_team_autofix_settings() == (False, "medium")
 
 
+@pytest.mark.asyncio
+async def test_autofix_settings_survive_team_settings_scrub() -> None:
+    # Regression (caught live by canary 3): get_team_settings carries a
+    # stale-field purge that previously deleted the autofix keys from every
+    # response, so the accessor read the opt-in as permanently off. This test
+    # goes through the REAL get_team_settings — mocking it hides the scrub.
+    with patch(
+        "agent.dashboard.team_settings._get_stored_team_settings",
+        new_callable=AsyncMock,
+        return_value={"autofix_enabled": True, "autofix_severity_threshold": "high"},
+    ):
+        assert await get_team_autofix_settings() == (True, "high")
+
+
 # --- upsert: unrelated saves must not erase the opt-in ---
 
 

--- a/tests/github/test_github_checks.py
+++ b/tests/github/test_github_checks.py
@@ -146,18 +146,85 @@ async def test_post_autofix_status_check_completes_neutral(
     assert body["details_url"] == "https://example.com/thread"
 
 
-def test_review_check_conclusion_mapping() -> None:
-    conclusion, title, _ = github_checks.review_check_conclusion(0)
-    assert conclusion == "success"
-    assert title == "No issues found"
+@pytest.mark.parametrize(
+    ("flag", "surfaced_count", "expected"),
+    [
+        (
+            None,
+            0,
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+        (
+            None,
+            3,
+            (
+                "success",
+                "Found 3 potential issues",
+                "Open SWE surfaced 3 potential issues on this pull request.",
+            ),
+        ),
+        (
+            "true",
+            0,
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+        (
+            "true",
+            1,
+            (
+                "failure",
+                "Found 1 potential issue",
+                "Open SWE surfaced 1 potential issue on this pull request.",
+            ),
+        ),
+        (
+            "TRUE",
+            2,
+            (
+                "failure",
+                "Found 2 potential issues",
+                "Open SWE surfaced 2 potential issues on this pull request.",
+            ),
+        ),
+        (
+            "false",
+            2,
+            (
+                "success",
+                "Found 2 potential issues",
+                "Open SWE surfaced 2 potential issues on this pull request.",
+            ),
+        ),
+    ],
+    ids=[
+        "flag-unset-zero-findings-success",
+        "flag-unset-three-findings-success",
+        "flag-true-zero-findings-success",
+        "flag-true-one-finding-failure",
+        "flag-uppercase-true-two-findings-failure",
+        "flag-false-two-findings-success",
+    ],
+)
+def test_review_check_conclusion_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str | None,
+    surfaced_count: int,
+    expected: tuple[str, str, str],
+) -> None:
+    if flag is None:
+        monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
+    else:
+        monkeypatch.setenv("REVIEW_CHECK_BLOCKING", flag)
 
-    conclusion, title, _ = github_checks.review_check_conclusion(1)
-    assert conclusion == "success"
-    assert "1 potential issue" in title
-
-    conclusion, title, _ = github_checks.review_check_conclusion(3)
-    assert conclusion == "success"
-    assert "3 potential issues" in title
+    assert github_checks.review_check_conclusion(surfaced_count) == expected
 
 
 async def test_settle_review_check_run_noop_without_tracked_id(

--- a/tests/middleware/test_settle_review_check.py
+++ b/tests/middleware/test_settle_review_check.py
@@ -1,0 +1,78 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain.agents.middleware import AgentState
+
+from agent.middleware.settle_review_check import settle_review_check_on_exit
+
+
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [
+        (
+            None,
+            (
+                "neutral",
+                "Review did not complete",
+                "The Open SWE review run ended without publishing a review. "
+                "Re-trigger the review by pushing a commit or re-requesting it.",
+            ),
+        ),
+        (
+            "true",
+            (
+                "failure",
+                "Review did not complete",
+                "The Open SWE review run ended without publishing a review. "
+                "Re-trigger the review by pushing a commit or re-requesting it.",
+            ),
+        ),
+    ],
+    ids=["flag-unset-neutral", "flag-true-failure"],
+)
+async def test_unpublished_review_settle_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str | None,
+    expected: tuple[str, str, str],
+) -> None:
+    if flag is None:
+        monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
+    else:
+        monkeypatch.setenv("REVIEW_CHECK_BLOCKING", flag)
+
+    state: AgentState = {"messages": []}
+    with (
+        patch(
+            "agent.middleware.settle_review_check.get_config",
+            return_value={
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "repo": {"owner": "acme", "name": "widgets"},
+                }
+            },
+        ),
+        patch(
+            "agent.middleware.settle_review_check.get_thread_metadata",
+            new_callable=AsyncMock,
+            return_value={"review_check_run_id": 42},
+        ),
+        patch(
+            "agent.middleware.settle_review_check.get_github_token",
+            return_value="token",
+        ),
+        patch(
+            "agent.middleware.settle_review_check.settle_review_check_run",
+            new_callable=AsyncMock,
+        ) as settle,
+    ):
+        result = await settle_review_check_on_exit.aafter_agent(state, MagicMock())
+
+    assert result is None
+    settle.assert_awaited_once()
+    call = settle.await_args
+    assert call is not None
+    assert (
+        call.kwargs["conclusion"],
+        call.kwargs["title"],
+        call.kwargs["summary"],
+    ) == expected

--- a/tests/reviewer/test_review_autofix_producer.py
+++ b/tests/reviewer/test_review_autofix_producer.py
@@ -105,6 +105,15 @@ def _autofix_profile_enabled() -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _pr_head_verified() -> Iterator[None]:
+    with patch(
+        "agent.tools.publish_review._verify_pr_head_is_local_branch",
+        AsyncMock(return_value=None),
+    ):
+        yield
+
+
 @contextmanager
 def _autofix_dependencies(store: _Store) -> Iterator[None]:
     with (
@@ -416,6 +425,101 @@ async def test_review_autofix_cycle_read_failure_skips_dispatch() -> None:
     assert status_args is not None
     assert status_args.kwargs["title"] == "Auto-fix dispatch failed"
     assert status_args.kwargs["summary"].endswith(": RuntimeError")
+
+
+# Captured before the autouse fixture patches the module attribute.
+from agent.tools.publish_review import (  # noqa: E402
+    _verify_pr_head_is_local_branch as _real_verify_pr_head,
+)
+
+
+def _pr_payload(full_name: str, ref: str) -> dict[str, Any]:
+    return {"head": {"repo": {"full_name": full_name}, "ref": ref}}
+
+
+def _patched_pr_fetch(payload: dict[str, Any]):  # noqa: ANN202
+    from contextlib import asynccontextmanager
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value=payload)
+
+    @asynccontextmanager
+    async def fake_client(**_kwargs: Any):  # noqa: ANN202
+        yield MagicMock()
+
+    return (
+        patch("agent.utils.github_http.github_client", fake_client),
+        patch("agent.utils.github_http.github_request", AsyncMock(return_value=response)),
+    )
+
+
+async def test_verify_pr_head_accepts_local_branch() -> None:
+    client_patch, request_patch = _patched_pr_fetch(_pr_payload("o/r", _BRANCH))
+    with client_patch, request_patch:
+        await _real_verify_pr_head(owner="o", repo="r", pr_number=7, branch_name=_BRANCH, token="t")
+
+
+async def test_verify_pr_head_rejects_fork_head() -> None:
+    # A fork can carry any branch name, including a copy of a victim thread's.
+    client_patch, request_patch = _patched_pr_fetch(_pr_payload("attacker/fork", _BRANCH))
+    with client_patch, request_patch:
+        with pytest.raises(RuntimeError, match="fork-headed"):
+            await _real_verify_pr_head(
+                owner="o", repo="r", pr_number=7, branch_name=_BRANCH, token="t"
+            )
+
+
+async def test_verify_pr_head_rejects_mismatched_ref() -> None:
+    client_patch, request_patch = _patched_pr_fetch(_pr_payload("o/r", "other-branch"))
+    with client_patch, request_patch:
+        with pytest.raises(RuntimeError, match="does not match branch"):
+            await _real_verify_pr_head(
+                owner="o", repo="r", pr_number=7, branch_name=_BRANCH, token="t"
+            )
+
+
+async def test_review_autofix_unverifiable_pr_head_skips_dispatch() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    dispatch = AsyncMock()
+    status = AsyncMock(return_value=True)
+    with (
+        patch(
+            "agent.tools.publish_review.get_team_autofix_settings",
+            AsyncMock(return_value=(True, "medium")),
+        ),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "agent.tools.publish_review._verify_pr_head_is_local_branch",
+            AsyncMock(side_effect=RuntimeError("head repo mismatch")),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    dispatch.assert_not_awaited()
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix dispatch failed"
 
 
 def test_thread_match_rejects_forged_and_foreign_threads() -> None:

--- a/tests/reviewer/test_review_autofix_producer.py
+++ b/tests/reviewer/test_review_autofix_producer.py
@@ -1,0 +1,757 @@
+"""Focused contract tests for the review-publish auto-fix producer."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.review.findings import Finding, Severity, new_finding
+from agent.review.publish import render_inline_comment_body
+
+_THREAD_ID = "123e4567-e89b-12d3-a456-426614174000"
+_BRANCH = f"open-swe/{_THREAD_ID}-fix-review"
+_SLUG_BRANCH = "open-swe/fix-review"
+_PENDING_KEY = (("autofix", _THREAD_ID), "pending_event")
+
+
+class _Store:
+    def __init__(self, *, enabled: bool = True, threshold: str = "medium") -> None:
+        self.enabled = enabled
+        self.threshold = threshold
+        self.cycle_count = 0
+        self.items: dict[tuple[tuple[str, ...], str], dict[str, Any]] = {}
+        self.puts: list[tuple[tuple[str, ...], str, dict[str, Any]]] = []
+        self.deleted: list[tuple[tuple[str, ...], str]] = []
+        self.fail_put_namespace: tuple[str, ...] | None = None
+
+    async def aput(self, namespace: tuple[str, ...], key: str, value: dict[str, Any]) -> None:
+        if namespace == self.fail_put_namespace:
+            raise RuntimeError("store unavailable")
+        self.items[(namespace, key)] = value
+        self.puts.append((namespace, key, value))
+
+    async def adelete(self, namespace: tuple[str, ...], key: str) -> None:
+        self.items.pop((namespace, key), None)
+        self.deleted.append((namespace, key))
+
+    async def get_cycle_count(self, owner: str, repo: str, pr_number: int) -> int:
+        return self.cycle_count
+
+    async def set_cycle_count(
+        self, owner: str, repo: str, pr_number: int, cycle_count: int
+    ) -> None:
+        self.cycle_count = cycle_count
+
+
+def _finding(*, severity: Severity = "high") -> Finding:
+    return new_finding(
+        severity=severity,
+        confidence="high",
+        category="correctness",
+        file="src/foo.py",
+        start_line=10,
+        end_line=10,
+        title="Broken guard",
+        description="boom",
+        suggestion="return early",
+        sha="head-sha",
+        finding_id="finding-1",
+    )
+
+
+def test_review_autofix_finding_detail_handles_legacy_title() -> None:
+    from agent.tools.publish_review import _review_autofix_finding_detail
+
+    finding = _finding()
+    finding.pop("title")
+    assert _review_autofix_finding_detail(finding) == (
+        "[HIGH] src/foo.py:10 — Code review finding: boom"
+    )
+
+
+def _client(*, branch_name: str = _BRANCH, search_result: bool = True) -> MagicMock:
+    client = MagicMock()
+    thread = {
+        "thread_id": _THREAD_ID,
+        "metadata": {
+            "branch_name": branch_name,
+            "source": "linear",
+            "github_login": "octocat",
+            "triggering_user_email": "octocat@example.com",
+            "source_context": {
+                "linear_issue": {
+                    "linear_project_id": "OSWE",
+                    "linear_issue_number": "56",
+                }
+            },
+        },
+    }
+    client.threads.search = AsyncMock(return_value=[thread] if search_result else [])
+    client.threads.get = AsyncMock(return_value=thread)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _autofix_profile_enabled() -> Iterator[None]:
+    with patch(
+        "agent.tools.publish_review.load_profile",
+        AsyncMock(return_value={"auto_fix_ci": True}),
+    ):
+        yield
+
+
+@contextmanager
+def _autofix_dependencies(store: _Store) -> Iterator[None]:
+    with (
+        patch(
+            "agent.tools.publish_review.get_team_autofix_settings",
+            AsyncMock(return_value=(store.enabled, store.threshold)),
+        ),
+        patch(
+            "agent.tools.publish_review.get_pr_autofix_cycle_count",
+            AsyncMock(side_effect=store.get_cycle_count),
+        ),
+        patch(
+            "agent.tools.publish_review.set_pr_autofix_cycle_count",
+            AsyncMock(side_effect=store.set_cycle_count),
+        ),
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("case", "enabled", "threshold", "severity", "repo_enabled", "pr_disabled", "findings"),
+    [
+        ("autofix-disabled", False, "medium", "high", True, False, 1),
+        ("below-threshold", True, "high", "medium", True, False, 1),
+        ("repo-not-enrolled", True, "medium", "high", False, False, 1),
+        ("pr-opted-out", True, "medium", "high", True, True, 1),
+        ("zero-newly-surfaced", True, "medium", "high", True, False, 0),
+    ],
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+async def test_review_autofix_trigger_truth_table_false_cases(
+    case: str,
+    enabled: bool,
+    threshold: str,
+    severity: Severity,
+    repo_enabled: bool,
+    pr_disabled: bool,
+    findings: int,
+) -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    del case
+    store = _Store(enabled=enabled, threshold=threshold)
+    dispatch = AsyncMock()
+    status = AsyncMock()
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=repo_enabled),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=pr_disabled),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding(severity=severity)] if findings else [],
+        )
+
+    assert _PENDING_KEY not in store.items
+    assert store.cycle_count == 0
+    dispatch.assert_not_awaited()
+    status.assert_not_awaited()
+
+
+async def test_review_autofix_profile_disabled_skips_dispatch() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    store = _Store()
+    client = _client()
+    dispatch = AsyncMock()
+    load_profile = AsyncMock(return_value={"auto_fix_ci": False})
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=client),
+        patch("agent.tools.publish_review.load_profile", load_profile),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    load_profile.assert_awaited_once_with("octocat")
+    assert _PENDING_KEY not in store.items
+    assert store.cycle_count == 0
+    dispatch.assert_not_awaited()
+
+
+async def test_review_autofix_slug_branch_enqueues_event_and_dispatches_minimal_nudge() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    store = _Store()
+    client = _client(branch_name=_SLUG_BRANCH)
+    dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    status = AsyncMock(return_value=True)
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=client),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_SLUG_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    client.threads.search.assert_awaited_once_with(
+        metadata={"branch_name": _SLUG_BRANCH},
+        limit=10,
+    )
+    client.threads.get.assert_not_awaited()
+    assert store.items[_PENDING_KEY] == {
+        "reason": "Open SWE Review surfaced findings for auto-fix.",
+        "details": [
+            "PR: https://github.com/o/r/pull/7",
+            "Head SHA: head-sha",
+            "[HIGH] src/foo.py:10 — Broken guard: boom",
+        ],
+    }
+    assert store.cycle_count == 1
+    dispatch.assert_awaited_once_with(
+        _THREAD_ID,
+        "Process the pending Open SWE review auto-fix event for this pull request.",
+        {
+            "thread_id": _THREAD_ID,
+            "source": "linear",
+            "repo": {"owner": "o", "name": "r"},
+            "pr_number": 7,
+            "pr_url": "https://github.com/o/r/pull/7",
+            "head_sha": "head-sha",
+            "github_login": "octocat",
+            "user_email": "octocat@example.com",
+            "linear_issue": {
+                "linear_project_id": "OSWE",
+                "linear_issue_number": "56",
+            },
+        },
+        source="review_autofix",
+        client=client,
+    )
+    dispatch_args = dispatch.await_args
+    assert dispatch_args is not None
+    assert "boom" not in dispatch_args.args[1]
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix cycle 1 dispatched"
+
+
+async def test_review_autofix_cycle_cap_stops_third_publish_and_survives_opt_out() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    store = _Store()
+    dispatch = AsyncMock(return_value={"run_id": "run-1"})
+    status = AsyncMock(return_value=True)
+    pr_disabled = AsyncMock(side_effect=[False, False, True, False])
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch("agent.tools.publish_review.is_pr_autofix_disabled", pr_disabled),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        for _ in range(4):
+            await _maybe_dispatch_review_autofix(
+                owner="o",
+                repo="r",
+                pr_number=7,
+                head_sha="head-sha",
+                branch_name=_BRANCH,
+                token="token",
+                surfaced_findings=[_finding()],
+            )
+
+    assert dispatch.await_count == 2
+    assert store.cycle_count == 2
+    assert [call.kwargs["title"] for call in status.await_args_list] == [
+        "Auto-fix cycle 1 dispatched",
+        "Auto-fix cycle 2 dispatched",
+        "Auto-fix cycle limit reached",
+    ]
+
+
+@pytest.mark.parametrize("failure", ["thread-resolution", "store-write"])
+async def test_review_autofix_producer_errors_are_neutral_and_do_not_raise(failure: str) -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    store = _Store()
+    if failure == "store-write":
+        store.fail_put_namespace = ("autofix", _THREAD_ID)
+    dispatch = AsyncMock()
+    status = AsyncMock(return_value=True)
+    client = _client(search_result=failure != "thread-resolution")
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=client),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name="open-swe/no-thread-id" if failure == "thread-resolution" else _BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix dispatch failed"
+
+
+async def test_review_autofix_cycle_read_failure_skips_dispatch() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    dispatch = AsyncMock()
+    status = AsyncMock(return_value=True)
+    with (
+        patch(
+            "agent.tools.publish_review.get_team_autofix_settings",
+            AsyncMock(return_value=(True, "medium")),
+        ),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch(
+            "agent.tools.publish_review.get_pr_autofix_cycle_count",
+            AsyncMock(side_effect=RuntimeError("store unavailable")),
+        ),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    dispatch.assert_not_awaited()
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix dispatch failed"
+    assert status_args.kwargs["summary"].endswith(": RuntimeError")
+
+
+def test_thread_match_rejects_forged_and_foreign_threads() -> None:
+    from agent.tools.publish_review import _thread_matches_review_pr
+
+    matching = {"metadata": {"branch_name": _BRANCH, "source": "linear"}}
+    assert _thread_matches_review_pr(matching, "o", "r", _BRANCH)
+
+    wrong_branch = {"metadata": {"branch_name": "open-swe/other", "source": "linear"}}
+    assert not _thread_matches_review_pr(wrong_branch, "o", "r", _BRANCH)
+
+    reviewer = {"metadata": {"branch_name": _BRANCH, "kind": "reviewer"}}
+    assert not _thread_matches_review_pr(reviewer, "o", "r", _BRANCH)
+
+    foreign_repo = {
+        "metadata": {"branch_name": _BRANCH, "repo": {"owner": "other", "name": "repo"}}
+    }
+    assert not _thread_matches_review_pr(foreign_repo, "o", "r", _BRANCH)
+
+    same_repo = {"metadata": {"branch_name": _BRANCH, "repo": {"owner": "O", "name": "R"}}}
+    assert _thread_matches_review_pr(same_repo, "o", "r", _BRANCH)
+
+    assert not _thread_matches_review_pr({"metadata": None}, "o", "r", _BRANCH)
+
+
+async def test_review_autofix_rejects_thread_that_does_not_match_branch() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    # The PR branch embeds a valid thread UUID, but that thread's own metadata
+    # names a different branch: a forged branch must not select a dispatch target.
+    dispatch = AsyncMock()
+    status = AsyncMock(return_value=True)
+    with (
+        patch(
+            "agent.tools.publish_review.get_team_autofix_settings",
+            AsyncMock(return_value=(True, "medium")),
+        ),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "agent.tools.publish_review.dispatch_client",
+            return_value=_client(branch_name="open-swe/some-other-branch"),
+        ),
+        patch(
+            "agent.tools.publish_review.get_pr_autofix_cycle_count",
+            AsyncMock(return_value=0),
+        ),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    dispatch.assert_not_awaited()
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix dispatch failed"
+
+
+async def test_review_autofix_optout_read_failure_skips_dispatch() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    dispatch = AsyncMock()
+    status = AsyncMock(return_value=True)
+    with (
+        patch(
+            "agent.tools.publish_review.get_team_autofix_settings",
+            AsyncMock(return_value=(True, "medium")),
+        ),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(side_effect=RuntimeError("store unavailable")),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    # An unreadable opt-out record must abort dispatch, not read as opted-in.
+    dispatch.assert_not_awaited()
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix dispatch failed"
+
+
+async def test_review_autofix_dispatch_failure_clears_pending_event() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    store = _Store()
+    store.cycle_count = 1
+    status = AsyncMock(return_value=True)
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch(
+            "agent.tools.publish_review.dispatch_agent_run",
+            AsyncMock(side_effect=RuntimeError("dispatch unavailable")),
+        ),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    assert _PENDING_KEY not in store.items
+    assert store.deleted == [_PENDING_KEY]
+    assert store.cycle_count == 1
+    status.assert_awaited_once()
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["summary"] == (
+        "Open SWE could not dispatch auto-fix for https://github.com/o/r/pull/7: RuntimeError"
+    )
+
+
+async def test_review_autofix_dispatch_cancellation_clears_pending_event() -> None:
+    from agent.tools.publish_review import _maybe_dispatch_review_autofix
+
+    store = _Store()
+    status = AsyncMock(return_value=True)
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch(
+            "agent.tools.publish_review.dispatch_agent_run",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await _maybe_dispatch_review_autofix(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            branch_name=_BRANCH,
+            token="token",
+            surfaced_findings=[_finding()],
+        )
+
+    assert _PENDING_KEY not in store.items
+    assert store.deleted == [_PENDING_KEY]
+    assert store.cycle_count == 0
+    status.assert_not_awaited()
+
+
+async def test_publish_review_config_off_preserves_literal_outcome() -> None:
+    from agent.tools.publish_review import _publish_review_async
+
+    finding = _finding()
+    store = _Store(enabled=False)
+    post_review = AsyncMock(return_value={"id": 555})
+    dispatch = AsyncMock()
+    status = AsyncMock()
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="reviewer"),
+        patch(
+            "agent.tools.publish_review.list_findings_async",
+            AsyncMock(return_value=[finding]),
+        ),
+        patch("agent.tools.publish_review.post_pull_request_review", post_review),
+        patch("agent.tools.publish_review.fetch_review_comments", AsyncMock(return_value=[])),
+        patch("agent.tools.publish_review._record_review_publication", AsyncMock()),
+        patch(
+            "agent.tools.publish_review._missing_comment_ids_for_published_findings",
+            return_value=False,
+        ),
+        patch("agent.tools.publish_review._store_thread_ids_on_findings", AsyncMock()),
+        patch(
+            "agent.tools.publish_review._resolve_threads_for_resolved_findings",
+            AsyncMock(return_value=0),
+        ),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()),
+        patch("agent.tools.publish_review._maybe_post_slack_completion_reply", AsyncMock()),
+        patch("agent.tools.publish_review.settle_review_check_run", AsyncMock()),
+        patch("agent.tools.publish_review.dispatch_agent_run", dispatch),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        result = await _publish_review_async(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            token="token",
+            severity_threshold="medium",
+            cap=15,
+            is_re_review=False,
+            branch_name=_BRANCH,
+        )
+
+    assert result == {
+        "success": True,
+        "review_id": 555,
+        "surfaced_count": 1,
+        "hidden_count": 0,
+        "resolved_thread_count": 0,
+    }
+    post_review_args = post_review.await_args
+    assert post_review_args is not None
+    assert (
+        post_review_args.kwargs["head_sha"],
+        post_review_args.kwargs["inline_comments"],
+    ) == (
+        "head-sha",
+        [
+            {
+                "path": "src/foo.py",
+                "line": 10,
+                "side": "RIGHT",
+                "body": render_inline_comment_body(finding),
+            }
+        ],
+    )
+    assert store.puts == []
+    dispatch.assert_not_awaited()
+    status.assert_not_awaited()
+
+
+async def test_publish_review_succeeds_when_autofix_store_write_raises() -> None:
+    from agent.tools.publish_review import _publish_review_async
+
+    finding = _finding()
+    store = _Store()
+    store.fail_put_namespace = ("autofix", _THREAD_ID)
+    status = AsyncMock(return_value=True)
+    with (
+        _autofix_dependencies(store),
+        patch("agent.tools.publish_review.get_store", return_value=store),
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="reviewer"),
+        patch(
+            "agent.tools.publish_review.list_findings_async",
+            AsyncMock(return_value=[finding]),
+        ),
+        patch(
+            "agent.tools.publish_review.post_pull_request_review",
+            AsyncMock(return_value={"id": 555}),
+        ),
+        patch("agent.tools.publish_review.fetch_review_comments", AsyncMock(return_value=[])),
+        patch("agent.tools.publish_review._record_review_publication", AsyncMock()),
+        patch(
+            "agent.tools.publish_review._missing_comment_ids_for_published_findings",
+            return_value=False,
+        ),
+        patch("agent.tools.publish_review._store_thread_ids_on_findings", AsyncMock()),
+        patch(
+            "agent.tools.publish_review._resolve_threads_for_resolved_findings",
+            AsyncMock(return_value=0),
+        ),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()),
+        patch("agent.tools.publish_review._maybe_post_slack_completion_reply", AsyncMock()),
+        patch("agent.tools.publish_review.settle_review_check_run", AsyncMock()),
+        patch(
+            "agent.tools.publish_review.is_review_repo_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review.is_pr_autofix_disabled",
+            AsyncMock(return_value=False),
+        ),
+        patch("agent.tools.publish_review.dispatch_client", return_value=_client()),
+        patch("agent.tools.publish_review.dispatch_agent_run", AsyncMock()),
+        patch("agent.tools.publish_review.post_autofix_status_check", status),
+    ):
+        result = await _publish_review_async(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="head-sha",
+            token="token",
+            severity_threshold="medium",
+            cap=15,
+            is_re_review=False,
+            branch_name=_BRANCH,
+        )
+
+    assert result == {
+        "success": True,
+        "review_id": 555,
+        "surfaced_count": 1,
+        "hidden_count": 0,
+        "resolved_thread_count": 0,
+    }
+    status_args = status.await_args
+    assert status_args is not None
+    assert status_args.kwargs["title"] == "Auto-fix dispatch failed"

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -788,6 +788,7 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
     post_review = AsyncMock()
     set_metadata = AsyncMock()
     resolve_threads = AsyncMock(return_value=1)
+    autofix = AsyncMock()
 
     with (
         patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="tid"),
@@ -802,6 +803,7 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
             "agent.tools.publish_review._maybe_post_slack_completion_reply",
             new_callable=AsyncMock,
         ),
+        patch("agent.tools.publish_review._maybe_dispatch_review_autofix", autofix),
     ):
         result = await _publish_review_async(
             owner="o",
@@ -822,6 +824,7 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
     assert result["surfaced_count"] == 0
     assert result["resolved_thread_count"] == 1
     assert result["skipped_empty_re_review"] is True
+    autofix.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -824,6 +824,112 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
     assert result["skipped_empty_re_review"] is True
 
 
+@pytest.mark.parametrize(
+    ("status", "flag", "expected"),
+    [
+        (
+            "open",
+            "true",
+            (
+                "failure",
+                "Found 1 potential issue",
+                "Open SWE surfaced 1 potential issue on this pull request.",
+            ),
+        ),
+        (
+            "resolved",
+            "true",
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+        (
+            "open",
+            None,
+            (
+                "success",
+                "No issues found",
+                "Open SWE reviewed this pull request and found no issues.",
+            ),
+        ),
+    ],
+    ids=[
+        "standing-open-surfaced-blocking-fails",
+        "standing-resolved-blocking-succeeds",
+        "standing-open-surfaced-informational-unchanged",
+    ],
+)
+async def test_publish_review_check_counts_standing_findings(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    flag: str | None,
+    expected: tuple[str, str, str],
+) -> None:
+    from agent.tools.publish_review import _publish_review_async
+
+    if flag is None:
+        monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
+    else:
+        monkeypatch.setenv("REVIEW_CHECK_BLOCKING", flag)
+
+    finding = _f(
+        id="f_standing",
+        status=status,
+        github_review_comment_id=100,
+    )
+    surface = finding["surface"]
+    assert surface is not None
+    surface["state"] = "surfaced"
+    settle = AsyncMock()
+    post_review = AsyncMock()
+
+    with (
+        patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="tid"),
+        patch(
+            "agent.tools.publish_review.list_findings_async",
+            AsyncMock(return_value=[finding]),
+        ),
+        patch(
+            "agent.tools.publish_review._open_swe_already_reviewed",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "agent.tools.publish_review._resolve_threads_for_resolved_findings",
+            AsyncMock(return_value=0),
+        ),
+        patch("agent.tools.publish_review.post_pull_request_review", post_review),
+        patch("agent.tools.publish_review.set_reviewer_thread_metadata", AsyncMock()),
+        patch("agent.tools.publish_review.settle_review_check_run", settle),
+        patch(
+            "agent.tools.publish_review._resolve_review_trace_url",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await _publish_review_async(
+            owner="o",
+            repo="r",
+            pr_number=7,
+            head_sha="newsha",
+            token="t",
+            severity_threshold="medium",
+            cap=15,
+            is_re_review=True,
+        )
+
+    post_review.assert_not_called()
+    settle.assert_awaited_once()
+    call = settle.await_args
+    assert call is not None
+    assert (
+        call.kwargs["conclusion"],
+        call.kwargs["title"],
+        call.kwargs["summary"],
+    ) == expected
+    assert result["surfaced_count"] == 0
+
+
 @pytest.mark.asyncio
 async def test_publish_review_does_not_surface_out_of_diff_finding() -> None:
     """Out-of-diff findings are disabled: a finding anchored outside the diff is

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -61,6 +61,7 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
 
 @pytest.mark.asyncio
 async def test_reviewer_error_settles_tracked_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REVIEW_CHECK_BLOCKING", raising=False)
     metadata = {
         "kind": "reviewer",
         "review_check_run_id": 42,
@@ -92,6 +93,35 @@ async def test_reviewer_error_settles_tracked_check(monkeypatch: pytest.MonkeyPa
             "Re-trigger the review by pushing a commit or re-requesting it."
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_reviewer_error_settles_failure_when_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REVIEW_CHECK_BLOCKING", "true")
+    metadata = {
+        "kind": "reviewer",
+        "review_check_run_id": 42,
+        "pr": {"owner": "acme", "name": "widgets"},
+        "source": "schedule",
+    }
+    client = _FakeClient(metadata)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    monkeypatch.setattr(
+        completion, "get_github_app_installation_token", AsyncMock(return_value="token")
+    )
+    settle = AsyncMock()
+    monkeypatch.setattr(completion, "settle_review_check_run", settle)
+
+    await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "error"}
+    )
+
+    # A crashed reviewer must not satisfy a blocking (required) check.
+    settle_args = settle.await_args
+    assert settle_args is not None
+    assert settle_args.kwargs["conclusion"] == "failure"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

**Stacked on #1793** (first commit; review the second commit, `6a0a95c8c`). Independent decisions welcome — if #1793 isn't wanted, we'll rework this one's base.

Completes the auto-fix loop whose **consumer already ships** in `check_message_queue` (the `("autofix", thread_id)` `pending_event` read): when `publish_review` surfaces findings on a PR whose implementation thread is known, it stores the finding details as a pending event and dispatches a run on that thread — the agent fixes its own review findings without a human comment, and re-review of the pushed fix resolves or re-surfaces findings as usual. Combined with #1793, this closes the dispatch → implement → review → fix → re-review → merge loop.

## Guardrails

- **Team-level opt-in, default off**: `autofix_enabled` + `autofix_severity_threshold` as tri-state fields on `TeamSettingsUpdate` — `None` preserves the stored value, so clients that don't render these fields can't erase the opt-in by saving unrelated settings.
- **Per-PR opt-out** via the existing autofix state record; lookup errors abort dispatch rather than reading as opted-in (safety controls fail closed).
- **2-cycle cap per PR** so review↔fix cannot loop. Counted on successful dispatch, deliberately: a transient dispatch failure shouldn't burn the small budget (comment in code documents the trade).
- **Validated thread resolution**: branch names embed thread UUIDs and are author-controlled, so the resolved thread's own persisted metadata must point back at the same branch (and repo, when recorded) before any dispatch — a crafted branch name can't target an unrelated thread.
- **No stale events**: the pending event is deleted if dispatch fails or is cancelled, so a failed dispatch can't leak an autofix nudge into the thread's next unrelated run.
- **Status via check runs** (`Open SWE Auto-fix`, always-neutral) rather than PR comments, so dispatch status can't trigger `issue_comment` automation.

**Default off:** with `autofix_enabled` unset, `publish_review` behavior is unchanged.

## Test Plan

- [x] Full suite passes (1623); `ruff check`, `ruff format --diff`, `basedpyright` clean
- [x] 646-line producer test module: trigger truth table, cycle cap, opt-outs (including store-failure abort), forged-branch rejection, pending-event cleanup on dispatch failure *and* cancellation (both fail on the unguarded ordering), config-off literal outcome
- [x] Team-settings preservation: saving unrelated settings keeps the stored opt-in (`tests/dashboard/test_team_settings_autofix.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)