### PR TITLE
fix: cap execute output by making SandboxBackendProxy a BaseSandbox

### DIFF
--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 
 from deepagents.backends.protocol import (
     EditResult,
+    ExecuteOffloadResult,
     ExecuteResponse,
     FileDownloadResponse,
     FileUploadResponse,
@@ -17,7 +18,9 @@ from deepagents.backends.protocol import (
     ReadResult,
     SandboxBackendProtocol,
     WriteResult,
+    execute_accepts_timeout,
 )
+from deepagents.backends.sandbox import BaseSandbox
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
@@ -26,8 +29,15 @@ from .sandbox import create_sandbox
 logger = logging.getLogger(__name__)
 
 
-class SandboxBackendProxy(SandboxBackendProtocol):
-    """Stable per-thread backend handle whose target can be replaced."""
+class SandboxBackendProxy(BaseSandbox):
+    """Stable per-thread backend handle whose target can be replaced.
+
+    Subclasses ``BaseSandbox`` (not just the protocol) so ``FilesystemMiddleware``
+    recognizes it as capture-at-source capable: its ``_resolve_capture`` gates the
+    ``execute`` offload path on ``isinstance(backend, BaseSandbox)``. Without this
+    the tool falls back to plain ``execute`` and the command's entire stdout is
+    pulled into the worker process, bypassing the in-sandbox size cap.
+    """
 
     def __init__(
         self,
@@ -179,6 +189,70 @@ class SandboxBackendProxy(SandboxBackendProtocol):
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         return await (await self._aget_backend()).aexecute(command, timeout=timeout)
+
+    def execute_with_offload(
+        self,
+        command: str,
+        capture_path: str,
+        *,
+        max_inline_bytes: int,
+        max_capture_bytes: int | None = None,
+        timeout: int | None = None,
+    ) -> ExecuteOffloadResult:
+        # Delegate to the live backend so each provider's own capture-offload
+        # behavior (enable_capture_offload, shell wrapper) is honored.
+        backend = self._get_backend()
+        offload = getattr(backend, "execute_with_offload", None)
+        if offload is None:
+            return ExecuteOffloadResult(
+                offloaded=False, response=self._plain(backend, command, timeout)
+            )
+        return offload(
+            command,
+            capture_path,
+            max_inline_bytes=max_inline_bytes,
+            max_capture_bytes=max_capture_bytes,
+            timeout=timeout,
+        )
+
+    async def aexecute_with_offload(
+        self,
+        command: str,
+        capture_path: str,
+        *,
+        max_inline_bytes: int,
+        max_capture_bytes: int | None = None,
+        timeout: int | None = None,  # noqa: ASYNC109 - forwarded to backend, not an asyncio contract
+    ) -> ExecuteOffloadResult:
+        backend = await self._aget_backend()
+        offload = getattr(backend, "aexecute_with_offload", None)
+        if offload is None:
+            return ExecuteOffloadResult(
+                offloaded=False, response=await self._aplain(backend, command, timeout)
+            )
+        return await offload(
+            command,
+            capture_path,
+            max_inline_bytes=max_inline_bytes,
+            max_capture_bytes=max_capture_bytes,
+            timeout=timeout,
+        )
+
+    @staticmethod
+    def _plain(
+        backend: SandboxBackendProtocol, command: str, timeout: int | None
+    ) -> ExecuteResponse:
+        if timeout is not None and execute_accepts_timeout(type(backend)):
+            return backend.execute(command, timeout=timeout)
+        return backend.execute(command)
+
+    @staticmethod
+    async def _aplain(
+        backend: SandboxBackendProtocol, command: str, timeout: int | None
+    ) -> ExecuteResponse:
+        if timeout is not None and execute_accepts_timeout(type(backend)):
+            return await backend.aexecute(command, timeout=timeout)
+        return await backend.aexecute(command)
 
 
 # Thread ID -> stable SandboxBackendProxy, shared between server.py and middleware.

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -7,10 +7,16 @@ from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
-from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+from deepagents.backends.protocol import (
+    ExecuteOffloadResult,
+    ExecuteResponse,
+    SandboxBackendProtocol,
+)
+from deepagents.backends.sandbox import BaseSandbox
 
 from agent.utils.sandbox_state import (
     SANDBOX_BACKENDS,
+    SandboxBackendProxy,
     clear_sandbox_backend,
     get_or_create_sandbox_backend_proxy,
     get_sandbox_id_from_metadata,
@@ -22,6 +28,91 @@ class _FakeSandboxBackend:
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         return ExecuteResponse(output=f"{self.id}: {command}: {timeout}", exit_code=0)
+
+
+class _OffloadCapableBackend(BaseSandbox):
+    """Minimal BaseSandbox whose offload records how it was called."""
+
+    def __init__(self) -> None:
+        self.offload_calls: list[dict[str, object]] = []
+
+    @property
+    def id(self) -> str:
+        return "offload-sandbox"
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        return ExecuteResponse(output=command, exit_code=0)
+
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        return ExecuteResponse(output=command, exit_code=0)
+
+    def upload_files(self, files):  # noqa: ANN001, ANN201 - unused stub
+        return []
+
+    def download_files(self, paths):  # noqa: ANN001, ANN201 - unused stub
+        return []
+
+    async def aexecute_with_offload(
+        self,
+        command: str,
+        capture_path: str,
+        *,
+        max_inline_bytes: int,
+        max_capture_bytes: int | None = None,
+        timeout: int | None = None,
+    ) -> ExecuteOffloadResult:
+        self.offload_calls.append(
+            {
+                "command": command,
+                "capture_path": capture_path,
+                "max_inline_bytes": max_inline_bytes,
+                "timeout": timeout,
+            }
+        )
+        return ExecuteOffloadResult(
+            offloaded=True, response=ExecuteResponse(output="preview", exit_code=0)
+        )
+
+
+def test_sandbox_proxy_is_capture_offload_capable() -> None:
+    # FilesystemMiddleware._resolve_capture gates the execute capture-at-source
+    # path on isinstance(backend, BaseSandbox); the proxy must satisfy it or the
+    # tool falls back to plain execute and pulls full stdout into the worker.
+    assert issubclass(SandboxBackendProxy, BaseSandbox)
+    assert isinstance(SandboxBackendProxy(thread_id="t"), BaseSandbox)
+
+
+@pytest.mark.asyncio
+async def test_sandbox_proxy_delegates_offload_to_live_backend() -> None:
+    backend = _OffloadCapableBackend()
+    proxy = SandboxBackendProxy(backend, thread_id="t")
+
+    result = await proxy.aexecute_with_offload(
+        "run tests", "/capture/path", max_inline_bytes=80_000, timeout=30
+    )
+
+    assert result.offloaded is True
+    assert result.response.output == "preview"
+    assert backend.offload_calls == [
+        {
+            "command": "run tests",
+            "capture_path": "/capture/path",
+            "max_inline_bytes": 80_000,
+            "timeout": 30,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_proxy_offload_falls_back_when_backend_lacks_it() -> None:
+    # A backend implementing only the protocol (no capture-offload) must not
+    # error: the proxy runs it plainly and reports offloaded=False.
+    proxy = SandboxBackendProxy(cast(SandboxBackendProtocol, _FakeSandboxBackend()), thread_id="t")
+
+    result = await proxy.aexecute_with_offload("cmd", "/capture/path", max_inline_bytes=80_000)
+
+    assert result.offloaded is False
+    assert result.response.output == "sandbox-1: cmd: None"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`SandboxBackendProxy` (the stable per-thread backend handle) now subclasses `deepagents`' `BaseSandbox` instead of just implementing `SandboxBackendProtocol`, and delegates `execute_with_offload` / `aexecute_with_offload` to the live backend.

## Why

deepagents' `FilesystemMiddleware` only applies **capture-at-source offload** for the `execute` tool when the backend passes an `isinstance(backend, BaseSandbox)` gate (`_resolve_capture`). Our proxy implemented only the protocol, so the gate failed and the tool fell back to **plain `execute`** — the command's entire stdout was pulled over the wire into the worker process with no in-sandbox size cap.

A single large-output command (verbose build/test logs, `git log -p`, a big `cat`) could therefore materialize hundreds of MB in one Python string in the queue worker, ×`N_JOBS_PER_WORKER` concurrent runs — a strong contributor to the queue-worker OOMs we've been seeing in prod.

With the fix, the offload wrapper caps output **in the sandbox** (`head -c`, 10 MB hard cap) and only a small head/tail preview crosses into the process; the full output stays at a capture path the model can `read_file`. Per-provider behavior is preserved: backends without offload (local/modal/etc.) fall back to plain execute cleanly.

Measured locally against a ~200 MB-output command:

| | bytes into the worker process | RSS spike |
|---|---|---|
| before (plain path) | 224,000,000 (214 MB) | +497 MB |
| after (capture-at-source) | 608 (preview) | ~0 MB |

## Test Plan

- [x] `uv run pytest tests/sandbox/test_sandbox_state.py` — 3 new regression tests (proxy is `BaseSandbox`; offload delegation forwards args; protocol-only backends fall back without error)
- [x] `uv run pytest tests/sandbox tests/middleware` — existing suites green
- [x] `make lint` clean, `basedpyright` 0 errors
