### PR TITLE
fix: merge concurrent trusted skill refs

### DIFF
--- a/agent/middleware/trusted_skills.py
+++ b/agent/middleware/trusted_skills.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, NotRequired, cast
+from typing import Annotated, Any, NotRequired, cast
 
 from deepagents.middleware.skills import SkillsMiddleware, SkillsState, SkillsStateUpdate
 from langgraph.graph.state import RunnableConfig
@@ -10,8 +10,12 @@ from langgraph.runtime import Runtime
 logger = logging.getLogger(__name__)
 
 
+def _take_latest_ref(_current: str, incoming: str) -> str:
+    return incoming
+
+
 class TrustedSkillsState(SkillsState):
-    trusted_skills_ref: NotRequired[str]
+    trusted_skills_ref: NotRequired[Annotated[str, _take_latest_ref]]
 
 
 class TrustedSkillsMiddleware(SkillsMiddleware):

--- a/tests/agent/test_trusted_skills_middleware.py
+++ b/tests/agent/test_trusted_skills_middleware.py
@@ -3,9 +3,30 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from deepagents.middleware.skills import SkillsMiddleware
+from langgraph.graph import END, START, StateGraph
 from langgraph.runtime import Runtime
 
 from agent.middleware.trusted_skills import TrustedSkillsMiddleware, TrustedSkillsState
+
+
+async def test_trusted_skills_ref_accepts_concurrent_updates() -> None:
+    trusted_ref = "a" * 40
+
+    async def set_ref(state: TrustedSkillsState) -> dict[str, str]:
+        assert "messages" in state
+        return {"trusted_skills_ref": trusted_ref}
+
+    builder = StateGraph(TrustedSkillsState)
+    builder.add_node("first", set_ref)
+    builder.add_node("second", set_ref)
+    builder.add_edge(START, "first")
+    builder.add_edge(START, "second")
+    builder.add_edge("first", END)
+    builder.add_edge("second", END)
+
+    result = await builder.compile().ainvoke({"messages": [], "trusted_skills_ref": "b" * 40})
+
+    assert result["trusted_skills_ref"] == trusted_ref
 
 
 async def test_trusted_skills_reload_when_ref_changes() -> None:


### PR DESCRIPTION
## Description
Prevent parallel trusted-skills middleware branches from crashing when they publish the same ref by giving the state channel a latest-value reducer. This also preserves ref replacement across later runs.

## Release Note
Fixed high-parallelism agent runs crashing while loading trusted repository skills.

## Test Plan
- [x] Reproduced and verified two concurrent graph writes merge successfully.

Made by [Open SWE](https://openswe.vercel.app/agents/29075ded-f057-e081-cbad-9bd30fdc419c)