### PR TITLE
feat: add Tenki sandbox provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ create_deep_agent(
 
 Every task runs in its own **isolated cloud sandbox** — a remote Linux environment with full shell access. The repo is cloned in, the agent gets full permissions, and the blast radius of any mistake is fully contained. No production access, no confirmation prompts.
 
-Open SWE supports multiple sandbox providers out of the box — [Modal](https://modal.com/), [Daytona](https://www.daytona.io/), [Runloop](https://www.runloop.ai/), [E2B](https://e2b.dev/), and [LangSmith](https://smith.langchain.com/) — and you can plug in your own. See the [Customization Guide](docs/CUSTOMIZATION.md#1-sandbox) for details.
+Open SWE supports multiple sandbox providers out of the box — [Tenki](https://tenki.cloud/), [Modal](https://modal.com/), [Daytona](https://www.daytona.io/), [Runloop](https://www.runloop.ai/), [E2B](https://e2b.dev/), and [LangSmith](https://smith.langchain.com/) — and you can plug in your own. See the [Customization Guide](docs/CUSTOMIZATION.md#1-sandbox) for details.
 
 This follows the principle all three companies converge on: **isolate first, then give full permissions inside the boundary.**
 

--- a/agent/integrations/tenki.py
+++ b/agent/integrations/tenki.py
@@ -1,0 +1,200 @@
+import os
+import posixpath
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+from deepagents.backends.sandbox import BaseSandbox
+from langsmith.sandbox import SandboxClientError
+from tenki_sandbox import AsyncClient, AsyncSandbox
+from tenki_sandbox.errors import (
+    CommandTimeoutError,
+    PermissionDeniedError,
+    SandboxError,
+)
+from tenki_sandbox.errors import (
+    FileNotFoundError as TenkiFileNotFoundError,
+)
+
+DEFAULT_COMMAND_TIMEOUT = 30 * 60
+DEFAULT_START_TIMEOUT = 180
+
+
+def validate_tenki_startup_config() -> None:
+    if not (os.getenv("TENKI_API_KEY", "").strip() or os.getenv("TENKI_AUTH_TOKEN", "").strip()):
+        raise ValueError("TENKI_API_KEY or TENKI_AUTH_TOKEN is required when SANDBOX_TYPE=tenki")
+    if not os.getenv("TENKI_SANDBOX_PROJECT_ID", "").strip():
+        raise ValueError("TENKI_SANDBOX_PROJECT_ID is required when SANDBOX_TYPE=tenki")
+
+
+def _positive_timeout(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be a positive integer") from None
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _combine_output(stdout: str, stderr: str) -> str:
+    if not stderr:
+        return stdout
+    return f"{stdout}\n{stderr}" if stdout else stderr
+
+
+class TenkiSandbox(BaseSandbox):
+    def __init__(
+        self,
+        *,
+        client: AsyncClient,
+        sandbox: AsyncSandbox,
+        command_timeout: int = DEFAULT_COMMAND_TIMEOUT,
+    ) -> None:
+        self._client = client
+        self._sandbox = sandbox
+        self._command_timeout = command_timeout
+        self._github_token: str | None = None
+
+    @property
+    def id(self) -> str:
+        return self._sandbox.id
+
+    def set_github_token(self, token: str) -> None:
+        self._github_token = token
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        raise NotImplementedError("TenkiSandbox is async-only; use aexecute")
+
+    async def aexecute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+    ) -> ExecuteResponse:
+        effective_timeout = timeout if timeout is not None else self._command_timeout
+        if effective_timeout < 0:
+            raise ValueError(f"timeout must be non-negative, got {effective_timeout}")
+
+        env = None
+        if self._github_token:
+            env = {"GH_TOKEN": self._github_token, "GIT_TOKEN": self._github_token}
+            command = command.replace("GH_TOKEN=dummy", 'GH_TOKEN="${GH_TOKEN:-dummy}"')
+
+        try:
+            result = await self._sandbox.shell(
+                command,
+                env=env,
+                timeout=effective_timeout,
+            )
+        except CommandTimeoutError:
+            return ExecuteResponse(
+                output=f"Command timed out after {effective_timeout} seconds",
+                exit_code=124,
+                truncated=False,
+            )
+        except SandboxError as exc:
+            raise SandboxClientError(f"Tenki sandbox {self.id}: {exc}") from exc
+
+        return ExecuteResponse(
+            output=_combine_output(result.stdout_text, result.stderr_text),
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        raise NotImplementedError("TenkiSandbox is async-only; use aupload_files")
+
+    async def aupload_files(
+        self,
+        files: list[tuple[str, bytes]],
+    ) -> list[FileUploadResponse]:
+        responses: list[FileUploadResponse] = []
+        for path, content in files:
+            if not path.startswith("/"):
+                responses.append(FileUploadResponse(path=path, error="invalid_path"))
+                continue
+            try:
+                await self._sandbox.fs.mkdir(posixpath.dirname(path), recursive=True)
+                await self._sandbox.fs.write_bytes(path, content)
+                responses.append(FileUploadResponse(path=path))
+            except PermissionDeniedError:
+                responses.append(FileUploadResponse(path=path, error="permission_denied"))
+            except TenkiFileNotFoundError:
+                responses.append(FileUploadResponse(path=path, error="file_not_found"))
+            except SandboxError as exc:
+                responses.append(FileUploadResponse(path=path, error=str(exc)))
+        return responses
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        raise NotImplementedError("TenkiSandbox is async-only; use adownload_files")
+
+    async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        responses: list[FileDownloadResponse] = []
+        for path in paths:
+            if not path.startswith("/"):
+                responses.append(FileDownloadResponse(path=path, error="invalid_path"))
+                continue
+            try:
+                info = await self._sandbox.fs.stat(path)
+                if info.is_dir:
+                    responses.append(FileDownloadResponse(path=path, error="is_directory"))
+                    continue
+                content = await self._sandbox.fs.read_bytes(path)
+                responses.append(FileDownloadResponse(path=path, content=content))
+            except TenkiFileNotFoundError:
+                responses.append(FileDownloadResponse(path=path, error="file_not_found"))
+            except PermissionDeniedError:
+                responses.append(FileDownloadResponse(path=path, error="permission_denied"))
+            except SandboxError as exc:
+                responses.append(FileDownloadResponse(path=path, error=str(exc)))
+        return responses
+
+    async def aclose(self) -> None:
+        try:
+            await self._sandbox.close_if_open()
+        finally:
+            await self._client.close()
+
+
+async def create_tenki_sandbox(sandbox_id: str | None = None) -> TenkiSandbox:
+    validate_tenki_startup_config()
+    start_timeout = _positive_timeout(
+        "TENKI_SANDBOX_START_TIMEOUT_SECONDS",
+        DEFAULT_START_TIMEOUT,
+    )
+    command_timeout = _positive_timeout(
+        "TENKI_SANDBOX_COMMAND_TIMEOUT_SECONDS",
+        DEFAULT_COMMAND_TIMEOUT,
+    )
+    client = AsyncClient()
+
+    try:
+        if sandbox_id:
+            sandbox = await client.get(sandbox_id)
+            if sandbox.state == "PAUSED":
+                await sandbox.resume()
+            if sandbox.state != "RUNNING":
+                await sandbox.wait_ready(start_timeout)
+        else:
+            project_id = os.environ["TENKI_SANDBOX_PROJECT_ID"].strip()
+            image = os.getenv("TENKI_SANDBOX_IMAGE", "").strip()
+            sandbox = await client.create(
+                timeout=start_timeout,
+                project_id=project_id,
+                image=image or None,
+            )
+    except Exception:
+        await client.close()
+        raise
+
+    return TenkiSandbox(
+        client=client,
+        sandbox=sandbox,
+        command_timeout=command_timeout,
+    )

--- a/agent/server.py
+++ b/agent/server.py
@@ -30,7 +30,7 @@ warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarnin
 
 from deepagents import create_deep_agent
 from deepagents.backends import LangSmithSandbox
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolRetryMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
@@ -263,18 +263,30 @@ async def _create_sandbox_with_proxy(
     repo: dict[str, str] | None = None,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
+    sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
+    token: str | None = None
+    expires_at: str | None = None
+    permissions = None
+    if sandbox_type in {"langsmith", "tenki"}:
+        token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
+        if not token:
+            msg = "Cannot configure sandbox GitHub auth: installation token is unavailable"
+            logger.error(msg)
+            raise ValueError(msg)
+
     snapshot_id = await _resolve_snapshot_id_for_repo(repo)
     sandbox_backend = await create_sandbox(snapshot_id=snapshot_id)
 
-    sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
-    if sandbox_type == "langsmith":
-        token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
-        if not token:
-            msg = "Cannot configure proxy: GitHub App installation token is unavailable"
-            logger.error(msg)
-            raise ValueError(msg)
-        await _start_langsmith_sandbox_if_needed(sandbox_backend)
-        await _configure_github_proxy(sandbox_backend.id, token)
+    if token:
+        if sandbox_type == "langsmith":
+            await _start_langsmith_sandbox_if_needed(sandbox_backend)
+            await _configure_github_proxy(sandbox_backend.id, token)
+        else:
+            current_backend = unwrap_sandbox_backend(sandbox_backend)
+            set_github_token = getattr(current_backend, "set_github_token", None)
+            if not callable(set_github_token):
+                raise TypeError("Tenki sandbox backend cannot receive GitHub credentials")
+            set_github_token(token)
         record_proxy_token_expiry(
             thread_id,
             expires_at,
@@ -292,19 +304,32 @@ async def _refresh_github_proxy(
     thread_id: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
 ) -> None:
-    """Refresh GitHub proxy credentials for reused LangSmith sandboxes."""
-    if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
+    """Refresh GitHub credentials for reused LangSmith and Tenki sandboxes."""
+    sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
+    if sandbox_type not in {"langsmith", "tenki"}:
         return
 
     token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
     if not token:
         logger.warning(
-            "Skipping GitHub proxy refresh for sandbox %s: installation token unavailable",
+            "Skipping GitHub auth refresh for sandbox %s: installation token unavailable",
             sandbox_backend.id,
         )
         return
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
+    if sandbox_type == "tenki":
+        set_github_token = getattr(current_backend, "set_github_token", None)
+        if not callable(set_github_token):
+            raise TypeError("Tenki sandbox backend cannot receive GitHub credentials")
+        set_github_token(token)
+        record_proxy_token_expiry(
+            thread_id,
+            expires_at,
+            repositories=github_proxy_repositories,
+            permissions=permissions,
+        )
+        return
     await _start_langsmith_sandbox_if_needed(current_backend)
     await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
@@ -322,7 +347,7 @@ async def _refresh_github_proxy_or_recreate(
     github_proxy_repositories: Sequence[str] | None = None,
     repo: dict[str, str] | None = None,
 ) -> SandboxBackendProtocol:
-    """Refresh proxy credentials, recreating stale LangSmith sandboxes on failure."""
+    """Refresh GitHub credentials, recreating stale sandboxes on failure."""
     try:
         await _refresh_github_proxy(
             sandbox_backend,
@@ -332,7 +357,7 @@ async def _refresh_github_proxy_or_recreate(
         )
     except Exception:  # noqa: BLE001
         logger.warning(
-            "Failed to refresh GitHub proxy for sandbox %s on thread %s, recreating sandbox",
+            "Failed to refresh GitHub auth for sandbox %s on thread %s, recreating sandbox",
             sandbox_backend.id,
             thread_id,
             exc_info=True,
@@ -347,11 +372,22 @@ async def _refresh_github_proxy_or_recreate(
 
 
 async def _configure_git_identity(sandbox_backend: SandboxBackendProtocol) -> None:
-    await asyncio.to_thread(
-        sandbox_backend.execute,
+    command = (
         f"git config --global user.name '{OPEN_SWE_BOT_NAME}' && "
-        f"git config --global user.email '{OPEN_SWE_BOT_EMAIL}'",
+        f"git config --global user.email '{OPEN_SWE_BOT_EMAIL}'"
     )
+    if os.getenv("SANDBOX_TYPE", "langsmith") == "tenki":
+        command += " && gh auth setup-git"
+    await _execute_sandbox_command(sandbox_backend, command)
+
+
+async def _execute_sandbox_command(
+    sandbox_backend: SandboxBackendProtocol,
+    command: str,
+) -> ExecuteResponse:
+    if os.getenv("SANDBOX_TYPE", "langsmith") == "tenki":
+        return await sandbox_backend.aexecute(command)
+    return await asyncio.to_thread(sandbox_backend.execute, command)
 
 
 async def _recreate_sandbox(
@@ -392,7 +428,7 @@ async def check_or_recreate_sandbox(
     Returns the original backend if healthy, or a new one if recreated.
     """
     try:
-        await asyncio.to_thread(sandbox_backend.execute, "echo ok")
+        await _execute_sandbox_command(sandbox_backend, "echo ok")
     except SandboxClientError:
         logger.warning(
             "Cached sandbox is no longer reachable for thread %s, recreating",
@@ -420,13 +456,14 @@ async def ensure_sandbox_for_thread(
     never provisions two sandboxes concurrently — no cross-process sentinel is
     needed):
 
-    1. Cached in memory -> ping; recreate on ``SandboxClientError``; refresh proxy.
-    2. Metadata has an id -> reconnect; recreate on failure; refresh proxy.
+    1. Cached in memory -> ping; recreate on ``SandboxClientError``; refresh GitHub auth.
+    2. Metadata has an id -> reconnect; recreate on failure; refresh GitHub auth.
     3. No sandbox at all -> create one and persist the id.
 
-    For LangSmith sandboxes, also refreshes the GitHub App proxy auth. When
-    ``repo`` has a ``ready`` repo-scoped snapshot, newly created sandboxes boot
-    from it; otherwise the configured ``DEFAULT_SANDBOX_SNAPSHOT_ID`` is used.
+    For LangSmith sandboxes, refreshes the GitHub App proxy auth. Tenki receives
+    the same short-lived token per command without storing it in the sandbox.
+    When ``repo`` has a ``ready`` repo-scoped snapshot, newly created LangSmith
+    sandboxes boot from it; otherwise ``DEFAULT_SANDBOX_SNAPSHOT_ID`` is used.
     Re-applies git identity every run because reused/reconnected sandboxes can
     lose their ``--global`` config, and Vercel preview deploys reject commits
     whose author email can't be resolved to a GitHub account.

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -11,12 +11,15 @@ SandboxFactory = Callable[..., Any]
 
 SANDBOX_FACTORIES: dict[str, tuple[str, str]] = {
     "langsmith": ("agent.integrations.langsmith", "create_langsmith_sandbox"),
+    "tenki": ("agent.integrations.tenki", "create_tenki_sandbox"),
     "daytona": ("agent.integrations.daytona", "create_daytona_sandbox"),
     "modal": ("agent.integrations.modal", "create_modal_sandbox"),
     "runloop": ("agent.integrations.runloop", "create_runloop_sandbox"),
     "e2b": ("agent.integrations.e2b", "create_e2b_sandbox"),
     "local": ("agent.integrations.local", "create_local_sandbox"),
 }
+
+ASYNC_SANDBOX_TYPES = {"langsmith", "tenki"}
 
 
 def _load_sandbox_factory(sandbox_type: str) -> SandboxFactory:
@@ -39,10 +42,10 @@ async def create_sandbox(
     """Create or reconnect to a sandbox using the configured provider.
 
     The provider is selected via the SANDBOX_TYPE environment variable.
-    Supported values: langsmith (default), daytona, modal, runloop, e2b, local.
+    Supported values: langsmith (default), tenki, daytona, modal, runloop, e2b, local.
 
-    The langsmith provider provisions natively async; the other providers wrap
-    sync SDKs and are bridged onto the event loop with ``asyncio.to_thread``.
+    LangSmith and Tenki provision natively async; providers with sync SDKs are
+    bridged onto the event loop with ``asyncio.to_thread``.
 
     Args:
         sandbox_id: Optional existing sandbox ID to reconnect to.
@@ -55,9 +58,10 @@ async def create_sandbox(
     """
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     factory = _load_sandbox_factory(sandbox_type)
-    if sandbox_type == "langsmith":
+    if sandbox_type in ASYNC_SANDBOX_TYPES:
         if snapshot_id is not None:
-            return await factory(sandbox_id, snapshot_id=snapshot_id)
+            if sandbox_type == "langsmith":
+                return await factory(sandbox_id, snapshot_id=snapshot_id)
         return await factory(sandbox_id)
     return await asyncio.to_thread(factory, sandbox_id)
 
@@ -74,3 +78,7 @@ def validate_sandbox_startup_config() -> None:
         from agent.integrations.langsmith import LangSmithProvider
 
         LangSmithProvider.validate_startup_config()
+    elif sandbox_type == "tenki":
+        from agent.integrations.tenki import validate_tenki_startup_config
+
+        validate_tenki_startup_config()

--- a/agent/utils/sandbox_paths.py
+++ b/agent/utils/sandbox_paths.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import posixpath
 import shlex
@@ -27,8 +26,11 @@ def resolve_repo_dir(sandbox_backend: SandboxBackendProtocol, repo_name: str) ->
 
 
 async def aresolve_repo_dir(sandbox_backend: SandboxBackendProtocol, repo_name: str) -> str:
-    """Async wrapper around resolve_repo_dir for use in event-loop code."""
-    return await asyncio.to_thread(resolve_repo_dir, sandbox_backend, repo_name)
+    """Resolve the repository directory without blocking the event loop."""
+    if not repo_name:
+        raise ValueError("repo_name must be a non-empty string")
+    work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+    return posixpath.join(work_dir, repo_name)
 
 
 def resolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
@@ -51,8 +53,52 @@ def resolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
 
 
 async def aresolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
-    """Async wrapper around resolve_sandbox_work_dir for use in event-loop code."""
-    return await asyncio.to_thread(resolve_sandbox_work_dir, sandbox_backend)
+    """Resolve a writable base directory using async sandbox operations."""
+    cached_work_dir = getattr(sandbox_backend, _WORK_DIR_CACHE_ATTR, None)
+    if isinstance(cached_work_dir, str) and cached_work_dir:
+        return cached_work_dir
+
+    checked_candidates: list[str] = []
+    seen: set[str] = set()
+
+    async def check(candidate: str | None) -> str | None:
+        if not candidate or candidate in seen:
+            return None
+        seen.add(candidate)
+        checked_candidates.append(candidate)
+        safe_directory = shlex.quote(candidate)
+        result = await sandbox_backend.aexecute(
+            f"test -d {safe_directory} && test -w {safe_directory}"
+        )
+        if result.exit_code == 0:
+            _cache_work_dir(sandbox_backend, candidate)
+            return candidate
+        return None
+
+    for candidate in _iter_provider_paths(sandbox_backend, "get_work_dir"):
+        if work_dir := await check(candidate):
+            return work_dir
+
+    result = await sandbox_backend.aexecute("pwd")
+    if work_dir := await check(_normalize_path(result.output) if result.exit_code == 0 else None):
+        return work_dir
+
+    for candidate in _iter_provider_paths(
+        sandbox_backend,
+        "get_user_home_dir",
+        "get_user_root_dir",
+    ):
+        if work_dir := await check(candidate):
+            return work_dir
+
+    result = await sandbox_backend.aexecute("printf '%s' \"$HOME\"")
+    if work_dir := await check(_normalize_path(result.output) if result.exit_code == 0 else None):
+        return work_dir
+
+    msg = "Failed to resolve a writable sandbox work directory"
+    if checked_candidates:
+        msg = f"{msg}. Candidates checked: {', '.join(checked_candidates)}"
+    raise RuntimeError(msg)
 
 
 def _iter_work_dir_candidates(

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -61,6 +61,7 @@ Set the `SANDBOX_TYPE` environment variable to switch providers. Each provider h
 | `SANDBOX_TYPE` | Integration file | Required env vars |
 |---|---|---|
 | `langsmith` (default) | `agent/integrations/langsmith.py` | `LANGSMITH_API_KEY_PROD`, `SANDBOX_TYPE="langsmith"` |
+| `tenki` | `agent/integrations/tenki.py` | `TENKI_API_KEY`, `TENKI_SANDBOX_PROJECT_ID`, `SANDBOX_TYPE="tenki"`, optional `TENKI_SANDBOX_IMAGE` |
 | `daytona` | `agent/integrations/daytona.py` | `DAYTONA_API_KEY`, `SANDBOX_TYPE="daytona"`, optional `DAYTONA_SANDBOX_SNAPSHOT` |
 | `runloop` | `agent/integrations/runloop.py` | `RUNLOOP_API_KEY`, `SANDBOX_TYPE="runloop"` |
 | `e2b` | `agent/integrations/e2b.py` | `E2B_API_KEY`, `SANDBOX_TYPE="e2b"`, optional `E2B_TEMPLATE` |
@@ -68,6 +69,8 @@ Set the `SANDBOX_TYPE` environment variable to switch providers. Each provider h
 | `local` | `agent/integrations/local.py` | None (no isolation — development only), `SANDBOX_TYPE="local"` |
 
 > **Warning**: `local` runs commands directly on your host with no sandboxing. Only use for local development with human-in-the-loop enabled.
+
+Tenki uses the native async `tenki-sandbox>=0.4.0` client. Open SWE supplies a fresh GitHub installation token to each command without persisting it in the sandbox, and automatically resumes paused sandboxes when reconnecting. `TENKI_SANDBOX_START_TIMEOUT_SECONDS` (default `180`) and `TENKI_SANDBOX_COMMAND_TIMEOUT_SECONDS` (default `1800`) can tune its timeouts.
 
 For `langsmith`, sandboxes default to the same LangSmith credentials as tracing. To run sandboxes against a **different** LangSmith workspace, set `SANDBOX_LANGSMITH_API_KEY` (falls back to `LANGSMITH_API_KEY` / `LANGSMITH_API_KEY_PROD`) and optionally `SANDBOX_LANGSMITH_ENDPOINT` (falls back to `LANGSMITH_ENDPOINT`). These apply to sandbox create/connect/delete, the GitHub proxy config, and repo snapshot builds — the `DEFAULT_SANDBOX_SNAPSHOT_ID` must exist in whichever workspace these credentials point at.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -517,8 +517,11 @@ REVIEWER_OUTCOMES_DATASET=""
 PUBLIC_REPO_ORG_GATE=""
 
 # === Sandbox (optional) ===
-# Provider: langsmith (default), modal, daytona, runloop, e2b, or local. See CUSTOMIZATION.md.
+# Provider: langsmith (default), tenki, modal, daytona, runloop, e2b, or local. See CUSTOMIZATION.md.
 SANDBOX_TYPE="langsmith"
+TENKI_API_KEY=""                       # Required when SANDBOX_TYPE=tenki
+TENKI_SANDBOX_PROJECT_ID=""             # Required when SANDBOX_TYPE=tenki
+TENKI_SANDBOX_IMAGE=""                  # Optional Tenki image; defaults to Tenki's sandbox image
 DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Required when SANDBOX_TYPE=langsmith (see step 4c)
 DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES=""  # Root FS size in bytes (default: 32 GiB)
 DEFAULT_SANDBOX_VCPUS=""               # vCPUs per sandbox (default: 4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.3.0",
     "stagehand>=3.21.0",
     "websockets>=15.0.1",
+    "tenki-sandbox>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/sandbox/test_sandbox_paths.py
+++ b/tests/sandbox/test_sandbox_paths.py
@@ -63,6 +63,9 @@ class _FakeSandboxBackend:
 
         return ExecuteResponse(output="", exit_code=1, truncated=False)
 
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        return self.execute(command, timeout=timeout)
+
 
 def test_resolve_repo_dir_uses_provider_work_dir() -> None:
     backend = _FakeSandboxBackend(
@@ -110,7 +113,7 @@ def test_resolve_sandbox_work_dir_caches_the_result() -> None:
     assert backend.commands == ["test -d /workspace && test -w /workspace"]
 
 
-async def test_aresolve_repo_dir_offloads_sync_resolution() -> None:
+async def test_aresolve_repo_dir_uses_async_resolution() -> None:
     backend = _FakeSandboxBackend(
         provider=_FakeProvider(work_dir="/home/daytona"),
         writable_dirs={"/home/daytona"},

--- a/tests/sandbox/test_tenki_integration.py
+++ b/tests/sandbox/test_tenki_integration.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from tenki_sandbox import AsyncClient, AsyncSandbox
+
+from agent.integrations import tenki
+
+
+@dataclass
+class _CommandResult:
+    stdout_text: str = ""
+    stderr_text: str = ""
+    exit_code: int = 0
+
+
+class _FakeFS:
+    def __init__(self) -> None:
+        self.mkdir = AsyncMock()
+        self.write_bytes = AsyncMock()
+        self.stat = AsyncMock(return_value=SimpleNamespace(is_dir=False))
+        self.read_bytes = AsyncMock(return_value=b"contents")
+
+
+class _FakeSandbox:
+    def __init__(self, sandbox_id: str = "sb-created", state: str = "RUNNING") -> None:
+        self.id = sandbox_id
+        self.state = state
+        self.fs = _FakeFS()
+        self.shell = AsyncMock(return_value=_CommandResult(stdout_text="out", stderr_text="err"))
+        self.close_if_open = AsyncMock()
+        self.resume = AsyncMock(side_effect=self._resume)
+        self.wait_ready = AsyncMock(side_effect=self._ready)
+
+    def _resume(self) -> None:
+        self.state = "RESUMING"
+
+    def _ready(self, _timeout: int) -> None:
+        self.state = "RUNNING"
+
+
+class _FakeClient:
+    def __init__(self, sandbox: _FakeSandbox) -> None:
+        self.sandbox = sandbox
+        self.create = AsyncMock(return_value=sandbox)
+        self.get = AsyncMock(return_value=sandbox)
+        self.close = AsyncMock()
+
+
+def test_validate_tenki_startup_config_requires_credentials(monkeypatch) -> None:
+    monkeypatch.delenv("TENKI_API_KEY", raising=False)
+    monkeypatch.delenv("TENKI_AUTH_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="TENKI_API_KEY or TENKI_AUTH_TOKEN"):
+        tenki.validate_tenki_startup_config()
+
+
+def test_validate_tenki_startup_config_requires_project(monkeypatch) -> None:
+    monkeypatch.setenv("TENKI_API_KEY", "tenki-key")
+    monkeypatch.delenv("TENKI_SANDBOX_PROJECT_ID", raising=False)
+
+    with pytest.raises(ValueError, match="TENKI_SANDBOX_PROJECT_ID"):
+        tenki.validate_tenki_startup_config()
+
+
+async def test_create_tenki_sandbox_uses_native_async_client(monkeypatch) -> None:
+    monkeypatch.setenv("TENKI_API_KEY", "tenki-key")
+    monkeypatch.setenv("TENKI_SANDBOX_PROJECT_ID", "project-1")
+    monkeypatch.setenv("TENKI_SANDBOX_IMAGE", "sandbox-v2")
+    sandbox = _FakeSandbox()
+    client = _FakeClient(sandbox)
+    monkeypatch.setattr(tenki, "AsyncClient", lambda: client)
+
+    backend = await tenki.create_tenki_sandbox()
+
+    assert backend.id == "sb-created"
+    client.create.assert_awaited_once_with(
+        timeout=180,
+        project_id="project-1",
+        image="sandbox-v2",
+    )
+
+
+async def test_create_tenki_sandbox_resumes_on_reconnect(monkeypatch) -> None:
+    monkeypatch.setenv("TENKI_API_KEY", "tenki-key")
+    monkeypatch.setenv("TENKI_SANDBOX_PROJECT_ID", "project-1")
+    sandbox = _FakeSandbox("sb-existing", state="PAUSED")
+    client = _FakeClient(sandbox)
+    monkeypatch.setattr(tenki, "AsyncClient", lambda: client)
+
+    backend = await tenki.create_tenki_sandbox("sb-existing")
+
+    assert backend.id == "sb-existing"
+    sandbox.resume.assert_awaited_once()
+    sandbox.wait_ready.assert_awaited_once_with(180)
+
+
+async def test_tenki_backend_exec_and_github_auth_translation() -> None:
+    sandbox = _FakeSandbox()
+    client = _FakeClient(sandbox)
+    backend = tenki.TenkiSandbox(
+        client=cast(AsyncClient, client),
+        sandbox=cast(AsyncSandbox, sandbox),
+    )
+    backend.set_github_token("github-token")
+
+    result = await backend.aexecute("GH_TOKEN=dummy gh repo view")
+
+    assert result.output == "out\nerr"
+    sandbox.shell.assert_awaited_once_with(
+        'GH_TOKEN="${GH_TOKEN:-dummy}" gh repo view',
+        env={"GH_TOKEN": "github-token", "GIT_TOKEN": "github-token"},
+        timeout=1800,
+    )
+
+
+async def test_tenki_backend_file_roundtrip_and_cleanup() -> None:
+    sandbox = _FakeSandbox()
+    client = _FakeClient(sandbox)
+    backend = tenki.TenkiSandbox(
+        client=cast(AsyncClient, client),
+        sandbox=cast(AsyncSandbox, sandbox),
+    )
+
+    uploads = await backend.aupload_files([("/home/tenki/project/file.txt", b"contents")])
+    downloads = await backend.adownload_files(["/home/tenki/project/file.txt"])
+    await backend.aclose()
+
+    assert uploads[0].error is None
+    assert downloads[0].content == b"contents"
+    sandbox.fs.mkdir.assert_awaited_once_with("/home/tenki/project", recursive=True)
+    sandbox.close_if_open.assert_awaited_once()
+    client.close.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2061,6 +2061,7 @@ dependencies = [
     { name = "markdownify" },
     { name = "pyjwt" },
     { name = "stagehand" },
+    { name = "tenki-sandbox" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
@@ -2102,6 +2103,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20" },
     { name = "stagehand", specifier = ">=3.21.0" },
+    { name = "tenki-sandbox", specifier = ">=0.4.0" },
     { name = "uvicorn", specifier = ">=0.50.2" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
@@ -3280,6 +3282,20 @@ wheels = [
 ]
 
 [[package]]
+name = "tenki-sandbox"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/58/f6527c63b2e4c94fd00a48ba4bd93ef52de22dbc72e247110949a17511f6/tenki_sandbox-0.4.0.tar.gz", hash = "sha256:2836e6e7100dfc81715b4d93ecfe80e3f055867498cb9f34be921a02969bb15f", size = 179392, upload-time = "2026-07-17T22:18:09.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/f7/3c02da98793dc0e56230c520064d7d233c6e0edab13b410c031e1cfe7fd9/tenki_sandbox-0.4.0-py3-none-any.whl", hash = "sha256:76d5ece2e1607b43705587d86277e983ef43601a86993077e379be8033a40b3e", size = 155246, upload-time = "2026-07-17T22:18:08.383Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3603,6 +3619,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add native async Tenki sandbox support with `tenki-sandbox>=0.4.0`
- support reconnect/resume and refreshed per-command GitHub auth
- document configuration and validate required credentials at startup

## Validation
- `make lint`, `make typecheck`, `make test` (1,596 passed)
- Tenki SDK suite (367 passed, 1 skipped)
- live Tenki E2E: exec, files, GitHub clone/fetch, reconnect, and termination
- cold startup: 1.91s
