### PR TITLE
fix: pass initialized backend instance to create_deep_agent (deepagents 0.7)

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -173,9 +173,8 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     async def reconnect_backend(_thread_id: str = thread_id):
         return await ensure_sandbox_for_thread(_thread_id)
 
-    def backend_factory(_runtime: object, _thread_id: str = thread_id):
-        default_backend = get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)
-        return CompositeBackend(default=default_backend, routes={SKILLS_ROUTE: StateBackend()})
+    default_backend = get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
+    backend = CompositeBackend(default=default_backend, routes={SKILLS_ROUTE: StateBackend()})
 
     model_id = DEFAULT_LLM_MODEL_ID
     use_gateway = await _cached_gateway_enabled()
@@ -190,7 +189,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
         model=_make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs),
         system_prompt="",
         tools=[save_review_style_prompt, read_finding_outcomes],
-        backend=backend_factory,
+        backend=backend,
         skills=[SKILLS_ROUTE],
         middleware=cast(
             list[AgentMiddleware[Any, Any, Any]],

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -1378,8 +1378,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         )
         return sandbox_backend
 
-    def backend_factory(_runtime: object, _thread_id: str = thread_id):
-        return get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)
+    backend = get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
 
     return create_deep_agent(
         model=reviewer_model,
@@ -1397,7 +1396,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             http_request,
         ],
         subagents=[_reviewer_subagent(reviewer_subagent_model)],
-        backend=backend_factory,
+        backend=backend,
         middleware=cast(
             list[AgentMiddleware[Any, Any, Any]],
             [

--- a/agent/server.py
+++ b/agent/server.py
@@ -820,8 +820,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
         return await ensure_sandbox_for_thread(_thread_id, repo=prompt_default_repo)
 
-    def backend_factory(_runtime: object, _thread_id: str = thread_id) -> SandboxBackendProtocol:
-        return _get_cached_sandbox_backend(_thread_id, reconnect=reconnect_backend)
+    backend = _get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
 
     (model_id, profile_effort), (subagent_model_id, subagent_effort) = team_defaults
     logger.info("Using team default agent model: model=%s effort=%s", model_id, profile_effort)
@@ -987,7 +986,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             _general_purpose_subagent(subagent_model),
             *([_browser_subagent(subagent_model, browser_tools)] if browser_tools else []),
         ],
-        backend=backend_factory,
+        backend=backend,
         middleware=cast(
             list[AgentMiddleware[Any, Any, Any]],
             [

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -15,6 +15,7 @@ import pytest
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import get_agent
+from agent.utils.sandbox_state import SandboxBackendProxy
 
 
 class _DummyAgent:
@@ -78,8 +79,11 @@ async def _capture_create_deep_agent_kwargs() -> dict[str, object]:
 async def test_agent_is_built_with_a_backend_for_eviction_and_summarization() -> None:
     captured = await _capture_create_deep_agent_kwargs()
     # The backend is what enables deepagents' auto-wired FilesystemMiddleware
-    # eviction + SummarizationMiddleware offloading.
-    assert callable(captured["backend"])
+    # eviction + SummarizationMiddleware offloading. deepagents 0.7 requires an
+    # initialized backend instance, not a factory callable.
+    backend = captured["backend"]
+    assert isinstance(backend, SandboxBackendProxy)
+    assert not callable(backend)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

deepagents 0.7 (bumped in #1804) removed backend factories: `create_deep_agent` now requires an initialized `BackendProtocol` **instance**, not a callable. All three graph factories still passed a factory closure, so `FilesystemMiddleware.__init__` raised on every run:

```
TypeError: backend must be an initialized backend instance. Backend factories were removed in deepagents 0.7; pass StateBackend(), CompositeBackend(...), or another BackendProtocol instance instead.
```

This took down `open-swe-v3` in prod (background runs failing).

`SandboxBackendProxy` is already a stable, self-reconnecting `BackendProtocol` instance, so we build it once and pass the instance directly instead of wrapping it in a factory. Fixed in `agent/server.py` (agent), `agent/reviewer.py`, and `agent/analyzer.py` — only the `agent` graph had surfaced in prod logs, but reviewer/analyzer would crash identically on their first real build.

## Test Plan

- [x] `make typecheck` clean (previously the loose factory type slipped past; 0.7 tightened `backend` to `BackendProtocol | None`, which flags the callable)
- [x] `make lint`
- [x] Existing suites pass (`tests/agent`, `tests/reviewer`, `tests/models`) — 647 tests
- [x] Updated `test_agent_assembly_context` which had asserted the now-invalid factory contract (`callable(backend)`)
- [x] Verified the real deepagents `FilesystemMiddleware` accepts a `SandboxBackendProxy` instance
