### PR TITLE
feat: add Claude Opus 5 support

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -19,6 +19,13 @@ class ModelOption(TypedDict):
 
 SUPPORTED_MODELS: list[ModelOption] = [
     {
+        "id": "anthropic:claude-opus-5",
+        "label": "Opus 5",
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "default_effort": "high",
+        "supports_images": True,
+    },
+    {
         "id": "anthropic:claude-opus-4-8",
         "label": "Opus 4.8",
         "efforts": ["low", "medium", "high", "xhigh", "max"],

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -165,7 +165,7 @@ def fallback_model_id_for(primary_model_id: str) -> str | None:
     if primary_model_id.startswith("anthropic:"):
         return "openai:gpt-5.6-sol"
     if primary_model_id.startswith("openai:"):
-        return "anthropic:claude-opus-4-8"
+        return "anthropic:claude-opus-5"
     return None
 
 

--- a/tests/models/test_agent_subagent_models.py
+++ b/tests/models/test_agent_subagent_models.py
@@ -208,6 +208,6 @@ async def test_agent_gate_swaps_disabled_fable_profile_to_opus() -> None:
         await get_agent(config)
 
     # Fable was scrubbed to Opus for both main and subagent; effort preserved.
-    assert make_model.call_args_list[0].args == ("anthropic:claude-opus-4-8",)
+    assert make_model.call_args_list[0].args == ("anthropic:claude-opus-5",)
     assert make_model.call_args_list[0].kwargs["effort"] == "high"
-    assert make_model.call_args_list[1].args == ("anthropic:claude-opus-4-8",)
+    assert make_model.call_args_list[1].args == ("anthropic:claude-opus-5",)

--- a/tests/models/test_anthropic_model.py
+++ b/tests/models/test_anthropic_model.py
@@ -3,8 +3,25 @@ import pytest
 from agent.dashboard.options import SUPPORTED_MODELS, provider_fallback_pair
 from agent.utils.model import provider_model_kwargs
 
+OPUS_5_ID = "anthropic:claude-opus-5"
 SONNET_5_ID = "anthropic:claude-sonnet-5"
 FABLE_5_ID = "anthropic:claude-fable-5"
+
+
+def test_opus_5_is_supported_with_documented_efforts() -> None:
+    opus = next(m for m in SUPPORTED_MODELS if m["id"] == OPUS_5_ID)
+    assert opus.get("label") == "Opus 5"
+    assert opus.get("efforts") == ["low", "medium", "high", "xhigh", "max"]
+    assert opus.get("default_effort") == "high"
+    assert opus["supports_images"] is True
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+def test_opus_5_efforts_map_to_anthropic_kwargs(effort: str) -> None:
+    kwargs = provider_model_kwargs(OPUS_5_ID, effort, max_tokens=64_000)
+    assert kwargs.get("max_tokens") == 64_000
+    assert kwargs.get("effort") == effort
+    assert kwargs.get("thinking") == {"type": "adaptive", "display": "summarized"}
 
 
 def test_sonnet_5_is_supported_with_documented_efforts() -> None:
@@ -31,8 +48,8 @@ def test_sonnet_46_fallback_uses_sonnet_5() -> None:
 
 
 def test_opus_fallback_stays_on_opus_family() -> None:
-    assert provider_fallback_pair("anthropic:claude-opus-4-7", "xhigh") == (
-        "anthropic:claude-opus-4-8",
+    assert provider_fallback_pair("anthropic:claude-opus-4-8", "xhigh") == (
+        OPUS_5_ID,
         "xhigh",
     )
 

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -23,7 +23,7 @@ from agent.dashboard.team_settings import (
 )
 
 STALE_ANTHROPIC = "anthropic:claude-opus-4-7"
-SUPPORTED_ANTHROPIC = "anthropic:claude-opus-4-8"
+SUPPORTED_ANTHROPIC = "anthropic:claude-opus-5"
 
 
 def test_provider_fallback_preserves_provider_and_effort() -> None:
@@ -225,7 +225,7 @@ def test_gate_fable_passthrough_when_enabled() -> None:
 
 def test_gate_fable_swaps_to_opus_when_disabled() -> None:
     assert gate_fable_model("anthropic:claude-fable-5", "high", fable_enabled=False) == (
-        "anthropic:claude-opus-4-8",
+        SUPPORTED_ANTHROPIC,
         "high",
     )
 
@@ -239,6 +239,6 @@ def test_gate_fable_leaves_non_fable_ids_alone() -> None:
 
 def test_fable_disabled_fallback_is_non_fable_anthropic() -> None:
     model, effort = fable_disabled_fallback("high")
-    assert model == "anthropic:claude-opus-4-8"
+    assert model == SUPPORTED_ANTHROPIC
     assert model not in FABLE_MODEL_IDS
     assert effort == "high"


### PR DESCRIPTION
## Description
Add Claude Opus 5 using Anthropic's documented model ID and all five supported effort levels. Promote it as the newest Opus fallback while retaining Opus 4.8 as a selectable model.

## Release Note
Claude Opus 5 is now available with low, medium, high, xhigh, and max effort.

## Test Plan
- [x] Verify all Opus 5 efforts map to Anthropic adaptive-thinking kwargs.

Made by [Open SWE](https://openswe.vercel.app/agents/019f953a-2a7f-70c9-80e4-27030b186d1a)