### PR TITLE
feat: add deployable Open SWE Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,10 @@ __pycache__
 .venv
 .DS_Store
 logs.txt
+ui/node_modules
+ui/.output
+ui/.nitro
+ui/.tanstack
+ui/dist
+ui/.vite
+ui/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,108 +1,24 @@
-FROM python:3.14.6-slim-trixie
+FROM langchain/langgraph-api:0.10.0rc3-py3.12
 
-ARG DOCKER_CLI_VERSION=5:29.1.5-1~debian.13~trixie
-ARG NODEJS_VERSION=22.22.0-1nodesource1
-ARG UV_VERSION=0.9.26
-ARG YARN_VERSION=4.12.0
-ARG GH_VERSION=2.83.1
-ARG SFW_VERSION=2.0.6
+ADD . /deps/open-swe
+RUN cd /deps/open-swe \
+    && PYTHONDONTWRITEBYTECODE=1 uv pip install --system --no-cache-dir -c /api/constraints.txt -e .
 
-ENV DEBIAN_FRONTEND=noninteractive
-# Skip sfw's daily background update check at runtime. The check hits
-# api.github.com/repos/SocketDev/sfw-free, which the sandbox proxy authenticates
-# with the GitHub App installation token (no access to that repo), so it fails
-# and the wrapper can't fall back to a binary it never managed to fetch. The
-# initial download still runs at build time below, where egress is unrestricted.
-ENV SFW_SKIP_UPDATE_CHECK=1
+ENV LANGGRAPH_HTTP='{"app":"agent.webapp:app"}'
+ENV LANGGRAPH_CHECKPOINTER='{"ttl":{"strategy":"delete","sweep_interval_minutes":60,"default_ttl":43200}}'
+ENV LANGSERVE_GRAPHS='{"agent":"agent.graphs.agent:traced_agent","reviewer":"agent.graphs.reviewer:traced_reviewer_agent","analyzer":"agent.graphs.analyzer:traced_analyzer","chat":"agent.graphs.chat:traced_chat_agent","scheduler":"agent.graphs.scheduler:get_scheduler"}'
 
-RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    wget \
-    ca-certificates \
-    gnupg \
-    lsb-release \
-    build-essential \
-    cargo \
-    openssh-client \
-    jq \
-    ripgrep \
-    unzip \
-    zip \
-    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /api/langgraph_api /api/langgraph_runtime /api/langgraph_license \
+    && touch /api/langgraph_api/__init__.py /api/langgraph_runtime/__init__.py /api/langgraph_license/__init__.py
+RUN PYTHONDONTWRITEBYTECODE=1 uv pip install --system --no-cache-dir --no-deps -e /api
+RUN pip uninstall -y pip setuptools wheel
+RUN rm -rf /usr/local/lib/python*/site-packages/pip* /usr/local/lib/python*/site-packages/setuptools* /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/bin -name "pip*" -delete || true
+RUN rm -rf /usr/lib/python*/site-packages/pip* /usr/lib/python*/site-packages/setuptools* /usr/lib/python*/site-packages/wheel* \
+    && find /usr/bin -name "pip*" -delete || true
+RUN uv pip uninstall --system pip setuptools wheel \
+    && rm /usr/bin/uv /usr/bin/uvx
 
-RUN install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
-    && chmod a+r /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
-      | tee /etc/apt/sources.list.d/docker.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y "docker-ce-cli=${DOCKER_CLI_VERSION}" \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /deps/open-swe
 
-RUN set -eux; \
-    arch="$(dpkg --print-architecture)"; \
-    case "${arch}" in \
-      amd64) gh_arch="amd64" ;; \
-      arm64) gh_arch="arm64" ;; \
-      *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
-    esac; \
-    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${gh_arch}.deb" -o /tmp/gh.deb; \
-    apt-get update; \
-    apt-get install -y /tmp/gh.deb; \
-    rm -rf /tmp/gh.deb /var/lib/apt/lists/*
-
-RUN set -eux; \
-    arch="$(dpkg --print-architecture)"; \
-    case "${arch}" in \
-      amd64) uv_arch="x86_64-unknown-linux-gnu"; uv_sha256="30ccbf0a66dc8727a02b0e245c583ee970bdafecf3a443c1686e1b30ec4939e8" ;; \
-      arm64) uv_arch="aarch64-unknown-linux-gnu"; uv_sha256="f71040c59798f79c44c08a7a1c1af7de95a8d334ea924b47b67ad6b9632be270" ;; \
-      *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
-    esac; \
-    curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${uv_arch}.tar.gz" -o /tmp/uv.tar.gz; \
-    echo "${uv_sha256}  /tmp/uv.tar.gz" | sha256sum -c -; \
-    tar -xzf /tmp/uv.tar.gz -C /tmp; \
-    install -m 0755 -d /root/.local/bin; \
-    install -m 0755 "/tmp/uv-${uv_arch}/uv" /root/.local/bin/uv; \
-    install -m 0755 "/tmp/uv-${uv_arch}/uvx" /root/.local/bin/uvx; \
-    rm -rf /tmp/uv.tar.gz "/tmp/uv-${uv_arch}"
-
-ENV PATH=/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y "nodejs=${NODEJS_VERSION}" \
-    && rm -rf /var/lib/apt/lists/* \
-    && corepack enable \
-    && corepack prepare "yarn@${YARN_VERSION}" --activate \
-    && npm i -g "sfw@${SFW_VERSION}" \
-    && sfw --version \
-    && test -e "$(npm root -g)/sfw/.sfw-cache/latest"
-
-# Chromium for Stagehand LOCAL browser mode (STAGEHAND_ENV=LOCAL). Skipped at
-# runtime when STAGEHAND_ENV=BROWSERBASE (browser runs on Browserbase cloud).
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends chromium \
-    && rm -rf /var/lib/apt/lists/*
-ENV STAGEHAND_LOCAL_CHROME_PATH=/usr/bin/chromium
-
-ENV GO_VERSION=1.23.5
-
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" | tar -C /usr/local -xz
-
-ENV PATH=/usr/local/go/bin:/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV GOPATH=/root/go
-ENV PATH=/root/go/bin:/usr/local/go/bin:/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-WORKDIR /workspace
-
-RUN echo "=== Installed versions ===" \
-    && python --version \
-    && uv --version \
-    && node --version \
-    && yarn --version \
-    && sfw --version \
-    && go version \
-    && cargo --version \
-    && docker --version \
-    && git --version \
-    && gh --version
+EXPOSE 8000

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,108 @@
+FROM python:3.14.6-slim-trixie
+
+ARG DOCKER_CLI_VERSION=5:29.1.5-1~debian.13~trixie
+ARG NODEJS_VERSION=22.22.0-1nodesource1
+ARG UV_VERSION=0.9.26
+ARG YARN_VERSION=4.12.0
+ARG GH_VERSION=2.83.1
+ARG SFW_VERSION=2.0.6
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Skip sfw's daily background update check at runtime. The check hits
+# api.github.com/repos/SocketDev/sfw-free, which the sandbox proxy authenticates
+# with the GitHub App installation token (no access to that repo), so it fails
+# and the wrapper can't fall back to a binary it never managed to fetch. The
+# initial download still runs at build time below, where egress is unrestricted.
+ENV SFW_SKIP_UPDATE_CHECK=1
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    build-essential \
+    cargo \
+    openssh-client \
+    jq \
+    ripgrep \
+    unzip \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
+      | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y "docker-ce-cli=${DOCKER_CLI_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "${arch}" in \
+      amd64) gh_arch="amd64" ;; \
+      arm64) gh_arch="arm64" ;; \
+      *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${gh_arch}.deb" -o /tmp/gh.deb; \
+    apt-get update; \
+    apt-get install -y /tmp/gh.deb; \
+    rm -rf /tmp/gh.deb /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "${arch}" in \
+      amd64) uv_arch="x86_64-unknown-linux-gnu"; uv_sha256="30ccbf0a66dc8727a02b0e245c583ee970bdafecf3a443c1686e1b30ec4939e8" ;; \
+      arm64) uv_arch="aarch64-unknown-linux-gnu"; uv_sha256="f71040c59798f79c44c08a7a1c1af7de95a8d334ea924b47b67ad6b9632be270" ;; \
+      *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${uv_arch}.tar.gz" -o /tmp/uv.tar.gz; \
+    echo "${uv_sha256}  /tmp/uv.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/uv.tar.gz -C /tmp; \
+    install -m 0755 -d /root/.local/bin; \
+    install -m 0755 "/tmp/uv-${uv_arch}/uv" /root/.local/bin/uv; \
+    install -m 0755 "/tmp/uv-${uv_arch}/uvx" /root/.local/bin/uvx; \
+    rm -rf /tmp/uv.tar.gz "/tmp/uv-${uv_arch}"
+
+ENV PATH=/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y "nodejs=${NODEJS_VERSION}" \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable \
+    && corepack prepare "yarn@${YARN_VERSION}" --activate \
+    && npm i -g "sfw@${SFW_VERSION}" \
+    && sfw --version \
+    && test -e "$(npm root -g)/sfw/.sfw-cache/latest"
+
+# Chromium for Stagehand LOCAL browser mode (STAGEHAND_ENV=LOCAL). Skipped at
+# runtime when STAGEHAND_ENV=BROWSERBASE (browser runs on Browserbase cloud).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium \
+    && rm -rf /var/lib/apt/lists/*
+ENV STAGEHAND_LOCAL_CHROME_PATH=/usr/bin/chromium
+
+ENV GO_VERSION=1.23.5
+
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" | tar -C /usr/local -xz
+
+ENV PATH=/usr/local/go/bin:/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV GOPATH=/root/go
+ENV PATH=/root/go/bin:/usr/local/go/bin:/root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+WORKDIR /workspace
+
+RUN echo "=== Installed versions ===" \
+    && python --version \
+    && uv --version \
+    && node --version \
+    && yarn --version \
+    && sfw --version \
+    && go version \
+    && cargo --version \
+    && docker --version \
+    && git --version \
+    && gh --version

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -45,7 +45,7 @@ REPO_SNAPSHOT_BASE_IMAGE="<registry>/<open-swe-sandbox-image>"      # Optional; 
 
 This is useful for pre-installing languages, frameworks, or internal tools that your repos depend on — reducing setup time per agent run. The default snapshot includes the GitHub CLI; agents invoke it as `GH_TOKEN=dummy gh <command>` and rely on the LangSmith proxy for the real credentials.
 
-`REPO_SNAPSHOT_BASE_IMAGE` should point to the published Docker image used to create your default Open SWE sandbox snapshot (typically the image built from this repository's `Dockerfile`). The admin **Repository Snapshots** page uses it as the base image when generating per-repo Dockerfile templates. If it is not configured, template generation fails closed instead of suggesting a bare image that would be missing Open SWE's required sandbox tools.
+`REPO_SNAPSHOT_BASE_IMAGE` should point to the published Docker image used to create your default Open SWE sandbox snapshot (typically the image built from this repository's `Dockerfile.sandbox`). The admin **Repository Snapshots** page uses it as the base image when generating per-repo Dockerfile templates. If it is not configured, template generation fails closed instead of suggesting a bare image that would be missing Open SWE's required sandbox tools.
 
 For LangSmith sandboxes, Open SWE configures two GitHub proxy rules whenever a sandbox is created or reattached to a run:
 
@@ -307,7 +307,7 @@ The tools are added in `agent/server.py` (gated by `load_browser_tools()`), and 
 | `STAGEHAND_LOCAL_CHROME_PATH` | `/usr/bin/chromium` in Docker | Path to the Chrome/Chromium binary for `LOCAL` mode. |
 | `STAGEHAND_HEADLESS` | `true` | Run the local browser headless. |
 
-For `LOCAL` mode the Dockerfile installs `chromium`; for `BROWSERBASE` mode no browser binary is needed in the image.
+For `LOCAL` mode the sandbox image in `Dockerfile.sandbox` installs `chromium`; for `BROWSERBASE` mode no browser binary is needed in the image.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -186,7 +186,7 @@ from langsmith.sandbox import SandboxClient
 client = SandboxClient(api_key="<your key>")
 snapshot = client.create_snapshot(
     name="open-swe",
-    docker_image="johanneslangchain/open-swe-sandbox:gh-cli-amd64",  # built from ./Dockerfile
+    docker_image="johanneslangchain/open-swe-sandbox:gh-cli-amd64",  # built from ./Dockerfile.sandbox
     fs_capacity_bytes=128 * 1024**3,
 )
 print(snapshot.id)
@@ -218,9 +218,9 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="1209600"
 REPO_SNAPSHOT_BASE_IMAGE="<your-docker-hub>/<name-of-your-image>"
 ```
 
-`DEFAULT_SANDBOX_SNAPSHOT_ID` is required when `SANDBOX_TYPE=langsmith`. The server validates this at startup and refuses to boot if it's missing. The snapshot should include the GitHub CLI from the project Dockerfile; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
+`DEFAULT_SANDBOX_SNAPSHOT_ID` is required when `SANDBOX_TYPE=langsmith`. The server validates this at startup and refuses to boot if it's missing. The snapshot should include the GitHub CLI from `Dockerfile.sandbox`; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
 
-`REPO_SNAPSHOT_BASE_IMAGE` should point at the same published Open SWE sandbox image you used to create the default snapshot (for example, the image built from `./Dockerfile`). The admin **Repository Snapshots** page uses it as the `FROM` line when generating per-repo Dockerfile templates. If it is not set, template generation is intentionally disabled so admins do not accidentally build repo-scoped snapshots from a bare image that lacks Open SWE's required tools (`git`, `gh`, `sfw`, language runtimes, and proxy assumptions).
+`REPO_SNAPSHOT_BASE_IMAGE` should point at the same published Open SWE sandbox image you used to create the default snapshot (for example, the image built from `./Dockerfile.sandbox`). The admin **Repository Snapshots** page uses it as the `FROM` line when generating per-repo Dockerfile templates. If it is not set, template generation is intentionally disabled so admins do not accidentally build repo-scoped snapshots from a bare image that lacks Open SWE's required tools (`git`, `gh`, `sfw`, language runtimes, and proxy assumptions).
 
 ## 5. Set up triggers
 
@@ -637,21 +637,36 @@ Other UI scripts: `pnpm run build`, `pnpm run typecheck`, `pnpm run lint`, `pnpm
 
 Production runs the backend and dashboard separately.
 
-**Backend** — deploy on [LangGraph Cloud / Platform](https://langchain-ai.github.io/langgraph/cloud/):
+**Backend — standalone Docker:** the root `Dockerfile` builds a production LangGraph API server image for Open SWE. It is not the sandbox image; build sandbox snapshots from `Dockerfile.sandbox`.
 
-1. Push your code to a GitHub repository
-2. Connect the repo to LangGraph Cloud
-3. Set all environment variables from step 6 in the deployment config. Set `DASHBOARD_BASE_URL` and `LANGGRAPH_URL` to your production URLs (all `https://`). Set `DASHBOARD_API_BASE_URL` to the URL browsers use for dashboard API requests and OAuth callbacks: either the backend URL for direct cross-origin calls, or the dashboard/Vercel URL when a same-origin rewrite proxies `/dashboard/api/*`.
-4. Update your webhook URLs (Linear, Slack, GitHub App) and the GitHub App / Slack OAuth callback URLs to your production URLs (replace the ngrok / localhost values). The dashboard GitHub App callback must be `<DASHBOARD_API_BASE_URL>/dashboard/api/auth/callback`.
+```bash
+docker build -t open-swe .
 
-The `langgraph.json` at the project root defines the three graphs and the HTTP app:
+docker run \
+  --env-file .env \
+  -p 8123:8000 \
+  -e DATABASE_URI="postgres://postgres:postgres@host.docker.internal:5432/postgres?sslmode=disable" \
+  -e REDIS_URI="redis://host.docker.internal:6379" \
+  -e LANGGRAPH_AUTH_TYPE="noop" \
+  -e LANGGRAPH_URL="https://<your-backend-url>" \
+  -e DASHBOARD_API_BASE_URL="https://<your-dashboard-or-backend-url>" \
+  open-swe
+```
+
+Set all environment variables from step 6, plus the standalone Agent Server requirements: `DATABASE_URI`, `REDIS_URI`, `LANGSMITH_API_KEY` (unless tracing is disabled for your deployment), and `LANGGRAPH_CLOUD_LICENSE_KEY` for the production LangGraph server. Expose the container's port `8000` through your ingress. Do not use scale-to-zero hosting; background runs rely on Redis/Postgres-backed workers staying available. If the built-in LangGraph API routes are reachable from the public internet, put the service behind a private network, API gateway, or custom LangGraph auth before using `LANGGRAPH_AUTH_TYPE=noop`.
+
+Set `LANGGRAPH_URL` to the public backend URL so webhooks and the dashboard can create runs against this same server. Set `DASHBOARD_API_BASE_URL` to the URL browsers use for dashboard API requests and OAuth callbacks: either the backend URL for direct cross-origin calls, or the dashboard/Vercel URL when a same-origin rewrite proxies `/dashboard/api/*`. Update your webhook URLs (Linear, Slack, GitHub App) and the GitHub App / Slack OAuth callback URLs to your production URLs. The dashboard GitHub App callback must be `<DASHBOARD_API_BASE_URL>/dashboard/api/auth/callback`.
+
+The `langgraph.json` at the project root defines the graphs and HTTP app baked into the image:
 
 ```json
 {
   "graphs": {
-    "agent": "agent.server:traced_agent",
-    "reviewer": "agent.reviewer:traced_reviewer_agent",
-    "analyzer": "agent.analyzer:traced_analyzer"
+    "agent": "agent.graphs.agent:traced_agent",
+    "reviewer": "agent.graphs.reviewer:traced_reviewer_agent",
+    "analyzer": "agent.graphs.analyzer:traced_analyzer",
+    "chat": "agent.graphs.chat:traced_chat_agent",
+    "scheduler": "agent.graphs.scheduler:get_scheduler"
   },
   "http": {
     "app": "agent.webapp:app"
@@ -659,7 +674,9 @@ The `langgraph.json` at the project root defines the three graphs and the HTTP a
 }
 ```
 
-**Dashboard** — the `ui/` app deploys to [Vercel](https://vercel.com/). The recommended production setup uses **same-origin** requests to `/dashboard/api/*` (leave `VITE_DASHBOARD_API_BASE_URL` empty), and `ui/vercel.json` rewrites those to the hosted LangGraph deployment. In this mode, set both `DASHBOARD_API_BASE_URL` and the GitHub App dashboard callback URL to the Vercel/dashboard origin (for example, `https://your-dashboard.vercel.app/dashboard/api/auth/callback`). The OAuth callback response then sets the `osw_session` cookie on the dashboard host, and later same-origin `/dashboard/api/*` requests include it. Update the rewrite `destination` in `ui/vercel.json` to your own LangGraph deployment URL.
+**Backend — LangGraph Cloud / Platform:** alternatively, push your code to a GitHub repository, connect the repo to LangGraph Cloud, set the same environment variables in the deployment config, and use the hosted deployment URL for `LANGGRAPH_URL` and webhook callbacks.
+
+**Dashboard** — the `ui/` app deploys to [Vercel](https://vercel.com/). The recommended production setup uses **same-origin** requests to `/dashboard/api/*` (leave `VITE_DASHBOARD_API_BASE_URL` empty), and `ui/vercel.json` rewrites those to the hosted backend. In this mode, set both `DASHBOARD_API_BASE_URL` and the GitHub App dashboard callback URL to the Vercel/dashboard origin (for example, `https://your-dashboard.vercel.app/dashboard/api/auth/callback`). The OAuth callback response then sets the `osw_session` cookie on the dashboard host, and later same-origin `/dashboard/api/*` requests include it. Update the rewrite `destination` in `ui/vercel.json` to your own backend URL.
 
 Alternatively, you can run the dashboard as a direct cross-origin client: set `VITE_DASHBOARD_API_BASE_URL` to the hosted backend origin, set `DASHBOARD_API_BASE_URL` to that same backend origin, and include the dashboard origin in `DASHBOARD_ALLOWED_ORIGINS`.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -160,10 +160,11 @@ To set up per-user OAuth:
 LangSmith sandboxes provide the isolated execution environment for each agent run. Open SWE boots each sandbox from a pre-built **snapshot** — you build the snapshot once (from a Docker image) and then reference it by UUID.
 
 (Optional) Build and Push a custom Docker Image to Docker hub
-First build and push the sandbox Docker image to a registry LangSmith can pull from. On Apple Silicon, force `linux/amd64`
+First build and push the sandbox Docker image to a registry LangSmith can pull from. The sandbox image is `Dockerfile.sandbox` — pass `-f Dockerfile.sandbox`, because the root `Dockerfile` builds the API server image instead and produces snapshots without `git`, `gh`, `sfw`, the Docker CLI, or the language runtimes agent runs need. On Apple Silicon, force `linux/amd64`
 
 ```bash
 docker buildx build \
+  -f Dockerfile.sandbox \
   --platform linux/amd64 \
   -t <your-docker-hub>/<name-of-your-image> \
   --push .
@@ -173,6 +174,7 @@ For a multi-arch tag that also runs locally on Apple Silicon:
 
 ```bash
 docker buildx build \
+  -f Dockerfile.sandbox \
   --platform linux/amd64,linux/arm64 \
   -t <your-docker-hub>/<name-of-your-image> \
   --push .
@@ -645,6 +647,7 @@ docker build -t open-swe .
 docker run \
   --env-file .env \
   -p 8123:8000 \
+  --add-host=host.docker.internal:host-gateway \
   -e DATABASE_URI="postgres://postgres:postgres@host.docker.internal:5432/postgres?sslmode=disable" \
   -e REDIS_URI="redis://host.docker.internal:6379" \
   -e LANGGRAPH_AUTH_TYPE="noop" \
@@ -652,6 +655,8 @@ docker run \
   -e DASHBOARD_API_BASE_URL="https://<your-dashboard-or-backend-url>" \
   open-swe
 ```
+
+The example above assumes Postgres and Redis run on the Docker host. `host.docker.internal` only resolves automatically on Docker Desktop, so `--add-host=host.docker.internal:host-gateway` is what makes it work on a plain Linux Docker Engine. If Postgres and Redis run as their own containers, drop the flag and point `DATABASE_URI` / `REDIS_URI` at their service names on a shared Docker network instead.
 
 Set all environment variables from step 6, plus the standalone Agent Server requirements: `DATABASE_URI`, `REDIS_URI`, `LANGSMITH_API_KEY` (unless tracing is disabled for your deployment), and `LANGGRAPH_CLOUD_LICENSE_KEY` for the production LangGraph server. Expose the container's port `8000` through your ingress. Do not use scale-to-zero hosting; background runs rely on Redis/Postgres-backed workers staying available. If the built-in LangGraph API routes are reachable from the public internet, put the service behind a private network, API gateway, or custom LangGraph auth before using `LANGGRAPH_AUTH_TYPE=noop`.
 


### PR DESCRIPTION
## Description
Add a production LangGraph API server Dockerfile for Open SWE and move the existing task sandbox image to Dockerfile.sandbox so the default build target is deployable. Document standalone Docker deployment requirements and update sandbox-image references.

## Test Plan
- [ ] Build the deployment image with `docker build -t open-swe .` on a host with a running Docker daemon
- [ ] Run the container with Postgres/Redis and verify `GET /ok`

Made by [Open SWE](https://openswe.vercel.app/agents/f53dfaf2-65bf-8120-e0a6-ec79387a5f21)