### PR TITLE
fix: never recreate or delete a thread's sandbox

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -27,6 +27,7 @@ from .utils.github_comments import post_github_comment
 from .utils.linear import comment_on_linear_issue
 from .utils.slack import post_slack_thread_reply
 from .utils.thread_ops import langgraph_client
+from .utils.user_messages import warning
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +72,9 @@ def _failure_text(status: str, dashboard_url: str | None = None) -> str:
         reason = "was interrupted before it could finish"
     else:
         reason = "hit an unexpected error"
-    text = (
-        f"⚠️ I wasn't able to finish that — the run {reason}. "
-        "Send another message and I'll pick it back up."
+    text = warning(
+        f"Open SWE wasn't able to finish that — the run {reason}. "
+        "Send another message and it will pick this back up."
     )
     if dashboard_url:
         text += f" You can view the error in <{dashboard_url}|Open SWE Web>."

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -290,22 +290,6 @@ async def _wait_for_reconnected_sandbox(
         last_sandbox = await client.get_sandbox(name=sandbox_id)
 
 
-async def _release_sandbox_name(client: AsyncSandboxClient, name: str | None) -> None:
-    """Best-effort delete of any existing sandbox holding ``name``.
-
-    Sandbox names are unique in LangSmith and thread-deterministic, so the only
-    box that can hold this name is this thread's own — typically a dead one
-    (idle-stopped past its TTL) we're recreating. Provisioning is serialized per
-    thread, so this never races a live box. Without this, recreate would 409.
-    """
-    if not name:
-        return
-    try:
-        await client.delete_sandbox(name)
-    except Exception as exc:  # noqa: BLE001 - name is free if nothing to delete
-        logger.debug("No pre-existing sandbox %s to release (%s)", name, type(exc).__name__)
-
-
 async def _create_sandbox_with_retry(
     client: AsyncSandboxClient,
     *,
@@ -595,7 +579,14 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
 
 
 class SandboxProvider(ABC):
-    """Interface for creating and deleting sandbox backends."""
+    """Interface for creating sandbox backends.
+
+    Intentionally has no delete. A sandbox holds the agent's only copy of its
+    working tree, and callers cannot reliably tell a free name from one held by
+    a live box — thread metadata reads and writes both fail open to "no sandbox".
+    Reclamation is the platform's job, via the idle TTL and delete-after-stop
+    set at create time.
+    """
 
     @abstractmethod
     async def get_or_create(
@@ -605,16 +596,6 @@ class SandboxProvider(ABC):
         **kwargs: Any,
     ) -> SandboxBackendProtocol:
         """Get an existing sandbox, or create one if needed."""
-        raise NotImplementedError
-
-    @abstractmethod
-    async def delete(
-        self,
-        *,
-        sandbox_id: str,
-        **kwargs: Any,
-    ) -> None:
-        """Delete a sandbox by id."""
         raise NotImplementedError
 
 
@@ -719,7 +700,6 @@ class LangSmithProvider(SandboxProvider):
                 raise ValueError(msg)
 
             _install_create_extra_fields(client, _get_sandbox_create_extra_fields())
-            await _release_sandbox_name(client, name)
 
             try:
                 sandbox = await _create_sandbox_with_retry(
@@ -738,10 +718,3 @@ class LangSmithProvider(SandboxProvider):
                 raise RuntimeError(msg) from e
 
             return TimeoutLangSmithSandbox(sandbox.to_sync())
-
-    async def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:
-        """Delete a LangSmith sandbox."""
-        async with AsyncSandboxClient(
-            api_key=self._api_key, api_endpoint=self._api_endpoint
-        ) as client:
-            await client.delete_sandbox(sandbox_id)

--- a/agent/middleware/notify_step_limit.py
+++ b/agent/middleware/notify_step_limit.py
@@ -11,6 +11,7 @@ from langgraph.config import get_config
 from langgraph.runtime import Runtime
 
 from ..utils.slack import post_slack_thread_reply
+from ..utils.user_messages import warning
 
 logger = logging.getLogger(__name__)
 
@@ -73,10 +74,10 @@ async def notify_step_limit_reached(
         logger.info("No Slack thread config — cannot send step-limit notification")
         return None
 
-    message = (
-        "I've reached my maximum step limit and had to stop. "
+    message = warning(
+        "Open SWE reached its maximum step limit and had to stop. "
         "The task may be incomplete. You can retry with a more focused request, "
-        "or ask me to continue from where I left off."
+        "or ask it to continue from where it left off."
     )
 
     try:

--- a/agent/middleware/sandbox_circuit_breaker.py
+++ b/agent/middleware/sandbox_circuit_breaker.py
@@ -6,7 +6,7 @@ import logging
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
 from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
@@ -18,20 +18,46 @@ from ..utils.github_comments import post_github_comment
 from ..utils.github_token import get_github_token
 from ..utils.linear import comment_on_linear_issue
 from ..utils.slack import post_slack_thread_reply
+from ..utils.user_messages import warning
 
 logger = logging.getLogger(__name__)
 
 SANDBOX_CIRCUIT_BREAKER_THRESHOLD = 2
-SANDBOX_UNRECOVERABLE_MESSAGE = "Sandbox became unrecoverable mid-task. Please retrigger."
+
+
+def sandbox_unreachable_message(
+    *, sandbox_id: str | None = None, sandbox_name: str | None = None
+) -> str:
+    """User-facing text for a sandbox that stopped answering.
+
+    Deliberately does not claim the sandbox is gone for good — all we observed is
+    that it stopped responding, and it may come back.
+    """
+    identifiers = [
+        part
+        for part in (
+            f"name {sandbox_name}" if sandbox_name else None,
+            f"id {sandbox_id}" if sandbox_id else None,
+        )
+        if part
+    ]
+    which = f" ({', '.join(identifiers)})" if identifiers else ""
+    return warning(
+        f"This thread's sandbox{which} stopped responding, and Open SWE can't tell "
+        "whether it will come back. Open SWE will not start a replacement on its "
+        "own: a new sandbox is empty, so swapping one in would throw away anything "
+        "not yet committed and pushed while still looking like a recovery. "
+        "Retrigger this thread to try the same sandbox again, or start a new thread "
+        "to get a fresh one."
+    )
+
 
 _CIRCUIT_BREAKER_MARKER = "Sandbox circuit breaker triggered"
-_SANDBOX_RECREATED_AFTER_CLIENT_ERROR = "sandbox_recreated_after_client_error"
 _SANDBOX_ID_RE = re.compile(r"\bsb-[A-Za-z0-9-]+\b")
 
 
 @dataclass(frozen=True)
 class SandboxErrorStreak:
-    reason: Literal["client_error", "recreated"]
     sandbox_id: str | None
     count: int
 
@@ -52,7 +78,7 @@ def _content_to_text(content: object) -> str:
     return " ".join(parts)
 
 
-def _extract_sandbox_id(text: str) -> str | None:
+def extract_sandbox_id(text: str) -> str | None:
     match = _SANDBOX_ID_RE.search(text)
     return match.group(0) if match else None
 
@@ -66,27 +92,17 @@ def _last_message_has_circuit_breaker_marker(messages: Sequence[BaseMessage]) ->
 
 def _sandbox_error_streak(messages: Sequence[BaseMessage]) -> SandboxErrorStreak | None:
     sandbox_id: str | None = None
-    reason: Literal["client_error", "recreated"] | None = None
     count = 0
 
     for message in reversed(messages):
         if isinstance(message, ToolMessage):
             text = _content_to_text(message.content)
-            if _SANDBOX_RECREATED_AFTER_CLIENT_ERROR in text:
-                if reason is None:
-                    reason = "recreated"
-                elif reason != "recreated":
-                    break
-                count += 1
-                continue
-
-            message_sandbox_id = _extract_sandbox_id(text)
+            message_sandbox_id = extract_sandbox_id(text)
             if "SandboxClientError" not in text or message_sandbox_id is None:
                 break
-            if reason is None:
-                reason = "client_error"
+            if sandbox_id is None:
                 sandbox_id = message_sandbox_id
-            elif reason != "client_error" or message_sandbox_id != sandbox_id:
+            elif message_sandbox_id != sandbox_id:
                 break
             count += 1
             continue
@@ -97,9 +113,9 @@ def _sandbox_error_streak(messages: Sequence[BaseMessage]) -> SandboxErrorStreak
         if getattr(message, "type", "") in {"human", "system"}:
             break
 
-    if reason is None:
+    if sandbox_id is None:
         return None
-    return SandboxErrorStreak(reason=reason, sandbox_id=sandbox_id, count=count)
+    return SandboxErrorStreak(sandbox_id=sandbox_id, count=count)
 
 
 def _get_slack_target(configurable: Mapping[str, Any]) -> tuple[str, str] | None:
@@ -165,22 +181,29 @@ def _get_github_target(configurable: Mapping[str, Any]) -> tuple[dict[str, str],
     return None
 
 
-async def _post_unrecoverable_notification(config: Mapping[str, Any]) -> None:
+async def post_sandbox_unrecoverable_notification(
+    config: Mapping[str, Any],
+    *,
+    sandbox_id: str | None = None,
+    sandbox_name: str | None = None,
+) -> None:
     configurable = config.get("configurable", {})
     if not isinstance(configurable, Mapping):
         logger.info("No runtime configurable found for sandbox circuit breaker notification")
         return
 
+    message = sandbox_unreachable_message(sandbox_id=sandbox_id, sandbox_name=sandbox_name)
+
     slack_target = _get_slack_target(configurable)
     if slack_target is not None:
         channel_id, thread_ts = slack_target
-        await post_slack_thread_reply(channel_id, thread_ts, SANDBOX_UNRECOVERABLE_MESSAGE)
+        await post_slack_thread_reply(channel_id, thread_ts, message)
         logger.info("Sent sandbox circuit breaker notification to Slack thread %s", thread_ts)
         return
 
     linear_issue_id = _get_linear_issue_id(configurable)
     if linear_issue_id is not None:
-        await comment_on_linear_issue(linear_issue_id, SANDBOX_UNRECOVERABLE_MESSAGE)
+        await comment_on_linear_issue(linear_issue_id, message)
         logger.info("Sent sandbox circuit breaker notification to Linear issue %s", linear_issue_id)
         return
 
@@ -191,12 +214,7 @@ async def _post_unrecoverable_notification(config: Mapping[str, Any]) -> None:
             logger.info("No GitHub token available for sandbox circuit breaker notification")
             return
         repo, issue_number = github_target
-        await post_github_comment(
-            repo,
-            issue_number,
-            SANDBOX_UNRECOVERABLE_MESSAGE,
-            token=token,
-        )
+        await post_github_comment(repo, issue_number, message, token=token)
         logger.info("Sent sandbox circuit breaker notification to GitHub item #%s", issue_number)
         return
 
@@ -221,13 +239,9 @@ class SandboxCircuitBreakerMiddleware(AgentMiddleware[AgentState, Any]):
         if streak is None or streak.count <= self.threshold:
             return None
 
-        if streak.reason == "recreated":
-            detail = (
-                f"{streak.count} consecutive sandbox recreations did not recover tool execution"
-            )
-        else:
-            detail = f"{streak.count} consecutive sandbox tool failures against {streak.sandbox_id}"
-        content = f"{_CIRCUIT_BREAKER_MARKER}: {detail}. {SANDBOX_UNRECOVERABLE_MESSAGE}"
+        detail = f"{streak.count} consecutive sandbox tool failures against {streak.sandbox_id}"
+        message = sandbox_unreachable_message(sandbox_id=streak.sandbox_id)
+        content = f"{_CIRCUIT_BREAKER_MARKER}: {detail}. {message}"
         return {"jump_to": "end", "messages": [AIMessage(content=content)]}
 
     @hook_config(can_jump_to=["end"])
@@ -254,7 +268,9 @@ class SandboxCircuitBreakerMiddleware(AgentMiddleware[AgentState, Any]):
 
         try:
             config = get_config()
-            await _post_unrecoverable_notification(config)
+            await post_sandbox_unrecoverable_notification(
+                config, sandbox_id=extract_sandbox_id(content)
+            )
         except Exception:
             logger.exception("Failed to send sandbox circuit breaker notification")
 

--- a/agent/middleware/sandbox_circuit_breaker.py
+++ b/agent/middleware/sandbox_circuit_breaker.py
@@ -1,4 +1,4 @@
-"""Circuit breaker for repeated unrecoverable sandbox failures."""
+"""Circuit breaker for runs stuck retrying an unreachable sandbox."""
 
 from __future__ import annotations
 
@@ -181,7 +181,7 @@ def _get_github_target(configurable: Mapping[str, Any]) -> tuple[dict[str, str],
     return None
 
 
-async def post_sandbox_unrecoverable_notification(
+async def post_sandbox_unreachable_notification(
     config: Mapping[str, Any],
     *,
     sandbox_id: str | None = None,
@@ -268,7 +268,7 @@ class SandboxCircuitBreakerMiddleware(AgentMiddleware[AgentState, Any]):
 
         try:
             config = get_config()
-            await post_sandbox_unrecoverable_notification(
+            await post_sandbox_unreachable_notification(
                 config, sandbox_id=extract_sandbox_id(content)
             )
         except Exception:

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -21,9 +21,15 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 from langsmith.sandbox import SandboxClientError
 
+from ..utils.sandbox_state import clear_sandbox_backend
+from .sandbox_circuit_breaker import (
+    extract_sandbox_id,
+    post_sandbox_unrecoverable_notification,
+)
+
 logger = logging.getLogger(__name__)
 
-SANDBOX_RECREATED_AFTER_CLIENT_ERROR = "sandbox_recreated_after_client_error"
+SANDBOX_UNRECOVERABLE = "sandbox_unrecoverable"
 
 
 def _get_name(candidate: object) -> str | None:
@@ -60,24 +66,28 @@ def _to_error_payload(e: Exception, request: ToolCallRequest | None = None) -> d
     return data
 
 
-def _to_sandbox_recreated_payload(
+def _to_sandbox_unrecoverable_payload(
     e: SandboxClientError,
-    sandbox_id: str,
     request: ToolCallRequest | None = None,
 ) -> dict[str, str]:
+    sandbox_id = extract_sandbox_id(str(e))
+    which = f" ({sandbox_id})" if sandbox_id else ""
     data: dict[str, str] = {
         "status": "error",
         "error_type": e.__class__.__name__,
         "previous_error": str(e),
-        "recovery": SANDBOX_RECREATED_AFTER_CLIENT_ERROR,
-        "sandbox_id": sandbox_id,
+        "recovery": SANDBOX_UNRECOVERABLE,
         "error": (
-            "The previous sandbox became unreachable mid-run. A fresh sandbox "
-            f"({sandbox_id}) has been created and cached for this thread. "
-            "Retry the last tool call; if repository files are missing, re-clone or "
-            "reinitialize the workspace first."
+            f"The sandbox for this thread{which} stopped responding. It will not be "
+            "replaced automatically: a fresh sandbox is empty, so swapping one in "
+            "would discard any uncommitted work while looking like a recovery. Stop "
+            "calling sandbox tools and tell the user their sandbox stopped "
+            "responding, naming it, and that retriggering the thread retries the "
+            "same sandbox while a new thread gets a fresh one."
         ),
     }
+    if sandbox_id:
+        data["sandbox_id"] = sandbox_id
     tool_name = _extract_tool_name(request)
     if tool_name:
         data["name"] = tool_name
@@ -90,21 +100,22 @@ def _get_tool_call_id(request: ToolCallRequest) -> str | None:
     return None
 
 
-def _get_thread_id(request: ToolCallRequest) -> str | None:
+def _get_run_config(request: ToolCallRequest) -> Mapping[str, Any] | None:
     runtime_config = getattr(getattr(request, "runtime", None), "config", None)
-    config: Mapping[str, Any] | None = (
-        runtime_config if isinstance(runtime_config, Mapping) else None
-    )
-    if config is None:
-        try:
-            maybe_config = get_config()
-        except Exception:
-            logger.exception("Failed to read runnable config while handling sandbox error")
-            return None
-        config = maybe_config if isinstance(maybe_config, Mapping) else None
+    if isinstance(runtime_config, Mapping):
+        return runtime_config
+    try:
+        maybe_config = get_config()
+    except Exception:
+        logger.exception("Failed to read runnable config while handling sandbox error")
+        return None
+    return maybe_config if isinstance(maybe_config, Mapping) else None
+
+
+def _get_thread_id(request: ToolCallRequest) -> str | None:
+    config = _get_run_config(request)
     if config is None:
         return None
-
     configurable = config.get("configurable", {})
     if not isinstance(configurable, Mapping):
         return None
@@ -112,23 +123,11 @@ def _get_thread_id(request: ToolCallRequest) -> str | None:
     return thread_id if isinstance(thread_id, str) and thread_id else None
 
 
-async def _recreate_sandbox_for_thread(thread_id: str) -> str:
-    from agent.server import _configure_git_identity, _recreate_sandbox, client
-    from agent.utils.sandbox_state import set_sandbox_backend
-
-    sandbox_backend = await _recreate_sandbox(thread_id)
-    sandbox_backend = set_sandbox_backend(thread_id, sandbox_backend)
-    await client.threads.update(thread_id=thread_id, metadata={"sandbox_id": sandbox_backend.id})
-    await _configure_git_identity(sandbox_backend)
-    return sandbox_backend.id
-
-
-def _sandbox_recreated_tool_message(
+def _sandbox_unrecoverable_tool_message(
     e: SandboxClientError,
-    sandbox_id: str,
     request: ToolCallRequest,
 ) -> ToolMessage:
-    data = _to_sandbox_recreated_payload(e, sandbox_id, request)
+    data = _to_sandbox_unrecoverable_payload(e, request)
     return ToolMessage(
         content=json.dumps(data),
         tool_call_id=_get_tool_call_id(request),
@@ -166,12 +165,16 @@ class ToolErrorMiddleware(AgentMiddleware):
             logger.exception("Sandbox error during tool call handling; request=%r", request)
             thread_id = _get_thread_id(request)
             if thread_id:
+                clear_sandbox_backend(thread_id)
+            config = _get_run_config(request)
+            if config is not None:
                 try:
-                    sandbox_id = await _recreate_sandbox_for_thread(thread_id)
-                    return _sandbox_recreated_tool_message(e, sandbox_id, request)
+                    await post_sandbox_unrecoverable_notification(
+                        config, sandbox_id=extract_sandbox_id(str(e))
+                    )
                 except Exception:
-                    logger.exception("Failed to recreate sandbox for thread %s", thread_id)
-            return _generic_error_tool_message(e, request)
+                    logger.exception("Failed to notify user of dead sandbox for %s", thread_id)
+            return _sandbox_unrecoverable_tool_message(e, request)
         except Exception as e:
             logger.exception("Error during tool call handling; request=%r", request)
             return _generic_error_tool_message(e, request)

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -24,12 +24,12 @@ from langsmith.sandbox import SandboxClientError
 from ..utils.sandbox_state import clear_sandbox_backend
 from .sandbox_circuit_breaker import (
     extract_sandbox_id,
-    post_sandbox_unrecoverable_notification,
+    post_sandbox_unreachable_notification,
 )
 
 logger = logging.getLogger(__name__)
 
-SANDBOX_UNRECOVERABLE = "sandbox_unrecoverable"
+SANDBOX_UNREACHABLE = "sandbox_unreachable"
 
 
 def _get_name(candidate: object) -> str | None:
@@ -66,7 +66,7 @@ def _to_error_payload(e: Exception, request: ToolCallRequest | None = None) -> d
     return data
 
 
-def _to_sandbox_unrecoverable_payload(
+def _to_sandbox_unreachable_payload(
     e: SandboxClientError,
     request: ToolCallRequest | None = None,
 ) -> dict[str, str]:
@@ -76,7 +76,7 @@ def _to_sandbox_unrecoverable_payload(
         "status": "error",
         "error_type": e.__class__.__name__,
         "previous_error": str(e),
-        "recovery": SANDBOX_UNRECOVERABLE,
+        "recovery": SANDBOX_UNREACHABLE,
         "error": (
             f"The sandbox for this thread{which} stopped responding. It will not be "
             "replaced automatically: a fresh sandbox is empty, so swapping one in "
@@ -123,11 +123,11 @@ def _get_thread_id(request: ToolCallRequest) -> str | None:
     return thread_id if isinstance(thread_id, str) and thread_id else None
 
 
-def _sandbox_unrecoverable_tool_message(
+def _sandbox_unreachable_tool_message(
     e: SandboxClientError,
     request: ToolCallRequest,
 ) -> ToolMessage:
-    data = _to_sandbox_unrecoverable_payload(e, request)
+    data = _to_sandbox_unreachable_payload(e, request)
     return ToolMessage(
         content=json.dumps(data),
         tool_call_id=_get_tool_call_id(request),
@@ -169,12 +169,12 @@ class ToolErrorMiddleware(AgentMiddleware):
             config = _get_run_config(request)
             if config is not None:
                 try:
-                    await post_sandbox_unrecoverable_notification(
+                    await post_sandbox_unreachable_notification(
                         config, sandbox_id=extract_sandbox_id(str(e))
                     )
                 except Exception:
                     logger.exception("Failed to notify user of dead sandbox for %s", thread_id)
-            return _sandbox_unrecoverable_tool_message(e, request)
+            return _sandbox_unreachable_tool_message(e, request)
         except Exception as e:
             logger.exception("Error during tool call handling; request=%r", request)
             return _generic_error_tool_message(e, request)

--- a/agent/runtime/__init__.py
+++ b/agent/runtime/__init__.py
@@ -9,7 +9,6 @@ from .sandbox import (
     configure_git_identity,
     ensure_sandbox_for_thread,
     get_cached_sandbox_backend,
-    recreate_sandbox,
 )
 
 __all__ = [
@@ -21,5 +20,4 @@ __all__ = [
     "ensure_sandbox_for_thread",
     "get_cached_sandbox_backend",
     "graph_loaded_for_execution",
-    "recreate_sandbox",
 ]

--- a/agent/runtime/sandbox.py
+++ b/agent/runtime/sandbox.py
@@ -34,20 +34,3 @@ async def configure_git_identity(sandbox_backend: SandboxBackendProtocol) -> Non
     from agent.server import configure_git_identity as configure
 
     await configure(sandbox_backend)
-
-
-async def recreate_sandbox(
-    thread_id: str,
-    *,
-    github_proxy_token: str | None = None,
-    github_proxy_repositories: Sequence[str] | None = None,
-    repo: dict[str, str] | None = None,
-) -> SandboxBackendProtocol:
-    from agent.server import recreate_sandbox as recreate
-
-    return await recreate(
-        thread_id,
-        github_proxy_token=github_proxy_token,
-        github_proxy_repositories=github_proxy_repositories,
-        repo=repo,
-    )

--- a/agent/server.py
+++ b/agent/server.py
@@ -86,6 +86,7 @@ from .middleware import (
     task_retry_on,
 )
 from .middleware.prepare_run import PrepareRunState
+from .middleware.sandbox_circuit_breaker import post_sandbox_unrecoverable_notification
 from .prompt import construct_system_prompt
 from .runtime.constants import (
     DEFAULT_LLM_MAX_TOKENS,
@@ -143,6 +144,8 @@ from .utils.sandbox import create_sandbox
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 from .utils.sandbox_state import (
     SANDBOX_BACKENDS,
+    SandboxUnrecoverableError,
+    clear_sandbox_backend,
     get_or_create_sandbox_backend_proxy,
     get_sandbox_id_from_metadata,
     set_sandbox_backend,
@@ -313,14 +316,13 @@ async def _refresh_github_proxy(
     )
 
 
-async def _refresh_github_proxy_or_recreate(
+async def _refresh_github_proxy_or_fail(
     sandbox_backend: SandboxBackendProtocol,
     thread_id: str,
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
-    repo: dict[str, str] | None = None,
 ) -> SandboxBackendProtocol:
-    """Refresh proxy credentials, recreating stale LangSmith sandboxes on failure."""
+    """Refresh proxy credentials; a sandbox we can't reconfigure is unrecoverable."""
     try:
         await _refresh_github_proxy(
             sandbox_backend,
@@ -328,19 +330,14 @@ async def _refresh_github_proxy_or_recreate(
             thread_id=thread_id,
             github_proxy_repositories=github_proxy_repositories,
         )
-    except Exception:  # noqa: BLE001
+    except Exception as exc:
         logger.warning(
-            "Failed to refresh GitHub proxy for sandbox %s on thread %s, recreating sandbox",
+            "Failed to refresh GitHub proxy for sandbox %s on thread %s",
             sandbox_backend.id,
             thread_id,
             exc_info=True,
         )
-        return await _recreate_sandbox(
-            thread_id,
-            github_proxy_token=github_proxy_token,
-            github_proxy_repositories=github_proxy_repositories,
-            repo=repo,
-        )
+        raise SandboxUnrecoverableError(thread_id, sandbox_backend.id, str(exc)) from exc
     return sandbox_backend
 
 
@@ -352,56 +349,16 @@ async def _configure_git_identity(sandbox_backend: SandboxBackendProtocol) -> No
     )
 
 
-async def _recreate_sandbox(
-    thread_id: str,
-    *,
-    github_proxy_token: str | None = None,
-    github_proxy_repositories: Sequence[str] | None = None,
-    repo: dict[str, str] | None = None,
-) -> SandboxBackendProtocol:
-    """Create a fresh sandbox (with proxy auth) after a connection failure.
-
-    The agent is responsible for cloning repos via tools.
-    """
-    return set_sandbox_backend(
-        thread_id,
-        await _create_sandbox_with_proxy(
-            github_proxy_token,
-            thread_id=thread_id,
-            github_proxy_repositories=github_proxy_repositories,
-            repo=repo,
-        ),
-    )
-
-
-async def check_or_recreate_sandbox(
+async def check_sandbox_reachable(
     sandbox_backend: SandboxBackendProtocol,
     thread_id: str,
-    github_proxy_token: str | None = None,
-    github_proxy_repositories: Sequence[str] | None = None,
-    repo: dict[str, str] | None = None,
 ) -> SandboxBackendProtocol:
-    """Check if a cached sandbox is reachable; recreate it if not.
-
-    Pings the sandbox with a lightweight command. If the sandbox is
-    unreachable (SandboxClientError), it is torn down and a fresh one
-    is created via _recreate_sandbox.
-
-    Returns the original backend if healthy, or a new one if recreated.
-    """
+    """Ping a cached sandbox; an unreachable one is unrecoverable, not replaceable."""
     try:
         await asyncio.to_thread(sandbox_backend.execute, "echo ok")
-    except SandboxClientError:
-        logger.warning(
-            "Cached sandbox is no longer reachable for thread %s, recreating",
-            thread_id,
-        )
-        sandbox_backend = await _recreate_sandbox(
-            thread_id,
-            github_proxy_token=github_proxy_token,
-            github_proxy_repositories=github_proxy_repositories,
-            repo=repo,
-        )
+    except SandboxClientError as exc:
+        logger.warning("Cached sandbox is no longer reachable for thread %s", thread_id)
+        raise SandboxUnrecoverableError(thread_id, sandbox_backend.id, str(exc)) from exc
     return sandbox_backend
 
 
@@ -418,9 +375,14 @@ async def ensure_sandbox_for_thread(
     never provisions two sandboxes concurrently — no cross-process sentinel is
     needed):
 
-    1. Cached in memory -> ping; recreate on ``SandboxClientError``; refresh proxy.
-    2. Metadata has an id -> reconnect; recreate on failure; refresh proxy.
+    1. Cached in memory -> ping, then refresh proxy.
+    2. Metadata has an id -> reconnect, then refresh proxy.
     3. No sandbox at all -> create one and persist the id.
+
+    Only case 3 creates. A sandbox that exists but can't be reached raises
+    ``SandboxUnrecoverableError`` instead of being replaced — a replacement is
+    empty, and swapping one in silently destroys whatever the agent had not yet
+    committed.
 
     For LangSmith sandboxes, also refreshes the GitHub App proxy auth. When
     ``repo`` has a ``ready`` repo-scoped snapshot, newly created sandboxes boot
@@ -436,14 +398,10 @@ async def ensure_sandbox_for_thread(
 
     if sandbox_backend:
         logger.info("Using cached sandbox backend for thread %s", thread_id)
-        original_sandbox_id = sandbox_backend.id
-        sandbox_backend = await check_or_recreate_sandbox(
-            sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories, repo
+        sandbox_backend = await check_sandbox_reachable(sandbox_backend, thread_id)
+        sandbox_backend = await _refresh_github_proxy_or_fail(
+            sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
         )
-        if sandbox_backend.id == original_sandbox_id:
-            sandbox_backend = await _refresh_github_proxy_or_recreate(
-                sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories, repo
-            )
     elif sandbox_id is None:
         logger.info("Creating new sandbox for thread %s", thread_id)
         sandbox_backend = await _create_sandbox_with_proxy(
@@ -457,23 +415,13 @@ async def ensure_sandbox_for_thread(
         logger.info("Connecting to existing sandbox %s", sandbox_id)
         try:
             sandbox_backend = await create_sandbox(sandbox_id)
-        except Exception:
-            logger.warning("Failed to connect to existing sandbox %s, creating new one", sandbox_id)
-            sandbox_backend = await _create_sandbox_with_proxy(
-                github_proxy_token,
-                thread_id=thread_id,
-                github_proxy_repositories=github_proxy_repositories,
-                repo=repo,
-            )
-        else:
-            original_sandbox_id = sandbox_backend.id
-            sandbox_backend = await check_or_recreate_sandbox(
-                sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories, repo
-            )
-            if sandbox_backend.id == original_sandbox_id:
-                sandbox_backend = await _refresh_github_proxy_or_recreate(
-                    sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories, repo
-                )
+        except Exception as exc:
+            logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
+            raise SandboxUnrecoverableError(thread_id, sandbox_id, str(exc)) from exc
+        sandbox_backend = await check_sandbox_reachable(sandbox_backend, thread_id)
+        sandbox_backend = await _refresh_github_proxy_or_fail(
+            sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
+        )
 
     sandbox_backend = set_sandbox_backend(thread_id, sandbox_backend)
 
@@ -572,7 +520,6 @@ def _get_cached_sandbox_backend(
 
 get_cached_sandbox_backend = _get_cached_sandbox_backend
 configure_git_identity = _configure_git_identity
-recreate_sandbox = _recreate_sandbox
 
 
 async def _observability_authorized(config: RunnableConfig, profile_login: str | None) -> bool:
@@ -735,10 +682,19 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         sandbox_task = asyncio.create_task(
             ensure_sandbox_for_thread(self._thread_id, repo=prompt_default_repo)
         )
-        triggering_user_identity, sandbox_backend = await asyncio.gather(
-            triggering_user_identity_task,
-            sandbox_task,
-        )
+        try:
+            triggering_user_identity, sandbox_backend = await asyncio.gather(
+                triggering_user_identity_task,
+                sandbox_task,
+            )
+        except SandboxUnrecoverableError as exc:
+            # The run is about to die with no sandbox; make sure the user hears
+            # why rather than getting silence.
+            clear_sandbox_backend(self._thread_id)
+            await post_sandbox_unrecoverable_notification(
+                self._config or {}, sandbox_id=exc.sandbox_id
+            )
+            raise
         del github_token
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
         repo_custom_instructions = await _resolve_repo_custom_instructions(prompt_default_repo)

--- a/agent/server.py
+++ b/agent/server.py
@@ -86,7 +86,7 @@ from .middleware import (
     task_retry_on,
 )
 from .middleware.prepare_run import PrepareRunState
-from .middleware.sandbox_circuit_breaker import post_sandbox_unrecoverable_notification
+from .middleware.sandbox_circuit_breaker import post_sandbox_unreachable_notification
 from .prompt import construct_system_prompt
 from .runtime.constants import (
     DEFAULT_LLM_MAX_TOKENS,
@@ -144,7 +144,7 @@ from .utils.sandbox import create_sandbox
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 from .utils.sandbox_state import (
     SANDBOX_BACKENDS,
-    SandboxUnrecoverableError,
+    SandboxUnreachableError,
     clear_sandbox_backend,
     get_or_create_sandbox_backend_proxy,
     get_sandbox_id_from_metadata,
@@ -322,7 +322,7 @@ async def _refresh_github_proxy_or_fail(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
 ) -> SandboxBackendProtocol:
-    """Refresh proxy credentials; a sandbox we can't reconfigure is unrecoverable."""
+    """Refresh proxy credentials; a sandbox we can't reconfigure is unreachable."""
     try:
         await _refresh_github_proxy(
             sandbox_backend,
@@ -337,7 +337,7 @@ async def _refresh_github_proxy_or_fail(
             thread_id,
             exc_info=True,
         )
-        raise SandboxUnrecoverableError(thread_id, sandbox_backend.id, str(exc)) from exc
+        raise SandboxUnreachableError(thread_id, sandbox_backend.id, str(exc)) from exc
     return sandbox_backend
 
 
@@ -353,12 +353,12 @@ async def check_sandbox_reachable(
     sandbox_backend: SandboxBackendProtocol,
     thread_id: str,
 ) -> SandboxBackendProtocol:
-    """Ping a cached sandbox; an unreachable one is unrecoverable, not replaceable."""
+    """Ping a cached sandbox; an unreachable one fails the run, never gets replaced."""
     try:
         await asyncio.to_thread(sandbox_backend.execute, "echo ok")
     except SandboxClientError as exc:
         logger.warning("Cached sandbox is no longer reachable for thread %s", thread_id)
-        raise SandboxUnrecoverableError(thread_id, sandbox_backend.id, str(exc)) from exc
+        raise SandboxUnreachableError(thread_id, sandbox_backend.id, str(exc)) from exc
     return sandbox_backend
 
 
@@ -380,7 +380,7 @@ async def ensure_sandbox_for_thread(
     3. No sandbox at all -> create one and persist the id.
 
     Only case 3 creates. A sandbox that exists but can't be reached raises
-    ``SandboxUnrecoverableError`` instead of being replaced — a replacement is
+    ``SandboxUnreachableError`` instead of being replaced — a replacement is
     empty, and swapping one in silently destroys whatever the agent had not yet
     committed.
 
@@ -417,7 +417,7 @@ async def ensure_sandbox_for_thread(
             sandbox_backend = await create_sandbox(sandbox_id)
         except Exception as exc:
             logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
-            raise SandboxUnrecoverableError(thread_id, sandbox_id, str(exc)) from exc
+            raise SandboxUnreachableError(thread_id, sandbox_id, str(exc)) from exc
         sandbox_backend = await check_sandbox_reachable(sandbox_backend, thread_id)
         sandbox_backend = await _refresh_github_proxy_or_fail(
             sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
@@ -687,11 +687,11 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 triggering_user_identity_task,
                 sandbox_task,
             )
-        except SandboxUnrecoverableError as exc:
+        except SandboxUnreachableError as exc:
             # The run is about to die with no sandbox; make sure the user hears
             # why rather than getting silence.
             clear_sandbox_backend(self._thread_id)
-            await post_sandbox_unrecoverable_notification(
+            await post_sandbox_unreachable_notification(
                 self._config or {}, sandbox_id=exc.sandbox_id
             )
             raise

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -23,6 +23,7 @@ from .github_token import (
 from .http import DEFAULT_HTTP_TIMEOUT
 from .linear import comment_on_linear_issue
 from .slack import post_slack_thread_reply
+from .user_messages import WARNING_ICON, warning
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ def is_bot_token_only_mode() -> bool:
 
 def _retry_instruction(source: str) -> str:
     if source == "slack":
-        return "Once authenticated, mention me again in this Slack thread to retry."
+        return "Once authenticated, mention Open SWE again in this Slack thread to retry."
     return "Once authenticated, reply to this issue mentioning @openswe to retry."
 
 
@@ -280,8 +281,11 @@ async def leave_failure_comment(
             await post_slack_thread_reply(
                 channel_id,
                 thread_ts,
-                "⚠️ I couldn't resolve your GitHub account for this run. Sign in with GitHub and "
-                f"connect your Slack account in {link}, then tag me again.",
+                warning(
+                    "Open SWE couldn't resolve your GitHub account for this run. Sign in "
+                    f"with GitHub and connect your Slack account in {link}, then mention "
+                    "it again."
+                ),
             )
         return
     if source in ("github", "github_push"):
@@ -322,8 +326,8 @@ async def resolve_token_from_email(
         raise ValueError("GitHub auth failed: missing thread_id")
     if not email:
         message = (
-            "❌ **GitHub Auth Error**\n\n"
-            "Failed to authenticate with GitHub: missing_user_email\n\n"
+            f"{WARNING_ICON} **GitHub Auth Error**\n\n"
+            "Open SWE failed to authenticate with GitHub: missing_user_email\n\n"
             "Please try again or contact support."
         )
         await leave_failure_comment(source, message)
@@ -365,8 +369,8 @@ async def resolve_token_from_email(
     if not token:
         error = auth_result.get("error", "unknown")
         message = (
-            "❌ **GitHub Auth Error**\n\n"
-            f"Failed to authenticate with GitHub: {error}\n\n"
+            f"{WARNING_ICON} **GitHub Auth Error**\n\n"
+            f"Open SWE failed to authenticate with GitHub: {error}\n\n"
             "Please try again or contact support."
         )
         await leave_failure_comment(source, message)

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -29,6 +29,22 @@ from .sandbox import create_sandbox
 logger = logging.getLogger(__name__)
 
 
+class SandboxUnrecoverableError(RuntimeError):
+    """The thread's sandbox is gone.
+
+    Never recovered by creating a replacement: the sandbox holds the agent's
+    only copy of its working tree, so a fresh one would silently discard
+    uncommitted work while the agent carried on believing it was still there.
+    """
+
+    def __init__(self, thread_id: str, sandbox_id: str | None, cause: str) -> None:
+        self.thread_id = thread_id
+        self.sandbox_id = sandbox_id
+        super().__init__(
+            f"Sandbox {sandbox_id or '<unknown>'} for thread {thread_id} is unrecoverable: {cause}"
+        )
+
+
 class SandboxBackendProxy(BaseSandbox):
     """Stable per-thread backend handle whose target can be replaced.
 

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -29,19 +29,21 @@ from .sandbox import create_sandbox
 logger = logging.getLogger(__name__)
 
 
-class SandboxUnrecoverableError(RuntimeError):
-    """The thread's sandbox is gone.
+class SandboxUnreachableError(RuntimeError):
+    """The thread's sandbox did not answer this run.
 
-    Never recovered by creating a replacement: the sandbox holds the agent's
-    only copy of its working tree, so a fresh one would silently discard
-    uncommitted work while the agent carried on believing it was still there.
+    Says nothing about whether it will answer the next one — a later run
+    reconnects to the same id and may well succeed. It is never resolved by
+    creating a replacement: the sandbox holds the agent's only copy of its
+    working tree, so a fresh one would discard uncommitted work while the agent
+    carried on believing it was still there.
     """
 
     def __init__(self, thread_id: str, sandbox_id: str | None, cause: str) -> None:
         self.thread_id = thread_id
         self.sandbox_id = sandbox_id
         super().__init__(
-            f"Sandbox {sandbox_id or '<unknown>'} for thread {thread_id} is unrecoverable: {cause}"
+            f"Sandbox {sandbox_id or '<unknown>'} for thread {thread_id} is unreachable: {cause}"
         )
 
 

--- a/agent/utils/user_messages.py
+++ b/agent/utils/user_messages.py
@@ -1,0 +1,12 @@
+"""Shared formatting for messages Open SWE posts on its own initiative.
+
+Automatic notices are written in the third person ("Open SWE …") so a reader
+scanning a Slack thread or PR can tell them apart from the agent's own replies,
+and they all lead with the same icon so they are recognizable at a glance.
+"""
+
+WARNING_ICON = "⚠️"
+
+
+def warning(text: str) -> str:
+    return f"{WARNING_ICON} {text}"

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -15,6 +15,7 @@ from langchain_core.messages.content import create_text_block
 from agent.utils.json_types import as_json_object
 from agent.utils.langsmith import get_langsmith_trace_url
 
+from ..utils.user_messages import warning
 from . import common
 
 _PLAN_APPROVAL_PHRASES = {
@@ -311,9 +312,9 @@ async def _notify_slack_processing_error(
         common.logger.debug("Could not clear Slack assistant status", exc_info=True)
 
     dashboard_url = common.dashboard_thread_url(thread_id)
-    message = (
-        "⚠️ I hit an unexpected error while handling this Slack thread. "
-        "Send another message and I'll try again."
+    message = warning(
+        "Open SWE hit an unexpected error while handling this Slack thread. "
+        "Send another message and it will try again."
     )
     if dashboard_url:
         message += f" You can view the error in <{dashboard_url}|Open SWE Web>."

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -2,6 +2,7 @@
 
 import base64
 import uuid
+from pathlib import Path
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
@@ -20,7 +21,6 @@ from agent.integrations.langsmith import (
     _get_sandbox_create_extra_fields,
     _get_sandbox_snapshot_config,
     _install_create_extra_fields,
-    _release_sandbox_name,
     _sandbox_name_for_thread,
     _wait_for_reconnected_sandbox,
 )
@@ -57,22 +57,24 @@ def test_sandbox_name_for_thread_none_or_invalid() -> None:
     assert _sandbox_name_for_thread("not-a-uuid") is None
 
 
-@pytest.mark.asyncio
-async def test_release_sandbox_name_deletes_stale_box() -> None:
-    client = AsyncMock()
-    await _release_sandbox_name(client, "openswe-abc")
-    client.delete_sandbox.assert_awaited_once_with("openswe-abc")
+def test_nothing_deletes_sandboxes() -> None:
+    """No code path may delete a sandbox.
 
-
-@pytest.mark.asyncio
-async def test_release_sandbox_name_swallows_missing_and_skips_none() -> None:
-    client = AsyncMock()
-    client.delete_sandbox.side_effect = RuntimeError("not found")
-    await _release_sandbox_name(client, "openswe-abc")  # must not raise
-
-    client.delete_sandbox.reset_mock(side_effect=True)
-    await _release_sandbox_name(client, None)
-    client.delete_sandbox.assert_not_awaited()
+    A sandbox holds the agent's only copy of its working tree, and callers can't
+    tell a free name from one held by a live box: both the metadata read
+    (``get_sandbox_id_from_metadata``) and write (``_update_thread_sandbox_metadata``)
+    fail open to "this thread has no sandbox". A delete keyed off that guess
+    destroys a running box. Reclamation belongs to the platform's idle TTL and
+    delete-after-stop.
+    """
+    agent_root = Path(__file__).resolve().parents[2] / "agent"
+    offenders = [
+        f"{path.relative_to(agent_root)}:{lineno}"
+        for path in agent_root.rglob("*.py")
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1)
+        if "delete_sandbox" in line
+    ]
+    assert offenders == []
 
 
 def test_defaults_when_env_unset() -> None:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -451,7 +451,7 @@ class TestRefreshProxyOnSandboxReuse:
 
     @pytest.mark.asyncio
     async def test_proxy_refresh_failure_raises_instead_of_replacing(self) -> None:
-        """A sandbox we can't reconfigure is unrecoverable, never swapped out.
+        """A sandbox we can't reconfigure fails the run, and is never swapped out.
 
         Replacing it would hand the agent an empty filesystem and discard any
         work the old sandbox still held.
@@ -480,9 +480,9 @@ class TestRefreshProxyOnSandboxReuse:
             patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as mock_create,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
-            from agent.server import SandboxUnrecoverableError, _refresh_github_proxy_or_fail
+            from agent.server import SandboxUnreachableError, _refresh_github_proxy_or_fail
 
-            with pytest.raises(SandboxUnrecoverableError) as excinfo:
+            with pytest.raises(SandboxUnreachableError) as excinfo:
                 await _refresh_github_proxy_or_fail(mock_sandbox, "thread-123")
 
             assert excinfo.value.sandbox_id == "sandbox-stale"

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -368,7 +368,7 @@ class TestRefreshProxyOnSandboxReuse:
                 return_value="/workspace",
             ),
             patch(
-                "agent.server.check_or_recreate_sandbox",
+                "agent.server.check_sandbox_reachable",
                 new_callable=AsyncMock,
                 return_value=mock_sandbox,
             ),
@@ -450,10 +450,13 @@ class TestRefreshProxyOnSandboxReuse:
             mock_proxy.assert_called_once_with("sandbox-existing", "ghs_fresh")
 
     @pytest.mark.asyncio
-    async def test_proxy_refresh_failure_recreates_sandbox(self) -> None:
-        """A stale sandbox whose proxy cannot be patched should be replaced."""
+    async def test_proxy_refresh_failure_raises_instead_of_replacing(self) -> None:
+        """A sandbox we can't reconfigure is unrecoverable, never swapped out.
+
+        Replacing it would hand the agent an empty filesystem and discard any
+        work the old sandbox still held.
+        """
         mock_sandbox = MagicMock(id="sandbox-stale")
-        replacement_sandbox = MagicMock(id="sandbox-replacement")
         request = httpx.Request(
             "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-stale"
         )
@@ -474,25 +477,17 @@ class TestRefreshProxyOnSandboxReuse:
                     response=response,
                 ),
             ) as mock_proxy,
-            patch(
-                "agent.server._recreate_sandbox",
-                new_callable=AsyncMock,
-                return_value=replacement_sandbox,
-            ) as mock_recreate,
+            patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as mock_create,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
-            from agent.server import _refresh_github_proxy_or_recreate
+            from agent.server import SandboxUnrecoverableError, _refresh_github_proxy_or_fail
 
-            sandbox = await _refresh_github_proxy_or_recreate(mock_sandbox, "thread-123")
+            with pytest.raises(SandboxUnrecoverableError) as excinfo:
+                await _refresh_github_proxy_or_fail(mock_sandbox, "thread-123")
 
-            assert sandbox is replacement_sandbox
+            assert excinfo.value.sandbox_id == "sandbox-stale"
             mock_proxy.assert_called_once_with("sandbox-stale", "ghs_fresh")
-            mock_recreate.assert_awaited_once_with(
-                "thread-123",
-                github_proxy_token=None,
-                github_proxy_repositories=None,
-                repo=None,
-            )
+            mock_create.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_starts_stopped_langsmith_sandbox_before_proxy_refresh(self) -> None:

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -10,8 +10,8 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langsmith.sandbox import SandboxClientError
 
 from agent.middleware.sandbox_circuit_breaker import (
-    SANDBOX_UNRECOVERABLE_MESSAGE,
     SandboxCircuitBreakerMiddleware,
+    sandbox_unreachable_message,
 )
 from agent.middleware.tool_error_handler import ToolErrorMiddleware
 from agent.utils.sandbox_state import SANDBOX_BACKENDS, clear_sandbox_backend, set_sandbox_backend
@@ -54,44 +54,42 @@ def _sandbox_error_message(tool_call_id: str, sandbox_id: str = "sb-dead") -> To
 
 
 @pytest.mark.asyncio
-async def test_sandbox_client_error_recreates_sandbox() -> None:
+async def test_sandbox_client_error_notifies_and_never_recreates() -> None:
+    """A dead sandbox surfaces an error to the user; it is never swapped out.
+
+    Replacing it mid-run gives the agent an empty filesystem while it still
+    believes its working tree is intact, silently destroying uncommitted work.
+    """
     middleware = ToolErrorMiddleware()
     request = _tool_request()
-    old_backend = FakeSandboxBackend("sb-old")
-    backend = FakeSandboxBackend("sb-new")
-    proxy = set_sandbox_backend("thread-1", old_backend)
+    set_sandbox_backend("thread-1", FakeSandboxBackend("sb-old"))
 
     async def handler(_request: ToolCallRequest) -> ToolMessage:
         raise SandboxClientError("Sandbox request timed out: sb-dead")
 
     try:
         with (
-            patch("agent.server._recreate_sandbox", new_callable=AsyncMock) as mock_recreate,
-            patch("agent.server.client") as mock_client,
+            patch(
+                "agent.middleware.tool_error_handler.post_sandbox_unrecoverable_notification",
+                new_callable=AsyncMock,
+            ) as mock_notify,
+            patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as mock_create,
         ):
-            mock_recreate.return_value = backend
-            mock_client.threads.update = AsyncMock()
-
             result = await middleware.awrap_tool_call(request, handler)
 
-        assert isinstance(result, ToolMessage)
-        mock_recreate.assert_awaited_once_with("thread-1")
-        mock_client.threads.update.assert_awaited_once_with(
-            thread_id="thread-1",
-            metadata={"sandbox_id": "sb-new"},
-        )
-        assert SANDBOX_BACKENDS["thread-1"] is proxy
-        assert proxy.current is backend
-        assert proxy.id == "sb-new"
-        assert proxy.execute("echo ok").output == "sb-new: echo ok: None"
+        mock_create.assert_not_awaited()
+        mock_notify.assert_awaited_once()
+        # The dead backend must not linger for the next tool call.
+        assert "thread-1" not in SANDBOX_BACKENDS
 
+        assert isinstance(result, ToolMessage)
         assert isinstance(result.content, str)
         payload = json.loads(result.content)
         assert payload["status"] == "error"
         assert payload["error_type"] == "SandboxClientError"
-        assert payload["recovery"] == "sandbox_recreated_after_client_error"
+        assert payload["recovery"] == "sandbox_unrecoverable"
         assert payload["previous_error"] == "Sandbox request timed out: sb-dead"
-        assert "sb-new" in payload["error"]
+        assert "will not be replaced" in payload["error"]
     finally:
         clear_sandbox_backend("thread-1")
 
@@ -122,59 +120,26 @@ def test_repeated_sandbox_errors_trigger_circuit_breaker_once() -> None:
     assert repeated is None
 
 
-def test_repeated_sandbox_recreations_trigger_circuit_breaker() -> None:
+def test_circuit_breaker_message_names_the_sandbox() -> None:
+    """The user gets told which sandbox went quiet, not just that one did."""
     middleware = SandboxCircuitBreakerMiddleware(threshold=2)
     messages = [
         HumanMessage(content="please fix this"),
         AIMessage(content="", tool_calls=[{"name": "ls", "args": {}, "id": "tc1"}]),
-        ToolMessage(
-            content=json.dumps(
-                {
-                    "error_type": "SandboxClientError",
-                    "previous_error": "Sandbox request timed out: sb-old-1",
-                    "recovery": "sandbox_recreated_after_client_error",
-                    "sandbox_id": "sb-new-1",
-                    "status": "error",
-                }
-            ),
-            tool_call_id="tc1",
-            status="error",
-        ),
+        _sandbox_error_message("tc1"),
         AIMessage(content="", tool_calls=[{"name": "grep", "args": {}, "id": "tc2"}]),
-        ToolMessage(
-            content=json.dumps(
-                {
-                    "error_type": "SandboxClientError",
-                    "previous_error": "Sandbox request timed out: sb-new-1",
-                    "recovery": "sandbox_recreated_after_client_error",
-                    "sandbox_id": "sb-new-2",
-                    "status": "error",
-                }
-            ),
-            tool_call_id="tc2",
-            status="error",
-        ),
+        _sandbox_error_message("tc2"),
         AIMessage(content="", tool_calls=[{"name": "execute", "args": {}, "id": "tc3"}]),
-        ToolMessage(
-            content=json.dumps(
-                {
-                    "error_type": "SandboxClientError",
-                    "previous_error": "Sandbox request timed out: sb-new-2",
-                    "recovery": "sandbox_recreated_after_client_error",
-                    "sandbox_id": "sb-new-3",
-                    "status": "error",
-                }
-            ),
-            tool_call_id="tc3",
-            status="error",
-        ),
+        _sandbox_error_message("tc3"),
     ]
 
     result = middleware.before_model({"messages": messages}, MagicMock())
 
     assert result is not None
-    assert result["jump_to"] == "end"
-    assert "consecutive sandbox recreations" in result["messages"][0].content
+    content = result["messages"][0].content
+    assert "id sb-dead" in content
+    # We only observed silence, so the copy must not assert permanence.
+    assert "can't tell whether it will come back" in content
 
 
 @pytest.mark.asyncio
@@ -217,6 +182,8 @@ async def test_circuit_breaker_posts_one_user_notification() -> None:
         result = await middleware.aafter_agent(cast(AgentState[Any], state), MagicMock())
 
     assert result is None
-    mock_slack.assert_awaited_once_with("C123", "171.123", SANDBOX_UNRECOVERABLE_MESSAGE)
+    mock_slack.assert_awaited_once_with(
+        "C123", "171.123", sandbox_unreachable_message(sandbox_id="sb-dead")
+    )
     mock_linear.assert_not_called()
     mock_github.assert_not_called()

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -70,7 +70,7 @@ async def test_sandbox_client_error_notifies_and_never_recreates() -> None:
     try:
         with (
             patch(
-                "agent.middleware.tool_error_handler.post_sandbox_unrecoverable_notification",
+                "agent.middleware.tool_error_handler.post_sandbox_unreachable_notification",
                 new_callable=AsyncMock,
             ) as mock_notify,
             patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as mock_create,
@@ -87,7 +87,7 @@ async def test_sandbox_client_error_notifies_and_never_recreates() -> None:
         payload = json.loads(result.content)
         assert payload["status"] == "error"
         assert payload["error_type"] == "SandboxClientError"
-        assert payload["recovery"] == "sandbox_unrecoverable"
+        assert payload["recovery"] == "sandbox_unreachable"
         assert payload["previous_error"] == "Sandbox request timed out: sb-dead"
         assert "will not be replaced" in payload["error"]
     finally:

--- a/tests/sandbox/test_stale_sandbox_creating.py
+++ b/tests/sandbox/test_stale_sandbox_creating.py
@@ -73,12 +73,12 @@ async def test_ensure_sandbox_reconnects_to_metadata_sandbox() -> None:
             return_value=existing_backend,
         ) as connect_sandbox,
         patch(
-            "agent.server.check_or_recreate_sandbox",
+            "agent.server.check_sandbox_reachable",
             new_callable=AsyncMock,
             side_effect=passthrough,
         ),
         patch(
-            "agent.server._refresh_github_proxy_or_recreate",
+            "agent.server._refresh_github_proxy_or_fail",
             new_callable=AsyncMock,
             side_effect=passthrough,
         ) as refresh_proxy,
@@ -124,12 +124,12 @@ async def test_ensure_sandbox_resolves_unresolved_backend_proxy() -> None:
             return_value=existing_backend,
         ) as connect_sandbox,
         patch(
-            "agent.server.check_or_recreate_sandbox",
+            "agent.server.check_sandbox_reachable",
             new_callable=AsyncMock,
             side_effect=passthrough,
         ),
         patch(
-            "agent.server._refresh_github_proxy_or_recreate",
+            "agent.server._refresh_github_proxy_or_fail",
             new_callable=AsyncMock,
             side_effect=passthrough,
         ) as refresh_proxy,


### PR DESCRIPTION
A sandbox holds the agent's only copy of its working tree. Every automatic replacement hands the agent an empty filesystem while it still believes its files are there, so uncommitted work is destroyed by something that reads as a recovery. This removes all of those paths and reports the failure instead.

Traced from a wedged prod sandbox (`openswe-uel7ixeevszgyatrtfdd3vqeai`, thread `a117f45c`): its host vanished mid-drain, four `POST /execute` calls returned `502`, and 161 ms after the fourth `ToolErrorMiddleware` deleted the box's name and tried to create a replacement. The delete was accepted (`204`) but its async worker then wedged on the dead host, so the row survived and every subsequent create returned `409 already exists` — the thread could never get a sandbox again. Roughly 40 minutes of the agent's work went with it.

## Recreate paths removed

| Was | Now |
|---|---|
| `ToolErrorMiddleware` recreated mid-run on any `SandboxClientError` ([#1274](https://github.com/langchain-ai/open-swe/pull/1274)) | posts a notice, drops the cached backend, returns an error tool message telling the model to stop calling sandbox tools |
| `check_or_recreate_sandbox` (ping failed) | `check_sandbox_reachable` — raises `SandboxUnreachableError` |
| `_refresh_github_proxy_or_recreate` (proxy refresh threw) | `_refresh_github_proxy_or_fail` — raises |
| reconnect `except` → create fresh | raises |

`_recreate_sandbox` and the `agent.runtime` re-export are gone, so no entry point remains. The circuit breaker's `reason == "recreated"` branch went with them — nothing can emit that marker now.

A side benefit: a transient blip on one tool call used to destroy a healthy sandbox. The agent now just gets an error tool message and can retry.

## Deletion removed

`_release_sandbox_name` issued a `DELETE` on the thread's deterministic name before every create. That was not only reachable on a wedge — it could delete a **live** box. Both `get_sandbox_id_from_metadata` (on a `threads.get` failure) and `_update_thread_sandbox_metadata` (`except Exception: pass`) fail open to "this thread has no sandbox", which routes a healthy thread down the create path where the deterministic name still resolves to its running sandbox. One transient LangGraph API blip was enough.

`SandboxProvider.delete` and `LangSmithProvider.delete` are removed too. `test_nothing_deletes_sandboxes` greps `agent/` to keep it that way. Reclamation is now entirely the platform's, via the `idle_ttl_seconds` (2h) and `delete_after_stop_seconds` (14d) already set at create time.

## User-visible errors

Removing recreate opened a gap: an unreachable sandbox at run start would have failed with a bare stack trace and no message. `PrepareAgentRunMiddleware` now catches and posts before re-raising, reusing the circuit breaker's Slack → Linear → GitHub fallback chain.

The copy no longer overclaims — we only observed that the sandbox stopped answering, not that it is gone — and it names the box:

> ⚠️ This thread's sandbox (id sb-…) stopped responding, and Open SWE can't tell whether it will come back. Open SWE will not start a replacement on its own: a new sandbox is empty, so swapping one in would throw away anything not yet committed and pushed while still looking like a recovery. Retrigger this thread to try the same sandbox again, or start a new thread to get a fresh one.

Retriggering genuinely retries the same sandbox now: with recreate gone, a new run reconnects to the existing `sandbox_id` and succeeds if the box recovered.

All automatically-posted errors moved to one `⚠️` icon and third person ("Open SWE …") via `agent/utils/user_messages.py` — sandbox unreachable, step limit (previously had no icon), Slack handler error, run-failure reply, and both GitHub Auth Errors (previously `❌`). The `🔐 GitHub Authentication Required` notices keep their icon: they are an actionable prompt rather than an error, and that exact string is a bot-message-detection prefix in three files, so changing it would make the bot react to its own comments.

## Test Plan

- [x] `make test` — 1602 passed
- [x] `make lint` — ruff check + format clean
- [x] `make typecheck` — basedpyright 0 errors
- [x] `test_nothing_deletes_sandboxes` fails if any `delete_sandbox` call returns to `agent/`
- [x] `test_sandbox_client_error_notifies_and_never_recreates` asserts no sandbox is created and the user is notified
- [x] `test_proxy_refresh_failure_raises_instead_of_replacing` asserts `SandboxUnreachableError` and no create
