### PR TITLE
fix: log automated Slack warnings as errors

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -23,6 +23,7 @@ from agent.utils.langsmith import get_langsmith_trace_url
 from agent.utils.thread_ids import generate_thread_id_from_slack_thread
 
 from .http import DEFAULT_HTTP_TIMEOUT
+from .user_messages import WARNING_ICON
 
 logger = logging.getLogger(__name__)
 
@@ -314,6 +315,24 @@ async def set_slack_assistant_status(
             return False
 
 
+def _log_automated_warning_sent_to_slack(
+    channel_id: str,
+    thread_ts: str | None,
+    text: str,
+) -> None:
+    if not text.lstrip().startswith(WARNING_ICON):
+        return
+    if thread_ts:
+        logger.error(
+            "Sent automated warning message to Slack thread %s/%s: %s",
+            channel_id,
+            thread_ts,
+            text,
+        )
+        return
+    logger.error("Sent automated warning message to Slack channel %s: %s", channel_id, text)
+
+
 async def _post_slack_message_with_ts(
     channel_id: str,
     text: str,
@@ -360,6 +379,7 @@ async def _post_slack_message_with_ts(
                 return None, error
             message_ts = data.get("ts")
             if isinstance(message_ts, str) and message_ts:
+                _log_automated_warning_sent_to_slack(channel_id, thread_ts, text)
                 return message_ts, None
             return None, None
         except httpx.HTTPError as exc:

--- a/tests/slack/test_slack_warning_logging.py
+++ b/tests/slack/test_slack_warning_logging.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.utils import slack as slack_utils
+from agent.utils.user_messages import warning
+
+
+def _ok_response() -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = {"ok": True, "ts": "2.0"}
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _async_client_cm(post_response: MagicMock) -> AsyncMock:
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = client_cm
+    client_cm.post = AsyncMock(return_value=post_response)
+    return client_cm
+
+
+@pytest.mark.asyncio
+async def test_slack_warning_post_logs_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    client_cm = _async_client_cm(_ok_response())
+
+    with (
+        caplog.at_level(logging.ERROR, logger=slack_utils.logger.name),
+        patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm),
+    ):
+        result = await slack_utils._post_slack_message_with_ts(
+            "C1",
+            warning("Open SWE reached its maximum step limit."),
+            thread_ts="1.0",
+        )
+
+    assert result == ("2.0", None)
+    assert "Sent automated warning message to Slack thread C1/1.0" in caplog.text
+    assert "⚠️ Open SWE reached its maximum step limit." in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_plain_slack_post_does_not_log_warning_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    client_cm = _async_client_cm(_ok_response())
+
+    with (
+        caplog.at_level(logging.ERROR, logger=slack_utils.logger.name),
+        patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm),
+    ):
+        result = await slack_utils._post_slack_message_with_ts(
+            "C1",
+            "Normal Slack reply",
+            thread_ts="1.0",
+        )
+
+    assert result == ("2.0", None)
+    assert "Sent automated warning message to Slack" not in caplog.text


### PR DESCRIPTION
## Description
Log an error whenever a warning-formatted automated Slack message is successfully posted, centralizing the behavior in the Slack post utility.

## Test Plan
- [x] make format
- [x] make lint
- [x] uv run --directory /workspace/open-swe pytest -vvv tests/slack/test_slack_warning_logging.py tests/slack/test_slack_webhook_errors.py

Made by [Open SWE](https://openswe.vercel.app/agents/3e960172-79f5-5cf3-8f74-35bcbcd8053b)