### PR TITLE
chore: bump deepagents and trim prompt shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Wired into `get_agent`:
 
 Reviewer-only tools (in `agent/reviewer.py`): `add_finding`, `update_finding`, `list_findings`, `publish_review`. The review-style analyzer uses `save_review_style` (exported as `save_review_style_prompt`).
 
-Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `execute`, `write_todos`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
+Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `execute`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
 
 ### Models, profiles, and team defaults
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Wired into `get_agent`:
 
 Reviewer-only tools (in `agent/reviewer.py`): `add_finding`, `update_finding`, `list_findings`, `publish_review`. The review-style analyzer uses `save_review_style` (exported as `save_review_style_prompt`).
 
-Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `execute`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
+Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `delete`, `ls`, `glob`, `grep`, `execute`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
 
 ### Models, profiles, and team defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Wired into `get_agent`:
 
 Reviewer-only tools (in `agent/reviewer.py`): `add_finding`, `update_finding`, `list_findings`, `publish_review`. The review-style analyzer uses `save_review_style` (exported as `save_review_style_prompt`).
 
-Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `execute`, `write_todos`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
+Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `execute`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
 
 ### Models, profiles, and team defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Wired into `get_agent`:
 
 Reviewer-only tools (in `agent/reviewer.py`): `add_finding`, `update_finding`, `list_findings`, `publish_review`. The review-style analyzer uses `save_review_style` (exported as `save_review_style_prompt`).
 
-Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `execute`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
+Built-in deepagents tools (`read_file`, `write_file`, `edit_file`, `delete`, `ls`, `glob`, `grep`, `execute`, `task` for subagent spawning, …) are added by `create_deep_agent` itself; don't duplicate them.
 
 ### Models, profiles, and team defaults
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Stripe's key insight: *tool curation matters more than tool quantity.* Open SWE 
 | `slack_add_reaction` | React to Slack messages |
 | `slack_thread_reply` | Reply in Slack threads |
 
-GitHub operations are performed with `GH_TOKEN=dummy gh` inside the sandbox, backed by the LangSmith proxy. Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `delete`, `ls`, `glob`, `grep`, and `task` (subagent spawning).
+GitHub operations are performed with `GH_TOKEN=dummy gh` inside the sandbox, backed by the LangSmith proxy. Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `delete`, `ls`, `glob`, `grep`, `execute`, and `task` (subagent spawning).
 
 **Optional observability tools (server-side):** Admins can connect Datadog and LangSmith from team settings (Admin → Observability credentials). When connected, the agent gains Datadog tools (via Datadog's hosted MCP server, default `toolsets=core`) and read-only LangSmith tools (`langsmith_get_trace`, `langsmith_list_runs`). These run in the LangGraph server process using credentials encrypted at rest — the sandbox never holds Datadog or LangSmith keys. They are loaded **only for runs triggered by an authorized user** (admins, plus any emails in `OBSERVABILITY_AUTHORIZED_EMAILS`), so a prompt-injected run from an untrusted contributor cannot reach team observability data. Use scoped, read-oriented keys regardless: observability data (logs, traces) is attacker-influenced content that can carry prompt injection, and the agent has network egress — the same residual-risk class as `web_search` / `fetch_url`.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Stripe's key insight: *tool curation matters more than tool quantity.* Open SWE 
 | `slack_add_reaction` | React to Slack messages |
 | `slack_thread_reply` | Reply in Slack threads |
 
-GitHub operations are performed with `GH_TOKEN=dummy gh` inside the sandbox, backed by the LangSmith proxy. Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, and `task` (subagent spawning).
+GitHub operations are performed with `GH_TOKEN=dummy gh` inside the sandbox, backed by the LangSmith proxy. Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `delete`, `ls`, `glob`, `grep`, and `task` (subagent spawning).
 
 **Optional observability tools (server-side):** Admins can connect Datadog and LangSmith from team settings (Admin → Observability credentials). When connected, the agent gains Datadog tools (via Datadog's hosted MCP server, default `toolsets=core`) and read-only LangSmith tools (`langsmith_get_trace`, `langsmith_list_runs`). These run in the LangGraph server process using credentials encrypted at rest — the sandbox never holds Datadog or LangSmith keys. They are loaded **only for runs triggered by an authorized user** (admins, plus any emails in `OBSERVABILITY_AUTHORIZED_EMAILS`), so a prompt-injected run from an untrusted contributor cannot reach team observability data. Use scoped, read-oriented keys regardless: observability data (logs, traces) is attacker-influenced content that can carry prompt injection, and the agent has network egress — the same residual-risk class as `web_search` / `fetch_url`.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Stripe's key insight: *tool curation matters more than tool quantity.* Open SWE 
 | `slack_add_reaction` | React to Slack messages |
 | `slack_thread_reply` | Reply in Slack threads |
 
-GitHub operations are performed with `GH_TOKEN=dummy gh` inside the sandbox, backed by the LangSmith proxy. Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, `write_todos`, and `task` (subagent spawning).
+GitHub operations are performed with `GH_TOKEN=dummy gh` inside the sandbox, backed by the LangSmith proxy. Plus the built-in Deep Agents tools: `read_file`, `write_file`, `edit_file`, `ls`, `glob`, `grep`, and `task` (subagent spawning).
 
 **Optional observability tools (server-side):** Admins can connect Datadog and LangSmith from team settings (Admin → Observability credentials). When connected, the agent gains Datadog tools (via Datadog's hosted MCP server, default `toolsets=core`) and read-only LangSmith tools (`langsmith_get_trace`, `langsmith_list_runs`). These run in the LangGraph server process using credentials encrypted at rest — the sandbox never holds Datadog or LangSmith keys. They are loaded **only for runs triggered by an authorized user** (admins, plus any emails in `OBSERVABILITY_AUTHORIZED_EMAILS`), so a prompt-injected run from an untrusted contributor cannot reach team observability data. Use scoped, read-oriented keys regardless: observability data (logs, traces) is attacker-influenced content that can carry prompt injection, and the agent has network egress — the same residual-risk class as `web_search` / `fetch_url`.
 
@@ -92,7 +92,7 @@ Open SWE gathers context from two sources:
 
 Open SWE's orchestration has two layers:
 
-**Subagents:** The Deep Agents framework natively supports spawning child agents via the `task` tool. The main agent can fan out independent subtasks to isolated subagents — each with its own middleware stack, todo list, and file operations. This is similar to Ramp's child sessions for parallel work.
+**Subagents:** The Deep Agents framework natively supports spawning child agents via the `task` tool. The main agent can fan out independent subtasks to isolated subagents — each with its own middleware stack and file operations. This is similar to Ramp's child sessions for parallel work.
 
 **Middleware:** Deterministic middleware hooks run around the agent loop:
 

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -76,7 +76,7 @@ CHAT_MODEL_CALL_LIMIT = 100
 # Read-only: the chat agent never mutates files or runs shell commands. These are
 # injected by deepagents' FilesystemMiddleware and stripped before the model sees
 # them (there is no sandbox, so ``execute`` would error anyway).
-_EXCLUDED_TOOLS = frozenset({"execute", "write_file", "edit_file"})
+_EXCLUDED_TOOLS = frozenset({"execute", "write_file", "edit_file", "delete"})
 
 CHAT_PROMPT = """You are a code-review chat assistant. You help the author and reviewers \
 understand one GitHub pull request: `{repo_owner}/{repo_name}` #{pr_number}.

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -28,6 +28,8 @@ warnings.filterwarnings("ignore", module="langchain_core._api.deprecation")
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 from deepagents import create_deep_agent
+from deepagents.middleware.filesystem import FilesystemMiddleware
+from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
@@ -77,6 +79,23 @@ CHAT_MODEL_CALL_LIMIT = 100
 # injected by deepagents' FilesystemMiddleware and stripped before the model sees
 # them (there is no sandbox, so ``execute`` would error anyway).
 _EXCLUDED_TOOLS = frozenset({"execute", "write_file", "edit_file", "delete"})
+
+
+def _chat_general_purpose_subagent() -> SubAgent:
+    # Deep Agents auto-adds a general-purpose subagent whose default
+    # FilesystemMiddleware would expose write_file/edit_file/delete/execute.
+    # Declaring the spec here suppresses that default and swaps in an
+    # allowlisted FilesystemMiddleware so delegated work stays read-only.
+    return {
+        "name": GENERAL_PURPOSE_SUBAGENT["name"],
+        "description": GENERAL_PURPOSE_SUBAGENT["description"],
+        "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
+        "middleware": cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [FilesystemMiddleware(tools=["read_file", "ls", "glob", "grep"])],
+        ),
+    }
+
 
 CHAT_PROMPT = """You are a code-review chat assistant. You help the author and reviewers \
 understand one GitHub pull request: `{repo_owner}/{repo_name}` #{pr_number}.
@@ -217,6 +236,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
             web_search,
             fetch_url,
         ],
+        subagents=[_chat_general_purpose_subagent()],
         middleware=cast(
             list[AgentMiddleware[Any, Any, Any]],
             [

--- a/agent/middleware/exclude_tools.py
+++ b/agent/middleware/exclude_tools.py
@@ -1,11 +1,8 @@
 """Hide named tools from the model without rebuilding the agent.
 
-`create_deep_agent` always wires the `task` tool when the auto-added
-general-purpose subagent is present. The reviewer agent has no use for
-subagent dispatch, so this middleware drops the named tools from the
-request before the model sees them. Mirrors the behavior of deepagents'
-own private `_ToolExclusionMiddleware` but lives here so we don't depend
-on a private import path.
+This provides per-agent tool filtering after Deep Agents injects its built-in
+tools. It mirrors Deep Agents' private `_ToolExclusionMiddleware` without
+depending on a private import path.
 """
 
 from __future__ import annotations

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -4,8 +4,6 @@ import shlex
 from importlib import resources
 from pathlib import Path
 
-from deepagents import HarnessProfile, register_harness_profile
-
 from .utils.authorship import (
     OPEN_SWE_BOT_EMAIL,
     OPEN_SWE_BOT_NAME,
@@ -17,25 +15,6 @@ from .utils.github_comments import UNTRUSTED_GITHUB_COMMENT_OPEN_TAG
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROMPT_PATH = os.environ.get("DEFAULT_PROMPT_PATH")
-ENABLE_TODOS_ENV_VAR = "OPEN_SWE_ENABLE_TODOS"
-
-
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _harness_excluded_tools() -> frozenset[str]:
-    return frozenset() if _env_flag(ENABLE_TODOS_ENV_VAR) else frozenset({"write_todos"})
-
-
-HARNESS_EXCLUDED_TOOLS: frozenset[str] = _harness_excluded_tools()
-
-# Provider keys the harness profile is registered under. deepagents resolves a
-# pre-built model's profile by `provider:identifier` then a provider-only
-# fallback, so registering per provider makes the Open SWE base prompt replace
-# deepagents' generic base regardless of which supported provider the team or
-# profile selects for the agent.
-HARNESS_PROFILE_KEYS: tuple[str, ...] = ("anthropic", "openai", "google_genai", "fireworks")
 
 
 def _load_default_prompt() -> str:
@@ -68,10 +47,8 @@ def _load_default_prompt() -> str:
     return ""
 
 
-# Static, run-invariant guidance shared by the main agent and its subagents.
-# Registered as the harness profile's `base_system_prompt`, it REPLACES
-# deepagents' generic base prompt so there is a single Open SWE voice. The
-# per-thread, main-agent-specific prompt (working dir, repo setup, PR workflow,
+# Static, run-invariant guidance for the main agent. The per-thread,
+# main-agent-specific prompt (working dir, repo setup, PR workflow,
 # source-channel reply) is layered in front of this via `construct_system_prompt`.
 OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on LangGraph and Deep Agents, operating in a remote, git-backed Linux sandbox invoked from Slack, Linear, or GitHub.
 
@@ -341,6 +318,7 @@ SYSTEM_PROMPT_TEMPLATE = (
     + "{pr_policy_override_section}"
     + "{collaboration_section}"
     + "{repo_instructions_section}"
+    + "\n\n{shared_base_section}"
 )
 
 
@@ -387,31 +365,7 @@ def construct_system_prompt(
         pr_policy_override_section=ALWAYS_CREATE_PR_SECTION if create_prs else "",
         collaboration_section=_render_collaboration_section(triggering_user_identity, thread_url),
         repo_instructions_section=_render_repo_instructions_section(repo_custom_instructions),
+        shared_base_section=OPEN_SWE_SHARED_BASE,
         commit_identity_name=commit_identity_name,
         commit_identity_email=commit_identity_email,
     )
-
-
-def register_open_swe_harness_profile() -> None:
-    """Register Open SWE's harness profile so its base prompt replaces deepagents'.
-
-    Registered per supported provider, the profile's ``base_system_prompt``
-    (``OPEN_SWE_SHARED_BASE``) supplants deepagents' generic base prompt for the
-    main agent and its subagents, leaving a single Open SWE voice. The per-thread
-    main-agent prompt is passed by the server via
-    ``system_prompt=construct_system_prompt(...)`` and is layered in front of the
-    shared base by deepagents. The shared base is intentionally neutral (no
-    PR/commit/mutation guidance — that lives only in the main agent's per-thread
-    prompt) so it is also safe under the read-only reviewer and analyzer graphs,
-    which share these providers. Idempotent in effect: deepagents merges
-    re-registrations under the same key.
-    """
-    profile = HarnessProfile(
-        base_system_prompt=OPEN_SWE_SHARED_BASE,
-        excluded_tools=HARNESS_EXCLUDED_TOOLS,
-    )
-    for key in HARNESS_PROFILE_KEYS:
-        register_harness_profile(key, profile)
-
-
-register_open_swe_harness_profile()

--- a/agent/server.py
+++ b/agent/server.py
@@ -87,7 +87,7 @@ from .middleware import (
 )
 from .middleware.prepare_run import PrepareRunState
 from .middleware.sandbox_circuit_breaker import post_sandbox_unreachable_notification
-from .prompt import construct_system_prompt
+from .prompt import OPEN_SWE_SHARED_BASE, construct_system_prompt
 from .runtime.constants import (
     DEFAULT_LLM_MAX_TOKENS,
     DEFAULT_RECURSION_LIMIT,
@@ -463,7 +463,10 @@ def _general_purpose_subagent(model: BaseChatModel) -> SubAgent:
     return {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
         "description": GENERAL_PURPOSE_SUBAGENT["description"],
-        "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
+        # Deep Agents' default GP prompt covers only task mechanics; the shared
+        # base carries the Open SWE identity and conventions (gh proxy usage,
+        # tool-call cadence) that delegated work also needs.
+        "system_prompt": OPEN_SWE_SHARED_BASE + "\n\n" + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
     }
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -217,7 +217,7 @@ Routing is applied centrally in `make_model` (`agent/utils/model.py`), which res
 
 ## 3. Tools
 
-Open SWE ships with a small set of custom tools on top of the built-in Deep Agents tools (file operations, shell execution, subagents, todos). GitHub operations are handled by `GH_TOKEN=dummy gh` inside the sandbox.
+Open SWE ships with a small set of custom tools on top of the built-in Deep Agents tools (file reads, writes, edits, deletes, search, shell execution, and subagents). GitHub operations are handled by `GH_TOKEN=dummy gh` inside the sandbox.
 
 | Tool | File | Purpose |
 |---|---|---|

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -462,10 +462,6 @@ ALLOWED_GITHUB_REPOS=""                # e.g. "some-user/their-repo,another-org/
 DEFAULT_REPO_OWNER=""                  # Default GitHub org (e.g. "my-org")
 DEFAULT_REPO_NAME=""                   # Default GitHub repo (e.g. "my-repo")
 
-# === Agent Behavior (optional) ===
-# Todos are hidden from the agent by default. Set true to re-enable the write_todos tool.
-OPEN_SWE_ENABLE_TODOS=""
-
 # === Dashboard (required to run the web dashboard) ===
 # Public URL that browsers use for /dashboard/api/* and OAuth callbacks.
 # Use the FastAPI backend URL for local/cross-origin direct API calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "deepagents==0.7.0b1",
+    "deepagents==0.7.0b2",
     "fastapi>=0.139.0",
     "uvicorn>=0.50.2",
     "httpx>=0.28.1",
@@ -47,9 +47,9 @@ dev = [
 # conservative `deepagents<0.7.0` upper bound, but the 0.7.0 pre-release keeps
 # the public API they rely on (SandboxBackendProtocol / BaseSandbox) backward
 # compatible. Override the transitive bound so we can track the latest pre-release.
-# deepagents 0.7.0b1 requires wcmatch>=11.0, while langchain-e2b's e2b dep still
+# deepagents 0.7.0b2 requires wcmatch>=11.0, while langchain-e2b's e2b dep still
 # caps wcmatch<11.0; override it so both can resolve (the glob API is unchanged).
-override-dependencies = ["deepagents==0.7.0b1", "wcmatch>=11.0"]
+override-dependencies = ["deepagents==0.7.0b2", "wcmatch>=11.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -127,3 +127,17 @@ async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
     names = [type(m).__name__ for m in middleware]
 
     assert names.index("ToolErrorMiddleware") < names.index("ToolRetryMiddleware")
+
+
+@pytest.mark.asyncio
+async def test_general_purpose_subagent_carries_open_swe_shared_base() -> None:
+    from agent.prompt import OPEN_SWE_SHARED_BASE
+
+    captured = await _capture_create_deep_agent_kwargs()
+    subagents = captured["subagents"]
+    assert isinstance(subagents, list)
+    gp = next(s for s in subagents if s["name"] == "general-purpose")
+    prompt = gp["system_prompt"]
+    assert prompt.startswith(OPEN_SWE_SHARED_BASE)
+    # GP task-mechanics guidance still trails the shared base.
+    assert "calling agent only sees your final" in prompt

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -127,10 +127,10 @@ def test_construct_system_prompt_identifies_own_repo() -> None:
     prompt = construct_system_prompt(working_dir="/workspace")
 
     # The per-thread prompt points self-referential tasks at the repo; the
-    # "Open SWE" identity lives in the harness-profile base prompt that
-    # deepagents prepends at runtime (OPEN_SWE_SHARED_BASE).
+    # shared base carries the Open SWE identity.
     assert "langchain-ai/open-swe" in prompt
     assert "Open SWE" in OPEN_SWE_SHARED_BASE
+    assert "Open SWE" in prompt
 
 
 def test_shared_base_requires_terse_slack_replies_with_share_path() -> None:
@@ -149,36 +149,13 @@ def test_shared_base_requires_terse_slack_replies_with_share_path() -> None:
     assert "does not enter plan mode" in OPEN_SWE_SHARED_BASE
 
 
-def test_harness_profile_replaces_deepagents_base_for_supported_providers() -> None:
-    """The Open SWE base prompt is registered per provider and replaces the SDK base."""
-    import deepagents.profiles.harness.harness_profiles as hp
+def test_construct_system_prompt_includes_shared_base_explicitly() -> None:
+    from agent.prompt import OPEN_SWE_SHARED_BASE
 
-    import agent.prompt  # noqa: F401  (registers the profile on import)
-    from agent.prompt import (
-        HARNESS_EXCLUDED_TOOLS,
-        HARNESS_PROFILE_KEYS,
-        OPEN_SWE_SHARED_BASE,
-    )
+    prompt = construct_system_prompt(working_dir="/workspace")
 
-    hp._ensure_harness_profiles_loaded()
-    assert set(HARNESS_PROFILE_KEYS) >= {"anthropic", "openai", "google_genai", "fireworks"}
-    assert "write_todos" in HARNESS_EXCLUDED_TOOLS
-    for key in HARNESS_PROFILE_KEYS:
-        profile = hp._HARNESS_PROFILES.get(key)
-        assert profile is not None, f"no harness profile registered for {key!r}"
-        assert profile.base_system_prompt == OPEN_SWE_SHARED_BASE
-        assert HARNESS_EXCLUDED_TOOLS <= profile.excluded_tools
-    resolved_profile = hp._get_harness_profile("openai:gpt-5.6-sol")
-    assert resolved_profile is not None
-    assert "write_todos" in resolved_profile.excluded_tools
-
-
-def test_enable_todos_env_clears_harness_tool_exclusion(monkeypatch) -> None:
-    from agent import prompt as prompt_module
-
-    monkeypatch.setenv(prompt_module.ENABLE_TODOS_ENV_VAR, "true")
-
-    assert prompt_module._harness_excluded_tools() == frozenset()
+    assert prompt.endswith(OPEN_SWE_SHARED_BASE)
+    assert "base prompt replaces deepagents" not in prompt
 
 
 def test_todo_tool_and_prompt_are_hidden_from_model_request_by_default() -> None:
@@ -195,8 +172,8 @@ def test_todo_tool_and_prompt_are_hidden_from_model_request_by_default() -> None
     assert "You have access to the `write_todos` tool" not in system_text
 
 
-def test_shared_base_is_neutral_for_read_only_agents() -> None:
-    """Shared base carries no PR/commit/mutation guidance (it also underlies the reviewer)."""
+def test_shared_base_keeps_pr_workflow_out_of_standing_guidance() -> None:
+    """Shared base carries no PR/commit/mutation guidance."""
     from agent.prompt import OPEN_SWE_SHARED_BASE
 
     lowered = OPEN_SWE_SHARED_BASE.lower()

--- a/tests/reviewer/test_review_chat.py
+++ b/tests/reviewer/test_review_chat.py
@@ -643,6 +643,12 @@ async def test_proxy_state_rejects_foreign_thread(monkeypatch) -> None:
 # --- graph factory guard -----------------------------------------------------
 
 
+def test_chat_excludes_mutating_filesystem_tools() -> None:
+    from agent.chat import _EXCLUDED_TOOLS
+
+    assert {"write_file", "edit_file", "delete", "execute"} <= _EXCLUDED_TOOLS
+
+
 @pytest.mark.asyncio
 async def test_chat_web_search_returns_inline_results_without_sandbox(monkeypatch) -> None:
     class FakeExa:

--- a/tests/reviewer/test_review_chat.py
+++ b/tests/reviewer/test_review_chat.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from deepagents.middleware.filesystem import FilesystemMiddleware
 from fastapi import HTTPException
 
 from agent.dashboard import review_chat_api
@@ -647,6 +648,20 @@ def test_chat_excludes_mutating_filesystem_tools() -> None:
     from agent.chat import _EXCLUDED_TOOLS
 
     assert {"write_file", "edit_file", "delete", "execute"} <= _EXCLUDED_TOOLS
+
+
+def test_chat_general_purpose_subagent_is_read_only() -> None:
+    from agent.chat import _chat_general_purpose_subagent
+
+    spec = _chat_general_purpose_subagent()
+
+    assert spec["name"] == "general-purpose"
+    fs_middleware = [m for m in spec["middleware"] if isinstance(m, FilesystemMiddleware)]
+    assert len(fs_middleware) == 1
+    enabled = fs_middleware[0]._enabled_tools
+    assert enabled is not None
+    assert {"write_file", "edit_file", "delete", "execute"}.isdisjoint(enabled)
+    assert {"read_file", "ls", "glob", "grep"} <= enabled
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "deepagents", specifier = "==0.7.0b1" },
+    { name = "deepagents", specifier = "==0.7.0b2" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]
 
@@ -668,7 +668,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.7.0b1"
+version = "0.7.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -678,9 +678,9 @@ dependencies = [
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/01/e6f554dbfe6219188db4b51ee96d277c4a0dbfddbc834dcb19bd87baf1d2/deepagents-0.7.0b1.tar.gz", hash = "sha256:219eff73f6641ed8c1292b61d1b1772b61ad69ab8e8259dcffa62c9a8397aee3", size = 266341, upload-time = "2026-07-23T16:16:18.734Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/61/1cd2455cd7645e60cdffdd7e60ae16c1d99cd355721276efc9e80aaa9a7f/deepagents-0.7.0b2.tar.gz", hash = "sha256:cc6da9edf864041008e7250f4925441e619b5fb711042580e6d9f6c17f0735cd", size = 263046, upload-time = "2026-07-24T03:55:36.585Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/7e/1677e806861f5ad4aa9096232f937a6d568414d1a02c0f809c29ffa60ad0/deepagents-0.7.0b1-py3-none-any.whl", hash = "sha256:0ea1e18454b9cb5107181e7d9059dcff1355e544127725e5c3fbf0290c91c9a5", size = 292176, upload-time = "2026-07-23T16:16:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/04/d1603d00b9b77a57257ac925ad7a7b32db501453da596bbcabbc013faff7/deepagents-0.7.0b2-py3-none-any.whl", hash = "sha256:088758990a290e8a5b8d7b64a800ae4a538e0198fd074ac83158a25b1c3350d7", size = 289122, upload-time = "2026-07-24T03:55:35.227Z" },
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=49.0.0" },
-    { name = "deepagents", specifier = "==0.7.0b1" },
+    { name = "deepagents", specifier = "==0.7.0b2" },
     { name = "exa-py", specifier = ">=2.16.0" },
     { name = "fastapi", specifier = ">=0.139.0" },
     { name = "fireworks-ai", specifier = ">=1.2.0a86" },


### PR DESCRIPTION
## Description
Bumps Deep Agents to 0.7.0b2 and removes the obsolete harness-profile prompt/todo shim. Keeps Open SWE prompting explicit, documents the complete built-in tool set, and excludes the new `delete` tool from read-only PR chat.

## Test Plan
- [x] make install
- [x] make format
- [x] make lint
- [x] uv run --project /workspace/open-swe pytest -vvv /workspace/open-swe/tests/github/test_github_comment_prompts.py --no-header --no-summary
- [x] uv run --project /workspace/open-swe pytest -vvv /workspace/open-swe/tests/reviewer/test_review_chat.py --no-header --no-summary

Made by [Open SWE](https://openswe.vercel.app/agents/b6fd4720-09ff-8c9d-22e7-ae03860c9c19)