### PR TITLE
fix: let the reviewer recover from an unreachable sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,15 @@ CI auto-fix ("PR babysitting") lives in `agent/ci_autofix.py`: when a CI check f
 
 ### Sandbox lifecycle (the tricky part)
 
-`SANDBOX_BACKENDS` (in `agent/utils/sandbox_state.py`) is an in-process dict keyed by `thread_id`. Thread metadata persists `sandbox_id` across processes. `ensure_sandbox_for_thread` handles four cases:
+`SANDBOX_BACKENDS` (in `agent/utils/sandbox_state.py`) is an in-process dict keyed by `thread_id`. Thread metadata persists `sandbox_id` across processes. `ensure_sandbox_for_thread` handles three cases:
 
-1. Sandbox cached in memory → ping it (`echo ok`); recreate on `SandboxClientError`. Healthy reused sandboxes also get a GitHub-proxy refresh (recreate on failure).
-2. Metadata says `__creating__` and no cache → reset stale metadata so a fresh sandbox can be created.
-3. No sandbox at all → set `__creating__` sentinel, create one, persist the real id.
-4. Metadata has an id but no cache → reconnect; fall back to recreate on failure.
+1. Sandbox cached in memory → ping it (`echo ok`), then refresh the GitHub proxy.
+2. Metadata has an id but no cache → reconnect, then refresh the GitHub proxy.
+3. No sandbox at all → create one and persist the id.
+
+Only case 3 creates. An existing sandbox that can't be reached raises `SandboxUnreachableError` (`agent/utils/sandbox_state.py`) rather than being replaced: a replacement is empty, so swapping one in would destroy uncommitted work while looking like a recovery. The main agent catches that in `PrepareAgentRunMiddleware` and notifies the user via `post_sandbox_unreachable_notification`.
+
+`allow_replacement=True` opts out of that protection and is passed **only** by the reviewer (`agent/reviewer.py:_ensure_reviewer_sandbox_for_thread`), whose sandbox holds nothing but a checkout `prepare_review_repo` re-derives every run. Reviewer threads are one-per-PR and outlive their sandbox, so without this a deleted sandbox bricks reviews on that PR permanently.
 
 For `SANDBOX_TYPE=langsmith` (default), every sandbox creation/refresh also calls `_configure_github_proxy` with a fresh GitHub App installation token (`get_github_app_installation_token`). The proxy injects Basic auth for `github.com` git traffic and Bearer auth for `api.github.com` so sandbox commands can use `GH_TOKEN=dummy gh ...` without storing real tokens in the sandbox. Other providers (modal, daytona, runloop, e2b, local) skip the proxy step. Provider is selected via `SANDBOX_TYPE`; factory is `agent/utils/sandbox.py:create_sandbox` (`SANDBOX_FACTORIES` maps each provider name to a creator in `agent/integrations/`).
 

--- a/agent/middleware/sandbox_circuit_breaker.py
+++ b/agent/middleware/sandbox_circuit_breaker.py
@@ -26,12 +26,17 @@ SANDBOX_CIRCUIT_BREAKER_THRESHOLD = 2
 
 
 def sandbox_unreachable_message(
-    *, sandbox_id: str | None = None, sandbox_name: str | None = None
+    *,
+    sandbox_id: str | None = None,
+    sandbox_name: str | None = None,
+    replacement_attempted: bool = False,
 ) -> str:
     """User-facing text for a sandbox that stopped answering.
 
     Deliberately does not claim the sandbox is gone for good — all we observed is
-    that it stopped responding, and it may come back.
+    that it stopped responding, and it may come back. ``replacement_attempted``
+    is for callers allowed to replace an unreachable sandbox (the read-only
+    reviewer), where "Open SWE will not start a replacement" would be untrue.
     """
     identifiers = [
         part
@@ -42,6 +47,12 @@ def sandbox_unreachable_message(
         if part
     ]
     which = f" ({', '.join(identifiers)})" if identifiers else ""
+    if replacement_attempted:
+        return warning(
+            f"This thread's sandbox{which} stopped responding and Open SWE could "
+            "not provision a replacement, so this run had nowhere to work. "
+            "Retrigger this thread to try again."
+        )
     return warning(
         f"This thread's sandbox{which} stopped responding, and Open SWE can't tell "
         "whether it will come back. Open SWE will not start a replacement on its "
@@ -186,13 +197,18 @@ async def post_sandbox_unreachable_notification(
     *,
     sandbox_id: str | None = None,
     sandbox_name: str | None = None,
+    replacement_attempted: bool = False,
 ) -> None:
     configurable = config.get("configurable", {})
     if not isinstance(configurable, Mapping):
         logger.info("No runtime configurable found for sandbox circuit breaker notification")
         return
 
-    message = sandbox_unreachable_message(sandbox_id=sandbox_id, sandbox_name=sandbox_name)
+    message = sandbox_unreachable_message(
+        sandbox_id=sandbox_id,
+        sandbox_name=sandbox_name,
+        replacement_attempted=replacement_attempted,
+    )
 
     slack_target = _get_slack_target(configurable)
     if slack_target is not None:

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -61,6 +61,7 @@ from .middleware import (
     settle_review_check_on_exit,
 )
 from .middleware.prepare_run import PrepareRunState
+from .middleware.sandbox_circuit_breaker import post_sandbox_unreachable_notification
 from .review.diff import (
     changed_files,
     compute_diff_line_set,
@@ -113,6 +114,7 @@ from .utils.github_token import cache_github_token_for_thread
 from .utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
 from .utils.repo_prep import materialize_trusted_skills, prepare_review_repo
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
+from .utils.sandbox_state import SandboxUnreachableError
 from .utils.tracing import REVIEW_TRACING_PROJECT, traced_graph_factory
 
 HISTORICAL_REVIEW_GUIDANCE = """- **Anything that overlaps an existing PR review thread.** A
@@ -951,6 +953,11 @@ async def _ensure_reviewer_sandbox_for_thread(
             github_proxy_token=github_token,
             github_proxy_repositories=[repo_name_for_scope] if repo_name_for_scope else None,
             repo=repo_for_snapshot,
+            # A reviewer sandbox holds nothing but a checkout `prepare_review_repo`
+            # re-derives every run, and reviewer threads outlive their sandbox: one
+            # thread per PR, re-triggered on every push. Refusing to replace an
+            # unreachable one would brick reviews on that PR for good.
+            allow_replacement=True,
         ),
         github_token,
     )
@@ -1000,9 +1007,17 @@ class PrepareReviewerRunMiddleware(BasePrepareRunMiddleware):
     async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:
         configurable = self._config.get("configurable") or {}
         repo_config = configurable.get("repo") or {}
-        sandbox_backend, github_token = await _ensure_reviewer_sandbox_for_thread(
-            self._thread_id, configurable
-        )
+        try:
+            sandbox_backend, github_token = await _ensure_reviewer_sandbox_for_thread(
+                self._thread_id, configurable
+            )
+        except SandboxUnreachableError as exc:
+            # Replacement was allowed and still failed, so this run dies without a
+            # sandbox. Say so on the PR instead of leaving it looking unreviewed.
+            await post_sandbox_unreachable_notification(
+                self._config or {}, sandbox_id=exc.sandbox_id, replacement_attempted=True
+            )
+            raise
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
 
         repo_owner = str(repo_config.get("owner", ""))

--- a/agent/runtime/sandbox.py
+++ b/agent/runtime/sandbox.py
@@ -9,6 +9,7 @@ async def ensure_sandbox_for_thread(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     repo: dict[str, str] | None = None,
+    allow_replacement: bool = False,
 ) -> SandboxBackendProtocol:
     from agent.server import ensure_sandbox_for_thread as ensure
 
@@ -17,6 +18,7 @@ async def ensure_sandbox_for_thread(
         github_proxy_token=github_proxy_token,
         github_proxy_repositories=github_proxy_repositories,
         repo=repo,
+        allow_replacement=allow_replacement,
     )
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -362,12 +362,38 @@ async def check_sandbox_reachable(
     return sandbox_backend
 
 
+async def _connect_existing_sandbox(
+    thread_id: str,
+    *,
+    cached: SandboxBackendProtocol | None,
+    sandbox_id: str | None,
+    github_proxy_token: str | None = None,
+    github_proxy_repositories: Sequence[str] | None = None,
+) -> SandboxBackendProtocol:
+    """Reuse the sandbox already bound to ``thread_id``, or fail unreachable."""
+    if cached is not None:
+        logger.info("Using cached sandbox backend for thread %s", thread_id)
+        sandbox_backend = await check_sandbox_reachable(cached, thread_id)
+    else:
+        logger.info("Connecting to existing sandbox %s", sandbox_id)
+        try:
+            sandbox_backend = await create_sandbox(str(sandbox_id))
+        except Exception as exc:
+            logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
+            raise SandboxUnreachableError(thread_id, sandbox_id, str(exc)) from exc
+        sandbox_backend = await check_sandbox_reachable(sandbox_backend, thread_id)
+    return await _refresh_github_proxy_or_fail(
+        sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
+    )
+
+
 async def ensure_sandbox_for_thread(
     thread_id: str,
     *,
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     repo: dict[str, str] | None = None,
+    allow_replacement: bool = False,
 ) -> SandboxBackendProtocol:
     """Get-or-create a healthy sandbox bound to ``thread_id``.
 
@@ -379,10 +405,17 @@ async def ensure_sandbox_for_thread(
     2. Metadata has an id -> reconnect, then refresh proxy.
     3. No sandbox at all -> create one and persist the id.
 
-    Only case 3 creates. A sandbox that exists but can't be reached raises
-    ``SandboxUnreachableError`` instead of being replaced — a replacement is
-    empty, and swapping one in silently destroys whatever the agent had not yet
-    committed.
+    By default only case 3 creates: a sandbox that exists but can't be reached
+    raises ``SandboxUnreachableError`` instead of being replaced, because a
+    replacement is empty and swapping one in silently destroys whatever the agent
+    had not yet committed.
+
+    ``allow_replacement`` opts out of that protection for callers whose sandbox
+    holds nothing but a re-derivable checkout — the read-only reviewer, which
+    re-preps the repo every run. There, refusing to replace bricks the thread
+    permanently: sandboxes are deleted once their retention window elapses, and
+    the stale id in thread metadata is what every later run keeps reconnecting
+    to. Replacing it clears that id in the metadata update below.
 
     For LangSmith sandboxes, also refreshes the GitHub App proxy auth. When
     ``repo`` has a ``ready`` repo-scoped snapshot, newly created sandboxes boot
@@ -396,13 +429,7 @@ async def ensure_sandbox_for_thread(
         sandbox_backend = None
     sandbox_id = await get_sandbox_id_from_metadata(thread_id)
 
-    if sandbox_backend:
-        logger.info("Using cached sandbox backend for thread %s", thread_id)
-        sandbox_backend = await check_sandbox_reachable(sandbox_backend, thread_id)
-        sandbox_backend = await _refresh_github_proxy_or_fail(
-            sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
-        )
-    elif sandbox_id is None:
+    if sandbox_backend is None and sandbox_id is None:
         logger.info("Creating new sandbox for thread %s", thread_id)
         sandbox_backend = await _create_sandbox_with_proxy(
             github_proxy_token,
@@ -412,16 +439,29 @@ async def ensure_sandbox_for_thread(
         )
         logger.info("Sandbox created: %s", sandbox_backend.id)
     else:
-        logger.info("Connecting to existing sandbox %s", sandbox_id)
         try:
-            sandbox_backend = await create_sandbox(sandbox_id)
-        except Exception as exc:
-            logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
-            raise SandboxUnreachableError(thread_id, sandbox_id, str(exc)) from exc
-        sandbox_backend = await check_sandbox_reachable(sandbox_backend, thread_id)
-        sandbox_backend = await _refresh_github_proxy_or_fail(
-            sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
-        )
+            sandbox_backend = await _connect_existing_sandbox(
+                thread_id,
+                cached=sandbox_backend,
+                sandbox_id=sandbox_id,
+                github_proxy_token=github_proxy_token,
+                github_proxy_repositories=github_proxy_repositories,
+            )
+        except SandboxUnreachableError as exc:
+            if not allow_replacement:
+                raise
+            logger.warning(
+                "Replacing unreachable sandbox %s for thread %s",
+                exc.sandbox_id,
+                thread_id,
+            )
+            sandbox_backend = await _create_sandbox_with_proxy(
+                github_proxy_token,
+                thread_id=thread_id,
+                github_proxy_repositories=github_proxy_repositories,
+                repo=repo,
+            )
+            logger.info("Replacement sandbox created: %s", sandbox_backend.id)
 
     sandbox_backend = set_sandbox_backend(thread_id, sandbox_backend)
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -455,12 +455,25 @@ async def ensure_sandbox_for_thread(
                 exc.sandbox_id,
                 thread_id,
             )
-            sandbox_backend = await _create_sandbox_with_proxy(
-                github_proxy_token,
-                thread_id=thread_id,
-                github_proxy_repositories=github_proxy_repositories,
-                repo=repo,
-            )
+            try:
+                sandbox_backend = await _create_sandbox_with_proxy(
+                    github_proxy_token,
+                    thread_id=thread_id,
+                    github_proxy_repositories=github_proxy_repositories,
+                    repo=repo,
+                )
+            except Exception as create_exc:
+                # Keep the failure typed so callers still recognize "this run has no
+                # sandbox" and can notify the user.
+                logger.warning(
+                    "Failed to replace unreachable sandbox %s for thread %s",
+                    exc.sandbox_id,
+                    thread_id,
+                    exc_info=True,
+                )
+                raise SandboxUnreachableError(
+                    thread_id, exc.sandbox_id, str(create_exc)
+                ) from create_exc
             logger.info("Replacement sandbox created: %s", sandbox_backend.id)
 
     sandbox_backend = set_sandbox_backend(thread_id, sandbox_backend)

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -310,6 +310,7 @@ async def test_reviewer_reuses_app_token_for_sandbox_proxy() -> None:
         github_proxy_token="app-token",
         github_proxy_repositories=["repo"],
         repo={"owner": "acme", "name": "repo"},
+        allow_replacement=True,
     )
 
 

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -90,6 +90,39 @@ async def test_replaces_unreachable_cached_sandbox_when_replacement_allowed() ->
 
 
 @pytest.mark.asyncio
+async def test_failed_replacement_still_raises_sandbox_unreachable() -> None:
+    thread_id = "thread-reviewer-replacement-fails"
+    SANDBOX_BACKENDS.clear()
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-deleted",
+        ),
+        patch(
+            "agent.server.create_sandbox",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Sandbox 'sandbox-deleted' not found"),
+        ),
+        patch(
+            "agent.server._create_sandbox_with_proxy",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("sandbox API outage"),
+        ),
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", new_callable=AsyncMock),
+        pytest.raises(SandboxUnreachableError) as excinfo,
+    ):
+        await ensure_sandbox_for_thread(thread_id, allow_replacement=True)
+
+    # Typed, so the reviewer still recognizes it and notifies on the PR.
+    assert excinfo.value.sandbox_id == "sandbox-deleted"
+    assert "sandbox API outage" in str(excinfo.value)
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
 async def test_unreachable_sandbox_still_fails_by_default() -> None:
     thread_id = "thread-agent-dead-sandbox"
     SANDBOX_BACKENDS.clear()

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -1,0 +1,169 @@
+"""The reviewer replaces an unreachable sandbox; the coding agent still fails loudly.
+
+A reviewer sandbox holds only a checkout `prepare_review_repo` re-derives every
+run, and reviewer threads (one per PR) outlive their sandbox, so refusing to
+replace one bricks reviews on that PR permanently.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langsmith.sandbox import SandboxClientError
+
+from agent.reviewer import PrepareReviewerRunMiddleware, _ensure_reviewer_sandbox_for_thread
+from agent.server import SANDBOX_BACKENDS, ensure_sandbox_for_thread
+from agent.utils.sandbox_state import SandboxUnreachableError, set_sandbox_backend
+
+
+@pytest.mark.asyncio
+async def test_replaces_unreachable_sandbox_when_replacement_allowed() -> None:
+    thread_id = "thread-reviewer-dead-sandbox"
+    SANDBOX_BACKENDS.clear()
+    replacement = MagicMock()
+    replacement.id = "sandbox-replacement"
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-deleted",
+        ),
+        patch(
+            "agent.server.create_sandbox",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Sandbox 'sandbox-deleted' not found"),
+        ),
+        patch(
+            "agent.server._create_sandbox_with_proxy",
+            new_callable=AsyncMock,
+            return_value=replacement,
+        ) as create_replacement,
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", new_callable=AsyncMock) as update_thread,
+    ):
+        result = await ensure_sandbox_for_thread(thread_id, allow_replacement=True)
+
+    assert result.id == "sandbox-replacement"
+    create_replacement.assert_awaited_once()
+    # The stale id is cleared by persisting the replacement, so later runs stop
+    # reconnecting to a sandbox that no longer exists.
+    assert update_thread.await_args_list[-1].kwargs == {
+        "thread_id": thread_id,
+        "metadata": {"sandbox_id": "sandbox-replacement"},
+    }
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_replaces_unreachable_cached_sandbox_when_replacement_allowed() -> None:
+    thread_id = "thread-reviewer-dead-cache"
+    SANDBOX_BACKENDS.clear()
+    dead = MagicMock()
+    dead.id = "sandbox-cached-dead"
+    dead.execute.side_effect = SandboxClientError("sandbox is gone")
+    proxy = set_sandbox_backend(thread_id, dead)
+    replacement = MagicMock()
+    replacement.id = "sandbox-replacement"
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-cached-dead",
+        ),
+        patch(
+            "agent.server._create_sandbox_with_proxy",
+            new_callable=AsyncMock,
+            return_value=replacement,
+        ) as create_replacement,
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", new_callable=AsyncMock),
+    ):
+        result = await ensure_sandbox_for_thread(thread_id, allow_replacement=True)
+
+    create_replacement.assert_awaited_once()
+    # Replaced in place, so handles already built around the proxy stay valid.
+    assert result is proxy
+    assert proxy.current is replacement
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_unreachable_sandbox_still_fails_by_default() -> None:
+    thread_id = "thread-agent-dead-sandbox"
+    SANDBOX_BACKENDS.clear()
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-deleted",
+        ),
+        patch(
+            "agent.server.create_sandbox",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Sandbox 'sandbox-deleted' not found"),
+        ),
+        patch(
+            "agent.server._create_sandbox_with_proxy",
+            new_callable=AsyncMock,
+        ) as create_replacement,
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", new_callable=AsyncMock),
+        pytest.raises(SandboxUnreachableError),
+    ):
+        await ensure_sandbox_for_thread(thread_id)
+
+    create_replacement.assert_not_awaited()
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_reviewer_opts_into_replacement() -> None:
+    sandbox_backend = MagicMock()
+
+    with patch(
+        "agent.reviewer.ensure_sandbox_for_thread",
+        new_callable=AsyncMock,
+        return_value=sandbox_backend,
+    ) as ensure:
+        result, github_token = await _ensure_reviewer_sandbox_for_thread(
+            "thread-reviewer", {"repo": {"owner": "langchain-ai", "name": "open-swe"}}
+        )
+
+    assert result is sandbox_backend
+    assert github_token is None
+    assert ensure.await_args is not None
+    assert ensure.await_args.kwargs["allow_replacement"] is True
+
+
+@pytest.mark.asyncio
+async def test_reviewer_notifies_when_replacement_also_fails() -> None:
+    config: RunnableConfig = {
+        "configurable": {"repo": {"owner": "langchain-ai", "name": "open-swe"}}
+    }
+    middleware = PrepareReviewerRunMiddleware(
+        thread_id="thread-reviewer", config=config, use_gateway=False
+    )
+
+    with (
+        patch(
+            "agent.reviewer._ensure_reviewer_sandbox_for_thread",
+            new_callable=AsyncMock,
+            side_effect=SandboxUnreachableError("thread-reviewer", "sandbox-deleted", "not found"),
+        ),
+        patch(
+            "agent.reviewer.post_sandbox_unreachable_notification",
+            new_callable=AsyncMock,
+        ) as notify,
+        pytest.raises(SandboxUnreachableError),
+    ):
+        await middleware._prepare({"messages": []}, MagicMock())
+
+    notify.assert_awaited_once()
+    assert notify.await_args is not None
+    assert notify.await_args.kwargs == {
+        "sandbox_id": "sandbox-deleted",
+        "replacement_attempted": True,
+    }


### PR DESCRIPTION
## Description

Reviewer runs have been crashing in `PrepareReviewerRunMiddleware.before_agent` with `SandboxUnreachableError` (LangSmith 404 — the sandbox was deleted by retention). Reviewer threads are one per PR (`uuid5("<owner>/<repo>/pr/<n>/reviewer")`) and outlive their sandbox, and nothing clears the stale `sandbox_id` from thread metadata, so once the sandbox is gone every later run on that PR reconnects to a dead id and dies — permanently, with no comment on the PR.

`ensure_sandbox_for_thread` gains an opt-in `allow_replacement`. It stays `False` for the coding agent, which must keep failing loudly rather than being handed an empty working tree (#1810). The reviewer passes `True`: it is read-only, and `PrepareReviewerRunMiddleware._prepare` already calls `prepare_review_repo` every run to clone-or-fetch and force-check-out the PR head, so a replacement costs one clone and loses nothing. Persisting the new id also clears the stale one. If even the replacement fails, the reviewer now posts the existing sandbox-unreachable notification on the PR instead of failing silently.

## Release Note

Reviewer runs now recover automatically when a PR's review sandbox has been deleted, instead of failing every subsequent review on that PR.

## Test Plan

- [ ] Re-trigger a review on a PR whose reviewer thread has a deleted `sandbox_id` in metadata; confirm the run provisions a replacement, persists the new id, and publishes a review.
- [ ] Confirm a coding-agent thread with an unreachable sandbox still fails with `SandboxUnreachableError` and notifies the user (no replacement).

Made by [Open SWE](https://openswe.vercel.app/agents/019fa514-d928-776d-8162-197243009825)
