### PR TITLE
feat: Cursor-style model picker; retire Opus 4.8 and GPT-5.5

### DIFF
--- a/agent/chat.py
+++ b/agent/chat.py
@@ -36,6 +36,7 @@ from langchain_core.language_models import BaseChatModel
 
 from .dashboard.options import (
     SUPPORTED_MODEL_IDS,
+    canonical_model_pair,
     gate_fable_model,
     model_supports_effort,
 )
@@ -199,6 +200,9 @@ async def _resolve_chat_model(configurable: dict[str, Any]) -> tuple[str, str]:
         and model_supports_effort(model_id, effort)
     ):
         return model_id, effort
+    canonical = canonical_model_pair(model_id, effort)
+    if canonical is not None:
+        return canonical
     # Team review-chat default, which itself inherits the Agent default if unset.
     return await _cached_team_chat_model()
 

--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -8,7 +8,12 @@ from typing import Any
 import httpx
 from langgraph_sdk import get_client
 
-from .options import SUPPORTED_MODEL_IDS, model_supports_effort, provider_fallback_pair
+from .options import (
+    SUPPORTED_MODEL_IDS,
+    canonical_model_pair,
+    model_supports_effort,
+    provider_fallback_pair,
+)
 from .profiles import PROFILES_NAMESPACE
 from .team_settings import get_team_default_model
 from .user_mappings import cached_login_for_email, login_for_email
@@ -153,6 +158,11 @@ async def resolve_agent_model_id(
             overridden_model, _ = normalize_profile_overrides(profile)
             if overridden_model:
                 model_id = overridden_model
-    if isinstance(per_thread_model_id, str) and per_thread_model_id in SUPPORTED_MODEL_IDS:
-        model_id = per_thread_model_id
+    if isinstance(per_thread_model_id, str):
+        if per_thread_model_id in SUPPORTED_MODEL_IDS:
+            model_id = per_thread_model_id
+        else:
+            canonical = canonical_model_pair(per_thread_model_id)
+            if canonical is not None:
+                model_id = canonical[0]
     return model_id

--- a/agent/dashboard/eval_jobs.py
+++ b/agent/dashboard/eval_jobs.py
@@ -53,7 +53,7 @@ DEFAULT_REVIEWER_EVAL_CONFIG: ReviewerEvalConfig = {
     "langsmith_project": DEFAULT_EVAL_PROJECT,
     "langgraph_url": "",
     "assistant_id": "reviewer",
-    "model_id": "google_genai:gemini-3.5-flash",
+    "model_id": "google_genai:gemini-3.6-flash",
     "reasoning_effort": "medium",
     "score_mode": "surfaced_findings",
     "severity_threshold": "low",

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -26,13 +26,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": True,
     },
     {
-        "id": "anthropic:claude-opus-4-8",
-        "label": "Opus 4.8",
-        "efforts": ["low", "medium", "high", "xhigh", "max"],
-        "default_effort": "high",
-        "supports_images": True,
-    },
-    {
         "id": "anthropic:claude-sonnet-5",
         "label": "Sonnet 5",
         "efforts": ["low", "medium", "high", "xhigh", "max"],
@@ -44,13 +37,6 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "label": "Fable 5",
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "default_effort": "high",
-        "supports_images": True,
-    },
-    {
-        "id": "openai:gpt-5.5",
-        "label": "GPT-5.5",
-        "efforts": ["none", "low", "medium", "high", "xhigh"],
-        "default_effort": "xhigh",
         "supports_images": True,
     },
     {
@@ -75,15 +61,15 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": True,
     },
     {
-        "id": "google_genai:gemini-3.5-flash",
-        "label": "Gemini 3.5 Flash",
+        "id": "google_genai:gemini-3.6-flash",
+        "label": "Gemini 3.6 Flash",
         "efforts": ["minimal", "low", "medium", "high"],
         "default_effort": "medium",
         "supports_images": True,
     },
     {
-        "id": "fireworks:accounts/fireworks/models/kimi-k2p7-code",
-        "label": "Kimi K2.7",
+        "id": "fireworks:accounts/fireworks/models/kimi-k3-code",
+        "label": "Kimi K3",
         "efforts": ["low", "medium", "high"],
         "default_effort": "high",
         "supports_images": False,
@@ -109,6 +95,19 @@ SUPPORTED_MODEL_IDS: frozenset[str] = frozenset(m["id"] for m in SUPPORTED_MODEL
 FABLE_MODEL_IDS: frozenset[str] = frozenset(
     m["id"] for m in SUPPORTED_MODELS if m["id"].startswith("anthropic:claude-fable")
 )
+
+# Retired ids mapped to the model that replaces them. Stored selections (profiles,
+# team defaults, per-thread config, schedules) are migrated onto the replacement
+# instead of being discarded, so a user who never revisits their settings keeps an
+# equivalent model rather than silently inheriting the team default.
+DEPRECATED_MODEL_REPLACEMENTS: dict[str, str] = {
+    "anthropic:claude-opus-4-8": "anthropic:claude-opus-5",
+    "openai:gpt-5.5": "openai:gpt-5.6-sol",
+    "google_genai:gemini-3.5-flash": "google_genai:gemini-3.6-flash",
+    "fireworks:accounts/fireworks/models/kimi-k2p7-code": (
+        "fireworks:accounts/fireworks/models/kimi-k3-code"
+    ),
+}
 
 ProfileLoader = Callable[[str], Mapping[str, object]]
 
@@ -192,7 +191,7 @@ def gate_fable_model(
     return model_id, effort
 
 
-DEFAULT_MODEL_ID: str = "openai:gpt-5.5"
+DEFAULT_MODEL_ID: str = "openai:gpt-5.6-sol"
 DEFAULT_MODEL_EFFORT: str = "medium"
 
 
@@ -239,6 +238,23 @@ def _fallback_effort_for(model: ModelOption, effort: object) -> str | None:
     return None
 
 
+def canonical_model_pair(model_id: object, effort: object = None) -> tuple[str, str] | None:
+    """Supported ``(model_id, effort)`` replacing a deprecated/renamed model id.
+
+    Preserves ``effort`` when the replacement supports it, otherwise uses the
+    replacement's default effort. Returns ``None`` for ids that aren't deprecated.
+    """
+    if not isinstance(model_id, str):
+        return None
+    replacement = DEPRECATED_MODEL_REPLACEMENTS.get(model_id)
+    if replacement is None:
+        return None
+    for m in SUPPORTED_MODELS:
+        if m["id"] == replacement:
+            return replacement, _fallback_effort_for(m, effort) or m["default_effort"]
+    return None
+
+
 def provider_fallback_pair(model_id: object, effort: object = None) -> tuple[str, str] | None:
     """Newest supported ``(model_id, effort)`` for the same provider/family.
 
@@ -248,9 +264,14 @@ def provider_fallback_pair(model_id: object, effort: object = None) -> tuple[str
     cross-provider global default. Preserves ``effort`` when the fallback model
     supports it, otherwise uses that model's default effort. Returns ``None`` when
     no supported model shares the provider.
+
+    Explicitly deprecated ids resolve to their mapped replacement first.
     """
     if not isinstance(model_id, str):
         return None
+    canonical = canonical_model_pair(model_id, effort)
+    if canonical is not None:
+        return canonical
     provider = _provider_of(model_id)
     if provider is None:
         return None

--- a/agent/dashboard/review_chat_api.py
+++ b/agent/dashboard/review_chat_api.py
@@ -24,7 +24,7 @@ from ..review.findings import REVIEWER_THREAD_KIND
 from ..utils.github_app import get_github_app_installation_token
 from ..utils.json_types import as_json_object
 from ..utils.thread_ops import langgraph_client, langgraph_url
-from .options import SUPPORTED_MODEL_IDS, model_supports_effort
+from .options import SUPPORTED_MODEL_IDS, canonical_model_pair, model_supports_effort
 from .review_api import classify_finding, get_pr_head_sha, get_review, reviewer_thread_id
 from .thread_api import (
     _DASHBOARD_STREAM_MODES,
@@ -313,6 +313,9 @@ def _normalize_chat_model(configurable: dict[str, Any]) -> tuple[str | None, str
         and model_supports_effort(model_id, effort)
     ):
         return model_id, effort
+    canonical = canonical_model_pair(model_id, effort)
+    if canonical is not None:
+        return canonical
     return None, None
 
 

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -16,7 +16,12 @@ from ..dispatch import create_durable_run
 from ..utils.slack import post_slack_top_level_message_with_ts, store_slack_run_mapping
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
 from ..utils.thread_ops import langgraph_client
-from .options import SUPPORTED_MODEL_IDS, gate_fable_model, model_supports_effort
+from .options import (
+    SUPPORTED_MODEL_IDS,
+    canonical_model_pair,
+    gate_fable_model,
+    model_supports_effort,
+)
 from .profiles import get_profile, get_valid_access_token
 from .repo_access import repo_config_for_user, require_repo_access_for_user
 from .team_settings import get_team_fable_enabled
@@ -93,8 +98,11 @@ def _now_iso() -> str:
 def _normalize_model_choice(
     model_id: str | None, effort: str | None
 ) -> tuple[str | None, str | None]:
-    if not isinstance(model_id, str) or model_id not in SUPPORTED_MODEL_IDS:
+    if not isinstance(model_id, str):
         return None, None
+    if model_id not in SUPPORTED_MODEL_IDS:
+        canonical = canonical_model_pair(model_id, effort)
+        return canonical if canonical is not None else (None, None)
     if not isinstance(effort, str) or not model_supports_effort(model_id, effort):
         return None, None
     return model_id, effort

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -19,6 +19,7 @@ from ..utils.gateway import resolve_gateway_enabled
 from .options import (
     FABLE_MODEL_IDS,
     SUPPORTED_MODEL_IDS,
+    canonical_model_pair,
     default_model_pair,
     gate_fable_model,
     model_supports_effort,
@@ -186,15 +187,15 @@ def _validate_model_effort_pair(model: str | None, effort: str | None, role: str
         raise ValueError(f"effort {effort!r} not supported by {role} model {model!r}")
 
 
-_RETIRED_MODEL_REPLACEMENTS: dict[str, str] = {}
-
-
 def _normalize_stale_model_pair(
     model: str | None, effort: str | None
 ) -> tuple[str | None, str | None]:
     if model is None:
         return model, effort
-    return _RETIRED_MODEL_REPLACEMENTS.get(model, model), effort
+    canonical = canonical_model_pair(model, effort)
+    if canonical is not None:
+        return canonical
+    return model, effort
 
 
 _MODEL_PAIR_FIELDS: tuple[tuple[str, str], ...] = (

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -36,6 +36,7 @@ from ..utils.thread_ops import (
 from .agent_overrides import normalize_profile_overrides
 from .options import (
     SUPPORTED_MODEL_IDS,
+    canonical_model_pair,
     default_vision_model_pair,
     gate_fable_model,
     model_supports_effort,
@@ -148,8 +149,11 @@ class ThreadResolveBody(BaseModel):
 def _normalize_model_choice(
     model_id: str | None, effort: str | None
 ) -> tuple[str | None, str | None]:
-    if not isinstance(model_id, str) or model_id not in SUPPORTED_MODEL_IDS:
+    if not isinstance(model_id, str):
         return None, None
+    if model_id not in SUPPORTED_MODEL_IDS:
+        canonical = canonical_model_pair(model_id, effort)
+        return canonical if canonical is not None else (None, None)
     if not isinstance(effort, str) or not model_supports_effort(model_id, effort):
         return None, None
     return model_id, effort
@@ -273,6 +277,9 @@ def _metadata_model_id(metadata: Mapping[str, Any]) -> str | None:
         model = metadata.get(key)
         if isinstance(model, str) and model in SUPPORTED_MODEL_IDS:
             return model
+        canonical = canonical_model_pair(model)
+        if canonical is not None:
+            return canonical[0]
     return None
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -48,6 +48,7 @@ from .dashboard.agent_overrides import (
 from .dashboard.agent_usage import record_agent_thread_usage
 from .dashboard.options import (
     SUPPORTED_MODEL_IDS,
+    canonical_model_pair,
     gate_fable_model,
     model_supports_effort,
 )
@@ -812,6 +813,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
     per_thread_model = configurable.get("agent_model_id")
     per_thread_effort = configurable.get("agent_effort")
+    canonical_per_thread = canonical_model_pair(per_thread_model, per_thread_effort)
+    if canonical_per_thread is not None:
+        per_thread_model, per_thread_effort = canonical_per_thread
     if (
         isinstance(per_thread_model, str)
         and per_thread_model in SUPPORTED_MODEL_IDS

--- a/evals/reviewer/config.toml
+++ b/evals/reviewer/config.toml
@@ -9,8 +9,8 @@ langsmith_project = "open-swe-evals"
 # Leave blank to use LANGGRAPH_URL or local dev.
 langgraph_url = ""
 assistant_id = "reviewer"
-# models: openai:gpt-5.6-sol, anthropic:claude-opus-4-8, google_genai:gemini-3.5-flash
-model_id = "google_genai:gemini-3.5-flash"
+# models: openai:gpt-5.6-sol, anthropic:claude-opus-5, google_genai:gemini-3.6-flash
+model_id = "google_genai:gemini-3.6-flash"
 reasoning_effort = "medium"
 
 # score_mode:

--- a/evals/reviewer/run_eval.py
+++ b/evals/reviewer/run_eval.py
@@ -79,7 +79,7 @@ DEFAULT_CONFIG: ReviewerEvalConfig = {
     "langgraph_url": "",
     "langsmith_project": DEFAULT_LANGSMITH_PROJECT,
     "assistant_id": "reviewer",
-    "model_id": "google_genai:gemini-3.5-flash",
+    "model_id": "google_genai:gemini-3.6-flash",
     "reasoning_effort": "medium",
     "score_mode": "surfaced_findings",
     "severity_threshold": "low",

--- a/tests/analyzer/test_eval_store_reporter.py
+++ b/tests/analyzer/test_eval_store_reporter.py
@@ -10,7 +10,7 @@ from evals.reviewer.store_reporter import StoreReporter, github_run_url, is_enab
 _CONFIG = {
     "experiment_prefix": "openswe-review-confidence",
     "langsmith_project": "open-swe-evals",
-    "model_id": "google_genai:gemini-3.5-flash",
+    "model_id": "google_genai:gemini-3.6-flash",
 }
 
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -12,7 +12,7 @@ from agent.dashboard.agent_overrides import resolve_agent_model_id
 from agent.dashboard.options import model_supports_images
 
 _TEXT_ONLY_MODEL = "fireworks:accounts/fireworks/models/deepseek-v4-pro"
-_VISION_MODEL = "openai:gpt-5.5"
+_VISION_MODEL = "openai:gpt-5.6-sol"
 _FABLE = "anthropic:claude-fable-5"
 _PAIR = ("openai:gpt-5.6-sol", "medium")
 
@@ -79,11 +79,26 @@ async def test_resolve_agent_model_choice_applies_request_before_profile(monkeyp
 
     model_id, effort = await thread_api._resolve_agent_model_choice(
         {"default_model": _TEXT_ONLY_MODEL, "reasoning_effort": "high"},
-        "anthropic:claude-opus-4-8",
+        "anthropic:claude-opus-5",
         "high",
     )
 
-    assert (model_id, effort) == ("anthropic:claude-opus-4-8", "high")
+    assert (model_id, effort) == ("anthropic:claude-opus-5", "high")
+
+
+async def test_resolve_agent_model_choice_migrates_deprecated_request_model(monkeypatch) -> None:
+    async def fake_team_default(role: str) -> tuple[str, str]:
+        return _VISION_MODEL, "medium"
+
+    monkeypatch.setattr(thread_api, "get_team_default_model", fake_team_default)
+
+    model_id, effort = await thread_api._resolve_agent_model_choice(
+        {},
+        "openai:gpt-5.5",
+        "high",
+    )
+
+    assert (model_id, effort) == ("openai:gpt-5.6-sol", "high")
 
 
 async def test_resolve_agent_model_id_defaults_to_team_default(monkeypatch) -> None:
@@ -119,8 +134,19 @@ async def test_resolve_agent_model_id_applies_per_thread_override(monkeypatch) -
     monkeypatch.setattr("agent.dashboard.agent_overrides.get_team_default_model", fake_team_default)
     monkeypatch.setattr("agent.dashboard.agent_overrides.load_profile", lambda login: None)
 
-    model_id = await resolve_agent_model_id(None, per_thread_model_id="anthropic:claude-opus-4-8")
-    assert model_id == "anthropic:claude-opus-4-8"
+    model_id = await resolve_agent_model_id(None, per_thread_model_id="anthropic:claude-opus-5")
+    assert model_id == "anthropic:claude-opus-5"
+
+
+async def test_resolve_agent_model_id_migrates_deprecated_per_thread_override(monkeypatch) -> None:
+    async def fake_team_default(role: str) -> tuple[str, str]:
+        return _TEXT_ONLY_MODEL, "high"
+
+    monkeypatch.setattr("agent.dashboard.agent_overrides.get_team_default_model", fake_team_default)
+    monkeypatch.setattr("agent.dashboard.agent_overrides.load_profile", lambda login: None)
+
+    model_id = await resolve_agent_model_id(None, per_thread_model_id="openai:gpt-5.5")
+    assert model_id == "openai:gpt-5.6-sol"
 
 
 def _new_thread_client(created: dict[str, object]) -> object:
@@ -1618,22 +1644,22 @@ async def test_status_filter_refreshes_threads_missing_run_status(monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_get_my_profile_preserves_gpt_5_5_models() -> None:
+async def test_get_my_profile_migrates_deprecated_models() -> None:
     with patch(
         "agent.dashboard.routes.get_profile",
         new_callable=AsyncMock,
         return_value={
             "default_model": "openai:gpt-5.5",
             "reasoning_effort": "medium",
-            "default_subagent_model": "openai:gpt-5.5",
+            "default_subagent_model": "anthropic:claude-opus-4-8",
             "subagent_reasoning_effort": "low",
         },
     ):
         payload = await routes.get_my_profile({"sub": "octocat"})
 
-    assert payload["default_model"] == "openai:gpt-5.5"
+    assert payload["default_model"] == "openai:gpt-5.6-sol"
     assert payload["reasoning_effort"] == "medium"
-    assert payload["default_subagent_model"] == "openai:gpt-5.5"
+    assert payload["default_subagent_model"] == "anthropic:claude-opus-5"
     assert payload["subagent_reasoning_effort"] == "low"
 
 

--- a/tests/dashboard/test_team_settings_grouping.py
+++ b/tests/dashboard/test_team_settings_grouping.py
@@ -11,7 +11,7 @@ from agent.dashboard.team_settings import (
 )
 
 _REVIEWER_SUBAGENT_PAIR = ("openai:gpt-5.6-sol", "low")
-_GROUPING_PAIR = ("google_genai:gemini-3.5-flash", "low")
+_GROUPING_PAIR = ("google_genai:gemini-3.6-flash", "low")
 
 
 def _settings(**overrides: object) -> dict[str, object]:

--- a/tests/dashboard/test_team_settings_org_guidelines.py
+++ b/tests/dashboard/test_team_settings_org_guidelines.py
@@ -14,8 +14,8 @@ from agent.dashboard.team_settings import (
     get_team_review_tracing_project,
 )
 
-_AGENT_PAIR = ("anthropic:claude-opus-4-8", "high")
-_CHAT_PAIR = ("google_genai:gemini-3.5-flash", "low")
+_AGENT_PAIR = ("anthropic:claude-opus-5", "high")
+_CHAT_PAIR = ("google_genai:gemini-3.6-flash", "low")
 
 
 def test_org_guidelines_blank_normalizes_to_none() -> None:

--- a/tests/models/test_agent_subagent_models.py
+++ b/tests/models/test_agent_subagent_models.py
@@ -56,7 +56,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
             "agent.server.load_profile",
             new_callable=AsyncMock,
             return_value={
-                "default_model": "anthropic:claude-opus-4-8",
+                "default_model": "anthropic:claude-opus-5",
                 "reasoning_effort": "high",
                 "default_subagent_model": "openai:gpt-5.6-sol",
                 "subagent_reasoning_effort": "xhigh",
@@ -76,7 +76,7 @@ async def test_agent_uses_profile_subagent_model_override() -> None:
     assert subagents[0]["model"] is subagent_model
 
     main_call = make_model.call_args_list[0]
-    assert main_call.args == ("anthropic:claude-opus-4-8",)
+    assert main_call.args == ("anthropic:claude-opus-5",)
     assert main_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert main_call.kwargs["effort"] == "high"
 
@@ -129,7 +129,7 @@ async def test_agent_subagent_inherits_profile_model_override_without_explicit_p
             "agent.server.load_profile",
             new_callable=AsyncMock,
             return_value={
-                "default_model": "anthropic:claude-opus-4-8",
+                "default_model": "anthropic:claude-opus-5",
                 "reasoning_effort": "high",
             },
         ),
@@ -143,8 +143,8 @@ async def test_agent_subagent_inherits_profile_model_override_without_explicit_p
     subagents = captured["subagents"]
     assert isinstance(subagents, list)
     assert subagents[0]["model"] is subagent_model
-    assert make_model.call_args_list[0].args == ("anthropic:claude-opus-4-8",)
-    assert make_model.call_args_list[1].args == ("anthropic:claude-opus-4-8",)
+    assert make_model.call_args_list[0].args == ("anthropic:claude-opus-5",)
+    assert make_model.call_args_list[1].args == ("anthropic:claude-opus-5",)
     assert make_model.call_args_list[1].kwargs["thinking"] == {
         "type": "adaptive",
         "display": "summarized",

--- a/tests/models/test_anthropic_model.py
+++ b/tests/models/test_anthropic_model.py
@@ -47,8 +47,15 @@ def test_sonnet_46_fallback_uses_sonnet_5() -> None:
     )
 
 
-def test_opus_fallback_stays_on_opus_family() -> None:
+def test_deprecated_opus_48_migrates_to_opus_5() -> None:
     assert provider_fallback_pair("anthropic:claude-opus-4-8", "xhigh") == (
+        OPUS_5_ID,
+        "xhigh",
+    )
+
+
+def test_opus_fallback_stays_on_opus_family() -> None:
+    assert provider_fallback_pair("anthropic:claude-opus-4-9", "xhigh") == (
         OPUS_5_ID,
         "xhigh",
     )

--- a/tests/models/test_fireworks_model.py
+++ b/tests/models/test_fireworks_model.py
@@ -1,11 +1,13 @@
 import pytest
 
-from agent.dashboard.options import SUPPORTED_MODELS
+from agent.dashboard.options import SUPPORTED_MODELS, provider_fallback_pair
 from agent.utils.model import (
     fallback_model_id_for,
     fireworks_reasoning_effort_for,
     provider_model_kwargs,
 )
+
+KIMI_K3_ID = "fireworks:accounts/fireworks/models/kimi-k3-code"
 
 
 def test_fireworks_reasoning_effort_maps_effort() -> None:
@@ -17,7 +19,7 @@ def test_fireworks_reasoning_effort_maps_effort() -> None:
 
 def test_provider_model_kwargs_for_fireworks() -> None:
     kwargs = provider_model_kwargs(
-        "fireworks:accounts/fireworks/models/kimi-k2p7-code",
+        KIMI_K3_ID,
         "high",
         max_tokens=16_000,
     )
@@ -25,19 +27,22 @@ def test_provider_model_kwargs_for_fireworks() -> None:
     assert kwargs.get("model_kwargs") == {"reasoning_effort": "high"}
 
 
-def test_kimi_k2p7_is_supported() -> None:
-    kimi_k2p7 = next(
-        (m for m in SUPPORTED_MODELS if m["id"].endswith("kimi-k2p7-code")),
-        None,
-    )
-    assert kimi_k2p7 is not None
-    assert kimi_k2p7.get("efforts") == ["low", "medium", "high"]
-    assert "none" not in kimi_k2p7.get("efforts", [])
-    assert kimi_k2p7.get("default_effort") == "high"
-    model_id = kimi_k2p7.get("id")
-    assert isinstance(model_id, str)
-    kwargs = provider_model_kwargs(model_id, "high", max_tokens=16_000)
+def test_kimi_k3_is_supported() -> None:
+    kimi_k3 = next((m for m in SUPPORTED_MODELS if m["id"] == KIMI_K3_ID), None)
+    assert kimi_k3 is not None
+    assert kimi_k3.get("label") == "Kimi K3"
+    assert kimi_k3.get("efforts") == ["low", "medium", "high"]
+    assert "none" not in kimi_k3.get("efforts", [])
+    assert kimi_k3.get("default_effort") == "high"
+    kwargs = provider_model_kwargs(KIMI_K3_ID, "high", max_tokens=16_000)
     assert kwargs.get("model_kwargs") == {"reasoning_effort": "high"}
+
+
+def test_renamed_kimi_k2p7_migrates_to_kimi_k3() -> None:
+    assert all(not m["id"].endswith("kimi-k2p7-code") for m in SUPPORTED_MODELS)
+    assert provider_fallback_pair(
+        "fireworks:accounts/fireworks/models/kimi-k2p7-code", "medium"
+    ) == (KIMI_K3_ID, "medium")
 
 
 def test_provider_model_kwargs_for_fireworks_none_disables_reasoning() -> None:

--- a/tests/models/test_google_model.py
+++ b/tests/models/test_google_model.py
@@ -5,9 +5,11 @@ from agent.utils.model import (
     provider_model_kwargs,
 )
 
+GEMINI_ID = "google_genai:gemini-3.6-flash"
+
 
 def test_gemini_3_family_detection() -> None:
-    assert is_gemini_3_family("google_genai:gemini-3.5-flash") is True
+    assert is_gemini_3_family(GEMINI_ID) is True
     assert is_gemini_3_family("google_genai:gemini-2.5-flash") is False
 
 
@@ -19,30 +21,41 @@ def test_google_thinking_level_maps_effort() -> None:
     assert google_thinking_level_for("unknown") is None
 
 
-def test_gemini_35_flash_is_supported_with_documented_efforts() -> None:
-    gemini = next(m for m in SUPPORTED_MODELS if m["id"] == "google_genai:gemini-3.5-flash")
-    assert gemini["label"] == "Gemini 3.5 Flash"
+def test_gemini_36_flash_is_supported_with_documented_efforts() -> None:
+    gemini = next(m for m in SUPPORTED_MODELS if m["id"] == GEMINI_ID)
+    assert gemini["label"] == "Gemini 3.6 Flash"
     assert gemini["efforts"] == ["minimal", "low", "medium", "high"]
     assert gemini["default_effort"] == "medium"
 
 
-def test_google_provider_fallback_uses_gemini_35_flash() -> None:
+def test_gemini_35_flash_is_no_longer_offered() -> None:
+    assert all(m["id"] != "google_genai:gemini-3.5-flash" for m in SUPPORTED_MODELS)
+
+
+def test_renamed_gemini_35_flash_migrates_to_gemini_36_flash() -> None:
+    assert provider_fallback_pair("google_genai:gemini-3.5-flash", "low") == (
+        GEMINI_ID,
+        "low",
+    )
+
+
+def test_google_provider_fallback_uses_gemini_36_flash() -> None:
     assert provider_fallback_pair("google_genai:gemini-3-flash-preview", "high") == (
-        "google_genai:gemini-3.5-flash",
+        GEMINI_ID,
         "high",
     )
 
 
 def test_google_provider_fallback_maps_legacy_none_to_minimal() -> None:
     assert provider_fallback_pair("google_genai:gemini-3-flash-preview", "none") == (
-        "google_genai:gemini-3.5-flash",
+        GEMINI_ID,
         "minimal",
     )
 
 
 def test_provider_model_kwargs_for_google() -> None:
     kwargs = provider_model_kwargs(
-        "google_genai:gemini-3.5-flash",
+        GEMINI_ID,
         "high",
         max_tokens=16_000,
     )

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -8,6 +8,7 @@ from agent.dashboard.options import (
     FABLE_MODEL_IDS,
     SUPPORTED_MODEL_IDS,
     SUPPORTED_MODELS,
+    canonical_model_pair,
     default_model_pair,
     fable_disabled_fallback,
     gate_fable_model,
@@ -16,6 +17,7 @@ from agent.dashboard.options import (
     provider_fallback_pair,
 )
 from agent.dashboard.profiles import ProfileUpdate, normalize_profile_for_response
+from agent.dashboard.schedules import _normalize_model_choice as normalize_schedule_model_choice
 from agent.dashboard.team_settings import (
     TeamSettingsUpdate,
     get_team_default_model,
@@ -24,6 +26,9 @@ from agent.dashboard.team_settings import (
 
 STALE_ANTHROPIC = "anthropic:claude-opus-4-7"
 SUPPORTED_ANTHROPIC = "anthropic:claude-opus-5"
+SUPPORTED_OPENAI = "openai:gpt-5.6-sol"
+DEPRECATED_ANTHROPIC = "anthropic:claude-opus-4-8"
+DEPRECATED_OPENAI = "openai:gpt-5.5"
 
 
 def test_provider_fallback_preserves_provider_and_effort() -> None:
@@ -39,19 +44,48 @@ def test_provider_fallback_resolves_openai_within_provider() -> None:
     fallback = provider_fallback_pair("openai:gpt-5-legacy", "low")
     assert fallback is not None
     model, effort = fallback
-    assert model == "openai:gpt-5.5"
+    assert model == SUPPORTED_OPENAI
     assert effort == "low"
 
 
-def test_supported_openai_models_include_gpt_5_5_and_gpt_5_6() -> None:
-    assert "openai:gpt-5.5" in SUPPORTED_MODEL_IDS
+def test_supported_openai_models_are_the_gpt_5_6_family() -> None:
     openai_options = [model for model in SUPPORTED_MODELS if model["id"].startswith("openai:")]
     assert [(model["id"], model["label"]) for model in openai_options] == [
-        ("openai:gpt-5.5", "GPT-5.5"),
         ("openai:gpt-5.6-sol", "GPT-5.6 Sol"),
         ("openai:gpt-5.6-terra", "GPT-5.6 Terra"),
         ("openai:gpt-5.6-luna", "GPT-5.6 Luna"),
     ]
+
+
+@pytest.mark.parametrize("model_id", [DEPRECATED_OPENAI, DEPRECATED_ANTHROPIC])
+def test_deprecated_models_are_no_longer_selectable(model_id: str) -> None:
+    assert model_id not in SUPPORTED_MODEL_IDS
+    assert all(model["id"] != model_id for model in SUPPORTED_MODELS)
+
+
+def test_canonical_model_pair_migrates_deprecated_ids() -> None:
+    assert canonical_model_pair(DEPRECATED_OPENAI, "xhigh") == (SUPPORTED_OPENAI, "xhigh")
+    assert canonical_model_pair(DEPRECATED_ANTHROPIC, "max") == (SUPPORTED_ANTHROPIC, "max")
+
+
+def test_canonical_model_pair_falls_back_to_replacement_default_effort() -> None:
+    assert canonical_model_pair(DEPRECATED_OPENAI, "bogus") == (SUPPORTED_OPENAI, "xhigh")
+    assert canonical_model_pair(DEPRECATED_ANTHROPIC, None) == (SUPPORTED_ANTHROPIC, "high")
+
+
+def test_schedule_model_choice_migrates_deprecated_ids() -> None:
+    assert normalize_schedule_model_choice(DEPRECATED_OPENAI, "high") == (SUPPORTED_OPENAI, "high")
+    assert normalize_schedule_model_choice(DEPRECATED_ANTHROPIC, "max") == (
+        SUPPORTED_ANTHROPIC,
+        "max",
+    )
+    assert normalize_schedule_model_choice("mystery:model", "high") == (None, None)
+
+
+def test_canonical_model_pair_ignores_live_and_unknown_ids() -> None:
+    assert canonical_model_pair(SUPPORTED_OPENAI, "high") is None
+    assert canonical_model_pair("mystery:model", "high") is None
+    assert canonical_model_pair(None) is None
 
 
 def test_supported_models_do_not_hardcode_context_windows() -> None:
@@ -59,7 +93,7 @@ def test_supported_models_do_not_hardcode_context_windows() -> None:
 
 
 def test_model_profile_context_window_uses_langchain_profile() -> None:
-    assert model_profile_context_window("openai:gpt-5.5") == 1_050_000
+    assert model_profile_context_window(SUPPORTED_OPENAI) == 1_050_000
 
 
 def test_models_with_profile_context_windows_enriches_copies() -> None:
@@ -67,7 +101,6 @@ def test_models_with_profile_context_windows_enriches_copies() -> None:
     enriched = models_with_profile_context_windows(openai_models)
     assert all("context_window" not in model for model in openai_models)
     assert {model["id"]: model.get("context_window") for model in enriched} == {
-        "openai:gpt-5.5": 1_050_000,
         "openai:gpt-5.6-sol": 1_050_000,
         "openai:gpt-5.6-terra": 1_050_000,
         "openai:gpt-5.6-luna": 1_050_000,
@@ -112,55 +145,71 @@ def test_profile_stale_anthropic_upgrades_to_supported() -> None:
     assert normalize_profile_overrides(profile) == (SUPPORTED_ANTHROPIC, "high")
 
 
-def test_profile_update_preserves_gpt_5_5_model() -> None:
-    update = ProfileUpdate(default_model="openai:gpt-5.5", reasoning_effort="medium")
+def test_profile_update_migrates_deprecated_gpt_5_5_model() -> None:
+    update = ProfileUpdate(default_model=DEPRECATED_OPENAI, reasoning_effort="medium")
     update.validate_pairing()
-    assert update.default_model == "openai:gpt-5.5"
+    assert update.default_model == SUPPORTED_OPENAI
     assert update.reasoning_effort == "medium"
 
 
-def test_profile_update_preserves_gpt_5_5_subagent_model() -> None:
+def test_profile_update_migrates_deprecated_opus_model() -> None:
+    update = ProfileUpdate(default_model=DEPRECATED_ANTHROPIC, reasoning_effort="high")
+    update.validate_pairing()
+    assert update.default_model == SUPPORTED_ANTHROPIC
+    assert update.reasoning_effort == "high"
+
+
+def test_profile_update_migrates_deprecated_subagent_model() -> None:
     update = ProfileUpdate(
         default_model="openai:gpt-5.6-terra",
         reasoning_effort="high",
-        default_subagent_model="openai:gpt-5.5",
+        default_subagent_model=DEPRECATED_OPENAI,
         subagent_reasoning_effort="low",
     )
     update.validate_pairing()
-    assert update.default_subagent_model == "openai:gpt-5.5"
+    assert update.default_subagent_model == SUPPORTED_OPENAI
     assert update.subagent_reasoning_effort == "low"
 
 
-def test_profile_response_preserves_gpt_5_5_models() -> None:
+def test_profile_response_migrates_deprecated_models() -> None:
     profile = normalize_profile_for_response(
         {
-            "default_model": "openai:gpt-5.5",
+            "default_model": DEPRECATED_OPENAI,
             "reasoning_effort": "medium",
-            "default_subagent_model": "openai:gpt-5.5",
+            "default_subagent_model": DEPRECATED_ANTHROPIC,
             "subagent_reasoning_effort": "low",
         }
     )
-    assert profile["default_model"] == "openai:gpt-5.5"
+    assert profile["default_model"] == SUPPORTED_OPENAI
     assert profile["reasoning_effort"] == "medium"
-    assert profile["default_subagent_model"] == "openai:gpt-5.5"
+    assert profile["default_subagent_model"] == SUPPORTED_ANTHROPIC
     assert profile["subagent_reasoning_effort"] == "low"
 
 
-def test_team_settings_update_preserves_gpt_5_5_models() -> None:
+def test_profile_overrides_migrate_deprecated_models() -> None:
+    assert normalize_profile_overrides(
+        {"default_model": DEPRECATED_OPENAI, "reasoning_effort": "high"}
+    ) == (SUPPORTED_OPENAI, "high")
+    assert normalize_profile_overrides(
+        {"default_model": DEPRECATED_ANTHROPIC, "reasoning_effort": "max"}
+    ) == (SUPPORTED_ANTHROPIC, "max")
+
+
+def test_team_settings_update_migrates_deprecated_models() -> None:
     update = TeamSettingsUpdate(
         default_agent_model="openai:gpt-5.6-sol",
         default_agent_reasoning_effort="medium",
-        default_agent_subagent_model="openai:gpt-5.5",
+        default_agent_subagent_model=DEPRECATED_OPENAI,
         default_agent_subagent_reasoning_effort="medium",
-        default_reviewer_model="openai:gpt-5.5",
+        default_reviewer_model=DEPRECATED_ANTHROPIC,
         default_reviewer_reasoning_effort="medium",
-        default_reviewer_subagent_model="openai:gpt-5.5",
+        default_reviewer_subagent_model=DEPRECATED_OPENAI,
         default_reviewer_subagent_reasoning_effort="low",
     )
 
-    assert update.default_agent_subagent_model == "openai:gpt-5.5"
-    assert update.default_reviewer_model == "openai:gpt-5.5"
-    assert update.default_reviewer_subagent_model == "openai:gpt-5.5"
+    assert update.default_agent_subagent_model == SUPPORTED_OPENAI
+    assert update.default_reviewer_model == SUPPORTED_ANTHROPIC
+    assert update.default_reviewer_subagent_model == SUPPORTED_OPENAI
 
 
 def test_team_settings_update_rejects_unknown_openai_model() -> None:
@@ -171,29 +220,29 @@ def test_team_settings_update_rejects_unknown_openai_model() -> None:
         )
 
 
-def test_team_settings_update_rejects_invalid_effort_for_gpt_5_5() -> None:
+def test_team_settings_update_rejects_invalid_effort_for_openai_model() -> None:
     with pytest.raises(ValueError, match="effort 'bogus' not supported"):
         TeamSettingsUpdate(
-            default_agent_model="openai:gpt-5.5",
+            default_agent_model=SUPPORTED_OPENAI,
             default_agent_reasoning_effort="bogus",
         )
 
 
-def test_team_settings_response_preserves_gpt_5_5_models() -> None:
+def test_team_settings_response_migrates_deprecated_models() -> None:
     settings = normalize_team_settings_for_response(
         {
-            "default_agent_subagent_model": "openai:gpt-5.5",
+            "default_agent_subagent_model": DEPRECATED_OPENAI,
             "default_agent_subagent_reasoning_effort": "medium",
-            "default_reviewer_model": "openai:gpt-5.5",
+            "default_reviewer_model": DEPRECATED_ANTHROPIC,
             "default_reviewer_reasoning_effort": "medium",
-            "default_reviewer_subagent_model": "openai:gpt-5.5",
+            "default_reviewer_subagent_model": DEPRECATED_OPENAI,
             "default_reviewer_subagent_reasoning_effort": "low",
         }
     )
 
-    assert settings["default_agent_subagent_model"] == "openai:gpt-5.5"
-    assert settings["default_reviewer_model"] == "openai:gpt-5.5"
-    assert settings["default_reviewer_subagent_model"] == "openai:gpt-5.5"
+    assert settings["default_agent_subagent_model"] == SUPPORTED_OPENAI
+    assert settings["default_reviewer_model"] == SUPPORTED_ANTHROPIC
+    assert settings["default_reviewer_subagent_model"] == SUPPORTED_OPENAI
 
 
 def test_profile_update_rejects_unknown_provider() -> None:
@@ -211,9 +260,9 @@ def test_profile_unknown_provider_defers_to_team_default() -> None:
     assert normalize_profile_overrides(profile) == (None, None)
 
 
-def test_global_default_is_gpt_5_5() -> None:
+def test_global_default_is_gpt_5_6_sol() -> None:
     model, _ = default_model_pair()
-    assert model == DEFAULT_MODEL_ID == "openai:gpt-5.5"
+    assert model == DEFAULT_MODEL_ID == SUPPORTED_OPENAI
 
 
 def test_gate_fable_passthrough_when_enabled() -> None:

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -358,7 +358,7 @@ async def test_reviewer_applies_eval_model_and_effort_overrides() -> None:
             "pr_url": "https://github.com/acme/repo/pull/1",
             "base_sha": "base",
             "head_sha": "head",
-            "reviewer_model_id": "anthropic:claude-opus-4-8",
+            "reviewer_model_id": "anthropic:claude-opus-5",
             "reviewer_reasoning_effort": "high",
             "reviewer_subagent_model_id": "openai:gpt-5.6-sol",
             "reviewer_subagent_reasoning_effort": "low",
@@ -389,7 +389,7 @@ async def test_reviewer_applies_eval_model_and_effort_overrides() -> None:
         await reviewer.get_reviewer_agent(config)
 
     main_model_call = make_model.call_args_list[0]
-    assert main_model_call.args == ("anthropic:claude-opus-4-8",)
+    assert main_model_call.args == ("anthropic:claude-opus-5",)
     assert main_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert main_model_call.kwargs["effort"] == "high"
     subagent_model_call = make_model.call_args_list[1]
@@ -408,7 +408,7 @@ async def test_reviewer_subagent_inherits_eval_model_without_explicit_override()
             "pr_url": "https://github.com/acme/repo/pull/1",
             "base_sha": "base",
             "head_sha": "head",
-            "reviewer_model_id": "anthropic:claude-opus-4-8",
+            "reviewer_model_id": "anthropic:claude-opus-5",
             "reviewer_reasoning_effort": "high",
         },
         "metadata": {},
@@ -437,11 +437,11 @@ async def test_reviewer_subagent_inherits_eval_model_without_explicit_override()
         await reviewer.get_reviewer_agent(config)
 
     main_model_call = make_model.call_args_list[0]
-    assert main_model_call.args == ("anthropic:claude-opus-4-8",)
+    assert main_model_call.args == ("anthropic:claude-opus-5",)
     assert main_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert main_model_call.kwargs["effort"] == "high"
     subagent_model_call = make_model.call_args_list[1]
-    assert subagent_model_call.args == ("anthropic:claude-opus-4-8",)
+    assert subagent_model_call.args == ("anthropic:claude-opus-5",)
     assert subagent_model_call.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert subagent_model_call.kwargs["effort"] == "high"
 

--- a/tests/reviewer/test_reviewer_eval_run.py
+++ b/tests/reviewer/test_reviewer_eval_run.py
@@ -22,7 +22,7 @@ def test_reviewer_eval_config_coerces_known_values() -> None:
             "max_concurrency": 2,
             "langgraph_url": "https://example.test",
             "assistant_id": "reviewer",
-            "model_id": "anthropic:claude-opus-4-8",
+            "model_id": "anthropic:claude-opus-5",
             "reasoning_effort": "high",
             "score_mode": "surfaced_findings",
             "severity_threshold": "medium",
@@ -37,7 +37,7 @@ def test_reviewer_eval_config_coerces_known_values() -> None:
         "max_concurrency": 2,
         "langgraph_url": "https://example.test",
         "assistant_id": "reviewer",
-        "model_id": "anthropic:claude-opus-4-8",
+        "model_id": "anthropic:claude-opus-5",
         "reasoning_effort": "high",
         "score_mode": "surfaced_findings",
         "severity_threshold": "medium",
@@ -55,7 +55,7 @@ def test_reviewer_eval_config_sets_target_env() -> None:
                 "langgraph_url": "https://example.test",
                 "langsmith_project": "project",
                 "assistant_id": "reviewer",
-                "model_id": "anthropic:claude-opus-4-8",
+                "model_id": "anthropic:claude-opus-5",
                 "reasoning_effort": "high",
                 "score_mode": "surfaced_findings",
                 "severity_threshold": "high",
@@ -70,7 +70,7 @@ def test_reviewer_eval_config_sets_target_env() -> None:
         assert os.environ["LANGSMITH_PROJECT"] == "project"
         assert os.environ["LANGCHAIN_PROJECT"] == "project"
         assert os.environ["REVIEWER_ASSISTANT_ID"] == "reviewer"
-        assert os.environ["REVIEWER_EVAL_MODEL_ID"] == "anthropic:claude-opus-4-8"
+        assert os.environ["REVIEWER_EVAL_MODEL_ID"] == "anthropic:claude-opus-5"
         assert os.environ["REVIEWER_EVAL_REASONING_EFFORT"] == "high"
         assert os.environ["REVIEWER_EVAL_SCORE_MODE"] == "surfaced_findings"
         assert os.environ["REVIEWER_EVAL_SEVERITY_THRESHOLD"] == "high"
@@ -141,7 +141,7 @@ def test_resolve_config_prefers_cli_then_env_then_toml() -> None:
             return_value={
                 "dataset_name": "dataset-config",
                 "experiment_prefix": "experiment-config",
-                "model_id": "anthropic:claude-opus-4-8",
+                "model_id": "anthropic:claude-opus-5",
                 "reasoning_effort": "high",
                 "langsmith_project": "project-config",
             },
@@ -149,7 +149,7 @@ def test_resolve_config_prefers_cli_then_env_then_toml() -> None:
         patch.dict(
             os.environ,
             {
-                "REVIEWER_EVAL_MODEL_ID": "google_genai:gemini-3.5-flash",
+                "REVIEWER_EVAL_MODEL_ID": "google_genai:gemini-3.6-flash",
                 "REVIEWER_EVAL_REASONING_EFFORT": "medium",
                 "LANGSMITH_PROJECT": "project-env",
             },

--- a/tests/reviewer/test_reviewer_eval_target.py
+++ b/tests/reviewer/test_reviewer_eval_target.py
@@ -47,7 +47,7 @@ def test_eval_target_passes_configured_cap(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_eval_target_passes_model_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("REVIEWER_EVAL_MODEL_ID", "anthropic:claude-opus-4-8")
+    monkeypatch.setenv("REVIEWER_EVAL_MODEL_ID", "anthropic:claude-opus-5")
     monkeypatch.setenv("REVIEWER_EVAL_REASONING_EFFORT", "high")
 
     configurable = target._build_configurable(
@@ -61,7 +61,7 @@ def test_eval_target_passes_model_overrides(monkeypatch: pytest.MonkeyPatch) -> 
         }
     )
 
-    assert configurable["reviewer_model_id"] == "anthropic:claude-opus-4-8"
+    assert configurable["reviewer_model_id"] == "anthropic:claude-opus-5"
     assert configurable["reviewer_reasoning_effort"] == "high"
 
 

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -103,7 +103,7 @@ def test_anthropic_overrides_have_no_responses_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-5")
     assert overrides == {
         "base_url": "https://gateway.smith.langchain.com/anthropic",
         "api_key": "ls-key",
@@ -242,7 +242,7 @@ async def test_fireworks_gateway_strips_legacy_function_call() -> None:
 
 def test_google_genai_routes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    overrides = gateway.gateway_overrides("google_genai:gemini-3.5-flash")
+    overrides = gateway.gateway_overrides("google_genai:gemini-3.6-flash")
     assert overrides == {
         "base_url": "https://gateway.smith.langchain.com/gemini",
         "api_key": "ls-key",
@@ -261,7 +261,7 @@ def test_missing_api_key_passes_through(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
-    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-5")
     assert overrides is not None
     assert overrides["api_key"] == "ls-prod-key"
 
@@ -269,7 +269,7 @@ def test_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_prod_key_preferred_over_platform_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-platform-key")
     monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
-    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-5")
     assert overrides is not None
     assert overrides["api_key"] == "ls-prod-key"
 
@@ -278,7 +278,7 @@ def test_gateway_key_preferred_over_prod_key(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-platform-key")
     monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
     monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "ls-gateway-key")
-    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-5")
     assert overrides is not None
     assert overrides["api_key"] == "ls-gateway-key"
 
@@ -286,7 +286,7 @@ def test_gateway_key_preferred_over_prod_key(monkeypatch: pytest.MonkeyPatch) ->
 def test_base_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     monkeypatch.setenv("LANGSMITH_GATEWAY_BASE_URL", "https://gw.internal.example.com/")
-    overrides = gateway.gateway_overrides("anthropic:claude-opus-4-8")
+    overrides = gateway.gateway_overrides("anthropic:claude-opus-5")
     assert overrides is not None
     # Trailing slash is stripped, then the provider path is appended.
     assert overrides["base_url"] == "https://gw.internal.example.com/anthropic"
@@ -413,7 +413,7 @@ def test_make_model_gateway_follows_env_default(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("anthropic:claude-opus-4-8")  # use_gateway=None -> env default
+        model.make_model("anthropic:claude-opus-5")  # use_gateway=None -> env default
     assert captured["base_url"] == "https://gateway.smith.langchain.com/anthropic"
     assert captured["api_key"] == "ls-key"
 
@@ -422,7 +422,7 @@ def test_make_model_gateway_google_genai(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("google_genai:gemini-3.5-flash", use_gateway=True)
+        model.make_model("google_genai:gemini-3.6-flash", use_gateway=True)
     assert captured["base_url"] == "https://gateway.smith.langchain.com/gemini"
     assert captured["api_key"] == "ls-key"
 

--- a/ui/src/features/agents/components/ModelPicker.test.tsx
+++ b/ui/src/features/agents/components/ModelPicker.test.tsx
@@ -1,0 +1,200 @@
+/** @vitest-environment jsdom */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ModelPicker } from "./ModelPicker"
+import type { ModelOption } from "@/lib/api"
+
+afterEach(() => cleanup())
+
+const MODELS: Array<ModelOption> = [
+  {
+    id: "openai:gpt-5.6-sol",
+    label: "GPT-5.6 Sol",
+    efforts: ["none", "low", "medium", "high", "xhigh"],
+    default_effort: "xhigh",
+    supports_images: true,
+    context_window: 272_000,
+  },
+  {
+    id: "google_genai:gemini-3.6-flash",
+    label: "Gemini 3.6 Flash",
+    efforts: ["minimal", "low", "medium", "high"],
+    default_effort: "medium",
+    supports_images: true,
+  },
+  {
+    id: "fireworks:accounts/fireworks/models/kimi-k3-code",
+    label: "Kimi K3",
+    efforts: ["low", "medium", "high"],
+    default_effort: "high",
+    supports_images: false,
+  },
+]
+
+function openPicker(
+  props: Partial<React.ComponentProps<typeof ModelPicker>> = {}
+) {
+  const onSelectionChange = props.onSelectionChange ?? vi.fn()
+  render(
+    <ModelPicker
+      models={MODELS}
+      selection={{ modelId: "openai:gpt-5.6-sol", effort: "high" }}
+      onSelectionChange={onSelectionChange}
+      {...props}
+    />
+  )
+  fireEvent.click(screen.getByRole("button", { name: /GPT-5.6 Sol High/ }))
+  return { onSelectionChange, panel: screen.getByTestId("model-picker-panel") }
+}
+
+describe("ModelPicker", () => {
+  it("labels the trigger with the selected model and effort", () => {
+    render(
+      <ModelPicker
+        models={MODELS}
+        selection={{ modelId: "openai:gpt-5.6-sol", effort: "xhigh" }}
+        onSelectionChange={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: /GPT-5.6 Sol Extra High/ })
+    ).toBeTruthy()
+  })
+
+  it("lists every model with its effort and filters on search", () => {
+    openPicker()
+
+    const models = screen.getByRole("listbox", { name: "Models" })
+    expect(
+      within(models)
+        .getAllByRole("option")
+        .map((option) => option.textContent)
+    ).toEqual(["GPT-5.6 Sol High", "Gemini 3.6 Flash Medium", "Kimi K3 High"])
+
+    fireEvent.change(screen.getByLabelText("Search models"), {
+      target: { value: "kimi" },
+    })
+
+    expect(
+      within(screen.getByRole("listbox", { name: "Models" }))
+        .getAllByRole("option")
+        .map((option) => option.textContent)
+    ).toEqual(["Kimi K3 High"])
+  })
+
+  it("shows the context window and reasoning options for the focused model", () => {
+    openPicker()
+
+    const panel = screen.getByTestId("model-picker-panel")
+    expect(panel.textContent).toContain("Context")
+    expect(panel.textContent).toContain("272.0K")
+
+    expect(
+      within(screen.getByRole("listbox", { name: "Reasoning effort" }))
+        .getAllByRole("option")
+        .map((option) => option.textContent)
+    ).toEqual(["None", "Low", "Medium", "High", "Extra High"])
+
+    fireEvent.mouseEnter(
+      screen.getByRole("option", { name: "Gemini 3.6 Flash Medium" })
+    )
+
+    expect(
+      within(screen.getByRole("listbox", { name: "Reasoning effort" }))
+        .getAllByRole("option")
+        .map((option) => option.textContent)
+    ).toEqual(["Minimal", "Low", "Medium", "High"])
+  })
+
+  it("omits the context section for models without a context window", () => {
+    openPicker()
+
+    fireEvent.mouseEnter(
+      screen.getByRole("option", { name: "Gemini 3.6 Flash Medium" })
+    )
+
+    expect(screen.getByTestId("model-picker-panel").textContent).not.toContain(
+      "Context"
+    )
+  })
+
+  it("selects a reasoning effort for the focused model", () => {
+    const { onSelectionChange } = openPicker()
+
+    fireEvent.mouseEnter(
+      screen.getByRole("option", { name: "Gemini 3.6 Flash Medium" })
+    )
+    fireEvent.click(
+      within(
+        screen.getByRole("listbox", { name: "Reasoning effort" })
+      ).getByRole("option", { name: "Low" })
+    )
+
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      modelId: "google_genai:gemini-3.6-flash",
+      effort: "low",
+    })
+    expect(screen.queryByTestId("model-picker-panel")).toBeNull()
+  })
+
+  it("selects a model row with that model's default effort", () => {
+    const { onSelectionChange } = openPicker()
+
+    fireEvent.click(screen.getByRole("option", { name: "Kimi K3 High" }))
+
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      modelId: "fireworks:accounts/fireworks/models/kimi-k3-code",
+      effort: "high",
+    })
+  })
+
+  it("disables models without image support when images are attached", () => {
+    const { onSelectionChange } = openPicker({ requireImageSupport: true })
+
+    const kimi = screen.getByRole("option", { name: "Kimi K3 High" })
+    expect(kimi).toHaveProperty("disabled", true)
+
+    fireEvent.click(kimi)
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  it("moves model focus and effort with the arrow keys", () => {
+    const { onSelectionChange } = openPicker()
+    const panel = screen.getByTestId("model-picker-panel")
+
+    fireEvent.keyDown(panel, { key: "ArrowDown" })
+    expect(
+      within(screen.getByRole("listbox", { name: "Reasoning effort" }))
+        .getAllByRole("option")
+        .map((option) => option.textContent)
+    ).toEqual(["Minimal", "Low", "Medium", "High"])
+
+    fireEvent.keyDown(panel, { key: "ArrowRight" })
+    fireEvent.keyDown(panel, { key: "ArrowDown" })
+
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      modelId: "google_genai:gemini-3.6-flash",
+      effort: "high",
+    })
+    expect(screen.getByTestId("model-picker-panel")).toBeTruthy()
+  })
+
+  it("closes on Escape", () => {
+    openPicker()
+
+    fireEvent.keyDown(screen.getByTestId("model-picker-panel"), {
+      key: "Escape",
+    })
+
+    expect(screen.queryByTestId("model-picker-panel")).toBeNull()
+  })
+})

--- a/ui/src/features/agents/components/ModelPicker.tsx
+++ b/ui/src/features/agents/components/ModelPicker.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Check, ChevronDown } from "lucide-react"
+
+import type { ModelOption } from "@/lib/api"
+import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
+import {
+  formatEffort,
+  formatModelSelection,
+} from "@/features/agents/lib/provider/useModelOptions"
+import { formatTokenCount } from "@/features/agents/lib/contextUsage"
+import { Z } from "@/features/agents/components/z-index"
+import { cn } from "@/lib/utils"
+
+export interface ModelPickerProps {
+  models: Array<ModelOption>
+  selection: ModelSelection | null
+  onSelectionChange?: (next: ModelSelection) => void
+  disabled?: boolean
+  /** Disables models that cannot accept image input (used when images are attached). */
+  requireImageSupport?: boolean
+  className?: string
+  triggerClassName?: string
+}
+
+type Pane = "models" | "efforts"
+
+function effortForModel(
+  model: ModelOption,
+  selection: ModelSelection | null
+): string {
+  if (selection && selection.modelId === model.id) {
+    if (model.efforts.includes(selection.effort)) return selection.effort
+  }
+  return model.default_effort
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-3 pt-2 pb-1 text-[11px] text-[color:var(--ui-text-dim)]">
+      {children}
+    </div>
+  )
+}
+
+function OptionRow({
+  label,
+  selected,
+  disabled = false,
+  focused = false,
+  onClick,
+  onMouseEnter,
+}: {
+  label: React.ReactNode
+  selected: boolean
+  disabled?: boolean
+  focused?: boolean
+  onClick?: () => void
+  onMouseEnter?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      disabled={disabled}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      className={cn(
+        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] whitespace-nowrap transition-colors",
+        selected
+          ? "text-[color:var(--ui-text)]"
+          : "text-[color:var(--ui-text-muted)]",
+        focused && "bg-[var(--ui-panel-2)]",
+        disabled
+          ? "cursor-default opacity-40"
+          : "cursor-pointer hover:bg-[var(--ui-panel-2)]"
+      )}
+    >
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {selected && (
+        <Check className="size-3.5 shrink-0 text-[color:var(--ui-text-dim)]" />
+      )}
+    </button>
+  )
+}
+
+/** Two-pane model picker: searchable model list plus context/reasoning detail. */
+export function ModelPicker({
+  models,
+  selection,
+  onSelectionChange,
+  disabled = false,
+  requireImageSupport = false,
+  className,
+  triggerClassName,
+}: ModelPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [focusedModelId, setFocusedModelId] = useState<string | null>(null)
+  const [pane, setPane] = useState<Pane>("models")
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const pickerDisabled = disabled || models.length === 0 || !onSelectionChange
+
+  const filteredModels = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return models
+    return models.filter(
+      (model) =>
+        model.label.toLowerCase().includes(q) ||
+        model.id.toLowerCase().includes(q)
+    )
+  }, [models, query])
+
+  const focusedModel =
+    filteredModels.find((model) => model.id === focusedModelId) ??
+    filteredModels.find((model) => model.id === selection?.modelId) ??
+    filteredModels[0]
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  const apply = useCallback(
+    (next: ModelSelection, { close }: { close: boolean }) => {
+      onSelectionChange?.(next)
+      if (!close) return
+      setOpen(false)
+      setQuery("")
+      setPane("models")
+    },
+    [onSelectionChange]
+  )
+
+  const modelDisabled = useCallback(
+    (model: ModelOption) => requireImageSupport && !model.supports_images,
+    [requireImageSupport]
+  )
+
+  const selectModel = useCallback(
+    (model: ModelOption) => {
+      if (modelDisabled(model)) return
+      apply(
+        { modelId: model.id, effort: effortForModel(model, selection) },
+        { close: true }
+      )
+    },
+    [apply, modelDisabled, selection]
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault()
+      setOpen(false)
+      return
+    }
+    if (e.key === "ArrowRight" && focusedModel) {
+      e.preventDefault()
+      setPane("efforts")
+      return
+    }
+    if (e.key === "ArrowLeft") {
+      e.preventDefault()
+      setPane("models")
+      return
+    }
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault()
+      const step = e.key === "ArrowDown" ? 1 : -1
+      if (pane === "efforts" && focusedModel && !modelDisabled(focusedModel)) {
+        const efforts = focusedModel.efforts
+        const current = efforts.indexOf(effortForModel(focusedModel, selection))
+        const next =
+          efforts[Math.min(Math.max(current + step, 0), efforts.length - 1)]
+        if (next) {
+          apply({ modelId: focusedModel.id, effort: next }, { close: false })
+        }
+        return
+      }
+      if (filteredModels.length === 0) return
+      const current = filteredModels.findIndex(
+        (model) => model.id === focusedModel?.id
+      )
+      const nextIndex = Math.min(
+        Math.max(current + step, 0),
+        filteredModels.length - 1
+      )
+      setFocusedModelId(filteredModels[nextIndex]?.id ?? null)
+      return
+    }
+    if (e.key === "Enter" && focusedModel) {
+      e.preventDefault()
+      selectModel(focusedModel)
+    }
+  }
+
+  const focusedContextWindow =
+    typeof focusedModel?.context_window === "number"
+      ? focusedModel.context_window
+      : null
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative min-w-0 shrink", className)}
+    >
+      <button
+        type="button"
+        disabled={pickerDisabled}
+        onClick={() => setOpen((value) => !value)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={cn(
+          "flex max-w-[220px] cursor-pointer items-center gap-0.5 text-[13px] text-[color:var(--ui-text-muted)] transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-60",
+          triggerClassName
+        )}
+      >
+        <span className="truncate">
+          {formatModelSelection(models, selection)}
+        </span>
+        {!pickerDisabled && (
+          <ChevronDown className="size-3.5 shrink-0 opacity-60" />
+        )}
+      </button>
+      {open && !pickerDisabled && (
+        <div
+          data-testid="model-picker-panel"
+          onKeyDown={handleKeyDown}
+          style={{ zIndex: Z.DROPDOWN }}
+          className="absolute bottom-full left-0 mb-1 flex overflow-hidden rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] shadow-lg"
+        >
+          <div className="flex w-60 flex-col">
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search models"
+              aria-label="Search models"
+              className="w-full border-b border-[var(--ui-border)] bg-transparent px-3 py-2 text-[13px] text-[color:var(--ui-text)] outline-none placeholder:text-[color:var(--ui-text-dim)]"
+            />
+            <div
+              role="listbox"
+              aria-label="Models"
+              className="max-h-72 overflow-y-auto py-1"
+            >
+              {filteredModels.length === 0 ? (
+                <p className="px-3 py-1.5 text-[13px] text-[color:var(--ui-text-dim)]">
+                  No matches
+                </p>
+              ) : (
+                filteredModels.map((model) => (
+                  <OptionRow
+                    key={model.id}
+                    selected={selection?.modelId === model.id}
+                    focused={focusedModel?.id === model.id}
+                    disabled={modelDisabled(model)}
+                    onMouseEnter={() => {
+                      setFocusedModelId(model.id)
+                      setPane("models")
+                    }}
+                    onClick={() => selectModel(model)}
+                    label={
+                      <>
+                        {model.label}{" "}
+                        <span className="text-[color:var(--ui-text-dim)]">
+                          {formatEffort(effortForModel(model, selection))}
+                        </span>
+                      </>
+                    }
+                  />
+                ))
+              )}
+            </div>
+          </div>
+          {focusedModel && (
+            <div className="flex w-52 flex-col border-l border-[var(--ui-border)] py-1">
+              {focusedContextWindow != null && (
+                <>
+                  <SectionHeading>Context</SectionHeading>
+                  <div
+                    className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-[color:var(--ui-text)]"
+                    title="Context window reported for this model"
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {formatTokenCount(focusedContextWindow)}
+                    </span>
+                    <Check className="size-3.5 shrink-0 text-[color:var(--ui-text-dim)]" />
+                  </div>
+                </>
+              )}
+              <SectionHeading>Reasoning</SectionHeading>
+              <div
+                role="listbox"
+                aria-label="Reasoning effort"
+                className="max-h-60 overflow-y-auto"
+              >
+                {focusedModel.efforts.map((effort) => (
+                  <OptionRow
+                    key={effort}
+                    label={formatEffort(effort)}
+                    selected={
+                      selection?.modelId === focusedModel.id &&
+                      selection.effort === effort
+                    }
+                    disabled={modelDisabled(focusedModel)}
+                    onMouseEnter={() => setPane("efforts")}
+                    onClick={() =>
+                      apply(
+                        { modelId: focusedModel.id, effort },
+                        { close: true }
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/features/agents/components/chat/CloudPromptBar.tsx
+++ b/ui/src/features/agents/components/chat/CloudPromptBar.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowUp,
-  ChevronDown,
   ImagePlus,
   LoaderCircle,
   Map as MapIcon,
@@ -12,7 +11,6 @@ import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import {
   memo,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -29,8 +27,7 @@ import {
   agentThreadKeys,
   invalidateAgentThreadLists,
 } from "@/features/agents/lib/queries"
-import { formatModelSelection } from "@/features/agents/lib/provider/useModelOptions"
-import { formatTokenCount } from "@/features/agents/lib/contextUsage"
+import { ModelPicker } from "@/features/agents/components/ModelPicker"
 import { IconButton } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
@@ -191,28 +188,14 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
   const [value, setValue] = useState("")
   const [pendingImages, setPendingImages] = useState<Array<ImageChunk>>([])
   const [isDragOver, setIsDragOver] = useState(false)
-  const [modelDropdownOpen, setModelDropdownOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const dragDepthRef = useRef(0)
-  const modelDropdownRef = useRef<HTMLDivElement>(null)
   // Synchronous double-submit guard: blocks a same-tick second send (Enter +
   // click, or two rapid Enters) before React re-renders. Scoped to the send
   // request only — never the run lifecycle.
   const submittingRef = useRef(false)
-
-  const combos = useMemo<Array<ModelSelection>>(() => {
-    const list: Array<ModelSelection> = []
-    for (const model of models) {
-      for (const effort of model.efforts) {
-        list.push({ modelId: model.id, effort })
-      }
-    }
-    return list
-  }, [models])
-
-  const selectionLabel = formatModelSelection(models, selection)
 
   const selectedModelSupportsImages = useMemo(() => {
     if (!selection || pendingImages.length === 0) return true
@@ -255,20 +238,6 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
     el.style.overflowY =
       el.scrollHeight > PROMPT_TEXTAREA_MAX_HEIGHT ? "auto" : "hidden"
   }, [value])
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      const target = e.target as Node
-      if (
-        modelDropdownRef.current &&
-        !modelDropdownRef.current.contains(target)
-      ) {
-        setModelDropdownOpen(false)
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside)
-    return () => document.removeEventListener("mousedown", handleClickOutside)
-  }, [])
 
   const addFiles = useCallback(async (files: FileList | Array<File>) => {
     const nextImages = await Promise.all(
@@ -350,8 +319,6 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
       onPlanModeChange(!planMode)
     }
   }
-
-  const pickerDisabled = combos.length === 0 || !onSelectionChange
 
   return (
     <div
@@ -451,59 +418,12 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
         />
 
         <div className="mt-auto flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 pt-2 text-xs text-[color:var(--ui-text-dim)]">
-          <div ref={modelDropdownRef} className="relative min-w-0 shrink">
-            <button
-              type="button"
-              disabled={pickerDisabled}
-              onClick={() => setModelDropdownOpen((open) => !open)}
-              className="flex max-w-[220px] cursor-pointer items-center gap-0.5 text-[13px] text-[color:var(--ui-text-muted)] transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-60"
-            >
-              <span className="truncate">{selectionLabel}</span>
-              {!pickerDisabled && (
-                <ChevronDown className="size-3.5 shrink-0 opacity-60" />
-              )}
-            </button>
-            {modelDropdownOpen && combos.length > 0 && (
-              <div className="absolute bottom-full left-0 z-50 mb-1 max-h-72 overflow-hidden overflow-y-auto rounded border border-[var(--ui-border)] bg-[var(--ui-surface)] shadow-lg">
-                {combos.map((combo) => {
-                  const selected =
-                    !!selection &&
-                    selection.modelId === combo.modelId &&
-                    selection.effort === combo.effort
-                  const model = models.find((m) => m.id === combo.modelId)
-                  const contextWindow = model?.context_window
-                  return (
-                    <button
-                      key={`${combo.modelId}::${combo.effort}`}
-                      type="button"
-                      onClick={() => {
-                        onSelectionChange?.(combo)
-                        setModelDropdownOpen(false)
-                      }}
-                      className={cn(
-                        "flex w-full items-center gap-2 px-3 py-1.5 text-left whitespace-nowrap transition-colors hover:bg-[var(--ui-panel-2)]",
-                        selected
-                          ? "text-[color:var(--ui-text)]"
-                          : "text-[color:var(--ui-text-muted)]"
-                      )}
-                    >
-                      <span>{formatModelSelection(models, combo)}</span>
-                      {typeof contextWindow === "number" && (
-                        <span className="pl-1 text-[color:var(--ui-text-dim)]">
-                          {formatTokenCount(contextWindow)} context
-                        </span>
-                      )}
-                      {selected && (
-                        <span className="ml-auto pl-3 text-[color:var(--ui-text-dim)]">
-                          ✓
-                        </span>
-                      )}
-                    </button>
-                  )
-                })}
-              </div>
-            )}
-          </div>
+          <ModelPicker
+            models={models}
+            selection={selection}
+            onSelectionChange={onSelectionChange}
+            requireImageSupport={pendingImages.length > 0}
+          />
 
           {onPlanModeChange && (
             <button

--- a/ui/src/features/agents/lib/provider/useModelOptions.ts
+++ b/ui/src/features/agents/lib/provider/useModelOptions.ts
@@ -62,8 +62,12 @@ const EFFORT_LABELS: Record<string, string> = {
   low: "Low",
   medium: "Medium",
   high: "High",
-  xhigh: "XHigh",
+  xhigh: "Extra High",
   max: "Max",
+}
+
+export function formatEffort(effort: string): string {
+  return EFFORT_LABELS[effort] ?? effort
 }
 
 export function formatModelSelection(
@@ -73,6 +77,5 @@ export function formatModelSelection(
   if (!selection) return "Default"
   const model = models.find((m) => m.id === selection.modelId)
   const modelLabel = model?.label ?? selection.modelId
-  const effortLabel = EFFORT_LABELS[selection.effort] ?? selection.effort
-  return `${modelLabel} ${effortLabel}`
+  return `${modelLabel} ${formatEffort(selection.effort)}`
 }

--- a/ui/src/features/automations/components/AutomationEditor.tsx
+++ b/ui/src/features/automations/components/AutomationEditor.tsx
@@ -1,11 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useState } from "react"
 import { Link, useNavigate } from "@tanstack/react-router"
-import {
-  CaretDownIcon,
-  CheckIcon,
-  ClockIcon,
-  TrashIcon,
-} from "@phosphor-icons/react"
+import { ClockIcon, TrashIcon } from "@phosphor-icons/react"
 
 import type { ModelOption } from "@/lib/api"
 import type { AgentSchedule } from "@/features/agents/lib/types"
@@ -21,12 +16,9 @@ import {
   useDeleteAgentSchedule,
   useUpdateAgentSchedule,
 } from "@/features/agents/lib/queries"
-import {
-  formatModelSelection,
-  useModelOptions,
-} from "@/features/agents/lib/provider/useModelOptions"
+import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
+import { ModelPicker } from "@/features/agents/components/ModelPicker"
 import { useRepos } from "@/lib/profile"
-import { cn } from "@/lib/utils"
 
 interface AutomationEditorProps {
   mode: "create" | "edit"
@@ -297,85 +289,5 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
     <h2 className="mt-8 mb-2 text-xs font-medium text-[var(--ui-text-muted)]">
       {children}
     </h2>
-  )
-}
-
-function ModelPicker({
-  models,
-  selection,
-  onSelectionChange,
-}: {
-  models: Array<ModelOption>
-  selection: ModelSelection | null
-  onSelectionChange: (next: ModelSelection) => void
-}) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
-  const combos = useMemo<Array<ModelSelection>>(() => {
-    const list: Array<ModelSelection> = []
-    for (const model of models) {
-      for (const effort of model.efforts) {
-        list.push({ modelId: model.id, effort })
-      }
-    }
-    return list
-  }, [models])
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false)
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside)
-    return () => document.removeEventListener("mousedown", handleClickOutside)
-  }, [])
-
-  const disabled = combos.length === 0
-
-  return (
-    <div ref={ref} className="relative">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => setOpen((value) => !value)}
-        className="flex items-center gap-1 text-xs text-[var(--ui-text-muted)] transition-opacity hover:opacity-80 disabled:opacity-60"
-      >
-        <span>{formatModelSelection(models, selection)}</span>
-        {!disabled && <CaretDownIcon className="size-3.5 opacity-60" />}
-      </button>
-      {open && combos.length > 0 && (
-        <div className="absolute bottom-full left-0 z-50 mb-1 max-h-72 overflow-y-auto rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] py-1 shadow-lg">
-          {combos.map((combo) => {
-            const selected =
-              !!selection &&
-              selection.modelId === combo.modelId &&
-              selection.effort === combo.effort
-            return (
-              <button
-                key={`${combo.modelId}::${combo.effort}`}
-                type="button"
-                onClick={() => {
-                  onSelectionChange(combo)
-                  setOpen(false)
-                }}
-                className={cn(
-                  "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs whitespace-nowrap transition-colors hover:bg-[var(--ui-panel-2)]",
-                  selected
-                    ? "text-[var(--ui-text)]"
-                    : "text-[var(--ui-text-muted)]"
-                )}
-              >
-                {formatModelSelection(models, combo)}
-                {selected && (
-                  <CheckIcon className="ml-auto size-3.5 text-[var(--ui-text-dim)]" />
-                )}
-              </button>
-            )
-          })}
-        </div>
-      )}
-    </div>
   )
 }


### PR DESCRIPTION
## Description

The model dropdown listed every model × effort combination as one flat row, which doesn't scale as the roster grows. This replaces it with a Cursor-style two-pane picker — searchable model list on the left, Context / Reasoning detail on the right — shared by the prompt bar and the automation editor (the duplicated local pickers are gone). Roster changes: `Kimi K2.7` → `Kimi K3`, `Gemini 3.5 Flash` → `Gemini 3.6 Flash`, and `Opus 4.8` / `GPT-5.5` are retired behind an explicit `DEPRECATED_MODEL_REPLACEMENTS` map wired into `provider_fallback_pair()` plus the membership checks that previously discarded unknown ids, so stored profiles, team defaults, per-thread config and schedules migrate to `Opus 5` / `GPT-5.6 Sol` (effort preserved) rather than silently reverting to the team default. `DEFAULT_MODEL_ID` moves to `openai:gpt-5.6-sol`.

Two notes for review: Cursor's `Auto Balance`, `Add Models`, per-model `Edit`, `Fast` toggle and `NEW` badge are not ported because nothing in open-swe backs them, and the `Context` section shows the model's single LangChain-profile context window as a read-only row (there is no 272K/1M choice to make). `.github/workflows/reviewer_eval.yml` still defaults its model input to the removed `google_genai:gemini-3.5-flash` — I left workflow files untouched; say the word and I'll update that one line.

## Release Note

Model picker redesigned as a searchable two-pane selector; Kimi K3 and Gemini 3.6 Flash replace Kimi K2.7 and Gemini 3.5 Flash, and Opus 4.8 / GPT-5.5 selections migrate automatically to Opus 5 / GPT-5.6 Sol.

## Test Plan

- [ ] Open the prompt-bar picker: search filters models, hovering a model updates the Context/Reasoning pane, clicking an effort commits and closes, ↑/↓/←/→/Esc navigate.
- [ ] With an image attached, models without vision support render disabled.
- [ ] A profile/team default still stored as `openai:gpt-5.5` or `anthropic:claude-opus-4-8` shows (and runs) as GPT-5.6 Sol / Opus 5 with the same effort.

Made by [Open SWE](https://openswe.vercel.app/agents/019fa50d-5df7-7559-bda5-f7578a6947cc)

## References
- Plan: https://openswe.vercel.app/agents/019fa50d-5df7-7559-bda5-f7578a6947cc/plan