### PR TITLE
fix: retry sandbox WS commands that close before start

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import os
+import time
 import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -20,6 +21,7 @@ from langsmith.sandbox import (
     AsyncSandboxClient,
     CommandTimeoutError,
     SandboxConnectionError,
+    SandboxOperationError,
     SandboxServerReloadError,
 )
 
@@ -49,6 +51,7 @@ PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
 PROXY_CONFIG_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+WS_SETUP_RETRY_DELAYS_SECONDS = (0.5, 1.5)
 
 
 def _get_langsmith_api_key() -> str | None:
@@ -475,7 +478,8 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
     overruns its own timeout by the grace window, kill it and surface a
     timed-out tool result instead of hanging the graph. WebSocket connect
     failures fall back to the base wait=True path, whose HTTP fallback carries
-    its own request deadline.
+    its own request deadline; a socket that closes before the command starts is
+    retried first, since nothing ran.
     """
 
     _WS_FALLBACK_ERRORS = (
@@ -517,6 +521,32 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         # which carries its own request deadline.
         return LangSmithSandbox.execute(self, command, timeout=timeout)
 
+    def _open_handle(self, command: str, effective: int) -> Any:
+        """Open a WS command handle, retrying a stream that closes pre-start.
+
+        ``run(wait=False)`` eagerly reads the "started" frame, so when the
+        dataplane accepts the upgrade and then closes the socket before sending
+        it (server rollout, recycled command daemon) the SDK raises
+        ``SandboxOperationError``. Neither the SDK's own HTTP fallback nor our
+        callers treat that as transient, so a momentary close used to kill the
+        whole run. The command provably never started, which makes re-running it
+        safe.
+        """
+        for delay in (*WS_SETUP_RETRY_DELAYS_SECONDS, None):
+            try:
+                return self._sandbox.run(command, timeout=effective, wait=False)
+            except CommandTimeoutError:
+                raise
+            except SandboxOperationError:
+                if delay is None:
+                    raise
+                logger.warning(
+                    "Sandbox WS command setup ended before start; retrying in %.1fs",
+                    delay,
+                    exc_info=True,
+                )
+                time.sleep(delay)
+
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         effective = timeout if timeout is not None else self._default_timeout
         if not effective:  # 0 / None: caller opted out of any deadline
@@ -524,8 +554,15 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         # run(wait=False) eagerly opens the WS and reads the "started" frame, so
         # connect/setup failures raise here — fall back to the base path.
         try:
-            handle = self._sandbox.run(command, timeout=effective, wait=False)
-        except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS, TimeoutError):
+            handle = self._open_handle(command, effective)
+        except CommandTimeoutError:
+            return self._timeout_response(effective, server_side=True)
+        except (
+            *self._WS_FALLBACK_ERRORS,
+            *SANDBOX_NOT_READY_ERRORS,
+            SandboxOperationError,
+            TimeoutError,
+        ):
             return self._base_execute(command, timeout)
         deadline = self._deadline(effective)
         pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sbx-exec")
@@ -558,10 +595,15 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         # (blocking, bounded by the SDK connect timeout); connect/setup failures
         # raise here — fall back to the base path.
         try:
-            handle = await asyncio.to_thread(
-                self._sandbox.run, command, timeout=effective, wait=False
-            )
-        except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS, TimeoutError):
+            handle = await asyncio.to_thread(self._open_handle, command, effective)
+        except CommandTimeoutError:
+            return self._timeout_response(effective, server_side=True)
+        except (
+            *self._WS_FALLBACK_ERRORS,
+            *SANDBOX_NOT_READY_ERRORS,
+            SandboxOperationError,
+            TimeoutError,
+        ):
             return await asyncio.to_thread(self._base_execute, command, timeout)
         deadline = self._deadline(effective)
         try:

--- a/agent/server.py
+++ b/agent/server.py
@@ -753,7 +753,17 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             )
             raise
         del github_token
-        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+        try:
+            work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+        except (SandboxClientError, RuntimeError) as exc:
+            # The sandbox answered the reachability ping but can't run the probe
+            # commands, so the run has nowhere to work; keep the failure typed and
+            # tell the user instead of dying with an opaque traceback.
+            clear_sandbox_backend(self._thread_id)
+            await post_sandbox_unreachable_notification(
+                self._config or {}, sandbox_id=sandbox_backend.id
+            )
+            raise SandboxUnreachableError(self._thread_id, sandbox_backend.id, str(exc)) from exc
         repo_custom_instructions = await _resolve_repo_custom_instructions(prompt_default_repo)
 
         try:

--- a/tests/sandbox/test_langsmith_sandbox_timeout.py
+++ b/tests/sandbox/test_langsmith_sandbox_timeout.py
@@ -7,7 +7,11 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from langsmith.sandbox import CommandTimeoutError, SandboxConnectionError
+from langsmith.sandbox import (
+    CommandTimeoutError,
+    SandboxConnectionError,
+    SandboxOperationError,
+)
 
 from agent.integrations.langsmith import TimeoutLangSmithSandbox
 
@@ -32,23 +36,39 @@ class _FakeHandle:
 
 
 class _FakeSandbox:
-    def __init__(self, handle: _FakeHandle, *, run_raises: Exception | None = None):
+    def __init__(
+        self,
+        handle: _FakeHandle,
+        *,
+        run_raises: Exception | None = None,
+        run_raises_first: int = 0,
+    ):
         self._handle = handle
         self._run_raises = run_raises
+        self._run_raises_first = run_raises_first
         self.run_calls: list[dict[str, Any]] = []
 
     def run(self, command: str, *, timeout: int, wait: bool) -> _FakeHandle:
         self.run_calls.append({"command": command, "timeout": timeout, "wait": wait})
-        if self._run_raises is not None:
+        if self._run_raises is not None and (
+            not self._run_raises_first or len(self.run_calls) <= self._run_raises_first
+        ):
             raise self._run_raises
         return self._handle
 
 
 def _backend(
-    handle: _FakeHandle, *, run_raises: Exception | None = None
+    handle: _FakeHandle,
+    *,
+    run_raises: Exception | None = None,
+    run_raises_first: int = 0,
 ) -> TimeoutLangSmithSandbox:
     sb = TimeoutLangSmithSandbox.__new__(TimeoutLangSmithSandbox)
-    object.__setattr__(sb, "_sandbox", _FakeSandbox(handle, run_raises=run_raises))
+    object.__setattr__(
+        sb,
+        "_sandbox",
+        _FakeSandbox(handle, run_raises=run_raises, run_raises_first=run_raises_first),
+    )
     sb._default_timeout = 30 * 60
     return sb
 
@@ -138,6 +158,38 @@ def test_execute_ws_connect_failure_falls_back_to_base(monkeypatch: pytest.Monke
     resp = sb.execute("git status", timeout=5)
     assert called == {"command": "git status", "timeout": 5}
     assert resp.output == "via-http"
+
+
+async def test_aexecute_retries_stream_closed_before_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agent.integrations.langsmith.WS_SETUP_RETRY_DELAYS_SECONDS", (0.0, 0.0))
+    handle = _FakeHandle(result=SimpleNamespace(stdout="out", stderr="", exit_code=0))
+    sb = _backend(
+        handle,
+        run_raises=SandboxOperationError("Command stream ended before 'started' message"),
+        run_raises_first=1,
+    )
+    resp = await sb.aexecute("git status", timeout=5)
+    assert resp.exit_code == 0
+    assert resp.output == "out"
+    assert len(cast(_FakeSandbox, sb._sandbox).run_calls) == 2
+
+
+async def test_aexecute_stream_closed_before_start_falls_back_to_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agent.integrations.langsmith.WS_SETUP_RETRY_DELAYS_SECONDS", (0.0, 0.0))
+    sb = _backend(
+        _FakeHandle(),
+        run_raises=SandboxOperationError("Command stream ended before 'started' message"),
+    )
+    called: dict[str, Any] = {}
+    _patch_base_execute(monkeypatch, called)
+    resp = await sb.aexecute("git status", timeout=5)
+    assert called["command"] == "git status"
+    assert resp.output == "via-http"
+    assert len(cast(_FakeSandbox, sb._sandbox).run_calls) == 3
 
 
 async def test_aexecute_midstream_ws_drop_falls_back_to_base(

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -14,7 +14,13 @@ from agent.middleware.sandbox_circuit_breaker import (
     sandbox_unreachable_message,
 )
 from agent.middleware.tool_error_handler import ToolErrorMiddleware
-from agent.utils.sandbox_state import SANDBOX_BACKENDS, clear_sandbox_backend, set_sandbox_backend
+from agent.server import PrepareAgentRunMiddleware
+from agent.utils.sandbox_state import (
+    SANDBOX_BACKENDS,
+    SandboxUnreachableError,
+    clear_sandbox_backend,
+    set_sandbox_backend,
+)
 
 
 class FakeSandboxBackend(SandboxBackendProtocol):
@@ -92,6 +98,55 @@ async def test_sandbox_client_error_notifies_and_never_recreates() -> None:
         assert "will not be replaced" in payload["error"]
     finally:
         clear_sandbox_backend("thread-1")
+
+
+@pytest.mark.asyncio
+async def test_work_dir_probe_failure_notifies_instead_of_crashing() -> None:
+    """A sandbox that pings but can't run the work-dir probe must not die silently."""
+    middleware = PrepareAgentRunMiddleware(
+        thread_id="thread-probe",
+        config={"configurable": {"thread_id": "thread-probe"}},
+        profile_login=None,
+        model_id="claude-sonnet-4-5",
+        effort=None,
+        source="slack",
+        user_email="",
+        linear_project_id="",
+        linear_issue_number="",
+        create_prs=False,
+        plan_mode=False,
+        corridor_enabled=False,
+    )
+
+    with (
+        patch(
+            "agent.server.resolve_github_token", new_callable=AsyncMock, return_value=("gh", None)
+        ),
+        patch(
+            "agent.server._resolve_prompt_default_repo", new_callable=AsyncMock, return_value=None
+        ),
+        patch("agent.server.resolve_triggering_user_identity", return_value=None),
+        patch(
+            "agent.server.ensure_sandbox_for_thread",
+            new_callable=AsyncMock,
+            return_value=FakeSandboxBackend("sb-quiet"),
+        ),
+        patch(
+            "agent.server.aresolve_sandbox_work_dir",
+            new_callable=AsyncMock,
+            side_effect=SandboxClientError("Command stream ended before 'started' message"),
+        ),
+        patch(
+            "agent.server.post_sandbox_unreachable_notification",
+            new_callable=AsyncMock,
+        ) as mock_notify,
+        pytest.raises(SandboxUnreachableError),
+    ):
+        await middleware._prepare(cast(Any, {"messages": []}), MagicMock())
+
+    mock_notify.assert_awaited_once()
+    assert mock_notify.await_args is not None
+    assert mock_notify.await_args.kwargs == {"sandbox_id": "sb-quiet"}
 
 
 def test_repeated_sandbox_errors_trigger_circuit_breaker_once() -> None:


### PR DESCRIPTION
## Description
A LangSmith sandbox dataplane that accepts the `/execute/ws` upgrade and then closes the socket before sending the `started` frame makes the SDK raise `SandboxOperationError("Command stream ended before 'started' message")`. That class was in neither the SDK's own HTTP-fallback set nor `TimeoutLangSmithSandbox._WS_FALLBACK_ERRORS`, so a single momentary close propagated and killed an entire run — in the reported trace out of `PrepareAgentRunMiddleware.before_agent` (work-dir probe), with no user-facing notification. `TimeoutLangSmithSandbox` now retries the pre-start handle open twice with backoff (the command provably never started, so re-running is safe) before falling back to the base path, and the agent's `_prepare` turns a work-dir probe failure into a typed `SandboxUnreachableError` plus the usual "sandbox stopped responding" notification instead of an opaque traceback.

## Release Note
Transient sandbox WebSocket closes no longer abort a run; commands are retried and users are notified if the sandbox really is unusable.

## Test Plan
- [ ] Simulate a dataplane that closes the execute socket before `started` and confirm the run continues (covered by unit tests for retry + base-path fallback).

Made by [Open SWE](https://openswe.vercel.app/agents/019fa62e-356e-73ea-9184-60657f4a9e35)