### PR TITLE
fix: make the web stop button work and bound stalled model calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Configured in `agent/server.py:get_agent`, runs around every model call (in this
 9. `SandboxCircuitBreakerMiddleware` — trips the agent out of repeated sandbox failures instead of looping.
 10. `ModelFallbackMiddleware` (optional) — added only when `LLM_FALLBACK_MODEL_ID` or the per-model default fallback differs from the primary model.
 11. `SanitizeThinkingBlocksMiddleware` — strips malformed empty Anthropic thinking blocks immediately before provider calls.
-12. `ModelCallTimeoutMiddleware` — innermost. Caps a single model call at `OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS` (default 15 min) so a stalled provider connection raises instead of parking the run; the timeout escalates outward to `ModelFallbackMiddleware`. Complements the per-request `timeout` `agent/utils/model.py` sets on every provider.
+12. `ModelCallTimeoutMiddleware` — innermost. Caps a single model call at `OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS` (default 15 min) so a stalled provider connection raises instead of parking the run; the timeout escalates outward to `ModelFallbackMiddleware`. Complements the per-request `timeout` `agent/utils/model.py` sets on every provider. Subagents compile into their own graphs, so each `SubAgent` spec carries its own instance (`_subagent_model_timeout_middleware`) — parent middleware never wraps a delegated `task`'s model calls, and a wedged one escalates via `ToolRetryMiddleware`'s `task` retry.
 
 The system prompt instructs the agent to call a tool every turn, and `ensure_no_empty_msg` re-injects a tool call when it doesn't — together these keep runs from stopping partway through a task.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Configured in `agent/server.py:get_agent`, runs around every model call (in this
 9. `SandboxCircuitBreakerMiddleware` — trips the agent out of repeated sandbox failures instead of looping.
 10. `ModelFallbackMiddleware` (optional) — added only when `LLM_FALLBACK_MODEL_ID` or the per-model default fallback differs from the primary model.
 11. `SanitizeThinkingBlocksMiddleware` — strips malformed empty Anthropic thinking blocks immediately before provider calls.
+12. `ModelCallTimeoutMiddleware` — innermost. Caps a single model call at `OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS` (default 15 min) so a stalled provider connection raises instead of parking the run; the timeout escalates outward to `ModelFallbackMiddleware`. Complements the per-request `timeout` `agent/utils/model.py` sets on every provider.
 
 The system prompt instructs the agent to call a tool every turn, and `ensure_no_empty_msg` re-injects a tool call when it doesn't — together these keep runs from stopping partway through a task.
 

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -48,6 +48,7 @@ from .dashboard.team_settings import (
 from .middleware import (
     BasePrepareRunMiddleware,
     ExcludeToolsMiddleware,
+    ModelCallTimeoutMiddleware,
     SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
@@ -93,7 +94,10 @@ def _chat_general_purpose_subagent() -> SubAgent:
         "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "middleware": cast(
             list[AgentMiddleware[Any, Any, Any]],
-            [FilesystemMiddleware(tools=["read_file", "ls", "glob", "grep"])],
+            [
+                FilesystemMiddleware(tools=["read_file", "ls", "glob", "grep"]),
+                ModelCallTimeoutMiddleware(),
+            ],
         ),
     }
 
@@ -251,6 +255,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
                 ExcludeToolsMiddleware(excluded=_EXCLUDED_TOOLS),
                 SanitizeFireworksMessagesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
+                ModelCallTimeoutMiddleware(),
             ],
         ),
     ).with_config(config)

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -341,9 +341,16 @@ def _metadata_repo(metadata: Mapping[str, Any]) -> tuple[str, str, str]:
 
 
 def _run_status_to_agent_status(thread_status: str | None, run_status: str | None) -> str:
+    # "interrupted" wins over a still-``busy`` thread: cancellation is async, so a
+    # just-cancelled thread reports busy for a moment and would otherwise look
+    # like it is still running. Callers refresh the newest run's real status
+    # first, so a follow-up run that superseded an interrupted one reads as
+    # pending/running here.
+    if run_status == "interrupted":
+        return "interrupted"
     if thread_status == "busy" or run_status in {"pending", "running"}:
         return "running"
-    if run_status in {"error", "failed", "timeout", "interrupted"}:
+    if run_status in {"error", "failed", "timeout"}:
         return "error"
     if run_status == "success":
         return "finished"
@@ -1489,6 +1496,14 @@ async def send_dashboard_message(
 async def cancel_dashboard_thread(
     thread_id: str, login: str, *, email: str | None = None
 ) -> dict[str, Any]:
+    """Interrupt every live run on a thread on behalf of its owner.
+
+    Cancels by thread rather than by ``latest_run_id`` so the stop button works
+    for runs this browser never started (Slack/Linear/GitHub triggers, CI
+    auto-fix): the client-side ``stream.stop()`` can only cancel a run it
+    dispatched itself, and cached ``latest_run_id`` metadata can lag the run the
+    platform is actually executing.
+    """
     client = langgraph_client()
     try:
         thread = await client.threads.get(thread_id)
@@ -1498,12 +1513,11 @@ async def cancel_dashboard_thread(
     metadata = thread_metadata(thread)
     _assert_thread_owner(metadata, login, email)
 
-    run_id = metadata.get("latest_run_id")
-    if isinstance(run_id, str) and run_id:
-        try:
-            await client.runs.cancel(thread_id, run_id, wait=False)
-        except Exception:
-            logger.debug("Could not cancel run %s for thread %s", run_id, thread_id, exc_info=True)
+    try:
+        await client.runs.cancel_many(thread_id=thread_id, status="all", action="interrupt")
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to cancel active runs for thread %s", thread_id)
+        raise HTTPException(502, "failed to request thread cancellation") from exc
 
     await client.threads.update(
         thread_id=thread_id,

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -11,6 +11,12 @@ busy-check and the custom store-queue) with one function that always uses:
   resumes from the last checkpoint instead of losing all work.
 - ``webhook=COMPLETION_WEBHOOK_URL`` — the platform calls us on completion or
   failure so every run ends with a signal even if the agent died.
+- ``stream_resumable=True`` — the run's event stream is retained so a client that
+  attaches later can replay it. Without this the dashboard cannot observe a run
+  it did not start: the v2 protocol only synthesizes the ``lifecycle: running``
+  event that drives ``stream.isLoading`` when it can replay the run's events, so
+  a Slack/Linear/GitHub-triggered run looked idle in the web UI (no stop button)
+  until it happened to emit its next event.
 """
 
 from __future__ import annotations
@@ -117,7 +123,7 @@ async def create_durable_run(
     durability: str = "sync",
     if_not_exists: str = "create",
     stream_mode: Any | None = None,
-    stream_resumable: bool | None = None,
+    stream_resumable: bool = True,
     after_seconds: int | float | None = None,
 ) -> Run:
     """Create a run with Open SWE's durable LangGraph defaults."""
@@ -128,13 +134,12 @@ async def create_durable_run(
         "multitask_strategy": multitask_strategy,
         "durability": durability,
         "if_not_exists": if_not_exists,
+        "stream_resumable": stream_resumable,
     }
     if COMPLETION_WEBHOOK_URL:
         create_kwargs["webhook"] = COMPLETION_WEBHOOK_URL
     if stream_mode is not None:
         create_kwargs["stream_mode"] = stream_mode
-    if stream_resumable is not None:
-        create_kwargs["stream_resumable"] = stream_resumable
     if after_seconds is not None:
         create_kwargs["after_seconds"] = after_seconds
 

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -6,6 +6,7 @@ _MIDDLEWARE_MODULES = {
     "check_message_queue_before_model": ".check_message_queue",
     "ensure_no_empty_msg": ".ensure_no_empty_msg",
     "ExcludeToolsMiddleware": ".exclude_tools",
+    "ModelCallTimeoutMiddleware": ".model_call_timeout",
     "ModelFallbackMiddleware": ".model_fallback",
     "notify_step_limit_reached": ".notify_step_limit",
     "PlanModeMiddleware": ".plan_mode",
@@ -31,6 +32,7 @@ _MIDDLEWARE_MODULES = {
 
 __all__ = [
     "ExcludeToolsMiddleware",
+    "ModelCallTimeoutMiddleware",
     "ModelFallbackMiddleware",
     "BasePrepareRunMiddleware",
     "PlanModeMiddleware",
@@ -60,6 +62,7 @@ if TYPE_CHECKING:
     from .check_message_queue import check_message_queue_before_model
     from .ensure_no_empty_msg import ensure_no_empty_msg
     from .exclude_tools import ExcludeToolsMiddleware
+    from .model_call_timeout import ModelCallTimeoutMiddleware
     from .model_fallback import ModelFallbackMiddleware
     from .notify_step_limit import notify_step_limit_reached
     from .plan_mode import PlanModeMiddleware

--- a/agent/middleware/model_call_timeout.py
+++ b/agent/middleware/model_call_timeout.py
@@ -1,0 +1,62 @@
+"""Wall-clock deadline around every model call.
+
+Provider ``timeout`` kwargs bound HTTP requests, but the OpenAI Responses
+websocket transport can stall without the client ever raising a read timeout,
+which parks the whole run: no stream events, no queued-message pickup, and
+nothing for ``ModelFallbackMiddleware`` to react to (a hang is not an error).
+This middleware turns that hang into a timeout error, so the fallback model — or
+the run-completion webhook — reports it instead of the run going silent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+logger = logging.getLogger(__name__)
+
+# Above the provider-level ``timeout`` (agent.utils.model), so a stalled HTTP
+# request fails and retries inside the provider client first and this only fires
+# for stalls the provider never notices.
+DEFAULT_MODEL_CALL_TIMEOUT_SECONDS = 900.0
+
+
+class ModelCallTimeoutError(TimeoutError):
+    """A model call exceeded its wall-clock deadline."""
+
+
+def _configured_timeout_seconds() -> float:
+    raw = os.environ.get("OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS")
+    if not raw:
+        return DEFAULT_MODEL_CALL_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_MODEL_CALL_TIMEOUT_SECONDS
+    return value if value > 0 else DEFAULT_MODEL_CALL_TIMEOUT_SECONDS
+
+
+class ModelCallTimeoutMiddleware(AgentMiddleware):
+    """Fail a model call that exceeds the deadline instead of hanging forever."""
+
+    def __init__(self, timeout_seconds: float | None = None) -> None:
+        super().__init__()
+        self._timeout_seconds = timeout_seconds or _configured_timeout_seconds()
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        try:
+            return await asyncio.wait_for(handler(request), timeout=self._timeout_seconds)
+        except TimeoutError as exc:
+            logger.warning("Model call exceeded %ss deadline; aborting", self._timeout_seconds)
+            raise ModelCallTimeoutError(
+                f"Model call exceeded the {self._timeout_seconds}s deadline"
+            ) from exc

--- a/agent/middleware/model_fallback.py
+++ b/agent/middleware/model_fallback.py
@@ -1,7 +1,8 @@
 """Middleware that retries model calls across a primary and fallback provider.
 
 Wraps the model call. When a model raises a transient provider error (5xx,
-429, connection/timeout), the request is retried, alternating between the
+429, connection/timeout, or a ``ModelCallTimeoutMiddleware`` deadline), the
+request is retried, alternating between the
 primary and the configured fallback model with exponential backoff between
 attempts. The fallback is bound to tools by the agent factory on each call,
 so swapping ``request.model`` is sufficient.
@@ -54,6 +55,9 @@ _TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     openai.RateLimitError,
     openai.InternalServerError,
     httpx.TransportError,
+    # Includes ``ModelCallTimeoutMiddleware``'s deadline: a wedged provider call
+    # is exactly the case where trying the other provider is worthwhile.
+    TimeoutError,
 )
 
 # Seconds slept before each retry attempt (attempt 0 is the initial call).

--- a/agent/middleware/task_retry.py
+++ b/agent/middleware/task_retry.py
@@ -10,6 +10,10 @@ _TRANSIENT_ERROR_NAMES = frozenset(
         "APIConnectionError",
         "APITimeoutError",
         "ConnectTimeout",
+        # A subagent's wedged model call (ModelCallTimeoutMiddleware). Subagents
+        # have no fallback middleware, so retrying the delegated task is the
+        # escalation path.
+        "ModelCallTimeoutError",
         "ReadTimeout",
         "TimeoutException",
         "TransportError",

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -358,6 +358,9 @@ def _reviewer_subagent(model: BaseChatModel) -> SubAgent:
         ),
         "system_prompt": REVIEWER_SUBAGENT_SYSTEM_PROMPT,
         "model": model,
+        # Subagents compile into their own graphs, so the reviewer's own
+        # middleware never wraps their model calls.
+        "middleware": cast(list[AgentMiddleware[Any, Any, Any]], [ModelCallTimeoutMiddleware()]),
     }
 
 

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -49,6 +49,7 @@ from .dashboard.team_settings import (
 )
 from .middleware import (
     BasePrepareRunMiddleware,
+    ModelCallTimeoutMiddleware,
     RepairOrphanedToolCallsMiddleware,
     SanitizeFireworksMessagesMiddleware,
     SanitizeThinkingBlocksMiddleware,
@@ -1430,6 +1431,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
                 SanitizeFireworksMessagesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
                 RepairOrphanedToolCallsMiddleware(),
+                ModelCallTimeoutMiddleware(),
                 settle_review_check_on_exit,
             ],
         ),

--- a/agent/server.py
+++ b/agent/server.py
@@ -514,6 +514,17 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
 )
 
 
+def _subagent_model_timeout_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
+    """Deadline for a subagent's own model calls.
+
+    Subagents are compiled into their own graphs, so the parent's middleware
+    never wraps them — while a delegated `task` runs, the parent is only waiting
+    on tool execution. Without this a stalled provider call inside a subagent
+    hangs the run exactly like it did in the parent.
+    """
+    return cast(list[AgentMiddleware[Any, Any, Any]], [ModelCallTimeoutMiddleware()])
+
+
 def _general_purpose_subagent(model: BaseChatModel) -> SubAgent:
     return {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
@@ -523,6 +534,7 @@ def _general_purpose_subagent(model: BaseChatModel) -> SubAgent:
         # tool-call cadence) that delegated work also needs.
         "system_prompt": OPEN_SWE_SHARED_BASE + "\n\n" + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
+        "middleware": _subagent_model_timeout_middleware(),
     }
 
 
@@ -565,6 +577,7 @@ def _browser_subagent(model: BaseChatModel, tools: list[Any]) -> SubAgent:
         "system_prompt": BROWSER_SUBAGENT_SYSTEM_PROMPT,
         "tools": tools,
         "model": model,
+        "middleware": _subagent_model_timeout_middleware(),
     }
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -69,6 +69,7 @@ from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
 from .middleware import (
     BasePrepareRunMiddleware,
+    ModelCallTimeoutMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
     PullRequestCreationGuardMiddleware,
@@ -1043,6 +1044,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 *plan_mode_middleware,
                 SanitizeFireworksMessagesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
+                # Innermost, so the deadline covers the provider call itself and a
+                # timeout escalates outward to the fallback model.
+                ModelCallTimeoutMiddleware(),
             ],
         ),
     ).with_config(config)

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -13,6 +13,14 @@ OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 # primary provider a fair chance before the fallback middleware kicks in.
 DEFAULT_MAX_RETRIES = 6
 
+# Per-request deadline. Without one a stalled provider connection can park a run
+# for as long as the socket stays half-open (observed: a single call wedged for an
+# hour). Every provider we ship accepts ``timeout``; keep it generous enough for
+# max-effort reasoning on a long context, and let ``max_retries`` above turn a
+# stall into a retry instead of a dead run.
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 600.0
+_TIMEOUT_PROVIDER_PREFIXES = ("openai:", "anthropic:", "google_genai:", "fireworks:")
+
 _MODEL_CACHE: dict[
     tuple[str, bool | None, int | None, tuple[tuple[str, str], ...], int | None], Any
 ] = {}
@@ -80,6 +88,7 @@ class ModelKwargs(TypedDict, total=False):
     thinking_level: GoogleThinkingLevel | None
     temperature: float | None
     max_retries: int | None
+    timeout: float | None
     store: bool | None
     include: list[str] | None
     output_version: Literal["responses/v1"] | None
@@ -121,6 +130,8 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
     """
     model_kwargs: dict[str, object] = dict(kwargs)
     model_kwargs.setdefault("max_retries", DEFAULT_MAX_RETRIES)
+    if model_id.startswith(_TIMEOUT_PROVIDER_PREFIXES):
+        model_kwargs.setdefault("timeout", DEFAULT_REQUEST_TIMEOUT_SECONDS)
 
     if model_id.startswith("openai:"):
         # Direct-provider default: Responses API over the OpenAI websocket base.

--- a/tests/agent/test_dispatch.py
+++ b/tests/agent/test_dispatch.py
@@ -82,6 +82,8 @@ async def test_create_durable_run_applies_defaults(monkeypatch: pytest.MonkeyPat
     assert created["multitask_strategy"] == "interrupt"
     assert created["if_not_exists"] == "create"
     assert created["webhook"] == "https://app/webhooks/run-complete"
+    # Resumable by default so the dashboard can join (and stop) a run it did not start.
+    assert created["stream_resumable"] is True
     assert created["config"]["metadata"] == {"kind": "test"}
     assert created["config"]["configurable"]["thread_id"] == "thread-1"
     assert isinstance(created["config"]["configurable"]["prepare_run_id"], str)
@@ -101,12 +103,12 @@ async def test_create_durable_run_preserves_existing_prepare_id_and_stream_kwarg
         source="schedule",
         config={"configurable": {"prepare_run_id": "existing"}},
         stream_mode=["values"],
-        stream_resumable=True,
+        stream_resumable=False,
         client=client,
     )
 
     created = client.runs.created[0]
     assert "webhook" not in created
     assert created["stream_mode"] == ["values"]
-    assert created["stream_resumable"] is True
+    assert created["stream_resumable"] is False
     assert created["config"]["configurable"]["prepare_run_id"] == "existing"

--- a/tests/agent/test_task_retry.py
+++ b/tests/agent/test_task_retry.py
@@ -5,6 +5,7 @@ import json
 import httpx
 import pytest
 
+from agent.middleware.model_call_timeout import ModelCallTimeoutError
 from agent.middleware.task_retry import task_on_failure, task_retry_on
 
 
@@ -26,6 +27,12 @@ def test_task_retry_on_transient_status() -> None:
     assert task_retry_on(_HTTPError(503)) is True
     assert task_retry_on(_HTTPError(529)) is True
     assert task_retry_on(_HTTPError(400)) is False
+
+
+def test_task_retry_on_subagent_model_deadline() -> None:
+    # A subagent has no fallback middleware, so retrying the delegated task is
+    # how a wedged model call inside it recovers.
+    assert task_retry_on(ModelCallTimeoutError("wedged")) is True
 
 
 def test_task_retry_on_httpx_transport_subclasses() -> None:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1743,6 +1743,81 @@ async def test_options_gates_stale_fable_default_when_disabled() -> None:
     assert payload["default_agent_subagent_model"] in model_ids
 
 
+async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+    thread = {
+        "thread_id": "thread-1",
+        "status": "busy",
+        "metadata": {
+            "title": "Slack-triggered thread",
+            "github_login": "owner",
+            "latest_run_status": "running",
+            "updated_at_ms": 1,
+        },
+    }
+
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            assert thread_id == "thread-1"
+            return thread
+
+        async def update(self, **kwargs: object) -> None:
+            calls.append(("update", kwargs))
+            metadata = kwargs["metadata"]
+            assert isinstance(metadata, dict)
+            thread["metadata"].update(metadata)
+
+    class FakeRuns:
+        async def cancel_many(self, **kwargs: object) -> None:
+            calls.append(("cancel_many", kwargs))
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    result = await thread_api.cancel_dashboard_thread("thread-1", "owner")
+
+    assert calls[0] == (
+        "cancel_many",
+        {"thread_id": "thread-1", "status": "all", "action": "interrupt"},
+    )
+    # Reported as interrupted even though the platform still says busy.
+    assert result["status"] == "interrupted"
+
+
+async def test_cancel_dashboard_thread_rejects_non_owner(monkeypatch) -> None:
+    cancelled = False
+
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "status": "busy",
+                "metadata": {"github_login": "owner"},
+            }
+
+        async def update(self, **kwargs: object) -> None:
+            raise AssertionError("must not update")
+
+    class FakeRuns:
+        async def cancel_many(self, **kwargs: object) -> None:
+            nonlocal cancelled
+            cancelled = True
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    with pytest.raises(HTTPException):
+        await thread_api.cancel_dashboard_thread("thread-1", "someone-else")
+
+    assert cancelled is False
+
+
 async def test_admin_cancel_dashboard_thread_interrupts_all_active_runs(monkeypatch) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
     thread = {

--- a/tests/middleware/test_model_call_timeout.py
+++ b/tests/middleware/test_model_call_timeout.py
@@ -52,6 +52,24 @@ class TestModelCallTimeoutMiddleware:
         monkeypatch.setenv("OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS", "120")
         assert ModelCallTimeoutMiddleware()._timeout_seconds == 120
 
+    def test_every_subagent_spec_carries_the_deadline(self) -> None:
+        # Subagents compile into their own graphs, so the parent's middleware
+        # never wraps their model calls.
+        from agent.reviewer import _reviewer_subagent
+        from agent.server import _browser_subagent, _general_purpose_subagent
+
+        model = MagicMock()
+        specs = [
+            _general_purpose_subagent(model),
+            _browser_subagent(model, []),
+            _reviewer_subagent(model),
+        ]
+        for spec in specs:
+            assert any(
+                isinstance(middleware, ModelCallTimeoutMiddleware)
+                for middleware in spec.get("middleware", [])
+            ), f"{spec['name']} subagent has no model-call deadline"
+
     def test_timeout_falls_back_on_invalid_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS", "soon")
         assert ModelCallTimeoutMiddleware()._timeout_seconds == DEFAULT_MODEL_CALL_TIMEOUT_SECONDS

--- a/tests/middleware/test_model_call_timeout.py
+++ b/tests/middleware/test_model_call_timeout.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+from agent.middleware.model_call_timeout import (
+    DEFAULT_MODEL_CALL_TIMEOUT_SECONDS,
+    ModelCallTimeoutError,
+    ModelCallTimeoutMiddleware,
+)
+
+
+def _request() -> ModelRequest[None]:
+    return cast(ModelRequest[None], MagicMock())
+
+
+class TestModelCallTimeoutMiddleware:
+    @pytest.mark.asyncio
+    async def test_passes_through_a_prompt_response(self) -> None:
+        response = MagicMock()
+
+        async def handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
+            return cast(ModelResponse[Any], response)
+
+        result = await ModelCallTimeoutMiddleware(timeout_seconds=5).awrap_model_call(
+            _request(), handler
+        )
+
+        assert result is response
+
+    @pytest.mark.asyncio
+    async def test_raises_when_the_model_call_hangs(self) -> None:
+        started = asyncio.Event()
+
+        async def handler(_req: ModelRequest[None]) -> ModelResponse[Any]:
+            started.set()
+            await asyncio.sleep(60)
+            raise AssertionError("handler should have been cancelled")
+
+        with pytest.raises(ModelCallTimeoutError):
+            await ModelCallTimeoutMiddleware(timeout_seconds=0.01).awrap_model_call(
+                _request(), handler
+            )
+
+        assert started.is_set()
+
+    def test_timeout_reads_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS", "120")
+        assert ModelCallTimeoutMiddleware()._timeout_seconds == 120
+
+    def test_timeout_falls_back_on_invalid_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS", "soon")
+        assert ModelCallTimeoutMiddleware()._timeout_seconds == DEFAULT_MODEL_CALL_TIMEOUT_SECONDS

--- a/tests/middleware/test_model_fallback_middleware.py
+++ b/tests/middleware/test_model_fallback_middleware.py
@@ -12,6 +12,7 @@ import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage
 
+from agent.middleware.model_call_timeout import ModelCallTimeoutError
 from agent.middleware.model_fallback import (
     ModelFallbackMiddleware,
     _should_fallback,
@@ -80,6 +81,9 @@ class TestShouldFallback:
         response = httpx.Response(400, request=request, json={"error": {}})
         exc = anthropic.BadRequestError("bad", response=response, body={})
         assert _should_fallback(exc) is False
+
+    def test_model_call_deadline_falls_back(self) -> None:
+        assert _should_fallback(ModelCallTimeoutError("wedged")) is True
 
     def test_value_error_does_not_fall_back(self) -> None:
         assert _should_fallback(ValueError("nope")) is False

--- a/tests/models/test_model_request_timeout.py
+++ b/tests/models/test_model_request_timeout.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from agent.utils import model
+
+
+def _capture() -> tuple[dict[str, Any], Any]:
+    captured: dict[str, Any] = {}
+
+    def _fake(model: str, **kwargs: Any) -> str:
+        captured["model"] = model
+        captured.update(kwargs)
+        return "MODEL"
+
+    return captured, _fake
+
+
+def _make_model(model_id: str, **kwargs: Any) -> dict[str, Any]:
+    model._MODEL_CACHE.clear()
+    captured, fake = _capture()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model(model_id, use_gateway=False, **kwargs)
+    return captured
+
+
+def test_openai_gets_a_default_request_timeout() -> None:
+    captured = _make_model("openai:gpt-5.6-sol")
+    assert captured["timeout"] == model.DEFAULT_REQUEST_TIMEOUT_SECONDS
+    assert captured["max_retries"] == model.DEFAULT_MAX_RETRIES
+
+
+def test_anthropic_gets_a_default_request_timeout() -> None:
+    assert _make_model("anthropic:claude-opus-5")["timeout"] == (
+        model.DEFAULT_REQUEST_TIMEOUT_SECONDS
+    )
+
+
+def test_explicit_timeout_wins() -> None:
+    assert _make_model("openai:gpt-5.6-sol", timeout=30.0)["timeout"] == 30.0
+
+
+def test_unknown_provider_gets_no_timeout() -> None:
+    assert "timeout" not in _make_model("ollama:llama4")

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -125,6 +125,10 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   }, [stream.messages, stream.toolCalls, stream.subagents, thread.messages])
 
   const isStreaming = thread.status === "running" || stream.isLoading
+  const activeRun = useMemo(
+    () => ({ threadId: thread.id, running: thread.status === "running" }),
+    [thread.id, thread.status]
+  )
   const queuedMessages = useMemo(
     () => visibleQueuedMessages(thread.queuedMessages, baseMessages),
     [baseMessages, thread.queuedMessages]
@@ -214,6 +218,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
                   placeholder="Add a follow up"
                   compact
                   busy={isStreaming}
+                  activeRun={activeRun}
                   onSubmit={(content, images) =>
                     sendMessage.mutateAsync({
                       content,
@@ -253,6 +258,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
                 placeholder="Send the first message"
                 compact
                 busy={isStreaming}
+                activeRun={activeRun}
                 onSubmit={(content, images) =>
                   sendMessage.mutateAsync({
                     content,

--- a/ui/src/features/agents/components/chat/CloudPromptBar.test.tsx
+++ b/ui/src/features/agents/components/chat/CloudPromptBar.test.tsx
@@ -75,6 +75,19 @@ describe("CloudPromptBar stop button", () => {
     await waitFor(() => expect(cancelThread).toHaveBeenCalledWith("thread-1"))
   })
 
+  it("keeps the run live when cancellation fails", async () => {
+    cancelThread.mockRejectedValueOnce(new Error("502"))
+    renderPromptBar(true)
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop run" }))
+
+    await waitFor(() => expect(cancelThread).toHaveBeenCalled())
+    // No false "stopped" state: the stream stays connected so status polling
+    // (which only runs while the cached status is `running`) keeps going.
+    expect(stream.disconnect).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "Stop run" })).toBeTruthy()
+  })
+
   it("shows the send button when no run is live", () => {
     renderPromptBar(false)
 

--- a/ui/src/features/agents/components/chat/CloudPromptBar.test.tsx
+++ b/ui/src/features/agents/components/chat/CloudPromptBar.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { CloudPromptBar } from "./CloudPromptBar"
+import { AgentThreadStreamBoundary } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
+
+const stream = {
+  isLoading: false,
+  threadId: "thread-1",
+  stop: vi.fn(),
+  disconnect: vi.fn(),
+}
+
+vi.mock("@langchain/react", () => ({
+  useStreamContext: () => stream,
+}))
+
+const cancelThread = vi.fn(async (threadId: string) => ({
+  id: threadId,
+  status: "interrupted",
+}))
+
+vi.mock("@/features/agents/lib/api", () => ({
+  agentsApi: { cancelThread: (threadId: string) => cancelThread(threadId) },
+  AgentsApiError: class AgentsApiError extends Error {},
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  stream.isLoading = false
+  stream.stop.mockClear()
+  stream.disconnect.mockClear()
+  cancelThread.mockClear()
+})
+
+function renderPromptBar(running: boolean) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <AgentThreadStreamBoundary>
+        <CloudPromptBar activeRun={{ threadId: "thread-1", running }} />
+      </AgentThreadStreamBoundary>
+    </QueryClientProvider>
+  )
+}
+
+describe("CloudPromptBar stop button", () => {
+  it("offers to stop a run this client never joined", async () => {
+    renderPromptBar(true)
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop run" }))
+
+    await waitFor(() => expect(cancelThread).toHaveBeenCalledWith("thread-1"))
+    expect(stream.disconnect).toHaveBeenCalled()
+  })
+
+  it("cancels server-side even while streaming, since stop() may know no run id", async () => {
+    stream.isLoading = true
+    renderPromptBar(false)
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop run" }))
+
+    await waitFor(() => expect(cancelThread).toHaveBeenCalledWith("thread-1"))
+  })
+
+  it("shows the send button when no run is live", () => {
+    renderPromptBar(false)
+
+    expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Stop run" })).toBeNull()
+  })
+})

--- a/ui/src/features/agents/components/chat/CloudPromptBar.tsx
+++ b/ui/src/features/agents/components/chat/CloudPromptBar.tsx
@@ -26,6 +26,7 @@ import { useIsInAgentThreadStream } from "@/features/agents/lib/provider/useIsIn
 import {
   agentThreadKeys,
   invalidateAgentThreadLists,
+  useCancelAgentThread,
 } from "@/features/agents/lib/queries"
 import { ModelPicker } from "@/features/agents/components/ModelPicker"
 import { IconButton } from "@/components/ui/button"
@@ -33,10 +34,17 @@ import { cn } from "@/lib/utils"
 
 const PROMPT_TEXTAREA_MAX_HEIGHT = 200
 
+export interface ActiveRun {
+  threadId: string
+  /** Server-reported run state, independent of this client's event stream. */
+  running: boolean
+}
+
 interface SubmitButtonProps {
   canSubmit: boolean
   submitting: boolean
   onSubmit: () => void
+  activeRun?: ActiveRun
 }
 
 function PlainSubmitButton({
@@ -73,13 +81,24 @@ function StreamSubmitButton(props: SubmitButtonProps) {
   const stream = useAgentThreadStream()
   const queryClient = useQueryClient()
   const [stopping, setStopping] = useState(false)
+  const threadId = props.activeRun?.threadId ?? stream.threadId ?? ""
+  const cancelThread = useCancelAgentThread(threadId)
 
   const handleStop = async () => {
     if (stopping) return
     setStopping(true)
     try {
-      await stream.stop()
-      const threadId = stream.threadId
+      // `stream.stop()` only cancels server-side when this client dispatched the
+      // run, so cancel by thread first: a run started from Slack/Linear/GitHub
+      // (or joined after a reload) has no client-side run id to cancel.
+      if (threadId) {
+        try {
+          await cancelThread.mutateAsync()
+        } catch {
+          // Surfaced by the mutation state; still disconnect below.
+        }
+      }
+      await stream.disconnect()
       if (threadId) {
         queryClient.setQueryData(agentThreadKeys.detail(threadId), (prev) =>
           prev ? { ...prev, status: "interrupted" as const } : prev
@@ -91,7 +110,12 @@ function StreamSubmitButton(props: SubmitButtonProps) {
     }
   }
 
-  if (!stream.isLoading) return <PlainSubmitButton {...props} />
+  // Server truth (`activeRun.running`) matters as much as the client stream:
+  // this browser only sees `isLoading` once it observes a lifecycle event, so a
+  // run it never joined would otherwise render an unusable send button.
+  if (!stream.isLoading && !props.activeRun?.running) {
+    return <PlainSubmitButton {...props} />
+  }
 
   return (
     <IconButton
@@ -124,6 +148,8 @@ export interface CloudPromptBarProps {
   compact?: boolean
   disabled?: boolean
   busy?: boolean
+  /** Enables the stop button for the thread's live run. */
+  activeRun?: ActiveRun
   onSubmit?: (value: string, images: Array<ImageChunk>) => void | Promise<void>
   models?: Array<ModelOption>
   selection?: ModelSelection | null
@@ -174,6 +200,7 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
   compact = false,
   disabled = false,
   busy = false,
+  activeRun,
   onSubmit,
   models = [],
   selection = null,
@@ -465,6 +492,7 @@ export const CloudPromptBar = memo(function CloudPromptBarComponent({
             canSubmit={canSubmit}
             submitting={isSubmitting}
             onSubmit={() => void handleSubmit()}
+            activeRun={activeRun}
           />
         </div>
       </div>

--- a/ui/src/features/agents/components/chat/CloudPromptBar.tsx
+++ b/ui/src/features/agents/components/chat/CloudPromptBar.tsx
@@ -95,7 +95,10 @@ function StreamSubmitButton(props: SubmitButtonProps) {
         try {
           await cancelThread.mutateAsync()
         } catch {
-          // Surfaced by the mutation state; still disconnect below.
+          // Cancellation failed (transient 5xx, or a non-owner viewer). Leave
+          // the stream and the thread's status polling untouched: presenting a
+          // stopped state here would strand the UI on a still-running run.
+          return
         }
       }
       await stream.disconnect()

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -22,6 +22,13 @@ const dashboardFetch: typeof fetch = (input, init) =>
  * omits the dashboard session cookie cross-origin, so the proxy rejects the
  * read with `401 "not authenticated"`. Override the SDK's global fetch so
  * every `Client` read carries the same credentials as the transport.
+ *
+ * Passing `fetch` to the transport is also what makes the SDK's SSE stream give
+ * up on reconnect (`maxReconnectAttempts = options.fetch != null ? 0 : 5`), and
+ * we cannot drop it — the transport's own requests would lose the session
+ * cookie. So a dropped event stream stays dropped for the life of the page, and
+ * run state must not be inferred from the stream alone: `useAgentThread` polls
+ * the thread while a run is live so the UI (and its stop button) keeps working.
  */
 overrideFetchImplementation(dashboardFetch);
 

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -117,6 +117,12 @@ export function useAgentThread(threadId: string) {
   return useQuery({
     queryKey: agentThreadKeys.detail(threadId),
     queryFn: () => agentsApi.getThread(threadId),
+    // Server truth heartbeat while a run is live. The SDK's SSE transport does
+    // not reconnect once a custom `fetch` is supplied (it needs the dashboard
+    // session cookie), so a dropped event stream must not leave the view — and
+    // its stop button — believing the run already ended.
+    refetchInterval: (query) =>
+      query.state.data?.status === "running" ? 3000 : false,
     // Lets the optimistic detail seeded by `AgentsHome` survive until the
     // proxied run.start stamps the server-side thread; an immediate refetch
     // would 404 and bounce the route back to /agents.


### PR DESCRIPTION
## Description
A run wedged inside one model call for an hour and the web UI offered no way to stop it. Three independent causes: the stop button rendered only off client-observed stream state (`stream.isLoading`), webhook-created runs were not `stream_resumable` so a browser could never observe a run it did not start, and nothing bounded a stalled provider call. Now the button follows server run state and cancels by thread (`stream.stop()` can only cancel runs this client dispatched), dispatched runs are resumable, every provider gets a request `timeout`, and a new innermost `ModelCallTimeoutMiddleware` escalates a wedged call to the fallback model instead of parking the run.

## Release Note
The web UI's stop button now cancels runs started from Slack/Linear/GitHub, and a stalled model call fails over instead of hanging the run.

## Test Plan
- [ ] Trigger a run from Slack, open the thread in the web UI mid-run, and confirm the prompt bar shows the stop button and that pressing it interrupts the run (Slack thread stops progressing, thread shows "interrupted").
- [ ] With the event stream broken (e.g. offline/online toggle), confirm the stop button still appears while the run is live and still cancels.
- [ ] Set `OPEN_SWE_MODEL_CALL_TIMEOUT_SECONDS=5` locally and confirm a slow model call fails over to the fallback model rather than hanging.

Made by [Open SWE](https://openswe.vercel.app/agents/f01d9c10-c5b9-a521-bc16-60637380e293)

## References
- Plan: https://openswe.vercel.app/agents/f01d9c10-c5b9-a521-bc16-60637380e293/plan