### PR TITLE
feat: add persistent diff line wrapping

### DIFF
--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -26,6 +26,7 @@ import { useAgentThreadPrDiff } from "@/features/agents/lib/queries"
 import { ReviewTab } from "@/features/reviews/components/ReviewTab"
 import { PrHeader } from "@/features/reviews/components/PrHeader"
 import { buttonVariants } from "@/components/ui/button"
+import { DiffWrapToggle } from "@/features/agents/components/DiffWrapToggle"
 import {
   DIFF_VIRTUALIZER_CONFIG,
   DIFF_VIRTUAL_METRICS,
@@ -532,6 +533,7 @@ export function AgentGitPanel({
                 </button>
               ))}
               <div className="ml-auto flex min-w-0 items-center gap-2">
+                {tab === "diff" && <DiffWrapToggle />}
                 {recoveryError && (
                   <span
                     title={recoveryError}

--- a/ui/src/features/agents/components/DiffWrapToggle.test.tsx
+++ b/ui/src/features/agents/components/DiffWrapToggle.test.tsx
@@ -1,0 +1,39 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { DiffWrapToggle } from "./DiffWrapToggle"
+
+beforeEach(() => window.localStorage.clear())
+afterEach(() => cleanup())
+
+describe("DiffWrapToggle", () => {
+  it("toggles and persists line wrapping", () => {
+    render(<DiffWrapToggle />)
+    const toggle = screen.getByRole("button", { name: "Wrap lines" })
+
+    expect(toggle.getAttribute("aria-pressed")).toBe("false")
+
+    fireEvent.click(toggle)
+
+    expect(toggle.getAttribute("aria-pressed")).toBe("true")
+    expect(window.localStorage.getItem("open-swe.diff.overflow")).toBe("wrap")
+  })
+
+  it("synchronizes mounted controls", () => {
+    render(
+      <>
+        <DiffWrapToggle />
+        <DiffWrapToggle />
+      </>
+    )
+    const toggles = screen.getAllByRole("button", { name: "Wrap lines" })
+
+    fireEvent.click(toggles[0] as HTMLButtonElement)
+
+    expect(
+      toggles.map((toggle) => toggle.getAttribute("aria-pressed"))
+    ).toEqual(["true", "true"])
+  })
+})

--- a/ui/src/features/agents/components/DiffWrapToggle.tsx
+++ b/ui/src/features/agents/components/DiffWrapToggle.tsx
@@ -1,0 +1,25 @@
+import { TextAlignLeftIcon } from "@phosphor-icons/react"
+
+import { useDiffWrap } from "@/features/agents/utils/diffUtils"
+import { cn } from "@/lib/utils"
+
+export function DiffWrapToggle({ className }: { className?: string }) {
+  const [wrap, setWrap] = useDiffWrap()
+
+  return (
+    <button
+      type="button"
+      onClick={() => setWrap(!wrap)}
+      aria-label="Wrap lines"
+      aria-pressed={wrap}
+      title="Wrap lines"
+      className={cn(
+        "flex size-6 items-center justify-center rounded text-[var(--ui-text-dim)] transition-colors hover:text-[var(--ui-text)]",
+        wrap && "bg-[var(--ui-accent-bubble)] text-[var(--ui-text)]",
+        className
+      )}
+    >
+      <TextAlignLeftIcon className="size-3.5" />
+    </button>
+  )
+}

--- a/ui/src/features/agents/components/chat/DiffView.tsx
+++ b/ui/src/features/agents/components/chat/DiffView.tsx
@@ -1,40 +1,39 @@
-import { useMemo } from "react";
-import { MultiFileDiff } from "@pierre/diffs/react";
-import type { DiffData } from "@/features/agents/lib/types";
-import { diffOptions } from "@/features/agents/utils/diffUtils";
-import { countLineChanges } from "@/features/agents/utils/diffStats";
+import { useMemo } from "react"
+import { MultiFileDiff } from "@pierre/diffs/react"
+import type { DiffData } from "@/features/agents/lib/types"
+import { useDiffOptions } from "@/features/agents/utils/diffUtils"
+import { countLineChanges } from "@/features/agents/utils/diffStats"
 
 interface DiffViewProps {
-  diffData: DiffData;
+  diffData: DiffData
 }
 
 export function DiffView({ diffData }: DiffViewProps) {
-  const { originalContent, newContent, filePath, isBinary } = diffData;
-  const displayPath = filePath.split("/").pop() || filePath;
+  const diffOptions = useDiffOptions()
+  const { originalContent, newContent, filePath, isBinary } = diffData
+  const displayPath = filePath.split("/").pop() || filePath
   const stats = useMemo(
     () => countLineChanges(originalContent, newContent, filePath),
-    [filePath, newContent, originalContent],
-  );
+    [filePath, newContent, originalContent]
+  )
 
   if (isBinary) {
     return (
-      <div className="mt-2 text-gray-500 text-xs font-mono">
+      <div className="mt-2 font-mono text-xs text-gray-500">
         Binary file - diff not available
       </div>
-    );
+    )
   }
 
   if (stats.additions === 0 && stats.deletions === 0) {
     return (
-      <div className="mt-2 text-gray-500 text-xs font-mono">
-        No changes
-      </div>
-    );
+      <div className="mt-2 font-mono text-xs text-gray-500">No changes</div>
+    )
   }
 
   return (
     <div className="mt-2 font-mono text-xs">
-      <div className="flex items-center gap-2 text-gray-500 mb-1">
+      <div className="mb-1 flex items-center gap-2 text-gray-500">
         <span className="text-gray-400">{displayPath}</span>
         {diffData.isNewFile && <span>(new)</span>}
         <span className="text-green-400">+{stats.additions}</span>
@@ -48,5 +47,5 @@ export function DiffView({ diffData }: DiffViewProps) {
         />
       </div>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/utils/diffUtils.test.ts
+++ b/ui/src/features/agents/utils/diffUtils.test.ts
@@ -1,6 +1,39 @@
-import { describe, expect, it } from "vitest"
+/** @vitest-environment jsdom */
 
-import { fileContentsCacheKey } from "./diffUtils"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  DIFF_FIXED_LINE_HEIGHT_CSS,
+  buildDiffOptions,
+  fileContentsCacheKey,
+  readStoredDiffOverflow,
+  writeStoredDiffOverflow,
+} from "./diffUtils"
+
+beforeEach(() => window.localStorage.clear())
+
+describe("diff overflow preference", () => {
+  it("defaults to horizontal scrolling", () => {
+    expect(readStoredDiffOverflow()).toBe("scroll")
+  })
+
+  it("persists wrapping", () => {
+    writeStoredDiffOverflow("wrap")
+
+    expect(readStoredDiffOverflow()).toBe("wrap")
+  })
+
+  it("keeps fixed line heights only in scroll mode", () => {
+    const scrollOptions = buildDiffOptions("unified", "scroll", "dark")
+    const wrapOptions = buildDiffOptions("split", "wrap", "light")
+
+    expect(scrollOptions.overflow).toBe("scroll")
+    expect(scrollOptions.unsafeCSS).toContain(DIFF_FIXED_LINE_HEIGHT_CSS)
+    expect(wrapOptions.overflow).toBe("wrap")
+    expect(wrapOptions.diffStyle).toBe("split")
+    expect(wrapOptions.unsafeCSS).not.toContain(DIFF_FIXED_LINE_HEIGHT_CSS)
+  })
+})
 
 describe("fileContentsCacheKey", () => {
   it("builds a stable key from string contents", () => {

--- a/ui/src/features/agents/utils/diffUtils.ts
+++ b/ui/src/features/agents/utils/diffUtils.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useMemo, useSyncExternalStore } from "react"
 import { preloadHighlighter } from "@pierre/diffs"
 import type {
   VirtualFileMetrics,
@@ -8,6 +8,61 @@ import type {
 import { useResolvedTheme } from "@/lib/theme"
 
 export type DiffStyle = "unified" | "split"
+export type DiffOverflow = "scroll" | "wrap"
+
+const DIFF_OVERFLOW_STORAGE_KEY = "open-swe.diff.overflow"
+const diffOverflowListeners = new Set<() => void>()
+let storageListenerAttached = false
+
+export function readStoredDiffOverflow(): DiffOverflow {
+  if (typeof window === "undefined") return "scroll"
+  return window.localStorage.getItem(DIFF_OVERFLOW_STORAGE_KEY) === "wrap"
+    ? "wrap"
+    : "scroll"
+}
+
+function subscribeToDiffOverflow(listener: () => void): () => void {
+  diffOverflowListeners.add(listener)
+  if (typeof window !== "undefined" && !storageListenerAttached) {
+    window.addEventListener("storage", handleDiffOverflowStorage)
+    storageListenerAttached = true
+  }
+  return () => {
+    diffOverflowListeners.delete(listener)
+    if (
+      typeof window !== "undefined" &&
+      storageListenerAttached &&
+      diffOverflowListeners.size === 0
+    ) {
+      window.removeEventListener("storage", handleDiffOverflowStorage)
+      storageListenerAttached = false
+    }
+  }
+}
+
+function handleDiffOverflowStorage(event: StorageEvent): void {
+  if (event.key !== DIFF_OVERFLOW_STORAGE_KEY) return
+  diffOverflowListeners.forEach((listener) => listener())
+}
+
+export function writeStoredDiffOverflow(overflow: DiffOverflow): void {
+  if (typeof window === "undefined") return
+  if (readStoredDiffOverflow() === overflow) return
+  window.localStorage.setItem(DIFF_OVERFLOW_STORAGE_KEY, overflow)
+  diffOverflowListeners.forEach((listener) => listener())
+}
+
+export function useDiffOverflow(): [
+  DiffOverflow,
+  (next: DiffOverflow) => void,
+] {
+  const overflow = useSyncExternalStore(
+    subscribeToDiffOverflow,
+    readStoredDiffOverflow,
+    (): DiffOverflow => "scroll"
+  )
+  return [overflow, writeStoredDiffOverflow]
+}
 
 export const DIFF_UNSAFE_CSS = `
 [data-diffs-header],
@@ -70,12 +125,9 @@ export const DIFF_UNSAFE_CSS = `
 [data-gutter-buffer="annotation"][data-selected-line] {
   --diffs-line-bg: var(--ui-panel) !important;
 }
+`
 
-/* Pin every code row to one exact, uniform height (kept in sync with
-   DIFF_VIRTUAL_METRICS.lineHeight below). In scroll mode code never wraps, so a
-   hard height won't clip content — it just makes the virtualizer's per-line
-   estimate match measured layout, so scroll-to lands precisely instead of
-   over/under-shooting as off-estimate rows reconcile while scrolling. */
+export const DIFF_FIXED_LINE_HEIGHT_CSS = `
 [data-line] {
   height: 18px !important;
   min-height: 18px !important;
@@ -90,7 +142,7 @@ export const diffOptions = {
   diffStyle: "unified" as const,
   overflow: "scroll" as const,
   disableFileHeader: true,
-  unsafeCSS: DIFF_UNSAFE_CSS,
+  unsafeCSS: `${DIFF_UNSAFE_CSS}${DIFF_FIXED_LINE_HEIGHT_CSS}`,
   collapsedContextThreshold: 4,
   lineDiffType: "word-alt" as const,
   maxLineDiffLength: 800,
@@ -98,12 +150,35 @@ export const diffOptions = {
   tokenizeMaxLength: 120_000,
 }
 
+export function buildDiffOptions(
+  diffStyle: DiffStyle,
+  overflow: DiffOverflow,
+  themeType: "light" | "dark"
+) {
+  return {
+    ...diffOptions,
+    themeType,
+    diffStyle,
+    overflow,
+    unsafeCSS:
+      overflow === "scroll"
+        ? `${DIFF_UNSAFE_CSS}${DIFF_FIXED_LINE_HEIGHT_CSS}`
+        : DIFF_UNSAFE_CSS,
+  }
+}
+
 export function useDiffOptions(diffStyle: DiffStyle = "unified") {
   const resolvedTheme = useResolvedTheme()
+  const [overflow] = useDiffOverflow()
   return useMemo(
-    () => ({ ...diffOptions, themeType: resolvedTheme, diffStyle }),
-    [resolvedTheme, diffStyle]
+    () => buildDiffOptions(diffStyle, overflow, resolvedTheme),
+    [resolvedTheme, diffStyle, overflow]
   )
+}
+
+export function useDiffWrap(): [boolean, (wrap: boolean) => void] {
+  const [overflow, setOverflow] = useDiffOverflow()
+  return [overflow === "wrap", (wrap) => setOverflow(wrap ? "wrap" : "scroll")]
 }
 
 // Shared virtualization + worker-pool config for <Virtualizer>/<MultiFileDiff>.
@@ -116,8 +191,8 @@ export const DIFF_VIRTUALIZER_CONFIG = {
 
 export const DIFF_VIRTUAL_METRICS = {
   hunkLineCount: 80,
-  // Must match the hard `[data-line]` height pinned in DIFF_UNSAFE_CSS so the
-  // virtualizer's pre-measurement estimate equals the measured row height.
+  // Exact in scroll mode; in wrap mode this seeds the estimate until Pierre
+  // measures the variable-height row and reconciles the virtualized layout.
   lineHeight: 18,
   diffHeaderHeight: 0,
   spacing: 8,

--- a/ui/src/features/reviews/components/ReviewMainBody.tsx
+++ b/ui/src/features/reviews/components/ReviewMainBody.tsx
@@ -68,6 +68,7 @@ import type {
 import type { ChatAttachment } from "@/features/reviews/components/ReviewChat"
 import type { DiffStyle } from "@/features/agents/utils/diffUtils"
 import { Markdown } from "@/features/agents/components/chat/Markdown"
+import { DiffWrapToggle } from "@/features/agents/components/DiffWrapToggle"
 import { PrHeader } from "@/features/reviews/components/PrHeader"
 import {
   ReviewChat,
@@ -1292,10 +1293,13 @@ function ReviewBodyInner({
                         </span>
                       )}
                       {diffFiles && diffFiles.length > 0 && (
-                        <DiffStyleToggle
-                          value={diffStyle}
-                          onChange={setDiffStyle}
-                        />
+                        <div className="flex items-center gap-1">
+                          <DiffWrapToggle className="size-5" />
+                          <DiffStyleToggle
+                            value={diffStyle}
+                            onChange={setDiffStyle}
+                          />
+                        </div>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Description
Add a persistent browser-wide line-wrap preference to every Pierre diff viewer, with synchronized controls in the Git and review toolbars. Wrapped mode drops fixed row heights so virtualized lines can be measured correctly.

## Release Note
Users can toggle persistent line wrapping while viewing files and diffs.

## Test Plan
- [x] Verify preference, synchronization, and mode-specific CSS with focused UI tests
- [x] Typecheck and production-build the dashboard

Made by [Open SWE](https://openswe.vercel.app/agents/019fa949-5e9d-72b9-ae65-ad8d58bbdd81)

## References
- Plan: https://openswe.vercel.app/agents/019fa949-5e9d-72b9-ae65-ad8d58bbdd81/plan