### PR TITLE
feat: add Run Cloud sandbox provider

### DIFF
--- a/agent/integrations/runcloud.py
+++ b/agent/integrations/runcloud.py
@@ -1,0 +1,76 @@
+import os
+import shlex
+from pathlib import PurePosixPath
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+from deepagents.backends.sandbox import BaseSandbox
+from runcloud import Client, Sandbox
+
+DEFAULT_RUN_CLOUD_IMAGE = "runcloud/agent-base"
+RUN_CLOUD_IMAGE_ENV = "RUN_CLOUD_IMAGE"
+
+
+class RunCloudSandbox(BaseSandbox):
+    """Deep Agents backend backed by a Run Cloud microVM."""
+
+    def __init__(self, sandbox: Sandbox):
+        self._sandbox = sandbox
+
+    @property
+    def id(self) -> str:
+        return self._sandbox.id
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        result = self._sandbox.exec(command, timeout=timeout)
+        return ExecuteResponse(
+            output=result.stdout + result.stderr,
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        responses: list[FileUploadResponse] = []
+        for path, content in files:
+            try:
+                parent = str(PurePosixPath(path).parent)
+                mkdir = self._sandbox.exec(f"mkdir -p {shlex.quote(parent)}")
+                if mkdir.exit_code != 0:
+                    responses.append(
+                        FileUploadResponse(path=path, error=mkdir.stderr or mkdir.stdout)
+                    )
+                    continue
+                self._sandbox.write_file(path, content)
+                responses.append(FileUploadResponse(path=path))
+            except Exception as exc:
+                responses.append(FileUploadResponse(path=path, error=str(exc)))
+        return responses
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        responses: list[FileDownloadResponse] = []
+        for path in paths:
+            try:
+                responses.append(
+                    FileDownloadResponse(path=path, content=self._sandbox.read_file(path))
+                )
+            except Exception as exc:
+                responses.append(FileDownloadResponse(path=path, error=str(exc)))
+        return responses
+
+
+def create_runcloud_sandbox(sandbox_id: str | None = None) -> RunCloudSandbox:
+    """Create or reconnect to a Run Cloud sandbox."""
+    client = Client()
+
+    if sandbox_id:
+        sandbox = client.get(sandbox_id)
+    else:
+        image = os.getenv(RUN_CLOUD_IMAGE_ENV, DEFAULT_RUN_CLOUD_IMAGE).strip()
+        if not image:
+            raise ValueError(f"{RUN_CLOUD_IMAGE_ENV} must not be empty")
+        sandbox = client.create(image=image)
+
+    return RunCloudSandbox(sandbox)

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -15,6 +15,7 @@ SANDBOX_FACTORIES: dict[str, tuple[str, str]] = {
     "modal": ("agent.integrations.modal", "create_modal_sandbox"),
     "runloop": ("agent.integrations.runloop", "create_runloop_sandbox"),
     "e2b": ("agent.integrations.e2b", "create_e2b_sandbox"),
+    "runcloud": ("agent.integrations.runcloud", "create_runcloud_sandbox"),
     "local": ("agent.integrations.local", "create_local_sandbox"),
 }
 
@@ -39,7 +40,7 @@ async def create_sandbox(
     """Create or reconnect to a sandbox using the configured provider.
 
     The provider is selected via the SANDBOX_TYPE environment variable.
-    Supported values: langsmith (default), daytona, modal, runloop, e2b, local.
+    Supported values: langsmith (default), daytona, modal, runloop, e2b, runcloud, local.
 
     The langsmith provider provisions natively async; the other providers wrap
     sync SDKs and are bridged onto the event loop with ``asyncio.to_thread``.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -65,6 +65,7 @@ Set the `SANDBOX_TYPE` environment variable to switch providers. Each provider h
 | `runloop` | `agent/integrations/runloop.py` | `RUNLOOP_API_KEY`, `SANDBOX_TYPE="runloop"` |
 | `e2b` | `agent/integrations/e2b.py` | `E2B_API_KEY`, `SANDBOX_TYPE="e2b"`, optional `E2B_TEMPLATE` |
 | `modal` | `agent/integrations/modal.py` | Modal credentials, `SANDBOX_TYPE="modal"` |
+| `runcloud` | `agent/integrations/runcloud.py` | `RUN_CLOUD_API_KEY`, `SANDBOX_TYPE="runcloud"`, optional `RUN_CLOUD_IMAGE` |
 | `local` | `agent/integrations/local.py` | None (no isolation — development only), `SANDBOX_TYPE="local"` |
 
 > **Warning**: `local` runs commands directly on your host with no sandboxing. Only use for local development with human-in-the-loop enabled.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -513,7 +513,7 @@ REVIEWER_OUTCOMES_DATASET=""
 PUBLIC_REPO_ORG_GATE=""
 
 # === Sandbox (optional) ===
-# Provider: langsmith (default), modal, daytona, runloop, e2b, or local. See CUSTOMIZATION.md.
+# Provider: langsmith (default), modal, daytona, runloop, e2b, runcloud, or local. See CUSTOMIZATION.md.
 SANDBOX_TYPE="langsmith"
 DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Required when SANDBOX_TYPE=langsmith (see step 4c)
 DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES=""  # Root FS size in bytes (default: 128 GiB)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "langchain-modal>=0.0.5",
     "langchain-runloop>=0.0.6",
     "langchain-e2b==0.0.5",
+    "runcloud-sdk>=0.8.0,<1",
     "exa-py>=2.16.0",
     "langchain-google-genai>=4.2.4",
     "langchain-mcp-adapters>=0.3.0",

--- a/tests/sandbox/test_runcloud_integration.py
+++ b/tests/sandbox/test_runcloud_integration.py
@@ -1,0 +1,147 @@
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass
+class _FakeExecResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class _FakeSandbox:
+    def __init__(self, sandbox_id: str):
+        self.id = sandbox_id
+        self.exec_calls: list[tuple[str, int | None]] = []
+        self.files: dict[str, bytes] = {}
+
+    def exec(self, command: str, *, timeout: int | None = None):
+        self.exec_calls.append((command, timeout))
+        if command.startswith("mkdir -p "):
+            return _FakeExecResult(exit_code=0, stdout="", stderr="")
+        return _FakeExecResult(exit_code=7, stdout="stdout\n", stderr="stderr\n")
+
+    def write_file(self, path: str, content: bytes):
+        self.files[path] = content
+
+    def read_file(self, path: str):
+        return self.files[path]
+
+
+class _FakeClient:
+    instances: list["_FakeClient"] = []
+
+    def __init__(self):
+        self.create_calls: list[dict[str, object]] = []
+        self.get_calls: list[str] = []
+        self.sandbox: _FakeSandbox | None = None
+        self.__class__.instances.append(self)
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        self.sandbox = _FakeSandbox("created-sandbox")
+        return self.sandbox
+
+    def get(self, sandbox_id: str):
+        self.get_calls.append(sandbox_id)
+        self.sandbox = _FakeSandbox(sandbox_id)
+        return self.sandbox
+
+
+def _load_runcloud_module(monkeypatch):
+    _FakeClient.instances = []
+    fake_runcloud = types.ModuleType("runcloud")
+    fake_runcloud.__dict__.update({"Client": _FakeClient, "Sandbox": _FakeSandbox})
+    monkeypatch.setitem(sys.modules, "runcloud", fake_runcloud)
+
+    module_path = ROOT / "agent" / "integrations" / "runcloud.py"
+    spec = importlib.util.spec_from_file_location("runcloud_under_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_create_run_cloud_sandbox_uses_default_image(monkeypatch):
+    monkeypatch.delenv("RUN_CLOUD_IMAGE", raising=False)
+    module = _load_runcloud_module(monkeypatch)
+
+    backend = module.create_runcloud_sandbox()
+
+    client = _FakeClient.instances[0]
+    assert backend.id == "created-sandbox"
+    assert client.create_calls == [{"image": "runcloud/agent-base"}]
+    assert client.get_calls == []
+
+
+def test_create_run_cloud_sandbox_uses_configured_image(monkeypatch):
+    monkeypatch.setenv("RUN_CLOUD_IMAGE", "ghcr.io/acme/open-swe:latest")
+    module = _load_runcloud_module(monkeypatch)
+
+    module.create_runcloud_sandbox()
+
+    assert _FakeClient.instances[0].create_calls == [{"image": "ghcr.io/acme/open-swe:latest"}]
+
+
+def test_create_run_cloud_sandbox_reconnects_by_id(monkeypatch):
+    module = _load_runcloud_module(monkeypatch)
+
+    backend = module.create_runcloud_sandbox("sbx_existing")
+
+    client = _FakeClient.instances[0]
+    assert backend.id == "sbx_existing"
+    assert client.get_calls == ["sbx_existing"]
+    assert client.create_calls == []
+
+
+def test_run_cloud_backend_executes_commands(monkeypatch):
+    module = _load_runcloud_module(monkeypatch)
+    backend = module.create_runcloud_sandbox()
+
+    response = backend.execute("git status", timeout=42)
+
+    assert response.output == "stdout\nstderr\n"
+    assert response.exit_code == 7
+    assert response.truncated is False
+    assert backend._sandbox.exec_calls == [("git status", 42)]
+
+
+def test_run_cloud_backend_uploads_and_downloads_files(monkeypatch):
+    module = _load_runcloud_module(monkeypatch)
+    backend = module.create_runcloud_sandbox()
+
+    uploads = backend.upload_files(
+        [
+            ("/workspace/a.txt", b"alpha"),
+            ("/workspace/dir/b.txt", b"beta"),
+        ]
+    )
+    downloads = backend.download_files(
+        ["/workspace/a.txt", "/workspace/dir/b.txt", "/workspace/missing.txt"]
+    )
+
+    assert [response.error for response in uploads] == [None, None]
+    assert downloads[0].content == b"alpha"
+    assert downloads[1].content == b"beta"
+    assert downloads[2].error
+    assert backend._sandbox.exec_calls == [
+        ("mkdir -p /workspace", None),
+        ("mkdir -p /workspace/dir", None),
+    ]
+
+
+def test_run_cloud_rejects_empty_image(monkeypatch):
+    monkeypatch.setenv("RUN_CLOUD_IMAGE", "  ")
+    module = _load_runcloud_module(monkeypatch)
+
+    try:
+        module.create_runcloud_sandbox()
+    except ValueError as exc:
+        assert "RUN_CLOUD_IMAGE must not be empty" in str(exc)
+    else:
+        raise AssertionError("expected empty Run Cloud image to fail")

--- a/uv.lock
+++ b/uv.lock
@@ -2063,6 +2063,7 @@ dependencies = [
     { name = "langsmith" },
     { name = "markdownify" },
     { name = "pyjwt" },
+    { name = "runcloud-sdk" },
     { name = "stagehand" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -2104,6 +2105,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20" },
+    { name = "runcloud-sdk", specifier = ">=0.8.0,<1" },
     { name = "stagehand", specifier = ">=3.21.0" },
     { name = "uvicorn", specifier = ">=0.50.2" },
     { name = "websockets", specifier = ">=15.0.1" },
@@ -3141,6 +3143,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
     { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
     { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "runcloud-sdk"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/76/6ff912486761e9487564507724add278361890fdacea87fcedf3e5a27fd3/runcloud_sdk-0.8.0.tar.gz", hash = "sha256:ae0e30ce8b37e4e3595be463766e619296abbd74ec34b6c4296c2a8124f5334e", size = 13759, upload-time = "2026-07-27T21:16:51.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/62/bfe4e656058e78af24878ba7a5e5c79af01f4354c421a6cef8d2b7794af8/runcloud_sdk-0.8.0-py3-none-any.whl", hash = "sha256:9ccdbe8671f174c56acfe8e1d512d605abbffc0722bbd9cf3b79eb67db99ae99", size = 13477, upload-time = "2026-07-27T21:16:50.168Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

- add a native `runcloud` sandbox integration using `runcloud-sdk`
- support sandbox creation and reconnect, command execution, and binary-safe file transfers
- document `SANDBOX_TYPE=runcloud`, `RUN_CLOUD_API_KEY`, and the optional image override
- add focused integration tests and lock the new dependency

## Why

Open SWE already makes sandbox providers pluggable. This gives users another managed option without changing the agent or task flow.

## Impact

The integration is opt-in and does not change existing provider defaults.

## Validation

- `uv run pytest tests/sandbox -q` — 128 passed
- `uv run ruff check agent/integrations/runcloud.py agent/utils/sandbox.py tests/sandbox/test_runcloud_integration.py`
- `uv run ruff format --check agent/integrations/runcloud.py agent/utils/sandbox.py tests/sandbox/test_runcloud_integration.py`
