### PR TITLE
perf: cache the dashboard repo picker's repo list

### DIFF
--- a/agent/dashboard/repo_cache.py
+++ b/agent/dashboard/repo_cache.py
@@ -1,0 +1,108 @@
+"""Per-user cache of the GitHub repo list behind the dashboard repo picker.
+
+Building the picker payload fans out to ``/user/installations`` plus a
+paginated ``/user/installations/{id}/repositories`` sweep per installation,
+which takes 10s+ for users whose App is installed across hundreds of repos.
+Installations change rarely, so the payload is cached per login in the
+LangGraph store and served stale-while-revalidate.
+
+Keys are derived from the authenticated session login only, so a cached
+payload is never served to a different user. Only the picker listing reads
+this cache — ``accessible_repo_full_names`` (an authorization boundary) stays
+fresh on every call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from langgraph_sdk import get_client
+
+logger = logging.getLogger(__name__)
+
+REPO_LIST_CACHE_NAMESPACE: list[str] = ["repo_list_cache"]
+REPO_LIST_FRESH_MS = 10 * 60 * 1000
+REPO_LIST_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+_refreshing: set[str] = set()
+_refresh_tasks: set[asyncio.Task[None]] = set()
+
+
+def _client():
+    return get_client()
+
+
+def _now_ms() -> int:
+    return int(datetime.now(UTC).timestamp() * 1000)
+
+
+def _cache_key(login: str) -> str:
+    return login.strip().lower()
+
+
+async def read_cached_repos(login: str) -> tuple[dict[str, Any], int] | None:
+    """Return ``(payload, age_ms)`` for a login, or ``None`` when unusable."""
+    if not login.strip():
+        return None
+    try:
+        item = await _client().store.get_item(REPO_LIST_CACHE_NAMESPACE, _cache_key(login))
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code != 404:
+            logger.debug("repo list cache lookup failed: %s", e)
+        return None
+    except Exception as e:
+        logger.debug("repo list cache lookup failed: %s", e)
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    if not isinstance(value, dict):
+        return None
+    payload = value.get("payload")
+    cached_at_ms = value.get("cached_at_ms")
+    if not isinstance(payload, dict) or not isinstance(cached_at_ms, int):
+        return None
+    age_ms = max(_now_ms() - cached_at_ms, 0)
+    if age_ms > REPO_LIST_MAX_AGE_MS:
+        return None
+    return payload, age_ms
+
+
+async def write_cached_repos(login: str, payload: dict[str, Any]) -> None:
+    if not login.strip():
+        return
+    try:
+        await _client().store.put_item(
+            REPO_LIST_CACHE_NAMESPACE,
+            _cache_key(login),
+            {"payload": payload, "cached_at_ms": _now_ms()},
+        )
+    except Exception as e:
+        logger.debug("repo list cache write failed: %s", e)
+
+
+def schedule_repo_cache_refresh(login: str, refresh: Callable[[], Awaitable[Any]]) -> None:
+    """Rebuild a login's cached payload in the background, once at a time."""
+    key = _cache_key(login)
+    if not key or key in _refreshing:
+        return
+
+    async def run() -> None:
+        try:
+            await refresh()
+        except Exception as e:
+            logger.warning("background repo list refresh for %s failed: %s", key, e)
+        finally:
+            _refreshing.discard(key)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    _refreshing.add(key)
+    task = loop.create_task(run())
+    _refresh_tasks.add(task)
+    task.add_done_callback(_refresh_tasks.discard)

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -75,6 +75,12 @@ from .profiles import (
     upsert_profile,
 )
 from .repo_access import require_repo_access_for_user
+from .repo_cache import (
+    REPO_LIST_FRESH_MS,
+    read_cached_repos,
+    schedule_repo_cache_refresh,
+    write_cached_repos,
+)
 from .repo_snapshots import (
     RepoSnapshotConfigError,
     RepoSnapshotCreate,
@@ -1000,13 +1006,9 @@ async def accessible_repo_full_names(login: str) -> frozenset[str]:
     )
 
 
-@router.get("/repos")
-async def list_repos(
-    session: dict[str, Any] = _SESSION_DEP,
-) -> dict[str, Any]:
-    """List repos where open-swe is installed and the user has access."""
-    installations, repositories = await _fetch_user_installations_and_repos(session["sub"])
-    return {
+async def _build_repo_payload(login: str) -> dict[str, Any]:
+    installations, repositories = await _fetch_user_installations_and_repos(login)
+    payload = {
         "installations": [
             {
                 "id": i.get("id"),
@@ -1021,6 +1023,30 @@ async def list_repos(
             if r.get("full_name")
         ],
     }
+    await write_cached_repos(login, payload)
+    return payload
+
+
+@router.get("/repos")
+async def list_repos(
+    refresh: bool = False,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    """List repos where open-swe is installed and the user has access.
+
+    Served from the per-login cache (stale-while-revalidate) unless
+    ``refresh=true``, because the fan-out over every installation takes 10s+
+    for users with hundreds of accessible repos.
+    """
+    login = session["sub"]
+    if not refresh:
+        cached = await read_cached_repos(login)
+        if cached is not None:
+            payload, age_ms = cached
+            if age_ms > REPO_LIST_FRESH_MS:
+                schedule_repo_cache_refresh(login, lambda: _build_repo_payload(login))
+            return payload
+    return await _build_repo_payload(login)
 
 
 @router.get("/review-styles")

--- a/tests/dashboard/test_dashboard_repos.py
+++ b/tests/dashboard/test_dashboard_repos.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 from fastapi import HTTPException
 
-from agent.dashboard import routes
+from agent.dashboard import repo_cache, routes
+
+
+@pytest.fixture(autouse=True)
+def _no_repo_cache(monkeypatch) -> None:
+    """Default every test to a cache miss with writes swallowed."""
+    monkeypatch.setattr(routes, "read_cached_repos", AsyncMock(return_value=None))
+    monkeypatch.setattr(routes, "write_cached_repos", AsyncMock(return_value=None))
 
 
 @pytest.mark.asyncio
@@ -90,3 +98,124 @@ async def test_list_repos_skips_inaccessible_installations(monkeypatch) -> None:
         "installations": [{"id": 123, "account": "acme", "account_type": "Organization"}],
         "repositories": [],
     }
+
+
+@pytest.mark.asyncio
+async def test_list_repos_serves_fresh_cache_without_calling_github(monkeypatch) -> None:
+    cached = {"installations": [], "repositories": [{"full_name": "acme/api", "private": True}]}
+    monkeypatch.setattr(routes, "read_cached_repos", AsyncMock(return_value=(cached, 1_000)))
+    fetch = AsyncMock(return_value=([], []))
+    monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
+    schedule = MagicMock()
+    monkeypatch.setattr(routes, "schedule_repo_cache_refresh", schedule)
+
+    result = await routes.list_repos(session={"sub": "octocat"})
+
+    assert result == cached
+    fetch.assert_not_awaited()
+    schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_repos_serves_stale_cache_and_schedules_refresh(monkeypatch) -> None:
+    cached = {"installations": [], "repositories": [{"full_name": "acme/api", "private": True}]}
+    monkeypatch.setattr(
+        routes,
+        "read_cached_repos",
+        AsyncMock(return_value=(cached, routes.REPO_LIST_FRESH_MS + 1)),
+    )
+    fetch = AsyncMock(return_value=([], []))
+    monkeypatch.setattr(routes, "_fetch_user_installations_and_repos", fetch)
+    schedule = MagicMock()
+    monkeypatch.setattr(routes, "schedule_repo_cache_refresh", schedule)
+
+    result = await routes.list_repos(session={"sub": "octocat"})
+
+    assert result == cached
+    fetch.assert_not_awaited()
+    assert schedule.call_args.args[0] == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_list_repos_refresh_bypasses_cache_and_writes_it(monkeypatch) -> None:
+    read = AsyncMock(return_value=({"installations": [], "repositories": []}, 0))
+    monkeypatch.setattr(routes, "read_cached_repos", read)
+    write = AsyncMock(return_value=None)
+    monkeypatch.setattr(routes, "write_cached_repos", write)
+    monkeypatch.setattr(
+        routes,
+        "_fetch_user_installations_and_repos",
+        AsyncMock(
+            return_value=(
+                [{"id": 123, "account": {"login": "acme", "type": "Organization"}}],
+                [{"full_name": "acme/api", "private": True}],
+            )
+        ),
+    )
+
+    result = await routes.list_repos(refresh=True, session={"sub": "octocat"})
+
+    read.assert_not_awaited()
+    assert result == {
+        "installations": [{"id": 123, "account": "acme", "account_type": "Organization"}],
+        "repositories": [{"full_name": "acme/api", "private": True}],
+    }
+    write.assert_awaited_once_with("octocat", result)
+
+
+@pytest.mark.asyncio
+async def test_read_cached_repos_rejects_expired_and_malformed_entries(monkeypatch) -> None:
+    now_ms = repo_cache._now_ms()
+
+    async def fake_get_item(namespace: list[str], key: str) -> dict[str, object]:
+        assert namespace == repo_cache.REPO_LIST_CACHE_NAMESPACE
+        return {"value": values[key]}
+
+    values: dict[str, object] = {
+        "fresh": {"payload": {"repositories": []}, "cached_at_ms": now_ms - 500},
+        "expired": {
+            "payload": {"repositories": []},
+            "cached_at_ms": now_ms - repo_cache.REPO_LIST_MAX_AGE_MS - 1,
+        },
+        "malformed": {"payload": "nope", "cached_at_ms": now_ms},
+    }
+    store = MagicMock()
+    store.get_item = fake_get_item
+    monkeypatch.setattr(repo_cache, "_client", lambda: MagicMock(store=store))
+
+    fresh = await repo_cache.read_cached_repos("fresh")
+    assert fresh is not None and fresh[0] == {"repositories": []}
+    assert await repo_cache.read_cached_repos("expired") is None
+    assert await repo_cache.read_cached_repos("malformed") is None
+
+
+@pytest.mark.asyncio
+async def test_read_cached_repos_swallows_store_failures(monkeypatch) -> None:
+    store = MagicMock()
+    store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
+    monkeypatch.setattr(repo_cache, "_client", lambda: MagicMock(store=store))
+
+    assert await repo_cache.read_cached_repos("octocat") is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_repo_cache_refresh_runs_once_per_login() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def refresh() -> None:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+
+    repo_cache.schedule_repo_cache_refresh("Octocat", refresh)
+    await started.wait()
+    repo_cache.schedule_repo_cache_refresh("octocat", refresh)
+    release.set()
+    await asyncio.sleep(0)
+    await asyncio.gather(*list(repo_cache._refresh_tasks))
+
+    assert calls == 1
+    assert "octocat" not in repo_cache._refreshing

--- a/ui/src/components/AgentInstructionsPanel.tsx
+++ b/ui/src/components/AgentInstructionsPanel.tsx
@@ -14,7 +14,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { InstructionsEditor } from "@/components/InstructionsEditor";
-import { ApiError, api, isGithubReauthError, loginUrl } from "@/lib/api";
+import { api, isGithubReauthError, loginUrl } from "@/lib/api";
+import { useRepos } from "@/lib/profile";
 import { normalizeRepoFullName } from "@/lib/repo";
 
 function formatMutationError(e: Error): string {
@@ -35,18 +36,7 @@ export function AgentInstructionsPanel() {
     queryFn: api.listAgentInstructions,
   });
 
-  const repos = useQuery({
-    queryKey: ["repos"],
-    queryFn: async () => {
-      try {
-        return await api.repos();
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 401)
-          return { installations: [], repositories: [] };
-        throw e;
-      }
-    },
-  });
+  const repos = useRepos();
 
   const detail = useQuery({
     queryKey: ["agentInstruction", selected],

--- a/ui/src/components/RepoSnapshotsPanel.tsx
+++ b/ui/src/components/RepoSnapshotsPanel.tsx
@@ -15,7 +15,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
 import { InstructionsEditor } from "@/components/InstructionsEditor"
-import { ApiError, api, isGithubReauthError, loginUrl } from "@/lib/api"
+import { api, isGithubReauthError, loginUrl } from "@/lib/api"
+import { useRepos } from "@/lib/profile"
 import { normalizeRepoFullName } from "@/lib/repo"
 
 function formatMutationError(e: Error): string {
@@ -50,18 +51,7 @@ export function RepoSnapshotsPanel() {
     queryFn: api.listRepoSnapshots,
   })
 
-  const repos = useQuery({
-    queryKey: ["repos"],
-    queryFn: async () => {
-      try {
-        return await api.repos()
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 401)
-          return { installations: [], repositories: [] }
-        throw e
-      }
-    },
-  })
+  const repos = useRepos()
 
   const detail = useQuery({
     queryKey: ["repoSnapshot", selected],

--- a/ui/src/components/ReviewStylesPanel.tsx
+++ b/ui/src/components/ReviewStylesPanel.tsx
@@ -16,7 +16,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
-import { ApiError, api, isGithubReauthError, loginUrl } from "@/lib/api";
+import { api, isGithubReauthError, loginUrl } from "@/lib/api";
+import { useRepos } from "@/lib/profile";
 import { normalizeRepoFullName } from "@/lib/repo";
 
 function formatMutationError(e: Error): string {
@@ -54,18 +55,7 @@ export function ReviewStylesPanel() {
     },
   });
 
-  const repos = useQuery({
-    queryKey: ["repos"],
-    queryFn: async () => {
-      try {
-        return await api.repos();
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 401)
-          return { installations: [], repositories: [] };
-        throw e;
-      }
-    },
-  });
+  const repos = useRepos();
 
   const detail = useQuery({
     queryKey: ["reviewStyle", selected],

--- a/ui/src/components/SidebarUserMenu.tsx
+++ b/ui/src/components/SidebarUserMenu.tsx
@@ -13,6 +13,7 @@ import type { SessionUser } from "@/lib/api";
 import type { Theme } from "@/lib/theme";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { api } from "@/lib/api";
+import { clearCachedRepos } from "@/lib/repoCache";
 import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 
@@ -53,6 +54,7 @@ export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserM
   const onLogout = async () => {
     setOpen(false);
     await api.logout();
+    clearCachedRepos();
     qc.setQueryData(["session"], null);
     navigate({ to: "/login" });
   };

--- a/ui/src/features/settings/components/RepoSelector.tsx
+++ b/ui/src/features/settings/components/RepoSelector.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import { CaretDownIcon, FolderIcon } from "@phosphor-icons/react"
+import {
+  ArrowsClockwiseIcon,
+  CaretDownIcon,
+  FolderIcon,
+} from "@phosphor-icons/react"
 
+import { useRefreshRepos } from "@/lib/profile"
 import { cn } from "@/lib/utils"
 
 type RepoOption = { full_name: string }
@@ -35,6 +40,7 @@ export function RepoSelector({
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const refresh = useRefreshRepos()
 
   const filteredRepos = useMemo(() => {
     const all = repos ?? []
@@ -78,13 +84,27 @@ export function RepoSelector({
             dropdownClassName
           )}
         >
-          <input
-            autoFocus
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={searchPlaceholder}
-            className="w-full border-b border-border bg-transparent px-2 py-1.5 text-foreground outline-none placeholder:text-muted-foreground"
-          />
+          <div className="flex items-center border-b border-border">
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={searchPlaceholder}
+              className="min-w-0 flex-1 bg-transparent px-2 py-1.5 text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            <button
+              type="button"
+              title="Refresh repositories"
+              aria-label="Refresh repositories"
+              disabled={refresh.isPending}
+              onClick={() => refresh.mutate()}
+              className="mr-1 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-muted disabled:cursor-default"
+            >
+              <ArrowsClockwiseIcon
+                className={cn("size-3.5", refresh.isPending && "animate-spin")}
+              />
+            </button>
+          </div>
           <div className="overflow-y-auto">
             <button
               type="button"

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -611,7 +611,8 @@ export const api = {
   profile: () => request<Profile>("/profile"),
   saveProfile: (body: ProfileUpdate) =>
     request<Profile>("/profile", { method: "PUT", body: JSON.stringify(body) }),
-  repos: () => request<ReposPayload>("/repos"),
+  repos: (options?: { refresh?: boolean }) =>
+    request<ReposPayload>(options?.refresh ? "/repos?refresh=true" : "/repos"),
   listReviewStyles: () => request<Array<ReviewStyle>>("/review-styles"),
   createReviewStyle: (full_name: string) =>
     request<ReviewStyle>("/review-styles", {

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -28,7 +28,8 @@ export function useOptions() {
   })
 }
 
-export const reposQueryKey = ["repos"] as const
+/** Keyed by login so a cached list never bleeds across accounts in one SPA session. */
+export const reposQueryKey = (login: string | null) => ["repos", login] as const
 
 /** Repos change rarely; revalidate in the background rather than on every mount. */
 export const REPOS_STALE_TIME_MS = 10 * 60 * 1000
@@ -44,16 +45,17 @@ export function useRepos() {
 
   useEffect(() => {
     if (!login) return
-    if (qc.getQueryData<ReposPayload>(reposQueryKey)) return
+    const key = reposQueryKey(login)
+    if (qc.getQueryData<ReposPayload>(key)) return
     const cached = readCachedRepos(login)
     if (!cached) return
-    qc.setQueryData<ReposPayload>(reposQueryKey, cached.payload, {
+    qc.setQueryData<ReposPayload>(key, cached.payload, {
       updatedAt: cached.updatedAt,
     })
   }, [login, qc])
 
   return useQuery({
-    queryKey: reposQueryKey,
+    queryKey: reposQueryKey(login),
     queryFn: async () => {
       try {
         const payload = await api.repos()
@@ -79,7 +81,7 @@ export function useRefreshRepos() {
   return useMutation({
     mutationFn: () => api.repos({ refresh: true }),
     onSuccess: (payload) => {
-      qc.setQueryData<ReposPayload>(reposQueryKey, payload)
+      qc.setQueryData<ReposPayload>(reposQueryKey(login), payload)
       if (login) writeCachedRepos(login, payload)
     },
   })

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -1,8 +1,14 @@
+import { useEffect } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { ApiError, api } from "./api"
+import {
+  REPOS_CACHE_MAX_AGE_MS,
+  readCachedRepos,
+  writeCachedRepos,
+} from "./repoCache"
 import { useSession } from "./session"
-import type { Profile, ProfileUpdate } from "./api"
+import type { Profile, ProfileUpdate, ReposPayload } from "./api"
 
 export function useProfile() {
   const session = useSession()
@@ -22,13 +28,37 @@ export function useOptions() {
   })
 }
 
+export const reposQueryKey = ["repos"] as const
+
+/** Repos change rarely; revalidate in the background rather than on every mount. */
+export const REPOS_STALE_TIME_MS = 10 * 60 * 1000
+
+/**
+ * Accessible repos, seeded from localStorage so the picker populates instantly
+ * instead of waiting on the multi-second GitHub installation fan-out.
+ */
 export function useRepos() {
   const session = useSession()
+  const login = session.data?.login ?? null
+  const qc = useQueryClient()
+
+  useEffect(() => {
+    if (!login) return
+    if (qc.getQueryData<ReposPayload>(reposQueryKey)) return
+    const cached = readCachedRepos(login)
+    if (!cached) return
+    qc.setQueryData<ReposPayload>(reposQueryKey, cached.payload, {
+      updatedAt: cached.updatedAt,
+    })
+  }, [login, qc])
+
   return useQuery({
-    queryKey: ["repos"],
+    queryKey: reposQueryKey,
     queryFn: async () => {
       try {
-        return await api.repos()
+        const payload = await api.repos()
+        if (login) writeCachedRepos(login, payload)
+        return payload
       } catch (e) {
         if (e instanceof ApiError && e.status === 401)
           return { installations: [], repositories: [] }
@@ -36,6 +66,22 @@ export function useRepos() {
       }
     },
     enabled: !!session.data,
+    staleTime: REPOS_STALE_TIME_MS,
+    gcTime: REPOS_CACHE_MAX_AGE_MS,
+  })
+}
+
+/** Force a fresh GitHub fan-out, e.g. after installing the App on new repos. */
+export function useRefreshRepos() {
+  const session = useSession()
+  const login = session.data?.login ?? null
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => api.repos({ refresh: true }),
+    onSuccess: (payload) => {
+      qc.setQueryData<ReposPayload>(reposQueryKey, payload)
+      if (login) writeCachedRepos(login, payload)
+    },
   })
 }
 

--- a/ui/src/lib/repoCache.test.ts
+++ b/ui/src/lib/repoCache.test.ts
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  REPOS_CACHE_MAX_AGE_MS,
+  clearCachedRepos,
+  readCachedRepos,
+  writeCachedRepos,
+} from "./repoCache"
+
+const STORAGE_KEY = "open-swe.repos.cache.v1"
+
+const payload = {
+  installations: [{ id: 1, account: "acme", account_type: "Organization" }],
+  repositories: [
+    { full_name: "acme/api", private: true },
+    { full_name: "acme/web", private: false },
+  ],
+}
+
+describe("repoCache", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("round-trips a payload for the same login", () => {
+    writeCachedRepos("octocat", payload)
+    const cached = readCachedRepos("octocat")
+    expect(cached?.payload).toEqual(payload)
+    expect(cached?.updatedAt).toBeGreaterThan(0)
+  })
+
+  it("rejects a payload cached for a different login", () => {
+    writeCachedRepos("octocat", payload)
+    expect(readCachedRepos("hubot")).toBeNull()
+  })
+
+  it("rejects entries older than the max age", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        login: "octocat",
+        updatedAt: Date.now() - REPOS_CACHE_MAX_AGE_MS - 1,
+        payload,
+      })
+    )
+    expect(readCachedRepos("octocat")).toBeNull()
+  })
+
+  it("drops malformed repositories and unusable entries", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        login: "octocat",
+        updatedAt: Date.now(),
+        payload: {
+          installations: [{ id: "nope" }],
+          repositories: [{ full_name: "acme/api" }, { private: true }, 42],
+        },
+      })
+    )
+    const cached = readCachedRepos("octocat")
+    expect(cached?.payload).toEqual({
+      installations: [],
+      repositories: [{ full_name: "acme/api", private: false }],
+    })
+  })
+
+  it("returns null for corrupt json and after clearing", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json")
+    expect(readCachedRepos("octocat")).toBeNull()
+    writeCachedRepos("octocat", payload)
+    clearCachedRepos()
+    expect(readCachedRepos("octocat")).toBeNull()
+  })
+})

--- a/ui/src/lib/repoCache.ts
+++ b/ui/src/lib/repoCache.ts
@@ -1,0 +1,108 @@
+/**
+ * localStorage cache for the repo picker payload.
+ *
+ * `/repos` fans out over every GitHub App installation, so a cold call takes
+ * 10s+ for users with hundreds of accessible repos. Seeding the query cache
+ * from here lets the picker paint immediately on load and revalidate in the
+ * background. Entries are keyed by login so one account never sees another's
+ * repos after a user switch.
+ */
+
+import type { Installation, ReposPayload, Repository } from "./api"
+
+const STORAGE_KEY = "open-swe.repos.cache.v1"
+
+export const REPOS_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+export interface CachedRepos {
+  login: string
+  updatedAt: number
+  payload: ReposPayload
+}
+
+function sanitizeRepositories(value: unknown): Array<Repository> {
+  if (!Array.isArray(value)) return []
+  const out: Array<Repository> = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue
+    const raw = entry as Record<string, unknown>
+    if (typeof raw.full_name !== "string" || !raw.full_name) continue
+    out.push({ full_name: raw.full_name, private: raw.private === true })
+  }
+  return out
+}
+
+function sanitizeInstallations(value: unknown): Array<Installation> {
+  if (!Array.isArray(value)) return []
+  const out: Array<Installation> = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue
+    const raw = entry as Record<string, unknown>
+    if (typeof raw.id !== "number") continue
+    out.push({
+      id: raw.id,
+      account: typeof raw.account === "string" ? raw.account : null,
+      account_type:
+        typeof raw.account_type === "string" ? raw.account_type : null,
+    })
+  }
+  return out
+}
+
+export function readCachedRepos(login: string): CachedRepos | null {
+  if (typeof window === "undefined" || !login) return null
+  let raw: string | null
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== "object") return null
+  const record = parsed as Record<string, unknown>
+  if (typeof record.login !== "string" || record.login !== login) return null
+  if (typeof record.updatedAt !== "number") return null
+  if (Date.now() - record.updatedAt > REPOS_CACHE_MAX_AGE_MS) return null
+  const payload =
+    record.payload && typeof record.payload === "object"
+      ? (record.payload as Record<string, unknown>)
+      : null
+  if (!payload) return null
+  const repositories = sanitizeRepositories(payload.repositories)
+  if (!repositories.length) return null
+  return {
+    login,
+    updatedAt: record.updatedAt,
+    payload: {
+      installations: sanitizeInstallations(payload.installations),
+      repositories,
+    },
+  }
+}
+
+export function writeCachedRepos(login: string, payload: ReposPayload): void {
+  if (typeof window === "undefined" || !login) return
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ login, updatedAt: Date.now(), payload })
+    )
+  } catch {
+    /* ignore persistence failures (private mode, quota, SSR) */
+  }
+}
+
+export function clearCachedRepos(): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* ignore */
+  }
+}

--- a/ui/src/lib/useRepos.test.tsx
+++ b/ui/src/lib/useRepos.test.tsx
@@ -1,0 +1,74 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useRepos } from "./profile"
+import { writeCachedRepos } from "./repoCache"
+import type { ReposPayload } from "./api"
+
+const sessionLogin = vi.hoisted(() => ({ current: "octocat" }))
+
+vi.mock("./session", () => ({
+  useSession: () => ({ data: { login: sessionLogin.current } }),
+}))
+
+const reposMock = vi.hoisted(() => vi.fn())
+
+vi.mock("./api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./api")>()),
+  api: { repos: reposMock },
+}))
+
+function payloadFor(login: string): ReposPayload {
+  return {
+    installations: [],
+    repositories: [{ full_name: `${login}/api`, private: false }],
+  }
+}
+
+function renderRepos() {
+  const seen: Array<ReposPayload | undefined> = []
+  function Probe() {
+    seen.push(useRepos().data)
+    return null
+  }
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const view = render(
+    <QueryClientProvider client={client}>
+      <Probe />
+    </QueryClientProvider>
+  )
+  return { seen, view }
+}
+
+afterEach(() => {
+  window.localStorage.clear()
+  reposMock.mockReset()
+  sessionLogin.current = "octocat"
+})
+
+describe("useRepos", () => {
+  it("serves the localStorage payload while the network call is in flight", async () => {
+    writeCachedRepos("octocat", payloadFor("octocat"))
+    reposMock.mockReturnValue(new Promise(() => {}))
+
+    const { seen } = renderRepos()
+
+    await waitFor(() => expect(seen.at(-1)).toEqual(payloadFor("octocat")))
+  })
+
+  it("never serves another login's cached payload", async () => {
+    writeCachedRepos("octocat", payloadFor("octocat"))
+    sessionLogin.current = "hubot"
+    reposMock.mockReturnValue(new Promise(() => {}))
+
+    const { seen } = renderRepos()
+
+    await waitFor(() => expect(reposMock).toHaveBeenCalled())
+    expect(seen.every((data) => data === undefined)).toBe(true)
+  })
+})

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -25,6 +25,7 @@ import {
   useSaveProfile,
 } from "@/lib/profile"
 import { RequireLogin } from "@/lib/auth-redirect"
+import { clearCachedRepos } from "@/lib/repoCache"
 import { useSession } from "@/lib/session"
 import {
   notificationsEnabled,
@@ -371,6 +372,7 @@ function MySettingsPage() {
 
   const handleLogout = async () => {
     await api.logout()
+    clearCachedRepos()
     qc.setQueryData(["session"], null)
     void navigate({ to: "/login" })
   }

--- a/ui/src/routes/review.tsx
+++ b/ui/src/routes/review.tsx
@@ -4,14 +4,15 @@ import { CaretRightIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
 import { IoLogoGithub } from "react-icons/io5";
 
-import type { ReposPayload, TeamSettings } from "@/lib/api";
+import type { TeamSettings } from "@/lib/api";
 import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { ApiError, api } from "@/lib/api";
+import { api } from "@/lib/api";
 import { RequireLogin } from "@/lib/auth-redirect";
+import { useRepos } from "@/lib/profile";
 import { useSession } from "@/lib/session";
 
 export const Route = createFileRoute("/review")({ component: ReviewPage });
@@ -189,18 +190,7 @@ function ReviewPage() {
 }
 
 function RepositoriesSection({ canEdit: _canEdit }: { canEdit: boolean }) {
-  const repos = useQuery<ReposPayload>({
-    queryKey: ["repos"],
-    queryFn: async () => {
-      try {
-        return await api.repos();
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 401)
-          return { installations: [], repositories: [] };
-        throw e;
-      }
-    },
-  });
+  const repos = useRepos();
 
   const autoReview = useQuery({
     queryKey: ["autoReviewRepos"],

--- a/ui/src/routes/review_.repositories.$owner.tsx
+++ b/ui/src/routes/review_.repositories.$owner.tsx
@@ -2,13 +2,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 
-import type { ReposPayload } from "@/lib/api";
 import { AppShell } from "@/components/AppShell";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
-import { ApiError, api } from "@/lib/api";
+import { api } from "@/lib/api";
 import { RequireLogin } from "@/lib/auth-redirect";
+import { useRepos } from "@/lib/profile";
 import { useSession } from "@/lib/session";
 
 const PAGE_SIZE = 20;
@@ -22,19 +22,7 @@ function RepositoriesOwnerPage() {
   const { owner } = Route.useParams();
   const qc = useQueryClient();
 
-  const repos = useQuery<ReposPayload>({
-    queryKey: ["repos"],
-    queryFn: async () => {
-      try {
-        return await api.repos();
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 401)
-          return { installations: [], repositories: [] };
-        throw e;
-      }
-    },
-    enabled: !!session.data,
-  });
+  const repos = useRepos();
 
   const autoReview = useQuery({
     queryKey: ["autoReviewRepos"],


### PR DESCRIPTION
## Description
The repo picker refetched `/repos` on every mount (query `staleTime` was 30s), and that endpoint fans out over `/user/installations` plus a paginated per-installation repo sweep, so users whose App is installed across hundreds of repos waited 10s+ every time the dropdown opened. This adds two caching layers: the payload is now cached per login in the LangGraph store and served stale-while-revalidate (fresh window 10 min, hard expiry 24h), and the UI seeds the `["repos"]` query from localStorage with a 10 min `staleTime` so the dropdown paints instantly and revalidates in the background. A refresh button in the dropdown forces a fresh fan-out (`/repos?refresh=true`) after installing the App on new repos. `accessible_repo_full_names` — the authorization boundary used to filter private PR metadata — deliberately stays uncached; cache keys are derived only from the authenticated session login, and the localStorage entry is rejected on login mismatch and cleared on logout. The five duplicated inline `["repos"]` queries now share the `useRepos()` hook so caching is consistent everywhere.

## Release Note
Dashboard repo picker now populates instantly instead of refetching the full GitHub repo list on every open.

## Test Plan
- [ ] Open the repo picker twice in a row: the second open is instant, no `/repos` request in flight blocking it.
- [ ] Hard reload with a warm localStorage cache: the picker lists repos on first paint, then quietly revalidates.
- [ ] Install the App on a new repo, hit the refresh icon in the dropdown, and confirm the new repo appears.
- [ ] Log out and back in as a different user: the picker shows only the new user's repos.

Made by [Open SWE](https://openswe.vercel.app/agents/019fa9c5-3e5f-761b-8a5c-728806351586)