### PR TITLE
fix: remove natural wording from approval prompts

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -97,7 +97,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. Do not send plan-approval buttons in Slack. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -134,7 +134,7 @@ Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside 
 - <targeted tests or manual checks that prove the behavior>
 ```
 
-After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, use plain text and tell the plan owner to reply in the thread to approve or request changes; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
+After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), then stop. For Slack, use plain text; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
 
 
 SELF_AWARENESS_SECTION = """---

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -97,7 +97,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. Do not send plan-approval buttons in Slack. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -134,7 +134,7 @@ Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside 
 - <targeted tests or manual checks that prove the behavior>
 ```
 
-After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), then stop. For Slack, use plain text; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
+After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, use plain text and tell the plan owner to reply in the thread to approve or request changes; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
 
 
 SELF_AWARENESS_SECTION = """---

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -97,7 +97,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply naturally in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -134,7 +134,7 @@ Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside 
 - <targeted tests or manual checks that prove the behavior>
 ```
 
-After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, use plain text and tell the plan owner to reply naturally in the thread to approve or request changes; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
+After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, use plain text and tell the plan owner to reply in the thread to approve or request changes; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
 
 
 SELF_AWARENESS_SECTION = """---

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -40,6 +40,9 @@ async def slack_thread_reply(
     render interactive buttons and the web UI will render the same choices.
     The user can still reply manually in the Slack thread.
 
+    When a plan is ready, post a plain-text summary with the dashboard review link
+    and ask the user to reply in the thread to approve it or request changes.
+
     To mention/tag a user, use Slack's mention format: <@USER_ID>.
     You can find user IDs in the conversation context (e.g. @Name(U06KD8BFY95)).
     Example: <@U06KD8BFY95> will tag that user in the message."""

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -40,9 +40,6 @@ async def slack_thread_reply(
     render interactive buttons and the web UI will render the same choices.
     The user can still reply manually in the Slack thread.
 
-    When a plan is ready, post a plain-text summary with the dashboard review link
-    and ask the user to reply in the thread to approve it or request changes.
-
     To mention/tag a user, use Slack's mention format: <@USER_ID>.
     You can find user IDs in the conversation context (e.g. @Name(U06KD8BFY95)).
     Example: <@U06KD8BFY95> will tag that user in the message."""

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -41,7 +41,7 @@ async def slack_thread_reply(
     The user can still reply manually in the Slack thread.
 
     When a plan is ready, post a plain-text summary with the dashboard review link
-    and ask the user to reply naturally in the thread to approve it or request changes.
+    and ask the user to reply in the thread to approve it or request changes.
 
     To mention/tag a user, use Slack's mention format: <@USER_ID>.
     You can find user IDs in the conversation context (e.g. @Name(U06KD8BFY95)).

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -386,5 +386,6 @@ def test_natural_language_plan_approval_rejects_ambiguous_or_negative_replies(re
 def test_plan_mode_prompt_uses_plain_text_slack_approval() -> None:
     prompt = construct_system_prompt(working_dir="/work", plan_mode=True)
 
-    assert "reply naturally in the thread" in prompt
+    assert "reply in the thread" in prompt
+    assert "reply naturally" not in prompt
     assert "do not use Block Kit or approval buttons" in prompt

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -383,9 +383,9 @@ def test_natural_language_plan_approval_rejects_ambiguous_or_negative_replies(re
     assert _is_natural_language_plan_approval(reply) is False
 
 
-def test_plan_mode_prompt_uses_plain_text_slack_approval() -> None:
+def test_plan_mode_prompt_does_not_recommend_slack_approval_reply() -> None:
     prompt = construct_system_prompt(working_dir="/work", plan_mode=True)
 
-    assert "reply in the thread" in prompt
+    assert "reply in the thread" not in prompt
     assert "reply naturally" not in prompt
     assert "do not use Block Kit or approval buttons" in prompt

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -383,9 +383,9 @@ def test_natural_language_plan_approval_rejects_ambiguous_or_negative_replies(re
     assert _is_natural_language_plan_approval(reply) is False
 
 
-def test_plan_mode_prompt_does_not_recommend_slack_approval_reply() -> None:
+def test_plan_mode_prompt_uses_plain_text_slack_approval() -> None:
     prompt = construct_system_prompt(working_dir="/work", plan_mode=True)
 
-    assert "reply in the thread" not in prompt
+    assert "reply in the thread" in prompt
     assert "reply naturally" not in prompt
     assert "do not use Block Kit or approval buttons" in prompt

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -26,7 +26,7 @@ def test_slack_thread_reply_prompt_requires_slack_only_terseness() -> None:
     assert "default to one sentence" in prompt
     assert "specific to Slack tool messages" in prompt
     assert "not normal web UI assistant messages" in prompt
-    assert "reply in the thread" in prompt
+    assert "reply in the thread" not in prompt
     assert "reply naturally" not in prompt
     assert "plan_approval" not in prompt
 
@@ -171,9 +171,7 @@ async def test_slack_thread_reply_posts_plain_text_without_options(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply(
-        "Plan ready: review it and reply to approve or request changes."
-    )
+    result = await slack_reply_tool.slack_thread_reply("Plan ready: https://example.com/plan")
 
     assert result == {"success": True}
     assert captured["blocks"] is None

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -26,7 +26,8 @@ def test_slack_thread_reply_prompt_requires_slack_only_terseness() -> None:
     assert "default to one sentence" in prompt
     assert "specific to Slack tool messages" in prompt
     assert "not normal web UI assistant messages" in prompt
-    assert "reply naturally" in prompt
+    assert "reply in the thread" in prompt
+    assert "reply naturally" not in prompt
     assert "plan_approval" not in prompt
 
 
@@ -171,7 +172,7 @@ async def test_slack_thread_reply_posts_plain_text_without_options(
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
     result = await slack_reply_tool.slack_thread_reply(
-        "Plan ready: review it and reply naturally to approve or request changes."
+        "Plan ready: review it and reply to approve or request changes."
     )
 
     assert result == {"success": True}

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -26,7 +26,7 @@ def test_slack_thread_reply_prompt_requires_slack_only_terseness() -> None:
     assert "default to one sentence" in prompt
     assert "specific to Slack tool messages" in prompt
     assert "not normal web UI assistant messages" in prompt
-    assert "reply in the thread" not in prompt
+    assert "reply in the thread" in prompt
     assert "reply naturally" not in prompt
     assert "plan_approval" not in prompt
 
@@ -171,7 +171,9 @@ async def test_slack_thread_reply_posts_plain_text_without_options(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("Plan ready: https://example.com/plan")
+    result = await slack_reply_tool.slack_thread_reply(
+        "Plan ready: review it and reply to approve or request changes."
+    )
 
     assert result == {"success": True}
     assert captured["blocks"] is None


### PR DESCRIPTION
## Description
Keeps natural-language plan approval working while removing the word “naturally” from agent-facing approval guidance. Slack completion messages still direct users to reply in the thread, without producing awkward wording like “approve this naturally.”

## Test Plan
- [x] `make test TEST_FILE=tests/agent/test_plan_mode.py`
- [x] `make test TEST_FILE=tests/slack/test_slack_thread_reply_tool.py`
- [x] `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/99dce4f6-3b4a-b00c-e148-957dd6985f72)