### PR TITLE
feat: user-level custom instructions with agent self-edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ There is intentionally no after-agent safety net that opens a PR for the agent. 
 All tools live in `agent/tools/` and are flat-imported via `agent/tools/__init__.py`. The set is intentionally small and curated — see README "Tools — Curated, Not Accumulated".
 
 Wired into `get_agent`:
-`http_request`, `fetch_url`, `web_search`, `approve_plan`, `enter_plan_mode`, `save_plan`, `linear_comment`, `linear_create_issue`, `linear_delete_issue`, `linear_get_issue`, `linear_get_issue_comments`, `linear_list_teams`, `linear_search_issues`, `linear_update_issue`, `open_pull_request`, `request_pr_review`, `report_platform_issue`, `schedule_thread_wakeup`, `slack_add_reaction`, `slack_read_thread_messages`, `slack_start_new_thread`, `slack_thread_reply`.
+`http_request`, `fetch_url`, `web_search`, `approve_plan`, `enter_plan_mode`, `save_plan`, `save_user_instructions`, `linear_comment`, `linear_create_issue`, `linear_delete_issue`, `linear_get_issue`, `linear_get_issue_comments`, `linear_list_teams`, `linear_search_issues`, `linear_update_issue`, `open_pull_request`, `request_pr_review`, `report_platform_issue`, `schedule_thread_wakeup`, `slack_add_reaction`, `slack_read_thread_messages`, `slack_start_new_thread`, `slack_thread_reply`.
 
 Reviewer-only tools (in `agent/reviewer.py`): `add_finding`, `update_finding`, `list_findings`, `publish_review`. The review-style analyzer uses `save_review_style` (exported as `save_review_style_prompt`).
 
@@ -104,6 +104,8 @@ Model + reasoning effort are resolved per run in this precedence (highest wins):
 1. Per-thread config (`agent_model_id` + `agent_effort` in `configurable`) — set by webhooks/UI.
 2. Per-user dashboard profile override (`agent/dashboard/agent_overrides.py:load_profile`), keyed by resolved GitHub login.
 3. Team default model (`agent/dashboard/team_settings.py:get_team_default_model("agent")`).
+
+Custom instructions are layered into the system prompt from two stores: per-repo (`agent/dashboard/agent_instructions.py`, edited on the Repository Instructions page) and per-user (`agent/dashboard/user_instructions.py`, edited in the dashboard Profile tab or by the agent itself via `save_user_instructions`). Repo instructions and `AGENTS.md` win over user-level ones on conflict.
 
 Supported model IDs and per-model effort/reasoning rules live in `agent/dashboard/options.py`. Profile flags also drive run behavior — e.g. `profile_create_prs` enables the opt-in Always Create PRs policy. Model construction goes through `agent/utils/model.py` (`make_model`, `provider_model_kwargs`, `fallback_model_id_for`).
 

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -192,6 +192,12 @@ from .user_credentials import (
     get_currents_status,
     get_notion_status,
 )
+from .user_instructions import (
+    UserInstructionsUpdate,
+    delete_user_instructions,
+    get_user_instructions,
+    set_user_instructions,
+)
 from .user_mappings import (
     delete_mapping,
     get_mapping,
@@ -435,6 +441,32 @@ async def me(session: dict[str, Any] = _SESSION_DEP) -> dict[str, Any]:
         "is_admin": _session_is_admin(session),
         "slack_oauth_enabled": slack_oauth_configured(),
     }
+
+
+@router.get("/me/instructions")
+async def api_get_my_instructions(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    login = session["sub"]
+    record = await get_user_instructions(login)
+    return record or {"login": login, "instructions": ""}
+
+
+@router.put("/me/instructions")
+async def api_put_my_instructions(
+    body: UserInstructionsUpdate,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    login = session["sub"]
+    return await set_user_instructions(login, body.instructions, updated_by=login)
+
+
+@router.delete("/me/instructions")
+async def api_delete_my_instructions(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> Response:
+    await delete_user_instructions(session["sub"])
+    return Response(status_code=204)
 
 
 @router.get("/options")

--- a/agent/dashboard/user_instructions.py
+++ b/agent/dashboard/user_instructions.py
@@ -1,0 +1,89 @@
+"""Per-user custom instructions for the main coding agent.
+
+Each record holds a user-authored instruction prompt (edited in the dashboard
+Profile tab, or by the agent itself via ``save_user_instructions``) that is
+appended to the main agent's system prompt for runs that user triggers.
+
+Stored in its own namespace rather than on the ``["profiles"]`` record so
+agent-written updates and dashboard profile saves can't clobber each other.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from langgraph_sdk import get_client
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+USER_INSTRUCTIONS_NAMESPACE: list[str] = ["user_instructions"]
+
+MAX_USER_INSTRUCTIONS_CHARS = 20_000
+
+
+class UserInstructionsUpdate(BaseModel):
+    instructions: str = Field(default="", max_length=MAX_USER_INSTRUCTIONS_CHARS)
+
+
+def _client():
+    return get_client()
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def get_user_instructions(login: str) -> dict[str, Any] | None:
+    try:
+        item = await _client().store.get_item(USER_INSTRUCTIONS_NAMESPACE, login)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return None
+        raise
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def set_user_instructions(
+    login: str,
+    instructions: str,
+    updated_by: str = "",
+) -> dict[str, Any]:
+    existing = await get_user_instructions(login) or {}
+    value: dict[str, Any] = {
+        **existing,
+        "login": login,
+        "instructions": instructions[:MAX_USER_INSTRUCTIONS_CHARS],
+        "created_at": existing.get("created_at") or _now_iso(),
+        "updated_at": _now_iso(),
+        "updated_by": updated_by or login,
+    }
+    await _client().store.put_item(USER_INSTRUCTIONS_NAMESPACE, login, value)
+    return value
+
+
+async def delete_user_instructions(login: str) -> None:
+    await _client().store.delete_item(USER_INSTRUCTIONS_NAMESPACE, login)
+
+
+async def get_user_custom_instructions(login: str | None) -> str | None:
+    """Return the user's custom instructions for prompt injection, if any."""
+    if not login:
+        return None
+    try:
+        record = await get_user_instructions(login)
+    except Exception:
+        logger.debug("Failed to load user custom instructions for %s", login, exc_info=True)
+        return None
+    if not record:
+        return None
+    instructions = record.get("instructions")
+    if isinstance(instructions, str) and instructions.strip():
+        return instructions.strip()
+    return None

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -301,6 +301,23 @@ def _render_repo_instructions_section(instructions: str | None) -> str:
     )
 
 
+def _render_user_instructions_section(instructions: str | None) -> str:
+    if not instructions or not instructions.strip():
+        return ""
+    return (
+        "---\n\n"
+        "### Your Custom Instructions (user-level)\n\n"
+        "The triggering user configured the following standing instructions for "
+        "you. Treat them as mandatory rules with the same authority as this "
+        "system prompt: they override default behavior, but repository-specific "
+        "custom instructions and `AGENTS.md` win when they conflict. The user "
+        "edits them in the dashboard Profile tab; when they ask you to change a "
+        'standing preference ("always…", "never…", "from now on…"), update '
+        "them with the `save_user_instructions` tool.\n\n"
+        f"{instructions.strip()}"
+    )
+
+
 # Per-thread, main-agent prompt layered in front of OPEN_SWE_SHARED_BASE. Holds
 # only run-specific content (working dir, commit identity, plan/collaboration/
 # repo toggles); standing guidance lives in the shared base above.
@@ -319,6 +336,7 @@ SYSTEM_PROMPT_TEMPLATE = (
     + "{pr_policy_override_section}"
     + "{collaboration_section}"
     + "{repo_instructions_section}"
+    + "{user_instructions_section}"
     + "\n\n{shared_base_section}"
 )
 
@@ -333,6 +351,7 @@ def construct_system_prompt(
     plan_mode: bool = False,
     plan_url: str | None = None,
     repo_custom_instructions: str | None = None,
+    user_custom_instructions: str | None = None,
     thread_url: str | None = None,
     corridor_enabled: bool = False,
 ) -> str:
@@ -366,6 +385,7 @@ def construct_system_prompt(
         pr_policy_override_section=ALWAYS_CREATE_PR_SECTION if create_prs else "",
         collaboration_section=_render_collaboration_section(triggering_user_identity, thread_url),
         repo_instructions_section=_render_repo_instructions_section(repo_custom_instructions),
+        user_instructions_section=_render_user_instructions_section(user_custom_instructions),
         shared_base_section=OPEN_SWE_SHARED_BASE,
         commit_identity_name=commit_identity_name,
         commit_identity_email=commit_identity_email,

--- a/agent/server.py
+++ b/agent/server.py
@@ -117,6 +117,7 @@ from .tools import (
     report_platform_issue,
     request_pr_review,
     save_plan,
+    save_user_instructions,
     schedule_thread_wakeup,
     slack_add_reaction,
     slack_read_thread_messages,
@@ -206,6 +207,19 @@ async def _resolve_repo_custom_instructions(
         return await get_repo_agent_instructions(default_repo["owner"], default_repo["name"])
     except Exception:
         logger.debug("Failed to load repo custom agent instructions", exc_info=True)
+        return None
+
+
+async def _resolve_user_custom_instructions(login: str | None) -> str | None:
+    """Load user-level custom agent instructions for the triggering user."""
+    if not login:
+        return None
+    try:
+        from .dashboard.user_instructions import get_user_custom_instructions
+
+        return await get_user_custom_instructions(login)
+    except Exception:
+        logger.debug("Failed to load user custom agent instructions", exc_info=True)
         return None
 
 
@@ -804,7 +818,10 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             raise
         del github_token
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
-        repo_custom_instructions = await _resolve_repo_custom_instructions(prompt_default_repo)
+        repo_custom_instructions, user_custom_instructions = await asyncio.gather(
+            _resolve_repo_custom_instructions(prompt_default_repo),
+            _resolve_user_custom_instructions(self._profile_login),
+        )
 
         try:
             await client.threads.update(
@@ -842,6 +859,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 plan_mode=self._plan_mode,
                 plan_url=dashboard_plan_url(self._thread_id),
                 repo_custom_instructions=repo_custom_instructions,
+                user_custom_instructions=user_custom_instructions,
                 thread_url=dashboard_thread_url(self._thread_id),
                 corridor_enabled=self._corridor_enabled,
             ),
@@ -1027,6 +1045,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             approve_plan,
             enter_plan_mode,
             save_plan,
+            save_user_instructions,
             linear_comment,
             linear_create_issue,
             linear_delete_issue,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -28,6 +28,7 @@ _TOOL_MODULES = {
     "reply_to_finding_thread": ".reply_to_finding_thread",
     "resolve_finding_thread": ".resolve_finding_thread",
     "save_plan": ".save_plan",
+    "save_user_instructions": ".save_user_instructions",
     "schedule_thread_wakeup": ".schedule_thread_wakeup",
     "search_repo_code": ".search_repo_code",
     "slack_add_reaction": ".slack_add_reaction",
@@ -64,6 +65,7 @@ __all__ = [
     "reply_to_finding_thread",
     "resolve_finding_thread",
     "save_plan",
+    "save_user_instructions",
     "schedule_thread_wakeup",
     "search_repo_code",
     "slack_add_reaction",
@@ -100,6 +102,7 @@ if TYPE_CHECKING:
     from .request_pr_review import request_pr_review
     from .resolve_finding_thread import resolve_finding_thread
     from .save_plan import save_plan
+    from .save_user_instructions import save_user_instructions
     from .schedule_thread_wakeup import schedule_thread_wakeup
     from .search_repo_code import search_repo_code
     from .slack_add_reaction import slack_add_reaction

--- a/agent/tools/save_user_instructions.py
+++ b/agent/tools/save_user_instructions.py
@@ -1,0 +1,68 @@
+"""Tool: persist the triggering user's user-level custom instructions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..dashboard.agent_overrides import resolve_github_login
+from ..dashboard.user_instructions import MAX_USER_INSTRUCTIONS_CHARS, set_user_instructions
+from ..utils.json_types import as_json_object
+
+logger = logging.getLogger(__name__)
+
+
+async def save_user_instructions(instructions: str) -> dict[str, Any]:
+    """Save the triggering user's standing, user-level custom instructions.
+
+    Call this only when the user states a standing behavioural preference
+    ("always …", "never …", "from now on …", "stop doing …") that should apply
+    to all their future runs — not for one-off task details.
+
+    This is a full replacement: pass the COMPLETE new instruction text. Your
+    current user-level instructions are shown in your system prompt under "Your
+    Custom Instructions (user-level)"; preserve those lines and add the new rule
+    unless the user asked you to change or remove something. Pass an empty string
+    only when the user asks to clear their instructions.
+
+    Changes take effect from the next run onward, and the user can edit them in
+    the dashboard Profile tab.
+
+    Args:
+        instructions: The complete user-level instruction text (markdown).
+
+    Returns:
+        ``{"ok": True, "login": str, "instructions": str}`` on success, or
+        ``{"ok": False, "error": str}`` when the user could not be resolved.
+    """
+    login = resolve_github_login(as_json_object(get_config()))
+    if not login:
+        return {
+            "ok": False,
+            "error": (
+                "Could not resolve the triggering user's GitHub login, so there is no "
+                "profile to save instructions to. Ask the user to set them in the "
+                "dashboard Profile tab."
+            ),
+        }
+
+    text = (instructions or "").strip()
+    if len(text) > MAX_USER_INSTRUCTIONS_CHARS:
+        return {
+            "ok": False,
+            "error": f"instructions exceed the {MAX_USER_INSTRUCTIONS_CHARS} character limit",
+        }
+
+    try:
+        record = await set_user_instructions(login, text, updated_by="open-swe")
+    except Exception as exc:
+        logger.exception("Failed to save user instructions for %s", login)
+        return {"ok": False, "error": f"failed to save user instructions: {exc}"}
+
+    return {
+        "ok": True,
+        "login": login,
+        "instructions": record.get("instructions", text),
+    }

--- a/tests/agent/test_user_instructions.py
+++ b/tests/agent/test_user_instructions.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.dashboard.user_instructions import (
+    get_user_custom_instructions,
+    set_user_instructions,
+)
+from agent.prompt import construct_system_prompt
+from agent.tools.save_user_instructions import save_user_instructions
+
+
+@pytest.mark.asyncio
+async def test_set_user_instructions_upserts_record() -> None:
+    mock_put = AsyncMock()
+    with (
+        patch(
+            "agent.dashboard.user_instructions.get_user_instructions",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("agent.dashboard.user_instructions._client") as mock_client,
+    ):
+        mock_client.return_value.store.put_item = mock_put
+        record = await set_user_instructions("octo", "Always run the linter.")
+    assert record["login"] == "octo"
+    assert record["instructions"] == "Always run the linter."
+    assert record["updated_by"] == "octo"
+    mock_put.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_user_custom_instructions_trims_text() -> None:
+    with patch(
+        "agent.dashboard.user_instructions.get_user_instructions",
+        new_callable=AsyncMock,
+        return_value={"instructions": "  Be terse.\n"},
+    ):
+        assert await get_user_custom_instructions("octo") == "Be terse."
+
+
+@pytest.mark.asyncio
+async def test_get_user_custom_instructions_returns_none_when_empty() -> None:
+    with patch(
+        "agent.dashboard.user_instructions.get_user_instructions",
+        new_callable=AsyncMock,
+        return_value={"instructions": "   "},
+    ):
+        assert await get_user_custom_instructions("octo") is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_custom_instructions_without_login() -> None:
+    assert await get_user_custom_instructions(None) is None
+
+
+def test_construct_system_prompt_appends_user_instructions() -> None:
+    prompt = construct_system_prompt(
+        working_dir="/work",
+        user_custom_instructions="Always reply in bullet points.",
+    )
+    assert "Your Custom Instructions (user-level)" in prompt
+    assert "Always reply in bullet points." in prompt
+
+
+def test_construct_system_prompt_without_user_instructions() -> None:
+    prompt = construct_system_prompt(working_dir="/work")
+    assert "Your Custom Instructions (user-level)" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_save_user_instructions_requires_login() -> None:
+    with patch(
+        "agent.tools.save_user_instructions.get_config",
+        return_value={"configurable": {}},
+    ):
+        result = await save_user_instructions("Always run tests.")
+    assert result["ok"] is False
+    assert "GitHub login" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_save_user_instructions_writes_record() -> None:
+    mock_set = AsyncMock(return_value={"instructions": "Always run tests."})
+    with (
+        patch(
+            "agent.tools.save_user_instructions.get_config",
+            return_value={"configurable": {"github_login": "octo"}},
+        ),
+        patch("agent.tools.save_user_instructions.set_user_instructions", mock_set),
+    ):
+        result = await save_user_instructions("  Always run tests.  ")
+    assert result == {"ok": True, "login": "octo", "instructions": "Always run tests."}
+    mock_set.assert_awaited_once_with("octo", "Always run tests.", updated_by="open-swe")

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -338,6 +338,14 @@ export interface AgentInstructions {
   updated_at?: string
 }
 
+export interface UserInstructions {
+  login?: string
+  instructions: string
+  created_at?: string
+  updated_at?: string
+  updated_by?: string
+}
+
 export type RepoSnapshotStatus = "none" | "building" | "ready" | "failed"
 
 export interface RepoSnapshot {
@@ -644,6 +652,14 @@ export const api = {
     request<void>(`/review-styles/${encodeURIComponent(full_name)}`, {
       method: "DELETE",
     }),
+  getMyInstructions: () => request<UserInstructions>("/me/instructions"),
+  saveMyInstructions: (instructions: string) =>
+    request<UserInstructions>("/me/instructions", {
+      method: "PUT",
+      body: JSON.stringify({ instructions }),
+    }),
+  deleteMyInstructions: () =>
+    request<void>("/me/instructions", { method: "DELETE" }),
   listAgentInstructions: () =>
     request<Array<AgentInstructions>>("/agent-instructions"),
   createAgentInstructions: (full_name: string) =>

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -222,6 +222,7 @@ function MyInstructionsSection() {
     onSuccess,
     onError,
   })
+  const mutating = save.isPending || clear.isPending
 
   return (
     <SettingsSection
@@ -231,12 +232,29 @@ function MyInstructionsSection() {
       <div className="flex flex-col gap-3 p-4">
         {instructions.isLoading ? (
           <Skeleton className="h-40 w-full" />
+        ) : instructions.isError ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs text-destructive">
+              Could not load your instructions:{" "}
+              {instructions.error instanceof Error
+                ? instructions.error.message
+                : "unknown error"}
+              . Editing is disabled so a failed load can't overwrite them.
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void instructions.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
         ) : (
           <>
             <div className="flex flex-wrap items-center gap-2">
               <Button
                 size="sm"
-                disabled={!dirty || save.isPending}
+                disabled={!dirty || mutating}
                 onClick={() => void save.mutateAsync(value)}
               >
                 Save instructions
@@ -250,7 +268,7 @@ function MyInstructionsSection() {
                 size="sm"
                 variant="outline"
                 className="ml-auto"
-                disabled={clear.isPending || (!saved && !dirty)}
+                disabled={mutating || (!saved && !dirty)}
                 onClick={() => {
                   if (
                     !window.confirm(
@@ -268,6 +286,7 @@ function MyInstructionsSection() {
             <InstructionsEditor
               value={value}
               onChange={setDraft}
+              disabled={mutating}
               placeholder="e.g. Always run the linter before pushing. Prefer terse Slack updates."
             />
             {error && <p className="text-xs text-destructive">{error}</p>}

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -8,6 +8,7 @@ import type { CurrentsConnectBody, SessionUser } from "@/lib/api"
 import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { InstructionsEditor } from "@/components/InstructionsEditor"
 import {
   Select,
   SelectContent,
@@ -187,6 +188,92 @@ function NotificationsSection() {
           />
         }
       />
+    </SettingsSection>
+  )
+}
+
+function MyInstructionsSection() {
+  const qc = useQueryClient()
+  const instructions = useQuery({
+    queryKey: ["myInstructions"],
+    queryFn: api.getMyInstructions,
+  })
+  const [draft, setDraft] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const saved = instructions.data?.instructions ?? ""
+  const value = draft ?? saved
+  const dirty = draft !== null && draft !== saved
+
+  const onSuccess = () => {
+    void qc.invalidateQueries({ queryKey: ["myInstructions"] })
+    setDraft(null)
+    setError(null)
+  }
+  const onError = (e: Error) => setError(e.message)
+
+  const save = useMutation({
+    mutationFn: (next: string) => api.saveMyInstructions(next),
+    onSuccess,
+    onError,
+  })
+  const clear = useMutation({
+    mutationFn: () => api.deleteMyInstructions(),
+    onSuccess,
+    onError,
+  })
+
+  return (
+    <SettingsSection
+      title="My instructions"
+      description="Personal standing instructions appended to the coding agent's system prompt for every run you trigger, on any surface. Repository instructions and AGENTS.md win when they conflict. Open SWE can also update these for you when you ask it to always or never do something."
+    >
+      <div className="flex flex-col gap-3 p-4">
+        {instructions.isLoading ? (
+          <Skeleton className="h-40 w-full" />
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                disabled={!dirty || save.isPending}
+                onClick={() => void save.mutateAsync(value)}
+              >
+                Save instructions
+              </Button>
+              {dirty && (
+                <span className="text-xs text-muted-foreground">
+                  Unsaved changes
+                </span>
+              )}
+              <Button
+                size="sm"
+                variant="outline"
+                className="ml-auto"
+                disabled={clear.isPending || (!saved && !dirty)}
+                onClick={() => {
+                  if (
+                    !window.confirm(
+                      "Clear your personal instructions? This cannot be undone."
+                    )
+                  ) {
+                    return
+                  }
+                  void clear.mutateAsync()
+                }}
+              >
+                Clear
+              </Button>
+            </div>
+            <InstructionsEditor
+              value={value}
+              onChange={setDraft}
+              placeholder="e.g. Always run the linter before pushing. Prefer terse Slack updates."
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </>
+        )}
+      </div>
     </SettingsSection>
   )
 }
@@ -446,6 +533,8 @@ function MySettingsPage() {
           }
         />
       </SettingsSection>
+
+      <MyInstructionsSection />
 
       <NotificationsSection />
 


### PR DESCRIPTION
## Description

There was no way to give Open SWE personal, user-level instructions — only per-repo ones. This adds a per-user instruction prompt (new `["user_instructions"]` store namespace keyed by GitHub login, deliberately separate from `["profiles"]` so agent writes and profile saves can't clobber each other) that is appended to the main agent's system prompt for every run that user triggers. Users edit it in the Profile tab, and the agent can update it itself via the new `save_user_instructions` tool when asked to "always/never do X". Precedence: `AGENTS.md` > repo instructions > user instructions > defaults.

## Release Note

Users can now set personal, user-level agent instructions in the dashboard Profile tab, and ask Open SWE to update them in conversation.

## Test Plan
- [ ] In the Profile tab, save personal instructions, reload, and confirm they persist; Clear removes them.
- [ ] Trigger a run and confirm the "Your Custom Instructions (user-level)" section appears in the system prompt and is followed.
- [ ] Tell the agent "always do X from now on" and confirm `save_user_instructions` updates the Profile-tab text.

Made by [Open SWE](https://openswe.vercel.app/agents/019faf34-ba2f-7457-bf33-274d5458aa83)

## References
- Plan: https://openswe.vercel.app/agents/019faf34-ba2f-7457-bf33-274d5458aa83/plan