### PR TITLE
fix: show Kimi K3 context window

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -120,6 +120,9 @@ _PROFILE_LOADER_MODULES: dict[str, str] = {
     "google_genai": "langchain_google_genai.chat_models",
     "openai": "langchain_openai.chat_models.base",
 }
+_PROFILE_CONTEXT_WINDOW_FALLBACKS: dict[str, int] = {
+    "fireworks:accounts/fireworks/models/kimi-k3-code": 1_040_000,
+}
 
 
 @cache
@@ -143,13 +146,12 @@ def model_profile_context_window(model_id: str) -> int | None:
     if not provider or not model_name:
         return None
     loader = _profile_loader(provider)
-    if loader is None:
-        return None
-    profile = loader(model_name)
-    context_window = profile.get("max_input_tokens")
-    if isinstance(context_window, int) and context_window > 0:
-        return context_window
-    return None
+    if loader is not None:
+        profile = loader(model_name)
+        context_window = profile.get("max_input_tokens")
+        if isinstance(context_window, int) and context_window > 0:
+            return context_window
+    return _PROFILE_CONTEXT_WINDOW_FALLBACKS.get(model_id)
 
 
 def models_with_profile_context_windows(models: Sequence[ModelOption]) -> list[ModelOption]:

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -27,6 +27,7 @@ from agent.dashboard.team_settings import (
 STALE_ANTHROPIC = "anthropic:claude-opus-4-7"
 SUPPORTED_ANTHROPIC = "anthropic:claude-opus-5"
 SUPPORTED_OPENAI = "openai:gpt-5.6-sol"
+SUPPORTED_KIMI = "fireworks:accounts/fireworks/models/kimi-k3-code"
 DEPRECATED_ANTHROPIC = "anthropic:claude-opus-4-8"
 DEPRECATED_OPENAI = "openai:gpt-5.5"
 
@@ -96,14 +97,23 @@ def test_model_profile_context_window_uses_langchain_profile() -> None:
     assert model_profile_context_window(SUPPORTED_OPENAI) == 1_050_000
 
 
+def test_model_profile_context_window_falls_back_for_kimi_k3() -> None:
+    assert model_profile_context_window(SUPPORTED_KIMI) == 1_040_000
+
+
 def test_models_with_profile_context_windows_enriches_copies() -> None:
-    openai_models = [model for model in SUPPORTED_MODELS if model["id"].startswith("openai:")]
-    enriched = models_with_profile_context_windows(openai_models)
-    assert all("context_window" not in model for model in openai_models)
+    models = [
+        model
+        for model in SUPPORTED_MODELS
+        if model["id"].startswith("openai:") or model["id"] == SUPPORTED_KIMI
+    ]
+    enriched = models_with_profile_context_windows(models)
+    assert all("context_window" not in model for model in models)
     assert {model["id"]: model.get("context_window") for model in enriched} == {
         "openai:gpt-5.6-sol": 1_050_000,
         "openai:gpt-5.6-terra": 1_050_000,
         "openai:gpt-5.6-luna": 1_050_000,
+        SUPPORTED_KIMI: 1_040_000,
     }
 
 


### PR DESCRIPTION
## Description
Kimi K3 was missing context metadata because LangChain's bundled Fireworks profiles have not added the renamed model yet. Fall back to Fireworks' published 1.04M-token limit while keeping available LangChain profiles authoritative.

## Release Note
Show Kimi K3's 1.04M-token context window in the web UI.

## Test Plan
- [x] Verify Kimi K3 is enriched while profile-backed model metadata remains unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/29295bc8-83b0-80c1-15a0-e90ab9c52547)