### PR TITLE
feat: support forwarded Slack message context

### DIFF
--- a/agent/tools/slack_read_thread_messages.py
+++ b/agent/tools/slack_read_thread_messages.py
@@ -45,7 +45,7 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
     you can extract the channel_id (C0AME1J0) and convert the timestamp
     by inserting a dot 6 digits from the end (1776281321.762829).
 
-    Returns formatted thread messages with author names."""
+    Returns formatted thread messages with author names and forwarded-message context."""
     if not channel_id or not channel_id.strip():
         return {"success": False, "error": "channel_id is required"}
     if not message_ts or not message_ts.strip():

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -53,6 +53,8 @@ DEFAULT_LOADING_MESSAGES: tuple[str, ...] = (
 SLACK_WEB_LINK_FOOTER_LABEL = "Open in Web"
 SLACK_SECTION_TEXT_MAX_CHARS = 3000
 SLACK_FORWARDED_ATTACHMENT_MAX_COUNT = 10
+SLACK_FORWARDED_ATTACHMENT_MAX_DEPTH = 4
+SLACK_FORWARDED_ATTACHMENT_MAX_NODES = 50
 SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS = 8000
 
 
@@ -234,42 +236,61 @@ def select_slack_context_messages(
 
 
 def _format_forwarded_slack_attachments(attachments: Any) -> str:
-    if not isinstance(attachments, list):
-        return ""
-
     forwarded: list[str] = []
-    for attachment in attachments:
-        if len(forwarded) >= SLACK_FORWARDED_ATTACHMENT_MAX_COUNT:
-            break
-        if not isinstance(attachment, dict) or not any(
-            attachment.get(flag) is True
-            for flag in ("is_share", "is_msg_unfurl", "is_reply_unfurl")
-        ):
-            continue
+    rendered_count = 0
+    visited_count = 0
 
-        author = attachment.get("author_name")
-        author = author.strip() if isinstance(author, str) else ""
-        content = attachment.get("text")
-        if not isinstance(content, str) or not content.strip():
-            content = attachment.get("fallback")
-        content = content.strip() if isinstance(content, str) else ""
-        if len(content) > SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS:
-            content = content[:SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS].rstrip() + "… [truncated]"
-        source = attachment.get("from_url")
-        source = source.strip() if isinstance(source, str) else ""
+    def visit(values: Any, depth: int) -> None:
+        nonlocal rendered_count, visited_count
+        if depth > SLACK_FORWARDED_ATTACHMENT_MAX_DEPTH or not isinstance(values, list):
+            return
 
-        label = "[Forwarded Slack message"
-        if author:
-            label += f" from {author}"
-        label += "]"
-        parts = [label]
-        if content:
-            parts.append(content)
-        if source:
-            parts.append(f"Source: {source}")
-        if len(parts) > 1:
-            forwarded.append("\n".join(parts))
+        for attachment in values:
+            if (
+                rendered_count >= SLACK_FORWARDED_ATTACHMENT_MAX_COUNT
+                or visited_count >= SLACK_FORWARDED_ATTACHMENT_MAX_NODES
+            ):
+                return
+            visited_count += 1
+            if not isinstance(attachment, dict):
+                continue
 
+            is_forwarded = any(
+                attachment.get(flag) is True
+                for flag in ("is_share", "is_msg_unfurl", "is_reply_unfurl")
+            )
+            if is_forwarded:
+                author = attachment.get("author_name")
+                author = author.strip() if isinstance(author, str) else ""
+                content = attachment.get("text")
+                if not isinstance(content, str) or not content.strip():
+                    content = attachment.get("fallback")
+                content = content.strip() if isinstance(content, str) else ""
+                if len(content) > SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS:
+                    content = (
+                        content[:SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS].rstrip()
+                        + "… [truncated]"
+                    )
+                source = attachment.get("from_url")
+                source = source.strip() if isinstance(source, str) else ""
+
+                label = "[Forwarded Slack message"
+                if author:
+                    label += f" from {author}"
+                label += "]"
+                parts = [label]
+                if content:
+                    parts.append(content)
+                if source:
+                    parts.append(f"Source: {source}")
+                if len(parts) > 1:
+                    indentation = "  " * depth
+                    forwarded.append("\n".join(f"{indentation}{part}" for part in parts))
+                    rendered_count += 1
+
+            visit(attachment.get("attachments"), depth + 1)
+
+    visit(attachments, 0)
     return "\n".join(forwarded)
 
 

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -52,6 +52,8 @@ DEFAULT_LOADING_MESSAGES: tuple[str, ...] = (
 )
 SLACK_WEB_LINK_FOOTER_LABEL = "Open in Web"
 SLACK_SECTION_TEXT_MAX_CHARS = 3000
+SLACK_FORWARDED_ATTACHMENT_MAX_COUNT = 10
+SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS = 8000
 
 
 @dataclass(frozen=True)
@@ -231,26 +233,64 @@ def select_slack_context_messages(
     return up_to_current, "thread_start"
 
 
+def _format_forwarded_slack_attachments(attachments: Any) -> str:
+    if not isinstance(attachments, list):
+        return ""
+
+    forwarded: list[str] = []
+    for attachment in attachments:
+        if len(forwarded) >= SLACK_FORWARDED_ATTACHMENT_MAX_COUNT:
+            break
+        if not isinstance(attachment, dict) or not any(
+            attachment.get(flag) is True
+            for flag in ("is_share", "is_msg_unfurl", "is_reply_unfurl")
+        ):
+            continue
+
+        author = attachment.get("author_name")
+        author = author.strip() if isinstance(author, str) else ""
+        content = attachment.get("text")
+        if not isinstance(content, str) or not content.strip():
+            content = attachment.get("fallback")
+        content = content.strip() if isinstance(content, str) else ""
+        if len(content) > SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS:
+            content = content[:SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS].rstrip() + "… [truncated]"
+        source = attachment.get("from_url")
+        source = source.strip() if isinstance(source, str) else ""
+
+        label = "[Forwarded Slack message"
+        if author:
+            label += f" from {author}"
+        label += "]"
+        parts = [label]
+        if content:
+            parts.append(content)
+        if source:
+            parts.append(f"Source: {source}")
+        if len(parts) > 1:
+            forwarded.append("\n".join(parts))
+
+    return "\n".join(forwarded)
+
+
 def format_slack_messages_for_prompt(
     messages: list[dict[str, Any]],
     user_names_by_id: dict[str, str] | None = None,
     bot_user_id: str = "",
     bot_username: str = "",
 ) -> str:
-    """Format Slack messages into readable prompt text."""
+    """Format Slack messages, including forwarded context, as readable prompt text."""
     if not messages:
         return "(no thread messages available)"
 
     lines: list[str] = []
     for message in messages:
-        text = (
-            replace_bot_mention_with_username(
-                str(message.get("text", "")),
-                bot_user_id=bot_user_id,
-                bot_username=bot_username,
-            ).strip()
-            or "[non-text message]"
-        )
+        forwarded = _format_forwarded_slack_attachments(message.get("attachments"))
+        text = replace_bot_mention_with_username(
+            str(message.get("text", "")),
+            bot_user_id=bot_user_id,
+            bot_username=bot_username,
+        ).strip() or ("[forwarded message]" if forwarded else "[non-text message]")
         user_id = message.get("user")
         if isinstance(user_id, str) and user_id:
             author_name = (user_names_by_id or {}).get(user_id) or user_id
@@ -262,7 +302,10 @@ def format_slack_messages_for_prompt(
             else:
                 bot_name = message.get("username") or "Bot"
             author = f"@{bot_name}(bot)"
-        lines.append(f"{author}: {text}")
+        line = f"{author}: {text}"
+        if forwarded:
+            line += f"\n{forwarded}"
+        lines.append(line)
     return "\n".join(lines)
 
 

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -334,6 +334,7 @@ async def _process_slack_mention_impl(
     event_ts = event_data.get("event_ts", "")
     user_id = event_data.get("user_id", "")
     text = event_data.get("text", "")
+    attachments = event_data.get("attachments", [])
     bot_user_id = event_data.get("bot_user_id", "")
     channel_context_raw = event_data.get("channel_context")
     channel_context = (
@@ -378,8 +379,21 @@ async def _process_slack_mention_impl(
                 )
 
     thread_messages = await common.fetch_slack_thread_messages(channel_id, thread_ts)
-    if not any(str(message.get("ts")) == str(event_ts) for message in thread_messages):
-        thread_messages.append({"ts": event_ts, "text": text, "user": user_id})
+    current_message = next(
+        (message for message in thread_messages if str(message.get("ts")) == str(event_ts)),
+        None,
+    )
+    if current_message is None:
+        thread_messages.append(
+            {
+                "ts": event_ts,
+                "text": text,
+                "user": user_id,
+                "attachments": attachments,
+            }
+        )
+    elif attachments and not current_message.get("attachments"):
+        current_message["attachments"] = attachments
 
     treat_all_messages_as_mentions = bool(event_data.get("treat_all_messages_as_mentions"))
     context_messages, context_mode = common.select_slack_context_messages(

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -154,6 +154,7 @@ async def slack_webhook(
         "event_ts": event_ts,
         "user_id": user_id,
         "text": text,
+        "attachments": event.get("attachments", []),
         "bot_user_id": bot_user_id,
         "treat_all_messages_as_mentions": is_direct_message,
     }

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -306,6 +306,73 @@ def test_format_slack_messages_for_prompt_uses_forwarded_fallback() -> None:
     )
 
 
+def test_format_slack_messages_for_prompt_includes_nested_forwarded_attachments() -> None:
+    formatted = format_slack_messages_for_prompt(
+        [
+            {
+                "ts": "1.0",
+                "text": "nested context",
+                "user": "U123",
+                "attachments": [
+                    {
+                        "is_share": True,
+                        "author_name": "Bob",
+                        "text": "First level",
+                        "attachments": [
+                            {
+                                "is_share": True,
+                                "author_name": "Carol",
+                                "text": "Second level",
+                                "attachments": [
+                                    {
+                                        "is_reply_unfurl": True,
+                                        "author_name": "Dave",
+                                        "text": "Third level",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        {"U123": "alice"},
+    )
+
+    assert formatted == (
+        "@alice(U123): nested context\n"
+        "[Forwarded Slack message from Bob]\n"
+        "First level\n"
+        "  [Forwarded Slack message from Carol]\n"
+        "  Second level\n"
+        "    [Forwarded Slack message from Dave]\n"
+        "    Third level"
+    )
+
+
+def test_format_slack_messages_for_prompt_caps_forwarded_attachment_depth() -> None:
+    root: dict[str, object] = {
+        "is_share": True,
+        "text": "level 0",
+    }
+    current = root
+    for depth in range(1, slack_utils.SLACK_FORWARDED_ATTACHMENT_MAX_DEPTH + 2):
+        nested: dict[str, object] = {
+            "is_share": True,
+            "text": f"level {depth}",
+        }
+        current["attachments"] = [nested]
+        current = nested
+
+    formatted = format_slack_messages_for_prompt(
+        [{"ts": "1.0", "text": "context", "user": "U123", "attachments": [root]}],
+        {"U123": "alice"},
+    )
+
+    assert f"level {slack_utils.SLACK_FORWARDED_ATTACHMENT_MAX_DEPTH}" in formatted
+    assert f"level {slack_utils.SLACK_FORWARDED_ATTACHMENT_MAX_DEPTH + 1}" not in formatted
+
+
 def test_format_slack_messages_for_prompt_ignores_regular_unfurl_attachment() -> None:
     formatted = format_slack_messages_for_prompt(
         [

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -252,6 +252,76 @@ def test_format_slack_messages_for_prompt_replaces_bot_id_mention_in_text() -> N
     assert formatted == "@alice(U123): @open-swe status update?"
 
 
+def test_format_slack_messages_for_prompt_includes_forwarded_attachment() -> None:
+    formatted = format_slack_messages_for_prompt(
+        [
+            {
+                "ts": "1.0",
+                "text": "please handle this",
+                "user": "U123",
+                "attachments": [
+                    {
+                        "is_share": True,
+                        "author_name": "Bob",
+                        "text": "The forwarded request",
+                        "from_url": "https://example.slack.com/archives/C123/p123",
+                    }
+                ],
+            }
+        ],
+        {"U123": "alice"},
+    )
+
+    assert formatted == (
+        "@alice(U123): please handle this\n"
+        "[Forwarded Slack message from Bob]\n"
+        "The forwarded request\n"
+        "Source: https://example.slack.com/archives/C123/p123"
+    )
+
+
+def test_format_slack_messages_for_prompt_uses_forwarded_fallback() -> None:
+    formatted = format_slack_messages_for_prompt(
+        [
+            {
+                "ts": "1.0",
+                "text": "",
+                "user": "U123",
+                "attachments": [
+                    {
+                        "is_reply_unfurl": True,
+                        "author_name": "Bob",
+                        "fallback": "Fallback forwarded text",
+                    }
+                ],
+            }
+        ],
+        {"U123": "alice"},
+    )
+
+    assert formatted == (
+        "@alice(U123): [forwarded message]\n"
+        "[Forwarded Slack message from Bob]\n"
+        "Fallback forwarded text"
+    )
+
+
+def test_format_slack_messages_for_prompt_ignores_regular_unfurl_attachment() -> None:
+    formatted = format_slack_messages_for_prompt(
+        [
+            {
+                "ts": "1.0",
+                "text": "look at this link",
+                "user": "U123",
+                "attachments": [{"title": "Example", "text": "Unfurl preview"}],
+            }
+        ],
+        {"U123": "alice"},
+    )
+
+    assert formatted == "@alice(U123): look at this link"
+
+
 def test_post_slack_thread_reply_adds_web_context_block(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
@@ -626,6 +696,59 @@ def _setup_slack_mention_fakes(
     monkeypatch.setattr(webhook_common, "refresh_user_mapping_cache", fake_refresh_cache)
     monkeypatch.setattr(webhook_common, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(webhook_common, "_post_account_link_prompt", fake_post_prompt)
+
+
+def test_process_slack_mention_preserves_forwarded_attachment_from_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    _setup_slack_mention_fakes(monkeypatch, captured)
+
+    async def fake_fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[dict]:
+        return [
+            {"ts": thread_ts, "text": "thread root", "user": "U123"},
+            {
+                "ts": "1700000000.000200",
+                "text": "<@UBOT> handle this",
+                "user": "U123",
+            },
+        ]
+
+    async def fake_thread_exists(thread_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        webhook_common, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages
+    )
+    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+
+    asyncio.run(
+        slack_webhooks.process_slack_mention(
+            {
+                "channel_id": "C123",
+                "thread_ts": "1700000000.000100",
+                "event_ts": "1700000000.000200",
+                "user_id": "U123",
+                "text": "<@UBOT> handle this",
+                "attachments": [
+                    {
+                        "is_share": True,
+                        "author_name": "Teammate",
+                        "text": "Forwarded requirements",
+                    }
+                ],
+                "bot_user_id": "UBOT",
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    run_create = captured["run_create"]
+    assert isinstance(run_create, dict)
+    kwargs = run_create["kwargs"]
+    prompt_block = kwargs["input"]["messages"][0]["content"][0]
+    assert "[Forwarded Slack message from Teammate]" in prompt_block["text"]
+    assert "Forwarded requirements" in prompt_block["text"]
 
 
 def test_process_slack_mention_creates_thread_first_run_without_trace_reply(


### PR DESCRIPTION
## Description
Slack forwards arrive as message attachments, but Open SWE dropped them while formatting thread context. Preserve those attachments through webhook ingestion and surface bounded forwarded content through both automatic prompts and `slack_read_thread_messages`, including nested forwards with strict depth/node/count limits.

## Test Plan
- [x] Forwarded, fallback, ignored-unfurl, nested-depth, and webhook-context fixtures pass in `tests/slack/test_slack_context.py`

Made by [Open SWE](https://openswe.vercel.app/agents/1984d144-875a-1404-a8ef-4061df1402a6)