### PR TITLE
fix: correct Kimi K3 Fireworks model id and effort levels

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -70,7 +70,8 @@ SUPPORTED_MODELS: list[ModelOption] = [
     {
         "id": "fireworks:accounts/fireworks/models/kimi-k3",
         "label": "Kimi K3",
-        "efforts": ["low", "medium", "high"],
+        # K3 always reasons and only accepts low/high/max — "medium" is rejected.
+        "efforts": ["low", "high", "max"],
         "default_effort": "high",
         "supports_images": False,
     },

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -68,7 +68,7 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": True,
     },
     {
-        "id": "fireworks:accounts/fireworks/models/kimi-k3-code",
+        "id": "fireworks:accounts/fireworks/models/kimi-k3",
         "label": "Kimi K3",
         "efforts": ["low", "medium", "high"],
         "default_effort": "high",
@@ -105,7 +105,12 @@ DEPRECATED_MODEL_REPLACEMENTS: dict[str, str] = {
     "openai:gpt-5.5": "openai:gpt-5.6-sol",
     "google_genai:gemini-3.5-flash": "google_genai:gemini-3.6-flash",
     "fireworks:accounts/fireworks/models/kimi-k2p7-code": (
-        "fireworks:accounts/fireworks/models/kimi-k3-code"
+        "fireworks:accounts/fireworks/models/kimi-k3"
+    ),
+    # Never a real Fireworks deployment: the K2.7 rename kept the `-code` suffix,
+    # which K3 does not use, so selections stored under it 404 at request time.
+    "fireworks:accounts/fireworks/models/kimi-k3-code": (
+        "fireworks:accounts/fireworks/models/kimi-k3"
     ),
 }
 

--- a/tests/models/test_fireworks_model.py
+++ b/tests/models/test_fireworks_model.py
@@ -7,7 +7,7 @@ from agent.utils.model import (
     provider_model_kwargs,
 )
 
-KIMI_K3_ID = "fireworks:accounts/fireworks/models/kimi-k3-code"
+KIMI_K3_ID = "fireworks:accounts/fireworks/models/kimi-k3"
 
 
 def test_fireworks_reasoning_effort_maps_effort() -> None:
@@ -43,6 +43,15 @@ def test_renamed_kimi_k2p7_migrates_to_kimi_k3() -> None:
     assert provider_fallback_pair(
         "fireworks:accounts/fireworks/models/kimi-k2p7-code", "medium"
     ) == (KIMI_K3_ID, "medium")
+
+
+def test_kimi_k3_code_is_not_offered_and_migrates_to_the_deployed_id() -> None:
+    """`kimi-k3-code` was never deployed on Fireworks and 404s at request time."""
+    assert all(not m["id"].endswith("kimi-k3-code") for m in SUPPORTED_MODELS)
+    assert provider_fallback_pair("fireworks:accounts/fireworks/models/kimi-k3-code", "medium") == (
+        KIMI_K3_ID,
+        "medium",
+    )
 
 
 def test_provider_model_kwargs_for_fireworks_none_disables_reasoning() -> None:

--- a/tests/models/test_fireworks_model.py
+++ b/tests/models/test_fireworks_model.py
@@ -31,26 +31,33 @@ def test_kimi_k3_is_supported() -> None:
     kimi_k3 = next((m for m in SUPPORTED_MODELS if m["id"] == KIMI_K3_ID), None)
     assert kimi_k3 is not None
     assert kimi_k3.get("label") == "Kimi K3"
-    assert kimi_k3.get("efforts") == ["low", "medium", "high"]
+    # K3 always reasons, and `reasoning_effort` only accepts low/high/max.
+    assert kimi_k3.get("efforts") == ["low", "high", "max"]
     assert "none" not in kimi_k3.get("efforts", [])
+    assert "medium" not in kimi_k3.get("efforts", [])
     assert kimi_k3.get("default_effort") == "high"
     kwargs = provider_model_kwargs(KIMI_K3_ID, "high", max_tokens=16_000)
     assert kwargs.get("model_kwargs") == {"reasoning_effort": "high"}
 
 
 def test_renamed_kimi_k2p7_migrates_to_kimi_k3() -> None:
+    """K2.7's `medium` is not a K3 effort, so migration lands on K3's default."""
     assert all(not m["id"].endswith("kimi-k2p7-code") for m in SUPPORTED_MODELS)
     assert provider_fallback_pair(
         "fireworks:accounts/fireworks/models/kimi-k2p7-code", "medium"
-    ) == (KIMI_K3_ID, "medium")
+    ) == (KIMI_K3_ID, "high")
+    assert provider_fallback_pair("fireworks:accounts/fireworks/models/kimi-k2p7-code", "low") == (
+        KIMI_K3_ID,
+        "low",
+    )
 
 
 def test_kimi_k3_code_is_not_offered_and_migrates_to_the_deployed_id() -> None:
     """`kimi-k3-code` was never deployed on Fireworks and 404s at request time."""
     assert all(not m["id"].endswith("kimi-k3-code") for m in SUPPORTED_MODELS)
-    assert provider_fallback_pair("fireworks:accounts/fireworks/models/kimi-k3-code", "medium") == (
+    assert provider_fallback_pair("fireworks:accounts/fireworks/models/kimi-k3-code", "high") == (
         KIMI_K3_ID,
-        "medium",
+        "high",
     )
 
 

--- a/ui/src/features/agents/components/ModelPicker.test.tsx
+++ b/ui/src/features/agents/components/ModelPicker.test.tsx
@@ -31,7 +31,7 @@ const MODELS: Array<ModelOption> = [
     supports_images: true,
   },
   {
-    id: "fireworks:accounts/fireworks/models/kimi-k3-code",
+    id: "fireworks:accounts/fireworks/models/kimi-k3",
     label: "Kimi K3",
     efforts: ["low", "medium", "high"],
     default_effort: "high",
@@ -152,7 +152,7 @@ describe("ModelPicker", () => {
     fireEvent.click(screen.getByRole("option", { name: "Kimi K3 High" }))
 
     expect(onSelectionChange).toHaveBeenCalledWith({
-      modelId: "fireworks:accounts/fireworks/models/kimi-k3-code",
+      modelId: "fireworks:accounts/fireworks/models/kimi-k3",
       effort: "high",
     })
   })

--- a/ui/src/features/agents/components/ModelPicker.test.tsx
+++ b/ui/src/features/agents/components/ModelPicker.test.tsx
@@ -33,7 +33,7 @@ const MODELS: Array<ModelOption> = [
   {
     id: "fireworks:accounts/fireworks/models/kimi-k3",
     label: "Kimi K3",
-    efforts: ["low", "medium", "high"],
+    efforts: ["low", "high", "max"],
     default_effort: "high",
     supports_images: false,
   },


### PR DESCRIPTION
## Description

Two config errors on the Kimi K3 entry, both introduced by the mechanical K2.7 → K3 rename in #1818.

1. **Wrong model id.** `accounts/fireworks/models/kimi-k3-code` was never deployed — Fireworks publishes `accounts/fireworks/models/kimi-k3` (the `-code` suffix is a K2.7-ism). Every run 404s with `Model not found, inaccessible, and/or not deployed`. The broken id is added to `DEPRECATED_MODEL_REPLACEMENTS` so already-stored profile/team/thread/schedule selections migrate instead of continuing to 404.
2. **Wrong effort levels.** K3 always reasons and its top-level `reasoning_effort` accepts only `low` / `high` / `max` (vendor default `max`); it has no `medium` and does not take the K2.x `thinking` parameter. We offered `low` / `medium` / `high`, so a `medium` selection is rejected by the API. Now `low` / `high` / `max`, keeping `high` as our default for consistency with the other Fireworks models. Existing `medium` selections coerce to the default via the usual `model_supports_effort` gates.

Note for whoever picks up `open-swe/kimi-k3-context-window`: that branch hardcodes a context-window fallback keyed on `kimi-k3-code` (1,040,000). It needs rebasing onto the corrected id, and the published limit is 1,048,576.

## Release Note

Fixes Kimi K3 failing with a Fireworks 404, and removes the unsupported `medium` reasoning effort.

## Test Plan
- [ ] Select Kimi K3 in the model picker and confirm a run reaches the model instead of 404ing.
- [ ] Confirm the effort menu offers Low/High/Max, and that a run at Max is accepted.
- [ ] With `kimi-k3-code` or a `medium` effort stored as a profile/team default, confirm the selection migrates rather than erroring.

Made by [Open SWE](https://openswe.vercel.app/agents/019fb449-6587-76c2-b2b2-23be4525b0d1)