### PR TITLE
fix: populate login→email mapping on GitHub OAuth login

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -417,6 +417,17 @@ async def auth_callback(request: Request, code: str, state: str) -> RedirectResp
 
     await upsert_access_token_from_github_response(login, email or "", token_data)
 
+    # Populate the login→email mapping so GitHub-sourced webhook handlers
+    # (process_github_issue, process_github_pr_comment) can resolve a
+    # per-user token without requiring Slack OAuth.
+    if email:
+        await upsert_mapping(
+            github_login=login,
+            work_email=email,
+            source="github_oauth",
+            status="active",
+        )
+
     session_jwt = issue_session(login=login, email=email, avatar_url=user.get("avatar_url"))
     response = RedirectResponse(redirect_to, status_code=302)
     _set_session_cookie(response, session_jwt)

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 USER_MAPPINGS_NAMESPACE: list[str] = ["user_mappings"]
 
-MappingSource = Literal["slack_oauth"]
+MappingSource = Literal["slack_oauth", "github_oauth"]
 MappingStatus = Literal["active", "pending"]
 
 

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -87,6 +87,16 @@ def test_auth_callback_preserves_relative_plan_redirect(monkeypatch) -> None:
     ) -> None:
         persisted.update({"login": login, "email": email, "data": data})
 
+    async def fake_upsert_mapping(
+        *,
+        github_login: str,
+        work_email: str,
+        slack_user_id: str | None = None,
+        source: str = "github_oauth",
+        status: str = "active",
+    ) -> dict[str, Any]:
+        return {"github_login": github_login, "work_email": work_email}
+
     monkeypatch.setattr(routes, "exchange_code", fake_exchange_code)
     monkeypatch.setattr(routes, "fetch_github_user", fake_fetch_github_user)
     monkeypatch.setattr(routes, "enforce_org_login_gate", fake_enforce_org_login_gate)


### PR DESCRIPTION
The login→email user mapping was only written by the Slack OAuth callback, making Slack configuration a hard dependency for GitHub-webhook-triggered agent runs. When a user triggered the agent via a GitHub issue comment or PR comment (@open-swe tag), process_github_issue and process_github_pr_comment called email_for_login() to resolve a per-user GitHub token. Without a prior Slack OAuth link, the mapping was absent, the email resolved to None, and the webhook handler silently returned — the agent never started.

The GitHub OAuth login callback (/auth/callback) already fetches the user's verified primary email via fetch_github_user() (which calls GET /user and falls back to GET /user/emails), but it only stored the OAuth token and did not write a user_mappings record.

This change calls upsert_mapping() in the GitHub OAuth callback so that the login→email mapping is populated at login time, independent of Slack. The existing upsert_mapping() implementation preserves a pre-existing slack_user_id when the new record carries none, so users who previously linked Slack are unaffected.

Changes:
- agent/dashboard/user_mappings.py: add "github_oauth" to the MappingSource literal type.
- agent/dashboard/routes.py: call upsert_mapping() in auth_callback() after fetch_github_user() returns a verified email.

Affected scope:
- process_github_issue — now works without Slack configured
- process_github_pr_comment — now works without Slack configured
- Slack OAuth callback — unchanged (still writes mappings with slack_user_id populated)
- Dashboard token resolution for source="github" — now finds a mapping via email_for_login() without requiring a prior Slack link