### PR TITLE
fix: cancel active dashboard runs by ID

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1493,6 +1493,26 @@ async def send_dashboard_message(
     return _thread_summary(thread)
 
 
+async def _cancel_active_thread_runs(client: Any, thread_id: str) -> None:
+    run_ids: set[str] = set()
+    for status in ("pending", "running"):
+        offset = 0
+        while True:
+            runs = await client.runs.list(thread_id, status=status, limit=100, offset=offset)
+            run_ids.update(
+                run_id for run in runs if isinstance((run_id := run.get("run_id")), str) and run_id
+            )
+            if len(runs) < 100:
+                break
+            offset += len(runs)
+    if run_ids:
+        await client.runs.cancel_many(
+            thread_id=thread_id,
+            run_ids=sorted(run_ids),
+            action="interrupt",
+        )
+
+
 async def cancel_dashboard_thread(
     thread_id: str, login: str, *, email: str | None = None
 ) -> dict[str, Any]:
@@ -1514,7 +1534,7 @@ async def cancel_dashboard_thread(
     _assert_thread_owner(metadata, login, email)
 
     try:
-        await client.runs.cancel_many(thread_id=thread_id, status="all", action="interrupt")
+        await _cancel_active_thread_runs(client, thread_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to cancel active runs for thread %s", thread_id)
         raise HTTPException(502, "failed to request thread cancellation") from exc
@@ -1535,7 +1555,7 @@ async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
         raise HTTPException(404, "thread not found") from exc
 
     try:
-        await client.runs.cancel_many(thread_id=thread_id, status="all", action="interrupt")
+        await _cancel_active_thread_runs(client, thread_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to cancel active runs for thread %s", thread_id)
         raise HTTPException(502, "failed to request thread cancellation") from exc

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1768,6 +1768,10 @@ async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypa
             thread["metadata"].update(metadata)
 
     class FakeRuns:
+        async def list(self, thread_id: str, **kwargs: object) -> list[dict[str, str]]:
+            calls.append(("list", {"thread_id": thread_id, **kwargs}))
+            return [{"run_id": f"{kwargs['status']}-run"}]
+
         async def cancel_many(self, **kwargs: object) -> None:
             calls.append(("cancel_many", kwargs))
 
@@ -1779,9 +1783,13 @@ async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypa
 
     result = await thread_api.cancel_dashboard_thread("thread-1", "owner")
 
-    assert calls[0] == (
+    assert calls[2] == (
         "cancel_many",
-        {"thread_id": "thread-1", "status": "all", "action": "interrupt"},
+        {
+            "thread_id": "thread-1",
+            "run_ids": ["pending-run", "running-run"],
+            "action": "interrupt",
+        },
     )
     # Reported as interrupted even though the platform still says busy.
     assert result["status"] == "interrupted"
@@ -1842,6 +1850,10 @@ async def test_admin_cancel_dashboard_thread_interrupts_all_active_runs(monkeypa
             thread["metadata"].update(metadata)
 
     class FakeRuns:
+        async def list(self, thread_id: str, **kwargs: object) -> list[dict[str, str]]:
+            calls.append(("list", {"thread_id": thread_id, **kwargs}))
+            return [{"run_id": f"{kwargs['status']}-run"}]
+
         async def cancel_many(self, **kwargs: object) -> None:
             calls.append(("cancel_many", kwargs))
 
@@ -1853,11 +1865,15 @@ async def test_admin_cancel_dashboard_thread_interrupts_all_active_runs(monkeypa
 
     result = await thread_api.admin_cancel_dashboard_thread("thread-1")
 
-    assert calls[0] == (
+    assert calls[2] == (
         "cancel_many",
-        {"thread_id": "thread-1", "status": "all", "action": "interrupt"},
+        {
+            "thread_id": "thread-1",
+            "run_ids": ["pending-run", "running-run"],
+            "action": "interrupt",
+        },
     )
-    assert calls[1][0] == "update"
+    assert calls[3][0] == "update"
     assert thread["metadata"]["latest_run_status"] == "interrupted"
     assert result["id"] == "thread-1"
 
@@ -1874,6 +1890,9 @@ async def test_admin_cancel_dashboard_thread_does_not_update_on_cancel_failure(m
             updated = True
 
     class FakeRuns:
+        async def list(self, thread_id: str, **kwargs: object) -> list[dict[str, str]]:
+            return [{"run_id": f"{kwargs['status']}-run"}]
+
         async def cancel_many(self, **kwargs: object) -> None:
             raise RuntimeError("runtime unavailable")
 

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -183,6 +183,46 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     });
   });
 
+  test("stops a Slack-started run from the web app", async ({ page }) => {
+    await loginAs(page, SAME_USER);
+    await page.goto("/mock/slack");
+    await page.locator("#reset").click();
+
+    const send = await page.request.post("/mock/slack/send", {
+      data: {
+        text: "<@U0BOT> E2E_BUSY_HOLD please add a greet() helper and open a PR",
+      },
+    });
+    expect(send.ok()).toBeTruthy();
+    const { thread_id: threadId } = (await send.json()) as {
+      thread_id: string;
+    };
+
+    await page.goto(`/agents/${threadId}`);
+    const stopButton = page.getByRole("button", { name: "Stop run" });
+    await expect(stopButton).toBeVisible();
+
+    const cancelResponsePromise = page.waitForResponse((response) => {
+      const path = new URL(response.url()).pathname;
+      return (
+        response.request().method() === "POST" &&
+        path === `/dashboard/api/threads/${threadId}/cancel`
+      );
+    });
+    await stopButton.click();
+
+    const cancelResponse = await cancelResponsePromise;
+    expect(cancelResponse.ok()).toBeTruthy();
+    await expect(cancelResponse.json()).resolves.toMatchObject({
+      id: threadId,
+      status: "interrupted",
+    });
+    await expect(
+      page.getByRole("button", { name: "Send message" }),
+    ).toBeVisible();
+    await expect(stopButton).toHaveCount(0);
+  });
+
   test("a DIFFERENT user can post, and their message is attributed", async ({
     page,
   }) => {


### PR DESCRIPTION
## Description
A Playwright reproduction showed the web stop button returned 502 because LangGraph rejects `cancel_many` requests that combine `thread_id` with a global `status` filter. Resolve the thread's active run IDs first, then cancel those IDs, with end-to-end coverage for Slack-started runs.

## Test Plan
- [x] Playwright stops a held Slack-originated run from the real dashboard
- [x] Focused dashboard cancellation unit tests and static checks

Made by [Open SWE](https://openswe.vercel.app/agents/4a34c63d-5634-08a5-0c11-c75a28faacfa)