### PR TITLE
feat: support max reasoning for GPT-5.6 Luna

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -56,7 +56,7 @@ SUPPORTED_MODELS: list[ModelOption] = [
     {
         "id": "openai:gpt-5.6-luna",
         "label": "GPT-5.6 Luna",
-        "efforts": ["none", "low", "medium", "high", "xhigh"],
+        "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
         "default_effort": "xhigh",
         "supports_images": True,
     },

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -54,7 +54,7 @@ async def close_cached_models() -> None:
                 await result
 
 
-OpenAIReasoningEffort = Literal["none", "low", "medium", "high", "xhigh"]
+OpenAIReasoningEffort = Literal["none", "low", "medium", "high", "xhigh", "max"]
 # OpenAI's Responses API only returns human-readable reasoning text when a
 # summary is requested; without it, reasoning happens silently (billed in
 # output tokens) and the reasoning content block arrives empty.
@@ -207,6 +207,8 @@ def openai_reasoning_for(
         return {"effort": "high", "summary": "auto"}
     if effort == "xhigh":
         return {"effort": "xhigh", "summary": "auto"}
+    if effort == "max":
+        return {"effort": "max", "summary": "auto"}
     return None
 
 


### PR DESCRIPTION
## Description
Expose `max` reasoning for GPT-5.6 Luna and map it to the OpenAI Responses API reasoning payload.

## Release Note
GPT-5.6 Luna now supports max reasoning effort.

## Test Plan
- [ ] Select Luna with Max effort and verify a model run succeeds.

Made by [Open SWE](https://openswe.vercel.app/agents/019fcec2-e260-72e2-a7e1-b501afcfc4cf)