### PR TITLE
feat: add user-managed agent skills

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
@@ -138,6 +138,8 @@ from .schedules import (
     update_agent_schedule,
 )
 from .skills import (
+    DEFAULT_SKILLS_PAGE_SIZE,
+    MAX_SKILLS_PAGE_SIZE,
     SkillCreate,
     SkillUpdate,
     create_skill,
@@ -1511,9 +1513,11 @@ async def api_delete_agent_instructions(
 
 @router.get("/skills")
 async def api_list_skills(
+    limit: int = Query(DEFAULT_SKILLS_PAGE_SIZE, ge=1, le=MAX_SKILLS_PAGE_SIZE),
+    offset: int = Query(0, ge=0),
     session: dict[str, Any] = _SESSION_DEP,
-) -> list[dict[str, Any]]:
-    return await list_skills(session["sub"])
+) -> dict[str, Any]:
+    return await list_skills(session["sub"], limit=limit, offset=offset)
 
 
 @router.post("/skills")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -137,6 +137,14 @@ from .schedules import (
     list_agent_schedules,
     update_agent_schedule,
 )
+from .skills import (
+    SkillCreate,
+    SkillUpdate,
+    create_skill,
+    delete_skill,
+    list_skills,
+    update_skill,
+)
 from .slack_oauth import (
     SLACK_STATE_COOKIE_NAME,
     build_authorize_url,
@@ -1498,6 +1506,39 @@ async def api_delete_agent_instructions(
     if not record:
         raise HTTPException(404, "agent instructions not found")
     await delete_agent_instructions(full_name)
+    return Response(status_code=204)
+
+
+@router.get("/skills")
+async def api_list_skills(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> list[dict[str, Any]]:
+    return await list_skills(session["sub"])
+
+
+@router.post("/skills")
+async def api_create_skill(
+    body: SkillCreate,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await create_skill(session["sub"], body)
+
+
+@router.put("/skills/{name}")
+async def api_update_skill(
+    name: str,
+    body: SkillUpdate,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await update_skill(session["sub"], name, body)
+
+
+@router.delete("/skills/{name}")
+async def api_delete_skill(
+    name: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> Response:
+    await delete_skill(session["sub"], name)
     return Response(status_code=204)
 
 

--- a/agent/dashboard/skills.py
+++ b/agent/dashboard/skills.py
@@ -1,0 +1,137 @@
+"""Per-user Agent Skills stored as virtual ``SKILL.md`` files."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import HTTPException
+from langgraph_sdk import get_client
+from pydantic import BaseModel, Field, field_validator
+
+SKILLS_NAMESPACE = "user_skills"
+MAX_SKILL_NAME_CHARS = 64
+MAX_SKILL_DESCRIPTION_CHARS = 1024
+MAX_SKILL_INSTRUCTIONS_CHARS = 20_000
+_SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+class SkillCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=MAX_SKILL_NAME_CHARS)
+    description: str = Field(min_length=1, max_length=MAX_SKILL_DESCRIPTION_CHARS)
+    instructions: str = Field(default="", max_length=MAX_SKILL_INSTRUCTIONS_CHARS)
+
+    @field_validator("name")
+    @classmethod
+    def _valid_name(cls, value: str) -> str:
+        value = value.strip()
+        if not _SKILL_NAME_RE.fullmatch(value):
+            raise ValueError("name must use lowercase letters, numbers, and single hyphens")
+        return value
+
+    @field_validator("description")
+    @classmethod
+    def _non_empty_description(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("description cannot be empty")
+        return value
+
+
+class SkillUpdate(BaseModel):
+    description: str = Field(min_length=1, max_length=MAX_SKILL_DESCRIPTION_CHARS)
+    instructions: str = Field(default="", max_length=MAX_SKILL_INSTRUCTIONS_CHARS)
+
+    @field_validator("description")
+    @classmethod
+    def _non_empty_description(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("description cannot be empty")
+        return value
+
+
+def _client():
+    return get_client()
+
+
+def _namespace(login: str) -> list[str]:
+    return [SKILLS_NAMESPACE, login]
+
+
+def _key(name: str) -> str:
+    return f"/{name}/SKILL.md"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _content(name: str, description: str, instructions: str) -> str:
+    return (
+        "---\n"
+        f"name: {json.dumps(name)}\n"
+        f"description: {json.dumps(description)}\n"
+        "---\n\n"
+        f"{instructions.strip()}\n"
+    )
+
+
+def _record(
+    name: str, description: str, instructions: str, existing: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    now = _now_iso()
+    return {
+        "name": name,
+        "description": description,
+        "instructions": instructions,
+        "content": _content(name, description, instructions),
+        "encoding": "utf-8",
+        "created_at": (existing or {}).get("created_at") or now,
+        "updated_at": now,
+    }
+
+
+def _value(item: Any) -> dict[str, Any] | None:
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def get_skill(login: str, name: str) -> dict[str, Any] | None:
+    item = await _client().store.get_item(_namespace(login), _key(name))
+    return _value(item) if item else None
+
+
+async def list_skills(login: str) -> list[dict[str, Any]]:
+    result = await _client().store.search_items(_namespace(login), limit=1000)
+    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+    skills = [value for item in items or [] if (value := _value(item)) is not None]
+    skills.sort(key=lambda skill: skill.get("name", ""))
+    return skills
+
+
+async def create_skill(login: str, body: SkillCreate) -> dict[str, Any]:
+    if await get_skill(login, body.name):
+        raise HTTPException(409, "skill already exists")
+    value = _record(body.name, body.description, body.instructions)
+    await _client().store.put_item(_namespace(login), _key(body.name), value)
+    return value
+
+
+async def update_skill(login: str, name: str, body: SkillUpdate) -> dict[str, Any]:
+    SkillCreate(name=name, description=body.description, instructions=body.instructions)
+    existing = await get_skill(login, name)
+    if not existing:
+        raise HTTPException(404, "skill not found")
+    value = _record(name, body.description, body.instructions, existing)
+    await _client().store.put_item(_namespace(login), _key(name), value)
+    return value
+
+
+async def delete_skill(login: str, name: str) -> None:
+    SkillCreate(name=name, description="valid")
+    if not await get_skill(login, name):
+        raise HTTPException(404, "skill not found")
+    await _client().store.delete_item(_namespace(login), _key(name))

--- a/agent/dashboard/skills.py
+++ b/agent/dashboard/skills.py
@@ -15,6 +15,8 @@ SKILLS_NAMESPACE = "user_skills"
 MAX_SKILL_NAME_CHARS = 64
 MAX_SKILL_DESCRIPTION_CHARS = 1024
 MAX_SKILL_INSTRUCTIONS_CHARS = 20_000
+DEFAULT_SKILLS_PAGE_SIZE = 100
+MAX_SKILLS_PAGE_SIZE = 100
 _SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
@@ -104,12 +106,15 @@ async def get_skill(login: str, name: str) -> dict[str, Any] | None:
     return _value(item) if item else None
 
 
-async def list_skills(login: str) -> list[dict[str, Any]]:
-    result = await _client().store.search_items(_namespace(login), limit=1000)
+async def list_skills(login: str, *, limit: int, offset: int) -> dict[str, Any]:
+    result = await _client().store.search_items(_namespace(login), limit=limit + 1, offset=offset)
     items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    skills = [value for item in items or [] if (value := _value(item)) is not None]
+    skills = [value for item in (items or [])[:limit] if (value := _value(item)) is not None]
     skills.sort(key=lambda skill: skill.get("name", ""))
-    return skills
+    return {
+        "items": skills,
+        "next_offset": offset + limit if len(items or []) > limit else None,
+    }
 
 
 async def create_skill(login: str, body: SkillCreate) -> dict[str, Any]:

--- a/agent/server.py
+++ b/agent/server.py
@@ -147,6 +147,7 @@ from .utils.model import (
     make_model,
     provider_model_kwargs,
 )
+from .utils.read_only_backend import ReadOnlyBackend
 from .utils.sandbox import create_sandbox
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 from .utils.sandbox_state import (
@@ -1042,8 +1043,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         agent_backend = CompositeBackend(
             default=backend,
             routes={
-                USER_SKILLS_ROUTE: StoreBackend(
-                    namespace=lambda _runtime, login=profile_login: (SKILLS_NAMESPACE, login)
+                USER_SKILLS_ROUTE: ReadOnlyBackend(
+                    StoreBackend(
+                        namespace=lambda _runtime, login=profile_login: (SKILLS_NAMESPACE, login)
+                    )
                 )
             },
         )

--- a/agent/server.py
+++ b/agent/server.py
@@ -30,7 +30,9 @@ warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarnin
 
 from deepagents import create_deep_agent
 from deepagents.backends import LangSmithSandbox
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.protocol import BackendProtocol, SandboxBackendProtocol
+from deepagents.backends.store import StoreBackend
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolRetryMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
@@ -53,6 +55,7 @@ from .dashboard.options import (
     model_supports_effort,
 )
 from .dashboard.repo_snapshots import resolve_repo_snapshot_id
+from .dashboard.skills import SKILLS_NAMESPACE
 from .dashboard.team_settings import (
     get_effective_gateway_enabled,
     get_team_default_model_pair,
@@ -160,6 +163,7 @@ from .utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
 client = get_client()
 
 DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS = 5.0
+USER_SKILLS_ROUTE = "/skills/"
 
 
 def _tool_loader_timeout_seconds() -> float:
@@ -575,8 +579,8 @@ def _subagent_model_timeout_middleware() -> list[AgentMiddleware[Any, Any, Any]]
     return cast(list[AgentMiddleware[Any, Any, Any]], [ModelCallTimeoutMiddleware()])
 
 
-def _general_purpose_subagent(model: BaseChatModel) -> SubAgent:
-    return {
+def _general_purpose_subagent(model: BaseChatModel, skills: list[str] | None = None) -> SubAgent:
+    subagent: SubAgent = {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
         "description": GENERAL_PURPOSE_SUBAGENT["description"],
         # Deep Agents' default GP prompt covers only task mechanics; the shared
@@ -586,6 +590,9 @@ def _general_purpose_subagent(model: BaseChatModel) -> SubAgent:
         "model": model,
         "middleware": _subagent_model_timeout_middleware(),
     }
+    if skills:
+        subagent["skills"] = skills
+    return subagent
 
 
 BROWSER_SUBAGENT_DESCRIPTION = (
@@ -1029,6 +1036,18 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         )
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)
+    agent_backend: BackendProtocol = backend
+    skill_sources: list[str] | None = None
+    if profile_login:
+        agent_backend = CompositeBackend(
+            default=backend,
+            routes={
+                USER_SKILLS_ROUTE: StoreBackend(
+                    namespace=lambda _runtime, login=profile_login: (SKILLS_NAMESPACE, login)
+                )
+            },
+        )
+        skill_sources = [USER_SKILLS_ROUTE]
     main_model = _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
     subagent_model = _make_model_or_defer(
         subagent_model_id,
@@ -1069,10 +1088,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             *notion_tools,
         ],
         subagents=[
-            _general_purpose_subagent(subagent_model),
+            _general_purpose_subagent(subagent_model, skill_sources),
             *([_browser_subagent(subagent_model, browser_tools)] if browser_tools else []),
         ],
-        backend=backend,
+        skills=skill_sources,
+        backend=agent_backend,
         middleware=cast(
             list[AgentMiddleware[Any, Any, Any]],
             [

--- a/agent/utils/read_only_backend.py
+++ b/agent/utils/read_only_backend.py
@@ -1,0 +1,63 @@
+"""Read-only adapter for virtual backend routes."""
+
+from __future__ import annotations
+
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    FileDownloadResponse,
+    GlobResult,
+    GrepResult,
+    LsResult,
+    ReadResult,
+)
+
+
+class ReadOnlyBackend(BackendProtocol):
+    """Delegate backend reads while rejecting inherited mutation operations."""
+
+    def __init__(self, backend: BackendProtocol) -> None:
+        self._backend = backend
+
+    def ls(self, path: str) -> LsResult:
+        return self._backend.ls(path)
+
+    async def als(self, path: str) -> LsResult:
+        return await self._backend.als(path)
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        return self._backend.read(file_path, offset, limit)
+
+    async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        return await self._backend.aread(file_path, offset, limit)
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
+    ) -> GrepResult:
+        return self._backend.grep(pattern, path, glob, max_count=max_count)
+
+    async def agrep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
+    ) -> GrepResult:
+        return await self._backend.agrep(pattern, path, glob, max_count=max_count)
+
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
+        return self._backend.glob(pattern, path)
+
+    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
+        return await self._backend.aglob(pattern, path)
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        return self._backend.download_files(paths)
+
+    async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        return await self._backend.adownload_files(paths)

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -16,6 +16,7 @@ from deepagents.backends.composite import CompositeBackend
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import get_agent
+from agent.utils.read_only_backend import ReadOnlyBackend
 from agent.utils.sandbox_state import SandboxBackendProxy
 
 
@@ -92,6 +93,11 @@ async def test_agent_is_built_with_a_backend_for_eviction_and_summarization() ->
 async def test_agent_wires_user_skills_into_main_and_general_purpose_agents() -> None:
     captured = await _capture_create_deep_agent_kwargs()
     assert captured["skills"] == ["/skills/"]
+    backend = captured["backend"]
+    assert isinstance(backend, CompositeBackend)
+    assert isinstance(backend.routes["/skills/"], ReadOnlyBackend)
+    with pytest.raises(NotImplementedError):
+        backend.write("/skills/poison/SKILL.md", "malicious")
     subagents = captured["subagents"]
     assert isinstance(subagents, list)
     gp = next(s for s in subagents if s["name"] == "general-purpose")

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from deepagents.backends.composite import CompositeBackend
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import get_agent
@@ -82,8 +83,19 @@ async def test_agent_is_built_with_a_backend_for_eviction_and_summarization() ->
     # eviction + SummarizationMiddleware offloading. deepagents 0.7 requires an
     # initialized backend instance, not a factory callable.
     backend = captured["backend"]
-    assert isinstance(backend, SandboxBackendProxy)
-    assert not callable(backend)
+    assert isinstance(backend, CompositeBackend)
+    assert isinstance(backend.default, SandboxBackendProxy)
+    assert not callable(backend.default)
+
+
+@pytest.mark.asyncio
+async def test_agent_wires_user_skills_into_main_and_general_purpose_agents() -> None:
+    captured = await _capture_create_deep_agent_kwargs()
+    assert captured["skills"] == ["/skills/"]
+    subagents = captured["subagents"]
+    assert isinstance(subagents, list)
+    gp = next(s for s in subagents if s["name"] == "general-purpose")
+    assert gp["skills"] == ["/skills/"]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_skills.py
+++ b/tests/agent/test_skills.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from agent.dashboard.skills import SkillCreate, create_skill
+
+
+async def test_skill_validation_and_persistence() -> None:
+    put_item = AsyncMock()
+    client = AsyncMock()
+    client.store.put_item = put_item
+
+    with pytest.raises(ValidationError):
+        SkillCreate(name="Invalid Name", description="Useful")
+
+    with (
+        patch("agent.dashboard.skills._client", return_value=client),
+        patch("agent.dashboard.skills.get_skill", new_callable=AsyncMock, return_value=None),
+    ):
+        record = await create_skill(
+            "octocat",
+            SkillCreate(
+                name="review-feedback",
+                description="Address PR review feedback",
+                instructions="Check every open comment.",
+            ),
+        )
+
+    assert record["content"] == (
+        '---\nname: "review-feedback"\n'
+        'description: "Address PR review feedback"\n---\n\n'
+        "Check every open comment.\n"
+    )
+    put_item.assert_awaited_once_with(
+        ["user_skills", "octocat"],
+        "/review-feedback/SKILL.md",
+        record,
+    )

--- a/tests/agent/test_skills.py
+++ b/tests/agent/test_skills.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic import ValidationError
 
-from agent.dashboard.skills import SkillCreate, create_skill
+from agent.dashboard.skills import SkillCreate, create_skill, list_skills
 
 
 async def test_skill_validation_and_persistence() -> None:
@@ -38,4 +38,22 @@ async def test_skill_validation_and_persistence() -> None:
         ["user_skills", "octocat"],
         "/review-feedback/SKILL.md",
         record,
+    )
+
+
+async def test_skill_listing_returns_next_offset() -> None:
+    client = AsyncMock()
+    client.store.search_items.return_value = {
+        "items": [
+            {"value": {"name": "first"}},
+            {"value": {"name": "second"}},
+        ]
+    }
+
+    with patch("agent.dashboard.skills._client", return_value=client):
+        page = await list_skills("octocat", limit=1, offset=3)
+
+    assert page == {"items": [{"name": "first"}], "next_offset": 4}
+    client.store.search_items.assert_awaited_once_with(
+        ["user_skills", "octocat"], limit=2, offset=3
     )

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -16,6 +16,7 @@ import {
   GitPullRequestIcon,
   LightningIcon,
   PlusIcon,
+  SparkleIcon,
   TrashIcon,
   TreeStructureIcon,
 } from "@phosphor-icons/react"
@@ -99,6 +100,7 @@ interface AgentsSidebarProps {
 }
 
 const NAV = [
+  { to: "/agents/skills", label: "Skills", icon: SparkleIcon },
   { to: "/agents/automations", label: "Automations", icon: LightningIcon },
   { to: "/my-settings", label: "Dashboard", icon: ChartLineUpIcon },
   { to: "/agents/reviews", label: "Reviews", icon: GitPullRequestIcon },

--- a/ui/src/features/agents/components/SkillsPage.tsx
+++ b/ui/src/features/agents/components/SkillsPage.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from "react"
+
+import type { Skill } from "@/lib/api"
+import { InstructionsEditor } from "@/components/InstructionsEditor"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  useAgentSkills,
+  useCreateAgentSkill,
+  useDeleteAgentSkill,
+  useUpdateAgentSkill,
+} from "@/features/agents/lib/queries"
+import { cn } from "@/lib/utils"
+
+const EMPTY_DRAFT = { description: "", instructions: "" }
+
+export function SkillsPage() {
+  const skills = useAgentSkills()
+  const create = useCreateAgentSkill()
+  const update = useUpdateAgentSkill()
+  const remove = useDeleteAgentSkill()
+  const [selectedName, setSelectedName] = useState<string | null>(null)
+  const [newName, setNewName] = useState("")
+  const [draft, setDraft] = useState(EMPTY_DRAFT)
+  const [error, setError] = useState<string | null>(null)
+
+  const selected = skills.data?.find((skill) => skill.name === selectedName)
+
+  useEffect(() => {
+    if (selected) {
+      setDraft({
+        description: selected.description,
+        instructions: selected.instructions,
+      })
+    }
+  }, [selected])
+
+  const select = (skill: Skill) => {
+    setSelectedName(skill.name)
+    setError(null)
+  }
+
+  const add = async () => {
+    try {
+      const skill = await create.mutateAsync({
+        name: newName.trim(),
+        ...draft,
+      })
+      setNewName("")
+      setSelectedName(skill.name)
+      setError(null)
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "Could not create skill"
+      )
+    }
+  }
+
+  const save = async () => {
+    if (!selectedName) return
+    try {
+      await update.mutateAsync({ name: selectedName, ...draft })
+      setError(null)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save skill")
+    }
+  }
+
+  const discardSelection = () => {
+    setSelectedName(null)
+    setNewName("")
+    setDraft(EMPTY_DRAFT)
+    setError(null)
+  }
+
+  const onDelete = async () => {
+    if (
+      !selectedName ||
+      !window.confirm(`Delete ${selectedName}? This cannot be undone.`)
+    ) {
+      return
+    }
+    try {
+      await remove.mutateAsync(selectedName)
+      discardSelection()
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "Could not delete skill"
+      )
+    }
+  }
+
+  if (skills.isLoading) return <Skeleton className="m-6 h-64 flex-1" />
+
+  const dirty =
+    selected != null &&
+    (draft.description !== selected.description ||
+      draft.instructions !== selected.instructions)
+  const creating = selectedName === null
+
+  return (
+    <main className="min-w-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-4xl px-6 py-8">
+        <h1 className="font-heading text-base font-medium text-[var(--ui-text)]">
+          Skills
+        </h1>
+        <p className="mt-1 text-xs text-[var(--ui-text-muted)]">
+          Reusable instructions Open SWE loads when a task matches their
+          description.
+        </p>
+
+        <div className="mt-6 grid gap-6 md:grid-cols-[220px_minmax(0,1fr)]">
+          <section>
+            <Button size="sm" className="w-full" onClick={discardSelection}>
+              New skill
+            </Button>
+            <div className="mt-3 space-y-1">
+              {(skills.data ?? []).map((skill) => (
+                <button
+                  key={skill.name}
+                  type="button"
+                  onClick={() => select(skill)}
+                  className={cn(
+                    "w-full rounded-md px-2.5 py-2 text-left transition-colors",
+                    selectedName === skill.name
+                      ? "bg-[var(--ui-sidebar-hover)]"
+                      : "hover:bg-[var(--ui-sidebar-hover)]"
+                  )}
+                >
+                  <span className="block truncate text-xs font-medium text-[var(--ui-text)]">
+                    {skill.name}
+                  </span>
+                  <span className="mt-0.5 block truncate text-[10px] text-[var(--ui-text-muted)]">
+                    {skill.description}
+                  </span>
+                </button>
+              ))}
+              {skills.data?.length === 0 && (
+                <p className="px-2.5 py-4 text-xs text-[var(--ui-text-muted)]">
+                  No skills yet.
+                </p>
+              )}
+            </div>
+          </section>
+
+          <section className="space-y-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-panel)] p-4">
+            {creating ? (
+              <div className="space-y-2">
+                <Label htmlFor="skill-name">Name</Label>
+                <Input
+                  id="skill-name"
+                  value={newName}
+                  onChange={(event) => setNewName(event.target.value)}
+                  placeholder="address-review-feedback"
+                />
+                <p className="text-[10px] text-[var(--ui-text-muted)]">
+                  Lowercase letters, numbers, and single hyphens.
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm font-medium text-[var(--ui-text)]">
+                {selectedName}
+              </p>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="skill-description">Description</Label>
+              <Input
+                id="skill-description"
+                value={draft.description}
+                onChange={(event) =>
+                  setDraft((value) => ({
+                    ...value,
+                    description: event.target.value,
+                  }))
+                }
+                placeholder="What this skill does and when Open SWE should use it"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Instructions</Label>
+              <InstructionsEditor
+                value={draft.instructions}
+                onChange={(instructions) =>
+                  setDraft((value) => ({ ...value, instructions }))
+                }
+                placeholder="Write the skill workflow in Markdown."
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                disabled={
+                  !draft.description.trim() ||
+                  (creating
+                    ? !newName.trim() || create.isPending
+                    : !dirty || update.isPending)
+                }
+                onClick={() => void (creating ? add() : save())}
+              >
+                {creating ? "Create skill" : "Save skill"}
+              </Button>
+              {dirty && (
+                <span className="text-xs text-[var(--ui-text-muted)]">
+                  Unsaved changes
+                </span>
+              )}
+              {!creating && (
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="ml-auto"
+                  disabled={remove.isPending}
+                  onClick={() => void onDelete()}
+                >
+                  Delete
+                </Button>
+              )}
+            </div>
+            {error && (
+              <p className="text-xs text-[var(--ui-danger)]">{error}</p>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -65,7 +65,19 @@ export const agentSkillKeys = {
 }
 
 export function useAgentSkills() {
-  return useQuery({ queryKey: agentSkillKeys.all, queryFn: api.listSkills })
+  return useQuery({
+    queryKey: agentSkillKeys.all,
+    queryFn: async () => {
+      const items = []
+      let offset = 0
+      do {
+        const page = await api.listSkills(offset)
+        items.push(...page.items)
+        offset = page.next_offset ?? 0
+      } while (offset)
+      return items
+    },
+  })
 }
 
 export function useCreateAgentSkill() {

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -10,6 +10,8 @@ import type {
   ThreadsPageParams,
 } from "./api"
 import type { AgentThread, Chunk, ImageChunk, Message } from "./types"
+import type { SkillInput } from "@/lib/api"
+import { api } from "@/lib/api"
 
 export const agentThreadKeys = {
   lists: ["agent-threads", "lists"] as const,
@@ -56,6 +58,43 @@ export function seedAgentThreadLists(
 
 export const agentScheduleKeys = {
   all: ["agent-schedules"] as const,
+}
+
+export const agentSkillKeys = {
+  all: ["agent-skills"] as const,
+}
+
+export function useAgentSkills() {
+  return useQuery({ queryKey: agentSkillKeys.all, queryFn: api.listSkills })
+}
+
+export function useCreateAgentSkill() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, ...body }: SkillInput & { name: string }) =>
+      api.createSkill(name, body),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: agentSkillKeys.all }),
+  })
+}
+
+export function useUpdateAgentSkill() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, ...body }: SkillInput & { name: string }) =>
+      api.saveSkill(name, body),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: agentSkillKeys.all }),
+  })
+}
+
+export function useDeleteAgentSkill() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: api.deleteSkill,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: agentSkillKeys.all }),
+  })
 }
 
 // Sidebar lists and detail reads return the same per-thread summary, so warming

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -346,6 +346,19 @@ export interface UserInstructions {
   updated_by?: string
 }
 
+export interface Skill {
+  name: string
+  description: string
+  instructions: string
+  created_at?: string
+  updated_at?: string
+}
+
+export interface SkillInput {
+  description: string
+  instructions: string
+}
+
 export type RepoSnapshotStatus = "none" | "building" | "ready" | "failed"
 
 export interface RepoSnapshot {
@@ -660,6 +673,21 @@ export const api = {
     }),
   deleteMyInstructions: () =>
     request<void>("/me/instructions", { method: "DELETE" }),
+  listSkills: () => request<Array<Skill>>("/skills"),
+  createSkill: (name: string, body: SkillInput) =>
+    request<Skill>("/skills", {
+      method: "POST",
+      body: JSON.stringify({ name, ...body }),
+    }),
+  saveSkill: (name: string, body: SkillInput) =>
+    request<Skill>(`/skills/${encodeURIComponent(name)}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  deleteSkill: (name: string) =>
+    request<void>(`/skills/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    }),
   listAgentInstructions: () =>
     request<Array<AgentInstructions>>("/agent-instructions"),
   createAgentInstructions: (full_name: string) =>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -359,6 +359,11 @@ export interface SkillInput {
   instructions: string
 }
 
+export interface SkillsPage {
+  items: Array<Skill>
+  next_offset: number | null
+}
+
 export type RepoSnapshotStatus = "none" | "building" | "ready" | "failed"
 
 export interface RepoSnapshot {
@@ -673,7 +678,8 @@ export const api = {
     }),
   deleteMyInstructions: () =>
     request<void>("/me/instructions", { method: "DELETE" }),
-  listSkills: () => request<Array<Skill>>("/skills"),
+  listSkills: (offset = 0) =>
+    request<SkillsPage>(`/skills?limit=100&offset=${offset}`),
   createSkill: (name: string, body: SkillInput) =>
     request<Skill>("/skills", {
       method: "POST",

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as ReviewStylesRouteImport } from './routes/review_.styles'
 import { Route as AgentsSnapshotsRouteImport } from './routes/agents_.snapshots'
 import { Route as AgentsInstructionsRouteImport } from './routes/agents_.instructions'
 import { Route as AgentsThreadsRouteImport } from './routes/agents/threads'
+import { Route as AgentsSkillsRouteImport } from './routes/agents/skills'
 import { Route as AgentsThreadIdRouteImport } from './routes/agents/$threadId'
 import { Route as AdminEvalsRouteImport } from './routes/admin_.evals'
 import { Route as AgentsReviewsIndexRouteImport } from './routes/agents/reviews/index'
@@ -104,6 +105,11 @@ const AgentsThreadsRoute = AgentsThreadsRouteImport.update({
   path: '/threads',
   getParentRoute: () => AgentsRoute,
 } as any)
+const AgentsSkillsRoute = AgentsSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => AgentsRoute,
+} as any)
 const AgentsThreadIdRoute = AgentsThreadIdRouteImport.update({
   id: '/$threadId',
   path: '/$threadId',
@@ -169,6 +175,7 @@ export interface FileRoutesByFullPath {
   '/usage': typeof UsageRoute
   '/admin/evals': typeof AdminEvalsRoute
   '/agents/$threadId': typeof AgentsThreadIdRoute
+  '/agents/skills': typeof AgentsSkillsRoute
   '/agents/threads': typeof AgentsThreadsRoute
   '/agents/instructions': typeof AgentsInstructionsRoute
   '/agents/snapshots': typeof AgentsSnapshotsRoute
@@ -194,6 +201,7 @@ export interface FileRoutesByTo {
   '/usage': typeof UsageRoute
   '/admin/evals': typeof AdminEvalsRoute
   '/agents/$threadId': typeof AgentsThreadIdRoute
+  '/agents/skills': typeof AgentsSkillsRoute
   '/agents/threads': typeof AgentsThreadsRoute
   '/agents/instructions': typeof AgentsInstructionsRoute
   '/agents/snapshots': typeof AgentsSnapshotsRoute
@@ -221,6 +229,7 @@ export interface FileRoutesById {
   '/usage': typeof UsageRoute
   '/admin_/evals': typeof AdminEvalsRoute
   '/agents/$threadId': typeof AgentsThreadIdRoute
+  '/agents/skills': typeof AgentsSkillsRoute
   '/agents/threads': typeof AgentsThreadsRoute
   '/agents_/instructions': typeof AgentsInstructionsRoute
   '/agents_/snapshots': typeof AgentsSnapshotsRoute
@@ -249,6 +258,7 @@ export interface FileRouteTypes {
     | '/usage'
     | '/admin/evals'
     | '/agents/$threadId'
+    | '/agents/skills'
     | '/agents/threads'
     | '/agents/instructions'
     | '/agents/snapshots'
@@ -274,6 +284,7 @@ export interface FileRouteTypes {
     | '/usage'
     | '/admin/evals'
     | '/agents/$threadId'
+    | '/agents/skills'
     | '/agents/threads'
     | '/agents/instructions'
     | '/agents/snapshots'
@@ -300,6 +311,7 @@ export interface FileRouteTypes {
     | '/usage'
     | '/admin_/evals'
     | '/agents/$threadId'
+    | '/agents/skills'
     | '/agents/threads'
     | '/agents_/instructions'
     | '/agents_/snapshots'
@@ -433,6 +445,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentsThreadsRouteImport
       parentRoute: typeof AgentsRoute
     }
+    '/agents/skills': {
+      id: '/agents/skills'
+      path: '/skills'
+      fullPath: '/agents/skills'
+      preLoaderRoute: typeof AgentsSkillsRouteImport
+      parentRoute: typeof AgentsRoute
+    }
     '/agents/$threadId': {
       id: '/agents/$threadId'
       path: '/$threadId'
@@ -508,6 +527,7 @@ declare module '@tanstack/react-router' {
 
 interface AgentsRouteChildren {
   AgentsThreadIdRoute: typeof AgentsThreadIdRoute
+  AgentsSkillsRoute: typeof AgentsSkillsRoute
   AgentsThreadsRoute: typeof AgentsThreadsRoute
   AgentsIndexRoute: typeof AgentsIndexRoute
   AgentsThreadIdPlanRoute: typeof AgentsThreadIdPlanRoute
@@ -520,6 +540,7 @@ interface AgentsRouteChildren {
 
 const AgentsRouteChildren: AgentsRouteChildren = {
   AgentsThreadIdRoute: AgentsThreadIdRoute,
+  AgentsSkillsRoute: AgentsSkillsRoute,
   AgentsThreadsRoute: AgentsThreadsRoute,
   AgentsIndexRoute: AgentsIndexRoute,
   AgentsThreadIdPlanRoute: AgentsThreadIdPlanRoute,

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -24,6 +24,7 @@ function AgentsLayout() {
     section === "agents" &&
     threadId &&
     threadId !== "automations" &&
+    threadId !== "skills" &&
     threadId !== "threads" &&
     threadId !== "reviews"
       ? threadId

--- a/ui/src/routes/agents/skills.tsx
+++ b/ui/src/routes/agents/skills.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { SkillsPage } from "@/features/agents/components/SkillsPage"
+
+export const Route = createFileRoute("/agents/skills")({
+  component: SkillsPage,
+})


### PR DESCRIPTION
## Description
Adds per-user Codex-compatible skills with persistent storage, read-only progressive disclosure through Deep Agents, and an Agents sidebar management UI. Skill listings use bounded pagination.

## Release Note
Users can create and manage reusable agent skills from the dashboard.

## Test Plan
- [x] Create, edit, and delete a skill from the Skills page
- [x] Verify skill storage is read-only to agent tools and pagination returns every skill

Made by [Open SWE](https://openswe.vercel.app/agents/019fceb7-6f11-75d0-a5d5-f177755492fb)