### PR TITLE
fix: strip server runtime before graph factory with_config

### DIFF
--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -10,6 +10,7 @@ from langgraph.graph.state import RunnableConfig
 
 from .dashboard.schedules import launch_scheduled_agent_run
 from .reconcile import reconcile_stale_runs
+from .utils.tracing import strip_server_runtime_config
 
 logger = logging.getLogger(__name__)
 
@@ -37,4 +38,4 @@ def get_scheduler(config: RunnableConfig | None = None):
     builder.add_node("launch", _launch)
     builder.add_edge(START, "launch")
     builder.add_edge("launch", END)
-    return builder.compile().with_config(config or {})
+    return builder.compile().with_config(strip_server_runtime_config(config or {}))

--- a/agent/utils/tracing.py
+++ b/agent/utils/tracing.py
@@ -10,6 +10,24 @@ from langgraph.pregel import Pregel
 AGENT_TRACING_PROJECT = "open-swe-agent"
 REVIEW_TRACING_PROJECT = "open-swe-review"
 
+# Injected by langgraph-api into factory config; must not be baked into the
+# compiled graph via `.with_config(config)` or `/assistants/{id}/graph` fails
+# with AttributeError: '_ReadRuntime' object has no attribute 'override'.
+_SERVER_RUNTIME_CONFIG_KEY = "__pregel_runtime"
+
+
+def strip_server_runtime_config(config: RunnableConfig) -> RunnableConfig:
+    """Return a copy of config without the server-injected runtime key."""
+    configurable = config.get("configurable")
+    if not isinstance(configurable, dict) or _SERVER_RUNTIME_CONFIG_KEY not in configurable:
+        return config
+    return {
+        **config,
+        "configurable": {
+            key: value for key, value in configurable.items() if key != _SERVER_RUNTIME_CONFIG_KEY
+        },
+    }
+
 
 def traced_graph_factory(
     factory: Callable[[RunnableConfig], Awaitable[Pregel]],
@@ -17,7 +35,7 @@ def traced_graph_factory(
 ) -> Callable[[RunnableConfig], contextlib.AbstractAsyncContextManager[Pregel]]:
     @contextlib.asynccontextmanager
     async def entrypoint(config: RunnableConfig) -> AsyncIterator[Pregel]:
-        graph = await factory(config)
+        graph = await factory(strip_server_runtime_config(config))
         with ls.tracing_context(project_name=project_name):
             yield graph
 

--- a/tests/agent/test_strip_server_runtime_config.py
+++ b/tests/agent/test_strip_server_runtime_config.py
@@ -1,0 +1,83 @@
+"""Regression tests for stripping langgraph-api server runtime from factory config."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langgraph.graph.state import RunnableConfig
+
+from agent.scheduler import get_scheduler
+from agent.utils.tracing import strip_server_runtime_config, traced_graph_factory
+
+
+def test_strip_server_runtime_config_removes_private_key() -> None:
+    config: RunnableConfig = {
+        "configurable": {
+            "__pregel_runtime": object(),
+            "thread_id": "t1",
+        },
+        "tags": ["keep"],
+    }
+
+    stripped = strip_server_runtime_config(config)
+
+    assert stripped is not config
+    assert stripped["tags"] == ["keep"]
+    assert stripped["configurable"] == {"thread_id": "t1"}
+    assert "__pregel_runtime" in config["configurable"]
+
+
+def test_strip_server_runtime_config_noop_without_key() -> None:
+    config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
+
+    assert strip_server_runtime_config(config) is config
+
+
+def test_strip_server_runtime_config_noop_without_configurable() -> None:
+    config: RunnableConfig = {"tags": ["a"]}
+
+    assert strip_server_runtime_config(config) is config
+
+
+@pytest.mark.asyncio
+async def test_traced_graph_factory_strips_runtime_before_factory() -> None:
+    received: dict[str, Any] = {}
+    graph = MagicMock(name="graph")
+
+    async def factory(config: RunnableConfig) -> MagicMock:
+        received["config"] = config
+        return graph
+
+    entrypoint = traced_graph_factory(factory, "test-project")
+    runtime_token = object()
+    inbound: RunnableConfig = {
+        "configurable": {
+            "__pregel_runtime": runtime_token,
+            "thread_id": "t1",
+        }
+    }
+
+    async with entrypoint(inbound) as yielded:
+        assert yielded is graph
+
+    assert received["config"]["configurable"] == {"thread_id": "t1"}
+    assert inbound["configurable"]["__pregel_runtime"] is runtime_token
+
+
+def test_get_scheduler_does_not_bake_server_runtime() -> None:
+    runtime_token = object()
+    config: RunnableConfig = {
+        "configurable": {
+            "__pregel_runtime": runtime_token,
+            "schedule_id": "sched-1",
+        }
+    }
+
+    graph = get_scheduler(config)
+    baked = graph.config.get("configurable") if graph.config else None
+
+    assert isinstance(baked, dict)
+    assert "__pregel_runtime" not in baked
+    assert baked.get("schedule_id") == "sched-1"


### PR DESCRIPTION
Fixes #1832

`langgraph-api` injects `__pregel_runtime` into factory `RunnableConfig` before calling graph factories. Open SWE factories then call `.with_config(config)`, which bakes the factory-time `_ReadRuntime` into the compiled graph. Later `GET /assistants/{id}/graph` fails with:

`AttributeError: '_ReadRuntime' object has no attribute 'override'`

This strips the private key before the factory runs:
- shared path: `traced_graph_factory` (agent, reviewer, analyzer, chat)
- direct path: `get_scheduler`

Verified with `pytest tests/agent/test_strip_server_runtime_config.py` (5 passed).