### PR TITLE
feat: show plans in the agent side panel

### DIFF
--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from langgraph_sdk import get_client
+from langgraph_sdk.schema import Run
 from pydantic import BaseModel
 
 from ..dispatch import dispatch_agent_run
@@ -209,13 +210,13 @@ async def approve_plan_for_thread(
         text = "The plan has been approved. Implement it now as described in the plan."
     if feedback:
         text += "\n\nAlso take this reviewer feedback into account:\n\n" + feedback
-    await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
+    run = await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
     await _maybe_post_plan_approved_to_slack(
         metadata,
         comment_count=len(comments),
         actor=actor,
     )
-    return {"status": PLAN_STATUS_APPROVED}
+    return {"status": PLAN_STATUS_APPROVED, "run_id": run["run_id"]}
 
 
 @plan_router.post("/{thread_id}/reject")
@@ -302,7 +303,7 @@ def _format_comments(comments: list[dict[str, Any]]) -> str:
 
 async def _dispatch_followup(
     thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
-) -> None:
+) -> Run:
     """Continue the existing thread with a new instruction run.
 
     Runs on the same LangGraph thread, so the agent resumes from the checkpoint
@@ -332,7 +333,7 @@ async def _dispatch_followup(
     # mode (implement), reject stays in plan mode (revise the plan).
     configurable["plan_mode"] = plan_mode
 
-    await dispatch_agent_run(
+    return await dispatch_agent_run(
         thread_id,
         text,
         configurable,

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -706,8 +706,9 @@ async def test_approve_plan_dispatches_published_markdown(
 
     async def fake_dispatch(
         thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
-    ) -> None:
+    ) -> dict[str, Any]:
         dispatched.update(text=text, plan_mode=plan_mode)
+        return {"run_id": "run-1"}
 
     monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
     monkeypatch.setattr(plan_api, "_user_owns_thread", lambda *a, **k: True)
@@ -717,7 +718,7 @@ async def test_approve_plan_dispatches_published_markdown(
     monkeypatch.setattr(plan_api, "_dispatch_followup", fake_dispatch)
 
     result = await plan_api.approve_plan("t1", session={"sub": "a", "email": None})
-    assert result["status"] == "approved"
+    assert result == {"status": "approved", "run_id": "run-1"}
     # The (possibly edited) published plan is the source of truth, plus feedback.
     assert "# Edited plan" in dispatched["text"]
     assert "use snake_case" in dispatched["text"]
@@ -756,8 +757,9 @@ async def test_approve_plan_posts_slack_approval_notice(
 
     async def fake_dispatch(
         thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
-    ) -> None:
+    ) -> dict[str, Any]:
         dispatched.update(text=text, plan_mode=plan_mode)
+        return {"run_id": "run-1"}
 
     monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
     monkeypatch.setattr(plan_api, "_user_owns_thread", lambda *a, **k: True)

--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -146,11 +146,14 @@ test.describe("Plan review (HTTP comments)", () => {
     const reviewLink = owner.getByTestId("review-plan-link");
     await expect(reviewLink).toBeVisible({ timeout: 30_000 });
     await reviewLink.click();
-    await expect(owner).toHaveURL(new RegExp(`/agents/${threadId}/plan$`));
+    await expect(owner).toHaveURL(new RegExp(`/agents/${threadId}$`));
+    await expect(
+      owner.locator('button[aria-current="page"]', { hasText: "Plan" }),
+    ).toBeVisible();
     await expect(owner.getByTestId("plan-review")).toBeVisible({
       timeout: 30_000,
     });
-    await expect(owner.getByText("Back to conversation")).toBeVisible();
+    await expect(owner.getByText("Back to conversation")).toHaveCount(0);
     await expect(owner.getByTestId("plan-document")).toContainText("greet", {
       timeout: 30_000,
     });
@@ -195,7 +198,11 @@ test.describe("Plan review (HTTP comments)", () => {
     await expect(collab.getByTestId("reject-plan")).toBeVisible();
 
     // Collaborator leaves feedback with Ctrl+Enter.
-    await addComment(collab, "Reviewer: please also add a docstring.", "control");
+    await addComment(
+      collab,
+      "Reviewer: please also add a docstring.",
+      "control",
+    );
     await expect(collab.getByTestId("plan-comment")).toHaveCount(2);
 
     // 6. The owner sees the collaborator's comment (polled), then approves and

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -1,4 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useStreamContext as useAgentThreadStream } from "@langchain/react"
+import { useQueryClient } from "@tanstack/react-query"
 import {
   MultiFileDiff,
   Virtualizer,
@@ -22,7 +24,11 @@ import type { AgentThread, Message } from "@/features/agents/lib/types"
 import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
 import type { ChangedFileSummaryItem } from "@/features/agents/components/messages"
 import { agentsApi } from "@/features/agents/lib/api"
-import { useAgentThreadPrDiff } from "@/features/agents/lib/queries"
+import {
+  agentThreadKeys,
+  invalidateAgentThreadLists,
+  useAgentThreadPrDiff,
+} from "@/features/agents/lib/queries"
 import { ReviewTab } from "@/features/reviews/components/ReviewTab"
 import { PrHeader } from "@/features/reviews/components/PrHeader"
 import { buttonVariants } from "@/components/ui/button"
@@ -271,6 +277,8 @@ export function AgentGitPanel({
   onCollapsedChange,
   onTabChange,
 }: AgentGitPanelProps) {
+  const queryClient = useQueryClient()
+  const stream = useAgentThreadStream()
   const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
   const [fullScreen, setFullScreen] = useState(false)
@@ -286,6 +294,26 @@ export function AgentGitPanel({
   )
 
   const topTab = hasPlan || requestedTab !== "plan" ? requestedTab : "git"
+  const onPlanApproved = useCallback(
+    (runId: string) => {
+      queryClient.setQueryData<AgentThread>(
+        agentThreadKeys.detail(thread.id),
+        (current) =>
+          current
+            ? { ...current, planStatus: "approved", status: "running" }
+            : current
+      )
+      void queryClient.invalidateQueries({ queryKey: ["plan", thread.id] })
+      invalidateAgentThreadLists(queryClient)
+      onTabChange("git")
+      void stream.client.runs.join(thread.id, runId).finally(() => {
+        void queryClient.invalidateQueries({
+          queryKey: agentThreadKeys.detail(thread.id),
+        })
+      })
+    },
+    [onTabChange, queryClient, stream, thread.id]
+  )
 
   // Collapsed state is owned by the parent (so the plan banner can reserve space
   // for the floating expand button); persistence to localStorage lives there too.
@@ -509,7 +537,7 @@ export function AgentGitPanel({
         )}
       >
         {topTab === "plan" ? (
-          <PlanView threadId={thread.id} onApprove={() => onTabChange("git")} />
+          <PlanView threadId={thread.id} onApprove={onPlanApproved} />
         ) : topTab !== "git" ? (
           <div className="flex flex-1 items-center justify-center p-6 text-xs text-muted-foreground/70">
             Coming Soon

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -491,6 +491,7 @@ export function AgentGitPanel({
           <button
             key={id}
             type="button"
+            aria-current={topTab === id ? "page" : undefined}
             onClick={() => onTabChange(id)}
             className={cn(
               "rounded-md px-2.5 py-1 text-xs transition-colors",

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -27,6 +27,7 @@ import { ReviewTab } from "@/features/reviews/components/ReviewTab"
 import { PrHeader } from "@/features/reviews/components/PrHeader"
 import { buttonVariants } from "@/components/ui/button"
 import { DiffWrapToggle } from "@/features/agents/components/DiffWrapToggle"
+import { PlanView } from "@/features/agents/components/PlanView"
 import {
   DIFF_VIRTUALIZER_CONFIG,
   DIFF_VIRTUAL_METRICS,
@@ -40,11 +41,15 @@ import { Z } from "@/features/agents/components/z-index"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 
+export type AgentPanelTab = "git" | "desktop" | "terminal" | "plan"
+
 interface AgentGitPanelProps {
   thread: AgentThread
   messages: Array<Message>
   collapsed: boolean
+  requestedTab: AgentPanelTab
   onCollapsedChange: (next: boolean) => void
+  onTabChange: (tab: AgentPanelTab) => void
 }
 
 interface PanelFile {
@@ -262,9 +267,10 @@ export function AgentGitPanel({
   thread,
   messages,
   collapsed,
+  requestedTab,
   onCollapsedChange,
+  onTabChange,
 }: AgentGitPanelProps) {
-  const [topTab, setTopTab] = useState<"git" | "desktop" | "terminal">("git")
   const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
   const [fullScreen, setFullScreen] = useState(false)
@@ -273,6 +279,13 @@ export function AgentGitPanel({
   // overlay that the user navigates to (and back from), like the sidebar.
   const overlay = fullScreen || isMobile
   const panelRef = useRef<HTMLDivElement>(null)
+  const hasPlan = Boolean(
+    thread.planStatus &&
+    thread.planStatus !== "approved" &&
+    thread.planStatus !== "cancelled"
+  )
+
+  const topTab = hasPlan || requestedTab !== "plan" ? requestedTab : "git"
 
   // Collapsed state is owned by the parent (so the plan banner can reserve space
   // for the floating expand button); persistence to localStorage lives there too.
@@ -444,12 +457,13 @@ export function AgentGitPanel({
             ["git", "Git"],
             ["desktop", "Desktop"],
             ["terminal", "Terminal"],
-          ] as const
+            ...(hasPlan ? ([["plan", "Plan"]] as const) : []),
+          ] satisfies Array<readonly [AgentPanelTab, string]>
         ).map(([id, label]) => (
           <button
             key={id}
             type="button"
-            onClick={() => setTopTab(id)}
+            onClick={() => onTabChange(id)}
             className={cn(
               "rounded-md px-2.5 py-1 text-xs transition-colors",
               topTab === id
@@ -494,7 +508,9 @@ export function AgentGitPanel({
           overlay ? "mx-3 mb-3" : "mr-4 mb-4 ml-1"
         )}
       >
-        {topTab !== "git" ? (
+        {topTab === "plan" ? (
+          <PlanView threadId={thread.id} onApprove={() => onTabChange("git")} />
+        ) : topTab !== "git" ? (
           <div className="flex flex-1 items-center justify-center p-6 text-xs text-muted-foreground/70">
             Coming Soon
           </div>

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from "react"
-import { Link } from "@tanstack/react-router"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { CircleAlert as CircleAlertIcon, Map as MapIcon } from "lucide-react"
 
@@ -9,6 +8,7 @@ import type {
   QueuedThreadMessage,
 } from "@/features/agents/lib/types"
 import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
+import type { AgentPanelTab } from "@/features/agents/components/AgentGitPanel"
 import { Alert, AlertAction, AlertDescription } from "@/components/ui/alert"
 import {
   AgentGitPanel,
@@ -107,6 +107,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed()
   )
+  const [panelTab, setPanelTab] = useState<AgentPanelTab>("git")
   const handlePanelCollapsedChange = useCallback((next: boolean) => {
     setPanelCollapsed(next)
     writeStoredPanelCollapsed(next)
@@ -200,11 +201,14 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
                 panelCollapsed && "pr-14"
               )}
             >
-              <Link
-                to="/agents/$threadId/plan"
-                params={{ threadId: thread.id }}
+              <button
+                type="button"
                 data-testid="review-plan-link"
-                className="block transition-colors hover:bg-info/8 rounded-xl"
+                className="block w-full rounded-xl text-left transition-colors hover:bg-info/8"
+                onClick={() => {
+                  setPanelTab("plan")
+                  handlePanelCollapsedChange(false)
+                }}
               >
                 <Alert variant="info">
                   <MapIcon />
@@ -227,7 +231,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
                     </span>
                   </AlertAction>
                 </Alert>
-              </Link>
+              </button>
             </div>
           )}
         {hasConversation ? (
@@ -314,7 +318,9 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
         thread={thread}
         messages={baseMessages}
         collapsed={panelCollapsed}
+        requestedTab={panelTab}
         onCollapsedChange={handlePanelCollapsedChange}
+        onTabChange={setPanelTab}
       />
     </div>
   )

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -57,7 +57,7 @@ export function PlanReview({
 }: {
   plan: PlanData
   compact?: boolean
-  onApprove?: () => void
+  onApprove?: (runId: string) => void
 }) {
   const navigate = useNavigate()
   const resolvedTheme = useResolvedTheme()
@@ -181,8 +181,8 @@ export function PlanReview({
       setError(null)
       try {
         if (kind === "approve") {
-          await approvePlan(plan.threadId)
-          if (onApprove) onApprove()
+          const { run_id: runId } = await approvePlan(plan.threadId)
+          if (onApprove) onApprove(runId)
           else
             await navigate({
               to: "/agents/$threadId",

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Markdown } from "@/features/agents/components/chat/Markdown"
 import { useResolvedTheme } from "@/lib/theme"
+import { cn } from "@/lib/utils"
 
 const POLL_MS = 4000
 
@@ -49,7 +50,15 @@ async function copyToClipboard(text: string): Promise<boolean> {
   }
 }
 
-export function PlanReview({ plan }: { plan: PlanData }) {
+export function PlanReview({
+  plan,
+  compact = false,
+  onApprove,
+}: {
+  plan: PlanData
+  compact?: boolean
+  onApprove?: () => void
+}) {
   const navigate = useNavigate()
   const resolvedTheme = useResolvedTheme()
   const [comments, setComments] = useState<Array<PlanComment>>([])
@@ -173,10 +182,12 @@ export function PlanReview({ plan }: { plan: PlanData }) {
       try {
         if (kind === "approve") {
           await approvePlan(plan.threadId)
-          await navigate({
-            to: "/agents/$threadId",
-            params: { threadId: plan.threadId },
-          })
+          if (onApprove) onApprove()
+          else
+            await navigate({
+              to: "/agents/$threadId",
+              params: { threadId: plan.threadId },
+            })
           return
         }
         await rejectPlan(plan.threadId)
@@ -187,7 +198,7 @@ export function PlanReview({ plan }: { plan: PlanData }) {
         setBusy(null)
       }
     },
-    [navigate, plan.threadId]
+    [navigate, onApprove, plan.threadId]
   )
 
   const copyPlan = useCallback(async () => {
@@ -205,7 +216,12 @@ export function PlanReview({ plan }: { plan: PlanData }) {
       data-testid="plan-review"
       className="flex min-h-0 flex-1 flex-col bg-background text-foreground"
     >
-      <div className="flex flex-col gap-3 border-b border-border px-4 py-3 md:flex-row md:items-center md:justify-between md:gap-4 md:px-6">
+      <div
+        className={cn(
+          "flex flex-col gap-3 border-b border-border px-4 py-3 md:flex-row md:items-center md:justify-between md:gap-4",
+          !compact && "md:px-6"
+        )}
+      >
         <div className="min-w-0">
           <h1 className="text-base font-semibold text-foreground">
             {isShared ? "Shared response" : "Implementation plan"}
@@ -296,17 +312,23 @@ export function PlanReview({ plan }: { plan: PlanData }) {
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col overflow-y-auto",
+          !compact && "md:flex-row md:overflow-hidden"
+        )}
+      >
         <div
-          className="min-w-0 px-4 py-4 md:min-h-0 md:flex-1 md:overflow-auto md:px-6"
+          className={cn(
+            "min-w-0 px-4 py-4 md:min-h-0 md:flex-1 md:overflow-auto",
+            !compact && "md:px-6"
+          )}
           data-testid="plan-document"
           data-color-scheme={resolvedTheme}
         >
           {editing ? (
             <div className="flex h-full flex-col gap-2">
-              {error && (
-                <p className="text-xs text-destructive">{error}</p>
-              )}
+              {error && <p className="text-xs text-destructive">{error}</p>}
               <textarea
                 data-testid="plan-editor"
                 value={editDraft}
@@ -325,7 +347,12 @@ export function PlanReview({ plan }: { plan: PlanData }) {
         </div>
 
         {!isShared && (
-          <aside className="flex shrink-0 flex-col border-t border-border md:w-80 md:border-t-0 md:border-l">
+          <aside
+            className={cn(
+              "flex shrink-0 flex-col border-t border-border",
+              !compact && "md:w-80 md:border-t-0 md:border-l"
+            )}
+          >
             <div className="border-b border-border px-4 py-3">
               <h2 className="text-sm font-semibold text-foreground">
                 Comments
@@ -368,9 +395,7 @@ export function PlanReview({ plan }: { plan: PlanData }) {
             </div>
             <div className="border-t border-border p-3">
               {error && (
-                <p className="mb-2 text-xs text-destructive">
-                  {error}
-                </p>
+                <p className="mb-2 text-xs text-destructive">{error}</p>
               )}
               <textarea
                 data-testid="comment-input"

--- a/ui/src/features/agents/components/PlanView.tsx
+++ b/ui/src/features/agents/components/PlanView.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { ArrowLeft } from "lucide-react"
+
+import { PlanReview } from "@/features/agents/components/PlanReview"
+import { buttonVariants } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { loginUrl } from "@/lib/api"
+import { currentAuthRedirectPath } from "@/lib/auth-redirect"
+import { PlanApiError, getPlan } from "@/lib/plan"
+import { cn } from "@/lib/utils"
+
+function Centered({
+  children,
+  standalone,
+}: {
+  children: React.ReactNode
+  standalone: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-1 items-center justify-center px-4 py-6",
+        standalone && "max-md:pt-14 md:p-6"
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+function BackLink({ threadId }: { threadId: string }) {
+  return (
+    <Link
+      to="/agents/$threadId"
+      params={{ threadId }}
+      className="inline-flex items-center gap-1 text-xs text-muted-foreground/70 hover:text-foreground"
+    >
+      <ArrowLeft className="size-3.5" />
+      Back to conversation
+    </Link>
+  )
+}
+
+export function planSignInHref(): string {
+  return loginUrl(currentAuthRedirectPath())
+}
+
+export function PlanSignInButton() {
+  return (
+    <a href={planSignInHref()} className={buttonVariants({ size: "sm" })}>
+      Sign in to view this plan
+    </a>
+  )
+}
+
+export function PlanView({
+  threadId,
+  standalone = false,
+  onApprove,
+}: {
+  threadId: string
+  standalone?: boolean
+  onApprove?: () => void
+}) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+
+  const query = useQuery({
+    queryKey: ["plan", threadId],
+    queryFn: () => getPlan(threadId),
+    refetchInterval: (q) => (q.state.data?.markdown ? false : 2000),
+    retry: (count, error) =>
+      !(
+        error instanceof PlanApiError &&
+        (error.status === 401 || error.status === 404)
+      ) && count < 3,
+  })
+  const backLink = standalone ? <BackLink threadId={threadId} /> : null
+
+  if (!mounted || query.isLoading) {
+    return (
+      <Centered standalone={standalone}>
+        <Skeleton className="h-48 w-full max-w-2xl" />
+      </Centered>
+    )
+  }
+
+  if (query.isError) {
+    const status = query.error instanceof PlanApiError ? query.error.status : 0
+    return (
+      <Centered standalone={standalone}>
+        <div className="space-y-3 text-center text-sm text-muted-foreground/70">
+          <p>
+            {status === 401
+              ? "Please sign in to view this plan."
+              : "This plan could not be found."}
+          </p>
+          {status === 401 ? <PlanSignInButton /> : null}
+          {backLink}
+        </div>
+      </Centered>
+    )
+  }
+
+  const plan = query.data
+  if (!plan?.markdown.trim()) {
+    return (
+      <Centered standalone={standalone}>
+        <div className="space-y-3 text-center text-sm text-muted-foreground/70">
+          <p>
+            The agent is still writing the content. This view will update
+            automatically…
+          </p>
+          {backLink}
+        </div>
+      </Centered>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      {standalone && (
+        <div className="border-b border-border px-4 pt-14 md:px-6 md:pt-3">
+          {backLink}
+        </div>
+      )}
+      <PlanReview plan={plan} compact={!standalone} onApprove={onApprove} />
+    </div>
+  )
+}

--- a/ui/src/features/agents/components/PlanView.tsx
+++ b/ui/src/features/agents/components/PlanView.tsx
@@ -62,7 +62,7 @@ export function PlanView({
 }: {
   threadId: string
   standalone?: boolean
-  onApprove?: () => void
+  onApprove?: (runId: string) => void
 }) {
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])

--- a/ui/src/lib/plan.ts
+++ b/ui/src/lib/plan.ts
@@ -119,7 +119,9 @@ export function updatePlan(
   })
 }
 
-export function approvePlan(threadId: string): Promise<{ status: string }> {
+export function approvePlan(
+  threadId: string
+): Promise<{ status: string; run_id: string }> {
   return req(`/plan/${encodeURIComponent(threadId)}/approve`, {
     method: "POST",
   })

--- a/ui/src/routes/agents/$threadId_.plan.tsx
+++ b/ui/src/routes/agents/$threadId_.plan.tsx
@@ -1,125 +1,12 @@
-import { Link, createFileRoute } from "@tanstack/react-router"
-import { useQuery } from "@tanstack/react-query"
-import { useEffect, useState } from "react"
-import { ArrowLeft } from "lucide-react"
+import { createFileRoute } from "@tanstack/react-router"
 
-import { PlanReview } from "@/features/agents/components/PlanReview"
-import { buttonVariants } from "@/components/ui/button"
-import { Skeleton } from "@/components/ui/skeleton"
-import { loginUrl } from "@/lib/api"
-import { currentAuthRedirectPath } from "@/lib/auth-redirect"
-import { PlanApiError, getPlan } from "@/lib/plan"
+import { PlanView } from "@/features/agents/components/PlanView"
 
 export const Route = createFileRoute("/agents/$threadId_/plan")({
   component: PlanPage,
 })
 
-function Centered({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex min-w-0 flex-1 items-center justify-center px-4 py-6 max-md:pt-14 md:p-6">
-      {children}
-    </div>
-  )
-}
-
-function BackLink({ threadId }: { threadId: string }) {
-  return (
-    <Link
-      to="/agents/$threadId"
-      params={{ threadId }}
-      className="inline-flex items-center gap-1 text-xs text-muted-foreground/70 hover:text-foreground"
-    >
-      <ArrowLeft className="size-3.5" />
-      Back to conversation
-    </Link>
-  )
-}
-
-export function planSignInHref(): string {
-  return loginUrl(currentAuthRedirectPath())
-}
-
-export function PlanSignInButton() {
-  return (
-    <a href={planSignInHref()} className={buttonVariants({ size: "sm" })}>
-      Sign in to view this plan
-    </a>
-  )
-}
-
 function PlanPage() {
   const { threadId } = Route.useParams()
-
-  // BlockNote + Yjs are browser-only; mount client-side before rendering.
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => setMounted(true), [])
-
-  const query = useQuery({
-    queryKey: ["plan", threadId],
-    queryFn: () => getPlan(threadId),
-    // The agent shares the link as soon as it enters plan mode, before the plan
-    // is written — poll until the plan content is published.
-    refetchInterval: (q) => (q.state.data?.markdown ? false : 2000),
-    retry: (count, error) =>
-      !(
-        error instanceof PlanApiError &&
-        (error.status === 401 || error.status === 404)
-      ) && count < 3,
-  })
-
-  if (!mounted || query.isLoading) {
-    return (
-      <Centered>
-        <Skeleton className="h-48 w-full max-w-2xl" />
-      </Centered>
-    )
-  }
-
-  if (query.isError) {
-    const status = query.error instanceof PlanApiError ? query.error.status : 0
-    return (
-      <Centered>
-        <div className="space-y-3 text-center text-sm text-muted-foreground/70">
-          <p>
-            {status === 401
-              ? "Please sign in to view this plan."
-              : "This plan could not be found."}
-          </p>
-          {status === 401 ? <PlanSignInButton /> : null}
-          <BackLink threadId={threadId} />
-        </div>
-      </Centered>
-    )
-  }
-
-  const plan = query.data
-  if (!plan) {
-    return (
-      <Centered>
-        <Skeleton className="h-48 w-full max-w-2xl" />
-      </Centered>
-    )
-  }
-  if (!plan.markdown.trim()) {
-    return (
-      <Centered>
-        <div className="space-y-3 text-center text-sm text-muted-foreground/70">
-          <p>
-            The agent is still writing the content. This page will update
-            automatically…
-          </p>
-          <BackLink threadId={threadId} />
-        </div>
-      </Centered>
-    )
-  }
-
-  return (
-    <div className="flex min-w-0 flex-1 flex-col">
-      <div className="border-b border-border px-4 pt-14 md:px-6 md:pt-3">
-        <BackLink threadId={threadId} />
-      </div>
-      <PlanReview plan={plan} />
-    </div>
-  )
+  return <PlanView threadId={threadId} standalone />
 }


### PR DESCRIPTION
## Description
Show active plans in a conditional right-panel tab so reviewers can stay in the conversation. Reuse the same plan view for standalone shared links.

## Release Note
Plans now open in the agent side panel.

## Test Plan
- [x] Typecheck, focused lint, and production build

Made by [Open SWE](https://openswe.vercel.app/agents/019fd297-80aa-733f-a8f7-6bb4edf4027d)