### PR TITLE
fix: collapse shell tool calls by default

### DIFF
--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -242,7 +242,6 @@ export function AgentTurn({
             entry={describeWorkEntry(item.chunk, projectPath)}
             timestamp={item.chunk.timestamp}
             body={<ShellEntryBody chunk={item.chunk} />}
-            defaultExpanded={item.chunk.status === "in_progress"}
           />
         );
 


### PR DESCRIPTION
## Description
Keep shell tool-call details collapsed by default, including while the call is running.

## Release Note
Shell tool calls now stay collapsed until expanded by the user.

## Test Plan
- [ ] Start a run with a shell call and verify its command/output is initially hidden.

Made by [Open SWE](https://openswe.vercel.app/agents/43d4825d-b106-1a47-8442-376020bdae15)