### PR TITLE
feat: autofocus new agent input

### DIFF
--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -124,6 +124,7 @@ export function AgentsHome() {
         <div className="flex w-full flex-col items-center gap-6">
           <Logo />
           <AgentPromptBar
+            autoFocus
             onSubmit={handleSubmit}
             disabled={submitting}
             models={models}

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ImagePlus, Map as MapIcon, X } from "lucide-react";
 
 import { ComposerCommandMenu } from "./ComposerCommandMenu";
@@ -45,6 +45,7 @@ const SLASH_COMMANDS: Array<SlashCommandSpec> = [
 
 export interface ChatComposerProps {
   placeholder?: string;
+  autoFocus?: boolean;
   compact?: boolean;
   disabled?: boolean;
   busy?: boolean;
@@ -136,6 +137,7 @@ export function buildCommandItems(
  */
 export const ChatComposer = memo(function ChatComposer({
   placeholder = "Ask Open SWE to build, fix bugs, explore",
+  autoFocus = false,
   compact = false,
   disabled = false,
   busy = false,
@@ -165,6 +167,11 @@ export const ChatComposer = memo(function ChatComposer({
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragDepthRef = useRef(0);
+
+  useEffect(() => {
+    if (autoFocus) editorRef.current?.focus();
+  }, [autoFocus]);
+
   // Synchronous double-submit guard: blocks a same-tick second send (Enter +
   // click, or two rapid Enters) before React re-renders. Scoped to the send
   // request only — never the run lifecycle.


### PR DESCRIPTION
## Description
Focus the composer when the new-agent page mounts, covering direct `/agents` landings and `+ New Agent` navigation.

## Release Note
The new-agent prompt is focused automatically.

## Test Plan
- [ ] Open `/agents` directly and via `+ New Agent`; confirm typing works immediately.

Made by [Open SWE](https://openswe.vercel.app/agents/80df5c6a-e471-f7f3-b226-4f4cb09ac200)