### PR TITLE
feat: give agent chat a distinct typeface

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@fontsource-variable/dm-sans": "^5.3.0",
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@langchain/core": "^1.1.48",
     "@langchain/langgraph-sdk": "^1.9.21",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@fontsource-variable/dm-sans':
+      '@fontsource-variable/ibm-plex-sans':
         specifier: ^5.3.0
         version: 5.3.0
       '@fontsource-variable/inter':
@@ -1083,8 +1083,8 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@fontsource-variable/dm-sans@5.3.0':
-    resolution: {integrity: sha512-BpUG5bqePiDFMBM4ZtLSlPdAIOM990uB1dlXzIf4aw21yQR7BmykedLXXXMqGWsR18aMLOsbWccwJNh3ztTQaA==}
+  '@fontsource-variable/ibm-plex-sans@5.3.0':
+    resolution: {integrity: sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==}
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
@@ -6962,7 +6962,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@fontsource-variable/dm-sans@5.3.0': {}
+  '@fontsource-variable/ibm-plex-sans@5.3.0': {}
 
   '@fontsource-variable/inter@5.2.8': {}
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2,7 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
-@import "@fontsource-variable/dm-sans";
+@import "@fontsource-variable/ibm-plex-sans";
 @import "./styles/agents.css";
 @source "../node_modules/streamdown/dist/*.js";
 

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -108,7 +108,7 @@ html.dark[data-agents-theme] {
 .agents-ui,
 html[data-agents-theme] {
   font-family:
-    "DM Sans Variable", "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+    "IBM Plex Sans Variable", "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Description
Replace the copied DM Sans face with IBM Plex Sans for a more technical, distinct Open SWE identity. It remains self-hosted through Fontsource; the package is OFL-1.1 licensed and actively maintained.

## Release Note
Agent chat now uses IBM Plex Sans.

## Test Plan
- [x] Build the dashboard production bundle

Made by [Open SWE](https://openswe.vercel.app/agents/019fd477-fa4e-7549-acd8-92abe4740fe8)