### PR TITLE
fix(open-swe): drop rotating Slack loading messages from assistant status

### DIFF
--- a/agent/middleware/refresh_slack_status.py
+++ b/agent/middleware/refresh_slack_status.py
@@ -28,7 +28,6 @@ from langgraph.types import Command
 
 from ..utils.slack import (
     DEFAULT_ASSISTANT_STATUS,
-    DEFAULT_LOADING_MESSAGES,
     set_slack_assistant_status,
 )
 
@@ -114,12 +113,7 @@ def _status_from_recent_tool_calls(messages: list[Any]) -> str:
 
 async def _set_status(channel_id: str, thread_ts: str, status: str) -> None:
     try:
-        await set_slack_assistant_status(
-            channel_id,
-            thread_ts,
-            status=status,
-            loading_messages=list(DEFAULT_LOADING_MESSAGES) if status else None,
-        )
+        await set_slack_assistant_status(channel_id, thread_ts, status=status)
     except Exception:
         logger.exception("Failed to update Slack assistant status")
 

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -37,20 +37,6 @@ DEFAULT_ASSISTANT_STATUS = "is thinking…"
 SlackChannelContext = dict[str, str]
 _SLACK_CHANNEL_INFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 
-# Curated rotating loading strings shown by Slack while the indicator is active.
-# Capped at 10 by Slack's API.
-DEFAULT_LOADING_MESSAGES: tuple[str, ...] = (
-    "Pondering…",
-    "Cogitating…",
-    "Ruminating…",
-    "Noodling…",
-    "Percolating…",
-    "Marinating…",
-    "Simmering…",
-    "Conjuring…",
-    "Tinkering…",
-    "Schlepping…",
-)
 SLACK_WEB_LINK_FOOTER_LABEL = "Open in Web"
 SLACK_SECTION_TEXT_MAX_CHARS = 3000
 SLACK_FORWARDED_ATTACHMENT_MAX_COUNT = 10

--- a/tests/slack/test_refresh_slack_status_middleware.py
+++ b/tests/slack/test_refresh_slack_status_middleware.py
@@ -10,7 +10,7 @@ from agent.middleware.refresh_slack_status import (
     SlackAssistantStatusMiddleware,
     _status_from_recent_tool_calls,
 )
-from agent.utils.slack import DEFAULT_ASSISTANT_STATUS, DEFAULT_LOADING_MESSAGES
+from agent.utils.slack import DEFAULT_ASSISTANT_STATUS
 
 
 class TestSlackAssistantStatusMiddleware:
@@ -40,7 +40,7 @@ class TestSlackAssistantStatusMiddleware:
         kwargs = await_args.kwargs
         assert args == ("C1", "1.0")
         assert kwargs["status"] == DEFAULT_ASSISTANT_STATUS
-        assert kwargs["loading_messages"] == list(DEFAULT_LOADING_MESSAGES)
+        assert "loading_messages" not in kwargs
 
     @pytest.mark.asyncio
     async def test_after_agent_clears_status_when_slack_thread_present(self) -> None:
@@ -58,7 +58,7 @@ class TestSlackAssistantStatusMiddleware:
         await_args = mock_set.await_args
         assert await_args is not None
         assert await_args.kwargs["status"] == ""
-        assert await_args.kwargs["loading_messages"] is None
+        assert "loading_messages" not in await_args.kwargs
 
     @pytest.mark.asyncio
     async def test_model_call_uses_contextual_status_from_last_tool_call(self) -> None:


### PR DESCRIPTION
The Slack assistant indicator rendered two lines: a rotating word from `DEFAULT_LOADING_MESSAGES` (Pondering…, Conjuring…, …) animating above the actual tool-derived status ("delegating to a subagent…"). The animation carries no information and pulls attention off the line that does.

`loading_messages` is optional on `assistant.threads.setStatus`, so omitting it leaves only the status text. Drops the now-unused constant.

## Test Plan
- [x] `uv run pytest tests/slack/test_refresh_slack_status_middleware.py tests/slack/test_slack_assistants_status.py`
- [x] `make lint`