### PR TITLE
feat: dynamically load integration tool schemas

### DIFF
--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 _MIDDLEWARE_MODULES = {
     "check_message_queue_before_model": ".check_message_queue",
+    "DynamicToolMiddleware": ".dynamic_tools",
     "ensure_no_empty_msg": ".ensure_no_empty_msg",
     "ExcludeToolsMiddleware": ".exclude_tools",
     "ModelCallTimeoutMiddleware": ".model_call_timeout",
@@ -31,6 +32,7 @@ _MIDDLEWARE_MODULES = {
 }
 
 __all__ = [
+    "DynamicToolMiddleware",
     "ExcludeToolsMiddleware",
     "ModelCallTimeoutMiddleware",
     "ModelFallbackMiddleware",
@@ -60,6 +62,7 @@ __all__ = [
 
 if TYPE_CHECKING:
     from .check_message_queue import check_message_queue_before_model
+    from .dynamic_tools import DynamicToolMiddleware
     from .ensure_no_empty_msg import ensure_no_empty_msg
     from .exclude_tools import ExcludeToolsMiddleware
     from .model_call_timeout import ModelCallTimeoutMiddleware

--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -1,0 +1,134 @@
+"""Load optional integration tool schemas only when requested."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
+from typing import Annotated, Any, NotRequired
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ModelRequest,
+    ModelResponse,
+    ToolCallRequest,
+)
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import BaseTool, InjectedToolCallId, StructuredTool
+from langgraph.prebuilt import InjectedState
+from langgraph.runtime import Runtime
+from langgraph.types import Command, Overwrite
+
+
+def _merge_tool_names(current: list[str], update: list[str]) -> list[str]:
+    return sorted(set(current) | set(update))
+
+
+class DynamicToolState(AgentState):
+    loaded_integration_tools: NotRequired[Annotated[list[str], _merge_tool_names]]
+
+
+class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
+    """Expose connected integration schemas only after explicit loading."""
+
+    state_schema = DynamicToolState
+
+    def __init__(
+        self,
+        groups: Mapping[str, Sequence[BaseTool]],
+        reserved_names: Collection[str] = (),
+    ) -> None:
+        self._tools_by_name: dict[str, BaseTool] = {}
+        reserved = {"load_integration_tools", *reserved_names}
+        catalog: list[str] = []
+        for group, tools in groups.items():
+            names: list[str] = []
+            for tool in tools:
+                if tool.name in reserved or tool.name in self._tools_by_name:
+                    raise ValueError(f"Duplicate integration tool name: {tool.name}")
+                self._tools_by_name[tool.name] = tool
+                names.append(tool.name)
+            if names:
+                catalog.append(f"- {group}: {', '.join(sorted(names))}")
+
+        async def load_integration_tools(
+            tool_names: list[str],
+            state: Annotated[DynamicToolState | None, InjectedState] = None,
+            tool_call_id: Annotated[str, InjectedToolCallId] = "",
+        ) -> Command:
+            unknown = sorted(set(tool_names) - self._tools_by_name.keys())
+            if unknown:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=f"Unknown integration tools: {', '.join(unknown)}",
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ]
+                    }
+                )
+            loaded = set(state.get("loaded_integration_tools", [])) if state else set()
+            loaded.update(tool_names)
+            names = sorted(loaded)
+            return Command(
+                update={
+                    "loaded_integration_tools": names,
+                    "messages": [
+                        ToolMessage(
+                            content=(
+                                f"Loaded integration tool schemas: {', '.join(sorted(tool_names))}. "
+                                "Call these tools normally on your next turn."
+                            ),
+                            tool_call_id=tool_call_id,
+                        )
+                    ],
+                }
+            )
+
+        description = (
+            "Load connected integration tool schemas before using them. Pass exact tool names, "
+            "then call the loaded tools normally on your next turn.\nAvailable tools:\n"
+            + "\n".join(catalog)
+        )
+        self.tools = [
+            StructuredTool.from_function(
+                coroutine=load_integration_tools,
+                name="load_integration_tools",
+                description=description,
+            )
+        ]
+
+    async def abefore_agent(self, state: DynamicToolState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
+        return {"loaded_integration_tools": Overwrite([])}
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        loaded = self._loaded_names(request.state)
+        tools = [self._tools_by_name[name] for name in loaded if name in self._tools_by_name]
+        return await handler(request.override(tools=[*request.tools, *tools]))
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        name = request.tool_call["name"]
+        tool = self._tools_by_name.get(name)
+        if tool is None:
+            return await handler(request)
+        if name not in self._loaded_names(request.state):
+            return ToolMessage(
+                content=f"Load {name} with load_integration_tools before calling it.",
+                tool_call_id=request.tool_call["id"],
+                status="error",
+            )
+        return await handler(request.override(tool=tool))
+
+    @staticmethod
+    def _loaded_names(state: Mapping[str, Any]) -> list[str]:
+        loaded = state.get("loaded_integration_tools", [])
+        return loaded if isinstance(loaded, list) else []

--- a/agent/server.py
+++ b/agent/server.py
@@ -592,7 +592,11 @@ def _subagent_model_timeout_middleware() -> list[AgentMiddleware[Any, Any, Any]]
     return cast(list[AgentMiddleware[Any, Any, Any]], [ModelCallTimeoutMiddleware()])
 
 
-def _general_purpose_subagent(model: BaseChatModel, skills: list[str] | None = None) -> SubAgent:
+def _general_purpose_subagent(
+    model: BaseChatModel,
+    skills: list[str] | None = None,
+    dynamic_tools: DynamicToolMiddleware | None = None,
+) -> SubAgent:
     subagent: SubAgent = {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
         "description": GENERAL_PURPOSE_SUBAGENT["description"],
@@ -601,7 +605,10 @@ def _general_purpose_subagent(model: BaseChatModel, skills: list[str] | None = N
         # tool-call cadence) that delegated work also needs.
         "system_prompt": OPEN_SWE_SHARED_BASE + "\n\n" + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
-        "middleware": _subagent_model_timeout_middleware(),
+        "middleware": [
+            *([dynamic_tools] if dynamic_tools else []),
+            *_subagent_model_timeout_middleware(),
+        ],
     }
     if skills:
         subagent["skills"] = skills
@@ -1074,7 +1081,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         slack_start_new_thread,
         slack_thread_reply,
     ]
-    dynamic_tool_middleware: list[Any] = []
+    dynamic_tool_middleware: DynamicToolMiddleware | None = None
     integration_tool_groups = {
         "Corridor": corridor_tools,
         "Observability": observability_tools,
@@ -1082,11 +1089,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         "Notion": notion_tools,
     }
     if any(integration_tool_groups.values()):
-        dynamic_tool_middleware.append(
-            DynamicToolMiddleware(
-                integration_tool_groups,
-                reserved_names={*DEEP_AGENT_TOOL_NAMES, *(tool.__name__ for tool in static_tools)},
-            )
+        dynamic_tool_middleware = DynamicToolMiddleware(
+            integration_tool_groups,
+            reserved_names={*DEEP_AGENT_TOOL_NAMES, *(tool.__name__ for tool in static_tools)},
         )
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)
@@ -1115,7 +1120,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         system_prompt="",
         tools=static_tools,
         subagents=[
-            _general_purpose_subagent(subagent_model, skill_sources),
+            _general_purpose_subagent(subagent_model, skill_sources, dynamic_tool_middleware),
             *([_browser_subagent(subagent_model, browser_tools)] if browser_tools else []),
         ],
         skills=skill_sources,
@@ -1137,7 +1142,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     plan_mode=plan_mode,
                     corridor_enabled=bool(corridor_tools),
                 ),
-                *dynamic_tool_middleware,
+                *([dynamic_tool_middleware] if dynamic_tool_middleware else []),
                 SanitizeToolInputsMiddleware(),
                 ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
                 ToolErrorMiddleware(),

--- a/agent/server.py
+++ b/agent/server.py
@@ -72,6 +72,7 @@ from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
 from .middleware import (
     BasePrepareRunMiddleware,
+    DynamicToolMiddleware,
     ModelCallTimeoutMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
@@ -165,6 +166,17 @@ client = get_client()
 
 DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS = 5.0
 USER_SKILLS_ROUTE = "/skills/"
+DEEP_AGENT_TOOL_NAMES = {
+    "delete",
+    "edit_file",
+    "execute",
+    "glob",
+    "grep",
+    "ls",
+    "read_file",
+    "task",
+    "write_file",
+}
 
 
 def _tool_loader_timeout_seconds() -> float:
@@ -1036,6 +1048,47 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             ),
         )
 
+    static_tools = [
+        http_request,
+        fetch_url,
+        web_search,
+        approve_plan,
+        enter_plan_mode,
+        save_plan,
+        save_user_instructions,
+        linear_comment,
+        linear_create_issue,
+        linear_delete_issue,
+        linear_get_issue,
+        linear_get_issue_comments,
+        linear_list_teams,
+        linear_search_issues,
+        linear_update_issue,
+        open_pull_request,
+        request_pr_review,
+        recreate_sandbox,
+        report_platform_issue,
+        schedule_thread_wakeup,
+        slack_add_reaction,
+        slack_read_thread_messages,
+        slack_start_new_thread,
+        slack_thread_reply,
+    ]
+    dynamic_tool_middleware: list[Any] = []
+    integration_tool_groups = {
+        "Corridor": corridor_tools,
+        "Observability": observability_tools,
+        "Currents": currents_tools,
+        "Notion": notion_tools,
+    }
+    if any(integration_tool_groups.values()):
+        dynamic_tool_middleware.append(
+            DynamicToolMiddleware(
+                integration_tool_groups,
+                reserved_names={*DEEP_AGENT_TOOL_NAMES, *(tool.__name__ for tool in static_tools)},
+            )
+        )
+
     logger.info("Returning agent with sandbox for thread %s", thread_id)
     agent_backend: BackendProtocol = backend
     skill_sources: list[str] | None = None
@@ -1060,36 +1113,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     return create_deep_agent(
         model=main_model,
         system_prompt="",
-        tools=[
-            http_request,
-            fetch_url,
-            web_search,
-            approve_plan,
-            enter_plan_mode,
-            save_plan,
-            save_user_instructions,
-            linear_comment,
-            linear_create_issue,
-            linear_delete_issue,
-            linear_get_issue,
-            linear_get_issue_comments,
-            linear_list_teams,
-            linear_search_issues,
-            linear_update_issue,
-            open_pull_request,
-            request_pr_review,
-            recreate_sandbox,
-            report_platform_issue,
-            schedule_thread_wakeup,
-            slack_add_reaction,
-            slack_read_thread_messages,
-            slack_start_new_thread,
-            slack_thread_reply,
-            *corridor_tools,
-            *observability_tools,
-            *currents_tools,
-            *notion_tools,
-        ],
+        tools=static_tools,
         subagents=[
             _general_purpose_subagent(subagent_model, skill_sources),
             *([_browser_subagent(subagent_model, browser_tools)] if browser_tools else []),
@@ -1113,6 +1137,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     plan_mode=plan_mode,
                     corridor_enabled=bool(corridor_tools),
                 ),
+                *dynamic_tool_middleware,
                 SanitizeToolInputsMiddleware(),
                 ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
                 ToolErrorMiddleware(),

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse, ToolCallRequest
@@ -85,3 +86,12 @@ async def test_dynamic_tools_load_only_selected_schemas_and_route_calls() -> Non
 
     with pytest.raises(ValueError, match="Duplicate integration tool name"):
         DynamicToolMiddleware({"Notion": [_tool("static")]}, reserved_names={"static"})
+
+
+def test_general_purpose_subagent_includes_dynamic_tools() -> None:
+    from agent.server import _general_purpose_subagent
+
+    middleware = DynamicToolMiddleware({"Notion": [_tool("notion-search")]})
+    subagent = _general_purpose_subagent(MagicMock(), dynamic_tools=middleware)
+
+    assert middleware in subagent.get("middleware", [])

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, cast
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse, ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import BaseTool, StructuredTool
+from langgraph.types import Command
+
+from agent.middleware.dynamic_tools import DynamicToolMiddleware
+
+
+def _tool(name: str, description: str = "schema details that must stay hidden") -> BaseTool:
+    async def run(value: str) -> str:
+        return value
+
+    return StructuredTool.from_function(coroutine=run, name=name, description=description)
+
+
+@dataclass
+class _Request:
+    state: dict[str, Any]
+    tools: list[BaseTool]
+    tool_call: dict[str, Any] | None = None
+    tool: BaseTool | None = None
+
+    def override(self, **kwargs: Any) -> _Request:
+        return replace(self, **kwargs)
+
+
+async def test_dynamic_tools_load_only_selected_schemas_and_route_calls() -> None:
+    notion_search = _tool("notion-search")
+    notion_update = _tool("notion-update-page")
+    middleware = DynamicToolMiddleware({"Notion": [notion_search, notion_update]})
+    loader = cast(StructuredTool, middleware.tools[0])
+
+    assert "notion-search, notion-update-page" in loader.description
+    assert "schema details that must stay hidden" not in loader.description
+    schema = cast(Any, loader.tool_call_schema).model_json_schema()
+    assert set(schema["properties"]) == {"tool_names"}
+
+    coroutine = cast(Any, loader.coroutine)
+    command = await coroutine(tool_names=["notion-search"], state={}, tool_call_id="load-1")
+    assert isinstance(command, Command)
+    loaded_state = cast(dict[str, Any], command.update)
+    assert loaded_state["loaded_integration_tools"] == ["notion-search"]
+    assert "next turn" in loaded_state["messages"][0].content
+
+    visible: list[str] = []
+
+    async def model_handler(request: ModelRequest) -> ModelResponse:
+        visible.extend(tool.name for tool in request.tools if isinstance(tool, BaseTool))
+        return cast(ModelResponse, object())
+
+    model_request = _Request(state=loaded_state, tools=[_tool("static")])
+    await middleware.awrap_model_call(cast(ModelRequest, model_request), model_handler)
+    assert visible == ["static", "notion-search"]
+
+    routed: list[str] = []
+
+    async def tool_handler(request: ToolCallRequest) -> ToolMessage:
+        assert request.tool is not None
+        routed.append(request.tool.name)
+        return ToolMessage(content="ok", tool_call_id=request.tool_call["id"])
+
+    loaded_call = _Request(
+        state=loaded_state,
+        tools=[],
+        tool_call={"name": "notion-search", "args": {"value": "x"}, "id": "call-1"},
+    )
+    result = await middleware.awrap_tool_call(cast(ToolCallRequest, loaded_call), tool_handler)
+    assert isinstance(result, ToolMessage)
+    assert routed == ["notion-search"]
+
+    unloaded_call = replace(
+        loaded_call,
+        tool_call={"name": "notion-update-page", "args": {}, "id": "call-2"},
+    )
+    result = await middleware.awrap_tool_call(cast(ToolCallRequest, unloaded_call), tool_handler)
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert routed == ["notion-search"]
+
+    with pytest.raises(ValueError, match="Duplicate integration tool name"):
+        DynamicToolMiddleware({"Notion": [_tool("static")]}, reserved_names={"static"})

--- a/tests/tools/test_corridor_mcp.py
+++ b/tests/tools/test_corridor_mcp.py
@@ -182,11 +182,15 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
             patch.object(server, "create_deep_agent", side_effect=fake_create_deep_agent),
         ):
             await server.get_agent(cast(RunnableConfig, config))
-            prepare = cast(AgentMiddleware, cast(list[object], captured["middleware"])[0])
+            middleware = cast(list[object], captured["middleware"])
+            prepare = cast(AgentMiddleware, middleware[0])
             await prepare.abefore_agent(
                 cast(AgentState[object], {"messages": []}),
                 cast(Runtime[None], MagicMock()),
             )
+            if corridor_tools:
+                assert corridor_tools[0] not in cast(list[object], captured["tools"])
+                assert "DynamicToolMiddleware" in {type(item).__name__ for item in middleware}
         return bool(prompt.call_args.kwargs["corridor_enabled"])
 
     assert await run_with_corridor_tools([]) is False


### PR DESCRIPTION
## Description
Connected optional integrations now load full schemas only after selection, including in delegated general-purpose agents.

## Release Note
Integration tool schemas now load on demand to reduce initial agent context.

## Test Plan
- [x] Verify selected schemas are available to parent and delegated agents.

Made by [Open SWE](https://openswe.vercel.app/agents/019fd844-e1ae-7308-9dd8-eccae293bd94)
