### PR TITLE
feat(reviewer): record structured auto-approval decisions

### DIFF
--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -101,6 +101,7 @@ from .tools import (
     http_request,
     list_findings,
     publish_review,
+    record_auto_approval_decision,
     reply_to_finding_thread,
     resolve_finding_thread,
     update_finding,
@@ -140,8 +141,14 @@ If a skills section appears below, the repo ships reviewer-relevant skills. Read
 the `SKILL.md` that matches the area you're reviewing and apply it.
 
 Tools: `fetch_review_diff`, `add_finding`, `update_finding`, `list_findings`,
-`publish_review`, `resolve_finding_thread`, `reply_to_finding_thread`.
+`publish_review`, `resolve_finding_thread`, `reply_to_finding_thread`,
+`record_auto_approval_decision`.
 Call `publish_review` once at the end.
+
+Call `record_auto_approval_decision` only when trusted repository instructions
+explicitly require an auto-approval assessment. Record it before
+`publish_review`. The decision is shadow telemetry and never substitutes for a
+finding or GitHub review.
 
 Delegate at most one review pass. Give the reviewer subagent an explicit,
 non-overlapping file list and ask it to return candidate defects only. The
@@ -1408,6 +1415,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
             update_finding,
             list_findings,
             publish_review,
+            record_auto_approval_decision,
             resolve_finding_thread,
             reply_to_finding_thread,
             web_search,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -21,6 +21,7 @@ _TOOL_MODULES = {
     "list_review_findings": ".list_review_findings",
     "open_pull_request": ".open_pull_request",
     "publish_review": ".publish_review",
+    "record_auto_approval_decision": ".record_auto_approval_decision",
     "read_repo_file": ".read_repo_file",
     "recreate_sandbox": ".recreate_sandbox",
     "report_platform_issue": ".report_platform_issue",
@@ -58,6 +59,7 @@ __all__ = [
     "list_review_findings",
     "open_pull_request",
     "publish_review",
+    "record_auto_approval_decision",
     "read_repo_file",
     "recreate_sandbox",
     "report_platform_issue",
@@ -95,6 +97,7 @@ if TYPE_CHECKING:
     from .list_review_findings import list_review_findings
     from .open_pull_request import open_pull_request
     from .publish_review import publish_review
+    from .record_auto_approval_decision import record_auto_approval_decision
     from .read_repo_file import read_repo_file
     from .recreate_sandbox import recreate_sandbox
     from .reply_to_finding_thread import reply_to_finding_thread

--- a/agent/tools/record_auto_approval_decision.py
+++ b/agent/tools/record_auto_approval_decision.py
@@ -1,0 +1,84 @@
+"""Tool: ``record_auto_approval_decision``. Persist a structured shadow decision."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..review.findings import (
+    ReviewerThreadMissingError,
+    get_thread_id_from_runtime,
+    resolve_review_head_sha,
+    set_reviewer_thread_metadata,
+    thread_missing_tool_result,
+)
+
+_OUTCOMES = {"AUTO_APPROVE_CANDIDATE", "HUMAN_REVIEW_REQUIRED", "ABSTAIN"}
+
+
+async def record_auto_approval_decision(
+    outcome: str,
+    evidence: list[str],
+    failed_requirements: list[str],
+    rubric_version: str,
+) -> dict[str, Any]:
+    """Record an explicit, non-publishing auto-approval shadow decision.
+
+    Use this tool only when trusted repository instructions explicitly require
+    an auto-approval assessment. A normal review with no findings is not an
+    auto-approval decision.
+
+    This tool records reviewer judgment for evaluation and downstream policy.
+    It does not approve the pull request, publish a GitHub review, change the
+    review Check Run conclusion, or override deterministic eligibility gates.
+
+    Args:
+        outcome: One of ``AUTO_APPROVE_CANDIDATE``, ``HUMAN_REVIEW_REQUIRED``,
+            or ``ABSTAIN``.
+        evidence: Concise facts supporting the outcome. Do not include hidden
+            reasoning or unsupported claims.
+        failed_requirements: Rubric requirements that failed or could not be
+            proven. Use an empty list only when every requirement is satisfied.
+        rubric_version: Stable version supplied by the repository rubric.
+
+    Returns:
+        The persisted decision, or ``success: false`` with a validation error.
+    """
+    if outcome not in _OUTCOMES:
+        return {"success": False, "error": f"Invalid outcome: {outcome}"}
+    if not rubric_version.strip():
+        return {"success": False, "error": "rubric_version must be non-empty"}
+    if not evidence:
+        return {"success": False, "error": "evidence must be non-empty"}
+    if outcome == "AUTO_APPROVE_CANDIDATE" and failed_requirements:
+        return {
+            "success": False,
+            "error": "AUTO_APPROVE_CANDIDATE cannot include failed_requirements",
+        }
+
+    config = get_config()
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    thread_id = get_thread_id_from_runtime()
+    try:
+        head_sha = await resolve_review_head_sha(thread_id, configurable)
+    except ReviewerThreadMissingError as exc:
+        return thread_missing_tool_result(exc)
+
+    decision = {
+        "outcome": outcome,
+        "evidence": evidence,
+        "failed_requirements": failed_requirements,
+        "rubric_version": rubric_version.strip(),
+        "head_sha": head_sha,
+        "recorded_at": datetime.now(UTC).isoformat(),
+    }
+    try:
+        await set_reviewer_thread_metadata(
+            thread_id,
+            extra={"auto_approval_decision": decision},
+        )
+    except ReviewerThreadMissingError as exc:
+        return thread_missing_tool_result(exc)
+    return {"success": True, "decision": decision}

--- a/tests/reviewer/test_reviewer_tools.py
+++ b/tests/reviewer/test_reviewer_tools.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.tools.add_finding import add_finding
 from agent.tools.list_findings import list_findings
+from agent.tools.record_auto_approval_decision import record_auto_approval_decision
 from agent.tools.resolve_finding_thread import resolve_finding_thread
 from agent.tools.update_finding import update_finding
 
@@ -70,6 +71,69 @@ async def test_add_finding_rejects_invalid_severity() -> None:
         )
     assert result["success"] is False
     assert "severity" in result["error"].lower()
+
+
+async def test_record_auto_approval_decision_persists_sha_bound_metadata() -> None:
+    set_metadata = AsyncMock()
+    with (
+        patch("agent.tools.record_auto_approval_decision.get_config", return_value=_config()),
+        patch(
+            "agent.tools.record_auto_approval_decision.get_thread_id_from_runtime",
+            return_value="tid-1",
+        ),
+        patch(
+            "agent.tools.record_auto_approval_decision.resolve_review_head_sha",
+            AsyncMock(return_value="sha-head"),
+        ),
+        patch(
+            "agent.tools.record_auto_approval_decision.set_reviewer_thread_metadata",
+            set_metadata,
+        ),
+    ):
+        result = await record_auto_approval_decision(
+            outcome="AUTO_APPROVE_CANDIDATE",
+            evidence=["frontend-only change"],
+            failed_requirements=[],
+            rubric_version="frontend-auto-approval-v1",
+        )
+
+    assert result["success"] is True
+    assert result["decision"]["head_sha"] == "sha-head"
+    set_metadata.assert_awaited_once()
+    persisted = set_metadata.await_args.kwargs["extra"]["auto_approval_decision"]
+    assert persisted == result["decision"]
+
+
+@pytest.mark.parametrize(
+    ("outcome", "evidence", "failed_requirements", "rubric_version", "error"),
+    [
+        ("APPROVE", ["fact"], [], "v1", "outcome"),
+        ("ABSTAIN", [], ["missing context"], "v1", "evidence"),
+        ("ABSTAIN", ["fact"], ["missing context"], "", "rubric_version"),
+        (
+            "AUTO_APPROVE_CANDIDATE",
+            ["fact"],
+            ["tests missing"],
+            "v1",
+            "failed_requirements",
+        ),
+    ],
+)
+async def test_record_auto_approval_decision_rejects_invalid_contract(
+    outcome: str,
+    evidence: list[str],
+    failed_requirements: list[str],
+    rubric_version: str,
+    error: str,
+) -> None:
+    result = await record_auto_approval_decision(
+        outcome=outcome,
+        evidence=evidence,
+        failed_requirements=failed_requirements,
+        rubric_version=rubric_version,
+    )
+    assert result["success"] is False
+    assert error in result["error"]
 
 
 async def test_add_finding_rejects_empty_title() -> None:


### PR DESCRIPTION
## Summary
- Add a reviewer-only `record_auto_approval_decision` tool with explicit candidate, human-review, and abstain outcomes.
- Persist evidence, failed requirements, rubric version, current head SHA, and timestamp in reviewer thread metadata so the decision is available in LangSmith traces and downstream evaluation.
- Keep the tool non-publishing: it does not approve PRs, alter findings, submit reviews, or change Check Run conclusions. The reviewer uses it only when trusted repository instructions explicitly request an auto-approval assessment.

## Test Plan
- [x] Verify valid candidate decisions persist SHA-bound structured metadata.
- [x] Verify invalid outcomes, empty evidence/version, and contradictory candidate decisions fail closed.
- [x] Exercise reviewer prompt/tool assembly and existing reviewer-tool behavior.