### PR TITLE
fix: let user scrolling override diff navigation

### DIFF
--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -443,18 +443,17 @@ export function AgentGitPanel({
     [files]
   )
 
-  const selectTreePath = useCallback(
-    (path: string) => {
-      setSelectedTreePath(path)
-      const target = files.find((file) => file.treePath === path)
-      if (!target) return
-      sectionRefs.current[target.filePath]?.scrollIntoView({
-        block: "start",
-        behavior: "smooth",
-      })
-    },
-    [files]
-  )
+  const filesRef = useRef(files)
+  filesRef.current = files
+  const selectTreePath = useCallback((path: string) => {
+    setSelectedTreePath(path)
+    const target = filesRef.current.find((file) => file.treePath === path)
+    if (!target) return
+    sectionRefs.current[target.filePath]?.scrollIntoView({
+      block: "start",
+      behavior: "smooth",
+    })
+  }, [])
 
   if (collapsed) {
     return (

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -443,15 +443,18 @@ export function AgentGitPanel({
     [files]
   )
 
-  useEffect(() => {
-    if (!selectedTreePath) return
-    const target = files.find((file) => file.treePath === selectedTreePath)
-    if (!target) return
-    sectionRefs.current[target.filePath]?.scrollIntoView({
-      block: "start",
-      behavior: "smooth",
-    })
-  }, [selectedTreePath, files])
+  const selectTreePath = useCallback(
+    (path: string) => {
+      setSelectedTreePath(path)
+      const target = files.find((file) => file.treePath === path)
+      if (!target) return
+      sectionRefs.current[target.filePath]?.scrollIntoView({
+        block: "start",
+        behavior: "smooth",
+      })
+    },
+    [files]
+  )
 
   if (collapsed) {
     return (
@@ -661,7 +664,7 @@ export function AgentGitPanel({
                     <FileTreeExplorer
                       files={files}
                       selectedTreePath={selectedTreePath}
-                      onSelect={setSelectedTreePath}
+                      onSelect={selectTreePath}
                     />
                   </div>
                 )}


### PR DESCRIPTION
## Description
Scroll to a diff only on an explicit file-tree selection, preventing later file-data updates from overriding manual scrolling.

## Release Note
Fixed full-screen diff navigation fighting user scrolling.

## Test Plan
- [x] Select a file, then manually scroll away without snapping back.

Made by [Open SWE](https://openswe.vercel.app/agents/019fd863-85ff-7441-be8d-b176edfdcba0)