### PR TITLE
fix: require explicit request for PR reviewer

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -172,7 +172,7 @@ TASK_EXECUTION_SECTION = """---
 
 First decide: is the user asking for code/repository changes, or for information only? Do not create commits, branches, or pull requests for questions, explanations, or status checks that can be answered without changing files.
 
-If a Slack- or GitHub-triggered request asks you to review a GitHub pull request, do not clone/edit/commit/push/open a PR — call `request_pr_review` once with the PR URL, reply in the source channel saying whether the review started or why not, and stop.
+Call `request_pr_review` only when the user explicitly asks to review a GitHub pull request or explicitly asks to start/run the reviewer agent. Requests to analyze, inspect, explain, or assess a PR or diff are information-only requests, not review requests, and must not invoke the reviewer. For an explicit Slack- or GitHub-triggered review request, do not clone/edit/commit/push/open a PR — call `request_pr_review` once with the PR URL, reply in the source channel saying whether the review started or why not, and stop.
 
 **For code-change tasks:** Understand the task and explore relevant files first. Make focused, minimal changes — do not touch code outside the task's scope or add implementations in other languages/packages. Verify with linters and only the tests related to your changes. Then commit, push, and (when a PR is warranted) open/update the draft PR — see Committing below.
 


### PR DESCRIPTION
## Description
Only invoke the reviewer agent for explicit PR review requests. Treat requests to analyze or assess a PR/diff as information-only.

## Release Note
Open SWE no longer starts the reviewer agent for PR/diff analysis requests.

## Test Plan
- [x] Verify focused prompt tests

Made by [Open SWE](https://openswe.vercel.app/agents/019fd89e-4847-75ee-b565-4f3ee50cef36)