### PR TITLE
feat: let agents manage user skills

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -105,6 +105,7 @@ from .runtime.constants import (
 from .runtime.execution import graph_loaded_for_execution
 from .tools import (
     approve_plan,
+    delete_user_skill,
     enter_plan_mode,
     fetch_url,
     http_request,
@@ -122,6 +123,7 @@ from .tools import (
     request_pr_review,
     save_plan,
     save_user_instructions,
+    save_user_skill,
     schedule_thread_wakeup,
     slack_add_reaction,
     slack_read_thread_messages,
@@ -1087,6 +1089,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         enter_plan_mode,
         save_plan,
         save_user_instructions,
+        save_user_skill,
+        delete_user_skill,
         linear_comment,
         linear_create_issue,
         linear_delete_issue,

--- a/agent/server.py
+++ b/agent/server.py
@@ -576,6 +576,8 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
         "open_pull_request",
         "recreate_sandbox",
         "request_pr_review",
+        "save_user_skill",
+        "delete_user_skill",
         "slack_start_new_thread",
         "linear_create_issue",
         "linear_update_issue",

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -29,6 +29,8 @@ _TOOL_MODULES = {
     "resolve_finding_thread": ".resolve_finding_thread",
     "save_plan": ".save_plan",
     "save_user_instructions": ".save_user_instructions",
+    "save_user_skill": ".user_skills",
+    "delete_user_skill": ".user_skills",
     "schedule_thread_wakeup": ".schedule_thread_wakeup",
     "search_repo_code": ".search_repo_code",
     "slack_add_reaction": ".slack_add_reaction",
@@ -66,6 +68,8 @@ __all__ = [
     "resolve_finding_thread",
     "save_plan",
     "save_user_instructions",
+    "save_user_skill",
+    "delete_user_skill",
     "schedule_thread_wakeup",
     "search_repo_code",
     "slack_add_reaction",
@@ -110,6 +114,7 @@ if TYPE_CHECKING:
     from .slack_start_new_thread import slack_start_new_thread
     from .slack_thread_reply import slack_thread_reply
     from .update_finding import update_finding
+    from .user_skills import delete_user_skill, save_user_skill
     from .web_search import web_search
 
 

--- a/agent/tools/user_skills.py
+++ b/agent/tools/user_skills.py
@@ -1,0 +1,55 @@
+"""Tools for managing the triggering user's skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..dashboard.agent_overrides import resolve_github_login
+from ..dashboard.skills import (
+    SkillCreate,
+    SkillUpdate,
+    create_skill,
+    delete_skill,
+    get_skill,
+    update_skill,
+)
+from ..utils.json_types import as_json_object
+
+
+def _login() -> str | None:
+    return resolve_github_login(as_json_object(get_config()))
+
+
+async def save_user_skill(name: str, description: str, instructions: str = "") -> dict[str, Any]:
+    """Create or update a skill owned by the triggering user.
+
+    Call this when the user asks to create or modify a reusable skill. The name
+    must use lowercase letters, numbers, and single hyphens. Changes apply to
+    future runs and cannot affect another user's or a bundled skill.
+    """
+    login = _login()
+    if not login:
+        return {"ok": False, "error": "Could not resolve the triggering user's GitHub login"}
+
+    existing = await get_skill(login, name)
+    if existing:
+        skill = await update_skill(
+            login, name, SkillUpdate(description=description, instructions=instructions)
+        )
+    else:
+        skill = await create_skill(
+            login, SkillCreate(name=name, description=description, instructions=instructions)
+        )
+    return {"ok": True, "skill": skill}
+
+
+async def delete_user_skill(name: str) -> dict[str, Any]:
+    """Delete a skill owned by the triggering user when they explicitly request it."""
+    login = _login()
+    if not login:
+        return {"ok": False, "error": "Could not resolve the triggering user's GitHub login"}
+
+    await delete_skill(login, name)
+    return {"ok": True, "name": name}

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -28,6 +28,8 @@ def test_plan_mode_excluded_tools_cover_mutating_tools() -> None:
         "open_pull_request",
         "recreate_sandbox",
         "request_pr_review",
+        "save_user_skill",
+        "delete_user_skill",
         "slack_start_new_thread",
         "linear_create_issue",
         "linear_update_issue",

--- a/tests/agent/test_skills.py
+++ b/tests/agent/test_skills.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 from pydantic import ValidationError
 
 from agent.dashboard.skills import SkillCreate, create_skill, list_skills
+from agent.tools.user_skills import save_user_skill
 
 
 async def test_skill_validation_and_persistence() -> None:
@@ -39,6 +40,22 @@ async def test_skill_validation_and_persistence() -> None:
         "/review-feedback/SKILL.md",
         record,
     )
+
+
+async def test_save_user_skill_uses_triggering_user_namespace() -> None:
+    create = AsyncMock(return_value={"name": "deslop"})
+    with (
+        patch(
+            "agent.tools.user_skills.get_config",
+            return_value={"configurable": {"github_login": "octocat"}},
+        ),
+        patch("agent.tools.user_skills.get_skill", new_callable=AsyncMock, return_value=None),
+        patch("agent.tools.user_skills.create_skill", create),
+    ):
+        result = await save_user_skill("deslop", "Minimize diffs", "Remove bloat.")
+
+    assert result == {"ok": True, "skill": {"name": "deslop"}}
+    create.assert_awaited_once_with("octocat", ANY)
 
 
 async def test_skill_listing_returns_next_offset() -> None:


### PR DESCRIPTION
## Description
Add user-scoped tools so Open SWE can create, update, and delete the triggering user’s skills while keeping the skills filesystem read-only and isolated.

## Release Note
Open SWE can now manage user skills from prompts.

## Test Plan
- [x] Create a skill through the agent tool and verify the triggering user namespace is used.

Made by [Open SWE](https://openswe.vercel.app/agents/019fd8b3-72b3-774e-9220-6521610faa8b)