### PR TITLE
fix: remember right panel state per thread

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -107,13 +107,16 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   // Own the git panel's collapsed state so the plan banner can reserve space for
   // the floating expand button the panel renders while collapsed.
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
-    readStoredPanelCollapsed()
+    readStoredPanelCollapsed(thread.id)
   )
   const [panelTab, setPanelTab] = useState<AgentPanelTab>("git")
-  const handlePanelCollapsedChange = useCallback((next: boolean) => {
-    setPanelCollapsed(next)
-    writeStoredPanelCollapsed(next)
-  }, [])
+  const handlePanelCollapsedChange = useCallback(
+    (next: boolean) => {
+      setPanelCollapsed(next)
+      writeStoredPanelCollapsed(thread.id, next)
+    },
+    [thread.id]
+  )
 
   const baseMessages = useMemo<Array<Message>>(() => {
     const live = streamMessagesToUi(

--- a/ui/src/features/agents/lib/gitPanelPreferences.test.ts
+++ b/ui/src/features/agents/lib/gitPanelPreferences.test.ts
@@ -1,58 +1,24 @@
 /** @vitest-environment jsdom */
 
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 
 import {
   readStoredPanelCollapsed,
   writeStoredPanelCollapsed,
 } from "./gitPanelPreferences"
 
-function mockViewport(matches: boolean): void {
-  Object.defineProperty(window, "matchMedia", {
-    configurable: true,
-    writable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
-      matches,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-}
-
-beforeEach(() => {
-  window.localStorage.clear()
-  mockViewport(false)
-})
+beforeEach(() => window.localStorage.clear())
 
 describe("git panel collapsed preference", () => {
-  it("defaults to collapsed before really wide screens", () => {
-    mockViewport(false)
-
-    expect(readStoredPanelCollapsed()).toBe(true)
+  it("defaults each thread to collapsed", () => {
+    expect(readStoredPanelCollapsed("thread-a")).toBe(true)
+    expect(readStoredPanelCollapsed("thread-b")).toBe(true)
   })
 
-  it("defaults to expanded on really wide screens", () => {
-    mockViewport(true)
+  it("keeps panel state per thread", () => {
+    writeStoredPanelCollapsed("thread-a", false)
 
-    expect(readStoredPanelCollapsed()).toBe(false)
-  })
-
-  it("keeps an explicit collapsed preference on really wide screens", () => {
-    mockViewport(true)
-    writeStoredPanelCollapsed(true)
-
-    expect(readStoredPanelCollapsed()).toBe(true)
-  })
-
-  it("keeps an explicit expanded preference before really wide screens", () => {
-    mockViewport(false)
-    writeStoredPanelCollapsed(false)
-
-    expect(readStoredPanelCollapsed()).toBe(false)
+    expect(readStoredPanelCollapsed("thread-a")).toBe(false)
+    expect(readStoredPanelCollapsed("thread-b")).toBe(true)
   })
 })

--- a/ui/src/features/agents/lib/gitPanelPreferences.ts
+++ b/ui/src/features/agents/lib/gitPanelPreferences.ts
@@ -1,20 +1,26 @@
 const PANEL_STORAGE_COLLAPSED = "open-swe.gitpanel.collapsed"
 const COLLAPSED_STATE_TRUE = "1"
 const COLLAPSED_STATE_FALSE = "0"
-const PANEL_DEFAULT_EXPANDED_MEDIA_QUERY = "(min-width: 1536px)"
 
-export function readStoredPanelCollapsed(): boolean {
-  if (typeof window === "undefined") return true
-  const stored = window.localStorage.getItem(PANEL_STORAGE_COLLAPSED)
-  if (stored === COLLAPSED_STATE_TRUE) return true
-  if (stored === COLLAPSED_STATE_FALSE) return false
-  return !window.matchMedia(PANEL_DEFAULT_EXPANDED_MEDIA_QUERY).matches
+function panelStorageKey(threadId: string): string {
+  return `${PANEL_STORAGE_COLLAPSED}.${threadId}`
 }
 
-export function writeStoredPanelCollapsed(collapsed: boolean): void {
+export function readStoredPanelCollapsed(threadId: string): boolean {
+  if (typeof window === "undefined") return true
+  return (
+    window.localStorage.getItem(panelStorageKey(threadId)) !==
+    COLLAPSED_STATE_FALSE
+  )
+}
+
+export function writeStoredPanelCollapsed(
+  threadId: string,
+  collapsed: boolean
+): void {
   if (typeof window === "undefined") return
   window.localStorage.setItem(
-    PANEL_STORAGE_COLLAPSED,
+    panelStorageKey(threadId),
     collapsed ? COLLAPSED_STATE_TRUE : COLLAPSED_STATE_FALSE
   )
 }

--- a/ui/src/routes/agents/$threadId.tsx
+++ b/ui/src/routes/agents/$threadId.tsx
@@ -27,7 +27,7 @@ function AgentThreadPage() {
 
   return (
     <AgentThreadStreamBoundary>
-      <AgentThreadView thread={threadQuery.data} />
+      <AgentThreadView key={threadId} thread={threadQuery.data} />
     </AgentThreadStreamBoundary>
   )
 }


### PR DESCRIPTION
## Description
Default the right panel to collapsed and persist its open state per thread.

## Release Note
Right-panel visibility is now remembered independently for each thread.

## Test Plan
- [x] Verify panel preference isolation between two thread IDs

Made by [Open SWE](https://openswe.vercel.app/agents/019fd8ca-d75a-736a-b0f5-c43095d2ff27)