### PR TITLE
fix: restore desktop agent live updates

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 COOKIE_NAME = "osw_session"
 STATE_COOKIE_NAME = "osw_oauth_state"
+_DESKTOP_APP_ORIGIN = "open-swe://app"
 SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
 STATE_TTL_SECONDS = 600
 JWT_ALG = "HS256"
@@ -246,6 +247,7 @@ def require_same_origin(request: Request) -> None:
     allowed = allowed_dashboard_origins()
     if not allowed:
         return
+    allowed.add(_DESKTOP_APP_ORIGIN)
     request_base_origin = _origin_of(str(request.base_url))
     if request_base_origin:
         allowed.add(request_base_origin)

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -1,6 +1,7 @@
 const path = require("node:path")
 
-const APP_URL = "open-swe://app/"
+const APP_ORIGIN = "open-swe://app"
+const APP_URL = `${APP_ORIGIN}/`
 const DEFAULT_DEVELOPMENT_BACKEND_URL = "http://localhost:2024"
 const ALLOWED_PERMISSIONS = new Set(["clipboard-sanitized-write", "notifications"])
 
@@ -112,6 +113,7 @@ function staticFilePath(root, appRequestUrl) {
 }
 
 module.exports = {
+  APP_ORIGIN,
   APP_URL,
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -19,6 +19,7 @@ const {
   removeProject,
 } = require("./project-store.cjs")
 const {
+  APP_ORIGIN,
   APP_URL,
   appRedirectUrl,
   backendRequestUrl,
@@ -290,7 +291,7 @@ async function proxyBackendRequest(request) {
   }
   headers.delete("host")
   headers.set("accept-encoding", "identity")
-  headers.set("origin", new URL(backendUrl).origin)
+  headers.set("origin", APP_ORIGIN)
   const targetUrl = backendRequestUrl(backendUrl, request.url)
   const cookies = await session.defaultSession.cookies.get({ url: targetUrl })
   if (cookies.length) {

--- a/tests/dashboard/test_dashboard_csrf.py
+++ b/tests/dashboard/test_dashboard_csrf.py
@@ -66,6 +66,13 @@ async def test_require_same_origin_allows_backend_origin(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_require_same_origin_allows_desktop_origin(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+
+    oauth.require_same_origin(_request(origin="open-swe://app"))
+
+
+@pytest.mark.asyncio
 async def test_require_same_origin_normalizes_case_and_trailing_slash(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "HTTPS://Dashboard.Example/")
     monkeypatch.setenv("DASHBOARD_ALLOWED_ORIGINS", "https://Preview.Example/")


### PR DESCRIPTION
Fix the desktop proxy's CSRF origin so SDK mutation requests, including thread history and live event streams, are accepted by the backend.

The backend permits the bundled `open-swe://app` origin for mutation checks without adding it to OAuth redirect allowlists.

Tests:
- `uv run pytest -q tests/dashboard/test_dashboard_csrf.py`
- `pnpm --dir desktop test`
- desktop CJS syntax checks
- focused Ruff checks
