### PR TITLE
fix: show one static Slack tip per run

### DIFF
--- a/agent/middleware/refresh_slack_status.py
+++ b/agent/middleware/refresh_slack_status.py
@@ -37,18 +37,18 @@ logger = logging.getLogger(__name__)
 _HEARTBEAT_INTERVAL_SECONDS = 60.0
 _MAX_HEARTBEAT_SECONDS = 60 * 60
 _LOADING_TIPS: tuple[str, ...] = (
-    "Tip: I work while you're away",
-    "Tip: Send follow-ups while I work",
-    "Tip: Run tasks in parallel",
-    "Tip: Each task gets an isolated sandbox",
-    "Tip: Mention me from Slack, Linear, or GitHub",
-    "Tip: Use repo:owner/name to choose the repository",
-    "Tip: I can open draft pull requests",
-    "Tip: I can delegate work to subagents",
-    "Tip: Open the web dashboard to follow my progress",
-    "Tip: Choose your model and effort in Profile",
-    "Tip: Add AGENTS.md to teach me repo conventions",
-    "Tip: Ask me to split work into a new Slack thread",
+    "Tip: Use repo:owner/name to override the repository",
+    "Tip: Send follow-ups mid-run; I read them before my next step",
+    "Tip: Ask for plan mode to review my approach before edits",
+    "Tip: Paste a LangSmith trace link for built-in inspection",
+    "Tip: Ask me to check back after CI or a deploy finishes",
+    'Tip: Say "split this out" to start a new Slack thread',
+    "Tip: Ask me to create a reusable skill for future runs",
+    'Tip: Say "always..." to save a standing preference',
+    "Tip: Toggle Always Create PRs in your Profile",
+    "Tip: Add Repository Instructions for repo-specific behavior",
+    "Tip: Use @open-swe autofix off to pause fixes on one PR",
+    "Tip: Customize reviewer style prompts in the dashboard",
 )
 
 _T = TypeVar("_T")

--- a/agent/middleware/refresh_slack_status.py
+++ b/agent/middleware/refresh_slack_status.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
@@ -35,6 +36,20 @@ logger = logging.getLogger(__name__)
 
 _HEARTBEAT_INTERVAL_SECONDS = 60.0
 _MAX_HEARTBEAT_SECONDS = 60 * 60
+_LOADING_TIPS: tuple[str, ...] = (
+    "Tip: I work while you're away",
+    "Tip: Send follow-ups while I work",
+    "Tip: Run tasks in parallel",
+    "Tip: Each task gets an isolated sandbox",
+    "Tip: Mention me from Slack, Linear, or GitHub",
+    "Tip: Use repo:owner/name to choose the repository",
+    "Tip: I can open draft pull requests",
+    "Tip: I can delegate work to subagents",
+    "Tip: Open the web dashboard to follow my progress",
+    "Tip: Choose your model and effort in Profile",
+    "Tip: Add AGENTS.md to teach me repo conventions",
+    "Tip: Ask me to split work into a new Slack thread",
+)
 
 _T = TypeVar("_T")
 
@@ -72,7 +87,12 @@ _TOOL_STATUS: dict[str, str] = {
 }
 
 
-def _slack_thread_from_config() -> tuple[str, str] | None:
+def _loading_tip_for_run(run_id: str) -> str:
+    digest = hashlib.sha256(run_id.encode()).digest()
+    return _LOADING_TIPS[int.from_bytes(digest[:8], "big") % len(_LOADING_TIPS)]
+
+
+def _slack_status_context_from_config() -> tuple[str, str, str] | None:
     config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
     slack_thread = configurable.get("slack_thread") if isinstance(configurable, dict) else None
@@ -85,7 +105,10 @@ def _slack_thread_from_config() -> tuple[str, str] | None:
         return None
     if not channel_id or not thread_ts:
         return None
-    return channel_id, thread_ts
+
+    prepare_run_id = configurable.get("prepare_run_id")
+    tip_key = prepare_run_id if isinstance(prepare_run_id, str) and prepare_run_id else thread_ts
+    return channel_id, thread_ts, _loading_tip_for_run(tip_key)
 
 
 def _tool_call_name(tool_call: object) -> str | None:
@@ -111,9 +134,14 @@ def _status_from_recent_tool_calls(messages: list[Any]) -> str:
     return DEFAULT_ASSISTANT_STATUS
 
 
-async def _set_status(channel_id: str, thread_ts: str, status: str) -> None:
+async def _set_status(channel_id: str, thread_ts: str, status: str, loading_tip: str) -> None:
     try:
-        await set_slack_assistant_status(channel_id, thread_ts, status=status)
+        await set_slack_assistant_status(
+            channel_id,
+            thread_ts,
+            status=status,
+            loading_messages=[loading_tip] if status else None,
+        )
     except Exception:
         logger.exception("Failed to update Slack assistant status")
 
@@ -170,26 +198,26 @@ class SlackAssistantStatusMiddleware(AgentMiddleware):
 
     async def _try_set(self, status: str) -> None:
         try:
-            slack_thread = _slack_thread_from_config()
-            if slack_thread is None:
+            status_context = _slack_status_context_from_config()
+            if status_context is None:
                 return
-            channel_id, thread_ts = slack_thread
-            await _set_status(channel_id, thread_ts, status)
+            channel_id, thread_ts, loading_tip = status_context
+            await _set_status(channel_id, thread_ts, status, loading_tip)
         except Exception:
             logger.exception("Failed to read Slack thread config")
 
     async def _run_with_heartbeat(self, status: str, awaitable: Awaitable[_T]) -> _T:
         try:
-            slack_thread = _slack_thread_from_config()
+            status_context = _slack_status_context_from_config()
         except Exception:
             logger.exception("Failed to read Slack thread config")
             return await awaitable
-        if slack_thread is None:
+        if status_context is None:
             return await awaitable
 
-        channel_id, thread_ts = slack_thread
-        await _set_status(channel_id, thread_ts, status)
-        heartbeat = asyncio.create_task(self._heartbeat(channel_id, thread_ts, status))
+        channel_id, thread_ts, loading_tip = status_context
+        await _set_status(channel_id, thread_ts, status, loading_tip)
+        heartbeat = asyncio.create_task(self._heartbeat(channel_id, thread_ts, status, loading_tip))
         try:
             return await awaitable
         finally:
@@ -197,7 +225,9 @@ class SlackAssistantStatusMiddleware(AgentMiddleware):
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat
 
-    async def _heartbeat(self, channel_id: str, thread_ts: str, status: str) -> None:
+    async def _heartbeat(
+        self, channel_id: str, thread_ts: str, status: str, loading_tip: str
+    ) -> None:
         loop = asyncio.get_running_loop()
         started_at = loop.time()
         while True:
@@ -208,4 +238,4 @@ class SlackAssistantStatusMiddleware(AgentMiddleware):
                     self._max_heartbeat_seconds,
                 )
                 return
-            await _set_status(channel_id, thread_ts, status)
+            await _set_status(channel_id, thread_ts, status, loading_tip)

--- a/tests/slack/test_refresh_slack_status_middleware.py
+++ b/tests/slack/test_refresh_slack_status_middleware.py
@@ -7,7 +7,9 @@ from langchain_core.messages import AIMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 
 from agent.middleware.refresh_slack_status import (
+    _LOADING_TIPS,
     SlackAssistantStatusMiddleware,
+    _loading_tip_for_run,
     _status_from_recent_tool_calls,
 )
 from agent.utils.slack import DEFAULT_ASSISTANT_STATUS
@@ -17,8 +19,13 @@ class TestSlackAssistantStatusMiddleware:
     def _runtime(self) -> MagicMock:
         return MagicMock()
 
-    def _config(self) -> dict:
-        return {"configurable": {"slack_thread": {"channel_id": "C1", "thread_ts": "1.0"}}}
+    def _config(self, run_id: str = "run-a") -> dict:
+        return {
+            "configurable": {
+                "prepare_run_id": run_id,
+                "slack_thread": {"channel_id": "C1", "thread_ts": "1.0"},
+            }
+        }
 
     @pytest.mark.asyncio
     async def test_before_agent_sets_status_when_slack_thread_present(self) -> None:
@@ -40,7 +47,13 @@ class TestSlackAssistantStatusMiddleware:
         kwargs = await_args.kwargs
         assert args == ("C1", "1.0")
         assert kwargs["status"] == DEFAULT_ASSISTANT_STATUS
-        assert "loading_messages" not in kwargs
+        assert kwargs["loading_messages"] == [_loading_tip_for_run("run-a")]
+
+    def test_loading_tip_is_stable_per_run_and_varies_across_runs(self) -> None:
+        assert _loading_tip_for_run("run-a") == _loading_tip_for_run("run-a")
+        selected_tips = {_loading_tip_for_run(f"run-{index}") for index in range(20)}
+        assert selected_tips <= set(_LOADING_TIPS)
+        assert len(selected_tips) > 1
 
     @pytest.mark.asyncio
     async def test_after_agent_clears_status_when_slack_thread_present(self) -> None:
@@ -58,7 +71,7 @@ class TestSlackAssistantStatusMiddleware:
         await_args = mock_set.await_args
         assert await_args is not None
         assert await_args.kwargs["status"] == ""
-        assert "loading_messages" not in await_args.kwargs
+        assert await_args.kwargs["loading_messages"] is None
 
     @pytest.mark.asyncio
     async def test_model_call_uses_contextual_status_from_last_tool_call(self) -> None:
@@ -121,11 +134,13 @@ class TestSlackAssistantStatusMiddleware:
         )
         refreshed = asyncio.Event()
         set_count = 0
+        loading_messages: list[object] = []
         real_sleep = asyncio.sleep
 
-        async def fake_set_status(*_args: object, **_kwargs: object) -> bool:
+        async def fake_set_status(*_args: object, **kwargs: object) -> bool:
             nonlocal set_count
             set_count += 1
+            loading_messages.append(kwargs["loading_messages"])
             if set_count >= 2:
                 refreshed.set()
             return True
@@ -156,6 +171,7 @@ class TestSlackAssistantStatusMiddleware:
 
         assert response.result[0].content == "done"
         assert set_count >= 2
+        assert loading_messages == [[_loading_tip_for_run("run-a")]] * set_count
 
     @pytest.mark.asyncio
     async def test_skips_when_slack_thread_missing(self) -> None:


### PR DESCRIPTION
## Description
Slack falls back to rotating generic loading messages when none are provided. Select one Open SWE feature tip from the durable run ID and reuse that singleton tip for every status update and heartbeat in the run.

## Test Plan
- [x] Verify one stable tip is sent per run and selections vary across run IDs
- [x] Run the focused Slack status tests and lint

Made by [Open SWE](https://openswe.vercel.app/agents/c5426a59-8e05-fde6-8a7a-a3e913a9f0d1)