### PR TITLE
refactor: run sandbox and LangSmith IO natively async

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -390,7 +390,7 @@ def _thread_source_url(metadata: Mapping[str, Any]) -> str | None:
     return permalink.strip() if isinstance(permalink, str) and permalink.strip() else None
 
 
-def _thread_summary(
+async def _thread_summary(
     thread: ThreadLike,
     *,
     latest_run_status: str | None = None,
@@ -418,7 +418,7 @@ def _thread_summary(
     pr_state = metadata.get("pr_state")
 
     thread_id = thread.get("thread_id") or thread.get("id")
-    trace_url = get_langsmith_trace_url(thread_id) if isinstance(thread_id, str) else None
+    trace_url = await get_langsmith_trace_url(thread_id) if isinstance(thread_id, str) else None
 
     raw_sandbox_id = metadata.get("sandbox_id")
     # "__creating__" is the in-flight sentinel written before the real id lands.
@@ -664,7 +664,7 @@ async def _summarize_thread(
         thread, latest_run_status, latest_run_id = await _refresh_latest_run_metadata(
             client, thread
         )
-    return _thread_summary(
+    return await _thread_summary(
         thread,
         latest_run_status=latest_run_status,
         latest_run_id=latest_run_id,
@@ -1046,7 +1046,7 @@ async def get_dashboard_thread(
         )
         thread = {**as_thread_dict(thread), "metadata": metadata}
 
-    return _thread_summary(
+    return await _thread_summary(
         thread,
         latest_run_status=latest_run_status,
         latest_run_id=latest_run_id,
@@ -1490,7 +1490,7 @@ async def send_dashboard_message(
     except Exception:
         logger.exception("Failed to update Slack message for dashboard handoff on %s", thread_id)
     thread = await client.threads.get(thread_id)
-    return _thread_summary(thread)
+    return await _thread_summary(thread)
 
 
 async def _cancel_active_thread_runs(client: Any, thread_id: str) -> None:
@@ -1544,7 +1544,7 @@ async def cancel_dashboard_thread(
         metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
     )
     thread = await client.threads.get(thread_id)
-    return _thread_summary(thread)
+    return await _thread_summary(thread)
 
 
 async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
@@ -1565,7 +1565,7 @@ async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
         metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
     )
     updated_thread = await client.threads.get(thread_id)
-    return _thread_summary(updated_thread)
+    return await _thread_summary(updated_thread)
 
 
 async def delete_dashboard_thread(thread_id: str, login: str, *, email: str | None = None) -> None:
@@ -1605,7 +1605,7 @@ async def resolve_dashboard_thread(
         logger.debug("Could not update resolved state for thread %s", thread_id, exc_info=True)
         raise HTTPException(502, "failed to update thread") from exc
     thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
-    return _thread_summary(thread)
+    return await _thread_summary(thread)
 
 
 async def _authorized_thread_metadata(
@@ -1876,8 +1876,7 @@ async def get_dashboard_thread_recovery_patch(
         raise HTTPException(502, "could not connect to thread sandbox") from exc
 
     try:
-        result = await asyncio.to_thread(
-            sandbox.execute,
+        result = await sandbox.aexecute(
             _recovery_patch_command(metadata, thread_id),
             timeout=_RECOVERY_PATCH_TIMEOUT_SECONDS,
         )
@@ -1910,7 +1909,7 @@ async def get_dashboard_thread_recovery_patch(
         raise HTTPException(502, "failed to generate recovery patch")
 
     try:
-        downloads = await asyncio.to_thread(sandbox.download_files, [patch_path])
+        downloads = await sandbox.adownload_files([patch_path])
     except Exception as exc:  # noqa: BLE001
         logger.debug("Recovery patch download failed for %s", thread_id, exc_info=True)
         raise HTTPException(502, "failed to download recovery patch") from exc

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -9,8 +9,6 @@ import logging
 import os
 import uuid
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeout
 from typing import Any
 
 import httpx
@@ -506,44 +504,17 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         )
 
     @staticmethod
-    def _safe_kill(handle: Any) -> None:
+    async def _asafe_kill(handle: Any) -> None:
         try:
-            handle.kill()
+            await handle.kill()
         except Exception:  # noqa: BLE001 - best-effort cleanup of a wedged command
             logger.warning("Failed to kill timed-out sandbox command", exc_info=True)
 
-    def _base_execute(self, command: str, timeout: int | None) -> ExecuteResponse:
-        # WS path unavailable; the base wait=True path falls back to HTTP,
-        # which carries its own request deadline.
-        return LangSmithSandbox.execute(self, command, timeout=timeout)
+    async def _abase_execute(self, command: str, timeout: int | None) -> ExecuteResponse:
+        return await LangSmithSandbox.aexecute(self, command, timeout=timeout)
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
-        effective = timeout if timeout is not None else self._default_timeout
-        if not effective:  # 0 / None: caller opted out of any deadline
-            return super().execute(command, timeout=timeout)
-        # run(wait=False) eagerly opens the WS and reads the "started" frame, so
-        # connect/setup failures raise here — fall back to the base path.
-        try:
-            handle = self._sandbox.run(command, timeout=effective, wait=False)
-        except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS, TimeoutError):
-            return self._base_execute(command, timeout)
-        deadline = self._deadline(effective)
-        pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sbx-exec")
-        try:
-            future = pool.submit(lambda: handle.result)
-            try:
-                result = future.result(timeout=deadline)
-            except FuturesTimeout:
-                self._safe_kill(handle)
-                return self._timeout_response(deadline, server_side=False)
-            except CommandTimeoutError:
-                return self._timeout_response(effective, server_side=True)
-            except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS):
-                return self._base_execute(command, timeout)
-            return self._result_to_response(result)
-        finally:
-            # Never join: a still-wedged worker must not block the caller.
-            pool.shutdown(wait=False)
+        raise NotImplementedError("TimeoutLangSmithSandbox is async-only; use aexecute.")
 
     async def aexecute(
         self,
@@ -554,27 +525,22 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         effective = timeout if timeout is not None else self._default_timeout
         if not effective:
             return await super().aexecute(command, timeout=timeout)
-        # run(wait=False) eagerly opens the WS and reads the "started" frame
-        # (blocking, bounded by the SDK connect timeout); connect/setup failures
-        # raise here — fall back to the base path.
+        # run(wait=False) opens the WS and reads the "started" frame, so
+        # connect/setup failures raise here — fall back to the base path.
         try:
-            handle = await asyncio.to_thread(
-                self._sandbox.run, command, timeout=effective, wait=False
-            )
+            handle = await self._aget_sandbox().run(command, timeout=effective, wait=False)
         except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS, TimeoutError):
-            return await asyncio.to_thread(self._base_execute, command, timeout)
+            return await self._abase_execute(command, timeout)
         deadline = self._deadline(effective)
         try:
-            result = await asyncio.wait_for(
-                asyncio.to_thread(lambda: handle.result), timeout=deadline
-            )
+            result = await asyncio.wait_for(handle.result, timeout=deadline)
         except TimeoutError:
-            await asyncio.to_thread(self._safe_kill, handle)
+            await self._asafe_kill(handle)
             return self._timeout_response(deadline, server_side=False)
         except CommandTimeoutError:
             return self._timeout_response(effective, server_side=True)
         except (*self._WS_FALLBACK_ERRORS, *SANDBOX_NOT_READY_ERRORS):
-            return await asyncio.to_thread(self._base_execute, command, timeout)
+            return await self._abase_execute(command, timeout)
         return self._result_to_response(result)
 
 

--- a/agent/integrations/langsmith_tools.py
+++ b/agent/integrations/langsmith_tools.py
@@ -15,6 +15,7 @@ from typing import Any
 from langchain_core.tools import BaseTool, StructuredTool
 
 from ..dashboard.team_credentials import LangSmithCredentials, get_langsmith_credentials
+from ..utils.langsmith import async_langsmith_client, sync_langsmith_client
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +23,7 @@ _MAX_LIST_RUNS = 50
 
 
 def _client(creds: LangSmithCredentials):
-    from langsmith import AsyncClient
-
-    return AsyncClient(api_key=creds.api_key, api_url=creds.endpoint)
+    return async_langsmith_client(creds.api_key, creds.endpoint)
 
 
 def _serialize_run(run: Any) -> dict[str, Any]:
@@ -60,16 +59,13 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
         try:
             if load_child_runs:
                 # AsyncClient.read_run has no load_child_runs; the sync one runs off-loop.
-                from langsmith import Client
-
                 run = await asyncio.to_thread(
-                    Client(api_key=creds.api_key, api_url=creds.endpoint).read_run,
+                    sync_langsmith_client(creds.api_key, creds.endpoint).read_run,
                     run_id,
                     load_child_runs=True,
                 )
             else:
-                async with _client(creds) as client:
-                    run = await client.read_run(run_id)
+                run = await _client(creds).read_run(run_id)
         except Exception as e:  # noqa: BLE001
             logger.warning("langsmith_get_trace failed", exc_info=True)
             return {"success": False, "error": f"{type(e).__name__}: {e}"}
@@ -93,15 +89,14 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
         capped = max(1, min(limit, _MAX_LIST_RUNS))
 
         try:
-            async with _client(creds) as client:
-                runs = [
-                    run
-                    async for run in client.list_runs(
-                        project_name=project_name,
-                        filter=filter,
-                        limit=capped,
-                    )
-                ]
+            runs = [
+                run
+                async for run in _client(creds).list_runs(
+                    project_name=project_name,
+                    filter=filter,
+                    limit=capped,
+                )
+            ]
         except Exception as e:  # noqa: BLE001
             logger.warning("langsmith_list_runs failed", exc_info=True)
             return {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/agent/integrations/langsmith_tools.py
+++ b/agent/integrations/langsmith_tools.py
@@ -22,9 +22,9 @@ _MAX_LIST_RUNS = 50
 
 
 def _client(creds: LangSmithCredentials):
-    from langsmith import Client
+    from langsmith import AsyncClient
 
-    return Client(api_key=creds.api_key, api_url=creds.endpoint)
+    return AsyncClient(api_key=creds.api_key, api_url=creds.endpoint)
 
 
 def _serialize_run(run: Any) -> dict[str, Any]:
@@ -58,9 +58,18 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
             Dictionary with the run details, or an error message.
         """
         try:
-            run = await asyncio.to_thread(
-                _client(creds).read_run, run_id, load_child_runs=load_child_runs
-            )
+            if load_child_runs:
+                # AsyncClient.read_run has no load_child_runs; the sync one runs off-loop.
+                from langsmith import Client
+
+                run = await asyncio.to_thread(
+                    Client(api_key=creds.api_key, api_url=creds.endpoint).read_run,
+                    run_id,
+                    load_child_runs=True,
+                )
+            else:
+                async with _client(creds) as client:
+                    run = await client.read_run(run_id)
         except Exception as e:  # noqa: BLE001
             logger.warning("langsmith_get_trace failed", exc_info=True)
             return {"success": False, "error": f"{type(e).__name__}: {e}"}
@@ -83,17 +92,16 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
         """
         capped = max(1, min(limit, _MAX_LIST_RUNS))
 
-        def _list() -> list[Any]:
-            return list(
-                _client(creds).list_runs(
-                    project_name=project_name,
-                    filter=filter,
-                    limit=capped,
-                )
-            )
-
         try:
-            runs = await asyncio.to_thread(_list)
+            async with _client(creds) as client:
+                runs = [
+                    run
+                    async for run in client.list_runs(
+                        project_name=project_name,
+                        filter=filter,
+                        limit=capped,
+                    )
+                ]
         except Exception as e:  # noqa: BLE001
             logger.warning("langsmith_list_runs failed", exc_info=True)
             return {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/agent/integrations/local.py
+++ b/agent/integrations/local.py
@@ -1,9 +1,10 @@
+import asyncio
 import os
 
 from deepagents.backends import LocalShellBackend
 
 
-def create_local_sandbox(sandbox_id: str | None = None):
+async def create_local_sandbox(sandbox_id: str | None = None):
     """Create a local shell sandbox with no isolation.
 
     WARNING: This runs commands directly on the host machine with no sandboxing.
@@ -20,7 +21,7 @@ def create_local_sandbox(sandbox_id: str | None = None):
         LocalShellBackend instance implementing SandboxBackendProtocol.
     """
     root_dir = os.getenv("LOCAL_SANDBOX_ROOT_DIR", os.getcwd())
-    os.makedirs(root_dir, exist_ok=True)
+    await asyncio.to_thread(os.makedirs, root_dir, exist_ok=True)
 
     return LocalShellBackend(
         root_dir=root_dir,

--- a/agent/integrations/modal.py
+++ b/agent/integrations/modal.py
@@ -6,7 +6,7 @@ from langchain_modal import ModalSandbox
 MODAL_APP_NAME = os.getenv("MODAL_APP_NAME", "open-swe")
 
 
-def create_modal_sandbox(sandbox_id: str | None = None):
+async def create_modal_sandbox(sandbox_id: str | None = None):
     """Create or reconnect to a Modal sandbox.
 
     Args:
@@ -17,9 +17,9 @@ def create_modal_sandbox(sandbox_id: str | None = None):
         ModalSandbox instance implementing SandboxBackendProtocol.
     """
     if sandbox_id:
-        sandbox = modal.Sandbox.from_id(sandbox_id)
+        sandbox = await modal.Sandbox.from_id.aio(sandbox_id)
     else:
-        app = modal.App.lookup(MODAL_APP_NAME)
-        sandbox = modal.Sandbox.create(app=app)
+        app = await modal.App.lookup.aio(MODAL_APP_NAME)
+        sandbox = await modal.Sandbox.create.aio(app=app)
 
     return ModalSandbox(sandbox=sandbox)

--- a/agent/middleware/workflow_push_guard.py
+++ b/agent/middleware/workflow_push_guard.py
@@ -225,9 +225,9 @@ def _git_command(repo_dir: str | None, args: str) -> str:
     return f"git {args}"
 
 
-def _run_git(backend: Any, repo_dir: str | None, args: str) -> GitInspectResult:
+async def _run_git(backend: Any, repo_dir: str | None, args: str) -> GitInspectResult:
     try:
-        response = backend.execute(_git_command(repo_dir, args), timeout=30)
+        response = await backend.aexecute(_git_command(repo_dir, args), timeout=30)
     except Exception:
         logger.debug("workflow push inspection failed for git %s", args, exc_info=True)
         return GitInspectResult("", False)
@@ -294,45 +294,47 @@ def _approval_url(thread_id: str | None, fingerprint: str) -> str | None:
     return dashboard_workflow_approval_url(thread_id, fingerprint)
 
 
-def _workflow_change_for_push(backend: Any, parsed: ParsedGitPush) -> WorkflowPushChange | None:
-    root_result = _run_git(backend, parsed.repo_dir, "rev-parse --show-toplevel")
+async def _workflow_change_for_push(
+    backend: Any, parsed: ParsedGitPush
+) -> WorkflowPushChange | None:
+    root_result = await _run_git(backend, parsed.repo_dir, "rev-parse --show-toplevel")
     if not root_result.ok:
         return None
     root = _first_line(root_result.output)
     if not root:
         return None
 
-    branch = _run_git(backend, root, "rev-parse --abbrev-ref HEAD")
+    branch = await _run_git(backend, root, "rev-parse --abbrev-ref HEAD")
     branch_name = _first_line(branch.output) if branch.ok else ""
     if not branch_name or branch_name == "HEAD" or parsed.remote_ref != branch_name:
         return None
     if parsed.local_ref not in {"HEAD", branch_name}:
         return None
 
-    target_sha = _run_git(backend, root, f"rev-parse {shlex.quote(parsed.local_ref)}")
+    target_sha = await _run_git(backend, root, f"rev-parse {shlex.quote(parsed.local_ref)}")
     head = _first_line(target_sha.output) if target_sha.ok else ""
     if not head or not _GIT_OBJECT_ID.fullmatch(head):
         return None
 
     remote_branch = f"refs/remotes/{parsed.remote}/{parsed.remote_ref}"
-    remote_branch_exists = _run_git(
+    remote_branch_exists = await _run_git(
         backend, root, f"rev-parse --verify {shlex.quote(remote_branch)}"
     )
     if remote_branch_exists.ok and _first_line(remote_branch_exists.output):
         base_ref = remote_branch
         range_expr = f"{shlex.quote(base_ref)}..{shlex.quote(head)}"
-        base_sha = _first_line(_run_git(backend, root, f"rev-parse {shlex.quote(base_ref)}").output)
+        base_result = await _run_git(backend, root, f"rev-parse {shlex.quote(base_ref)}")
+        base_sha = _first_line(base_result.output)
     else:
-        origin_head = _run_git(backend, root, "symbolic-ref --short refs/remotes/origin/HEAD")
+        origin_head = await _run_git(backend, root, "symbolic-ref --short refs/remotes/origin/HEAD")
         base_ref = _first_line(origin_head.output) if origin_head.ok else "origin/main"
         range_expr = f"{shlex.quote(base_ref)}...{shlex.quote(head)}"
-        base_sha = _first_line(
-            _run_git(
-                backend, root, f"merge-base {shlex.quote(head)} {shlex.quote(base_ref)}"
-            ).output
+        merge_base = await _run_git(
+            backend, root, f"merge-base {shlex.quote(head)} {shlex.quote(base_ref)}"
         )
+        base_sha = _first_line(merge_base.output)
 
-    names = _run_git(
+    names = await _run_git(
         backend,
         root,
         f"diff --name-only --diff-filter=ACMRTD {range_expr} -- .github/workflows",
@@ -347,14 +349,16 @@ def _workflow_change_for_push(backend: Any, parsed: ParsedGitPush) -> WorkflowPu
     if not files:
         return None
 
-    diff = _run_git(backend, root, f"diff --binary --full-index {range_expr} -- .github/workflows")
+    diff = await _run_git(
+        backend, root, f"diff --binary --full-index {range_expr} -- .github/workflows"
+    )
     if not diff.ok or not diff.output:
         return None
-    numstat = _run_git(backend, root, f"diff --numstat {range_expr} -- .github/workflows")
+    numstat = await _run_git(backend, root, f"diff --numstat {range_expr} -- .github/workflows")
     diff_preview, diff_preview_truncated = _diff_preview(diff.output)
     diff_stats = _diff_stats(files, numstat.output if numstat.ok else "")
 
-    remote = _run_git(backend, root, "config --get remote.origin.url")
+    remote = await _run_git(backend, root, "config --get remote.origin.url")
     repo = _normalize_remote(_first_line(remote.output)) if remote.ok else ""
     fixed_refspec = f"{head}:refs/heads/{parsed.remote_ref}"
     fixed_args = ["push"]
@@ -514,7 +518,7 @@ class WorkflowPushGuardMiddleware(AgentMiddleware):
 
     state_schema = AgentState
 
-    def _change_for_request(self, request: ToolCallRequest) -> WorkflowPushChange | None:
+    async def _change_for_request(self, request: ToolCallRequest) -> WorkflowPushChange | None:
         if _tool_name(request) != "execute":
             return None
         command = _tool_args(request).get("command")
@@ -526,7 +530,7 @@ class WorkflowPushGuardMiddleware(AgentMiddleware):
         backend = _backend(_thread_id(request))
         if backend is None:
             return None
-        return _workflow_change_for_push(backend, parsed)
+        return await _workflow_change_for_push(backend, parsed)
 
     async def _handle_change_async(
         self,
@@ -553,7 +557,7 @@ class WorkflowPushGuardMiddleware(AgentMiddleware):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
     ) -> ToolMessage | Command:
-        change = self._change_for_request(request)
+        change = await self._change_for_request(request)
         if change is None:
             return await handler(request)
         return await self._handle_change_async(request, handler, change)

--- a/agent/review/diff.py
+++ b/agent/review/diff.py
@@ -14,7 +14,6 @@ The reviewer needs three things from a PR diff:
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
 import re
@@ -404,7 +403,7 @@ async def compute_diff_in_sandbox(
     """
     operator = "..." if merge_base else ".."
     cmd = f"cd {work_dir} && git diff --no-color {base_ref}{operator}{head_ref}"
-    result = await asyncio.to_thread(sandbox_backend.execute, cmd)
+    result = await sandbox_backend.aexecute(cmd)
     exit_code = getattr(result, "exit_code", None)
     if exit_code not in (0, None):
         output = _stdout_from_result(result)

--- a/agent/review/trace_context.py
+++ b/agent/review/trace_context.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -225,7 +224,7 @@ async def _resolve_session(
         thread_id=thread_id,
         evidence=evidence,
         confidence=confidence,
-        trace_url=_trace_url(thread_id, project),
+        trace_url=await _trace_url(thread_id, project),
         runs=runs,
     )
     return session, "Resolved.", project
@@ -347,20 +346,17 @@ async def _list_thread_runs(client: Any, project: str, thread_id: str, *, limit:
 async def _list_runs(client: Any, project: str, filter_expr: str, *, limit: int) -> list[Any]:
     capped = max(1, min(limit, _MAX_SESSION_RUNS))
 
-    def _call() -> list[Any]:
-        kwargs: dict[str, Any] = {"filter": filter_expr, "limit": capped}
-        if _looks_uuid(project):
-            kwargs["project_id"] = project
-        else:
-            kwargs["project_name"] = project
-        try:
-            return list(client.list_runs(**kwargs))
-        except TypeError:
-            kwargs.pop("project_id", None)
-            kwargs["project_name"] = project
-            return list(client.list_runs(**kwargs))
-
-    return await asyncio.to_thread(_call)
+    kwargs: dict[str, Any] = {"filter": filter_expr, "limit": capped}
+    if _looks_uuid(project):
+        kwargs["project_id"] = project
+    else:
+        kwargs["project_name"] = project
+    try:
+        return [run async for run in client.list_runs(**kwargs)]
+    except TypeError:
+        kwargs.pop("project_id", None)
+        kwargs["project_name"] = project
+        return [run async for run in client.list_runs(**kwargs)]
 
 
 def _serialize_run(run: Any) -> dict[str, Any]:
@@ -469,8 +465,8 @@ def _is_specific_branch(branch: str) -> bool:
     return normalized not in _GENERIC_BRANCHES
 
 
-def _trace_url(thread_id: str, project: str) -> str | None:
-    resolved = get_langsmith_trace_url(thread_id, project_name=project)
+async def _trace_url(thread_id: str, project: str) -> str | None:
+    resolved = await get_langsmith_trace_url(thread_id, project_name=project)
     if resolved:
         return resolved
     tenant_id = os.environ.get("LANGSMITH_TENANT_ID_PROD")

--- a/agent/server.py
+++ b/agent/server.py
@@ -381,8 +381,7 @@ async def _refresh_github_proxy_or_fail(
 
 
 async def _configure_git_identity(sandbox_backend: SandboxBackendProtocol) -> None:
-    await asyncio.to_thread(
-        sandbox_backend.execute,
+    await sandbox_backend.aexecute(
         f"git config --global user.name '{OPEN_SWE_BOT_NAME}' && "
         f"git config --global user.email '{OPEN_SWE_BOT_EMAIL}'",
     )
@@ -394,7 +393,7 @@ async def check_sandbox_reachable(
 ) -> SandboxBackendProtocol:
     """Ping a cached sandbox; an unreachable one fails the run, never gets replaced."""
     try:
-        await asyncio.to_thread(sandbox_backend.execute, "echo ok")
+        await sandbox_backend.aexecute("echo ok")
     except SandboxClientError as exc:
         logger.warning("Cached sandbox is no longer reachable for thread %s", thread_id)
         raise SandboxUnreachableError(thread_id, sandbox_backend.id, str(exc)) from exc

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -187,7 +187,7 @@ async def _resolve_review_trace_url(thread_id: str, config_override: object) -> 
         return None
     if not thread_id:
         return None
-    return get_langsmith_trace_url(thread_id, project_name=REVIEW_TRACING_PROJECT)
+    return await get_langsmith_trace_url(thread_id, project_name=REVIEW_TRACING_PROJECT)
 
 
 def _is_reviewer_eval_mode(configurable: dict[str, Any]) -> bool:

--- a/agent/tools/read_finding_outcomes.py
+++ b/agent/tools/read_finding_outcomes.py
@@ -14,7 +14,7 @@ from langgraph.config import get_config
 from ..utils.reviewer_outcomes import read_outcomes_for_repo
 
 
-def read_finding_outcomes(limit: int = 60) -> dict[str, Any]:
+async def read_finding_outcomes(limit: int = 60) -> dict[str, Any]:
     """Return confirmed and dismissed past findings for the repo being analyzed.
 
     Call this before synthesizing the style prompt. Use the ``confirmed``
@@ -27,7 +27,7 @@ def read_finding_outcomes(limit: int = 60) -> dict[str, Any]:
     if not isinstance(full_name, str) or "/" not in full_name:
         return {"ok": False, "error": "no repo under analysis", "confirmed": [], "dismissed": []}
 
-    outcomes = read_outcomes_for_repo(full_name, limit=limit)
+    outcomes = await read_outcomes_for_repo(full_name, limit=limit)
     confirmed = outcomes["confirmed"]
     dismissed = outcomes["dismissed"]
     return {

--- a/agent/tools/resolve_finding_thread.py
+++ b/agent/tools/resolve_finding_thread.py
@@ -82,7 +82,7 @@ async def resolve_finding_thread(
         return thread_missing_tool_result(exc)
     if result.get("success") and isinstance(result.get("finding"), dict):
         thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
-        emit_finding_status_outcome(
+        await emit_finding_status_outcome(
             result["finding"],
             status,
             configurable=configurable,

--- a/agent/tools/slack_start_new_thread.py
+++ b/agent/tools/slack_start_new_thread.py
@@ -87,9 +87,9 @@ def _visible_message(title: str, instructions: str, repo: dict[str, str] | None)
     )
 
 
-def _run_links_section(thread_id: str) -> str:
+async def _run_links_section(thread_id: str) -> str:
     dashboard_url = dashboard_thread_url(thread_id)
-    trace_url = get_langsmith_trace_url(thread_id)
+    trace_url = await get_langsmith_trace_url(thread_id)
     lines = ["## Open SWE Links"]
     if dashboard_url:
         lines.append(f"- Web: {dashboard_url}")
@@ -101,7 +101,7 @@ def _run_links_section(thread_id: str) -> str:
     return "\n".join(lines)
 
 
-def _run_prompt(
+async def _run_prompt(
     title: str,
     instructions: str,
     repo: dict[str, str] | None,
@@ -119,7 +119,7 @@ def _run_prompt(
         "## Source Slack Thread\n"
         f"- Channel: {channel_id}\n"
         f"- Thread TS: {thread_ts}\n\n"
-        f"{_run_links_section(thread_id)}\n\n"
+        f"{await _run_links_section(thread_id)}\n\n"
         "## Breakout Instructions\n"
         f"{instructions}"
     )
@@ -276,7 +276,7 @@ async def slack_start_new_thread(
 
     run = await dispatch_agent_run(
         thread_id,
-        _run_prompt(clean_title, clean_instructions, repo, current_slack_thread, thread_id),
+        await _run_prompt(clean_title, clean_instructions, repo, current_slack_thread, thread_id),
         new_configurable,
         source="slack",
         client=client,

--- a/agent/tools/update_finding.py
+++ b/agent/tools/update_finding.py
@@ -212,7 +212,9 @@ async def update_finding(
     if updated is None:
         return {"success": False, "error": f"No finding found with id {finding_id}"}
     if status in {"resolved", "dismissed"} and not delegated_resolution:
-        emit_finding_status_outcome(updated, status, configurable=configurable, thread_id=thread_id)
+        await emit_finding_status_outcome(
+            updated, status, configurable=configurable, thread_id=thread_id
+        )
     result = {"success": True, "finding": updated}
     if suggestion_dropped:
         result["suggestion_dropped"] = True

--- a/agent/utils/github_feedback.py
+++ b/agent/utils/github_feedback.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import re
@@ -213,10 +212,9 @@ async def process_github_reaction(
     }
     score = _score_reactions(active_reactions)
     if score is None:
-        success = await asyncio.to_thread(delete_langsmith_feedback, run_id, key)
+        success = await delete_langsmith_feedback(run_id, key)
     else:
-        success = await asyncio.to_thread(
-            create_langsmith_feedback,
+        success = await create_langsmith_feedback(
             run_id,
             key,
             score=score,
@@ -226,8 +224,7 @@ async def process_github_reaction(
     outcome = outcome_from_score(score, source="github")
     if outcome is not None:
         label, label_source = outcome
-        await asyncio.to_thread(
-            upsert_finding_outcome,
+        await upsert_finding_outcome(
             finding,
             label=label,
             label_source=label_source,

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
 from typing import Any
 
+from langsmith import AsyncClient as AsyncLangSmithClient
 from langsmith import Client as LangSmithClient
 from langsmith.utils import LangSmithNotFoundError
 
@@ -17,7 +19,7 @@ logger = logging.getLogger(__name__)
 _PROJECT_ID_CACHE: dict[str, str] = {}
 
 
-def _build_prod_langsmith_client() -> LangSmithClient | None:
+def _build_prod_langsmith_client() -> AsyncLangSmithClient | None:
     """Build a LangSmith client scoped to the prod tenant for project lookups."""
     api_key = (
         os.environ.get("LANGSMITH_API_KEY_PROD")
@@ -29,10 +31,10 @@ def _build_prod_langsmith_client() -> LangSmithClient | None:
     api_url = os.environ.get("LANGSMITH_ENDPOINT_PROD") or os.environ.get(
         "LANGSMITH_ENDPOINT", "https://api.smith.langchain.com"
     )
-    return LangSmithClient(api_key=api_key, api_url=api_url)
+    return AsyncLangSmithClient(api_key=api_key, api_url=api_url)
 
 
-def _resolve_project_id_by_name(project_name: str) -> str | None:
+async def _resolve_project_id_by_name(project_name: str) -> str | None:
     """Resolve a LangSmith project id from its name, caching both successful and
     failed lookups so an unconfigured/unauthorized tenant isn't re-queried per call."""
     if project_name in _PROJECT_ID_CACHE:
@@ -41,7 +43,8 @@ def _resolve_project_id_by_name(project_name: str) -> str | None:
     if client is None:
         return None
     try:
-        project = client.read_project(project_name=project_name)
+        async with client:
+            project = await client.read_project(project_name=project_name)
     except LangSmithNotFoundError:
         _PROJECT_ID_CACHE[project_name] = ""
         return None
@@ -55,14 +58,14 @@ def _resolve_project_id_by_name(project_name: str) -> str | None:
     return resolved or None
 
 
-def _compose_langsmith_project_url(project_name: str = AGENT_TRACING_PROJECT) -> str | None:
+async def _compose_langsmith_project_url(project_name: str = AGENT_TRACING_PROJECT) -> str | None:
     """Build the LangSmith project URL base, or None when tracing isn't configured
     for the prod tenant. Bails before any API call when the tenant id is unset."""
     tenant_id = os.environ.get("LANGSMITH_TENANT_ID_PROD")
     if not tenant_id:
         return None
     host_url = os.environ.get("LANGSMITH_URL_PROD", "https://smith.langchain.com")
-    project_id = _resolve_project_id_by_name(project_name) or os.environ.get(
+    project_id = await _resolve_project_id_by_name(project_name) or os.environ.get(
         "LANGSMITH_TRACING_PROJECT_ID_PROD"
     )
     if not project_id:
@@ -70,19 +73,19 @@ def _compose_langsmith_project_url(project_name: str = AGENT_TRACING_PROJECT) ->
     return f"{host_url}/o/{tenant_id}/projects/p/{project_id}"
 
 
-def get_langsmith_trace_url(
+async def get_langsmith_trace_url(
     thread_id: str, project_name: str = AGENT_TRACING_PROJECT
 ) -> str | None:
     """Build the LangSmith thread URL for a given thread ID, or None if tracing
     isn't configured. This is a best-effort convenience link, not an error path."""
-    project_url = _compose_langsmith_project_url(project_name)
+    project_url = await _compose_langsmith_project_url(project_name)
     return f"{project_url}/t/{thread_id}" if project_url else None
 
 
-def _build_langsmith_feedback_clients() -> tuple[LangSmithClient, ...]:
-    """Build feedback clients from current env. Re-read each call so rotated
-    keys / late secret hydration are picked up."""
-    clients: list[LangSmithClient] = []
+def _build_langsmith_feedback_clients() -> tuple[tuple[str, str], ...]:
+    """Resolve feedback client configs from current env. Re-read each call so
+    rotated keys / late secret hydration are picked up."""
+    configs: list[tuple[str, str]] = []
     seen: set[tuple[str, str]] = set()
 
     api_endpoint = os.environ.get("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
@@ -103,17 +106,30 @@ def _build_langsmith_feedback_clients() -> tuple[LangSmithClient, ...]:
         identity = (api_key, api_url)
         if identity in seen:
             continue
-        clients.append(LangSmithClient(api_key=api_key, api_url=api_url))
+        configs.append(identity)
         seen.add(identity)
 
-    return tuple(clients)
+    return tuple(configs)
 
 
 def _feedback_id(run_id: str, key: str) -> uuid.UUID:
     return uuid.uuid5(uuid.NAMESPACE_URL, f"langsmith-feedback:{run_id}:{key}")
 
 
-def create_langsmith_feedback(
+async def _update_feedback(
+    api_key: str,
+    api_url: str,
+    feedback_id: uuid.UUID,
+    *,
+    score: float,
+    comment: str | None,
+) -> None:
+    # AsyncClient exposes no update_feedback; the sync one runs off-loop.
+    client = LangSmithClient(api_key=api_key, api_url=api_url)
+    await asyncio.to_thread(client.update_feedback, feedback_id, score=score, comment=comment)
+
+
+async def create_langsmith_feedback(
     run_id: str,
     key: str,
     *,
@@ -121,50 +137,54 @@ def create_langsmith_feedback(
     comment: str | None = None,
     source_info: dict[str, Any] | None = None,
 ) -> bool:
-    """Create or update deterministic feedback on all configured LangSmith clients."""
-    clients = _build_langsmith_feedback_clients()
-    if not clients:
+    """Create or update deterministic feedback on all configured LangSmith tenants."""
+    configs = _build_langsmith_feedback_clients()
+    if not configs:
         logger.warning("No LangSmith API key configured, skipping feedback")
         return False
 
     feedback_id = _feedback_id(run_id, key)
     any_success = False
-    for client in clients:
+    for api_key, api_url in configs:
+        async with AsyncLangSmithClient(api_key=api_key, api_url=api_url) as client:
+            try:
+                await client.create_feedback(
+                    run_id=run_id,
+                    key=key,
+                    score=score,
+                    comment=comment,
+                    source_info=source_info,
+                    feedback_source_type="api",
+                    feedback_id=feedback_id,
+                )
+                any_success = True
+                continue
+            except Exception:  # noqa: BLE001 - feedback already exists; update in place
+                pass
         try:
-            client.create_feedback(
-                run_id=run_id,
-                key=key,
-                score=score,
-                comment=comment,
-                source_info=source_info,
-                feedback_source_type="api",
-                feedback_id=feedback_id,
-            )
+            await _update_feedback(api_key, api_url, feedback_id, score=score, comment=comment)
             any_success = True
         except Exception:
-            try:
-                client.update_feedback(feedback_id, score=score, comment=comment)
-                any_success = True
-            except Exception:
-                logger.exception("Failed to create or update LangSmith feedback for run %s", run_id)
+            logger.exception("Failed to create or update LangSmith feedback for run %s", run_id)
     return any_success
 
 
-def delete_langsmith_feedback(run_id: str, key: str) -> bool:
-    """Delete deterministic feedback from all configured LangSmith clients."""
-    clients = _build_langsmith_feedback_clients()
-    if not clients:
+async def delete_langsmith_feedback(run_id: str, key: str) -> bool:
+    """Delete deterministic feedback from all configured LangSmith tenants."""
+    configs = _build_langsmith_feedback_clients()
+    if not configs:
         logger.warning("No LangSmith API key configured, skipping feedback deletion")
         return False
 
     feedback_id = _feedback_id(run_id, key)
     any_success = False
-    for client in clients:
-        try:
-            client.delete_feedback(feedback_id)
-            any_success = True
-        except LangSmithNotFoundError:
-            any_success = True
-        except Exception:
-            logger.exception("Failed to delete LangSmith feedback for run %s", run_id)
+    for api_key, api_url in configs:
+        async with AsyncLangSmithClient(api_key=api_key, api_url=api_url) as client:
+            try:
+                await client.delete_feedback(feedback_id)
+                any_success = True
+            except LangSmithNotFoundError:
+                any_success = True
+            except Exception:
+                logger.exception("Failed to delete LangSmith feedback for run %s", run_id)
     return any_success

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -17,6 +17,31 @@ from .tracing import AGENT_TRACING_PROJECT
 logger = logging.getLogger(__name__)
 
 _PROJECT_ID_CACHE: dict[str, str] = {}
+_ASYNC_CLIENTS: dict[tuple[str, str], AsyncLangSmithClient] = {}
+_SYNC_CLIENTS: dict[tuple[str, str], LangSmithClient] = {}
+
+
+def async_langsmith_client(api_key: str, api_url: str) -> AsyncLangSmithClient:
+    """Return a pooled ``AsyncClient`` for these credentials.
+
+    Each client owns an ``httpx`` connection pool bound to the event loop that
+    built it, so this assumes one loop per process. Keyed on the credentials so
+    a test that repoints the env gets a fresh client instead of a stale pool.
+    """
+    key = (api_key, api_url)
+    client = _ASYNC_CLIENTS.get(key)
+    if client is None:
+        client = _ASYNC_CLIENTS[key] = AsyncLangSmithClient(api_key=api_key, api_url=api_url)
+    return client
+
+
+def sync_langsmith_client(api_key: str, api_url: str) -> LangSmithClient:
+    """Return a pooled sync ``Client``, for the few endpoints AsyncClient lacks."""
+    key = (api_key, api_url)
+    client = _SYNC_CLIENTS.get(key)
+    if client is None:
+        client = _SYNC_CLIENTS[key] = LangSmithClient(api_key=api_key, api_url=api_url)
+    return client
 
 
 def _build_prod_langsmith_client() -> AsyncLangSmithClient | None:
@@ -31,7 +56,7 @@ def _build_prod_langsmith_client() -> AsyncLangSmithClient | None:
     api_url = os.environ.get("LANGSMITH_ENDPOINT_PROD") or os.environ.get(
         "LANGSMITH_ENDPOINT", "https://api.smith.langchain.com"
     )
-    return AsyncLangSmithClient(api_key=api_key, api_url=api_url)
+    return async_langsmith_client(api_key, api_url)
 
 
 async def _resolve_project_id_by_name(project_name: str) -> str | None:
@@ -43,8 +68,7 @@ async def _resolve_project_id_by_name(project_name: str) -> str | None:
     if client is None:
         return None
     try:
-        async with client:
-            project = await client.read_project(project_name=project_name)
+        project = await client.read_project(project_name=project_name)
     except LangSmithNotFoundError:
         _PROJECT_ID_CACHE[project_name] = ""
         return None
@@ -125,7 +149,7 @@ async def _update_feedback(
     comment: str | None,
 ) -> None:
     # AsyncClient exposes no update_feedback; the sync one runs off-loop.
-    client = LangSmithClient(api_key=api_key, api_url=api_url)
+    client = sync_langsmith_client(api_key, api_url)
     await asyncio.to_thread(client.update_feedback, feedback_id, score=score, comment=comment)
 
 
@@ -146,21 +170,20 @@ async def create_langsmith_feedback(
     feedback_id = _feedback_id(run_id, key)
     any_success = False
     for api_key, api_url in configs:
-        async with AsyncLangSmithClient(api_key=api_key, api_url=api_url) as client:
-            try:
-                await client.create_feedback(
-                    run_id=run_id,
-                    key=key,
-                    score=score,
-                    comment=comment,
-                    source_info=source_info,
-                    feedback_source_type="api",
-                    feedback_id=feedback_id,
-                )
-                any_success = True
-                continue
-            except Exception:  # noqa: BLE001 - feedback already exists; update in place
-                pass
+        try:
+            await async_langsmith_client(api_key, api_url).create_feedback(
+                run_id=run_id,
+                key=key,
+                score=score,
+                comment=comment,
+                source_info=source_info,
+                feedback_source_type="api",
+                feedback_id=feedback_id,
+            )
+            any_success = True
+            continue
+        except Exception:  # noqa: BLE001 - feedback already exists; update in place
+            pass
         try:
             await _update_feedback(api_key, api_url, feedback_id, score=score, comment=comment)
             any_success = True
@@ -179,12 +202,11 @@ async def delete_langsmith_feedback(run_id: str, key: str) -> bool:
     feedback_id = _feedback_id(run_id, key)
     any_success = False
     for api_key, api_url in configs:
-        async with AsyncLangSmithClient(api_key=api_key, api_url=api_url) as client:
-            try:
-                await client.delete_feedback(feedback_id)
-                any_success = True
-            except LangSmithNotFoundError:
-                any_success = True
-            except Exception:
-                logger.exception("Failed to delete LangSmith feedback for run %s", run_id)
+        try:
+            await async_langsmith_client(api_key, api_url).delete_feedback(feedback_id)
+            any_success = True
+        except LangSmithNotFoundError:
+            any_success = True
+        except Exception:
+            logger.exception("Failed to delete LangSmith feedback for run %s", run_id)
     return any_success

--- a/agent/utils/linear.py
+++ b/agent/utils/linear.py
@@ -69,7 +69,7 @@ async def post_linear_trace_comment(
     issue_id: str, thread_id: str, triggering_comment_id: str
 ) -> None:
     """Post a trace URL comment on a Linear issue."""
-    trace_url = get_langsmith_trace_url(thread_id)
+    trace_url = await get_langsmith_trace_url(thread_id)
     if trace_url:
         await comment_on_linear_issue(
             issue_id,

--- a/agent/utils/read_only_backend.py
+++ b/agent/utils/read_only_backend.py
@@ -11,6 +11,8 @@ from deepagents.backends.protocol import (
     ReadResult,
 )
 
+_SYNC_UNSUPPORTED = "ReadOnlyBackend is async-only; use the a-prefixed method instead."
+
 
 class ReadOnlyBackend(BackendProtocol):
     """Delegate backend reads while rejecting inherited mutation operations."""
@@ -19,13 +21,13 @@ class ReadOnlyBackend(BackendProtocol):
         self._backend = backend
 
     def ls(self, path: str) -> LsResult:
-        return self._backend.ls(path)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def als(self, path: str) -> LsResult:
         return await self._backend.als(path)
 
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
-        return self._backend.read(file_path, offset, limit)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
         return await self._backend.aread(file_path, offset, limit)
@@ -38,7 +40,7 @@ class ReadOnlyBackend(BackendProtocol):
         *,
         max_count: int | None = None,
     ) -> GrepResult:
-        return self._backend.grep(pattern, path, glob, max_count=max_count)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def agrep(
         self,
@@ -51,13 +53,13 @@ class ReadOnlyBackend(BackendProtocol):
         return await self._backend.agrep(pattern, path, glob, max_count=max_count)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
-        return self._backend.glob(pattern, path)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
         return await self._backend.aglob(pattern, path)
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        return self._backend.download_files(paths)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
         return await self._backend.adownload_files(paths)

--- a/agent/utils/repo_prep.py
+++ b/agent/utils/repo_prep.py
@@ -12,7 +12,6 @@ the fetched diff) and returns ``False`` so callers can skip skill wiring.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import posixpath
 import shlex
@@ -93,9 +92,7 @@ async def prepare_review_repo(
 
     command = _prep_command(work_dir, repo_owner, repo_name, head_sha, pr_number, base_sha)
     try:
-        result = await asyncio.to_thread(
-            sandbox_backend.execute, command, timeout=CLONE_TIMEOUT_SECONDS
-        )
+        result = await sandbox_backend.aexecute(command, timeout=CLONE_TIMEOUT_SECONDS)
     except Exception:  # noqa: BLE001
         logger.warning("Failed to prep review repo %s/%s", repo_owner, repo_name, exc_info=True)
         return False
@@ -155,7 +152,7 @@ async def materialize_trusted_skills(
             f"echo {q_dest}"
         )
         try:
-            result = await asyncio.to_thread(sandbox_backend.execute, command)
+            result = await sandbox_backend.aexecute(command)
         except Exception:  # noqa: BLE001
             logger.warning("Failed to extract trusted skills %s", skill_dir, exc_info=True)
             continue

--- a/agent/utils/reviewer_outcomes.py
+++ b/agent/utils/reviewer_outcomes.py
@@ -20,9 +20,9 @@ import uuid
 from typing import Any
 
 from langsmith import AsyncClient as AsyncLangSmithClient
-from langsmith import Client as LangSmithClient
 
 from ..review.findings import Finding
+from .langsmith import async_langsmith_client, sync_langsmith_client
 
 logger = logging.getLogger(__name__)
 
@@ -128,8 +128,7 @@ async def _create_or_update_example(
         )
     except Exception:  # noqa: BLE001 — example already exists; update in place
         # AsyncClient exposes no update_example; the sync one runs off-loop.
-        api_key, api_url = credentials
-        sync_client = LangSmithClient(api_key=api_key, api_url=api_url)
+        sync_client = sync_langsmith_client(*credentials)
         await asyncio.to_thread(
             sync_client.update_example,
             example_id=example_id,
@@ -195,16 +194,16 @@ async def upsert_finding_outcome(
             "thread_id": thread_id,
             "first_seen_sha": finding.get("first_seen_sha"),
         }
-        async with AsyncLangSmithClient(api_key=credentials[0], api_url=credentials[1]) as client:
-            await _create_or_update_example(
-                client,
-                credentials,
-                dataset_id=await _ensure_dataset(client),
-                example_id=_example_id(repo, finding_id, label_source),
-                inputs=inputs,
-                outputs=outputs,
-                metadata=metadata,
-            )
+        client = async_langsmith_client(*credentials)
+        await _create_or_update_example(
+            client,
+            credentials,
+            dataset_id=await _ensure_dataset(client),
+            example_id=_example_id(repo, finding_id, label_source),
+            inputs=inputs,
+            outputs=outputs,
+            metadata=metadata,
+        )
         return True
     except Exception:  # noqa: BLE001 — dataset writes must never break a review
         logger.exception("Failed to upsert reviewer finding outcome for %s", finding_id)

--- a/agent/utils/reviewer_outcomes.py
+++ b/agent/utils/reviewer_outcomes.py
@@ -13,11 +13,13 @@ updates in place instead of duplicating.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
 from typing import Any
 
+from langsmith import AsyncClient as AsyncLangSmithClient
 from langsmith import Client as LangSmithClient
 
 from ..review.findings import Finding
@@ -62,26 +64,31 @@ def outcome_from_score(score: float | None, *, source: str) -> tuple[str, str] |
     return FALSE_POSITIVE, f"{source}_thumbs_down"
 
 
-def _outcomes_client() -> LangSmithClient | None:
-    """Build a single LangSmith client, preferring the prod tenant."""
+def _outcomes_credentials() -> tuple[str, str] | None:
+    """Resolve the outcomes-dataset credentials, preferring the prod tenant."""
     prod_key = os.environ.get("LANGSMITH_API_KEY_PROD")
     if prod_key:
         api_url = os.environ.get("LANGSMITH_ENDPOINT_PROD") or os.environ.get(
             "LANGSMITH_ENDPOINT", "https://api.smith.langchain.com"
         )
-        return LangSmithClient(api_key=prod_key, api_url=api_url)
+        return prod_key, api_url
     api_key = os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGCHAIN_API_KEY")
     if not api_key:
         return None
-    api_url = os.environ.get("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
-    return LangSmithClient(api_key=api_key, api_url=api_url)
+    return api_key, os.environ.get("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
 
 
-def _ensure_dataset(client: LangSmithClient) -> Any:
-    existing = next((d for d in client.list_datasets(dataset_name=OUTCOMES_DATASET_NAME)), None)
+async def _find_dataset(client: AsyncLangSmithClient) -> Any:
+    async for dataset in client.list_datasets(dataset_name=OUTCOMES_DATASET_NAME):
+        return dataset
+    return None
+
+
+async def _ensure_dataset(client: AsyncLangSmithClient) -> Any:
+    existing = await _find_dataset(client)
     if existing is not None:
         return existing.id
-    ds = client.create_dataset(
+    ds = await client.create_dataset(
         dataset_name=OUTCOMES_DATASET_NAME,
         description=(
             "Open SWE reviewer finding outcomes (resolved / dismissed / 👍👎) "
@@ -101,8 +108,9 @@ def _truncate(value: Any, limit: int) -> Any:
     return value
 
 
-def _create_or_update_example(
-    client: LangSmithClient,
+async def _create_or_update_example(
+    client: AsyncLangSmithClient,
+    credentials: tuple[str, str],
     *,
     dataset_id: Any,
     example_id: uuid.UUID,
@@ -111,7 +119,7 @@ def _create_or_update_example(
     metadata: dict[str, Any],
 ) -> None:
     try:
-        client.create_example(
+        await client.create_example(
             inputs=inputs,
             outputs=outputs,
             metadata=metadata,
@@ -119,7 +127,11 @@ def _create_or_update_example(
             example_id=example_id,
         )
     except Exception:  # noqa: BLE001 — example already exists; update in place
-        client.update_example(
+        # AsyncClient exposes no update_example; the sync one runs off-loop.
+        api_key, api_url = credentials
+        sync_client = LangSmithClient(api_key=api_key, api_url=api_url)
+        await asyncio.to_thread(
+            sync_client.update_example,
             example_id=example_id,
             inputs=inputs,
             outputs=outputs,
@@ -127,7 +139,7 @@ def _create_or_update_example(
         )
 
 
-def upsert_finding_outcome(
+async def upsert_finding_outcome(
     finding: Finding,
     *,
     label: str,
@@ -144,12 +156,11 @@ def upsert_finding_outcome(
     finding_id = str(finding.get("id") or "")
     if not finding_id or not repo:
         return False
-    client = _outcomes_client()
-    if client is None:
+    credentials = _outcomes_credentials()
+    if credentials is None:
         logger.debug("No LangSmith client configured; skipping outcome example")
         return False
     try:
-        dataset_id = _ensure_dataset(client)
         inputs = {
             "repo": repo,
             "pr_number": pr_number,
@@ -184,21 +195,23 @@ def upsert_finding_outcome(
             "thread_id": thread_id,
             "first_seen_sha": finding.get("first_seen_sha"),
         }
-        _create_or_update_example(
-            client,
-            dataset_id=dataset_id,
-            example_id=_example_id(repo, finding_id, label_source),
-            inputs=inputs,
-            outputs=outputs,
-            metadata=metadata,
-        )
+        async with AsyncLangSmithClient(api_key=credentials[0], api_url=credentials[1]) as client:
+            await _create_or_update_example(
+                client,
+                credentials,
+                dataset_id=await _ensure_dataset(client),
+                example_id=_example_id(repo, finding_id, label_source),
+                inputs=inputs,
+                outputs=outputs,
+                metadata=metadata,
+            )
         return True
     except Exception:  # noqa: BLE001 — dataset writes must never break a review
         logger.exception("Failed to upsert reviewer finding outcome for %s", finding_id)
         return False
 
 
-def upsert_run_outcome(
+async def upsert_run_outcome(
     *,
     label: str,
     label_source: str,
@@ -213,11 +226,10 @@ def upsert_run_outcome(
     """
     if not run_id:
         return False
-    client = _outcomes_client()
-    if client is None:
+    credentials = _outcomes_credentials()
+    if credentials is None:
         return False
     try:
-        dataset_id = _ensure_dataset(client)
         inputs = {"repo": repo, "run_id": run_id, **(extra or {})}
         outputs = {"label": label, "label_source": label_source}
         metadata = {
@@ -227,14 +239,16 @@ def upsert_run_outcome(
             "label": label,
             "label_source": label_source,
         }
-        _create_or_update_example(
-            client,
-            dataset_id=dataset_id,
-            example_id=uuid.uuid5(uuid.NAMESPACE_URL, f"run-outcome:{run_id}:{label_source}"),
-            inputs=inputs,
-            outputs=outputs,
-            metadata=metadata,
-        )
+        async with AsyncLangSmithClient(api_key=credentials[0], api_url=credentials[1]) as client:
+            await _create_or_update_example(
+                client,
+                credentials,
+                dataset_id=await _ensure_dataset(client),
+                example_id=uuid.uuid5(uuid.NAMESPACE_URL, f"run-outcome:{run_id}:{label_source}"),
+                inputs=inputs,
+                outputs=outputs,
+                metadata=metadata,
+            )
         return True
     except Exception:  # noqa: BLE001
         logger.exception("Failed to upsert run outcome for run %s", run_id)
@@ -248,7 +262,7 @@ def repo_full_name_from_config(configurable: dict[str, Any]) -> str:
     return ""
 
 
-def emit_finding_status_outcome(
+async def emit_finding_status_outcome(
     finding: Finding,
     status: str,
     *,
@@ -271,7 +285,7 @@ def emit_finding_status_outcome(
         return False
     label, label_source = mapping
     pr_number = configurable.get("pr_number")
-    return upsert_finding_outcome(
+    return await upsert_finding_outcome(
         finding,
         label=label,
         label_source=label_source,
@@ -284,41 +298,42 @@ def emit_finding_status_outcome(
     )
 
 
-def read_outcomes_for_repo(repo: str, *, limit: int = 100) -> dict[str, list[dict[str, Any]]]:
+async def read_outcomes_for_repo(repo: str, *, limit: int = 100) -> dict[str, list[dict[str, Any]]]:
     """Return confirmed (true-positive) and dismissed (false-positive) findings
     for ``repo`` from the outcomes dataset. Best-effort; returns empty on error."""
     confirmed: list[dict[str, Any]] = []
     dismissed: list[dict[str, Any]] = []
-    client = _outcomes_client()
-    if client is None or not repo:
+    credentials = _outcomes_credentials()
+    if credentials is None or not repo:
         return {"confirmed": confirmed, "dismissed": dismissed}
     try:
-        existing = next((d for d in client.list_datasets(dataset_name=OUTCOMES_DATASET_NAME)), None)
-        if existing is None:
-            return {"confirmed": confirmed, "dismissed": dismissed}
-        for example in client.list_examples(dataset_id=existing.id):
-            metadata = getattr(example, "metadata", None) or {}
-            if metadata.get("granularity") != "finding" or metadata.get("repo") != repo:
-                continue
-            outputs = getattr(example, "outputs", None) or {}
-            inputs = getattr(example, "inputs", None) or {}
-            finding = outputs.get("finding") or {}
-            row = {
-                "file": inputs.get("file"),
-                "title": finding.get("title"),
-                "description": finding.get("description"),
-                "severity": finding.get("severity"),
-                "category": finding.get("category"),
-                "label_source": outputs.get("label_source"),
-                "diff_hunk": inputs.get("diff_hunk"),
-                "resolution_note": outputs.get("resolution_note"),
-            }
-            if outputs.get("label") == TRUE_POSITIVE:
-                confirmed.append(row)
-            elif outputs.get("label") == FALSE_POSITIVE:
-                dismissed.append(row)
-            if len(confirmed) + len(dismissed) >= limit:
-                break
+        async with AsyncLangSmithClient(api_key=credentials[0], api_url=credentials[1]) as client:
+            existing = await _find_dataset(client)
+            if existing is None:
+                return {"confirmed": confirmed, "dismissed": dismissed}
+            async for example in client.list_examples(dataset_id=existing.id):
+                metadata = getattr(example, "metadata", None) or {}
+                if metadata.get("granularity") != "finding" or metadata.get("repo") != repo:
+                    continue
+                outputs = getattr(example, "outputs", None) or {}
+                inputs = getattr(example, "inputs", None) or {}
+                finding = outputs.get("finding") or {}
+                row = {
+                    "file": inputs.get("file"),
+                    "title": finding.get("title"),
+                    "description": finding.get("description"),
+                    "severity": finding.get("severity"),
+                    "category": finding.get("category"),
+                    "label_source": outputs.get("label_source"),
+                    "diff_hunk": inputs.get("diff_hunk"),
+                    "resolution_note": outputs.get("resolution_note"),
+                }
+                if outputs.get("label") == TRUE_POSITIVE:
+                    confirmed.append(row)
+                elif outputs.get("label") == FALSE_POSITIVE:
+                    dismissed.append(row)
+                if len(confirmed) + len(dismissed) >= limit:
+                    break
     except Exception:  # noqa: BLE001
         logger.exception("Failed to read outcomes for repo %s", repo)
     return {"confirmed": confirmed, "dismissed": dismissed}

--- a/agent/utils/reviewer_outcomes.py
+++ b/agent/utils/reviewer_outcomes.py
@@ -238,16 +238,16 @@ async def upsert_run_outcome(
             "label": label,
             "label_source": label_source,
         }
-        async with AsyncLangSmithClient(api_key=credentials[0], api_url=credentials[1]) as client:
-            await _create_or_update_example(
-                client,
-                credentials,
-                dataset_id=await _ensure_dataset(client),
-                example_id=uuid.uuid5(uuid.NAMESPACE_URL, f"run-outcome:{run_id}:{label_source}"),
-                inputs=inputs,
-                outputs=outputs,
-                metadata=metadata,
-            )
+        client = async_langsmith_client(*credentials)
+        await _create_or_update_example(
+            client,
+            credentials,
+            dataset_id=await _ensure_dataset(client),
+            example_id=uuid.uuid5(uuid.NAMESPACE_URL, f"run-outcome:{run_id}:{label_source}"),
+            inputs=inputs,
+            outputs=outputs,
+            metadata=metadata,
+        )
         return True
     except Exception:  # noqa: BLE001
         logger.exception("Failed to upsert run outcome for run %s", run_id)
@@ -306,33 +306,33 @@ async def read_outcomes_for_repo(repo: str, *, limit: int = 100) -> dict[str, li
     if credentials is None or not repo:
         return {"confirmed": confirmed, "dismissed": dismissed}
     try:
-        async with AsyncLangSmithClient(api_key=credentials[0], api_url=credentials[1]) as client:
-            existing = await _find_dataset(client)
-            if existing is None:
-                return {"confirmed": confirmed, "dismissed": dismissed}
-            async for example in client.list_examples(dataset_id=existing.id):
-                metadata = getattr(example, "metadata", None) or {}
-                if metadata.get("granularity") != "finding" or metadata.get("repo") != repo:
-                    continue
-                outputs = getattr(example, "outputs", None) or {}
-                inputs = getattr(example, "inputs", None) or {}
-                finding = outputs.get("finding") or {}
-                row = {
-                    "file": inputs.get("file"),
-                    "title": finding.get("title"),
-                    "description": finding.get("description"),
-                    "severity": finding.get("severity"),
-                    "category": finding.get("category"),
-                    "label_source": outputs.get("label_source"),
-                    "diff_hunk": inputs.get("diff_hunk"),
-                    "resolution_note": outputs.get("resolution_note"),
-                }
-                if outputs.get("label") == TRUE_POSITIVE:
-                    confirmed.append(row)
-                elif outputs.get("label") == FALSE_POSITIVE:
-                    dismissed.append(row)
-                if len(confirmed) + len(dismissed) >= limit:
-                    break
+        client = async_langsmith_client(*credentials)
+        existing = await _find_dataset(client)
+        if existing is None:
+            return {"confirmed": confirmed, "dismissed": dismissed}
+        async for example in client.list_examples(dataset_id=existing.id):
+            metadata = getattr(example, "metadata", None) or {}
+            if metadata.get("granularity") != "finding" or metadata.get("repo") != repo:
+                continue
+            outputs = getattr(example, "outputs", None) or {}
+            inputs = getattr(example, "inputs", None) or {}
+            finding = outputs.get("finding") or {}
+            row = {
+                "file": inputs.get("file"),
+                "title": finding.get("title"),
+                "description": finding.get("description"),
+                "severity": finding.get("severity"),
+                "category": finding.get("category"),
+                "label_source": outputs.get("label_source"),
+                "diff_hunk": inputs.get("diff_hunk"),
+                "resolution_note": outputs.get("resolution_note"),
+            }
+            if outputs.get("label") == TRUE_POSITIVE:
+                confirmed.append(row)
+            elif outputs.get("label") == FALSE_POSITIVE:
+                dismissed.append(row)
+            if len(confirmed) + len(dismissed) >= limit:
+                break
     except Exception:  # noqa: BLE001
         logger.exception("Failed to read outcomes for repo %s", repo)
     return {"confirmed": confirmed, "dismissed": dismissed}

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import os
 from collections.abc import Callable
 from importlib import import_module
@@ -41,8 +42,11 @@ async def create_sandbox(
     The provider is selected via the SANDBOX_TYPE environment variable.
     Supported values: langsmith (default), daytona, modal, runloop, e2b, local.
 
-    The langsmith provider provisions natively async; the other providers wrap
-    sync SDKs and are bridged onto the event loop with ``asyncio.to_thread``.
+    langsmith, modal and local provision natively async. daytona, e2b and
+    runloop stay on ``asyncio.to_thread``: their ``langchain_*`` backend
+    wrappers bind a *sync* SDK handle (``E2BSandbox(sandbox=e2b.Sandbox)``,
+    ``RunloopSandbox`` calling ``devbox.cmd.exec``), so the async SDK client
+    cannot be handed to them.
 
     Args:
         sandbox_id: Optional existing sandbox ID to reconnect to.
@@ -55,9 +59,9 @@ async def create_sandbox(
     """
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     factory = _load_sandbox_factory(sandbox_type)
-    if sandbox_type == "langsmith":
-        if snapshot_id is not None:
-            return await factory(sandbox_id, snapshot_id=snapshot_id)
+    if sandbox_type == "langsmith" and snapshot_id is not None:
+        return await factory(sandbox_id, snapshot_id=snapshot_id)
+    if inspect.iscoroutinefunction(factory):
         return await factory(sandbox_id)
     return await asyncio.to_thread(factory, sandbox_id)
 

--- a/agent/utils/sandbox_paths.py
+++ b/agent/utils/sandbox_paths.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import posixpath
 import shlex
-from collections.abc import Iterable
+from collections.abc import AsyncIterable, Iterable
 from typing import Any
 
 from deepagents.backends.protocol import SandboxBackendProtocol
@@ -17,30 +16,25 @@ _WORK_DIR_CACHE_ATTR = "_open_swe_resolved_work_dir"
 _PROVIDER_ATTR_NAMES = ("sandbox", "_sandbox")
 
 
-def resolve_repo_dir(sandbox_backend: SandboxBackendProtocol, repo_name: str) -> str:
+async def aresolve_repo_dir(sandbox_backend: SandboxBackendProtocol, repo_name: str) -> str:
     """Resolve the repository directory for a sandbox backend."""
     if not repo_name:
         raise ValueError("repo_name must be a non-empty string")
 
-    work_dir = resolve_sandbox_work_dir(sandbox_backend)
+    work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
     return posixpath.join(work_dir, repo_name)
 
 
-async def aresolve_repo_dir(sandbox_backend: SandboxBackendProtocol, repo_name: str) -> str:
-    """Async wrapper around resolve_repo_dir for use in event-loop code."""
-    return await asyncio.to_thread(resolve_repo_dir, sandbox_backend, repo_name)
-
-
-def resolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
+async def aresolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
     """Resolve a writable base directory for repository operations."""
     cached_work_dir = getattr(sandbox_backend, _WORK_DIR_CACHE_ATTR, None)
     if isinstance(cached_work_dir, str) and cached_work_dir:
         return cached_work_dir
 
     checked_candidates: list[str] = []
-    for candidate in _iter_work_dir_candidates(sandbox_backend):
+    async for candidate in _iter_work_dir_candidates(sandbox_backend):
         checked_candidates.append(candidate)
-        if _is_writable_directory(sandbox_backend, candidate):
+        if await _is_writable_directory(sandbox_backend, candidate):
             _cache_work_dir(sandbox_backend, candidate)
             return candidate
 
@@ -50,14 +44,9 @@ def resolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
     raise RuntimeError(msg)
 
 
-async def aresolve_sandbox_work_dir(sandbox_backend: SandboxBackendProtocol) -> str:
-    """Async wrapper around resolve_sandbox_work_dir for use in event-loop code."""
-    return await asyncio.to_thread(resolve_sandbox_work_dir, sandbox_backend)
-
-
-def _iter_work_dir_candidates(
+async def _iter_work_dir_candidates(
     sandbox_backend: SandboxBackendProtocol,
-) -> Iterable[str]:
+) -> AsyncIterable[str]:
     seen: set[str] = set()
 
     for candidate in _iter_provider_paths(sandbox_backend, "get_work_dir"):
@@ -65,7 +54,7 @@ def _iter_work_dir_candidates(
             seen.add(candidate)
             yield candidate
 
-    shell_work_dir = _resolve_shell_path(sandbox_backend, "pwd")
+    shell_work_dir = await _resolve_shell_path(sandbox_backend, "pwd")
     if shell_work_dir and shell_work_dir not in seen:
         seen.add(shell_work_dir)
         yield shell_work_dir
@@ -79,7 +68,7 @@ def _iter_work_dir_candidates(
             seen.add(candidate)
             yield candidate
 
-    shell_home_dir = _resolve_shell_path(sandbox_backend, "printf '%s' \"$HOME\"")
+    shell_home_dir = await _resolve_shell_path(sandbox_backend, "printf '%s' \"$HOME\"")
     if shell_home_dir and shell_home_dir not in seen:
         seen.add(shell_home_dir)
         yield shell_home_dir
@@ -117,11 +106,11 @@ def _call_path_method(provider: Any, method_name: str) -> str | None:
         return None
 
 
-def _resolve_shell_path(
+async def _resolve_shell_path(
     sandbox_backend: SandboxBackendProtocol,
     command: str,
 ) -> str | None:
-    result = sandbox_backend.execute(command)
+    result = await sandbox_backend.aexecute(command)
     if result.exit_code != 0:
         return None
     return _normalize_path(result.output)
@@ -138,12 +127,12 @@ def _normalize_path(raw_path: str | None) -> str | None:
     return posixpath.normpath(path)
 
 
-def _is_writable_directory(
+async def _is_writable_directory(
     sandbox_backend: SandboxBackendProtocol,
     directory: str,
 ) -> bool:
     safe_directory = shlex.quote(directory)
-    result = sandbox_backend.execute(f"test -d {safe_directory} && test -w {safe_directory}")
+    result = await sandbox_backend.aexecute(f"test -d {safe_directory} && test -w {safe_directory}")
     return result.exit_code == 0
 
 

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -47,6 +47,9 @@ class SandboxUnreachableError(RuntimeError):
         )
 
 
+_SYNC_UNSUPPORTED = "SandboxBackendProxy is async-only; use the a-prefixed method instead."
+
+
 class SandboxBackendProxy(BaseSandbox):
     """Stable per-thread backend handle whose target can be replaced.
 
@@ -127,13 +130,13 @@ class SandboxBackendProxy(BaseSandbox):
             return self._backend
 
     def ls(self, path: str) -> LsResult:
-        return self._get_backend().ls(path)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def als(self, path: str) -> LsResult:
         return await (await self._aget_backend()).als(path)
 
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
-        return self._get_backend().read(file_path, offset, limit)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
         return await (await self._aget_backend()).aread(file_path, offset, limit)
@@ -146,7 +149,7 @@ class SandboxBackendProxy(BaseSandbox):
         *,
         max_count: int | None = None,
     ) -> GrepResult:
-        return self._get_backend().grep(pattern, path, glob, max_count=max_count)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def agrep(
         self,
@@ -159,13 +162,13 @@ class SandboxBackendProxy(BaseSandbox):
         return await (await self._aget_backend()).agrep(pattern, path, glob, max_count=max_count)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
-        return self._get_backend().glob(pattern, path)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
         return await (await self._aget_backend()).aglob(pattern, path)
 
     def write(self, file_path: str, content: str) -> WriteResult:
-        return self._get_backend().write(file_path, content)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def awrite(self, file_path: str, content: str) -> WriteResult:
         return await (await self._aget_backend()).awrite(file_path, content)
@@ -177,7 +180,7 @@ class SandboxBackendProxy(BaseSandbox):
         new_string: str,
         replace_all: bool = False,
     ) -> EditResult:
-        return self._get_backend().edit(file_path, old_string, new_string, replace_all)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aedit(
         self,
@@ -191,19 +194,19 @@ class SandboxBackendProxy(BaseSandbox):
         )
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        return self._get_backend().upload_files(files)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         return await (await self._aget_backend()).aupload_files(files)
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        return self._get_backend().download_files(paths)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
         return await (await self._aget_backend()).adownload_files(paths)
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
-        return self._get_backend().execute(command, timeout=timeout)
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         return await (await self._aget_backend()).aexecute(command, timeout=timeout)
@@ -217,21 +220,7 @@ class SandboxBackendProxy(BaseSandbox):
         max_capture_bytes: int | None = None,
         timeout: int | None = None,
     ) -> ExecuteOffloadResult:
-        # Delegate to the live backend so each provider's own capture-offload
-        # behavior (enable_capture_offload, shell wrapper) is honored.
-        backend = self._get_backend()
-        offload = getattr(backend, "execute_with_offload", None)
-        if offload is None:
-            return ExecuteOffloadResult(
-                offloaded=False, response=self._plain(backend, command, timeout)
-            )
-        return offload(
-            command,
-            capture_path,
-            max_inline_bytes=max_inline_bytes,
-            max_capture_bytes=max_capture_bytes,
-            timeout=timeout,
-        )
+        raise NotImplementedError(_SYNC_UNSUPPORTED)
 
     async def aexecute_with_offload(
         self,
@@ -255,14 +244,6 @@ class SandboxBackendProxy(BaseSandbox):
             max_capture_bytes=max_capture_bytes,
             timeout=timeout,
         )
-
-    @staticmethod
-    def _plain(
-        backend: SandboxBackendProtocol, command: str, timeout: int | None
-    ) -> ExecuteResponse:
-        if timeout is not None and execute_accepts_timeout(type(backend)):
-            return backend.execute(command, timeout=timeout)
-        return backend.execute(command)
 
     @staticmethod
     async def _aplain(

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -1177,7 +1177,7 @@ async def post_slack_trace_reply(
     channel_id: str, thread_ts: str, thread_id: str, *, include_dashboard_link: bool = True
 ) -> str | None:
     """Post a trace URL reply in a Slack thread and return its Slack timestamp."""
-    trace_url = get_langsmith_trace_url(thread_id)
+    trace_url = await get_langsmith_trace_url(thread_id)
     dashboard_url = dashboard_thread_url(thread_id) if include_dashboard_link else None
     message_ts, _ = await post_slack_thread_reply_with_ts(
         channel_id,
@@ -1193,7 +1193,7 @@ async def update_slack_trace_reply_for_web_handoff(
     channel_id: str, message_ts: str, thread_id: str
 ) -> bool:
     """Update the initial Slack trace reply after a dashboard handoff."""
-    trace_url = get_langsmith_trace_url(thread_id)
+    trace_url = await get_langsmith_trace_url(thread_id)
     dashboard_url = dashboard_thread_url(thread_id)
     ok, error = await update_slack_message(
         channel_id,

--- a/agent/utils/slack_feedback.py
+++ b/agent/utils/slack_feedback.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 from collections.abc import Mapping
@@ -193,10 +192,9 @@ async def process_slack_reaction(
     }
     score = _score_reactions(active_reactions)
     if score is None:
-        success = await asyncio.to_thread(delete_langsmith_feedback, run_id, key)
+        success = await delete_langsmith_feedback(run_id, key)
     else:
-        success = await asyncio.to_thread(
-            create_langsmith_feedback,
+        success = await create_langsmith_feedback(
             run_id,
             key,
             score=score,
@@ -207,8 +205,7 @@ async def process_slack_reaction(
     outcome = _outcome_from_score(score, source="slack")
     if outcome is not None:
         label, label_source = outcome
-        await asyncio.to_thread(
-            upsert_run_outcome,
+        await upsert_run_outcome(
             label=label,
             label_source=label_source,
             run_id=run_id,

--- a/agent/utils/turn_checkpoint.py
+++ b/agent/utils/turn_checkpoint.py
@@ -12,7 +12,6 @@ gets ``None`` / ``status="error"`` and the UI degrades to "diff unavailable".
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import binascii
 import json
@@ -136,7 +135,7 @@ def _ok(response: Any) -> bool:
 
 
 async def _execute(sandbox: Any, command: str, timeout: int) -> Any:
-    return await asyncio.to_thread(sandbox.execute, command, timeout=timeout)
+    return await sandbox.aexecute(command, timeout=timeout)
 
 
 def parse_numstat(raw: str) -> list[tuple[str, int | None, int | None]]:

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -207,9 +207,9 @@ def _format_slack_thread_section(
     return "\n".join(lines)
 
 
-def _format_slack_run_links_section(thread_id: str) -> str:
+async def _format_slack_run_links_section(thread_id: str) -> str:
     dashboard_url = common.dashboard_thread_url(thread_id)
-    trace_url = get_langsmith_trace_url(thread_id)
+    trace_url = await get_langsmith_trace_url(thread_id)
     lines = ["## Open SWE Links"]
     if dashboard_url:
         lines.append(f"- Web: {dashboard_url}")
@@ -445,7 +445,7 @@ async def _process_slack_mention_impl(
         "Use this only if the Slack conversation does not identify a different repository.\n\n"
         f"## Triggered by\n{trigger_user}\n\n"
         f"{slack_thread_section}\n\n"
-        f"{_format_slack_run_links_section(thread_id)}\n\n"
+        f"{await _format_slack_run_links_section(thread_id)}\n\n"
         f"## Conversation Context\n{context_text}\n\n"
         f"## Latest Mention Request\n{clean_text}"
         + (f"\n\n{resolved_links_section}" if resolved_links_section else "")

--- a/tests/agent/test_langsmith_trace_url.py
+++ b/tests/agent/test_langsmith_trace_url.py
@@ -9,81 +9,100 @@ def _clear_cache() -> None:
     ls_utils._PROJECT_ID_CACHE.clear()
 
 
+def _resolver(ids: dict[str, str], *, default: str | None = None):
+    async def _resolve(name: str) -> str | None:
+        return ids.get(name, default)
+
+    return _resolve
+
+
 def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_URL_PROD", "https://smith.example")
     monkeypatch.setenv("LANGSMITH_TENANT_ID_PROD", "tenant-1")
     monkeypatch.delenv("LANGSMITH_TRACING_PROJECT_ID_PROD", raising=False)
 
 
-def test_trace_url_resolves_project_id_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trace_url_resolves_project_id_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_env(monkeypatch)
     monkeypatch.setattr(
         ls_utils,
         "_resolve_project_id_by_name",
-        lambda name: "agent-pid" if name == AGENT_TRACING_PROJECT else "review-pid",
+        _resolver({AGENT_TRACING_PROJECT: "agent-pid"}, default="review-pid"),
     )
 
-    agent_url = ls_utils.get_langsmith_trace_url("t1")
-    review_url = ls_utils.get_langsmith_trace_url("t2", project_name=REVIEW_TRACING_PROJECT)
+    agent_url = await ls_utils.get_langsmith_trace_url("t1")
+    review_url = await ls_utils.get_langsmith_trace_url("t2", project_name=REVIEW_TRACING_PROJECT)
 
     assert agent_url == "https://smith.example/o/tenant-1/projects/p/agent-pid/t/t1"
     assert review_url == "https://smith.example/o/tenant-1/projects/p/review-pid/t/t2"
 
 
-def test_trace_url_falls_back_to_env_project_id(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trace_url_falls_back_to_env_project_id(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_env(monkeypatch)
     monkeypatch.setenv("LANGSMITH_TRACING_PROJECT_ID_PROD", "env-pid")
-    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", lambda name: None)
+    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", _resolver({}))
 
-    url = ls_utils.get_langsmith_trace_url("t3")
+    url = await ls_utils.get_langsmith_trace_url("t3")
 
     assert url == "https://smith.example/o/tenant-1/projects/p/env-pid/t/t3"
 
 
-def test_trace_url_none_when_unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trace_url_none_when_unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_env(monkeypatch)
-    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", lambda name: None)
+    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", _resolver({}))
 
-    assert ls_utils.get_langsmith_trace_url("t4") is None
+    assert await ls_utils.get_langsmith_trace_url("t4") is None
 
 
-def test_resolve_project_id_caches_success(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_resolve_project_id_caches_success(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     class _FakeProject:
         id = "pid-123"
 
     class _FakeClient:
-        def read_project(self, *, project_name: str) -> _FakeProject:
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def read_project(self, *, project_name: str) -> _FakeProject:
             calls.append(project_name)
             return _FakeProject()
 
     monkeypatch.setattr(ls_utils, "_build_prod_langsmith_client", lambda: _FakeClient())
 
-    first = ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT)
-    second = ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT)
+    first = await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT)
+    second = await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT)
 
     assert first == "pid-123"
     assert second == "pid-123"
     assert calls == [AGENT_TRACING_PROJECT]
 
 
-def test_resolve_project_id_caches_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_resolve_project_id_caches_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     class _FakeClient:
-        def read_project(self, *, project_name: str) -> None:
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def read_project(self, *, project_name: str) -> None:
             calls.append(project_name)
             raise RuntimeError("403 Forbidden")
 
     monkeypatch.setattr(ls_utils, "_build_prod_langsmith_client", lambda: _FakeClient())
 
-    assert ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT) is None
-    assert ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT) is None
+    assert await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT) is None
+    assert await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT) is None
     assert calls == [AGENT_TRACING_PROJECT]
 
 
-def test_trace_url_none_when_tenant_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trace_url_none_when_tenant_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_TENANT_ID_PROD", raising=False)
 
     def _boom() -> None:
@@ -91,4 +110,4 @@ def test_trace_url_none_when_tenant_unset(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(ls_utils, "_build_prod_langsmith_client", _boom)
 
-    assert ls_utils.get_langsmith_trace_url("t5") is None
+    assert await ls_utils.get_langsmith_trace_url("t5") is None

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -149,13 +149,13 @@ def test_run_start_omits_plan_mode_when_disabled(
     assert "plan_mode" not in configurable
 
 
-def test_thread_summary_reports_plan_mode() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_reports_plan_mode() -> None:
+    summary = await thread_api._thread_summary(
         {"thread_id": "t1", "metadata": {"source": "dashboard", "plan_mode": True}}
     )
     assert summary["planMode"] is True
 
-    summary_off = thread_api._thread_summary(
+    summary_off = await thread_api._thread_summary(
         {"thread_id": "t2", "metadata": {"source": "dashboard"}}
     )
     assert summary_off["planMode"] is False

--- a/tests/agent/test_repo_prep.py
+++ b/tests/agent/test_repo_prep.py
@@ -26,7 +26,7 @@ class _FakeSandboxBackend:
     def id(self) -> str:
         return "fake-sandbox"
 
-    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         del timeout
         if self._raise:
             raise RuntimeError("sandbox unreachable")

--- a/tests/agent/test_workflow_push_guard.py
+++ b/tests/agent/test_workflow_push_guard.py
@@ -27,7 +27,7 @@ class _Backend:
         self.commands: list[str] = []
         self.head = "a" * 40
 
-    def execute(self, command: str, *, timeout: int | None = None) -> _Response:
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> _Response:
         self.commands.append(command)
         if "rev-parse --show-toplevel" in command:
             return _Response("/repo\n")
@@ -103,9 +103,9 @@ def test_parse_git_push_supports_git_c_and_cd() -> None:
     assert guard._parse_git_push("git push origin feature; git push origin evil:feature") is None
 
 
-def test_workflow_change_for_push_fingerprints_workflow_diff() -> None:
+async def test_workflow_change_for_push_fingerprints_workflow_diff() -> None:
     backend = _Backend()
-    change = guard._workflow_change_for_push(
+    change = await guard._workflow_change_for_push(
         backend,
         guard.ParsedGitPush(
             repo_dir="/repo", remote="origin", local_ref="feature", remote_ref="feature"
@@ -154,11 +154,11 @@ def test_workflow_approval_response_serializes_review_fields() -> None:
     assert response["approvalUrl"].endswith("workflowApproval=abc")
 
 
-def test_workflow_change_for_push_ignores_non_workflow_push() -> None:
+async def test_workflow_change_for_push_ignores_non_workflow_push() -> None:
     backend = _Backend(workflow_files="")
 
     assert (
-        guard._workflow_change_for_push(
+        await guard._workflow_change_for_push(
             backend,
             guard.ParsedGitPush(
                 repo_dir="/repo", remote="origin", local_ref="feature", remote_ref="feature"
@@ -168,11 +168,11 @@ def test_workflow_change_for_push_ignores_non_workflow_push() -> None:
     )
 
 
-def test_workflow_change_for_push_rejects_non_current_refspec() -> None:
+async def test_workflow_change_for_push_rejects_non_current_refspec() -> None:
     backend = _Backend()
 
     assert (
-        guard._workflow_change_for_push(
+        await guard._workflow_change_for_push(
             backend,
             guard.ParsedGitPush(
                 repo_dir="/repo", remote="origin", local_ref="evil", remote_ref="feature"

--- a/tests/dashboard/test_dashboard_repo_optional.py
+++ b/tests/dashboard/test_dashboard_repo_optional.py
@@ -8,6 +8,10 @@ import pytest
 from agent.dashboard import thread_api
 
 
+async def _fake_trace_url(thread_id: str, **kwargs: object) -> str:
+    return f"https://smith.example/t/{thread_id}"
+
+
 def test_resolve_repo_config_parses_request_repo() -> None:
     assert thread_api._resolve_repo_config("octo/repo") == {"owner": "octo", "name": "repo"}
 
@@ -18,16 +22,16 @@ def test_resolve_repo_config_returns_empty_when_no_repo_given() -> None:
     assert thread_api._resolve_repo_config("not-a-repo") == {}
 
 
-def test_thread_summary_blanks_repo_when_absent() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_blanks_repo_when_absent() -> None:
+    summary = await thread_api._thread_summary(
         {"thread_id": "t1", "metadata": {"source": "dashboard", "title": "no repo run"}}
     )
     assert summary["repo"] == ""
     assert summary["repoFullName"] == ""
 
 
-def test_thread_summary_keeps_repo_when_present() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_keeps_repo_when_present() -> None:
+    summary = await thread_api._thread_summary(
         {
             "thread_id": "t2",
             "metadata": {
@@ -42,13 +46,13 @@ def test_thread_summary_keeps_repo_when_present() -> None:
     assert summary["repoFullName"] == "octo/repo"
 
 
-def test_thread_summary_includes_trace_url(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_thread_summary_includes_trace_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         thread_api,
         "get_langsmith_trace_url",
-        lambda thread_id: f"https://smith.example/t/{thread_id}",
+        _fake_trace_url,
     )
-    summary = thread_api._thread_summary(
+    summary = await thread_api._thread_summary(
         {"thread_id": "t3", "metadata": {"source": "dashboard", "title": "traced run"}}
     )
     assert summary["traceUrl"] == "https://smith.example/t/t3"

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -293,8 +293,8 @@ def _thread_with_metadata(metadata: dict) -> dict:
     return {"thread_id": "t1", "status": "idle", "metadata": metadata}
 
 
-def test_thread_summary_includes_pr_and_diff_stats() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_includes_pr_and_diff_stats() -> None:
+    summary = await thread_api._thread_summary(
         _thread_with_metadata(
             {
                 "repo_full_name": "langchain-ai/open-swe",
@@ -321,8 +321,8 @@ def test_thread_summary_includes_pr_and_diff_stats() -> None:
     assert summary["diffStats"] == {"files": 3, "additions": 10, "deletions": 2}
 
 
-def test_thread_summary_defaults_unknown_pr_state_to_open() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_defaults_unknown_pr_state_to_open() -> None:
+    summary = await thread_api._thread_summary(
         _thread_with_metadata(
             {
                 "pr_number": 7,
@@ -335,27 +335,29 @@ def test_thread_summary_defaults_unknown_pr_state_to_open() -> None:
     assert summary["pr"]["state"] == "open"
 
 
-def test_thread_summary_omits_pr_when_no_pr_metadata() -> None:
-    summary = thread_api._thread_summary(_thread_with_metadata({"title": "No PR"}))
+async def test_thread_summary_omits_pr_when_no_pr_metadata() -> None:
+    summary = await thread_api._thread_summary(_thread_with_metadata({"title": "No PR"}))
 
     assert "pr" not in summary
     assert "diffStats" not in summary
 
 
-def test_thread_summary_exposes_sandbox_id() -> None:
-    summary = thread_api._thread_summary(_thread_with_metadata({"sandbox_id": "sb-abc123"}))
+async def test_thread_summary_exposes_sandbox_id() -> None:
+    summary = await thread_api._thread_summary(_thread_with_metadata({"sandbox_id": "sb-abc123"}))
 
     assert summary["sandboxId"] == "sb-abc123"
 
 
-def test_thread_summary_hides_creating_sandbox_sentinel() -> None:
-    summary = thread_api._thread_summary(_thread_with_metadata({"sandbox_id": "__creating__"}))
+async def test_thread_summary_hides_creating_sandbox_sentinel() -> None:
+    summary = await thread_api._thread_summary(
+        _thread_with_metadata({"sandbox_id": "__creating__"})
+    )
 
     assert summary["sandboxId"] is None
 
 
-def test_thread_summary_includes_slack_source_url_for_private_repo() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_includes_slack_source_url_for_private_repo() -> None:
+    summary = await thread_api._thread_summary(
         _thread_with_metadata(
             {
                 "source": "slack",
@@ -368,8 +370,8 @@ def test_thread_summary_includes_slack_source_url_for_private_repo() -> None:
     assert summary["sourceUrl"] == "https://slack.example/thread"
 
 
-def test_thread_summary_omits_slack_source_url_for_public_repo() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_omits_slack_source_url_for_public_repo() -> None:
+    summary = await thread_api._thread_summary(
         _thread_with_metadata(
             {
                 "source": "slack",
@@ -429,7 +431,7 @@ async def test_recovery_patch_downloads_generated_patch(monkeypatch) -> None:
         }
 
     class FakeSandbox:
-        def execute(self, command: str, *, timeout: int | None = None):
+        async def aexecute(self, command: str, *, timeout: int | None = None):
             assert "repo" in command
             assert timeout == thread_api._RECOVERY_PATCH_TIMEOUT_SECONDS
             return SimpleNamespace(
@@ -437,7 +439,7 @@ async def test_recovery_patch_downloads_generated_patch(monkeypatch) -> None:
                 exit_code=0,
             )
 
-        def download_files(self, paths: list[str]):
+        async def adownload_files(self, paths: list[str]):
             assert paths == ["/tmp/open-swe-tid.patch"]
             return [SimpleNamespace(content=b"patch bytes")]
 
@@ -455,7 +457,7 @@ async def test_recovery_patch_rejects_empty_patch(monkeypatch) -> None:
         return {"thread_id": thread_id, "metadata": {"sandbox_id": "sbx", "github_login": login}}
 
     class FakeSandbox:
-        def execute(self, command: str, *, timeout: int | None = None):
+        async def aexecute(self, command: str, *, timeout: int | None = None):
             return SimpleNamespace(
                 output=json.dumps({"ok": True, "path": "/tmp/open-swe-tid.patch", "size": 0}),
                 exit_code=0,
@@ -476,7 +478,7 @@ async def test_recovery_patch_enforces_size_limit(monkeypatch) -> None:
         return {"thread_id": thread_id, "metadata": {"sandbox_id": "sbx", "github_login": login}}
 
     class FakeSandbox:
-        def execute(self, command: str, *, timeout: int | None = None):
+        async def aexecute(self, command: str, *, timeout: int | None = None):
             return SimpleNamespace(
                 output=json.dumps(
                     {
@@ -1134,8 +1136,8 @@ async def test_send_dashboard_message_does_not_attribute_owner(monkeypatch) -> N
     assert payload["text"] == "ship it"
 
 
-def test_thread_summary_exposes_resolved_state() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_exposes_resolved_state() -> None:
+    summary = await thread_api._thread_summary(
         {
             "thread_id": "tid",
             "metadata": {
@@ -1151,8 +1153,8 @@ def test_thread_summary_exposes_resolved_state() -> None:
     assert summary["resolvedAt"] == 1700
 
 
-def test_thread_summary_defaults_to_not_resolved() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_defaults_to_not_resolved() -> None:
+    summary = await thread_api._thread_summary(
         {"thread_id": "tid", "metadata": {"source": "dashboard", "github_login": "octocat"}}
     )
 
@@ -1160,8 +1162,8 @@ def test_thread_summary_defaults_to_not_resolved() -> None:
     assert summary["resolvedAt"] is None
 
 
-def test_thread_summary_is_owner_true_for_matching_login() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_is_owner_true_for_matching_login() -> None:
+    summary = await thread_api._thread_summary(
         {"thread_id": "tid", "metadata": {"source": "slack", "github_login": "octocat"}},
         owner_login="octocat",
     )
@@ -1169,8 +1171,8 @@ def test_thread_summary_is_owner_true_for_matching_login() -> None:
     assert summary["isOwner"] is True
 
 
-def test_thread_summary_is_owner_false_for_non_owner() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_is_owner_false_for_non_owner() -> None:
+    summary = await thread_api._thread_summary(
         {"thread_id": "tid", "metadata": {"source": "slack", "github_login": "octocat"}},
         owner_login="teammate",
     )
@@ -1178,8 +1180,8 @@ def test_thread_summary_is_owner_false_for_non_owner() -> None:
     assert summary["isOwner"] is False
 
 
-def test_thread_summary_is_owner_true_for_matching_email() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_is_owner_true_for_matching_email() -> None:
+    summary = await thread_api._thread_summary(
         {
             "thread_id": "tid",
             "metadata": {
@@ -1195,8 +1197,8 @@ def test_thread_summary_is_owner_true_for_matching_email() -> None:
     assert summary["isOwner"] is True
 
 
-def test_thread_summary_is_owner_defaults_true_without_owner_login() -> None:
-    summary = thread_api._thread_summary(
+async def test_thread_summary_is_owner_defaults_true_without_owner_login() -> None:
+    summary = await thread_api._thread_summary(
         {"thread_id": "tid", "metadata": {"source": "slack", "github_login": "octocat"}},
     )
 

--- a/tests/github/test_github_feedback.py
+++ b/tests/github/test_github_feedback.py
@@ -73,7 +73,7 @@ async def test_github_reaction_added_creates_langsmith_feedback(
     client = _FakeClient()
     created: dict[str, Any] = {}
 
-    def fake_create_feedback(
+    async def fake_create_feedback(
         run_id: str,
         key: str,
         *,
@@ -136,7 +136,7 @@ async def test_github_reaction_removed_deletes_langsmith_feedback(
     }
     deleted: dict[str, str] = {}
 
-    def fake_delete_feedback(run_id: str, key: str) -> bool:
+    async def fake_delete_feedback(run_id: str, key: str) -> bool:
         deleted["run_id"] = run_id
         deleted["key"] = key
         return True

--- a/tests/reviewer/test_reviewer_diff.py
+++ b/tests/reviewer/test_reviewer_diff.py
@@ -162,17 +162,17 @@ async def test_materialize_review_diff_writes_supplied_diff() -> None:
 @pytest.mark.asyncio
 async def test_compute_diff_in_sandbox_uses_three_dot_for_merge_base() -> None:
     """First-review path passes merge_base=True so we use base...head, not base..head."""
-    from unittest.mock import MagicMock
+    from unittest.mock import AsyncMock, MagicMock
 
     from agent.review.diff import compute_diff_in_sandbox
 
     backend = MagicMock()
-    backend.execute = MagicMock(return_value="")
+    backend.aexecute = AsyncMock(return_value="")
 
     await compute_diff_in_sandbox(
         backend, work_dir="/w", base_ref="base", head_ref="head", merge_base=True
     )
-    cmd = backend.execute.call_args.args[0]
+    cmd = backend.aexecute.call_args.args[0]
     assert "base...head" in cmd
     assert "base..head" not in cmd.replace("base...head", "")
     assert "--no-prefix" not in cmd  # invalid flag must not appear
@@ -180,14 +180,14 @@ async def test_compute_diff_in_sandbox_uses_three_dot_for_merge_base() -> None:
 
 @pytest.mark.asyncio
 async def test_compute_diff_in_sandbox_reads_execute_response_output() -> None:
-    from unittest.mock import MagicMock
+    from unittest.mock import AsyncMock, MagicMock
 
     from deepagents.backends.protocol import ExecuteResponse
 
     from agent.review.diff import compute_diff_in_sandbox
 
     backend = MagicMock()
-    backend.execute = MagicMock(return_value=ExecuteResponse(output=_TWO_FILE_DIFF, exit_code=0))
+    backend.aexecute = AsyncMock(return_value=ExecuteResponse(output=_TWO_FILE_DIFF, exit_code=0))
 
     result = await compute_diff_in_sandbox(
         backend, work_dir="/w/repo", base_ref="base", head_ref="head"
@@ -199,14 +199,14 @@ async def test_compute_diff_in_sandbox_reads_execute_response_output() -> None:
 @pytest.mark.asyncio
 async def test_compute_diff_in_sandbox_uses_two_dot_by_default() -> None:
     """Re-review delta path passes merge_base=False so we use base..head."""
-    from unittest.mock import MagicMock
+    from unittest.mock import AsyncMock, MagicMock
 
     from agent.review.diff import compute_diff_in_sandbox
 
     backend = MagicMock()
-    backend.execute = MagicMock(return_value="")
+    backend.aexecute = AsyncMock(return_value="")
 
     await compute_diff_in_sandbox(backend, work_dir="/w", base_ref="oldsha", head_ref="newsha")
-    cmd = backend.execute.call_args.args[0]
+    cmd = backend.aexecute.call_args.args[0]
     assert "oldsha..newsha" in cmd
     assert "oldsha...newsha" not in cmd

--- a/tests/reviewer/test_reviewer_outcomes.py
+++ b/tests/reviewer/test_reviewer_outcomes.py
@@ -64,10 +64,16 @@ class _FakeClient:
         self.updated: list[dict[str, Any]] = []
         self.conflict_once = False
 
-    def list_datasets(self, dataset_name: str):  # noqa: ANN001
-        return iter([_FakeDataset()])
+    async def __aenter__(self) -> _FakeClient:
+        return self
 
-    def create_example(self, **kwargs: Any) -> None:
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    async def list_datasets(self, dataset_name: str):  # noqa: ANN001
+        yield _FakeDataset()
+
+    async def create_example(self, **kwargs: Any) -> None:
         if self.conflict_once:
             self.conflict_once = False
             raise RuntimeError("already exists")
@@ -75,6 +81,15 @@ class _FakeClient:
 
     def update_example(self, **kwargs: Any) -> None:
         self.updated.append(kwargs)
+
+
+def _patch_client(monkeypatch, fake: _FakeClient | None) -> None:  # noqa: ANN001
+    if fake is None:
+        monkeypatch.setattr(reviewer_outcomes, "_outcomes_credentials", lambda: None)
+        return
+    monkeypatch.setattr(reviewer_outcomes, "_outcomes_credentials", lambda: ("k", "https://api"))
+    monkeypatch.setattr(reviewer_outcomes, "AsyncLangSmithClient", lambda **kwargs: fake)
+    monkeypatch.setattr(reviewer_outcomes, "LangSmithClient", lambda **kwargs: cast(Any, fake))
 
 
 def _finding() -> Finding:
@@ -99,11 +114,11 @@ def _finding() -> Finding:
     )
 
 
-def test_upsert_finding_outcome_builds_payload(monkeypatch) -> None:  # noqa: ANN001
+async def test_upsert_finding_outcome_builds_payload(monkeypatch) -> None:  # noqa: ANN001
     fake = _FakeClient()
-    monkeypatch.setattr(reviewer_outcomes, "_outcomes_client", lambda: fake)
+    _patch_client(monkeypatch, fake)
 
-    ok = upsert_finding_outcome(
+    ok = await upsert_finding_outcome(
         _finding(),
         label=TRUE_POSITIVE,
         label_source="resolved_by_commit",
@@ -129,12 +144,12 @@ def test_upsert_finding_outcome_builds_payload(monkeypatch) -> None:  # noqa: AN
     assert call["metadata"]["run_id"] == "run_1"
 
 
-def test_upsert_finding_outcome_updates_on_conflict(monkeypatch) -> None:  # noqa: ANN001
+async def test_upsert_finding_outcome_updates_on_conflict(monkeypatch) -> None:  # noqa: ANN001
     fake = _FakeClient()
     fake.conflict_once = True
-    monkeypatch.setattr(reviewer_outcomes, "_outcomes_client", lambda: fake)
+    _patch_client(monkeypatch, fake)
 
-    ok = upsert_finding_outcome(
+    ok = await upsert_finding_outcome(
         _finding(), label=FALSE_POSITIVE, label_source="dismissed", repo="o/r"
     )
     assert ok
@@ -142,18 +157,18 @@ def test_upsert_finding_outcome_updates_on_conflict(monkeypatch) -> None:  # noq
     assert len(fake.updated) == 1
 
 
-def test_upsert_no_client_is_noop(monkeypatch) -> None:  # noqa: ANN001
-    monkeypatch.setattr(reviewer_outcomes, "_outcomes_client", lambda: None)
+async def test_upsert_no_client_is_noop(monkeypatch) -> None:  # noqa: ANN001
+    _patch_client(monkeypatch, None)
     assert (
-        upsert_finding_outcome(_finding(), label=TRUE_POSITIVE, label_source="x", repo="o/r")
+        await upsert_finding_outcome(_finding(), label=TRUE_POSITIVE, label_source="x", repo="o/r")
         is False
     )
 
 
-def test_emit_finding_status_outcome_maps_and_calls(monkeypatch) -> None:  # noqa: ANN001
+async def test_emit_finding_status_outcome_maps_and_calls(monkeypatch) -> None:  # noqa: ANN001
     captured: dict[str, Any] = {}
 
-    def fake_upsert(finding, **kwargs: Any) -> bool:  # noqa: ANN001
+    async def fake_upsert(finding, **kwargs: Any) -> bool:  # noqa: ANN001
         captured.update(kwargs)
         captured["finding_id"] = finding["id"]
         return True
@@ -167,7 +182,7 @@ def test_emit_finding_status_outcome_maps_and_calls(monkeypatch) -> None:  # noq
         "base_sha": "aaa",
         "head_sha": "bbb",
     }
-    assert emit_finding_status_outcome(
+    assert await emit_finding_status_outcome(
         _finding(), "resolved", configurable=configurable, thread_id="t1"
     )
     assert captured["repo"] == "o/r"
@@ -176,9 +191,9 @@ def test_emit_finding_status_outcome_maps_and_calls(monkeypatch) -> None:  # noq
     assert captured["pr_number"] == 7
 
 
-def test_emit_finding_status_outcome_no_repo_is_noop(monkeypatch) -> None:  # noqa: ANN001
+async def test_emit_finding_status_outcome_no_repo_is_noop(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setattr(reviewer_outcomes, "upsert_finding_outcome", lambda *a, **k: pytest_fail())
-    assert emit_finding_status_outcome(_finding(), "dismissed", configurable={}) is False
+    assert await emit_finding_status_outcome(_finding(), "dismissed", configurable={}) is False
 
 
 def pytest_fail() -> bool:

--- a/tests/reviewer/test_reviewer_outcomes.py
+++ b/tests/reviewer/test_reviewer_outcomes.py
@@ -88,8 +88,8 @@ def _patch_client(monkeypatch, fake: _FakeClient | None) -> None:  # noqa: ANN00
         monkeypatch.setattr(reviewer_outcomes, "_outcomes_credentials", lambda: None)
         return
     monkeypatch.setattr(reviewer_outcomes, "_outcomes_credentials", lambda: ("k", "https://api"))
-    monkeypatch.setattr(reviewer_outcomes, "AsyncLangSmithClient", lambda **kwargs: fake)
-    monkeypatch.setattr(reviewer_outcomes, "LangSmithClient", lambda **kwargs: cast(Any, fake))
+    monkeypatch.setattr(reviewer_outcomes, "async_langsmith_client", lambda *a: fake)
+    monkeypatch.setattr(reviewer_outcomes, "sync_langsmith_client", lambda *a: cast(Any, fake))
 
 
 def _finding() -> Finding:

--- a/tests/reviewer/test_reviewer_trace_context.py
+++ b/tests/reviewer/test_reviewer_trace_context.py
@@ -60,24 +60,23 @@ class _FakeLangSmithClient:
             }
         )
 
-    def list_runs(self, **kwargs: Any) -> list[dict[str, Any]]:
+    async def list_runs(self, **kwargs: Any):
         filter_expr = kwargs["filter"]
         self.filters.append(filter_expr)
         for needle, runs in self.search_results.items():
             if needle in filter_expr:
-                return runs
+                for run in runs:
+                    yield run
+                return
         thread_id = _thread_id_from_filter(filter_expr)
         if thread_id:
-            return [
-                _run(
-                    f"turn-{thread_id}",
-                    thread_id,
-                    metadata={"repository_name": "langchain-ai/open-swe"},
-                    inputs={"message": "Need to update reviewer.py"},
-                    outputs={"message": "Edited reviewer.py after checking edge cases."},
-                )
-            ]
-        return []
+            yield _run(
+                f"turn-{thread_id}",
+                thread_id,
+                metadata={"repository_name": "langchain-ai/open-swe"},
+                inputs={"message": "Need to update reviewer.py"},
+                outputs={"message": "Edited reviewer.py after checking edge cases."},
+            )
 
 
 class _CapturingSandbox:

--- a/tests/sandbox/test_langsmith_sandbox_timeout.py
+++ b/tests/sandbox/test_langsmith_sandbox_timeout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from types import SimpleNamespace
 from typing import Any, cast
@@ -20,14 +21,14 @@ class _FakeHandle:
         self.killed = False
 
     @property
-    def result(self) -> Any:
+    async def result(self) -> Any:
         if self._sleep:
-            time.sleep(self._sleep)
+            await asyncio.sleep(self._sleep)
         if self._raises is not None:
             raise self._raises
         return self._result
 
-    def kill(self) -> None:
+    async def kill(self) -> None:
         self.killed = True
 
 
@@ -37,7 +38,7 @@ class _FakeSandbox:
         self._run_raises = run_raises
         self.run_calls: list[dict[str, Any]] = []
 
-    def run(self, command: str, *, timeout: int, wait: bool) -> _FakeHandle:
+    async def run(self, command: str, *, timeout: int, wait: bool) -> _FakeHandle:
         self.run_calls.append({"command": command, "timeout": timeout, "wait": wait})
         if self._run_raises is not None:
             raise self._run_raises
@@ -48,7 +49,8 @@ def _backend(
     handle: _FakeHandle, *, run_raises: Exception | None = None
 ) -> TimeoutLangSmithSandbox:
     sb = TimeoutLangSmithSandbox.__new__(TimeoutLangSmithSandbox)
-    object.__setattr__(sb, "_sandbox", _FakeSandbox(handle, run_raises=run_raises))
+    object.__setattr__(sb, "_async_sandbox", _FakeSandbox(handle, run_raises=run_raises))
+    object.__setattr__(sb, "_async_client", None)
     sb._default_timeout = 30 * 60
     return sb
 
@@ -67,7 +69,7 @@ async def test_aexecute_kills_on_client_timeout() -> None:
     assert resp.exit_code == 124
     assert "killed" in resp.output
     assert handle.killed
-    sandbox = cast(_FakeSandbox, sb._sandbox)
+    sandbox = cast(_FakeSandbox, sb._async_sandbox)
     assert sandbox.run_calls[0]["wait"] is False
 
 
@@ -89,23 +91,13 @@ async def test_aexecute_server_timeout_not_killed() -> None:
     assert not handle.killed
 
 
-def test_execute_kills_on_client_timeout() -> None:
-    handle = _FakeHandle(sleep=5.0)
-    sb = _backend(handle)
-    start = time.monotonic()
-    resp = sb.execute("sleep 999", timeout=1)
-    assert time.monotonic() - start < 3.0
-    assert resp.exit_code == 124
-    assert handle.killed
-
-
 def _patch_base_execute(monkeypatch: pytest.MonkeyPatch, sink: dict[str, Any]) -> None:
-    def fake_base_execute(self: Any, command: str, *, timeout: int | None = None) -> Any:
+    async def fake_base_execute(self: Any, command: str, *, timeout: int | None = None) -> Any:
         sink["command"] = command
         sink["timeout"] = timeout
         return SimpleNamespace(output="via-http", exit_code=0, truncated=False)
 
-    monkeypatch.setattr("agent.integrations.langsmith.LangSmithSandbox.execute", fake_base_execute)
+    monkeypatch.setattr("agent.integrations.langsmith.LangSmithSandbox.aexecute", fake_base_execute)
 
 
 async def test_aexecute_ws_connect_failure_falls_back_to_base(
@@ -131,15 +123,6 @@ async def test_aexecute_ws_connect_timeout_falls_back_to_base(
     assert resp.output == "via-http"
 
 
-def test_execute_ws_connect_failure_falls_back_to_base(monkeypatch: pytest.MonkeyPatch) -> None:
-    sb = _backend(_FakeHandle(), run_raises=SandboxConnectionError("no ws"))
-    called: dict[str, Any] = {}
-    _patch_base_execute(monkeypatch, called)
-    resp = sb.execute("git status", timeout=5)
-    assert called == {"command": "git status", "timeout": 5}
-    assert resp.output == "via-http"
-
-
 async def test_aexecute_midstream_ws_drop_falls_back_to_base(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -150,3 +133,8 @@ async def test_aexecute_midstream_ws_drop_falls_back_to_base(
     resp = await sb.aexecute("git status", timeout=5)
     assert called["command"] == "git status"
     assert resp.output == "via-http"
+
+
+def test_execute_is_async_only() -> None:
+    with pytest.raises(NotImplementedError):
+        _backend(_FakeHandle()).execute("echo hi", timeout=5)

--- a/tests/sandbox/test_local_integration.py
+++ b/tests/sandbox/test_local_integration.py
@@ -10,12 +10,12 @@ class _StubLocalShellBackend:
         self.inherit_env = inherit_env
 
 
-def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
+async def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
     root = tmp_path / "nested" / "openswe-sandbox"
     monkeypatch.setenv("LOCAL_SANDBOX_ROOT_DIR", str(root))
     monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
 
-    backend = local_mod.create_local_sandbox()
+    backend = await local_mod.create_local_sandbox()
 
     assert root.is_dir()
     stub = cast(_StubLocalShellBackend, backend)
@@ -24,12 +24,12 @@ def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
     assert stub.inherit_env is True
 
 
-def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
+async def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
     monkeypatch.delenv("LOCAL_SANDBOX_ROOT_DIR", raising=False)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
 
-    backend = local_mod.create_local_sandbox()
+    backend = await local_mod.create_local_sandbox()
 
     stub = cast(_StubLocalShellBackend, backend)
     assert stub.root_dir == str(tmp_path)

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -339,6 +339,7 @@ class TestRefreshProxyOnSandboxReuse:
         """Cached sandboxes should get a fresh proxy token before git operations."""
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-cached")
+        mock_sandbox.aexecute = AsyncMock()
         captured: dict[str, object] = {}
 
         def fake_create_deep_agent(**kwargs):
@@ -398,6 +399,7 @@ class TestRefreshProxyOnSandboxReuse:
         """Reconnected sandboxes should also get a fresh proxy token."""
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-existing")
+        mock_sandbox.aexecute = AsyncMock()
         captured: dict[str, object] = {}
 
         def fake_create_deep_agent(**kwargs):

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -61,7 +61,7 @@ async def test_replaces_unreachable_cached_sandbox_when_replacement_allowed() ->
     SANDBOX_BACKENDS.clear()
     dead = MagicMock()
     dead.id = "sandbox-cached-dead"
-    dead.execute.side_effect = SandboxClientError("sandbox is gone")
+    dead.aexecute.side_effect = SandboxClientError("sandbox is gone")
     proxy = set_sandbox_backend(thread_id, dead)
     replacement = MagicMock()
     replacement.id = "sandbox-replacement"

--- a/tests/sandbox/test_sandbox_paths.py
+++ b/tests/sandbox/test_sandbox_paths.py
@@ -5,11 +5,7 @@ from typing import cast
 
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
-from agent.utils.sandbox_paths import (
-    aresolve_repo_dir,
-    resolve_repo_dir,
-    resolve_sandbox_work_dir,
-)
+from agent.utils.sandbox_paths import aresolve_repo_dir, aresolve_sandbox_work_dir
 
 
 class _FakeProvider:
@@ -45,7 +41,7 @@ class _FakeSandboxBackend:
     def id(self) -> str:
         return "fake-sandbox"
 
-    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         del timeout
         self.commands.append(command)
 
@@ -64,19 +60,19 @@ class _FakeSandboxBackend:
         return ExecuteResponse(output="", exit_code=1, truncated=False)
 
 
-def test_resolve_repo_dir_uses_provider_work_dir() -> None:
+async def test_resolve_repo_dir_uses_provider_work_dir() -> None:
     backend = _FakeSandboxBackend(
         provider=_FakeProvider(work_dir="/workspace"),
         writable_dirs={"/workspace"},
     )
 
-    repo_dir = resolve_repo_dir(cast(SandboxBackendProtocol, backend), "open-swe")
+    repo_dir = await aresolve_repo_dir(cast(SandboxBackendProtocol, backend), "open-swe")
 
     assert repo_dir == "/workspace/open-swe"
     assert backend.commands == ["test -d /workspace && test -w /workspace"]
 
 
-def test_resolve_sandbox_work_dir_falls_back_to_home_when_work_dir_is_not_writable() -> None:
+async def test_resolve_sandbox_work_dir_falls_back_to_home_when_work_dir_is_not_writable() -> None:
     backend = _FakeSandboxBackend(
         provider=_FakeProvider(work_dir="/workspace", home_dir="/home/daytona"),
         shell_paths={
@@ -86,7 +82,7 @@ def test_resolve_sandbox_work_dir_falls_back_to_home_when_work_dir_is_not_writab
         writable_dirs={"/home/daytona"},
     )
 
-    work_dir = resolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
+    work_dir = await aresolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
 
     assert work_dir == "/home/daytona"
     assert backend.commands == [
@@ -96,21 +92,21 @@ def test_resolve_sandbox_work_dir_falls_back_to_home_when_work_dir_is_not_writab
     ]
 
 
-def test_resolve_sandbox_work_dir_caches_the_result() -> None:
+async def test_resolve_sandbox_work_dir_caches_the_result() -> None:
     backend = _FakeSandboxBackend(
         provider=_FakeProvider(work_dir="/workspace"),
         writable_dirs={"/workspace"},
     )
 
-    first = resolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
-    second = resolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
+    first = await aresolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
+    second = await aresolve_sandbox_work_dir(cast(SandboxBackendProtocol, backend))
 
     assert first == "/workspace"
     assert second == "/workspace"
     assert backend.commands == ["test -d /workspace && test -w /workspace"]
 
 
-async def test_aresolve_repo_dir_offloads_sync_resolution() -> None:
+async def test_aresolve_repo_dir_resolves_home_dir() -> None:
     backend = _FakeSandboxBackend(
         provider=_FakeProvider(work_dir="/home/daytona"),
         writable_dirs={"/home/daytona"},

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -20,6 +20,10 @@ from agent.webhooks import common as webhook_common
 from agent.webhooks import slack as slack_webhooks
 
 
+async def _fake_trace_url(thread_id: str, **kwargs: object) -> str:
+    return "https://smith/x"
+
+
 class _FakeNotFoundError(Exception):
     status_code = 404
 
@@ -561,7 +565,7 @@ def test_post_slack_trace_reply_has_no_tip(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         slack_utils, "post_slack_thread_reply_with_ts", fake_post_slack_thread_reply_with_ts
     )
-    monkeypatch.setattr(slack_utils, "get_langsmith_trace_url", lambda thread_id: "https://smith/x")
+    monkeypatch.setattr(slack_utils, "get_langsmith_trace_url", _fake_trace_url)
 
     asyncio.run(post_slack_trace_reply("C123", "1.0", "thread-id"))
 
@@ -772,9 +776,7 @@ def _setup_slack_mention_fakes(
         threads = _FakeThreadsClientForProcess()
 
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://app.example.com")
-    monkeypatch.setattr(
-        slack_webhooks, "get_langsmith_trace_url", lambda thread_id: "https://smith/x"
-    )
+    monkeypatch.setattr(slack_webhooks, "get_langsmith_trace_url", _fake_trace_url)
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "open-swe")
     monkeypatch.setattr(webhook_common, "get_slack_user_info", fake_get_slack_user_info)
     monkeypatch.setattr(

--- a/tests/slack/test_slack_feedback.py
+++ b/tests/slack/test_slack_feedback.py
@@ -75,7 +75,7 @@ async def test_reaction_added_creates_feedback(monkeypatch: pytest.MonkeyPatch) 
     _store_message_mapping(client, "C123", "2.000")
     created: dict[str, Any] = {}
 
-    def fake_create_feedback(
+    async def fake_create_feedback(
         run_id: str,
         key: str,
         *,
@@ -112,7 +112,7 @@ async def test_reaction_added_skips_duplicate_event(monkeypatch: pytest.MonkeyPa
     _store_message_mapping(client, "C123", "2.000")
     client.store.items[(("slack_reaction_events", "C123"), "Ev1")] = {"value": {"event_id": "Ev1"}}
 
-    def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
+    async def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
         raise AssertionError("duplicate event should not create feedback")
 
     monkeypatch.setattr(slack_feedback, "get_client", lambda url: client)
@@ -137,7 +137,7 @@ async def test_reaction_removed_deletes_feedback_when_last_reaction_removed(
     }
     deleted: dict[str, str] = {}
 
-    def fake_delete_feedback(run_id: str, key: str) -> bool:
+    async def fake_delete_feedback(run_id: str, key: str) -> bool:
         deleted["run_id"] = run_id
         deleted["key"] = key
         return True
@@ -158,7 +158,7 @@ async def test_reaction_without_message_mapping_is_ignored(
 ) -> None:
     client = _FakeClient()
 
-    def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
+    async def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
         raise AssertionError("unmapped message should not create feedback")
 
     monkeypatch.setattr(slack_feedback, "get_client", lambda url: client)
@@ -174,7 +174,7 @@ async def test_reaction_from_non_triggering_user_is_ignored(
     client = _FakeClient()
     _store_message_mapping(client, "C123", "2.000", triggering_user_id="UTRIGGER")
 
-    def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
+    async def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
         raise AssertionError("non-triggering user should not create feedback")
 
     monkeypatch.setattr(slack_feedback, "get_client", lambda url: client)
@@ -199,10 +199,10 @@ async def test_conflicting_reactions_clear_feedback(
     }
     deleted: dict[str, str] = {}
 
-    def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
+    async def fail_create_feedback(*args: Any, **kwargs: Any) -> bool:
         raise AssertionError("conflicting reactions must not record a numeric score")
 
-    def fake_delete_feedback(run_id: str, key: str) -> bool:
+    async def fake_delete_feedback(run_id: str, key: str) -> bool:
         deleted["run_id"] = run_id
         deleted["key"] = key
         return True

--- a/tests/slack/test_slack_start_new_thread_tool.py
+++ b/tests/slack/test_slack_start_new_thread_tool.py
@@ -10,6 +10,10 @@ from agent.utils.thread_ids import generate_thread_id_from_slack_thread
 slack_breakout_tool = importlib.import_module("agent.tools.slack_start_new_thread")
 
 
+async def _fake_trace_url(thread_id: str, **kwargs: object) -> str:
+    return "https://smith/x"
+
+
 def _config() -> dict[str, Any]:
     return {
         "configurable": {
@@ -118,9 +122,7 @@ async def test_slack_start_new_thread_success(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(slack_breakout_tool, "dispatch_agent_run", fake_dispatch_agent_run)
     monkeypatch.setattr(slack_breakout_tool, "store_slack_run_mapping", fake_store_mapping)
-    monkeypatch.setattr(
-        slack_breakout_tool, "get_langsmith_trace_url", lambda thread_id: "https://smith/x"
-    )
+    monkeypatch.setattr(slack_breakout_tool, "get_langsmith_trace_url", _fake_trace_url)
     monkeypatch.setattr(
         slack_breakout_tool,
         "dashboard_thread_url",

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -167,7 +167,13 @@ async def test_langsmith_get_trace_serializes() -> None:
         outputs = {"b": 2}
 
     class _FakeClient:
-        def read_run(self, run_id: str, load_child_runs: bool = False):
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return None
+
+        async def read_run(self, run_id: str):
             assert run_id == "run-1"
             return _Run()
 
@@ -186,10 +192,17 @@ async def test_langsmith_list_runs_caps_limit() -> None:
     captured: dict[str, object] = {}
 
     class _FakeClient:
-        def list_runs(self, *, project_name: str, filter, limit: int):
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return None
+
+        async def list_runs(self, *, project_name: str, filter, limit: int):
             captured["limit"] = limit
             captured["project_name"] = project_name
-            return []
+            return
+            yield
 
     tools = langsmith_tools._make_tools(creds)
     list_runs = next(t for t in tools if t.name == "langsmith_list_runs")

--- a/tests/webhooks/test_linear_trace_comment.py
+++ b/tests/webhooks/test_linear_trace_comment.py
@@ -1,0 +1,35 @@
+"""Tests for the Linear trace-URL comment."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from agent.utils import linear as linear_utils
+
+
+async def test_posts_resolved_trace_url() -> None:
+    with (
+        patch.object(
+            linear_utils,
+            "get_langsmith_trace_url",
+            AsyncMock(return_value="https://smith.example/t/thread-1"),
+        ),
+        patch.object(linear_utils, "comment_on_linear_issue", AsyncMock()) as comment,
+    ):
+        await linear_utils.post_linear_trace_comment("issue-1", "thread-1", "comment-1")
+
+    assert comment.await_args is not None
+    body = comment.await_args.args[1]
+    assert body == "On it! [View trace](https://smith.example/t/thread-1)"
+    assert "coroutine" not in body
+
+
+async def test_falls_back_when_trace_url_unresolved() -> None:
+    with (
+        patch.object(linear_utils, "get_langsmith_trace_url", AsyncMock(return_value=None)),
+        patch.object(linear_utils, "comment_on_linear_issue", AsyncMock()) as comment,
+    ):
+        await linear_utils.post_linear_trace_comment("issue-1", "thread-1", "comment-1")
+
+    assert comment.await_args is not None
+    assert comment.await_args.args[1] == "On it!"


### PR DESCRIPTION
## Summary

An audit for blocking IO on the event loop found three classes of problem.

**Thread-offloaded work that has a native async path.** Sandbox commands went through `asyncio.to_thread(backend.execute, ...)` at 8 call sites even though every deepagents backend exposes `aexecute`, and `TimeoutLangSmithSandbox.aexecute` drove a *sync* `CommandHandle` across three separate thread hops. These now use `AsyncSandbox.run(wait=False)` / `await handle.result` / `await handle.kill()` directly. Same for the modal and local sandbox factories, the recovery-patch download (`adownload_files`), and LangSmith feedback, reviewer outcomes, observability tools and trace-URL resolution, which move to `AsyncClient`.

**Two paths blocking the loop with no offload at all.** `WorkflowPushGuardMiddleware` ran up to 14 sequential sandbox git commands synchronously inside `awrap_tool_call` — on every `git push`. And `emit_finding_status_outcome` / `read_outcomes_for_repo` issued synchronous LangSmith HTTP straight from `async def` tool bodies. Both are now async.

**Dead sync surface.** Sync methods on `SandboxBackendProxy` and `ReadOnlyBackend` existed only to satisfy the protocol; nothing in `agent/` or `deepagents` calls them. They now raise `NotImplementedError` rather than offering a blocking path someone might reach for.

`create_sandbox` dispatches on `inspect.iscoroutinefunction` instead of special-casing `langsmith`, so async factories are awaited directly.

### What still uses `to_thread`, and why

- `update_feedback`, `update_example` — no async form exists in `langsmith`; adding them in langchain-ai/langsmith-sdk#3348
- `read_run(load_child_runs=True)` — `AsyncClient.read_run` has no such parameter, and it is deprecated on the sync client
- daytona, e2b, runloop — their `langchain_*` backend wrappers bind a *sync* SDK handle (`E2BSandbox(sandbox=e2b.Sandbox)`, `RunloopSandbox` calling `devbox.cmd.exec`), so the async SDK client cannot be handed to them. Making these genuinely async means writing our own backends against `AsyncSandbox`/`AsyncDaytona`/`AsyncRunloop`.
- Exa/Tavily clients, Docker snapshot build, `resolve_triggering_user_identity`, skill pull — sync third-party or sync by design

## Test Plan

- [x] `make test` — 1672 passed
- [x] `make lint` — ruff check + format clean
- [x] `make typecheck` — basedpyright 0 errors
- [x] Sandbox timeout behaviour re-covered against the async handle, including client-timeout kill, server timeout, and WS-drop fallback to the base path
- [x] `TimeoutLangSmithSandbox.execute` asserted to raise `NotImplementedError`