### PR TITLE
fix: show approval state on shared threads

### DIFF
--- a/agent/dashboard/workflow_approval_api.py
+++ b/agent/dashboard/workflow_approval_api.py
@@ -31,8 +31,6 @@ async def list_workflow_push_approvals(
     if not _thread_is_readable(metadata):
         raise HTTPException(404, "thread not found")
     is_owner = _user_owns_thread(metadata, session["sub"], session.get("email"))
-    if not is_owner:
-        raise HTTPException(403, "only the thread owner can view workflow approvals")
     approvals = await get_workflow_push_approvals(thread_id)
     return {
         "threadId": thread_id,

--- a/tests/dashboard/test_workflow_approval_api.py
+++ b/tests/dashboard/test_workflow_approval_api.py
@@ -1,34 +1,31 @@
 from __future__ import annotations
 
-import pytest
-from fastapi import HTTPException
-
 from agent.dashboard import workflow_approval_api
 
 
-async def test_list_workflow_push_approvals_requires_thread_owner(monkeypatch) -> None:
+async def test_list_workflow_push_approvals_returns_records_for_non_owner(monkeypatch) -> None:
     async def fake_thread_metadata(thread_id: str) -> dict:
         assert thread_id == "thread-1"
         return {"source": "dashboard", "github_login": "owner"}
 
-    async def fail_get_workflow_push_approvals(thread_id: str) -> dict:
-        raise AssertionError("approval records should not be fetched for non-owners")
+    async def fake_get_workflow_push_approvals(thread_id: str) -> dict:
+        assert thread_id == "thread-1"
+        return {"fp-1": {"fingerprint": "fp-1", "status": "pending"}}
 
     monkeypatch.setattr(workflow_approval_api, "_thread_metadata", fake_thread_metadata)
     monkeypatch.setattr(
         workflow_approval_api,
         "get_workflow_push_approvals",
-        fail_get_workflow_push_approvals,
+        fake_get_workflow_push_approvals,
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await workflow_approval_api.list_workflow_push_approvals(
-            "thread-1",
-            session={"sub": "other", "email": "other@example.com"},
-        )
+    response = await workflow_approval_api.list_workflow_push_approvals(
+        "thread-1",
+        session={"sub": "other", "email": "other@example.com"},
+    )
 
-    assert exc_info.value.status_code == 403
-    assert "thread owner" in str(exc_info.value.detail)
+    assert response["isOwner"] is False
+    assert response["approvals"][0]["fingerprint"] == "fp-1"
 
 
 async def test_list_workflow_push_approvals_returns_records_for_owner(monkeypatch) -> None:


### PR DESCRIPTION
## Description
Allow readable shared threads to fetch workflow approval state while preserving owner-only approval decisions. Existing UI capability flags keep approve/reject disabled for non-owners.

## Release Note
Shared agent threads now load normally when workflow approval state exists.

## Test Plan
- [x] Verify a non-owner can read approval records with `isOwner: false`

Made by [Open SWE](https://openswe.vercel.app/agents/1c49ee62-8c49-9ba4-b2f5-22bd42a4cb66)

## References
- Plan: https://openswe.vercel.app/agents/1c49ee62-8c49-9ba4-b2f5-22bd42a4cb66/plan