### PR TITLE
fix(web): bind the stream transport to the active thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,5 @@ __pycache__/
 *.egg-info/
 .eggs/
 
-# 
+#
+logs/

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -90,6 +90,21 @@ async function expectTranscriptVisible(page: Page) {
   }).toPass({ timeout: 60000 });
 }
 
+async function waitForThreadIdle(page: Page, threadId: string) {
+  await expect
+    .poll(
+      async () => {
+        const res = await page.request.get(
+          `/dashboard/api/threads/${threadId}?mark_viewed=false`,
+        );
+        if (!res.ok()) return "unknown";
+        return ((await res.json()) as { status?: string }).status ?? "unknown";
+      },
+      { timeout: 30_000, intervals: [500] },
+    )
+    .not.toBe("running");
+}
+
 async function latestPrBody(page: Page): Promise<string> {
   const res = await page.request.get("/mock/github/data");
   expect(res.ok()).toBeTruthy();
@@ -151,6 +166,29 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect(
       page.getByRole("link", { name: "Add greet() helper" }).first(),
     ).toBeVisible();
+  });
+
+  // A cold load of a finished thread must hydrate from `getState()` alone. The
+  // event stream is blocked so run replay can't stand in for that read: a
+  // long-finished run has no replay left, which is what makes a broken hydrate
+  // surface as a permanently empty transcript.
+  test("a cold load renders a finished thread's transcript without run replay", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page);
+    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(threadId).not.toBe("");
+    await waitForThreadIdle(page, threadId);
+
+    await page.route("**/stream/events", (route) => route.abort());
+    await page.goto(`/agents/${threadId}`);
+    await expect(
+      page.getByRole("link", { name: "Add greet() helper" }).first(),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByText("This thread has no messages yet."),
+    ).toHaveCount(0);
   });
 
   test("does not expose the originating Slack thread for public repos", async ({

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { CircleAlert as CircleAlertIcon, Map as MapIcon } from "lucide-react"
 
@@ -173,8 +173,20 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   // Show a loading state during that one-time fetch instead of the empty state.
   const isHydrating = stream.isThreadLoading && !hasMessages
   // A failed hydrate is indistinguishable from an empty thread in the snapshot,
-  // so say so rather than claiming the thread has no messages.
-  const hydrationFailed = !isHydrating && !hasMessages && stream.error != null
+  // so say so rather than claiming the thread has no messages. `stream.error`
+  // also carries run failures, hence the dedicated hydration signal.
+  const [hydrateRejected, setHydrateRejected] = useState(false)
+  useEffect(() => {
+    let active = true
+    setHydrateRejected(false)
+    stream.hydrationPromise.catch(() => {
+      if (active) setHydrateRejected(true)
+    })
+    return () => {
+      active = false
+    }
+  }, [stream.hydrationPromise])
+  const hydrationFailed = !isHydrating && !hasMessages && hydrateRejected
 
   return (
     <div className="flex min-w-0 flex-1">

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -172,6 +172,9 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   // The transcript hydrates from the SDK (`GET …/state` → `stream.messages`).
   // Show a loading state during that one-time fetch instead of the empty state.
   const isHydrating = stream.isThreadLoading && !hasMessages
+  // A failed hydrate is indistinguishable from an empty thread in the snapshot,
+  // so say so rather than claiming the thread has no messages.
+  const hydrationFailed = !isHydrating && !hasMessages && stream.error != null
 
   return (
     <div className="flex min-w-0 flex-1">
@@ -305,9 +308,21 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
           </div>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
-            <p className="text-xs text-muted-foreground/70">
-              This thread has no messages yet.
-            </p>
+            {hydrationFailed ? (
+              <Alert variant="error" className="max-w-3xl">
+                <CircleAlertIcon />
+                <AlertDescription>
+                  <span>
+                    This thread&apos;s messages could not be loaded. Reload to
+                    try again.
+                  </span>
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <p className="text-xs text-muted-foreground/70">
+                This thread has no messages yet.
+              </p>
+            )}
             <div className="w-full max-w-3xl">
               <AgentPromptBar
                 placeholder="Send the first message"

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -115,6 +115,13 @@ export function AgentThreadStreamProvider({
     []
   )
 
+  // `StreamController` never binds the thread id on a transport it did not
+  // build — only `client.threads.stream(threadId, { transport })` does, which
+  // runs on submit. Hydration reads `transport.getState()` first, so an unbound
+  // transport throws there and leaves the transcript empty. Bind in render: the
+  // SDK's hydrate effect fires before any effect of ours could.
+  transport.setThreadId(threadId ?? "")
+
   // The SDK captures the lifecycle callbacks once at controller creation, so
   // they must be stable. Read the live thread id from a ref instead of
   // closing over the (changing) prop.


### PR DESCRIPTION
Every cloud agent thread page has rendered "This thread has no messages yet." since #1876 deployed.

That PR swapped `StreamProvider`'s `apiUrl`/`assistantId`/`fetch` for a provider-owned `transport`. The SDK binds a thread id to a transport in exactly one place — `client.threads.stream(threadId, { transport })`, which runs on submit — and `StreamController` never calls `setThreadId` on a transport it did not build. Since `#fetchHydrationState()` prefers `transport.getState()` over `client.threads.getState(id)`, every hydrate threw:

```
Protocol transport has no bound threadId. Bind one — the framework calls
client.threads.stream(threadId, { transport }) / transport.setThreadId(threadId)
— before issuing requests.
```

Server state was fine throughout (prod returns 200 with the full message list). The transcript only ever appeared when a live run's SSE pump opened and replayed the run — which is why a just-finished thread looked fine and an old one stayed blank forever, and why CI stayed green.

Bind the id in render, where it lands before the SDK's hydrate effect. Also surface a hydration failure in the UI: an empty snapshot and a failed read were indistinguishable, which is what made this invisible.

The new e2e blocks `**/stream/events` so run replay can't substitute for the `getState()` read — the same condition a long-finished thread hits in production.

## Test Plan
- [x] `npx playwright test dashboard.spec.ts` — 7 passed, including the new cold-load spec
- [x] New spec fails on the pre-fix build (`element(s) not found` for the transcript) and passes after
- [x] `pnpm exec tsc --noEmit` clean
- [x] Root cause verified against production: read `stream.error` off the live React tree on openswe.vercel.app

[no screenshot]