### PR TITLE
fix: soften dark and light theme palettes

### DIFF
--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -106,7 +106,7 @@ export function TerminalPanel(props: TerminalPanelProps) {
   }, [localCwd, localId])
 
   return (
-    <div className="relative h-full min-h-0 bg-[#111111] p-2">
+    <div className="relative h-full min-h-0 bg-[#1c1c1c] p-2">
       <div ref={containerRef} className="h-full w-full" />
       {error && (
         <div className="absolute inset-x-3 top-3 rounded-md border border-destructive/40 bg-background/95 px-3 py-2 text-xs text-destructive shadow-sm">

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -24,7 +24,7 @@ export function TerminalPanel(props: TerminalPanelProps) {
         "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       fontSize: 13,
       theme: {
-        background: "#111111",
+        background: "#1c1c1c",
         foreground: "#e5e7eb",
         cursor: "#e5e7eb",
       },

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -23,7 +23,7 @@ export const Route = createRootRoute({
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#000000" },
+      { name: "theme-color", content: "#1c1c1c" },
       { title: "open-swe" },
     ],
     links: [

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -85,19 +85,19 @@
 }
 
 :root {
-    --background: oklch(1 0 0);
+    --background: oklch(0.974 0.002 106);
     --foreground: oklch(0.148 0 0);
-    --card: oklch(1 0 0);
+    --card: oklch(0.994 0.001 106);
     --card-foreground: oklch(0.148 0 0);
-    --popover: oklch(1 0 0);
+    --popover: oklch(0.994 0.001 106);
     --popover-foreground: oklch(0.148 0 0);
     --primary: oklch(0.21 0 0);
     --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.967 0 0);
+    --secondary: oklch(0.95 0.002 106);
     --secondary-foreground: oklch(0.21 0 0);
-    --muted: oklch(0.963 0 0);
+    --muted: oklch(0.945 0.002 106);
     --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.963 0 0);
+    --accent: oklch(0.945 0.002 106);
     --accent-foreground: oklch(0.21 0 0);
     --destructive: oklch(0.577 0.245 27.325);
     --destructive-foreground: oklch(0.505 0.213 27.518);
@@ -107,8 +107,8 @@
     --warning-foreground: oklch(0.555 0.163 48.998);
     --info: oklch(0.623 0.214 259.815);
     --info-foreground: oklch(0.488 0.243 264.376);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
+    --border: oklch(0.906 0.003 106);
+    --input: oklch(0.906 0.003 106);
     --ring: oklch(0.708 0 0);
     --app-chrome-background: var(--background);
     --surface-raised: color-mix(in srgb, var(--card) 20%, transparent);
@@ -124,13 +124,13 @@
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
     --radius: 0.625rem;
-    --sidebar: oklch(0.987 0 0);
+    --sidebar: oklch(0.963 0.002 106);
     --sidebar-foreground: oklch(0.148 0 0);
     --sidebar-primary: oklch(0.21 0 0);
     --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.963 0 0);
+    --sidebar-accent: oklch(0.945 0.002 106);
     --sidebar-accent-foreground: oklch(0.21 0 0);
-    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-border: oklch(0.906 0.003 106);
     --sidebar-ring: oklch(0.708 0 0);
     --sidebar-muted-foreground: var(--muted-foreground);
     --sidebar-control-surface: var(--accent);
@@ -140,19 +140,19 @@
 }
 
 .dark {
-    --background: oklch(0.148 0 0);
+    --background: oklch(0.226 0 0);
     --foreground: oklch(0.985 0 0);
-    --card: oklch(0.218 0 0);
+    --card: oklch(0.262 0 0);
     --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.218 0 0);
+    --popover: oklch(0.262 0 0);
     --popover-foreground: oklch(0.985 0 0);
     --primary: oklch(0.92 0 0);
     --primary-foreground: oklch(0.21 0 0);
-    --secondary: oklch(0.274 0 0);
+    --secondary: oklch(0.31 0 0);
     --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.275 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.275 0 0);
+    --muted: oklch(0.31 0 0);
+    --muted-foreground: oklch(0.72 0 0);
+    --accent: oklch(0.31 0 0);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.704 0.191 22.216);
@@ -162,8 +162,8 @@
     --warning-foreground: oklch(0.828 0.189 84.429);
     --info: oklch(0.623 0.214 259.815);
     --info-foreground: oklch(0.707 0.165 254.624);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
+    --border: oklch(1 0 0 / 12%);
+    --input: oklch(1 0 0 / 16%);
     --ring: oklch(0.556 0 0);
     --glass-blur: 16px;
     --chart-1: oklch(0.872 0 0);
@@ -171,13 +171,13 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0.218 0 0);
+    --sidebar: oklch(0.262 0 0);
     --sidebar-foreground: oklch(0.985 0 0);
     --sidebar-primary: oklch(0.92 0 0);
     --sidebar-primary-foreground: oklch(0.21 0 0);
-    --sidebar-accent: oklch(0.275 0 0);
+    --sidebar-accent: oklch(0.31 0 0);
     --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-border: oklch(1 0 0 / 12%);
     --sidebar-ring: oklch(0.556 0 0);
     --sidebar-control-surface: var(--accent);
     --sidebar-row-hover: var(--accent);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -21,21 +21,21 @@
 html[data-agents-theme] {
   color-scheme: light;
 
-  --background: oklch(99.2% 0 0); /* zinc-25 */
+  --background: oklch(97.4% 0.002 106); /* soft warm off-white */
   --app-chrome-background: var(--background);
   --foreground: oklch(27.4% 0.006 286.033); /* zinc-800 */
-  --card: #fff;
+  --card: oklch(99.3% 0.001 106);
   --card-foreground: var(--foreground);
   --surface-raised: color-mix(in srgb, var(--card) 20%, transparent);
-  --popover: #fff;
+  --popover: oklch(99.3% 0.001 106);
   --popover-foreground: var(--foreground);
   --primary: oklch(0.488 0.217 264);
   --primary-foreground: #fff;
-  --secondary: oklch(98.5% 0 0); /* zinc-50 */
+  --secondary: oklch(96.3% 0.002 106);
   --secondary-foreground: var(--foreground);
-  --muted: oklch(98.5% 0 0);
+  --muted: oklch(96.3% 0.002 106);
   --muted-foreground: oklch(55.2% 0.016 285.938); /* zinc-500 */
-  --accent: oklch(96.7% 0.001 286.375); /* zinc-100 */
+  --accent: oklch(94.2% 0.003 106);
   --accent-foreground: oklch(21% 0.006 285.885); /* zinc-900 */
   --destructive: oklch(63.7% 0.237 25.331); /* red-500 */
   --destructive-foreground: oklch(50.5% 0.213 27.518); /* red-700 */
@@ -45,17 +45,17 @@ html[data-agents-theme] {
   --success-foreground: oklch(50.8% 0.118 165.612); /* emerald-700 */
   --warning: oklch(76.9% 0.188 70.08); /* amber-500 */
   --warning-foreground: oklch(55.5% 0.163 48.998); /* amber-700 */
-  --border: oklch(92% 0.004 286.32); /* zinc-200 */
-  --input: oklch(87.1% 0.006 286.286); /* zinc-300 */
+  --border: oklch(90.6% 0.003 106);
+  --input: oklch(86.5% 0.004 106);
   --ring: oklch(0.488 0.217 264);
 
-  --sidebar: oklch(98.5% 0 0);
+  --sidebar: oklch(96.3% 0.002 106);
   --sidebar-foreground: var(--foreground);
   --sidebar-muted-foreground: var(--muted-foreground);
-  --sidebar-control-surface: oklch(96.7% 0.001 286.375);
-  --sidebar-row-hover: oklch(99.2% 0 0);
-  --sidebar-row-active: #fff;
-  --sidebar-row-selected: #fff;
+  --sidebar-control-surface: oklch(94.2% 0.003 106);
+  --sidebar-row-hover: oklch(97.9% 0.002 106);
+  --sidebar-row-active: var(--card);
+  --sidebar-row-selected: var(--card);
   --sidebar-border: var(--border);
   --sidebar-accent: var(--accent);
   --sidebar-accent-foreground: var(--accent-foreground);
@@ -69,7 +69,7 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: oklch(14.5% 0 0); /* neutral-950 */
+  --background: oklch(22.6% 0 0); /* soft charcoal, not black */
   --app-chrome-background: var(--background);
   --foreground: oklch(97% 0 0); /* neutral-100 */
   --card: color-mix(in srgb, var(--background) 97%, #fff);
@@ -93,8 +93,8 @@ html.dark[data-agents-theme] {
   --success-foreground: oklch(76.5% 0.177 163.223); /* emerald-400 */
   --warning: oklch(76.9% 0.188 70.08);
   --warning-foreground: oklch(82.8% 0.189 84.429); /* amber-400 */
-  --border: color-mix(in srgb, #fff 6%, transparent);
-  --input: color-mix(in srgb, #fff 8%, transparent);
+  --border: color-mix(in srgb, #fff 9%, transparent);
+  --input: color-mix(in srgb, #fff 12%, transparent);
   --ring: oklch(0.588 0.217 264);
 
   --sidebar: var(--card);


### PR DESCRIPTION
## Description

Dark mode sat on a near-black `#0a0a0a` base and light mode on pure white, both hard on the eyes. Shifts the dark base to a soft charcoal (`#1c1c1c`, Codex-like) and the light base to a warm off-white (`#f6f6f5`) in both `agents.css` and the app-wide `styles.css`, lifting cards/popovers/hover surfaces to keep the same elevation relationships and nudging borders up so panel edges stay visible on the lighter base. Also updates the xterm background and the `theme-color` meta to match.

## Release Note

Softer dark and light dashboard themes — dark is no longer near-black, light is no longer pure white.

## Test Plan
- [ ] Open the dashboard/desktop app in dark and light mode and confirm surfaces, hover states, and borders are still distinguishable (sidebar, chat, diff view, terminal, menus).

Made by [Open SWE](https://openswe.vercel.app/agents/019fdd41-4a31-749a-b2bb-ea7286171aaa)