### PR TITLE
feat: add per-user PR draft preference

### DIFF
--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -97,6 +97,12 @@ def profile_create_prs(profile: dict[str, Any] | None) -> bool:
     return False
 
 
+def profile_draft_prs(profile: dict[str, Any] | None) -> bool:
+    """Return whether new PRs should be drafts. Defaults to True."""
+    value = profile.get("draft_prs") if isinstance(profile, dict) else None
+    return value if isinstance(value, bool) else True
+
+
 def _normalize_profile_model_pair(
     profile: dict[str, Any],
     *,

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -45,6 +45,7 @@ class ProfileUpdate(BaseModel):
     branch_prefix: str | None = None
     auto_fix_ci: bool = True
     create_prs: bool = False
+    draft_prs: bool = True
     review_draft_prs: bool | None = None
 
     @model_validator(mode="after")
@@ -158,6 +159,7 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "branch_prefix": update.branch_prefix,
         "auto_fix_ci": update.auto_fix_ci,
         "create_prs": update.create_prs,
+        "draft_prs": update.draft_prs,
         "review_draft_prs": update.review_draft_prs,
         "updated_at": datetime.now(UTC).isoformat(),
     }

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -45,7 +45,7 @@ class ProfileUpdate(BaseModel):
     branch_prefix: str | None = None
     auto_fix_ci: bool = True
     create_prs: bool = False
-    draft_prs: bool = True
+    draft_prs: bool | None = None
     review_draft_prs: bool | None = None
 
     @model_validator(mode="after")
@@ -159,7 +159,9 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "branch_prefix": update.branch_prefix,
         "auto_fix_ci": update.auto_fix_ci,
         "create_prs": update.create_prs,
-        "draft_prs": update.draft_prs,
+        "draft_prs": (
+            update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)
+        ),
         "review_draft_prs": update.review_draft_prs,
         "updated_at": datetime.now(UTC).isoformat(),
     }

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -213,7 +213,7 @@ COMMIT_PR_SECTION = """---
 
 ### Committing Changes and Opening Pull Requests
 
-This applies only after you've made code changes. By default, open or update a draft PR when the user asks for one or when a PR is necessary to deliver or review the changes; if a code-change task doesn't need a PR, still commit and push the branch so the work is preserved, then notify the source channel with the branch URL. (If the Always Create PRs setting is on, always open/update a draft PR for code-change tasks.)
+This applies only after you've made code changes. By default, open or update a draft PR when the user asks for one or when a PR is necessary to deliver or review the changes; the user's profile setting controls whether a new PR is a draft. If a code-change task doesn't need a PR, still commit and push the branch so the work is preserved, then notify the source channel with the branch URL. (If the Always Create PRs setting is on, always open/update a PR for code-change tasks.)
 
 Steps, in order:
 
@@ -285,7 +285,7 @@ ALWAYS_CREATE_PR_SECTION = """---
 
 ### Always Create PRs Policy Override
 
-The user's dashboard setting **Always Create PRs** is enabled. For code-change tasks, always open or update a draft pull request after committing and pushing the branch. This does not apply to questions, explanations, status checks, or other information-only requests where no files are changed."""
+The user's dashboard setting **Always Create PRs** is enabled. For code-change tasks, always open or update a pull request after committing and pushing the branch. New pull requests follow the user's **Create PRs as draft** preference; existing pull requests are updated separately. This does not apply to questions, explanations, status checks, or other information-only requests where no files are changed."""
 
 
 def _render_repo_instructions_section(instructions: str | None) -> str:
@@ -348,6 +348,7 @@ def construct_system_prompt(
     linear_issue_number: str = "",
     triggering_user_identity: CollaboratorIdentity | None = None,
     create_prs: bool = False,
+    draft_prs: bool = True,
     default_repo: dict[str, str] | None = None,
     plan_mode: bool = False,
     plan_url: str | None = None,
@@ -383,7 +384,10 @@ def construct_system_prompt(
         ),
         default_prompt_section=default_prompt_section,
         corridor_prompt_section=CORRIDOR_PROMPT if corridor_enabled else "",
-        pr_policy_override_section=ALWAYS_CREATE_PR_SECTION if create_prs else "",
+        pr_policy_override_section=(
+            (ALWAYS_CREATE_PR_SECTION if create_prs else "")
+            + f"\n\nNew PRs are created {'as drafts' if draft_prs else 'ready for review'} by default."
+        ),
         collaboration_section=_render_collaboration_section(triggering_user_identity, thread_url),
         repo_instructions_section=_render_repo_instructions_section(repo_custom_instructions),
         user_instructions_section=_render_user_instructions_section(user_custom_instructions),

--- a/agent/server.py
+++ b/agent/server.py
@@ -47,6 +47,7 @@ from .dashboard.agent_overrides import (
     normalize_profile_overrides,
     normalize_profile_subagent_overrides,
     profile_create_prs,
+    profile_draft_prs,
     resolve_github_login,
 )
 from .dashboard.agent_usage import record_agent_thread_usage
@@ -813,6 +814,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         linear_project_id: str,
         linear_issue_number: str,
         create_prs: bool,
+        draft_prs: bool,
         plan_mode: bool,
         corridor_enabled: bool,
     ) -> None:
@@ -826,6 +828,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         self._linear_project_id = linear_project_id
         self._linear_issue_number = linear_issue_number
         self._create_prs = create_prs
+        self._draft_prs = draft_prs
         self._plan_mode = plan_mode
         self._corridor_enabled = corridor_enabled
 
@@ -837,6 +840,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             "source": self._source,
             "repo": configurable.get("repo"),
             "plan_mode": self._plan_mode,
+            "draft_prs": self._draft_prs,
             "model": self._model_id,
             "effort": self._effort,
         }
@@ -873,6 +877,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
     async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
         github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
         configurable = (self._config or {}).get("configurable") or {}
+        configurable["draft_prs"] = self._draft_prs
         prompt_default_repo = await _resolve_prompt_default_repo(configurable)
         triggering_user_identity_task = asyncio.create_task(
             asyncio.to_thread(
@@ -936,6 +941,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 linear_issue_number=self._linear_issue_number,
                 triggering_user_identity=triggering_user_identity,
                 create_prs=self._create_prs,
+                draft_prs=self._draft_prs,
                 default_repo=prompt_default_repo,
                 plan_mode=self._plan_mode,
                 plan_url=dashboard_plan_url(self._thread_id),
@@ -1035,6 +1041,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         subagent_effort = per_thread_effort
 
     always_create_prs = profile_create_prs(profile)
+    draft_prs = profile_draft_prs(profile)
     if always_create_prs:
         logger.info("Always Create PRs enabled by profile for %s", profile_login)
 
@@ -1201,6 +1208,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     linear_project_id=linear_project_id,
                     linear_issue_number=linear_issue_number,
                     create_prs=always_create_prs,
+                    draft_prs=draft_prs,
                     plan_mode=plan_mode,
                     corridor_enabled=bool(corridor_tools),
                 ),

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -76,6 +76,12 @@ def _github_message(resp: httpx.Response) -> str:
     return resp.text.strip() or f"HTTP {resp.status_code}"
 
 
+def _effective_draft(draft: bool) -> bool:
+    configurable = _configurable()
+    preference = configurable.get("draft_prs")
+    return preference if isinstance(preference, bool) else draft
+
+
 def _configurable() -> dict[str, Any]:
     try:
         config = get_config()
@@ -658,7 +664,14 @@ async def _open_pull_request(
         if preflight_failure is not None:
             return preflight_failure
         body = await _maybe_append_references(client, token, owner, repo, body)
-        payload = {"title": title, "head": head, "base": base, "body": body, "draft": draft}
+        draft = _effective_draft(draft)
+        payload = {
+            "title": title,
+            "head": head,
+            "base": base,
+            "body": body,
+            "draft": draft,
+        }
         resp = await client.post(
             f"{GITHUB_API}/repos/{owner}/{repo}/pulls",
             headers=_auth_headers(token),
@@ -772,7 +785,8 @@ async def open_pull_request(
         base: The branch you want to merge into (e.g. "main").
         title: PR title.
         body: PR description (Markdown).
-        draft: Open as a draft PR. Defaults to True.
+        draft: Requested draft status. The authenticated user's dashboard preference
+          overrides this value for newly created PRs; existing PRs are returned unchanged.
 
     Returns:
         On success: {"success": True, "created": bool, "url": str, "number": int,

--- a/tests/dashboard/test_profile_draft_preference.py
+++ b/tests/dashboard/test_profile_draft_preference.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.dashboard.profiles import ProfileUpdate, upsert_profile
+
+
+@pytest.mark.asyncio
+async def test_omitted_draft_preference_preserves_existing_value() -> None:
+    update = ProfileUpdate(default_model="openai:gpt-5.6-sol", reasoning_effort="medium")
+    put_item = AsyncMock()
+
+    with (
+        patch(
+            "agent.dashboard.profiles.get_profile",
+            new_callable=AsyncMock,
+            return_value={"draft_prs": False},
+        ),
+        patch("agent.dashboard.profiles._client") as client,
+    ):
+        client.return_value.store.put_item = put_item
+        profile = await upsert_profile("octocat", "octocat@example.com", update)
+
+    assert profile["draft_prs"] is False
+    assert put_item.await_args.args[2]["draft_prs"] is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_draft_preference_is_persisted() -> None:
+    update = ProfileUpdate(
+        default_model="openai:gpt-5.6-sol",
+        reasoning_effort="medium",
+        draft_prs=True,
+    )
+    put_item = AsyncMock()
+
+    with (
+        patch("agent.dashboard.profiles.get_profile", new_callable=AsyncMock, return_value=None),
+        patch("agent.dashboard.profiles._client") as client,
+    ):
+        client.return_value.store.put_item = put_item
+        profile = await upsert_profile("octocat", "octocat@example.com", update)
+
+    assert profile["draft_prs"] is True
+    assert put_item.await_args.args[2]["draft_prs"] is True

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -8,7 +8,7 @@ from langchain_core.language_models.base import LangSmithParams
 from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-from agent.dashboard.agent_overrides import profile_create_prs
+from agent.dashboard.agent_overrides import profile_create_prs, profile_draft_prs
 from agent.prompt import construct_system_prompt
 from agent.utils import github_comments
 from agent.utils.authorship import (
@@ -257,13 +257,27 @@ def test_construct_system_prompt_includes_always_create_prs_override() -> None:
     prompt = construct_system_prompt(working_dir="/workspace", create_prs=True)
 
     assert "Always Create PRs Policy Override" in prompt
+    assert "New PRs are created as drafts by default" in prompt
     assert "This does not apply to questions" in prompt
+
+
+def test_construct_system_prompt_includes_ready_pr_preference() -> None:
+    prompt = construct_system_prompt(working_dir="/workspace", draft_prs=False)
+
+    assert "New PRs are created ready for review by default" in prompt
 
 
 def test_profile_create_prs_defaults_to_normal_pr_policy() -> None:
     assert profile_create_prs(None) is False
     assert profile_create_prs({}) is False
     assert profile_create_prs({"create_prs": True}) is True
+
+
+def test_profile_draft_prs_defaults_to_draft_policy() -> None:
+    assert profile_draft_prs(None) is True
+    assert profile_draft_prs({}) is True
+    assert profile_draft_prs({"draft_prs": False}) is False
+    assert profile_draft_prs({"draft_prs": True}) is True
 
 
 def test_construct_system_prompt_forbids_force_push() -> None:

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -143,6 +143,23 @@ def test_uses_user_token_for_slack_with_login(monkeypatch: pytest.MonkeyPatch) -
     }
 
 
+def test_profile_draft_preference_overrides_tool_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_config(monkeypatch, {"source": "slack", "github_login": "johannes117", "draft_prs": False})
+    _stub_token(monkeypatch)
+    client = _FakeClient(
+        post=_FakeResponse(
+            201,
+            {"html_url": "https://x/pull/1", "number": 1, "user": {"login": "johannes117"}},
+        )
+    )
+    _install_client(monkeypatch, client)
+
+    result = _open()
+
+    assert result["success"] is True
+    assert client.post_calls[0]["json"]["draft"] is False
+
+
 def test_uses_user_token_for_linear_with_login(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_config(monkeypatch, {"source": "linear", "github_login": "johannes117"})
 

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -155,6 +155,12 @@ def test_profile_stale_anthropic_upgrades_to_supported() -> None:
     assert normalize_profile_overrides(profile) == (SUPPORTED_ANTHROPIC, "high")
 
 
+def test_profile_update_defaults_draft_prs_to_none_for_legacy_clients() -> None:
+    update = ProfileUpdate(default_model=SUPPORTED_OPENAI, reasoning_effort="medium")
+
+    assert update.draft_prs is None
+
+
 def test_profile_update_migrates_deprecated_gpt_5_5_model() -> None:
     update = ProfileUpdate(default_model=DEPRECATED_OPENAI, reasoning_effort="medium")
     update.validate_pairing()

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -147,6 +147,7 @@ export interface Profile {
   branch_prefix?: string | null
   auto_fix_ci?: boolean
   create_prs?: boolean
+  draft_prs?: boolean
   review_draft_prs?: boolean | null
   updated_at?: string
 }
@@ -161,6 +162,7 @@ export interface ProfileUpdate {
   branch_prefix?: string | null
   auto_fix_ci?: boolean
   create_prs?: boolean
+  draft_prs?: boolean
   review_draft_prs?: boolean | null
 }
 

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -120,6 +120,7 @@ export function buildProfileUpdate(
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
     create_prs: current?.create_prs ?? false,
+    draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,
   }

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -493,7 +493,22 @@ function MySettingsPage() {
 
   const draftChoice = toChoice(profile.data?.review_draft_prs)
   const teamDefaultOn = teamSettings.data?.review_draft_prs ?? false
+  const createDraftPrs = profile.data?.draft_prs ?? true
   const teamDefaultLabel = `Use team default (currently: ${teamDefaultOn ? "On" : "Off"})`
+
+  const handleDraftPrsChange = (checked: boolean) => {
+    setError(null)
+    save
+      .mutateAsync(
+        buildProfileUpdate(
+          profile.data,
+          { draft_prs: checked },
+          fallbackModel,
+          fallbackEffort
+        )
+      )
+      .catch((e: Error) => setError(e.message))
+  }
 
   const handleDraftChoiceChange = (next: DraftReviewChoice) => {
     setError(null)
@@ -523,6 +538,20 @@ function MySettingsPage() {
       </SettingsSection>
 
       <UserMappingSection session={session.data} />
+
+      <SettingsSection title="Pull Requests">
+        <SettingsRow
+          label="Create PRs as draft"
+          description="New pull requests are created as drafts by default. Existing pull requests are updated without changing their draft status."
+          control={
+            <Switch
+              checked={createDraftPrs}
+              onCheckedChange={handleDraftPrsChange}
+              disabled={profile.isLoading || save.isPending}
+            />
+          }
+        />
+      </SettingsSection>
 
       <SettingsSection title="Open SWE Review">
         <SettingsRow


### PR DESCRIPTION
## Description
Adds a per-user dashboard preference for creating new pull requests as drafts, defaulting to enabled. The authenticated runtime now applies it centrally while leaving existing PR updates and Always Create PRs behavior unchanged.

## Release Note
Adds a per-user preference for creating new PRs as drafts.

## Test Plan
- [ ] Verify the Profile Settings toggle persists and new PRs honor both settings.

Made by [Open SWE](https://openswe.vercel.app/agents/019fdd6d-2658-72bf-b898-85854f3228e9)

## References
- Plan: https://openswe.vercel.app/agents/019fdd6d-2658-72bf-b898-85854f3228e9/plan