### PR TITLE
fix: make sidebar Local/Cloud headers read as headings

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -251,7 +251,10 @@ export function AgentsSidebar({
         {isDesktop && (
           <SectionHeader
             label="Cloud"
-count={filteredActive.length + (showResolved ? filteredResolved.length : 0)}
+            count={
+              filteredActive.length +
+              (showResolved ? filteredResolved.length : 0)
+            }
             collapsed={prefs.collapsed.cloud}
             onToggle={() => toggleSection("cloud")}
           />
@@ -327,18 +330,18 @@ function SectionHeader({
   onToggle: () => void
   children?: ReactNode
 }) {
-  const ToggleIcon = collapsed ? CaretRightIcon : CaretDownIcon
   return (
     <div className="flex items-center">
       <button
         type="button"
         onClick={onToggle}
-        className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1 text-left text-[10px] font-medium tracking-wide text-muted-foreground/70 uppercase transition-colors hover:text-muted-foreground"
+        className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1.5 text-left font-heading text-xs font-semibold tracking-wide text-foreground uppercase transition-colors hover:text-foreground/80"
         aria-expanded={!collapsed}
       >
-        <ToggleIcon className="size-3" />
         <span className="min-w-0 flex-1 truncate">{label}</span>
-        <span>{count}</span>
+        <span className="text-[10px] font-medium text-muted-foreground/70">
+          {count}
+        </span>
       </button>
       {children}
     </div>


### PR DESCRIPTION
## Description

The Local/Cloud group headers looked identical to the nested project/date rows. Removed their carets and restyled them as bold, larger uppercase headings (count de-emphasised); the whole header is still click-to-collapse.

## Release Note

none

## Test Plan
- [ ] In the desktop sidebar, confirm Local/Cloud read as headings without carets and still collapse/expand on click.

Made by [Open SWE](https://openswe.vercel.app/agents/019fde4e-ffe3-7228-b830-64eff0715c24)
