### PR TITLE
fix: isolate desktop dev profile from installed app

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -42,6 +42,11 @@ pnpm --dir desktop install
 pnpm --dir desktop run dev
 ```
 
+Source launches use an isolated `Open SWE Development` Electron profile, so the dev app can run
+beside an installed `Open SWE` app without sharing its login session, backend configuration,
+projects, or single-instance lock. The dev window is labeled **Open SWE Development**; its first
+launch may require signing in and adding projects again.
+
 The Python dcode CLI must also be installed and configured. Confirm it is available with
 `dcode --version` before starting the desktop app.
 

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -2,8 +2,27 @@ const path = require("node:path")
 
 const APP_ORIGIN = "open-swe://app"
 const APP_URL = `${APP_ORIGIN}/`
+const APP_NAME = "Open SWE"
+const DEVELOPMENT_APP_NAME = "Open SWE Development"
+const APP_USER_MODEL_ID = "com.langchain.openswe"
+const DEVELOPMENT_APP_USER_MODEL_ID = "com.langchain.openswe.dev"
+const DEVELOPMENT_USER_DATA_DIRECTORY = "Open SWE Development"
 const DEFAULT_DEVELOPMENT_BACKEND_URL = "http://localhost:2024"
 const ALLOWED_PERMISSIONS = new Set(["clipboard-sanitized-write", "notifications"])
+
+function resolveAppRuntime({ argv, isPackaged, appDataPath }) {
+  const isDevelopment = !isPackaged || argv.includes("--dev")
+  return {
+    isDevelopment,
+    name: isDevelopment ? DEVELOPMENT_APP_NAME : APP_NAME,
+    appUserModelId: isDevelopment
+      ? DEVELOPMENT_APP_USER_MODEL_ID
+      : APP_USER_MODEL_ID,
+    userDataPath: isDevelopment
+      ? path.join(appDataPath, DEVELOPMENT_USER_DATA_DIRECTORY)
+      : null,
+  }
+}
 
 function cliBackendUrl(argv) {
   for (const name of ["--backend-url", "--url"]) {
@@ -117,6 +136,7 @@ module.exports = {
   APP_URL,
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,
+  resolveAppRuntime,
   backendRequestUrl,
   isAppUrl,
   isGithubOAuthUrl,

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -30,9 +30,22 @@ const {
   isTrustedProxyRequest,
   localCallbackUrl,
   resolveBackendUrl,
+  resolveAppRuntime,
   staticFilePath,
   validateBackendUrl,
 } = require("./config.cjs")
+
+const appRuntime = resolveAppRuntime({
+  argv: process.argv,
+  isPackaged: app.isPackaged,
+  appDataPath: app.getPath("appData"),
+})
+const isDevelopment = appRuntime.isDevelopment
+if (appRuntime.userDataPath) {
+  app.setName(appRuntime.name)
+  app.setPath("userData", appRuntime.userDataPath)
+}
+app.setAppUserModelId(appRuntime.appUserModelId)
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -48,7 +61,6 @@ protocol.registerSchemesAsPrivileged([
   },
 ])
 
-const isDevelopment = !app.isPackaged || process.argv.includes("--dev")
 let backendUrl = null
 let mainWindow = null
 let setupWindow = null
@@ -496,7 +508,7 @@ function handleNavigation(window, event, url) {
 function createWindow() {
   if (!backendUrl) return createSetupWindow()
   const window = new BrowserWindow({
-    title: "Open SWE",
+    title: appRuntime.name,
     width: 1440,
     height: 900,
     minWidth: 900,
@@ -550,7 +562,7 @@ function createSetupWindow() {
   }
 
   const window = new BrowserWindow({
-    title: "Configure Open SWE",
+    title: `Configure ${appRuntime.name}`,
     width: 560,
     height: 460,
     minWidth: 480,
@@ -586,7 +598,7 @@ function createSetupWindow() {
       else createWindow()
       window.close()
     } catch (error) {
-      dialog.showErrorBox("Invalid Open SWE backend URL", error.message)
+      dialog.showErrorBox(`Invalid ${appRuntime.name} backend URL`, error.message)
     }
   })
 
@@ -632,12 +644,11 @@ if (!hasSingleInstanceLock) {
         storedUrl: readStoredBackendUrl(),
       })
     } catch (error) {
-      dialog.showErrorBox("Invalid Open SWE backend URL", error.message)
+      dialog.showErrorBox(`Invalid ${appRuntime.name} backend URL`, error.message)
       app.exit(1)
       return
     }
 
-    app.setAppUserModelId("com.langchain.openswe")
     if (process.platform === "darwin") app.dock.setIcon(iconPath())
     protocol.handle("open-swe", serveBundledUi)
     configurePermissions()

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -42,6 +42,7 @@ const appRuntime = resolveAppRuntime({
 })
 const isDevelopment = appRuntime.isDevelopment
 if (appRuntime.userDataPath) {
+  fs.mkdirSync(appRuntime.userDataPath, { recursive: true })
   app.setName(appRuntime.name)
   app.setPath("userData", appRuntime.userDataPath)
 }

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -11,6 +11,7 @@ const {
   isTrustedProxyRequest,
   localCallbackUrl,
   resolveBackendUrl,
+  resolveAppRuntime,
   staticFilePath,
   validateBackendUrl,
 } = require("../src/config.cjs")
@@ -19,6 +20,33 @@ test("uses the local backend for development", () => {
   assert.equal(
     resolveBackendUrl({ argv: [], env: {}, isPackaged: false }),
     `${DEFAULT_DEVELOPMENT_BACKEND_URL}/`
+  )
+})
+
+test("uses an isolated app profile for development runs", () => {
+  const appDataPath = path.join("/tmp", "open-swe-app-data")
+  const expected = {
+    isDevelopment: true,
+    name: "Open SWE Development",
+    appUserModelId: "com.langchain.openswe.dev",
+    userDataPath: path.join(appDataPath, "Open SWE Development"),
+  }
+  assert.deepEqual(
+    resolveAppRuntime({ argv: [], isPackaged: false, appDataPath }),
+    expected
+  )
+  assert.deepEqual(
+    resolveAppRuntime({ argv: ["--dev"], isPackaged: true, appDataPath }),
+    expected
+  )
+  assert.deepEqual(
+    resolveAppRuntime({ argv: [], isPackaged: true, appDataPath }),
+    {
+      isDevelopment: false,
+      name: "Open SWE",
+      appUserModelId: "com.langchain.openswe",
+      userDataPath: null,
+    }
   )
 })
 


### PR DESCRIPTION
Source and --dev desktop launches now use a separate Electron profile, app identity, and window label so they can run alongside the installed app without sharing local state or the single-instance lock.

Tests: pnpm --dir desktop run test; node --check desktop/src/config.cjs; node --check desktop/src/main.cjs