### PR TITLE
fix: route desktop login through backend

### DIFF
--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -99,6 +99,17 @@ function backendRequestUrl(backendUrl, appRequestUrl) {
   return target.toString()
 }
 
+function backendLoginUrl(navigationUrl, backendUrl) {
+  try {
+    const target = new URL(navigationUrl)
+    return isAppUrl(navigationUrl) && target.pathname === "/dashboard/api/auth/login"
+      ? backendRequestUrl(backendUrl, navigationUrl)
+      : null
+  } catch {
+    return null
+  }
+}
+
 function localCallbackUrl(navigationUrl, backendUrl) {
   try {
     const target = new URL(navigationUrl)
@@ -137,6 +148,7 @@ module.exports = {
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,
   resolveAppRuntime,
+  backendLoginUrl,
   backendRequestUrl,
   isAppUrl,
   isGithubOAuthUrl,

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -82,7 +82,9 @@ function isGithubOAuthUrl(value) {
     return (
       url.protocol === "https:" &&
       url.hostname === "github.com" &&
-      url.pathname.startsWith("/login/")
+      ["/login", "/session", "/sessions"].some(
+        (path) => url.pathname === path || url.pathname.startsWith(`${path}/`)
+      )
     )
   } catch {
     return false
@@ -97,17 +99,6 @@ function backendRequestUrl(backendUrl, appRequestUrl) {
     target.searchParams.set("desktop", "true")
   }
   return target.toString()
-}
-
-function backendLoginUrl(navigationUrl, backendUrl) {
-  try {
-    const target = new URL(navigationUrl)
-    return isAppUrl(navigationUrl) && target.pathname === "/dashboard/api/auth/login"
-      ? backendRequestUrl(backendUrl, navigationUrl)
-      : null
-  } catch {
-    return null
-  }
 }
 
 function localCallbackUrl(navigationUrl, backendUrl) {
@@ -148,7 +139,6 @@ module.exports = {
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,
   resolveAppRuntime,
-  backendLoginUrl,
   backendRequestUrl,
   isAppUrl,
   isGithubOAuthUrl,

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -23,7 +23,6 @@ const {
   APP_ORIGIN,
   APP_URL,
   appRedirectUrl,
-  backendLoginUrl,
   backendRequestUrl,
   isAppUrl,
   isGithubOAuthUrl,
@@ -470,11 +469,10 @@ function createMenu() {
 }
 
 function handleNavigation(window, event, url) {
-  const login = backendUrl ? backendLoginUrl(url, backendUrl) : null
   const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null
-  if (login || callback) {
+  if (callback) {
     event.preventDefault()
-    void window.loadURL(login || callback)
+    void window.loadURL(callback)
     return
   }
   if (isAppUrl(url) || isGithubOAuthUrl(url)) return

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -23,6 +23,7 @@ const {
   APP_ORIGIN,
   APP_URL,
   appRedirectUrl,
+  backendLoginUrl,
   backendRequestUrl,
   isAppUrl,
   isGithubOAuthUrl,
@@ -469,10 +470,11 @@ function createMenu() {
 }
 
 function handleNavigation(window, event, url) {
+  const login = backendUrl ? backendLoginUrl(url, backendUrl) : null
   const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null
-  if (callback) {
+  if (login || callback) {
     event.preventDefault()
-    void window.loadURL(callback)
+    void window.loadURL(login || callback)
     return
   }
   if (isAppUrl(url) || isGithubOAuthUrl(url)) return

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -5,6 +5,7 @@ const {
   APP_URL,
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,
+  backendLoginUrl,
   backendRequestUrl,
   isGithubOAuthUrl,
   isTrustedPermissionRequest,
@@ -154,6 +155,13 @@ test("maps desktop API requests to the selected backend", () => {
   assert.equal(
     backendRequestUrl("https://backend.example", `${APP_URL}dashboard/api/auth/login`),
     "https://backend.example/dashboard/api/auth/login?desktop=true"
+  )
+  assert.equal(
+    backendLoginUrl(
+      `${APP_URL}dashboard/api/auth/login?redirect_to=%2Fagents`,
+      "http://localhost:2024"
+    ),
+    "http://localhost:2024/dashboard/api/auth/login?redirect_to=%2Fagents&desktop=true"
   )
 })
 

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -5,7 +5,6 @@ const {
   APP_URL,
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,
-  backendLoginUrl,
   backendRequestUrl,
   isGithubOAuthUrl,
   isTrustedPermissionRequest,
@@ -139,7 +138,9 @@ test("only proxies requests from the bundled app window", () => {
 
 test("only keeps GitHub login pages in the app window", () => {
   assert.equal(isGithubOAuthUrl("https://github.com/login/oauth/authorize?client_id=1"), true)
-  assert.equal(isGithubOAuthUrl("https://github.com/login"), false)
+  assert.equal(isGithubOAuthUrl("https://github.com/login?return_to=%2Flogin%2Foauth"), true)
+  assert.equal(isGithubOAuthUrl("https://github.com/session"), true)
+  assert.equal(isGithubOAuthUrl("https://github.com/sessions/two-factor"), true)
   assert.equal(isGithubOAuthUrl("https://github.com/langchain-ai/open-swe"), false)
   assert.equal(isGithubOAuthUrl("https://evil.example/login/oauth/authorize"), false)
 })
@@ -155,13 +156,6 @@ test("maps desktop API requests to the selected backend", () => {
   assert.equal(
     backendRequestUrl("https://backend.example", `${APP_URL}dashboard/api/auth/login`),
     "https://backend.example/dashboard/api/auth/login?desktop=true"
-  )
-  assert.equal(
-    backendLoginUrl(
-      `${APP_URL}dashboard/api/auth/login?redirect_to=%2Fagents`,
-      "http://localhost:2024"
-    ),
-    "http://localhost:2024/dashboard/api/auth/login?redirect_to=%2Fagents&desktop=true"
   )
 })
 


### PR DESCRIPTION
## Description
Desktop sign-in now navigates through the configured backend instead of following an OAuth redirect from the custom protocol, avoiding Chromium's `chrome-error://` origin failure.

## Release Note
Fixed GitHub sign-in in the desktop app.

## Test Plan
- [x] Desktop login URL maps to the configured local backend.

Made by [Open SWE](https://openswe.vercel.app/agents/019fde70-92c3-70ee-9459-02a85a49e4c2)