### PR TITLE
style(web): format entire UI tree and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,22 @@ jobs:
       - name: Run unit tests
         run: make test
 
+  ui-format:
+    name: UI format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
+      - run: corepack enable
+      - name: Install UI dependencies
+        working-directory: ui
+        run: pnpm install --frozen-lockfile
+      - name: Run format check
+        working-directory: ui
+        run: pnpm run format:check
+
   desktop:
     name: Desktop checks
     runs-on: ubuntu-latest

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,3 +1,4 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+src/routeTree.gen.ts

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx}\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/ui/src/components/AgentInstructionsPanel.tsx
+++ b/ui/src/components/AgentInstructionsPanel.tsx
@@ -1,7 +1,7 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 import {
   Combobox,
   ComboboxContent,
@@ -9,111 +9,117 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-} from "@/components/ui/combobox";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Skeleton } from "@/components/ui/skeleton";
-import { InstructionsEditor } from "@/components/InstructionsEditor";
-import { api, isGithubReauthError, loginUrl } from "@/lib/api";
-import { useRepos } from "@/lib/profile";
-import { normalizeRepoFullName } from "@/lib/repo";
+} from "@/components/ui/combobox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { InstructionsEditor } from "@/components/InstructionsEditor"
+import { api, isGithubReauthError, loginUrl } from "@/lib/api"
+import { useRepos } from "@/lib/profile"
+import { normalizeRepoFullName } from "@/lib/repo"
 
 function formatMutationError(e: Error): string {
   return isGithubReauthError(e)
     ? "GitHub token expired — sign in again using the link above."
-    : e.message;
+    : e.message
 }
 
 export function AgentInstructionsPanel() {
-  const qc = useQueryClient();
-  const [error, setError] = useState<string | null>(null);
-  const [addRepo, setAddRepo] = useState("");
-  const [selected, setSelected] = useState<string | null>(null);
-  const [draft, setDraft] = useState("");
+  const qc = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [addRepo, setAddRepo] = useState("")
+  const [selected, setSelected] = useState<string | null>(null)
+  const [draft, setDraft] = useState("")
 
   const instructions = useQuery({
     queryKey: ["agentInstructions"],
     queryFn: api.listAgentInstructions,
-  });
+  })
 
-  const repos = useRepos();
+  const repos = useRepos()
 
   const detail = useQuery({
     queryKey: ["agentInstruction", selected],
     queryFn: () => api.getAgentInstructions(selected!),
     enabled: !!selected,
-  });
+  })
 
   useEffect(() => {
-    if (detail.data) setDraft(detail.data.instructions);
-  }, [detail.data?.instructions, detail.data?.full_name]);
+    if (detail.data) setDraft(detail.data.instructions)
+  }, [detail.data?.instructions, detail.data?.full_name])
 
   const create = useMutation({
     mutationFn: (full_name: string) => api.createAgentInstructions(full_name),
     onSuccess: (record) => {
-      void qc.invalidateQueries({ queryKey: ["agentInstructions"] });
-      setSelected(record.full_name);
-      setError(null);
+      void qc.invalidateQueries({ queryKey: ["agentInstructions"] })
+      setSelected(record.full_name)
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   const save = useMutation({
     mutationFn: ({ full_name, value }: { full_name: string; value: string }) =>
       api.saveAgentInstructions(full_name, value),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["agentInstructions"] });
-      void qc.invalidateQueries({ queryKey: ["agentInstruction", selected] });
-      setError(null);
+      void qc.invalidateQueries({ queryKey: ["agentInstructions"] })
+      void qc.invalidateQueries({ queryKey: ["agentInstruction", selected] })
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   const remove = useMutation({
     mutationFn: (full_name: string) => api.deleteAgentInstructions(full_name),
     onSuccess: (_data, full_name) => {
-      void qc.invalidateQueries({ queryKey: ["agentInstructions"] });
+      void qc.invalidateQueries({ queryKey: ["agentInstructions"] })
       if (selected === full_name) {
-        setSelected(null);
-        setDraft("");
+        setSelected(null)
+        setDraft("")
       }
-      setError(null);
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   if (instructions.isLoading) {
-    return <Skeleton className="h-40" />;
+    return <Skeleton className="h-40" />
   }
 
-  const configured = new Set((instructions.data ?? []).map((s) => s.full_name));
+  const configured = new Set((instructions.data ?? []).map((s) => s.full_name))
   const suggestedRepos = (repos.data?.repositories ?? []).filter(
-    (r) => !configured.has(r.full_name),
-  );
-  const normalizedAddRepo = normalizeRepoFullName(addRepo);
-  const canAdd = normalizedAddRepo !== null && !configured.has(normalizedAddRepo);
+    (r) => !configured.has(r.full_name)
+  )
+  const normalizedAddRepo = normalizeRepoFullName(addRepo)
+  const canAdd =
+    normalizedAddRepo !== null && !configured.has(normalizedAddRepo)
   const active =
-    detail.data ?? instructions.data?.find((s) => s.full_name === selected) ?? null;
-  const dirty = active != null && draft !== active.instructions;
+    detail.data ??
+    instructions.data?.find((s) => s.full_name === selected) ??
+    null
+  const dirty = active != null && draft !== active.instructions
 
   const handleAdd = () => {
-    if (!normalizedAddRepo || !canAdd) return;
+    if (!normalizedAddRepo || !canAdd) return
     void create
       .mutateAsync(normalizedAddRepo)
       .then(() => setAddRepo(""))
-      .catch(() => undefined);
-  };
+      .catch(() => undefined)
+  }
 
   const githubReauth =
     (repos.isError && isGithubReauthError(repos.error)) ||
-    (error !== null && /github token|re-login required/i.test(error));
+    (error !== null && /github token|re-login required/i.test(error))
 
   return (
     <div className="flex flex-col gap-6 p-4">
       {githubReauth && (
         <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
           Your GitHub connection expired.{" "}
-          <a href={loginUrl()} className="font-medium underline underline-offset-2">
+          <a
+            href={loginUrl()}
+            className="font-medium underline underline-offset-2"
+          >
             Sign in with GitHub again
           </a>{" "}
           to list installed repos.
@@ -130,8 +136,8 @@ export function AgentInstructionsPanel() {
               onChange={(e) => setAddRepo(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleAdd();
+                  e.preventDefault()
+                  handleAdd()
                 }
               }}
               className="sm:flex-1"
@@ -178,7 +184,9 @@ export function AgentInstructionsPanel() {
         <div className="space-y-2">
           <p className="text-xs font-medium text-foreground">Repositories</p>
           {(instructions.data ?? []).length === 0 ? (
-            <p className="text-xs text-muted-foreground">No repositories yet.</p>
+            <p className="text-xs text-muted-foreground">
+              No repositories yet.
+            </p>
           ) : (
             <ul className="flex flex-wrap gap-2">
               {(instructions.data ?? []).map((s) => (
@@ -206,11 +214,14 @@ export function AgentInstructionsPanel() {
       <section className="space-y-3">
         {!selected || !active ? (
           <p className="text-xs text-muted-foreground">
-            Select a repository above to view or edit its custom agent instructions.
+            Select a repository above to view or edit its custom agent
+            instructions.
           </p>
         ) : (
           <>
-            <p className="text-sm font-medium text-foreground">{active.full_name}</p>
+            <p className="text-sm font-medium text-foreground">
+              {active.full_name}
+            </p>
             <div className="flex flex-wrap gap-2">
               <Button
                 size="sm"
@@ -237,12 +248,12 @@ export function AgentInstructionsPanel() {
                 onClick={() => {
                   if (
                     !window.confirm(
-                      `Remove custom instructions for ${active.full_name}? This cannot be undone.`,
+                      `Remove custom instructions for ${active.full_name}? This cannot be undone.`
                     )
                   ) {
-                    return;
+                    return
                   }
-                  void remove.mutateAsync(active.full_name);
+                  void remove.mutateAsync(active.full_name)
                 }}
               >
                 Remove
@@ -258,5 +269,5 @@ export function AgentInstructionsPanel() {
         {error && <p className="text-xs text-destructive">{error}</p>}
       </section>
     </div>
-  );
+  )
 }

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -1,18 +1,18 @@
-import { Link } from "@tanstack/react-router";
-import { ArrowLeftIcon } from "@phosphor-icons/react";
-import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router"
+import { ArrowLeftIcon } from "@phosphor-icons/react"
+import type { ReactNode } from "react"
 
-import type { SessionUser } from "@/lib/api";
-import { AppSidebar } from "@/components/AppSidebar";
-import { cn } from "@/lib/utils";
+import type { SessionUser } from "@/lib/api"
+import { AppSidebar } from "@/components/AppSidebar"
+import { cn } from "@/lib/utils"
 
 interface AppShellProps {
-  user: SessionUser;
-  title: string;
-  description?: string;
-  backTo?: { to: string; label: string };
-  className?: string;
-  children: ReactNode;
+  user: SessionUser
+  title: string
+  description?: string
+  backTo?: { to: string; label: string }
+  className?: string
+  children: ReactNode
 }
 
 export function AppShell({
@@ -27,7 +27,12 @@ export function AppShell({
     <div className="flex h-svh overflow-hidden bg-background text-foreground">
       <AppSidebar user={user} />
       <main className="flex-1 overflow-y-auto">
-        <div className={cn("mx-auto max-w-3xl px-4 pt-14 pb-6 sm:px-8 sm:py-10", className)}>
+        <div
+          className={cn(
+            "mx-auto max-w-3xl px-4 pt-14 pb-6 sm:px-8 sm:py-10",
+            className
+          )}
+        >
           {backTo && (
             <Link
               to={backTo.to}
@@ -40,48 +45,57 @@ export function AppShell({
           <header className="mb-8">
             <h1 className="font-heading text-base font-medium">{title}</h1>
             {description && (
-              <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {description}
+              </p>
             )}
           </header>
           <div className="space-y-8">{children}</div>
         </div>
       </main>
     </div>
-  );
+  )
 }
 
 interface SettingsSectionProps {
-  title: string;
-  description?: string;
-  action?: ReactNode;
-  children: ReactNode;
+  title: string
+  description?: string
+  action?: ReactNode
+  children: ReactNode
 }
 
-export function SettingsSection({ title, description, action, children }: SettingsSectionProps) {
+export function SettingsSection({
+  title,
+  description,
+  action,
+  children,
+}: SettingsSectionProps) {
   return (
     <section className="space-y-3">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
             {title}
           </h2>
           {description && (
-            <p className="mt-0.5 text-xs text-muted-foreground/80">{description}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground/80">
+              {description}
+            </p>
           )}
         </div>
         {action}
       </div>
       <div className="rounded-lg border border-border bg-card">{children}</div>
     </section>
-  );
+  )
 }
 
 interface SettingsRowProps {
-  label: string;
-  description?: string;
-  control: ReactNode;
-  htmlFor?: string;
-  comingSoon?: boolean;
+  label: string
+  description?: string
+  control: ReactNode
+  htmlFor?: string
+  comingSoon?: boolean
 }
 
 export function SettingsRow({
@@ -112,7 +126,9 @@ export function SettingsRow({
           <span className="text-xs text-muted-foreground">{description}</span>
         )}
       </label>
-      <div className={`sm:shrink-0 ${comingSoon ? "opacity-50" : ""}`}>{control}</div>
+      <div className={`sm:shrink-0 ${comingSoon ? "opacity-50" : ""}`}>
+        {control}
+      </div>
     </div>
-  );
+  )
 }

--- a/ui/src/components/ReviewStylesPanel.tsx
+++ b/ui/src/components/ReviewStylesPanel.tsx
@@ -1,9 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
 
-import type { ReviewStyle } from "@/lib/api";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import type { ReviewStyle } from "@/lib/api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Combobox,
   ComboboxContent,
@@ -11,151 +11,163 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-} from "@/components/ui/combobox";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
-import { api, isGithubReauthError, loginUrl } from "@/lib/api";
-import { useRepos } from "@/lib/profile";
-import { normalizeRepoFullName } from "@/lib/repo";
+} from "@/components/ui/combobox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Textarea } from "@/components/ui/textarea"
+import { api, isGithubReauthError, loginUrl } from "@/lib/api"
+import { useRepos } from "@/lib/profile"
+import { normalizeRepoFullName } from "@/lib/repo"
 
 function formatMutationError(e: Error): string {
   return isGithubReauthError(e)
     ? "GitHub token expired — sign in again using the link above."
-    : e.message;
+    : e.message
 }
 
 function statusVariant(status: ReviewStyle["status"]) {
   switch (status) {
     case "completed":
-      return "default" as const;
+      return "default" as const
     case "running":
-      return "secondary" as const;
+      return "secondary" as const
     case "failed":
-      return "destructive" as const;
+      return "destructive" as const
     default:
-      return "outline" as const;
+      return "outline" as const
   }
 }
 
 export function ReviewStylesPanel() {
-  const qc = useQueryClient();
-  const [error, setError] = useState<string | null>(null);
-  const [addRepo, setAddRepo] = useState("");
-  const [selected, setSelected] = useState<string | null>(null);
-  const [draftPrompt, setDraftPrompt] = useState("");
+  const qc = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [addRepo, setAddRepo] = useState("")
+  const [selected, setSelected] = useState<string | null>(null)
+  const [draftPrompt, setDraftPrompt] = useState("")
 
   const styles = useQuery({
     queryKey: ["reviewStyles"],
     queryFn: api.listReviewStyles,
     refetchInterval: (q) => {
-      const hasRunning = (q.state.data ?? []).some((r) => r.status === "running");
-      return hasRunning ? 4000 : false;
+      const hasRunning = (q.state.data ?? []).some(
+        (r) => r.status === "running"
+      )
+      return hasRunning ? 4000 : false
     },
-  });
+  })
 
-  const repos = useRepos();
+  const repos = useRepos()
 
   const detail = useQuery({
     queryKey: ["reviewStyle", selected],
     queryFn: () => api.getReviewStyle(selected!),
     enabled: !!selected,
     refetchInterval: (q) => (q.state.data?.status === "running" ? 4000 : false),
-  });
+  })
 
   useEffect(() => {
     if (detail.data?.custom_prompt != null) {
-      setDraftPrompt(detail.data.custom_prompt);
+      setDraftPrompt(detail.data.custom_prompt)
     } else if (detail.data) {
-      setDraftPrompt("");
+      setDraftPrompt("")
     }
-  }, [detail.data?.custom_prompt, detail.data?.full_name]);
+  }, [detail.data?.custom_prompt, detail.data?.full_name])
 
   const createStyle = useMutation({
     mutationFn: (full_name: string) => api.createReviewStyle(full_name),
     onSuccess: (record) => {
-      void qc.invalidateQueries({ queryKey: ["reviewStyles"] });
-      setSelected(record.full_name);
-      setError(null);
+      void qc.invalidateQueries({ queryKey: ["reviewStyles"] })
+      setSelected(record.full_name)
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   const analyze = useMutation({
     mutationFn: (full_name: string) => api.analyzeReviewStyle(full_name),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["reviewStyles"] });
-      void qc.invalidateQueries({ queryKey: ["reviewStyle", selected] });
-      setError(null);
+      void qc.invalidateQueries({ queryKey: ["reviewStyles"] })
+      void qc.invalidateQueries({ queryKey: ["reviewStyle", selected] })
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   const savePrompt = useMutation({
-    mutationFn: ({ full_name, custom_prompt }: { full_name: string; custom_prompt: string }) =>
-      api.saveReviewStylePrompt(full_name, custom_prompt),
+    mutationFn: ({
+      full_name,
+      custom_prompt,
+    }: {
+      full_name: string
+      custom_prompt: string
+    }) => api.saveReviewStylePrompt(full_name, custom_prompt),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["reviewStyles"] });
-      void qc.invalidateQueries({ queryKey: ["reviewStyle", selected] });
-      setError(null);
+      void qc.invalidateQueries({ queryKey: ["reviewStyles"] })
+      void qc.invalidateQueries({ queryKey: ["reviewStyle", selected] })
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   const cancelAnalysis = useMutation({
     mutationFn: (full_name: string) => api.cancelReviewStyle(full_name),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["reviewStyles"] });
-      void qc.invalidateQueries({ queryKey: ["reviewStyle", selected] });
-      setError(null);
+      void qc.invalidateQueries({ queryKey: ["reviewStyles"] })
+      void qc.invalidateQueries({ queryKey: ["reviewStyle", selected] })
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   const removeStyle = useMutation({
     mutationFn: (full_name: string) => api.deleteReviewStyle(full_name),
     onSuccess: (_data, full_name) => {
-      void qc.invalidateQueries({ queryKey: ["reviewStyles"] });
+      void qc.invalidateQueries({ queryKey: ["reviewStyles"] })
       if (selected === full_name) {
-        setSelected(null);
-        setDraftPrompt("");
+        setSelected(null)
+        setDraftPrompt("")
       }
-      setError(null);
+      setError(null)
     },
     onError: (e: Error) => setError(formatMutationError(e)),
-  });
+  })
 
   if (styles.isLoading) {
-    return <Skeleton className="h-40" />;
+    return <Skeleton className="h-40" />
   }
 
-  const configured = new Set((styles.data ?? []).map((s) => s.full_name));
+  const configured = new Set((styles.data ?? []).map((s) => s.full_name))
   const suggestedRepos = (repos.data?.repositories ?? []).filter(
-    (r) => !configured.has(r.full_name),
-  );
-  const normalizedAddRepo = normalizeRepoFullName(addRepo);
-  const canAdd = normalizedAddRepo !== null && !configured.has(normalizedAddRepo);
-  const active = detail.data ?? styles.data?.find((s) => s.full_name === selected) ?? null;
+    (r) => !configured.has(r.full_name)
+  )
+  const normalizedAddRepo = normalizeRepoFullName(addRepo)
+  const canAdd =
+    normalizedAddRepo !== null && !configured.has(normalizedAddRepo)
+  const active =
+    detail.data ?? styles.data?.find((s) => s.full_name === selected) ?? null
 
   const handleAdd = () => {
-    if (!normalizedAddRepo || !canAdd) return;
+    if (!normalizedAddRepo || !canAdd) return
     void createStyle
       .mutateAsync(normalizedAddRepo)
       .then(() => setAddRepo(""))
-      .catch(() => undefined);
-  };
+      .catch(() => undefined)
+  }
 
   const githubReauth =
     (repos.isError && isGithubReauthError(repos.error)) ||
-    (error !== null && /github token|re-login required/i.test(error));
+    (error !== null && /github token|re-login required/i.test(error))
 
   return (
     <div className="flex flex-col gap-6 p-4">
       {githubReauth && (
         <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
           Your GitHub connection expired.{" "}
-          <a href={loginUrl()} className="font-medium underline underline-offset-2">
+          <a
+            href={loginUrl()}
+            className="font-medium underline underline-offset-2"
+          >
             Sign in with GitHub again
           </a>{" "}
           to list installed repos and run style analysis.
@@ -172,8 +184,8 @@ export function ReviewStylesPanel() {
               onChange={(e) => setAddRepo(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleAdd();
+                  e.preventDefault()
+                  handleAdd()
                 }
               }}
               className="sm:flex-1"
@@ -220,7 +232,9 @@ export function ReviewStylesPanel() {
         <div className="space-y-2">
           <p className="text-xs font-medium text-foreground">Repositories</p>
           {(styles.data ?? []).length === 0 ? (
-            <p className="text-xs text-muted-foreground">No repositories yet.</p>
+            <p className="text-xs text-muted-foreground">
+              No repositories yet.
+            </p>
           ) : (
             <ul className="flex flex-wrap gap-2">
               {(styles.data ?? []).map((s) => (
@@ -235,7 +249,10 @@ export function ReviewStylesPanel() {
                     onClick={() => setSelected(s.full_name)}
                   >
                     <span className="truncate">{s.full_name}</span>
-                    <Badge variant={statusVariant(s.status)} className="shrink-0">
+                    <Badge
+                      variant={statusVariant(s.status)}
+                      className="shrink-0"
+                    >
                       {s.status}
                     </Badge>
                   </button>
@@ -255,9 +272,13 @@ export function ReviewStylesPanel() {
           </p>
         ) : (
           <>
-            <p className="text-sm font-medium text-foreground">{active.full_name}</p>
+            <p className="text-sm font-medium text-foreground">
+              {active.full_name}
+            </p>
             <div className="flex flex-wrap items-center gap-2 text-xs">
-              <Badge variant={statusVariant(active.status)}>{active.status}</Badge>
+              <Badge variant={statusVariant(active.status)}>
+                {active.status}
+              </Badge>
               {active.top_reviewers.length > 0 && (
                 <span className="text-muted-foreground">
                   Reviewers: {active.top_reviewers.join(", ")}
@@ -265,21 +286,28 @@ export function ReviewStylesPanel() {
               )}
               {active.prs_sampled > 0 && (
                 <span className="text-muted-foreground">
-                  {active.prs_sampled} PRs · {active.reviews_sampled} reviews sampled
+                  {active.prs_sampled} PRs · {active.reviews_sampled} reviews
+                  sampled
                 </span>
               )}
             </div>
             {active.analysis_summary && (
-              <p className="text-xs text-muted-foreground">{active.analysis_summary}</p>
+              <p className="text-xs text-muted-foreground">
+                {active.analysis_summary}
+              </p>
             )}
-            {active.error && <p className="text-xs text-destructive">{active.error}</p>}
+            {active.error && (
+              <p className="text-xs text-destructive">{active.error}</p>
+            )}
             <div className="flex flex-wrap gap-2">
               <Button
                 size="sm"
                 variant="secondary"
                 disabled={active.status === "running" || analyze.isPending}
                 onClick={() => {
-                  void analyze.mutateAsync(active.full_name).catch(() => undefined);
+                  void analyze
+                    .mutateAsync(active.full_name)
+                    .catch(() => undefined)
                 }}
               >
                 {active.status === "running" ? "Analyzing…" : "Run analysis"}
@@ -289,7 +317,9 @@ export function ReviewStylesPanel() {
                   size="sm"
                   variant="outline"
                   disabled={cancelAnalysis.isPending}
-                  onClick={() => void cancelAnalysis.mutateAsync(active.full_name)}
+                  onClick={() =>
+                    void cancelAnalysis.mutateAsync(active.full_name)
+                  }
                 >
                   Cancel
                 </Button>
@@ -313,12 +343,12 @@ export function ReviewStylesPanel() {
                 onClick={() => {
                   if (
                     !window.confirm(
-                      `Remove ${active.full_name} from review style prompts? This cannot be undone.`,
+                      `Remove ${active.full_name} from review style prompts? This cannot be undone.`
                     )
                   ) {
-                    return;
+                    return
                   }
-                  void removeStyle.mutateAsync(active.full_name);
+                  void removeStyle.mutateAsync(active.full_name)
                 }}
               >
                 Remove
@@ -340,5 +370,5 @@ export function ReviewStylesPanel() {
         {error && <p className="text-xs text-destructive">{error}</p>}
       </section>
     </div>
-  );
+  )
 }

--- a/ui/src/components/SidebarUserMenu.tsx
+++ b/ui/src/components/SidebarUserMenu.tsx
@@ -1,65 +1,72 @@
-import { Link, useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "@tanstack/react-router"
+import { useQueryClient } from "@tanstack/react-query"
+import { useEffect, useRef, useState } from "react"
 import {
   IoDesktopOutline,
   IoLogOutOutline,
   IoMoonOutline,
   IoSettingsOutline,
   IoSunnyOutline,
-} from "react-icons/io5";
+} from "react-icons/io5"
 
-import type { SessionUser } from "@/lib/api";
-import type { Theme } from "@/lib/theme";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { api } from "@/lib/api";
-import { clearCachedRepos } from "@/lib/repoCache";
-import { useTheme } from "@/lib/theme";
-import { cn } from "@/lib/utils";
+import type { SessionUser } from "@/lib/api"
+import type { Theme } from "@/lib/theme"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { api } from "@/lib/api"
+import { clearCachedRepos } from "@/lib/repoCache"
+import { useTheme } from "@/lib/theme"
+import { cn } from "@/lib/utils"
 
-const THEME_OPTIONS: Array<{ value: Theme; label: string; icon: typeof IoSunnyOutline }> = [
+const THEME_OPTIONS: Array<{
+  value: Theme
+  label: string
+  icon: typeof IoSunnyOutline
+}> = [
   { value: "light", label: "Light", icon: IoSunnyOutline },
   { value: "dark", label: "Dark", icon: IoMoonOutline },
   { value: "system", label: "System", icon: IoDesktopOutline },
-];
+]
 
 interface SidebarUserMenuProps {
-  user: SessionUser;
-  showSettingsLink?: boolean;
+  user: SessionUser
+  showSettingsLink?: boolean
 }
 
-export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserMenuProps) {
-  const qc = useQueryClient();
-  const navigate = useNavigate();
-  const { theme, setTheme } = useTheme();
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
+export function SidebarUserMenu({
+  user,
+  showSettingsLink = false,
+}: SidebarUserMenuProps) {
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+  const { theme, setTheme } = useTheme()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) return
     const onClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onClickOutside);
-    document.addEventListener("keydown", onKey);
+      if (e.key === "Escape") setOpen(false)
+    }
+    document.addEventListener("mousedown", onClickOutside)
+    document.addEventListener("keydown", onKey)
     return () => {
-      document.removeEventListener("mousedown", onClickOutside);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+      document.removeEventListener("mousedown", onClickOutside)
+      document.removeEventListener("keydown", onKey)
+    }
+  }, [open])
 
   const onLogout = async () => {
-    setOpen(false);
-    await api.logout();
-    clearCachedRepos();
-    qc.setQueryData(["session"], null);
-    navigate({ to: "/login" });
-  };
+    setOpen(false)
+    await api.logout()
+    clearCachedRepos()
+    qc.setQueryData(["session"], null)
+    navigate({ to: "/login" })
+  }
 
-  const initials = (user.login || "?").slice(0, 2).toUpperCase();
+  const initials = (user.login || "?").slice(0, 2).toUpperCase()
 
   return (
     <div ref={ref} className="relative">
@@ -71,13 +78,17 @@ export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserM
         className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left outline-none hover:bg-sidebar-accent"
       >
         <Avatar className="size-7">
-          {user.avatar_url && <AvatarImage src={user.avatar_url} alt={user.login} />}
+          {user.avatar_url && (
+            <AvatarImage src={user.avatar_url} alt={user.login} />
+          )}
           <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
         <div className="flex min-w-0 flex-1 flex-col">
           <span className="truncate text-xs font-medium">{user.login}</span>
           {user.email && (
-            <span className="truncate text-[10px] text-muted-foreground">{user.email}</span>
+            <span className="truncate text-[10px] text-muted-foreground">
+              {user.email}
+            </span>
           )}
         </div>
       </button>
@@ -87,13 +98,13 @@ export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserM
           className="absolute right-0 bottom-full left-0 mb-2 overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
         >
           <div className="px-2 py-1.5">
-            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            <span className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
               Theme
             </span>
             <div className="mt-1.5 grid grid-cols-3 gap-1">
               {THEME_OPTIONS.map((option) => {
-                const Icon = option.icon;
-                const active = theme === option.value;
+                const Icon = option.icon
+                const active = theme === option.value
                 return (
                   <button
                     key={option.value}
@@ -104,13 +115,13 @@ export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserM
                       "flex flex-col items-center gap-1 rounded-sm border px-1 py-1.5 text-[10px] transition-colors",
                       active
                         ? "border-primary/40 bg-primary/10 text-primary"
-                        : "border-transparent text-muted-foreground hover:bg-muted",
+                        : "border-transparent text-muted-foreground hover:bg-muted"
                     )}
                   >
                     <Icon className="size-3.5" />
                     {option.label}
                   </button>
-                );
+                )
               })}
             </div>
           </div>
@@ -138,5 +149,5 @@ export function SidebarUserMenu({ user, showSettingsLink = false }: SidebarUserM
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -5,100 +5,108 @@ import {
   useEffect,
   useRef,
   useState,
-} from "react";
-import { SidebarSimpleIcon } from "@phosphor-icons/react";
+} from "react"
+import { SidebarSimpleIcon } from "@phosphor-icons/react"
 
-import { useHotkey } from "@/lib/hotkeys";
-import { cn } from "@/lib/utils";
+import { useHotkey } from "@/lib/hotkeys"
+import { cn } from "@/lib/utils"
 
-const STORAGE_WIDTH = "open-swe.sidebar.width";
-const STORAGE_COLLAPSED = "open-swe.sidebar.collapsed";
+const STORAGE_WIDTH = "open-swe.sidebar.width"
+const STORAGE_COLLAPSED = "open-swe.sidebar.collapsed"
 
-export const SIDEBAR_DEFAULT_WIDTH = 260;
-export const SIDEBAR_MIN_WIDTH = 200;
-export const SIDEBAR_MAX_WIDTH = 420;
+export const SIDEBAR_DEFAULT_WIDTH = 260
+export const SIDEBAR_MIN_WIDTH = 200
+export const SIDEBAR_MAX_WIDTH = 420
 
 function readStoredWidth(): number {
-  if (typeof window === "undefined") return SIDEBAR_DEFAULT_WIDTH;
-  const raw = window.localStorage.getItem(STORAGE_WIDTH);
-  const parsed = raw ? Number(raw) : NaN;
-  if (!Number.isFinite(parsed)) return SIDEBAR_DEFAULT_WIDTH;
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, parsed));
+  if (typeof window === "undefined") return SIDEBAR_DEFAULT_WIDTH
+  const raw = window.localStorage.getItem(STORAGE_WIDTH)
+  const parsed = raw ? Number(raw) : NaN
+  if (!Number.isFinite(parsed)) return SIDEBAR_DEFAULT_WIDTH
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, parsed))
 }
 
 function readStoredCollapsed(): boolean {
-  if (typeof window === "undefined") return false;
+  if (typeof window === "undefined") return false
   // On mobile the sidebar is a full-screen overlay, so start collapsed to keep
   // the chat visible regardless of the stored desktop preference.
-  if (window.matchMedia("(max-width: 767px)").matches) return true;
-  return window.localStorage.getItem(STORAGE_COLLAPSED) === "1";
+  if (window.matchMedia("(max-width: 767px)").matches) return true
+  return window.localStorage.getItem(STORAGE_COLLAPSED) === "1"
 }
 
 export function useSidebarLayout() {
-  const [width, setWidthState] = useState<number>(() => readStoredWidth());
-  const [collapsed, setCollapsedState] = useState<boolean>(() => readStoredCollapsed());
+  const [width, setWidthState] = useState<number>(() => readStoredWidth())
+  const [collapsed, setCollapsedState] = useState<boolean>(() =>
+    readStoredCollapsed()
+  )
 
   const setWidth = useCallback((next: number) => {
-    const clamped = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, next));
-    setWidthState(clamped);
-    window.localStorage.setItem(STORAGE_WIDTH, String(clamped));
-  }, []);
+    const clamped = Math.min(
+      SIDEBAR_MAX_WIDTH,
+      Math.max(SIDEBAR_MIN_WIDTH, next)
+    )
+    setWidthState(clamped)
+    window.localStorage.setItem(STORAGE_WIDTH, String(clamped))
+  }, [])
 
   const setCollapsed = useCallback((next: boolean) => {
-    setCollapsedState(next);
-    window.localStorage.setItem(STORAGE_COLLAPSED, next ? "1" : "0");
-  }, []);
+    setCollapsedState(next)
+    window.localStorage.setItem(STORAGE_COLLAPSED, next ? "1" : "0")
+  }, [])
 
-  const toggle = useCallback(() => setCollapsed(!collapsed), [collapsed, setCollapsed]);
+  const toggle = useCallback(
+    () => setCollapsed(!collapsed),
+    [collapsed, setCollapsed]
+  )
 
-  useHotkey("mod+b", toggle, { enableInFormFields: true, ignoreRepeat: true });
+  useHotkey("mod+b", toggle, { enableInFormFields: true, ignoreRepeat: true })
 
   const closeOnMobile = useCallback(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined") return
     // State-only: don't persist, so the desktop collapsed preference is preserved.
-    if (window.matchMedia("(max-width: 767px)").matches) setCollapsedState(true);
-  }, []);
+    if (window.matchMedia("(max-width: 767px)").matches) setCollapsedState(true)
+  }, [])
 
-  return { width, collapsed, setWidth, setCollapsed, toggle, closeOnMobile };
+  return { width, collapsed, setWidth, setCollapsed, toggle, closeOnMobile }
 }
 
-export type SidebarLayout = ReturnType<typeof useSidebarLayout>;
+export type SidebarLayout = ReturnType<typeof useSidebarLayout>
 
 // Shares the single sidebar-layout instance with page content so it can react
 // to the collapsed state (e.g. clear room for the fixed collapse toggle).
-const SidebarLayoutContext = createContext<SidebarLayout | null>(null);
+const SidebarLayoutContext = createContext<SidebarLayout | null>(null)
 
 export function SidebarLayoutProvider({
   value,
   children,
 }: {
-  value: SidebarLayout;
-  children: React.ReactNode;
+  value: SidebarLayout
+  children: React.ReactNode
 }) {
   return (
     <SidebarLayoutContext.Provider value={value}>
       {children}
     </SidebarLayoutContext.Provider>
-  );
+  )
 }
 
 export function useSidebarCollapsed(): boolean {
-  return useContext(SidebarLayoutContext)?.collapsed ?? false;
+  return useContext(SidebarLayoutContext)?.collapsed ?? false
 }
 
 // Full sidebar controls (collapse/expand) for pages that want to drive the nav,
 // e.g. the review detail page collapsing it by default. Null outside the provider.
 export function useSidebarControls(): SidebarLayout | null {
-  return useContext(SidebarLayoutContext);
+  return useContext(SidebarLayoutContext)
 }
 
 interface SidebarFrameProps {
-  width: number;
-  setWidth: (next: number) => void;
-  collapsed: boolean;
-  toggle: () => void;
-  className?: string;
-  children: React.ReactNode;
+  width: number
+  setWidth: (next: number) => void
+  collapsed: boolean
+  toggle: () => void
+  className?: string
+  children: React.ReactNode
 }
 
 export function SidebarFrame({
@@ -120,7 +128,7 @@ export function SidebarFrame({
       >
         <SidebarSimpleIcon className="size-4" />
       </button>
-    );
+    )
   }
 
   return (
@@ -129,8 +137,8 @@ export function SidebarFrame({
       className={cn(
         "relative flex h-svh shrink-0 flex-col",
         "max-md:fixed max-md:inset-0 max-md:z-40 max-md:!w-full",
-        "max-md:animate-in max-md:fade-in-0 max-md:slide-in-from-left-4 max-md:duration-200 max-md:ease-out",
-        className,
+        "max-md:animate-in max-md:duration-200 max-md:ease-out max-md:fade-in-0 max-md:slide-in-from-left-4",
+        className
       )}
     >
       {children}
@@ -138,42 +146,48 @@ export function SidebarFrame({
         <ResizeHandle width={width} onResize={setWidth} />
       </div>
     </aside>
-  );
+  )
 }
 
-function ResizeHandle({ width, onResize }: { width: number; onResize: (next: number) => void }) {
-  const startRef = useRef<{ x: number; width: number } | null>(null);
-  const [dragging, setDragging] = useState(false);
+function ResizeHandle({
+  width,
+  onResize,
+}: {
+  width: number
+  onResize: (next: number) => void
+}) {
+  const startRef = useRef<{ x: number; width: number } | null>(null)
+  const [dragging, setDragging] = useState(false)
 
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    startRef.current = { x: e.clientX, width };
-    setDragging(true);
-    e.currentTarget.setPointerCapture(e.pointerId);
-  };
+    e.preventDefault()
+    startRef.current = { x: e.clientX, width }
+    setDragging(true)
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!startRef.current) return;
-    const next = startRef.current.width + (e.clientX - startRef.current.x);
-    onResize(next);
-  };
+    if (!startRef.current) return
+    const next = startRef.current.width + (e.clientX - startRef.current.x)
+    onResize(next)
+  }
 
   const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    startRef.current = null;
-    setDragging(false);
+    startRef.current = null
+    setDragging(false)
     if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-      e.currentTarget.releasePointerCapture(e.pointerId);
+      e.currentTarget.releasePointerCapture(e.pointerId)
     }
-  };
+  }
 
   useEffect(() => {
-    if (!dragging) return;
-    const prev = document.body.style.cursor;
-    document.body.style.cursor = "col-resize";
+    if (!dragging) return
+    const prev = document.body.style.cursor
+    document.body.style.cursor = "col-resize"
     return () => {
-      document.body.style.cursor = prev;
-    };
-  }, [dragging]);
+      document.body.style.cursor = prev
+    }
+  }, [dragging])
 
   return (
     <div
@@ -187,18 +201,21 @@ function ResizeHandle({ width, onResize }: { width: number; onResize: (next: num
         "absolute top-0 right-0 z-20 h-full w-1 cursor-col-resize touch-none select-none",
         "after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-transparent after:transition-colors",
         "hover:after:bg-border",
-        dragging && "after:bg-border",
+        dragging && "after:bg-border"
       )}
     />
-  );
+  )
 }
 
 interface SidebarCollapseButtonProps {
-  onToggle: () => void;
-  className?: string;
+  onToggle: () => void
+  className?: string
 }
 
-export function SidebarCollapseButton({ onToggle, className }: SidebarCollapseButtonProps) {
+export function SidebarCollapseButton({
+  onToggle,
+  className,
+}: SidebarCollapseButtonProps) {
   return (
     <button
       type="button"
@@ -206,10 +223,10 @@ export function SidebarCollapseButton({ onToggle, className }: SidebarCollapseBu
       onClick={onToggle}
       className={cn(
         "flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground",
-        className,
+        className
       )}
     >
       <SidebarSimpleIcon className="size-4" />
     </button>
-  );
+  )
 }

--- a/ui/src/components/ui/alert.tsx
+++ b/ui/src/components/ui/alert.tsx
@@ -5,14 +5,15 @@ import type * as React from "react"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative rounded-xl border px-3.5 py-3 text-card-foreground text-sm",
+  "relative rounded-xl border px-3.5 py-3 text-sm text-card-foreground",
   {
     defaultVariants: {
       variant: "default",
     },
     variants: {
       variant: {
-        default: "bg-transparent dark:bg-input/32 [&_svg]:text-muted-foreground",
+        default:
+          "bg-transparent dark:bg-input/32 [&_svg]:text-muted-foreground",
         error:
           "border-destructive/32 bg-destructive/4 text-destructive-foreground [&_[data-slot=alert-description]]:text-destructive-foreground/80 [&_svg]:text-destructive",
         info: "border-info/32 bg-info/4 [&_svg]:text-info",
@@ -107,7 +108,9 @@ function Alert({
           <div
             className={cn(
               "flex shrink-0 items-center",
-              controlAlignment === "first-line" ? "h-lh self-start" : "self-center"
+              controlAlignment === "first-line"
+                ? "h-lh self-start"
+                : "self-center"
             )}
           >
             {action}
@@ -128,7 +131,10 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
     <div
       className={cn("flex flex-col gap-2.5 text-muted-foreground", className)}
@@ -140,7 +146,11 @@ function AlertDescription({ className, ...props }: React.ComponentProps<"div">) 
 
 function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div className={cn("flex gap-1", className)} data-slot="alert-action" {...props} />
+    <div
+      className={cn("flex gap-1", className)}
+      data-slot="alert-action"
+      {...props}
+    />
   )
 }
 

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
-import {  cva } from "class-variance-authority"
-import type {VariantProps} from "class-variance-authority";
+import { cva } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import {  cva } from "class-variance-authority"
-import type {VariantProps} from "class-variance-authority";
+import { cva } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
@@ -61,12 +61,7 @@ function IconButton({
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   return (
-    <Button
-      variant={variant}
-      size={size}
-      className={className}
-      {...props}
-    />
+    <Button variant={variant} size={size} className={className} {...props} />
   )
 }
 

--- a/ui/src/components/ui/combobox.tsx
+++ b/ui/src/components/ui/combobox.tsx
@@ -110,7 +110,10 @@ function ComboboxContent({
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"
           data-chips={!!anchor}
-          className={cn("group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[chips=true]:min-w-(--anchor-width) data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-7 *:data-[slot=input-group]:border-none *:data-[slot=input-group]:bg-input/20 *:data-[slot=input-group]:shadow-none dark:bg-popover data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn(
+            "group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[chips=true]:min-w-(--anchor-width) data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-7 *:data-[slot=input-group]:border-none *:data-[slot=input-group]:bg-input/20 *:data-[slot=input-group]:shadow-none dark:bg-popover data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
           {...props}
         />
       </ComboboxPrimitive.Positioner>

--- a/ui/src/components/ui/kbd.tsx
+++ b/ui/src/components/ui/kbd.tsx
@@ -6,7 +6,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       className={cn(
-        "pointer-events-none inline-flex h-5 min-w-5 select-none items-center justify-center gap-1 rounded bg-muted px-1 font-sans text-xs font-medium text-muted-foreground [&_svg:not([class*='size-'])]:size-3",
+        "pointer-events-none inline-flex h-5 min-w-5 items-center justify-center gap-1 rounded bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*='size-'])]:size-3",
         className
       )}
       data-slot="kbd"

--- a/ui/src/components/ui/menu.tsx
+++ b/ui/src/components/ui/menu.tsx
@@ -8,9 +8,17 @@ const Menu = MenuPrimitive.Root
 
 const MenuPortal = MenuPrimitive.Portal
 
-function MenuTrigger({ className, children, ...props }: MenuPrimitive.Trigger.Props) {
+function MenuTrigger({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.Trigger.Props) {
   return (
-    <MenuPrimitive.Trigger className={className} data-slot="menu-trigger" {...props}>
+    <MenuPrimitive.Trigger
+      className={className}
+      data-slot="menu-trigger"
+      {...props}
+    >
       {children}
     </MenuPrimitive.Trigger>
   )
@@ -45,7 +53,7 @@ function MenuPopup({
       >
         <MenuPrimitive.Popup
           className={cn(
-            "dropdown-glass relative flex min-w-32 origin-(--transform-origin) rounded-lg outline-none transition-[scale,opacity] data-starting-style:scale-98 data-starting-style:opacity-0",
+            "dropdown-glass relative flex min-w-32 origin-(--transform-origin) rounded-lg transition-[scale,opacity] outline-none data-starting-style:scale-98 data-starting-style:opacity-0",
             className
           )}
           data-slot="menu-popup"
@@ -76,7 +84,7 @@ function MenuItem({
   return (
     <MenuPrimitive.Item
       className={cn(
-        "flex min-h-7 cursor-default select-none items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed text-foreground outline-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground data-inset:ps-8 data-[variant=destructive]:text-destructive [&>svg]:pointer-events-none [&>svg]:shrink-0 [&>svg:not([class*='size-'])]:size-3.5 [&>svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:[&>svg:not([class*='text-'])]:text-current",
+        "flex min-h-7 cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed text-foreground outline-none select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-inset:ps-8 data-[variant=destructive]:text-destructive data-disabled:pointer-events-none data-disabled:opacity-50 [&>svg]:pointer-events-none [&>svg]:shrink-0 [&>svg:not([class*='size-'])]:size-3.5 [&>svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:[&>svg:not([class*='text-'])]:text-current",
         className
       )}
       data-inset={inset}
@@ -97,7 +105,7 @@ function MenuCheckboxItem({
     <MenuPrimitive.CheckboxItem
       checked={checked}
       className={cn(
-        "grid min-h-7 cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-md py-1 pe-4 ps-2 text-xs/relaxed text-foreground outline-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        "grid min-h-7 cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-md py-1 ps-2 pe-4 text-xs/relaxed text-foreground outline-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}
       data-slot="menu-checkbox-item"
@@ -127,11 +135,15 @@ function MenuRadioGroup(props: MenuPrimitive.RadioGroup.Props) {
   return <MenuPrimitive.RadioGroup data-slot="menu-radio-group" {...props} />
 }
 
-function MenuRadioItem({ className, children, ...props }: MenuPrimitive.RadioItem.Props) {
+function MenuRadioItem({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.RadioItem.Props) {
   return (
     <MenuPrimitive.RadioItem
       className={cn(
-        "flex min-h-7 cursor-default items-center rounded-md px-2 py-1 text-xs/relaxed text-foreground outline-none data-checked:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        "flex min-h-7 cursor-default items-center rounded-md px-2 py-1 text-xs/relaxed text-foreground outline-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-checked:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}
       data-slot="menu-radio-item"
@@ -196,7 +208,7 @@ function MenuSubTrigger({
   return (
     <MenuPrimitive.SubmenuTrigger
       className={cn(
-        "flex min-h-7 items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed text-foreground outline-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground data-inset:ps-8 data-popup-open:bg-accent data-popup-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex min-h-7 items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed text-foreground outline-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-inset:ps-8 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       data-inset={inset}
@@ -204,7 +216,7 @@ function MenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="-me-0.5 ms-auto opacity-80" />
+      <ChevronRightIcon className="ms-auto -me-0.5 opacity-80" />
     </MenuPrimitive.SubmenuTrigger>
   )
 }

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -51,8 +51,8 @@ function PopoverPopup({
       >
         <PopoverPrimitive.Popup
           className={cn(
-            "dropdown-glass relative max-h-(--available-height) origin-(--transform-origin) overflow-y-auto rounded-lg p-3 text-popover-foreground outline-none transition-[scale,opacity] data-starting-style:scale-98 data-starting-style:opacity-0",
-            tooltipStyle && "w-fit text-balance rounded-md p-2 text-xs",
+            "dropdown-glass relative max-h-(--available-height) origin-(--transform-origin) overflow-y-auto rounded-lg p-3 text-popover-foreground transition-[scale,opacity] outline-none data-starting-style:scale-98 data-starting-style:opacity-0",
+            tooltipStyle && "w-fit rounded-md p-2 text-xs text-balance",
             className
           )}
           data-slot="popover-popup"
@@ -72,7 +72,7 @@ function PopoverClose(props: PopoverPrimitive.Close.Props) {
 function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
   return (
     <PopoverPrimitive.Title
-      className={cn("text-sm font-semibold leading-none", className)}
+      className={cn("text-sm leading-none font-semibold", className)}
       data-slot="popover-title"
       {...props}
     />

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -83,7 +83,10 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
           {...props}
         >
           <SelectScrollUpButton />
@@ -165,8 +168,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <CaretUpIcon
-      />
+      <CaretUpIcon />
     </SelectPrimitive.ScrollUpArrow>
   )
 }
@@ -184,8 +186,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <CaretDownIcon
-      />
+      <CaretDownIcon />
     </SelectPrimitive.ScrollDownArrow>
   )
 }

--- a/ui/src/components/ui/switch.tsx
+++ b/ui/src/components/ui/switch.tsx
@@ -1,8 +1,8 @@
-"use client";
+"use client"
 
-import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
   return (
@@ -14,19 +14,19 @@ function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
         "disabled:cursor-not-allowed disabled:opacity-40 disabled:grayscale",
         "data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[disabled]:grayscale",
         "bg-input data-[checked]:bg-primary",
-        className,
+        className
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block size-4 rounded-full bg-background ring-0 shadow-sm transition-transform",
-          "translate-x-0.5 data-[checked]:translate-x-[18px]",
+          "pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform",
+          "translate-x-0.5 data-[checked]:translate-x-[18px]"
         )}
       />
     </SwitchPrimitive.Root>
-  );
+  )
 }
 
-export { Switch };
+export { Switch }

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -38,7 +38,7 @@ function TooltipPopup({
       >
         <TooltipPrimitive.Popup
           className={cn(
-            "relative origin-(--transform-origin) text-balance rounded-md px-2 py-1 text-xs text-popover-foreground transition-[scale,opacity] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0",
+            "relative origin-(--transform-origin) rounded-md px-2 py-1 text-xs text-balance text-popover-foreground transition-[scale,opacity] data-ending-style:scale-98 data-ending-style:opacity-0 data-instant:duration-0 data-starting-style:scale-98 data-starting-style:opacity-0",
             variant === "glass"
               ? "dropdown-glass shadow-xl shadow-black/25"
               : "border bg-popover shadow-md",

--- a/ui/src/features/agents/components/AgentPromptBar.tsx
+++ b/ui/src/features/agents/components/AgentPromptBar.tsx
@@ -1,2 +1,2 @@
-export { ChatComposer as AgentPromptBar } from "@/features/agents/components/composer/ChatComposer";
-export type { ChatComposerProps as AgentPromptBarProps } from "@/features/agents/components/composer/ChatComposer";
+export { ChatComposer as AgentPromptBar } from "@/features/agents/components/composer/ChatComposer"
+export type { ChatComposerProps as AgentPromptBarProps } from "@/features/agents/components/composer/ChatComposer"

--- a/ui/src/features/agents/components/AgentRunCard.tsx
+++ b/ui/src/features/agents/components/AgentRunCard.tsx
@@ -49,9 +49,7 @@ export function AgentRunCard({ thread }: AgentRunCardProps) {
               <span className="text-success-foreground">
                 +{stats.additions}
               </span>
-              <span className="text-destructive">
-                -{stats.deletions}
-              </span>
+              <span className="text-destructive">-{stats.deletions}</span>
             </div>
           </>
         ) : (

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -57,8 +57,11 @@ export function AgentsHome() {
   const [runTarget, setRunTarget] = useState<RunTarget>("cloud")
   const [localProjectPath, setLocalProjectPath] = useState<string | null>(null)
   const [localError, setLocalError] = useState<string | null>(null)
-  const { projects: localProjects, addProject, removeProject } =
-    useDesktopProjects()
+  const {
+    projects: localProjects,
+    addProject,
+    removeProject,
+  } = useDesktopProjects()
 
   const reposQuery = useRepos()
   const profileQuery = useProfile()

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -160,10 +160,7 @@ export function AgentsSidebar({
   const cloudCollapsed = isDesktop && prefs.collapsed.cloud
 
   return (
-    <SidebarFrame
-      {...layout}
-      className="border-r border-border bg-sidebar"
-    >
+    <SidebarFrame {...layout} className="border-r border-border bg-sidebar">
       <div className="flex items-center justify-between px-4 pt-5 pb-4">
         <Link
           to="/my-settings"
@@ -196,8 +193,7 @@ export function AgentsSidebar({
               onClick={layout.closeOnMobile}
               className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
               activeProps={{
-                className:
-                  "bg-sidebar-row-hover !text-foreground font-medium",
+                className: "bg-sidebar-row-hover !text-foreground font-medium",
               }}
             >
               <Icon className="size-4" />
@@ -409,7 +405,7 @@ function LocalThreadGroup({
         </button>
         <button
           aria-label={`Remove ${project.name}`}
-          className="mr-1 flex size-5 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity hover:bg-sidebar-row-hover hover:text-destructive group-hover/project:opacity-100 focus:opacity-100 [@media(hover:none)]:opacity-100"
+          className="mr-1 flex size-5 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity group-hover/project:opacity-100 hover:bg-sidebar-row-hover hover:text-destructive focus:opacity-100 [@media(hover:none)]:opacity-100"
           onClick={onRemove}
           title="Remove project"
           type="button"
@@ -668,9 +664,7 @@ function ThreadRow({
             <span
               className={cn(
                 "size-2 shrink-0 rounded-full",
-                showFinishedIndicator
-                  ? "bg-primary"
-                  : "bg-border"
+                showFinishedIndicator ? "bg-primary" : "bg-border"
               )}
               aria-label={
                 showFinishedIndicator ? "Thread finished" : "Thread viewed"

--- a/ui/src/features/agents/components/AgentsThreadsPage.tsx
+++ b/ui/src/features/agents/components/AgentsThreadsPage.tsx
@@ -7,10 +7,17 @@ import {
 } from "@phosphor-icons/react"
 import { useState } from "react"
 
-import type { AgentSource, AgentStatus, AgentThread } from "@/features/agents/lib/types"
+import type {
+  AgentSource,
+  AgentStatus,
+  AgentThread,
+} from "@/features/agents/lib/types"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { useResolveAgentThread, useThreadsPage } from "@/features/agents/lib/queries"
+import {
+  useResolveAgentThread,
+  useThreadsPage,
+} from "@/features/agents/lib/queries"
 import { cn } from "@/lib/utils"
 
 const PAGE_SIZE = 25
@@ -62,7 +69,9 @@ function triToBool(value: TriState): boolean | undefined {
 }
 
 function displayStatus(status: AgentStatus): string {
-  return STATUS_OPTIONS.find((option) => option.value === status)?.label ?? status
+  return (
+    STATUS_OPTIONS.find((option) => option.value === status)?.label ?? status
+  )
 }
 
 export function AgentsThreadsPage({

--- a/ui/src/features/agents/components/ModelPicker.tsx
+++ b/ui/src/features/agents/components/ModelPicker.tsx
@@ -70,9 +70,7 @@ function OptionRow({
       onMouseEnter={onMouseEnter}
       className={cn(
         "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] whitespace-nowrap transition-colors",
-        selected
-          ? "text-foreground"
-          : "text-muted-foreground",
+        selected ? "text-foreground" : "text-muted-foreground",
         focused && "bg-accent",
         disabled
           ? "cursor-default opacity-40"

--- a/ui/src/features/agents/components/WorkflowApprovalCard.tsx
+++ b/ui/src/features/agents/components/WorkflowApprovalCard.tsx
@@ -116,9 +116,7 @@ export function WorkflowApprovalCard({
                 </p>
               )}
               {error && (
-                <p className="mt-3 text-xs text-destructive">
-                  {error}
-                </p>
+                <p className="mt-3 text-xs text-destructive">{error}</p>
               )}
 
               <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">

--- a/ui/src/features/agents/components/chat/CodeBlock.tsx
+++ b/ui/src/features/agents/components/chat/CodeBlock.tsx
@@ -1,20 +1,20 @@
-import { useEffect, useMemo, useState } from "react";
-import { getSingletonHighlighter } from "shiki";
-import type { ThemedToken } from "shiki";
-import { useResolvedTheme } from "@/lib/theme";
+import { useEffect, useMemo, useState } from "react"
+import { getSingletonHighlighter } from "shiki"
+import type { ThemedToken } from "shiki"
+import { useResolvedTheme } from "@/lib/theme"
 
 interface CodeBlockProps {
-  text: string;
-  language?: string;
+  text: string
+  language?: string
 }
 
-const SHIKI_THEME = { light: "github-light", dark: "github-dark" } as const;
+const SHIKI_THEME = { light: "github-light", dark: "github-dark" } as const
 
-const TOKEN_CACHE = new Map<string, Array<Array<ThemedToken>>>();
+const TOKEN_CACHE = new Map<string, Array<Array<ThemedToken>>>()
 
 function normalizeLanguage(language?: string): string {
-  const raw = (language || "").toLowerCase().trim();
-  if (!raw) return "text";
+  const raw = (language || "").toLowerCase().trim()
+  if (!raw) return "text"
 
   const aliases: Record<string, string> = {
     ts: "typescript",
@@ -33,37 +33,43 @@ function normalizeLanguage(language?: string): string {
     "c#": "csharp",
     plaintext: "text",
     txt: "text",
-  };
+  }
 
-  return aliases[raw] || raw;
+  return aliases[raw] || raw
 }
 
 function languageLabel(language: string): string {
-  if (language === "text") return "text";
-  if (language === "typescript") return "ts";
-  if (language === "javascript") return "js";
-  return language;
+  if (language === "text") return "text"
+  if (language === "typescript") return "ts"
+  if (language === "javascript") return "js"
+  return language
 }
 
 export function CodeBlock({ text, language }: CodeBlockProps) {
-  const [tokens, setTokens] = useState<Array<Array<ThemedToken>> | null>(null);
-  const [copied, setCopied] = useState(false);
-  const resolvedTheme = useResolvedTheme();
-  const shikiTheme = SHIKI_THEME[resolvedTheme];
-  const normalizedLanguage = useMemo(() => normalizeLanguage(language), [language]);
-  const displayLanguage = useMemo(() => languageLabel(normalizedLanguage), [normalizedLanguage]);
+  const [tokens, setTokens] = useState<Array<Array<ThemedToken>> | null>(null)
+  const [copied, setCopied] = useState(false)
+  const resolvedTheme = useResolvedTheme()
+  const shikiTheme = SHIKI_THEME[resolvedTheme]
+  const normalizedLanguage = useMemo(
+    () => normalizeLanguage(language),
+    [language]
+  )
+  const displayLanguage = useMemo(
+    () => languageLabel(normalizedLanguage),
+    [normalizedLanguage]
+  )
 
   useEffect(() => {
-    let cancelled = false;
-    setTokens(null);
+    let cancelled = false
+    setTokens(null)
 
-    if (normalizedLanguage === "text") return;
+    if (normalizedLanguage === "text") return
 
-    const cacheKey = `${shikiTheme}::${normalizedLanguage}::${text}`;
-    const cached = TOKEN_CACHE.get(cacheKey);
+    const cacheKey = `${shikiTheme}::${normalizedLanguage}::${text}`
+    const cached = TOKEN_CACHE.get(cacheKey)
     if (cached) {
-      setTokens(cached);
-      return;
+      setTokens(cached)
+      return
     }
 
     getSingletonHighlighter({
@@ -71,55 +77,60 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
       langs: [normalizedLanguage as any],
     })
       .then((highlighter) => {
-        if (cancelled) return;
+        if (cancelled) return
         const result = highlighter.codeToTokens(text, {
           lang: normalizedLanguage as any,
           theme: shikiTheme,
-        });
-        if (TOKEN_CACHE.size >= 500) TOKEN_CACHE.clear();
-        TOKEN_CACHE.set(cacheKey, result.tokens);
-        setTokens(result.tokens);
+        })
+        if (TOKEN_CACHE.size >= 500) TOKEN_CACHE.clear()
+        TOKEN_CACHE.set(cacheKey, result.tokens)
+        setTokens(result.tokens)
       })
       .catch((err: unknown) => {
-        console.warn('[code-block] Tokenization failed:', err);
+        console.warn("[code-block] Tokenization failed:", err)
         if (!cancelled) {
-          setTokens(null);
+          setTokens(null)
         }
-      });
+      })
 
     return () => {
-      cancelled = true;
-    };
-  }, [text, normalizedLanguage, shikiTheme]);
+      cancelled = true
+    }
+  }, [text, normalizedLanguage, shikiTheme])
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1200);
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
     } catch {
-      setCopied(false);
+      setCopied(false)
     }
-  };
+  }
 
   return (
     <div className="my-2 max-w-full overflow-hidden rounded-xl border border-border/60 bg-muted">
       <div className="flex items-center justify-between px-3 py-2 text-xs">
-        <span className="font-mono text-muted-foreground">{displayLanguage}</span>
+        <span className="font-mono text-muted-foreground">
+          {displayLanguage}
+        </span>
         <button
           type="button"
           onClick={handleCopy}
-          className="text-muted-foreground hover:text-foreground transition-colors"
+          className="text-muted-foreground transition-colors hover:text-foreground"
           title="Copy code"
         >
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
-      <pre className="max-w-full px-3 pb-3 text-[12px] whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+      <pre className="max-w-full px-3 pb-3 text-[12px] [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
         {tokens ? (
           <code className="block max-w-full">
             {tokens.map((lineTokens, lineIndex) => (
-              <div key={lineIndex} className="max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+              <div
+                key={lineIndex}
+                className="max-w-full [overflow-wrap:anywhere] break-words whitespace-pre-wrap"
+              >
                 {lineTokens.map((token, tokenIndex) => (
                   <span key={tokenIndex} style={{ color: token.color }}>
                     {token.content}
@@ -129,9 +140,11 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
             ))}
           </code>
         ) : (
-          <code className="block max-w-full text-foreground whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{text}</code>
+          <code className="block max-w-full [overflow-wrap:anywhere] break-words whitespace-pre-wrap text-foreground">
+            {text}
+          </code>
         )}
       </pre>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/chat/Logo.tsx
+++ b/ui/src/features/agents/components/chat/Logo.tsx
@@ -9,7 +9,7 @@ export function Logo() {
     "          ░███                                                                     ",
     "          █████                                                                    ",
     "         ░░░░░                                                                     ",
-  ].join("\n");
+  ].join("\n")
 
   return (
     <div className="w-full" style={{ containerType: "inline-size" }}>
@@ -20,5 +20,5 @@ export function Logo() {
         {ascii}
       </pre>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/chat/Markdown.tsx
+++ b/ui/src/features/agents/components/chat/Markdown.tsx
@@ -1,18 +1,18 @@
-import { Component, memo, useMemo } from "react";
-import { Streamdown, defaultUrlTransform } from "streamdown";
-import type { ComponentProps, ReactNode } from "react";
-import "streamdown/styles.css";
+import { Component, memo, useMemo } from "react"
+import { Streamdown, defaultUrlTransform } from "streamdown"
+import type { ComponentProps, ReactNode } from "react"
+import "streamdown/styles.css"
 
 interface MarkdownProps {
-  content: string;
+  content: string
   /** When true, keep Streamdown in streaming mode for the duration of the run. */
-  isLive?: boolean;
+  isLive?: boolean
   /**
    * Rewrite image `src` URLs before rendering (e.g. route private GitHub
    * attachments through an authenticated proxy). Return the URL unchanged to
    * leave it as-is.
    */
-  transformImageUrl?: (src: string) => string;
+  transformImageUrl?: (src: string) => string
 }
 
 /**
@@ -27,26 +27,26 @@ const STREAMDOWN_ANIMATED = {
   duration: 60,
   stagger: 10,
   easing: "ease-out",
-} as const;
+} as const
 
 const STREAMDOWN_COMPONENTS = {
   h1: ({ children }: { children?: ReactNode }) => (
-    <div className="text-foreground text-[15px] font-medium mt-4 mb-1.5 tracking-tight">
+    <div className="mt-4 mb-1.5 text-[15px] font-medium tracking-tight text-foreground">
       {children}
     </div>
   ),
   h2: ({ children }: { children?: ReactNode }) => (
-    <div className="text-foreground text-[14px] font-medium mt-3 mb-1.5 tracking-tight">
+    <div className="mt-3 mb-1.5 text-[14px] font-medium tracking-tight text-foreground">
       {children}
     </div>
   ),
   h3: ({ children }: { children?: ReactNode }) => (
-    <div className="text-foreground text-[13px] font-medium mt-3 mb-1">
+    <div className="mt-3 mb-1 text-[13px] font-medium text-foreground">
       {children}
     </div>
   ),
   p: ({ children }: { children?: ReactNode }) => (
-    <p className="my-1.5 text-foreground break-words [overflow-wrap:anywhere]">
+    <p className="my-1.5 [overflow-wrap:anywhere] break-words text-foreground">
       {children}
     </p>
   ),
@@ -57,16 +57,16 @@ const STREAMDOWN_COMPONENTS = {
     <div className="my-1.5 ml-4 min-w-0">{children}</div>
   ),
   li: ({ children }: { children?: ReactNode }) => (
-    <div className="text-foreground break-words [overflow-wrap:anywhere] [&>p]:inline [&>p]:my-0">
+    <div className="[overflow-wrap:anywhere] break-words text-foreground [&>p]:my-0 [&>p]:inline">
       - {children}
     </div>
   ),
   blockquote: ({ children }: { children?: ReactNode }) => (
-    <div className="my-2 border-l-2 border-border pl-3 text-muted-foreground break-words [overflow-wrap:anywhere]">
+    <div className="my-2 border-l-2 border-border pl-3 [overflow-wrap:anywhere] break-words text-muted-foreground">
       {children}
     </div>
   ),
-  hr: () => <hr className="border-border/60 my-3" />,
+  hr: () => <hr className="my-3 border-border/60" />,
   img: ({ src, alt }: ComponentProps<"img">) => (
     <img
       src={typeof src === "string" ? src : undefined}
@@ -75,58 +75,68 @@ const STREAMDOWN_COMPONENTS = {
       className="my-2 h-auto max-w-full rounded-md border border-border/60"
     />
   ),
-  code: ({ className, children }: { className?: string; children?: ReactNode }) => {
-    const text = String(children);
-    const match = /language-([^\s]+)/.exec(className || "");
-    const isBlock = match || text.includes("\n");
-    if (isBlock) return <code className={className}>{children}</code>;
+  code: ({
+    className,
+    children,
+  }: {
+    className?: string
+    children?: ReactNode
+  }) => {
+    const text = String(children)
+    const match = /language-([^\s]+)/.exec(className || "")
+    const isBlock = match || text.includes("\n")
+    if (isBlock) return <code className={className}>{children}</code>
     return (
-      <code className="rounded-md bg-accent px-1.5 py-0.5 font-mono text-[0.85em] text-primary whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+      <code className="rounded-md bg-accent px-1.5 py-0.5 font-mono text-[0.85em] [overflow-wrap:anywhere] break-words whitespace-pre-wrap text-primary">
         {text}
       </code>
-    );
+    )
   },
-};
+}
 
-const SHIKI_THEME: ["github-light", "github-dark"] = ["github-light", "github-dark"];
+const SHIKI_THEME: ["github-light", "github-dark"] = [
+  "github-light",
+  "github-dark",
+]
 
 interface BoundaryProps {
-  content: string;
-  children: ReactNode;
+  content: string
+  children: ReactNode
 }
 
 interface BoundaryState {
-  failed: boolean;
-  key: string;
+  failed: boolean
+  key: string
 }
 
 // Streamdown bundles Mermaid and renders ```mermaid blocks itself; a diagram it
 // can't parse throws during render and, with no boundary, white-screens the
 // whole page. Contain it and fall back to the raw markdown text.
 class MarkdownErrorBoundary extends Component<BoundaryProps, BoundaryState> {
-  state: BoundaryState = { failed: false, key: this.props.content };
+  state: BoundaryState = { failed: false, key: this.props.content }
 
   static getDerivedStateFromError(): Partial<BoundaryState> {
-    return { failed: true };
+    return { failed: true }
   }
 
   static getDerivedStateFromProps(
     props: BoundaryProps,
     state: BoundaryState
   ): Partial<BoundaryState> | null {
-    if (props.content !== state.key) return { failed: false, key: props.content };
-    return null;
+    if (props.content !== state.key)
+      return { failed: false, key: props.content }
+    return null
   }
 
   render(): ReactNode {
     if (this.state.failed) {
       return (
-        <pre className="whitespace-pre-wrap break-words [overflow-wrap:anywhere] font-sans text-foreground">
+        <pre className="font-sans [overflow-wrap:anywhere] break-words whitespace-pre-wrap text-foreground">
           {this.props.content}
         </pre>
-      );
+      )
     }
-    return this.props.children;
+    return this.props.children
   }
 }
 
@@ -140,7 +150,7 @@ export const Markdown = memo(function Markdown({
       ...STREAMDOWN_COMPONENTS,
       a: ({ href, children }: { href?: string; children?: ReactNode }) => (
         <a
-          className="text-primary underline decoration-primary/50 break-words [overflow-wrap:anywhere]"
+          className="[overflow-wrap:anywhere] break-words text-primary underline decoration-primary/50"
           href={href}
           target="_blank"
           rel="noreferrer"
@@ -150,20 +160,22 @@ export const Markdown = memo(function Markdown({
       ),
     }),
     []
-  );
+  )
 
   const urlTransform = useMemo(() => {
-    if (!transformImageUrl) return undefined;
+    if (!transformImageUrl) return undefined
     return (
       url: string,
       key: string,
       node: Parameters<typeof defaultUrlTransform>[2]
     ) =>
-      key === "src" ? transformImageUrl(url) : defaultUrlTransform(url, key, node);
-  }, [transformImageUrl]);
+      key === "src"
+        ? transformImageUrl(url)
+        : defaultUrlTransform(url, key, node)
+  }, [transformImageUrl])
 
   return (
-    <div className="min-w-0 max-w-full text-[13px] leading-6 break-words [overflow-wrap:anywhere] [&_.streamdown]:text-foreground">
+    <div className="max-w-full min-w-0 text-[13px] leading-6 [overflow-wrap:anywhere] break-words [&_.streamdown]:text-foreground">
       <MarkdownErrorBoundary content={content}>
         <Streamdown
           mode={isLive ? "streaming" : "static"}
@@ -171,7 +183,7 @@ export const Markdown = memo(function Markdown({
           isAnimating={isLive}
           animated={isLive ? STREAMDOWN_ANIMATED : false}
           shikiTheme={SHIKI_THEME}
-          className="streamdown-agent min-w-0 max-w-full"
+          className="streamdown-agent max-w-full min-w-0"
           components={components}
           urlTransform={urlTransform}
         >
@@ -179,5 +191,5 @@ export const Markdown = memo(function Markdown({
         </Streamdown>
       </MarkdownErrorBoundary>
     </div>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/chat/ReplyCard.tsx
+++ b/ui/src/features/agents/components/chat/ReplyCard.tsx
@@ -152,12 +152,7 @@ function renderSlackBlocks(blocks: Array<SlackBlock>): ReactNode {
           )
         }
         if (block.type === "divider") {
-          return (
-            <div
-              key={index}
-              className="border-t border-border/60"
-            />
-          )
+          return <div key={index} className="border-t border-border/60" />
         }
         return null
       })}

--- a/ui/src/features/agents/components/chat/ToolExecution.test.ts
+++ b/ui/src/features/agents/components/chat/ToolExecution.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 
-import { formatToolDisplay } from "./toolExecutionDisplay";
+import { formatToolDisplay } from "./toolExecutionDisplay"
 
 describe("formatToolDisplay", () => {
-  const projectPath = "/workspace/open-swe";
+  const projectPath = "/workspace/open-swe"
 
   it("renders read_file with the file_path alias consistently", () => {
     expect(
@@ -11,10 +11,10 @@ describe("formatToolDisplay", () => {
         "read_file /workspace/open-swe/AGENTS.md",
         "read",
         { file_path: "/workspace/open-swe/AGENTS.md" },
-        projectPath,
-      ),
-    ).toBe("Read AGENTS.md");
-  });
+        projectPath
+      )
+    ).toBe("Read AGENTS.md")
+  })
 
   it("renders ls as a list operation with a relative path", () => {
     expect(
@@ -22,28 +22,37 @@ describe("formatToolDisplay", () => {
         "ls /workspace/open-swe/ui",
         "read",
         { path: "/workspace/open-swe/ui" },
-        projectPath,
-      ),
-    ).toBe("List ui");
-  });
+        projectPath
+      )
+    ).toBe("List ui")
+  })
 
   it("renders search tools with their pattern", () => {
     expect(
-      formatToolDisplay("grep", "search", { pattern: "tool_calls" }, projectPath),
-    ).toBe('Search "tool_calls"');
-  });
+      formatToolDisplay(
+        "grep",
+        "search",
+        { pattern: "tool_calls" },
+        projectPath
+      )
+    ).toBe('Search "tool_calls"')
+  })
 
   it("normalizes write_todos", () => {
-    expect(formatToolDisplay("write todos", "other", {}, projectPath)).toBe("Update todos");
-  });
+    expect(formatToolDisplay("write todos", "other", {}, projectPath)).toBe(
+      "Update todos"
+    )
+  })
 
   it("sentence-cases raw tool names", () => {
     expect(formatToolDisplay("enter_plan_mode", "other", {}, projectPath)).toBe(
-      "Enter plan mode",
-    );
-    expect(formatToolDisplay("save_plan", "other", {}, projectPath)).toBe("Save plan");
-    expect(formatToolDisplay("slack_thread_reply", "other", {}, projectPath)).toBe(
-      "Slack thread reply",
-    );
-  });
-});
+      "Enter plan mode"
+    )
+    expect(formatToolDisplay("save_plan", "other", {}, projectPath)).toBe(
+      "Save plan"
+    )
+    expect(
+      formatToolDisplay("slack_thread_reply", "other", {}, projectPath)
+    ).toBe("Slack thread reply")
+  })
+})

--- a/ui/src/features/agents/components/chat/ToolExecution.tsx
+++ b/ui/src/features/agents/components/chat/ToolExecution.tsx
@@ -1,29 +1,36 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { MultiFileDiff } from "@pierre/diffs/react";
-import { DiffView } from "./DiffView";
-import { formatToolDisplay } from "./toolExecutionDisplay";
-import type { ToolExecutionChunk } from "@/features/agents/lib/types";
-import { useDiffOptions } from "@/features/agents/utils/diffUtils";
-import { countLineChanges } from "@/features/agents/utils/diffStats";
+import {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { MultiFileDiff } from "@pierre/diffs/react"
+import { DiffView } from "./DiffView"
+import { formatToolDisplay } from "./toolExecutionDisplay"
+import type { ToolExecutionChunk } from "@/features/agents/lib/types"
+import { useDiffOptions } from "@/features/agents/utils/diffUtils"
+import { countLineChanges } from "@/features/agents/utils/diffStats"
 
 interface ToolExecutionProps {
-  chunk: ToolExecutionChunk;
-  projectPath?: string;
-  onApprove?: (approvalRequestId: string) => void;
-  onReject?: (approvalRequestId: string) => void;
-  onAutoApprove?: (approvalRequestId: string) => void;
+  chunk: ToolExecutionChunk
+  projectPath?: string
+  onApprove?: (approvalRequestId: string) => void
+  onReject?: (approvalRequestId: string) => void
+  onAutoApprove?: (approvalRequestId: string) => void
 }
 
 function stripProjectPath(path: string, projectPath?: string): string {
-  if (!projectPath || !path.startsWith(projectPath)) return path;
-  const relative = path.slice(projectPath.length);
-  return relative.startsWith("/") ? "." + relative : "./" + relative;
+  if (!projectPath || !path.startsWith(projectPath)) return path
+  const relative = path.slice(projectPath.length)
+  return relative.startsWith("/") ? "." + relative : "./" + relative
 }
 
 function getFileName(path: string): string {
-  const normalized = path.replace(/\\/g, "/");
-  const parts = normalized.split("/").filter(Boolean);
-  return parts[parts.length - 1] || path;
+  const normalized = path.replace(/\\/g, "/")
+  const parts = normalized.split("/").filter(Boolean)
+  return parts[parts.length - 1] || path
 }
 
 const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
@@ -35,45 +42,45 @@ const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
   deletions,
   isError,
 }: {
-  filePath: string;
-  fileName: string;
-  originalContent: string;
-  newContent: string;
-  additions: number;
-  deletions: number;
-  isError: boolean;
+  filePath: string
+  fileName: string
+  originalContent: string
+  newContent: string
+  additions: number
+  deletions: number
+  isError: boolean
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const toggle = useCallback(() => setExpanded((prev) => !prev), []);
-  const diffOptions = useDiffOptions();
+  const [expanded, setExpanded] = useState(false)
+  const toggle = useCallback(() => setExpanded((prev) => !prev), [])
+  const diffOptions = useDiffOptions()
   const inlineDiffOptions = useMemo(
     () => ({ ...diffOptions, disableFileHeader: true }),
     [diffOptions]
-  );
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [scrolledFromTop, setScrolledFromTop] = useState(false);
-  const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
+  )
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [scrolledFromTop, setScrolledFromTop] = useState(false)
+  const [scrolledFromBottom, setScrolledFromBottom] = useState(false)
 
   const updateScrollIndicators = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setScrolledFromTop(el.scrollTop > 0);
-    setScrolledFromBottom(el.scrollTop < el.scrollHeight - el.clientHeight - 1);
-  }, []);
+    const el = scrollRef.current
+    if (!el) return
+    setScrolledFromTop(el.scrollTop > 0)
+    setScrolledFromBottom(el.scrollTop < el.scrollHeight - el.clientHeight - 1)
+  }, [])
 
   useLayoutEffect(() => {
-    if (expanded) updateScrollIndicators();
-  }, [expanded, updateScrollIndicators]);
+    if (expanded) updateScrollIndicators()
+  }, [expanded, updateScrollIndicators])
 
   const edgeShadows = [
     scrolledFromTop ? "inset 0 12px 10px -10px rgba(42, 63, 95, 0.95)" : "",
     scrolledFromBottom ? "inset 0 -12px 10px -10px rgba(42, 63, 95, 0.95)" : "",
   ]
     .filter(Boolean)
-    .join(", ");
+    .join(", ")
 
-  const oldFile = { name: filePath, contents: originalContent };
-  const newFile = { name: filePath, contents: newContent };
+  const oldFile = { name: filePath, contents: originalContent }
+  const newFile = { name: filePath, contents: newContent }
 
   if (!expanded) {
     return (
@@ -81,37 +88,39 @@ const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
         <button
           type="button"
           onClick={toggle}
-          className="inline-flex items-center gap-1.5 text-left hover:brightness-125 transition-colors"
+          className="inline-flex items-center gap-1.5 text-left transition-colors hover:brightness-125"
         >
           <span className={isError ? "text-red-400" : "text-muted-foreground"}>
             Edited <span className="text-primary">{fileName}</span>
           </span>
         </button>
       </div>
-    );
+    )
   }
 
   return (
     <div className="my-1">
-      <div className="my-0.5 text-[12px] leading-5 mb-1.5">
+      <div className="my-0.5 mb-1.5 text-[12px] leading-5">
         <button
           type="button"
           onClick={toggle}
-          className="inline-flex items-center gap-1.5 text-left hover:brightness-125 transition-colors"
+          className="inline-flex items-center gap-1.5 text-left transition-colors hover:brightness-125"
         >
           <span className={isError ? "text-red-400" : "text-muted-foreground"}>
             Edited file
           </span>
-          <span className="text-muted-foreground/70 text-[10px]">▾</span>
+          <span className="text-[10px] text-muted-foreground/70">▾</span>
         </button>
       </div>
 
-      <div className="rounded-lg bg-muted overflow-hidden border border-border/60">
-        <div className="px-3 py-2 flex items-center gap-2">
-          <span className={`text-[13px] truncate flex-1 min-w-0 ${isError ? "text-red-400" : "text-primary"}`}>
+      <div className="overflow-hidden rounded-lg border border-border/60 bg-muted">
+        <div className="flex items-center gap-2 px-3 py-2">
+          <span
+            className={`min-w-0 flex-1 truncate text-[13px] ${isError ? "text-red-400" : "text-primary"}`}
+          >
             {filePath}
           </span>
-          <span className="shrink-0 text-xs flex items-center gap-2">
+          <span className="flex shrink-0 items-center gap-2 text-xs">
             <span className="text-green-400">+{additions}</span>
             <span className="text-red-400">-{deletions}</span>
           </span>
@@ -120,7 +129,7 @@ const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
         <div
           ref={scrollRef}
           onScroll={updateScrollIndicators}
-          className="border-t border-border max-h-[250px] overflow-auto"
+          className="max-h-[250px] overflow-auto border-t border-border"
           style={{ boxShadow: edgeShadows || "none" }}
         >
           <MultiFileDiff
@@ -131,22 +140,39 @@ const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
         </div>
       </div>
     </div>
-  );
-});
+  )
+})
 
 export const ToolExecution = memo(function ToolExecution({
   chunk,
   projectPath,
 }: ToolExecutionProps) {
-  const { title, toolKind, input, status, output } = chunk;
-  const diffs = chunk.diffs?.length ? chunk.diffs : (chunk.diffData ? [chunk.diffData] : []);
-  const diffData = diffs[diffs.length - 1];
+  const { title, toolKind, input, status, output } = chunk
+  const diffs = chunk.diffs?.length
+    ? chunk.diffs
+    : chunk.diffData
+      ? [chunk.diffData]
+      : []
+  const diffData = diffs[diffs.length - 1]
 
-  const isEditOp = toolKind === "edit" || toolKind === "delete" || toolKind === "move" || diffData != null;
-  const isCompletedEditOp = isEditOp && diffData && (status === "completed" || status === "error");
-  const editedFilePath = diffData ? stripProjectPath(diffData.filePath, projectPath) : "";
-  const editedFileName = editedFilePath ? getFileName(editedFilePath) : "";
-  const diffStats = diffData ? countLineChanges(diffData.originalContent, diffData.newContent, diffData.filePath) : null;
+  const isEditOp =
+    toolKind === "edit" ||
+    toolKind === "delete" ||
+    toolKind === "move" ||
+    diffData != null
+  const isCompletedEditOp =
+    isEditOp && diffData && (status === "completed" || status === "error")
+  const editedFilePath = diffData
+    ? stripProjectPath(diffData.filePath, projectPath)
+    : ""
+  const editedFileName = editedFilePath ? getFileName(editedFilePath) : ""
+  const diffStats = diffData
+    ? countLineChanges(
+        diffData.originalContent,
+        diffData.newContent,
+        diffData.filePath
+      )
+    : null
 
   if (isCompletedEditOp && diffStats) {
     return (
@@ -159,48 +185,53 @@ export const ToolExecution = memo(function ToolExecution({
         deletions={diffStats.deletions}
         isError={status === "error"}
       />
-    );
+    )
   }
 
   if (isEditOp && status === "pending" && diffData) {
     return (
       <div className="my-1 text-[12px] leading-5">
         <DiffView diffData={diffData} />
-        <span className="text-muted-foreground/70">Waiting for approval...</span>
+        <span className="text-muted-foreground/70">
+          Waiting for approval...
+        </span>
       </div>
-    );
+    )
   }
 
   if (isEditOp && status === "in_progress") {
     const path = stripProjectPath(
       diffData?.filePath ||
-      (input?.filePath as string) ||
-      (input?.path as string) || "file",
-      projectPath,
-    );
+        (input?.filePath as string) ||
+        (input?.path as string) ||
+        "file",
+      projectPath
+    )
     return (
       <div className="my-0.5 text-[12px] leading-5">
         <span className="text-yellow-400">Editing {getFileName(path)}...</span>
       </div>
-    );
+    )
   }
 
-  const displayName = formatToolDisplay(title, toolKind, input, projectPath);
+  const displayName = formatToolDisplay(title, toolKind, input, projectPath)
   const statusTextClass =
     status === "error"
       ? "text-red-400"
       : status === "in_progress" || status === "pending"
         ? "text-yellow-400"
-        : "text-muted-foreground";
+        : "text-muted-foreground"
 
   return (
     <div className="my-0.5 text-[12px] leading-5">
-      <div className="flex items-center gap-2 min-w-0">
+      <div className="flex min-w-0 items-center gap-2">
         <span className={`${statusTextClass} truncate`}>{displayName}</span>
         {status === "error" && output && (
-          <span className="text-red-400/80 truncate">{output.slice(0, 80)}</span>
+          <span className="truncate text-red-400/80">
+            {output.slice(0, 80)}
+          </span>
         )}
       </div>
     </div>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/chat/toolExecutionDisplay.ts
+++ b/ui/src/features/agents/components/chat/toolExecutionDisplay.ts
@@ -1,42 +1,42 @@
-import type { AcpToolKind } from "@/features/agents/lib/types";
-import { humanizeToolName } from "@/features/agents/lib/toolNames";
+import type { AcpToolKind } from "@/features/agents/lib/types"
+import { humanizeToolName } from "@/features/agents/lib/toolNames"
 
 function stripProjectPath(path: string, projectPath?: string): string {
-  if (!projectPath || !path.startsWith(projectPath)) return path;
-  const relative = path.slice(projectPath.length);
-  return relative.replace(/^\/+/, "") || ".";
+  if (!projectPath || !path.startsWith(projectPath)) return path
+  const relative = path.slice(projectPath.length)
+  return relative.replace(/^\/+/, "") || "."
 }
 
 function firstStringArg(
   input: Record<string, unknown> | undefined,
-  keys: Array<string>,
+  keys: Array<string>
 ): string | undefined {
-  if (!input) return undefined;
+  if (!input) return undefined
   for (const key of keys) {
-    const value = input[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
+    const value = input[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
   }
-  return undefined;
+  return undefined
 }
 
 function truncateMiddle(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value
 }
 
 function normalizedToolName(title: string): string {
-  return title.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+  return title.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? ""
 }
 
 function humanizeToolTitle(title: string): string {
-  const trimmed = title.trim();
-  if (!trimmed) return "Tool";
+  const trimmed = title.trim()
+  if (!trimmed) return "Tool"
 
-  const [name, ...rest] = trimmed.split(/\s+/);
-  const suffix = rest.join(" ");
+  const [name, ...rest] = trimmed.split(/\s+/)
+  const suffix = rest.join(" ")
   if (name && suffix && /^(?:[./~]|[a-z]+:\/\/)/i.test(suffix)) {
-    return `${humanizeToolName(name)} ${suffix}`;
+    return `${humanizeToolName(name)} ${suffix}`
   }
-  return humanizeToolName(trimmed);
+  return humanizeToolName(trimmed)
 }
 
 /**
@@ -46,60 +46,79 @@ function humanizeToolTitle(title: string): string {
  * rather than being pre-joined into one string.
  */
 export interface ToolDisplayParts {
-  heading: string;
-  preview: string | null;
+  heading: string
+  preview: string | null
 }
 
 export function formatToolDisplayParts(
   title: string,
   toolKind: AcpToolKind,
   input: Record<string, unknown> | undefined,
-  projectPath?: string,
+  projectPath?: string
 ): ToolDisplayParts {
-  const toolName = normalizedToolName(title);
-  const path = firstStringArg(input, ["path", "file_path", "target_file"]);
-  const pattern = firstStringArg(input, ["pattern"]);
-  const query = firstStringArg(input, ["query"]);
-  const url = firstStringArg(input, ["url"]);
-  const command = firstStringArg(input, ["command"]);
-  const plain = (heading: string): ToolDisplayParts => ({ heading, preview: null });
+  const toolName = normalizedToolName(title)
+  const path = firstStringArg(input, ["path", "file_path", "target_file"])
+  const pattern = firstStringArg(input, ["pattern"])
+  const query = firstStringArg(input, ["query"])
+  const url = firstStringArg(input, ["url"])
+  const command = firstStringArg(input, ["command"])
+  const plain = (heading: string): ToolDisplayParts => ({
+    heading,
+    preview: null,
+  })
 
   switch (toolKind) {
     case "read": {
       if (path) {
-        const displayPath = stripProjectPath(path, projectPath);
-        return { heading: toolName === "ls" ? "List" : "Read", preview: displayPath };
+        const displayPath = stripProjectPath(path, projectPath)
+        return {
+          heading: toolName === "ls" ? "List" : "Read",
+          preview: displayPath,
+        }
       }
-      return plain(humanizeToolTitle(title));
+      return plain(humanizeToolTitle(title))
     }
     case "search": {
-      if (pattern) return { heading: "Search", preview: `"${truncateMiddle(pattern, 40)}"` };
-      if (query) return { heading: "Search", preview: `"${truncateMiddle(query, 40)}"` };
-      if (path) return { heading: "Search", preview: stripProjectPath(path, projectPath) };
-      return plain(humanizeToolTitle(title));
+      if (pattern)
+        return {
+          heading: "Search",
+          preview: `"${truncateMiddle(pattern, 40)}"`,
+        }
+      if (query)
+        return { heading: "Search", preview: `"${truncateMiddle(query, 40)}"` }
+      if (path)
+        return {
+          heading: "Search",
+          preview: stripProjectPath(path, projectPath),
+        }
+      return plain(humanizeToolTitle(title))
     }
     case "fetch": {
-      if (url) return { heading: "Fetch", preview: truncateMiddle(url, 50) };
-      return plain(humanizeToolTitle(title));
+      if (url) return { heading: "Fetch", preview: truncateMiddle(url, 50) }
+      return plain(humanizeToolTitle(title))
     }
     case "execute": {
-      if (command) return { heading: "Shell", preview: truncateMiddle(command, 60) };
-      return plain(humanizeToolTitle(title));
+      if (command)
+        return { heading: "Shell", preview: truncateMiddle(command, 60) }
+      return plain(humanizeToolTitle(title))
     }
     case "edit":
     case "delete":
     case "move":
-      return plain(humanizeToolTitle(title));
+      return plain(humanizeToolTitle(title))
     case "think":
-      return plain("Thinking...");
+      return plain("Thinking...")
     default: {
-      if (toolName === "write_todos" || title.toLowerCase().startsWith("write todos")) {
-        return plain("Update todos");
+      if (
+        toolName === "write_todos" ||
+        title.toLowerCase().startsWith("write todos")
+      ) {
+        return plain("Update todos")
       }
       if (toolName === "ls" && path) {
-        return { heading: "List", preview: stripProjectPath(path, projectPath) };
+        return { heading: "List", preview: stripProjectPath(path, projectPath) }
       }
-      return plain(humanizeToolTitle(title));
+      return plain(humanizeToolTitle(title))
     }
   }
 }
@@ -108,8 +127,13 @@ export function formatToolDisplay(
   title: string,
   toolKind: AcpToolKind,
   input: Record<string, unknown> | undefined,
-  projectPath?: string,
+  projectPath?: string
 ): string {
-  const { heading, preview } = formatToolDisplayParts(title, toolKind, input, projectPath);
-  return preview ? `${heading} ${preview}` : heading;
+  const { heading, preview } = formatToolDisplayParts(
+    title,
+    toolKind,
+    input,
+    projectPath
+  )
+  return preview ? `${heading} ${preview}` : heading
 }

--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -121,13 +121,17 @@ describe("ChatComposer skill autocomplete", () => {
       rangeStart: 7,
       rangeEnd: 12,
     }
-    const items = buildCommandItems(trigger, [], [
-      {
-        name: "plan",
-        description: "Create an implementation plan",
-        instructions: "",
-      },
-    ])
+    const items = buildCommandItems(
+      trigger,
+      [],
+      [
+        {
+          name: "plan",
+          description: "Create an implementation plan",
+          instructions: "",
+        },
+      ]
+    )
 
     expect(items).toEqual([
       expect.objectContaining({ type: "skill", name: "plan" }),

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -1,122 +1,149 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ImagePlus, Map as MapIcon, X } from "lucide-react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { ImagePlus, Map as MapIcon, X } from "lucide-react"
 
-import { ComposerCommandMenu } from "./ComposerCommandMenu";
-import { ComposerControl, ComposerControlIcon } from "./ComposerControl";
-import { ComposerPrimaryActions } from "./ComposerPrimaryActions";
-import { ComposerPromptEditor, mentionReplacementText } from "./ComposerPromptEditor";
-import { ContextWindowMeter } from "./ContextWindowMeter";
-import { RunTargetSelector } from "./RunTargetSelector";
+import { ComposerCommandMenu } from "./ComposerCommandMenu"
+import { ComposerControl, ComposerControlIcon } from "./ComposerControl"
+import { ComposerPrimaryActions } from "./ComposerPrimaryActions"
+import {
+  ComposerPromptEditor,
+  mentionReplacementText,
+} from "./ComposerPromptEditor"
+import { ContextWindowMeter } from "./ContextWindowMeter"
+import { RunTargetSelector } from "./RunTargetSelector"
 import {
   COMPOSER_PATH_DRAG_MIME,
   detectComposerTrigger,
   replaceTextRange,
-} from "./composerTrigger";
-import type { ComposerCommandItem } from "./ComposerCommandMenu";
-import type { ActiveRun } from "./ComposerPrimaryActions";
-import type { ComposerCommandKey, ComposerPromptEditorHandle } from "./ComposerPromptEditor";
-import type { ComposerSlashCommand, ComposerTrigger } from "./composerTrigger";
-import type { RunTarget } from "./RunTargetSelector";
-import type { DesktopProject } from "@/desktop";
-import type { ModelOption, Skill } from "@/lib/api";
-import type { ImageChunk } from "@/features/agents/lib/types";
-import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions";
-import { ModelPicker } from "@/features/agents/components/ModelPicker";
-import { RepoSelector } from "@/features/settings/components/RepoSelector";
-import { Kbd } from "@/components/ui/kbd";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+} from "./composerTrigger"
+import type { ComposerCommandItem } from "./ComposerCommandMenu"
+import type { ActiveRun } from "./ComposerPrimaryActions"
+import type {
+  ComposerCommandKey,
+  ComposerPromptEditorHandle,
+} from "./ComposerPromptEditor"
+import type { ComposerSlashCommand, ComposerTrigger } from "./composerTrigger"
+import type { RunTarget } from "./RunTargetSelector"
+import type { DesktopProject } from "@/desktop"
+import type { ModelOption, Skill } from "@/lib/api"
+import type { ImageChunk } from "@/features/agents/lib/types"
+import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
+import { ModelPicker } from "@/features/agents/components/ModelPicker"
+import { RepoSelector } from "@/features/settings/components/RepoSelector"
+import { Kbd } from "@/components/ui/kbd"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
-export type { ActiveRun };
+export type { ActiveRun }
 
-const MAX_IMAGE_COUNT = 5;
-const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
-const MAX_MENTION_SUGGESTIONS = 8;
-const SUPPORTED_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const MAX_IMAGE_COUNT = 5
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+const MAX_MENTION_SUGGESTIONS = 8
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+])
 
 interface SlashCommandSpec {
-  command: ComposerSlashCommand;
-  label: string;
-  description: string;
+  command: ComposerSlashCommand
+  label: string
+  description: string
 }
 
 const SLASH_COMMANDS: Array<SlashCommandSpec> = [
-  { command: "plan", label: "/plan", description: "Research read-only and propose a plan first" },
-  { command: "default", label: "/default", description: "Leave plan mode and edit directly" },
-  { command: "model", label: "/model", description: "Pick a model and reasoning effort" },
-];
+  {
+    command: "plan",
+    label: "/plan",
+    description: "Research read-only and propose a plan first",
+  },
+  {
+    command: "default",
+    label: "/default",
+    description: "Leave plan mode and edit directly",
+  },
+  {
+    command: "model",
+    label: "/model",
+    description: "Pick a model and reasoning effort",
+  },
+]
 
 export interface ChatComposerProps {
-  placeholder?: string;
-  autoFocus?: boolean;
-  compact?: boolean;
-  disabled?: boolean;
-  busy?: boolean;
+  placeholder?: string
+  autoFocus?: boolean
+  compact?: boolean
+  disabled?: boolean
+  busy?: boolean
   /** Enables the stop button for the thread's live run. */
-  activeRun?: ActiveRun;
-  onStop?: () => void | Promise<void>;
-  onSubmit?: (value: string, images: Array<ImageChunk>) => void | Promise<void>;
-  models?: Array<ModelOption>;
-  selection?: ModelSelection | null;
-  onSelectionChange?: (next: ModelSelection) => void;
+  activeRun?: ActiveRun
+  onStop?: () => void | Promise<void>
+  onSubmit?: (value: string, images: Array<ImageChunk>) => void | Promise<void>
+  models?: Array<ModelOption>
+  selection?: ModelSelection | null
+  onSelectionChange?: (next: ModelSelection) => void
   /** Repos the user can target. When provided with onRepoChange, a repo picker is shown. */
-  repos?: Array<{ full_name: string }>;
-  selectedRepo?: string | null;
-  onRepoChange?: (repo: string | null) => void;
+  repos?: Array<{ full_name: string }>
+  selectedRepo?: string | null
+  onRepoChange?: (repo: string | null) => void
   /** Desktop-only execution target. Omit this prop to keep the control out of the web UI. */
-  runTarget?: RunTarget;
-  onRunTargetChange?: (next: RunTarget) => void;
-  localProjects?: Array<DesktopProject>;
-  selectedLocalProjectPath?: string | null;
-  onSelectLocalProject?: (cwd: string) => void;
-  onAddLocalProject?: () => void;
-  onRemoveLocalProject?: (cwd: string) => void;
+  runTarget?: RunTarget
+  onRunTargetChange?: (next: RunTarget) => void
+  localProjects?: Array<DesktopProject>
+  selectedLocalProjectPath?: string | null
+  onSelectLocalProject?: (cwd: string) => void
+  onAddLocalProject?: () => void
+  onRemoveLocalProject?: (cwd: string) => void
   /** When provided, a Plan mode toggle is shown. Plan mode researches read-only and proposes a plan before editing. */
-  planMode?: boolean;
-  onPlanModeChange?: (next: boolean) => void;
+  planMode?: boolean
+  onPlanModeChange?: (next: boolean) => void
   /** Paths offered by `@` autocomplete — in a thread, the files the agent has touched. */
-  mentionPaths?: Array<string>;
-  skills?: Array<Skill>;
+  mentionPaths?: Array<string>
+  skills?: Array<Skill>
   contextUsage?: {
-    usedTokens?: number | null;
-    contextWindow?: number | null;
-    hasMessages?: boolean;
-  };
+    usedTokens?: number | null
+    contextWindow?: number | null
+    hasMessages?: boolean
+  }
 }
 
 function fileToImageChunk(file: File): Promise<ImageChunk | null> {
   if (!SUPPORTED_IMAGE_TYPES.has(file.type) || file.size > MAX_IMAGE_BYTES) {
-    return Promise.resolve(null);
+    return Promise.resolve(null)
   }
 
   return new Promise((resolve) => {
-    const reader = new FileReader();
+    const reader = new FileReader()
     reader.onload = () => {
-      const dataUrl = typeof reader.result === "string" ? reader.result : "";
-      const base64 = dataUrl.split(",")[1];
-      resolve(base64 ? { kind: "image", base64, mimeType: file.type, fileName: file.name } : null);
-    };
-    reader.onerror = () => resolve(null);
-    reader.readAsDataURL(file);
-  });
+      const dataUrl = typeof reader.result === "string" ? reader.result : ""
+      const base64 = dataUrl.split(",")[1]
+      resolve(
+        base64
+          ? { kind: "image", base64, mimeType: file.type, fileName: file.name }
+          : null
+      )
+    }
+    reader.onerror = () => resolve(null)
+    reader.readAsDataURL(file)
+  })
 }
 
 export function buildCommandItems(
   trigger: ComposerTrigger,
   mentionPaths: Array<string>,
   skills: Array<Skill>,
-  includeModelCommand = true,
+  includeModelCommand = true
 ): Array<ComposerCommandItem> {
-  const query = trigger.query.toLowerCase();
+  const query = trigger.query.toLowerCase()
 
   if (trigger.kind === "slash-command") {
-    const skillNames = new Set(skills.map((skill) => skill.name));
+    const skillNames = new Set(skills.map((skill) => skill.name))
     return [
       ...SLASH_COMMANDS.filter(
         (spec) =>
           spec.command.startsWith(query) &&
           !skillNames.has(spec.command) &&
-          (includeModelCommand || spec.command !== "model"),
+          (includeModelCommand || spec.command !== "model")
       ).map((spec) => ({
         id: `slash:${spec.command}`,
         type: "slash-command" as const,
@@ -124,14 +151,16 @@ export function buildCommandItems(
         label: spec.label,
         description: spec.description,
       })),
-      ...skills.filter((skill) => skill.name.startsWith(query)).map((skill) => ({
-        id: `skill:${skill.name}`,
-        type: "skill" as const,
-        name: skill.name,
-        label: `/${skill.name}`,
-        description: skill.description,
-      })),
-    ];
+      ...skills
+        .filter((skill) => skill.name.startsWith(query))
+        .map((skill) => ({
+          id: `skill:${skill.name}`,
+          type: "skill" as const,
+          name: skill.name,
+          label: `/${skill.name}`,
+          description: skill.description,
+        })),
+    ]
   }
 
   return mentionPaths
@@ -143,7 +172,7 @@ export function buildCommandItems(
       path,
       label: path.slice(path.lastIndexOf("/") + 1),
       description: path,
-    }));
+    }))
 }
 
 /**
@@ -179,108 +208,124 @@ export const ChatComposer = memo(function ChatComposer({
   skills = [],
   contextUsage,
 }: ChatComposerProps) {
-  const [value, setValue] = useState("");
-  const [cursor, setCursor] = useState(0);
-  const [pendingImages, setPendingImages] = useState<Array<ImageChunk>>([]);
-  const [dragKind, setDragKind] = useState<"files" | "path" | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [activeItemId, setActiveItemId] = useState<string | null>(null);
-  const [dismissedTriggerKey, setDismissedTriggerKey] = useState<string | null>(null);
-  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const [value, setValue] = useState("")
+  const [cursor, setCursor] = useState(0)
+  const [pendingImages, setPendingImages] = useState<Array<ImageChunk>>([])
+  const [dragKind, setDragKind] = useState<"files" | "path" | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [activeItemId, setActiveItemId] = useState<string | null>(null)
+  const [dismissedTriggerKey, setDismissedTriggerKey] = useState<string | null>(
+    null
+  )
+  const [modelPickerOpen, setModelPickerOpen] = useState(false)
 
-  const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const dragDepthRef = useRef(0);
+  const editorRef = useRef<ComposerPromptEditorHandle | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const dragDepthRef = useRef(0)
 
   useEffect(() => {
-    if (autoFocus) editorRef.current?.focus();
-  }, [autoFocus]);
+    if (autoFocus) editorRef.current?.focus()
+  }, [autoFocus])
 
   // Synchronous double-submit guard: blocks a same-tick second send (Enter +
   // click, or two rapid Enters) before React re-renders. Scoped to the send
   // request only — never the run lifecycle.
-  const submittingRef = useRef(false);
+  const submittingRef = useRef(false)
 
-  const trigger = useMemo(() => detectComposerTrigger(value, cursor), [cursor, value]);
-  const triggerKey = trigger ? `${trigger.kind}:${trigger.rangeStart}` : null;
+  const trigger = useMemo(
+    () => detectComposerTrigger(value, cursor),
+    [cursor, value]
+  )
+  const triggerKey = trigger ? `${trigger.kind}:${trigger.rangeStart}` : null
   const commandItems = useMemo(
     () =>
       trigger
         ? buildCommandItems(trigger, mentionPaths, skills, models.length > 0)
         : [],
-    [mentionPaths, models.length, skills, trigger],
-  );
+    [mentionPaths, models.length, skills, trigger]
+  )
   const menuOpen =
-    trigger !== null && commandItems.length > 0 && dismissedTriggerKey !== triggerKey;
+    trigger !== null &&
+    commandItems.length > 0 &&
+    dismissedTriggerKey !== triggerKey
   const activeItem =
-    commandItems.find((item) => item.id === activeItemId) ?? commandItems[0] ?? null;
+    commandItems.find((item) => item.id === activeItemId) ??
+    commandItems[0] ??
+    null
 
   const selectedModelSupportsImages = useMemo(() => {
-    if (!selection || pendingImages.length === 0) return true;
-    return models.some((m) => m.id === selection.modelId && m.supports_images);
-  }, [models, pendingImages.length, selection]);
+    if (!selection || pendingImages.length === 0) return true
+    return models.some((m) => m.id === selection.modelId && m.supports_images)
+  }, [models, pendingImages.length, selection])
 
   const canSubmit =
     !disabled &&
     !isSubmitting &&
     selectedModelSupportsImages &&
-    (value.trim().length > 0 || pendingImages.length > 0);
+    (value.trim().length > 0 || pendingImages.length > 0)
 
   const applyPrompt = useCallback((nextValue: string, nextCursor: number) => {
-    setValue(nextValue);
-    setCursor(nextCursor);
-    setDismissedTriggerKey(null);
-    setActiveItemId(null);
-  }, []);
+    setValue(nextValue)
+    setCursor(nextCursor)
+    setDismissedTriggerKey(null)
+    setActiveItemId(null)
+  }, [])
 
   const handleSubmit = useCallback(async () => {
-    if (submittingRef.current || disabled) return;
+    if (submittingRef.current || disabled) return
     // The editor is the source of truth for what is on screen; a keystroke that
     // has not yet round-tripped through state would otherwise be dropped.
-    const snapshot = editorRef.current?.readSnapshot();
-    const trimmed = (snapshot?.value ?? value).trim();
-    if (trimmed.length === 0 && pendingImages.length === 0) return;
+    const snapshot = editorRef.current?.readSnapshot()
+    const trimmed = (snapshot?.value ?? value).trim()
+    if (trimmed.length === 0 && pendingImages.length === 0) return
 
-    const images = pendingImages;
-    submittingRef.current = true;
-    setIsSubmitting(true);
-    applyPrompt("", 0);
-    setPendingImages([]);
+    const images = pendingImages
+    submittingRef.current = true
+    setIsSubmitting(true)
+    applyPrompt("", 0)
+    setPendingImages([])
     try {
-      await onSubmit?.(trimmed, images);
+      await onSubmit?.(trimmed, images)
     } catch {
       // Caller surfaces send errors (e.g. via react-query mutation state).
     } finally {
-      submittingRef.current = false;
-      setIsSubmitting(false);
+      submittingRef.current = false
+      setIsSubmitting(false)
     }
-  }, [applyPrompt, disabled, onSubmit, pendingImages, value]);
+  }, [applyPrompt, disabled, onSubmit, pendingImages, value])
 
   const selectCommandItem = useCallback(
     (item: ComposerCommandItem) => {
-      if (!trigger) return;
+      if (!trigger) return
 
       if (item.type === "path" || item.type === "skill") {
         const next = replaceTextRange(
           value,
           trigger.rangeStart,
           trigger.rangeEnd,
-          item.type === "path" ? mentionReplacementText(item.path) : `/${item.name} `,
-        );
-        applyPrompt(next.text, next.cursor);
-        return;
+          item.type === "path"
+            ? mentionReplacementText(item.path)
+            : `/${item.name} `
+        )
+        applyPrompt(next.text, next.cursor)
+        return
       }
 
       // Slash commands are settings, not prose: they act and then erase
       // themselves rather than being sent to the agent.
-      const next = replaceTextRange(value, trigger.rangeStart, trigger.rangeEnd, "");
-      applyPrompt(next.text, next.cursor);
-      if (item.command === "plan") onPlanModeChange?.(true);
-      if (item.command === "default") onPlanModeChange?.(false);
-      if (item.command === "model") setModelPickerOpen(true);
+      const next = replaceTextRange(
+        value,
+        trigger.rangeStart,
+        trigger.rangeEnd,
+        ""
+      )
+      applyPrompt(next.text, next.cursor)
+      if (item.command === "plan") onPlanModeChange?.(true)
+      if (item.command === "default") onPlanModeChange?.(false)
+      if (item.command === "model") setModelPickerOpen(true)
     },
-    [applyPrompt, onPlanModeChange, trigger, value],
-  );
+    [applyPrompt, onPlanModeChange, trigger, value]
+  )
 
   const handleCommandKeyDown = useCallback(
     (key: ComposerCommandKey, event: KeyboardEvent): boolean => {
@@ -288,33 +333,38 @@ export const ChatComposer = memo(function ChatComposer({
         switch (key) {
           case "ArrowDown":
           case "ArrowUp": {
-            const index = commandItems.findIndex((item) => item.id === activeItem.id);
-            const step = key === "ArrowDown" ? 1 : -1;
-            const next = commandItems[(index + step + commandItems.length) % commandItems.length];
-            if (next) setActiveItemId(next.id);
-            return true;
+            const index = commandItems.findIndex(
+              (item) => item.id === activeItem.id
+            )
+            const step = key === "ArrowDown" ? 1 : -1
+            const next =
+              commandItems[
+                (index + step + commandItems.length) % commandItems.length
+              ]
+            if (next) setActiveItemId(next.id)
+            return true
           }
           case "Enter":
           case "Tab":
-            selectCommandItem(activeItem);
-            return true;
+            selectCommandItem(activeItem)
+            return true
           case "Escape":
-            setDismissedTriggerKey(triggerKey);
-            return true;
+            setDismissedTriggerKey(triggerKey)
+            return true
         }
       }
 
       if (key === "Tab" && event.shiftKey && onPlanModeChange) {
-        onPlanModeChange(!planMode);
-        return true;
+        onPlanModeChange(!planMode)
+        return true
       }
       if (key === "Enter" && !event.shiftKey) {
-        if (canSubmit) void handleSubmit();
+        if (canSubmit) void handleSubmit()
         // Swallow it either way: a bare Enter must never insert a newline in a
         // composer whose Enter means "send".
-        return true;
+        return true
       }
-      return false;
+      return false
     },
     [
       activeItem,
@@ -326,102 +376,123 @@ export const ChatComposer = memo(function ChatComposer({
       planMode,
       selectCommandItem,
       triggerKey,
-    ],
-  );
+    ]
+  )
 
   const addFiles = useCallback(async (files: FileList | Array<File>) => {
-    const nextImages = await Promise.all(Array.from(files).map(fileToImageChunk));
-    const validImages = nextImages.filter((image): image is ImageChunk => image !== null);
-    if (validImages.length === 0) return;
-    setPendingImages((prev) => [...prev, ...validImages].slice(0, MAX_IMAGE_COUNT));
-  }, []);
+    const nextImages = await Promise.all(
+      Array.from(files).map(fileToImageChunk)
+    )
+    const validImages = nextImages.filter(
+      (image): image is ImageChunk => image !== null
+    )
+    if (validImages.length === 0) return
+    setPendingImages((prev) =>
+      [...prev, ...validImages].slice(0, MAX_IMAGE_COUNT)
+    )
+  }, [])
 
   const handleFileChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (event.target.files) void addFiles(event.target.files);
-      event.target.value = "";
+      if (event.target.files) void addFiles(event.target.files)
+      event.target.value = ""
     },
-    [addFiles],
-  );
+    [addFiles]
+  )
 
   const insertMentionAtEnd = useCallback(
     (path: string) => {
-      const separator = value.length === 0 || /\s$/.test(value) ? "" : " ";
-      const nextValue = `${value}${separator}${mentionReplacementText(path)}`;
-      applyPrompt(nextValue, nextValue.length);
-      editorRef.current?.focusAtEnd();
+      const separator = value.length === 0 || /\s$/.test(value) ? "" : " "
+      const nextValue = `${value}${separator}${mentionReplacementText(path)}`
+      applyPrompt(nextValue, nextValue.length)
+      editorRef.current?.focusAtEnd()
     },
-    [applyPrompt, value],
-  );
+    [applyPrompt, value]
+  )
 
   // Two accepted payloads: OS image files, and a repo path dragged out of the
   // changed-files list. The drop only lands if dragover is also prevented, so
   // every handler has to agree on what it accepts.
-  const dragKindOf = (event: React.DragEvent<HTMLDivElement>): "files" | "path" | null => {
-    if (event.dataTransfer.types.includes(COMPOSER_PATH_DRAG_MIME)) return "path";
-    if (event.dataTransfer.types.includes("Files")) return "files";
-    return null;
-  };
+  const dragKindOf = (
+    event: React.DragEvent<HTMLDivElement>
+  ): "files" | "path" | null => {
+    if (event.dataTransfer.types.includes(COMPOSER_PATH_DRAG_MIME))
+      return "path"
+    if (event.dataTransfer.types.includes("Files")) return "files"
+    return null
+  }
 
-  const handleDragEnter = useCallback((event: React.DragEvent<HTMLDivElement>) => {
-    const kind = dragKindOf(event);
-    if (!kind) return;
-    event.preventDefault();
-    dragDepthRef.current += 1;
-    setDragKind(kind);
-  }, []);
+  const handleDragEnter = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      const kind = dragKindOf(event)
+      if (!kind) return
+      event.preventDefault()
+      dragDepthRef.current += 1
+      setDragKind(kind)
+    },
+    []
+  )
 
-  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
-    const kind = dragKindOf(event);
-    if (!kind) return;
-    event.preventDefault();
-    setDragKind(kind);
-  }, []);
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      const kind = dragKindOf(event)
+      if (!kind) return
+      event.preventDefault()
+      setDragKind(kind)
+    },
+    []
+  )
 
-  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
-    if (!dragKindOf(event)) return;
-    event.preventDefault();
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) setDragKind(null);
-  }, []);
+  const handleDragLeave = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!dragKindOf(event)) return
+      event.preventDefault()
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+      if (dragDepthRef.current === 0) setDragKind(null)
+    },
+    []
+  )
 
   const handleDrop = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
-      const droppedPath = event.dataTransfer.getData(COMPOSER_PATH_DRAG_MIME);
+      const droppedPath = event.dataTransfer.getData(COMPOSER_PATH_DRAG_MIME)
       if (droppedPath) {
-        event.preventDefault();
-        dragDepthRef.current = 0;
-        setDragKind(null);
-        insertMentionAtEnd(droppedPath);
-        return;
+        event.preventDefault()
+        dragDepthRef.current = 0
+        setDragKind(null)
+        insertMentionAtEnd(droppedPath)
+        return
       }
-      if (!event.dataTransfer.types.includes("Files")) return;
-      event.preventDefault();
-      dragDepthRef.current = 0;
-      setDragKind(null);
-      void addFiles(event.dataTransfer.files);
+      if (!event.dataTransfer.types.includes("Files")) return
+      event.preventDefault()
+      dragDepthRef.current = 0
+      setDragKind(null)
+      void addFiles(event.dataTransfer.files)
     },
-    [addFiles, insertMentionAtEnd],
-  );
+    [addFiles, insertMentionAtEnd]
+  )
 
   const handlePaste = useCallback(
     (event: React.ClipboardEvent<HTMLElement>) => {
-      const files: Array<File> = [];
+      const files: Array<File> = []
       for (const item of Array.from(event.clipboardData.items)) {
-        if (item.kind !== "file") continue;
-        const file = item.getAsFile();
-        if (file && SUPPORTED_IMAGE_TYPES.has(file.type)) files.push(file);
+        if (item.kind !== "file") continue
+        const file = item.getAsFile()
+        if (file && SUPPORTED_IMAGE_TYPES.has(file.type)) files.push(file)
       }
-      if (files.length === 0) return;
-      event.preventDefault();
-      void addFiles(files);
+      if (files.length === 0) return
+      event.preventDefault()
+      void addFiles(files)
     },
-    [addFiles],
-  );
+    [addFiles]
+  )
 
   return (
     <div
-      className={cn("relative w-full font-sans text-[13px]", compact ? "max-w-none" : "max-w-2xl")}
+      className={cn(
+        "relative w-full font-sans text-[13px]",
+        compact ? "max-w-none" : "max-w-2xl"
+      )}
     >
       {(onRepoChange || onRunTargetChange) && (
         <div className="mb-2 flex items-center gap-2 px-1 text-xs">
@@ -454,7 +525,8 @@ export const ChatComposer = memo(function ChatComposer({
       {!selectedModelSupportsImages && (
         <div className="dropdown-glass mb-2 rounded-xl border border-warning/30 px-3 py-2 text-xs text-muted-foreground">
           The selected model does not accept image input. Remove the image
-          {pendingImages.length > 1 ? "s" : ""} or switch to a vision-enabled model to send.
+          {pendingImages.length > 1 ? "s" : ""} or switch to a vision-enabled
+          model to send.
         </div>
       )}
 
@@ -462,7 +534,7 @@ export const ChatComposer = memo(function ChatComposer({
         className={cn(
           "relative flex flex-col rounded-2xl border border-border bg-card px-3 py-2.5 shadow-sm transition-colors",
           compact ? "min-h-[88px]" : "min-h-[106px]",
-          dragKind && "border-primary",
+          dragKind && "border-primary"
         )}
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
@@ -482,7 +554,9 @@ export const ChatComposer = memo(function ChatComposer({
         {dragKind && (
           <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-2xl bg-card/80 backdrop-blur-sm">
             <span className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground">
-              {dragKind === "path" ? "Drop to mention this file" : "Drop images here"}
+              {dragKind === "path"
+                ? "Drop to mention this file"
+                : "Drop images here"}
             </span>
           </div>
         )}
@@ -499,7 +573,10 @@ export const ChatComposer = memo(function ChatComposer({
         {pendingImages.length > 0 && (
           <div className="mb-2 flex flex-wrap gap-2">
             {pendingImages.map((image, index) => (
-              <div className="group relative" key={`${image.fileName ?? "image"}-${index}`}>
+              <div
+                className="group relative"
+                key={`${image.fileName ?? "image"}-${index}`}
+              >
                 <img
                   alt={image.fileName || "Pending image"}
                   className="size-16 rounded-lg border border-border object-cover"
@@ -508,7 +585,11 @@ export const ChatComposer = memo(function ChatComposer({
                 <button
                   aria-label="Remove image"
                   className="absolute -top-1.5 -right-1.5 flex size-5 items-center justify-center rounded-full border border-border bg-card text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 hover:text-foreground"
-                  onClick={() => setPendingImages((prev) => prev.filter((_, i) => i !== index))}
+                  onClick={() =>
+                    setPendingImages((prev) =>
+                      prev.filter((_, i) => i !== index)
+                    )
+                  }
                   type="button"
                 >
                   <X className="size-3" />
@@ -524,8 +605,8 @@ export const ChatComposer = memo(function ChatComposer({
           disabled={disabled}
           editorRef={editorRef}
           onChange={(nextValue, nextCursor) => {
-            setValue(nextValue);
-            setCursor(nextCursor);
+            setValue(nextValue)
+            setCursor(nextCursor)
           }}
           onCommandKeyDown={handleCommandKeyDown}
           onPaste={handlePaste}
@@ -553,7 +634,8 @@ export const ChatComposer = memo(function ChatComposer({
                   <ComposerControl
                     aria-pressed={planMode}
                     className={cn(
-                      planMode && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+                      planMode &&
+                        "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
                     )}
                     onClick={() => onPlanModeChange(!planMode)}
                     type="button"
@@ -563,8 +645,12 @@ export const ChatComposer = memo(function ChatComposer({
                 <ComposerControlIcon icon={MapIcon} />
                 <span>Plan</span>
               </TooltipTrigger>
-              <TooltipPopup className="max-w-[18rem] whitespace-normal" side="top">
-                Research read-only and propose a plan before editing <Kbd>⇧</Kbd>
+              <TooltipPopup
+                className="max-w-[18rem] whitespace-normal"
+                side="top"
+              >
+                Research read-only and propose a plan before editing{" "}
+                <Kbd>⇧</Kbd>
                 <Kbd>Tab</Kbd>
               </TooltipPopup>
             </Tooltip>
@@ -605,5 +691,5 @@ export const ChatComposer = memo(function ChatComposer({
         </div>
       </div>
     </div>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/composer/ComposerCommandMenu.tsx
+++ b/ui/src/features/agents/components/composer/ComposerCommandMenu.tsx
@@ -1,21 +1,39 @@
-import { memo, useLayoutEffect, useRef } from "react";
-import { Bot, File as FileIcon } from "lucide-react";
+import { memo, useLayoutEffect, useRef } from "react"
+import { Bot, File as FileIcon } from "lucide-react"
 
-import type { ComposerTriggerKind } from "./composerTrigger";
-import { cn } from "@/lib/utils";
+import type { ComposerTriggerKind } from "./composerTrigger"
+import { cn } from "@/lib/utils"
 
 export type ComposerCommandItem =
-  | { id: string; type: "path"; path: string; label: string; description: string }
-  | { id: string; type: "slash-command"; command: string; label: string; description: string }
-  | { id: string; type: "skill"; name: string; label: string; description: string };
+  | {
+      id: string
+      type: "path"
+      path: string
+      label: string
+      description: string
+    }
+  | {
+      id: string
+      type: "slash-command"
+      command: string
+      label: string
+      description: string
+    }
+  | {
+      id: string
+      type: "skill"
+      name: string
+      label: string
+      description: string
+    }
 
 interface ComposerCommandMenuProps {
-  items: Array<ComposerCommandItem>;
-  triggerKind: ComposerTriggerKind;
-  activeItemId: string | null;
-  emptyStateText?: string;
-  onHighlight: (itemId: string) => void;
-  onSelect: (item: ComposerCommandItem) => void;
+  items: Array<ComposerCommandItem>
+  triggerKind: ComposerTriggerKind
+  activeItemId: string | null
+  emptyStateText?: string
+  onHighlight: (itemId: string) => void
+  onSelect: (item: ComposerCommandItem) => void
 }
 
 /**
@@ -31,14 +49,16 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu({
   onHighlight,
   onSelect,
 }: ComposerCommandMenuProps) {
-  const listRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
-    if (!activeItemId || !listRef.current) return;
+    if (!activeItemId || !listRef.current) return
     listRef.current
-      .querySelector<HTMLElement>(`[data-composer-item-id="${CSS.escape(activeItemId)}"]`)
-      ?.scrollIntoView({ block: "nearest" });
-  }, [activeItemId]);
+      .querySelector<HTMLElement>(
+        `[data-composer-item-id="${CSS.escape(activeItemId)}"]`
+      )
+      ?.scrollIntoView({ block: "nearest" })
+  }, [activeItemId])
 
   return (
     <div
@@ -53,7 +73,9 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu({
               aria-selected={activeItemId === item.id}
               className={cn(
                 "flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs/relaxed select-none",
-                activeItemId === item.id ? "bg-accent text-accent-foreground" : "text-foreground",
+                activeItemId === item.id
+                  ? "bg-accent text-accent-foreground"
+                  : "text-foreground"
               )}
               data-composer-item-id={item.id}
               key={item.id}
@@ -61,7 +83,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu({
               // insertion is anchored to disappears before the click lands.
               onMouseDown={(event) => event.preventDefault()}
               onMouseMove={() => {
-                if (activeItemId !== item.id) onHighlight(item.id);
+                if (activeItemId !== item.id) onHighlight(item.id)
               }}
               onClick={() => onSelect(item)}
               role="option"
@@ -82,9 +104,11 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu({
       ) : (
         <p className="px-4 py-3 text-xs text-muted-foreground/70">
           {emptyStateText ??
-            (triggerKind === "path" ? "No matching files." : "No matching command.")}
+            (triggerKind === "path"
+              ? "No matching files."
+              : "No matching command.")}
         </p>
       )}
     </div>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/composer/ComposerControl.tsx
+++ b/ui/src/features/agents/components/composer/ComposerControl.tsx
@@ -1,12 +1,12 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react"
 
-import type { ComponentProps } from "react";
-import type { LucideIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import type { ComponentProps } from "react"
+import type { LucideIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 const composerControlClassName =
-  "h-7 min-h-7 gap-1.5 px-2 text-muted-foreground/70 transition-none hover:text-foreground/80";
+  "h-7 min-h-7 gap-1.5 px-2 text-muted-foreground/70 transition-none hover:text-foreground/80"
 
 /** A button in the composer's bottom control row (model, plan mode, attach). */
 export function ComposerControl({
@@ -22,11 +22,19 @@ export function ComposerControl({
       variant={variant}
       {...props}
     />
-  );
+  )
 }
 
-export function ComposerControlIcon({ className, icon: Icon }: { className?: string; icon: LucideIcon }) {
-  return <Icon aria-hidden="true" className={cn("size-3.5 shrink-0", className)} />;
+export function ComposerControlIcon({
+  className,
+  icon: Icon,
+}: {
+  className?: string
+  icon: LucideIcon
+}) {
+  return (
+    <Icon aria-hidden="true" className={cn("size-3.5 shrink-0", className)} />
+  )
 }
 
 export function ComposerControlChevron() {
@@ -36,5 +44,5 @@ export function ComposerControlChevron() {
       className="-mx-0.5 size-3 shrink-0 text-muted-foreground opacity-70"
       strokeWidth={2.25}
     />
-  );
+  )
 }

--- a/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
@@ -1,35 +1,41 @@
-import { useState } from "react";
-import { LoaderCircle } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
-import { useStreamContext as useAgentThreadStream } from "@langchain/react";
+import { useState } from "react"
+import { LoaderCircle } from "lucide-react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 
-import { useIsInAgentThreadStream } from "@/features/agents/lib/provider/useIsInAgentThreadStream";
+import { useIsInAgentThreadStream } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
 import {
   agentThreadKeys,
   invalidateAgentThreadLists,
   useCancelAgentThread,
-} from "@/features/agents/lib/queries";
-import { cn } from "@/lib/utils";
+} from "@/features/agents/lib/queries"
+import { cn } from "@/lib/utils"
 
 export interface ActiveRun {
-  threadId: string;
+  threadId: string
   /** Server-reported run state, independent of this client's event stream. */
-  running: boolean;
+  running: boolean
 }
 
 export interface ComposerPrimaryActionsProps {
-  canSubmit: boolean;
-  submitting: boolean;
-  onSubmit: () => void;
+  canSubmit: boolean
+  submitting: boolean
+  onSubmit: () => void
   /** Enables the stop button for the thread's live run. */
-  activeRun?: ActiveRun;
+  activeRun?: ActiveRun
   /** Direct stop handler for non-LangGraph runtimes such as desktop ACP. */
-  onStop?: () => void | Promise<void>;
+  onStop?: () => void | Promise<void>
 }
 
 function SendIcon() {
   return (
-    <svg aria-hidden="true" fill="none" height="14" viewBox="0 0 14 14" width="14">
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="14"
+      viewBox="0 0 14 14"
+      width="14"
+    >
       <path
         d="M7 11.5V2.5M7 2.5L3 6.5M7 2.5L11 6.5"
         stroke="currentColor"
@@ -38,35 +44,49 @@ function SendIcon() {
         strokeWidth="1.8"
       />
     </svg>
-  );
+  )
 }
 
-function SendButton({ canSubmit, submitting, onSubmit }: ComposerPrimaryActionsProps) {
+function SendButton({
+  canSubmit,
+  submitting,
+  onSubmit,
+}: ComposerPrimaryActionsProps) {
   return (
     <button
       aria-label="Send message"
       className={cn(
         "relative isolate flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/90 text-primary-foreground shadow-xs shadow-primary/25 transition-all duration-150",
-        "enabled:cursor-pointer hover:bg-primary hover:scale-105 active:shadow-none",
-        "disabled:pointer-events-none disabled:opacity-30 disabled:shadow-none",
+        "hover:scale-105 hover:bg-primary active:shadow-none enabled:cursor-pointer",
+        "disabled:pointer-events-none disabled:opacity-30 disabled:shadow-none"
       )}
       disabled={!canSubmit}
       onClick={onSubmit}
       type="button"
     >
-      {submitting ? <LoaderCircle className="size-3.5 animate-spin" /> : <SendIcon />}
+      {submitting ? (
+        <LoaderCircle className="size-3.5 animate-spin" />
+      ) : (
+        <SendIcon />
+      )}
     </button>
-  );
+  )
 }
 
-function StopButton({ disabled, onStop }: { disabled: boolean; onStop: () => void }) {
+function StopButton({
+  disabled,
+  onStop,
+}: {
+  disabled: boolean
+  onStop: () => void
+}) {
   return (
     <button
       aria-label="Stop run"
       className={cn(
         "flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-full bg-destructive/90 text-white shadow-xs shadow-destructive/25 transition-all duration-150",
-        "hover:bg-destructive hover:scale-105 active:shadow-none",
-        "disabled:pointer-events-none disabled:opacity-40",
+        "hover:scale-105 hover:bg-destructive active:shadow-none",
+        "disabled:pointer-events-none disabled:opacity-40"
       )}
       disabled={disabled}
       onClick={onStop}
@@ -76,75 +96,83 @@ function StopButton({ disabled, onStop }: { disabled: boolean; onStop: () => voi
       {disabled ? (
         <LoaderCircle className="size-3.5 animate-spin" />
       ) : (
-        <svg aria-hidden="true" fill="currentColor" height="12" viewBox="0 0 12 12" width="12">
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+        >
           <rect height="8" rx="1.5" width="8" x="2" y="2" />
         </svg>
       )}
     </button>
-  );
+  )
 }
 
 function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
-  const stream = useAgentThreadStream();
-  const queryClient = useQueryClient();
-  const [stopping, setStopping] = useState(false);
-  const threadId = props.activeRun?.threadId ?? stream.threadId ?? "";
-  const cancelThread = useCancelAgentThread(threadId);
+  const stream = useAgentThreadStream()
+  const queryClient = useQueryClient()
+  const [stopping, setStopping] = useState(false)
+  const threadId = props.activeRun?.threadId ?? stream.threadId ?? ""
+  const cancelThread = useCancelAgentThread(threadId)
 
   const handleStop = async () => {
-    if (stopping) return;
-    setStopping(true);
+    if (stopping) return
+    setStopping(true)
     try {
       // `stream.stop()` only cancels server-side when this client dispatched the
       // run, so cancel by thread first: a run started from Slack/Linear/GitHub
       // (or joined after a reload) has no client-side run id to cancel.
       if (threadId) {
         try {
-          await cancelThread.mutateAsync();
+          await cancelThread.mutateAsync()
         } catch {
           // Cancellation failed (transient 5xx, or a non-owner viewer). Leave
           // the stream and the thread's status polling untouched: presenting a
           // stopped state here would strand the UI on a still-running run.
-          return;
+          return
         }
       }
-      await stream.disconnect();
+      await stream.disconnect()
       if (threadId) {
         queryClient.setQueryData(agentThreadKeys.detail(threadId), (prev) =>
-          prev ? { ...prev, status: "interrupted" as const } : prev,
-        );
-        invalidateAgentThreadLists(queryClient);
+          prev ? { ...prev, status: "interrupted" as const } : prev
+        )
+        invalidateAgentThreadLists(queryClient)
       }
     } finally {
-      setStopping(false);
+      setStopping(false)
     }
-  };
+  }
 
   // Server truth (`activeRun.running`) matters as much as the client stream:
   // this browser only sees `isLoading` once it observes a lifecycle event, so a
   // run it never joined would otherwise render an unusable send button.
-  if (!stream.isLoading && !props.activeRun?.running) return <SendButton {...props} />;
+  if (!stream.isLoading && !props.activeRun?.running)
+    return <SendButton {...props} />
 
-  return <StopButton disabled={stopping} onStop={() => void handleStop()} />;
+  return <StopButton disabled={stopping} onStop={() => void handleStop()} />
 }
 
 function DirectPrimaryActions(props: ComposerPrimaryActionsProps) {
-  const [stopping, setStopping] = useState(false);
-  if (!props.activeRun?.running || !props.onStop) return <SendButton {...props} />;
+  const [stopping, setStopping] = useState(false)
+  if (!props.activeRun?.running || !props.onStop)
+    return <SendButton {...props} />
   const stop = async () => {
-    setStopping(true);
+    setStopping(true)
     try {
-      await props.onStop?.();
+      await props.onStop?.()
     } finally {
-      setStopping(false);
+      setStopping(false)
     }
-  };
-  return <StopButton disabled={stopping} onStop={() => void stop()} />;
+  }
+  return <StopButton disabled={stopping} onStop={() => void stop()} />
 }
 
 /** The composer's send button, which becomes a stop button while a run is live. */
 export function ComposerPrimaryActions(props: ComposerPrimaryActionsProps) {
-  const inAgentThreadStream = useIsInAgentThreadStream();
-  if (inAgentThreadStream) return <StreamPrimaryActions {...props} />;
-  return <DirectPrimaryActions {...props} />;
+  const inAgentThreadStream = useIsInAgentThreadStream()
+  if (inAgentThreadStream) return <StreamPrimaryActions {...props} />
+  return <DirectPrimaryActions {...props} />
 }

--- a/ui/src/features/agents/components/composer/ComposerPromptEditor.test.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPromptEditor.test.tsx
@@ -31,7 +31,9 @@ function Harness({ initialValue = "" }: { initialValue?: string }) {
 describe("ComposerPromptEditor", () => {
   it("renders plain text as text", () => {
     render(<Harness initialValue="rename the handler" />)
-    expect(screen.getByTestId("composer-editor").textContent).toBe("rename the handler")
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "rename the handler"
+    )
   })
 
   it("renders a file link as a chip whose text content is the original source", () => {

--- a/ui/src/features/agents/components/composer/ComposerPromptEditor.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPromptEditor.tsx
@@ -1,11 +1,18 @@
-import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef } from "react";
-import { LexicalComposer } from "@lexical/react/LexicalComposer";
-import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { ContentEditable } from "@lexical/react/LexicalContentEditable";
-import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
-import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
-import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
-import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react"
+import { LexicalComposer } from "@lexical/react/LexicalComposer"
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
+import { ContentEditable } from "@lexical/react/LexicalContentEditable"
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary"
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin"
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin"
+import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin"
 import {
   $applyNodeReplacement,
   $createLineBreakNode,
@@ -26,49 +33,65 @@ import {
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
-} from "lexical";
-import { File as FileIcon } from "lucide-react";
+} from "lexical"
+import { File as FileIcon } from "lucide-react"
 
-import { basenameOfPath, serializeComposerFileLink } from "./composerTrigger";
-import { splitPromptIntoSegments } from "./composerMentions";
-import type { InitialConfigType } from "@lexical/react/LexicalComposer";
-import type { EditorState, LexicalNode, NodeKey, SerializedLexicalNode, Spread } from "lexical";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { basenameOfPath, serializeComposerFileLink } from "./composerTrigger"
+import { splitPromptIntoSegments } from "./composerMentions"
+import type { InitialConfigType } from "@lexical/react/LexicalComposer"
+import type {
+  EditorState,
+  LexicalNode,
+  NodeKey,
+  SerializedLexicalNode,
+  Spread,
+} from "lexical"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
-export type ComposerCommandKey = "ArrowDown" | "ArrowUp" | "Enter" | "Tab" | "Escape";
+export type ComposerCommandKey =
+  "ArrowDown" | "ArrowUp" | "Enter" | "Tab" | "Escape"
 
 export interface ComposerPromptEditorHandle {
-  focus: () => void;
-  focusAtEnd: () => void;
+  focus: () => void
+  focusAtEnd: () => void
   /** The prompt as plain text plus the caret offset into it, read straight from the editor. */
-  readSnapshot: () => { value: string; cursor: number };
+  readSnapshot: () => { value: string; cursor: number }
 }
 
 const MENTION_CHIP_CLASS_NAME =
-  "inline-flex max-w-full select-none items-center gap-1 rounded-md border border-border/70 bg-accent/40 px-1.5 py-px align-middle text-[12px] font-medium leading-[1.1] text-foreground";
+  "inline-flex max-w-full select-none items-center gap-1 rounded-md border border-border/70 bg-accent/40 px-1.5 py-px align-middle text-[12px] font-medium leading-[1.1] text-foreground"
 
 type SerializedComposerMentionNode = Spread<
   { path: string; source: string; type: "composer-mention"; version: 1 },
   SerializedLexicalNode
->;
+>
 
 function ComposerMentionChip({ path }: { path: string }) {
   return (
     <Tooltip>
       <TooltipTrigger
         render={
-          <span className={MENTION_CHIP_CLASS_NAME} contentEditable={false} spellCheck={false}>
+          <span
+            className={MENTION_CHIP_CLASS_NAME}
+            contentEditable={false}
+            spellCheck={false}
+          >
             <FileIcon className="size-3.5 shrink-0 opacity-70" aria-hidden />
-            <span className="select-none truncate leading-tight">{basenameOfPath(path)}</span>
+            <span className="truncate leading-tight select-none">
+              {basenameOfPath(path)}
+            </span>
           </span>
         }
       />
-      <TooltipPopup className="max-w-[30rem] whitespace-normal break-words leading-tight" side="top">
+      <TooltipPopup
+        className="max-w-[30rem] leading-tight break-words whitespace-normal"
+        side="top"
+      >
         {path}
       </TooltipPopup>
     </Tooltip>
-  );
+  )
 }
 
 /**
@@ -77,25 +100,30 @@ function ComposerMentionChip({ path }: { path: string }) {
  * the root's text content reconstructs the prompt exactly.
  */
 class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
-  __path: string;
-  __source: string;
+  __path: string
+  __source: string
 
   static override getType(): string {
-    return "composer-mention";
+    return "composer-mention"
   }
 
   static override clone(node: ComposerMentionNode): ComposerMentionNode {
-    return new ComposerMentionNode(node.__path, node.__source, node.__key);
+    return new ComposerMentionNode(node.__path, node.__source, node.__key)
   }
 
-  static override importJSON(serialized: SerializedComposerMentionNode): ComposerMentionNode {
-    return $createComposerMentionNode(serialized.path, serialized.source).updateFromJSON(serialized);
+  static override importJSON(
+    serialized: SerializedComposerMentionNode
+  ): ComposerMentionNode {
+    return $createComposerMentionNode(
+      serialized.path,
+      serialized.source
+    ).updateFromJSON(serialized)
   }
 
   constructor(path: string, source: string, key?: NodeKey) {
-    super(key);
-    this.__path = path;
-    this.__source = source;
+    super(key)
+    this.__path = path
+    this.__source = source
   }
 
   override exportJSON(): SerializedComposerMentionNode {
@@ -105,52 +133,57 @@ class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
       source: this.__source,
       type: "composer-mention",
       version: 1,
-    };
+    }
   }
 
   override createDOM(): HTMLElement {
-    const dom = document.createElement("span");
-    dom.className = "relative inline-flex align-middle leading-none";
-    return dom;
+    const dom = document.createElement("span")
+    dom.className = "relative inline-flex align-middle leading-none"
+    return dom
   }
 
   override updateDOM(): false {
-    return false;
+    return false
   }
 
   override getTextContent(): string {
-    return this.__source;
+    return this.__source
   }
 
   override isInline(): true {
-    return true;
+    return true
   }
 
   override decorate(): React.ReactElement {
-    return <ComposerMentionChip path={this.__path} />;
+    return <ComposerMentionChip path={this.__path} />
   }
 }
 
-function $createComposerMentionNode(path: string, source: string): ComposerMentionNode {
-  return $applyNodeReplacement(new ComposerMentionNode(path, source));
+function $createComposerMentionNode(
+  path: string,
+  source: string
+): ComposerMentionNode {
+  return $applyNodeReplacement(new ComposerMentionNode(path, source))
 }
 
 function isMentionNode(node: unknown): node is ComposerMentionNode {
-  return node instanceof ComposerMentionNode;
+  return node instanceof ComposerMentionNode
 }
 
 function nodeTextLength(node: LexicalNode): number {
-  if (isMentionNode(node)) return node.getTextContent().length;
-  if ($isTextNode(node)) return node.getTextContentSize();
-  if ($isLineBreakNode(node)) return 1;
+  if (isMentionNode(node)) return node.getTextContent().length
+  if ($isTextNode(node)) return node.getTextContentSize()
+  if ($isLineBreakNode(node)) return 1
   if ($isElementNode(node)) {
-    return node.getChildren().reduce((sum, child) => sum + nodeTextLength(child), 0);
+    return node
+      .getChildren()
+      .reduce((sum, child) => sum + nodeTextLength(child), 0)
   }
-  return 0;
+  return 0
 }
 
 function $rootTextLength(): number {
-  return nodeTextLength($getRoot());
+  return nodeTextLength($getRoot())
 }
 
 /**
@@ -158,204 +191,248 @@ function $rootTextLength(): number {
  * plus a local offset; the prompt is a flat string, so the two have to be
  * reconciled by walking the tree in document order.
  */
-function offsetOfPoint(root: LexicalNode, key: NodeKey, localOffset: number): number | null {
-  let offset = 0;
-  let found: number | null = null;
+function offsetOfPoint(
+  root: LexicalNode,
+  key: NodeKey,
+  localOffset: number
+): number | null {
+  let offset = 0
+  let found: number | null = null
 
   const walk = (node: LexicalNode): boolean => {
     if (node.getKey() === key) {
       if ($isTextNode(node)) {
-        found = offset + Math.min(localOffset, node.getTextContentSize());
-        return true;
+        found = offset + Math.min(localOffset, node.getTextContentSize())
+        return true
       }
       if ($isElementNode(node)) {
         // An element point addresses a gap between children, so consume every
         // child that sits before it.
-        const children = node.getChildren();
-        let elementOffset = offset;
-        for (let index = 0; index < Math.min(localOffset, children.length); index += 1) {
-          elementOffset += nodeTextLength(children[index] as LexicalNode);
+        const children = node.getChildren()
+        let elementOffset = offset
+        for (
+          let index = 0;
+          index < Math.min(localOffset, children.length);
+          index += 1
+        ) {
+          elementOffset += nodeTextLength(children[index] as LexicalNode)
         }
-        found = elementOffset;
-        return true;
+        found = elementOffset
+        return true
       }
-      found = offset + (localOffset > 0 ? nodeTextLength(node) : 0);
-      return true;
+      found = offset + (localOffset > 0 ? nodeTextLength(node) : 0)
+      return true
     }
 
     if ($isElementNode(node)) {
       for (const child of node.getChildren()) {
-        if (walk(child)) return true;
+        if (walk(child)) return true
       }
-      return false;
+      return false
     }
 
-    offset += nodeTextLength(node);
-    return false;
-  };
+    offset += nodeTextLength(node)
+    return false
+  }
 
-  walk(root);
-  return found;
+  walk(root)
+  return found
 }
 
 interface SelectionPoint {
-  key: NodeKey;
-  offset: number;
-  type: "text" | "element";
+  key: NodeKey
+  offset: number
+  type: "text" | "element"
 }
 
-function findPointAtOffset(node: LexicalNode, remaining: { value: number }): SelectionPoint | null {
+function findPointAtOffset(
+  node: LexicalNode,
+  remaining: { value: number }
+): SelectionPoint | null {
   if (isMentionNode(node)) {
-    const size = nodeTextLength(node);
-    const parent = node.getParent();
-    if (!parent) return null;
-    const index = node.getIndexWithinParent();
+    const size = nodeTextLength(node)
+    const parent = node.getParent()
+    if (!parent) return null
+    const index = node.getIndexWithinParent()
     // A chip is atomic: the caret may sit before or after it, never inside.
-    if (remaining.value === 0) return { key: parent.getKey(), offset: index, type: "element" };
+    if (remaining.value === 0)
+      return { key: parent.getKey(), offset: index, type: "element" }
     if (remaining.value <= size) {
-      remaining.value = 0;
-      return { key: parent.getKey(), offset: index + 1, type: "element" };
+      remaining.value = 0
+      return { key: parent.getKey(), offset: index + 1, type: "element" }
     }
-    remaining.value -= size;
-    return null;
+    remaining.value -= size
+    return null
   }
 
   if ($isTextNode(node)) {
-    const size = node.getTextContentSize();
-    if (remaining.value <= size) return { key: node.getKey(), offset: remaining.value, type: "text" };
-    remaining.value -= size;
-    return null;
+    const size = node.getTextContentSize()
+    if (remaining.value <= size)
+      return { key: node.getKey(), offset: remaining.value, type: "text" }
+    remaining.value -= size
+    return null
   }
 
   if ($isLineBreakNode(node)) {
-    const parent = node.getParent();
-    if (!parent) return null;
-    const index = node.getIndexWithinParent();
-    if (remaining.value === 0) return { key: parent.getKey(), offset: index, type: "element" };
+    const parent = node.getParent()
+    if (!parent) return null
+    const index = node.getIndexWithinParent()
+    if (remaining.value === 0)
+      return { key: parent.getKey(), offset: index, type: "element" }
     if (remaining.value === 1) {
-      remaining.value = 0;
-      return { key: parent.getKey(), offset: index + 1, type: "element" };
+      remaining.value = 0
+      return { key: parent.getKey(), offset: index + 1, type: "element" }
     }
-    remaining.value -= 1;
-    return null;
+    remaining.value -= 1
+    return null
   }
 
   if ($isElementNode(node)) {
-    const children = node.getChildren();
+    const children = node.getChildren()
     for (const child of children) {
-      const point = findPointAtOffset(child, remaining);
-      if (point) return point;
+      const point = findPointAtOffset(child, remaining)
+      if (point) return point
     }
     if (remaining.value === 0) {
-      return { key: node.getKey(), offset: children.length, type: "element" };
+      return { key: node.getKey(), offset: children.length, type: "element" }
     }
   }
 
-  return null;
+  return null
 }
 
 function $setSelectionAtOffset(nextOffset: number): void {
-  const root = $getRoot();
-  const bounded = Math.max(0, Math.min(nextOffset, $rootTextLength()));
+  const root = $getRoot()
+  const bounded = Math.max(0, Math.min(nextOffset, $rootTextLength()))
   const point = findPointAtOffset(root, { value: bounded }) ?? {
     key: root.getKey(),
     offset: root.getChildren().length,
     type: "element" as const,
-  };
-  const selection = $createRangeSelection();
-  selection.anchor.set(point.key, point.offset, point.type);
-  selection.focus.set(point.key, point.offset, point.type);
-  $setSelection(selection);
+  }
+  const selection = $createRangeSelection()
+  selection.anchor.set(point.key, point.offset, point.type)
+  selection.focus.set(point.key, point.offset, point.type)
+  $setSelection(selection)
 }
 
 function $readSelectionOffset(fallback: number): number {
-  const selection = $getSelection();
-  if (!$isRangeSelection(selection)) return fallback;
-  const offset = offsetOfPoint($getRoot(), selection.anchor.key, selection.anchor.offset);
-  return offset ?? fallback;
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection)) return fallback
+  const offset = offsetOfPoint(
+    $getRoot(),
+    selection.anchor.key,
+    selection.anchor.offset
+  )
+  return offset ?? fallback
 }
 
-function $appendTextWithLineBreaks(parent: ReturnType<typeof $createParagraphNode>, text: string) {
-  const lines = text.split("\n");
+function $appendTextWithLineBreaks(
+  parent: ReturnType<typeof $createParagraphNode>,
+  text: string
+) {
+  const lines = text.split("\n")
   lines.forEach((line, index) => {
-    if (index > 0) parent.append($createLineBreakNode());
-    if (line) parent.append($createTextNode(line));
-  });
+    if (index > 0) parent.append($createLineBreakNode())
+    if (line) parent.append($createTextNode(line))
+  })
 }
 
 /** Rewrites the editor to match `value`, turning every mention it contains into a chip. */
 function $setComposerPrompt(value: string): void {
-  const root = $getRoot();
-  root.clear();
-  const paragraph = $createParagraphNode();
+  const root = $getRoot()
+  root.clear()
+  const paragraph = $createParagraphNode()
   for (const segment of splitPromptIntoSegments(value)) {
     if (segment.type === "text") {
-      $appendTextWithLineBreaks(paragraph, segment.text);
+      $appendTextWithLineBreaks(paragraph, segment.text)
     } else {
-      paragraph.append($createComposerMentionNode(segment.path, segment.source));
+      paragraph.append($createComposerMentionNode(segment.path, segment.source))
     }
   }
-  root.append(paragraph);
+  root.append(paragraph)
 }
 
 function CommandKeyPlugin({
   onCommandKeyDown,
 }: {
-  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean;
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean
 }) {
-  const handlerRef = useRef(onCommandKeyDown);
+  const handlerRef = useRef(onCommandKeyDown)
   useEffect(() => {
-    handlerRef.current = onCommandKeyDown;
-  }, [onCommandKeyDown]);
+    handlerRef.current = onCommandKeyDown
+  }, [onCommandKeyDown])
 
-  const [editor] = useLexicalComposerContext();
+  const [editor] = useLexicalComposerContext()
 
   useEffect(() => {
-    const handle = (key: ComposerCommandKey, event: KeyboardEvent | null): boolean => {
-      const handler = handlerRef.current;
-      if (!handler || !event) return false;
+    const handle = (
+      key: ComposerCommandKey,
+      event: KeyboardEvent | null
+    ): boolean => {
+      const handler = handlerRef.current
+      if (!handler || !event) return false
       // An IME composition ends on Enter; swallowing it here keeps the
       // composition from being submitted as a message.
       if (key === "Enter" && (event.isComposing || event.keyCode === 229)) {
-        event.stopPropagation();
-        return true;
+        event.stopPropagation()
+        return true
       }
-      const handled = handler(key, event);
+      const handled = handler(key, event)
       if (handled) {
-        event.preventDefault();
-        event.stopPropagation();
+        event.preventDefault()
+        event.stopPropagation()
       }
-      return handled;
-    };
+      return handled
+    }
 
     const unregister = [
-      editor.registerCommand(KEY_ARROW_DOWN_COMMAND, (e) => handle("ArrowDown", e), COMMAND_PRIORITY_HIGH),
-      editor.registerCommand(KEY_ARROW_UP_COMMAND, (e) => handle("ArrowUp", e), COMMAND_PRIORITY_HIGH),
-      editor.registerCommand(KEY_ENTER_COMMAND, (e) => handle("Enter", e), COMMAND_PRIORITY_HIGH),
-      editor.registerCommand(KEY_TAB_COMMAND, (e) => handle("Tab", e), COMMAND_PRIORITY_HIGH),
-      editor.registerCommand(KEY_ESCAPE_COMMAND, (e) => handle("Escape", e), COMMAND_PRIORITY_HIGH),
-    ];
-    return () => unregister.forEach((fn) => fn());
-  }, [editor]);
+      editor.registerCommand(
+        KEY_ARROW_DOWN_COMMAND,
+        (e) => handle("ArrowDown", e),
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        KEY_ARROW_UP_COMMAND,
+        (e) => handle("ArrowUp", e),
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        KEY_ENTER_COMMAND,
+        (e) => handle("Enter", e),
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        KEY_TAB_COMMAND,
+        (e) => handle("Tab", e),
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        KEY_ESCAPE_COMMAND,
+        (e) => handle("Escape", e),
+        COMMAND_PRIORITY_HIGH
+      ),
+    ]
+    return () => unregister.forEach((fn) => fn())
+  }, [editor])
 
-  return null;
+  return null
 }
 
 interface ComposerPromptEditorProps {
-  value: string;
+  value: string
   /**
    * Where to put the caret after a programmatic `value` change (inserting a
    * mention, clearing a slash command). Ignored while the user types, so it
    * never fights the caret the browser already placed.
    */
-  cursor?: number;
-  disabled?: boolean;
-  placeholder: string;
-  className?: string;
-  editorRef: React.RefObject<ComposerPromptEditorHandle | null>;
-  onChange: (value: string, cursor: number) => void;
-  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean;
-  onPaste?: React.ClipboardEventHandler<HTMLElement>;
+  cursor?: number
+  disabled?: boolean
+  placeholder: string
+  className?: string
+  editorRef: React.RefObject<ComposerPromptEditorHandle | null>
+  onChange: (value: string, cursor: number) => void
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean
+  onPaste?: React.ClipboardEventHandler<HTMLElement>
 }
 
 function ComposerPromptEditorInner({
@@ -369,59 +446,65 @@ function ComposerPromptEditorInner({
   onCommandKeyDown,
   onPaste,
 }: ComposerPromptEditorProps) {
-  const [editor] = useLexicalComposerContext();
-  const onChangeRef = useRef(onChange);
-  const snapshotRef = useRef({ value, cursor: value.length });
+  const [editor] = useLexicalComposerContext()
+  const onChangeRef = useRef(onChange)
+  const snapshotRef = useRef({ value, cursor: value.length })
   // Set while a controlled `value` change is being written into the editor, so
   // the resulting OnChange doesn't echo back to the parent as a user edit.
-  const applyingControlledUpdateRef = useRef(false);
+  const applyingControlledUpdateRef = useRef(false)
 
   useEffect(() => {
-    onChangeRef.current = onChange;
-  }, [onChange]);
+    onChangeRef.current = onChange
+  }, [onChange])
 
   useEffect(() => {
-    editor.setEditable(!disabled);
-  }, [disabled, editor]);
+    editor.setEditable(!disabled)
+  }, [disabled, editor])
 
   useLayoutEffect(() => {
-    if (snapshotRef.current.value === value) return;
-    const nextCursor = Math.max(0, Math.min(cursor ?? value.length, value.length));
-    snapshotRef.current = { value, cursor: nextCursor };
-    applyingControlledUpdateRef.current = true;
+    if (snapshotRef.current.value === value) return
+    const nextCursor = Math.max(
+      0,
+      Math.min(cursor ?? value.length, value.length)
+    )
+    snapshotRef.current = { value, cursor: nextCursor }
+    applyingControlledUpdateRef.current = true
     editor.update(() => {
-      $setComposerPrompt(value);
-      $setSelectionAtOffset(nextCursor);
-    });
+      $setComposerPrompt(value)
+      $setSelectionAtOffset(nextCursor)
+    })
     queueMicrotask(() => {
-      applyingControlledUpdateRef.current = false;
-    });
-  }, [cursor, editor, value]);
+      applyingControlledUpdateRef.current = false
+    })
+  }, [cursor, editor, value])
 
   const readSnapshot = useCallback(() => {
-    let snapshot = snapshotRef.current;
+    let snapshot = snapshotRef.current
     editor.getEditorState().read(() => {
-      const nextValue = $getRoot().getTextContent();
+      const nextValue = $getRoot().getTextContent()
       snapshot = {
         value: nextValue,
-        cursor: Math.min($readSelectionOffset(snapshotRef.current.cursor), nextValue.length),
-      };
-    });
-    snapshotRef.current = snapshot;
-    return snapshot;
-  }, [editor]);
+        cursor: Math.min(
+          $readSelectionOffset(snapshotRef.current.cursor),
+          nextValue.length
+        ),
+      }
+    })
+    snapshotRef.current = snapshot
+    return snapshot
+  }, [editor])
 
   const focusAt = useCallback(
     (cursor: number) => {
-      const rootElement = editor.getRootElement();
-      if (!rootElement) return;
-      rootElement.focus({ preventScroll: true });
+      const rootElement = editor.getRootElement()
+      if (!rootElement) return
+      rootElement.focus({ preventScroll: true })
       editor.update(() => {
-        $setSelectionAtOffset(cursor);
-      });
+        $setSelectionAtOffset(cursor)
+      })
     },
-    [editor],
-  );
+    [editor]
+  )
 
   useImperativeHandle(
     editorRef,
@@ -430,23 +513,23 @@ function ComposerPromptEditorInner({
       focusAtEnd: () => focusAt(snapshotRef.current.value.length),
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
-  );
+    [focusAt, readSnapshot]
+  )
 
   const handleEditorChange = useCallback((editorState: EditorState) => {
     editorState.read(() => {
-      const nextValue = $getRoot().getTextContent();
+      const nextValue = $getRoot().getTextContent()
       const nextCursor = Math.min(
         $readSelectionOffset(snapshotRef.current.cursor),
-        nextValue.length,
-      );
-      const previous = snapshotRef.current;
-      if (previous.value === nextValue && previous.cursor === nextCursor) return;
-      snapshotRef.current = { value: nextValue, cursor: nextCursor };
-      if (applyingControlledUpdateRef.current) return;
-      onChangeRef.current(nextValue, nextCursor);
-    });
-  }, []);
+        nextValue.length
+      )
+      const previous = snapshotRef.current
+      if (previous.value === nextValue && previous.cursor === nextCursor) return
+      snapshotRef.current = { value: nextValue, cursor: nextCursor }
+      if (applyingControlledUpdateRef.current) return
+      onChangeRef.current(nextValue, nextCursor)
+    })
+  }, [])
 
   return (
     <div className="relative">
@@ -457,8 +540,8 @@ function ComposerPromptEditorInner({
             aria-label="Message"
             aria-placeholder={placeholder}
             className={cn(
-              "block max-h-50 w-full overflow-y-auto break-words whitespace-pre-wrap bg-transparent text-[13px] leading-relaxed text-foreground focus:outline-none",
-              className,
+              "block max-h-50 w-full overflow-y-auto bg-transparent text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground focus:outline-none",
+              className
             )}
             data-testid="composer-editor"
             onPaste={onPaste}
@@ -475,34 +558,34 @@ function ComposerPromptEditorInner({
       <CommandKeyPlugin {...(onCommandKeyDown ? { onCommandKeyDown } : {})} />
       <HistoryPlugin />
     </div>
-  );
+  )
 }
 
 export function ComposerPromptEditor(props: ComposerPromptEditorProps) {
-  const initialValueRef = useRef(props.value);
+  const initialValueRef = useRef(props.value)
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "open-swe-composer",
       editable: true,
       nodes: [ComposerMentionNode],
       editorState: () => {
-        $setComposerPrompt(initialValueRef.current);
+        $setComposerPrompt(initialValueRef.current)
       },
       onError: (error: Error) => {
-        throw error;
+        throw error
       },
     }),
-    [],
-  );
+    []
+  )
 
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <ComposerPromptEditorInner {...props} />
     </LexicalComposer>
-  );
+  )
 }
 
 /** Builds the text a mention insertion replaces the trigger with (chip source + trailing space). */
 export function mentionReplacementText(path: string): string {
-  return `${serializeComposerFileLink(path)} `;
+  return `${serializeComposerFileLink(path)} `
 }

--- a/ui/src/features/agents/components/composer/ContextWindowMeter.test.tsx
+++ b/ui/src/features/agents/components/composer/ContextWindowMeter.test.tsx
@@ -1,6 +1,12 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
 import { afterEach, describe, expect, it } from "vitest"
 
 import { ContextWindowMeter } from "./ContextWindowMeter"
@@ -9,7 +15,9 @@ afterEach(() => cleanup())
 
 /** The numbers live in a popover, so the collapsed ring carries the accessible label. */
 function meterLabel() {
-  return screen.getByTestId("context-window-indicator").getAttribute("aria-label")
+  return screen
+    .getByTestId("context-window-indicator")
+    .getAttribute("aria-label")
 }
 
 describe("ContextWindowMeter", () => {

--- a/ui/src/features/agents/components/composer/ContextWindowMeter.tsx
+++ b/ui/src/features/agents/components/composer/ContextWindowMeter.tsx
@@ -1,23 +1,27 @@
-import { Popover, PopoverPopup, PopoverTrigger } from "@/components/ui/popover";
-import { formatTokenCount } from "@/features/agents/lib/contextUsage";
-import { cn } from "@/lib/utils";
+import { Popover, PopoverPopup, PopoverTrigger } from "@/components/ui/popover"
+import { formatTokenCount } from "@/features/agents/lib/contextUsage"
+import { cn } from "@/lib/utils"
 
 export interface ContextWindowMeterProps {
-  usedTokens?: number | null;
-  contextWindow?: number | null;
-  hasMessages?: boolean;
+  usedTokens?: number | null
+  contextWindow?: number | null
+  hasMessages?: boolean
 }
 
-const RADIUS = 9.75;
-const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
-const OVERLOADED_PERCENTAGE = 90;
+const RADIUS = 9.75
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+const OVERLOADED_PERCENTAGE = 90
 
 function cleanTokenCount(value: number | null | undefined): number | null {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null
 }
 
 function formatPercentage(value: number): string {
-  return value < 10 ? `${value.toFixed(1).replace(/\.0$/, "")}%` : `${Math.round(value)}%`;
+  return value < 10
+    ? `${value.toFixed(1).replace(/\.0$/, "")}%`
+    : `${Math.round(value)}%`
 }
 
 /** Ring gauge for context usage; the detail panel opens on hover. */
@@ -26,20 +30,22 @@ export function ContextWindowMeter({
   contextWindow,
   hasMessages = false,
 }: ContextWindowMeterProps) {
-  const used = cleanTokenCount(usedTokens);
-  const limit = cleanTokenCount(contextWindow);
-  if (used == null && limit == null) return null;
+  const used = cleanTokenCount(usedTokens)
+  const limit = cleanTokenCount(contextWindow)
+  if (used == null && limit == null) return null
 
   const percentage =
-    used != null && limit != null ? Math.max(0, Math.min(100, (used / limit) * 100)) : 0;
-  const hasPercentage = used != null && limit != null;
-  const isOverloaded = hasPercentage && percentage >= OVERLOADED_PERCENTAGE;
+    used != null && limit != null
+      ? Math.max(0, Math.min(100, (used / limit) * 100))
+      : 0
+  const hasPercentage = used != null && limit != null
+  const isOverloaded = hasPercentage && percentage >= OVERLOADED_PERCENTAGE
   const usageColor = isOverloaded
     ? "var(--color-destructive)"
-    : "color-mix(in oklab, var(--color-muted-foreground) 72%, transparent)";
+    : "color-mix(in oklab, var(--color-muted-foreground) 72%, transparent)"
   const label = hasPercentage
     ? `Context window ${formatPercentage(percentage)} used`
-    : `Context window ${formatTokenCount(used ?? limit ?? 0)} tokens`;
+    : `Context window ${formatTokenCount(used ?? limit ?? 0)} tokens`
 
   return (
     <Popover>
@@ -51,9 +57,9 @@ export function ContextWindowMeter({
           <button
             aria-label={label}
             className={cn(
-              "inline-flex size-7 cursor-pointer items-center justify-center rounded-full border border-transparent text-muted-foreground outline-none transition-colors",
+              "inline-flex size-7 cursor-pointer items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors outline-none",
               "hover:bg-accent data-[pressed]:bg-accent",
-              "focus-visible:ring-2 focus-visible:ring-ring",
+              "focus-visible:ring-2 focus-visible:ring-ring"
             )}
             data-testid="context-window-indicator"
             type="button"
@@ -92,11 +98,18 @@ export function ContextWindowMeter({
           </button>
         }
       />
-      <PopoverPopup align="end" className="w-64 max-w-none text-left whitespace-normal" side="top" tooltipStyle>
+      <PopoverPopup
+        align="end"
+        className="w-64 max-w-none text-left whitespace-normal"
+        side="top"
+        tooltipStyle
+      >
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between gap-3">
-            <div className="text-xs font-medium text-muted-foreground">Context window</div>
-            <div className="text-[11px] tabular-nums text-muted-foreground/70">
+            <div className="text-xs font-medium text-muted-foreground">
+              Context window
+            </div>
+            <div className="text-[11px] text-muted-foreground/70 tabular-nums">
               {hasPercentage ? (
                 <>
                   <span>{formatPercentage(percentage)}</span>
@@ -136,11 +149,12 @@ export function ContextWindowMeter({
           )}
           {isOverloaded && (
             <p className="text-[11px] leading-4 font-medium text-destructive">
-              Approaching the context limit — start a new thread if replies degrade.
+              Approaching the context limit — start a new thread if replies
+              degrade.
             </p>
           )}
         </div>
       </PopoverPopup>
     </Popover>
-  );
+  )
 }

--- a/ui/src/features/agents/components/composer/composerMentions.ts
+++ b/ui/src/features/agents/components/composer/composerMentions.ts
@@ -5,88 +5,109 @@
  * typed by hand.
  */
 
-import { basenameOfPath } from "./composerTrigger";
+import { basenameOfPath } from "./composerTrigger"
 
 export interface ComposerMentionToken {
-  readonly path: string;
+  readonly path: string
   /** The exact source text, so replacing a chip round-trips to what was typed. */
-  readonly source: string;
-  readonly start: number;
-  readonly end: number;
+  readonly source: string
+  readonly start: number
+  readonly end: number
 }
 
 export type ComposerPromptSegment =
   | { type: "text"; text: string }
-  | { type: "mention"; path: string; source: string };
+  | { type: "mention"; path: string; source: string }
 
 // Both require a boundary on each side: a mention is a whole token, never a
 // fragment of a longer word or of an inline code span.
-const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s|$)/g;
-const FILE_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s|$)/g;
-const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
-const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s|$)/g
+const FILE_LINK_TOKEN_REGEX =
+  /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s|$)/g
+const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/
+const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/
 
 function collectFileLinkTokens(text: string): Array<ComposerMentionToken> {
-  const tokens: Array<ComposerMentionToken> = [];
+  const tokens: Array<ComposerMentionToken> = []
 
   for (const match of text.matchAll(FILE_LINK_TOKEN_REGEX)) {
-    const prefix = match[1] ?? "";
-    const label = (match[2] ?? "").replace(/\\(.)/g, "$1");
-    const encodedPath = match[3] ?? "";
-    let path = encodedPath;
+    const prefix = match[1] ?? ""
+    const label = (match[2] ?? "").replace(/\\(.)/g, "$1")
+    const encodedPath = match[3] ?? ""
+    let path = encodedPath
     try {
-      path = decodeURIComponent(encodedPath);
+      path = decodeURIComponent(encodedPath)
     } catch {
       // Keep the malformed source rather than dropping a user-authored link.
     }
-    const hasExternalScheme = URI_SCHEME_REGEX.test(path) && !WINDOWS_DRIVE_PATH_REGEX.test(path);
+    const hasExternalScheme =
+      URI_SCHEME_REGEX.test(path) && !WINDOWS_DRIVE_PATH_REGEX.test(path)
     // Only links this composer could have written become chips; an ordinary
     // markdown link to a doc or a URL stays plain text.
-    if (!path || hasExternalScheme || label !== basenameOfPath(path)) continue;
+    if (!path || hasExternalScheme || label !== basenameOfPath(path)) continue
 
-    const start = match.index + prefix.length;
-    tokens.push({ path, source: text.slice(start, start + match[0].length - prefix.length), start, end: start + match[0].length - prefix.length });
+    const start = match.index + prefix.length
+    tokens.push({
+      path,
+      source: text.slice(start, start + match[0].length - prefix.length),
+      start,
+      end: start + match[0].length - prefix.length,
+    })
   }
 
-  return tokens;
+  return tokens
 }
 
 function collectAtTokens(text: string): Array<ComposerMentionToken> {
-  const tokens: Array<ComposerMentionToken> = [];
+  const tokens: Array<ComposerMentionToken> = []
 
   for (const match of text.matchAll(MENTION_TOKEN_REGEX)) {
-    const prefix = match[1] ?? "";
-    const quotedPath = match[2];
-    const path = quotedPath !== undefined ? quotedPath.replace(/\\(.)/g, "$1") : (match[3] ?? "");
-    if (!path) continue;
+    const prefix = match[1] ?? ""
+    const quotedPath = match[2]
+    const path =
+      quotedPath !== undefined
+        ? quotedPath.replace(/\\(.)/g, "$1")
+        : (match[3] ?? "")
+    if (!path) continue
 
-    const start = match.index + prefix.length;
-    tokens.push({ path, source: text.slice(start, start + match[0].length - prefix.length), start, end: start + match[0].length - prefix.length });
+    const start = match.index + prefix.length
+    tokens.push({
+      path,
+      source: text.slice(start, start + match[0].length - prefix.length),
+      start,
+      end: start + match[0].length - prefix.length,
+    })
   }
 
-  return tokens;
+  return tokens
 }
 
-export function collectComposerMentions(text: string): Array<ComposerMentionToken> {
+export function collectComposerMentions(
+  text: string
+): Array<ComposerMentionToken> {
   return [...collectFileLinkTokens(text), ...collectAtTokens(text)].sort(
-    (left, right) => left.start - right.start,
-  );
+    (left, right) => left.start - right.start
+  )
 }
 
 /** Splits a prompt into the alternating runs of plain text and mentions the editor renders. */
-export function splitPromptIntoSegments(prompt: string): Array<ComposerPromptSegment> {
-  if (!prompt) return [];
+export function splitPromptIntoSegments(
+  prompt: string
+): Array<ComposerPromptSegment> {
+  if (!prompt) return []
 
-  const segments: Array<ComposerPromptSegment> = [];
-  let cursor = 0;
+  const segments: Array<ComposerPromptSegment> = []
+  let cursor = 0
 
   for (const token of collectComposerMentions(prompt)) {
-    if (token.start < cursor) continue;
-    if (token.start > cursor) segments.push({ type: "text", text: prompt.slice(cursor, token.start) });
-    segments.push({ type: "mention", path: token.path, source: token.source });
-    cursor = token.end;
+    if (token.start < cursor) continue
+    if (token.start > cursor)
+      segments.push({ type: "text", text: prompt.slice(cursor, token.start) })
+    segments.push({ type: "mention", path: token.path, source: token.source })
+    cursor = token.end
   }
 
-  if (cursor < prompt.length) segments.push({ type: "text", text: prompt.slice(cursor) });
-  return segments;
+  if (cursor < prompt.length)
+    segments.push({ type: "text", text: prompt.slice(cursor) })
+  return segments
 }

--- a/ui/src/features/agents/components/composer/composerTrigger.test.ts
+++ b/ui/src/features/agents/components/composer/composerTrigger.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 
-import { collectComposerMentions, splitPromptIntoSegments } from "./composerMentions";
+import {
+  collectComposerMentions,
+  splitPromptIntoSegments,
+} from "./composerMentions"
 import {
   detectComposerTrigger,
   replaceTextRange,
   serializeComposerFileLink,
-} from "./composerTrigger";
+} from "./composerTrigger"
 
 describe("detectComposerTrigger", () => {
   it("opens the file menu on a bare @ and tracks the query", () => {
@@ -14,16 +17,16 @@ describe("detectComposerTrigger", () => {
       query: "",
       rangeStart: 8,
       rangeEnd: 9,
-    });
+    })
     expect(detectComposerTrigger("look at @src/app", 16)).toMatchObject({
       kind: "path",
       query: "src/app",
-    });
-  });
+    })
+  })
 
   it("ignores an @ that is part of a longer token", () => {
-    expect(detectComposerTrigger("mail me@example.com", 19)).toBeNull();
-  });
+    expect(detectComposerTrigger("mail me@example.com", 19)).toBeNull()
+  })
 
   it("treats a whitespace-delimited slash token as a command anywhere", () => {
     expect(detectComposerTrigger("/pl", 3)).toEqual({
@@ -31,65 +34,77 @@ describe("detectComposerTrigger", () => {
       query: "pl",
       rangeStart: 0,
       rangeEnd: 3,
-    });
+    })
     expect(detectComposerTrigger("fix with /review-pr please", 19)).toEqual({
       kind: "slash-command",
       query: "review-pr",
       rangeStart: 9,
       rangeEnd: 19,
-    });
-    expect(detectComposerTrigger("see src/a/b", 11)).toBeNull();
-  });
+    })
+    expect(detectComposerTrigger("see src/a/b", 11)).toBeNull()
+  })
 
   it("closes the trigger once the cursor moves off the token", () => {
-    expect(detectComposerTrigger("@src/app.tsx done", 17)).toBeNull();
-  });
+    expect(detectComposerTrigger("@src/app.tsx done", 17)).toBeNull()
+  })
 
   it("clamps an out-of-range cursor instead of reading past the text", () => {
-    expect(detectComposerTrigger("@app", 999)).toMatchObject({ query: "app" });
-    expect(detectComposerTrigger("@app", -5)).toBeNull();
-  });
-});
+    expect(detectComposerTrigger("@app", 999)).toMatchObject({ query: "app" })
+    expect(detectComposerTrigger("@app", -5)).toBeNull()
+  })
+})
 
 describe("replaceTextRange", () => {
   it("splices the replacement in and reports the cursor after it", () => {
-    expect(replaceTextRange("look at @src", 8, 12, "[a.tsx](src/a.tsx) ")).toEqual({
+    expect(
+      replaceTextRange("look at @src", 8, 12, "[a.tsx](src/a.tsx) ")
+    ).toEqual({
       text: "look at [a.tsx](src/a.tsx) ",
       cursor: 27,
-    });
-  });
-});
+    })
+  })
+})
 
 describe("serializeComposerFileLink", () => {
   it("labels with the basename and encodes the path", () => {
-    expect(serializeComposerFileLink("ui/src/app.tsx")).toBe("[app.tsx](ui/src/app.tsx)");
+    expect(serializeComposerFileLink("ui/src/app.tsx")).toBe(
+      "[app.tsx](ui/src/app.tsx)"
+    )
     expect(serializeComposerFileLink("ui/my file (1).tsx")).toBe(
-      "[my file (1).tsx](ui/my%20file%20%281%29.tsx)",
-    );
-  });
-});
+      "[my file (1).tsx](ui/my%20file%20%281%29.tsx)"
+    )
+  })
+})
 
 describe("collectComposerMentions", () => {
   it("recognises both markdown links and bare @paths, in document order", () => {
-    const mentions = collectComposerMentions("see [a.tsx](src/a.tsx) and @src/b.ts too");
-    expect(mentions.map((m) => m.path)).toEqual(["src/a.tsx", "src/b.ts"]);
-  });
+    const mentions = collectComposerMentions(
+      "see [a.tsx](src/a.tsx) and @src/b.ts too"
+    )
+    expect(mentions.map((m) => m.path)).toEqual(["src/a.tsx", "src/b.ts"])
+  })
 
   it("leaves ordinary links and external URLs alone", () => {
-    expect(collectComposerMentions("read [the docs](src/a.tsx)")).toEqual([]);
-    expect(collectComposerMentions("[example.com](https://example.com)")).toEqual([]);
-  });
+    expect(collectComposerMentions("read [the docs](src/a.tsx)")).toEqual([])
+    expect(
+      collectComposerMentions("[example.com](https://example.com)")
+    ).toEqual([])
+  })
 
   it("round-trips a mention through segments", () => {
-    const prompt = "fix [app.tsx](ui/src/app.tsx) please";
-    const segments = splitPromptIntoSegments(prompt);
+    const prompt = "fix [app.tsx](ui/src/app.tsx) please"
+    const segments = splitPromptIntoSegments(prompt)
     expect(segments).toEqual([
       { type: "text", text: "fix " },
-      { type: "mention", path: "ui/src/app.tsx", source: "[app.tsx](ui/src/app.tsx)" },
+      {
+        type: "mention",
+        path: "ui/src/app.tsx",
+        source: "[app.tsx](ui/src/app.tsx)",
+      },
       { type: "text", text: " please" },
-    ]);
+    ])
     expect(
-      segments.map((s) => (s.type === "text" ? s.text : s.source)).join(""),
-    ).toBe(prompt);
-  });
-});
+      segments.map((s) => (s.type === "text" ? s.text : s.source)).join("")
+    ).toBe(prompt)
+  })
+})

--- a/ui/src/features/agents/components/composer/composerTrigger.ts
+++ b/ui/src/features/agents/components/composer/composerTrigger.ts
@@ -5,38 +5,41 @@
  * text plus a cursor offset rather than on editor nodes.
  */
 
-export type ComposerTriggerKind = "path" | "slash-command";
+export type ComposerTriggerKind = "path" | "slash-command"
 
 /** Slash commands open-swe understands. `model` opens the picker rather than editing the prompt. */
-export type ComposerSlashCommand = "plan" | "default" | "model";
+export type ComposerSlashCommand = "plan" | "default" | "model"
 
 export interface ComposerTrigger {
-  kind: ComposerTriggerKind;
-  query: string;
-  rangeStart: number;
-  rangeEnd: number;
+  kind: ComposerTriggerKind
+  query: string
+  rangeStart: number
+  rangeEnd: number
 }
 
 /**
  * Drag payload for dropping a repo path onto the composer. A private type, not
  * `text/plain`, so dragging arbitrary prose in never becomes a file mention.
  */
-export const COMPOSER_PATH_DRAG_MIME = "application/x-open-swe-path";
+export const COMPOSER_PATH_DRAG_MIME = "application/x-open-swe-path"
 
-const SIMPLE_MENTION_PATH_REGEX = /^[^\s@"\\]+$/;
+const SIMPLE_MENTION_PATH_REGEX = /^[^\s@"\\]+$/
 
 export function serializeComposerMentionPath(path: string): string {
-  if (SIMPLE_MENTION_PATH_REGEX.test(path)) return path;
-  return `"${path.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+  if (SIMPLE_MENTION_PATH_REGEX.test(path)) return path
+  return `"${path.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
 }
 
 export function basenameOfPath(path: string): string {
-  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-  return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
+  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"))
+  return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path
 }
 
 function escapeMarkdownLinkLabel(label: string): string {
-  return label.replaceAll("\\", "\\\\").replaceAll("[", "\\[").replaceAll("]", "\\]");
+  return label
+    .replaceAll("\\", "\\\\")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
 }
 
 function encodeMarkdownLinkDestination(path: string): string {
@@ -45,7 +48,7 @@ function encodeMarkdownLinkDestination(path: string): string {
     .replaceAll(")", "%29")
     .replaceAll("#", "%23")
     .replaceAll("?", "%3F")
-    .replaceAll("\\", "%5C");
+    .replaceAll("\\", "%5C")
 }
 
 /**
@@ -53,44 +56,47 @@ function encodeMarkdownLinkDestination(path: string): string {
  * path even though the composer displays a compact chip.
  */
 export function serializeComposerFileLink(path: string): string {
-  return `[${escapeMarkdownLinkLabel(basenameOfPath(path))}](${encodeMarkdownLinkDestination(path)})`;
+  return `[${escapeMarkdownLinkLabel(basenameOfPath(path))}](${encodeMarkdownLinkDestination(path)})`
 }
 
 function clampCursor(text: string, cursor: number): number {
-  if (!Number.isFinite(cursor)) return text.length;
-  return Math.max(0, Math.min(text.length, Math.floor(cursor)));
+  if (!Number.isFinite(cursor)) return text.length
+  return Math.max(0, Math.min(text.length, Math.floor(cursor)))
 }
 
 function isWhitespace(char: string): boolean {
-  return char === " " || char === "\n" || char === "\t" || char === "\r";
+  return char === " " || char === "\n" || char === "\t" || char === "\r"
 }
 
-export function detectComposerTrigger(text: string, cursorInput: number): ComposerTrigger | null {
-  const cursor = clampCursor(text, cursorInput);
-  let tokenIdx = cursor - 1;
-  while (tokenIdx >= 0 && !isWhitespace(text[tokenIdx] ?? "")) tokenIdx -= 1;
-  const tokenStart = tokenIdx + 1;
-  const token = text.slice(tokenStart, cursor);
-  if (!token.startsWith("@") && !token.startsWith("/")) return null;
+export function detectComposerTrigger(
+  text: string,
+  cursorInput: number
+): ComposerTrigger | null {
+  const cursor = clampCursor(text, cursorInput)
+  let tokenIdx = cursor - 1
+  while (tokenIdx >= 0 && !isWhitespace(text[tokenIdx] ?? "")) tokenIdx -= 1
+  const tokenStart = tokenIdx + 1
+  const token = text.slice(tokenStart, cursor)
+  if (!token.startsWith("@") && !token.startsWith("/")) return null
 
   return {
     kind: token.startsWith("/") ? "slash-command" : "path",
     query: token.slice(1),
     rangeStart: tokenStart,
     rangeEnd: cursor,
-  };
+  }
 }
 
 export function replaceTextRange(
   text: string,
   rangeStart: number,
   rangeEnd: number,
-  replacement: string,
+  replacement: string
 ): { text: string; cursor: number } {
-  const safeStart = Math.max(0, Math.min(text.length, rangeStart));
-  const safeEnd = Math.max(safeStart, Math.min(text.length, rangeEnd));
+  const safeStart = Math.max(0, Math.min(text.length, rangeStart))
+  const safeEnd = Math.max(safeStart, Math.min(text.length, rangeEnd))
   return {
     text: `${text.slice(0, safeStart)}${replacement}${text.slice(safeEnd)}`,
     cursor: safeStart + replacement.length,
-  };
+  }
 }

--- a/ui/src/features/agents/components/messages/ChunkRenderer.tsx
+++ b/ui/src/features/agents/components/messages/ChunkRenderer.tsx
@@ -1,26 +1,30 @@
-import type { Chunk } from "@/features/agents/lib/types";
-import type { ApprovalCallbacks } from "./types";
-import { CodeBlock } from "@/features/agents/components/chat/CodeBlock";
-import { Markdown } from "@/features/agents/components/chat/Markdown";
-import { ToolExecution } from "@/features/agents/components/chat/ToolExecution";
+import type { Chunk } from "@/features/agents/lib/types"
+import type { ApprovalCallbacks } from "./types"
+import { CodeBlock } from "@/features/agents/components/chat/CodeBlock"
+import { Markdown } from "@/features/agents/components/chat/Markdown"
+import { ToolExecution } from "@/features/agents/components/chat/ToolExecution"
 
 export function ChunkRenderer({
   chunk,
   projectPath,
   isMarkdownLive,
   ...callbacks
-}: { chunk: Chunk; projectPath?: string; isMarkdownLive?: boolean } & ApprovalCallbacks) {
+}: {
+  chunk: Chunk
+  projectPath?: string
+  isMarkdownLive?: boolean
+} & ApprovalCallbacks) {
   switch (chunk.kind) {
     case "text":
       return (
         <div className="text-foreground">
           <Markdown content={chunk.text} isLive={isMarkdownLive} />
         </div>
-      );
+      )
     case "code":
-      return <CodeBlock text={chunk.text} language={chunk.language} />;
+      return <CodeBlock text={chunk.text} language={chunk.language} />
     case "error":
-      return <span className="text-destructive">{chunk.text}</span>;
+      return <span className="text-destructive">{chunk.text}</span>
     case "list":
       return (
         <div className="ml-2 text-muted-foreground">
@@ -28,7 +32,7 @@ export function ChunkRenderer({
             <div key={i}>- {line}</div>
           ))}
         </div>
-      );
+      )
     case "tool-execution":
       return (
         <ToolExecution
@@ -38,7 +42,7 @@ export function ChunkRenderer({
           onReject={callbacks.onReject}
           onAutoApprove={callbacks.onAutoApprove}
         />
-      );
+      )
     case "image":
       return (
         <img
@@ -46,6 +50,6 @@ export function ChunkRenderer({
           alt={chunk.fileName || "image"}
           className="max-h-48 max-w-48 rounded border border-border"
         />
-      );
+      )
   }
 }

--- a/ui/src/features/agents/components/messages/MessageTimestamp.tsx
+++ b/ui/src/features/agents/components/messages/MessageTimestamp.tsx
@@ -1,15 +1,15 @@
 type MessageTimestampProps = {
-  timestamp: string;
-  startedAt?: string;
-  align?: "left" | "right";
-  className?: string;
-};
+  timestamp: string
+  startedAt?: string
+  align?: "left" | "right"
+  className?: string
+}
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
   minute: "2-digit",
   second: "2-digit",
-});
+})
 
 const datedTimeFormatter = new Intl.DateTimeFormat(undefined, {
   month: "short",
@@ -17,17 +17,17 @@ const datedTimeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
   minute: "2-digit",
   second: "2-digit",
-});
+})
 
 const fullFormatter = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
   timeStyle: "medium",
-});
+})
 
 function parseTimestamp(value?: string | null): Date | null {
-  if (!value) return null;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 function isSameLocalDay(a: Date, b: Date): boolean {
@@ -35,13 +35,13 @@ function isSameLocalDay(a: Date, b: Date): boolean {
     a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
     a.getDate() === b.getDate()
-  );
+  )
 }
 
 function shortTimestamp(date: Date): string {
   return isSameLocalDay(date, new Date())
     ? timeFormatter.format(date)
-    : datedTimeFormatter.format(date);
+    : datedTimeFormatter.format(date)
 }
 
 export function MessageTimestamp({
@@ -50,14 +50,14 @@ export function MessageTimestamp({
   align = "left",
   className = "",
 }: MessageTimestampProps) {
-  const date = parseTimestamp(timestamp);
-  if (!date) return null;
+  const date = parseTimestamp(timestamp)
+  if (!date) return null
 
-  const startDate = parseTimestamp(startedAt);
+  const startDate = parseTimestamp(startedAt)
   const title =
     startDate && Math.abs(date.getTime() - startDate.getTime()) >= 1000
       ? `Started ${fullFormatter.format(startDate)} · Last updated ${fullFormatter.format(date)}`
-      : fullFormatter.format(date);
+      : fullFormatter.format(date)
 
   return (
     <div
@@ -66,10 +66,10 @@ export function MessageTimestamp({
       <time
         dateTime={date.toISOString()}
         title={title}
-        className="select-none text-[11px] leading-4 tabular-nums text-muted-foreground/70 opacity-0 transition-opacity duration-200 group-hover/turn:opacity-100"
+        className="text-[11px] leading-4 text-muted-foreground/70 tabular-nums opacity-0 transition-opacity duration-200 select-none group-hover/turn:opacity-100"
       >
         {shortTimestamp(date)}
       </time>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -1,49 +1,63 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown } from "lucide-react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { ChevronDown } from "lucide-react"
 
-import { AgentTurn } from "./timeline/AgentTurn";
-import { ThinkingSpinner } from "./ThinkingSpinner";
-import { UserMessage } from "./UserMessage";
-import type { MessagesProps } from "./types";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { useLiveMarkdownMessageId } from "@/features/agents/lib/provider/useLiveMarkdownMessageId";
+import { AgentTurn } from "./timeline/AgentTurn"
+import { ThinkingSpinner } from "./ThinkingSpinner"
+import { UserMessage } from "./UserMessage"
+import type { MessagesProps } from "./types"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { useLiveMarkdownMessageId } from "@/features/agents/lib/provider/useLiveMarkdownMessageId"
 
-const BOTTOM_LOCK_THRESHOLD_PX = 24;
+const BOTTOM_LOCK_THRESHOLD_PX = 24
 
 function QueuedMessages({
   queuedMessages,
 }: {
-  queuedMessages: NonNullable<MessagesProps["queuedMessages"]>;
+  queuedMessages: NonNullable<MessagesProps["queuedMessages"]>
 }) {
-  if (queuedMessages.length === 0) return null;
+  if (queuedMessages.length === 0) return null
 
   return (
     <div className="mb-3 space-y-2" data-testid="queued-messages">
       {queuedMessages.map((message, index) => {
-        const imageCount = message.images?.length ?? 0;
+        const imageCount = message.images?.length ?? 0
         return (
           <div
             key={message.id}
             className="ml-auto max-w-[85%] rounded-2xl border border-dashed border-border bg-accent/40 px-3 py-2 text-[13px] text-foreground shadow-sm"
             data-testid="queued-message"
           >
-            <div className="mb-1 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            <div className="mb-1 flex items-center gap-2 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
               <span>
-                {queuedMessages.length > 1 ? `Queued next #${index + 1}` : "Queued next"}
+                {queuedMessages.length > 1
+                  ? `Queued next #${index + 1}`
+                  : "Queued next"}
               </span>
               <span className="size-1.5 animate-status-pulse rounded-full bg-foreground/60" />
             </div>
-            {message.content && <div className="whitespace-pre-wrap break-words">{message.content}</div>}
+            {message.content && (
+              <div className="break-words whitespace-pre-wrap">
+                {message.content}
+              </div>
+            )}
             {imageCount > 0 && (
               <div className="mt-1 text-xs text-muted-foreground">
                 {imageCount} image{imageCount === 1 ? "" : "s"} attached
               </div>
             )}
           </div>
-        );
+        )
       })}
     </div>
-  );
+  )
 }
 
 export const Messages = memo(function MessagesComponent({
@@ -66,217 +80,233 @@ export const Messages = memo(function MessagesComponent({
   onAutoApprove,
   onOpenFile,
 }: MessagesProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const autoScrollEnabledRef = useRef(true);
-  const lastManualScrollTopRef = useRef(0);
-  const previousScrollTopRef = useRef(0);
-  const pendingScrollFrameRef = useRef<number | null>(null);
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const autoScrollEnabledRef = useRef(true)
+  const lastManualScrollTopRef = useRef(0)
+  const previousScrollTopRef = useRef(0)
+  const pendingScrollFrameRef = useRef<number | null>(null)
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 
   const clearScheduledScroll = useCallback(() => {
-    if (pendingScrollFrameRef.current === null) return;
-    window.cancelAnimationFrame(pendingScrollFrameRef.current);
-    pendingScrollFrameRef.current = null;
-  }, []);
+    if (pendingScrollFrameRef.current === null) return
+    window.cancelAnimationFrame(pendingScrollFrameRef.current)
+    pendingScrollFrameRef.current = null
+  }, [])
 
   const isNearBottom = useCallback((el: HTMLDivElement) => {
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    return distanceFromBottom <= BOTTOM_LOCK_THRESHOLD_PX;
-  }, []);
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    return distanceFromBottom <= BOTTOM_LOCK_THRESHOLD_PX
+  }, [])
 
-  const syncScrollButtonVisibility = useCallback((el: HTMLDivElement) => {
-    setShowScrollToBottom(!isNearBottom(el));
-  }, [isNearBottom]);
+  const syncScrollButtonVisibility = useCallback(
+    (el: HTMLDivElement) => {
+      setShowScrollToBottom(!isNearBottom(el))
+    },
+    [isNearBottom]
+  )
 
   const scrollToBottomNow = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
+    const el = scrollRef.current
+    if (!el) return
 
-    el.scrollTop = el.scrollHeight;
-    const currentTop = el.scrollTop;
-    lastManualScrollTopRef.current = currentTop;
-    previousScrollTopRef.current = currentTop;
-    syncScrollButtonVisibility(el);
-  }, [syncScrollButtonVisibility]);
+    el.scrollTop = el.scrollHeight
+    const currentTop = el.scrollTop
+    lastManualScrollTopRef.current = currentTop
+    previousScrollTopRef.current = currentTop
+    syncScrollButtonVisibility(el)
+  }, [syncScrollButtonVisibility])
 
   const scheduleScrollToBottom = useCallback(() => {
-    if (!autoScrollEnabledRef.current) return;
+    if (!autoScrollEnabledRef.current) return
 
-    clearScheduledScroll();
+    clearScheduledScroll()
     pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
-      pendingScrollFrameRef.current = null;
-      if (!autoScrollEnabledRef.current) return;
-      scrollToBottomNow();
-    });
-  }, [clearScheduledScroll, scrollToBottomNow]);
+      pendingScrollFrameRef.current = null
+      if (!autoScrollEnabledRef.current) return
+      scrollToBottomNow()
+    })
+  }, [clearScheduledScroll, scrollToBottomNow])
 
   useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
+    const el = scrollRef.current
+    if (!el) return
 
     const handleScroll = () => {
-      const currentTop = el.scrollTop;
-      const scrolledUp = currentTop < previousScrollTopRef.current - 1;
-      const nearBottom = isNearBottom(el);
+      const currentTop = el.scrollTop
+      const scrolledUp = currentTop < previousScrollTopRef.current - 1
+      const nearBottom = isNearBottom(el)
 
       if (scrolledUp) {
-        autoScrollEnabledRef.current = false;
-        clearScheduledScroll();
+        autoScrollEnabledRef.current = false
+        clearScheduledScroll()
       } else if (nearBottom) {
-        autoScrollEnabledRef.current = true;
+        autoScrollEnabledRef.current = true
       }
 
-      syncScrollButtonVisibility(el);
-      lastManualScrollTopRef.current = currentTop;
-      previousScrollTopRef.current = currentTop;
-    };
+      syncScrollButtonVisibility(el)
+      lastManualScrollTopRef.current = currentTop
+      previousScrollTopRef.current = currentTop
+    }
 
-    scrollToBottomNow();
-    autoScrollEnabledRef.current = true;
+    scrollToBottomNow()
+    autoScrollEnabledRef.current = true
 
-    el.addEventListener("scroll", handleScroll, { passive: true });
+    el.addEventListener("scroll", handleScroll, { passive: true })
     return () => {
-      el.removeEventListener("scroll", handleScroll);
-      clearScheduledScroll();
-    };
-  }, [clearScheduledScroll, isNearBottom, scrollToBottomNow, syncScrollButtonVisibility]);
+      el.removeEventListener("scroll", handleScroll)
+      clearScheduledScroll()
+    }
+  }, [
+    clearScheduledScroll,
+    isNearBottom,
+    scrollToBottomNow,
+    syncScrollButtonVisibility,
+  ])
 
   useLayoutEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
+    const el = scrollRef.current
+    if (!el) return
 
     if (autoScrollEnabledRef.current) {
-      scheduleScrollToBottom();
-      return;
+      scheduleScrollToBottom()
+      return
     }
 
-    const maxTop = Math.max(0, el.scrollHeight - el.clientHeight);
-    const targetTop = Math.min(lastManualScrollTopRef.current, maxTop);
-    const jumpDistance = Math.abs(el.scrollTop - targetTop);
+    const maxTop = Math.max(0, el.scrollHeight - el.clientHeight)
+    const targetTop = Math.min(lastManualScrollTopRef.current, maxTop)
+    const jumpDistance = Math.abs(el.scrollTop - targetTop)
 
     if (jumpDistance > el.clientHeight * 0.5) {
-      el.scrollTop = targetTop;
+      el.scrollTop = targetTop
     }
 
-    previousScrollTopRef.current = el.scrollTop;
-    syncScrollButtonVisibility(el);
-  }, [messages, isStreaming, scheduleScrollToBottom, syncScrollButtonVisibility]);
+    previousScrollTopRef.current = el.scrollTop
+    syncScrollButtonVisibility(el)
+  }, [
+    messages,
+    isStreaming,
+    scheduleScrollToBottom,
+    syncScrollButtonVisibility,
+  ])
 
   useEffect(() => {
-    const scroller = scrollRef.current;
-    const content = contentRef.current;
-    if (!scroller || !content || typeof ResizeObserver === "undefined") return;
+    const scroller = scrollRef.current
+    const content = contentRef.current
+    if (!scroller || !content || typeof ResizeObserver === "undefined") return
 
     const resizeObserver = new ResizeObserver(() => {
       if (autoScrollEnabledRef.current) {
-        scheduleScrollToBottom();
-        return;
+        scheduleScrollToBottom()
+        return
       }
 
-      const maxTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+      const maxTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
       if (lastManualScrollTopRef.current > maxTop) {
-        scroller.scrollTop = maxTop;
-        lastManualScrollTopRef.current = maxTop;
-        previousScrollTopRef.current = maxTop;
+        scroller.scrollTop = maxTop
+        lastManualScrollTopRef.current = maxTop
+        previousScrollTopRef.current = maxTop
       }
 
-      syncScrollButtonVisibility(scroller);
-    });
+      syncScrollButtonVisibility(scroller)
+    })
 
-    resizeObserver.observe(scroller);
-    resizeObserver.observe(content);
+    resizeObserver.observe(scroller)
+    resizeObserver.observe(content)
 
-    return () => resizeObserver.disconnect();
-  }, [scheduleScrollToBottom, syncScrollButtonVisibility]);
+    return () => resizeObserver.disconnect()
+  }, [scheduleScrollToBottom, syncScrollButtonVisibility])
 
-  const visibleMessages = useMemo(() => messages.filter((message) => !message.hidden), [messages]);
+  const visibleMessages = useMemo(
+    () => messages.filter((message) => !message.hidden),
+    [messages]
+  )
   const liveMarkdownMessageId = useLiveMarkdownMessageId(
     visibleMessages,
     streamIsLoading,
-    isStreaming,
-  );
+    isStreaming
+  )
 
   const handleScrollToBottom = useCallback(() => {
-    autoScrollEnabledRef.current = true;
-    clearScheduledScroll();
-    scrollToBottomNow();
-  }, [clearScheduledScroll, scrollToBottomNow]);
+    autoScrollEnabledRef.current = true
+    clearScheduledScroll()
+    scrollToBottomNow()
+  }, [clearScheduledScroll, scrollToBottomNow])
 
   useEffect(() => {
-    if (!scrollControlRef) return;
-    scrollControlRef.current = { scrollToBottom: handleScrollToBottom };
+    if (!scrollControlRef) return
+    scrollControlRef.current = { scrollToBottom: handleScrollToBottom }
     return () => {
-      scrollControlRef.current = null;
-    };
-  }, [handleScrollToBottom, scrollControlRef]);
+      scrollControlRef.current = null
+    }
+  }, [handleScrollToBottom, scrollControlRef])
 
   useEffect(() => {
-    onShowScrollToBottomChange?.(showScrollToBottom);
-  }, [onShowScrollToBottomChange, showScrollToBottom]);
+    onShowScrollToBottomChange?.(showScrollToBottom)
+  }, [onShowScrollToBottomChange, showScrollToBottom])
 
-  const projectPath = project?.path;
+  const projectPath = project?.path
   const lastAgentIndex = visibleMessages.findLastIndex(
-    (message) => message.author === "agent",
-  );
+    (message) => message.author === "agent"
+  )
 
   return (
     <TooltipProvider delay={250} closeDelay={0}>
-    <div className="relative flex-1 min-h-0 min-w-0">
-      <div
-        ref={scrollRef}
-        className="h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden py-5 text-[13px] leading-6 antialiased"
-      >
+      <div className="relative min-h-0 min-w-0 flex-1">
         <div
-          ref={contentRef}
-          className={`w-full ${contentWidthClass} mx-auto min-w-0 ${contentPaddingClass}`}
-          style={bottomInset > 0 ? { paddingBottom: bottomInset } : undefined}
+          ref={scrollRef}
+          className="h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto py-5 text-[13px] leading-6 antialiased"
         >
-          {visibleMessages.map((message, index) => {
-            const isLastMessage = index === visibleMessages.length - 1;
-            const messageIsStreaming = isStreaming && isLastMessage;
-            const messageIsMarkdownLive = message.id === liveMarkdownMessageId;
+          <div
+            ref={contentRef}
+            className={`w-full ${contentWidthClass} mx-auto min-w-0 ${contentPaddingClass}`}
+            style={bottomInset > 0 ? { paddingBottom: bottomInset } : undefined}
+          >
+            {visibleMessages.map((message, index) => {
+              const isLastMessage = index === visibleMessages.length - 1
+              const messageIsStreaming = isStreaming && isLastMessage
+              const messageIsMarkdownLive = message.id === liveMarkdownMessageId
 
-            if (message.author === "user") {
-              return <UserMessage key={message.id} message={message} />;
-            }
+              if (message.author === "user") {
+                return <UserMessage key={message.id} message={message} />
+              }
 
-            return (
-              <AgentTurn
-                key={message.id}
-                message={message}
-                isStreaming={messageIsStreaming}
-                isMarkdownLive={messageIsMarkdownLive}
-                projectPath={projectPath}
-                threadId={threadId}
-                isLatestTurn={index === lastAgentIndex}
-                onApprove={onApprove}
-                onReject={onReject}
-                onAutoApprove={onAutoApprove}
-                onOpenFile={onOpenFile}
-              />
-            );
-          })}
-          <QueuedMessages queuedMessages={queuedMessages} />
-          <ThinkingSpinner
-            isActive={isThinking ?? streamIsLoading ?? isStreaming}
-            settingUpSandbox={settingUpSandbox}
-          />
+              return (
+                <AgentTurn
+                  key={message.id}
+                  message={message}
+                  isStreaming={messageIsStreaming}
+                  isMarkdownLive={messageIsMarkdownLive}
+                  projectPath={projectPath}
+                  threadId={threadId}
+                  isLatestTurn={index === lastAgentIndex}
+                  onApprove={onApprove}
+                  onReject={onReject}
+                  onAutoApprove={onAutoApprove}
+                  onOpenFile={onOpenFile}
+                />
+              )
+            })}
+            <QueuedMessages queuedMessages={queuedMessages} />
+            <ThinkingSpinner
+              isActive={isThinking ?? streamIsLoading ?? isStreaming}
+              settingUpSandbox={settingUpSandbox}
+            />
+          </div>
         </div>
-      </div>
 
-      {scrollButtonSlot === "internal" && showScrollToBottom && (
-        <button
-          type="button"
-          onClick={handleScrollToBottom}
-          aria-label="Scroll to bottom"
-          className="dropdown-glass absolute left-1/2 z-30 inline-flex size-8 -translate-x-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
-          style={{ bottom: bottomInset > 0 ? bottomInset + 8 : 16 }}
-        >
-          <ChevronDown className="size-3.5" />
-        </button>
-      )}
-    </div>
+        {scrollButtonSlot === "internal" && showScrollToBottom && (
+          <button
+            type="button"
+            onClick={handleScrollToBottom}
+            aria-label="Scroll to bottom"
+            className="dropdown-glass absolute left-1/2 z-30 inline-flex size-8 -translate-x-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
+            style={{ bottom: bottomInset > 0 ? bottomInset + 8 : 16 }}
+          >
+            <ChevronDown className="size-3.5" />
+          </button>
+        )}
+      </div>
     </TooltipProvider>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/messages/ReasoningBlock.tsx
+++ b/ui/src/features/agents/components/messages/ReasoningBlock.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef, useState } from "react";
-import { ChevronRight } from "lucide-react";
+import { useEffect, useRef, useState } from "react"
+import { ChevronRight } from "lucide-react"
 
-import { formatElapsed } from "@/lib/utils";
+import { formatElapsed } from "@/lib/utils"
 
 function reasoningLabel(elapsedMs: number | null): string {
-  if (elapsedMs === null) return "Thought";
-  if (elapsedMs < 1000) return "Thought briefly";
-  return `Thought for ${formatElapsed(elapsedMs)}`;
+  if (elapsedMs === null) return "Thought"
+  if (elapsedMs < 1000) return "Thought briefly"
+  return `Thought for ${formatElapsed(elapsedMs)}`
 }
 
 /**
@@ -15,35 +15,41 @@ function reasoningLabel(elapsedMs: number | null): string {
  * reasoning ends it auto-collapses into a "Thought for …" toggle the user can
  * expand on demand.
  */
-export function ReasoningBlock({ text, isLive }: { text: string; isLive: boolean }) {
-  const [userExpanded, setUserExpanded] = useState(false);
-  const [elapsedMs, setElapsedMs] = useState<number | null>(null);
-  const startedAtRef = useRef<number | null>(null);
-  const wasLiveRef = useRef(false);
+export function ReasoningBlock({
+  text,
+  isLive,
+}: {
+  text: string
+  isLive: boolean
+}) {
+  const [userExpanded, setUserExpanded] = useState(false)
+  const [elapsedMs, setElapsedMs] = useState<number | null>(null)
+  const startedAtRef = useRef<number | null>(null)
+  const wasLiveRef = useRef(false)
 
   useEffect(() => {
     if (isLive) {
-      if (startedAtRef.current === null) startedAtRef.current = Date.now();
-      wasLiveRef.current = true;
-      return;
+      if (startedAtRef.current === null) startedAtRef.current = Date.now()
+      wasLiveRef.current = true
+      return
     }
     if (wasLiveRef.current && startedAtRef.current !== null) {
-      setElapsedMs(Date.now() - startedAtRef.current);
-      wasLiveRef.current = false;
+      setElapsedMs(Date.now() - startedAtRef.current)
+      wasLiveRef.current = false
     }
-  }, [isLive]);
+  }, [isLive])
 
-  const trimmed = text.trim();
-  if (!trimmed && !isLive) return null;
+  const trimmed = text.trim()
+  if (!trimmed && !isLive) return null
 
-  const expanded = isLive || userExpanded;
+  const expanded = isLive || userExpanded
 
   return (
     <div className="my-1">
       <button
         type="button"
         onClick={() => {
-          if (!isLive) setUserExpanded((value) => !value);
+          if (!isLive) setUserExpanded((value) => !value)
         }}
         className="flex items-center gap-1 text-left transition-opacity hover:opacity-90 disabled:cursor-default"
         aria-expanded={expanded}
@@ -57,15 +63,17 @@ export function ReasoningBlock({ text, isLive }: { text: string; isLive: boolean
               className={`size-3 shrink-0 text-muted-foreground/65 transition-transform ${expanded ? "rotate-90" : ""}`}
               aria-hidden
             />
-            <span className="text-xs text-muted-foreground">{reasoningLabel(elapsedMs)}</span>
+            <span className="text-xs text-muted-foreground">
+              {reasoningLabel(elapsedMs)}
+            </span>
           </>
         )}
       </button>
       {expanded && trimmed && (
-        <div className="ms-1 mt-1 whitespace-pre-wrap break-words border-s border-border/45 ps-3 text-[12px] leading-5 text-muted-foreground">
+        <div className="ms-1 mt-1 border-s border-border/45 ps-3 text-[12px] leading-5 break-words whitespace-pre-wrap text-muted-foreground">
           {trimmed}
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/ThinkingSpinner.tsx
+++ b/ui/src/features/agents/components/messages/ThinkingSpinner.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react"
 
-import { formatElapsed } from "@/lib/utils";
+import { formatElapsed } from "@/lib/utils"
 
 const BUSY_TEXTS: Array<{ present: string; past: string }> = [
   { present: "Vibing...", past: "Vibed" },
@@ -14,82 +14,94 @@ const BUSY_TEXTS: Array<{ present: string; past: string }> = [
   { present: "Crunching...", past: "Crunched" },
   { present: "Scheming...", past: "Schemed" },
   { present: "Processing...", past: "Processed" },
-];
+]
 
-const THINKING_SETTLE_MS = 300;
+const THINKING_SETTLE_MS = 300
 
 export function ThinkingSpinner({
   isActive,
   settingUpSandbox = false,
 }: {
-  isActive: boolean;
-  settingUpSandbox?: boolean;
+  isActive: boolean
+  settingUpSandbox?: boolean
 }) {
-  const [textIdx, setTextIdx] = useState(0);
-  const [done, setDone] = useState<{ past: string; elapsed: string } | null>(null);
-  const [settledActive, setSettledActive] = useState(isActive);
-  const startTimeRef = useRef(0);
-  const sessionActiveRef = useRef(false);
-  const textIdxRef = useRef(textIdx);
-  const settingUpSandboxRef = useRef(settingUpSandbox);
-  textIdxRef.current = textIdx;
+  const [textIdx, setTextIdx] = useState(0)
+  const [done, setDone] = useState<{ past: string; elapsed: string } | null>(
+    null
+  )
+  const [settledActive, setSettledActive] = useState(isActive)
+  const startTimeRef = useRef(0)
+  const sessionActiveRef = useRef(false)
+  const textIdxRef = useRef(textIdx)
+  const settingUpSandboxRef = useRef(settingUpSandbox)
+  textIdxRef.current = textIdx
 
   useEffect(() => {
-    settingUpSandboxRef.current = settingUpSandbox;
-  }, [settingUpSandbox]);
+    settingUpSandboxRef.current = settingUpSandbox
+  }, [settingUpSandbox])
 
   useEffect(() => {
     if (isActive) {
-      setSettledActive(true);
-      return;
+      setSettledActive(true)
+      return
     }
-    const id = window.setTimeout(() => setSettledActive(false), THINKING_SETTLE_MS);
-    return () => window.clearTimeout(id);
-  }, [isActive]);
+    const id = window.setTimeout(
+      () => setSettledActive(false),
+      THINKING_SETTLE_MS
+    )
+    return () => window.clearTimeout(id)
+  }, [isActive])
 
   useEffect(() => {
     if (settledActive) {
       if (!sessionActiveRef.current) {
-        sessionActiveRef.current = true;
-        startTimeRef.current = Date.now();
-        setTextIdx(Math.floor(Math.random() * BUSY_TEXTS.length));
-        setDone(null);
+        sessionActiveRef.current = true
+        startTimeRef.current = Date.now()
+        setTextIdx(Math.floor(Math.random() * BUSY_TEXTS.length))
+        setDone(null)
       }
-      return;
+      return
     }
-    if (!sessionActiveRef.current) return;
-    sessionActiveRef.current = false;
+    if (!sessionActiveRef.current) return
+    sessionActiveRef.current = false
     setDone({
       past: settingUpSandboxRef.current
         ? "Set up sandbox"
-        : BUSY_TEXTS[textIdxRef.current]?.past ?? "",
+        : (BUSY_TEXTS[textIdxRef.current]?.past ?? ""),
       elapsed: formatElapsed(Date.now() - startTimeRef.current),
-    });
-  }, [settledActive]);
+    })
+  }, [settledActive])
 
   useEffect(() => {
-    if (!settledActive || settingUpSandbox) return;
-    const BUSY_TEXT_ROTATE_INTERVAL_MS = 12000;
-    const id = setInterval(() => setTextIdx((i) => (i + 1) % BUSY_TEXTS.length), BUSY_TEXT_ROTATE_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [settledActive, settingUpSandbox]);
+    if (!settledActive || settingUpSandbox) return
+    const BUSY_TEXT_ROTATE_INTERVAL_MS = 12000
+    const id = setInterval(
+      () => setTextIdx((i) => (i + 1) % BUSY_TEXTS.length),
+      BUSY_TEXT_ROTATE_INTERVAL_MS
+    )
+    return () => clearInterval(id)
+  }, [settledActive, settingUpSandbox])
 
-  const showActive = isActive || settledActive;
-  if (!showActive && !done) return null;
+  const showActive = isActive || settledActive
+  if (!showActive && !done) return null
 
   if (done && !showActive) {
     return (
       <div className="my-2 flex items-center gap-2">
-        <span className="text-xs text-muted-foreground/70">{done.past} for {done.elapsed}</span>
+        <span className="text-xs text-muted-foreground/70">
+          {done.past} for {done.elapsed}
+        </span>
       </div>
-    );
+    )
   }
 
   return (
     <div className="my-2 flex items-center gap-2">
       <span className="shimmer-text text-xs">
-        {settingUpSandbox ? "Setting up sandbox..." : BUSY_TEXTS[textIdx]?.present ?? ""}
+        {settingUpSandbox
+          ? "Setting up sandbox..."
+          : (BUSY_TEXTS[textIdx]?.present ?? "")}
       </span>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/UserMessage.tsx
+++ b/ui/src/features/agents/components/messages/UserMessage.tsx
@@ -1,38 +1,38 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
 
-import { MessageTimestamp } from "./MessageTimestamp";
-import type { Message } from "@/features/agents/lib/types";
+import { MessageTimestamp } from "./MessageTimestamp"
+import type { Message } from "@/features/agents/lib/types"
 
 export function UserMessage({ message }: { message: Message }) {
   const text = message.chunks
     .filter((c) => c.kind === "text")
     .map((c) => c.text)
-    .join("");
+    .join("")
 
-  const images = message.chunks.filter((c) => c.kind === "image");
-  const textRef = useRef<HTMLDivElement>(null);
-  const [scrolledFromTop, setScrolledFromTop] = useState(false);
-  const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
+  const images = message.chunks.filter((c) => c.kind === "image")
+  const textRef = useRef<HTMLDivElement>(null)
+  const [scrolledFromTop, setScrolledFromTop] = useState(false)
+  const [scrolledFromBottom, setScrolledFromBottom] = useState(false)
 
   const updateScrollIndicators = useCallback(() => {
-    const el = textRef.current;
-    if (!el) return;
-    setScrolledFromTop(el.scrollTop > 0);
-    setScrolledFromBottom(el.scrollTop < el.scrollHeight - el.clientHeight - 1);
-  }, []);
+    const el = textRef.current
+    if (!el) return
+    setScrolledFromTop(el.scrollTop > 0)
+    setScrolledFromBottom(el.scrollTop < el.scrollHeight - el.clientHeight - 1)
+  }, [])
 
   useLayoutEffect(() => {
-    updateScrollIndicators();
-  }, [text, updateScrollIndicators]);
+    updateScrollIndicators()
+  }, [text, updateScrollIndicators])
 
-  const topStop = scrolledFromTop ? "transparent 0, black 24px" : "black 0";
+  const topStop = scrolledFromTop ? "transparent 0, black 24px" : "black 0"
   const bottomStop = scrolledFromBottom
     ? "black calc(100% - 24px), transparent 100%"
-    : "black 100%";
+    : "black 100%"
   const textEdgeMask =
     scrolledFromTop || scrolledFromBottom
       ? `linear-gradient(to bottom, ${topStop}, ${bottomStop})`
-      : undefined;
+      : undefined
 
   return (
     <div className="group/turn my-4 flex flex-col items-end gap-1">
@@ -59,7 +59,7 @@ export function UserMessage({ message }: { message: Message }) {
               <div
                 ref={textRef}
                 onScroll={updateScrollIndicators}
-                className="max-h-[250px] overflow-auto whitespace-pre-wrap break-words text-[13px] leading-6 text-accent-foreground"
+                className="max-h-[250px] overflow-auto text-[13px] leading-6 break-words whitespace-pre-wrap text-accent-foreground"
                 style={{
                   maskImage: textEdgeMask,
                   WebkitMaskImage: textEdgeMask,
@@ -79,5 +79,5 @@ export function UserMessage({ message }: { message: Message }) {
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/index.ts
+++ b/ui/src/features/agents/components/messages/index.ts
@@ -1,6 +1,6 @@
-export { Messages } from "./Messages";
+export { Messages } from "./Messages"
 export type {
   ApprovalCallbacks,
   MessagesProps,
   MessagesScrollControl,
-} from "./types";
+} from "./types"

--- a/ui/src/features/agents/components/messages/renderItems.ts
+++ b/ui/src/features/agents/components/messages/renderItems.ts
@@ -1,61 +1,71 @@
-import type { Chunk, ToolExecutionChunk } from "@/features/agents/lib/types";
+import type { Chunk, ToolExecutionChunk } from "@/features/agents/lib/types"
 
 export type RenderItem =
   | { type: "text-chunk"; key: string; chunk: Chunk }
   | { type: "reasoning-item"; key: string; chunk: Chunk }
-  | { type: "explored-group"; key: string; id: string; chunks: Array<ToolExecutionChunk> }
+  | {
+      type: "explored-group"
+      key: string
+      id: string
+      chunks: Array<ToolExecutionChunk>
+    }
   /**
    * One or more `task` (subagent) tool calls collapsed into a single group so
    * they can be rendered side by side as a card grid (see subagents/SubagentGroup).
    */
-  | { type: "subagent-group"; key: string; id: string; chunks: Array<ToolExecutionChunk> }
+  | {
+      type: "subagent-group"
+      key: string
+      id: string
+      chunks: Array<ToolExecutionChunk>
+    }
   | { type: "edit-item"; key: string; chunk: ToolExecutionChunk }
   | { type: "shell-item"; key: string; chunk: ToolExecutionChunk }
   | { type: "reply-item"; key: string; chunk: ToolExecutionChunk }
-  | { type: "tool-item"; key: string; chunk: ToolExecutionChunk };
+  | { type: "tool-item"; key: string; chunk: ToolExecutionChunk }
 
 function getChunkRenderKey(chunk: Chunk, sourceIndex: number): string {
   switch (chunk.kind) {
     case "tool-execution":
-      return `tool-${chunk.toolCallId}`;
+      return `tool-${chunk.toolCallId}`
     case "text":
-      return `text-${sourceIndex}`;
+      return `text-${sourceIndex}`
     case "reasoning":
-      return `reasoning-${sourceIndex}`;
+      return `reasoning-${sourceIndex}`
     case "code":
-      return `code-${sourceIndex}`;
+      return `code-${sourceIndex}`
     case "error":
-      return `error-${sourceIndex}`;
+      return `error-${sourceIndex}`
     case "list":
-      return `list-${sourceIndex}`;
+      return `list-${sourceIndex}`
     case "image":
-      return `image-${sourceIndex}`;
+      return `image-${sourceIndex}`
     default:
-      return `chunk-${sourceIndex}`;
+      return `chunk-${sourceIndex}`
   }
 }
 
 function isEditTool(chunk: ToolExecutionChunk): boolean {
-  const kind = chunk.toolKind;
-  if (kind === "edit" || kind === "delete" || kind === "move") return true;
-  if (chunk.diffs?.length) return true;
-  if (chunk.diffData) return true;
-  return false;
+  const kind = chunk.toolKind
+  if (kind === "edit" || kind === "delete" || kind === "move") return true
+  if (chunk.diffs?.length) return true
+  if (chunk.diffData) return true
+  return false
 }
 
 function isExplorationTool(chunk: ToolExecutionChunk): boolean {
-  if (chunk.diffs?.length) return false;
-  if (chunk.diffData) return false;
-  const kind = chunk.toolKind;
-  return kind === "read" || kind === "search";
+  if (chunk.diffs?.length) return false
+  if (chunk.diffData) return false
+  const kind = chunk.toolKind
+  return kind === "read" || kind === "search"
 }
 
 function isShellTool(chunk: ToolExecutionChunk): boolean {
-  return chunk.toolKind === "execute";
+  return chunk.toolKind === "execute"
 }
 
 function isReplyTool(chunk: ToolExecutionChunk): boolean {
-  return chunk.toolKind === "slack" || chunk.toolKind === "linear";
+  return chunk.toolKind === "slack" || chunk.toolKind === "linear"
 }
 
 /**
@@ -65,107 +75,132 @@ function isReplyTool(chunk: ToolExecutionChunk): boolean {
  * These are grouped and rendered as cards instead of a plain tool line.
  */
 function isSubagentTool(chunk: ToolExecutionChunk): boolean {
-  return chunk.toolKind === "task";
+  return chunk.toolKind === "task"
 }
 
-export function buildRenderItems(chunks: Array<Chunk>, messageId?: string): Array<RenderItem> {
-  const items: Array<RenderItem> = [];
-  let exploredBuffer: Array<ToolExecutionChunk> = [];
-  let exploredStartIndex = -1;
-  let subagentBuffer: Array<ToolExecutionChunk> = [];
-  let subagentStartIndex = -1;
+export function buildRenderItems(
+  chunks: Array<Chunk>,
+  messageId?: string
+): Array<RenderItem> {
+  const items: Array<RenderItem> = []
+  let exploredBuffer: Array<ToolExecutionChunk> = []
+  let exploredStartIndex = -1
+  let subagentBuffer: Array<ToolExecutionChunk> = []
+  let subagentStartIndex = -1
 
   const flushExplored = () => {
-    if (exploredBuffer.length === 0) return;
-    const firstId = exploredBuffer[0]?.toolCallId;
-    const id = `explored-${firstId || exploredStartIndex}`;
+    if (exploredBuffer.length === 0) return
+    const firstId = exploredBuffer[0]?.toolCallId
+    const id = `explored-${firstId || exploredStartIndex}`
     items.push({
       type: "explored-group",
       key: id,
       id,
       chunks: [...exploredBuffer],
-    });
-    exploredBuffer = [];
-    exploredStartIndex = -1;
-  };
+    })
+    exploredBuffer = []
+    exploredStartIndex = -1
+  }
 
   const flushSubagents = () => {
-    if (subagentBuffer.length === 0) return;
-    const firstId = subagentBuffer[0]?.toolCallId;
-    const id = `subagents-${firstId || subagentStartIndex}`;
+    if (subagentBuffer.length === 0) return
+    const firstId = subagentBuffer[0]?.toolCallId
+    const id = `subagents-${firstId || subagentStartIndex}`
     items.push({
       type: "subagent-group",
       key: id,
       id,
       chunks: [...subagentBuffer],
-    });
-    subagentBuffer = [];
-    subagentStartIndex = -1;
-  };
+    })
+    subagentBuffer = []
+    subagentStartIndex = -1
+  }
 
   const flushGroups = () => {
-    flushExplored();
-    flushSubagents();
-  };
+    flushExplored()
+    flushSubagents()
+  }
 
   for (let i = 0; i < chunks.length; i += 1) {
-    const chunk = chunks[i];
-    if (!chunk) continue;
+    const chunk = chunks[i]
+    if (!chunk) continue
 
     if (chunk.kind === "tool-execution") {
       if (isSubagentTool(chunk)) {
-        flushExplored();
-        if (subagentBuffer.length === 0) subagentStartIndex = i;
-        subagentBuffer.push(chunk);
-        continue;
+        flushExplored()
+        if (subagentBuffer.length === 0) subagentStartIndex = i
+        subagentBuffer.push(chunk)
+        continue
       }
 
       if (isExplorationTool(chunk)) {
-        flushSubagents();
-        if (exploredBuffer.length === 0) exploredStartIndex = i;
-        exploredBuffer.push(chunk);
-        continue;
+        flushSubagents()
+        if (exploredBuffer.length === 0) exploredStartIndex = i
+        exploredBuffer.push(chunk)
+        continue
       }
 
-      flushGroups();
+      flushGroups()
 
       if (isEditTool(chunk)) {
-        items.push({ type: "edit-item", key: `tool-${chunk.toolCallId}`, chunk });
+        items.push({
+          type: "edit-item",
+          key: `tool-${chunk.toolCallId}`,
+          chunk,
+        })
       } else if (isShellTool(chunk)) {
-        items.push({ type: "shell-item", key: `tool-${chunk.toolCallId}`, chunk });
+        items.push({
+          type: "shell-item",
+          key: `tool-${chunk.toolCallId}`,
+          chunk,
+        })
       } else if (isReplyTool(chunk)) {
-        items.push({ type: "reply-item", key: `tool-${chunk.toolCallId}`, chunk });
+        items.push({
+          type: "reply-item",
+          key: `tool-${chunk.toolCallId}`,
+          chunk,
+        })
       } else {
-        items.push({ type: "tool-item", key: `tool-${chunk.toolCallId}`, chunk });
+        items.push({
+          type: "tool-item",
+          key: `tool-${chunk.toolCallId}`,
+          chunk,
+        })
       }
-      continue;
+      continue
     }
 
-    if (chunk.kind === "text" && !chunk.text.trim()) continue;
+    if (chunk.kind === "text" && !chunk.text.trim()) continue
 
     if (chunk.kind === "reasoning") {
-      flushGroups();
+      flushGroups()
       items.push({
         type: "reasoning-item",
-        key: messageId ? `${messageId}-${getChunkRenderKey(chunk, i)}` : getChunkRenderKey(chunk, i),
+        key: messageId
+          ? `${messageId}-${getChunkRenderKey(chunk, i)}`
+          : getChunkRenderKey(chunk, i),
         chunk,
-      });
-      continue;
+      })
+      continue
     }
 
-    flushGroups();
+    flushGroups()
     items.push({
       type: "text-chunk",
-      key: messageId ? `${messageId}-${getChunkRenderKey(chunk, i)}` : getChunkRenderKey(chunk, i),
+      key: messageId
+        ? `${messageId}-${getChunkRenderKey(chunk, i)}`
+        : getChunkRenderKey(chunk, i),
       chunk,
-    });
+    })
   }
 
-  flushGroups();
-  return items;
+  flushGroups()
+  return items
 }
 
-export function summarizeExploration(chunks: Array<ToolExecutionChunk>): string {
-  const count = chunks.length;
-  return `Explored ${count} file${count === 1 ? "" : "s"}`;
+export function summarizeExploration(
+  chunks: Array<ToolExecutionChunk>
+): string {
+  const count = chunks.length
+  return `Explored ${count} file${count === 1 ? "" : "s"}`
 }

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -1,47 +1,53 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
-import { ChunkRenderer } from "../ChunkRenderer";
-import { MessageTimestamp } from "../MessageTimestamp";
-import { ReasoningBlock } from "../ReasoningBlock";
-import { buildRenderItems } from "../renderItems";
-import { TurnChangedFilesCard } from "../TurnChangedFilesCard";
-import { MessageCopyButton } from "./MessageCopyButton";
-import { WorkEntryRow } from "./WorkEntryRow";
-import { describeWorkEntry, latestDiff } from "./workEntry";
-import { TurnFoldRow, WorkGroupToggleRow } from "./foldRows";
-import { ShellEntryBody } from "./entryBodies";
-import type { ReactNode } from "react";
-import type { RenderItem } from "../renderItems";
-import type { ApprovalCallbacks } from "../types";
-import type { Message, ToolExecutionChunk } from "@/features/agents/lib/types";
-import { ReplyCard } from "@/features/agents/components/chat/ReplyCard";
-import { SubagentGroup } from "@/features/agents/components/subagents";
-import { formatElapsed } from "@/lib/utils";
+import { ChunkRenderer } from "../ChunkRenderer"
+import { MessageTimestamp } from "../MessageTimestamp"
+import { ReasoningBlock } from "../ReasoningBlock"
+import { buildRenderItems } from "../renderItems"
+import { TurnChangedFilesCard } from "../TurnChangedFilesCard"
+import { MessageCopyButton } from "./MessageCopyButton"
+import { WorkEntryRow } from "./WorkEntryRow"
+import { describeWorkEntry, latestDiff } from "./workEntry"
+import { TurnFoldRow, WorkGroupToggleRow } from "./foldRows"
+import { ShellEntryBody } from "./entryBodies"
+import type { ReactNode } from "react"
+import type { RenderItem } from "../renderItems"
+import type { ApprovalCallbacks } from "../types"
+import type { Message, ToolExecutionChunk } from "@/features/agents/lib/types"
+import { ReplyCard } from "@/features/agents/components/chat/ReplyCard"
+import { SubagentGroup } from "@/features/agents/components/subagents"
+import { formatElapsed } from "@/lib/utils"
 
 /**
  * How many entries of a work group stay visible while it is collapsed. One
  * keeps the group's most recent activity legible without letting a long
  * exploration burst push the reply off screen.
  */
-const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
+const MAX_VISIBLE_WORK_LOG_ENTRIES = 1
 
 /**
  * Render-item types that count as the agent's reply rather than its work.
  * Everything before the trailing run of these folds away when a turn settles.
  */
-const REPLY_ITEM_TYPES = new Set<RenderItem["type"]>(["text-chunk", "reply-item"]);
+const REPLY_ITEM_TYPES = new Set<RenderItem["type"]>([
+  "text-chunk",
+  "reply-item",
+])
 
 function splitWorkAndReply(items: Array<RenderItem>): {
-  workItems: Array<RenderItem>;
-  replyItems: Array<RenderItem>;
+  workItems: Array<RenderItem>
+  replyItems: Array<RenderItem>
 } {
-  let splitIndex = items.length;
+  let splitIndex = items.length
   while (splitIndex > 0) {
-    const prev = items[splitIndex - 1];
-    if (!prev || !REPLY_ITEM_TYPES.has(prev.type)) break;
-    splitIndex -= 1;
+    const prev = items[splitIndex - 1]
+    if (!prev || !REPLY_ITEM_TYPES.has(prev.type)) break
+    splitIndex -= 1
   }
-  return { workItems: items.slice(0, splitIndex), replyItems: items.slice(splitIndex) };
+  return {
+    workItems: items.slice(0, splitIndex),
+    replyItems: items.slice(splitIndex),
+  }
 }
 
 /**
@@ -54,18 +60,20 @@ function EditWorkEntry({
   projectPath,
   onOpenFile,
 }: {
-  chunk: ToolExecutionChunk;
-  projectPath?: string;
-  onOpenFile?: (filePath: string) => void;
+  chunk: ToolExecutionChunk
+  projectPath?: string
+  onOpenFile?: (filePath: string) => void
 }) {
-  const filePath = latestDiff(chunk)?.filePath;
+  const filePath = latestDiff(chunk)?.filePath
   return (
     <WorkEntryRow
       entry={describeWorkEntry(chunk, projectPath)}
       timestamp={chunk.timestamp}
-      onActivate={filePath && onOpenFile ? () => onOpenFile(filePath) : undefined}
+      onActivate={
+        filePath && onOpenFile ? () => onOpenFile(filePath) : undefined
+      }
     />
-  );
+  )
 }
 
 /**
@@ -78,18 +86,24 @@ function WorkGroup({
   expanded,
   onToggle,
 }: {
-  chunks: Array<ToolExecutionChunk>;
-  projectPath?: string;
-  expanded: boolean;
-  onToggle: () => void;
+  chunks: Array<ToolExecutionChunk>
+  projectPath?: string
+  expanded: boolean
+  onToggle: () => void
 }) {
-  const hiddenCount = Math.max(0, chunks.length - MAX_VISIBLE_WORK_LOG_ENTRIES);
-  const visible = expanded ? chunks : chunks.slice(chunks.length - MAX_VISIBLE_WORK_LOG_ENTRIES);
+  const hiddenCount = Math.max(0, chunks.length - MAX_VISIBLE_WORK_LOG_ENTRIES)
+  const visible = expanded
+    ? chunks
+    : chunks.slice(chunks.length - MAX_VISIBLE_WORK_LOG_ENTRIES)
 
   return (
     <div>
       {hiddenCount > 0 && (
-        <WorkGroupToggleRow hiddenCount={hiddenCount} expanded={expanded} onToggle={onToggle} />
+        <WorkGroupToggleRow
+          hiddenCount={hiddenCount}
+          expanded={expanded}
+          onToggle={onToggle}
+        />
       )}
       {visible.map((chunk, index) => (
         <WorkEntryRow
@@ -99,7 +113,7 @@ function WorkGroup({
         />
       ))}
     </div>
-  );
+  )
 }
 
 export function AgentTurn({
@@ -111,70 +125,92 @@ export function AgentTurn({
   isLatestTurn,
   ...callbacks
 }: {
-  message: Message;
-  isStreaming?: boolean;
-  isMarkdownLive?: boolean;
-  projectPath?: string;
+  message: Message
+  isStreaming?: boolean
+  isMarkdownLive?: boolean
+  projectPath?: string
   /** Cloud threads only; enables the git-sourced changed-files card. */
-  threadId?: string;
-  isLatestTurn?: boolean;
+  threadId?: string
+  isLatestTurn?: boolean
 } & ApprovalCallbacks) {
   const renderItems = useMemo(
     () => buildRenderItems(message.chunks, message.id),
-    [message.chunks, message.id],
-  );
+    [message.chunks, message.id]
+  )
 
-  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
+    {}
+  )
   const toggleGroup = useCallback((id: string) => {
-    setExpandedGroups((prev) => ({ ...prev, [id]: !(prev[id] ?? false) }));
-  }, []);
+    setExpandedGroups((prev) => ({ ...prev, [id]: !(prev[id] ?? false) }))
+  }, [])
 
   // Measure wall-clock work time for live runs (most accurate); fall back to
   // the turn's first→last message timestamps for transcripts loaded from state.
-  const [measuredDurationMs, setMeasuredDurationMs] = useState<number | null>(null);
-  const workStartRef = useRef<number | null>(null);
-  const wasStreamingRef = useRef(false);
+  const [measuredDurationMs, setMeasuredDurationMs] = useState<number | null>(
+    null
+  )
+  const workStartRef = useRef<number | null>(null)
+  const wasStreamingRef = useRef(false)
   useEffect(() => {
     if (isStreaming) {
-      if (workStartRef.current === null) workStartRef.current = Date.now();
-      wasStreamingRef.current = true;
-      return;
+      if (workStartRef.current === null) workStartRef.current = Date.now()
+      wasStreamingRef.current = true
+      return
     }
     if (wasStreamingRef.current && workStartRef.current !== null) {
-      setMeasuredDurationMs(Date.now() - workStartRef.current);
-      wasStreamingRef.current = false;
+      setMeasuredDurationMs(Date.now() - workStartRef.current)
+      wasStreamingRef.current = false
     }
-  }, [isStreaming]);
+  }, [isStreaming])
 
   const workDurationMs = useMemo(() => {
-    if (measuredDurationMs !== null) return measuredDurationMs;
-    if (!message.startedAt || message.timestampIsFallback) return null;
-    const start = Date.parse(message.startedAt);
-    const end = Date.parse(message.timestamp);
-    if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
-    const delta = end - start;
-    return delta > 0 ? delta : null;
-  }, [measuredDurationMs, message.startedAt, message.timestamp, message.timestampIsFallback]);
+    if (measuredDurationMs !== null) return measuredDurationMs
+    if (!message.startedAt || message.timestampIsFallback) return null
+    const start = Date.parse(message.startedAt)
+    const end = Date.parse(message.timestamp)
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return null
+    const delta = end - start
+    return delta > 0 ? delta : null
+  }, [
+    measuredDurationMs,
+    message.startedAt,
+    message.timestamp,
+    message.timestampIsFallback,
+  ])
 
-  const { workItems, replyItems } = useMemo(() => splitWorkAndReply(renderItems), [renderItems]);
+  const { workItems, replyItems } = useMemo(
+    () => splitWorkAndReply(renderItems),
+    [renderItems]
+  )
   const replyText = useMemo(
     () =>
       replyItems
         .map((item) =>
-          item.type === "text-chunk" && item.chunk.kind === "text" ? item.chunk.text : "",
+          item.type === "text-chunk" && item.chunk.kind === "text"
+            ? item.chunk.text
+            : ""
         )
         .join("")
         .trim(),
-    [replyItems],
-  );
-  const canFoldWork = !isStreaming && workItems.length > 0;
-  const [workFoldExpanded, setWorkFoldExpanded] = useState(false);
-  const toggleWorkFold = useCallback(() => setWorkFoldExpanded((value) => !value), []);
+    [replyItems]
+  )
+  const canFoldWork = !isStreaming && workItems.length > 0
+  const [workFoldExpanded, setWorkFoldExpanded] = useState(false)
+  const toggleWorkFold = useCallback(
+    () => setWorkFoldExpanded((value) => !value),
+    []
+  )
 
-  const renderItem = (item: RenderItem, index: number, total: number): ReactNode => {
+  const renderItem = (
+    item: RenderItem,
+    index: number,
+    total: number
+  ): ReactNode => {
     switch (item.type) {
       case "reasoning-item": {
-        const reasoningChunk = item.chunk.kind === "reasoning" ? item.chunk : null;
+        const reasoningChunk =
+          item.chunk.kind === "reasoning" ? item.chunk : null
         return (
           <div key={item.key} className="min-w-0 flex-1">
             <ReasoningBlock
@@ -182,7 +218,7 @@ export function AgentTurn({
               isLive={!!isStreaming && index === total - 1}
             />
           </div>
-        );
+        )
       }
 
       case "explored-group":
@@ -194,10 +230,10 @@ export function AgentTurn({
             expanded={expandedGroups[item.id] ?? false}
             onToggle={() => toggleGroup(item.id)}
           />
-        );
+        )
 
       case "subagent-group":
-        return <SubagentGroup key={item.key} chunks={item.chunks} />;
+        return <SubagentGroup key={item.key} chunks={item.chunks} />
 
       case "edit-item":
         return (
@@ -207,7 +243,7 @@ export function AgentTurn({
             projectPath={projectPath}
             onOpenFile={callbacks.onOpenFile}
           />
-        );
+        )
 
       case "shell-item":
         return (
@@ -217,10 +253,10 @@ export function AgentTurn({
             timestamp={item.chunk.timestamp}
             body={<ShellEntryBody chunk={item.chunk} />}
           />
-        );
+        )
 
       case "reply-item":
-        return <ReplyCard key={item.key} chunk={item.chunk} />;
+        return <ReplyCard key={item.key} chunk={item.chunk} />
 
       case "tool-item":
         return (
@@ -229,7 +265,7 @@ export function AgentTurn({
             entry={describeWorkEntry(item.chunk, projectPath)}
             timestamp={item.chunk.timestamp}
           />
-        );
+        )
 
       // Not only prose: buildRenderItems funnels code/error/list/image chunks
       // here too, so this has to go through the full chunk renderer.
@@ -243,14 +279,14 @@ export function AgentTurn({
               {...callbacks}
             />
           </div>
-        );
+        )
     }
-  };
+  }
 
   const foldLabel =
     workDurationMs && workDurationMs >= 1000
       ? `Worked for ${formatElapsed(workDurationMs)}`
-      : "Worked";
+      : "Worked"
 
   return (
     <div className="group/turn my-2 min-w-0 space-y-1.5">
@@ -263,15 +299,19 @@ export function AgentTurn({
           />
           {workFoldExpanded && (
             <div className="space-y-0.5">
-              {workItems.map((item, index) => renderItem(item, index, workItems.length))}
+              {workItems.map((item, index) =>
+                renderItem(item, index, workItems.length)
+              )}
             </div>
           )}
           {replyItems.map((item, index) =>
-            renderItem(item, workItems.length + index, renderItems.length),
+            renderItem(item, workItems.length + index, renderItems.length)
           )}
         </>
       ) : (
-        renderItems.map((item, index) => renderItem(item, index, renderItems.length))
+        renderItems.map((item, index) =>
+          renderItem(item, index, renderItems.length)
+        )
       )}
 
       {threadId && message.turnKey && !isStreaming && (
@@ -291,9 +331,12 @@ export function AgentTurn({
           />
         )}
         {!message.timestampIsFallback && (
-          <MessageTimestamp timestamp={message.timestamp} startedAt={message.startedAt} />
+          <MessageTimestamp
+            timestamp={message.timestamp}
+            startedAt={message.startedAt}
+          />
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/timeline/MessageCopyButton.tsx
+++ b/ui/src/features/agents/components/messages/timeline/MessageCopyButton.tsx
@@ -1,39 +1,39 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { Check, Copy } from "lucide-react";
+import { memo, useCallback, useEffect, useRef, useState } from "react"
+import { Check, Copy } from "lucide-react"
 
-import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
-const COPIED_RESET_MS = 1500;
+const COPIED_RESET_MS = 1500
 
 export const MessageCopyButton = memo(function MessageCopyButton({
   text,
   className,
 }: {
-  text: string;
-  className?: string;
+  text: string
+  className?: string
 }) {
-  const [copied, setCopied] = useState(false);
-  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [copied, setCopied] = useState(false)
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(
     () => () => {
-      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
     },
-    [],
-  );
+    []
+  )
 
   const copy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(text)
     } catch {
-      return;
+      return
     }
-    setCopied(true);
-    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
-    resetTimerRef.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
-  }, [text]);
+    setCopied(true)
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+    resetTimerRef.current = setTimeout(() => setCopied(false), COPIED_RESET_MS)
+  }, [text])
 
   return (
     <Tooltip>
@@ -41,7 +41,10 @@ export const MessageCopyButton = memo(function MessageCopyButton({
         render={
           <Button
             aria-label="Copy message"
-            className={cn("text-muted-foreground hover:text-foreground", className)}
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              className
+            )}
             onClick={copy}
             size="icon-xs"
             type="button"
@@ -53,5 +56,5 @@ export const MessageCopyButton = memo(function MessageCopyButton({
       </TooltipTrigger>
       <TooltipPopup>{copied ? "Copied!" : "Copy to clipboard"}</TooltipPopup>
     </Tooltip>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState } from "react"
 import {
   Bot,
   Check,
@@ -13,13 +13,13 @@ import {
   Wrench,
   X,
   Zap,
-} from "lucide-react";
-import type { KeyboardEvent, ReactNode } from "react";
+} from "lucide-react"
+import type { KeyboardEvent, ReactNode } from "react"
 
-import type { WorkEntryIconName, WorkEntryView } from "./workEntry";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
-import { formatHoverTimestamp } from "@/features/agents/lib/messageTimestamps";
-import { cn } from "@/lib/utils";
+import type { WorkEntryIconName, WorkEntryView } from "./workEntry"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+import { formatHoverTimestamp } from "@/features/agents/lib/messageTimestamps"
+import { cn } from "@/lib/utils"
 
 const ICONS: Record<WorkEntryIconName, typeof Bot> = {
   bot: Bot,
@@ -33,14 +33,21 @@ const ICONS: Record<WorkEntryIconName, typeof Bot> = {
   terminal: Terminal,
   wrench: Wrench,
   zap: Zap,
-};
-
-function WorkEntryIcon({ name, className }: { name: WorkEntryIconName; className: string }) {
-  const Icon = ICONS[name];
-  return <Icon className={className} aria-hidden />;
 }
 
-const stopRowToggle = (event: { stopPropagation: () => void }) => event.stopPropagation();
+function WorkEntryIcon({
+  name,
+  className,
+}: {
+  name: WorkEntryIconName
+  className: string
+}) {
+  const Icon = ICONS[name]
+  return <Icon className={className} aria-hidden />
+}
+
+const stopRowToggle = (event: { stopPropagation: () => void }) =>
+  event.stopPropagation()
 
 function StatusIndicator({ status }: { status: WorkEntryView["status"] }) {
   if (status === "error") {
@@ -58,28 +65,34 @@ function StatusIndicator({ status }: { status: WorkEntryView["status"] }) {
         </TooltipTrigger>
         <TooltipPopup>Failed</TooltipPopup>
       </Tooltip>
-    );
+    )
   }
 
   if (status === "completed") {
     return (
       <Tooltip>
-        <TooltipTrigger render={<span className="flex size-4 items-center justify-center" />}>
+        <TooltipTrigger
+          render={<span className="flex size-4 items-center justify-center" />}
+        >
           <Check className="block size-3 shrink-0 stroke-current" aria-hidden />
         </TooltipTrigger>
         <TooltipPopup>Completed</TooltipPopup>
       </Tooltip>
-    );
+    )
   }
 
   return (
     <Tooltip>
-      <TooltipTrigger render={<span className="flex size-4 items-center justify-center" />}>
+      <TooltipTrigger
+        render={<span className="flex size-4 items-center justify-center" />}
+      >
         <span className="block size-1.5 shrink-0 animate-status-pulse rounded-full bg-current" />
       </TooltipTrigger>
-      <TooltipPopup>{status === "pending" ? "Waiting" : "Running"}</TooltipPopup>
+      <TooltipPopup>
+        {status === "pending" ? "Waiting" : "Running"}
+      </TooltipPopup>
     </Tooltip>
-  );
+  )
 }
 
 /**
@@ -95,52 +108,55 @@ export function WorkEntryRow({
   onActivate,
   defaultExpanded = false,
 }: {
-  entry: WorkEntryView;
-  timestamp?: string;
-  body?: ReactNode;
-  trailing?: ReactNode;
+  entry: WorkEntryView
+  timestamp?: string
+  body?: ReactNode
+  trailing?: ReactNode
   /** Clicking the row runs this instead of expanding it (e.g. reveal a file). */
-  onActivate?: () => void;
-  defaultExpanded?: boolean;
+  onActivate?: () => void
+  defaultExpanded?: boolean
 }) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
-  const toggle = useCallback(() => setExpanded((value) => !value), []);
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const toggle = useCallback(() => setExpanded((value) => !value), [])
 
-  const canExpand = onActivate == null && (body != null || entry.expandedText != null);
-  const activate = onActivate ?? (canExpand ? toggle : null);
-  const isError = entry.tone === "error";
-  const hoverTimestamp = formatHoverTimestamp(timestamp);
+  const canExpand =
+    onActivate == null && (body != null || entry.expandedText != null)
+  const activate = onActivate ?? (canExpand ? toggle : null)
+  const isError = entry.tone === "error"
+  const hoverTimestamp = formatHoverTimestamp(timestamp)
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
-      if (event.key !== "Enter" && event.key !== " ") return;
-      event.preventDefault();
-      activate?.();
+      if (event.key !== "Enter" && event.key !== " ") return
+      event.preventDefault()
+      activate?.()
     },
-    [activate],
-  );
+    [activate]
+  )
 
   const rowToggleProps = activate
     ? {
         role: "button" as const,
         tabIndex: 0,
         ...(canExpand ? { "aria-expanded": expanded } : {}),
-        "aria-label": entry.preview ? `${entry.heading} ${entry.preview}` : entry.heading,
+        "aria-label": entry.preview
+          ? `${entry.heading} ${entry.preview}`
+          : entry.heading,
         onClick: activate,
         onKeyDown: handleKeyDown,
       }
-    : {};
+    : {}
 
   return (
     <div
       className={cn(
         "group/entry flex flex-col rounded-md px-0.5 py-0.5 transition-colors",
         activate &&
-          "cursor-pointer hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
+          "cursor-pointer hover:bg-accent/20 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:outline-none focus-visible:ring-inset"
       )}
       {...rowToggleProps}
     >
-      <div className="flex select-none items-center gap-1.5">
+      <div className="flex items-center gap-1.5 select-none">
         <span
           className={cn(
             "flex size-5 shrink-0 items-center justify-center",
@@ -148,7 +164,7 @@ export function WorkEntryRow({
               ? "text-destructive"
               : entry.tone === "thinking"
                 ? "text-foreground/92"
-                : "text-muted-foreground/65",
+                : "text-muted-foreground/65"
           )}
         >
           <WorkEntryIcon
@@ -163,7 +179,7 @@ export function WorkEntryRow({
               <span
                 className={cn(
                   "min-w-0 shrink truncate font-medium",
-                  isError ? "text-destructive" : "text-foreground/82",
+                  isError ? "text-destructive" : "text-foreground/82"
                 )}
               >
                 {entry.heading}
@@ -183,12 +199,15 @@ export function WorkEntryRow({
                 {hoverTimestamp}
               </time>
             )}
-            <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden={!canExpand}>
+            <span
+              className="flex size-4 shrink-0 items-center justify-center"
+              aria-hidden={!canExpand}
+            >
               {canExpand ? (
                 <ChevronDown
                   className={cn(
                     "size-3 shrink-0 opacity-70 transition-transform duration-200",
-                    expanded && "rotate-180",
+                    expanded && "rotate-180"
                   )}
                   aria-hidden
                 />
@@ -208,12 +227,12 @@ export function WorkEntryRow({
           onPointerDown={stopRowToggle}
         >
           {body ?? (
-            <pre className="max-h-64 cursor-text select-text overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
+            <pre className="max-h-64 cursor-text overflow-auto font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap text-muted-foreground select-text">
               {entry.expandedText}
             </pre>
           )}
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
+++ b/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
@@ -1,25 +1,26 @@
-import { memo } from "react";
+import { memo } from "react"
 
-import type { ToolExecutionChunk } from "@/features/agents/lib/types";
+import type { ToolExecutionChunk } from "@/features/agents/lib/types"
 
 export const ShellEntryBody = memo(function ShellEntryBody({
   chunk,
 }: {
-  chunk: ToolExecutionChunk;
+  chunk: ToolExecutionChunk
 }) {
-  const command = typeof chunk.input?.command === "string" ? chunk.input.command : "";
-  const output = chunk.output ?? "";
+  const command =
+    typeof chunk.input?.command === "string" ? chunk.input.command : ""
+  const output = chunk.output ?? ""
 
   return (
     <div className="space-y-1.5">
       {command && (
-        <pre className="cursor-text select-text overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed text-foreground/85">
+        <pre className="cursor-text overflow-x-auto font-mono text-[11px] leading-relaxed whitespace-pre text-foreground/85 select-text">
           <span className="text-muted-foreground/60">$ </span>
           {command}
         </pre>
       )}
       {output && (
-        <pre className="max-h-64 cursor-text select-text overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed text-muted-foreground">
+        <pre className="max-h-64 cursor-text overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre text-muted-foreground select-text">
           {output}
         </pre>
       )}
@@ -27,8 +28,10 @@ export const ShellEntryBody = memo(function ShellEntryBody({
         <p className="font-mono text-[11px] text-muted-foreground">Running…</p>
       )}
       {!output && chunk.status === "pending" && (
-        <p className="font-mono text-[11px] text-warning-foreground">Waiting for approval…</p>
+        <p className="font-mono text-[11px] text-warning-foreground">
+          Waiting for approval…
+        </p>
       )}
     </div>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/messages/timeline/foldRows.tsx
+++ b/ui/src/features/agents/components/messages/timeline/foldRows.tsx
@@ -1,6 +1,6 @@
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 /**
  * Collapses a settled turn's work log behind a single "Worked for …" line, so
@@ -11,25 +11,25 @@ export function TurnFoldRow({
   expanded,
   onToggle,
 }: {
-  label: string;
-  expanded: boolean;
-  onToggle: () => void;
+  label: string
+  expanded: boolean
+  onToggle: () => void
 }) {
-  const Icon = expanded ? ChevronDown : ChevronRight;
+  const Icon = expanded ? ChevronDown : ChevronRight
 
   return (
-    <div className="border-b border-border/60 pb-2 pt-1">
+    <div className="border-b border-border/60 pt-1 pb-2">
       <button
         type="button"
         aria-expanded={expanded}
         onClick={onToggle}
-        className="flex cursor-pointer select-none items-center gap-1 rounded-md px-1 text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+        className="flex cursor-pointer items-center gap-1 rounded-md px-1 text-xs text-muted-foreground tabular-nums transition-colors select-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:outline-none focus-visible:ring-inset"
       >
         <span>{label}</span>
         <Icon className="size-3.5" />
       </button>
     </div>
-  );
+  )
 }
 
 /**
@@ -41,24 +41,24 @@ export function WorkGroupToggleRow({
   expanded,
   onToggle,
 }: {
-  hiddenCount: number;
-  expanded: boolean;
-  onToggle: () => void;
+  hiddenCount: number
+  expanded: boolean
+  onToggle: () => void
 }) {
-  const noun = hiddenCount === 1 ? "tool call" : "tool calls";
+  const noun = hiddenCount === 1 ? "tool call" : "tool calls"
 
   return (
     <button
       type="button"
       aria-expanded={expanded}
       onClick={onToggle}
-      className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+      className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:outline-none focus-visible:ring-inset"
     >
       <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/65">
         <ChevronDown
           className={cn(
             "size-3.5 shrink-0 opacity-70 transition-transform duration-200",
-            expanded && "rotate-180",
+            expanded && "rotate-180"
           )}
           aria-hidden
         />
@@ -67,5 +67,5 @@ export function WorkGroupToggleRow({
         {expanded ? `Show fewer ${noun}` : `+${hiddenCount} previous ${noun}`}
       </span>
     </button>
-  );
+  )
 }

--- a/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 
-import { describeWorkEntry } from "./workEntry";
-import type { DiffData, ToolExecutionChunk } from "@/features/agents/lib/types";
+import { describeWorkEntry } from "./workEntry"
+import type { DiffData, ToolExecutionChunk } from "@/features/agents/lib/types"
 
-const projectPath = "/workspace/open-swe";
+const projectPath = "/workspace/open-swe"
 
-function chunk(overrides: Partial<ToolExecutionChunk> = {}): ToolExecutionChunk {
+function chunk(
+  overrides: Partial<ToolExecutionChunk> = {}
+): ToolExecutionChunk {
   return {
     kind: "tool-execution",
     toolCallId: "call_1",
@@ -13,7 +15,7 @@ function chunk(overrides: Partial<ToolExecutionChunk> = {}): ToolExecutionChunk 
     toolKind: "read",
     status: "completed",
     ...overrides,
-  };
+  }
 }
 
 function diff(overrides: Partial<DiffData> = {}): DiffData {
@@ -26,74 +28,79 @@ function diff(overrides: Partial<DiffData> = {}): DiffData {
     isTruncated: false,
     totalLines: 1,
     ...overrides,
-  };
+  }
 }
 
 describe("describeWorkEntry", () => {
   it("splits a read into a verb heading and a project-relative preview", () => {
     const entry = describeWorkEntry(
       chunk({ input: { file_path: `${projectPath}/AGENTS.md` } }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.heading).toBe("Read");
-    expect(entry.preview).toBe("AGENTS.md");
-    expect(entry.icon).toBe("eye");
-  });
+    expect(entry.heading).toBe("Read")
+    expect(entry.preview).toBe("AGENTS.md")
+    expect(entry.icon).toBe("eye")
+  })
 
   it("describes a completed edit from its diff rather than the raw tool title", () => {
     const entry = describeWorkEntry(
       chunk({ title: "edit_file", toolKind: "edit", diffData: diff() }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.heading).toBe("Edited");
-    expect(entry.preview).toBe("ui/src/app.tsx");
-    expect(entry.icon).toBe("square-pen");
+    expect(entry.heading).toBe("Edited")
+    expect(entry.preview).toBe("ui/src/app.tsx")
+    expect(entry.icon).toBe("square-pen")
     // The diff is rendered as the row body, so there is no text fallback.
-    expect(entry.expandedText).toBeNull();
-  });
+    expect(entry.expandedText).toBeNull()
+  })
 
   it("distinguishes a created file from an edited one", () => {
     const entry = describeWorkEntry(
       chunk({ toolKind: "edit", diffData: diff({ isNewFile: true }) }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.heading).toBe("Created");
-  });
+    expect(entry.heading).toBe("Created")
+  })
 
   it("reports an in-flight edit in the present tense", () => {
     const entry = describeWorkEntry(
       chunk({ toolKind: "edit", status: "in_progress", diffData: diff() }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.heading).toBe("Editing");
-    expect(entry.status).toBe("in_progress");
-  });
+    expect(entry.heading).toBe("Editing")
+    expect(entry.status).toBe("in_progress")
+  })
 
   it("marks failed calls with the error tone", () => {
     const entry = describeWorkEntry(
-      chunk({ title: "shell", toolKind: "execute", status: "error", input: { command: "pnpm test" } }),
-      projectPath,
-    );
+      chunk({
+        title: "shell",
+        toolKind: "execute",
+        status: "error",
+        input: { command: "pnpm test" },
+      }),
+      projectPath
+    )
 
-    expect(entry.tone).toBe("error");
-    expect(entry.icon).toBe("terminal");
-    expect(entry.heading).toBe("Shell");
-    expect(entry.preview).toBe("pnpm test");
-  });
+    expect(entry.tone).toBe("error")
+    expect(entry.icon).toBe("terminal")
+    expect(entry.heading).toBe("Shell")
+    expect(entry.preview).toBe("pnpm test")
+  })
 
   it("drops a preview that would only repeat the heading", () => {
     const entry = describeWorkEntry(
       chunk({ title: "write_todos", toolKind: "other", input: {} }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.heading).toBe("Update todos");
-    expect(entry.preview).toBeNull();
-  });
+    expect(entry.heading).toBe("Update todos")
+    expect(entry.preview).toBeNull()
+  })
 
   it("falls back to tool locations when the input carries no argument", () => {
     const entry = describeWorkEntry(
@@ -106,11 +113,11 @@ describe("describeWorkEntry", () => {
           { path: `${projectPath}/b.ts` },
         ],
       }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.preview).toBe("a.ts +1 more");
-  });
+    expect(entry.preview).toBe("a.ts +1 more")
+  })
 
   it("builds an expandable body from the command and its output", () => {
     const entry = describeWorkEntry(
@@ -120,9 +127,9 @@ describe("describeWorkEntry", () => {
         input: { command: "ls" },
         output: "a.ts\nb.ts",
       }),
-      projectPath,
-    );
+      projectPath
+    )
 
-    expect(entry.expandedText).toBe("ls\n\na.ts\nb.ts");
-  });
-});
+    expect(entry.expandedText).toBe("ls\n\na.ts\nb.ts")
+  })
+})

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -1,5 +1,8 @@
-import type { AcpToolStatus, ToolExecutionChunk } from "@/features/agents/lib/types";
-import { formatToolDisplayParts } from "@/features/agents/components/chat/toolExecutionDisplay";
+import type {
+  AcpToolStatus,
+  ToolExecutionChunk,
+} from "@/features/agents/lib/types"
+import { formatToolDisplayParts } from "@/features/agents/components/chat/toolExecutionDisplay"
 
 export type WorkEntryIconName =
   | "bot"
@@ -12,109 +15,122 @@ export type WorkEntryIconName =
   | "square-pen"
   | "terminal"
   | "wrench"
-  | "zap";
+  | "zap"
 
-export type WorkEntryTone = "tool" | "thinking" | "error" | "info";
+export type WorkEntryTone = "tool" | "thinking" | "error" | "info"
 
 export interface WorkEntryView {
-  icon: WorkEntryIconName;
-  heading: string;
+  icon: WorkEntryIconName
+  heading: string
   /** Dimmed argument shown after the heading; null when it would just repeat it. */
-  preview: string | null;
-  tone: WorkEntryTone;
-  status: AcpToolStatus;
+  preview: string | null
+  tone: WorkEntryTone
+  status: AcpToolStatus
   /** Plain-text detail for rows that have no richer renderer of their own. */
-  expandedText: string | null;
+  expandedText: string | null
 }
 
 function iconForChunk(chunk: ToolExecutionChunk): WorkEntryIconName {
-  if (chunk.diffs?.length || chunk.diffData) return "square-pen";
+  if (chunk.diffs?.length || chunk.diffData) return "square-pen"
 
   switch (chunk.toolKind) {
     case "execute":
-      return "terminal";
+      return "terminal"
     case "read":
-      return "eye";
+      return "eye"
     case "search":
-      return "eye";
+      return "eye"
     case "edit":
     case "delete":
     case "move":
-      return "square-pen";
+      return "square-pen"
     case "fetch":
-      return "globe";
+      return "globe"
     case "think":
-      return "bot";
+      return "bot"
     case "slack":
     case "linear":
-      return "message-circle";
+      return "message-circle"
     case "task":
-      return "hammer";
+      return "hammer"
     default:
-      return "wrench";
+      return "wrench"
   }
 }
 
 function toneForChunk(chunk: ToolExecutionChunk): WorkEntryTone {
-  if (chunk.status === "error") return "error";
-  if (chunk.toolKind === "think") return "thinking";
-  return "tool";
+  if (chunk.status === "error") return "error"
+  if (chunk.toolKind === "think") return "thinking"
+  return "tool"
 }
 
-function firstLocationPath(chunk: ToolExecutionChunk, projectPath?: string): string | null {
-  const locations = chunk.locations ?? [];
-  const first = locations[0];
-  if (!first) return null;
-  const display = stripProjectPath(first.path, projectPath);
-  return locations.length === 1 ? display : `${display} +${locations.length - 1} more`;
+function firstLocationPath(
+  chunk: ToolExecutionChunk,
+  projectPath?: string
+): string | null {
+  const locations = chunk.locations ?? []
+  const first = locations[0]
+  if (!first) return null
+  const display = stripProjectPath(first.path, projectPath)
+  return locations.length === 1
+    ? display
+    : `${display} +${locations.length - 1} more`
 }
 
 function stripProjectPath(path: string, projectPath?: string): string {
-  if (!projectPath || !path.startsWith(projectPath)) return path;
-  return path.slice(projectPath.length).replace(/^\/+/, "") || ".";
+  if (!projectPath || !path.startsWith(projectPath)) return path
+  return path.slice(projectPath.length).replace(/^\/+/, "") || "."
 }
 
 function normalizeForCompare(value: string): string {
-  return value.trim().replace(/\s+/g, " ").toLowerCase();
+  return value.trim().replace(/\s+/g, " ").toLowerCase()
 }
 
 /**
  * Truncated so a runaway tool output can't blow up the row; the full text stays
  * reachable through the tool's own renderer where one exists.
  */
-const MAX_EXPANDED_TEXT_LENGTH = 4000;
+const MAX_EXPANDED_TEXT_LENGTH = 4000
 
-function expandedTextForChunk(chunk: ToolExecutionChunk, projectPath?: string): string | null {
-  const blocks: Array<string> = [];
+function expandedTextForChunk(
+  chunk: ToolExecutionChunk,
+  projectPath?: string
+): string | null {
+  const blocks: Array<string> = []
 
-  const command = typeof chunk.input?.command === "string" ? chunk.input.command.trim() : "";
-  if (command) blocks.push(command);
+  const command =
+    typeof chunk.input?.command === "string" ? chunk.input.command.trim() : ""
+  if (command) blocks.push(command)
 
-  const output = chunk.output?.trim();
-  if (output) blocks.push(output);
+  const output = chunk.output?.trim()
+  if (output) blocks.push(output)
 
-  const locations = chunk.locations ?? [];
+  const locations = chunk.locations ?? []
   if (!output && locations.length > 0) {
-    blocks.push(locations.map((loc) => stripProjectPath(loc.path, projectPath)).join("\n"));
+    blocks.push(
+      locations.map((loc) => stripProjectPath(loc.path, projectPath)).join("\n")
+    )
   }
 
-  if (blocks.length === 0) return null;
-  const joined = blocks.join("\n\n");
+  if (blocks.length === 0) return null
+  const joined = blocks.join("\n\n")
   return joined.length > MAX_EXPANDED_TEXT_LENGTH
     ? `${joined.slice(0, MAX_EXPANDED_TEXT_LENGTH)}\n…`
-    : joined;
+    : joined
 }
 
 /** The diff a tool call ultimately produced — the last one wins when a call touched a file repeatedly. */
 export function latestDiff(chunk: ToolExecutionChunk) {
-  return chunk.diffs?.length ? chunk.diffs[chunk.diffs.length - 1] : chunk.diffData;
+  return chunk.diffs?.length
+    ? chunk.diffs[chunk.diffs.length - 1]
+    : chunk.diffData
 }
 
 export function describeWorkEntry(
   chunk: ToolExecutionChunk,
-  projectPath?: string,
+  projectPath?: string
 ): WorkEntryView {
-  const diff = latestDiff(chunk);
+  const diff = latestDiff(chunk)
   if (diff) {
     const heading =
       chunk.status === "error"
@@ -123,7 +139,7 @@ export function describeWorkEntry(
           ? diff.isNewFile
             ? "Created"
             : "Edited"
-          : "Editing";
+          : "Editing"
     return {
       icon: "square-pen",
       heading,
@@ -132,26 +148,27 @@ export function describeWorkEntry(
       status: chunk.status,
       // The diff itself is the body; a text dump alongside it would be noise.
       expandedText: null,
-    };
+    }
   }
 
   const { heading, preview } = formatToolDisplayParts(
     chunk.title,
     chunk.toolKind,
     chunk.input,
-    projectPath,
-  );
-  const resolvedPreview = preview ?? firstLocationPath(chunk, projectPath);
+    projectPath
+  )
+  const resolvedPreview = preview ?? firstLocationPath(chunk, projectPath)
 
   return {
     icon: iconForChunk(chunk),
     heading,
     preview:
-      resolvedPreview && normalizeForCompare(resolvedPreview) !== normalizeForCompare(heading)
+      resolvedPreview &&
+      normalizeForCompare(resolvedPreview) !== normalizeForCompare(heading)
         ? resolvedPreview
         : null,
     tone: toneForChunk(chunk),
     status: chunk.status,
     expandedText: expandedTextForChunk(chunk, projectPath),
-  };
+  }
 }

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -1,36 +1,40 @@
-import type { Message, Project, QueuedThreadMessage } from "@/features/agents/lib/types";
+import type {
+  Message,
+  Project,
+  QueuedThreadMessage,
+} from "@/features/agents/lib/types"
 
 export interface ApprovalCallbacks {
-  onApprove?: (approvalRequestId: string) => void;
-  onReject?: (approvalRequestId: string) => void;
-  onAutoApprove?: (approvalRequestId: string) => void;
+  onApprove?: (approvalRequestId: string) => void
+  onReject?: (approvalRequestId: string) => void
+  onAutoApprove?: (approvalRequestId: string) => void
   /** Reveal a path in the side panel's diff view. */
-  onOpenFile?: (filePath: string) => void;
+  onOpenFile?: (filePath: string) => void
 }
 
 export type MessagesScrollControl = {
-  scrollToBottom: () => void;
-};
+  scrollToBottom: () => void
+}
 
 export interface MessagesProps extends ApprovalCallbacks {
-  messages: Array<Message>;
+  messages: Array<Message>
   /** Cloud threads only; enables the git-sourced changed-files card per turn. */
-  threadId?: string;
-  queuedMessages?: Array<QueuedThreadMessage>;
-  isStreaming: boolean;
+  threadId?: string
+  queuedMessages?: Array<QueuedThreadMessage>
+  isStreaming: boolean
   /** Live run signal from `useStream().isLoading` — drives Streamdown token animation. */
-  streamIsLoading?: boolean;
+  streamIsLoading?: boolean
   /** When set, drives the thinking spinner (stream + pending). Falls back to streamIsLoading/isStreaming. */
-  isThinking?: boolean;
-  settingUpSandbox?: boolean;
-  project?: Project | null;
-  contentWidthClass?: string;
+  isThinking?: boolean
+  settingUpSandbox?: boolean
+  project?: Project | null
+  contentWidthClass?: string
   /** Horizontal padding on centered content (scroll track stays edge-to-edge). */
-  contentPaddingClass?: string;
+  contentPaddingClass?: string
   /** Extra scroll padding so content can scroll under a bottom overlay (e.g. floating prompt). */
-  bottomInset?: number;
+  bottomInset?: number
   /** When "external", parent renders the scroll button (e.g. above a floating prompt). */
-  scrollButtonSlot?: "internal" | "external";
-  onShowScrollToBottomChange?: (show: boolean) => void;
-  scrollControlRef?: React.MutableRefObject<MessagesScrollControl | null>;
+  scrollButtonSlot?: "internal" | "external"
+  onShowScrollToBottomChange?: (show: boolean) => void
+  scrollControlRef?: React.MutableRefObject<MessagesScrollControl | null>
 }

--- a/ui/src/features/agents/components/subagents/SubagentActivity.tsx
+++ b/ui/src/features/agents/components/subagents/SubagentActivity.tsx
@@ -1,4 +1,7 @@
-import { useStreamContext as useAgentThreadStream, useToolCalls } from "@langchain/react"
+import {
+  useStreamContext as useAgentThreadStream,
+  useToolCalls,
+} from "@langchain/react"
 import { Check, Loader2, X } from "lucide-react"
 
 import { humanizeToolName } from "@/features/agents/lib/toolNames"
@@ -43,7 +46,7 @@ export function SubagentActivity({ namespace }: { namespace: Array<string> }) {
       <span className="truncate text-[10px] text-muted-foreground/70">
         {humanizeToolName(current.name)}
       </span>
-      <span className="ml-auto shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+      <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/70 tabular-nums">
         {stepCount} {stepCount === 1 ? "step" : "steps"}
       </span>
     </div>

--- a/ui/src/features/agents/components/subagents/SubagentCard.tsx
+++ b/ui/src/features/agents/components/subagents/SubagentCard.tsx
@@ -1,37 +1,44 @@
-import { memo } from "react";
-import { Bot, Loader2 } from "lucide-react";
+import { memo } from "react"
+import { Bot, Loader2 } from "lucide-react"
 
-import { SubagentActivity } from "./SubagentActivity";
-import type { ToolExecutionChunk } from "@/features/agents/lib/types";
-import { useIsInAgentThreadStream } from "@/features/agents/lib/provider/useIsInAgentThreadStream";
+import { SubagentActivity } from "./SubagentActivity"
+import type { ToolExecutionChunk } from "@/features/agents/lib/types"
+import { useIsInAgentThreadStream } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
 
 /** Coerce an unknown tool-argument value to a trimmed string, or `""`. */
 function asString(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
+  return typeof value === "string" ? value.trim() : ""
 }
 
 /**
  * A single subagent spawned via the `task` tool. Shows the subagent type and
  * the task input (its `description`) as a compact rectangle.
  */
-export const SubagentCard = memo(function SubagentCard({ chunk }: { chunk: ToolExecutionChunk }) {
-  const inLiveStream = useIsInAgentThreadStream();
-  const input = chunk.input ?? {};
-  const subagentType = asString(input.subagent_type) || "subagent";
-  const description = asString(input.description);
-  const isRunning = chunk.status === "in_progress" || chunk.status === "pending";
-  const isError = chunk.status === "error";
-  const namespace = chunk.subagentNamespace;
+export const SubagentCard = memo(function SubagentCard({
+  chunk,
+}: {
+  chunk: ToolExecutionChunk
+}) {
+  const inLiveStream = useIsInAgentThreadStream()
+  const input = chunk.input ?? {}
+  const subagentType = asString(input.subagent_type) || "subagent"
+  const description = asString(input.description)
+  const isRunning = chunk.status === "in_progress" || chunk.status === "pending"
+  const isError = chunk.status === "error"
+  const namespace = chunk.subagentNamespace
   const activity =
     inLiveStream && namespace && namespace.length > 0 ? (
       <SubagentActivity namespace={namespace} />
-    ) : null;
+    ) : null
 
   return (
     <div className="flex min-w-0 flex-col gap-1.5 overflow-hidden rounded-lg border border-border bg-accent p-2.5">
-      <div className="flex items-center gap-1.5 min-w-0">
+      <div className="flex min-w-0 items-center gap-1.5">
         {isRunning ? (
-          <Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" aria-hidden />
+          <Loader2
+            className="h-3 w-3 shrink-0 animate-spin text-primary"
+            aria-hidden
+          />
         ) : (
           <Bot
             className={`h-3 w-3 shrink-0 ${isError ? "text-red-400" : "text-primary"}`}
@@ -43,11 +50,11 @@ export const SubagentCard = memo(function SubagentCard({ chunk }: { chunk: ToolE
         </span>
       </div>
       {description && (
-        <p className="line-clamp-5 whitespace-pre-wrap break-words text-[11px] leading-4 text-muted-foreground/70">
+        <p className="line-clamp-5 text-[11px] leading-4 break-words whitespace-pre-wrap text-muted-foreground/70">
           {description}
         </p>
       )}
       {activity}
     </div>
-  );
-});
+  )
+})

--- a/ui/src/features/agents/components/subagents/SubagentGroup.tsx
+++ b/ui/src/features/agents/components/subagents/SubagentGroup.tsx
@@ -1,8 +1,8 @@
-import { SubagentCard } from "./SubagentCard";
-import type { ToolExecutionChunk } from "@/features/agents/lib/types";
+import { SubagentCard } from "./SubagentCard"
+import type { ToolExecutionChunk } from "@/features/agents/lib/types"
 
 /** Maximum number of subagent cards rendered per row. */
-const MAX_SUBAGENT_COLUMNS = 4;
+const MAX_SUBAGENT_COLUMNS = 4
 
 /**
  * Renders the subagents from a `subagent-group` render item as a responsive
@@ -10,8 +10,12 @@ const MAX_SUBAGENT_COLUMNS = 4;
  * {@link MAX_SUBAGENT_COLUMNS}, so 1–4 subagents fill the row evenly and 5+
  * wrap onto additional rows.
  */
-export function SubagentGroup({ chunks }: { chunks: Array<ToolExecutionChunk> }) {
-  const columns = Math.min(Math.max(chunks.length, 1), MAX_SUBAGENT_COLUMNS);
+export function SubagentGroup({
+  chunks,
+}: {
+  chunks: Array<ToolExecutionChunk>
+}) {
+  const columns = Math.min(Math.max(chunks.length, 1), MAX_SUBAGENT_COLUMNS)
   return (
     <div
       className="grid gap-2"
@@ -21,5 +25,5 @@ export function SubagentGroup({ chunks }: { chunks: Array<ToolExecutionChunk> })
         <SubagentCard key={chunk.toolCallId} chunk={chunk} />
       ))}
     </div>
-  );
+  )
 }

--- a/ui/src/features/agents/components/subagents/index.ts
+++ b/ui/src/features/agents/components/subagents/index.ts
@@ -1,3 +1,3 @@
-export { SubagentActivity } from "./SubagentActivity";
-export { SubagentCard } from "./SubagentCard";
-export { SubagentGroup } from "./SubagentGroup";
+export { SubagentActivity } from "./SubagentActivity"
+export { SubagentCard } from "./SubagentCard"
+export { SubagentGroup } from "./SubagentGroup"

--- a/ui/src/features/agents/components/z-index.ts
+++ b/ui/src/features/agents/components/z-index.ts
@@ -3,4 +3,4 @@ export const Z = {
   OVERLAY: 40,
   DROPDOWN: 50,
   MODAL: 60,
-} as const;
+} as const

--- a/ui/src/features/agents/lib/messageTimestamps.ts
+++ b/ui/src/features/agents/lib/messageTimestamps.ts
@@ -65,5 +65,7 @@ const hoverTimeFormatter = new Intl.DateTimeFormat(undefined, {
 export function formatHoverTimestamp(value?: string): string | undefined {
   if (!value) return undefined
   const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? undefined : hoverTimeFormatter.format(date)
+  return Number.isNaN(date.getTime())
+    ? undefined
+    : hoverTimeFormatter.format(date)
 }

--- a/ui/src/features/agents/lib/provider/useIsInAgentThreadStream.tsx
+++ b/ui/src/features/agents/lib/provider/useIsInAgentThreadStream.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext } from "react";
-import type { ReactNode } from "react";
+import { createContext, useContext } from "react"
+import type { ReactNode } from "react"
 
 /**
  * Lightweight marker for whether the current subtree is rendering inside an
@@ -13,16 +13,20 @@ import type { ReactNode } from "react";
  * boundary is wrapped only around the thread view, so this stays `false` on
  * the home page where there is no thread to act on.
  */
-const AgentThreadStreamBoundaryContext = createContext(false);
+const AgentThreadStreamBoundaryContext = createContext(false)
 
 export function useIsInAgentThreadStream(): boolean {
-  return useContext(AgentThreadStreamBoundaryContext);
+  return useContext(AgentThreadStreamBoundaryContext)
 }
 
-export function AgentThreadStreamBoundary({ children }: { children: ReactNode }) {
+export function AgentThreadStreamBoundary({
+  children,
+}: {
+  children: ReactNode
+}) {
   return (
     <AgentThreadStreamBoundaryContext.Provider value={true}>
       {children}
     </AgentThreadStreamBoundaryContext.Provider>
-  );
+  )
 }

--- a/ui/src/features/agents/lib/provider/useLiveMarkdownMessageId.ts
+++ b/ui/src/features/agents/lib/provider/useLiveMarkdownMessageId.ts
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react"
 
-import type { Message } from "@/features/agents/lib/types";
+import type { Message } from "@/features/agents/lib/types"
 
 /** How long run-idle must persist before clearing the live markdown target. */
-const LIVE_MARKDOWN_CLEAR_MS = 2000;
+const LIVE_MARKDOWN_CLEAR_MS = 2000
 
 /**
  * Latches the agent message id that should stay in Streamdown "live" mode.
@@ -13,45 +13,49 @@ const LIVE_MARKDOWN_CLEAR_MS = 2000;
 export function useLiveMarkdownMessageId(
   visibleMessages: Array<Message>,
   streamIsLoading: boolean | undefined,
-  isStreaming: boolean,
+  isStreaming: boolean
 ): string | null {
-  const [liveMessageId, setLiveMessageId] = useState<string | null>(null);
-  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const runActive = Boolean(streamIsLoading || isStreaming);
+  const [liveMessageId, setLiveMessageId] = useState<string | null>(null)
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
+  const runActive = Boolean(streamIsLoading || isStreaming)
 
   useEffect(() => {
     if (runActive) {
       if (clearTimerRef.current) {
-        clearTimeout(clearTimerRef.current);
-        clearTimerRef.current = undefined;
+        clearTimeout(clearTimerRef.current)
+        clearTimerRef.current = undefined
       }
 
-      const lastMessage = visibleMessages[visibleMessages.length - 1];
+      const lastMessage = visibleMessages[visibleMessages.length - 1]
       // A new user prompt at the tail means the prior agent turn is done — keep it
       // static so Streamdown does not re-animate it while waiting for the reply.
       if (!lastMessage || lastMessage.author === "user") {
-        setLiveMessageId(null);
-        return;
+        setLiveMessageId(null)
+        return
       }
 
       if (lastMessage.author === "agent") {
-        setLiveMessageId((prev) => (prev === lastMessage.id ? prev : lastMessage.id));
+        setLiveMessageId((prev) =>
+          prev === lastMessage.id ? prev : lastMessage.id
+        )
       }
-      return;
+      return
     }
 
     clearTimerRef.current = setTimeout(() => {
-      clearTimerRef.current = undefined;
-      setLiveMessageId(null);
-    }, LIVE_MARKDOWN_CLEAR_MS);
+      clearTimerRef.current = undefined
+      setLiveMessageId(null)
+    }, LIVE_MARKDOWN_CLEAR_MS)
 
     return () => {
       if (clearTimerRef.current) {
-        clearTimeout(clearTimerRef.current);
-        clearTimerRef.current = undefined;
+        clearTimeout(clearTimerRef.current)
+        clearTimerRef.current = undefined
       }
-    };
-  }, [runActive, visibleMessages]);
+    }
+  }, [runActive, visibleMessages])
 
-  return liveMessageId;
+  return liveMessageId
 }

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -1,70 +1,84 @@
-import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
-import { messageArrivalTimestamp } from "./messageTimestamps";
-import { humanizeToolName } from "./toolNames";
-import type { BaseMessage, ContentBlock } from "@langchain/core/messages";
-import type { AssembledToolCall, SubagentDiscoverySnapshot } from "@langchain/react";
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
+import { messageArrivalTimestamp } from "./messageTimestamps"
+import { humanizeToolName } from "./toolNames"
+import type { BaseMessage, ContentBlock } from "@langchain/core/messages"
+import type {
+  AssembledToolCall,
+  SubagentDiscoverySnapshot,
+} from "@langchain/react"
 
-import type { Chunk, DiffData, Message, ToolExecutionChunk } from "./types";
+import type { Chunk, DiffData, Message, ToolExecutionChunk } from "./types"
 
-const READ_TOOLS = new Set(["read_file", "read", "ls"]);
-const EDIT_TOOLS = new Set(["write_file", "edit_file", "str_replace", "write", "edit", "patch"]);
-const EXECUTE_TOOLS = new Set(["execute", "bash", "shell", "run_terminal_cmd"]);
-const SEARCH_TOOLS = new Set(["glob", "grep", "web_search", "search"]);
-const FETCH_TOOLS = new Set(["fetch", "fetch_url", "http_request"]);
-const INTERNAL_TOOLS = new Set(["confirming_completion", "no_op"]);
+const READ_TOOLS = new Set(["read_file", "read", "ls"])
+const EDIT_TOOLS = new Set([
+  "write_file",
+  "edit_file",
+  "str_replace",
+  "write",
+  "edit",
+  "patch",
+])
+const EXECUTE_TOOLS = new Set(["execute", "bash", "shell", "run_terminal_cmd"])
+const SEARCH_TOOLS = new Set(["glob", "grep", "web_search", "search"])
+const FETCH_TOOLS = new Set(["fetch", "fetch_url", "http_request"])
+const INTERNAL_TOOLS = new Set(["confirming_completion", "no_op"])
 
-type ToolKind = ToolExecutionChunk["toolKind"];
+type ToolKind = ToolExecutionChunk["toolKind"]
 
 function toolKind(name: string): ToolKind {
-  const lowered = name.toLowerCase();
+  const lowered = name.toLowerCase()
   // deepagents' subagent spawner — surfaced as a subagent card in Messages.
-  if (lowered === "task") return "task";
-  if (lowered === "slack_thread_reply") return "slack";
-  if (lowered === "linear_comment") return "linear";
-  if (lowered === "write_todos") return "other";
-  if (EDIT_TOOLS.has(lowered) || ["edit", "write", "replace"].some((t) => lowered.includes(t))) {
-    return "edit";
+  if (lowered === "task") return "task"
+  if (lowered === "slack_thread_reply") return "slack"
+  if (lowered === "linear_comment") return "linear"
+  if (lowered === "write_todos") return "other"
+  if (
+    EDIT_TOOLS.has(lowered) ||
+    ["edit", "write", "replace"].some((t) => lowered.includes(t))
+  ) {
+    return "edit"
   }
-  if (EXECUTE_TOOLS.has(lowered)) return "execute";
-  if (FETCH_TOOLS.has(lowered)) return "fetch";
-  if (SEARCH_TOOLS.has(lowered)) return "search";
-  if (READ_TOOLS.has(lowered) || lowered.includes("read")) return "read";
-  if (lowered === "think") return "think";
-  return "other";
+  if (EXECUTE_TOOLS.has(lowered)) return "execute"
+  if (FETCH_TOOLS.has(lowered)) return "fetch"
+  if (SEARCH_TOOLS.has(lowered)) return "search"
+  if (READ_TOOLS.has(lowered) || lowered.includes("read")) return "read"
+  if (lowered === "think") return "think"
+  return "other"
 }
 
 function toolTitle(name: string, args: Record<string, unknown>): string {
-  const path = args.path ?? args.file_path ?? args.target_file;
-  if (typeof path === "string" && path.trim()) return `${name} ${path.trim()}`;
-  const command = args.command;
+  const path = args.path ?? args.file_path ?? args.target_file
+  if (typeof path === "string" && path.trim()) return `${name} ${path.trim()}`
+  const command = args.command
   if (typeof command === "string" && command.trim()) {
-    return command.trim().split("\n")[0]?.slice(0, 120) ?? "";
+    return command.trim().split("\n")[0]?.slice(0, 120) ?? ""
   }
-  return humanizeToolName(name);
+  return humanizeToolName(name)
 }
 
 function parseToolArgs(raw: unknown): Record<string, unknown> {
-  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>;
+  if (raw && typeof raw === "object" && !Array.isArray(raw))
+    return raw as Record<string, unknown>
   if (typeof raw === "string") {
     try {
-      const parsed = JSON.parse(raw);
+      const parsed = JSON.parse(raw)
       return parsed && typeof parsed === "object" && !Array.isArray(parsed)
         ? (parsed as Record<string, unknown>)
-        : { raw };
+        : { raw }
     } catch {
-      return { raw };
+      return { raw }
     }
   }
-  return {};
+  return {}
 }
 
 function maybeDiffFromArgs(args: Record<string, unknown>): DiffData | null {
-  const path = args.path ?? args.file_path ?? args.target_file;
-  if (typeof path !== "string" || !path.trim()) return null;
-  const oldContent = args.old_string ?? args.original_content;
-  const newContent = args.new_string ?? args.content ?? args.new_content;
-  if (typeof newContent !== "string") return null;
-  const original = typeof oldContent === "string" ? oldContent : null;
+  const path = args.path ?? args.file_path ?? args.target_file
+  if (typeof path !== "string" || !path.trim()) return null
+  const oldContent = args.old_string ?? args.original_content
+  const newContent = args.new_string ?? args.content ?? args.new_content
+  if (typeof newContent !== "string") return null
+  const original = typeof oldContent === "string" ? oldContent : null
   return {
     originalContent: original,
     newContent,
@@ -73,53 +87,54 @@ function maybeDiffFromArgs(args: Record<string, unknown>): DiffData | null {
     isBinary: false,
     isTruncated: false,
     totalLines: Math.max(newContent.split("\n").length, 1),
-  };
+  }
 }
 
 function mergeTextChunks(chunks: Array<Chunk>): Array<Chunk> {
-  const textIndices = chunks.flatMap((c, i) => (c.kind === "text" ? [i] : []));
-  if (textIndices.length <= 1) return chunks;
-  const lastText = textIndices[textIndices.length - 1];
-  return chunks.filter((c, i) => c.kind !== "text" || i === lastText);
+  const textIndices = chunks.flatMap((c, i) => (c.kind === "text" ? [i] : []))
+  if (textIndices.length <= 1) return chunks
+  const lastText = textIndices[textIndices.length - 1]
+  return chunks.filter((c, i) => c.kind !== "text" || i === lastText)
 }
 
 type AgentTurn = {
-  id: string;
-  author: Message["author"];
-  timestamp: string;
-  turnKey?: string;
-  startedAt: string;
-  timestampIsFallback?: boolean;
-  chunks: Array<Chunk>;
-};
+  id: string
+  author: Message["author"]
+  timestamp: string
+  turnKey?: string
+  startedAt: string
+  timestampIsFallback?: boolean
+  chunks: Array<Chunk>
+}
 
 type MessageTimestamp = {
-  value: string;
-  isFallback: boolean;
-};
+  value: string
+  isFallback: boolean
+}
 
 function messageTimestamp(
   raw: BaseMessage,
   msgId: string,
-  resolveCreatedAt?: (messageId: string) => string | undefined,
+  resolveCreatedAt?: (messageId: string) => string | undefined
 ): MessageTimestamp {
-  const msg = raw as unknown as Record<string, unknown>;
-  const createdAt = msg.created_at;
+  const msg = raw as unknown as Record<string, unknown>
+  const createdAt = msg.created_at
   if (typeof createdAt === "string" && createdAt) {
-    return { value: createdAt, isFallback: false };
+    return { value: createdAt, isFallback: false }
   }
-  const responseMetadata = msg.response_metadata;
+  const responseMetadata = msg.response_metadata
   if (responseMetadata && typeof responseMetadata === "object") {
-    const metadataCreatedAt = (responseMetadata as Record<string, unknown>).created_at;
+    const metadataCreatedAt = (responseMetadata as Record<string, unknown>)
+      .created_at
     if (typeof metadataCreatedAt === "string" && metadataCreatedAt) {
-      return { value: metadataCreatedAt, isFallback: false };
+      return { value: metadataCreatedAt, isFallback: false }
     }
   }
-  const resolved = resolveCreatedAt?.(msgId);
+  const resolved = resolveCreatedAt?.(msgId)
   if (typeof resolved === "string" && resolved) {
-    return { value: resolved, isFallback: true };
+    return { value: resolved, isFallback: true }
   }
-  return { value: new Date().toISOString(), isFallback: true };
+  return { value: new Date().toISOString(), isFallback: true }
 }
 
 /**
@@ -130,69 +145,69 @@ function messageTimestamp(
  * provider's raw shape ourselves.
  */
 function reasoningText(raw: BaseMessage): string {
-  let blocks: Array<ContentBlock.Standard>;
+  let blocks: Array<ContentBlock.Standard>
   try {
-    blocks = raw.contentBlocks;
+    blocks = raw.contentBlocks
   } catch {
-    return "";
+    return ""
   }
-  let text = "";
+  let text = ""
   for (const block of blocks) {
-    if (block.type !== "reasoning") continue;
+    if (block.type !== "reasoning") continue
     // Reasoning blocks can arrive without a summary (e.g. OpenAI reasoning
     // models emit `{ type: "reasoning", extras: { content: [] } }` with no
     // `reasoning` field) — skip those so we don't render a "Thought" block
     // whose body is the literal string "undefined".
-    const reasoning: unknown = block.reasoning;
-    if (typeof reasoning === "string") text += reasoning;
+    const reasoning: unknown = block.reasoning
+    if (typeof reasoning === "string") text += reasoning
   }
-  return text.trim();
+  return text.trim()
 }
 
 function imageChunks(content: unknown): Array<Chunk> {
-  if (!Array.isArray(content)) return [];
+  if (!Array.isArray(content)) return []
 
-  const chunks: Array<Chunk> = [];
+  const chunks: Array<Chunk> = []
   for (const item of content) {
-    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-    const block = item as Record<string, unknown>;
-    const type = block.type;
-    let base64: string | undefined;
-    let mimeType: string | undefined;
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue
+    const block = item as Record<string, unknown>
+    const type = block.type
+    let base64: string | undefined
+    let mimeType: string | undefined
 
     if (type === "image") {
-      const data = block.data ?? block.base64;
-      const mime = block.mime_type ?? block.mimeType;
+      const data = block.data ?? block.base64
+      const mime = block.mime_type ?? block.mimeType
       if (typeof data === "string" && typeof mime === "string") {
-        base64 = data;
-        mimeType = mime;
+        base64 = data
+        mimeType = mime
       }
     } else if (type === "image_url") {
-      const imageUrl = block.image_url;
+      const imageUrl = block.image_url
       const url =
         imageUrl && typeof imageUrl === "object"
           ? (imageUrl as Record<string, unknown>).url
-          : undefined;
+          : undefined
       if (typeof url === "string") {
-        const match = /^data:(image\/[^;]+);base64,(.+)$/s.exec(url);
+        const match = /^data:(image\/[^;]+);base64,(.+)$/s.exec(url)
         if (match) {
-          mimeType = match[1];
-          base64 = match[2];
+          mimeType = match[1]
+          base64 = match[2]
         }
       }
     }
 
     if (base64 && mimeType) {
-      const fileName = block.fileName ?? block.file_name;
+      const fileName = block.fileName ?? block.file_name
       chunks.push({
         kind: "image",
         base64,
         mimeType,
         ...(typeof fileName === "string" && fileName ? { fileName } : {}),
-      });
+      })
     }
   }
-  return chunks;
+  return chunks
 }
 
 /**
@@ -203,41 +218,41 @@ function imageChunks(content: unknown): Array<Chunk> {
  */
 function toolStatus(
   assembled: AssembledToolCall | undefined,
-  toolMessage: ToolMessage | undefined,
+  toolMessage: ToolMessage | undefined
 ): ToolExecutionChunk["status"] {
   if (assembled) {
-    if (assembled.status === "finished") return "completed";
-    if (assembled.status === "error") return "error";
-    return "in_progress";
+    if (assembled.status === "finished") return "completed"
+    if (assembled.status === "error") return "error"
+    return "in_progress"
   }
-  if (toolMessage) return toolMessage.status === "error" ? "error" : "completed";
-  return "in_progress";
+  if (toolMessage) return toolMessage.status === "error" ? "error" : "completed"
+  return "in_progress"
 }
 
 /** Map a {@link SubagentDiscoverySnapshot}'s lifecycle to the UI tool status. */
 function subagentStatus(
-  snapshot: SubagentDiscoverySnapshot,
+  snapshot: SubagentDiscoverySnapshot
 ): ToolExecutionChunk["status"] {
-  if (snapshot.status === "complete") return "completed";
-  if (snapshot.status === "error") return "error";
-  return "in_progress";
+  if (snapshot.status === "complete") return "completed"
+  if (snapshot.status === "error") return "error"
+  return "in_progress"
 }
 
 function toolOutputText(
   assembled: AssembledToolCall | undefined,
-  toolMessage: ToolMessage | undefined,
+  toolMessage: ToolMessage | undefined
 ): string | undefined {
-  const value = assembled?.output;
+  const value = assembled?.output
   if (value != null) {
-    if (typeof value === "string") return value.trim() || undefined;
+    if (typeof value === "string") return value.trim() || undefined
     try {
-      return JSON.stringify(value);
+      return JSON.stringify(value)
     } catch {
-      return String(value);
+      return String(value)
     }
   }
-  const text = toolMessage?.text.trim();
-  return text || undefined;
+  const text = toolMessage?.text.trim()
+  return text || undefined
 }
 
 /**
@@ -262,44 +277,44 @@ export function streamMessagesToUi(
   messages: Array<BaseMessage>,
   toolCalls: ReadonlyArray<AssembledToolCall> = [],
   subagents: ReadonlyMap<string, SubagentDiscoverySnapshot> = new Map(),
-  resolveCreatedAt?: (messageId: string) => string | undefined,
+  resolveCreatedAt?: (messageId: string) => string | undefined
 ): Array<Message> {
-  const toolCallsById = new Map<string, AssembledToolCall>();
+  const toolCallsById = new Map<string, AssembledToolCall>()
   for (const toolCall of toolCalls) {
-    const id = toolCall.id || toolCall.callId;
-    if (id) toolCallsById.set(id, toolCall);
+    const id = toolCall.id || toolCall.callId
+    if (id) toolCallsById.set(id, toolCall)
   }
 
   // The discovery map is keyed by subagent name (one entry per name), but each
   // snapshot records the `task` tool-call id that spawned it — so re-index by
   // that id to correlate a snapshot to the exact `task` chunk that created it.
-  const subagentsByCallId = new Map<string, SubagentDiscoverySnapshot>();
+  const subagentsByCallId = new Map<string, SubagentDiscoverySnapshot>()
   for (const snapshot of subagents.values()) {
-    if (snapshot.id) subagentsByCallId.set(snapshot.id, snapshot);
+    if (snapshot.id) subagentsByCallId.set(snapshot.id, snapshot)
   }
 
-  const toolMessagesById = new Map<string, ToolMessage>();
+  const toolMessagesById = new Map<string, ToolMessage>()
   for (const raw of messages) {
     if (ToolMessage.isInstance(raw) && typeof raw.tool_call_id === "string") {
-      toolMessagesById.set(raw.tool_call_id, raw);
+      toolMessagesById.set(raw.tool_call_id, raw)
     }
   }
 
-  const uiMessages: Array<Message> = [];
-  let agentTurn: AgentTurn | null = null;
-  let turnKey: string | undefined;
+  const uiMessages: Array<Message> = []
+  let agentTurn: AgentTurn | null = null
+  let turnKey: string | undefined
 
   const flushAgentTurn = () => {
-    if (!agentTurn) return;
-    uiMessages.push({ ...agentTurn, chunks: mergeTextChunks(agentTurn.chunks) });
-    agentTurn = null;
-  };
+    if (!agentTurn) return
+    uiMessages.push({ ...agentTurn, chunks: mergeTextChunks(agentTurn.chunks) })
+    agentTurn = null
+  }
 
   const appendAgentChunks = (
     msgId: string,
     timestamp: string,
     timestampIsFallback: boolean,
-    chunks: Array<Chunk>,
+    chunks: Array<Chunk>
   ) => {
     if (!agentTurn) {
       agentTurn = {
@@ -310,52 +325,52 @@ export function streamMessagesToUi(
         startedAt: timestamp,
         timestampIsFallback,
         chunks: [...chunks],
-      };
+      }
     } else {
-      agentTurn.timestamp = timestamp;
+      agentTurn.timestamp = timestamp
       agentTurn.timestampIsFallback =
-        agentTurn.timestampIsFallback || timestampIsFallback;
-      agentTurn.chunks.push(...chunks);
+        agentTurn.timestampIsFallback || timestampIsFallback
+      agentTurn.chunks.push(...chunks)
     }
-  };
+  }
 
   messages.forEach((raw, index) => {
-    const msgId = typeof raw.id === "string" && raw.id ? raw.id : `msg-${index}`;
+    const msgId = typeof raw.id === "string" && raw.id ? raw.id : `msg-${index}`
     const { value: timestamp, isFallback: timestampIsFallback } =
-      messageTimestamp(raw, msgId, resolveCreatedAt);
+      messageTimestamp(raw, msgId, resolveCreatedAt)
 
     if (HumanMessage.isInstance(raw)) {
-      flushAgentTurn();
-      turnKey = typeof raw.id === "string" ? raw.id : undefined;
-      const content = (raw as unknown as { content?: unknown }).content;
-      const chunks = imageChunks(content);
-      const text = raw.text.trim();
-      if (text) chunks.push({ kind: "text", text });
-      if (!chunks.length) return;
+      flushAgentTurn()
+      turnKey = typeof raw.id === "string" ? raw.id : undefined
+      const content = (raw as unknown as { content?: unknown }).content
+      const chunks = imageChunks(content)
+      const text = raw.text.trim()
+      if (text) chunks.push({ kind: "text", text })
+      if (!chunks.length) return
       uiMessages.push({
         id: msgId,
         author: "user",
         timestamp,
         timestampIsFallback,
         chunks,
-      });
-      return;
+      })
+      return
     }
 
     if (AIMessage.isInstance(raw)) {
-      const chunks: Array<Chunk> = [];
-      const reasoning = reasoningText(raw);
-      if (reasoning) chunks.push({ kind: "reasoning", text: reasoning });
-      const text = raw.text.trim();
-      if (text) chunks.push({ kind: "text", text });
+      const chunks: Array<Chunk> = []
+      const reasoning = reasoningText(raw)
+      if (reasoning) chunks.push({ kind: "reasoning", text: reasoning })
+      const text = raw.text.trim()
+      if (text) chunks.push({ kind: "text", text })
 
       for (const toolCall of raw.tool_calls ?? []) {
-        const name = toolCall.name || "tool";
-        if (INTERNAL_TOOLS.has(name)) continue;
-        const toolCallId = toolCall.id || `tool-${index}-${chunks.length}`;
-        const args = parseToolArgs(toolCall.args);
-        const assembled = toolCallsById.get(toolCallId);
-        const toolMessage = toolMessagesById.get(toolCallId);
+        const name = toolCall.name || "tool"
+        if (INTERNAL_TOOLS.has(name)) continue
+        const toolCallId = toolCall.id || `tool-${index}-${chunks.length}`
+        const args = parseToolArgs(toolCall.args)
+        const assembled = toolCallsById.get(toolCallId)
+        const toolMessage = toolMessagesById.get(toolCallId)
         const chunk: ToolExecutionChunk = {
           kind: "tool-execution",
           toolCallId,
@@ -364,30 +379,30 @@ export function streamMessagesToUi(
           toolKind: toolKind(name),
           input: args,
           status: toolStatus(assembled, toolMessage),
-        };
-        const output = toolOutputText(assembled, toolMessage);
-        if (output) chunk.output = output;
-        const diffData = maybeDiffFromArgs(args);
-        if (diffData) chunk.diffData = diffData;
+        }
+        const output = toolOutputText(assembled, toolMessage)
+        if (output) chunk.output = output
+        const diffData = maybeDiffFromArgs(args)
+        if (diffData) chunk.diffData = diffData
         // When the SDK has discovered the subagent this `task` call spawned, take
         // its namespace (for scoped nested activity) and authoritative status.
-        const subagent = subagentsByCallId.get(toolCallId);
+        const subagent = subagentsByCallId.get(toolCallId)
         if (subagent) {
-          chunk.subagentNamespace = [...subagent.namespace];
-          chunk.status = subagentStatus(subagent);
+          chunk.subagentNamespace = [...subagent.namespace]
+          chunk.status = subagentStatus(subagent)
         }
-        chunks.push(chunk);
+        chunks.push(chunk)
       }
 
       if (chunks.length) {
-        appendAgentChunks(msgId, timestamp, timestampIsFallback, chunks);
+        appendAgentChunks(msgId, timestamp, timestampIsFallback, chunks)
       }
     }
 
     // `ToolMessage`s no longer produce their own chunk — their status/output is
     // attached to the originating tool-call chunk above via `stream.toolCalls`.
-  });
+  })
 
-  flushAgentTurn();
-  return uiMessages;
+  flushAgentTurn()
+  return uiMessages
 }

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -13,18 +13,10 @@ export type ChunkKind =
 export type TodoStatus = "pending" | "in_progress" | "completed"
 
 export type AgentStatus =
-  | "idle"
-  | "running"
-  | "finished"
-  | "interrupted"
-  | "error"
+  "idle" | "running" | "finished" | "interrupted" | "error"
 
 export type AgentSource =
-  | "dashboard"
-  | "github"
-  | "slack"
-  | "linear"
-  | "schedule"
+  "dashboard" | "github" | "slack" | "linear" | "schedule"
 
 export interface TodoItem {
   content: string

--- a/ui/src/features/agents/utils/diffStats.ts
+++ b/ui/src/features/agents/utils/diffStats.ts
@@ -1,20 +1,20 @@
-import { parseDiffFromFile } from "@pierre/diffs";
+import { parseDiffFromFile } from "@pierre/diffs"
 
 export function countLineChanges(
   originalContent: string | null | undefined,
   newContent: string,
-  filePath = "file",
+  filePath = "file"
 ): { additions: number; deletions: number } {
   const meta = parseDiffFromFile(
     { name: filePath, contents: originalContent ?? "" },
-    { name: filePath, contents: newContent },
-  );
+    { name: filePath, contents: newContent }
+  )
 
-  let additions = 0;
-  let deletions = 0;
+  let additions = 0
+  let deletions = 0
   for (const hunk of meta.hunks) {
-    additions += hunk.additionLines;
-    deletions += hunk.deletionLines;
+    additions += hunk.additionLines
+    deletions += hunk.deletionLines
   }
-  return { additions, deletions };
+  return { additions, deletions }
 }

--- a/ui/src/features/automations/components/AutomationEditor.tsx
+++ b/ui/src/features/automations/components/AutomationEditor.tsx
@@ -10,7 +10,10 @@ import { RepoSelector } from "@/features/settings/components/RepoSelector"
 import { ScheduleTriggerPicker } from "@/features/automations/components/ScheduleTriggerPicker"
 import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
-import { describeCron, isDescribableCron } from "@/features/automations/lib/cron"
+import {
+  describeCron,
+  isDescribableCron,
+} from "@/features/automations/lib/cron"
 import {
   useCreateAgentSchedule,
   useDeleteAgentSchedule,
@@ -36,9 +39,7 @@ function scheduleToSelection(
     (model) =>
       model.id === schedule.model && model.efforts.includes(schedule.effort!)
   )
-  return supported
-    ? { modelId: schedule.model, effort: schedule.effort }
-    : null
+  return supported ? { modelId: schedule.model, effort: schedule.effort } : null
 }
 
 export function AutomationEditor({

--- a/ui/src/features/automations/components/AutomationsList.tsx
+++ b/ui/src/features/automations/components/AutomationsList.tsx
@@ -43,9 +43,7 @@ export function AutomationsList() {
   return (
     <div className="flex min-w-0 flex-1 flex-col overflow-y-auto">
       <div className="mx-auto w-full max-w-4xl px-6 py-8 max-md:pt-16">
-        <h1 className="text-base font-medium text-foreground">
-          Automations
-        </h1>
+        <h1 className="text-base font-medium text-foreground">Automations</h1>
         <p className="mt-1 text-xs text-muted-foreground">
           Run Open SWE on a recurring schedule. Each run starts a fresh agent
           thread.
@@ -55,7 +53,11 @@ export function AutomationsList() {
           <StatCard label="Total" value={total} />
           <StatCard label="Active" value={active} />
           <StatCard label="Paused" value={paused} />
-          <StatCard label="Needs attention" value={issues} highlight={issues > 0} />
+          <StatCard
+            label="Needs attention"
+            value={issues}
+            highlight={issues > 0}
+          />
         </div>
 
         <div className="mt-8 flex items-center justify-between">

--- a/ui/src/features/automations/lib/cron.ts
+++ b/ui/src/features/automations/lib/cron.ts
@@ -35,7 +35,13 @@ export function describeCron(expr: string): string {
   const [min, hour, dom, mon, dow] = parts
   if (!min || !hour || !dom || !mon || !dow) return expr
 
-  if (min === "0" && hour === "*" && dom === "*" && mon === "*" && dow === "*") {
+  if (
+    min === "0" &&
+    hour === "*" &&
+    dom === "*" &&
+    mon === "*" &&
+    dow === "*"
+  ) {
     return "Every hour"
   }
 

--- a/ui/src/features/reviews/components/ReviewChat.tsx
+++ b/ui/src/features/reviews/components/ReviewChat.tsx
@@ -101,9 +101,13 @@ function attachmentPillLabel(attachment: ChatAttachment): string {
 
 // Serialize attachments as fenced code blocks ahead of the prose so the model
 // receives the code as context. The UI renders pills instead (see parse below).
-function serializeMessage(text: string, attachments: Array<ChatAttachment>): string {
+function serializeMessage(
+  text: string,
+  attachments: Array<ChatAttachment>
+): string {
   const blocks = attachments.map(
-    (a) => `\`${a.path}:${a.lineLabel}\`\n\`\`\`${a.language}\n${a.snippet}\n\`\`\``
+    (a) =>
+      `\`${a.path}:${a.lineLabel}\`\n\`\`\`${a.language}\n${a.snippet}\n\`\`\``
   )
   return [...blocks, text.trim()].filter(Boolean).join("\n\n")
 }
@@ -146,7 +150,7 @@ function AttachmentPill({
   onRemove?: () => void
 }) {
   return (
-    <span className="inline-flex max-w-[200px] items-center gap-1 rounded-md border border-border bg-muted/60 py-0.5 pl-1.5 pr-1 text-[11px] text-foreground">
+    <span className="inline-flex max-w-[200px] items-center gap-1 rounded-md border border-border bg-muted/60 py-0.5 pr-1 pl-1.5 text-[11px] text-foreground">
       <CodeIcon className="size-3 shrink-0 text-muted-foreground" />
       <span className="truncate font-mono">{label}</span>
       {onRemove && (
@@ -236,7 +240,11 @@ function storageKey(owner: string, repo: string, number: number): string {
 }
 
 function newDraft(): Conversation {
-  return { id: crypto.randomUUID(), title: DEFAULT_TITLE, createdAt: Date.now() }
+  return {
+    id: crypto.randomUUID(),
+    title: DEFAULT_TITLE,
+    createdAt: Date.now(),
+  }
 }
 
 function isConversation(value: unknown): value is Conversation {
@@ -298,7 +306,7 @@ function useConversations(key: string) {
         return next
       })
     },
-    [key],
+    [key]
   )
 
   const select = useCallback(
@@ -310,7 +318,7 @@ function useConversations(key: string) {
         activeId: conversation.id,
       }))
     },
-    [update],
+    [update]
   )
 
   const newChat = useCallback(() => {
@@ -319,7 +327,10 @@ function useConversations(key: string) {
       // Reuse a pristine, never-sent draft instead of stacking empty tabs.
       if (active && active.title === DEFAULT_TITLE) return prev
       const draft = newDraft()
-      return { conversations: [...prev.conversations, draft], activeId: draft.id }
+      return {
+        conversations: [...prev.conversations, draft],
+        activeId: draft.id,
+      }
     })
   }, [update])
 
@@ -332,12 +343,12 @@ function useConversations(key: string) {
         return {
           ...prev,
           conversations: prev.conversations.map((c) =>
-            c.id === id ? { ...c, title } : c,
+            c.id === id ? { ...c, title } : c
           ),
         }
       })
     },
-    [update],
+    [update]
   )
 
   const close = useCallback(
@@ -357,7 +368,7 @@ function useConversations(key: string) {
         }
       })
     },
-    [update],
+    [update]
   )
 
   return { ...state, select, newChat, nameConversation, close }
@@ -450,7 +461,7 @@ function ChatBody({
       onUserSend(trimmed || (first ? attachmentPillLabel(first) : ""))
       void stream.submit({ messages: [{ type: "human", content }] })
     },
-    [busy, stream, onUserSend],
+    [busy, stream, onUserSend]
   )
 
   const visible = messages.filter((message) => {
@@ -557,7 +568,7 @@ function ChatBody({
       <div className="p-3">
         <div className="flex flex-col gap-1.5 rounded-2xl border border-border bg-background px-1.5 py-1.5 transition-colors focus-within:border-ring/60">
           {attachments.length > 0 && (
-            <div className="flex flex-wrap gap-1 pl-2 pt-0.5">
+            <div className="flex flex-wrap gap-1 pt-0.5 pl-2">
               {attachments.map((attachment) => (
                 <AttachmentPill
                   key={attachment.id}
@@ -611,7 +622,7 @@ function ChatPanel({
   const qc = useQueryClient()
   const threadsKey = useMemo(
     () => ["review-chat-threads", owner, repo, number] as const,
-    [owner, repo, number],
+    [owner, repo, number]
   )
   const { conversations, activeId, select, newChat, nameConversation, close } =
     useConversations(storageKey(owner, repo, number))
@@ -622,7 +633,7 @@ function ChatPanel({
   })
   const serverThreads = useMemo(
     () => threadsQuery.data?.threads ?? [],
-    [threadsQuery.data],
+    [threadsQuery.data]
   )
 
   const invalidateThreads = useCallback(() => {
@@ -633,8 +644,10 @@ function ChatPanel({
     mutationFn: (id: string) =>
       api.deleteReviewChatThread(owner, repo, number, id),
     onMutate: (id: string) => {
-      qc.setQueryData<{ threads: Array<ReviewChatThread> }>(threadsKey, (old) =>
-        old ? { threads: old.threads.filter((t) => t.thread_id !== id) } : old,
+      qc.setQueryData<{ threads: Array<ReviewChatThread> }>(
+        threadsKey,
+        (old) =>
+          old ? { threads: old.threads.filter((t) => t.thread_id !== id) } : old
       )
     },
     onSettled: invalidateThreads,
@@ -662,7 +675,9 @@ function ChatPanel({
     }
     return {
       openTabs: conversations.map((c) => byId.get(c.id) ?? c),
-      historyItems: [...byId.values()].sort((a, b) => b.createdAt - a.createdAt),
+      historyItems: [...byId.values()].sort(
+        (a, b) => b.createdAt - a.createdAt
+      ),
     }
   }, [conversations, serverThreads])
 
@@ -673,14 +688,14 @@ function ChatPanel({
       }
       close(id)
     },
-    [serverThreads, deleteThread, close],
+    [serverThreads, deleteThread, close]
   )
 
   const handleUserSend = useCallback(
     (text: string) => {
       nameConversation(activeId, deriveTitle(text))
     },
-    [nameConversation, activeId],
+    [nameConversation, activeId]
   )
 
   // Whether the active conversation should already have messages: it exists
@@ -700,10 +715,10 @@ function ChatPanel({
             <div
               key={tab.id}
               className={cn(
-                "flex shrink-0 items-center gap-1 rounded-md py-1 pl-2 pr-1 text-xs",
+                "flex shrink-0 items-center gap-1 rounded-md py-1 pr-1 pl-2 text-xs",
                 tab.id === activeId
                   ? "bg-muted text-foreground"
-                  : "text-muted-foreground hover:bg-muted/50",
+                  : "text-muted-foreground hover:bg-muted/50"
               )}
             >
               <button
@@ -753,7 +768,7 @@ function ChatPanel({
           />
           <Menu.Portal>
             <Menu.Positioner align="end" sideOffset={6} className="z-50">
-              <Menu.Popup className="origin-(--transform-origin) max-h-80 w-64 overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none">
+              <Menu.Popup className="max-h-80 w-64 origin-(--transform-origin) overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none">
                 {historyItems.length === 0 ? (
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
                     No conversations yet
@@ -766,7 +781,7 @@ function ChatPanel({
                     >
                       <Menu.Item
                         onClick={() => select(item)}
-                        className="flex flex-1 cursor-default items-center gap-2 rounded-md py-1.5 pl-2 pr-8 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                        className="flex flex-1 cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
                       >
                         {item.id === activeId ? (
                           <CheckIcon className="size-3.5 shrink-0" />
@@ -782,7 +797,7 @@ function ChatPanel({
                         variant="ghost"
                         size="icon-xs"
                         aria-label="Delete chat"
-                        className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover/hist:opacity-100"
+                        className="absolute top-1/2 right-1 -translate-y-1/2 opacity-0 group-hover/hist:opacity-100"
                         onClick={() => handleClose(item.id)}
                       >
                         <TrashIcon />

--- a/ui/src/features/reviews/components/ReviewSidebar.tsx
+++ b/ui/src/features/reviews/components/ReviewSidebar.tsx
@@ -231,9 +231,7 @@ const ReviewGroupRow = memo(function ReviewGroupRow({
       <span
         className={cn(
           "min-w-0 text-xs leading-5",
-          active
-            ? "font-medium text-foreground"
-            : "text-muted-foreground"
+          active ? "font-medium text-foreground" : "text-muted-foreground"
         )}
       >
         {title}

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -112,9 +112,13 @@ export function buildProfileUpdate(
     default_model: current?.default_model ?? fallbackModel,
     reasoning_effort: current?.reasoning_effort ?? fallbackEffort,
     default_subagent_model:
-      current?.default_subagent_model ?? current?.default_model ?? fallbackModel,
+      current?.default_subagent_model ??
+      current?.default_model ??
+      fallbackModel,
     subagent_reasoning_effort:
-      current?.subagent_reasoning_effort ?? current?.reasoning_effort ?? fallbackEffort,
+      current?.subagent_reasoning_effort ??
+      current?.reasoning_effort ??
+      fallbackEffort,
     default_repo: current?.default_repo ?? null,
     base_branch: current?.base_branch ?? null,
     branch_prefix: current?.branch_prefix ?? null,

--- a/ui/src/lib/query.ts
+++ b/ui/src/lib/query.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query"
 
 export function makeQueryClient() {
   return new QueryClient({
@@ -9,5 +9,5 @@ export function makeQueryClient() {
         refetchOnWindowFocus: false,
       },
     },
-  });
+  })
 }

--- a/ui/src/lib/repo.test.ts
+++ b/ui/src/lib/repo.test.ts
@@ -1,19 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 
-import { normalizeRepoFullName } from "./repo";
+import { normalizeRepoFullName } from "./repo"
 
 describe("normalizeRepoFullName", () => {
   it("accepts owner/repo", () => {
-    expect(normalizeRepoFullName("langchain-ai/langgraph")).toBe("langchain-ai/langgraph");
-  });
+    expect(normalizeRepoFullName("langchain-ai/langgraph")).toBe(
+      "langchain-ai/langgraph"
+    )
+  })
 
   it("accepts github URLs", () => {
-    expect(normalizeRepoFullName("https://github.com/withmartian/code-review-benchmark")).toBe(
-      "withmartian/code-review-benchmark",
-    );
-  });
+    expect(
+      normalizeRepoFullName(
+        "https://github.com/withmartian/code-review-benchmark"
+      )
+    ).toBe("withmartian/code-review-benchmark")
+  })
 
   it("rejects invalid input", () => {
-    expect(normalizeRepoFullName("not-a-repo")).toBeNull();
-  });
-});
+    expect(normalizeRepoFullName("not-a-repo")).toBeNull()
+  })
+})

--- a/ui/src/lib/repo.ts
+++ b/ui/src/lib/repo.ts
@@ -1,13 +1,17 @@
 /** Normalize GitHub repo input to `owner/name`. */
 export function normalizeRepoFullName(raw: string): string | null {
-  let v = raw.trim();
-  for (const prefix of ["https://github.com/", "http://github.com/", "github.com/"]) {
+  let v = raw.trim()
+  for (const prefix of [
+    "https://github.com/",
+    "http://github.com/",
+    "github.com/",
+  ]) {
     if (v.toLowerCase().startsWith(prefix)) {
-      v = v.slice(prefix.length);
+      v = v.slice(prefix.length)
     }
   }
-  v = v.replace(/\/$/, "").replace(/\.git$/, "");
-  const parts = v.split("/").filter(Boolean);
-  if (parts.length !== 2) return null;
-  return `${parts[0]}/${parts[1]}`;
+  v = v.replace(/\/$/, "").replace(/\.git$/, "")
+  const parts = v.split("/").filter(Boolean)
+  if (parts.length !== 2) return null
+  return `${parts[0]}/${parts[1]}`
 }

--- a/ui/src/lib/session.ts
+++ b/ui/src/lib/session.ts
@@ -1,19 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
-import { ApiError,  api } from "./api";
-import type {SessionUser} from "./api";
+import { useQuery } from "@tanstack/react-query"
+import { ApiError, api } from "./api"
+import type { SessionUser } from "./api"
 
 export function useSession() {
   return useQuery<SessionUser | null>({
     queryKey: ["session"],
     queryFn: async () => {
       try {
-        return await api.me();
+        return await api.me()
       } catch (e) {
-        if (e instanceof ApiError && e.status === 401) return null;
-        throw e;
+        if (e instanceof ApiError && e.status === 401) return null
+        throw e
       }
     },
     staleTime: 60_000,
     retry: false,
-  });
+  })
 }

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
-import type { ClassValue } from "clsx";
+import type { ClassValue } from "clsx"
 
 /**
  * Merge class names into a single string.
@@ -18,20 +18,20 @@ export function cn(...inputs: Array<ClassValue>) {
  * Format an elapsed duration in milliseconds as a compact string (e.g. "5s", "3m 20s").
  */
 export function formatElapsed(ms: number): string {
-  const secs = Math.max(1, Math.ceil(ms / 1000));
-  return secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  const secs = Math.max(1, Math.ceil(ms / 1000))
+  return secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`
 }
 
 /**
  * Intl.RelativeTimeFormat instance for formatting relative times.
  */
-const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" })
 
 /**
  * Format a timestamp as a relative time string.
  * @param ts - The timestamp to format.
  * @returns The relative time string.
- * 
+ *
  * @example
  * formatRelativeTime(Date.now()) // "just now"
  * formatRelativeTime(Date.now() - 1000) // "1 second ago"
@@ -41,22 +41,23 @@ const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
  * formatRelativeTime(Date.now() - 7 * 24 * 60 * 60 * 1000) // "1 week ago"
  */
 export function formatRelativeTime(ts: number): string {
-  const diffMs = ts - Date.now(); // negative for past
-  const absMs = Math.abs(diffMs);
+  const diffMs = ts - Date.now() // negative for past
+  const absMs = Math.abs(diffMs)
 
-  if (absMs < 60_000) return rtf.format(Math.round(diffMs / 1000), "second");
-  if (absMs < 60 * 60_000) return rtf.format(Math.round(diffMs / 60_000), "minute");
+  if (absMs < 60_000) return rtf.format(Math.round(diffMs / 1000), "second")
+  if (absMs < 60 * 60_000)
+    return rtf.format(Math.round(diffMs / 60_000), "minute")
   if (absMs < 24 * 60 * 60_000) {
-    return rtf.format(Math.round(diffMs / (60 * 60_000)), "hour");
+    return rtf.format(Math.round(diffMs / (60 * 60_000)), "hour")
   }
   if (absMs < 7 * 24 * 60 * 60_000) {
-    return rtf.format(Math.round(diffMs / (24 * 60 * 60_000)), "day");
+    return rtf.format(Math.round(diffMs / (24 * 60 * 60_000)), "day")
   }
   if (absMs < 30 * 24 * 60 * 60_000) {
-    return rtf.format(Math.round(diffMs / (7 * 24 * 60 * 60_000)), "week");
+    return rtf.format(Math.round(diffMs / (7 * 24 * 60 * 60_000)), "week")
   }
   if (absMs < 365 * 24 * 60 * 60_000) {
-    return rtf.format(Math.round(diffMs / (30 * 24 * 60 * 60_000)), "month");
+    return rtf.format(Math.round(diffMs / (30 * 24 * 60 * 60_000)), "month")
   }
-  return rtf.format(Math.round(diffMs / (365 * 24 * 60 * 60_000)), "year");
+  return rtf.format(Math.round(diffMs / (365 * 24 * 60 * 60_000)), "year")
 }

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -156,7 +156,9 @@ function RunningAgentsSection() {
                       setMessage(null)
                       cancel.mutate(thread.id, {
                         onSuccess: () =>
-                          setMessage(`Interruption requested for ${thread.title}.`),
+                          setMessage(
+                            `Interruption requested for ${thread.title}.`
+                          ),
                         onError: (error: Error) => setMessage(error.message),
                       })
                     }}
@@ -732,7 +734,9 @@ function LLMGatewaySection() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="inherit">Inherit deployment default</SelectItem>
+                <SelectItem value="inherit">
+                  Inherit deployment default
+                </SelectItem>
                 <SelectItem value="enabled">Enabled</SelectItem>
                 <SelectItem value="disabled">Disabled</SelectItem>
               </SelectContent>
@@ -747,7 +751,10 @@ function LLMGatewaySection() {
 
 function FableSection() {
   const qc = useQueryClient()
-  const settings = useQuery({ queryKey: ["teamSettings"], queryFn: api.getTeamSettings })
+  const settings = useQuery({
+    queryKey: ["teamSettings"],
+    queryFn: api.getTeamSettings,
+  })
   const [error, setError] = useState<string | null>(null)
   const save = useMutation({
     mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
@@ -771,7 +778,8 @@ function FableSection() {
             <Switch
               checked={!!settings.data?.fable_enabled}
               onCheckedChange={(next) =>
-                settings.data && save.mutate({ ...settings.data, fable_enabled: next })
+                settings.data &&
+                save.mutate({ ...settings.data, fable_enabled: next })
               }
               disabled={!settings.data || save.isPending}
             />

--- a/ui/src/routes/admin_.evals.tsx
+++ b/ui/src/routes/admin_.evals.tsx
@@ -10,7 +10,9 @@ import { api } from "@/lib/api"
 import { RequireLogin } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
 
-export const Route = createFileRoute("/admin_/evals")({ component: ReviewerEvalPage })
+export const Route = createFileRoute("/admin_/evals")({
+  component: ReviewerEvalPage,
+})
 
 function ReviewerEvalPage() {
   const session = useSession()
@@ -79,9 +81,15 @@ function ReviewerEvalStatusView({ data }: { data: ReviewerEvalStatus | null }) {
     <div className="grid gap-2 p-4 text-xs text-muted-foreground sm:grid-cols-2">
       <StatusLine label="Status" value={data.status} strong />
       <StatusLine label="Progress" value={progressLabel(data)} />
-      <StatusLine label="Run name" value={data.run_name ?? config?.experiment_prefix} />
+      <StatusLine
+        label="Run name"
+        value={data.run_name ?? config?.experiment_prefix}
+      />
       <StatusLine label="Dataset" value={config?.dataset_name} />
-      <StatusLine label="Limit" value={data.limit ? String(data.limit) : "full dataset"} />
+      <StatusLine
+        label="Limit"
+        value={data.limit ? String(data.limit) : "full dataset"}
+      />
       <StatusLine label="Model" value={config?.model_id} />
       <StatusLine label="Effort" value={config?.reasoning_effort} />
       <StatusLine label="Score mode" value={config?.score_mode} />
@@ -202,7 +210,7 @@ function ReviewerEvalLogs() {
                 el.scrollHeight - el.scrollTop - el.clientHeight < 24
               setFollow(atBottom)
             }}
-            className="max-h-[28rem] overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 p-3 font-mono text-xs text-foreground"
+            className="max-h-[28rem] overflow-auto rounded-md bg-muted/50 p-3 font-mono text-xs break-words whitespace-pre-wrap text-foreground"
           >
             {logTail}
           </pre>

--- a/ui/src/routes/agents/reviews/index.tsx
+++ b/ui/src/routes/agents/reviews/index.tsx
@@ -174,9 +174,7 @@ function ReviewsPage() {
           </div>
           {(page > 0 || reviews.data?.has_more) && (
             <div className="flex items-center justify-between gap-4 border-t border-border px-4 py-2 text-xs">
-              <span className="text-muted-foreground">
-                Page {page + 1}
-              </span>
+              <span className="text-muted-foreground">Page {page + 1}</span>
               <div className="flex items-center gap-2">
                 <Button
                   size="sm"

--- a/ui/src/routes/agents/threads.tsx
+++ b/ui/src/routes/agents/threads.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 
 import type { AgentSource, AgentStatus } from "@/features/agents/lib/types"
-import type { ThreadsPageFilters } from "@/features/agents/components/AgentsThreadsPage";
+import type { ThreadsPageFilters } from "@/features/agents/components/AgentsThreadsPage"
 import { AgentsThreadsPage } from "@/features/agents/components/AgentsThreadsPage"
 
 const SOURCES: ReadonlyArray<AgentSource> = [

--- a/ui/src/routes/agents_.instructions.tsx
+++ b/ui/src/routes/agents_.instructions.tsx
@@ -1,26 +1,26 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router"
 
-import { AgentInstructionsPanel } from "@/components/AgentInstructionsPanel";
-import { AppShell } from "@/components/AppShell";
-import { Skeleton } from "@/components/ui/skeleton";
-import { RequireLogin } from "@/lib/auth-redirect";
-import { useSession } from "@/lib/session";
+import { AgentInstructionsPanel } from "@/components/AgentInstructionsPanel"
+import { AppShell } from "@/components/AppShell"
+import { Skeleton } from "@/components/ui/skeleton"
+import { RequireLogin } from "@/lib/auth-redirect"
+import { useSession } from "@/lib/session"
 
 export const Route = createFileRoute("/agents_/instructions")({
   component: AgentInstructionsPage,
-});
+})
 
 function AgentInstructionsPage() {
-  const session = useSession();
+  const session = useSession()
 
   if (session.isLoading) {
     return (
       <main className="p-6">
         <Skeleton className="h-64 w-full" />
       </main>
-    );
+    )
   }
-  if (!session.data) return <RequireLogin />;
+  if (!session.data) return <RequireLogin />
 
   return (
     <AppShell
@@ -33,5 +33,5 @@ function AgentInstructionsPage() {
         <AgentInstructionsPanel />
       </div>
     </AppShell>
-  );
+  )
 }

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,7 +1,7 @@
-import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { Navigate, createFileRoute } from "@tanstack/react-router"
 
-export const Route = createFileRoute("/")({ component: Index });
+export const Route = createFileRoute("/")({ component: Index })
 
 function Index() {
-  return <Navigate to="/agents" />;
+  return <Navigate to="/agents" />
 }

--- a/ui/src/routes/integrations.tsx
+++ b/ui/src/routes/integrations.tsx
@@ -1,7 +1,7 @@
-import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { Navigate, createFileRoute } from "@tanstack/react-router"
 
 // Integrations were folded into Profile Settings. Keep the route as a redirect
 // so existing links don't 404.
 export const Route = createFileRoute("/integrations")({
   component: () => <Navigate to="/my-settings" replace />,
-});
+})

--- a/ui/src/routes/login.tsx
+++ b/ui/src/routes/login.tsx
@@ -1,54 +1,60 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useMemo } from "react";
+import { createFileRoute } from "@tanstack/react-router"
+import { useEffect, useMemo } from "react"
 
-import { buttonVariants } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { loginUrl } from "@/lib/api";
+import { buttonVariants } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { loginUrl } from "@/lib/api"
 import {
   DEFAULT_AUTH_REDIRECT,
   consumeAuthRedirect,
   getRememberedAuthRedirect,
   rememberAuthRedirect,
-} from "@/lib/auth-redirect";
-import { useSession } from "@/lib/session";
-import { cn } from "@/lib/utils";
+} from "@/lib/auth-redirect"
+import { useSession } from "@/lib/session"
+import { cn } from "@/lib/utils"
 
-type LoginSearch = { redirect?: string };
+type LoginSearch = { redirect?: string }
 
 export const Route = createFileRoute("/login")({
   validateSearch: (search: Record<string, unknown>): LoginSearch => ({
     redirect: typeof search.redirect === "string" ? search.redirect : undefined,
   }),
   component: Login,
-});
+})
 
 function Login() {
-  const session = useSession();
-  const search = Route.useSearch();
-  const redirectParam = search.redirect;
+  const session = useSession()
+  const search = Route.useSearch()
+  const redirectParam = search.redirect
   const intendedPath = useMemo(
     () =>
       redirectParam
         ? rememberAuthRedirect(redirectParam)
-        : getRememberedAuthRedirect() ?? DEFAULT_AUTH_REDIRECT,
+        : (getRememberedAuthRedirect() ?? DEFAULT_AUTH_REDIRECT),
     [redirectParam]
-  );
+  )
   const authenticatedRedirect = useMemo(
     () => (session.data ? consumeAuthRedirect(redirectParam) : null),
     [redirectParam, session.data]
-  );
+  )
 
   if (session.isLoading) {
     return (
       <main className="flex min-h-svh items-center justify-center p-6">
         <Skeleton className="h-40 w-80" />
       </main>
-    );
+    )
   }
 
   if (authenticatedRedirect) {
-    return <ClientRedirect path={authenticatedRedirect} />;
+    return <ClientRedirect path={authenticatedRedirect} />
   }
 
   return (
@@ -57,8 +63,9 @@ function Login() {
         <CardHeader>
           <CardTitle>Sign in to open-swe</CardTitle>
           <CardDescription>
-            Use your GitHub account. We'll configure your default model, reasoning effort, and
-            default repo for Slack/Linear/GitHub triggered runs.
+            Use your GitHub account. We'll configure your default model,
+            reasoning effort, and default repo for Slack/Linear/GitHub triggered
+            runs.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -71,17 +78,17 @@ function Login() {
         </CardContent>
       </Card>
     </main>
-  );
+  )
 }
 
 function ClientRedirect({ path }: { path: string }) {
   useEffect(() => {
-    if (typeof window !== "undefined") window.location.replace(path);
-  }, [path]);
+    if (typeof window !== "undefined") window.location.replace(path)
+  }, [path])
 
   return (
     <main className="flex min-h-svh items-center justify-center p-6">
       <Skeleton className="h-40 w-80" />
     </main>
-  );
+  )
 }

--- a/ui/src/routes/review.tsx
+++ b/ui/src/routes/review.tsx
@@ -1,21 +1,21 @@
-import { Link, createFileRoute } from "@tanstack/react-router";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CaretRightIcon } from "@phosphor-icons/react";
-import { useEffect, useMemo, useState } from "react";
-import { IoLogoGithub } from "react-icons/io5";
+import { Link, createFileRoute } from "@tanstack/react-router"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { CaretRightIcon } from "@phosphor-icons/react"
+import { useEffect, useMemo, useState } from "react"
+import { IoLogoGithub } from "react-icons/io5"
 
-import type { TeamSettings } from "@/lib/api";
-import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
-import { api } from "@/lib/api";
-import { RequireLogin } from "@/lib/auth-redirect";
-import { useRepos } from "@/lib/profile";
-import { useSession } from "@/lib/session";
+import type { TeamSettings } from "@/lib/api"
+import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { api } from "@/lib/api"
+import { RequireLogin } from "@/lib/auth-redirect"
+import { useRepos } from "@/lib/profile"
+import { useSession } from "@/lib/session"
 
-export const Route = createFileRoute("/review")({ component: ReviewPage });
+export const Route = createFileRoute("/review")({ component: ReviewPage })
 
 const DEFAULT_SETTINGS: TeamSettings = {
   review_draft_prs: false,
@@ -31,62 +31,62 @@ const DEFAULT_SETTINGS: TeamSettings = {
   default_reviewer_reasoning_effort: null,
   default_reviewer_subagent_model: null,
   default_reviewer_subagent_reasoning_effort: null,
-};
+}
 
 function ReviewPage() {
-  const session = useSession();
-  const qc = useQueryClient();
+  const session = useSession()
+  const qc = useQueryClient()
   const settings = useQuery({
     queryKey: ["teamSettings"],
     queryFn: api.getTeamSettings,
     enabled: !!session.data,
-  });
-  const [local, setLocal] = useState<TeamSettings>(DEFAULT_SETTINGS);
-  const [guidelinesDraft, setGuidelinesDraft] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  })
+  const [local, setLocal] = useState<TeamSettings>(DEFAULT_SETTINGS)
+  const [guidelinesDraft, setGuidelinesDraft] = useState("")
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (settings.data) {
-      setLocal(settings.data);
-      setGuidelinesDraft(settings.data.org_guidelines ?? "");
+      setLocal(settings.data)
+      setGuidelinesDraft(settings.data.org_guidelines ?? "")
     }
-  }, [settings.data]);
+  }, [settings.data])
 
   const save = useMutation({
     mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
     onSuccess: (saved) => {
-      qc.setQueryData(["teamSettings"], saved);
-      setError(null);
+      qc.setQueryData(["teamSettings"], saved)
+      setError(null)
     },
     onError: (e: Error) => setError(e.message),
-  });
+  })
 
   if (session.isLoading) {
     return (
       <main className="p-6">
         <Skeleton className="h-64 w-full" />
       </main>
-    );
+    )
   }
-  if (!session.data) return <RequireLogin />;
+  if (!session.data) return <RequireLogin />
 
-  const current: TeamSettings = local;
-  const canEdit = session.data.is_admin;
+  const current: TeamSettings = local
+  const canEdit = session.data.is_admin
 
   const persist = (patch: Partial<TeamSettings>) => {
-    const next: TeamSettings = { ...current, ...patch };
-    setLocal(next);
-    if (canEdit) save.mutate(next);
-  };
+    const next: TeamSettings = { ...current, ...patch }
+    setLocal(next)
+    if (canEdit) save.mutate(next)
+  }
 
-  const trimmedGuidelines = guidelinesDraft.trim();
-  const savedGuidelines = current.org_guidelines ?? "";
-  const guidelinesDirty = trimmedGuidelines !== savedGuidelines.trim();
+  const trimmedGuidelines = guidelinesDraft.trim()
+  const savedGuidelines = current.org_guidelines ?? ""
+  const guidelinesDirty = trimmedGuidelines !== savedGuidelines.trim()
 
   const saveGuidelines = () => {
-    if (!canEdit) return;
-    persist({ org_guidelines: trimmedGuidelines || null });
-  };
+    if (!canEdit) return
+    persist({ org_guidelines: trimmedGuidelines || null })
+  }
 
   return (
     <AppShell
@@ -102,7 +102,9 @@ function ReviewPage() {
           className="flex items-center justify-between gap-6 px-4 py-3 hover:bg-muted/40"
         >
           <div className="flex flex-col gap-0.5">
-            <span className="text-xs font-medium text-foreground">Review Style Prompts</span>
+            <span className="text-xs font-medium text-foreground">
+              Review Style Prompts
+            </span>
             <span className="text-xs text-muted-foreground">
               Per-repo style guides learned from past PR review feedback.
             </span>
@@ -133,7 +135,9 @@ function ReviewPage() {
                 Save guidelines
               </Button>
               {guidelinesDirty && (
-                <span className="text-xs text-muted-foreground">Unsaved changes</span>
+                <span className="text-xs text-muted-foreground">
+                  Unsaved changes
+                </span>
               )}
             </div>
           )}
@@ -186,35 +190,38 @@ function ReviewPage() {
 
       {error && <p className="text-xs text-destructive">{error}</p>}
     </AppShell>
-  );
+  )
 }
 
 function RepositoriesSection({ canEdit: _canEdit }: { canEdit: boolean }) {
-  const repos = useRepos();
+  const repos = useRepos()
 
   const autoReview = useQuery({
     queryKey: ["autoReviewRepos"],
     queryFn: api.listAutoReviewRepos,
-  });
+  })
 
   const autoReviewSet = useMemo(
     () => new Set(autoReview.data?.repos ?? []),
-    [autoReview.data?.repos],
-  );
+    [autoReview.data?.repos]
+  )
 
   const grouped = useMemo(() => {
-    const byOwner = new Map<string, Array<{ full_name: string; private: boolean }>>();
+    const byOwner = new Map<
+      string,
+      Array<{ full_name: string; private: boolean }>
+    >()
     for (const r of repos.data?.repositories ?? []) {
-      const [owner] = r.full_name.split("/");
-      if (!owner) continue;
-      const arr = byOwner.get(owner) ?? [];
-      arr.push(r);
-      byOwner.set(owner, arr);
+      const [owner] = r.full_name.split("/")
+      if (!owner) continue
+      const arr = byOwner.get(owner) ?? []
+      arr.push(r)
+      byOwner.set(owner, arr)
     }
-    return Array.from(byOwner.entries()).sort(([a], [b]) => a.localeCompare(b));
-  }, [repos.data?.repositories]);
+    return Array.from(byOwner.entries()).sort(([a], [b]) => a.localeCompare(b))
+  }, [repos.data?.repositories])
 
-  const loading = repos.isLoading || autoReview.isLoading;
+  const loading = repos.isLoading || autoReview.isLoading
 
   return (
     <SettingsSection
@@ -229,12 +236,14 @@ function RepositoriesSection({ canEdit: _canEdit }: { canEdit: boolean }) {
         )}
         {!loading && grouped.length === 0 && (
           <p className="px-4 py-3 text-xs text-muted-foreground">
-            No GitHub App installations found. Install the open-swe GitHub App on an
-            account or org to manage repos here.
+            No GitHub App installations found. Install the open-swe GitHub App
+            on an account or org to manage repos here.
           </p>
         )}
         {grouped.map(([owner, list]) => {
-          const autoReviewCount = list.filter((r) => autoReviewSet.has(r.full_name)).length;
+          const autoReviewCount = list.filter((r) =>
+            autoReviewSet.has(r.full_name)
+          ).length
           return (
             <Link
               key={owner}
@@ -258,10 +267,9 @@ function RepositoriesSection({ canEdit: _canEdit }: { canEdit: boolean }) {
                 <CaretRightIcon className="size-3.5" />
               </div>
             </Link>
-          );
+          )
         })}
       </div>
     </SettingsSection>
-  );
+  )
 }
-

--- a/ui/src/routes/review_.repositories.$owner.tsx
+++ b/ui/src/routes/review_.repositories.$owner.tsx
@@ -1,77 +1,79 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useMemo, useState } from "react"
 
-import { AppShell } from "@/components/AppShell";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Switch } from "@/components/ui/switch";
-import { api } from "@/lib/api";
-import { RequireLogin } from "@/lib/auth-redirect";
-import { useRepos } from "@/lib/profile";
-import { useSession } from "@/lib/session";
+import { AppShell } from "@/components/AppShell"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
+import { api } from "@/lib/api"
+import { RequireLogin } from "@/lib/auth-redirect"
+import { useRepos } from "@/lib/profile"
+import { useSession } from "@/lib/session"
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 20
 
 export const Route = createFileRoute("/review_/repositories/$owner")({
   component: RepositoriesOwnerPage,
-});
+})
 
 function RepositoriesOwnerPage() {
-  const session = useSession();
-  const { owner } = Route.useParams();
-  const qc = useQueryClient();
+  const session = useSession()
+  const { owner } = Route.useParams()
+  const qc = useQueryClient()
 
-  const repos = useRepos();
+  const repos = useRepos()
 
   const autoReview = useQuery({
     queryKey: ["autoReviewRepos"],
     queryFn: api.listAutoReviewRepos,
     enabled: !!session.data,
-  });
+  })
 
   const toggleAutoReview = useMutation({
     mutationFn: ({ full_name, on }: { full_name: string; on: boolean }) =>
       api.setAutoReviewRepo(full_name, on),
     onSuccess: (data) => {
-      qc.setQueryData(["autoReviewRepos"], data);
+      qc.setQueryData(["autoReviewRepos"], data)
     },
-  });
+  })
 
   const ownerRepos = useMemo(
     () =>
       (repos.data?.repositories ?? [])
         .filter((r) => r.full_name.split("/")[0] === owner)
         .sort((a, b) => a.full_name.localeCompare(b.full_name)),
-    [repos.data?.repositories, owner],
-  );
+    [repos.data?.repositories, owner]
+  )
 
   const autoReviewSet = useMemo(
     () => new Set(autoReview.data?.repos ?? []),
-    [autoReview.data?.repos],
-  );
+    [autoReview.data?.repos]
+  )
 
-  const [page, setPage] = useState(0);
-  useEffect(() => setPage(0), [owner]);
+  const [page, setPage] = useState(0)
+  useEffect(() => setPage(0), [owner])
 
-  const totalPages = Math.max(1, Math.ceil(ownerRepos.length / PAGE_SIZE));
-  const safePage = Math.min(page, totalPages - 1);
-  const pageStart = safePage * PAGE_SIZE;
-  const pageEnd = Math.min(pageStart + PAGE_SIZE, ownerRepos.length);
-  const pageRepos = ownerRepos.slice(pageStart, pageEnd);
+  const totalPages = Math.max(1, Math.ceil(ownerRepos.length / PAGE_SIZE))
+  const safePage = Math.min(page, totalPages - 1)
+  const pageStart = safePage * PAGE_SIZE
+  const pageEnd = Math.min(pageStart + PAGE_SIZE, ownerRepos.length)
+  const pageRepos = ownerRepos.slice(pageStart, pageEnd)
 
   if (session.isLoading) {
     return (
       <main className="p-6">
         <Skeleton className="h-64 w-full" />
       </main>
-    );
+    )
   }
-  if (!session.data) return <RequireLogin />;
+  if (!session.data) return <RequireLogin />
 
-  const canEdit = session.data.is_admin;
-  const autoReviewCount = ownerRepos.filter((r) => autoReviewSet.has(r.full_name)).length;
-  const loading = repos.isLoading || autoReview.isLoading;
+  const canEdit = session.data.is_admin
+  const autoReviewCount = ownerRepos.filter((r) =>
+    autoReviewSet.has(r.full_name)
+  ).length
+  const loading = repos.isLoading || autoReview.isLoading
 
   return (
     <AppShell
@@ -86,7 +88,7 @@ function RepositoriesOwnerPage() {
     >
       <section className="space-y-3">
         <div className="flex items-center justify-between">
-          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
             Repositories
           </h2>
           <span className="text-xs text-muted-foreground">
@@ -106,7 +108,7 @@ function RepositoriesOwnerPage() {
           )}
           <ul className="divide-y divide-border">
             {pageRepos.map((r) => {
-              const runsAutomatically = autoReviewSet.has(r.full_name);
+              const runsAutomatically = autoReviewSet.has(r.full_name)
               return (
                 <li
                   key={r.full_name}
@@ -120,11 +122,15 @@ function RepositoriesOwnerPage() {
                       </span>
                     </span>
                     {r.private && (
-                      <span className="text-[10px] text-muted-foreground">private</span>
+                      <span className="text-[10px] text-muted-foreground">
+                        private
+                      </span>
                     )}
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground">Run automatically</span>
+                    <span className="text-xs text-muted-foreground">
+                      Run automatically
+                    </span>
                     <span
                       title={
                         !canEdit
@@ -138,13 +144,16 @@ function RepositoriesOwnerPage() {
                         checked={runsAutomatically}
                         disabled={!canEdit || toggleAutoReview.isPending}
                         onCheckedChange={(v) =>
-                          toggleAutoReview.mutate({ full_name: r.full_name, on: v })
+                          toggleAutoReview.mutate({
+                            full_name: r.full_name,
+                            on: v,
+                          })
                         }
                       />
                     </span>
                   </div>
                 </li>
-              );
+              )
             })}
           </ul>
           {ownerRepos.length > PAGE_SIZE && (
@@ -168,7 +177,9 @@ function RepositoriesOwnerPage() {
                   size="sm"
                   variant="outline"
                   disabled={safePage >= totalPages - 1}
-                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  onClick={() =>
+                    setPage((p) => Math.min(totalPages - 1, p + 1))
+                  }
                 >
                   Next
                 </Button>
@@ -178,5 +189,5 @@ function RepositoriesOwnerPage() {
         </div>
       </section>
     </AppShell>
-  );
+  )
 }

--- a/ui/src/routes/review_.styles.tsx
+++ b/ui/src/routes/review_.styles.tsx
@@ -1,24 +1,26 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router"
 
-import { AppShell } from "@/components/AppShell";
-import { ReviewStylesPanel } from "@/components/ReviewStylesPanel";
-import { Skeleton } from "@/components/ui/skeleton";
-import { RequireLogin } from "@/lib/auth-redirect";
-import { useSession } from "@/lib/session";
+import { AppShell } from "@/components/AppShell"
+import { ReviewStylesPanel } from "@/components/ReviewStylesPanel"
+import { Skeleton } from "@/components/ui/skeleton"
+import { RequireLogin } from "@/lib/auth-redirect"
+import { useSession } from "@/lib/session"
 
-export const Route = createFileRoute("/review_/styles")({ component: ReviewStylesPage });
+export const Route = createFileRoute("/review_/styles")({
+  component: ReviewStylesPage,
+})
 
 function ReviewStylesPage() {
-  const session = useSession();
+  const session = useSession()
 
   if (session.isLoading) {
     return (
       <main className="p-6">
         <Skeleton className="h-64 w-full" />
       </main>
-    );
+    )
   }
-  if (!session.data) return <RequireLogin />;
+  if (!session.data) return <RequireLogin />
 
   return (
     <AppShell
@@ -31,5 +33,5 @@ function ReviewStylesPage() {
         <ReviewStylesPanel />
       </div>
     </AppShell>
-  );
+  )
 }


### PR DESCRIPTION
`pnpm format` had never been run across `ui/`, so 91 files drifted from the repo's own prettier config. This reformats all of them and adds a CI gate so it stays that way.

- Ran `pnpm format` over `ui/` (91 files, whitespace/quotes/wrapping only — no logic changes).
- Added `src/routeTree.gen.ts` to `ui/.prettierignore`. TanStack Router rewrites that file on every dev/build with its own formatting, so leaving it in scope would make the check flap.
- Added a `format:check` script and a `ui-format` job to `.github/workflows/ci.yml`, running on every PR and push to `main`.

Note: `pnpm run lint` in `ui/` fails with `eslint: command not found` — `eslint` itself isn't in devDependencies, only `@tanstack/eslint-config`. Pre-existing, not touched here.

## Test Plan

- [x] `pnpm run format:check` passes in `ui/`
- [x] `pnpm run typecheck` passes in `ui/`
- [x] No screenshot — formatting-only, no rendered output changes