### PR TITLE
feat(open-swe): pre-clone common repos into the sandbox snapshot

### DIFF
--- a/.github/workflows/snapshot_cache_e2e.yml
+++ b/.github/workflows/snapshot_cache_e2e.yml
@@ -1,0 +1,50 @@
+# Verifies the sandbox repo cache against real LangSmith sandboxes: warm a
+# builder, capture it, boot a fresh sandbox from the capture, and take the repo
+# out of the cache. The unit tests only assert on generated shell strings, so
+# this is the only thing that catches a capture that drops the cache or a work
+# dir that moves between builder and run.
+#
+# Not run on pull requests: it creates real cloud resources and costs money.
+#
+# Required repository config:
+#   secrets: LANGSMITH_API_KEY   (must have sandbox access)
+#   vars:    SNAPSHOT_E2E_ENDPOINT  (optional; defaults to prod)
+name: Snapshot cache E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: Public owner/name to cache
+        type: string
+        default: langchain-ai/open-swe
+  schedule:
+    # Weekly, well clear of the nightly base-snapshot rebuild window.
+    - cron: "0 13 * * 1"
+
+permissions:
+  contents: read
+
+# Serialized: concurrent runs would each create sandboxes and snapshots in the
+# same workspace, and a cancelled run cannot clean up after itself.
+concurrency:
+  group: snapshot-cache-e2e
+  cancel-in-progress: false
+
+jobs:
+  snapshot-cache-e2e:
+    name: Snapshot cache E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Run snapshot cache E2E
+        env:
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+        run: |
+          uv run python tests/e2e/snapshot_cache_e2e.py \
+            --repo "${{ inputs.repo || 'langchain-ai/open-swe' }}" \
+            ${{ vars.SNAPSHOT_E2E_ENDPOINT && format('--endpoint {0}', vars.SNAPSHOT_E2E_ENDPOINT) || '' }}

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -18,11 +18,13 @@ from .health import router as health_router
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    from ..dashboard.base_snapshot import schedule_base_snapshot_cron_sync
     from ..utils.model import close_cached_models, validate_local_dev_llm_config
     from ..utils.sandbox import validate_sandbox_startup_config
 
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
+    schedule_base_snapshot_cron_sync()
     try:
         yield
     finally:

--- a/agent/dashboard/base_snapshot.py
+++ b/agent/dashboard/base_snapshot.py
@@ -197,8 +197,10 @@ async def resolve_base_snapshot_id() -> str | None:
         return None
     if not record or not _coerce_settings(record.get("settings")).enabled:
         return None
-    if record.get("status") != "ready":
-        return None
+    # Deliberately not gated on status: a snapshot_id is only written after a
+    # capture succeeds, so the last good one stays usable when a later rebuild
+    # fails. Gating on ``ready`` would drop the whole warm cache on one
+    # transient hook, clone, or capture failure.
     snapshot_id = record.get("snapshot_id")
     return snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None
 
@@ -463,7 +465,10 @@ async def rebuild_base_snapshot(from_scratch: bool = False) -> dict[str, Any]:
 
     existing = await _read_record()
     settings = _coerce_settings(existing.get("settings"))
-    prior_status = existing.get("status") or "none"
+    # Never derived from the record's current status: the route marks it
+    # ``building`` before this runs, so echoing that back on a terminal path
+    # would leave the UI polling a build that already finished.
+    idle_status = "ready" if existing.get("snapshot_id") else "none"
     previous = await mark_base_snapshot_building()
     started_at = _now_iso()
 
@@ -492,7 +497,7 @@ async def rebuild_base_snapshot(from_scratch: bool = False) -> dict[str, Any]:
     )
     if not repos:
         logger.info("No repos in the clone ledger yet; skipping base snapshot rebuild")
-        return await _store(status=prior_status, status_message="no repos recorded yet")
+        return await _store(status=idle_status, status_message="no repos recorded yet")
 
     if provider != "langsmith":
         # No capture API outside LangSmith. Where the sandbox filesystem

--- a/agent/dashboard/base_snapshot.py
+++ b/agent/dashboard/base_snapshot.py
@@ -1,0 +1,679 @@
+"""Scheduled warming of the sandbox repo cache.
+
+On the configured schedule the repos Open SWE actually works on (from
+:mod:`agent.dashboard.repo_clone_stats`) are cloned into a hidden cache dir as
+ready-to-use checkouts, so a run takes one with a rename instead of paying for
+a clone.
+
+Two modes, picked from ``SANDBOX_TYPE``:
+
+- ``snapshot`` (LangSmith) -- warm a throwaway builder, then capture it as an
+  image. New sandboxes boot from that image with the cache already present.
+  Incremental: the builder boots from the previous capture, so each warm only
+  fetches what changed and anything baked into a checkout survives. It falls
+  back to the pristine seed when the seed itself changes, or when an operator
+  asks for a clean rebuild.
+- ``cache`` (providers whose filesystem persists, e.g. ``local``) -- warm the
+  shared work dir in place. No image is involved; the cache simply stays.
+
+Providers that are neither fail loudly rather than warming a throwaway sandbox
+that is discarded moments later.
+
+Everything operators tune lives in one store record edited from the admin
+Snapshots page -- there is no env-var configuration. Resolution stays additive:
+runs fall back to the seed snapshot whenever no ready capture exists, so a
+failed rebuild degrades to today's behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+from datetime import UTC, datetime
+from typing import Any
+
+from langgraph_sdk import get_client
+from pydantic import BaseModel, Field, field_validator
+
+from ..utils.repo_clone import (
+    PREFERRED_WORK_DIR,
+    build_mirror_sweep_script,
+    parse_mirror_sweep_output,
+)
+from .repo_clone_stats import repos_to_preclone
+from .schedules import normalize_cron_schedule
+
+logger = logging.getLogger(__name__)
+
+BASE_SNAPSHOT_NAMESPACE: list[str] = ["base_snapshot"]
+BASE_SNAPSHOT_KEY = "current"
+
+SNAPSHOT_NAME_PREFIX = "openswe-base-"
+
+CLONE_TIMEOUT_SECONDS = 900
+CAPTURE_TIMEOUT_SECONDS = 900
+
+# The builder is reclaimed by the platform, never by an explicit delete (see
+# tests/sandbox/test_langsmith_sandbox_config.py). Idle only starts counting
+# once the clone sweep and capture stop touching the box, so a short TTL is
+# safe and keeps a crashed build from lingering.
+BUILDER_IDLE_TTL_SECONDS = 600
+BUILDER_DELETE_AFTER_STOP_SECONDS = 60
+
+STATUS_MESSAGE_MAX_CHARS = 1000
+SCRIPT_MAX_CHARS = 20_000
+HOOK_TIMEOUT_SECONDS = 1800
+
+# Past this, a record still on ``building`` is treated as a crashed run rather
+# than a slow one. Comfortably above the clone + capture timeouts.
+STALE_BUILD_SECONDS = 2 * (CLONE_TIMEOUT_SECONDS + CAPTURE_TIMEOUT_SECONDS)
+
+PROGRESS_POLL_SECONDS = 2
+
+DEFAULT_SCHEDULE = "0 9 * * *"  # 09:00 UTC, after the analyzer's 05:00-08:59 window
+DEFAULT_PRECLONE_LIMIT = 10
+DEFAULT_MAX_AGE_DAYS = 30
+DEFAULT_KEEP_SNAPSHOTS = 3
+
+MIN_PRECLONE_LIMIT, MAX_PRECLONE_LIMIT = 1, 50
+MIN_MAX_AGE_DAYS, MAX_MAX_AGE_DAYS = 1, 365
+MIN_KEEP_SNAPSHOTS, MAX_KEEP_SNAPSHOTS = 1, 10
+
+_SCHEDULER_ASSISTANT_ID = "scheduler"
+_REBUILD_TASK = "rebuild_base_snapshot"
+
+
+class BaseSnapshotSettings(BaseModel):
+    """Operator-tunable knobs for the nightly rebuild."""
+
+    enabled: bool = False
+    schedule: str = DEFAULT_SCHEDULE
+    preclone_limit: int = Field(default=DEFAULT_PRECLONE_LIMIT)
+    max_age_days: int = Field(default=DEFAULT_MAX_AGE_DAYS)
+    keep_snapshots: int = Field(default=DEFAULT_KEEP_SNAPSHOTS)
+    # Run in the builder around the repo sweep. This is where work that should
+    # be baked into the image goes -- installing dependencies, warming package
+    # caches -- so a run inherits it instead of doing it itself.
+    pre_script: str = ""
+    post_script: str = ""
+
+    @field_validator("pre_script", "post_script")
+    @classmethod
+    def _script_len(cls, v: str) -> str:
+        if len(v) > SCRIPT_MAX_CHARS:
+            raise ValueError(f"script must be at most {SCRIPT_MAX_CHARS} characters")
+        return v
+
+    @field_validator("schedule")
+    @classmethod
+    def _schedule(cls, v: str) -> str:
+        return normalize_cron_schedule(v)
+
+    @field_validator("preclone_limit")
+    @classmethod
+    def _preclone_limit(cls, v: int) -> int:
+        if not MIN_PRECLONE_LIMIT <= v <= MAX_PRECLONE_LIMIT:
+            raise ValueError(
+                f"preclone_limit must be between {MIN_PRECLONE_LIMIT} and {MAX_PRECLONE_LIMIT}"
+            )
+        return v
+
+    @field_validator("max_age_days")
+    @classmethod
+    def _max_age_days(cls, v: int) -> int:
+        if not MIN_MAX_AGE_DAYS <= v <= MAX_MAX_AGE_DAYS:
+            raise ValueError(
+                f"max_age_days must be between {MIN_MAX_AGE_DAYS} and {MAX_MAX_AGE_DAYS}"
+            )
+        return v
+
+    @field_validator("keep_snapshots")
+    @classmethod
+    def _keep_snapshots(cls, v: int) -> int:
+        if not MIN_KEEP_SNAPSHOTS <= v <= MAX_KEEP_SNAPSHOTS:
+            raise ValueError(
+                f"keep_snapshots must be between {MIN_KEEP_SNAPSHOTS} and {MAX_KEEP_SNAPSHOTS}"
+            )
+        return v
+
+
+def _client():
+    return get_client()
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _coerce_settings(raw: object) -> BaseSnapshotSettings:
+    """Read stored settings, falling back to defaults for anything invalid."""
+    if not isinstance(raw, dict):
+        return BaseSnapshotSettings()
+    try:
+        return BaseSnapshotSettings.model_validate(raw)
+    except Exception:  # noqa: BLE001
+        logger.warning("Stored base snapshot settings are invalid; using defaults")
+        return BaseSnapshotSettings()
+
+
+async def _read_record() -> dict[str, Any]:
+    try:
+        item = await _client().store.get_item(BASE_SNAPSHOT_NAMESPACE, BASE_SNAPSHOT_KEY)
+    except Exception:  # noqa: BLE001
+        logger.debug("base snapshot lookup failed", exc_info=True)
+        return {}
+    if item is None:
+        return {}
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else {}
+
+
+async def get_base_snapshot_record() -> dict[str, Any]:
+    """Return the stored record with settings always populated."""
+    record = await _read_record()
+    return {**record, "settings": _coerce_settings(record.get("settings")).model_dump()}
+
+
+async def get_base_snapshot_settings() -> BaseSnapshotSettings:
+    return _coerce_settings((await _read_record()).get("settings"))
+
+
+async def _put_record(value: dict[str, Any]) -> None:
+    await _client().store.put_item(BASE_SNAPSHOT_NAMESPACE, BASE_SNAPSHOT_KEY, value)
+
+
+async def resolve_base_snapshot_id() -> str | None:
+    """Return the ready nightly snapshot id, or ``None`` to use the seed.
+
+    Never raises: any failure resolves to ``None`` so sandbox creation falls
+    back to ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
+    """
+    try:
+        record = await _read_record()
+    except Exception:  # noqa: BLE001
+        logger.debug("base snapshot resolution failed", exc_info=True)
+        return None
+    if not record or not _coerce_settings(record.get("settings")).enabled:
+        return None
+    if record.get("status") != "ready":
+        return None
+    snapshot_id = record.get("snapshot_id")
+    return snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None
+
+
+async def update_base_snapshot_settings(settings: BaseSnapshotSettings) -> dict[str, Any]:
+    """Persist settings and bring the rebuild cron in line with them."""
+    record = await _read_record()
+    cron_id = await _sync_cron(record, settings)
+    record = {
+        **record,
+        "settings": settings.model_dump(),
+        "cron_id": cron_id,
+        "cron_schedule": settings.schedule if cron_id else None,
+        "updated_at": _now_iso(),
+    }
+    await _put_record(record)
+    return record
+
+
+async def mark_base_snapshot_building() -> dict[str, Any]:
+    """Flip the record to ``building`` before the rebuild starts.
+
+    Done up front, and awaited by the route before it returns, so the UI starts
+    polling immediately instead of watching a stale ``ready`` until the whole
+    rebuild finishes.
+    """
+    record = await _read_record()
+    record = {
+        **record,
+        "status": "building",
+        "status_message": None,
+        "build_started_at": _now_iso(),
+        "progress": {"phase": "starting", "completed": 0, "total": 0},
+        "updated_at": _now_iso(),
+    }
+    await _put_record(record)
+    return record
+
+
+def is_base_snapshot_build_stale(record: dict[str, Any]) -> bool:
+    """Whether a ``building`` record is old enough to be a crashed run.
+
+    Without this a process that dies mid-rebuild wedges the record on
+    ``building`` forever, and the UI never offers the button again.
+    """
+    if record.get("status") != "building":
+        return False
+    started = record.get("build_started_at")
+    if not isinstance(started, str) or not started.strip():
+        return True
+    try:
+        parsed = datetime.fromisoformat(started)
+    except ValueError:
+        return True
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - parsed).total_seconds() > STALE_BUILD_SECONDS
+
+
+async def _set_progress(phase: str, completed: int, total: int) -> None:
+    """Best-effort progress write; a lost update must not fail the build."""
+    try:
+        record = await _read_record()
+        record["progress"] = {"phase": phase, "completed": completed, "total": total}
+        record["updated_at"] = _now_iso()
+        await _put_record(record)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not write base snapshot progress", exc_info=True)
+
+
+def _seed_snapshot_id() -> str | None:
+    """Snapshot the builder boots from, or ``None`` to take the platform default.
+
+    Always the configured seed, never the previous capture, so a bad clone can't
+    compound across rebuilds.
+    """
+    return (os.environ.get("DEFAULT_SANDBOX_SNAPSHOT_ID") or "").strip() or None
+
+
+async def _resolve_builder_work_dir(sandbox: Any) -> str:
+    """The work dir to warm, which must be the one runs will read back.
+
+    Deliberately not the shell's cwd: a sandbox booted from a capture starts at
+    ``/`` because WORKDIR is image metadata that capture does not carry, so
+    trusting ``pwd`` would warm a different directory each time depending on
+    how the builder happened to boot. Matches the preference
+    ``aresolve_sandbox_work_dir`` applies at run time.
+    """
+    try:
+        result = await sandbox.run(
+            f"mkdir -p {shlex.quote(PREFERRED_WORK_DIR)} "
+            f"&& cd {shlex.quote(PREFERRED_WORK_DIR)} && pwd"
+        )
+        resolved = (result.stdout or "").strip().splitlines()
+        if resolved and resolved[-1].startswith("/"):
+            return resolved[-1]
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not prepare the builder work dir", exc_info=True)
+    return PREFERRED_WORK_DIR
+
+
+async def _run_clone_sweep(sandbox: Any, work_dir: str, repos: list[str]) -> Any:
+    """Run the clone sweep, publishing progress as each repo lands.
+
+    The sweep prints one line per repo, so a reader task can count them while
+    the (single, long) command is still running. ``on_stdout`` is synchronous,
+    hence the buffer-and-poll split rather than awaiting inside the callback.
+    """
+    chunks: list[str] = []
+    total = len(repos)
+
+    async def _publish() -> None:
+        last = -1
+        while True:
+            await asyncio.sleep(PROGRESS_POLL_SECONDS)
+            done, failed = parse_mirror_sweep_output("".join(chunks))
+            completed = len(done) + len(failed)
+            if completed != last:
+                await _set_progress("cloning", completed, total)
+                last = completed
+
+    await _set_progress("cloning", 0, total)
+    publisher = asyncio.create_task(_publish())
+    try:
+        return await sandbox.run(
+            build_mirror_sweep_script(work_dir, repos, proxy_auth=True),
+            timeout=CLONE_TIMEOUT_SECONDS,
+            on_stdout=chunks.append,
+        )
+    finally:
+        publisher.cancel()
+
+
+def _sandbox_provider() -> str:
+    return os.getenv("SANDBOX_TYPE", "langsmith")
+
+
+# Providers whose sandbox filesystem outlives a single run. There, warming the
+# cache in place is durable on its own and no image capture is involved.
+PERSISTENT_PROVIDERS = frozenset({"local"})
+
+
+async def _warm_shared_cache(
+    repos: list[str], settings: BaseSnapshotSettings
+) -> tuple[list[str], list[str]]:
+    """Fill the cache through the generic backend, for providers without capture.
+
+    Uses ``create_sandbox`` rather than a provider SDK, so this works anywhere
+    ``SANDBOX_FACTORIES`` does. The backend protocol has no output streaming, so
+    progress here is start-and-finish rather than per-repo.
+    """
+    from ..utils.sandbox import create_sandbox
+    from ..utils.sandbox_paths import aresolve_sandbox_work_dir
+
+    backend = await create_sandbox()
+    work_dir = await aresolve_sandbox_work_dir(backend)
+
+    async def _exec(command: str, timeout: int) -> Any:
+        return await backend.aexecute(command, timeout=timeout)
+
+    hook_error = await _run_hook(_exec, "pre_script", settings.pre_script, work_dir)
+    if hook_error:
+        raise RuntimeError(hook_error)
+
+    await _set_progress("cloning", 0, len(repos))
+    result = await backend.aexecute(
+        build_mirror_sweep_script(work_dir, repos, proxy_auth=False),
+        timeout=CLONE_TIMEOUT_SECONDS,
+    )
+    output = getattr(result, "output", None) or getattr(result, "stdout", "") or ""
+    cloned, failed = parse_mirror_sweep_output(output)
+    await _set_progress("cloning", len(cloned) + len(failed), len(repos))
+
+    hook_error = await _run_hook(_exec, "post_script", settings.post_script, work_dir)
+    if hook_error:
+        raise RuntimeError(hook_error)
+    return cloned, failed
+
+
+async def _run_hook(
+    execute: Any,
+    label: str,
+    script: str,
+    work_dir: str,
+) -> str | None:
+    """Run a pre/post hook in the builder. Returns an error message, or None.
+
+    A failing hook fails the whole build on purpose: a snapshot whose
+    dependency install half-ran is worse than no new snapshot, because every
+    run would inherit the broken state and none would report why.
+    """
+    if not script.strip():
+        return None
+    await _set_progress(label, 0, 0)
+    logger.info("Running %s script in the base snapshot builder", label)
+    wrapped = f"set -e\ncd {shlex.quote(work_dir)}\n{script}"
+    result = await execute(wrapped, HOOK_TIMEOUT_SECONDS)
+    output = getattr(result, "stdout", None) or getattr(result, "output", "") or ""
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (0, None):
+        return f"{label} script exited {exit_code}: {output[-500:]}"
+    return None
+
+
+async def _prune_old_snapshots(client: Any, keep_snapshot_id: str, keep: int) -> None:
+    """Delete superseded nightly snapshots, keeping the newest few."""
+    try:
+        snapshots = await client.list_snapshots(name_contains=SNAPSHOT_NAME_PREFIX, limit=100)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not list base snapshots for pruning", exc_info=True)
+        return
+
+    ours = [s for s in snapshots if (s.name or "").startswith(SNAPSHOT_NAME_PREFIX)]
+    ours.sort(key=lambda s: s.name or "", reverse=True)
+    for snapshot in ours[keep:]:
+        if snapshot.id == keep_snapshot_id:
+            continue
+        try:
+            await client.delete_snapshot(snapshot.id)
+            logger.info("Pruned old base snapshot %s (%s)", snapshot.id, snapshot.name)
+        except Exception:  # noqa: BLE001
+            logger.debug("Could not prune base snapshot %s", snapshot.id, exc_info=True)
+
+
+def _builder_base_snapshot(
+    existing: dict[str, Any], seed: str | None, from_scratch: bool
+) -> str | None:
+    """Snapshot the builder boots from: yesterday's capture, or the seed.
+
+    Building on the previous capture keeps the warm incremental -- only the
+    commits since last time, and baked dependencies survive instead of being
+    reinstalled nightly.
+
+    It falls back to the seed when there is nothing to build on, when the
+    operator asks for a clean rebuild, or when the seed itself has changed --
+    that last one matters because a new base image (new tools, new runtimes)
+    would otherwise never reach the chain.
+    """
+    if from_scratch:
+        return seed
+    if existing.get("status") != "ready" or existing.get("mode") != "snapshot":
+        return seed
+    if existing.get("seed_snapshot_id") != seed:
+        logger.info("Seed snapshot changed; rebuilding the base snapshot from scratch")
+        return seed
+    previous = existing.get("snapshot_id")
+    return previous if isinstance(previous, str) and previous else seed
+
+
+async def rebuild_base_snapshot(from_scratch: bool = False) -> dict[str, Any]:
+    """Build the next base snapshot and persist the result.
+
+    Incremental by default: the builder boots from the previous capture and the
+    warm only fetches what changed. ``from_scratch`` discards that lineage and
+    starts from the seed, which is the escape hatch when accumulated state has
+    gone wrong.
+
+    Returns the stored record. On failure the previous ready snapshot id is
+    kept so runs keep booting from the last good capture.
+    """
+    from ..utils.github_app import get_github_app_installation_token
+
+    existing = await _read_record()
+    settings = _coerce_settings(existing.get("settings"))
+    prior_status = existing.get("status") or "none"
+    previous = await mark_base_snapshot_building()
+    started_at = _now_iso()
+
+    async def _store(**fields: Any) -> dict[str, Any]:
+        # Every terminal write clears the in-flight markers, so a finished run
+        # can never leave the UI stuck on a progress bar.
+        record = {
+            **previous,
+            **fields,
+            "progress": None,
+            "build_started_at": None,
+            "last_attempt_at": started_at,
+            "updated_at": _now_iso(),
+        }
+        await _put_record(record)
+        return record
+
+    async def _fail(message: str) -> dict[str, Any]:
+        return await _store(status="failed", status_message=message[:STATUS_MESSAGE_MAX_CHARS])
+
+    seed_snapshot_id = _seed_snapshot_id()
+    provider = _sandbox_provider()
+
+    repos = await repos_to_preclone(
+        limit=settings.preclone_limit, max_age_days=settings.max_age_days
+    )
+    if not repos:
+        logger.info("No repos in the clone ledger yet; skipping base snapshot rebuild")
+        return await _store(status=prior_status, status_message="no repos recorded yet")
+
+    if provider != "langsmith":
+        # No capture API outside LangSmith. Where the sandbox filesystem
+        # persists, warming it in place is enough; where it doesn't, warming a
+        # throwaway box would be discarded, so say so rather than appear to work.
+        if provider not in PERSISTENT_PROVIDERS:
+            return await _fail(
+                f"SANDBOX_TYPE={provider} has no snapshot capture and no persistent "
+                "filesystem, so a warmed cache would not survive the run that built it"
+            )
+        try:
+            cloned, failed = await _warm_shared_cache(repos, settings)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Cache warm failed", exc_info=True)
+            return await _fail(f"{type(e).__name__}: {e}")
+        if not cloned:
+            return await _fail(f"no repos cloned successfully (failed: {', '.join(failed)})")
+        logger.info("Warmed repo cache with %d repos (%d failed)", len(cloned), len(failed))
+        return await _store(
+            status="ready",
+            status_message=None,
+            mode="cache",
+            snapshot_id=None,
+            snapshot_name=None,
+            repos=cloned,
+            failed_repos=failed,
+            built_at=_now_iso(),
+        )
+
+    from ..integrations.langsmith import _configure_github_proxy, get_async_sandbox_client
+
+    builder_base = _builder_base_snapshot(existing, seed_snapshot_id, from_scratch)
+    logger.info(
+        "Warming base snapshot from %s",
+        "seed" if builder_base == seed_snapshot_id else f"previous capture {builder_base}",
+    )
+
+    token = await get_github_app_installation_token()
+    if not token:
+        return await _fail("GitHub App installation token unavailable")
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    snapshot_name = f"{SNAPSHOT_NAME_PREFIX}{timestamp}"
+    builder_name = f"openswe-base-builder-{timestamp}"
+
+    client = get_async_sandbox_client()
+    sandbox = None
+    try:
+        sandbox = await client.create_sandbox(
+            snapshot_id=builder_base,
+            name=builder_name,
+            idle_ttl_seconds=BUILDER_IDLE_TTL_SECONDS,
+            delete_after_stop_seconds=BUILDER_DELETE_AFTER_STOP_SECONDS,
+        )
+        await _configure_github_proxy(sandbox.name, token)
+
+        work_dir = await _resolve_builder_work_dir(sandbox)
+
+        async def _exec(command: str, timeout: int) -> Any:
+            return await sandbox.run(command, timeout=timeout)
+
+        hook_error = await _run_hook(_exec, "pre_script", settings.pre_script, work_dir)
+        if hook_error:
+            return await _fail(hook_error)
+
+        result = await _run_clone_sweep(sandbox, work_dir, repos)
+        cloned, failed = parse_mirror_sweep_output(result.stdout or "")
+        if not cloned:
+            return await _fail(f"no repos cloned successfully (failed: {', '.join(failed)})")
+
+        hook_error = await _run_hook(_exec, "post_script", settings.post_script, work_dir)
+        if hook_error:
+            return await _fail(hook_error)
+
+        # The capture is one blocking call with no interim signal, so this phase
+        # is honestly indeterminate rather than a fake-advancing bar.
+        await _set_progress("capturing", len(cloned), len(repos))
+        snapshot = await client.capture_snapshot(
+            sandbox.name, snapshot_name, timeout=CAPTURE_TIMEOUT_SECONDS
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Base snapshot rebuild failed", exc_info=True)
+        return await _fail(f"{type(e).__name__}: {e}")
+    finally:
+        if sandbox is not None:
+            try:
+                await client.stop_sandbox(sandbox.name)
+            except Exception:  # noqa: BLE001
+                logger.debug("Could not stop base snapshot builder %s", builder_name, exc_info=True)
+
+    record = await _store(
+        snapshot_id=snapshot.id,
+        snapshot_name=snapshot_name,
+        seed_snapshot_id=seed_snapshot_id,
+        mode="snapshot",
+        status="ready",
+        status_message=None,
+        repos=cloned,
+        failed_repos=failed,
+        built_at=_now_iso(),
+    )
+    logger.info(
+        "Built base snapshot %s with %d pre-cloned repos (%d failed)",
+        snapshot.id,
+        len(cloned),
+        len(failed),
+    )
+
+    await _prune_old_snapshots(client, snapshot.id, settings.keep_snapshots)
+    return record
+
+
+async def _delete_cron(cron_id: str) -> None:
+    try:
+        await _client().crons.delete(cron_id)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not delete base snapshot cron %s", cron_id, exc_info=True)
+
+
+async def _sync_cron(record: dict[str, Any], settings: BaseSnapshotSettings) -> str | None:
+    """Make the registered cron match ``settings``. Returns the live cron id.
+
+    Schedule changes go through delete-then-create so a stale cron can never
+    outlive the schedule it was created from.
+    """
+    existing = record.get("cron_id")
+    existing = existing if isinstance(existing, str) and existing else None
+
+    if not settings.enabled:
+        if existing:
+            await _delete_cron(existing)
+        return None
+
+    if existing and record.get("cron_schedule") == settings.schedule:
+        return existing
+    if existing:
+        await _delete_cron(existing)
+
+    try:
+        cron = await _client().crons.create(
+            _SCHEDULER_ASSISTANT_ID,
+            schedule=settings.schedule,
+            input={"task": _REBUILD_TASK},
+            config={"configurable": {"task": _REBUILD_TASK}},
+            metadata={"kind": "base_snapshot_rebuild"},
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to create base snapshot rebuild cron", exc_info=True)
+        return None
+
+    cron_id = cron.get("cron_id") if isinstance(cron, dict) else getattr(cron, "cron_id", None)
+    return cron_id if isinstance(cron_id, str) and cron_id else None
+
+
+async def sync_base_snapshot_cron() -> str | None:
+    """Reconcile the cron with stored settings (idempotent)."""
+    record = await _read_record()
+    settings = _coerce_settings(record.get("settings"))
+    cron_id = await _sync_cron(record, settings)
+    if cron_id != record.get("cron_id") or record.get("cron_schedule") != settings.schedule:
+        await _put_record(
+            {
+                **record,
+                "cron_id": cron_id,
+                "cron_schedule": settings.schedule if cron_id else None,
+                "updated_at": _now_iso(),
+            }
+        )
+    return cron_id
+
+
+def schedule_base_snapshot_cron_sync() -> None:
+    """Fire-and-forget cron reconciliation for the FastAPI lifespan hook."""
+
+    async def _run() -> None:
+        try:
+            await sync_base_snapshot_cron()
+        except Exception:  # noqa: BLE001
+            logger.debug("Base snapshot cron sync failed", exc_info=True)
+
+    try:
+        asyncio.get_running_loop().create_task(_run())
+    except RuntimeError:
+        logger.debug("No running loop; skipping base snapshot cron sync")

--- a/agent/dashboard/repo_clone_stats.py
+++ b/agent/dashboard/repo_clone_stats.py
@@ -1,0 +1,103 @@
+"""Ledger of repos Open SWE has cloned into a sandbox.
+
+Every run that preps a repo bumps that repo's counter here. The nightly base
+snapshot rebuild reads the ledger to decide which repos to pre-clone, so repos
+the fleet actually works on stop paying the clone cost on every cold start.
+
+Recording is best-effort and never raises: a failed ledger write must not take
+down a run.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from langgraph_sdk import get_client
+
+from .review_styles import normalize_repo_full_name
+
+logger = logging.getLogger(__name__)
+
+REPO_CLONE_STATS_NAMESPACE: list[str] = ["repo_clone_stats"]
+
+
+def _client():
+    return get_client()
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+async def record_repo_clone(owner: str | None, name: str | None) -> None:
+    """Bump the clone counter for ``owner/name``. Never raises."""
+    if not owner or not name:
+        return
+    try:
+        full_name = normalize_repo_full_name(f"{owner}/{name}")
+    except Exception:  # noqa: BLE001
+        logger.debug("Skipping clone ledger for invalid repo %r/%r", owner, name)
+        return
+
+    try:
+        item = await _client().store.get_item(REPO_CLONE_STATS_NAMESPACE, full_name)
+        existing = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+        if not isinstance(existing, dict):
+            existing = {}
+        count = existing.get("clone_count")
+        value = {
+            "full_name": full_name,
+            "clone_count": (count if isinstance(count, int) and count > 0 else 0) + 1,
+            "first_cloned_at": existing.get("first_cloned_at") or _now_iso(),
+            "last_cloned_at": _now_iso(),
+        }
+        await _client().store.put_item(REPO_CLONE_STATS_NAMESPACE, full_name, value)
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record repo clone for %s", full_name, exc_info=True)
+
+
+async def list_repo_clone_stats() -> list[dict[str, Any]]:
+    try:
+        result = await _client().store.search_items(REPO_CLONE_STATS_NAMESPACE, limit=1000)
+    except Exception:  # noqa: BLE001
+        logger.debug("repo clone stats lookup failed", exc_info=True)
+        return []
+    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+    out: list[dict[str, Any]] = []
+    for item in items or []:
+        value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+        if isinstance(value, dict) and isinstance(value.get("full_name"), str):
+            out.append(value)
+    return out
+
+
+async def repos_to_preclone(*, limit: int, max_age_days: int) -> list[str]:
+    """Return the repos worth baking into the next snapshot, most-used first.
+
+    Repos untouched for ``max_age_days`` drop out so the snapshot tracks what
+    the fleet works on now rather than growing forever.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
+
+    fresh: list[tuple[int, datetime, str]] = []
+    for record in await list_repo_clone_stats():
+        last = _parse_iso(record.get("last_cloned_at"))
+        if last is None or last < cutoff:
+            continue
+        count = record.get("clone_count")
+        fresh.append((count if isinstance(count, int) else 0, last, record["full_name"]))
+
+    fresh.sort(key=lambda row: (-row[0], -row[1].timestamp(), row[2]))
+    return [full_name for _count, _last, full_name in fresh[:limit]]

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -806,6 +806,11 @@ async def api_get_base_snapshot(
     settings = BaseSnapshotSettings.model_validate(record["settings"])
     return {
         "record": record,
+        # The UI disables the rebuild controls while a build is running, so it
+        # needs to know when a "building" record is really a dead worker --
+        # otherwise a crashed build locks admins out of the recovery the
+        # backend already allows.
+        "build_stale": is_base_snapshot_build_stale(record),
         "clone_stats": await list_repo_clone_stats(),
         "next_preclone": await repos_to_preclone(
             limit=settings.preclone_limit, max_age_days=settings.max_age_days

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -29,6 +29,14 @@ from .agent_usage import (
     refresh_usage_leaderboard_cache,
 )
 from .analyzer_cron import remove_continual_cron
+from .base_snapshot import (
+    BaseSnapshotSettings,
+    get_base_snapshot_record,
+    is_base_snapshot_build_stale,
+    mark_base_snapshot_building,
+    rebuild_base_snapshot,
+    update_base_snapshot_settings,
+)
 from .enabled_repos import (
     list_enabled_review_repos,
     set_review_repo_enabled,
@@ -81,6 +89,7 @@ from .repo_cache import (
     schedule_repo_cache_refresh,
     write_cached_repos,
 )
+from .repo_clone_stats import list_repo_clone_stats, repos_to_preclone
 from .repo_snapshots import (
     RepoSnapshotConfigError,
     RepoSnapshotCreate,
@@ -787,6 +796,48 @@ async def api_set_enabled_review_repo(
 ) -> dict[str, list[str]]:
     repos = await set_review_repo_enabled(update.full_name, update.enabled)
     return {"repos": repos}
+
+
+@router.get("/base-snapshot")
+async def api_get_base_snapshot(
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    record = await get_base_snapshot_record()
+    settings = BaseSnapshotSettings.model_validate(record["settings"])
+    return {
+        "record": record,
+        "clone_stats": await list_repo_clone_stats(),
+        "next_preclone": await repos_to_preclone(
+            limit=settings.preclone_limit, max_age_days=settings.max_age_days
+        ),
+    }
+
+
+@router.put("/base-snapshot/settings")
+async def api_update_base_snapshot_settings(
+    body: BaseSnapshotSettings,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    return await update_base_snapshot_settings(body)
+
+
+@router.post("/base-snapshot/rebuild")
+async def api_rebuild_base_snapshot(
+    background_tasks: BackgroundTasks,
+    from_scratch: bool = False,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    record = await get_base_snapshot_record()
+    settings = BaseSnapshotSettings.model_validate(record["settings"])
+    if not settings.enabled:
+        raise HTTPException(400, "nightly base snapshot rebuilds are disabled")
+    if record.get("status") == "building" and not is_base_snapshot_build_stale(record):
+        raise HTTPException(409, "a rebuild is already in progress")
+    # Marked here rather than only inside the background task: the poll can
+    # otherwise land first, read a stale "ready", and stop polling.
+    record = await mark_base_snapshot_building()
+    background_tasks.add_task(rebuild_base_snapshot, from_scratch)
+    return record
 
 
 @router.get("/repo-snapshots")

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -152,7 +152,7 @@ REPO_SETUP_SECTION = """---
 Before any task that changes code, set up the repo in your sandbox, in order:
 
 1. **Identify the repo** from task context (use `GH_TOKEN=dummy gh repo list` / `gh search repos` / `gh search code` if needed).
-2. **Clone** — `cd {working_dir} && GH_TOKEN=dummy gh repo clone <owner>/<repo>`.
+2. **Clone** — call the `repo` tool with `action: "clone"` and `repo: "<owner>/<repo>"`. Never run `git clone` or `gh repo clone` yourself: the tool clones from a pre-baked local copy when there is one (near-instant) and brings the checkout up to date with origin either way. It returns the path to work in. Call it once per repository — a task may legitimately need several.
 3. **Set the commit identity** — immediately after cloning, `cd` into the repo and run:
 
    ```bash

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -8,6 +8,7 @@ from typing import Any, TypedDict
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import RunnableConfig
 
+from .dashboard.base_snapshot import rebuild_base_snapshot
 from .dashboard.schedules import launch_scheduled_agent_run
 from .reconcile import reconcile_stale_runs
 
@@ -25,6 +26,8 @@ async def _launch(state: SchedulerState, config: RunnableConfig) -> dict[str, An
     task = state.get("task") or configurable.get("task")
     if task == "reconcile":
         return {"result": await reconcile_stale_runs()}
+    if task == "rebuild_base_snapshot":
+        return {"result": await rebuild_base_snapshot()}
     schedule_id = state.get("schedule_id") or configurable.get("schedule_id")
     if not isinstance(schedule_id, str) or not schedule_id:
         logger.warning("Scheduled agent tick missing schedule_id")

--- a/agent/server.py
+++ b/agent/server.py
@@ -51,6 +51,7 @@ from .dashboard.agent_overrides import (
     resolve_github_login,
 )
 from .dashboard.agent_usage import record_agent_thread_usage
+from .dashboard.base_snapshot import resolve_base_snapshot_id
 from .dashboard.options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
@@ -132,6 +133,9 @@ from .tools import (
     slack_start_new_thread,
     slack_thread_reply,
     web_search,
+)
+from .tools import (
+    repo as repo_tool,
 )
 from .utils import ttl_cache
 from .utils.auth import resolve_github_token
@@ -282,18 +286,21 @@ async def _resolve_proxy_token(
 
 
 async def _resolve_snapshot_id_for_repo(repo: dict[str, str] | None) -> str | None:
-    """Resolve a repo's ready snapshot id; ``None`` falls back to the default.
+    """Resolve the snapshot a new sandbox should boot from.
 
-    Never raises: any failure resolves to ``None`` so sandbox creation falls
-    back to the configured ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
+    Order: the repo's own ready snapshot, then the nightly base snapshot with
+    common repos pre-cloned, then ``None`` -- which falls back to the
+    configured ``DEFAULT_SANDBOX_SNAPSHOT_ID``. Never raises.
     """
-    if not repo:
-        return None
-    try:
-        return await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
-    except Exception:  # noqa: BLE001
-        logger.debug("Failed to resolve repo-scoped snapshot", exc_info=True)
-        return None
+    if repo:
+        try:
+            repo_snapshot_id = await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to resolve repo-scoped snapshot", exc_info=True)
+            repo_snapshot_id = None
+        if repo_snapshot_id:
+            return repo_snapshot_id
+    return await resolve_base_snapshot_id()
 
 
 async def _create_sandbox_with_proxy(
@@ -1143,6 +1150,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         open_pull_request,
         request_pr_review,
         recreate_sandbox,
+        repo_tool,
         report_platform_issue,
         schedule_thread_wakeup,
         slack_add_reaction,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -23,6 +23,7 @@ _TOOL_MODULES = {
     "publish_review": ".publish_review",
     "read_repo_file": ".read_repo_file",
     "recreate_sandbox": ".recreate_sandbox",
+    "repo": ".repo_tool",
     "report_platform_issue": ".report_platform_issue",
     "request_pr_review": ".request_pr_review",
     "reply_to_finding_thread": ".reply_to_finding_thread",
@@ -62,6 +63,7 @@ __all__ = [
     "publish_review",
     "read_repo_file",
     "recreate_sandbox",
+    "repo",
     "report_platform_issue",
     "request_pr_review",
     "reply_to_finding_thread",
@@ -102,6 +104,7 @@ if TYPE_CHECKING:
     from .read_repo_file import read_repo_file
     from .recreate_sandbox import recreate_sandbox
     from .reply_to_finding_thread import reply_to_finding_thread
+    from .repo_tool import repo
     from .report_platform_issue import report_platform_issue
     from .request_pr_review import request_pr_review
     from .resolve_finding_thread import resolve_finding_thread

--- a/agent/tools/repo_tool.py
+++ b/agent/tools/repo_tool.py
@@ -1,0 +1,128 @@
+"""Tool: ``repo``. Get repositories into the sandbox.
+
+Cloning goes through this tool rather than a raw ``gh repo clone`` so that the
+clone is recorded -- the ledger that picks which repos the nightly snapshot
+bakes in is built from these calls. A thread may clone as many repos as it
+needs; nothing here assumes one repo per thread.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from langgraph.config import get_config
+
+from ..dashboard.repo_clone_stats import record_repo_clone
+from ..utils.repo_clone import build_clone_script, parse_clone_result
+from ..utils.sandbox_paths import aresolve_sandbox_work_dir
+
+logger = logging.getLogger(__name__)
+
+CLONE_TIMEOUT_SECONDS = 300
+
+RepoAction = Literal["clone"]
+
+
+def _split_full_name(value: str) -> tuple[str, str]:
+    cleaned = (value or "").strip().strip("/")
+    for prefix in ("https://github.com/", "http://github.com/", "github.com/"):
+        if cleaned.lower().startswith(prefix):
+            cleaned = cleaned[len(prefix) :]
+            break
+    if cleaned.endswith(".git"):
+        cleaned = cleaned[: -len(".git")]
+    owner, sep, name = cleaned.partition("/")
+    if not sep or not owner or not name or "/" in name:
+        return "", ""
+    return owner, name
+
+
+async def repo(
+    action: RepoAction,
+    repo: str,
+    ref: str | None = None,
+) -> dict[str, Any]:
+    """Get a repository into the sandbox, ready to work in.
+
+    Always use this instead of running ``git clone`` / ``gh repo clone`` yourself.
+    Commonly used repos are pre-baked into the sandbox image, so this is usually
+    near-instant; it works the same for a repo that isn't, just slower. Either
+    way it fetches origin before returning.
+
+    Safe to call again for a repo you already have — it refreshes the checkout
+    instead of clobbering it, so use it to pull in new commits too. Call it once
+    per repository you need; a task may span several.
+
+    Args:
+        action: ``clone``.
+        repo: Repository as ``owner/name``.
+        ref: Optional branch, tag, or commit sha to check out. Defaults to the
+            repository's default branch.
+
+    Returns:
+        ``{success, path, source, fetched, head, repo}`` on success, where
+        ``source`` is ``cache`` (pre-baked), ``github`` (network clone), or
+        ``existing``. **``fetched: False`` means the fetch from origin failed and
+        the checkout may be behind** — up to a day behind for a pre-baked repo.
+        Re-run before trusting it for anything that depends on recent commits.
+        On failure: ``{success: False, error}``.
+    """
+    owner, name = _split_full_name(repo)
+    if not owner or not name:
+        return {"success": False, "error": f"repo must be 'owner/name', got {repo!r}"}
+    if action != "clone":
+        return {"success": False, "error": f"unknown action {action!r}; use 'clone'"}
+
+    try:
+        config = get_config()
+    except Exception as exc:  # noqa: BLE001
+        return {"success": False, "error": f"Unable to read the current run config: {exc}"}
+
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
+    if not isinstance(thread_id, str) or not thread_id:
+        return {"success": False, "error": "No thread_id in current run config"}
+
+    from ..server import ensure_sandbox_for_thread
+
+    try:
+        sandbox_backend = await ensure_sandbox_for_thread(thread_id)
+        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("repo tool could not reach the sandbox", exc_info=True)
+        return {"success": False, "error": f"sandbox unavailable: {exc}"}
+
+    script = build_clone_script(work_dir=work_dir, owner=owner, name=name, ref=ref or "")
+
+    try:
+        result = await sandbox_backend.aexecute(script, timeout=CLONE_TIMEOUT_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("repo %s failed for %s/%s", action, owner, name, exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+    exit_code = getattr(result, "exit_code", None)
+    output = getattr(result, "output", "") or ""
+    if exit_code not in (0, None):
+        return {"success": False, "error": output[-2000:] or f"exit code {exit_code}"}
+
+    fields = parse_clone_result(output)
+    if not fields.get("path"):
+        return {"success": False, "error": output[-2000:] or "clone produced no result"}
+
+    # Record only what actually landed on disk, so the nightly snapshot bakes in
+    # repos that were really cloned rather than ones a run merely referenced.
+    await record_repo_clone(owner, name)
+
+    fetched = fields.get("fetched") == "true"
+    if not fetched:
+        logger.warning("repo clone for %s/%s could not fetch origin", owner, name)
+
+    return {
+        "success": True,
+        "repo": f"{owner}/{name}",
+        "path": fields["path"],
+        "source": fields.get("source", "unknown"),
+        "fetched": fetched,
+        "head": fields.get("head", ""),
+    }

--- a/agent/utils/repo_clone.py
+++ b/agent/utils/repo_clone.py
@@ -1,0 +1,251 @@
+"""Shared clone-from-cache logic for the sandbox.
+
+The scheduled warm bakes ready-to-use checkouts into a hidden cache dir inside
+the sandbox work dir. Taking one is a ``mv`` within a single filesystem -- a
+rename, O(1) whatever the repo's size -- so a run gets a full working tree with
+real history without paying for a clone. The checkout is only as fresh as the
+last warm, so every take fetches origin afterwards.
+
+Full checkouts rather than bare mirrors because materializing a working tree is
+the expensive half: hardlinking a bare repo's objects still writes out every
+file. It also leaves room to bake installed dependencies into the tree, which
+then ride along with the same rename.
+
+A repo that was never baked in still clones, just over the network. Nothing here
+depends on the warm -- or on any particular sandbox provider -- having run.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import shlex
+
+# Hidden and inside the work dir rather than an absolute path like /opt: the
+# local provider's work dir is a real directory on the developer's machine, so
+# an absolute root would write outside LOCAL_SANDBOX_ROOT_DIR. Dot-prefixed so
+# it stays out of `ls` and the agent's view of an otherwise empty work dir.
+# Pinned rather than read from the shell's cwd: a snapshot captured from a
+# running sandbox carries the filesystem but not the image's WORKDIR, so shells
+# there start at `/`. Both the warm and the run must agree on one directory.
+PREFERRED_WORK_DIR = "/workspace"
+
+REPO_CACHE_DIRNAME = ".repo-cache"
+
+RESULT_MARKER = "OPENSWE_CLONE"
+
+
+def _repo_url(owner: str, name: str) -> str:
+    return shlex.quote(f"https://github.com/{owner}/{name}.git")
+
+
+def cache_root_for(work_dir: str) -> str:
+    return posixpath.join(work_dir, REPO_CACHE_DIRNAME)
+
+
+def cache_path_for(work_dir: str, owner: str, name: str) -> str:
+    """Path of the baked checkout for ``owner/name``.
+
+    Owner-scoped on purpose: two orgs can both own a repo called ``tools``, and
+    a flat layout would silently serve one for the other.
+    """
+    return posixpath.join(cache_root_for(work_dir), owner, name)
+
+
+def _resolve_ref_lines(ref: str) -> list[str]:
+    """Shell lines that leave the checkout at ``ref``, or the default branch."""
+    if ref:
+        q_ref = shlex.quote(ref)
+        return [
+            f"GH_TOKEN=dummy git fetch origin {q_ref} --quiet 2>/dev/null || true",
+            f"git checkout --force {q_ref} --quiet",
+        ]
+    return [
+        "GH_TOKEN=dummy git remote set-head origin --auto >/dev/null 2>&1 || true",
+        'DEFAULT="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)"',
+        'DEFAULT="${DEFAULT#origin/}"',
+        'git checkout --force -B "$DEFAULT" "origin/$DEFAULT" --quiet',
+    ]
+
+
+def build_clone_script(
+    *,
+    work_dir: str,
+    owner: str,
+    name: str,
+    ref: str = "",
+) -> str:
+    """Script that puts ``owner/name`` at ``work_dir/name``, from cache if baked.
+
+    Idempotent: it reuses an existing checkout and refreshes it rather than
+    re-cloning over it, so calling it again never clobbers uncommitted work.
+    """
+    dest = posixpath.join(work_dir, name)
+    q_dest = shlex.quote(dest)
+    q_work_dir = shlex.quote(work_dir)
+    q_cache = shlex.quote(cache_path_for(work_dir, owner, name))
+    q_name = shlex.quote(name)
+
+    lines = [
+        "set -e",
+        f"if [ -d {q_dest}/.git ]; then",
+        "  SOURCE=existing",
+        f"  cd {q_dest}",
+        # A rename, not a copy: both paths live under the work dir, so this is
+        # O(1) however large the repo. Falls through to a network clone if the
+        # move fails for any reason (a cache on another filesystem, say).
+        f"elif [ -d {q_cache} ] && mv {q_cache} {q_dest} 2>/dev/null; then",
+        "  SOURCE=cache",
+        f"  cd {q_dest}",
+        "else",
+        "  SOURCE=github",
+        f"  mkdir -p {q_work_dir}",
+        f"  cd {q_work_dir}",
+        f"  GH_TOKEN=dummy git clone {_repo_url(owner, name)} {q_name} --quiet",
+        f"  cd {q_dest}",
+        "fi",
+        # A baked checkout is as stale as the last warm, and an existing one as
+        # stale as its last use, so always pull in what came after.
+        # A failed fetch is survivable but must not pass for up-to-date: the
+        # caller reports it so a day-old tree is never mistaken for current.
+        "if GH_TOKEN=dummy git fetch origin --prune --quiet 2>/dev/null; then",
+        "  FETCHED=true",
+        "else",
+        "  FETCHED=false",
+        "fi",
+        *_resolve_ref_lines(ref),
+        f'echo "{RESULT_MARKER} source=$SOURCE fetched=$FETCHED'
+        f' path={dest} head=$(git rev-parse HEAD)"',
+    ]
+    return "\n".join(lines)
+
+
+def build_mirror_sweep_script(
+    work_dir: str,
+    repos: list[str],
+    *,
+    proxy_auth: bool,
+) -> str:
+    """Script that brings the cache in line with ``repos``, one repo at a time.
+
+    Incremental by design: a repo already in the cache is fetched and reset
+    rather than re-cloned, so a warm that starts from yesterday's image only
+    pays for the commits since. That matters more the more is baked into each
+    checkout -- installed dependencies survive the update instead of being
+    thrown away nightly.
+
+    Never aborts on a single repo's failure, and prints one ``ok``/``fail`` line
+    per repo so callers can report progress and record what landed.
+
+    Cloning is plain ``git`` over https rather than ``gh repo clone``: ``gh``
+    demands an authenticated login even for a public repo, while git over https
+    works unauthenticated for public repos and picks up the LangSmith proxy's
+    injected credentials for private ones. One command covers both.
+
+    ``proxy_auth`` prefixes ``GH_TOKEN=dummy``, which is how that proxy injects
+    real credentials. Providers without it pass ``False`` -- deliberately, so no
+    real token is ever interpolated into a command string.
+
+    A failed clone reports git's own error on the ``fail`` line; swallowing it
+    leaves an operator with a red status and nothing to diagnose.
+    """
+    git = "GH_TOKEN=dummy git" if proxy_auth else "git"
+    cache_root = cache_root_for(work_dir)
+    q_root = shlex.quote(cache_root)
+    # Outside the cache root on purpose: anything left inside it is captured
+    # into the snapshot, and a stray file breaks hooks that glob
+    # `.repo-cache/*/*` for repositories.
+    q_err = shlex.quote("/tmp/openswe-warm.err")
+
+    lines = [f"mkdir -p {q_root}"]
+    for full_name in repos:
+        owner, name = full_name.split("/", 1)
+        cache_path = cache_path_for(work_dir, owner, name)
+        q_full = shlex.quote(full_name)
+        q_cache = shlex.quote(cache_path)
+        q_parent = shlex.quote(posixpath.dirname(cache_path))
+        lines.extend(
+            [
+                f"mkdir -p {q_parent}",
+                f"if [ -d {q_cache}/.git ] && cd {q_cache} && {_update_checkout(git)}; then",
+                f"  echo ok {q_full}",
+                "else",
+                f"  rm -rf {q_cache}",
+                f"  if {git} clone {_repo_url(owner, name)} {q_cache} --quiet 2>{q_err}; then",
+                f"    echo ok {q_full}",
+                "  else",
+                f"    rm -rf {q_cache}",
+                f"    echo \"fail {full_name} $(tr '\\n' ' ' < {q_err} | tail -c 200)\"",
+                "  fi",
+                "fi",
+            ]
+        )
+
+    lines.extend(_prune_cache_lines(cache_root, repos))
+    return "\n".join(lines)
+
+
+def _update_checkout(git: str) -> str:
+    """One `&&` chain that fast-forwards a cached checkout to its default branch.
+
+    Any failure falls through to a fresh clone, so a corrupted or diverged
+    checkout self-heals instead of being carried forward for good -- the main
+    hazard of building each image from the previous one.
+    """
+    return (
+        f"{git} fetch origin --prune --quiet >/dev/null 2>&1 "
+        f"&& {git} remote set-head origin --auto >/dev/null 2>&1 "
+        '&& DEFAULT="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)" '
+        '&& DEFAULT="${DEFAULT#origin/}" '
+        '&& git checkout --force -B "$DEFAULT" "origin/$DEFAULT" --quiet >/dev/null 2>&1 '
+        "&& git clean -qfd"
+    )
+
+
+def _prune_cache_lines(cache_root: str, repos: list[str]) -> list[str]:
+    """Drop cached repos that are no longer wanted.
+
+    Without this an incremental cache only ever grows: a repo that falls out of
+    the ledger would keep its checkout -- and its dependencies -- in every image
+    from then on.
+    """
+    keep = " ".join(sorted(repos))
+    q_root = shlex.quote(cache_root)
+    return [
+        f"KEEP={shlex.quote(keep)}",
+        f"for dir in {q_root}/*/*; do",
+        '  [ -d "$dir" ] || continue',
+        f'  rel="${{dir#{cache_root}/}}"',
+        '  case " $KEEP " in',
+        '    *" $rel "*) ;;',
+        '    *) rm -rf "$dir" ;;',
+        "  esac",
+        "done",
+    ]
+
+
+def parse_mirror_sweep_output(stdout: str) -> tuple[list[str], list[str]]:
+    """Split a sweep's output into ``(cloned, failed)`` repo names."""
+    cloned: list[str] = []
+    failed: list[str] = []
+    buckets = {"ok": cloned, "fail": failed}
+    for line in stdout.splitlines():
+        status, _, full_name = line.strip().partition(" ")
+        bucket = buckets.get(status)
+        if bucket is not None and full_name:
+            bucket.append(full_name)
+    return cloned, failed
+
+
+def parse_clone_result(stdout: str) -> dict[str, str]:
+    """Pull the marker line's fields out of a clone/update script's output."""
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if not line.startswith(f"{RESULT_MARKER} "):
+            continue
+        fields: dict[str, str] = {}
+        for token in line[len(RESULT_MARKER) + 1 :].split(" "):
+            key, sep, value = token.partition("=")
+            if sep and key:
+                fields[key] = value
+        return fields
+    return {}

--- a/agent/utils/repo_clone.py
+++ b/agent/utils/repo_clone.py
@@ -97,34 +97,47 @@ def build_clone_script(
     name: str,
     ref: str = "",
 ) -> str:
-    """Script that puts ``owner/name`` at ``work_dir/name``, from cache if baked.
+    """Script that puts ``owner/name`` under ``work_dir``, from cache if baked.
 
-    Idempotent: it reuses an existing checkout and refreshes it rather than
-    re-cloning over it, so calling it again never clobbers uncommitted work.
+    Idempotent: it reuses an existing checkout of the *same* repo and refreshes
+    it rather than re-cloning over it, so calling it again never clobbers
+    uncommitted work.
+
+    The destination is chosen at run time. It is ``work_dir/name`` normally, but
+    falls back to ``work_dir/owner-name`` when a different repo already occupies
+    that path -- two orgs can both own a repo called ``tools``, and handing back
+    the wrong one would have the agent silently editing the wrong code. The
+    caller reads the real path off the result line rather than assuming it.
     """
-    dest = posixpath.join(work_dir, name)
-    q_dest = shlex.quote(dest)
     q_work_dir = shlex.quote(work_dir)
     q_cache = shlex.quote(cache_path_for(work_dir, owner, name))
-    q_name = shlex.quote(name)
+    q_plain = shlex.quote(posixpath.join(work_dir, name))
+    q_scoped = shlex.quote(posixpath.join(work_dir, f"{owner}-{name}"))
+    q_pattern = shlex.quote(f"[:/]{owner}/{name}(\\.git)?/?$")
 
     lines = [
         "set -e",
-        f"if [ -d {q_dest}/.git ]; then",
+        f"mkdir -p {q_work_dir}",
+        # Belongs to this repo, some other repo, or nobody -- the three cases
+        # that decide both where to put it and whether it can be reused.
+        f"DEST={q_plain}",
+        'if [ -d "$DEST/.git" ] && ! git -C "$DEST" remote get-url origin 2>/dev/null'
+        f" | grep -qiE {q_pattern}; then",
+        f"  DEST={q_scoped}",
+        "fi",
+        'if [ -d "$DEST/.git" ]; then',
         "  SOURCE=existing",
-        f"  cd {q_dest}",
+        '  cd "$DEST"',
         # A rename, not a copy: both paths live under the work dir, so this is
         # O(1) however large the repo. Falls through to a network clone if the
         # move fails for any reason (a cache on another filesystem, say).
-        f"elif [ -d {q_cache} ] && mv {q_cache} {q_dest} 2>/dev/null; then",
+        f'elif [ -d {q_cache} ] && mv {q_cache} "$DEST" 2>/dev/null; then',
         "  SOURCE=cache",
-        f"  cd {q_dest}",
+        '  cd "$DEST"',
         "else",
         "  SOURCE=github",
-        f"  mkdir -p {q_work_dir}",
-        f"  cd {q_work_dir}",
-        f"  {_clone_expr(owner, name, q_name, proxy_auth=True)}",
-        f"  cd {q_dest}",
+        "  " + _clone_expr(owner, name, '"$DEST"', proxy_auth=True),
+        '  cd "$DEST"',
         "fi",
         # A baked checkout is as stale as the last warm, and an existing one as
         # stale as its last use, so always pull in what came after.
@@ -137,7 +150,7 @@ def build_clone_script(
         "fi",
         *_resolve_ref_lines(ref),
         f'echo "{RESULT_MARKER} source=$SOURCE fetched=$FETCHED'
-        f' path={dest} head=$(git rev-parse HEAD)"',
+        ' path=$DEST head=$(git rev-parse HEAD)"',
     ]
     return "\n".join(lines)
 

--- a/agent/utils/repo_clone.py
+++ b/agent/utils/repo_clone.py
@@ -38,6 +38,29 @@ def _repo_url(owner: str, name: str) -> str:
     return shlex.quote(f"https://github.com/{owner}/{name}.git")
 
 
+def _clone_expr(owner: str, name: str, dest: str, *, proxy_auth: bool, stderr: str = "") -> str:
+    """Shell expression that clones ``owner/name`` into ``dest``.
+
+    With the LangSmith proxy, plain git is the whole story -- it injects the
+    credentials and there is no ``gh`` login in the sandbox.
+
+    Without it, prefer an authenticated ``gh`` when one is present: that is the
+    only way a private repo clones on a developer's machine, and it uses their
+    existing login rather than a token interpolated into a command string. Falls
+    back to git, which still covers every public repo.
+    """
+    url = _repo_url(owner, name)
+    redirect = f" 2>{stderr}" if stderr else ""
+    if proxy_auth:
+        return f"GH_TOKEN=dummy git clone {url} {dest} --quiet{redirect}"
+    gh_clone = f"gh repo clone {shlex.quote(f'{owner}/{name}')} {dest} -- --quiet{redirect}"
+    git_clone = f"git clone {url} {dest} --quiet{redirect}"
+    return (
+        "{ command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1 "
+        f"&& {gh_clone}; }} || {git_clone}"
+    )
+
+
 def cache_root_for(work_dir: str) -> str:
     return posixpath.join(work_dir, REPO_CACHE_DIRNAME)
 
@@ -100,7 +123,7 @@ def build_clone_script(
         "  SOURCE=github",
         f"  mkdir -p {q_work_dir}",
         f"  cd {q_work_dir}",
-        f"  GH_TOKEN=dummy git clone {_repo_url(owner, name)} {q_name} --quiet",
+        f"  {_clone_expr(owner, name, q_name, proxy_auth=True)}",
         f"  cd {q_dest}",
         "fi",
         # A baked checkout is as stale as the last warm, and an existing one as
@@ -170,7 +193,7 @@ def build_mirror_sweep_script(
                 f"  echo ok {q_full}",
                 "else",
                 f"  rm -rf {q_cache}",
-                f"  if {git} clone {_repo_url(owner, name)} {q_cache} --quiet 2>{q_err}; then",
+                f"  if {_clone_expr(owner, name, q_cache, proxy_auth=proxy_auth, stderr=q_err)}; then",
                 f"    echo ok {q_full}",
                 "  else",
                 f"    rm -rf {q_cache}",

--- a/agent/utils/repo_prep.py
+++ b/agent/utils/repo_prep.py
@@ -19,6 +19,8 @@ from collections.abc import Sequence
 
 from deepagents.backends.protocol import SandboxBackendProtocol
 
+from .repo_clone import cache_path_for
+
 logger = logging.getLogger(__name__)
 
 CLONE_TIMEOUT_SECONDS = 240
@@ -43,12 +45,19 @@ def _prep_command(
     q_repo_name = shlex.quote(repo_name)
     q_head = shlex.quote(head_sha) if head_sha else ""
 
+    q_cache = shlex.quote(cache_path_for(work_dir, repo_owner, repo_name))
+
     lines = [
         "set -e",
         f"if [ -d {q_repo_dir}/.git ]; then",
         # Tolerate fetch-all failures: the targeted head/base fetches below
         # are what the checkout actually needs.
         f"  cd {q_repo_dir} && {{ GH_TOKEN=dummy git fetch --all --quiet || true; }}",
+        # Taking a baked checkout is a rename within one filesystem, so the
+        # fetch below only has to carry commits made since the last warm.
+        f"elif [ -d {q_cache} ] && mv {q_cache} {q_repo_dir} 2>/dev/null; then",
+        f"  cd {q_repo_dir}",
+        "  GH_TOKEN=dummy git fetch origin --prune --quiet 2>/dev/null || true",
         "else",
         f"  cd {q_work_dir} && GH_TOKEN=dummy gh repo clone {q_full_name} && cd {q_repo_name}",
         "fi",

--- a/agent/utils/sandbox_paths.py
+++ b/agent/utils/sandbox_paths.py
@@ -10,7 +10,10 @@ from typing import Any
 
 from deepagents.backends.protocol import SandboxBackendProtocol
 
+from .repo_clone import PREFERRED_WORK_DIR
+
 logger = logging.getLogger(__name__)
+
 
 _WORK_DIR_CACHE_ATTR = "_open_swe_resolved_work_dir"
 _PROVIDER_ATTR_NAMES = ("sandbox", "_sandbox")
@@ -53,6 +56,16 @@ async def _iter_work_dir_candidates(
         if candidate not in seen:
             seen.add(candidate)
             yield candidate
+
+    # Ahead of `pwd`, because `pwd` is not stable across how a sandbox was
+    # booted: a snapshot captured from a running sandbox carries the filesystem
+    # but not the image's WORKDIR, so shells there start at `/`. Resolving to
+    # `/` would clone repos at the filesystem root and hide anything the
+    # snapshot left under the real work dir. Skipped when it isn't a writable
+    # directory, so providers without it keep their old behavior.
+    if PREFERRED_WORK_DIR not in seen:
+        seen.add(PREFERRED_WORK_DIR)
+        yield PREFERRED_WORK_DIR
 
     shell_work_dir = await _resolve_shell_path(sandbox_backend, "pwd")
     if shell_work_dir and shell_work_dir not in seen:

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -47,6 +47,28 @@ This is useful for pre-installing languages, frameworks, or internal tools that 
 
 `REPO_SNAPSHOT_BASE_IMAGE` should point to the published Docker image used to create your default Open SWE sandbox snapshot (typically the image built from this repository's `Dockerfile.sandbox`). The admin **Repository Snapshots** page uses it as the base image when generating per-repo Dockerfile templates. If it is not configured, template generation fails closed instead of suggesting a bare image that would be missing Open SWE's required sandbox tools.
 
+### Scheduled repo cache warming
+
+Open SWE records every repo it preps a sandbox for. On a schedule it can rebuild the shared snapshot with the most-used of those repos already cloned into the sandbox work dir, so runs skip the cold clone.
+
+This is configured entirely from the admin **Snapshots** page (`/agents/snapshots`) — there are no environment variables. It is off until an admin turns it on, and the page controls the schedule, how many repos to bake in, how long a repo may go unused before it drops out, and how many captures to retain. The same page shows the clone ledger, the last build's result, and a **Rebuild now** button.
+
+Repos are cached as ready-to-use checkouts under `<work-dir>/.repo-cache/<owner>/<name>`. A run takes one with a `mv` — a rename within a single filesystem, so it is O(1) whatever the repo's size — then fetches origin. Full checkouts rather than bare mirrors because materializing the working tree is the expensive half, and because installed dependencies can be baked into the tree and ride along with the same rename.
+
+Warms are incremental: the builder boots from the previous capture and each repo is fetched rather than re-cloned, so anything baked in survives. It falls back to the seed image automatically when `DEFAULT_SANDBOX_SNAPSHOT_ID` changes — otherwise a new base image would never reach the chain — and on demand via **Rebuild from scratch** on the admin page. How the cache reaches a run depends on the provider:
+
+| `SANDBOX_TYPE` | Mode | How it works |
+|---|---|---|
+| `langsmith` | `snapshot` | Warms a throwaway builder booted from the previous capture, then captures it as an image. New sandboxes boot from that capture unless the repo has its own snapshot, which still wins. |
+| `local` | `cache` | Warms the shared work dir in place. No image involved — the cache simply persists. |
+| others | — | Fails with a clear message: without a capture API *and* without a persistent filesystem, a warmed cache would be discarded with the sandbox that built it. |
+
+A failed run leaves the last good capture in place, and with no capture at all runs fall back to `DEFAULT_SANDBOX_SNAPSHOT_ID`.
+
+The cache dir is hidden (dot-prefixed) and lives inside the work dir rather than at an absolute path, so the `local` provider writes inside `LOCAL_SANDBOX_ROOT_DIR` instead of your host's filesystem. The visible work dir stays empty. The agent gets a repo by calling the `repo` tool with `action: "clone"`, which takes the baked checkout when one exists (a rename, effectively free) and clones over the network when it doesn't, then fetches origin either way so the checkout carries commits made since the last warm. A `fetched: false` in its result means that fetch failed and the tree may be behind. The ledger is built from those tool calls, so it records what was actually cloned — a thread may clone as many repos as the task needs.
+
+Every repo baked in is readable by every run booting from that snapshot, including runs targeting a different repo. Leave the nightly rebuild off if that is not acceptable for your installation.
+
 For LangSmith sandboxes, Open SWE configures two GitHub proxy rules whenever a sandbox is created or reattached to a run:
 
 - `github.com` / `*.github.com` receive Basic auth for git-over-HTTPS operations.

--- a/tests/e2e/langgraph.e2e.json
+++ b/tests/e2e/langgraph.e2e.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://langgra.ph/schema.json",
   "python_version": "3.12",
-  "dependencies": ["."],
+  "dependencies": [
+    "."
+  ],
   "graphs": {
-    "agent": "./tests/e2e/agent_entrypoint.py:traced_agent"
+    "agent": "./tests/e2e/agent_entrypoint.py:traced_agent",
+    "scheduler": "agent.graphs.scheduler:get_scheduler"
   },
   "http": {
     "app": "./tests/e2e/harness.py:app"

--- a/tests/e2e/snapshot_cache_e2e.py
+++ b/tests/e2e/snapshot_cache_e2e.py
@@ -1,0 +1,272 @@
+"""End-to-end check of the sandbox repo cache against real LangSmith sandboxes.
+
+Not part of ``make test``: it creates real cloud resources and costs money. Run
+it deliberately when the cache mechanics change.
+
+It exists because the unit tests assert on generated shell strings and mocked
+SDK calls, which cannot answer the questions that decide whether the feature
+works at all:
+
+  A1  Does ``capture_snapshot`` preserve the work dir? If the work dir is a
+      mount rather than part of the captured rootfs, the cache vanishes at
+      capture and every run silently falls back to a network clone.
+  A2  Does a run resolve the same work dir the builder wrote the cache into?
+  A3  Are the cache and the checkout destination on one filesystem, so taking a
+      repo is a rename and not a full copy?
+  A4  Does the sweep's ``git clone`` into the cache path work in the image?
+  A5  Does booting from a capture and re-fetching work (the incremental path)?
+
+Every resource it creates is prefixed ``openswe-e2e-`` and cleaned up. Sandboxes
+are stopped, never deleted, matching the rule the agent code follows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+import time
+from typing import Any
+
+from langsmith.sandbox import SandboxClient
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from agent.utils.repo_clone import (  # noqa: E402
+    PREFERRED_WORK_DIR,
+    build_clone_script,
+    build_mirror_sweep_script,
+    cache_path_for,
+    parse_clone_result,
+    parse_mirror_sweep_output,
+)
+
+PROD_ENDPOINT = "https://api.smith.langchain.com/v2/sandboxes"
+DEFAULT_REPO = "langchain-ai/open-swe"
+
+# Short TTLs: these are throwaways, and the platform reclaims them.
+IDLE_TTL_SECONDS = 600
+DELETE_AFTER_STOP_SECONDS = 60
+
+results: list[tuple[str, bool, str]] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> bool:
+    results.append((label, ok, detail))
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}{f' -- {detail}' if detail else ''}", flush=True)
+    return ok
+
+
+def run(sandbox: Any, command: str, timeout: int = 300) -> tuple[str, int]:
+    result = sandbox.run(command, timeout=timeout)
+    return (result.stdout or "").strip(), result.exit_code
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="public owner/name to cache")
+    parser.add_argument(
+        "--key-file",
+        default=str(pathlib.Path.home() / ".langsmith/api_keys/gcp_prod"),
+        help="file holding the LangSmith API key; LANGSMITH_API_KEY wins (never printed)",
+    )
+    parser.add_argument("--endpoint", default=PROD_ENDPOINT)
+    args = parser.parse_args()
+
+    owner, name = args.repo.split("/", 1)
+    stamp = time.strftime("%Y%m%d%H%M%S")
+    run_prefix = f"openswe-e2e-{stamp}"
+    capture_name = run_prefix
+
+    api_key = (os.environ.get("LANGSMITH_API_KEY") or "").strip()
+    if not api_key:
+        key_path = pathlib.Path(args.key_file)
+        if not key_path.exists():
+            print(f"No LANGSMITH_API_KEY and no key file at {key_path}", file=sys.stderr)
+            return 2
+        api_key = key_path.read_text().strip()
+    client = SandboxClient(api_key=api_key, api_endpoint=args.endpoint)
+
+    started_sandboxes: list[str] = []
+    timings: dict[str, float] = {}
+
+    def phase(label: str) -> float:
+        print(f"\n== {label}", flush=True)
+        return time.monotonic()
+
+    try:
+        t = phase("Boot builder on the platform default base")
+        builder = client.create_sandbox(
+            name=f"openswe-e2e-builder-{stamp}",
+            idle_ttl_seconds=IDLE_TTL_SECONDS,
+            delete_after_stop_seconds=DELETE_AFTER_STOP_SECONDS,
+        )
+        started_sandboxes.append(builder.name)
+        timings["builder_boot"] = time.monotonic() - t
+
+        builder_wd = PREFERRED_WORK_DIR
+        run(builder, f"mkdir -p {builder_wd}")
+        raw_pwd, _ = run(builder, "pwd")
+        versions, _ = run(builder, "git --version; gh --version | head -1")
+        print(f"  work dir: {builder_wd} (raw pwd: {raw_pwd})\n  {versions}", flush=True)
+
+        t = phase(f"Warm the cache with {args.repo}")
+        sweep = build_mirror_sweep_script(builder_wd, [args.repo], proxy_auth=False)
+        out, _code = run(builder, sweep, timeout=900)
+        cloned, failed = parse_mirror_sweep_output(out)
+        timings["warm"] = time.monotonic() - t
+        clone_worked = check(
+            "A4  git clone into the cache path works in the sandbox image",
+            bool(cloned) and not failed,
+            f"cloned={cloned} failed={failed}",
+        )
+        if not clone_worked:
+            print(f"  sweep output:\n{out[-1500:]}", flush=True)
+            return 1
+
+        t = phase("Run the post-clone hook (dependency install slot)")
+        hook = 'for repo in .repo-cache/*/*; do (cd "$repo" && git rev-parse --short HEAD); done'
+        hook_out, hook_code = run(builder, f"set -e\ncd {builder_wd}\n{hook}")
+        timings["post_hook"] = time.monotonic() - t
+        check(
+            "A6  post-clone hook runs with the work dir as cwd",
+            hook_code == 0 and len(hook_out) >= 7,
+            f"exit={hook_code} out={hook_out[:80]}",
+        )
+
+        cache_dir = cache_path_for(builder_wd, owner, name)
+        sizes, _ = run(builder, f"du -sh {cache_dir} 2>/dev/null; df -h {builder_wd} | tail -1")
+        print(f"  {sizes}", flush=True)
+
+        same_fs, _ = run(
+            builder,
+            f"a=$(stat -c %d {cache_dir}); b=$(stat -c %d {builder_wd}); "
+            'if [ "$a" = "$b" ]; then echo SAME; else echo "DIFFERENT $a $b"; fi',
+        )
+        check(
+            "A3  cache and work dir on one filesystem (mv is a rename)", same_fs == "SAME", same_fs
+        )
+
+        t = phase("Capture the snapshot")
+        capture = client.capture_snapshot(builder.name, capture_name, timeout=1800)
+        timings["capture"] = time.monotonic() - t
+        print(f"  capture {capture.id} ({timings['capture']:.1f}s)", flush=True)
+
+        t = phase("Boot a fresh sandbox from the capture")
+        runtime = client.create_sandbox(
+            snapshot_id=capture.id,
+            name=f"openswe-e2e-runtime-{stamp}",
+            idle_ttl_seconds=IDLE_TTL_SECONDS,
+            delete_after_stop_seconds=DELETE_AFTER_STOP_SECONDS,
+        )
+        started_sandboxes.append(runtime.name)
+        timings["runtime_boot"] = time.monotonic() - t
+
+        runtime_pwd, _ = run(runtime, "pwd")
+        runtime_wd = PREFERRED_WORK_DIR
+        writable, _ = run(runtime, f"test -d {runtime_wd} && test -w {runtime_wd} && echo OK")
+        check(
+            "A2  the pinned work dir survives capture and is writable",
+            writable == "OK",
+            f"pinned={runtime_wd} writable={writable} raw pwd={runtime_pwd}",
+        )
+
+        listing, _ = run(runtime, f"ls -a {runtime_wd}; echo '--'; ls {cache_dir} 2>&1 | head -3")
+        survived, _ = run(runtime, f"[ -d {cache_dir}/.git ] && echo PRESENT || echo MISSING")
+        check(
+            "A1  capture preserved the cache in the work dir",
+            survived == "PRESENT",
+            survived,
+        )
+        print(f"  work dir contents:\n{listing}", flush=True)
+
+        t = phase("Take the repo out of the cache (the real clone script)")
+        script = build_clone_script(work_dir=runtime_wd, owner=owner, name=name)
+        out, code = run(runtime, script, timeout=600)
+        timings["take_from_cache"] = time.monotonic() - t
+        fields = parse_clone_result(out)
+        check(
+            "A5  clone script succeeded against the captured cache",
+            code == 0 and fields.get("path") != "",
+            f"exit={code} {fields or out[-400:]}",
+        )
+        check(
+            "     came from the cache, not the network",
+            fields.get("source") == "cache",
+            f"source={fields.get('source')}",
+        )
+        check(
+            "     fetched origin after taking it",
+            fields.get("fetched") == "true",
+            f"fetched={fields.get('fetched')}",
+        )
+
+        history, _ = run(runtime, f"cd {runtime_wd}/{name} && git rev-list --count HEAD")
+        check(
+            "     full history, not shallow",
+            history.isdigit() and int(history) > 100,
+            f"{history} commits",
+        )
+        shallow, _ = run(
+            runtime, f"cd {runtime_wd}/{name} && git rev-parse --is-shallow-repository"
+        )
+        check("     repository is not shallow", shallow == "false", shallow)
+
+        gone, _ = run(runtime, f"[ -d {cache_dir} ] && echo STILL_THERE || echo CONSUMED")
+        check("     cache entry consumed by the move", gone == "CONSUMED", gone)
+
+        t = phase("Cold clone for comparison (no cache)")
+        cold = build_clone_script(work_dir=f"{runtime_wd}/cold", owner=owner, name=name)
+        run(runtime, f"mkdir -p {runtime_wd}/cold")
+        _out, _code = run(runtime, cold, timeout=900)
+        timings["cold_clone"] = time.monotonic() - t
+
+    finally:
+        print("\n== Cleanup", flush=True)
+        for sandbox_name in started_sandboxes:
+            try:
+                client.stop_sandbox(sandbox_name)
+                print(f"  stopped {sandbox_name}", flush=True)
+            except Exception as e:  # noqa: BLE001
+                print(f"  could not stop {sandbox_name}: {type(e).__name__}", flush=True)
+        # Swept by name, not by a list built as we go: a snapshot that times out
+        # mid-build never makes it into such a list and would be left orphaned.
+        # A snapshot cannot be deleted while a sandbox still references it, and
+        # stopped sandboxes are only reclaimed delete_after_stop_seconds later,
+        # so retry rather than leaving snapshots behind in a shared workspace.
+        deadline = time.monotonic() + 600
+        while time.monotonic() < deadline:
+            leftover = list(client.list_snapshots(name_contains=run_prefix, limit=50))
+            if not leftover:
+                print("  no snapshots left", flush=True)
+                break
+            for snapshot in leftover:
+                try:
+                    client.delete_snapshot(snapshot.id)
+                    print(f"  deleted snapshot {snapshot.name}", flush=True)
+                except Exception:  # noqa: BLE001
+                    pass
+            else:
+                time.sleep(30)
+        else:
+            names = [s.name for s in client.list_snapshots(name_contains=run_prefix, limit=50)]
+            print(f"  LEFTOVER SNAPSHOTS, delete by hand: {names}", flush=True)
+        client.close()
+
+    print("\n== Timings")
+    for label, seconds in timings.items():
+        print(f"  {label:18s} {seconds:7.1f}s")
+    if "cold_clone" in timings and "take_from_cache" in timings:
+        speedup = timings["cold_clone"] / max(timings["take_from_cache"], 0.001)
+        print(f"  cache vs cold clone: {speedup:.1f}x faster")
+
+    failures = [label for label, ok, _ in results if not ok]
+    print(f"\n{len(results) - len(failures)}/{len(results)} checks passed")
+    for label in failures:
+        print(f"  FAILED: {label}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sandbox/test_base_snapshot.py
+++ b/tests/sandbox/test_base_snapshot.py
@@ -1,0 +1,784 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from pydantic import ValidationError
+
+from agent.dashboard import base_snapshot, repo_clone_stats, routes
+from agent.utils.repo_clone import build_mirror_sweep_script, parse_mirror_sweep_output
+
+
+def _iso(days_ago: float) -> str:
+    return (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+
+
+def _stat(full_name: str, count: int, days_ago: float) -> dict[str, object]:
+    return {
+        "full_name": full_name,
+        "clone_count": count,
+        "first_cloned_at": _iso(days_ago + 1),
+        "last_cloned_at": _iso(days_ago),
+    }
+
+
+@pytest.mark.asyncio
+async def test_record_repo_clone_increments_existing_count() -> None:
+    store = MagicMock()
+    store.get_item = AsyncMock(
+        return_value={"value": {"full_name": "acme/repo", "clone_count": 4, "first_cloned_at": "x"}}
+    )
+    store.put_item = AsyncMock()
+    with patch.object(repo_clone_stats, "_client", return_value=SimpleNamespace(store=store)):
+        await repo_clone_stats.record_repo_clone("acme", "repo")
+
+    _namespace, key, value = store.put_item.await_args.args
+    assert key == "acme/repo"
+    assert value["clone_count"] == 5
+    assert value["first_cloned_at"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_record_repo_clone_swallows_store_failures() -> None:
+    store = MagicMock()
+    store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
+    with patch.object(repo_clone_stats, "_client", return_value=SimpleNamespace(store=store)):
+        await repo_clone_stats.record_repo_clone("acme", "repo")
+
+
+@pytest.mark.asyncio
+async def test_repos_to_preclone_orders_by_count_and_drops_stale() -> None:
+    stats = [
+        _stat("acme/cold", 99, days_ago=90),
+        _stat("acme/busy", 30, days_ago=1),
+        _stat("acme/quiet", 2, days_ago=2),
+    ]
+    with patch.object(repo_clone_stats, "list_repo_clone_stats", AsyncMock(return_value=stats)):
+        repos = await repo_clone_stats.repos_to_preclone(limit=5, max_age_days=30)
+    assert repos == ["acme/busy", "acme/quiet"]
+
+
+@pytest.mark.asyncio
+async def test_repos_to_preclone_respects_limit() -> None:
+    stats = [_stat(f"acme/r{i}", count=i, days_ago=1) for i in range(10)]
+    with patch.object(repo_clone_stats, "list_repo_clone_stats", AsyncMock(return_value=stats)):
+        repos = await repo_clone_stats.repos_to_preclone(limit=3, max_age_days=30)
+    assert repos == ["acme/r9", "acme/r8", "acme/r7"]
+
+
+def test_settings_reject_bad_schedule() -> None:
+    with pytest.raises(ValidationError):
+        base_snapshot.BaseSnapshotSettings(schedule="not a cron")
+
+
+def test_settings_reject_out_of_range_limits() -> None:
+    with pytest.raises(ValidationError):
+        base_snapshot.BaseSnapshotSettings(preclone_limit=0)
+    with pytest.raises(ValidationError):
+        base_snapshot.BaseSnapshotSettings(max_age_days=9999)
+    with pytest.raises(ValidationError):
+        base_snapshot.BaseSnapshotSettings(keep_snapshots=0)
+
+
+def test_corrupt_stored_settings_fall_back_to_defaults() -> None:
+    settings = base_snapshot._coerce_settings({"schedule": "garbage", "preclone_limit": -4})
+    assert settings.enabled is False
+    assert settings.schedule == base_snapshot.DEFAULT_SCHEDULE
+    assert settings.preclone_limit == base_snapshot.DEFAULT_PRECLONE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_resolve_base_snapshot_id_returns_none_when_disabled() -> None:
+    record = {"status": "ready", "snapshot_id": "snap-1", "settings": {"enabled": False}}
+    with patch.object(base_snapshot, "_read_record", AsyncMock(return_value=record)):
+        assert await base_snapshot.resolve_base_snapshot_id() is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_base_snapshot_id_returns_ready_snapshot() -> None:
+    record = {"status": "ready", "snapshot_id": "snap-1", "settings": {"enabled": True}}
+    with patch.object(base_snapshot, "_read_record", AsyncMock(return_value=record)):
+        assert await base_snapshot.resolve_base_snapshot_id() == "snap-1"
+
+
+@pytest.mark.asyncio
+async def test_resolve_base_snapshot_id_ignores_failed_record() -> None:
+    record = {"status": "failed", "snapshot_id": "snap-1", "settings": {"enabled": True}}
+    with patch.object(base_snapshot, "_read_record", AsyncMock(return_value=record)):
+        assert await base_snapshot.resolve_base_snapshot_id() is None
+
+
+@pytest.mark.asyncio
+async def test_enabling_settings_creates_cron_and_persists_id() -> None:
+    crons = MagicMock()
+    crons.create = AsyncMock(return_value={"cron_id": "cron-1"})
+    put = AsyncMock()
+    with (
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "_put_record", put),
+        patch.object(base_snapshot, "_client", return_value=SimpleNamespace(crons=crons)),
+    ):
+        record = await base_snapshot.update_base_snapshot_settings(
+            base_snapshot.BaseSnapshotSettings(enabled=True, schedule="30 4 * * *")
+        )
+
+    assert record["cron_id"] == "cron-1"
+    assert record["cron_schedule"] == "30 4 * * *"
+    assert crons.create.await_args.kwargs["schedule"] == "30 4 * * *"
+    put.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disabling_settings_deletes_cron() -> None:
+    crons = MagicMock()
+    crons.create = AsyncMock()
+    crons.delete = AsyncMock()
+    existing = {"cron_id": "cron-1", "cron_schedule": "0 9 * * *"}
+    with (
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value=existing)),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_client", return_value=SimpleNamespace(crons=crons)),
+    ):
+        record = await base_snapshot.update_base_snapshot_settings(
+            base_snapshot.BaseSnapshotSettings(enabled=False)
+        )
+
+    crons.delete.assert_awaited_once_with("cron-1")
+    crons.create.assert_not_awaited()
+    assert record["cron_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_unchanged_schedule_reuses_existing_cron() -> None:
+    crons = MagicMock()
+    crons.create = AsyncMock()
+    crons.delete = AsyncMock()
+    existing = {
+        "cron_id": "cron-1",
+        "cron_schedule": "0 9 * * *",
+        "settings": {"enabled": True, "schedule": "0 9 * * *"},
+    }
+    with (
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value=existing)),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_client", return_value=SimpleNamespace(crons=crons)),
+    ):
+        record = await base_snapshot.update_base_snapshot_settings(
+            base_snapshot.BaseSnapshotSettings(enabled=True, schedule="0 9 * * *")
+        )
+
+    crons.create.assert_not_awaited()
+    crons.delete.assert_not_awaited()
+    assert record["cron_id"] == "cron-1"
+
+
+@pytest.mark.asyncio
+async def test_changed_schedule_replaces_cron() -> None:
+    crons = MagicMock()
+    crons.create = AsyncMock(return_value={"cron_id": "cron-2"})
+    crons.delete = AsyncMock()
+    existing = {"cron_id": "cron-1", "cron_schedule": "0 9 * * *"}
+    with (
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value=existing)),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_client", return_value=SimpleNamespace(crons=crons)),
+    ):
+        record = await base_snapshot.update_base_snapshot_settings(
+            base_snapshot.BaseSnapshotSettings(enabled=True, schedule="15 3 * * *")
+        )
+
+    crons.delete.assert_awaited_once_with("cron-1")
+    assert record["cron_id"] == "cron-2"
+
+
+@pytest.mark.asyncio
+async def test_rebuild_keeps_previous_snapshot_id_on_failure() -> None:
+    previous = {"status": "ready", "snapshot_id": "snap-old", "settings": {"enabled": True}}
+    put = AsyncMock()
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value=previous)),
+        patch.object(
+            base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value=previous)
+        ),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/repo"])),
+        patch.object(base_snapshot, "_put_record", put),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "failed"
+    assert record["snapshot_id"] == "snap-old"
+    put.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_uses_stored_limits() -> None:
+    previous = {"settings": {"enabled": True, "preclone_limit": 4, "max_age_days": 7}}
+    preclone = AsyncMock(return_value=[])
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value=previous)),
+        patch.object(base_snapshot, "repos_to_preclone", preclone),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+    ):
+        await base_snapshot.rebuild_base_snapshot()
+
+    preclone_call = preclone.await_args
+    assert preclone_call is not None
+    assert preclone_call.kwargs == {"limit": 4, "max_age_days": 7}
+
+
+def _builder_client() -> tuple[Any, Any]:
+    sandbox = SimpleNamespace(name="openswe-base-builder-x")
+    sandbox.run = AsyncMock(
+        return_value=SimpleNamespace(stdout="ok acme/one\nfail acme/two\n", stderr="", exit_code=0)
+    )
+    client = MagicMock()
+    client.create_sandbox = AsyncMock(return_value=sandbox)
+    client.capture_snapshot = AsyncMock(return_value=SimpleNamespace(id="snap-new"))
+    client.stop_sandbox = AsyncMock()
+    return sandbox, client
+
+
+@pytest.mark.asyncio
+async def test_rebuild_captures_snapshot_and_stops_builder() -> None:
+    _sandbox, client = _builder_client()
+    prune = AsyncMock()
+
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(
+            base_snapshot,
+            "_read_record",
+            AsyncMock(return_value={"settings": {"enabled": True, "keep_snapshots": 2}}),
+        ),
+        patch.object(
+            base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one", "acme/two"])
+        ),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_prune_old_snapshots", prune),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "ready"
+    assert record["snapshot_id"] == "snap-new"
+    assert record["repos"] == ["acme/one"]
+    assert record["failed_repos"] == ["acme/two"]
+    client.stop_sandbox.assert_awaited_once_with("openswe-base-builder-x")
+    prune_call = prune.await_args
+    assert prune_call is not None
+    assert prune_call.args[2] == 2
+
+
+@pytest.mark.asyncio
+async def test_rebuild_stops_builder_when_capture_fails() -> None:
+    _sandbox, client = _builder_client()
+    client.capture_snapshot = AsyncMock(side_effect=RuntimeError("capture exploded"))
+
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(
+            base_snapshot, "_read_record", AsyncMock(return_value={"settings": {"enabled": True}})
+        ),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "failed"
+    assert "capture exploded" in record["status_message"]
+    client.stop_sandbox.assert_awaited_once_with("openswe-base-builder-x")
+
+
+@pytest.mark.asyncio
+async def test_rebuild_endpoint_rejects_when_disabled() -> None:
+    with patch.object(
+        routes,
+        "get_base_snapshot_record",
+        AsyncMock(return_value={"settings": {"enabled": False}}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await routes.api_rebuild_base_snapshot(BackgroundTasks(), _admin={"sub": "octo"})
+    assert exc.value.status_code == 400
+
+
+def test_seed_snapshot_id_is_optional() -> None:
+    # The platform picks a default when none is configured; a missing seed must
+    # not block a rebuild.
+    with patch.dict("os.environ", {}, clear=True):
+        assert base_snapshot._seed_snapshot_id() is None
+    with patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "  "}):
+        assert base_snapshot._seed_snapshot_id() is None
+    with patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-9"}):
+        assert base_snapshot._seed_snapshot_id() == "seed-9"
+
+
+@pytest.mark.asyncio
+async def test_rebuild_runs_without_a_configured_seed() -> None:
+    _sandbox, client = _builder_client()
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch.object(
+            base_snapshot, "_read_record", AsyncMock(return_value={"settings": {"enabled": True}})
+        ),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_prune_old_snapshots", AsyncMock()),
+        patch.object(base_snapshot, "_set_progress", AsyncMock()),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "ready"
+    assert client.create_sandbox.await_args.kwargs["snapshot_id"] is None
+
+
+def test_build_is_stale_only_after_the_timeout() -> None:
+    assert base_snapshot.is_base_snapshot_build_stale({"status": "ready"}) is False
+    assert (
+        base_snapshot.is_base_snapshot_build_stale(
+            {"status": "building", "build_started_at": _iso(0)}
+        )
+        is False
+    )
+
+    old = (
+        datetime.now(UTC) - timedelta(seconds=base_snapshot.STALE_BUILD_SECONDS + 60)
+    ).isoformat()
+    assert (
+        base_snapshot.is_base_snapshot_build_stale({"status": "building", "build_started_at": old})
+        is True
+    )
+    # A building record with no start time can't be aged, so treat it as dead.
+    assert base_snapshot.is_base_snapshot_build_stale({"status": "building"}) is True
+
+
+@pytest.mark.asyncio
+async def test_mark_building_sets_progress_and_start_time() -> None:
+    with (
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value={"status": "ready"})),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+    ):
+        record = await base_snapshot.mark_base_snapshot_building()
+
+    assert record["status"] == "building"
+    assert record["build_started_at"]
+    assert record["progress"] == {"phase": "starting", "completed": 0, "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_terminal_write_clears_progress_so_the_bar_cannot_stick() -> None:
+    _sandbox, client = _builder_client()
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(
+            base_snapshot, "_read_record", AsyncMock(return_value={"settings": {"enabled": True}})
+        ),
+        patch.object(
+            base_snapshot,
+            "mark_base_snapshot_building",
+            AsyncMock(return_value={"status": "building", "progress": {"phase": "starting"}}),
+        ),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_prune_old_snapshots", AsyncMock()),
+        patch.object(base_snapshot, "_set_progress", AsyncMock()),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["progress"] is None
+    assert record["build_started_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_clone_sweep_publishes_progress_per_repo() -> None:
+    published: list[tuple[str, int, int]] = []
+
+    async def _capture(phase: str, completed: int, total: int) -> None:
+        published.append((phase, completed, total))
+
+    async def _run(_command, timeout=None, on_stdout=lambda _chunk: None):
+        on_stdout("ok acme/one\n")
+        on_stdout("fail acme/two\n")
+        # Long enough for at least one publisher tick.
+        await asyncio.sleep(base_snapshot.PROGRESS_POLL_SECONDS * 1.5)
+        return SimpleNamespace(stdout="ok acme/one\nfail acme/two\n", exit_code=0)
+
+    sandbox = SimpleNamespace(run=_run)
+    with patch.object(base_snapshot, "_set_progress", _capture):
+        await base_snapshot._run_clone_sweep(
+            sandbox, "/workspace", ["acme/one", "acme/two", "acme/three"]
+        )
+
+    assert published[0] == ("cloning", 0, 3)
+    # Both a success and a failure count as progress: the bar tracks work done.
+    assert ("cloning", 2, 3) in published
+
+
+@pytest.mark.asyncio
+async def test_rebuild_endpoint_rejects_a_concurrent_rebuild() -> None:
+    record = {"settings": {"enabled": True}, "status": "building", "build_started_at": _iso(0)}
+    with patch.object(routes, "get_base_snapshot_record", AsyncMock(return_value=record)):
+        with pytest.raises(HTTPException) as exc:
+            await routes.api_rebuild_base_snapshot(BackgroundTasks(), _admin={"sub": "octo"})
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_rebuild_endpoint_marks_building_before_returning() -> None:
+    record = {"settings": {"enabled": True}, "status": "ready"}
+    mark = AsyncMock(return_value={"status": "building"})
+    with (
+        patch.object(routes, "get_base_snapshot_record", AsyncMock(return_value=record)),
+        patch.object(routes, "mark_base_snapshot_building", mark),
+    ):
+        result = await routes.api_rebuild_base_snapshot(BackgroundTasks(), _admin={"sub": "octo"})
+
+    # Without this the UI's poll reads a stale "ready" and stops polling.
+    mark.assert_awaited_once()
+    assert result["status"] == "building"
+
+
+def test_mirror_sweep_is_owner_scoped_and_fault_tolerant() -> None:
+    command = build_mirror_sweep_script("/workspace", ["acme/one", "other/one"], proxy_auth=True)
+    assert "/workspace/.repo-cache/acme/one" in command
+    # Same repo name, different owners: owner-scoped paths keep them distinct.
+    assert "/workspace/.repo-cache/other/one" in command
+    # Working trees, not bare mirrors: taking one must be a rename, and baked
+    # dependencies have to live somewhere.
+    assert "--bare" not in command
+    # One repo's failure must not abort the sweep.
+    assert "set -e" not in command
+
+
+def test_mirror_sweep_updates_an_existing_checkout_instead_of_recloning() -> None:
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=True)
+    assert "if [ -d /workspace/.repo-cache/acme/one/.git ]" in command
+    assert "git fetch origin --prune" in command
+    # A broken or diverged checkout still self-heals via a fresh clone.
+    assert "git clone https://github.com/acme/one.git" in command
+
+
+def test_mirror_sweep_prunes_repos_that_dropped_out() -> None:
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=True)
+    # Without this an incremental cache only ever grows.
+    assert "KEEP=acme/one" in command
+    assert "for dir in /workspace/.repo-cache/*/*" in command
+    assert 'rm -rf "$dir"' in command
+
+
+def test_mirror_sweep_only_uses_proxy_auth_when_asked() -> None:
+    # LangSmith injects real credentials behind GH_TOKEN=dummy via its proxy.
+    assert "GH_TOKEN=dummy git clone" in build_mirror_sweep_script(
+        "/workspace", ["acme/one"], proxy_auth=True
+    )
+    # Elsewhere, no token is interpolated at all.
+    plain = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
+    assert "GH_TOKEN" not in plain
+    assert "git clone https://github.com/acme/one.git" in plain
+
+
+def test_mirror_sweep_clones_with_git_not_gh() -> None:
+    # gh demands an authenticated login even for a public repo; git over https
+    # works unauthenticated and still picks up the proxy's injected auth.
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
+    assert "gh repo clone" not in command
+
+
+def test_mirror_sweep_reports_why_a_clone_failed() -> None:
+    # A red status with no diagnosis is not actionable.
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
+    assert ".err" in command
+    assert "fail acme/one $(" in command
+
+
+def test_mirror_sweep_quotes_hostile_repo_names() -> None:
+    command = build_mirror_sweep_script("/workspace", ["acme/a;rm -rf /"], proxy_auth=True)
+    assert "'acme/a;rm -rf /'" in command
+    assert "'/workspace/.repo-cache/acme/a;rm -rf /'" in command
+
+
+def test_parse_mirror_sweep_output_buckets_results() -> None:
+    cloned, failed = parse_mirror_sweep_output("ok acme/one\nfail acme/two\nnoise\n")
+    assert cloned == ["acme/one"]
+    assert failed == ["acme/two"]
+
+
+@pytest.mark.asyncio
+async def test_persistent_provider_warms_the_cache_without_a_snapshot() -> None:
+    backend = SimpleNamespace(
+        aexecute=AsyncMock(return_value=SimpleNamespace(output="ok acme/one\n", exit_code=0))
+    )
+    with (
+        patch.dict("os.environ", {"SANDBOX_TYPE": "local"}),
+        patch.object(
+            base_snapshot, "_read_record", AsyncMock(return_value={"settings": {"enabled": True}})
+        ),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_set_progress", AsyncMock()),
+        patch("agent.utils.sandbox.create_sandbox", AsyncMock(return_value=backend)),
+        patch(
+            "agent.utils.sandbox_paths.aresolve_sandbox_work_dir",
+            AsyncMock(return_value="/sbx"),
+        ),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "ready"
+    assert record["mode"] == "cache"
+    # No image is involved, so runs keep booting the default snapshot.
+    assert record["snapshot_id"] is None
+    assert record["repos"] == ["acme/one"]
+    assert "/sbx/.repo-cache" in backend.aexecute.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_provider_without_capture_fails_loudly() -> None:
+    # Warming a throwaway box that is discarded moments later helps nobody, and
+    # reporting success would be a lie.
+    with (
+        patch.dict("os.environ", {"SANDBOX_TYPE": "e2b"}),
+        patch.object(
+            base_snapshot, "_read_record", AsyncMock(return_value={"settings": {"enabled": True}})
+        ),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "failed"
+    assert "e2b" in record["status_message"]
+
+
+@pytest.mark.asyncio
+async def test_langsmith_rebuild_is_tagged_as_snapshot_mode() -> None:
+    _sandbox, client = _builder_client()
+    with (
+        patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "DEFAULT_SANDBOX_SNAPSHOT_ID": "s"}),
+        patch.object(
+            base_snapshot, "_read_record", AsyncMock(return_value={"settings": {"enabled": True}})
+        ),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_prune_old_snapshots", AsyncMock()),
+        patch.object(base_snapshot, "_set_progress", AsyncMock()),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["mode"] == "snapshot"
+    assert record["snapshot_id"] == "snap-new"
+
+
+def test_builder_builds_on_the_previous_capture() -> None:
+    existing = {
+        "status": "ready",
+        "mode": "snapshot",
+        "snapshot_id": "snap-yesterday",
+        "seed_snapshot_id": "seed-1",
+    }
+    assert (
+        base_snapshot._builder_base_snapshot(existing, "seed-1", from_scratch=False)
+        == "snap-yesterday"
+    )
+
+
+def test_builder_falls_back_to_seed_when_there_is_nothing_to_build_on() -> None:
+    assert base_snapshot._builder_base_snapshot({}, "seed-1", from_scratch=False) == "seed-1"
+    failed = {"status": "failed", "mode": "snapshot", "snapshot_id": "snap-bad"}
+    assert base_snapshot._builder_base_snapshot(failed, "seed-1", from_scratch=False) == "seed-1"
+    # A cache-mode record has no image to build on.
+    cache_mode = {"status": "ready", "mode": "cache", "snapshot_id": None}
+    assert (
+        base_snapshot._builder_base_snapshot(cache_mode, "seed-1", from_scratch=False) == "seed-1"
+    )
+
+
+def test_builder_restarts_from_seed_when_the_seed_changes() -> None:
+    # Otherwise a new base image (new tools, new runtimes) would never reach the
+    # chain, because every build would keep descending from the old one.
+    existing = {
+        "status": "ready",
+        "mode": "snapshot",
+        "snapshot_id": "snap-yesterday",
+        "seed_snapshot_id": "seed-old",
+    }
+    assert base_snapshot._builder_base_snapshot(existing, "seed-new", from_scratch=False) == (
+        "seed-new"
+    )
+
+
+def test_from_scratch_discards_the_previous_capture() -> None:
+    existing = {
+        "status": "ready",
+        "mode": "snapshot",
+        "snapshot_id": "snap-yesterday",
+        "seed_snapshot_id": "seed-1",
+    }
+    assert base_snapshot._builder_base_snapshot(existing, "seed-1", from_scratch=True) == "seed-1"
+
+
+@pytest.mark.asyncio
+async def test_rebuild_boots_the_builder_from_the_previous_capture() -> None:
+    _sandbox, client = _builder_client()
+    existing = {
+        "settings": {"enabled": True},
+        "status": "ready",
+        "mode": "snapshot",
+        "snapshot_id": "snap-yesterday",
+        "seed_snapshot_id": "seed-1",
+    }
+    with (
+        patch.dict(
+            "os.environ", {"SANDBOX_TYPE": "langsmith", "DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}
+        ),
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value=existing)),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_prune_old_snapshots", AsyncMock()),
+        patch.object(base_snapshot, "_set_progress", AsyncMock()),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        await base_snapshot.rebuild_base_snapshot()
+
+    assert client.create_sandbox.await_args.kwargs["snapshot_id"] == "snap-yesterday"
+
+
+@pytest.mark.asyncio
+async def test_rebuild_endpoint_passes_from_scratch_through() -> None:
+    record = {"settings": {"enabled": True}, "status": "ready"}
+    tasks = BackgroundTasks()
+    with (
+        patch.object(routes, "get_base_snapshot_record", AsyncMock(return_value=record)),
+        patch.object(routes, "mark_base_snapshot_building", AsyncMock(return_value={})),
+    ):
+        await routes.api_rebuild_base_snapshot(tasks, from_scratch=True, _admin={"sub": "octo"})
+
+    assert tasks.tasks[0].args == (True,)
+
+
+def test_scripts_are_length_limited() -> None:
+    with pytest.raises(ValidationError):
+        base_snapshot.BaseSnapshotSettings(pre_script="x" * (base_snapshot.SCRIPT_MAX_CHARS + 1))
+
+
+@pytest.mark.asyncio
+async def test_hooks_run_around_the_sweep_in_the_work_dir() -> None:
+    calls: list[str] = []
+
+    async def _exec(command: str, timeout: int) -> Any:
+        calls.append(command)
+        return SimpleNamespace(stdout="", exit_code=0)
+
+    with patch.object(base_snapshot, "_set_progress", AsyncMock()):
+        err = await base_snapshot._run_hook(_exec, "post_script", "pnpm install", "/workspace")
+
+    assert err is None
+    # cd first so a script can address .repo-cache relatively.
+    assert calls == ["set -e\ncd /workspace\npnpm install"]
+
+
+@pytest.mark.asyncio
+async def test_empty_script_is_a_no_op() -> None:
+    async def _exec(command: str, timeout: int) -> Any:
+        raise AssertionError("should not run")
+
+    assert await base_snapshot._run_hook(_exec, "pre_script", "   ", "/workspace") is None
+
+
+@pytest.mark.asyncio
+async def test_failing_hook_fails_the_build() -> None:
+    # A half-installed snapshot is worse than no new snapshot: every run would
+    # inherit the broken state and none would say why.
+    async def _exec(command: str, timeout: int) -> Any:
+        return SimpleNamespace(stdout="pnpm: command not found", exit_code=127)
+
+    with patch.object(base_snapshot, "_set_progress", AsyncMock()):
+        err = await base_snapshot._run_hook(_exec, "post_script", "pnpm install", "/workspace")
+
+    assert err is not None
+    assert "exited 127" in err
+    assert "command not found" in err
+
+
+@pytest.mark.asyncio
+async def test_failing_post_script_blocks_the_capture() -> None:
+    _sandbox, client = _builder_client()
+    settings = {"enabled": True, "post_script": "exit 1"}
+    with (
+        patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
+        patch.object(base_snapshot, "_read_record", AsyncMock(return_value={"settings": settings})),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=["acme/one"])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+        patch.object(base_snapshot, "_set_progress", AsyncMock()),
+        patch.object(
+            base_snapshot, "_run_hook", AsyncMock(side_effect=[None, "post_script exited 1"])
+        ),
+        patch(
+            "agent.utils.github_app.get_github_app_installation_token",
+            AsyncMock(return_value="ghs_token"),
+        ),
+        patch("agent.integrations.langsmith._configure_github_proxy", AsyncMock()),
+        patch("agent.integrations.langsmith.get_async_sandbox_client", return_value=client),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "failed"
+    client.capture_snapshot.assert_not_awaited()
+
+
+def test_mirror_sweep_keeps_scratch_files_out_of_the_cache() -> None:
+    # Anything left inside the cache root is captured into the snapshot, and a
+    # stray file breaks hooks that glob `.repo-cache/*/*` for repositories.
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
+    assert "/workspace/.repo-cache/acme/one.err" not in command
+    assert "/tmp/openswe-warm.err" in command

--- a/tests/sandbox/test_base_snapshot.py
+++ b/tests/sandbox/test_base_snapshot.py
@@ -107,8 +107,17 @@ async def test_resolve_base_snapshot_id_returns_ready_snapshot() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_base_snapshot_id_ignores_failed_record() -> None:
+async def test_a_failed_rebuild_keeps_serving_the_last_good_snapshot() -> None:
+    # A snapshot_id is only written after a capture succeeds, so one transient
+    # hook/clone/capture failure must not drop the whole warm cache.
     record = {"status": "failed", "snapshot_id": "snap-1", "settings": {"enabled": True}}
+    with patch.object(base_snapshot, "_read_record", AsyncMock(return_value=record)):
+        assert await base_snapshot.resolve_base_snapshot_id() == "snap-1"
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_when_nothing_was_ever_captured() -> None:
+    record = {"status": "failed", "snapshot_id": None, "settings": {"enabled": True}}
     with patch.object(base_snapshot, "_read_record", AsyncMock(return_value=record)):
         assert await base_snapshot.resolve_base_snapshot_id() is None
 
@@ -218,6 +227,52 @@ async def test_rebuild_keeps_previous_snapshot_id_on_failure() -> None:
     assert record["status"] == "failed"
     assert record["snapshot_id"] == "snap-old"
     put.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_empty_ledger_does_not_leave_the_record_building() -> None:
+    # The route marks the record building before the rebuild runs, so echoing
+    # the current status back would strand the UI on a finished build.
+    stored: dict[str, Any] = {}
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(
+            base_snapshot,
+            "_read_record",
+            AsyncMock(return_value={"settings": {"enabled": True}, "status": "building"}),
+        ),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=[])),
+        patch.object(base_snapshot, "_put_record", AsyncMock(side_effect=stored.update)),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "none"
+    assert record["build_started_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_ledger_keeps_a_previous_capture_ready() -> None:
+    with (
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "seed-1"}),
+        patch.object(
+            base_snapshot,
+            "_read_record",
+            AsyncMock(
+                return_value={
+                    "settings": {"enabled": True},
+                    "status": "building",
+                    "snapshot_id": "snap-old",
+                }
+            ),
+        ),
+        patch.object(base_snapshot, "mark_base_snapshot_building", AsyncMock(return_value={})),
+        patch.object(base_snapshot, "repos_to_preclone", AsyncMock(return_value=[])),
+        patch.object(base_snapshot, "_put_record", AsyncMock()),
+    ):
+        record = await base_snapshot.rebuild_base_snapshot()
+
+    assert record["status"] == "ready"
 
 
 @pytest.mark.asyncio
@@ -794,3 +849,34 @@ def test_mirror_sweep_keeps_scratch_files_out_of_the_cache() -> None:
     command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
     assert "/workspace/.repo-cache/acme/one.err" not in command
     assert "/tmp/openswe-warm.err" in command
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_reports_a_stale_build() -> None:
+    # The UI disables rebuild while "building"; without this flag a crashed
+    # worker locks admins out of the recovery the backend already allows.
+    old = (
+        datetime.now(UTC) - timedelta(seconds=base_snapshot.STALE_BUILD_SECONDS + 60)
+    ).isoformat()
+    record = {"settings": {"enabled": True}, "status": "building", "build_started_at": old}
+    with (
+        patch.object(routes, "get_base_snapshot_record", AsyncMock(return_value=record)),
+        patch.object(routes, "list_repo_clone_stats", AsyncMock(return_value=[])),
+        patch.object(routes, "repos_to_preclone", AsyncMock(return_value=[])),
+    ):
+        result = await routes.api_get_base_snapshot(_admin={"sub": "octo"})
+
+    assert result["build_stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_does_not_call_a_live_build_stale() -> None:
+    record = {"settings": {"enabled": True}, "status": "building", "build_started_at": _iso(0)}
+    with (
+        patch.object(routes, "get_base_snapshot_record", AsyncMock(return_value=record)),
+        patch.object(routes, "list_repo_clone_stats", AsyncMock(return_value=[])),
+        patch.object(routes, "repos_to_preclone", AsyncMock(return_value=[])),
+    ):
+        result = await routes.api_get_base_snapshot(_admin={"sub": "octo"})
+
+    assert result["build_stale"] is False

--- a/tests/sandbox/test_base_snapshot.py
+++ b/tests/sandbox/test_base_snapshot.py
@@ -508,14 +508,26 @@ def test_mirror_sweep_only_uses_proxy_auth_when_asked() -> None:
     # Elsewhere, no token is interpolated at all.
     plain = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
     assert "GH_TOKEN" not in plain
-    assert "git clone https://github.com/acme/one.git" in plain
 
 
-def test_mirror_sweep_clones_with_git_not_gh() -> None:
-    # gh demands an authenticated login even for a public repo; git over https
-    # works unauthenticated and still picks up the proxy's injected auth.
-    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
+def test_proxy_path_clones_with_git_only() -> None:
+    # gh demands an authenticated login, and there is none in the sandbox; git
+    # over https picks up the proxy's injected credentials.
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=True)
     assert "gh repo clone" not in command
+    assert "GH_TOKEN=dummy git clone" in command
+
+
+def test_local_path_prefers_an_authenticated_gh() -> None:
+    # Without a proxy, an authenticated gh is the only way a private repo
+    # clones -- and it uses the developer's existing login rather than a token
+    # interpolated into a command string.
+    command = build_mirror_sweep_script("/workspace", ["acme/one"], proxy_auth=False)
+    assert "gh auth status" in command
+    assert "gh repo clone acme/one" in command
+    # Still falls back to git, which covers every public repo.
+    assert "|| git clone https://github.com/acme/one.git" in command
+    assert "GH_TOKEN" not in command
 
 
 def test_mirror_sweep_reports_why_a_clone_failed() -> None:

--- a/tests/tools/test_repo_tool.py
+++ b/tests/tools/test_repo_tool.py
@@ -33,10 +33,10 @@ def test_cache_root_follows_the_work_dir() -> None:
 def test_clone_script_prefers_cache_but_falls_back_to_github() -> None:
     script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
     # Taking a baked checkout is a rename, not a copy: O(1) whatever the size.
-    assert "mv /workspace/.repo-cache/acme/tools /workspace/tools" in script
+    assert 'mv /workspace/.repo-cache/acme/tools "$DEST"' in script
     # Falls through to a network clone when the move fails or nothing is baked.
     assert "2>/dev/null; then" in script
-    assert "git clone https://github.com/acme/tools.git tools" in script
+    assert 'git clone https://github.com/acme/tools.git "$DEST"' in script
 
 
 def test_clone_script_always_fetches_after_local_clone() -> None:
@@ -56,10 +56,19 @@ def test_clone_script_records_whether_the_fetch_succeeded() -> None:
 
 def test_clone_script_reuses_an_existing_checkout() -> None:
     script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
-    assert "if [ -d /workspace/tools/.git ]" in script
+    assert 'if [ -d "$DEST/.git" ]' in script
     assert "SOURCE=existing" in script
     # Never clobber a checkout that may hold uncommitted work.
     assert "rm -rf" not in script
+
+
+def test_clone_script_will_not_reuse_a_different_repo_of_the_same_name() -> None:
+    # org-a/tools then org-b/tools must not hand back the first checkout, or
+    # the agent silently edits the wrong code.
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
+    assert "remote get-url origin" in script
+    assert "[:/]acme/tools" in script
+    assert "DEST=/workspace/acme-tools" in script
 
 
 def test_clone_script_checks_out_explicit_ref() -> None:
@@ -75,7 +84,7 @@ def test_clone_script_defaults_to_the_default_branch() -> None:
 
 def test_clone_script_quotes_hostile_input() -> None:
     script = build_clone_script(work_dir="/work dir", owner="acme", name="a;rm -rf /")
-    assert "'a;rm -rf /'" in script
+    assert "'/work dir/a;rm -rf /'" in script
     assert "rm -rf /\n" not in script
 
 

--- a/tests/tools/test_repo_tool.py
+++ b/tests/tools/test_repo_tool.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.tools.repo_tool import _split_full_name, repo
+from agent.utils.repo_clone import (
+    build_clone_script,
+    cache_path_for,
+    cache_root_for,
+    parse_clone_result,
+)
+
+
+def test_cache_path_is_owner_scoped_and_inside_the_work_dir() -> None:
+    assert cache_path_for("/workspace", "acme", "tools") == "/workspace/.repo-cache/acme/tools"
+    # Two owners can each have a repo named "tools"; the paths must not collide.
+    assert cache_path_for("/workspace", "other", "tools") != cache_path_for(
+        "/workspace", "acme", "tools"
+    )
+
+
+def test_cache_root_follows_the_work_dir() -> None:
+    # The local provider's work dir is a real host directory, so the cache must
+    # stay inside it rather than at an absolute path like /opt.
+    assert cache_root_for("/tmp/sbx") == "/tmp/sbx/.repo-cache"
+    # Hidden, so it stays out of `ls` in an otherwise empty work dir.
+    assert cache_root_for("/tmp/sbx").rsplit("/", 1)[-1].startswith(".")
+
+
+def test_clone_script_prefers_cache_but_falls_back_to_github() -> None:
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
+    # Taking a baked checkout is a rename, not a copy: O(1) whatever the size.
+    assert "mv /workspace/.repo-cache/acme/tools /workspace/tools" in script
+    # Falls through to a network clone when the move fails or nothing is baked.
+    assert "2>/dev/null; then" in script
+    assert "git clone https://github.com/acme/tools.git tools" in script
+
+
+def test_clone_script_always_fetches_after_local_clone() -> None:
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
+    # The mirror is only as fresh as the last snapshot build.
+    assert "git fetch origin --prune" in script
+
+
+def test_clone_script_records_whether_the_fetch_succeeded() -> None:
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
+    # A failed fetch must not silently pass for up-to-date.
+    assert "FETCHED=true" in script
+    assert "FETCHED=false" in script
+    assert "fetched=$FETCHED" in script
+    assert "git fetch origin --prune --quiet || true" not in script
+
+
+def test_clone_script_reuses_an_existing_checkout() -> None:
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
+    assert "if [ -d /workspace/tools/.git ]" in script
+    assert "SOURCE=existing" in script
+    # Never clobber a checkout that may hold uncommitted work.
+    assert "rm -rf" not in script
+
+
+def test_clone_script_checks_out_explicit_ref() -> None:
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools", ref="v1.2.3")
+    assert "git checkout --force v1.2.3" in script
+
+
+def test_clone_script_defaults_to_the_default_branch() -> None:
+    script = build_clone_script(work_dir="/workspace", owner="acme", name="tools")
+    assert "refs/remotes/origin/HEAD" in script
+    assert '"origin/$DEFAULT"' in script
+
+
+def test_clone_script_quotes_hostile_input() -> None:
+    script = build_clone_script(work_dir="/work dir", owner="acme", name="a;rm -rf /")
+    assert "'a;rm -rf /'" in script
+    assert "rm -rf /\n" not in script
+
+
+def test_parse_clone_result_reads_the_marker_line() -> None:
+    fields = parse_clone_result(
+        "cloning...\nOPENSWE_CLONE source=cache fetched=true path=/workspace/tools head=abc123\n"
+    )
+    assert fields == {
+        "source": "cache",
+        "fetched": "true",
+        "path": "/workspace/tools",
+        "head": "abc123",
+    }
+
+
+def test_parse_clone_result_ignores_output_without_a_marker() -> None:
+    assert parse_clone_result("fatal: repository not found\n") == {}
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("acme/tools", ("acme", "tools")),
+        ("https://github.com/acme/tools", ("acme", "tools")),
+        ("github.com/acme/tools.git", ("acme", "tools")),
+        ("acme", ("", "")),
+        ("acme/tools/extra", ("", "")),
+        ("", ("", "")),
+    ],
+)
+def test_split_full_name(value: str, expected: tuple[str, str]) -> None:
+    assert _split_full_name(value) == expected
+
+
+@pytest.mark.asyncio
+async def test_repo_tool_rejects_a_malformed_name() -> None:
+    result = await repo("clone", "not-a-repo")
+    assert result["success"] is False
+    assert "owner/name" in result["error"]
+
+
+def _sandbox(stdout: str, exit_code: int = 0):
+    backend = SimpleNamespace()
+    backend.aexecute = AsyncMock(return_value=SimpleNamespace(output=stdout, exit_code=exit_code))
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_repo_tool_records_the_clone_and_returns_the_path() -> None:
+    backend = _sandbox(
+        "OPENSWE_CLONE source=cache fetched=true path=/workspace/tools head=abc123\n"
+    )
+    record = AsyncMock()
+    with (
+        patch(
+            "agent.tools.repo_tool.get_config",
+            return_value={"configurable": {"thread_id": "t-1"}},
+        ),
+        patch("agent.server.ensure_sandbox_for_thread", AsyncMock(return_value=backend)),
+        patch(
+            "agent.tools.repo_tool.aresolve_sandbox_work_dir", AsyncMock(return_value="/workspace")
+        ),
+        patch("agent.tools.repo_tool.record_repo_clone", record),
+    ):
+        result = await repo("clone", "acme/tools")
+
+    assert result["success"] is True
+    assert result["path"] == "/workspace/tools"
+    assert result["source"] == "cache"
+    assert result["fetched"] is True
+    record.assert_awaited_once_with("acme", "tools")
+
+
+@pytest.mark.asyncio
+async def test_repo_tool_does_not_record_a_failed_clone() -> None:
+    backend = _sandbox("fatal: repository not found\n", exit_code=1)
+    record = AsyncMock()
+    with (
+        patch(
+            "agent.tools.repo_tool.get_config",
+            return_value={"configurable": {"thread_id": "t-1"}},
+        ),
+        patch("agent.server.ensure_sandbox_for_thread", AsyncMock(return_value=backend)),
+        patch(
+            "agent.tools.repo_tool.aresolve_sandbox_work_dir", AsyncMock(return_value="/workspace")
+        ),
+        patch("agent.tools.repo_tool.record_repo_clone", record),
+    ):
+        result = await repo("clone", "acme/tools")
+
+    assert result["success"] is False
+    record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_repo_tool_does_not_record_when_the_marker_is_missing() -> None:
+    # Exit 0 with no marker means the script did not get far enough to matter.
+    backend = _sandbox("some unrelated chatter\n")
+    record = AsyncMock()
+    with (
+        patch(
+            "agent.tools.repo_tool.get_config",
+            return_value={"configurable": {"thread_id": "t-1"}},
+        ),
+        patch("agent.server.ensure_sandbox_for_thread", AsyncMock(return_value=backend)),
+        patch(
+            "agent.tools.repo_tool.aresolve_sandbox_work_dir", AsyncMock(return_value="/workspace")
+        ),
+        patch("agent.tools.repo_tool.record_repo_clone", record),
+    ):
+        result = await repo("clone", "acme/tools")
+
+    assert result["success"] is False
+    record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_repo_tool_rejects_an_unknown_action() -> None:
+    result = await repo("update", "acme/tools")  # type: ignore[arg-type]
+    assert result["success"] is False
+    assert "unknown action" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_repo_tool_surfaces_a_stale_checkout() -> None:
+    # Exit 0 with a failed fetch: usable, but behind. The caller must be told.
+    backend = _sandbox("OPENSWE_CLONE source=cache fetched=false path=/workspace/tools head=abc\n")
+    with (
+        patch(
+            "agent.tools.repo_tool.get_config",
+            return_value={"configurable": {"thread_id": "t-1"}},
+        ),
+        patch("agent.server.ensure_sandbox_for_thread", AsyncMock(return_value=backend)),
+        patch(
+            "agent.tools.repo_tool.aresolve_sandbox_work_dir", AsyncMock(return_value="/workspace")
+        ),
+        patch("agent.tools.repo_tool.record_repo_clone", AsyncMock()),
+    ):
+        result = await repo("clone", "acme/tools")
+
+    assert result["success"] is True
+    assert result["fetched"] is False

--- a/ui/src/components/BaseSnapshotPanel.tsx
+++ b/ui/src/components/BaseSnapshotPanel.tsx
@@ -111,7 +111,11 @@ export function BaseSnapshotPanel() {
   const record = view.data?.record
   const status = record?.status ?? "none"
   const dirty = stored != null && !sameSettings(draft, stored)
-  const building = status === "building"
+  // A crashed worker leaves the record on "building" forever. The backend
+  // already treats an old one as replaceable, so the UI must not keep the
+  // recovery buttons disabled past that point.
+  const buildStale = view.data?.build_stale === true
+  const building = status === "building" && !buildStale
   const builtAt = formatDate(record?.built_at)
   const cloneStats = [...(view.data?.clone_stats ?? [])].sort(
     (a, b) => b.clone_count - a.clone_count

--- a/ui/src/components/BaseSnapshotPanel.tsx
+++ b/ui/src/components/BaseSnapshotPanel.tsx
@@ -1,0 +1,450 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
+
+import type { BaseSnapshotSettings, RepoSnapshotStatus } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
+import { InstructionsEditor } from "@/components/InstructionsEditor"
+import { api } from "@/lib/api"
+
+const STATUS_LABEL: Record<RepoSnapshotStatus, string> = {
+  none: "Never built",
+  building: "Building…",
+  ready: "Ready",
+  failed: "Failed",
+}
+
+const STATUS_CLASS: Record<RepoSnapshotStatus, string> = {
+  none: "text-muted-foreground",
+  building: "text-amber-500",
+  ready: "text-emerald-500",
+  failed: "text-destructive",
+}
+
+const DEFAULT_SETTINGS: BaseSnapshotSettings = {
+  enabled: false,
+  schedule: "0 9 * * *",
+  preclone_limit: 10,
+  max_age_days: 30,
+  keep_snapshots: 3,
+  pre_script: "",
+  post_script: "",
+}
+
+const LIMITS = {
+  preclone_limit: { min: 1, max: 50 },
+  max_age_days: { min: 1, max: 365 },
+  keep_snapshots: { min: 1, max: 10 },
+}
+
+function sameSettings(
+  a: BaseSnapshotSettings,
+  b: BaseSnapshotSettings
+): boolean {
+  return (
+    a.enabled === b.enabled &&
+    a.schedule === b.schedule &&
+    a.preclone_limit === b.preclone_limit &&
+    a.max_age_days === b.max_age_days &&
+    a.keep_snapshots === b.keep_snapshots &&
+    a.pre_script === b.pre_script &&
+    a.post_script === b.post_script
+  )
+}
+
+function formatDate(value: string | null | undefined): string | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toLocaleString()
+}
+
+export function BaseSnapshotPanel() {
+  const qc = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [draft, setDraft] = useState<BaseSnapshotSettings>(DEFAULT_SETTINGS)
+
+  const view = useQuery({
+    queryKey: ["baseSnapshot"],
+    queryFn: api.getBaseSnapshot,
+    refetchInterval: (query) =>
+      query.state.data?.record.status === "building" ? 5000 : false,
+  })
+
+  const stored = view.data?.record.settings
+  useEffect(() => {
+    if (stored) setDraft(stored)
+  }, [stored])
+
+  const save = useMutation({
+    mutationFn: (body: BaseSnapshotSettings) =>
+      api.saveBaseSnapshotSettings(body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["baseSnapshot"] })
+      setError(null)
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  const rebuild = useMutation({
+    mutationFn: (fromScratch: boolean) => api.rebuildBaseSnapshot(fromScratch),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["baseSnapshot"] })
+      setError(null)
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  if (view.isLoading) return <Skeleton className="h-56" />
+  if (view.isError) {
+    return (
+      <p className="p-4 text-xs text-destructive">
+        Could not load the nightly snapshot config: {view.error.message}
+      </p>
+    )
+  }
+
+  const record = view.data?.record
+  const status = record?.status ?? "none"
+  const dirty = stored != null && !sameSettings(draft, stored)
+  const building = status === "building"
+  const builtAt = formatDate(record?.built_at)
+  const cloneStats = [...(view.data?.clone_stats ?? [])].sort(
+    (a, b) => b.clone_count - a.clone_count
+  )
+  const cronMissing = stored?.enabled === true && !record?.cron_id
+  const progress = record?.progress ?? {
+    phase: "starting",
+    completed: 0,
+    total: 0,
+  }
+  // The capture is a single opaque call, so only the clone sweep can honestly
+  // show a filling bar; everything else pulses.
+  const determinate = progress.phase === "cloning" && progress.total > 0
+  const progressLabel =
+    progress.phase === "capturing"
+      ? "Capturing the snapshot…"
+      : progress.phase === "cloning"
+        ? "Cloning repositories…"
+        : "Starting the builder…"
+
+  const setNumber = (key: keyof typeof LIMITS, raw: string) => {
+    const parsed = Number.parseInt(raw, 10)
+    if (Number.isNaN(parsed)) return
+    setDraft({ ...draft, [key]: parsed })
+  }
+
+  const outOfRange = (
+    Object.entries(LIMITS) as Array<
+      [keyof typeof LIMITS, { min: number; max: number }]
+    >
+  ).some(([key, { min, max }]) => draft[key] < min || draft[key] > max)
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <section className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="base-snapshot-enabled">Nightly rebuild</Label>
+            <p className="text-xs text-muted-foreground">
+              Rebuilds the shared sandbox snapshot on a schedule with the most
+              used repos already cloned, so runs skip the cold clone. Off means
+              every run boots the default snapshot as it does today.
+            </p>
+          </div>
+          <Switch
+            id="base-snapshot-enabled"
+            checked={draft.enabled}
+            onCheckedChange={(checked) =>
+              setDraft({ ...draft, enabled: checked })
+            }
+            disabled={save.isPending}
+          />
+        </div>
+
+        {draft.enabled && (
+          <p className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+            Every pre-cloned repo is readable by every run booting this
+            snapshot, including runs targeting a different repo.
+          </p>
+        )}
+
+        {cronMissing && (
+          <p className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            Enabled, but the schedule could not be registered — nothing will
+            rebuild automatically. Save again to retry, or use Rebuild now.
+          </p>
+        )}
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="base-snapshot-schedule">Schedule (UTC cron)</Label>
+            <Input
+              id="base-snapshot-schedule"
+              value={draft.schedule}
+              placeholder="0 9 * * *"
+              onChange={(e) => setDraft({ ...draft, schedule: e.target.value })}
+              disabled={save.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="base-snapshot-limit">Repos to pre-clone</Label>
+            <Input
+              id="base-snapshot-limit"
+              type="number"
+              min={LIMITS.preclone_limit.min}
+              max={LIMITS.preclone_limit.max}
+              value={draft.preclone_limit}
+              onChange={(e) => setNumber("preclone_limit", e.target.value)}
+              disabled={save.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="base-snapshot-age">
+              Drop repos unused for (days)
+            </Label>
+            <Input
+              id="base-snapshot-age"
+              type="number"
+              min={LIMITS.max_age_days.min}
+              max={LIMITS.max_age_days.max}
+              value={draft.max_age_days}
+              onChange={(e) => setNumber("max_age_days", e.target.value)}
+              disabled={save.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="base-snapshot-keep">Snapshots to retain</Label>
+            <Input
+              id="base-snapshot-keep"
+              type="number"
+              min={LIMITS.keep_snapshots.min}
+              max={LIMITS.keep_snapshots.max}
+              value={draft.keep_snapshots}
+              onChange={(e) => setNumber("keep_snapshots", e.target.value)}
+              disabled={save.isPending}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="base-snapshot-pre">Before cloning</Label>
+            <p className="text-xs text-muted-foreground">
+              Runs in the builder before any repo is cloned or updated. Use it
+              for machine-wide setup — extra tooling, package registries.
+            </p>
+            <InstructionsEditor
+              value={draft.pre_script}
+              onChange={(v) => setDraft({ ...draft, pre_script: v })}
+              language="shell"
+              disabled={save.isPending}
+              placeholder="#!/bin/sh&#10;# e.g. corepack enable"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="base-snapshot-post">After cloning</Label>
+            <p className="text-xs text-muted-foreground">
+              Runs once every repo is cloned and up to date, with the working
+              directory as its cwd. This is where dependency installs go — each
+              repo is at <code>.repo-cache/&lt;owner&gt;/&lt;name&gt;</code>,
+              and whatever you install there is baked into the snapshot.
+            </p>
+            <InstructionsEditor
+              value={draft.post_script}
+              onChange={(v) => setDraft({ ...draft, post_script: v })}
+              language="shell"
+              disabled={save.isPending}
+              placeholder={
+                "#!/bin/sh\n" +
+                "for repo in .repo-cache/*/*; do\n" +
+                '  [ -f "$repo/pnpm-lock.yaml" ] && (cd "$repo" && pnpm install --frozen-lockfile)\n' +
+                '  [ -f "$repo/uv.lock" ] && (cd "$repo" && uv sync)\n' +
+                "done"
+              }
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            A failing script fails the whole build — no snapshot is published,
+            and runs keep using the previous one.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            disabled={!dirty || outOfRange || save.isPending}
+            onClick={() => void save.mutateAsync(draft).catch(() => undefined)}
+          >
+            Save settings
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={
+              dirty || !stored?.enabled || building || rebuild.isPending
+            }
+            onClick={() =>
+              void rebuild.mutateAsync(false).catch(() => undefined)
+            }
+          >
+            {building ? "Building…" : "Rebuild now"}
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={
+              dirty || !stored?.enabled || building || rebuild.isPending
+            }
+            onClick={() => {
+              if (
+                !window.confirm(
+                  "Discard the current snapshot and rebuild from the base image? " +
+                    "Every repo is re-cloned from scratch, so this is much slower " +
+                    "than a normal rebuild. Runs keep using the current snapshot " +
+                    "until the new one is ready."
+                )
+              ) {
+                return
+              }
+              void rebuild.mutateAsync(true).catch(() => undefined)
+            }}
+          >
+            Rebuild from scratch
+          </Button>
+          {dirty && (
+            <span className="text-xs text-muted-foreground">
+              Save before rebuilding
+            </span>
+          )}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Rebuilds start from the current snapshot and only fetch what changed.
+          Rebuild from scratch discards it and starts from the base sandbox
+          image — use it when accumulated state has gone wrong.
+        </p>
+
+        {building && (
+          <div className="space-y-1.5">
+            <div className="flex items-baseline justify-between gap-2 text-xs">
+              <span className="text-foreground">{progressLabel}</span>
+              {determinate && (
+                <span className="text-muted-foreground tabular-nums">
+                  {progress.completed} / {progress.total}
+                </span>
+              )}
+            </div>
+            <div
+              className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+              role="progressbar"
+              aria-label="Base snapshot rebuild progress"
+              aria-valuemin={determinate ? 0 : undefined}
+              aria-valuemax={determinate ? progress.total : undefined}
+              aria-valuenow={determinate ? progress.completed : undefined}
+            >
+              <div
+                className={
+                  determinate
+                    ? "h-full rounded-full bg-primary transition-[width] duration-500"
+                    : "h-full w-1/3 animate-pulse rounded-full bg-primary"
+                }
+                style={
+                  determinate
+                    ? {
+                        width: `${Math.round((progress.completed / progress.total) * 100)}%`,
+                      }
+                    : undefined
+                }
+              />
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              Cloning every repo and capturing the image takes a while — this
+              keeps running if you navigate away.
+            </p>
+          </div>
+        )}
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+      </section>
+
+      <div className="border-t border-border" />
+
+      <section className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-medium text-foreground">Latest build</p>
+          <span className={`text-xs ${STATUS_CLASS[status]}`}>
+            {STATUS_LABEL[status]}
+          </span>
+          {record?.snapshot_id && (
+            <span className="text-[10px] text-muted-foreground">
+              snapshot {record.snapshot_id}
+            </span>
+          )}
+          {builtAt && (
+            <span className="text-[10px] text-muted-foreground">
+              built {builtAt}
+            </span>
+          )}
+        </div>
+        {status === "failed" && record?.status_message && (
+          <p className="text-xs text-destructive">{record.status_message}</p>
+        )}
+        {(record?.repos?.length ?? 0) > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Pre-cloned: {record?.repos?.join(", ")}
+          </p>
+        )}
+        {(record?.failed_repos?.length ?? 0) > 0 && (
+          <p className="text-xs text-destructive">
+            Failed to clone: {record?.failed_repos?.join(", ")}
+          </p>
+        )}
+        {(view.data?.next_preclone.length ?? 0) > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Next build will pre-clone: {view.data?.next_preclone.join(", ")}
+          </p>
+        )}
+      </section>
+
+      <div className="border-t border-border" />
+
+      <section className="space-y-2">
+        <p className="text-sm font-medium text-foreground">
+          Repositories Open SWE has cloned
+        </p>
+        {cloneStats.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Nothing recorded yet. Repos appear here after a run preps a sandbox
+            for them.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-xs">
+              <thead className="text-muted-foreground">
+                <tr>
+                  <th className="py-1 pr-4 font-medium">Repository</th>
+                  <th className="py-1 pr-4 font-medium">Runs</th>
+                  <th className="py-1 font-medium">Last used</th>
+                </tr>
+              </thead>
+              <tbody>
+                {cloneStats.map((stat) => (
+                  <tr key={stat.full_name} className="border-t border-border">
+                    <td className="py-1 pr-4">{stat.full_name}</td>
+                    <td className="py-1 pr-4">{stat.clone_count}</td>
+                    <td className="py-1 text-muted-foreground">
+                      {formatDate(stat.last_cloned_at) ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/ui/src/components/BaseSnapshotPanel.tsx
+++ b/ui/src/components/BaseSnapshotPanel.tsx
@@ -117,6 +117,13 @@ export function BaseSnapshotPanel() {
     (a, b) => b.clone_count - a.clone_count
   )
   const cronMissing = stored?.enabled === true && !record?.cron_id
+  // The warm reports each failure as "owner/name <git's error>"; split them so
+  // the same message repeated per repo doesn't become a wall of text.
+  const failures = (record?.failed_repos ?? []).map((entry) => {
+    const [repo, ...rest] = entry.split(" ")
+    return { repo, reason: rest.join(" ") }
+  })
+  const partial = status === "ready" && failures.length > 0
   const progress = record?.progress ?? {
     phase: "starting",
     completed: 0,
@@ -408,6 +415,12 @@ export function BaseSnapshotPanel() {
           <span className={`text-xs ${STATUS_CLASS[status]}`}>
             {STATUS_LABEL[status]}
           </span>
+          {partial && (
+            <span className="text-xs text-amber-600 dark:text-amber-400">
+              {failures.length} of{" "}
+              {failures.length + (record?.repos?.length ?? 0)} repos missing
+            </span>
+          )}
           {record?.snapshot_id && (
             <span className="text-[10px] text-muted-foreground">
               snapshot {record.snapshot_id}
@@ -427,10 +440,23 @@ export function BaseSnapshotPanel() {
             Pre-cloned: {record?.repos?.join(", ")}
           </p>
         )}
-        {(record?.failed_repos?.length ?? 0) > 0 && (
-          <p className="text-xs text-destructive">
-            Failed to clone: {record?.failed_repos?.join(", ")}
-          </p>
+        {failures.length > 0 && (
+          <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2">
+            <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+              Could not clone {failures.length}{" "}
+              {failures.length === 1 ? "repository" : "repositories"} — runs
+              still work, they just clone{" "}
+              {failures.length === 1 ? "it" : "them"} over the network.
+            </p>
+            <ul className="space-y-0.5">
+              {failures.map(({ repo, reason }) => (
+                <li key={repo} className="text-xs text-muted-foreground">
+                  <span className="text-foreground">{repo}</span>
+                  {reason && <> — {reason}</>}
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
         {(view.data?.next_preclone.length ?? 0) > 0 && (
           <p className="text-xs text-muted-foreground">

--- a/ui/src/components/BaseSnapshotPanel.tsx
+++ b/ui/src/components/BaseSnapshotPanel.tsx
@@ -1,3 +1,4 @@
+import { Dialog } from "@base-ui/react/dialog"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 
@@ -65,6 +66,7 @@ export function BaseSnapshotPanel() {
   const qc = useQueryClient()
   const [error, setError] = useState<string | null>(null)
   const [draft, setDraft] = useState<BaseSnapshotSettings>(DEFAULT_SETTINGS)
+  const [scratchOpen, setScratchOpen] = useState(false)
 
   const view = useQuery({
     queryKey: ["baseSnapshot"],
@@ -298,19 +300,7 @@ export function BaseSnapshotPanel() {
             disabled={
               dirty || !stored?.enabled || building || rebuild.isPending
             }
-            onClick={() => {
-              if (
-                !window.confirm(
-                  "Discard the current snapshot and rebuild from the base image? " +
-                    "Every repo is re-cloned from scratch, so this is much slower " +
-                    "than a normal rebuild. Runs keep using the current snapshot " +
-                    "until the new one is ready."
-                )
-              ) {
-                return
-              }
-              void rebuild.mutateAsync(true).catch(() => undefined)
-            }}
+            onClick={() => setScratchOpen(true)}
           >
             Rebuild from scratch
           </Button>
@@ -320,6 +310,46 @@ export function BaseSnapshotPanel() {
             </span>
           )}
         </div>
+
+        <Dialog.Root open={scratchOpen} onOpenChange={setScratchOpen}>
+          <Dialog.Portal>
+            <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+            <Dialog.Popup className="fixed top-1/2 left-1/2 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-popover p-6 text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+              <div className="flex flex-col gap-4">
+                <Dialog.Title className="text-sm font-medium">
+                  Rebuild from scratch
+                </Dialog.Title>
+                <Dialog.Description className="text-xs text-muted-foreground">
+                  Discards the current snapshot and starts from the base sandbox
+                  image. Every repo is cloned again and both scripts re-run, so
+                  this is much slower than a normal rebuild. Runs keep using the
+                  current snapshot until the new one is ready.
+                </Dialog.Description>
+                <div className="mt-2 flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setScratchOpen(false)}
+                    disabled={rebuild.isPending}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    disabled={rebuild.isPending}
+                    onClick={() => {
+                      setScratchOpen(false)
+                      void rebuild.mutateAsync(true).catch(() => undefined)
+                    }}
+                  >
+                    Rebuild from scratch
+                  </Button>
+                </div>
+              </div>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>
 
         <p className="text-xs text-muted-foreground">
           Rebuilds start from the current snapshot and only fetch what changed.

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -393,6 +393,51 @@ export interface RepoSnapshot {
   updated_at?: string
 }
 
+export interface BaseSnapshotSettings {
+  enabled: boolean
+  schedule: string
+  preclone_limit: number
+  max_age_days: number
+  keep_snapshots: number
+  pre_script: string
+  post_script: string
+}
+
+export interface BaseSnapshotProgress {
+  phase: "starting" | "cloning" | "capturing"
+  completed: number
+  total: number
+}
+
+export interface BaseSnapshotRecord {
+  settings: BaseSnapshotSettings
+  mode?: "snapshot" | "cache"
+  progress?: BaseSnapshotProgress | null
+  snapshot_id?: string | null
+  snapshot_name?: string | null
+  status?: RepoSnapshotStatus
+  status_message?: string | null
+  repos?: Array<string>
+  skipped_repos?: Array<string>
+  failed_repos?: Array<string>
+  built_at?: string | null
+  last_attempt_at?: string | null
+  cron_id?: string | null
+}
+
+export interface RepoCloneStat {
+  full_name: string
+  clone_count: number
+  first_cloned_at?: string
+  last_cloned_at?: string
+}
+
+export interface BaseSnapshotView {
+  record: BaseSnapshotRecord
+  clone_stats: Array<RepoCloneStat>
+  next_preclone: Array<string>
+}
+
 export interface RepoSnapshotUpdateBody {
   dockerfile: string
   fs_capacity_bytes?: number | null
@@ -722,6 +767,17 @@ export const api = {
     request<void>(`/agent-instructions/${encodeURIComponent(full_name)}`, {
       method: "DELETE",
     }),
+  getBaseSnapshot: () => request<BaseSnapshotView>("/base-snapshot"),
+  saveBaseSnapshotSettings: (body: BaseSnapshotSettings) =>
+    request<BaseSnapshotRecord>("/base-snapshot/settings", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  rebuildBaseSnapshot: (fromScratch = false) =>
+    request<BaseSnapshotRecord>(
+      `/base-snapshot/rebuild?from_scratch=${fromScratch}`,
+      { method: "POST" }
+    ),
   listRepoSnapshots: () => request<Array<RepoSnapshot>>("/repo-snapshots"),
   createRepoSnapshot: (full_name: string) =>
     request<RepoSnapshot>("/repo-snapshots", {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -434,6 +434,7 @@ export interface RepoCloneStat {
 
 export interface BaseSnapshotView {
   record: BaseSnapshotRecord
+  build_stale: boolean
   clone_stats: Array<RepoCloneStat>
   next_preclone: Array<string>
 }

--- a/ui/src/routes/agents_.snapshots.tsx
+++ b/ui/src/routes/agents_.snapshots.tsx
@@ -1,6 +1,7 @@
 import { Navigate, createFileRoute } from "@tanstack/react-router"
 
 import { AppShell } from "@/components/AppShell"
+import { BaseSnapshotPanel } from "@/components/BaseSnapshotPanel"
 import { RepoSnapshotsPanel } from "@/components/RepoSnapshotsPanel"
 import { RequireLogin } from "@/lib/auth-redirect"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -27,11 +28,36 @@ function RepoSnapshotsPage() {
     <AppShell
       user={session.data}
       title="Repository Snapshots"
-      description="Build a per-repo sandbox image from a custom Dockerfile. Repos without a ready snapshot fall back to the default sandbox image."
+      description="Control the sandbox images runs boot from. Anything without its own snapshot falls back to the default sandbox image."
       backTo={{ to: "/cloud-agents", label: "Back to Open SWE Agent" }}
     >
-      <div className="rounded-lg border border-border bg-card">
-        <RepoSnapshotsPanel />
+      <div className="flex flex-col gap-6">
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold text-foreground">
+            Nightly base snapshot
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Rebuild the shared sandbox snapshot on a schedule with the repos
+            Open SWE works on most already cloned. Repos with their own snapshot
+            below still take precedence.
+          </p>
+          <div className="rounded-lg border border-border bg-card">
+            <BaseSnapshotPanel />
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold text-foreground">
+            Per-repository snapshots
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Build a sandbox image for one repo from a custom Dockerfile, for
+            repos needing toolchains the default image doesn't carry.
+          </p>
+          <div className="rounded-lg border border-border bg-card">
+            <RepoSnapshotsPanel />
+          </div>
+        </section>
       </div>
     </AppShell>
   )


### PR DESCRIPTION
Runs pay a network clone for the repos the fleet works on every day. This warms a cache of ready-to-use checkouts on a schedule, and a run takes one with a rename instead of cloning.

Off until an admin enables it, and additive throughout: with no capture, or after a failed rebuild, runs boot the snapshot they boot today.

## What changed

**A `repo` tool replaces `gh repo clone` in the prompt.** Cloning through a tool is what makes the ledger record what was *actually* cloned — the previous plan inferred it from each run's configured repo, which overcounted a team default nobody cloned and missed anything cloned mid-run. It also drops the one-repo-per-thread assumption; a task can clone as many as it needs.

**Cache layout.** `<work-dir>/.repo-cache/<owner>/<name>` — owner-scoped so two orgs' same-named repos can't collide, hidden so the work dir stays clean, and inside the work dir so `local` writes within `LOCAL_SANDBOX_ROOT_DIR` rather than the host filesystem.

**Full checkouts, not bare mirrors.** Materializing a working tree is the expensive half — hardlinking a bare repo's objects still writes every file. A checkout is taken with `mv`, a rename within one filesystem, so it is O(1) whatever the repo's size. It also leaves somewhere for installed dependencies to live.

**Incremental.** The builder boots from the previous capture and repos are fetched, not re-cloned, so anything baked into a checkout survives. It falls back to the seed automatically when `DEFAULT_SANDBOX_SNAPSHOT_ID` changes — otherwise a new base image would never reach the chain — and on demand via **Rebuild from scratch**.

**Admin-editable pre/post shell hooks** around the sweep, for dependency installs. A failing hook fails the build: a snapshot whose install half-ran is worse than no new snapshot, because every run inherits the broken state and none reports why.

**Configured entirely from the admin Snapshots page** — schedule, repo count, staleness cutoff, retention, both scripts. No environment variables.

## The work-dir bug

`capture_snapshot` preserves the filesystem but not the image's `WORKDIR`, so a sandbox booted from a capture starts at `/`. The work dir was resolved by running `pwd`, which meant the cache was written to `/workspace` and read from `/` — and every run's working directory would have moved to the filesystem root once the feature was on.

`/workspace` is now preferred ahead of `pwd`, and skipped when it isn't writable, so providers without it keep their existing behaviour.

## Verification

Unit tests assert on generated shell strings and mocked SDK calls, which cannot tell you whether a capture keeps the cache. `tests/e2e/snapshot_cache_e2e.py` runs the real round trip against LangSmith sandboxes — warm, capture, boot a fresh sandbox, take the repo from cache — and passes 11/11. It found three bugs the unit tests could not: the work-dir mismatch above, `gh repo clone` requiring an authenticated login even for public repos (now plain `git`), and scratch files left inside the cache breaking hooks that glob `.repo-cache/*/*`.

It runs weekly and on demand via `.github/workflows/snapshot_cache_e2e.yml`, never on PRs, and needs a `LANGSMITH_API_KEY` secret with sandbox access.

Measured on `langchain-ai/open-swe` (30 MB, 1216 commits): **3.4s from cache against 6.4s cold.** Most of the 3.4s is the mandatory `git fetch`, not the rename. The git half of this saves a few seconds per run; the dependency-install hooks are where the minutes are.

## Test Plan

- [x] `make test` — 1754 pass
- [x] `make lint`, `make typecheck` — clean (2 pre-existing errors in an untouched file)
- [x] `pnpm typecheck` — clean
- [x] Real LangSmith E2E — 11/11, resources cleaned up
- [x] Admin panel exercised in a browser against the mock harness
