### PR TITLE
feat(open-swe): set the sandbox base snapshot at runtime

### DIFF
--- a/agent/dashboard/github_token_auth.py
+++ b/agent/dashboard/github_token_auth.py
@@ -21,6 +21,7 @@ from .admin import is_admin
 logger = logging.getLogger(__name__)
 
 _GITHUB_USER_URL = "https://api.github.com/user"
+_GITHUB_EMAILS_URL = "https://api.github.com/user/emails"
 _GITHUB_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
 
 
@@ -34,16 +35,26 @@ def bearer_github_token(request: Request) -> str | None:
 
 
 async def _github_identity(token: str) -> tuple[str, str | None]:
-    """Resolve a GitHub token to ``(login, email)``."""
+    """Resolve a GitHub token to ``(login, email)``.
+
+    ``GET /user`` only carries an email when the account publishes one, so fall
+    back to the primary from ``/user/emails`` — same as the browser OAuth path —
+    otherwise an admin allowlisted by email is unauthenticatable. That endpoint
+    needs the token to be able to read email addresses; failure just leaves the
+    email unresolved, and login matching still works.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    email: str | None = None
     try:
         async with httpx.AsyncClient(timeout=_GITHUB_TIMEOUT) as client:
-            response = await client.get(
-                _GITHUB_USER_URL,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
-                },
-            )
+            response = await client.get(_GITHUB_USER_URL, headers=headers)
+            if response.status_code == 200:
+                email = _email_of(response) or _primary_email(
+                    await client.get(_GITHUB_EMAILS_URL, headers=headers)
+                )
     except httpx.HTTPError as e:
         raise HTTPException(502, f"could not verify GitHub token: {e}") from e
 
@@ -60,8 +71,28 @@ async def _github_identity(token: str) -> tuple[str, str | None]:
     login = data.get("login") if isinstance(data, dict) else None
     if not isinstance(login, str) or not login.strip():
         raise HTTPException(401, "GitHub token did not resolve to a user")
+    return login.strip(), email
+
+
+def _email_of(response: httpx.Response) -> str | None:
+    data = response.json() if response.content else {}
     email = data.get("email") if isinstance(data, dict) else None
-    return login.strip(), email if isinstance(email, str) and email.strip() else None
+    return email.strip() if isinstance(email, str) and email.strip() else None
+
+
+def _primary_email(response: httpx.Response) -> str | None:
+    if response.status_code != 200 or not response.content:
+        return None
+    entries = response.json()
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get("primary"):
+            continue
+        email = entry.get("email")
+        if isinstance(email, str) and email.strip():
+            return email.strip()
+    return None
 
 
 async def admin_session_for_github_token(token: str) -> dict[str, Any]:

--- a/agent/dashboard/github_token_auth.py
+++ b/agent/dashboard/github_token_auth.py
@@ -1,0 +1,76 @@
+"""Admin authentication for non-browser callers using a GitHub user token.
+
+The dashboard API is normally cookie-authenticated through the GitHub OAuth
+login flow, which automation cannot complete. A CI job (typically in the repo
+that builds the sandbox image) instead sends ``Authorization: Bearer <token>``
+with a personal access token: the token is resolved to a GitHub identity via
+``GET /user``, which must match a ``CONFIGURED_ADMINS`` entry.
+
+Only endpoints that explicitly opt in accept this; the ambient session cookie
+remains the only credential for everything else.
+"""
+
+import logging
+from typing import Any
+
+import httpx
+from fastapi import HTTPException, Request
+
+from .admin import is_admin
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_USER_URL = "https://api.github.com/user"
+_GITHUB_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
+
+
+def bearer_github_token(request: Request) -> str | None:
+    """Return the ``Authorization: Bearer`` token, if the request carries one."""
+    header = request.headers.get("authorization", "")
+    scheme, _, value = header.partition(" ")
+    if scheme.strip().lower() != "bearer":
+        return None
+    return value.strip() or None
+
+
+async def _github_identity(token: str) -> tuple[str, str | None]:
+    """Resolve a GitHub token to ``(login, email)``."""
+    try:
+        async with httpx.AsyncClient(timeout=_GITHUB_TIMEOUT) as client:
+            response = await client.get(
+                _GITHUB_USER_URL,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+    except httpx.HTTPError as e:
+        raise HTTPException(502, f"could not verify GitHub token: {e}") from e
+
+    if response.status_code == 403:
+        raise HTTPException(
+            401,
+            "GitHub token cannot identify a user — use a personal access token "
+            "for an admin account, not a GitHub App installation token",
+        )
+    if response.status_code >= 400:
+        raise HTTPException(401, "invalid GitHub token")
+
+    data = response.json() if response.content else {}
+    login = data.get("login") if isinstance(data, dict) else None
+    if not isinstance(login, str) or not login.strip():
+        raise HTTPException(401, "GitHub token did not resolve to a user")
+    email = data.get("email") if isinstance(data, dict) else None
+    return login.strip(), email if isinstance(email, str) and email.strip() else None
+
+
+async def admin_session_for_github_token(token: str) -> dict[str, Any]:
+    """Return a session-shaped identity for an admin's GitHub token.
+
+    Raises 401 when the token is unusable and 403 when its owner is not an admin.
+    """
+    login, email = await _github_identity(token)
+    if not is_admin(email, login=login):
+        logger.warning("Rejected GitHub-token admin request for non-admin %s", login)
+        raise HTTPException(403, "admin only")
+    return {"sub": login, "email": email, "auth": "github_token"}

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException, Request
 from agent.utils.github_org_membership import is_user_active_org_member
 
 from ..utils.http import DEFAULT_HTTP_TIMEOUT
+from .github_token_auth import bearer_github_token
 
 logger = logging.getLogger(__name__)
 
@@ -264,6 +265,11 @@ def require_same_origin(request: Request) -> None:
 
 def require_same_origin_for_mutations(request: Request) -> None:
     if request.method in {"GET", "HEAD", "OPTIONS"}:
+        return
+    # The origin allowlist defends the ambient session cookie. A request whose
+    # only credential is an explicit bearer header can't be forged by a browser,
+    # so it has nothing to defend.
+    if bearer_github_token(request) and not request.cookies.get(COOKIE_NAME):
         return
     require_same_origin(request)
 

--- a/agent/dashboard/oidc_auth.py
+++ b/agent/dashboard/oidc_auth.py
@@ -1,0 +1,141 @@
+"""Admin authentication for GitHub Actions workflows via OIDC.
+
+A workflow with ``permissions: id-token: write`` can mint a short-lived OIDC
+token that GitHub signs and scopes to the repo, ref, and audience it was
+requested for. That is a better CI credential than a stored PAT: nothing
+long-lived is kept in the calling repo's secrets.
+
+Configuration:
+
+``ADMIN_OIDC_SUBJECTS``
+    Comma-separated allowlist, and the on/off switch — empty means this auth path
+    is unavailable. An entry containing ``:`` is matched against the token's full
+    ``sub`` claim (``repo:acme/images:ref:refs/heads/main``); an ``owner/repo``
+    entry matches the ``repository`` claim, allowing any workflow or ref in that
+    repo.
+
+``ADMIN_OIDC_AUDIENCE``
+    Optional; the audience the workflow must request. Defaults to ``open-swe``.
+    Verified either way, so a token minted for another service can't be replayed
+    here.
+
+Anyone able to run a workflow in an allowlisted repo (or ref) gets admin on the
+endpoints that accept this, so scope the allowlist to internal repos.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import jwt
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+GITHUB_ACTIONS_ISSUER = "https://token.actions.githubusercontent.com"
+DEFAULT_OIDC_AUDIENCE = "open-swe"
+_JWKS_URL = f"{GITHUB_ACTIONS_ISSUER}/.well-known/jwks"
+_JWKS_CACHE_SECONDS = 600
+
+_jwk_client: jwt.PyJWKClient | None = None
+
+
+def _client() -> jwt.PyJWKClient:
+    global _jwk_client
+    if _jwk_client is None:
+        _jwk_client = jwt.PyJWKClient(
+            _JWKS_URL, cache_keys=True, cache_jwk_set=True, lifespan=_JWKS_CACHE_SECONDS
+        )
+    return _jwk_client
+
+
+def _audience() -> str:
+    return os.environ.get("ADMIN_OIDC_AUDIENCE", "").strip() or DEFAULT_OIDC_AUDIENCE
+
+
+def _allowlist() -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(exact subjects, repositories)`` from ``ADMIN_OIDC_SUBJECTS``."""
+    subjects: set[str] = set()
+    repositories: set[str] = set()
+    for raw in os.environ.get("ADMIN_OIDC_SUBJECTS", "").split(","):
+        entry = raw.strip()
+        if not entry:
+            continue
+        if ":" in entry:
+            subjects.add(entry)
+        else:
+            repositories.add(entry.lower())
+    return frozenset(subjects), frozenset(repositories)
+
+
+def actions_oidc_configured() -> bool:
+    subjects, repositories = _allowlist()
+    return bool(subjects or repositories)
+
+
+def is_actions_oidc_token(token: str) -> bool:
+    """Whether ``token`` claims to be a GitHub Actions OIDC token.
+
+    Routing only — the claim is unverified here and re-checked during decode.
+    """
+    try:
+        claims = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return False
+    return claims.get("iss") == GITHUB_ACTIONS_ISSUER
+
+
+def _decode(token: str, audience: str) -> dict[str, Any]:
+    signing_key = _client().get_signing_key_from_jwt(token)
+    return jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        audience=audience,
+        issuer=GITHUB_ACTIONS_ISSUER,
+        options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+    )
+
+
+def _subject_allowed(claims: dict[str, Any]) -> bool:
+    subjects, repositories = _allowlist()
+    subject = claims.get("sub")
+    if isinstance(subject, str) and subject in subjects:
+        return True
+    repository = claims.get("repository")
+    return isinstance(repository, str) and repository.lower() in repositories
+
+
+async def admin_session_for_actions_oidc(token: str) -> dict[str, Any]:
+    """Return a session-shaped identity for an allowlisted Actions workflow.
+
+    Raises 401 when the token is invalid or this auth path is unconfigured, and
+    403 when the token's subject is not allowlisted.
+    """
+    if not actions_oidc_configured():
+        raise HTTPException(401, "GitHub Actions OIDC auth is not configured")
+    audience = _audience()
+
+    # PyJWKClient fetches over blocking urllib; keep it off the event loop.
+    try:
+        claims = await asyncio.to_thread(_decode, token, audience)
+    except jwt.PyJWTError as e:
+        raise HTTPException(401, f"invalid GitHub Actions OIDC token: {e}") from e
+    except Exception as e:  # noqa: BLE001 - JWKS fetch failures
+        raise HTTPException(502, f"could not verify GitHub Actions OIDC token: {e}") from e
+
+    if not _subject_allowed(claims):
+        logger.warning(
+            "Rejected GitHub Actions OIDC request for unlisted subject %r", claims.get("sub")
+        )
+        raise HTTPException(403, "workflow is not allowed to act as an admin")
+
+    repository = claims.get("repository")
+    identity = repository if isinstance(repository, str) and repository else claims.get("sub")
+    return {
+        "sub": f"actions:{identity}",
+        "email": None,
+        "auth": "actions_oidc",
+        "oidc_subject": claims.get("sub"),
+    }

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -36,6 +36,7 @@ from .enabled_repos import (
 from .eval_jobs import (
     get_reviewer_eval_status,
 )
+from .github_token_auth import admin_session_for_github_token, bearer_github_token
 from .notion_oauth import (
     NOTION_STATE_COOKIE_NAME,
     NotionOAuthError,
@@ -60,6 +61,7 @@ from .oauth import (
     require_session,
     sanitize_redirect_to,
 )
+from .oidc_auth import admin_session_for_actions_oidc, is_actions_oidc_token
 from .options import (
     FABLE_MODEL_IDS,
     SUPPORTED_MODELS,
@@ -128,6 +130,11 @@ from .review_styles import (
     list_review_styles,
     normalize_repo_full_name,
     set_custom_prompt,
+)
+from .sandbox_settings import (
+    SandboxSettingsUpdate,
+    get_sandbox_settings,
+    upsert_sandbox_settings,
 )
 from .schedules import (
     ScheduleCreateBody,
@@ -245,6 +252,20 @@ def _admin_session(session: dict[str, Any] = _SESSION_DEP) -> dict[str, Any]:
 
 
 _ADMIN_DEP = Depends(_admin_session)
+
+
+async def _admin_session_or_ci_token(request: Request) -> dict[str, Any]:
+    """Admin gate that also accepts CI credentials: an Actions OIDC token, or an
+    admin's GitHub personal access token."""
+    token = bearer_github_token(request)
+    if token:
+        if is_actions_oidc_token(token):
+            return await admin_session_for_actions_oidc(token)
+        return await admin_session_for_github_token(token)
+    return _require_admin(require_session(request))
+
+
+_ADMIN_OR_TOKEN_DEP = Depends(_admin_session_or_ci_token)
 
 
 async def _filter_repo_records_for_user(
@@ -787,6 +808,21 @@ async def api_set_enabled_review_repo(
 ) -> dict[str, list[str]]:
     repos = await set_review_repo_enabled(update.full_name, update.enabled)
     return {"repos": repos}
+
+
+@router.get("/sandbox-settings")
+async def api_get_sandbox_settings(
+    _admin: dict[str, Any] = _ADMIN_OR_TOKEN_DEP,
+) -> dict[str, Any]:
+    return await get_sandbox_settings()
+
+
+@router.put("/sandbox-settings")
+async def api_set_sandbox_settings(
+    body: SandboxSettingsUpdate,
+    _admin: dict[str, Any] = _ADMIN_OR_TOKEN_DEP,
+) -> dict[str, Any]:
+    return await upsert_sandbox_settings(body, updated_by=_admin.get("sub"))
 
 
 @router.get("/repo-snapshots")

--- a/agent/dashboard/sandbox_settings.py
+++ b/agent/dashboard/sandbox_settings.py
@@ -1,0 +1,130 @@
+"""Instance-wide sandbox settings an admin can change at runtime.
+
+New sandboxes boot from a base snapshot, normally configured with the
+``DEFAULT_SANDBOX_SNAPSHOT_ID`` env var. Admins can override it from the
+dashboard so rolling out a rebuilt base image does not require a redeploy: the
+stored value wins, and an unset record falls back to the env var.
+
+The value is an opaque provider-scoped identifier — for ``SANDBOX_TYPE=langsmith``
+it is a LangSmith snapshot id — so it is stored as free text with no format
+validation. Per-repo snapshots (:mod:`agent.dashboard.repo_snapshots`) still take
+precedence over this base for runs that target a repo with a ready snapshot.
+"""
+
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from langgraph_sdk import get_client
+from pydantic import BaseModel, field_validator
+
+logger = logging.getLogger(__name__)
+
+SANDBOX_SETTINGS_NAMESPACE: list[str] = ["sandbox_settings"]
+SANDBOX_SETTINGS_KEY = "default"
+
+BASE_SNAPSHOT_MAX_CHARS = 512
+
+BaseSnapshotSource = Literal["admin", "env", "unset"]
+
+
+class SandboxSettingsUpdate(BaseModel):
+    base_snapshot_id: str | None = None
+
+    @field_validator("base_snapshot_id", mode="before")
+    @classmethod
+    def _normalize_base_snapshot_id(cls, v: object) -> str | None:
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            raise ValueError("base_snapshot_id must be a string")
+        text = v.strip()
+        if not text:
+            return None
+        if len(text) > BASE_SNAPSHOT_MAX_CHARS:
+            raise ValueError(
+                f"base_snapshot_id must be at most {BASE_SNAPSHOT_MAX_CHARS} characters"
+            )
+        return text
+
+
+def _client():
+    return get_client()
+
+
+def env_base_snapshot_id() -> str | None:
+    value = os.environ.get("DEFAULT_SANDBOX_SNAPSHOT_ID", "").strip()
+    return value or None
+
+
+async def get_admin_base_snapshot_id() -> str | None:
+    """Return the admin-configured base snapshot, ignoring the env default.
+
+    Never raises: a store failure resolves to ``None`` so sandbox creation falls
+    back to ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
+    """
+    try:
+        item = await _client().store.get_item(SANDBOX_SETTINGS_NAMESPACE, SANDBOX_SETTINGS_KEY)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("sandbox settings lookup failed: %s", e)
+        return None
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    if not isinstance(value, dict):
+        return None
+    snapshot_id = value.get("base_snapshot_id")
+    if not isinstance(snapshot_id, str):
+        return None
+    return snapshot_id.strip() or None
+
+
+async def resolve_base_snapshot_id() -> str | None:
+    """Return the base snapshot new sandboxes boot from: admin setting, else env."""
+    return await get_admin_base_snapshot_id() or env_base_snapshot_id()
+
+
+async def get_sandbox_settings() -> dict[str, Any]:
+    """Return the stored settings plus the resolved effective base snapshot."""
+    try:
+        item = await _client().store.get_item(SANDBOX_SETTINGS_NAMESPACE, SANDBOX_SETTINGS_KEY)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("sandbox settings lookup failed: %s", e)
+        item = None
+    value = {}
+    if item is not None:
+        stored = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+        if isinstance(stored, dict):
+            value = stored
+    admin_snapshot_id = value.get("base_snapshot_id")
+    admin_snapshot_id = (
+        admin_snapshot_id.strip() or None if isinstance(admin_snapshot_id, str) else None
+    )
+    env_snapshot_id = env_base_snapshot_id()
+    source: BaseSnapshotSource = (
+        "admin" if admin_snapshot_id else ("env" if env_snapshot_id else "unset")
+    )
+    return {
+        "base_snapshot_id": admin_snapshot_id,
+        "env_base_snapshot_id": env_snapshot_id,
+        "effective_base_snapshot_id": admin_snapshot_id or env_snapshot_id,
+        "base_snapshot_source": source,
+        "updated_at": value.get("updated_at"),
+        "updated_by": value.get("updated_by"),
+    }
+
+
+async def upsert_sandbox_settings(
+    update: SandboxSettingsUpdate, updated_by: str | None = None
+) -> dict[str, Any]:
+    await _client().store.put_item(
+        SANDBOX_SETTINGS_NAMESPACE,
+        SANDBOX_SETTINGS_KEY,
+        {
+            "base_snapshot_id": update.base_snapshot_id,
+            "updated_at": datetime.now(UTC).isoformat(),
+            "updated_by": updated_by,
+        },
+    )
+    return await get_sandbox_settings()

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -583,8 +583,12 @@ class LangSmithProvider(SandboxProvider):
     def validate_startup_config(cls) -> None:
         """Validate env-var configuration at server startup. Raises ValueError if invalid."""
         if not os.environ.get("DEFAULT_SANDBOX_SNAPSHOT_ID"):
-            msg = "DEFAULT_SANDBOX_SNAPSHOT_ID must be set when SANDBOX_TYPE=langsmith"
-            raise ValueError(msg)
+            # Not fatal: an admin can set the base snapshot at runtime from the
+            # dashboard, which is stored outside the environment.
+            logger.warning(
+                "DEFAULT_SANDBOX_SNAPSHOT_ID is not set; sandbox creation will fail until a "
+                "base snapshot is configured in admin settings"
+            )
         for name in (
             "DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES",
             "DEFAULT_SANDBOX_VCPUS",
@@ -666,7 +670,10 @@ class LangSmithProvider(SandboxProvider):
                 return TimeoutLangSmithSandbox(sandbox.to_sync())
 
             if not snapshot_id:
-                msg = "DEFAULT_SANDBOX_SNAPSHOT_ID must be set when SANDBOX_TYPE=langsmith"
+                msg = (
+                    "No base snapshot configured: set it in admin settings or via "
+                    "DEFAULT_SANDBOX_SNAPSHOT_ID"
+                )
                 raise ValueError(msg)
 
             _install_create_extra_fields(client, _get_sandbox_create_extra_fields())

--- a/agent/server.py
+++ b/agent/server.py
@@ -58,6 +58,7 @@ from .dashboard.options import (
     model_supports_effort,
 )
 from .dashboard.repo_snapshots import resolve_repo_snapshot_id
+from .dashboard.sandbox_settings import get_admin_base_snapshot_id
 from .dashboard.skills import SKILLS_NAMESPACE
 from .dashboard.team_settings import (
     get_effective_gateway_enabled,
@@ -281,19 +282,22 @@ async def _resolve_proxy_token(
     return token, expires_at, None
 
 
-async def _resolve_snapshot_id_for_repo(repo: dict[str, str] | None) -> str | None:
-    """Resolve a repo's ready snapshot id; ``None`` falls back to the default.
+async def _resolve_snapshot_id(repo: dict[str, str] | None) -> str | None:
+    """Resolve the snapshot a new sandbox boots from.
 
+    A repo's ready snapshot wins, then the admin-configured base snapshot.
     Never raises: any failure resolves to ``None`` so sandbox creation falls
     back to the configured ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
     """
-    if not repo:
-        return None
-    try:
-        return await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
-    except Exception:  # noqa: BLE001
-        logger.debug("Failed to resolve repo-scoped snapshot", exc_info=True)
-        return None
+    if repo:
+        try:
+            repo_snapshot_id = await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to resolve repo-scoped snapshot", exc_info=True)
+            repo_snapshot_id = None
+        if repo_snapshot_id:
+            return repo_snapshot_id
+    return await get_admin_base_snapshot_id()
 
 
 async def _create_sandbox_with_proxy(
@@ -304,7 +308,7 @@ async def _create_sandbox_with_proxy(
     repo: dict[str, str] | None = None,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
-    snapshot_id = await _resolve_snapshot_id_for_repo(repo)
+    snapshot_id = await _resolve_snapshot_id(repo)
     sandbox_backend = await create_sandbox(snapshot_id=snapshot_id)
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
@@ -458,7 +462,8 @@ async def ensure_sandbox_for_thread(
 
     For LangSmith sandboxes, also refreshes the GitHub App proxy auth. When
     ``repo`` has a ``ready`` repo-scoped snapshot, newly created sandboxes boot
-    from it; otherwise the configured ``DEFAULT_SANDBOX_SNAPSHOT_ID`` is used.
+    from it; otherwise the base snapshot (admin setting, else
+    ``DEFAULT_SANDBOX_SNAPSHOT_ID``) is used.
     Re-applies git identity every run because reused/reconnected sandboxes can
     lose their ``--global`` config, and Vercel preview deploys reject commits
     whose author email can't be resolved to a GitHub account.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -34,7 +34,7 @@ By default, Open SWE runs each task in a [LangSmith cloud sandbox](https://docs.
 Build a snapshot in LangSmith (UI or `SandboxClient.create_snapshot`) from your Docker image and point Open SWE at its UUID:
 
 ```bash
-DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"                      # Required
+DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"                      # Required unless an admin sets the base snapshot at runtime
 DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES="137438953472"          # Optional, default 128 GiB
 DEFAULT_SANDBOX_VCPUS="4"                                          # Optional, default 4
 DEFAULT_SANDBOX_MEM_BYTES="17179869184"                            # Optional, default 16 GiB
@@ -44,6 +44,8 @@ REPO_SNAPSHOT_BASE_IMAGE="<registry>/<open-swe-sandbox-image>"      # Optional; 
 ```
 
 This is useful for pre-installing languages, frameworks, or internal tools that your repos depend on — reducing setup time per agent run. The default snapshot includes the GitHub CLI; agents invoke it as `GH_TOKEN=dummy gh <command>` and rely on the LangSmith proxy for the real credentials.
+
+`DEFAULT_SANDBOX_SNAPSHOT_ID` is only the deployment default. Admins can override it at runtime — from the **Repository Snapshots** page or via `PUT /dashboard/api/sandbox-settings` — so a rebuilt image can be rolled out without a redeploy. See [INSTALLATION.md](./INSTALLATION.md) and `examples/github-actions/set-base-snapshot.yml` for the CI flow.
 
 `REPO_SNAPSHOT_BASE_IMAGE` should point to the published Docker image used to create your default Open SWE sandbox snapshot (typically the image built from this repository's `Dockerfile.sandbox`). The admin **Repository Snapshots** page uses it as the base image when generating per-repo Dockerfile templates. If it is not configured, template generation fails closed instead of suggesting a bare image that would be missing Open SWE's required sandbox tools.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -248,7 +248,7 @@ ADMIN_OIDC_AUDIENCE="open-swe"                                  # optional; this
 
 `ADMIN_OIDC_SUBJECTS` is the on/off switch — while it is empty, OIDC auth is unavailable. Entries containing `:` are matched against the token's `sub` claim, and `owner/repo` entries against its `repository` claim. The audience is verified either way, defaulting to `open-swe`; override it only if you set the workflow's requested audience to match. Anyone who can run a workflow on an allowlisted repo/ref gets admin on these endpoints, so keep the list to internal repos.
 
-**Admin personal access token.** The token only needs to identify its owner (`GET /user`), and that login (or email) must appear in `CONFIGURED_ADMINS`. Prefer a machine user over a human's token.
+**Admin personal access token.** The token only needs to identify its owner (`GET /user`), and that login (or email) must appear in `CONFIGURED_ADMINS`. Matching by login needs no token permissions; matching by email needs a token that can read email addresses (classic `user:email`, or the fine-grained "Email addresses" read permission) when the account's email isn't public. Prefer a machine user over a human's token.
 
 `secrets.GITHUB_TOKEN` works for neither: installation tokens have no user identity, and they are not OIDC tokens. `examples/github-actions/set-base-snapshot.yml` is a copy-ready workflow using the OIDC path.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -220,7 +220,37 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="2592000"
 REPO_SNAPSHOT_BASE_IMAGE="<your-docker-hub>/<name-of-your-image>"
 ```
 
-`DEFAULT_SANDBOX_SNAPSHOT_ID` is required when `SANDBOX_TYPE=langsmith`. The server validates this at startup and refuses to boot if it's missing. The snapshot should include the GitHub CLI from `Dockerfile.sandbox`; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
+A base snapshot is required when `SANDBOX_TYPE=langsmith` — either `DEFAULT_SANDBOX_SNAPSHOT_ID` or the runtime setting described below. The server logs a warning at startup when neither the env var nor a stored setting is present, and sandbox creation fails until one is. The snapshot should include the GitHub CLI from `Dockerfile.sandbox`; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
+
+### Changing the base snapshot without a redeploy
+
+Admins can override `DEFAULT_SANDBOX_SNAPSHOT_ID` at runtime from the **Repository Snapshots** page (**Base snapshot** field). The stored value wins; clearing it falls back to the env var. Per-repo snapshots still take precedence for runs targeting a repo with a ready snapshot.
+
+The same setting is available over the API, which is how the repo that builds your sandbox image can roll a new snapshot out on its own:
+
+```bash
+curl -X PUT "$OPEN_SWE_BASE_URL/dashboard/api/sandbox-settings" \
+  -H "Authorization: Bearer $ADMIN_GITHUB_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"base_snapshot_id": "<snapshot-uuid>"}'
+```
+
+Admin-gated sandbox-settings requests accept two CI credentials in place of the browser session cookie, both as `Authorization: Bearer`:
+
+**GitHub Actions OIDC (preferred — no stored secret).** A workflow with `permissions: id-token: write` mints a short-lived token that GitHub signs and scopes to the repo, ref, and audience it requested. Allowlist it on the deployment:
+
+```bash
+ADMIN_OIDC_SUBJECTS="acme/sandbox-images"                       # any workflow/ref in this repo
+# or pin the ref with a full subject:
+# ADMIN_OIDC_SUBJECTS="repo:acme/sandbox-images:ref:refs/heads/main"
+ADMIN_OIDC_AUDIENCE="open-swe"                                  # optional; this is the default
+```
+
+`ADMIN_OIDC_SUBJECTS` is the on/off switch — while it is empty, OIDC auth is unavailable. Entries containing `:` are matched against the token's `sub` claim, and `owner/repo` entries against its `repository` claim. The audience is verified either way, defaulting to `open-swe`; override it only if you set the workflow's requested audience to match. Anyone who can run a workflow on an allowlisted repo/ref gets admin on these endpoints, so keep the list to internal repos.
+
+**Admin personal access token.** The token only needs to identify its owner (`GET /user`), and that login (or email) must appear in `CONFIGURED_ADMINS`. Prefer a machine user over a human's token.
+
+`secrets.GITHUB_TOKEN` works for neither: installation tokens have no user identity, and they are not OIDC tokens. `examples/github-actions/set-base-snapshot.yml` is a copy-ready workflow using the OIDC path.
 
 `REPO_SNAPSHOT_BASE_IMAGE` should point at the same published Open SWE sandbox image you used to create the default snapshot (for example, the image built from `./Dockerfile.sandbox`). The admin **Repository Snapshots** page uses it as the `FROM` line when generating per-repo Dockerfile templates. If it is not set, template generation is intentionally disabled so admins do not accidentally build repo-scoped snapshots from a bare image that lacks Open SWE's required tools (`git`, `gh`, `sfw`, language runtimes, and proxy assumptions).
 
@@ -484,6 +514,10 @@ DASHBOARD_ALLOWED_ORIGINS="http://localhost:3000"  # prod: your frontend origin(
 # Comma-separated GitHub login or email allowlist for admin dashboard endpoints.
 # Empty => nobody is an admin.
 CONFIGURED_ADMINS=""                   # e.g. "alice,bob@my-org.com"
+# Optional; lets a GitHub Actions workflow act as an admin over the API via OIDC
+# (see step 4c). Empty => off.
+ADMIN_OIDC_SUBJECTS=""                 # e.g. "acme/sandbox-images" or "repo:acme/sandbox-images:ref:refs/heads/main"
+ADMIN_OIDC_AUDIENCE=""                 # audience the workflow must request; defaults to "open-swe"
 # URL of the LangGraph server the FastAPI side calls to trigger/stream runs.
 # Defaults to http://localhost:2024 locally; set to your deployment URL in prod.
 LANGGRAPH_URL="http://localhost:2024"
@@ -519,7 +553,7 @@ PUBLIC_REPO_ORG_GATE=""
 # === Sandbox (optional) ===
 # Provider: langsmith (default), modal, daytona, runloop, e2b, or local. See CUSTOMIZATION.md.
 SANDBOX_TYPE="langsmith"
-DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Required when SANDBOX_TYPE=langsmith (see step 4c)
+DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Required when SANDBOX_TYPE=langsmith unless set at runtime by an admin (see step 4c)
 DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES=""  # Root FS size in bytes (default: 128 GiB)
 DEFAULT_SANDBOX_VCPUS=""               # vCPUs per sandbox (default: 4)
 DEFAULT_SANDBOX_MEM_BYTES=""           # Memory in bytes per sandbox (default: 16 GiB)
@@ -736,7 +770,7 @@ Alternatively, you can run the dashboard as a direct cross-origin client: set `V
 
 - Verify `LANGSMITH_API_KEY_PROD` is set and valid
 - Check LangSmith sandbox quotas in your workspace settings
-- If the server refuses to start with `DEFAULT_SANDBOX_SNAPSHOT_ID must be set`, build a snapshot (see step 4c) and export its UUID
+- If sandbox creation fails with `No base snapshot configured`, build a snapshot (see step 4c) and either export its UUID as `DEFAULT_SANDBOX_SNAPSHOT_ID` or set it as the base snapshot on the admin **Repository Snapshots** page
 - If you see `Failed to create sandbox from snapshot '<id>'`, confirm the snapshot exists in your workspace and has status `ready`
 - If you get a 403 Forbidden error on the sandbox endpoints, your LangSmith workspace may not have sandbox access enabled — contact LangSmith support
 

--- a/examples/github-actions/set-base-snapshot.yml
+++ b/examples/github-actions/set-base-snapshot.yml
@@ -1,0 +1,73 @@
+# Example: point Open SWE at a new base sandbox snapshot from CI.
+#
+# This is a reference file, not an active workflow — copy it into
+# .github/workflows/ of the repo that builds your sandbox image.
+#
+# Auth is GitHub Actions OIDC: this job mints a short-lived token that GitHub
+# signs and scopes to this repo, ref, and audience, so nothing long-lived is
+# stored in secrets. On the Open SWE deployment, allowlist it with:
+#
+#   ADMIN_OIDC_SUBJECTS=<owner>/<this-repo>
+#
+# Use a full subject to also pin the ref, e.g.
+#   ADMIN_OIDC_SUBJECTS=repo:<owner>/<this-repo>:ref:refs/heads/main
+#
+# The audience defaults to "open-swe" on both sides; override it by setting
+# ADMIN_OIDC_AUDIENCE on the deployment and AUDIENCE below to match.
+#
+# Variables to configure in this repo:
+#   OPEN_SWE_BASE_URL  e.g. https://open-swe.internal.example.com
+#
+# The alternative to OIDC is a personal access token belonging to a login in
+# CONFIGURED_ADMINS, sent as the same bearer header. secrets.GITHUB_TOKEN does
+# NOT work either way: installation tokens have no user identity, and they are
+# not OIDC tokens.
+
+name: Set Open SWE base snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      snapshot_id:
+        description: Snapshot the agent should boot new sandboxes from
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write # required to mint the OIDC token
+
+jobs:
+  set-base-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      # Replace with whatever produces the snapshot (docker build + push, then
+      # a LangSmith snapshot build) and pass its id along as SNAPSHOT_ID.
+      - name: Publish base snapshot
+        id: publish
+        run: echo "snapshot_id=${{ inputs.snapshot_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Point Open SWE at the new snapshot
+        uses: actions/github-script@v8
+        env:
+          BASE_URL: ${{ vars.OPEN_SWE_BASE_URL }}
+          AUDIENCE: open-swe
+          SNAPSHOT_ID: ${{ steps.publish.outputs.snapshot_id }}
+        with:
+          script: |
+            const { BASE_URL, AUDIENCE, SNAPSHOT_ID } = process.env
+            const idToken = await core.getIDToken(AUDIENCE)
+            core.setSecret(idToken)
+
+            const response = await fetch(`${BASE_URL}/dashboard/api/sandbox-settings`, {
+              method: "PUT",
+              headers: {
+                Authorization: `Bearer ${idToken}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ base_snapshot_id: SNAPSHOT_ID }),
+            })
+            if (!response.ok) {
+              throw new Error(`${response.status}: ${await response.text()}`)
+            }
+            core.info(`Base snapshot set to ${SNAPSHOT_ID}`)

--- a/examples/github-actions/set-base-snapshot.yml
+++ b/examples/github-actions/set-base-snapshot.yml
@@ -18,8 +18,9 @@
 # Variables to configure in this repo:
 #   OPEN_SWE_BASE_URL  e.g. https://open-swe.internal.example.com
 #
-# The alternative to OIDC is a personal access token belonging to a login in
-# CONFIGURED_ADMINS, sent as the same bearer header. secrets.GITHUB_TOKEN does
+# The alternative to OIDC is a personal access token whose owner is listed in
+# CONFIGURED_ADMINS, sent as the same bearer header (allowlisting that owner by
+# login needs no token permissions). secrets.GITHUB_TOKEN does
 # NOT work either way: installation tokens have no user identity, and they are
 # not OIDC tokens.
 

--- a/tests/dashboard/test_actions_oidc_auth.py
+++ b/tests/dashboard/test_actions_oidc_auth.py
@@ -1,0 +1,164 @@
+"""Admin auth for GitHub Actions workflows via OIDC."""
+
+import time
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import HTTPException
+
+from agent.dashboard import oidc_auth
+from agent.dashboard.oidc_auth import (
+    DEFAULT_OIDC_AUDIENCE,
+    GITHUB_ACTIONS_ISSUER,
+    actions_oidc_configured,
+    admin_session_for_actions_oidc,
+    is_actions_oidc_token,
+)
+
+_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _token(
+    *,
+    sub: str = "repo:acme/images:ref:refs/heads/main",
+    repository: str | None = "acme/images",
+    audience: str = "open-swe",
+    issuer: str = GITHUB_ACTIONS_ISSUER,
+    expired: bool = False,
+    key: Any = _KEY,
+) -> str:
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": sub,
+        "iat": now - 60,
+        "exp": now - 10 if expired else now + 300,
+    }
+    if repository is not None:
+        claims["repository"] = repository
+    return jwt.encode(claims, key, algorithm="RS256")
+
+
+class _FakeJWKClient:
+    """Stands in for GitHub's JWKS endpoint, serving the local test key."""
+
+    def get_signing_key_from_jwt(self, token: str) -> Any:
+        return type("PyJWK", (), {"key": _KEY.public_key()})()
+
+
+@pytest.fixture(autouse=True)
+def _signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oidc_auth, "_client", _FakeJWKClient)
+
+
+@pytest.fixture
+def configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ADMIN_OIDC_AUDIENCE", raising=False)
+    monkeypatch.setenv("ADMIN_OIDC_SUBJECTS", "acme/images")
+
+
+def test_is_actions_oidc_token_routes_only_actions_jwts() -> None:
+    assert is_actions_oidc_token(_token())
+    # Routing must not depend on validity, or a stale token would be sent to
+    # GitHub as if it were a user token and fail with an unrelated error.
+    assert is_actions_oidc_token(_token(expired=True))
+    assert not is_actions_oidc_token(_token(issuer="https://evil.example"))
+    assert not is_actions_oidc_token("github_pat_abc123")
+
+
+def test_not_configured_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ADMIN_OIDC_AUDIENCE", raising=False)
+    monkeypatch.delenv("ADMIN_OIDC_SUBJECTS", raising=False)
+
+    assert not actions_oidc_configured()
+
+
+def test_audience_without_subjects_stays_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_OIDC_AUDIENCE", "custom-aud")
+    monkeypatch.delenv("ADMIN_OIDC_SUBJECTS", raising=False)
+
+    assert not actions_oidc_configured()
+
+
+async def test_audience_defaults_to_open_swe(configured: None) -> None:
+    """`configured` leaves ADMIN_OIDC_AUDIENCE unset."""
+    session = await admin_session_for_actions_oidc(_token(audience=DEFAULT_OIDC_AUDIENCE))
+
+    assert session["sub"] == "actions:acme/images"
+
+
+async def test_audience_override_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_OIDC_SUBJECTS", "acme/images")
+    monkeypatch.setenv("ADMIN_OIDC_AUDIENCE", "custom-aud")
+
+    session = await admin_session_for_actions_oidc(_token(audience="custom-aud"))
+    assert session["sub"] == "actions:acme/images"
+
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(_token(audience=DEFAULT_OIDC_AUDIENCE))
+    assert exc.value.status_code == 401
+
+
+async def test_rejects_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ADMIN_OIDC_AUDIENCE", raising=False)
+    monkeypatch.delenv("ADMIN_OIDC_SUBJECTS", raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(_token())
+
+    assert exc.value.status_code == 401
+
+
+async def test_accepts_allowlisted_repository(configured: None) -> None:
+    session = await admin_session_for_actions_oidc(_token())
+
+    assert session["sub"] == "actions:acme/images"
+    assert session["auth"] == "actions_oidc"
+    assert session["oidc_subject"] == "repo:acme/images:ref:refs/heads/main"
+
+
+async def test_accepts_exact_subject(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_OIDC_AUDIENCE", "open-swe")
+    monkeypatch.setenv("ADMIN_OIDC_SUBJECTS", "repo:acme/images:ref:refs/heads/main")
+
+    session = await admin_session_for_actions_oidc(_token())
+    assert session["sub"] == "actions:acme/images"
+
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(_token(sub="repo:acme/images:ref:refs/heads/feature"))
+    assert exc.value.status_code == 403
+
+
+async def test_rejects_other_repository(configured: None) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(
+            _token(sub="repo:evil/images:ref:refs/heads/main", repository="evil/images")
+        )
+
+    assert exc.value.status_code == 403
+
+
+async def test_rejects_wrong_audience(configured: None) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(_token(audience="other-service"))
+
+    assert exc.value.status_code == 401
+
+
+async def test_rejects_expired_token(configured: None) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(_token(expired=True))
+
+    assert exc.value.status_code == 401
+
+
+async def test_rejects_foreign_signature(configured: None) -> None:
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    with pytest.raises(HTTPException) as exc:
+        await admin_session_for_actions_oidc(_token(key=other_key))
+
+    assert exc.value.status_code == 401

--- a/tests/dashboard/test_github_token_auth.py
+++ b/tests/dashboard/test_github_token_auth.py
@@ -1,0 +1,133 @@
+"""Admin auth for CI callers using a GitHub user token."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from agent.dashboard import github_token_auth, oauth, routes
+
+
+def _request(
+    *,
+    method: str = "PUT",
+    path: str = "/dashboard/api/sandbox-settings",
+    authorization: str | None = None,
+    cookie: str | None = None,
+) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if authorization is not None:
+        headers.append((b"authorization", authorization.encode()))
+    if cookie is not None:
+        headers.append((b"cookie", cookie.encode()))
+    return Request(
+        {
+            "type": "http",
+            "scheme": "https",
+            "server": ("backend.example", 443),
+            "method": method,
+            "path": path,
+            "headers": headers,
+        }
+    )
+
+
+def test_bearer_token_parsing() -> None:
+    assert (
+        github_token_auth.bearer_github_token(_request(authorization="Bearer gh-tok")) == "gh-tok"
+    )
+    assert (
+        github_token_auth.bearer_github_token(_request(authorization="bearer gh-tok")) == "gh-tok"
+    )
+    assert github_token_auth.bearer_github_token(_request(authorization="Basic gh-tok")) is None
+    assert github_token_auth.bearer_github_token(_request(authorization="Bearer  ")) is None
+    assert github_token_auth.bearer_github_token(_request()) is None
+
+
+async def test_admin_token_accepted_for_configured_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octo")
+    with patch.object(
+        github_token_auth,
+        "_github_identity",
+        new_callable=AsyncMock,
+        return_value=("octo", None),
+    ):
+        session = await github_token_auth.admin_session_for_github_token("gh-tok")
+
+    assert session["sub"] == "octo"
+    assert session["auth"] == "github_token"
+
+
+async def test_admin_token_rejected_for_non_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octo")
+    with (
+        patch.object(
+            github_token_auth,
+            "_github_identity",
+            new_callable=AsyncMock,
+            return_value=("intruder", None),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await github_token_auth.admin_session_for_github_token("gh-tok")
+
+    assert exc.value.status_code == 403
+
+
+async def test_admin_dep_prefers_bearer_over_missing_cookie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octo")
+    with patch.object(
+        github_token_auth,
+        "_github_identity",
+        new_callable=AsyncMock,
+        return_value=("octo", "octo@example.com"),
+    ):
+        session = await routes._admin_session_or_ci_token(_request(authorization="Bearer gh-tok"))
+
+    assert session["sub"] == "octo"
+
+
+async def test_admin_dep_routes_oidc_tokens_to_oidc_verifier() -> None:
+    """An Actions OIDC token must never be treated as a user token."""
+    with (
+        patch.object(routes, "is_actions_oidc_token", return_value=True),
+        patch.object(
+            routes,
+            "admin_session_for_actions_oidc",
+            new_callable=AsyncMock,
+            return_value={"sub": "actions:acme/images", "auth": "actions_oidc"},
+        ) as verify_oidc,
+        patch.object(github_token_auth, "_github_identity", new_callable=AsyncMock) as user_lookup,
+    ):
+        session = await routes._admin_session_or_ci_token(_request(authorization="Bearer oidc-jwt"))
+
+    assert session["auth"] == "actions_oidc"
+    verify_oidc.assert_awaited_once_with("oidc-jwt")
+    user_lookup.assert_not_awaited()
+
+
+async def test_admin_dep_requires_a_credential() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await routes._admin_session_or_ci_token(_request())
+
+    assert exc.value.status_code == 401
+
+
+def test_bearer_mutation_skips_csrf(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+
+    oauth.require_same_origin_for_mutations(_request(authorization="Bearer gh-tok"))
+
+
+def test_bearer_with_session_cookie_still_enforces_csrf(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+
+    with pytest.raises(HTTPException) as exc:
+        oauth.require_same_origin_for_mutations(
+            _request(authorization="Bearer gh-tok", cookie=f"{oauth.COOKIE_NAME}=abc")
+        )
+
+    assert exc.value.status_code == 403

--- a/tests/dashboard/test_github_token_auth.py
+++ b/tests/dashboard/test_github_token_auth.py
@@ -1,7 +1,9 @@
 """Admin auth for CI callers using a GitHub user token."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -43,6 +45,63 @@ def test_bearer_token_parsing() -> None:
     assert github_token_auth.bearer_github_token(_request(authorization="Basic gh-tok")) is None
     assert github_token_auth.bearer_github_token(_request(authorization="Bearer  ")) is None
     assert github_token_auth.bearer_github_token(_request()) is None
+
+
+def _github_transport(user: dict[str, Any], emails: Any = None, *, emails_status: int = 200):
+    """Serve /user and /user/emails without touching the network."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/user":
+            return httpx.Response(200, json=user)
+        if request.url.path == "/user/emails":
+            return httpx.Response(emails_status, json=emails if emails is not None else [])
+        raise AssertionError(f"unexpected request to {request.url}")
+
+    return httpx.MockTransport(handler)
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def _patched_client(transport: httpx.MockTransport):
+    def factory(**kwargs: Any) -> httpx.AsyncClient:
+        return _REAL_ASYNC_CLIENT(transport=transport, base_url="https://api.github.com")
+
+    return patch.object(github_token_auth.httpx, "AsyncClient", factory)
+
+
+async def test_identity_falls_back_to_primary_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A private-email admin allowlisted by email must still authenticate."""
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octo@example.com")
+    transport = _github_transport(
+        {"login": "octo", "email": None},
+        [{"email": "alt@example.com"}, {"email": "octo@example.com", "primary": True}],
+    )
+    with _patched_client(transport):
+        session = await github_token_auth.admin_session_for_github_token("gh-tok")
+
+    assert session["sub"] == "octo"
+    assert session["email"] == "octo@example.com"
+
+
+async def test_identity_skips_email_lookup_when_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octo@example.com")
+    transport = _github_transport({"login": "octo", "email": "octo@example.com"}, emails_status=403)
+    with _patched_client(transport):
+        session = await github_token_auth.admin_session_for_github_token("gh-tok")
+
+    assert session["email"] == "octo@example.com"
+
+
+async def test_identity_tolerates_email_scope_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No email permission is fine — login matching still authenticates."""
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octo")
+    transport = _github_transport({"login": "octo", "email": None}, emails_status=403)
+    with _patched_client(transport):
+        session = await github_token_auth.admin_session_for_github_token("gh-tok")
+
+    assert session["sub"] == "octo"
+    assert session["email"] is None
 
 
 async def test_admin_token_accepted_for_configured_admin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sandbox/test_sandbox_settings.py
+++ b/tests/sandbox/test_sandbox_settings.py
@@ -1,0 +1,118 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.dashboard import sandbox_settings
+from agent.dashboard.sandbox_settings import (
+    SandboxSettingsUpdate,
+    get_admin_base_snapshot_id,
+    get_sandbox_settings,
+    resolve_base_snapshot_id,
+    upsert_sandbox_settings,
+)
+
+
+def _store(item: object) -> MagicMock:
+    client = MagicMock()
+    client.store.get_item = AsyncMock(return_value=item)
+    client.store.put_item = AsyncMock()
+    return client
+
+
+def test_update_normalizes_blank_to_none() -> None:
+    assert SandboxSettingsUpdate(base_snapshot_id="  ").base_snapshot_id is None
+    assert SandboxSettingsUpdate(base_snapshot_id=" snap-1 ").base_snapshot_id == "snap-1"
+
+
+def test_update_rejects_oversized_value() -> None:
+    with pytest.raises(ValueError, match="at most"):
+        SandboxSettingsUpdate(base_snapshot_id="x" * 513)
+
+
+async def test_admin_value_wins_over_env() -> None:
+    with (
+        patch.object(
+            sandbox_settings,
+            "_client",
+            return_value=_store({"value": {"base_snapshot_id": "admin-snap"}}),
+        ),
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
+    ):
+        assert await get_admin_base_snapshot_id() == "admin-snap"
+        assert await resolve_base_snapshot_id() == "admin-snap"
+
+
+async def test_falls_back_to_env_without_record() -> None:
+    with (
+        patch.object(sandbox_settings, "_client", return_value=_store(None)),
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
+    ):
+        assert await get_admin_base_snapshot_id() is None
+        assert await resolve_base_snapshot_id() == "env-snap"
+
+
+async def test_store_failure_falls_back_to_env() -> None:
+    client = MagicMock()
+    client.store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
+    with (
+        patch.object(sandbox_settings, "_client", return_value=client),
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
+    ):
+        assert await resolve_base_snapshot_id() == "env-snap"
+
+
+async def test_settings_report_source() -> None:
+    with (
+        patch.object(sandbox_settings, "_client", return_value=_store(None)),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        unset = await get_sandbox_settings()
+    assert unset["base_snapshot_source"] == "unset"
+    assert unset["effective_base_snapshot_id"] is None
+
+    with (
+        patch.object(sandbox_settings, "_client", return_value=_store(None)),
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
+    ):
+        from_env = await get_sandbox_settings()
+    assert from_env["base_snapshot_source"] == "env"
+    assert from_env["effective_base_snapshot_id"] == "env-snap"
+
+
+async def test_upsert_persists_and_returns_effective() -> None:
+    client = _store({"value": {"base_snapshot_id": "admin-snap"}})
+    with (
+        patch.object(sandbox_settings, "_client", return_value=client),
+        patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
+    ):
+        result = await upsert_sandbox_settings(
+            SandboxSettingsUpdate(base_snapshot_id="admin-snap"), updated_by="octo"
+        )
+    stored = client.store.put_item.await_args.args[2]
+    assert stored["base_snapshot_id"] == "admin-snap"
+    assert stored["updated_by"] == "octo"
+    assert result["base_snapshot_source"] == "admin"
+    assert result["effective_base_snapshot_id"] == "admin-snap"
+
+
+async def test_server_prefers_repo_snapshot_then_admin_base() -> None:
+    from agent import server
+
+    with (
+        patch.object(
+            server, "resolve_repo_snapshot_id", new_callable=AsyncMock, return_value="repo-snap"
+        ),
+        patch.object(
+            server, "get_admin_base_snapshot_id", new_callable=AsyncMock, return_value="admin-snap"
+        ),
+    ):
+        assert await server._resolve_snapshot_id({"owner": "acme", "name": "repo"}) == "repo-snap"
+
+    with (
+        patch.object(server, "resolve_repo_snapshot_id", new_callable=AsyncMock, return_value=None),
+        patch.object(
+            server, "get_admin_base_snapshot_id", new_callable=AsyncMock, return_value="admin-snap"
+        ),
+    ):
+        assert await server._resolve_snapshot_id({"owner": "acme", "name": "repo"}) == "admin-snap"
+        assert await server._resolve_snapshot_id(None) == "admin-snap"

--- a/ui/src/components/RepoSnapshotsPanel.tsx
+++ b/ui/src/components/RepoSnapshotsPanel.tsx
@@ -45,10 +45,26 @@ export function RepoSnapshotsPanel() {
   const [addRepo, setAddRepo] = useState("")
   const [selected, setSelected] = useState<string | null>(null)
   const [draft, setDraft] = useState("")
+  const [baseDraft, setBaseDraft] = useState<string | null>(null)
 
   const snapshots = useQuery({
     queryKey: ["repoSnapshots"],
     queryFn: api.listRepoSnapshots,
+  })
+
+  const sandboxSettings = useQuery({
+    queryKey: ["sandboxSettings"],
+    queryFn: api.getSandboxSettings,
+  })
+
+  const saveBase = useMutation({
+    mutationFn: (value: string | null) => api.saveSandboxSettings(value),
+    onSuccess: (settings) => {
+      qc.setQueryData(["sandboxSettings"], settings)
+      setBaseDraft(null)
+      setError(null)
+    },
+    onError: (e: Error) => setError(formatMutationError(e)),
   })
 
   const repos = useRepos()
@@ -134,6 +150,18 @@ export function RepoSnapshotsPanel() {
       .catch(() => undefined)
   }
 
+  const base = sandboxSettings.data
+  const baseValue = baseDraft ?? base?.base_snapshot_id ?? ""
+  const baseDirty = baseValue.trim() !== (base?.base_snapshot_id ?? "")
+  const baseHint =
+    base?.base_snapshot_source === "admin"
+      ? `Overrides DEFAULT_SANDBOX_SNAPSHOT_ID${
+          base.env_base_snapshot_id ? ` (${base.env_base_snapshot_id})` : ""
+        }. New sandboxes boot from this unless the repo has a ready snapshot below.`
+      : base?.base_snapshot_source === "env"
+        ? `Using DEFAULT_SANDBOX_SNAPSHOT_ID. Set a value here to change it without a redeploy.`
+        : "No base snapshot configured — new sandboxes cannot start until one is set here or in DEFAULT_SANDBOX_SNAPSHOT_ID."
+
   const githubReauth =
     (repos.isError && isGithubReauthError(repos.error)) ||
     (error !== null && /github token|re-login required/i.test(error))
@@ -152,6 +180,50 @@ export function RepoSnapshotsPanel() {
           to list installed repos.
         </div>
       )}
+      <section className="space-y-2">
+        <Label htmlFor="base-snapshot">Base snapshot</Label>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <Input
+            id="base-snapshot"
+            placeholder={base?.env_base_snapshot_id ?? "snapshot id"}
+            value={baseValue}
+            onChange={(e) => setBaseDraft(e.target.value)}
+            disabled={sandboxSettings.isLoading}
+            className="sm:flex-1"
+          />
+          <Button
+            size="sm"
+            className="shrink-0 sm:w-auto"
+            disabled={!baseDirty || saveBase.isPending}
+            onClick={() => void saveBase.mutateAsync(baseValue.trim() || null)}
+          >
+            Save
+          </Button>
+          {base?.base_snapshot_id && (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="shrink-0 sm:w-auto"
+              disabled={saveBase.isPending}
+              onClick={() => void saveBase.mutateAsync(null)}
+            >
+              Use env default
+            </Button>
+          )}
+        </div>
+        <p
+          className={`text-xs ${
+            base?.base_snapshot_source === "unset"
+              ? "text-destructive"
+              : "text-muted-foreground"
+          }`}
+        >
+          {baseHint}
+        </p>
+      </section>
+
+      <div className="border-t border-border" />
+
       <section className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="add-snapshot-repo">Add repository</Label>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -369,6 +369,15 @@ export interface SkillsPage {
   next_offset: number | null
 }
 
+export interface SandboxSettings {
+  base_snapshot_id: string | null
+  env_base_snapshot_id: string | null
+  effective_base_snapshot_id: string | null
+  base_snapshot_source: "admin" | "env" | "unset"
+  updated_at: string | null
+  updated_by: string | null
+}
+
 export type RepoSnapshotStatus = "none" | "building" | "ready" | "failed"
 
 export interface RepoSnapshot {
@@ -721,6 +730,12 @@ export const api = {
   deleteAgentInstructions: (full_name: string) =>
     request<void>(`/agent-instructions/${encodeURIComponent(full_name)}`, {
       method: "DELETE",
+    }),
+  getSandboxSettings: () => request<SandboxSettings>("/sandbox-settings"),
+  saveSandboxSettings: (base_snapshot_id: string | null) =>
+    request<SandboxSettings>("/sandbox-settings", {
+      method: "PUT",
+      body: JSON.stringify({ base_snapshot_id }),
     }),
   listRepoSnapshots: () => request<Array<RepoSnapshot>>("/repo-snapshots"),
   createRepoSnapshot: (full_name: string) =>


### PR DESCRIPTION
The base snapshot new sandboxes boot from could only be set with `DEFAULT_SANDBOX_SNAPSHOT_ID`, so shipping a rebuilt sandbox image required a redeploy. Admins can now set it at runtime from the **Repository Snapshots** page, and the repo that builds the image can set it from CI.

Resolution order for a new sandbox: repo snapshot → admin base snapshot → `DEFAULT_SANDBOX_SNAPSHOT_ID`. Startup no longer refuses to boot when the env var is missing (it warns) — a missing base snapshot surfaces at sandbox creation instead.

### CI auth

Admin-gated `/dashboard/api/sandbox-settings` accepts two CI credentials as `Authorization: Bearer`, dispatched on the token's unverified issuer (routing only; full verification follows):

- **GitHub Actions OIDC** (preferred, no stored secret) — verified against GitHub's JWKS with issuer, audience and expiry required, then matched against `ADMIN_OIDC_SUBJECTS` (`owner/repo`, or a full `repo:owner/name:ref:...` subject to pin the ref). Unavailable until that allowlist is set; audience defaults to `open-swe`.
- **An admin's GitHub PAT** — resolved to a login via `GET /user`, matched against `CONFIGURED_ADMINS`. `secrets.GITHUB_TOKEN` works for neither: installation tokens have no user identity.

Bearer-only mutations skip the CSRF origin check, which exists to protect the ambient session cookie; a request carrying both cookie and bearer is still checked.

`examples/github-actions/set-base-snapshot.yml` is a copy-ready workflow using the OIDC path. Anyone who can run a workflow on an allowlisted repo/ref gets admin on these endpoints, so the docs steer the allowlist at internal repos and ref pinning.

## Test Plan

- [x] `make test` — 1709 passed, including new coverage for the resolution order, store-failure fallback to env, OIDC accept/reject (wrong audience, wrong repo, expired, foreign signature, unconfigured), PAT admin gate, bearer/OIDC dispatch, and the CSRF exemption
- [x] `make lint`
- [x] `make typecheck` — no new errors (2 pre-existing in `tests/dashboard/test_profile_draft_preference.py`)
- [x] UI `tsc --noEmit` and `prettier --check`