### PR TITLE
fix: keep queued messages visible during active runs

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -256,11 +256,13 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect.poll(() => latestPrBody(page)).toContain("Slack thread");
   });
 
-  test("shows follow-ups queued while the agent is still running", async ({
+  test("keeps follow-ups visible while queued during a running agent", async ({
     page,
   }, testInfo) => {
     await loginAs(page, SAME_USER);
     await openRunningThreadViaSlackLink(page);
+    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(threadId).not.toBe("");
 
     const queuedText = "Please queue this follow-up while you finish the PR.";
     const busyComposer = composerFor(page, /Send a message to queue next/);
@@ -280,6 +282,24 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       path: screenshotPath,
       contentType: "image/png",
     });
+
+    const serverRefresh = await page.waitForResponse((response) => {
+      const path = new URL(response.url()).pathname;
+      return (
+        response.request().method() === "GET" &&
+        path === `/dashboard/api/threads/${threadId}`
+      );
+    });
+    expect(serverRefresh.ok()).toBeTruthy();
+    await expect(serverRefresh.json()).resolves.toMatchObject({
+      status: "running",
+    });
+
+    test.fail(
+      true,
+      "Queued follow-ups disappear when the running thread summary refreshes",
+    );
+    await expect(queuedMessage).toBeVisible();
   });
 
   test("stops a Slack-started run from the web app", async ({ page }) => {

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -256,13 +256,11 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect.poll(() => latestPrBody(page)).toContain("Slack thread");
   });
 
-  test("keeps follow-ups visible while queued during a running agent", async ({
+  test("shows follow-ups queued while the agent is still running", async ({
     page,
   }, testInfo) => {
     await loginAs(page, SAME_USER);
     await openRunningThreadViaSlackLink(page);
-    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
-    expect(threadId).not.toBe("");
 
     const queuedText = "Please queue this follow-up while you finish the PR.";
     const busyComposer = composerFor(page, /Send a message to queue next/);
@@ -282,24 +280,6 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       path: screenshotPath,
       contentType: "image/png",
     });
-
-    const serverRefresh = await page.waitForResponse((response) => {
-      const path = new URL(response.url()).pathname;
-      return (
-        response.request().method() === "GET" &&
-        path === `/dashboard/api/threads/${threadId}`
-      );
-    });
-    expect(serverRefresh.ok()).toBeTruthy();
-    await expect(serverRefresh.json()).resolves.toMatchObject({
-      status: "running",
-    });
-
-    test.fail(
-      true,
-      "Queued follow-ups disappear when the running thread summary refreshes",
-    );
-    await expect(queuedMessage).toBeVisible();
   });
 
   test("stops a Slack-started run from the web app", async ({ page }) => {

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -256,11 +256,13 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect.poll(() => latestPrBody(page)).toContain("Slack thread");
   });
 
-  test("shows follow-ups queued while the agent is still running", async ({
+  test("keeps follow-ups visible while queued during a running agent", async ({
     page,
   }, testInfo) => {
     await loginAs(page, SAME_USER);
     await openRunningThreadViaSlackLink(page);
+    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(threadId).not.toBe("");
 
     const queuedText = "Please queue this follow-up while you finish the PR.";
     const busyComposer = composerFor(page, /Send a message to queue next/);
@@ -280,6 +282,19 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       path: screenshotPath,
       contentType: "image/png",
     });
+
+    const serverRefresh = await page.waitForResponse((response) => {
+      const path = new URL(response.url()).pathname;
+      return (
+        response.request().method() === "GET" &&
+        path === `/dashboard/api/threads/${threadId}`
+      );
+    });
+    expect(serverRefresh.ok()).toBeTruthy();
+    await expect(serverRefresh.json()).resolves.toMatchObject({
+      status: "running",
+    });
+    await expect(queuedMessage).toBeVisible();
   });
 
   test("stops a Slack-started run from the web app", async ({ page }) => {

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -167,9 +167,19 @@ export function useSidebarThreads(
 }
 
 export function useAgentThread(threadId: string) {
+  const queryClient = useQueryClient()
+  const queryKey = agentThreadKeys.detail(threadId)
+
   return useQuery({
-    queryKey: agentThreadKeys.detail(threadId),
-    queryFn: () => agentsApi.getThread(threadId),
+    queryKey,
+    queryFn: async () => {
+      const thread = await agentsApi.getThread(threadId)
+      const queuedMessages =
+        queryClient.getQueryData<AgentThread>(queryKey)?.queuedMessages
+      return thread.status === "running" && queuedMessages?.length
+        ? { ...thread, queuedMessages }
+        : thread
+    },
     // Server truth heartbeat while a run is live. The SDK's SSE transport does
     // not reconnect once a custom `fetch` is supplied (it needs the dashboard
     // session cookie), so a dropped event stream must not leave the view — and


### PR DESCRIPTION
## Description
Fixes queued dashboard follow-ups disappearing when the running-thread heartbeat refreshes metadata. Active refreshes retain optimistic queue entries until the run leaves its running state, with Playwright coverage that failed before the fix and now passes.

## Test Plan
- [x] Playwright waits for a confirmed running-status detail refresh and verifies the queued message remains visible.
- [x] UI typecheck and ESLint on the modified query hook.

Made by [Open SWE](https://openswe.vercel.app/agents/fc97a873-8937-15b1-6551-bb62466d8680)