### PR TITLE
fix: always include Slack loading tips

### DIFF
--- a/agent/middleware/refresh_slack_status.py
+++ b/agent/middleware/refresh_slack_status.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
@@ -30,26 +29,13 @@ from langgraph.types import Command
 from ..utils.slack import (
     DEFAULT_ASSISTANT_STATUS,
     set_slack_assistant_status,
+    slack_loading_tip,
 )
 
 logger = logging.getLogger(__name__)
 
 _HEARTBEAT_INTERVAL_SECONDS = 60.0
 _MAX_HEARTBEAT_SECONDS = 60 * 60
-_LOADING_TIPS: tuple[str, ...] = (
-    "Tip: Use repo:owner/name to override the repository",
-    "Tip: Send follow-ups mid-run; I read them before my next step",
-    "Tip: Ask for plan mode to review my approach before edits",
-    "Tip: Paste a LangSmith trace link for built-in inspection",
-    "Tip: Ask me to check back after CI or a deploy finishes",
-    'Tip: Say "split this out" to start a new Slack thread',
-    "Tip: Ask me to create a reusable skill for future runs",
-    'Tip: Say "always..." to save a standing preference',
-    "Tip: Toggle Always Create PRs in your Profile",
-    "Tip: Add Repository Instructions for repo-specific behavior",
-    "Tip: Use @open-swe autofix off to pause fixes on one PR",
-    "Tip: Customize reviewer style prompts in the dashboard",
-)
 
 _T = TypeVar("_T")
 
@@ -87,11 +73,6 @@ _TOOL_STATUS: dict[str, str] = {
 }
 
 
-def _loading_tip_for_run(run_id: str) -> str:
-    digest = hashlib.sha256(run_id.encode()).digest()
-    return _LOADING_TIPS[int.from_bytes(digest[:8], "big") % len(_LOADING_TIPS)]
-
-
 def _slack_status_context_from_config() -> tuple[str, str, str] | None:
     config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
@@ -108,7 +89,7 @@ def _slack_status_context_from_config() -> tuple[str, str, str] | None:
 
     prepare_run_id = configurable.get("prepare_run_id")
     tip_key = prepare_run_id if isinstance(prepare_run_id, str) and prepare_run_id else thread_ts
-    return channel_id, thread_ts, _loading_tip_for_run(tip_key)
+    return channel_id, thread_ts, slack_loading_tip(tip_key)
 
 
 def _tool_call_name(tool_call: object) -> str | None:

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -33,6 +33,20 @@ SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 SLACK_THREAD_MAX_MESSAGES = 500
 SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS = 300
 DEFAULT_ASSISTANT_STATUS = "is thinking…"
+SLACK_LOADING_TIPS: tuple[str, ...] = (
+    "Tip: Use repo:owner/name to override the repository",
+    "Tip: Send follow-ups mid-run; I read them before my next step",
+    "Tip: Ask for plan mode to review my approach before edits",
+    "Tip: Paste a LangSmith trace link for built-in inspection",
+    "Tip: Ask me to check back after CI or a deploy finishes",
+    'Tip: Say "split this out" to start a new Slack thread',
+    "Tip: Ask me to create a reusable skill for future runs",
+    'Tip: Say "always..." to save a standing preference',
+    "Tip: Toggle Always Create PRs in your Profile",
+    "Tip: Add Repository Instructions for repo-specific behavior",
+    "Tip: Use @open-swe autofix off to pause fixes on one PR",
+    "Tip: Customize reviewer style prompts in the dashboard",
+)
 
 SlackChannelContext = dict[str, str]
 _SLACK_CHANNEL_INFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
@@ -317,6 +331,11 @@ def format_slack_messages_for_prompt(
     return "\n".join(lines)
 
 
+def slack_loading_tip(key: str) -> str:
+    digest = hashlib.sha256(key.encode()).digest()
+    return SLACK_LOADING_TIPS[int.from_bytes(digest[:8], "big") % len(SLACK_LOADING_TIPS)]
+
+
 async def set_slack_assistant_status(
     channel_id: str,
     thread_ts: str,
@@ -331,7 +350,7 @@ async def set_slack_assistant_status(
     want it visible across longer runs must refresh it periodically.
 
     `loading_messages` is an optional list (max 10) of strings Slack rotates
-    through while the indicator is visible.
+    through while the indicator is visible. Active statuses default to one tip.
 
     No-op (returning False) when the bot token is missing or the
     channel/thread is not provided. Failures are logged but never raised —
@@ -345,6 +364,8 @@ async def set_slack_assistant_status(
         "thread_ts": thread_ts,
         "status": status,
     }
+    if status and not loading_messages:
+        loading_messages = [slack_loading_tip(thread_ts)]
     if loading_messages:
         payload["loading_messages"] = list(loading_messages)[:10]
 

--- a/tests/e2e/fakes.py
+++ b/tests/e2e/fakes.py
@@ -18,6 +18,7 @@ from e2e_env import BARE_REMOTE, BASE_BRANCH, OWNER, REPO
 # --- Slack -----------------------------------------------------------------
 # (channel, thread_ts) -> list of {user, text, ts, blocks, is_bot}
 SLACK_MESSAGES: dict[tuple[str, str], list[dict[str, Any]]] = {}
+SLACK_STATUSES: list[dict[str, Any]] = []
 _slack_seq = [1]
 
 
@@ -174,6 +175,7 @@ def repo_private() -> bool:
 
 def reset() -> None:
     SLACK_MESSAGES.clear()
+    SLACK_STATUSES.clear()
     PULLS.clear()
     REPO_PRIVATE[0] = False
     _pr_seq[0] = 0

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -387,6 +387,11 @@ async def slack_messages() -> JSONResponse:
     )
 
 
+@app.get("/mock/slack/statuses")
+async def slack_statuses() -> JSONResponse:
+    return JSONResponse(fakes.SLACK_STATUSES)
+
+
 # --- mock UIs --------------------------------------------------------------
 @app.get("/mock/slack", response_class=HTMLResponse)
 async def mock_slack_page() -> str:
@@ -536,7 +541,9 @@ async def slack_post_ephemeral(request: Request) -> JSONResponse:
 
 @app.post("/fake-slack/assistant.threads.setStatus")
 async def slack_set_status(request: Request) -> JSONResponse:
-    await request.body()
+    body = await request.json()
+    if isinstance(body, dict):
+        fakes.SLACK_STATUSES.append(body)
     return _ok()
 
 

--- a/tests/e2e/tests/slack_loading_tips.spec.ts
+++ b/tests/e2e/tests/slack_loading_tips.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+
+type SlackStatus = {
+  status?: string;
+  loading_messages?: string[];
+};
+
+test.describe("Slack assistant loading tips", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mock/slack");
+    await page.locator("#reset").click();
+    await expect(page.locator("#thread")).toContainText("No messages yet");
+  });
+
+  test("includes a tip on every active status update", async ({ page }) => {
+    await page.locator("#text").fill("<@U0BOT> please add a greet() helper and open a PR");
+    await page.locator("#send").click();
+
+    await expect(page.locator(".msg.bot").filter({ hasText: "Add greet() helper" })).toBeVisible();
+
+    const response = await page.request.get("/mock/slack/statuses");
+    const statuses = (await response.json()) as SlackStatus[];
+    const activeStatuses = statuses.filter(({ status }) => status);
+
+    expect(activeStatuses.length).toBeGreaterThan(0);
+    for (const status of activeStatuses) {
+      expect(status.loading_messages).toHaveLength(1);
+      expect(status.loading_messages?.[0]).toMatch(/^Tip: /);
+    }
+  });
+});

--- a/tests/slack/test_refresh_slack_status_middleware.py
+++ b/tests/slack/test_refresh_slack_status_middleware.py
@@ -7,12 +7,10 @@ from langchain_core.messages import AIMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 
 from agent.middleware.refresh_slack_status import (
-    _LOADING_TIPS,
     SlackAssistantStatusMiddleware,
-    _loading_tip_for_run,
     _status_from_recent_tool_calls,
 )
-from agent.utils.slack import DEFAULT_ASSISTANT_STATUS
+from agent.utils.slack import DEFAULT_ASSISTANT_STATUS, SLACK_LOADING_TIPS, slack_loading_tip
 
 
 class TestSlackAssistantStatusMiddleware:
@@ -47,12 +45,12 @@ class TestSlackAssistantStatusMiddleware:
         kwargs = await_args.kwargs
         assert args == ("C1", "1.0")
         assert kwargs["status"] == DEFAULT_ASSISTANT_STATUS
-        assert kwargs["loading_messages"] == [_loading_tip_for_run("run-a")]
+        assert kwargs["loading_messages"] == [slack_loading_tip("run-a")]
 
     def test_loading_tip_is_stable_per_run_and_varies_across_runs(self) -> None:
-        assert _loading_tip_for_run("run-a") == _loading_tip_for_run("run-a")
-        selected_tips = {_loading_tip_for_run(f"run-{index}") for index in range(20)}
-        assert selected_tips <= set(_LOADING_TIPS)
+        assert slack_loading_tip("run-a") == slack_loading_tip("run-a")
+        selected_tips = {slack_loading_tip(f"run-{index}") for index in range(20)}
+        assert selected_tips <= set(SLACK_LOADING_TIPS)
         assert len(selected_tips) > 1
 
     @pytest.mark.asyncio
@@ -171,7 +169,7 @@ class TestSlackAssistantStatusMiddleware:
 
         assert response.result[0].content == "done"
         assert set_count >= 2
-        assert loading_messages == [[_loading_tip_for_run("run-a")]] * set_count
+        assert loading_messages == [[slack_loading_tip("run-a")]] * set_count
 
     @pytest.mark.asyncio
     async def test_skips_when_slack_thread_missing(self) -> None:

--- a/tests/slack/test_slack_assistants_status.py
+++ b/tests/slack/test_slack_assistants_status.py
@@ -69,6 +69,7 @@ async def test_set_slack_assistant_status_calls_correct_endpoint(
         "channel_id": "C1",
         "thread_ts": "1.0",
         "status": "thinking…",
+        "loading_messages": [slack_utils.slack_loading_tip("1.0")],
     }
 
 
@@ -107,7 +108,7 @@ async def test_set_slack_assistant_status_caps_loading_messages_at_10(
 
 
 @pytest.mark.asyncio
-async def test_set_slack_assistant_status_omits_loading_messages_when_unset(
+async def test_set_slack_assistant_status_defaults_to_tip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
@@ -115,6 +116,20 @@ async def test_set_slack_assistant_status_omits_loading_messages_when_unset(
     client_cm = _async_client_cm(_ok_response())
     with patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm):
         await slack_utils.set_slack_assistant_status("C1", "1.0", "thinking…")
+
+    _, kwargs = client_cm.post.call_args
+    assert kwargs["json"]["loading_messages"] == [slack_utils.slack_loading_tip("1.0")]
+
+
+@pytest.mark.asyncio
+async def test_set_slack_assistant_status_clear_omits_loading_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+
+    client_cm = _async_client_cm(_ok_response())
+    with patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm):
+        await slack_utils.set_slack_assistant_status("C1", "1.0", status="")
 
     _, kwargs = client_cm.post.call_args
     assert "loading_messages" not in kwargs["json"]


### PR DESCRIPTION
## Description
Ensure every active Slack assistant status includes a deterministic `Tip:` loading message, including webhook bootstrap updates that run before middleware. The fake Slack boundary now records status payloads for a Playwright regression test.

## Test Plan
- [x] `uv run pytest -q tests/slack/test_slack_assistants_status.py tests/slack/test_refresh_slack_status_middleware.py`
- [x] `npx playwright test tests/slack_loading_tips.spec.ts --project=chromium`

Made by [Open SWE](https://openswe.vercel.app/agents/d8c8c52c-40a4-c095-62ea-28d77af0f6d6)