### PR TITLE
fix: reconnect chat after plan decisions

### DIFF
--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -233,4 +233,74 @@ test.describe("Plan review (HTTP comments)", () => {
     await ownerCtx.close();
     await collabCtx.close();
   });
+
+  test("plan decisions return to a connected conversation", async ({
+    browser,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    await request.post("/control/reset");
+    const send = await request.post("/mock/slack/send", {
+      data: {
+        text: "<@U0BOT> plan how to add a greet() helper",
+        mention_bot: true,
+      },
+    });
+    const { thread_id: threadId } = (await send.json()) as {
+      thread_id: string;
+    };
+    const planPath = `/agents/${threadId}/plan`;
+
+    await expect
+      .poll(async () => (await botMessages(request, threadId)).join("\n"), {
+        timeout: 60_000,
+      })
+      .toMatch(/ready for review/i);
+
+    const ownerCtx = await browser.newContext();
+    await ownerCtx.request.post("/control/login", { data: OWNER });
+    const owner = await ownerCtx.newPage();
+    await owner.goto(planPath);
+    await expect(owner.getByTestId("plan-review")).toBeVisible({
+      timeout: 30_000,
+    });
+    await addComment(owner, "Please revise the verification steps.");
+    await expect(owner.getByTestId("reject-plan")).toBeEnabled();
+
+    const hydrated = owner.waitForResponse((response) => {
+      const path = new URL(response.url()).pathname;
+      return (
+        response.request().method() === "GET" &&
+        path === `/dashboard/api/threads/${threadId}/state`
+      );
+    });
+    await owner.getByTestId("reject-plan").click();
+    await expect(owner).toHaveURL(new RegExp(`/agents/${threadId}$`));
+    expect((await hydrated).ok()).toBeTruthy();
+    await expect(
+      owner.getByText(
+        "I'll wait for your review and approval before implementing.",
+      ),
+    ).toHaveCount(2, { timeout: 60_000 });
+    await expect(
+      owner.getByText("A plan is ready for your review."),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await owner.goto(planPath);
+    await expect(owner.getByTestId("approve-plan")).toBeVisible({
+      timeout: 30_000,
+    });
+    await owner.getByTestId("approve-plan").click();
+    await expect(owner).toHaveURL(new RegExp(`/agents/${threadId}$`));
+    await expect
+      .poll(async () => {
+        const prs = (await (
+          await request.get("/mock/github/data")
+        ).json()) as Array<unknown>;
+        return prs.length;
+      })
+      .toBeGreaterThan(0);
+
+    await ownerCtx.close();
+  });
 });

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -191,14 +191,21 @@ export function PlanReview({
           return
         }
         await rejectPlan(plan.threadId)
-        setDecision("Changes requested — the agent is revising the plan.")
+        if (compact) {
+          setDecision("Changes requested — the agent is revising the plan.")
+        } else {
+          await navigate({
+            to: "/agents/$threadId",
+            params: { threadId: plan.threadId },
+          })
+        }
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setBusy(null)
       }
     },
-    [navigate, onApprove, plan.threadId]
+    [compact, navigate, onApprove, plan.threadId]
   )
 
   const copyPlan = useCallback(async () => {

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -31,10 +31,11 @@ function AgentsLayout() {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
-  const [, section, threadId, localSessionId] = pathname.split("/")
+  const [, section, threadId, nestedRoute] = pathname.split("/")
   const activeThreadId =
     section === "agents" &&
     threadId &&
+    nestedRoute !== "plan" &&
     threadId !== "automations" &&
     threadId !== "skills" &&
     threadId !== "threads" &&
@@ -43,7 +44,7 @@ function AgentsLayout() {
       ? threadId
       : undefined
   const activeLocalSessionId =
-    section === "agents" && threadId === "local" ? localSessionId : undefined
+    section === "agents" && threadId === "local" ? nestedRoute : undefined
 
   if (session.isLoading) {
     return (


### PR DESCRIPTION
## Description
Standalone plan review kept the same active stream binding as chat, so returning during a revision did not rehydrate the conversation. Treat the plan page as non-chat and return successful standalone decisions to the connected conversation.

## Test Plan
- [x] Playwright plan-review flow reproduces revision, verifies rehydration/output, and covers revision/approval redirects
- [x] Existing stream-navigation Playwright regression
- [x] UI typecheck, formatting, and focused ESLint

Made by [Open SWE](https://openswe.vercel.app/agents/1dfecd80-c30f-97b7-6a3d-15791bd28590)

## References
- Plan: https://openswe.vercel.app/agents/1dfecd80-c30f-97b7-6a3d-15791bd28590/plan