### PR TITLE
feat: add deployment-aware dashboard UI context

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -94,6 +94,15 @@ WORKING_ENV_SECTION = """### Working Environment
 You are operating in a remote Linux sandbox at `{working_dir}` — use it as your working directory for all operations. The sandbox starts clean; no repo is pre-cloned."""
 
 
+DASHBOARD_CONTEXT_SECTION = """---
+
+### Dashboard Context
+
+The active dashboard base URL for this deployment is `{dashboard_base_url}`. Use it as the base for dashboard routes.
+
+"""
+
+
 PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
@@ -324,6 +333,7 @@ def _render_user_instructions_section(instructions: str | None) -> str:
 # repo toggles); standing guidance lives in the shared base above.
 SYSTEM_PROMPT_TEMPLATE = (
     WORKING_ENV_SECTION
+    + DASHBOARD_CONTEXT_SECTION
     + PLAN_MODE_GUIDANCE_SECTION
     + "{plan_mode_section}"
     + SELF_AWARENESS_SECTION
@@ -344,6 +354,7 @@ SYSTEM_PROMPT_TEMPLATE = (
 
 def construct_system_prompt(
     working_dir: str,
+    dashboard_base_url: str = "",
     linear_project_id: str = "",
     linear_issue_number: str = "",
     triggering_user_identity: CollaboratorIdentity | None = None,
@@ -374,6 +385,7 @@ def construct_system_prompt(
         commit_identity_email = shlex.quote(OPEN_SWE_BOT_EMAIL)
     return SYSTEM_PROMPT_TEMPLATE.format(
         working_dir=working_dir,
+        dashboard_base_url=dashboard_base_url or "(dashboard URL unavailable)",
         linear_project_id=linear_project_id or "<PROJECT_ID>",
         linear_issue_number=linear_issue_number or "<ISSUE_NUMBER>",
         plan_review_url=plan_url or "(the dashboard plan-review page)",

--- a/agent/resources/default_prompt.md
+++ b/agent/resources/default_prompt.md
@@ -2,6 +2,12 @@
 
 When a repository is not explicitly mentioned, use the repository provided in the run metadata or dashboard settings. Do not assume a hardcoded repository name.
 
-## Notion Access
+## Dashboard UI Map
 
-When asked how to give Open SWE access to Notion, answer directly without investigating first: open Profile Settings at https://openswe.vercel.app/my-settings, find the Notion integration, click **Connect Notion**, and complete the Notion OAuth flow.
+Dashboard paths are relative to the active deployment's base URL, configured by `DASHBOARD_BASE_URL`; use the deployment URL from the run context rather than assuming a hosted domain.
+
+- **Agents** (`/agents`): start or continue agent conversations and inspect their work.
+- **Profile Settings** (`/my-settings`): manage Slack identity mapping, pull request and review preferences, personal instructions, notifications, and user-scoped Currents.dev and Notion connections. **Connect Notion** starts the Notion OAuth flow.
+- **Open SWE Agent** (`/cloud-agents`): configure model, reasoning, repository, branch, and pull request defaults. **Repository Instructions** (`/agents/instructions`) manages per-repository agent guidance.
+- **Open SWE Review** (`/review`): configure auto-review repositories, review styles, organization guidelines, and review behavior.
+- **Usage** (`/usage`): view agent usage and reviewer statistics.

--- a/agent/resources/default_prompt.md
+++ b/agent/resources/default_prompt.md
@@ -4,7 +4,7 @@ When a repository is not explicitly mentioned, use the repository provided in th
 
 ## Dashboard UI Map
 
-Dashboard paths are relative to the active deployment's base URL, configured by `DASHBOARD_BASE_URL`; use the deployment URL from the run context rather than assuming a hosted domain.
+Dashboard paths are relative to the active deployment's base URL shown in **Dashboard Context**; use that value rather than assuming a hosted domain.
 
 - **Agents** (`/agents`): start or continue agent conversations and inspect their work.
 - **Profile Settings** (`/my-settings`): manage Slack identity mapping, pull request and review preferences, personal instructions, notifications, and user-scoped Currents.dev and Notion connections. **Connect Notion** starts the Notion OAuth flow.

--- a/agent/resources/default_prompt.md
+++ b/agent/resources/default_prompt.md
@@ -1,3 +1,7 @@
 # Default Prompt
 
 When a repository is not explicitly mentioned, use the repository provided in the run metadata or dashboard settings. Do not assume a hardcoded repository name.
+
+## Notion Access
+
+When asked how to give Open SWE access to Notion, answer directly without investigating first: open Profile Settings at https://openswe.vercel.app/my-settings, find the Notion integration, click **Connect Notion**, and complete the Notion OAuth flow.

--- a/agent/server.py
+++ b/agent/server.py
@@ -140,7 +140,7 @@ from .utils.authorship import (
     OPEN_SWE_BOT_NAME,
     resolve_triggering_user_identity,
 )
-from .utils.dashboard_links import dashboard_plan_url, dashboard_thread_url
+from .utils.dashboard_links import dashboard_base_url, dashboard_plan_url, dashboard_thread_url
 from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import get_github_app_installation_token_with_expiry
 from .utils.github_org_membership import is_user_active_org_member
@@ -937,6 +937,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             "work_dir": work_dir,
             "rendered_system_prompt": construct_system_prompt(
                 working_dir=work_dir,
+                dashboard_base_url=dashboard_base_url(),
                 linear_project_id=self._linear_project_id,
                 linear_issue_number=self._linear_issue_number,
                 triggering_user_identity=triggering_user_identity,

--- a/agent/utils/dashboard_links.py
+++ b/agent/utils/dashboard_links.py
@@ -6,13 +6,14 @@ from urllib.parse import quote
 _DEFAULT_DASHBOARD_BASE_URL = "https://openswe.vercel.app"
 
 
-def _dashboard_base_url() -> str:
+def dashboard_base_url() -> str:
+    """Return the configured dashboard base URL."""
     return os.environ.get("DASHBOARD_BASE_URL", _DEFAULT_DASHBOARD_BASE_URL).strip().rstrip("/")
 
 
 def dashboard_thread_url(thread_id: str) -> str | None:
     """Build the dashboard thread URL for a given thread id."""
-    base_url = _dashboard_base_url()
+    base_url = dashboard_base_url()
     if not base_url or not thread_id:
         return None
     return f"{base_url}/agents/{quote(thread_id, safe='')}"
@@ -20,7 +21,7 @@ def dashboard_thread_url(thread_id: str) -> str | None:
 
 def dashboard_plan_url(thread_id: str) -> str | None:
     """Build the dashboard plan-review URL for a given thread id."""
-    base_url = _dashboard_base_url()
+    base_url = dashboard_base_url()
     if not base_url or not thread_id:
         return None
     return f"{base_url}/agents/{quote(thread_id, safe='')}/plan"
@@ -36,7 +37,7 @@ def dashboard_workflow_approval_url(thread_id: str, fingerprint: str) -> str | N
 
 def dashboard_review_url(owner: str, repo: str, pr_number: int) -> str | None:
     """Build the dashboard review-detail URL for a PR."""
-    base_url = _dashboard_base_url()
+    base_url = dashboard_base_url()
     if not base_url or not owner or not repo or not pr_number:
         return None
     return (

--- a/tests/dashboard/test_dashboard_links.py
+++ b/tests/dashboard/test_dashboard_links.py
@@ -3,6 +3,12 @@ import importlib
 from agent.utils import dashboard_links
 
 
+def test_dashboard_base_url_uses_configured_deployment(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", " https://dashboard.example/ ")
+
+    assert dashboard_links.dashboard_base_url() == "https://dashboard.example"
+
+
 def test_dashboard_review_url_points_to_reviews_page(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://example.com")
     importlib.reload(dashboard_links)

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -134,9 +134,12 @@ def test_construct_system_prompt_identifies_own_repo() -> None:
 
 
 def test_construct_system_prompt_includes_dashboard_ui_map() -> None:
-    prompt = construct_system_prompt(working_dir="/workspace")
+    prompt = construct_system_prompt(
+        working_dir="/workspace", dashboard_base_url="https://dashboard.example"
+    )
 
-    assert "DASHBOARD_BASE_URL" in prompt
+    assert "Dashboard Context" in prompt
+    assert "https://dashboard.example" in prompt
     assert "Profile Settings" in prompt
     assert "/my-settings" in prompt
     assert "Connect Notion" in prompt

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -133,13 +133,17 @@ def test_construct_system_prompt_identifies_own_repo() -> None:
     assert "Open SWE" in prompt
 
 
-def test_construct_system_prompt_includes_notion_access_setup() -> None:
+def test_construct_system_prompt_includes_dashboard_ui_map() -> None:
     prompt = construct_system_prompt(working_dir="/workspace")
 
-    assert "https://openswe.vercel.app/my-settings" in prompt
+    assert "DASHBOARD_BASE_URL" in prompt
+    assert "Profile Settings" in prompt
+    assert "/my-settings" in prompt
     assert "Connect Notion" in prompt
-    assert "complete the Notion OAuth flow" in prompt
-    assert "answer directly without investigating first" in prompt
+    assert "/cloud-agents" in prompt
+    assert "/agents/instructions" in prompt
+    assert "/review" in prompt
+    assert "https://openswe.vercel.app/my-settings" not in prompt
 
 
 def test_shared_base_requires_terse_slack_replies_with_share_path() -> None:

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -133,6 +133,15 @@ def test_construct_system_prompt_identifies_own_repo() -> None:
     assert "Open SWE" in prompt
 
 
+def test_construct_system_prompt_includes_notion_access_setup() -> None:
+    prompt = construct_system_prompt(working_dir="/workspace")
+
+    assert "https://openswe.vercel.app/my-settings" in prompt
+    assert "Connect Notion" in prompt
+    assert "complete the Notion OAuth flow" in prompt
+    assert "answer directly without investigating first" in prompt
+
+
 def test_shared_base_requires_terse_slack_replies_with_share_path() -> None:
     from agent.prompt import OPEN_SWE_SHARED_BASE
 

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -135,11 +135,11 @@ def test_construct_system_prompt_identifies_own_repo() -> None:
 
 def test_construct_system_prompt_includes_dashboard_ui_map() -> None:
     prompt = construct_system_prompt(
-        working_dir="/workspace", dashboard_base_url="https://dashboard.example"
+        working_dir="/workspace", dashboard_base_url="deployment-dashboard-base"
     )
 
     assert "Dashboard Context" in prompt
-    assert "https://dashboard.example" in prompt
+    assert "deployment-dashboard-base" in prompt
     assert "Profile Settings" in prompt
     assert "/my-settings" in prompt
     assert "Connect Notion" in prompt


### PR DESCRIPTION
## Description
Give future Open SWE agents a compact map of dashboard features and routes so they can answer setup questions from embedded product knowledge. Each run now receives its deployment-specific dashboard base URL in system context, so self-hosted links resolve correctly.

## Release Note
Open SWE now understands common dashboard locations and receives the active deployment URL in context.

## Test Plan
- [x] Construct a prompt with a custom dashboard URL and verify the deployment context and UI map.
- [x] Verify dashboard URL normalization and existing route builders.

Made by [Open SWE](https://openswe.vercel.app/agents/f7d3c7f3-c702-4dbe-8610-7da0f9905763)
