### PR TITLE
fix: auto-open plan panel instead of in-progress plan banner

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { CircleAlert as CircleAlertIcon, Map as MapIcon } from "lucide-react"
 
@@ -10,6 +10,7 @@ import type {
 import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
 import type { AgentPanelTab } from "@/features/agents/components/AgentGitPanel"
 import { Alert, AlertAction, AlertDescription } from "@/components/ui/alert"
+import { useSidebarCollapsed } from "@/components/sidebar-layout"
 import { AgentGitPanel } from "@/features/agents/components/AgentGitPanel"
 import { PANEL_MIN_CHAT_WIDTH } from "@/features/agents/components/AgentPanelShell"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
@@ -89,6 +90,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   const sendMessage = useSubmitAgentMessage(thread.id)
   const stream = useAgentThreadStream()
   const isMobile = useIsMobile()
+  const sidebarCollapsed = useSidebarCollapsed()
   const skills = useAgentSkills()
 
   const { models, defaultSelection } = useModelOptions()
@@ -125,6 +127,20 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
     },
     [thread.id]
   )
+  // The plan renders in the panel, so open it as soon as the agent finishes
+  // writing rather than banner-nagging while it works. Mobile is excluded: there
+  // the panel is a full-screen overlay that would hide the conversation.
+  const planStatus = thread.planStatus
+  const planReady = planStatus === "ready" || planStatus === "shared"
+  const lastPlanStatus = useRef<string | null | undefined>(undefined)
+  useEffect(() => {
+    const previous = lastPlanStatus.current
+    lastPlanStatus.current = planStatus
+    if (isMobile || !planReady || previous === planStatus) return
+    setPanelTab("plan")
+    handlePanelCollapsedChange(false)
+  }, [handlePanelCollapsedChange, isMobile, planReady, planStatus])
+
   const [revealFilePath, setRevealFilePath] = useState<string | null>(null)
   const handleOpenFile = useCallback(
     (filePath: string) => {
@@ -221,50 +237,45 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
           threadId={thread.id}
           pollWhileActive={isStreaming}
         />
-        {thread.planStatus &&
-          thread.planStatus !== "approved" &&
-          thread.planStatus !== "cancelled" && (
-            <div
-              className={cn(
-                "mx-auto w-full max-w-3xl shrink-0 px-4 pt-3",
-                // The collapsed panel floats a fixed expand button in the
-                // top-right corner; clear it so it never covers "Review plan →".
-                panelCollapsed && "pr-14"
-              )}
+        {planReady && (
+          <div
+            className={cn(
+              "mx-auto w-full max-w-3xl shrink-0 px-4 pt-3",
+              // Both collapsed panels float a fixed expand button in a top
+              // corner; clear them so neither covers the banner.
+              sidebarCollapsed && "pl-14",
+              panelCollapsed && "pr-14"
+            )}
+          >
+            <button
+              type="button"
+              data-testid="review-plan-link"
+              className="block w-full rounded-xl text-left transition-colors hover:bg-info/8"
+              onClick={() => {
+                setPanelTab("plan")
+                handlePanelCollapsedChange(false)
+              }}
             >
-              <button
-                type="button"
-                data-testid="review-plan-link"
-                className="block w-full rounded-xl text-left transition-colors hover:bg-info/8"
-                onClick={() => {
-                  setPanelTab("plan")
-                  handlePanelCollapsedChange(false)
-                }}
-              >
-                <Alert variant="info">
-                  <MapIcon />
-                  <AlertDescription>
-                    <span className="text-foreground">
-                      {thread.planStatus === "ready"
-                        ? "A plan is ready for your review."
-                        : thread.planStatus === "shared"
-                          ? "The agent shared a longer response."
-                          : thread.planStatus === "revising"
-                            ? "The agent is revising the plan."
-                            : "The agent is writing a plan."}
-                    </span>
-                  </AlertDescription>
-                  <AlertAction>
-                    <span className="text-xs font-medium text-info-foreground">
-                      {thread.planStatus === "shared"
-                        ? "Open response →"
-                        : "Review plan →"}
-                    </span>
-                  </AlertAction>
-                </Alert>
-              </button>
-            </div>
-          )}
+              <Alert variant="info">
+                <MapIcon />
+                <AlertDescription>
+                  <span className="text-foreground">
+                    {planStatus === "shared"
+                      ? "The agent shared a longer response."
+                      : "A plan is ready for your review."}
+                  </span>
+                </AlertDescription>
+                <AlertAction>
+                  <span className="text-xs font-medium text-info-foreground">
+                    {planStatus === "shared"
+                      ? "Open response →"
+                      : "Review plan →"}
+                  </span>
+                </AlertAction>
+              </Alert>
+            </button>
+          </div>
+        )}
         {hasConversation ? (
           <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
             <Messages

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -132,7 +132,10 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   // the panel is a full-screen overlay that would hide the conversation.
   const planStatus = thread.planStatus
   const planReady = planStatus === "ready" || planStatus === "shared"
-  const lastPlanStatus = useRef<string | null | undefined>(undefined)
+  // Seeded from the mount status (the view is keyed by thread id and only
+  // renders once the thread has loaded) so revisiting a thread with an
+  // already-ready plan keeps the user's collapsed preference.
+  const lastPlanStatus = useRef<string | null | undefined>(planStatus)
   useEffect(() => {
     const previous = lastPlanStatus.current
     lastPlanStatus.current = planStatus


### PR DESCRIPTION
## Description
The plan renders in the side panel now, so the "The agent is writing a plan" / "revising" banner is noise — and it sat under the collapsed nav sidebar's fixed expand button. The banner now only shows when there is something to review (`ready` / `shared`), the panel opens on the Plan tab automatically when the plan lands (desktop only; on mobile the panel is a full-screen overlay), and the banner clears the sidebar's floating button when collapsed. Slack behaviour is unchanged.

## Release Note
Dashboard opens the plan panel automatically when a plan is ready instead of showing an in-progress plan banner.

## Test Plan
- [ ] Run a plan-mode thread: no banner while writing, panel opens on the Plan tab when the plan is ready.
- [ ] Collapse the left sidebar with a ready plan: the banner text is not covered by the expand button.

Made by [Open SWE](https://openswe.vercel.app/agents/019feda7-fd22-75f9-91d5-11941694be7e)