### PR TITLE
fix: improve agents chat legibility and surface contrast

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -176,7 +176,7 @@ export function AgentsSidebar({
         <Link
           to="/agents"
           onClick={layout.closeOnMobile}
-          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
+          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
         >
           <PlusIcon className="size-4" />
           New Agent
@@ -191,7 +191,7 @@ export function AgentsSidebar({
               key={item.to}
               to={item.to}
               onClick={layout.closeOnMobile}
-              className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+              className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
               activeProps={{
                 className: "bg-sidebar-row-hover !text-foreground font-medium",
               }}
@@ -460,7 +460,9 @@ function LocalThreadRow({
       ) : (
         <span className="size-2 shrink-0 rounded-full bg-border" />
       )}
-      <span className="min-w-0 flex-1 truncate text-xs">{session.title}</span>
+      <span className="min-w-0 flex-1 truncate text-[13px]">
+        {session.title}
+      </span>
     </Link>
   )
 }
@@ -561,7 +563,7 @@ function ResolvedThreadGroup({
               to="/agents/threads"
               search={{ resolved: true, page: 1 }}
               onClick={onNavigate}
-              className="mt-0.5 flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+              className="mt-0.5 flex items-center gap-1 rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
             >
               Show all
             </Link>
@@ -679,7 +681,7 @@ function ThreadRow({
               <title>{source.label}</title>
             </SourceIcon>
           )}
-          <span className="min-w-0 flex-1 truncate text-xs">
+          <span className="min-w-0 flex-1 truncate text-[13px]">
             {thread.title}
           </span>
           {!compact && prMeta && PrIcon && (

--- a/ui/src/features/agents/components/chat/Markdown.tsx
+++ b/ui/src/features/agents/components/chat/Markdown.tsx
@@ -31,17 +31,17 @@ const STREAMDOWN_ANIMATED = {
 
 const STREAMDOWN_COMPONENTS = {
   h1: ({ children }: { children?: ReactNode }) => (
-    <div className="mt-4 mb-1.5 text-[15px] font-medium tracking-tight text-foreground">
+    <div className="mt-4 mb-1.5 text-[17px] font-medium tracking-tight text-foreground">
       {children}
     </div>
   ),
   h2: ({ children }: { children?: ReactNode }) => (
-    <div className="mt-3 mb-1.5 text-[14px] font-medium tracking-tight text-foreground">
+    <div className="mt-3 mb-1.5 text-[15px] font-medium tracking-tight text-foreground">
       {children}
     </div>
   ),
   h3: ({ children }: { children?: ReactNode }) => (
-    <div className="mt-3 mb-1 text-[13px] font-medium text-foreground">
+    <div className="mt-3 mb-1 text-[14px] font-medium text-foreground">
       {children}
     </div>
   ),
@@ -175,7 +175,7 @@ export const Markdown = memo(function Markdown({
   }, [transformImageUrl])
 
   return (
-    <div className="max-w-full min-w-0 text-[13px] leading-6 [overflow-wrap:anywhere] break-words [&_.streamdown]:text-foreground">
+    <div className="max-w-full min-w-0 text-[14px] leading-[1.6] [overflow-wrap:anywhere] break-words [&_.streamdown]:text-foreground">
       <MarkdownErrorBoundary content={content}>
         <Streamdown
           mode={isLive ? "streaming" : "static"}

--- a/ui/src/features/agents/components/chat/ReplyCard.tsx
+++ b/ui/src/features/agents/components/chat/ReplyCard.tsx
@@ -179,7 +179,7 @@ export const ReplyCard = memo(function ReplyCard({ chunk }: ReplyCardProps) {
       </div>
       {body && (
         <div className="overflow-hidden rounded-xl border border-border/60 bg-muted/40">
-          <div className="max-h-[250px] overflow-auto px-3 py-2 text-[13px] text-foreground">
+          <div className="max-h-[250px] overflow-auto px-3 py-2 text-[14px] text-foreground">
             {isLinear ? (
               <Markdown content={body} />
             ) : blocks ? (

--- a/ui/src/features/agents/components/composer/ComposerPromptEditor.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPromptEditor.tsx
@@ -540,7 +540,7 @@ function ComposerPromptEditorInner({
             aria-label="Message"
             aria-placeholder={placeholder}
             className={cn(
-              "block max-h-50 w-full overflow-y-auto bg-transparent text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground focus:outline-none",
+              "block max-h-50 w-full overflow-y-auto bg-transparent text-[14px] leading-relaxed break-words whitespace-pre-wrap text-foreground focus:outline-none",
               className
             )}
             data-testid="composer-editor"
@@ -549,7 +549,7 @@ function ComposerPromptEditorInner({
           />
         }
         placeholder={
-          <div className="pointer-events-none absolute inset-0 text-[13px] leading-relaxed text-muted-foreground/60">
+          <div className="pointer-events-none absolute inset-0 text-[14px] leading-relaxed text-muted-foreground/60">
             {placeholder}
           </div>
         }

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -32,7 +32,7 @@ function QueuedMessages({
         return (
           <div
             key={message.id}
-            className="ml-auto max-w-[85%] rounded-2xl border border-dashed border-border bg-accent/40 px-3 py-2 text-[13px] text-foreground shadow-sm"
+            className="ml-auto max-w-[85%] rounded-2xl border border-dashed border-border bg-accent/40 px-3 py-2 text-[14px] text-foreground shadow-sm"
             data-testid="queued-message"
           >
             <div className="mb-1 flex items-center gap-2 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
@@ -255,7 +255,7 @@ export const Messages = memo(function MessagesComponent({
       <div className="relative min-h-0 min-w-0 flex-1">
         <div
           ref={scrollRef}
-          className="h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto py-5 text-[13px] leading-6 antialiased"
+          className="h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto py-5 text-[14px] leading-[1.6] antialiased"
         >
           <div
             ref={contentRef}

--- a/ui/src/features/agents/components/messages/ReasoningBlock.tsx
+++ b/ui/src/features/agents/components/messages/ReasoningBlock.tsx
@@ -56,21 +56,21 @@ export function ReasoningBlock({
         disabled={isLive}
       >
         {isLive ? (
-          <span className="shimmer-text text-xs">Thinking...</span>
+          <span className="shimmer-text text-[13px]">Thinking...</span>
         ) : (
           <>
             <ChevronRight
               className={`size-3 shrink-0 text-muted-foreground/65 transition-transform ${expanded ? "rotate-90" : ""}`}
               aria-hidden
             />
-            <span className="text-xs text-muted-foreground">
+            <span className="text-[13px] text-muted-foreground">
               {reasoningLabel(elapsedMs)}
             </span>
           </>
         )}
       </button>
       {expanded && trimmed && (
-        <div className="ms-1 mt-1 border-s border-border/45 ps-3 text-[12px] leading-5 break-words whitespace-pre-wrap text-muted-foreground">
+        <div className="ms-1 mt-1 border-s border-border/45 ps-3 text-[13px] leading-5 break-words whitespace-pre-wrap text-muted-foreground">
           {trimmed}
         </div>
       )}

--- a/ui/src/features/agents/components/messages/UserMessage.tsx
+++ b/ui/src/features/agents/components/messages/UserMessage.tsx
@@ -59,7 +59,7 @@ export function UserMessage({ message }: { message: Message }) {
               <div
                 ref={textRef}
                 onScroll={updateScrollIndicators}
-                className="max-h-[250px] overflow-auto text-[13px] leading-6 break-words whitespace-pre-wrap text-accent-foreground"
+                className="max-h-[250px] overflow-auto text-[14px] leading-[1.6] break-words whitespace-pre-wrap text-accent-foreground"
                 style={{
                   maskImage: textEdgeMask,
                   WebkitMaskImage: textEdgeMask,

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -175,7 +175,7 @@ export function WorkEntryRow({
 
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <div className="min-w-0 flex-1 overflow-hidden">
-            <p className="flex w-full min-w-0 items-baseline gap-1.5 text-[12px] leading-5">
+            <p className="flex w-full min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
               <span
                 className={cn(
                   "min-w-0 shrink truncate font-medium",
@@ -185,14 +185,14 @@ export function WorkEntryRow({
                 {entry.heading}
               </span>
               {entry.preview && (
-                <span className="min-w-0 flex-1 truncate text-muted-foreground/55">
+                <span className="min-w-0 flex-1 truncate text-muted-foreground">
                   {entry.preview}
                 </span>
               )}
             </p>
           </div>
 
-          <div className="flex shrink-0 items-center gap-1 text-muted-foreground/55">
+          <div className="flex shrink-0 items-center gap-1 text-muted-foreground">
             {trailing}
             {hoverTimestamp && (
               <time className="text-[10px] tabular-nums opacity-0 transition-opacity group-hover/entry:opacity-100">
@@ -227,7 +227,7 @@ export function WorkEntryRow({
           onPointerDown={stopRowToggle}
         >
           {body ?? (
-            <pre className="max-h-64 cursor-text overflow-auto font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap text-muted-foreground select-text">
+            <pre className="max-h-64 cursor-text overflow-auto font-mono text-[12px] leading-relaxed break-words whitespace-pre-wrap text-muted-foreground select-text">
               {entry.expandedText}
             </pre>
           )}

--- a/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
+++ b/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
@@ -14,21 +14,21 @@ export const ShellEntryBody = memo(function ShellEntryBody({
   return (
     <div className="space-y-1.5">
       {command && (
-        <pre className="cursor-text overflow-x-auto font-mono text-[11px] leading-relaxed whitespace-pre text-foreground/85 select-text">
-          <span className="text-muted-foreground/60">$ </span>
+        <pre className="cursor-text overflow-x-auto font-mono text-[12px] leading-relaxed whitespace-pre text-foreground/85 select-text">
+          <span className="text-muted-foreground/80">$ </span>
           {command}
         </pre>
       )}
       {output && (
-        <pre className="max-h-64 cursor-text overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre text-muted-foreground select-text">
+        <pre className="max-h-64 cursor-text overflow-auto font-mono text-[12px] leading-relaxed whitespace-pre text-muted-foreground select-text">
           {output}
         </pre>
       )}
       {!output && chunk.status === "in_progress" && (
-        <p className="font-mono text-[11px] text-muted-foreground">Running…</p>
+        <p className="font-mono text-[12px] text-muted-foreground">Running…</p>
       )}
       {!output && chunk.status === "pending" && (
-        <p className="font-mono text-[11px] text-warning-foreground">
+        <p className="font-mono text-[12px] text-warning-foreground">
           Waiting for approval…
         </p>
       )}

--- a/ui/src/features/agents/components/messages/timeline/foldRows.tsx
+++ b/ui/src/features/agents/components/messages/timeline/foldRows.tsx
@@ -23,7 +23,7 @@ export function TurnFoldRow({
         type="button"
         aria-expanded={expanded}
         onClick={onToggle}
-        className="flex cursor-pointer items-center gap-1 rounded-md px-1 text-xs text-muted-foreground tabular-nums transition-colors select-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:outline-none focus-visible:ring-inset"
+        className="flex cursor-pointer items-center gap-1 rounded-md px-1 text-[13px] text-muted-foreground tabular-nums transition-colors select-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:outline-none focus-visible:ring-inset"
       >
         <span>{label}</span>
         <Icon className="size-3.5" />

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -71,7 +71,7 @@ html.dark[data-agents-theme] {
 
   --background: oklch(22.6% 0 0); /* soft charcoal, not black */
   --app-chrome-background: var(--background);
-  --foreground: oklch(97% 0 0); /* neutral-100 */
+  --foreground: #fff;
   --card: color-mix(in srgb, var(--background) 92%, #fff);
   --card-foreground: var(--foreground);
   --surface-raised: var(--secondary);
@@ -82,7 +82,7 @@ html.dark[data-agents-theme] {
   --secondary: color-mix(in srgb, #fff 4%, transparent);
   --secondary-foreground: var(--foreground);
   --muted: color-mix(in srgb, #fff 4%, transparent);
-  --muted-foreground: oklch(72% 0 0);
+  --muted-foreground: oklch(85% 0 0);
   --accent: color-mix(in srgb, #fff 4%, transparent);
   --accent-foreground: var(--foreground);
   --destructive: color-mix(in srgb, oklch(63.7% 0.237 25.331) 90%, #fff);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -34,7 +34,7 @@ html[data-agents-theme] {
   --secondary: oklch(96.3% 0.002 106);
   --secondary-foreground: var(--foreground);
   --muted: oklch(96.3% 0.002 106);
-  --muted-foreground: oklch(55.2% 0.016 285.938); /* zinc-500 */
+  --muted-foreground: oklch(48% 0.016 285.938); /* zinc-600 */
   --accent: oklch(94.2% 0.003 106);
   --accent-foreground: oklch(21% 0.006 285.885); /* zinc-900 */
   --destructive: oklch(63.7% 0.237 25.331); /* red-500 */
@@ -72,17 +72,17 @@ html.dark[data-agents-theme] {
   --background: oklch(22.6% 0 0); /* soft charcoal, not black */
   --app-chrome-background: var(--background);
   --foreground: oklch(97% 0 0); /* neutral-100 */
-  --card: color-mix(in srgb, var(--background) 97%, #fff);
+  --card: color-mix(in srgb, var(--background) 92%, #fff);
   --card-foreground: var(--foreground);
   --surface-raised: var(--secondary);
-  --popover: color-mix(in srgb, var(--background) 94%, #fff);
+  --popover: color-mix(in srgb, var(--background) 88%, #fff);
   --popover-foreground: var(--foreground);
   --primary: oklch(0.588 0.217 264);
   --primary-foreground: #fff;
   --secondary: color-mix(in srgb, #fff 4%, transparent);
   --secondary-foreground: var(--foreground);
   --muted: color-mix(in srgb, #fff 4%, transparent);
-  --muted-foreground: color-mix(in srgb, oklch(55.6% 0 0) 90%, #fff);
+  --muted-foreground: oklch(72% 0 0);
   --accent: color-mix(in srgb, #fff 4%, transparent);
   --accent-foreground: var(--foreground);
   --destructive: color-mix(in srgb, oklch(63.7% 0.237 25.331) 90%, #fff);
@@ -93,7 +93,7 @@ html.dark[data-agents-theme] {
   --success-foreground: oklch(76.5% 0.177 163.223); /* emerald-400 */
   --warning: oklch(76.9% 0.188 70.08);
   --warning-foreground: oklch(82.8% 0.189 84.429); /* amber-400 */
-  --border: color-mix(in srgb, #fff 9%, transparent);
+  --border: color-mix(in srgb, #fff 14%, transparent);
   --input: color-mix(in srgb, #fff 12%, transparent);
   --ring: oklch(0.588 0.217 264);
 
@@ -125,8 +125,8 @@ html[data-agents-theme] {
  */
 .agents-ui {
   color: var(--foreground);
-  font-size: 13px;
-  line-height: 1.45;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .agents-ui *,


### PR DESCRIPTION
## Description

Improves Agents UI legibility with larger chat, timeline, composer, and sidebar text plus stronger surface separation.

Dark mode now uses true white for primary text and 85% lightness for secondary text, keeping `/60`–`/70` metadata visibly subordinate without making it hard to read. Light-mode secondary text is also darker for better contrast.

## Release Note

Agents chat text is larger, brighter, and easier to read, especially in dark mode.

## Test Plan

- `pnpm run build`
- Verify primary and secondary text in light and dark Agents views

Made by [Open SWE](https://openswe.vercel.app/agents/019fed9e-e0f6-7495-b346-84b9a5515d1d)