### PR TITLE
feat: git diff panel for desktop local mode sessions

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -17,6 +17,9 @@ app's local data and can be selected from the **This Mac** submenu or managed fr
 dcode runs are ephemeral: their sessions remain available only for the lifetime of the desktop
 process and cannot be resumed after it exits.
 
+The side panel's **Changes** tab diffs the project against a git snapshot taken when the session
+started, so it shows what the agent changed and not the working tree's prior state.
+
 ## How it connects
 
 The bundled UI runs at an internal `open-swe://app` origin. Electron proxies its

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "dev": "pnpm run build:ui && electron . --dev",
     "start": "pnpm run build:ui && electron .",
     "test": "node --test test/*.test.cjs",
-    "check": "node --check src/config.cjs && node --check src/acp-client.cjs && node --check src/project-store.cjs && node --check src/terminal-manager.cjs && node --check src/main.cjs && node --check src/preload.cjs && pnpm run test && pnpm run build:ui",
+    "check": "node --check src/config.cjs && node --check src/acp-client.cjs && node --check src/git-diff.cjs && node --check src/project-store.cjs && node --check src/terminal-manager.cjs && node --check src/main.cjs && node --check src/preload.cjs && pnpm run test && pnpm run build:ui",
     "pack": "pnpm run build:ui && electron-builder --dir",
     "dist": "pnpm run build:ui && electron-builder"
   },

--- a/desktop/src/git-diff.cjs
+++ b/desktop/src/git-diff.cjs
@@ -1,0 +1,209 @@
+const { execFile, execFileSync, spawn } = require("node:child_process")
+const fs = require("node:fs")
+const path = require("node:path")
+const { randomUUID } = require("node:crypto")
+
+const MAX_FILES = 200
+const MAX_FILE_BYTES = 400_000
+const MAX_OUTPUT_BYTES = 64 * 1024 * 1024
+const CHECKPOINT_NAMESPACE = "refs/open-swe/local"
+
+function git(cwd, args, env) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "git",
+      args,
+      { cwd, env: env || process.env, encoding: "buffer", maxBuffer: MAX_OUTPUT_BYTES },
+      (error, stdout) => (error ? reject(error) : resolve(stdout))
+    )
+  })
+}
+
+function gitStdin(cwd, args, input) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, { cwd, stdio: ["pipe", "pipe", "ignore"] })
+    const chunks = []
+    child.stdout.on("data", (chunk) => chunks.push(chunk))
+    child.on("error", reject)
+    child.on("close", () => resolve(Buffer.concat(chunks)))
+    child.stdin.end(input)
+  })
+}
+
+function text(buffer) {
+  return buffer.toString("utf8").trim()
+}
+
+function ok(promise) {
+  return promise.then(
+    () => true,
+    () => false
+  )
+}
+
+function checkpointRef(sessionId) {
+  return `${CHECKPOINT_NAMESPACE}/${sessionId.replace(/[^A-Za-z0-9._-]/g, "-")}`
+}
+
+async function repoRoot(cwd) {
+  try {
+    return text(await git(cwd, ["rev-parse", "--show-toplevel"])) || null
+  } catch {
+    return null
+  }
+}
+
+/** Snapshot the worktree (tracked + untracked, ignoring .gitignore) into a tree oid. */
+async function writeWorktreeTree(repo) {
+  const gitDir = text(await git(repo, ["rev-parse", "--absolute-git-dir"]))
+  const indexFile = path.join(gitDir, `open-swe-index-${randomUUID()}`)
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile }
+  try {
+    const hasHead = await ok(git(repo, ["rev-parse", "--verify", "-q", "HEAD"], env))
+    await git(repo, ["read-tree", ...(hasHead ? ["HEAD"] : ["--empty"])], env)
+    await git(repo, ["add", "-A", "--", "."], env)
+    return text(await git(repo, ["write-tree"], env))
+  } finally {
+    fs.rmSync(indexFile, { force: true })
+  }
+}
+
+async function captureCheckpoint(repo, ref) {
+  const tree = await writeWorktreeTree(repo)
+  const hasHead = await ok(git(repo, ["rev-parse", "--verify", "-q", "HEAD"]))
+  const commit = text(
+    await git(
+      repo,
+      ["commit-tree", tree, ...(hasHead ? ["-p", "HEAD"] : []), "-m", "open-swe-local-turn"],
+      {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Open SWE",
+        GIT_AUTHOR_EMAIL: "open-swe@users.noreply.github.com",
+        GIT_COMMITTER_NAME: "Open SWE",
+        GIT_COMMITTER_EMAIL: "open-swe@users.noreply.github.com",
+      }
+    )
+  )
+  await git(repo, ["update-ref", ref, commit])
+  return ref
+}
+
+/** Synchronous so it can also run from Electron's `before-quit`. */
+function deleteRefs(repo, refs) {
+  for (const ref of refs) {
+    try {
+      execFileSync("git", ["update-ref", "-d", ref], { cwd: repo, stdio: "ignore" })
+    } catch {}
+  }
+}
+
+/** Checkpoint refs in `repo` that no live session owns any more. */
+async function staleRefs(repo, liveRefs) {
+  const listed = await git(repo, [
+    "for-each-ref",
+    "--format=%(refname)",
+    CHECKPOINT_NAMESPACE,
+  ]).catch(() => Buffer.alloc(0))
+  return text(listed)
+    .split("\n")
+    .filter((ref) => ref && !liveRefs.includes(ref))
+}
+
+function parseNumstat(raw) {
+  const stats = []
+  for (const record of raw.split("\0")) {
+    const parts = record.split("\t")
+    if (parts.length !== 3 || !parts[2]) continue
+    stats.push({
+      path: parts[2],
+      additions: parts[0] === "-" ? null : Number(parts[0]),
+      deletions: parts[1] === "-" ? null : Number(parts[1]),
+    })
+  }
+  return stats
+}
+
+function parseNameStatus(raw) {
+  const fields = raw.split("\0").filter(Boolean)
+  const statuses = new Map()
+  for (let i = 0; i + 1 < fields.length; i += 2) {
+    const kind = fields[i][0]
+    statuses.set(fields[i + 1], kind === "A" ? "added" : kind === "D" ? "removed" : "modified")
+  }
+  return statuses
+}
+
+/** Both sides of every changed path in one `cat-file --batch`; `false` means too large. */
+async function readBlobs(repo, base, head, paths) {
+  const specs = paths.flatMap((file) => [`${base}:${file}`, `${head}:${file}`])
+  const output = await gitStdin(repo, ["cat-file", "--batch"], `${specs.join("\n")}\n`)
+  const blobs = []
+  let at = 0
+  for (let i = 0; i < specs.length; i++) {
+    const end = output.indexOf("\n", at)
+    if (end < 0) {
+      blobs.push(null)
+      continue
+    }
+    const header = output.subarray(at, end).toString("utf8").split(" ")
+    at = end + 1
+    if (header.length < 3) {
+      blobs.push(null)
+      continue
+    }
+    const size = Number(header[2])
+    blobs.push(size <= MAX_FILE_BYTES ? output.subarray(at, at + size) : false)
+    at += size + 1
+  }
+  return new Map(paths.map((file, i) => [file, { base: blobs[i * 2], head: blobs[i * 2 + 1] }]))
+}
+
+function decode(blob) {
+  if (blob === false) return [null, true]
+  if (!Buffer.isBuffer(blob)) return [null, false]
+  const content = blob.toString("utf8")
+  return content.includes("\u0000") ? [null, true] : [content, false]
+}
+
+/** Files changed between `base` and the live worktree, shaped like the cloud turn diff. */
+async function readDiff(repo, base) {
+  const head = await writeWorktreeTree(repo)
+  const range = ["--no-renames", base, head]
+  const numstat = (await git(repo, ["diff", "--numstat", "-z", ...range])).toString("utf8")
+  const nameStatus = (await git(repo, ["diff", "--name-status", "-z", ...range])).toString("utf8")
+  const stats = parseNumstat(numstat)
+  const statuses = parseNameStatus(nameStatus)
+  const shown = stats.slice(0, MAX_FILES)
+  const blobs = shown.length
+    ? await readBlobs(repo, base, head, shown.map((stat) => stat.path))
+    : new Map()
+
+  return {
+    status: "ready",
+    truncated: stats.length > MAX_FILES,
+    files: shown.map((stat) => {
+      const sides = blobs.get(stat.path) || {}
+      const [originalContent, badBase] = decode(sides.base)
+      const [modifiedContent, badHead] = decode(sides.head)
+      return {
+        path: stat.path,
+        previousPath: null,
+        status: statuses.get(stat.path) || "modified",
+        additions: stat.additions ?? 0,
+        deletions: stat.deletions ?? 0,
+        originalContent,
+        modifiedContent,
+        unrenderable: stat.additions === null || badBase || badHead,
+      }
+    }),
+  }
+}
+
+module.exports = {
+  captureCheckpoint,
+  checkpointRef,
+  deleteRefs,
+  readDiff,
+  repoRoot,
+  staleRefs,
+}

--- a/desktop/src/git-diff.cjs
+++ b/desktop/src/git-diff.cjs
@@ -5,14 +5,19 @@ const { randomUUID } = require("node:crypto")
 
 const MAX_FILES = 200
 const MAX_FILE_BYTES = 400_000
+const MAX_CONTENT_BYTES = 16 * 1024 * 1024
 const MAX_OUTPUT_BYTES = 64 * 1024 * 1024
 const CHECKPOINT_NAMESPACE = "refs/open-swe/local"
+
+// The project is whatever directory the user picked, so never let its git config
+// start helper processes of its own on our behalf.
+const HARDENED = ["-c", "core.fsmonitor=false", "-c", "core.untrackedCache=false"]
 
 function git(cwd, args, env) {
   return new Promise((resolve, reject) => {
     execFile(
       "git",
-      args,
+      [...HARDENED, ...args],
       { cwd, env: env || process.env, encoding: "buffer", maxBuffer: MAX_OUTPUT_BYTES },
       (error, stdout) => (error ? reject(error) : resolve(stdout))
     )
@@ -21,7 +26,10 @@ function git(cwd, args, env) {
 
 function gitStdin(cwd, args, input) {
   return new Promise((resolve, reject) => {
-    const child = spawn("git", args, { cwd, stdio: ["pipe", "pipe", "ignore"] })
+    const child = spawn("git", [...HARDENED, ...args], {
+      cwd,
+      stdio: ["pipe", "pipe", "ignore"],
+    })
     const chunks = []
     child.stdout.on("data", (chunk) => chunks.push(chunk))
     child.on("error", reject)
@@ -133,28 +141,63 @@ function parseNameStatus(raw) {
   return statuses
 }
 
-/** Both sides of every changed path in one `cat-file --batch`; `false` means too large. */
-async function readBlobs(repo, base, head, paths) {
-  const specs = paths.flatMap((file) => [`${base}:${file}`, `${head}:${file}`])
+/** Blob sizes for each spec: `null` when the spec does not resolve. */
+async function readBlobSizes(repo, specs) {
+  const output = await gitStdin(repo, ["cat-file", "--batch-check"], `${specs.join("\n")}\n`)
+  return output
+    .toString("utf8")
+    .split("\n")
+    .slice(0, specs.length)
+    .map((line) => {
+      const fields = line.split(" ")
+      return fields.length === 3 && fields[1] === "blob" ? Number(fields[2]) : null
+    })
+}
+
+/** Bodies of `specs`, in order, from one `cat-file --batch`. */
+async function readBlobBodies(repo, specs) {
   const output = await gitStdin(repo, ["cat-file", "--batch"], `${specs.join("\n")}\n`)
-  const blobs = []
+  const bodies = []
   let at = 0
   for (let i = 0; i < specs.length; i++) {
     const end = output.indexOf("\n", at)
-    if (end < 0) {
-      blobs.push(null)
-      continue
-    }
+    if (end < 0) break
     const header = output.subarray(at, end).toString("utf8").split(" ")
     at = end + 1
     if (header.length < 3) {
-      blobs.push(null)
+      bodies.push(null)
       continue
     }
     const size = Number(header[2])
-    blobs.push(size <= MAX_FILE_BYTES ? output.subarray(at, at + size) : false)
+    bodies.push(output.subarray(at, at + size))
     at += size + 1
   }
+  return bodies
+}
+
+/**
+ * Both sides of every changed path, `false` when too large to render. Sizes are
+ * checked before any content is read so one huge file cannot balloon the main
+ * process, and the whole read stays under a fixed budget.
+ */
+async function readBlobs(repo, base, head, paths) {
+  const specs = paths.flatMap((file) => [`${base}:${file}`, `${head}:${file}`])
+  const sizes = await readBlobSizes(repo, specs)
+  const wanted = []
+  let budget = MAX_CONTENT_BYTES
+  sizes.forEach((size, i) => {
+    if (size === null || size > MAX_FILE_BYTES || size > budget) return
+    budget -= size
+    wanted.push(i)
+  })
+
+  const bodies = wanted.length
+    ? await readBlobBodies(repo, wanted.map((i) => specs[i]))
+    : []
+  const blobs = sizes.map((size) => (size === null ? null : false))
+  wanted.forEach((specIndex, i) => {
+    blobs[specIndex] = bodies[i] ?? null
+  })
   return new Map(paths.map((file, i) => [file, { base: blobs[i * 2], head: blobs[i * 2 + 1] }]))
 }
 
@@ -168,7 +211,7 @@ function decode(blob) {
 /** Files changed between `base` and the live worktree, shaped like the cloud turn diff. */
 async function readDiff(repo, base) {
   const head = await writeWorktreeTree(repo)
-  const range = ["--no-renames", base, head]
+  const range = ["--no-renames", "--no-ext-diff", "--no-textconv", base, head]
   const numstat = (await git(repo, ["diff", "--numstat", "-z", ...range])).toString("utf8")
   const nameStatus = (await git(repo, ["diff", "--name-status", "-z", ...range])).toString("utf8")
   const stats = parseNumstat(numstat)

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -13,6 +13,14 @@ const {
   shell,
 } = require("electron")
 const { AcpSession, dcodeTarget } = require("./acp-client.cjs")
+const {
+  captureCheckpoint,
+  checkpointRef,
+  deleteRefs,
+  readDiff,
+  repoRoot,
+  staleRefs,
+} = require("./git-diff.cjs")
 const { closeAllTerminals, configureTerminalIpc } = require("./terminal-manager.cjs")
 const {
   addProject,
@@ -66,6 +74,9 @@ let backendUrl = null
 let mainWindow = null
 let setupWindow = null
 const acpSessions = new Map()
+// sessionId -> { repo, ref }: the worktree snapshot a local session started from, so
+// the diff panel can show what the agent changed rather than the repo's prior state.
+const acpCheckpoints = new Map()
 
 function requireTrustedDesktopIpc(event) {
   const senderUrl = event.senderFrame?.url || event.sender.getURL()
@@ -80,6 +91,22 @@ function sendAcpEvent(sessionId, event) {
       session: acpSessions.get(sessionId)?.summary(),
     })
   }
+}
+
+async function recordAcpCheckpoint(localSession) {
+  const repo = await repoRoot(localSession.cwd)
+  if (!repo) return
+  const ref = checkpointRef(localSession.id)
+  const live = [...acpCheckpoints.values()]
+    .filter((checkpoint) => checkpoint.repo === repo)
+    .map((checkpoint) => checkpoint.ref)
+  try {
+    // Refs from sessions this or an earlier process lost track of; never pushed,
+    // but they should not pile up in the user's own repository either.
+    deleteRefs(repo, await staleRefs(repo, [...live, ref]))
+    await captureCheckpoint(repo, ref)
+    acpCheckpoints.set(localSession.id, { repo, ref })
+  } catch {}
 }
 
 function projectsPath() {
@@ -172,6 +199,7 @@ function configureDesktopIpc() {
       localSession.close()
       throw error
     }
+    await recordAcpCheckpoint(localSession)
     void localSession.prompt(input.prompt || "", input.images || []).catch(() => {})
     return localSession.snapshot()
   })
@@ -192,6 +220,24 @@ function configureDesktopIpc() {
   ipcMain.handle("desktop:acp-session", (event, sessionId) => {
     requireTrustedDesktopIpc(event)
     return acpSessions.get(sessionId)?.snapshot() || null
+  })
+
+  ipcMain.handle("desktop:acp-diff", async (event, sessionId) => {
+    requireTrustedDesktopIpc(event)
+    const localSession = acpSessions.get(sessionId)
+    const checkpoint = acpCheckpoints.get(sessionId)
+    if (
+      !localSession ||
+      !checkpoint ||
+      !listProjects().some((project) => project.cwd === localSession.cwd)
+    ) {
+      return { status: "missing", files: [], truncated: false }
+    }
+    try {
+      return await readDiff(checkpoint.repo, checkpoint.ref)
+    } catch {
+      return { status: "error", files: [], truncated: false }
+    }
   })
 
   ipcMain.handle("desktop:acp-sessions", (event) => {
@@ -653,5 +699,7 @@ if (!hasSingleInstanceLock) {
     closeAllTerminals()
     for (const localSession of acpSessions.values()) localSession.close()
     acpSessions.clear()
+    for (const { repo, ref } of acpCheckpoints.values()) deleteRefs(repo, [ref])
+    acpCheckpoints.clear()
   })
 }

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   cancelAcpSession: (sessionId) => ipcRenderer.invoke("desktop:acp-cancel", sessionId),
   getAcpSession: (sessionId) => ipcRenderer.invoke("desktop:acp-session", sessionId),
   listAcpSessions: () => ipcRenderer.invoke("desktop:acp-sessions"),
+  getAcpDiff: (sessionId) => ipcRenderer.invoke("desktop:acp-diff", sessionId),
   onAcpEvent: (callback) => {
     const listener = (_event, payload) => callback(payload)
     ipcRenderer.on("desktop:acp-event", listener)

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -1,0 +1,57 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { execFileSync } = require("node:child_process")
+const fs = require("node:fs")
+const os = require("node:os")
+const path = require("node:path")
+
+const {
+  captureCheckpoint,
+  checkpointRef,
+  readDiff,
+  repoRoot,
+} = require("../src/git-diff.cjs")
+
+function git(cwd, args) {
+  execFileSync("git", args, { cwd, stdio: "ignore" })
+}
+
+test("diffs the worktree against a session checkpoint", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "open-swe-git-"))
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }))
+  git(dir, ["init", "-q", "-b", "main"])
+  git(dir, ["config", "user.email", "test@example.com"])
+  git(dir, ["config", "user.name", "Test"])
+  fs.writeFileSync(path.join(dir, "kept.txt"), "one\ntwo\n")
+  fs.writeFileSync(path.join(dir, "gone.txt"), "bye\n")
+  git(dir, ["add", "-A"])
+  git(dir, ["commit", "-qm", "init"])
+
+  const repo = await repoRoot(dir)
+  const ref = checkpointRef("session-id")
+  await captureCheckpoint(repo, ref)
+
+  fs.writeFileSync(path.join(dir, "kept.txt"), "one\ntwo\nthree\n")
+  fs.writeFileSync(path.join(dir, "added.txt"), "fresh\n")
+  fs.writeFileSync(path.join(dir, "binary.dat"), Buffer.from([0, 1, 2, 0]))
+  fs.rmSync(path.join(dir, "gone.txt"))
+
+  const diff = await readDiff(repo, ref)
+  assert.equal(diff.status, "ready")
+  assert.equal(diff.truncated, false)
+  assert.deepEqual(
+    diff.files.map((file) => [file.path, file.status, file.additions, file.deletions]),
+    [
+      ["added.txt", "added", 1, 0],
+      ["binary.dat", "added", 0, 0],
+      ["gone.txt", "removed", 0, 1],
+      ["kept.txt", "modified", 1, 0],
+    ]
+  )
+  const kept = diff.files.find((file) => file.path === "kept.txt")
+  assert.equal(kept.originalContent, "one\ntwo\n")
+  assert.equal(kept.modifiedContent, "one\ntwo\nthree\n")
+  assert.equal(kept.unrenderable, false)
+  assert.equal(diff.files.find((file) => file.path === "binary.dat").unrenderable, true)
+  assert.equal(diff.files.find((file) => file.path === "gone.txt").modifiedContent, null)
+})

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -34,6 +34,7 @@ test("diffs the worktree against a session checkpoint", async (t) => {
   fs.writeFileSync(path.join(dir, "kept.txt"), "one\ntwo\nthree\n")
   fs.writeFileSync(path.join(dir, "added.txt"), "fresh\n")
   fs.writeFileSync(path.join(dir, "binary.dat"), Buffer.from([0, 1, 2, 0]))
+  fs.writeFileSync(path.join(dir, "huge.txt"), "x".repeat(500_000))
   fs.rmSync(path.join(dir, "gone.txt"))
 
   const diff = await readDiff(repo, ref)
@@ -45,6 +46,7 @@ test("diffs the worktree against a session checkpoint", async (t) => {
       ["added.txt", "added", 1, 0],
       ["binary.dat", "added", 0, 0],
       ["gone.txt", "removed", 0, 1],
+      ["huge.txt", "added", 1, 0],
       ["kept.txt", "modified", 1, 0],
     ]
   )
@@ -54,4 +56,9 @@ test("diffs the worktree against a session checkpoint", async (t) => {
   assert.equal(kept.unrenderable, false)
   assert.equal(diff.files.find((file) => file.path === "binary.dat").unrenderable, true)
   assert.equal(diff.files.find((file) => file.path === "gone.txt").modifiedContent, null)
+
+  // Oversized blobs are never read into memory, only reported.
+  const huge = diff.files.find((file) => file.path === "huge.txt")
+  assert.equal(huge.unrenderable, true)
+  assert.equal(huge.modifiedContent, null)
 })

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -1,3 +1,4 @@
+import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
 import type { ImageChunk } from "@/features/agents/lib/types"
 
 export interface DesktopProject {
@@ -24,6 +25,13 @@ export interface DesktopAcpSessionSummary {
 
 export interface DesktopAcpSession extends DesktopAcpSessionSummary {
   events: Array<DesktopAcpEvent>
+}
+
+/** What a local session changed, shaped like the cloud thread's turn diff. */
+export interface DesktopAcpDiff {
+  status: "ready" | "missing" | "error"
+  truncated: boolean
+  files: Array<ThreadPrDiffFile>
 }
 
 export interface DesktopAcpPromptInput {
@@ -54,6 +62,7 @@ declare global {
       cancelAcpSession: (sessionId: string) => Promise<void>
       getAcpSession: (sessionId: string) => Promise<DesktopAcpSession | null>
       listAcpSessions: () => Promise<Array<DesktopAcpSessionSummary>>
+      getAcpDiff: (sessionId: string) => Promise<DesktopAcpDiff>
       onAcpEvent: (
         callback: (payload: {
           sessionId: string

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -1,22 +1,8 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { useQueryClient } from "@tanstack/react-query"
-import {
-  MultiFileDiff,
-  Virtualizer,
-  WorkerPoolContextProvider,
-} from "@pierre/diffs/react"
-import {
-  FileTree,
-  useFileTree,
-  useFileTreeSelection,
-} from "@pierre/trees/react"
-import { CaretDownIcon } from "@phosphor-icons/react"
-import type { FileContents } from "@pierre/diffs/react"
-import type { GitStatus, GitStatusEntry } from "@pierre/trees"
 
 import type { AgentThread } from "@/features/agents/lib/types"
-import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
 import { agentsApi } from "@/features/agents/lib/api"
 import {
   agentThreadKeys,
@@ -28,17 +14,11 @@ import { ReviewTab } from "@/features/reviews/components/ReviewTab"
 import { PrHeader } from "@/features/reviews/components/PrHeader"
 import { buttonVariants } from "@/components/ui/button"
 import { AgentPanelShell } from "@/features/agents/components/AgentPanelShell"
-import { DiffWrapToggle } from "@/features/agents/components/DiffWrapToggle"
-import { PlanView } from "@/features/agents/components/PlanView"
 import {
-  DIFF_VIRTUALIZER_CONFIG,
-  DIFF_VIRTUAL_METRICS,
-  DIFF_WORKER_HIGHLIGHTER_OPTIONS,
-  DIFF_WORKER_POOL_OPTIONS,
-  fileContentsCacheKey,
-  useDiffOptions,
-} from "@/features/agents/utils/diffUtils"
-import { useIsMobile } from "@/lib/useIsMobile"
+  DiffFilesView,
+  toPanelFiles,
+} from "@/features/agents/components/DiffFilesView"
+import { PlanView } from "@/features/agents/components/PlanView"
 import { cn } from "@/lib/utils"
 
 export type AgentPanelTab = "git" | "plan"
@@ -53,84 +33,6 @@ interface AgentGitPanelProps {
   onTabChange: (tab: AgentPanelTab) => void
 }
 
-interface PanelFile {
-  filePath: string
-  treePath: string
-  additions: number
-  deletions: number
-  originalContent: string
-  modifiedContent: string
-  status: GitStatus
-  unrenderable?: boolean
-}
-
-function prFileStatus(file: ThreadPrDiffFile): GitStatus {
-  if (file.status === "added") return "added"
-  if (file.status === "removed") return "deleted"
-  return "modified"
-}
-
-function commonDirPrefix(paths: Array<string>): string {
-  const first = paths[0]
-  if (paths.length === 0 || first === undefined) return ""
-  const base = first.split("/").slice(0, -1)
-  let depth = base.length
-  for (const path of paths) {
-    const segments = path.split("/").slice(0, -1)
-    let i = 0
-    while (i < depth && i < segments.length && segments[i] === base[i]) i++
-    depth = i
-  }
-  return depth === 0 ? "" : `${base.slice(0, depth).join("/")}/`
-}
-
-// Neutral filename foreground from the pierre Shiki themes (pierre-light /
-// pierre-dark sidebar foreground). The tree tints filename text by git status,
-// so feeding this keeps names neutral grey/white instead of accent-blue.
-const TREE_FILE_FG = "light-dark(#525252, #a3a3a3)"
-
-// Selected rows must read as high-contrast (white in dark, near-black in light)
-// while the rest stay neutral. The built-in git-status content color outranks
-// the selection color by specificity, so override it from the `unsafe` layer.
-export const TREE_UNSAFE_CSS = `
-  [data-item-selected="true"] [data-item-section="content"] {
-    color: var(--trees-selected-fg);
-  }
-
-  /* On click a row is focus-ringed a frame before it's marked selected, which
-   * flashes the accent outline. Pointer focus doesn't match :focus-visible, so
-   * drop the ring there; keyboard navigation keeps it. */
-  [data-item-focused="true"]:not(:focus-visible)::before {
-    outline-color: transparent;
-  }
-`
-
-export function treeThemeStyle(): React.CSSProperties {
-  return {
-    "--trees-theme-sidebar-bg": "var(--card)",
-    "--trees-theme-sidebar-fg": "var(--foreground)",
-    "--trees-theme-sidebar-border": "var(--border)",
-    "--trees-theme-sidebar-header-fg": "var(--muted-foreground)",
-    "--trees-theme-list-hover-bg":
-      "color-mix(in oklab, var(--primary) 10%, transparent)",
-    "--trees-theme-list-active-selection-bg":
-      "color-mix(in oklab, var(--primary) 22%, transparent)",
-    "--trees-theme-list-active-selection-fg": "var(--foreground)",
-    "--trees-selected-focused-border-color-override": "transparent",
-    "--trees-theme-input-bg": "var(--card)",
-    "--trees-theme-input-fg": "var(--foreground)",
-    "--trees-theme-input-border": "var(--border)",
-    "--trees-theme-focus-ring": "var(--primary)",
-    "--trees-theme-scrollbar-thumb": "var(--border)",
-    "--trees-theme-git-added-fg": TREE_FILE_FG,
-    "--trees-theme-git-modified-fg": TREE_FILE_FG,
-    "--trees-theme-git-deleted-fg": TREE_FILE_FG,
-    "--trees-theme-git-renamed-fg": TREE_FILE_FG,
-    "--trees-theme-git-untracked-fg": TREE_FILE_FG,
-    "--trees-theme-git-ignored-fg": "var(--muted-foreground)",
-  } as React.CSSProperties
-}
-
 export function AgentGitPanel({
   thread,
   revealFilePath,
@@ -142,7 +44,6 @@ export function AgentGitPanel({
   const queryClient = useQueryClient()
   const stream = useAgentThreadStream()
   const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
-  const isMobile = useIsMobile()
   const hasPlan = Boolean(
     thread.planStatus &&
     thread.planStatus !== "approved" &&
@@ -175,8 +76,6 @@ export function AgentGitPanel({
   // for the floating expand button); persistence to localStorage lives there too.
   const setCollapsed = onCollapsedChange
 
-  const [selectedTreePath, setSelectedTreePath] = useState<string | null>(null)
-  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const pr = thread.pr
 
   // The open/closed state is persisted to localStorage, so it carries across
@@ -224,58 +123,58 @@ export function AgentGitPanel({
     }
   }, [thread.id])
 
-  const files = useMemo<Array<PanelFile>>(() => {
-    const diffFiles = prDiff.data?.files ?? turnDiff.data?.files ?? []
-    const prefix = commonDirPrefix(diffFiles.map((file) => file.path))
-    return diffFiles.map((file) => ({
-      filePath: file.path,
-      treePath:
-        prefix && file.path.startsWith(prefix)
-          ? file.path.slice(prefix.length)
-          : file.path,
-      additions: file.additions,
-      deletions: file.deletions,
-      originalContent: file.originalContent ?? "",
-      modifiedContent: file.modifiedContent ?? "",
-      status: prFileStatus(file),
-      unrenderable: file.unrenderable,
-    }))
-  }, [prDiff.data, turnDiff.data])
-
-  const totals = useMemo(
-    () =>
-      files.reduce(
-        (acc, file) => ({
-          additions: acc.additions + file.additions,
-          deletions: acc.deletions + file.deletions,
-        }),
-        { additions: 0, deletions: 0 }
-      ),
-    [files]
+  const files = useMemo(
+    () => toPanelFiles(prDiff.data?.files ?? turnDiff.data?.files ?? []),
+    [prDiff.data, turnDiff.data]
   )
 
-  const filesRef = useRef(files)
-  filesRef.current = files
-  const selectTreePath = useCallback((path: string) => {
-    setSelectedTreePath(path)
-    const target = filesRef.current.find((file) => file.treePath === path)
-    if (!target) return
-    sectionRefs.current[target.filePath]?.scrollIntoView({
-      block: "start",
-      behavior: "smooth",
-    })
-  }, [])
+  const tabs = (
+    [
+      ["diff", "Diff"],
+      ["review", "Review"],
+      ["commits", "Commits"],
+    ] as const
+  ).map(([id, label]) => (
+    <button
+      key={id}
+      type="button"
+      onClick={() => setTab(id)}
+      className={cn(
+        "rounded-md px-2.5 py-1 text-xs transition-colors",
+        tab === id
+          ? "bg-accent font-medium text-foreground"
+          : "text-muted-foreground/70 hover:bg-accent"
+      )}
+    >
+      {label}
+    </button>
+  ))
 
-  useEffect(() => {
-    if (!revealFilePath) return
-    // Transcript rows carry sandbox-absolute paths; diff files are repo-relative.
-    const target = filesRef.current.find(
-      (file) =>
-        file.filePath === revealFilePath ||
-        revealFilePath.endsWith(`/${file.filePath}`)
-    )
-    if (target) selectTreePath(target.treePath)
-  }, [revealFilePath, files, selectTreePath])
+  const actions = (
+    <>
+      {recoveryError && (
+        <span
+          title={recoveryError}
+          className="max-w-40 truncate text-[11px] text-destructive"
+        >
+          {recoveryError}
+        </span>
+      )}
+      {canDownloadRecovery && (
+        <button
+          type="button"
+          onClick={downloadRecoveryPatch}
+          disabled={recoveringPatch}
+          className={cn(
+            buttonVariants({ variant: "outline", size: "sm" }),
+            "h-7 px-2 text-[11px]"
+          )}
+        >
+          {recoveringPatch ? "Preparing…" : "Download patch"}
+        </button>
+      )}
+    </>
+  )
 
   return (
     <AgentPanelShell
@@ -308,247 +207,40 @@ export function AgentGitPanel({
                 />
               )}
 
-              <div className="flex items-center gap-1 border-b border-border px-3 py-2">
-                {(
-                  [
-                    ["diff", "Diff"],
-                    ["review", "Review"],
-                    ["commits", "Commits"],
-                  ] as const
-                ).map(([id, label]) => (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => setTab(id)}
-                    className={cn(
-                      "rounded-md px-2.5 py-1 text-xs transition-colors",
-                      tab === id
-                        ? "bg-accent font-medium text-foreground"
-                        : "text-muted-foreground/70 hover:bg-accent"
-                    )}
-                  >
-                    {label}
-                  </button>
-                ))}
-                <div className="ml-auto flex min-w-0 items-center gap-2">
-                  {tab === "diff" && <DiffWrapToggle />}
-                  {recoveryError && (
-                    <span
-                      title={recoveryError}
-                      className="max-w-40 truncate text-[11px] text-destructive"
-                    >
-                      {recoveryError}
-                    </span>
-                  )}
-                  {canDownloadRecovery && (
-                    <button
-                      type="button"
-                      onClick={downloadRecoveryPatch}
-                      disabled={recoveringPatch}
-                      className={cn(
-                        buttonVariants({ variant: "outline", size: "sm" }),
-                        "h-7 px-2 text-[11px]"
-                      )}
-                    >
-                      {recoveringPatch ? "Preparing…" : "Download patch"}
-                    </button>
-                  )}
-                  {files.length > 0 && (
-                    <span className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
-                      <span>
-                        {files.length} file{files.length === 1 ? "" : "s"}
-                      </span>
-                      <span className="text-success-foreground">
-                        +{totals.additions}
-                      </span>
-                      <span className="text-destructive">
-                        -{totals.deletions}
-                      </span>
-                    </span>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex min-h-0 flex-1">
-                {tab === "review" ? (
-                  <ReviewTab thread={thread} />
-                ) : tab === "diff" && files.length > 0 ? (
-                  <WorkerPoolContextProvider
-                    poolOptions={DIFF_WORKER_POOL_OPTIONS}
-                    highlighterOptions={DIFF_WORKER_HIGHLIGHTER_OPTIONS}
-                  >
-                    <Virtualizer
-                      className="min-h-0 flex-1 overflow-y-auto"
-                      contentClassName="space-y-2 p-2"
-                      config={DIFF_VIRTUALIZER_CONFIG}
-                    >
-                      {files.map((file) => (
-                        <FileDiffSection
-                          key={file.filePath}
-                          file={file}
-                          sectionRef={(node) => {
-                            sectionRefs.current[file.filePath] = node
-                          }}
-                        />
-                      ))}
-                    </Virtualizer>
-                  </WorkerPoolContextProvider>
-                ) : (
-                  <div className="min-h-0 flex-1 overflow-y-auto p-6 text-center text-xs text-muted-foreground/70">
-                    {tab !== "diff"
-                      ? "Coming Soon"
-                      : prDiff.isLoading
-                        ? "Loading PR diff…"
-                        : "No diff available."}
-                  </div>
-                )}
-
-                {tab === "diff" &&
-                  fullScreen &&
-                  !isMobile &&
-                  files.length > 0 && (
-                    <div className="w-72 shrink-0 border-l border-border bg-card">
-                      <FileTreeExplorer
-                        files={files}
-                        selectedTreePath={selectedTreePath}
-                        onSelect={selectTreePath}
-                      />
+              {tab === "diff" ? (
+                <DiffFilesView
+                  files={files}
+                  revealFilePath={revealFilePath}
+                  fullScreen={fullScreen}
+                  emptyLabel={
+                    prDiff.isLoading ? "Loading PR diff…" : "No diff available."
+                  }
+                  leading={tabs}
+                  actions={actions}
+                />
+              ) : (
+                <>
+                  <div className="flex items-center gap-1 border-b border-border px-3 py-2">
+                    {tabs}
+                    <div className="ml-auto flex min-w-0 items-center gap-2">
+                      {actions}
                     </div>
-                  )}
-              </div>
+                  </div>
+                  <div className="flex min-h-0 flex-1">
+                    {tab === "review" ? (
+                      <ReviewTab thread={thread} />
+                    ) : (
+                      <div className="min-h-0 flex-1 overflow-y-auto p-6 text-center text-xs text-muted-foreground/70">
+                        Coming Soon
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
             </>
           )}
         </>
       )}
     </AgentPanelShell>
-  )
-}
-
-const FileDiffSection = memo(
-  function FileDiffSection({
-    file,
-    sectionRef,
-  }: {
-    file: PanelFile
-    sectionRef: (node: HTMLDivElement | null) => void
-  }) {
-    const [open, setOpen] = useState(true)
-    const diffOptions = useDiffOptions()
-    const oldFile = useMemo<FileContents>(
-      () => ({
-        name: file.treePath,
-        contents: file.originalContent,
-        cacheKey: fileContentsCacheKey(
-          file.filePath,
-          "old",
-          file.originalContent
-        ),
-      }),
-      [file.filePath, file.originalContent, file.treePath]
-    )
-    const newFile = useMemo<FileContents>(
-      () => ({
-        name: file.treePath,
-        contents: file.modifiedContent,
-        cacheKey: fileContentsCacheKey(
-          file.filePath,
-          "new",
-          file.modifiedContent
-        ),
-      }),
-      [file.filePath, file.modifiedContent, file.treePath]
-    )
-
-    return (
-      <div
-        ref={sectionRef}
-        className="mb-2 scroll-mt-2 overflow-hidden rounded-lg border border-border"
-      >
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="flex w-full items-center gap-2 bg-accent px-3 py-2 text-left text-xs"
-        >
-          <CaretDownIcon
-            className={cn("size-3 transition-transform", !open && "-rotate-90")}
-          />
-          <span className="truncate font-medium text-foreground">
-            {file.treePath}
-          </span>
-          <span className="ml-auto flex shrink-0 items-center gap-2">
-            <span className="text-success-foreground">+{file.additions}</span>
-            <span className="text-destructive">-{file.deletions}</span>
-          </span>
-        </button>
-        {open &&
-          (file.unrenderable ? (
-            <div className="bg-card p-4 text-center text-xs text-muted-foreground/70">
-              Binary or large file — diff not shown.
-            </div>
-          ) : (
-            <div className="overflow-hidden bg-card p-2">
-              <MultiFileDiff
-                oldFile={oldFile}
-                newFile={newFile}
-                options={diffOptions}
-                metrics={DIFF_VIRTUAL_METRICS}
-              />
-            </div>
-          ))}
-      </div>
-    )
-  },
-  (prev, next) => prev.file === next.file
-)
-
-function FileTreeExplorer({
-  files,
-  selectedTreePath,
-  onSelect,
-}: {
-  files: Array<PanelFile>
-  selectedTreePath: string | null
-  onSelect: (path: string) => void
-}) {
-  const paths = useMemo(() => files.map((file) => file.treePath), [files])
-  const gitStatus = useMemo<Array<GitStatusEntry>>(
-    () => files.map((file) => ({ path: file.treePath, status: file.status })),
-    [files]
-  )
-
-  const { model } = useFileTree({
-    paths,
-    gitStatus,
-    initialExpansion: "open",
-    flattenEmptyDirectories: true,
-    search: true,
-    icons: "complete",
-    unsafeCSS: TREE_UNSAFE_CSS,
-  })
-
-  useEffect(() => {
-    model.resetPaths(paths)
-  }, [model, paths])
-
-  useEffect(() => {
-    model.setGitStatus(gitStatus)
-  }, [model, gitStatus])
-
-  const selection = useFileTreeSelection(model)
-  useEffect(() => {
-    const path = selection[0]
-    if (path) onSelect(path)
-  }, [selection, onSelect])
-
-  useEffect(() => {
-    if (selectedTreePath) {
-      model.scrollToPath(selectedTreePath, { focus: false })
-    }
-  }, [model, selectedTreePath])
-
-  return (
-    <div className="flex h-full flex-col">
-      <FileTree model={model} style={{ height: "100%", ...treeThemeStyle() }} />
-    </div>
   )
 }

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -215,6 +215,7 @@ export function AgentGitPanel({
                   emptyLabel={
                     prDiff.isLoading ? "Loading PR diff…" : "No diff available."
                   }
+                  truncated={prDiff.data?.truncated ?? turnDiff.data?.truncated}
                   leading={tabs}
                   actions={actions}
                 />

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -130,6 +130,8 @@ interface DiffFilesViewProps {
   /** Full-screen panels have room for the file tree alongside the diff. */
   fullScreen: boolean
   emptyLabel: string
+  /** The change set was capped, so `files` is not everything that changed. */
+  truncated?: boolean
   /** Rendered at the start of the header row (the panel's own tabs). */
   leading?: React.ReactNode
   /** Rendered in the header row, before the wrap toggle and diff stats. */
@@ -146,6 +148,7 @@ export function DiffFilesView({
   revealFilePath,
   fullScreen,
   emptyLabel,
+  truncated,
   leading,
   actions,
 }: DiffFilesViewProps) {
@@ -197,7 +200,10 @@ export function DiffFilesView({
           {actions}
           {files.length > 0 && (
             <span className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
-              <span>
+              <span
+                title={truncated ? "Only the first files are shown" : undefined}
+              >
+                {truncated ? "first " : ""}
                 {files.length} file{files.length === 1 ? "" : "s"}
               </span>
               <span className="text-success-foreground">

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -1,0 +1,381 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  MultiFileDiff,
+  Virtualizer,
+  WorkerPoolContextProvider,
+} from "@pierre/diffs/react"
+import {
+  FileTree,
+  useFileTree,
+  useFileTreeSelection,
+} from "@pierre/trees/react"
+import { CaretDownIcon } from "@phosphor-icons/react"
+import type { FileContents } from "@pierre/diffs/react"
+import type { GitStatus, GitStatusEntry } from "@pierre/trees"
+
+import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
+import { DiffWrapToggle } from "@/features/agents/components/DiffWrapToggle"
+import {
+  DIFF_VIRTUALIZER_CONFIG,
+  DIFF_VIRTUAL_METRICS,
+  DIFF_WORKER_HIGHLIGHTER_OPTIONS,
+  DIFF_WORKER_POOL_OPTIONS,
+  fileContentsCacheKey,
+  useDiffOptions,
+} from "@/features/agents/utils/diffUtils"
+import { useIsMobile } from "@/lib/useIsMobile"
+import { cn } from "@/lib/utils"
+
+export interface PanelFile {
+  filePath: string
+  treePath: string
+  additions: number
+  deletions: number
+  originalContent: string
+  modifiedContent: string
+  status: GitStatus
+  unrenderable?: boolean
+}
+
+function prFileStatus(file: ThreadPrDiffFile): GitStatus {
+  if (file.status === "added") return "added"
+  if (file.status === "removed") return "deleted"
+  return "modified"
+}
+
+export function commonDirPrefix(paths: Array<string>): string {
+  const first = paths[0]
+  if (paths.length === 0 || first === undefined) return ""
+  const base = first.split("/").slice(0, -1)
+  let depth = base.length
+  for (const path of paths) {
+    const segments = path.split("/").slice(0, -1)
+    let i = 0
+    while (i < depth && i < segments.length && segments[i] === base[i]) i++
+    depth = i
+  }
+  return depth === 0 ? "" : `${base.slice(0, depth).join("/")}/`
+}
+
+export function toPanelFiles(
+  diffFiles: Array<ThreadPrDiffFile>
+): Array<PanelFile> {
+  const prefix = commonDirPrefix(diffFiles.map((file) => file.path))
+  return diffFiles.map((file) => ({
+    filePath: file.path,
+    treePath:
+      prefix && file.path.startsWith(prefix)
+        ? file.path.slice(prefix.length)
+        : file.path,
+    additions: file.additions,
+    deletions: file.deletions,
+    originalContent: file.originalContent ?? "",
+    modifiedContent: file.modifiedContent ?? "",
+    status: prFileStatus(file),
+    unrenderable: file.unrenderable,
+  }))
+}
+
+// Neutral filename foreground from the pierre Shiki themes (pierre-light /
+// pierre-dark sidebar foreground). The tree tints filename text by git status,
+// so feeding this keeps names neutral grey/white instead of accent-blue.
+const TREE_FILE_FG = "light-dark(#525252, #a3a3a3)"
+
+// Selected rows must read as high-contrast (white in dark, near-black in light)
+// while the rest stay neutral. The built-in git-status content color outranks
+// the selection color by specificity, so override it from the `unsafe` layer.
+export const TREE_UNSAFE_CSS = `
+  [data-item-selected="true"] [data-item-section="content"] {
+    color: var(--trees-selected-fg);
+  }
+
+  /* On click a row is focus-ringed a frame before it's marked selected, which
+   * flashes the accent outline. Pointer focus doesn't match :focus-visible, so
+   * drop the ring there; keyboard navigation keeps it. */
+  [data-item-focused="true"]:not(:focus-visible)::before {
+    outline-color: transparent;
+  }
+`
+
+export function treeThemeStyle(): React.CSSProperties {
+  return {
+    "--trees-theme-sidebar-bg": "var(--card)",
+    "--trees-theme-sidebar-fg": "var(--foreground)",
+    "--trees-theme-sidebar-border": "var(--border)",
+    "--trees-theme-sidebar-header-fg": "var(--muted-foreground)",
+    "--trees-theme-list-hover-bg":
+      "color-mix(in oklab, var(--primary) 10%, transparent)",
+    "--trees-theme-list-active-selection-bg":
+      "color-mix(in oklab, var(--primary) 22%, transparent)",
+    "--trees-theme-list-active-selection-fg": "var(--foreground)",
+    "--trees-selected-focused-border-color-override": "transparent",
+    "--trees-theme-input-bg": "var(--card)",
+    "--trees-theme-input-fg": "var(--foreground)",
+    "--trees-theme-input-border": "var(--border)",
+    "--trees-theme-focus-ring": "var(--primary)",
+    "--trees-theme-scrollbar-thumb": "var(--border)",
+    "--trees-theme-git-added-fg": TREE_FILE_FG,
+    "--trees-theme-git-modified-fg": TREE_FILE_FG,
+    "--trees-theme-git-deleted-fg": TREE_FILE_FG,
+    "--trees-theme-git-renamed-fg": TREE_FILE_FG,
+    "--trees-theme-git-untracked-fg": TREE_FILE_FG,
+    "--trees-theme-git-ignored-fg": "var(--muted-foreground)",
+  } as React.CSSProperties
+}
+
+interface DiffFilesViewProps {
+  files: Array<PanelFile>
+  /** Path to select and scroll to, set when a transcript row is clicked. */
+  revealFilePath?: string | null
+  /** Full-screen panels have room for the file tree alongside the diff. */
+  fullScreen: boolean
+  emptyLabel: string
+  /** Rendered at the start of the header row (the panel's own tabs). */
+  leading?: React.ReactNode
+  /** Rendered in the header row, before the wrap toggle and diff stats. */
+  actions?: React.ReactNode
+}
+
+/**
+ * The changed-files reader shared by cloud threads and local desktop sessions:
+ * a header row with the diff totals, the virtualized per-file diffs, and the
+ * file tree when there is room for it.
+ */
+export function DiffFilesView({
+  files,
+  revealFilePath,
+  fullScreen,
+  emptyLabel,
+  leading,
+  actions,
+}: DiffFilesViewProps) {
+  const isMobile = useIsMobile()
+  const [selectedTreePath, setSelectedTreePath] = useState<string | null>(null)
+  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({})
+
+  const totals = useMemo(
+    () =>
+      files.reduce(
+        (acc, file) => ({
+          additions: acc.additions + file.additions,
+          deletions: acc.deletions + file.deletions,
+        }),
+        { additions: 0, deletions: 0 }
+      ),
+    [files]
+  )
+
+  const filesRef = useRef(files)
+  filesRef.current = files
+  const selectTreePath = useCallback((path: string) => {
+    setSelectedTreePath(path)
+    const target = filesRef.current.find((file) => file.treePath === path)
+    if (!target) return
+    sectionRefs.current[target.filePath]?.scrollIntoView({
+      block: "start",
+      behavior: "smooth",
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!revealFilePath) return
+    // Transcript rows carry absolute paths; diff files are repo-relative.
+    const target = filesRef.current.find(
+      (file) =>
+        file.filePath === revealFilePath ||
+        revealFilePath.endsWith(`/${file.filePath}`)
+    )
+    if (target) selectTreePath(target.treePath)
+  }, [revealFilePath, files, selectTreePath])
+
+  return (
+    <>
+      <div className="flex items-center gap-1 border-b border-border px-3 py-2">
+        {leading}
+        <div className="ml-auto flex min-w-0 items-center gap-2">
+          <DiffWrapToggle />
+          {actions}
+          {files.length > 0 && (
+            <span className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
+              <span>
+                {files.length} file{files.length === 1 ? "" : "s"}
+              </span>
+              <span className="text-success-foreground">
+                +{totals.additions}
+              </span>
+              <span className="text-destructive">-{totals.deletions}</span>
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {files.length > 0 ? (
+          <WorkerPoolContextProvider
+            poolOptions={DIFF_WORKER_POOL_OPTIONS}
+            highlighterOptions={DIFF_WORKER_HIGHLIGHTER_OPTIONS}
+          >
+            <Virtualizer
+              className="min-h-0 flex-1 overflow-y-auto"
+              contentClassName="space-y-2 p-2"
+              config={DIFF_VIRTUALIZER_CONFIG}
+            >
+              {files.map((file) => (
+                <FileDiffSection
+                  key={file.filePath}
+                  file={file}
+                  sectionRef={(node) => {
+                    sectionRefs.current[file.filePath] = node
+                  }}
+                />
+              ))}
+            </Virtualizer>
+          </WorkerPoolContextProvider>
+        ) : (
+          <div className="min-h-0 flex-1 overflow-y-auto p-6 text-center text-xs text-muted-foreground/70">
+            {emptyLabel}
+          </div>
+        )}
+
+        {fullScreen && !isMobile && files.length > 0 && (
+          <div className="w-72 shrink-0 border-l border-border bg-card">
+            <FileTreeExplorer
+              files={files}
+              selectedTreePath={selectedTreePath}
+              onSelect={selectTreePath}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+const FileDiffSection = memo(
+  function FileDiffSection({
+    file,
+    sectionRef,
+  }: {
+    file: PanelFile
+    sectionRef: (node: HTMLDivElement | null) => void
+  }) {
+    const [open, setOpen] = useState(true)
+    const diffOptions = useDiffOptions()
+    const oldFile = useMemo<FileContents>(
+      () => ({
+        name: file.treePath,
+        contents: file.originalContent,
+        cacheKey: fileContentsCacheKey(
+          file.filePath,
+          "old",
+          file.originalContent
+        ),
+      }),
+      [file.filePath, file.originalContent, file.treePath]
+    )
+    const newFile = useMemo<FileContents>(
+      () => ({
+        name: file.treePath,
+        contents: file.modifiedContent,
+        cacheKey: fileContentsCacheKey(
+          file.filePath,
+          "new",
+          file.modifiedContent
+        ),
+      }),
+      [file.filePath, file.modifiedContent, file.treePath]
+    )
+
+    return (
+      <div
+        ref={sectionRef}
+        className="mb-2 scroll-mt-2 overflow-hidden rounded-lg border border-border"
+      >
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full items-center gap-2 bg-accent px-3 py-2 text-left text-xs"
+        >
+          <CaretDownIcon
+            className={cn("size-3 transition-transform", !open && "-rotate-90")}
+          />
+          <span className="truncate font-medium text-foreground">
+            {file.treePath}
+          </span>
+          <span className="ml-auto flex shrink-0 items-center gap-2">
+            <span className="text-success-foreground">+{file.additions}</span>
+            <span className="text-destructive">-{file.deletions}</span>
+          </span>
+        </button>
+        {open &&
+          (file.unrenderable ? (
+            <div className="bg-card p-4 text-center text-xs text-muted-foreground/70">
+              Binary or large file — diff not shown.
+            </div>
+          ) : (
+            <div className="overflow-hidden bg-card p-2">
+              <MultiFileDiff
+                oldFile={oldFile}
+                newFile={newFile}
+                options={diffOptions}
+                metrics={DIFF_VIRTUAL_METRICS}
+              />
+            </div>
+          ))}
+      </div>
+    )
+  },
+  (prev, next) => prev.file === next.file
+)
+
+function FileTreeExplorer({
+  files,
+  selectedTreePath,
+  onSelect,
+}: {
+  files: Array<PanelFile>
+  selectedTreePath: string | null
+  onSelect: (path: string) => void
+}) {
+  const paths = useMemo(() => files.map((file) => file.treePath), [files])
+  const gitStatus = useMemo<Array<GitStatusEntry>>(
+    () => files.map((file) => ({ path: file.treePath, status: file.status })),
+    [files]
+  )
+
+  const { model } = useFileTree({
+    paths,
+    gitStatus,
+    initialExpansion: "open",
+    flattenEmptyDirectories: true,
+    search: true,
+    icons: "complete",
+    unsafeCSS: TREE_UNSAFE_CSS,
+  })
+
+  useEffect(() => {
+    model.resetPaths(paths)
+  }, [model, paths])
+
+  useEffect(() => {
+    model.setGitStatus(gitStatus)
+  }, [model, gitStatus])
+
+  const selection = useFileTreeSelection(model)
+  useEffect(() => {
+    const path = selection[0]
+    if (path) onSelect(path)
+  }, [selection, onSelect])
+
+  useEffect(() => {
+    if (selectedTreePath) {
+      model.scrollToPath(selectedTreePath, { focus: false })
+    }
+  }, [model, selectedTreePath])
+
+  return (
+    <div className="flex h-full flex-col">
+      <FileTree model={model} style={{ height: "100%", ...treeThemeStyle() }} />
+    </div>
+  )
+}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -166,6 +166,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
                   diff.data?.status,
                   diff.isPending
                 )}
+                truncated={diff.data?.truncated}
               />
             )}
             {/* Kept mounted across tabs: unmounting kills the user's shell. */}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { CircleAlert, FolderOpen } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
@@ -8,17 +8,29 @@ import {
   PANEL_MIN_CHAT_WIDTH,
 } from "@/features/agents/components/AgentPanelShell"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
+import {
+  DiffFilesView,
+  toPanelFiles,
+} from "@/features/agents/components/DiffFilesView"
 import { Messages } from "@/features/agents/components/messages"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
 import {
   readStoredPanelCollapsed,
   writeStoredPanelCollapsed,
 } from "@/features/agents/lib/gitPanelPreferences"
-import { useDesktopAcpSession } from "@/features/agents/lib/desktopAcp"
+import {
+  useDesktopAcpSession,
+  useLocalSessionDiff,
+} from "@/features/agents/lib/desktopAcp"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 
-const LOCAL_PANEL_TABS = [["terminal", "Terminal"]] as const
+const LOCAL_PANEL_TABS = [
+  ["changes", "Changes"],
+  ["terminal", "Terminal"],
+] as const
+
+type LocalPanelTab = (typeof LOCAL_PANEL_TABS)[number][0]
 
 export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const { session, messages, loaded } = useDesktopAcpSession(sessionId)
@@ -26,12 +38,34 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed(sessionId)
   )
+  const [panelTab, setPanelTab] = useState<LocalPanelTab>("changes")
+  const [revealFilePath, setRevealFilePath] = useState<string | null>(null)
   const handlePanelCollapsedChange = useCallback(
     (next: boolean) => {
       setPanelCollapsed(next)
       writeStoredPanelCollapsed(sessionId, next)
     },
     [sessionId]
+  )
+  const handleOpenFile = useCallback(
+    (filePath: string) => {
+      setRevealFilePath(filePath)
+      setPanelTab("changes")
+      handlePanelCollapsedChange(false)
+    },
+    [handlePanelCollapsedChange]
+  )
+
+  const isRunning =
+    session?.status === "running" || session?.status === "starting"
+  const diff = useLocalSessionDiff(
+    sessionId,
+    !panelCollapsed && panelTab === "changes" && Boolean(session),
+    isRunning
+  )
+  const files = useMemo(
+    () => toPanelFiles(diff.data?.files ?? []),
+    [diff.data?.files]
   )
 
   if (!session) {
@@ -51,9 +85,6 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
       </div>
     )
   }
-
-  const isRunning =
-    session.status === "running" || session.status === "starting"
 
   return (
     <div className="flex min-w-0 flex-1">
@@ -91,6 +122,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             isStreaming={isRunning}
             isThinking={isRunning}
             messages={messages}
+            onOpenFile={handleOpenFile}
             streamIsLoading={isRunning}
           />
           <div className="shrink-0 px-4 pb-4">
@@ -118,15 +150,49 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
       </div>
       <AgentPanelShell
         tabs={LOCAL_PANEL_TABS}
-        activeTab="terminal"
-        onTabChange={() => {}}
+        activeTab={panelTab}
+        onTabChange={setPanelTab}
         collapsed={panelCollapsed}
         onCollapsedChange={handlePanelCollapsedChange}
       >
-        {() => (
-          <TerminalPanel id={`local-session:${session.id}`} cwd={session.cwd} />
+        {({ fullScreen }) => (
+          <>
+            {panelTab === "changes" && (
+              <DiffFilesView
+                files={files}
+                revealFilePath={revealFilePath}
+                fullScreen={fullScreen}
+                emptyLabel={localDiffEmptyLabel(
+                  diff.data?.status,
+                  diff.isPending
+                )}
+              />
+            )}
+            {/* Kept mounted across tabs: unmounting kills the user's shell. */}
+            <div
+              className={cn(
+                "min-h-0 flex-1",
+                panelTab !== "terminal" && "hidden"
+              )}
+            >
+              <TerminalPanel
+                id={`local-session:${session.id}`}
+                cwd={session.cwd}
+              />
+            </div>
+          </>
         )}
       </AgentPanelShell>
     </div>
   )
+}
+
+function localDiffEmptyLabel(
+  status: string | undefined,
+  isPending: boolean
+): string {
+  if (isPending) return "Reading changes…"
+  if (status === "missing") return "This project is not a git repository."
+  if (status === "error") return "Could not read this project's git changes."
+  return "No changes yet."
 }

--- a/ui/src/features/agents/lib/desktopAcp.ts
+++ b/ui/src/features/agents/lib/desktopAcp.ts
@@ -1,11 +1,19 @@
 import { useEffect, useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 
 import { desktopAcpMessages } from "./desktopAcpMessages"
 import type {
+  DesktopAcpDiff,
   DesktopAcpEvent,
   DesktopAcpSession,
   DesktopAcpSessionSummary,
 } from "@/desktop"
+
+const NO_DIFF: DesktopAcpDiff = {
+  status: "missing",
+  truncated: false,
+  files: [],
+}
 
 function mergeSession(
   current: DesktopAcpSession | null,
@@ -86,6 +94,31 @@ export function useDesktopAcpSession(sessionId: string) {
     messages,
     loaded: loadedSessionId === sessionId,
   }
+}
+
+/**
+ * What a local session changed, read from git in the desktop main process. The
+ * agent edits the real project, so the panel polls while a run is live and
+ * settles with one more read once it finishes.
+ */
+export function useLocalSessionDiff(
+  sessionId: string,
+  enabled: boolean,
+  isRunning: boolean
+) {
+  const query = useQuery({
+    queryKey: ["local-session-diff", sessionId],
+    queryFn: () => window.openSweDesktop?.getAcpDiff(sessionId) ?? NO_DIFF,
+    enabled,
+    refetchInterval: isRunning ? 5000 : false,
+  })
+
+  const { refetch } = query
+  useEffect(() => {
+    if (enabled && !isRunning) void refetch()
+  }, [enabled, isRunning, refetch])
+
+  return query
 }
 
 function mergeSummaries(

--- a/ui/src/features/reviews/components/ReviewSidebar.tsx
+++ b/ui/src/features/reviews/components/ReviewSidebar.tsx
@@ -17,7 +17,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import {
   TREE_UNSAFE_CSS,
   treeThemeStyle,
-} from "@/features/agents/components/AgentGitPanel"
+} from "@/features/agents/components/DiffFilesView"
 import { cn } from "@/lib/utils"
 
 function reviewFileGitStatus(status: ReviewDiffFile["status"]): GitStatus {


### PR DESCRIPTION
## Description

Cloud threads get their side-panel diff from `GET /threads/{id}/turn-diff`, which runs git inside the thread's sandbox. Local **This Mac** sessions have no sandbox, so the panel only had a Terminal tab. This ports the same checkpoint plumbing (temp `GIT_INDEX_FILE` → `add -A` → `write-tree` → `commit-tree` → `update-ref`, to the Electron main process, running against the project's real repo, and feeds the existing pierre renderer — extracted from `AgentGitPanel` into a shared `DiffFilesView` so there is one diff view, not two.

Checkpoint refs live under `refs/open-swe/local/<sessionId>`, are never pushed, and are deleted on quit plus pruned at session start. One deviation from the plan: refs are *not* deleted when a session errors — the checkpoint is only recorded after `initialize()` succeeds (so the failure path can't leak one), and keeping it means the diff still works for post-mortem inspection of a failed run.

## Release Note

Desktop local sessions now show a Changes tab with the full git diff of what the agent changed.

## Test Plan

- [ ] Start a **This Mac** session in a git project, let the agent edit files, confirm the Changes tab shows them live (and that clicking a file row in the transcript reveals it).
- [ ] Switch to Terminal and back — the shell survives the tab switch.
- [ ] Start a session in a non-git directory — panel says the project is not a git repository.
- [ ] Quit the app, then `git for-each-ref refs/open-swe/local` in the project reports nothing.

Made by [Open SWE](https://openswe.vercel.app/agents/019fde6d-282b-706f-ba6c-7ae04b121b5a)

## References
- Plan: https://openswe.vercel.app/agents/019fde6d-282b-706f-ba6c-7ae04b121b5a/plan