### PR TITLE
feat: add macOS release pipeline

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,193 @@
+name: Release Desktop
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: "Version increment type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release
+  cancel-in-progress: false
+
+jobs:
+  release-desktop:
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - run: corepack enable
+
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
+
+      - name: Bump desktop version
+        id: bump
+        env:
+          BUMP_TYPE: ${{ inputs.version_bump }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'desktop/package.json';
+          const bump = process.env.BUMP_TYPE;
+
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          const current = pkg.version;
+          const parts = current.split('.').map(Number);
+
+          if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) {
+            throw new Error(`Invalid semver in ${path}: ${current}`);
+          }
+
+          let [major, minor, patch] = parts;
+          if (bump === 'major') {
+            major += 1;
+            minor = 0;
+            patch = 0;
+          } else if (bump === 'minor') {
+            minor += 1;
+            patch = 0;
+          } else if (bump === 'patch') {
+            patch += 1;
+          } else {
+            throw new Error(`Unsupported bump type: ${bump}`);
+          }
+
+          const next = `${major}.${minor}.${patch}`;
+          pkg.version = next;
+          fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `new_version=${next}\n`);
+          NODE
+
+      - name: Install UI dependencies
+        working-directory: ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Install desktop dependencies
+        working-directory: desktop
+        env:
+          ELECTRON_GET_USE_PROXY: "true"
+        run: pnpm install --frozen-lockfile
+
+      - name: Import signing certificate
+        env:
+          SIGNING_CERT_B64: ${{ secrets.APPLE_SIGNING_CERT }}
+          SIGNING_CERT_PASSWORD: ${{ secrets.APPLE_SIGNING_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          printf '%s' "$SIGNING_CERT_B64" | base64 --decode > "$RUNNER_TEMP/signing.p12"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/signing.p12" -P "$SIGNING_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "CSC_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Write App Store Connect API key
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          printf '%s' "$APPLE_API_KEY_CONTENT" > "$RUNNER_TEMP/AuthKey.p8"
+          echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
+
+      - name: Build macOS distribution
+        working-directory: desktop
+        env:
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: pnpm run build:ui && pnpm exec electron-builder --mac zip dmg --publish never
+
+      - name: Verify and package release assets
+        id: assets
+        env:
+          VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          shopt -s nullglob
+          mac_zips=(desktop/dist/"Open SWE-${VERSION}"-*-mac.zip)
+          mac_dmgs=(desktop/dist/"Open SWE-${VERSION}"-*.dmg)
+
+          if [ "${#mac_zips[@]}" -ne 1 ] || [ "${#mac_dmgs[@]}" -ne 1 ]; then
+            echo "Expected one macOS zip and one DMG for version ${VERSION}"
+            ls -la desktop/dist
+            exit 1
+          fi
+
+          unpacked="desktop/dist/release-unpacked"
+          mkdir -p "$unpacked"
+          ditto -x -k "${mac_zips[0]}" "$unpacked"
+
+          apps=("$unpacked"/*.app)
+          if [ "${#apps[@]}" -ne 1 ]; then
+            echo "Expected one app bundle in ${mac_zips[0]}"
+            ls -la "$unpacked"
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=2 "${apps[0]}"
+          xcrun stapler validate "${apps[0]}"
+          spctl --assess --type execute --verbose=2 "${apps[0]}"
+          hdiutil verify "${mac_dmgs[0]}"
+
+          app_zip="desktop/dist/Open SWE-${VERSION}.app.zip"
+          ditto -c -k --sequesterRsrc --keepParent "${apps[0]}" "$app_zip"
+
+          echo "mac_zip=${mac_zips[0]}" >> "$GITHUB_OUTPUT"
+          echo "mac_dmg=${mac_dmgs[0]}" >> "$GITHUB_OUTPUT"
+          echo "app_zip=$app_zip" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag desktop version
+        env:
+          VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          git add desktop/package.json
+          git -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "chore(desktop): release v${VERSION}"
+          git tag "desktop-v${VERSION}"
+          git push origin HEAD:main
+          git push origin "desktop-v${VERSION}"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: desktop-v${{ steps.bump.outputs.new_version }}
+          name: Open SWE Desktop v${{ steps.bump.outputs.new_version }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            ${{ steps.assets.outputs.mac_zip }}
+            ${{ steps.assets.outputs.mac_dmg }}
+            ${{ steps.assets.outputs.app_zip }}
+
+      - name: Remove signing credentials
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+          rm -f "$RUNNER_TEMP/signing.p12" "$RUNNER_TEMP/AuthKey.p8"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -81,6 +81,16 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `new_version=${next}\n`);
           NODE
 
+      - name: Commit desktop version
+        env:
+          VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          git add desktop/package.json
+          git -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "chore(desktop): release v${VERSION}"
+          git push origin HEAD:main
+
       - name: Install UI dependencies
         working-directory: ui
         run: pnpm install --frozen-lockfile
@@ -162,16 +172,11 @@ jobs:
           echo "mac_dmg=${mac_dmgs[0]}" >> "$GITHUB_OUTPUT"
           echo "app_zip=$app_zip" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag desktop version
+      - name: Tag desktop version
         env:
           VERSION: ${{ steps.bump.outputs.new_version }}
         run: |
-          git add desktop/package.json
-          git -c user.name="github-actions[bot]" \
-            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-            commit -m "chore(desktop): release v${VERSION}"
           git tag "desktop-v${VERSION}"
-          git push origin HEAD:main
           git push origin "desktop-v${VERSION}"
 
       - name: Create GitHub release

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -70,6 +70,27 @@ pnpm --dir desktop run dist # installer for the current platform
 Both commands build `ui/` and package its static output with Electron. Build outputs are written
 to `desktop/dist/`.
 
+## macOS releases
+
+Maintainers can run **Release Desktop** from the GitHub Actions page on `main` and choose a patch,
+minor, or major version bump. The workflow builds the current `ui/` bundle, signs and notarizes the
+Electron app, verifies the resulting app and DMG, bumps `desktop/package.json`, creates a
+`desktop-vX.Y.Z` tag, and publishes the DMG, macOS zip, and app zip to a GitHub release. The
+desktop-prefixed tags keep this release stream separate from web and backend releases; the workflow
+packages the web UI but does not deploy or otherwise change the hosted web app.
+
+The workflow requires these GitHub Actions secrets:
+
+- `RELEASE_PAT`: token allowed to push to `main` and create tags
+- `APPLE_SIGNING_CERT`: base64-encoded Developer ID Application `.p12` certificate
+- `APPLE_SIGNING_CERT_PASSWORD`: password for the certificate
+- `APPLE_API_KEY`: App Store Connect `.p8` key contents
+- `APPLE_API_KEY_ID`: App Store Connect key ID
+- `APPLE_API_ISSUER`: App Store Connect issuer ID
+
+Local packaging remains available without those credentials; signing and notarization are performed
+by the release workflow.
+
 ## Deployment security
 
 The backend URL is public configuration, not a credential. Dashboard routes require an

--- a/desktop/entitlements.mac.plist
+++ b/desktop/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/notarize.cjs
+++ b/desktop/notarize.cjs
@@ -1,0 +1,16 @@
+const { notarize } = require('@electron/notarize');
+
+exports.default = async function (context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  if (!process.env.APPLE_API_KEY) return;
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = `${context.appOutDir}/${appName}.app`;
+
+  return notarize({
+    appPath,
+    appleApiKey: process.env.APPLE_API_KEY,
+    appleApiKeyId: process.env.APPLE_API_KEY_ID,
+    appleApiIssuer: process.env.APPLE_API_ISSUER,
+  });
+};

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,6 +17,8 @@
     "appId": "com.langchain.openswe",
     "productName": "Open SWE",
     "asar": true,
+    "afterSign": "notarize.cjs",
+    "npmRebuild": true,
     "icon": "resources/icon.png",
     "directories": {
       "output": "dist"
@@ -41,6 +43,10 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "resources/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "entitlements.mac.plist",
+      "entitlementsInherit": "entitlements.mac.plist",
       "target": [
         "dmg",
         "zip"
@@ -63,6 +69,7 @@
   "homepage": "https://github.com/langchain-ai/open-swe",
   "packageManager": "pnpm@11.13.1",
   "devDependencies": {
+    "@electron/notarize": "3.1.1",
     "electron": "41.10.3",
     "electron-builder": "26.15.3"
   },

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
     devDependencies:
+      '@electron/notarize':
+        specifier: 3.1.1
+        version: 3.1.1
       electron:
         specifier: 41.10.3
         version: 41.10.3
@@ -45,6 +48,10 @@ packages:
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
     engines: {node: '>= 10.0.0'}
+
+  '@electron/notarize@3.1.1':
+    resolution: {integrity: sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==}
+    engines: {node: '>= 22.12.0'}
 
   '@electron/osx-sign@1.3.3':
     resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
@@ -1098,6 +1105,13 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fs-extra: 9.1.0
+      promise-retry: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/notarize@3.1.1':
+    dependencies:
+      debug: 4.4.3
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Adds a desktop-specific macOS release workflow based on the previous Open SWE app pipeline. It builds the bundled web UI, signs and notarizes the Electron app, verifies the DMG, and publishes desktop-prefixed GitHub releases without changing the hosted web release flow.

Validation:
- `pnpm --dir desktop run check`
- `pnpm --dir desktop run pack`
- Workflow YAML, package JSON, lockfile, Node, and plist validation
