### PR TITLE
fix: even out chat composer gutters beside the git panel

### DIFF
--- a/ui/src/features/agents/components/AgentPanelShell.tsx
+++ b/ui/src/features/agents/components/AgentPanelShell.tsx
@@ -123,8 +123,9 @@ function PanelResizeHandle({
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       className={cn(
-        "absolute top-0 left-0 z-20 h-full w-1 cursor-col-resize touch-none select-none",
-        "after:absolute after:inset-y-0 after:left-0 after:w-px after:bg-transparent after:transition-colors",
+        // Straddles the seam so the grab strip never sits on top of panel content.
+        "absolute top-0 -left-1 z-20 h-full w-2 cursor-col-resize touch-none select-none",
+        "after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-transparent after:transition-colors",
         "hover:after:bg-border",
         dragging && "after:bg-border"
       )}
@@ -270,7 +271,9 @@ export function AgentPanelShell<TTab extends string>({
       <div
         className={cn(
           "flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card",
-          overlay ? "mx-3 mb-3" : "mr-4 mb-4 ml-1"
+          // No left margin: the seam is the chat column's own `px-4`, so the gap
+          // to the composer matches the gap on the sidebar side.
+          overlay ? "mx-3 mb-3" : "mr-4 mb-4"
         )}
       >
         {children({ fullScreen })}

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -255,7 +255,9 @@ export const Messages = memo(function MessagesComponent({
       <div className="relative min-h-0 min-w-0 flex-1">
         <div
           ref={scrollRef}
-          className="h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto py-5 text-[14px] leading-[1.6] antialiased"
+          // Gutter on both edges: the centered column keeps its position when the
+          // scrollbar appears, so it stays aligned with the composer below it.
+          className="h-full min-h-0 min-w-0 [scrollbar-gutter:stable_both-edges] overflow-x-hidden overflow-y-auto py-5 text-[14px] leading-[1.6] antialiased"
         >
           <div
             ref={contentRef}


### PR DESCRIPTION
## Description
The composer sat 16px from the sidebar but 20px from the git panel: the chat column pads `px-4` and the panel card added another `ml-1`. Separately, the transcript's scroll container had no scrollbar gutter, so with the global `scrollbar-width: thin` the centered `max-w-3xl` column shifted left by half a scrollbar the moment one appeared, breaking alignment with the composer. 

## Release Note
Dashboard: the chat composer is now evenly spaced between the sidebar and the git panel, and the transcript no longer shifts when its scrollbar appears.

## Test Plan
- [ ] Open a thread with the git panel expanded and confirm the composer's gap to the panel card matches its gap to the sidebar, both collapsed and expanded.
- [ ] Scroll a long transcript and confirm messages stay centered/aligned with the composer as the scrollbar appears and disappears.
- [ ] Drag the panel edge to resize; the grab strip should still work without covering panel content.

Made by [Open SWE](https://openswe.vercel.app/agents/019fedf9-4f21-7584-9c82-e982fecda994)