### PR TITLE
feat: preview deployment environment

### DIFF
--- a/.github/workflows/build_preview_branch.yml
+++ b/.github/workflows/build_preview_branch.yml
@@ -1,0 +1,37 @@
+name: Build preview branch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  push:
+    branches: ["main"]
+  pull_request_target:
+    types: [labeled, unlabeled, synchronize, reopened, closed]
+  workflow_dispatch:
+
+concurrency:
+  group: build-preview-branch
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Rebuild preview from main + labeled PRs
+    if: >-
+      github.event_name != 'pull_request_target'
+      || contains(github.event.pull_request.labels.*.name, 'preview')
+      || github.event.label.name == 'preview'
+    runs-on: ubuntu-latest
+    steps:
+      # Always main's copy of the script — never the PR's.
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Rebuild preview branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: ./scripts/build_preview_branch.sh

--- a/agent/utils/github_comments.py
+++ b/agent/utils/github_comments.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import os
 import re
 from typing import Any
 
@@ -20,19 +21,54 @@ __all__ = [
     "GitHubAuthError",
     "OPEN_SWE_TAGS",
     "build_pr_prompt",
+    "describe_open_swe_tags",
     "extract_pr_context",
     "fetch_issue_comments",
     "fetch_pr_branch",
     "fetch_pr_comments_since_last_tag",
     "format_github_comment_body_for_prompt",
     "get_thread_id_from_branch",
+    "mentions_open_swe",
     "post_github_comment",
     "react_to_github_comment",
     "sanitize_github_comment_body",
     "verify_github_signature",
 ]
 
-OPEN_SWE_TAGS = ("@openswe", "@open-swe", "@openswe-dev")
+_DEFAULT_OPEN_SWE_TAGS = ("@openswe", "@open-swe", "@openswe-dev")
+
+
+def _load_open_swe_tags() -> tuple[str, ...]:
+    configured = tuple(
+        tag.strip().lower()
+        for tag in os.environ.get("OPEN_SWE_MENTION_TAGS", "").split(",")
+        if tag.strip()
+    )
+    return configured or _DEFAULT_OPEN_SWE_TAGS
+
+
+OPEN_SWE_TAGS = _load_open_swe_tags()
+
+# Deployments sharing a workspace each own a distinct handle, so a tag must not
+# match when it is only a prefix of a longer one (@openswe vs @openswe-preview).
+_OPEN_SWE_TAG_RE = re.compile(
+    "(?:"
+    + "|".join(re.escape(tag) for tag in sorted(OPEN_SWE_TAGS, key=len, reverse=True))
+    + r")(?![\w-])",
+    re.IGNORECASE,
+)
+
+
+def mentions_open_swe(text: str | None) -> bool:
+    """Whether text mentions one of this deployment's handles."""
+    return bool(text) and _OPEN_SWE_TAG_RE.search(text or "") is not None
+
+
+def describe_open_swe_tags() -> str:
+    """Human-readable handle list for ignore reasons in webhook responses."""
+    return " or ".join(OPEN_SWE_TAGS)
+
+
 UNTRUSTED_GITHUB_COMMENT_OPEN_TAG = "<dangerous-external-untrusted-users-comment>"
 UNTRUSTED_GITHUB_COMMENT_CLOSE_TAG = "</dangerous-external-untrusted-users-comment>"
 _SANITIZED_UNTRUSTED_GITHUB_COMMENT_OPEN_TAG = "[blocked-untrusted-comment-tag-open]"
@@ -345,11 +381,8 @@ async def fetch_pr_comments_since_last_tag(
     # Sort all comments chronologically
     all_comments.sort(key=lambda c: c.get("created_at", ""))
 
-    # Find all @openswe / @open-swe mention positions
     tag_indices = [
-        i
-        for i, comment in enumerate(all_comments)
-        if any(tag in (comment.get("body") or "").lower() for tag in OPEN_SWE_TAGS)
+        i for i, comment in enumerate(all_comments) if mentions_open_swe(comment.get("body"))
     ]
 
     if not tag_indices:

--- a/agent/utils/github_org_membership.py
+++ b/agent/utils/github_org_membership.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from urllib.parse import quote
 
 import httpx
@@ -14,7 +15,14 @@ from .github_app import (
 
 logger = logging.getLogger(__name__)
 
-INTERNAL_BOT_LOGINS: frozenset[str] = frozenset({"open-swe[bot]", "openswe-dev[bot]"})
+INTERNAL_BOT_LOGINS: frozenset[str] = frozenset(
+    {"open-swe[bot]", "openswe-dev[bot]"}
+    | {
+        login.strip()
+        for login in os.environ.get("EXTRA_INTERNAL_BOT_LOGINS", "").split(",")
+        if login.strip()
+    }
+)
 
 
 async def is_user_active_org_member(username: str, org: str) -> bool:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -68,11 +68,13 @@ from ..utils.github_comments import (
     OPEN_SWE_TAGS,
     build_pr_prompt,  # noqa: F401
     derive_pr_state,
+    describe_open_swe_tags,  # noqa: F401
     extract_pr_context,  # noqa: F401
     fetch_issue_comments,  # noqa: F401
     fetch_pr_comments_since_last_tag,  # noqa: F401
     format_github_comment_body_for_prompt,
     get_thread_id_from_branch,  # noqa: F401
+    mentions_open_swe,  # noqa: F401
     react_to_github_comment,  # noqa: F401
     sanitize_github_comment_body,  # noqa: F401
     verify_github_signature,
@@ -143,6 +145,8 @@ __all__ = [
     "SLACK_BOT_USER_ID",
     "SLACK_SIGNING_SECRET",
     "_AGENT_VERSION_METADATA",
+    "describe_open_swe_tags",
+    "mentions_open_swe",
     "_GH_PR_AGENT_STATE_ACTIONS",
     "_GH_PR_FIRST_REVIEW_ACTIONS",
     "_GH_PR_WATCH_TOGGLE_ACTIONS",

--- a/agent/webhooks/github_routes.py
+++ b/agent/webhooks/github_routes.py
@@ -100,10 +100,11 @@ async def github_webhook(
                 common.logger.info("Ignoring GitHub issue edit without title/body changes")
                 return {"status": "ignored", "reason": "Issue edit did not change title or body"}
 
-        issue_text = f"{issue.get('title', '')}\n\n{issue.get('body', '')}".lower()
-        if not any(tag in issue_text for tag in common.OPEN_SWE_TAGS):
-            common.logger.info("Ignoring issue that does not mention @openswe or @open-swe")
-            return {"status": "ignored", "reason": "Issue does not mention @openswe or @open-swe"}
+        issue_text = f"{issue.get('title', '')}\n\n{issue.get('body', '')}"
+        if not common.mentions_open_swe(issue_text):
+            tags = common.describe_open_swe_tags()
+            common.logger.info("Ignoring issue that does not mention %s", tags)
+            return {"status": "ignored", "reason": f"Issue does not mention {tags}"}
 
         gate_rejection = await common._enforce_public_repo_org_gate(payload, event_type)
         if gate_rejection is not None:
@@ -135,13 +136,15 @@ async def github_webhook(
         background_tasks.add_task(service.process_github_review_finding_reply, payload)
         return {"status": "accepted", "message": "Processing review finding reply"}
 
-    if not any(tag in comment_body.lower() for tag in common.OPEN_SWE_TAGS):
+    if not common.mentions_open_swe(comment_body):
+        tags = common.describe_open_swe_tags()
         common.logger.debug(
-            "Ignoring GitHub %s%s that does not mention @openswe or @open-swe",
+            "Ignoring GitHub %s%s that does not mention %s",
             event_type,
             f" action={action}" if action else "",
+            tags,
         )
-        return {"status": "ignored", "reason": "Comment does not mention @openswe or @open-swe"}
+        return {"status": "ignored", "reason": f"Comment does not mention {tags}"}
 
     gate_rejection = await common._enforce_public_repo_org_gate(payload, event_type)
     if gate_rejection is not None:

--- a/agent/webhooks/linear_routes.py
+++ b/agent/webhooks/linear_routes.py
@@ -62,9 +62,10 @@ async def linear_webhook(  # noqa: PLR0911, PLR0912, PLR0915
         if comment_body.startswith(prefix):
             common.logger.debug("Ignoring webhook: comment is our own bot message")
             return {"status": "ignored", "reason": "Comment is our own bot message"}
-    if "@openswe" not in comment_body.lower():
-        common.logger.debug("Ignoring webhook: comment doesn't mention @openswe")
-        return {"status": "ignored", "reason": "Comment doesn't mention @openswe"}
+    if not common.mentions_open_swe(comment_body):
+        tags = common.describe_open_swe_tags()
+        common.logger.debug("Ignoring webhook: comment doesn't mention %s", tags)
+        return {"status": "ignored", "reason": f"Comment doesn't mention {tags}"}
 
     issue = data.get("issue", {})
     if not issue:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -265,6 +265,8 @@ GitHub triggering works automatically once your GitHub App is set up (step 3). U
 - Tag `@openswe` in issue comments for follow-up instructions
 - Tag `@openswe` in PR review comments to have it address review feedback
 
+The handles this deployment answers to default to `@openswe,@open-swe,@openswe-dev` and are configurable — set `OPEN_SWE_MENTION_TAGS` to a comma-separated list. Handles are matched on a word boundary, so `@openswe` does not fire on `@openswe-preview`. Give each deployment a distinct handle when more than one shares a GitHub org, Slack workspace, or Linear workspace.
+
 Which GitHub users can trigger the agent is controlled by the **user mapping** (GitHub login ⇄ work email ⇄ optional Slack ID), stored in the LangGraph Store rather than in code. Manage it in the dashboard under **Admin → User mappings**:
 
 - **Add / update** a single mapping (GitHub login + work email, plus an optional Slack user ID). The list is paged (20 per page).
@@ -465,6 +467,15 @@ GITHUB_APP_INSTALLATION_ID=""          # From step 3d
 
 # === GitHub Webhook (required) ===
 GITHUB_WEBHOOK_SECRET=""               # The secret you generated in step 3b
+
+# === Mention handles (optional) ===
+# Comma-separated handles this deployment answers to, across GitHub, Linear and Slack.
+# Defaults to "@openswe,@open-swe,@openswe-dev".
+OPEN_SWE_MENTION_TAGS=""               # e.g. "@openswe-preview"
+# Comma-separated bot logins to treat as internal rather than untrusted external
+# commenters. Set this to the bot logins of any other Open SWE deployments sharing
+# these repos.
+EXTRA_INTERNAL_BOT_LOGINS=""           # e.g. "openswe-preview[bot]"
 
 # === Dashboard GitHub OAuth (required for the dashboard) ===
 # Direct GitHub OAuth used by the dashboard login flow (not via LangSmith).

--- a/docs/PREVIEW_ENV.md
+++ b/docs/PREVIEW_ENV.md
@@ -1,0 +1,120 @@
+# Preview environment
+
+A second, fully separate deployment of Open SWE that runs ahead of production, with
+its own GitHub App, Slack app, LangGraph deployment, and Vercel project. Nothing is
+shared with prod except the source repository.
+
+## Branches
+
+| Branch | Contents | Updated by |
+|---|---|---|
+| `main` | Merged work | PRs |
+| `preview` | `main` + every open PR labeled `preview` (org members only) | `.github/workflows/build_preview_branch.yml`, on every push to `main` and on every label/push event for a labeled PR |
+| `prod` | Snapshot of `main` | `.github/workflows/promote_main_to_prod.yml`, daily at 08:00 UTC |
+
+`preview` is force-pushed and rebuilt from scratch on every run — never commit to it
+directly. Removing the `preview` label (or merging/closing the PR) drops the PR from
+the branch on the next build.
+
+### Testing an unmerged PR on preview
+
+Add the `preview` label. The build merges labeled PRs into `preview` in ascending PR
+number order, and the LangGraph deployment picks it up. A PR that fails to merge is
+skipped and the build continues with the next one — so one conflict never blocks the
+rest of the queue.
+
+Every labeled PR gets a single comment reporting its status (merged, conflicting, or
+rejected for authorship). It is updated in place rather than re-posted, so repeated
+rebuilds produce no extra notifications. Because merges run in PR number order, a
+conflict is always reported against the lower-numbered PR already on the branch.
+
+**Only PRs whose `authorAssociation` is `OWNER` or `MEMBER` are merged.** GitHub computes
+that server-side from organization membership, so it covers private members and cannot be
+set by the PR author. Outside collaborators and drive-by contributors are excluded.
+
+This gate is a security boundary: code merged into `preview` runs in the preview
+deployment with preview credentials, and a merged `.github/workflows/` change would run
+with repository secrets if it triggers on `preview`. The workflow itself only ever runs
+`main`'s copy of `scripts/build_preview_branch.sh` and never executes PR code in CI.
+
+## What to provision
+
+Each item below is created by hand once. Everything the application reads is an
+environment variable, so no code changes are needed per environment.
+
+### 1. GitHub App
+
+Create a second app (e.g. "Open SWE Preview") following [INSTALLATION.md §3](INSTALLATION.md),
+with its own webhook URL pointed at the preview LangGraph deployment. Install it only on
+the repositories you want preview to touch — the app's installation list is what keeps
+preview off production repositories.
+
+Its bot login (e.g. `openswe-preview[bot]`) must be added to `EXTRA_INTERNAL_BOT_LOGINS`
+on **both** deployments so neither treats the other's comments as untrusted external input.
+
+### 2. Slack app
+
+A second Slack app with its own bot token, signing secret, and OAuth client. Give it a
+distinct handle so a mention routes to exactly one deployment, and invite it only to the
+channels preview should serve.
+
+### 3. Linear
+
+Linear webhooks are per-workspace, so both deployments see the same comments. Isolation
+comes from `OPEN_SWE_MENTION_TAGS` (below), not from the webhook. Use a separate Linear
+API key so preview's comments are attributable.
+
+### 4. LangGraph deployment
+
+A new deployment tracking the `preview` branch, with the environment variables below.
+
+### 5. Vercel project
+
+A new project with root directory `ui/`, production branch `preview`, and
+`VITE_DASHBOARD_API_BASE_URL` set to the preview LangGraph deployment URL. The UI calls
+that URL directly (cross-origin with credentials), so add the preview Vercel domain to
+`DASHBOARD_ALLOWED_ORIGINS` on the preview deployment.
+
+> `ui/vercel.json` hardcodes the production LangGraph URL in a `/dashboard/api/:path*`
+> rewrite. Vercel does not interpolate environment variables in `vercel.json`, so the
+> preview project cannot override it. It is unused as long as
+> `VITE_DASHBOARD_API_BASE_URL` is an absolute URL — which it must be for preview.
+
+## Environment variables
+
+### Must differ from prod
+
+| Variable | Why |
+|---|---|
+| `OPEN_SWE_MENTION_TAGS` | Comma-separated mention handles this deployment answers to. Set to `@openswe-preview` on preview. Matching is boundary-aware, so prod's `@openswe` does **not** match `@openswe-preview`. Defaults to `@openswe,@open-swe,@openswe-dev`. |
+| `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_OAUTH_PROVIDER_ID` | Preview's own GitHub App. |
+| `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_BOT_USER_ID`, `SLACK_BOT_USERNAME` | Preview's own Slack app. |
+| `LINEAR_API_KEY`, `LINEAR_WEBHOOK_SECRET` | Preview's own Linear integration. |
+| `DASHBOARD_BASE_URL`, `DASHBOARD_API_BASE_URL`, `DASHBOARD_ALLOWED_ORIGINS` | Preview's Vercel domain and LangGraph URL. |
+| `LANGGRAPH_URL` | Preview's own deployment URL. |
+| `TOKEN_ENCRYPTION_KEY` | A fresh key. Sharing it would let either deployment decrypt the other's stored user tokens; a separate key means users authenticate to preview separately. |
+| `RUN_COMPLETE_WEBHOOK_SECRET`, `X_SERVICE_AUTH_JWT_SECRET` | Independent secrets. |
+| `EXTRA_INTERNAL_BOT_LOGINS` | The *other* deployment's bot login, on both sides. |
+| `REVIEWER_OUTCOMES_DATASET` | Keeps preview's reviewer outcomes out of the production learning dataset. |
+
+### Should differ
+
+| Variable | Why |
+|---|---|
+| `ALLOWED_GITHUB_ORGS`, `PUBLIC_REPO_ORG_GATE` | Narrow preview to the repositories it should serve. |
+| `DEFAULT_REPO_OWNER`, `DEFAULT_REPO_NAME`, `SLACK_REPO_OWNER`, `SLACK_REPO_NAME` | Point preview at a test repository. |
+| `LANGCHAIN_PROJECT` / LangSmith tracing project | Keeps preview traces separate. |
+| `OBSERVABILITY_AUTHORIZED_EMAILS` | Usually a smaller list on preview. |
+
+### Safe to share
+
+LLM provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`),
+`DEFAULT_SANDBOX_SNAPSHOT_ID`, `REPO_SNAPSHOT_BASE_IMAGE`, and the timeout/limit tuning
+variables.
+
+## Verifying isolation
+
+1. Mention `@openswe-preview` on a test PR — only the preview bot should reply.
+2. Mention `@openswe` on the same PR — only the production bot should reply.
+3. Label an open PR `preview`, then check the workflow run summary lists it under **Merged**.
+4. Open the preview Vercel URL and confirm the dashboard loads and login succeeds.

--- a/docs/PREVIEW_ENV.md
+++ b/docs/PREVIEW_ENV.md
@@ -1,120 +1,72 @@
 # Preview environment
 
-A second, fully separate deployment of Open SWE that runs ahead of production, with
-its own GitHub App, Slack app, LangGraph deployment, and Vercel project. Nothing is
-shared with prod except the source repository.
+A preview environment is a second instance of Open SWE, deployed from the `preview`
+branch, that runs ahead of production. Set it up by following
+[INSTALLATION.md](INSTALLATION.md) end to end a second time — its own GitHub App, Slack
+app, Linear webhook, LangGraph deployment, and Vercel project.
 
-## Branches
+This page covers only what is specific to running two instances side by side.
+
+## The `preview` branch
 
 | Branch | Contents | Updated by |
 |---|---|---|
-| `main` | Merged work | PRs |
-| `preview` | `main` + every open PR labeled `preview` (org members only) | `.github/workflows/build_preview_branch.yml`, on every push to `main` and on every label/push event for a labeled PR |
+| `preview` | `main` + every open PR labeled `preview` | `.github/workflows/build_preview_branch.yml`, on every push to `main` and on every label/push event for a labeled PR |
 | `prod` | Snapshot of `main` | `.github/workflows/promote_main_to_prod.yml`, daily at 08:00 UTC |
 
 `preview` is force-pushed and rebuilt from scratch on every run — never commit to it
-directly. Removing the `preview` label (or merging/closing the PR) drops the PR from
-the branch on the next build.
+directly, and do not enable branch protection on it. Removing the `preview` label (or
+merging/closing the PR) drops that PR on the next build.
 
-### Testing an unmerged PR on preview
+### Testing an unmerged PR
 
-Add the `preview` label. The build merges labeled PRs into `preview` in ascending PR
-number order, and the LangGraph deployment picks it up. A PR that fails to merge is
-skipped and the build continues with the next one — so one conflict never blocks the
-rest of the queue.
-
-Every labeled PR gets a single comment reporting its status (merged, conflicting, or
-rejected for authorship). It is updated in place rather than re-posted, so repeated
-rebuilds produce no extra notifications. Because merges run in PR number order, a
-conflict is always reported against the lower-numbered PR already on the branch.
+Add the `preview` label. Labeled PRs are merged in ascending PR number order; one that
+fails to merge is skipped and the build continues with the next, so a single conflict
+never blocks the queue. Each labeled PR gets one status comment (merged, conflicting, or
+rejected), updated in place rather than re-posted.
 
 **Only PRs whose `authorAssociation` is `OWNER` or `MEMBER` are merged.** GitHub computes
 that server-side from organization membership, so it covers private members and cannot be
-set by the PR author. Outside collaborators and drive-by contributors are excluded.
+set by the PR author.
 
-This gate is a security boundary: code merged into `preview` runs in the preview
+That gate is a security boundary: code merged into `preview` runs in the preview
 deployment with preview credentials, and a merged `.github/workflows/` change would run
 with repository secrets if it triggers on `preview`. The workflow itself only ever runs
 `main`'s copy of `scripts/build_preview_branch.sh` and never executes PR code in CI.
 
-## What to provision
+## Keeping the two instances apart
 
-Each item below is created by hand once. Everything the application reads is an
-environment variable, so no code changes are needed per environment.
+Give preview a distinct `OPEN_SWE_MENTION_TAGS` (e.g. `@openswe-preview`). Linear
+webhooks are per-workspace and a Slack workspace is shared, so the handle — not the
+webhook — is what routes a mention to exactly one instance. Set each instance's
+`EXTRA_INTERNAL_BOT_LOGINS` to the other's bot login so neither treats the other's
+comments as untrusted external input.
 
-### 1. GitHub App
+Beyond the credentials that are obviously per-app, two variables are easy to
+copy across by mistake:
 
-Create a second app (e.g. "Open SWE Preview") following [INSTALLATION.md §3](INSTALLATION.md),
-with its own webhook URL pointed at the preview LangGraph deployment. Install it only on
-the repositories you want preview to touch — the app's installation list is what keeps
-preview off production repositories.
+- `TOKEN_ENCRYPTION_KEY` — generate a fresh one. A shared key lets either instance
+  decrypt the other's stored user tokens; a separate key means users authenticate to
+  preview separately.
+- `REVIEWER_OUTCOMES_DATASET` — keeps preview's reviewer outcomes out of the production
+  learning dataset.
 
-Its bot login (e.g. `openswe-preview[bot]`) must be added to `EXTRA_INTERNAL_BOT_LOGINS`
-on **both** deployments so neither treats the other's comments as untrusted external input.
+Scope preview with its own `ALLOWED_GITHUB_ORGS` / `ALLOWED_GITHUB_REPOS` and install its
+GitHub App only on the repositories it should touch.
 
-### 2. Slack app
+## Vercel
 
-A second Slack app with its own bot token, signing secret, and OAuth client. Give it a
-distinct handle so a mention routes to exactly one deployment, and invite it only to the
-channels preview should serve.
-
-### 3. Linear
-
-Linear webhooks are per-workspace, so both deployments see the same comments. Isolation
-comes from `OPEN_SWE_MENTION_TAGS` (below), not from the webhook. Use a separate Linear
-API key so preview's comments are attributable.
-
-### 4. LangGraph deployment
-
-A new deployment tracking the `preview` branch, with the environment variables below.
-
-### 5. Vercel project
-
-A new project with root directory `ui/`, production branch `preview`, and
-`VITE_DASHBOARD_API_BASE_URL` set to the preview LangGraph deployment URL. The UI calls
-that URL directly (cross-origin with credentials), so add the preview Vercel domain to
-`DASHBOARD_ALLOWED_ORIGINS` on the preview deployment.
+Root directory `ui/`, production branch `preview`, and `VITE_DASHBOARD_API_BASE_URL` set
+to the preview LangGraph deployment URL. The UI calls that URL directly (cross-origin
+with credentials), so add the preview Vercel domain to `DASHBOARD_ALLOWED_ORIGINS`.
 
 > `ui/vercel.json` hardcodes the production LangGraph URL in a `/dashboard/api/:path*`
 > rewrite. Vercel does not interpolate environment variables in `vercel.json`, so the
 > preview project cannot override it. It is unused as long as
 > `VITE_DASHBOARD_API_BASE_URL` is an absolute URL — which it must be for preview.
 
-## Environment variables
-
-### Must differ from prod
-
-| Variable | Why |
-|---|---|
-| `OPEN_SWE_MENTION_TAGS` | Comma-separated mention handles this deployment answers to. Set to `@openswe-preview` on preview. Matching is boundary-aware, so prod's `@openswe` does **not** match `@openswe-preview`. Defaults to `@openswe,@open-swe,@openswe-dev`. |
-| `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_OAUTH_PROVIDER_ID` | Preview's own GitHub App. |
-| `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_BOT_USER_ID`, `SLACK_BOT_USERNAME` | Preview's own Slack app. |
-| `LINEAR_API_KEY`, `LINEAR_WEBHOOK_SECRET` | Preview's own Linear integration. |
-| `DASHBOARD_BASE_URL`, `DASHBOARD_API_BASE_URL`, `DASHBOARD_ALLOWED_ORIGINS` | Preview's Vercel domain and LangGraph URL. |
-| `LANGGRAPH_URL` | Preview's own deployment URL. |
-| `TOKEN_ENCRYPTION_KEY` | A fresh key. Sharing it would let either deployment decrypt the other's stored user tokens; a separate key means users authenticate to preview separately. |
-| `RUN_COMPLETE_WEBHOOK_SECRET`, `X_SERVICE_AUTH_JWT_SECRET` | Independent secrets. |
-| `EXTRA_INTERNAL_BOT_LOGINS` | The *other* deployment's bot login, on both sides. |
-| `REVIEWER_OUTCOMES_DATASET` | Keeps preview's reviewer outcomes out of the production learning dataset. |
-
-### Should differ
-
-| Variable | Why |
-|---|---|
-| `ALLOWED_GITHUB_ORGS`, `PUBLIC_REPO_ORG_GATE` | Narrow preview to the repositories it should serve. |
-| `DEFAULT_REPO_OWNER`, `DEFAULT_REPO_NAME`, `SLACK_REPO_OWNER`, `SLACK_REPO_NAME` | Point preview at a test repository. |
-| `LANGCHAIN_PROJECT` / LangSmith tracing project | Keeps preview traces separate. |
-| `OBSERVABILITY_AUTHORIZED_EMAILS` | Usually a smaller list on preview. |
-
-### Safe to share
-
-LLM provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`),
-`DEFAULT_SANDBOX_SNAPSHOT_ID`, `REPO_SNAPSHOT_BASE_IMAGE`, and the timeout/limit tuning
-variables.
-
 ## Verifying isolation
 
-1. Mention `@openswe-preview` on a test PR — only the preview bot should reply.
-2. Mention `@openswe` on the same PR — only the production bot should reply.
-3. Label an open PR `preview`, then check the workflow run summary lists it under **Merged**.
-4. Open the preview Vercel URL and confirm the dashboard loads and login succeeds.
+1. Mention `@openswe-preview` on a test PR — only the preview bot replies.
+2. Mention `@openswe` on the same PR — only the production bot replies.
+3. Label an open PR `preview` and confirm the workflow run summary lists it under **Merged**.

--- a/scripts/build_preview_branch.sh
+++ b/scripts/build_preview_branch.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Rebuild the `preview` deploy branch as main + every open PR carrying the
+# preview label, in ascending PR order, restricted to org members. Runs only
+# from main's checkout, and never executes anything from the PRs it merges.
+set -euo pipefail
+
+PREVIEW_BRANCH="${PREVIEW_BRANCH:-preview}"
+PREVIEW_LABEL="${PREVIEW_LABEL:-preview}"
+PREVIEW_MAX_PRS="${PREVIEW_MAX_PRS:-50}"
+
+MARKER_PREFIX="<!-- open-swe-preview-branch"
+
+summary() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+# Post or update the single preview-branch comment on a PR. The state is
+# encoded in the marker so an unchanged status is left alone rather than
+# rewritten on every rebuild.
+upsert_pr_comment() {
+  local number="$1" state="$2" body="$3"
+  local marker="${MARKER_PREFIX} state=${state} -->"
+  local full_body existing existing_id existing_marker
+
+  full_body="${marker}"$'\n'"${body}"
+
+  existing="$(gh api --paginate "repos/${GH_REPO}/issues/${number}/comments" \
+    --jq ".[] | select(.body != null and (.body | startswith(\"${MARKER_PREFIX}\"))) | [.id, (.body | split(\"\n\")[0])] | @tsv" |
+    head -n 1)"
+  existing_id="${existing%%$'\t'*}"
+  existing_marker="${existing#*$'\t'}"
+
+  if [[ -n "$existing_id" && "$existing_marker" == "$marker" ]]; then
+    return 0
+  fi
+
+  if [[ -n "$existing_id" ]]; then
+    gh api --method PATCH "repos/${GH_REPO}/issues/comments/${existing_id}" \
+      -f body="$full_body" >/dev/null
+  else
+    gh api --method POST "repos/${GH_REPO}/issues/${number}/comments" \
+      -f body="$full_body" >/dev/null
+  fi
+}
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git fetch origin main
+git checkout -B "$PREVIEW_BRANCH" origin/main
+base_sha="$(git rev-parse HEAD)"
+
+prs="$(gh pr list \
+  --state open \
+  --label "$PREVIEW_LABEL" \
+  --limit "$PREVIEW_MAX_PRS" \
+  --json number,headRefOid,authorAssociation,author)"
+
+included=()
+skipped=()
+
+while IFS=$'\t' read -r number head_sha association login; do
+  [[ -z "$number" ]] && continue
+
+  case "$association" in
+    OWNER | MEMBER) ;;
+    *)
+      skipped+=("#${number} (@${login}) — author is \`${association}\`, not an org member")
+      upsert_pr_comment "$number" "not-member:${association}" \
+        "This PR is labeled \`${PREVIEW_LABEL}\` but was **not** merged into the \`${PREVIEW_BRANCH}\` branch: only PRs authored by organization members are deployed to the preview environment."
+      continue
+      ;;
+  esac
+
+  if ! git fetch --no-tags origin "pull/${number}/head:refs/preview-prs/${number}" 2>/dev/null; then
+    skipped+=("#${number} (@${login}) — could not fetch PR head")
+    upsert_pr_comment "$number" "fetch-failed" \
+      "Could not fetch this PR's head commit while rebuilding the \`${PREVIEW_BRANCH}\` branch, so it is **not** deployed to the preview environment."
+    continue
+  fi
+
+  fetched_sha="$(git rev-parse "refs/preview-prs/${number}")"
+  if [[ "$fetched_sha" != "$head_sha" ]]; then
+    # Transient: a push landed mid-run and will retrigger this workflow.
+    skipped+=("#${number} (@${login}) — head moved mid-run, will pick up on the next build")
+    continue
+  fi
+
+  if git merge --no-ff -m "preview: merge PR #${number} from @${login}" "$fetched_sha"; then
+    included+=("#${number} (@${login}) — \`${fetched_sha:0:7}\`")
+    upsert_pr_comment "$number" "merged:${fetched_sha:0:7}" \
+      "Merged into the \`${PREVIEW_BRANCH}\` branch at \`${fetched_sha:0:7}\` and deployed to the preview environment."
+  else
+    git merge --abort
+    skipped+=("#${number} (@${login}) — merge conflict with the current preview branch")
+    upsert_pr_comment "$number" "conflict:${fetched_sha:0:7}" \
+      "This PR conflicts with the \`${PREVIEW_BRANCH}\` branch (\`main\` plus the other PRs labeled \`${PREVIEW_LABEL}\` with a lower number), so it is **not** deployed to the preview environment. Rebase on \`main\` or wait for the conflicting PR to merge, then push to retry."
+  fi
+done < <(echo "$prs" | jq -r 'sort_by(.number)[] | [.number, .headRefOid, .authorAssociation, .author.login] | @tsv')
+
+git push --force origin "HEAD:refs/heads/${PREVIEW_BRANCH}"
+
+summary "## Preview branch rebuilt"
+summary ""
+summary "Base: \`main\` @ \`${base_sha:0:7}\`"
+summary ""
+if ((${#included[@]})); then
+  summary "### Merged (${#included[@]})"
+  for entry in "${included[@]}"; do summary "- ${entry}"; done
+else
+  summary "### Merged (0)"
+  summary "- _preview is identical to main_"
+fi
+if ((${#skipped[@]})); then
+  summary ""
+  summary "### Skipped (${#skipped[@]})"
+  for entry in "${skipped[@]}"; do summary "- ${entry}"; done
+fi

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -297,12 +297,13 @@ def test_github_webhook_ignores_unmentioned_comment_without_info_log(monkeypatch
         },
     )
 
+    tags = webhook_common.describe_open_swe_tags()
     assert response.status_code == 200
     assert response.json() == {
         "status": "ignored",
-        "reason": "Comment does not mention @openswe or @open-swe",
+        "reason": f"Comment does not mention {tags}",
     }
-    assert "does not mention @openswe or @open-swe" not in caplog.text
+    assert f"does not mention {tags}" not in caplog.text
 
 
 def test_github_webhook_routes_review_comment_reply_without_tag(monkeypatch) -> None:

--- a/tests/github/test_mention_tags.py
+++ b/tests/github/test_mention_tags.py
@@ -1,0 +1,62 @@
+"""Mention-handle matching, which keeps parallel deployments from double-firing."""
+
+import importlib
+
+import pytest
+
+from agent.utils import github_comments
+
+
+@pytest.fixture
+def reload_tags(monkeypatch):
+    def _reload(value: str | None):
+        if value is None:
+            monkeypatch.delenv("OPEN_SWE_MENTION_TAGS", raising=False)
+        else:
+            monkeypatch.setenv("OPEN_SWE_MENTION_TAGS", value)
+        return importlib.reload(github_comments)
+
+    yield _reload
+    monkeypatch.delenv("OPEN_SWE_MENTION_TAGS", raising=False)
+    importlib.reload(github_comments)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "@openswe please fix this",
+        "hey @open-swe, take a look",
+        "@OpenSWE ping",
+        "cc @openswe-dev",
+        "@openswe: do the thing",
+        "(@openswe)",
+    ],
+)
+def test_matches_configured_handles(body: str) -> None:
+    assert github_comments.mentions_open_swe(body)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "@openswe-preview please fix this",
+        "@openswefoo",
+        "no mention here",
+        "",
+        None,
+    ],
+)
+def test_ignores_longer_handles_and_empty(body: str | None) -> None:
+    assert not github_comments.mentions_open_swe(body)
+
+
+def test_env_overrides_handles(reload_tags) -> None:
+    module = reload_tags("@openswe-preview")
+    assert module.OPEN_SWE_TAGS == ("@openswe-preview",)
+    assert module.mentions_open_swe("@openswe-preview ship it")
+    assert not module.mentions_open_swe("@openswe ship it")
+
+
+def test_blank_env_falls_back_to_defaults(reload_tags) -> None:
+    module = reload_tags("  ,  ")
+    assert module.OPEN_SWE_TAGS == module._DEFAULT_OPEN_SWE_TAGS


### PR DESCRIPTION
Adds the plumbing for a second Open SWE deployment ("preview") that runs ahead of prod with its own GitHub App, Slack app, Linear credentials, LangGraph deployment, and Vercel project. No code assumed prod before this — the two gaps were the mention-handle matching and the absence of a `preview` branch builder.

### The `preview` branch

`.github/workflows/build_preview_branch.yml` rebuilds `preview` as `main` plus every open PR labeled `preview`, on every push to `main` and on every label/push event for a labeled PR. PRs merge in ascending number order; one that conflicts is skipped and the build continues with the next. Each labeled PR gets a single status comment (merged / conflict / rejected) that is updated in place, so repeated rebuilds produce no extra notifications.

Only PRs whose `authorAssociation` is `OWNER` or `MEMBER` are merged. GitHub computes that server-side from organization membership, so it covers private members and cannot be set by the PR author. The workflow always runs `main`'s copy of the build script and never executes PR code in CI.

### Mention handles

`OPEN_SWE_TAGS` matched by substring, so `@openswe` matched inside `@openswe-preview` — a preview deployment sharing a Slack workspace or Linear workspace with prod would have made both bots answer the same mention. Matching is now boundary-aware and the handle list is configurable via `OPEN_SWE_MENTION_TAGS`. `EXTRA_INTERNAL_BOT_LOGINS` lets each deployment recognize the other's bot as internal rather than untrusted external input.

### Docs

`docs/PREVIEW_ENV.md` covers the provisioning steps that have to be done by hand and splits the environment variables into must-differ, should-differ, and safe-to-share. It also records that `ui/vercel.json` hardcodes the production LangGraph URL in a rewrite — Vercel cannot interpolate env vars there, so the preview project relies on an absolute `VITE_DASHBOARD_API_BASE_URL` instead, which makes the rewrite unused.

## Test Plan

- [x] `make test` — 1729 passed, including new `tests/github/test_mention_tags.py` covering boundary matching, env override, and blank-env fallback
- [x] `make lint` clean; `make typecheck` reports no new errors
- [x] `scripts/build_preview_branch.sh` exercised end-to-end against a throwaway git repo with a stubbed `gh`: PRs fed out of order (4, 3, 1, 2) merged as 1 then 2; a conflicting PR and a `CONTRIBUTOR`-authored PR were both skipped with the build continuing; all four received the correct status comment
- [x] Re-running the same build with those comments already present produced zero API writes, confirming the sticky comment is idempotent
