### PR TITLE
fix: read PR author association from the REST pulls endpoint

### DIFF
--- a/scripts/build_preview_branch.sh
+++ b/scripts/build_preview_branch.sh
@@ -54,11 +54,15 @@ git fetch origin main
 git checkout -B "$PREVIEW_BRANCH" origin/main
 base_sha="$(git rev-parse HEAD)"
 
-prs="$(gh pr list \
-  --state open \
-  --label "$PREVIEW_LABEL" \
-  --limit "$PREVIEW_MAX_PRS" \
-  --json number,headRefOid,authorAssociation,author)"
+# The REST pulls endpoint is the only one carrying author_association alongside
+# the head sha; `gh pr list --json` does not expose it.
+prs="$(gh api --paginate "repos/${GH_REPO}/pulls?state=open&per_page=100" \
+  --jq ".[]
+        | select(any(.labels[]; .name == \"${PREVIEW_LABEL}\"))
+        | [.number, .head.sha, .author_association, .user.login]
+        | @tsv" |
+  sort -n |
+  awk -v max="$PREVIEW_MAX_PRS" 'NR<=max')"
 
 included=()
 skipped=()
@@ -100,7 +104,7 @@ while IFS=$'\t' read -r number head_sha association login; do
     upsert_pr_comment "$number" "conflict:${fetched_sha:0:7}" \
       "This PR conflicts with the \`${PREVIEW_BRANCH}\` branch (\`main\` plus the other PRs labeled \`${PREVIEW_LABEL}\` with a lower number), so it is **not** deployed to the preview environment. Rebase on \`main\` or wait for the conflicting PR to merge, then push to retry."
   fi
-done < <(echo "$prs" | jq -r 'sort_by(.number)[] | [.number, .headRefOid, .authorAssociation, .author.login] | @tsv')
+done < <(printf '%s\n' "$prs")
 
 git push --force origin "HEAD:refs/heads/${PREVIEW_BRANCH}"
 


### PR DESCRIPTION
`gh pr list --json authorAssociation` is not a valid field, so every run of the preview-branch build failed immediately: https://github.com/langchain-ai/open-swe/actions/runs/31506950999

The REST pulls endpoint carries `author_association` alongside `head.sha`, `labels`, and `user.login`, so one `gh api` call replaces the `gh pr list` call and the label filtering moves into jq. Ordering is now `sort -n` on the emitted TSV rather than `jq sort_by`.

The stub `gh` I tested against accepted the invalid `--json` field, which is why this reached CI. The local harness now replays the real pulls-endpoint response shape.

## Test Plan

- [x] Ran the exact `gh api --paginate .../pulls?state=open --jq ...` query against this repo — returns `1882 0746bcf MEMBER ramon-langchain`, the one PR currently labeled `preview`
- [x] Re-ran `scripts/build_preview_branch.sh` end-to-end against a throwaway repo with a stub serving the real response shape: 5 PRs fed out of order, unlabeled PR excluded, a multi-label PR included, merges in ascending order (1 then 2), conflicting and non-member PRs skipped with the build continuing and all four commented
