### PR TITLE
ci: restore permissive PR title lint

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,0 +1,34 @@
+name: PR Title Lint
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            release
+          requireScope: false
+          ignoreLabels: |
+            ignore-lint-pr-title


### PR DESCRIPTION
Restores PR title linting without the fixed scope allowlist.

Arbitrary optional scopes such as `feat(terminal): add shell support` are accepted, while the existing conventional type validation remains.

Test: `git diff --check`
