### PR TITLE
fix: keep local sandbox setup off event loop

### DIFF
--- a/agent/integrations/local.py
+++ b/agent/integrations/local.py
@@ -1,10 +1,9 @@
-import asyncio
 import os
 
 from deepagents.backends import LocalShellBackend
 
 
-async def create_local_sandbox(sandbox_id: str | None = None):
+def create_local_sandbox(sandbox_id: str | None = None):
     """Create a local shell sandbox with no isolation.
 
     WARNING: This runs commands directly on the host machine with no sandboxing.
@@ -21,7 +20,7 @@ async def create_local_sandbox(sandbox_id: str | None = None):
         LocalShellBackend instance implementing SandboxBackendProtocol.
     """
     root_dir = os.getenv("LOCAL_SANDBOX_ROOT_DIR", os.getcwd())
-    await asyncio.to_thread(os.makedirs, root_dir, exist_ok=True)
+    os.makedirs(root_dir, exist_ok=True)
 
     return LocalShellBackend(
         root_dir=root_dir,

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -42,11 +42,10 @@ async def create_sandbox(
     The provider is selected via the SANDBOX_TYPE environment variable.
     Supported values: langsmith (default), daytona, modal, runloop, e2b, local.
 
-    langsmith, modal and local provision natively async. daytona, e2b and
-    runloop stay on ``asyncio.to_thread``: their ``langchain_*`` backend
-    wrappers bind a *sync* SDK handle (``E2BSandbox(sandbox=e2b.Sandbox)``,
-    ``RunloopSandbox`` calling ``devbox.cmd.exec``), so the async SDK client
-    cannot be handed to them.
+    langsmith and modal provision natively async. local stays on
+    ``asyncio.to_thread`` because ``LocalShellBackend`` setup performs synchronous
+    filesystem I/O. daytona, e2b and runloop stay there because their
+    ``langchain_*`` wrappers bind synchronous SDK handles.
 
     Args:
         sandbox_id: Optional existing sandbox ID to reconnect to.

--- a/tests/sandbox/test_local_integration.py
+++ b/tests/sandbox/test_local_integration.py
@@ -10,12 +10,12 @@ class _StubLocalShellBackend:
         self.inherit_env = inherit_env
 
 
-async def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
+def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
     root = tmp_path / "nested" / "openswe-sandbox"
     monkeypatch.setenv("LOCAL_SANDBOX_ROOT_DIR", str(root))
     monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
 
-    backend = await local_mod.create_local_sandbox()
+    backend = local_mod.create_local_sandbox()
 
     assert root.is_dir()
     stub = cast(_StubLocalShellBackend, backend)
@@ -24,12 +24,12 @@ async def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_pa
     assert stub.inherit_env is True
 
 
-async def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
+def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
     monkeypatch.delenv("LOCAL_SANDBOX_ROOT_DIR", raising=False)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
 
-    backend = await local_mod.create_local_sandbox()
+    backend = local_mod.create_local_sandbox()
 
     stub = cast(_StubLocalShellBackend, backend)
     assert stub.root_dir == str(tmp_path)


### PR DESCRIPTION
Fix local sandbox creation failing under LangGraph dev's blocking-call detector.

- Route synchronous local backend setup through the existing factory thread bridge.
- Preserve native async sandbox execution and remote provider setup.
- Restore the local factory tests to the synchronous contract.

Tests:
- `uv run pytest -q tests/sandbox/test_local_integration.py tests/sandbox/test_proxy_auth.py::TestSandboxFactoryLoading`
- Targeted Ruff check and format check
- Targeted BlockBuster filesystem probe
