### PR TITLE
feat: rebuild the agent side panel as a tabbed workspace

### DIFF
--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -71,7 +71,7 @@ window.addEventListener("DOMContentLoaded", () => {
       user-select: none;
     }
 
-    aside > div:first-child {
+    [data-sidebar-frame] > div:first-child {
       -webkit-app-region: drag;
       box-sizing: border-box;
       height: 52px;
@@ -81,7 +81,7 @@ window.addEventListener("DOMContentLoaded", () => {
       padding-bottom: 0 !important;
     }
 
-    aside > div:first-child :is(a, button, input, textarea, select, [role="button"]) {
+    [data-sidebar-frame] > div:first-child :is(a, button, input, textarea, select, [role="button"]) {
       -webkit-app-region: no-drag;
     }
 

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -133,6 +133,7 @@ export function SidebarFrame({
 
   return (
     <aside
+      data-sidebar-frame=""
       style={{ width }}
       className={cn(
         "relative flex h-svh shrink-0 flex-col",

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -178,9 +178,13 @@ export function AgentGitPanel({
 
   return (
     <AgentPanelShell
-      tabs={[["git", "Git"], ...(hasPlan ? ([["plan", "Plan"]] as const) : [])]}
-      activeTab={topTab}
-      onTabChange={onTabChange}
+      tabs={[
+        { id: "git", kind: "review" as const },
+        ...(hasPlan ? [{ id: "plan", kind: "plan" as const }] : []),
+      ]}
+      activeTabId={topTab}
+      onSelectTab={(id) => onTabChange(id as AgentPanelTab)}
+      menuKinds={[]}
       collapsed={collapsed}
       onCollapsedChange={setCollapsed}
     >
@@ -188,10 +192,6 @@ export function AgentGitPanel({
         <>
           {topTab === "plan" ? (
             <PlanView threadId={thread.id} onApprove={onPlanApproved} />
-          ) : topTab !== "git" ? (
-            <div className="flex flex-1 items-center justify-center p-6 text-xs text-muted-foreground/70">
-              Coming Soon
-            </div>
           ) : (
             <>
               {pr && (

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -184,6 +184,7 @@ export function AgentGitPanel({
       ]}
       activeTabId={topTab}
       onSelectTab={(id) => onTabChange(id as AgentPanelTab)}
+      onCloseTab={() => setCollapsed(true)}
       menuKinds={[]}
       collapsed={collapsed}
       onCollapsedChange={setCollapsed}
@@ -196,14 +197,14 @@ export function AgentGitPanel({
             <>
               {pr && (
                 <PrHeader
-                  className="border-b border-border px-4 py-3"
+                  compact
+                  className="border-b border-border px-3 py-2"
                   url={pr.url}
                   title={pr.title}
                   number={pr.number}
                   state={pr.state}
                   headRef={pr.headRef}
                   baseRef={pr.baseRef}
-                  titleClassName="truncate text-sm"
                 />
               )}
 
@@ -221,7 +222,7 @@ export function AgentGitPanel({
                 />
               ) : (
                 <>
-                  <div className="flex items-center gap-1 border-b border-border px-3 py-2">
+                  <div className="flex min-h-9 items-center gap-1 border-b border-border px-3 py-1">
                     {tabs}
                     <div className="ml-auto flex min-w-0 items-center gap-2">
                       {actions}

--- a/ui/src/features/agents/components/AgentPanelShell.tsx
+++ b/ui/src/features/agents/components/AgentPanelShell.tsx
@@ -318,14 +318,12 @@ export function AgentPanelShell({
     <aside
       ref={panelRef}
       className={cn(
-        "relative flex shrink-0 flex-col",
-        overlay
-          ? "fixed inset-0 !w-full bg-background"
-          : "h-full border-l border-border"
+        "relative flex shrink-0 flex-col bg-background",
+        overlay ? "fixed inset-0 !w-full" : "h-full border-l border-border"
       )}
       style={overlay ? { zIndex: Z.MODAL } : { width }}
     >
-      <div className="flex h-11 shrink-0 items-center px-2">
+      <div className="flex h-11 shrink-0 items-center border-b border-border px-2">
         <div className="flex min-w-0 flex-1 items-center overflow-x-auto">
           {tabs.map((tab, index) => {
             const { label, Icon } = PANEL_TAB_META[tab.kind]

--- a/ui/src/features/agents/components/AgentPanelShell.tsx
+++ b/ui/src/features/agents/components/AgentPanelShell.tsx
@@ -4,10 +4,34 @@ import {
   ArrowsOutIcon,
   SidebarSimpleIcon,
 } from "@phosphor-icons/react"
+import {
+  FileDiff,
+  Folder,
+  Globe,
+  ListChecks,
+  Plus,
+  SquareTerminal,
+  X,
+} from "lucide-react"
 
+import type { PanelTab, PanelTabKind } from "@/features/agents/lib/panelTabs"
+import { isMultiInstanceKind } from "@/features/agents/lib/panelTabs"
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@/components/ui/menu"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
 import { Z } from "@/features/agents/components/z-index"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
+
+const PANEL_TAB_META: Record<
+  PanelTabKind,
+  { label: string; hint?: string; Icon: typeof FileDiff }
+> = {
+  review: { label: "Review", hint: "⌃⇧G", Icon: FileDiff },
+  terminal: { label: "Terminal", Icon: SquareTerminal },
+  browser: { label: "Browser", hint: "⌘T", Icon: Globe },
+  files: { label: "Files", hint: "⌘P", Icon: Folder },
+  plan: { label: "Plan", Icon: ListChecks },
+}
 
 const PANEL_STORAGE_WIDTH = "open-swe.gitpanel.width"
 const PANEL_DEFAULT_WIDTH = 420
@@ -133,29 +157,101 @@ function PanelResizeHandle({
   )
 }
 
-interface AgentPanelShellProps<TTab extends string> {
-  tabs: ReadonlyArray<readonly [TTab, string]>
-  activeTab: TTab
-  onTabChange: (tab: TTab) => void
+function PanelControl({
+  label,
+  onClick,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        aria-label={label}
+        className="rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+        onClick={onClick}
+        type="button"
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipPopup>{label}</TooltipPopup>
+    </Tooltip>
+  )
+}
+
+function PanelLauncher({
+  kinds,
+  onOpen,
+}: {
+  kinds: ReadonlyArray<PanelTabKind>
+  onOpen: (kind: PanelTabKind) => void
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col justify-center gap-1 p-3">
+      {kinds.map((kind) => {
+        const { label, hint, Icon } = PANEL_TAB_META[kind]
+        return (
+          <button
+            key={kind}
+            type="button"
+            onClick={() => onOpen(kind)}
+            className="flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm text-foreground transition-colors hover:bg-accent"
+          >
+            <Icon className="size-4 text-muted-foreground" />
+            <span>{label}</span>
+            {hint && (
+              <span className="ml-auto text-xs tracking-widest text-muted-foreground/60">
+                {hint}
+              </span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export function PanelComingSoon() {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-xs text-muted-foreground/70">
+      Coming Soon
+    </div>
+  )
+}
+
+interface AgentPanelShellProps {
+  tabs: ReadonlyArray<PanelTab>
+  activeTabId: string | null
+  onSelectTab: (id: string) => void
+  /** Omit to make tabs non-closable (cloud threads). */
+  onCloseTab?: (id: string) => void
+  onOpenKind?: (kind: PanelTabKind) => void
+  /** Kinds offered by the launcher and the "+" menu. */
+  menuKinds: ReadonlyArray<PanelTabKind>
   collapsed: boolean
   onCollapsedChange: (next: boolean) => void
-  /** Rendered inside the panel card; `fullScreen` drives layout-only extras. */
+  /** Rendered as the panel body; `fullScreen` drives layout-only extras. */
   children: (state: { fullScreen: boolean }) => React.ReactNode
 }
 
 /**
  * The resizable right-hand column shared by cloud threads and local desktop
- * sessions: tab bar, collapse/full-screen controls, and the card the active tab
- * renders into. On mobile it becomes a full-screen overlay instead of a column.
+ * sessions: a tab strip with a "+" menu, panel controls, and the body the
+ * active tab renders into. On mobile it becomes a full-screen overlay.
  */
-export function AgentPanelShell<TTab extends string>({
+export function AgentPanelShell({
   tabs,
-  activeTab,
-  onTabChange,
+  activeTabId,
+  onSelectTab,
+  onCloseTab,
+  onOpenKind,
+  menuKinds,
   collapsed,
   onCollapsedChange,
   children,
-}: AgentPanelShellProps<TTab>) {
+}: AgentPanelShellProps) {
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
   const [fullScreen, setFullScreen] = useState(false)
   const isMobile = useIsMobile()
@@ -202,8 +298,8 @@ export function AgentPanelShell<TTab extends string>({
       <button
         type="button"
         onClick={() => onCollapsedChange(false)}
-        aria-label="Expand panel"
-        title="Expand panel"
+        aria-label="Show panel"
+        title="Show panel"
         className="fixed top-3 right-3 z-30 flex size-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm hover:bg-accent hover:text-foreground"
       >
         <SidebarSimpleIcon className="size-4" />
@@ -211,72 +307,134 @@ export function AgentPanelShell<TTab extends string>({
     )
   }
 
+  const openableKinds = onOpenKind
+    ? menuKinds.filter(
+        (kind) =>
+          isMultiInstanceKind(kind) || !tabs.some((tab) => tab.kind === kind)
+      )
+    : []
+
   return (
     <aside
       ref={panelRef}
       className={cn(
-        // No background or rule of its own: the panel shares the main surface
-        // (and its grain) with the conversation. The seam is the gap between
-        // the two cards; the resize handle only paints on hover.
         "relative flex shrink-0 flex-col",
-        overlay ? "fixed inset-0 !w-full bg-background" : "h-full"
+        overlay
+          ? "fixed inset-0 !w-full bg-background"
+          : "h-full border-l border-border"
       )}
       style={overlay ? { zIndex: Z.MODAL } : { width }}
     >
-      <div className="flex h-11 shrink-0 items-center gap-1 px-3">
-        {tabs.map(([id, label]) => (
-          <button
-            key={id}
-            type="button"
-            aria-current={activeTab === id ? "page" : undefined}
-            onClick={() => onTabChange(id)}
-            className={cn(
-              "rounded-md px-2.5 py-1 text-xs transition-colors",
-              activeTab === id
-                ? "bg-accent font-medium text-foreground"
-                : "text-muted-foreground/70 hover:bg-accent"
-            )}
+      <div className="flex h-11 shrink-0 items-center px-2">
+        <div className="flex min-w-0 flex-1 items-center overflow-x-auto">
+          {tabs.map((tab, index) => {
+            const { label, Icon } = PANEL_TAB_META[tab.kind]
+            const title = tab.title ?? label
+            const active = tab.id === activeTabId
+            return (
+              <div key={tab.id} className="flex min-w-0 items-center">
+                {index > 0 && (
+                  <div
+                    className={cn(
+                      "h-4 w-px shrink-0 bg-border",
+                      (active || tabs[index - 1]?.id === activeTabId) &&
+                        "bg-transparent"
+                    )}
+                  />
+                )}
+                <div
+                  className={cn(
+                    "flex min-w-0 items-center rounded-md",
+                    active && "bg-accent"
+                  )}
+                >
+                  <button
+                    type="button"
+                    aria-current={active ? "page" : undefined}
+                    onClick={() => onSelectTab(tab.id)}
+                    title={title}
+                    className={cn(
+                      "flex min-w-0 items-center gap-1.5 px-2 py-1 text-xs transition-colors",
+                      active
+                        ? "font-medium text-foreground"
+                        : "text-muted-foreground/70 hover:text-foreground"
+                    )}
+                  >
+                    <Icon className="size-3.5 shrink-0" />
+                    <span className="max-w-28 truncate">{title}</span>
+                  </button>
+                  {active && onCloseTab && (
+                    <button
+                      type="button"
+                      aria-label={`Close ${title}`}
+                      onClick={() => onCloseTab(tab.id)}
+                      className="pr-1.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+          {openableKinds.length > 0 && (
+            <Menu>
+              <MenuTrigger
+                aria-label="Open a new tab"
+                className="ml-1 shrink-0 rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <Plus className="size-4" />
+              </MenuTrigger>
+              <MenuPopup align="start" className="w-44">
+                {openableKinds.map((kind) => {
+                  const { label, hint, Icon } = PANEL_TAB_META[kind]
+                  return (
+                    <MenuItem key={kind} onClick={() => onOpenKind?.(kind)}>
+                      <Icon />
+                      {label}
+                      {hint && (
+                        <span className="ml-auto tracking-widest text-muted-foreground/60">
+                          {hint}
+                        </span>
+                      )}
+                    </MenuItem>
+                  )
+                })}
+              </MenuPopup>
+            </Menu>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center">
+          {!isMobile && (
+            <PanelControl
+              label={fullScreen ? "Exit full screen" : "Expand panel"}
+              onClick={() => setFullScreen((v) => !v)}
+            >
+              {fullScreen ? (
+                <ArrowsInIcon className="size-4" />
+              ) : (
+                <ArrowsOutIcon className="size-4" />
+              )}
+            </PanelControl>
+          )}
+          <PanelControl
+            label="Hide panel"
+            onClick={() => {
+              setFullScreen(false)
+              onCollapsedChange(true)
+            }}
           >
-            {label}
-          </button>
-        ))}
-        <button
-          type="button"
-          onClick={() => {
-            setFullScreen(false)
-            onCollapsedChange(true)
-          }}
-          aria-label="Collapse panel"
-          title="Collapse panel"
-          className="ml-auto rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <SidebarSimpleIcon className="size-4" />
-        </button>
-        {!isMobile && (
-          <button
-            type="button"
-            onClick={() => setFullScreen((v) => !v)}
-            aria-label={fullScreen ? "Exit full screen" : "Enter full screen"}
-            className="rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
-          >
-            {fullScreen ? (
-              <ArrowsInIcon className="size-4" />
-            ) : (
-              <ArrowsOutIcon className="size-4" />
-            )}
-          </button>
-        )}
+            <SidebarSimpleIcon className="size-4" />
+          </PanelControl>
+        </div>
       </div>
 
-      <div
-        className={cn(
-          "flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card",
-          // No left margin: the seam is the chat column's own `px-4`, so the gap
-          // to the composer matches the gap on the sidebar side.
-          overlay ? "mx-3 mb-3" : "mr-4 mb-4"
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {tabs.length === 0 && onOpenKind ? (
+          <PanelLauncher kinds={menuKinds} onOpen={onOpenKind} />
+        ) : (
+          children({ fullScreen })
         )}
-      >
-        {children({ fullScreen })}
       </div>
       {!overlay && (
         <PanelResizeHandle

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -193,7 +193,7 @@ export function DiffFilesView({
 
   return (
     <>
-      <div className="flex items-center gap-1 border-b border-border px-3 py-2">
+      <div className="flex min-h-9 items-center gap-1 border-b border-border px-3 py-1">
         {leading}
         <div className="ml-auto flex min-w-0 items-center gap-2">
           <DiffWrapToggle />
@@ -223,7 +223,7 @@ export function DiffFilesView({
           >
             <Virtualizer
               className="min-h-0 flex-1 overflow-y-auto"
-              contentClassName="space-y-2 p-2"
+              contentClassName="p-0"
               config={DIFF_VIRTUALIZER_CONFIG}
             >
               {files.map((file) => (
@@ -291,22 +291,29 @@ const FileDiffSection = memo(
       }),
       [file.filePath, file.modifiedContent, file.treePath]
     )
+    const lastSlash = file.treePath.lastIndexOf("/")
+    const directory =
+      lastSlash === -1 ? "" : file.treePath.slice(0, lastSlash + 1)
+    const fileName = file.treePath.slice(lastSlash + 1)
 
     return (
-      <div
-        ref={sectionRef}
-        className="mb-2 scroll-mt-2 overflow-hidden rounded-lg border border-border"
-      >
+      <div ref={sectionRef} className="overflow-hidden border-b border-border">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="flex w-full items-center gap-2 bg-accent px-3 py-2 text-left text-xs"
+          className="flex w-full items-center gap-2 bg-card px-3 py-2 text-left text-xs transition-colors hover:bg-accent"
         >
           <CaretDownIcon
-            className={cn("size-3 transition-transform", !open && "-rotate-90")}
+            className={cn(
+              "size-3 shrink-0 text-muted-foreground transition-transform",
+              !open && "-rotate-90"
+            )}
           />
-          <span className="truncate font-medium text-foreground">
-            {file.treePath}
+          <span className="min-w-0 truncate" title={file.treePath}>
+            {directory && (
+              <span className="text-muted-foreground">{directory}</span>
+            )}
+            <span className="font-medium text-foreground">{fileName}</span>
           </span>
           <span className="ml-auto flex shrink-0 items-center gap-2">
             <span className="text-success-foreground">+{file.additions}</span>
@@ -315,11 +322,18 @@ const FileDiffSection = memo(
         </button>
         {open &&
           (file.unrenderable ? (
-            <div className="bg-card p-4 text-center text-xs text-muted-foreground/70">
+            <div className="bg-background p-4 text-center text-xs text-muted-foreground/70">
               Binary or large file — diff not shown.
             </div>
           ) : (
-            <div className="overflow-hidden bg-card p-2">
+            <div
+              className="overflow-hidden bg-background"
+              style={
+                {
+                  "--panel-diff-bg": "var(--background)",
+                } as React.CSSProperties
+              }
+            >
               <MultiFileDiff
                 oldFile={oldFile}
                 newFile={newFile}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -1,11 +1,14 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { CircleAlert, FolderOpen, X } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
+import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
+import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
   AgentPanelShell,
   PANEL_MIN_CHAT_WIDTH,
+  PanelComingSoon,
 } from "@/features/agents/components/AgentPanelShell"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
 import {
@@ -14,6 +17,8 @@ import {
 } from "@/features/agents/components/DiffFilesView"
 import { Messages } from "@/features/agents/components/messages"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
+import { usePanelTabs } from "@/features/agents/lib/panelTabs"
+import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import {
   readStoredPanelCollapsed,
   writeStoredPanelCollapsed,
@@ -25,12 +30,12 @@ import {
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 
-const LOCAL_PANEL_TABS = [
-  ["changes", "Changes"],
-  ["terminal", "Terminal"],
-] as const
-
-type LocalPanelTab = (typeof LOCAL_PANEL_TABS)[number][0]
+const LOCAL_PANEL_KINDS: ReadonlyArray<PanelTabKind> = [
+  "review",
+  "terminal",
+  "browser",
+  "files",
+]
 
 export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const { session, messages, loaded } = useDesktopAcpSession(sessionId)
@@ -38,7 +43,8 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed(sessionId)
   )
-  const [panelTab, setPanelTab] = useState<LocalPanelTab>("changes")
+  const panel = usePanelTabs(sessionId)
+  const terminals = useTerminalGroups(sessionId, session?.cwd ?? "")
   const [revealFilePath, setRevealFilePath] = useState<string | null>(null)
   const [terminalContexts, setTerminalContexts] = useState<Array<string>>([])
   const handlePanelCollapsedChange = useCallback(
@@ -51,17 +57,55 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const handleOpenFile = useCallback(
     (filePath: string) => {
       setRevealFilePath(filePath)
-      setPanelTab("changes")
+      panel.open({ id: "review", kind: "review" })
       handlePanelCollapsedChange(false)
     },
-    [handlePanelCollapsedChange]
+    [handlePanelCollapsedChange, panel]
   )
+  const handleOpenKind = useCallback(
+    (kind: PanelTabKind) => {
+      if (kind !== "terminal") {
+        panel.open({ id: kind, kind })
+        return
+      }
+      panel.open({ id: terminals.addGroup(), kind })
+    },
+    [panel, terminals]
+  )
+  const handleSelectTab = useCallback(
+    (id: string) => {
+      panel.select(id)
+      const group = terminals.state.terminalGroups.find(
+        (candidate) => candidate.id === id
+      )
+      const terminalId = group?.terminalIds[0]
+      if (terminalId) terminals.focus(terminalId)
+    },
+    [panel, terminals]
+  )
+  const handleCloseTab = useCallback(
+    (id: string) => {
+      if (panel.tabs.find((tab) => tab.id === id)?.kind === "terminal") {
+        terminals.closeGroup(id)
+      }
+      panel.close(id)
+    },
+    [panel, terminals]
+  )
+
+  const terminalGroupIds = terminals.state.terminalGroups
+    .map((group) => group.id)
+    .join(",")
+  const syncTerminals = panel.syncTerminals
+  useEffect(() => {
+    syncTerminals(terminalGroupIds ? terminalGroupIds.split(",") : [])
+  }, [syncTerminals, terminalGroupIds])
 
   const isRunning =
     session?.status === "running" || session?.status === "starting"
   const diff = useLocalSessionDiff(
     sessionId,
-    !panelCollapsed && panelTab === "changes" && Boolean(session),
+    !panelCollapsed && panel.activeTab?.kind === "review" && Boolean(session),
     isRunning
   )
   const files = useMemo(
@@ -182,37 +226,80 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         </div>
       </div>
       <AgentPanelShell
-        tabs={LOCAL_PANEL_TABS}
-        activeTab={panelTab}
-        onTabChange={setPanelTab}
+        tabs={panel.tabs.map((tab) =>
+          tab.kind === "terminal"
+            ? { ...tab, title: terminalTabTitle(terminals, tab.id) }
+            : tab
+        )}
+        activeTabId={panel.activeTabId}
+        onSelectTab={handleSelectTab}
+        onCloseTab={handleCloseTab}
+        onOpenKind={handleOpenKind}
+        menuKinds={LOCAL_PANEL_KINDS}
         collapsed={panelCollapsed}
         onCollapsedChange={handlePanelCollapsedChange}
       >
-        {({ fullScreen }) =>
-          panelTab === "changes" ? (
-            <DiffFilesView
-              files={files}
-              revealFilePath={revealFilePath}
-              fullScreen={fullScreen}
-              emptyLabel={localDiffEmptyLabel(
-                diff.data?.status,
-                diff.isPending
-              )}
-              truncated={diff.data?.truncated}
-            />
-          ) : (
-            <TerminalPanel
-              localSessionId={session.id}
-              cwd={session.cwd}
-              onOpenFile={handleOpenFile}
-              onAddToChat={(text) =>
-                setTerminalContexts((current) => [...current, text])
-              }
-            />
-          )
-        }
+        {({ fullScreen }) => (
+          <>
+            {panel.activeTab?.kind === "review" && (
+              <DiffFilesView
+                files={files}
+                revealFilePath={revealFilePath}
+                fullScreen={fullScreen}
+                emptyLabel={localDiffEmptyLabel(
+                  diff.data?.status,
+                  diff.isPending
+                )}
+                truncated={diff.data?.truncated}
+              />
+            )}
+            {(panel.activeTab?.kind === "browser" ||
+              panel.activeTab?.kind === "files") && <PanelComingSoon />}
+            {/* Kept mounted across tabs: unmounting kills the user's shell. */}
+            {panel.tabs
+              .filter((tab) => tab.kind === "terminal")
+              .map((tab) => (
+                <div
+                  key={tab.id}
+                  className={cn(
+                    "min-h-0 flex-1",
+                    tab.id !== panel.activeTabId && "hidden"
+                  )}
+                >
+                  <TerminalPanel
+                    localSessionId={session.id}
+                    cwd={session.cwd}
+                    groupId={tab.id}
+                    terminals={terminals}
+                    onOpenFile={handleOpenFile}
+                    onAddToChat={(text) =>
+                      setTerminalContexts((current) => [...current, text])
+                    }
+                  />
+                </div>
+              ))}
+          </>
+        )}
       </AgentPanelShell>
     </div>
+  )
+}
+
+function terminalTabTitle(
+  terminals: TerminalGroupsController,
+  groupId: string
+): string {
+  const group = terminals.state.terminalGroups.find(
+    (candidate) => candidate.id === groupId
+  )
+  const terminalId = group?.terminalIds.includes(
+    terminals.state.activeTerminalId
+  )
+    ? terminals.state.activeTerminalId
+    : group?.terminalIds[0]
+  return (
+    (terminalId ? terminals.metadataById.get(terminalId)?.label : null) ||
+    "Terminal"
   )
 }
 

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -84,9 +84,12 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     [panel, terminals]
   )
   const handleCloseTab = useCallback(
-    (id: string) => {
-      if (panel.tabs.find((tab) => tab.id === id)?.kind === "terminal") {
-        terminals.closeGroup(id)
+    async (id: string) => {
+      if (
+        panel.tabs.find((tab) => tab.id === id)?.kind === "terminal" &&
+        !(await terminals.closeGroup(id))
+      ) {
+        return
       }
       panel.close(id)
     },

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -1,36 +1,26 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   Copy,
   Plus,
   RefreshCw,
   SquareSplitHorizontal,
   SquareSplitVertical,
-  TerminalSquare,
   Trash2,
   X,
 } from "lucide-react"
 
-import type { TerminalUiState } from "@/features/agents/lib/terminalState"
+import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import { cn } from "@/lib/utils"
-import {
-  MAX_TERMINALS_PER_GROUP,
-  addTerminalGroup,
-  closeTerminal,
-  focusTerminal,
-  readTerminalState,
-  reconcileTerminalIds,
-  splitTerminal,
-  writeTerminalState,
-} from "@/features/agents/lib/terminalState"
-import {
-  useAttachedTerminal,
-  useDesktopTerminalMetadata,
-} from "@/features/agents/lib/terminalSession"
+import { MAX_TERMINALS_PER_GROUP } from "@/features/agents/lib/terminalState"
+import { useAttachedTerminal } from "@/features/agents/lib/terminalSession"
 import { GhosttyTerminalSurface } from "@/features/agents/terminal/ghostty/surface"
 
 interface TerminalPanelProps {
   localSessionId: string
   cwd: string
+  /** The terminal group this tab renders; splits live inside it. */
+  groupId: string
+  terminals: TerminalGroupsController
   onOpenFile: (path: string) => void
   onAddToChat: (text: string) => void
 }
@@ -258,307 +248,106 @@ function ActionButton({
 export function TerminalPanel({
   localSessionId,
   cwd,
+  groupId,
+  terminals,
   onOpenFile,
   onAddToChat,
 }: TerminalPanelProps) {
-  const [state, setState] = useState<TerminalUiState>(() =>
-    readTerminalState(localSessionId)
-  )
-  const metadata = useDesktopTerminalMetadata(localSessionId)
   const [focusRequest, setFocusRequest] = useState(0)
-  const [actionError, setActionError] = useState<string | null>(null)
-
-  const updateState = useCallback(
-    (update: (current: TerminalUiState) => TerminalUiState) => {
-      setState((current) => {
-        const next = update(current)
-        writeTerminalState(localSessionId, next)
-        return next
-      })
-    },
-    [localSessionId]
+  const group = terminals.state.terminalGroups.find(
+    (candidate) => candidate.id === groupId
   )
-
-  useEffect(() => {
-    setState(readTerminalState(localSessionId))
-    setActionError(null)
-  }, [localSessionId])
-
-  useEffect(() => {
-    updateState((current) =>
-      reconcileTerminalIds(
-        current,
-        metadata.map((terminal) => terminal.terminalId)
-      )
-    )
-  }, [metadata, updateState])
-
-  const activeGroup = state.terminalGroups.find(
-    (group) => group.id === state.activeTerminalGroupId
+  const terminalIds = group?.terminalIds ?? []
+  const activeTerminalId = terminalIds.includes(
+    terminals.state.activeTerminalId
   )
-  const visibleIds = activeGroup?.terminalIds ?? []
-  const metadataById = useMemo(
-    () => new Map(metadata.map((terminal) => [terminal.terminalId, terminal])),
-    [metadata]
-  )
-  const atSplitLimit = visibleIds.length >= MAX_TERMINALS_PER_GROUP
-  const showGroupHeaders =
-    state.terminalGroups.length > 1 ||
-    state.terminalGroups.some((group) => group.terminalIds.length > 1)
-
-  const runStateAction = useCallback(
-    async (terminalId: string, action: "clear" | "restart") => {
-      const bridge = window.openSweDesktop?.terminal
-      if (!bridge) return
-      setActionError(null)
-      try {
-        if (action === "clear") {
-          await bridge.clear({ localSessionId, terminalId })
-          return
-        }
-        const surface = metadataById.get(terminalId)
-        await bridge.restart({
-          localSessionId,
-          terminalId,
-          cwd: surface?.cwd ?? cwd,
-        })
-      } catch (error) {
-        setActionError(
-          error instanceof Error
-            ? error.message
-            : `Unable to ${action} terminal`
-        )
-      }
-    },
-    [cwd, metadataById, localSessionId]
-  )
-
-  const close = useCallback(
-    async (terminalId: string) => {
-      const bridge = window.openSweDesktop?.terminal
-      if (!bridge) return
-      setActionError(null)
-      try {
-        await bridge.close({
-          localSessionId,
-          terminalId,
-          deleteHistory: true,
-        })
-        updateState((current) => closeTerminal(current, terminalId))
-      } catch (error) {
-        setActionError(
-          error instanceof Error ? error.message : "Unable to close terminal"
-        )
-      }
-    },
-    [localSessionId, updateState]
-  )
-
-  if (state.terminalIds.length === 0) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <button
-          type="button"
-          className="rounded-md border border-border px-3 py-1.5 text-xs hover:bg-accent"
-          onClick={() => updateState(addTerminalGroup)}
-        >
-          New terminal
-        </button>
-      </div>
-    )
-  }
+    ? terminals.state.activeTerminalId
+    : (terminalIds[0] ?? "")
+  const atSplitLimit = terminalIds.length >= MAX_TERMINALS_PER_GROUP
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-card">
-      <div className="flex h-9 shrink-0 items-center border-b border-border px-2">
+    <div className="group/terminal relative flex h-full min-h-0 flex-col">
+      <div className="absolute top-1 right-2 z-10 flex items-center rounded-md border border-border bg-background/95 opacity-0 shadow-sm transition-opacity group-hover/terminal:opacity-100 focus-within:opacity-100">
         <ActionButton
           label={`Split horizontally${atSplitLimit ? " (maximum 4)" : ""}`}
           disabled={atSplitLimit}
-          onClick={() =>
-            updateState((current) => splitTerminal(current, "horizontal"))
-          }
+          onClick={() => terminals.split("horizontal")}
         >
           <SquareSplitHorizontal className="size-3.5" />
         </ActionButton>
         <ActionButton
           label={`Split vertically${atSplitLimit ? " (maximum 4)" : ""}`}
           disabled={atSplitLimit}
-          onClick={() =>
-            updateState((current) => splitTerminal(current, "vertical"))
-          }
+          onClick={() => terminals.split("vertical")}
         >
           <SquareSplitVertical className="size-3.5" />
         </ActionButton>
         <ActionButton
-          label="New terminal group"
-          onClick={() => updateState(addTerminalGroup)}
-        >
-          <Plus className="size-3.5" />
-        </ActionButton>
-        <div className="mx-1 h-4 w-px bg-border" />
-        <ActionButton
           label="Clear terminal"
-          onClick={() => void runStateAction(state.activeTerminalId, "clear")}
+          onClick={() => terminals.clear(activeTerminalId)}
         >
           <Trash2 className="size-3.5" />
         </ActionButton>
         <ActionButton
           label="Restart terminal"
-          onClick={() => void runStateAction(state.activeTerminalId, "restart")}
+          onClick={() => terminals.restart(activeTerminalId)}
         >
           <RefreshCw className="size-3.5" />
         </ActionButton>
-        <ActionButton
-          label="Close terminal"
-          onClick={() => void close(state.activeTerminalId)}
-        >
-          <X className="size-3.5" />
-        </ActionButton>
-        {actionError && (
-          <span className="ml-2 truncate text-xs text-destructive">
-            {actionError}
-          </span>
+        {terminalIds.length > 1 && (
+          <ActionButton
+            label="Close terminal"
+            onClick={() => terminals.closeTerminal(activeTerminalId)}
+          >
+            <X className="size-3.5" />
+          </ActionButton>
         )}
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        <div className="min-w-0 flex-1">
-          <div
-            className="grid h-full min-h-0"
-            style={
-              activeGroup?.splitDirection === "vertical"
-                ? {
-                    gridTemplateRows: `repeat(${visibleIds.length}, minmax(0, 1fr))`,
-                  }
-                : {
-                    gridTemplateColumns: `repeat(${visibleIds.length}, minmax(0, 1fr))`,
-                  }
-            }
-          >
-            {visibleIds.map((terminalId, index) => (
-              <div
-                key={terminalId}
-                className={cn(
-                  "min-h-0 min-w-0 p-1",
-                  index > 0 &&
-                    (activeGroup?.splitDirection === "vertical"
-                      ? "border-t border-border"
-                      : "border-l border-border")
-                )}
-              >
-                <TerminalViewport
-                  localSessionId={localSessionId}
-                  terminalId={terminalId}
-                  cwd={metadataById.get(terminalId)?.cwd ?? cwd}
-                  active={state.activeTerminalId === terminalId}
-                  focusRequest={focusRequest}
-                  onFocus={() => {
-                    updateState((current) => focusTerminal(current, terminalId))
-                    setFocusRequest((value) => value + 1)
-                  }}
-                  onOpenFile={onOpenFile}
-                  onAddToChat={onAddToChat}
-                />
-              </div>
-            ))}
-          </div>
+      {terminals.error && (
+        <div className="absolute inset-x-2 top-2 z-10 rounded-md border border-destructive/40 bg-background/95 px-3 py-2 text-xs text-destructive shadow-sm">
+          {terminals.error}
         </div>
+      )}
 
-        {state.terminalIds.length > 1 && (
-          <aside className="flex w-36 min-w-36 shrink-0 flex-col overflow-y-auto border-l border-border p-1">
-            {state.terminalGroups.map((group, groupIndex) => {
-              const isGroupActive = group.terminalIds.includes(
-                state.activeTerminalId
-              )
-              const groupActiveTerminalId = isGroupActive
-                ? state.activeTerminalId
-                : group.terminalIds[0]
-
-              return (
-                <div key={group.id} className="pb-0.5">
-                  {showGroupHeaders && (
-                    <button
-                      type="button"
-                      className={cn(
-                        "flex w-full items-center rounded px-1 py-0.5 text-[10px] tracking-[0.08em] uppercase",
-                        isGroupActive
-                          ? "bg-accent/70 text-foreground"
-                          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                      )}
-                      onClick={() => {
-                        if (groupActiveTerminalId) {
-                          updateState((current) =>
-                            focusTerminal(current, groupActiveTerminalId)
-                          )
-                        }
-                      }}
-                    >
-                      Group {groupIndex + 1}
-                    </button>
-                  )}
-                  <div
-                    className={cn(
-                      showGroupHeaders &&
-                        "ml-1 border-l border-border/60 pl-1.5"
-                    )}
-                  >
-                    {group.terminalIds.map((terminalId) => {
-                      const summary = metadataById.get(terminalId)
-                      const running = summary?.hasRunningSubprocess === true
-                      const isActive = terminalId === state.activeTerminalId
-                      return (
-                        <div
-                          key={terminalId}
-                          className={cn(
-                            "group flex items-center gap-1 rounded px-1 py-0.5 text-[11px]",
-                            isActive
-                              ? "bg-accent text-foreground"
-                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                          )}
-                        >
-                          {showGroupHeaders && (
-                            <span className="text-[10px] text-muted-foreground/80">
-                              └
-                            </span>
-                          )}
-                          <button
-                            type="button"
-                            className="flex min-w-0 flex-1 items-center gap-1 text-left"
-                            onClick={() => {
-                              updateState((current) =>
-                                focusTerminal(current, terminalId)
-                              )
-                              setFocusRequest((value) => value + 1)
-                            }}
-                          >
-                            <TerminalSquare className="size-3 shrink-0" />
-                            <span className="truncate">
-                              {summary?.label || terminalId}
-                            </span>
-                            {running && (
-                              <span
-                                className="ml-auto size-1.5 shrink-0 rounded-full bg-emerald-500"
-                                title="Running process"
-                              />
-                            )}
-                          </button>
-                          <button
-                            type="button"
-                            aria-label={`Close ${summary?.label || terminalId}`}
-                            className="inline-flex size-3.5 items-center justify-center rounded text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-accent hover:text-foreground"
-                            onClick={() => void close(terminalId)}
-                          >
-                            <X className="size-2.5" />
-                          </button>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              )
-            })}
-          </aside>
-        )}
+      <div
+        className="grid min-h-0 flex-1"
+        style={
+          group?.splitDirection === "vertical"
+            ? {
+                gridTemplateRows: `repeat(${terminalIds.length}, minmax(0, 1fr))`,
+              }
+            : {
+                gridTemplateColumns: `repeat(${terminalIds.length}, minmax(0, 1fr))`,
+              }
+        }
+      >
+        {terminalIds.map((terminalId, index) => (
+          <div
+            key={terminalId}
+            className={cn(
+              "min-h-0 min-w-0",
+              index > 0 &&
+                (group?.splitDirection === "vertical"
+                  ? "border-t border-border"
+                  : "border-l border-border")
+            )}
+          >
+            <TerminalViewport
+              localSessionId={localSessionId}
+              terminalId={terminalId}
+              cwd={terminals.metadataById.get(terminalId)?.cwd ?? cwd}
+              active={activeTerminalId === terminalId}
+              focusRequest={focusRequest}
+              onFocus={() => {
+                terminals.focus(terminalId)
+                setFocusRequest((value) => value + 1)
+              }}
+              onOpenFile={onOpenFile}
+              onAddToChat={onAddToChat}
+            />
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/ui/src/features/agents/lib/panelTabs.test.ts
+++ b/ui/src/features/agents/lib/panelTabs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { closePanelTab, openPanelTab, syncTerminalTabs } from "./panelTabs"
+
+describe("panel tabs", () => {
+  it("focuses an existing single-instance tab instead of duplicating it", () => {
+    const opened = openPanelTab(
+      openPanelTab(
+        { tabs: [], activeTabId: null },
+        { id: "review", kind: "review" }
+      ),
+      { id: "term-a", kind: "terminal" }
+    )
+    const reopened = openPanelTab(opened, { id: "review", kind: "review" })
+
+    expect(reopened.tabs).toHaveLength(2)
+    expect(reopened.activeTabId).toBe("review")
+  })
+
+  it("activates a neighbour when the active tab closes", () => {
+    const state = {
+      tabs: [
+        { id: "review", kind: "review" as const },
+        { id: "group-term-1", kind: "terminal" as const },
+      ],
+      activeTabId: "group-term-1",
+    }
+
+    expect(closePanelTab(state, "group-term-1").activeTabId).toBe("review")
+    expect(syncTerminalTabs(state, []).tabs).toEqual([state.tabs[0]])
+  })
+})

--- a/ui/src/features/agents/lib/panelTabs.ts
+++ b/ui/src/features/agents/lib/panelTabs.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+export type PanelTabKind = "review" | "terminal" | "browser" | "files" | "plan"
+
+export interface PanelTab {
+  id: string
+  kind: PanelTabKind
+  /** Overrides the kind's default label (terminal tabs use the shell label). */
+  title?: string
+}
+
+export interface PanelTabsState {
+  tabs: Array<PanelTab>
+  activeTabId: string | null
+}
+
+const STORAGE_PREFIX = "open-swe.panel-tabs.v1:"
+const EMPTY: PanelTabsState = { tabs: [], activeTabId: null }
+const KINDS: ReadonlyArray<PanelTabKind> = [
+  "review",
+  "terminal",
+  "browser",
+  "files",
+  "plan",
+]
+
+/** Only terminals can be opened more than once. */
+export function isMultiInstanceKind(kind: PanelTabKind): boolean {
+  return kind === "terminal"
+}
+
+export function openPanelTab(
+  state: PanelTabsState,
+  tab: PanelTab
+): PanelTabsState {
+  const existing = state.tabs.find((candidate) =>
+    isMultiInstanceKind(tab.kind)
+      ? candidate.id === tab.id
+      : candidate.kind === tab.kind
+  )
+  if (existing) return { ...state, activeTabId: existing.id }
+  return { tabs: [...state.tabs, tab], activeTabId: tab.id }
+}
+
+export function closePanelTab(
+  state: PanelTabsState,
+  id: string
+): PanelTabsState {
+  const index = state.tabs.findIndex((tab) => tab.id === id)
+  if (index < 0) return state
+  const tabs = state.tabs.filter((tab) => tab.id !== id)
+  return {
+    tabs,
+    activeTabId:
+      state.activeTabId === id
+        ? (tabs[Math.min(index, tabs.length - 1)]?.id ?? null)
+        : state.activeTabId,
+  }
+}
+
+/** Terminal tabs mirror the live terminal groups owned by `terminalState`. */
+export function syncTerminalTabs(
+  state: PanelTabsState,
+  groupIds: ReadonlyArray<string>
+): PanelTabsState {
+  const live = new Set(groupIds)
+  const kept = state.tabs.filter(
+    (tab) => tab.kind !== "terminal" || live.has(tab.id)
+  )
+  const known = new Set(kept.map((tab) => tab.id))
+  const added = groupIds
+    .filter((id) => !known.has(id))
+    .map((id): PanelTab => ({ id, kind: "terminal" }))
+  if (added.length === 0 && kept.length === state.tabs.length) return state
+  const tabs = [...kept, ...added]
+  return {
+    tabs,
+    activeTabId: tabs.some((tab) => tab.id === state.activeTabId)
+      ? state.activeTabId
+      : (added[0]?.id ?? tabs.at(-1)?.id ?? null),
+  }
+}
+
+function isPanelTab(value: unknown): value is PanelTab {
+  const tab = value as PanelTab | null
+  return (
+    typeof tab?.id === "string" && tab.id.length > 0 && KINDS.includes(tab.kind)
+  )
+}
+
+export function readPanelTabs(sessionId: string): PanelTabsState {
+  if (typeof window === "undefined") return EMPTY
+  const raw = window.localStorage.getItem(`${STORAGE_PREFIX}${sessionId}`)
+  if (!raw) return EMPTY
+  try {
+    const parsed = JSON.parse(raw) as Partial<PanelTabsState>
+    const tabs = (Array.isArray(parsed.tabs) ? parsed.tabs : []).filter(
+      isPanelTab
+    )
+    return {
+      tabs,
+      activeTabId:
+        tabs.find((tab) => tab.id === parsed.activeTabId)?.id ??
+        tabs[0]?.id ??
+        null,
+    }
+  } catch {
+    return EMPTY
+  }
+}
+
+export function writePanelTabs(sessionId: string, state: PanelTabsState): void {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(
+    `${STORAGE_PREFIX}${sessionId}`,
+    JSON.stringify(state)
+  )
+}
+
+export function usePanelTabs(sessionId: string) {
+  const [state, setState] = useState<PanelTabsState>(() =>
+    readPanelTabs(sessionId)
+  )
+
+  useEffect(() => setState(readPanelTabs(sessionId)), [sessionId])
+
+  const update = useCallback(
+    (change: (current: PanelTabsState) => PanelTabsState) => {
+      setState((current) => {
+        const next = change(current)
+        if (next !== current) writePanelTabs(sessionId, next)
+        return next
+      })
+    },
+    [sessionId]
+  )
+
+  return useMemo(
+    () => ({
+      tabs: state.tabs,
+      activeTabId: state.activeTabId,
+      activeTab: state.tabs.find((tab) => tab.id === state.activeTabId) ?? null,
+      open: (tab: PanelTab) => update((current) => openPanelTab(current, tab)),
+      select: (id: string) =>
+        update((current) => ({ ...current, activeTabId: id })),
+      close: (id: string) => update((current) => closePanelTab(current, id)),
+      syncTerminals: (groupIds: ReadonlyArray<string>) =>
+        update((current) => syncTerminalTabs(current, groupIds)),
+    }),
+    [state, update]
+  )
+}

--- a/ui/src/features/agents/lib/terminalGroups.ts
+++ b/ui/src/features/agents/lib/terminalGroups.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import type { DesktopTerminalBridge, DesktopTerminalSummary } from "@/desktop"
+import type {
+  TerminalSplitDirection,
+  TerminalUiState,
+} from "@/features/agents/lib/terminalState"
+import {
+  addTerminalGroup,
+  closeTerminal,
+  focusTerminal,
+  readTerminalState,
+  reconcileTerminalIds,
+  splitTerminal,
+  writeTerminalState,
+} from "@/features/agents/lib/terminalState"
+import { useDesktopTerminalMetadata } from "@/features/agents/lib/terminalSession"
+
+export interface TerminalGroupsController {
+  state: TerminalUiState
+  metadataById: Map<string, DesktopTerminalSummary>
+  error: string | null
+  /** Creates a terminal group and returns its id so a tab can be opened for it. */
+  addGroup: () => string
+  closeGroup: (groupId: string) => void
+  closeTerminal: (terminalId: string) => void
+  focus: (terminalId: string) => void
+  split: (direction: TerminalSplitDirection) => void
+  clear: (terminalId: string) => void
+  restart: (terminalId: string) => void
+}
+
+export function useTerminalGroups(
+  localSessionId: string,
+  cwd: string
+): TerminalGroupsController {
+  const [state, setState] = useState<TerminalUiState>(() =>
+    readTerminalState(localSessionId)
+  )
+  const [error, setError] = useState<string | null>(null)
+  const metadata = useDesktopTerminalMetadata(localSessionId)
+  const stateRef = useRef(state)
+  stateRef.current = state
+
+  const commit = useCallback(
+    (next: TerminalUiState) => {
+      stateRef.current = next
+      writeTerminalState(localSessionId, next)
+      setState(next)
+      return next
+    },
+    [localSessionId]
+  )
+
+  useEffect(() => {
+    setError(null)
+    commit(readTerminalState(localSessionId))
+  }, [commit, localSessionId])
+
+  useEffect(() => {
+    const next = reconcileTerminalIds(
+      stateRef.current,
+      metadata.map((terminal) => terminal.terminalId)
+    )
+    if (next.terminalIds.length !== stateRef.current.terminalIds.length) {
+      commit(next)
+    }
+  }, [commit, metadata])
+
+  const metadataById = useMemo(
+    () => new Map(metadata.map((terminal) => [terminal.terminalId, terminal])),
+    [metadata]
+  )
+
+  const run = useCallback(
+    (
+      fallback: string,
+      action: (bridge: DesktopTerminalBridge) => Promise<void>
+    ) => {
+      const bridge = window.openSweDesktop?.terminal
+      if (!bridge) return
+      setError(null)
+      void action(bridge).catch((cause: unknown) =>
+        setError(cause instanceof Error ? cause.message : fallback)
+      )
+    },
+    []
+  )
+
+  const closeTerminals = useCallback(
+    (terminalIds: ReadonlyArray<string>) => {
+      run("Unable to close terminal", async (bridge) => {
+        for (const terminalId of terminalIds) {
+          await bridge.close({
+            localSessionId,
+            terminalId,
+            deleteHistory: true,
+          })
+        }
+        commit(terminalIds.reduce(closeTerminal, stateRef.current))
+      })
+    },
+    [commit, localSessionId, run]
+  )
+
+  return useMemo(
+    () => ({
+      state,
+      metadataById,
+      error,
+      addGroup: () =>
+        commit(addTerminalGroup(stateRef.current)).activeTerminalGroupId,
+      closeGroup: (groupId: string) =>
+        closeTerminals(
+          stateRef.current.terminalGroups.find((group) => group.id === groupId)
+            ?.terminalIds ?? []
+        ),
+      closeTerminal: (terminalId: string) => closeTerminals([terminalId]),
+      focus: (terminalId: string) =>
+        commit(focusTerminal(stateRef.current, terminalId)),
+      split: (direction: TerminalSplitDirection) =>
+        commit(splitTerminal(stateRef.current, direction)),
+      clear: (terminalId: string) =>
+        run("Unable to clear terminal", (bridge) =>
+          bridge.clear({ localSessionId, terminalId })
+        ),
+      restart: (terminalId: string) =>
+        run("Unable to restart terminal", async (bridge) => {
+          await bridge.restart({
+            localSessionId,
+            terminalId,
+            cwd: metadataById.get(terminalId)?.cwd ?? cwd,
+          })
+        }),
+    }),
+    [
+      closeTerminals,
+      commit,
+      cwd,
+      error,
+      localSessionId,
+      metadataById,
+      run,
+      state,
+    ]
+  )
+}

--- a/ui/src/features/agents/lib/terminalGroups.ts
+++ b/ui/src/features/agents/lib/terminalGroups.ts
@@ -22,8 +22,8 @@ export interface TerminalGroupsController {
   error: string | null
   /** Creates a terminal group and returns its id so a tab can be opened for it. */
   addGroup: () => string
-  closeGroup: (groupId: string) => void
-  closeTerminal: (terminalId: string) => void
+  closeGroup: (groupId: string) => Promise<boolean>
+  closeTerminal: (terminalId: string) => Promise<boolean>
   focus: (terminalId: string) => void
   split: (direction: TerminalSplitDirection) => void
   clear: (terminalId: string) => void
@@ -73,23 +73,27 @@ export function useTerminalGroups(
   )
 
   const run = useCallback(
-    (
+    async (
       fallback: string,
       action: (bridge: DesktopTerminalBridge) => Promise<void>
-    ) => {
+    ): Promise<boolean> => {
       const bridge = window.openSweDesktop?.terminal
-      if (!bridge) return
+      if (!bridge) return false
       setError(null)
-      void action(bridge).catch((cause: unknown) =>
+      try {
+        await action(bridge)
+        return true
+      } catch (cause) {
         setError(cause instanceof Error ? cause.message : fallback)
-      )
+        return false
+      }
     },
     []
   )
 
   const closeTerminals = useCallback(
     (terminalIds: ReadonlyArray<string>) => {
-      run("Unable to close terminal", async (bridge) => {
+      return run("Unable to close terminal", async (bridge) => {
         for (const terminalId of terminalIds) {
           await bridge.close({
             localSessionId,

--- a/ui/src/features/agents/lib/terminalState.test.ts
+++ b/ui/src/features/agents/lib/terminalState.test.ts
@@ -15,8 +15,12 @@ import {
 beforeEach(() => window.localStorage.clear())
 
 describe("terminal state", () => {
+  it("starts a session with no terminals", () => {
+    expect(createTerminalState().terminalIds).toEqual([])
+  })
+
   it("allocates stable term-N ids without reusing closed ids", () => {
-    let state = createTerminalState()
+    let state = addTerminalGroup(createTerminalState())
     state = splitTerminal(state, "horizontal")
     state = closeTerminal(state, "term-2")
     state = addTerminalGroup(state)
@@ -26,7 +30,7 @@ describe("terminal state", () => {
   })
 
   it("creates groups and caps a split at four terminals", () => {
-    let state = createTerminalState()
+    let state = addTerminalGroup(createTerminalState())
     state = splitTerminal(state, "vertical")
     state = splitTerminal(state, "vertical")
     state = splitTerminal(state, "vertical")
@@ -41,7 +45,10 @@ describe("terminal state", () => {
   })
 
   it("keeps state isolated and persisted per local session", () => {
-    const first = splitTerminal(createTerminalState(), "horizontal")
+    const first = splitTerminal(
+      addTerminalGroup(createTerminalState()),
+      "horizontal"
+    )
     const second = focusTerminal(addTerminalGroup(first), "term-1")
     writeTerminalState("session-a", first)
     writeTerminalState("session-b", second)

--- a/ui/src/features/agents/lib/terminalState.ts
+++ b/ui/src/features/agents/lib/terminalState.ts
@@ -1,5 +1,4 @@
 export const MAX_TERMINALS_PER_GROUP = 4
-export const DEFAULT_TERMINAL_ID = "term-1"
 
 export type TerminalSplitDirection = "horizontal" | "vertical"
 
@@ -97,15 +96,14 @@ export function normalizeTerminalState(
   }
 }
 
+/** Sessions start with no terminals: the panel shows its launcher instead. */
 export function createTerminalState(): TerminalUiState {
   return {
-    terminalIds: [DEFAULT_TERMINAL_ID],
-    activeTerminalId: DEFAULT_TERMINAL_ID,
-    terminalGroups: [
-      { id: groupId(DEFAULT_TERMINAL_ID), terminalIds: [DEFAULT_TERMINAL_ID] },
-    ],
-    activeTerminalGroupId: groupId(DEFAULT_TERMINAL_ID),
-    nextTerminalNumber: 2,
+    terminalIds: [],
+    activeTerminalId: "",
+    terminalGroups: [],
+    activeTerminalGroupId: "",
+    nextTerminalNumber: 1,
   }
 }
 

--- a/ui/src/features/agents/utils/diffUtils.ts
+++ b/ui/src/features/agents/utils/diffUtils.ts
@@ -70,33 +70,34 @@ export const DIFF_UNSAFE_CSS = `
 [data-file],
 [data-error-wrapper],
 [data-virtualizer-buffer] {
-  --diffs-bg: var(--card) !important;
-  --diffs-light-bg: var(--card) !important;
-  --diffs-dark-bg: var(--card) !important;
+  --diffs-surface: var(--panel-diff-bg, var(--card));
+  --diffs-bg: var(--diffs-surface) !important;
+  --diffs-light-bg: var(--diffs-surface) !important;
+  --diffs-dark-bg: var(--diffs-surface) !important;
   --diffs-token-light-bg: transparent;
   --diffs-token-dark-bg: transparent;
 
-  --diffs-bg-context-override: var(--card);
+  --diffs-bg-context-override: var(--diffs-surface);
   --diffs-bg-hover-override: var(--accent);
   --diffs-bg-separator-override: var(--accent);
-  --diffs-bg-buffer-override: var(--card);
+  --diffs-bg-buffer-override: var(--diffs-surface);
 
-  --diffs-bg-addition-override: color-mix(in srgb, var(--card) 80%, #22c55e);
-  --diffs-bg-addition-number-override: color-mix(in srgb, var(--card) 75%, #22c55e);
-  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--card) 70%, #22c55e);
-  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--card) 60%, #22c55e);
+  --diffs-bg-addition-override: color-mix(in srgb, var(--diffs-surface) 80%, #22c55e);
+  --diffs-bg-addition-number-override: color-mix(in srgb, var(--diffs-surface) 75%, #22c55e);
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--diffs-surface) 70%, #22c55e);
+  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--diffs-surface) 60%, #22c55e);
 
-  --diffs-bg-deletion-override: color-mix(in srgb, var(--card) 80%, #ef4444);
-  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--card) 75%, #ef4444);
-  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--card) 70%, #ef4444);
-  --diffs-bg-deletion-emphasis-override: color-mix(in srgb, var(--card) 60%, #ef4444);
+  --diffs-bg-deletion-override: color-mix(in srgb, var(--diffs-surface) 80%, #ef4444);
+  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--diffs-surface) 75%, #ef4444);
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--diffs-surface) 70%, #ef4444);
+  --diffs-bg-deletion-emphasis-override: color-mix(in srgb, var(--diffs-surface) 60%, #ef4444);
 
   --diffs-fg-number-override: var(--muted-foreground);
   --diffs-font-size: 12px;
   --diffs-line-height: 1.5;
   --diffs-font-family: "SF Mono", "Fira Code", "Cascadia Code", Menlo, Monaco, monospace;
 
-  background-color: var(--card) !important;
+  background-color: var(--diffs-surface) !important;
 }
 
 [data-file-info] {
@@ -123,7 +124,7 @@ export const DIFF_UNSAFE_CSS = `
    Keep the code line highlighted, but hold the annotation row at the panel bg. */
 [data-line-annotation][data-selected-line],
 [data-gutter-buffer="annotation"][data-selected-line] {
-  --diffs-line-bg: var(--card) !important;
+  --diffs-line-bg: var(--diffs-surface, var(--card)) !important;
 }
 `
 

--- a/ui/src/features/reviews/components/PrHeader.tsx
+++ b/ui/src/features/reviews/components/PrHeader.tsx
@@ -24,6 +24,7 @@ export interface PrHeaderProps {
   } | null
   className?: string
   titleClassName?: string
+  compact?: boolean
 }
 
 export function PrHeader({
@@ -37,49 +38,80 @@ export function PrHeader({
   stats,
   className,
   titleClassName,
+  compact = false,
 }: PrHeaderProps) {
   return (
     <div className={className}>
-      <span
+      <div className={cn(compact && "flex min-w-0 items-center gap-2")}>
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] capitalize",
+            STATE_STYLES[state] ?? STATE_STYLES.open
+          )}
+        >
+          <GitPullRequestIcon className="size-3" />
+          {state}
+        </span>
+        <h1
+          className={cn(
+            compact
+              ? "min-w-0 flex-1 truncate text-sm font-medium"
+              : "mt-2 text-base font-medium",
+            titleClassName
+          )}
+        >
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className={cn("hover:underline", compact && "block truncate")}
+          >
+            {title}
+            {number != null && (
+              <span className="text-muted-foreground"> #{number}</span>
+            )}
+          </a>
+        </h1>
+      </div>
+      <div
         className={cn(
-          "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] capitalize",
-          STATE_STYLES[state] ?? STATE_STYLES.open
+          "flex items-center gap-2 text-xs text-muted-foreground",
+          compact ? "mt-1.5 min-w-0 overflow-hidden" : "mt-2 flex-wrap"
         )}
       >
-        <GitPullRequestIcon className="size-3" />
-        {state}
-      </span>
-      <h1 className={cn("mt-2 text-base font-medium", titleClassName)}>
-        <a
-          href={url}
-          target="_blank"
-          rel="noreferrer"
-          className="hover:underline"
-        >
-          {title}
-          {number != null && (
-            <span className="text-muted-foreground"> #{number}</span>
-          )}
-        </a>
-      </h1>
-      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         {author && (
-          <span className="font-medium text-foreground">{author}</span>
+          <span className="shrink-0 font-medium text-foreground">{author}</span>
         )}
-        <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[11px]">
-          {baseRef}
-        </span>
-        <span>←</span>
-        <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[11px]">
-          {headRef}
-        </span>
+        {compact ? (
+          <>
+            <span className="min-w-0 truncate font-mono" title={headRef}>
+              {headRef}
+            </span>
+            <span className="shrink-0">→</span>
+            <span className="min-w-0 truncate font-mono" title={baseRef}>
+              {baseRef}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[11px]">
+              {baseRef}
+            </span>
+            <span>←</span>
+            <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[11px]">
+              {headRef}
+            </span>
+          </>
+        )}
         {stats && (
           <>
-            <span>
+            <span className="shrink-0">
               {stats.changedFiles} file{stats.changedFiles === 1 ? "" : "s"}
             </span>
-            <span className="text-emerald-500">+{stats.additions}</span>
-            <span className="text-red-500">-{stats.deletions}</span>
+            <span className="shrink-0 text-emerald-500">
+              +{stats.additions}
+            </span>
+            <span className="shrink-0 text-red-500">-{stats.deletions}</span>
           </>
         )}
       </div>


### PR DESCRIPTION
## Description

The right panel's fixed two-tab card couldn't host more than one terminal or grow to new surfaces. It's now a tab strip (icon, title, close) with a `+` menu and a launcher for the empty state, and the card wrapper is gone — the body is flush with a `border-l` seam. Review and Terminal are live; Browser and Files are placeholders. Terminal groups map 1:1 to tabs, so the terminal's internal group sidebar is gone and its split/clear/restart controls float on hover. Cloud threads use the same shell with non-closable Review/Plan tabs.

Shortcut hints (`⌘T`, `⌘P`, `⌃⇧G`) render as labels only — not bound yet.

## Release Note

Desktop local sessions get a tabbed side panel: multiple terminals, a Review tab, and a launcher when nothing is open.

## Test Plan
- [ ] In a local desktop session: open Review and several Terminal tabs from the launcher and the `+` menu, switch between them, confirm shells keep their history and closing a terminal tab kills its shell.
- [ ] Reload mid-session and confirm open terminals come back as tabs.
- [ ] Browser and Files show "Coming Soon"; expand/hide panel controls and cloud thread Review/Plan tabs still work.

Made by [Open SWE](https://openswe.vercel.app/agents/019ff1ea-05e2-766f-bf46-605b1dc97d16)

## References
- Plan: https://openswe.vercel.app/agents/019ff1ea-05e2-766f-bf46-605b1dc97d16/plan