### PR TITLE
fix: separate web and Slack model defaults

### DIFF
--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/features/agents/lib/provider/useModelOptions"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
 import { useProfile, useRepos } from "@/lib/profile"
+import { useSession } from "@/lib/session"
 import {
   requestNotificationPermission,
   setNotificationsPref,
@@ -47,12 +48,13 @@ export function AgentsHome() {
   const stream = useAgentThreadStream()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const session = useSession()
   const { models, defaultSelection } = useModelOptions()
   const [selection, setSelection] = useState<ModelSelection | null>(null)
   const activeSelection = selection ?? defaultSelection
   const handleSelectionChange = (next: ModelSelection) => {
     setSelection(next)
-    persistModelSelection(next, profileQuery.data?.login ?? "")
+    persistModelSelection(next, session.data?.login ?? "")
   }
   const activeModel = models.find(
     (model) => model.id === activeSelection?.modelId

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -17,7 +17,10 @@ import {
   seedAgentThreadLists,
   useAgentSkills,
 } from "@/features/agents/lib/queries"
-import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
+import {
+  persistModelSelection,
+  useModelOptions,
+} from "@/features/agents/lib/provider/useModelOptions"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
 import { useProfile, useRepos } from "@/lib/profile"
 import {
@@ -47,6 +50,10 @@ export function AgentsHome() {
   const { models, defaultSelection } = useModelOptions()
   const [selection, setSelection] = useState<ModelSelection | null>(null)
   const activeSelection = selection ?? defaultSelection
+  const handleSelectionChange = (next: ModelSelection) => {
+    setSelection(next)
+    persistModelSelection(next)
+  }
   const activeModel = models.find(
     (model) => model.id === activeSelection?.modelId
   )
@@ -208,7 +215,7 @@ export function AgentsHome() {
             disabled={submitting}
             models={models}
             selection={activeSelection}
-            onSelectionChange={setSelection}
+            onSelectionChange={handleSelectionChange}
             repos={reposQuery.data?.repositories}
             selectedRepo={repo}
             onRepoChange={setRepoOverride}

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -52,7 +52,7 @@ export function AgentsHome() {
   const activeSelection = selection ?? defaultSelection
   const handleSelectionChange = (next: ModelSelection) => {
     setSelection(next)
-    persistModelSelection(next)
+    persistModelSelection(next, profileQuery.data?.login ?? "")
   }
   const activeModel = models.find(
     (model) => model.id === activeSelection?.modelId

--- a/ui/src/features/agents/lib/provider/useModelOptions.ts
+++ b/ui/src/features/agents/lib/provider/useModelOptions.ts
@@ -1,5 +1,5 @@
 import type { ModelOption } from "@/lib/api"
-import { useOptions } from "@/lib/profile"
+import { useOptions, useProfile } from "@/lib/profile"
 
 export interface ModelSelection {
   modelId: string
@@ -14,17 +14,21 @@ export interface ModelOptionsResult {
 
 const STORAGE_KEY = "open-swe.agents.model-selection"
 
-function storedSelection(models: Array<ModelOption>): ModelSelection | null {
-  if (typeof window === "undefined") return null
+function storedSelection(
+  models: Array<ModelOption>,
+  login: string
+): ModelSelection | null {
+  if (typeof window === "undefined" || !login) return null
   try {
     const selection = JSON.parse(
       window.localStorage.getItem(STORAGE_KEY) ?? "null"
-    ) as Partial<ModelSelection> | null
-    return models.some(
-      (model) =>
-        model.id === selection?.modelId &&
-        model.efforts.includes(selection.effort ?? "")
-    )
+    ) as (Partial<ModelSelection> & { login?: string }) | null
+    return selection?.login === login &&
+      models.some(
+        (model) =>
+          model.id === selection.modelId &&
+          model.efforts.includes(selection.effort ?? "")
+      )
       ? (selection as ModelSelection)
       : null
   } catch {
@@ -32,10 +36,16 @@ function storedSelection(models: Array<ModelOption>): ModelSelection | null {
   }
 }
 
-export function persistModelSelection(selection: ModelSelection): void {
-  if (typeof window === "undefined") return
+export function persistModelSelection(
+  selection: ModelSelection,
+  login: string
+): void {
+  if (typeof window === "undefined" || !login) return
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selection))
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...selection, login })
+    )
   } catch {}
 }
 
@@ -53,6 +63,7 @@ function toSupportedSelection(
 
 export function useModelOptions(): ModelOptionsResult {
   const optionsQuery = useOptions()
+  const profileQuery = useProfile()
   const models = optionsQuery.data?.models ?? []
   const teamDefaultSelection = toSupportedSelection(
     models,
@@ -64,13 +75,15 @@ export function useModelOptions(): ModelOptionsResult {
     ? { modelId: firstModel.id, effort: firstModel.default_effort }
     : null
   const defaultSelection = optionsQuery.data
-    ? (storedSelection(models) ?? teamDefaultSelection ?? firstSelection)
+    ? (storedSelection(models, profileQuery.data?.login ?? "") ??
+      teamDefaultSelection ??
+      firstSelection)
     : null
 
   return {
     models,
     defaultSelection,
-    isLoading: optionsQuery.isLoading,
+    isLoading: optionsQuery.isLoading || profileQuery.isLoading,
   }
 }
 

--- a/ui/src/features/agents/lib/provider/useModelOptions.ts
+++ b/ui/src/features/agents/lib/provider/useModelOptions.ts
@@ -1,5 +1,5 @@
 import type { ModelOption } from "@/lib/api"
-import { useOptions, useProfile } from "@/lib/profile"
+import { useOptions } from "@/lib/profile"
 
 export interface ModelSelection {
   modelId: string
@@ -10,6 +10,33 @@ export interface ModelOptionsResult {
   models: Array<ModelOption>
   defaultSelection: ModelSelection | null
   isLoading: boolean
+}
+
+const STORAGE_KEY = "open-swe.agents.model-selection"
+
+function storedSelection(models: Array<ModelOption>): ModelSelection | null {
+  if (typeof window === "undefined") return null
+  try {
+    const selection = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) ?? "null"
+    ) as Partial<ModelSelection> | null
+    return models.some(
+      (model) =>
+        model.id === selection?.modelId &&
+        model.efforts.includes(selection.effort ?? "")
+    )
+      ? (selection as ModelSelection)
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function persistModelSelection(selection: ModelSelection): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selection))
+  } catch {}
 }
 
 function toSupportedSelection(
@@ -26,15 +53,7 @@ function toSupportedSelection(
 
 export function useModelOptions(): ModelOptionsResult {
   const optionsQuery = useOptions()
-  const profileQuery = useProfile()
-
   const models = optionsQuery.data?.models ?? []
-  const profile = profileQuery.data
-  const profileSelection = toSupportedSelection(
-    models,
-    profile?.default_model,
-    profile?.reasoning_effort
-  )
   const teamDefaultSelection = toSupportedSelection(
     models,
     optionsQuery.data?.default_agent_model,
@@ -44,15 +63,14 @@ export function useModelOptions(): ModelOptionsResult {
   const firstSelection = firstModel
     ? { modelId: firstModel.id, effort: firstModel.default_effort }
     : null
-  const defaultSelection =
-    optionsQuery.data && !profileQuery.isLoading
-      ? (profileSelection ?? teamDefaultSelection ?? firstSelection)
-      : null
+  const defaultSelection = optionsQuery.data
+    ? (storedSelection(models) ?? teamDefaultSelection ?? firstSelection)
+    : null
 
   return {
     models,
     defaultSelection,
-    isLoading: optionsQuery.isLoading || profileQuery.isLoading,
+    isLoading: optionsQuery.isLoading,
   }
 }
 

--- a/ui/src/features/agents/lib/provider/useModelOptions.ts
+++ b/ui/src/features/agents/lib/provider/useModelOptions.ts
@@ -1,5 +1,6 @@
 import type { ModelOption } from "@/lib/api"
-import { useOptions, useProfile } from "@/lib/profile"
+import { useOptions } from "@/lib/profile"
+import { useSession } from "@/lib/session"
 
 export interface ModelSelection {
   modelId: string
@@ -63,7 +64,7 @@ function toSupportedSelection(
 
 export function useModelOptions(): ModelOptionsResult {
   const optionsQuery = useOptions()
-  const profileQuery = useProfile()
+  const session = useSession()
   const models = optionsQuery.data?.models ?? []
   const teamDefaultSelection = toSupportedSelection(
     models,
@@ -75,7 +76,7 @@ export function useModelOptions(): ModelOptionsResult {
     ? { modelId: firstModel.id, effort: firstModel.default_effort }
     : null
   const defaultSelection = optionsQuery.data
-    ? (storedSelection(models, profileQuery.data?.login ?? "") ??
+    ? (storedSelection(models, session.data?.login ?? "") ??
       teamDefaultSelection ??
       firstSelection)
     : null
@@ -83,7 +84,7 @@ export function useModelOptions(): ModelOptionsResult {
   return {
     models,
     defaultSelection,
-    isLoading: optionsQuery.isLoading || profileQuery.isLoading,
+    isLoading: optionsQuery.isLoading || session.isLoading,
   }
 }
 


### PR DESCRIPTION
## Description
Keep the web model picker's last selection in browser storage. Dashboard model settings now remain dedicated to Slack and other default invocations.

## Release Note
Web model picker selections no longer change the configured Slack default.

## Test Plan
- [x] Verify UI typecheck and formatting

Made by [Open SWE](https://openswe.vercel.app/agents/019ff239-4a9d-72ea-95f3-1da0b19ea68d)