### PR TITLE
feat: show repository in cloud session header

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
-import { CircleAlert as CircleAlertIcon, Map as MapIcon } from "lucide-react"
+import {
+  CircleAlert as CircleAlertIcon,
+  FolderOpen,
+  Map as MapIcon,
+} from "lucide-react"
 
 import type {
   AgentThread,
@@ -211,6 +215,21 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
         className="flex min-w-0 flex-1 flex-col"
         style={isMobile ? undefined : { minWidth: PANEL_MIN_CHAT_WIDTH }}
       >
+        {thread.repoFullName && (
+          <div
+            className={cn(
+              "mx-auto flex w-full max-w-3xl shrink-0 items-center gap-2 px-4 pt-3 text-xs text-muted-foreground",
+              sidebarCollapsed && "pl-14",
+              panelCollapsed && "pr-14"
+            )}
+          >
+            <FolderOpen className="size-3.5" />
+            <span className="truncate" title={thread.repoFullName}>
+              {thread.repoFullName}
+            </span>
+            <span className="ml-auto shrink-0">Cloud</span>
+          </div>
+        )}
         {thread.status === "error" && (
           <div className="mx-auto w-full max-w-3xl shrink-0 px-4 pt-3">
             <Alert variant="error" controlAlignment="first-line">


### PR DESCRIPTION
## Description
Mirror the desktop session header for cloud chats, showing the selected repository and a Cloud label. Repo-less sessions omit the header.

## Release Note
Cloud session chats now show their repository in the header.

## Test Plan
- [x] Verify typecheck and focused lint

Made by [Open SWE](https://openswe.vercel.app/agents/019ff2d0-bb09-7339-8f68-105a9e196016)