### PR TITLE
feat: trigger automations as tests

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -142,6 +142,7 @@ from .schedules import (
     create_agent_schedule,
     delete_agent_schedule,
     list_agent_schedules,
+    trigger_agent_schedule,
     update_agent_schedule,
 )
 from .skills import (
@@ -1630,6 +1631,14 @@ async def api_update_schedule(
     return await update_agent_schedule(
         schedule_id, session["sub"], body, email=session.get("email")
     )
+
+
+@router.post("/schedules/{schedule_id}/trigger")
+async def api_trigger_schedule(
+    schedule_id: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await trigger_agent_schedule(schedule_id, session["sub"], email=session.get("email"))
 
 
 @router.delete("/schedules/{schedule_id}")

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -31,6 +31,7 @@ from .user_mappings import slack_id_for_login
 logger = logging.getLogger(__name__)
 
 SCHEDULES_NAMESPACE: list[str] = ["agent_schedules"]
+SCHEDULE_RUN_STATE_NAMESPACE: list[str] = ["agent_schedule_run_state"]
 _AGENT_ASSISTANT_ID = "agent"
 _SCHEDULER_ASSISTANT_ID = "scheduler"
 _CRON_FIELD_RANGES = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
@@ -158,8 +159,11 @@ def _repo_full_name(repo: dict[str, str] | None) -> str | None:
     return f"{owner}/{name}" if owner and name else None
 
 
-def _schedule_summary(record: dict[str, Any]) -> dict[str, Any]:
+def _schedule_summary(
+    record: dict[str, Any], run_state: dict[str, Any] | None = None
+) -> dict[str, Any]:
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
+    state = run_state or record
     return {
         "id": record.get("id"),
         "name": record.get("name"),
@@ -171,11 +175,11 @@ def _schedule_summary(record: dict[str, Any]) -> dict[str, Any]:
         "effort": record.get("effort"),
         "enabled": bool(record.get("enabled")),
         "cronId": record.get("cron_id"),
-        "lastThreadId": record.get("last_thread_id"),
-        "lastRunId": record.get("last_run_id"),
-        "lastTriggeredAt": record.get("last_triggered_at"),
-        "lastError": record.get("last_error"),
-        "lastErrorAt": record.get("last_error_at"),
+        "lastThreadId": state.get("last_thread_id"),
+        "lastRunId": state.get("last_run_id"),
+        "lastTriggeredAt": state.get("last_triggered_at"),
+        "lastError": state.get("last_error"),
+        "lastErrorAt": state.get("last_error_at"),
         "createdAt": record.get("created_at"),
         "updatedAt": record.get("updated_at"),
     }
@@ -193,6 +197,35 @@ async def _put_value(record: dict[str, Any]) -> dict[str, Any]:
     record = {**record, "updated_at": _now_iso()}
     await _client().store.put_item(SCHEDULES_NAMESPACE, record["id"], record)
     return record
+
+
+async def _get_run_state(schedule_id: str) -> dict[str, Any] | None:
+    item = await _client().store.get_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def _put_run_state(record: dict[str, Any], patch: dict[str, Any]) -> None:
+    schedule_id = record["id"]
+    existing = await _get_run_state(schedule_id)
+    fallback = {
+        "last_thread_id": record.get("last_thread_id"),
+        "last_run_id": record.get("last_run_id"),
+        "last_triggered_at": record.get("last_triggered_at"),
+        "last_error": record.get("last_error"),
+        "last_error_at": record.get("last_error_at"),
+    }
+    value = {
+        **fallback,
+        **(existing or {}),
+        **patch,
+        "schedule_id": schedule_id,
+        "created_by": record.get("created_by"),
+        "user_email": record.get("user_email"),
+    }
+    await _client().store.put_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id, value)
 
 
 async def get_agent_schedule(schedule_id: str) -> dict[str, Any] | None:
@@ -213,13 +246,13 @@ def _assert_schedule_owner(
         raise HTTPException(404, "schedule not found")
 
 
-async def _search_schedule_values(filter: dict[str, Any]) -> list[dict[str, Any]]:
+async def _search_values(namespace: list[str], filter: dict[str, Any]) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     limit = 100
     offset = 0
     while True:
         result = await _client().store.search_items(
-            SCHEDULES_NAMESPACE,
+            namespace,
             filter=filter,
             limit=limit,
             offset=offset,
@@ -243,14 +276,19 @@ async def list_agent_schedules(login: str, *, email: str | None = None) -> list[
         searches.append({"user_email": email.strip().lower()})
 
     seen: dict[str, dict[str, Any]] = {}
+    run_states: dict[str, dict[str, Any]] = {}
     for filter in searches:
-        for record in await _search_schedule_values(filter):
+        for record in await _search_values(SCHEDULES_NAMESPACE, filter):
             schedule_id = record.get("id")
             if isinstance(schedule_id, str) and _user_owns_schedule(record, login, email):
                 seen[schedule_id] = record
+        for state in await _search_values(SCHEDULE_RUN_STATE_NAMESPACE, filter):
+            schedule_id = state.get("schedule_id")
+            if isinstance(schedule_id, str):
+                run_states[schedule_id] = state
     records = list(seen.values())
     records.sort(key=lambda item: item.get("updated_at", ""), reverse=True)
-    return [_schedule_summary(record) for record in records]
+    return [_schedule_summary(record, run_states.get(record["id"])) for record in records]
 
 
 async def _ensure_dashboard_github_token(login: str) -> None:
@@ -382,7 +420,7 @@ async def update_agent_schedule(
         updated["cron_id"] = None
 
     updated = await _put_value(updated)
-    return _schedule_summary(updated)
+    return _schedule_summary(updated, await _get_run_state(schedule_id))
 
 
 async def delete_agent_schedule(schedule_id: str, login: str, *, email: str | None = None) -> None:
@@ -391,14 +429,16 @@ async def delete_agent_schedule(schedule_id: str, login: str, *, email: str | No
     assert existing is not None
     await _delete_cron(existing.get("cron_id"))
     await _client().store.delete_item(SCHEDULES_NAMESPACE, schedule_id)
+    await _client().store.delete_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
 
 
-def _slack_root_message(record: dict[str, Any]) -> str:
+def _slack_root_message(record: dict[str, Any], *, test_run: bool = False) -> str:
     repo = _repo_full_name(record.get("repo") if isinstance(record.get("repo"), dict) else None)
     repo_line = f"\n*Repository:* `{repo}`" if repo else ""
+    run_kind = "test" if test_run else "scheduled"
     return (
         f"*Open SWE automation:* {record.get('name') or 'Scheduled agent'}{repo_line}\n\n"
-        "A scheduled run started. Reply in this thread to follow up with the agent."
+        f"A {run_kind} run started. Reply in this thread to follow up with the agent."
     )
 
 
@@ -414,17 +454,23 @@ def _scheduled_prompt(record: dict[str, Any], slack_thread: dict[str, Any] | Non
 
 
 def _agent_run_metadata(
-    record: dict[str, Any], thread_id: str, slack_thread: dict[str, Any] | None = None
+    record: dict[str, Any],
+    thread_id: str,
+    slack_thread: dict[str, Any] | None = None,
+    *,
+    test_run: bool = False,
 ) -> dict[str, Any]:
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
     now_ms = _now_ms()
+    title_prefix = "Test" if test_run else "Scheduled"
     metadata: dict[str, Any] = {
         "source": "schedule",
         "schedule_id": record["id"],
         "schedule_name": record.get("name"),
+        "schedule_test": test_run,
         "github_login": record.get("created_by"),
         "triggering_user_email": record.get("user_email"),
-        "title": f"Scheduled: {record.get('name') or 'Agent'}",
+        "title": f"{title_prefix}: {record.get('name') or 'Agent'}",
         "base_branch": record.get("base_branch") or "main",
         "branch_prefix": record.get("branch_prefix"),
         "model": record.get("model") or "Default",
@@ -441,7 +487,11 @@ def _agent_run_metadata(
 
 
 async def _agent_run_config(
-    record: dict[str, Any], thread_id: str, slack_thread: dict[str, Any] | None = None
+    record: dict[str, Any],
+    thread_id: str,
+    slack_thread: dict[str, Any] | None = None,
+    *,
+    test_run: bool = False,
 ) -> dict[str, Any]:
     configurable: dict[str, Any] = {
         "thread_id": thread_id,
@@ -449,6 +499,7 @@ async def _agent_run_config(
         "github_login": record.get("created_by"),
         "user_email": record.get("user_email"),
         "schedule_id": record["id"],
+        "schedule_test": test_run,
         "prepare_run_id": str(uuid.uuid4()),
     }
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
@@ -466,11 +517,11 @@ async def _agent_run_config(
     return {"configurable": configurable, "metadata": _agent_version_metadata()}
 
 
-async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
-    record = await get_agent_schedule(schedule_id)
-    if not record:
-        return {"status": "missing", "schedule_id": schedule_id}
-    if not record.get("enabled"):
+async def _launch_agent_schedule_record(
+    record: dict[str, Any], *, test_run: bool = False
+) -> dict[str, Any]:
+    schedule_id = record["id"]
+    if not test_run and not record.get("enabled"):
         return {"status": "disabled", "schedule_id": schedule_id}
 
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
@@ -478,12 +529,12 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
     login = record.get("created_by")
     if full_name:
         if not (isinstance(login, str) and login):
-            await _put_value(
+            await _put_run_state(
+                record,
                 {
-                    **record,
                     "last_error": "schedule owner unavailable",
                     "last_error_at": _now_iso(),
-                }
+                },
             )
             return {
                 "status": "unauthorized",
@@ -493,27 +544,35 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
         try:
             await require_repo_access_for_user(login, full_name)
         except HTTPException as exc:
-            await _put_value(
+            await _put_run_state(
+                record,
                 {
-                    **record,
                     "last_error": str(exc.detail),
                     "last_error_at": _now_iso(),
-                }
+                },
             )
-            return {"status": "unauthorized", "schedule_id": schedule_id, "error": exc.detail}
+            return {
+                "status": "unauthorized",
+                "schedule_id": schedule_id,
+                "error": exc.detail,
+                "status_code": exc.status_code,
+            }
 
     slack_thread: dict[str, Any] | None = None
     slack_channel_id = record.get("slack_channel_id")
     if isinstance(slack_channel_id, str) and slack_channel_id:
         message_ts, slack_error = await post_slack_top_level_message_with_ts(
             slack_channel_id,
-            _slack_root_message(record),
+            _slack_root_message(record, test_run=test_run),
             unfurl_links=False,
             unfurl_media=False,
         )
         if not message_ts:
             error = f"Slack post failed: {slack_error or 'unknown error'}"
-            await _put_value({**record, "last_error": error, "last_error_at": _now_iso()})
+            await _put_run_state(
+                record,
+                {"last_error": error, "last_error_at": _now_iso()},
+            )
             return {"status": "error", "schedule_id": schedule_id, "error": error}
         slack_thread = {
             "channel_id": slack_channel_id,
@@ -529,7 +588,7 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
     else:
         thread_id = str(uuid.uuid4())
 
-    metadata = _agent_run_metadata(record, thread_id, slack_thread)
+    metadata = _agent_run_metadata(record, thread_id, slack_thread, test_run=test_run)
     client = _client()
     await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
     await client.threads.update(thread_id=thread_id, metadata=metadata)
@@ -538,7 +597,7 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
         _AGENT_ASSISTANT_ID,
         input={"messages": [{"role": "user", "content": _scheduled_prompt(record, slack_thread)}]},
         source="schedule",
-        config=await _agent_run_config(record, thread_id, slack_thread),
+        config=await _agent_run_config(record, thread_id, slack_thread, test_run=test_run),
         client=client,
         stream_mode=["values", "updates", "messages-tuple"],
         stream_resumable=True,
@@ -557,15 +616,15 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
         thread_id=thread_id,
         metadata={"latest_run_id": run_id, "latest_run_status": "pending", "updated_at_ms": now_ms},
     )
-    await _put_value(
+    await _put_run_state(
+        record,
         {
-            **record,
             "last_thread_id": thread_id,
             "last_run_id": run_id,
             "last_triggered_at": _now_iso(),
             "last_error": None,
             "last_error_at": None,
-        }
+        },
     )
     return {
         "status": "started",
@@ -573,3 +632,30 @@ async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
         "thread_id": thread_id,
         "run_id": run_id,
     }
+
+
+async def launch_scheduled_agent_run(schedule_id: str) -> dict[str, Any]:
+    record = await get_agent_schedule(schedule_id)
+    if not record:
+        return {"status": "missing", "schedule_id": schedule_id}
+    return await _launch_agent_schedule_record(record)
+
+
+async def trigger_agent_schedule(
+    schedule_id: str, login: str, *, email: str | None = None
+) -> dict[str, Any]:
+    record = await get_agent_schedule(schedule_id)
+    _assert_schedule_owner(record, login, email)
+    assert record is not None
+
+    result = await _launch_agent_schedule_record(record, test_run=True)
+    status = result.get("status")
+    if status == "started":
+        return result
+    if status == "unauthorized":
+        status_code = result.get("status_code")
+        raise HTTPException(
+            status_code if isinstance(status_code, int) else 403,
+            result.get("error") or "automation repository unavailable",
+        )
+    raise HTTPException(502, result.get("error") or "failed to start automation test")

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -228,6 +228,16 @@ async def test_list_agent_schedules_uses_owner_filters_and_paginates(fake_client
             },
         )
     await fake_client.store.put_item(
+        schedules.SCHEDULE_RUN_STATE_NAMESPACE,
+        "alice_0",
+        {
+            "schedule_id": "alice_0",
+            "created_by": "alice",
+            "user_email": "alice@example.com",
+            "last_triggered_at": "2026-01-02T00:00:00+00:00",
+        },
+    )
+    await fake_client.store.put_item(
         schedules.SCHEDULES_NAMESPACE,
         "bob_1",
         {
@@ -249,6 +259,8 @@ async def test_list_agent_schedules_uses_owner_filters_and_paginates(fake_client
 
     assert len(result) == 125
     assert {item["id"] for item in result} == {f"alice_{i}" for i in range(125)}
+    alice_zero = next(item for item in result if item["id"] == "alice_0")
+    assert alice_zero["lastTriggeredAt"] == "2026-01-02T00:00:00+00:00"
 
 
 async def test_update_agent_schedule_rechecks_repo_access(fake_client, auth, monkeypatch) -> None:  # noqa: ANN001, ARG001
@@ -341,6 +353,102 @@ async def test_update_agent_schedule_pause_deletes_cron(fake_client) -> None:  #
     assert fake_client.crons.deleted == ["cron_old"]
 
 
+async def test_trigger_agent_schedule_runs_paused_automation_as_test(
+    fake_client, monkeypatch
+) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Weekly dependencies",
+        "prompt": "Check dependencies",
+        "schedule": "0 9 * * 1",
+        "repo": None,
+        "model": "Default",
+        "effort": None,
+        "base_branch": "main",
+        "branch_prefix": "open-swe",
+        "enabled": False,
+        "cron_id": None,
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    async def create_run(thread_id: str, assistant_id: str, **kwargs: Any) -> dict[str, str]:
+        fake_client.runs.created.append(
+            {"thread_id": thread_id, "assistant_id": assistant_id, **kwargs}
+        )
+        await fake_client.store.put_item(
+            schedules.SCHEDULES_NAMESPACE,
+            "sched_1",
+            {**record, "enabled": True, "cron_id": "cron_new"},
+        )
+        return {"run_id": "run_123"}
+
+    monkeypatch.setattr(schedules, "create_durable_run", create_run)
+
+    result = await schedules.trigger_agent_schedule("sched_1", "alice", email="alice@example.com")
+
+    assert result["status"] == "started"
+    metadata = fake_client.threads.created[0]["metadata"]
+    assert metadata["title"] == "Test: Weekly dependencies"
+    assert metadata["schedule_test"] is True
+    run = fake_client.runs.created[0]
+    assert run["config"]["configurable"]["schedule_test"] is True
+    stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
+    assert stored["enabled"] is True
+    assert stored["cron_id"] == "cron_new"
+
+
+async def test_trigger_agent_schedule_hides_unowned_automation(fake_client) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Daily report",
+        "prompt": "Summarize updates",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "model": "Default",
+        "enabled": True,
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    with pytest.raises(HTTPException) as exc:
+        await schedules.trigger_agent_schedule("sched_1", "bob", email="bob@example.com")
+
+    assert exc.value.status_code == 404
+    assert fake_client.runs.created == []
+
+
+async def test_trigger_agent_schedule_preserves_repo_auth_error(fake_client, monkeypatch) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Daily report",
+        "prompt": "Summarize updates",
+        "schedule": "0 9 * * *",
+        "repo": {"owner": "langchain-ai", "name": "open-swe"},
+        "model": "Default",
+        "enabled": True,
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    async def expired_token(login: str, full_name: str) -> str:
+        raise HTTPException(401, "github token unavailable, re-login required")
+
+    monkeypatch.setattr(schedules, "require_repo_access_for_user", expired_token)
+
+    with pytest.raises(HTTPException) as exc:
+        await schedules.trigger_agent_schedule("sched_1", "alice", email="alice@example.com")
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "github token unavailable, re-login required"
+    assert fake_client.runs.created == []
+
+
 async def test_launch_scheduled_agent_run_skips_when_repo_access_revoked(
     fake_client, auth, monkeypatch
 ) -> None:  # noqa: ANN001, ARG001
@@ -374,9 +482,10 @@ async def test_launch_scheduled_agent_run_skips_when_repo_access_revoked(
         "status": "unauthorized",
         "schedule_id": "sched_1",
         "error": "no access to this private repository",
+        "status_code": 403,
     }
     assert fake_client.runs.created == []
-    stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
+    stored = fake_client.store.items[(tuple(schedules.SCHEDULE_RUN_STATE_NAMESPACE), "sched_1")]
     assert stored["last_error"] == "no access to this private repository"
 
 
@@ -419,7 +528,7 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(fake_client,
     assert run["config"]["configurable"]["source"] == "schedule"
     assert run["config"]["configurable"]["repo"] == record["repo"]
 
-    stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
+    stored = fake_client.store.items[(tuple(schedules.SCHEDULE_RUN_STATE_NAMESPACE), "sched_1")]
     assert stored["last_thread_id"] == thread_id
     assert stored["last_run_id"] == "run_123"
 
@@ -511,5 +620,5 @@ async def test_launch_scheduled_agent_run_stops_when_slack_post_fails(
     }
     assert fake_client.threads.created == []
     assert fake_client.runs.created == []
-    stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
+    stored = fake_client.store.items[(tuple(schedules.SCHEDULE_RUN_STATE_NAMESPACE), "sched_1")]
     assert stored["last_error"] == "Slack post failed: not_in_channel"

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -48,6 +48,13 @@ export interface ScheduleUpdateRequest {
   enabled?: boolean | null
 }
 
+export interface ScheduleTriggerResult {
+  status: "started"
+  schedule_id: string
+  thread_id: string
+  run_id: string | null
+}
+
 export interface ThreadPrDiffFile {
   path: string
   previousPath: string | null
@@ -243,6 +250,11 @@ export const agentsApi = {
         method: "PATCH",
         body: JSON.stringify(body),
       }
+    ),
+  triggerSchedule: (scheduleId: string) =>
+    agentsRequest<ScheduleTriggerResult>(
+      `/schedules/${encodeURIComponent(scheduleId)}/trigger`,
+      { method: "POST" }
     ),
   deleteSchedule: (scheduleId: string) =>
     agentsRequest<void>(`/schedules/${encodeURIComponent(scheduleId)}`, {

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -288,6 +288,18 @@ export function useUpdateAgentSchedule() {
   })
 }
 
+export function useTriggerAgentSchedule() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: agentsApi.triggerSchedule,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentScheduleKeys.all })
+      invalidateAgentThreadLists(queryClient)
+    },
+  })
+}
+
 export function useDeleteAgentSchedule() {
   const queryClient = useQueryClient()
 

--- a/ui/src/features/automations/components/AutomationsList.tsx
+++ b/ui/src/features/automations/components/AutomationsList.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import {
   ClockIcon,
   LightningIcon,
@@ -15,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { describeCron } from "@/features/automations/lib/cron"
 import {
   useAgentSchedules,
+  useTriggerAgentSchedule,
   useUpdateAgentSchedule,
 } from "@/features/agents/lib/queries"
 import { cn } from "@/lib/utils"
@@ -142,14 +143,37 @@ function EmptyState() {
 }
 
 function AutomationRow({ schedule }: { schedule: AgentSchedule }) {
+  const navigate = useNavigate()
   const updateSchedule = useUpdateAgentSchedule()
+  const triggerSchedule = useTriggerAgentSchedule()
   const isToggling =
     updateSchedule.isPending &&
     updateSchedule.variables.scheduleId === schedule.id
+  const isTesting =
+    triggerSchedule.isPending && triggerSchedule.variables === schedule.id
+  const testError =
+    triggerSchedule.isError && triggerSchedule.variables === schedule.id
+      ? triggerSchedule.error.message
+      : null
+
+  const onTest = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (isTesting || isToggling) return
+    triggerSchedule.mutate(schedule.id, {
+      onSuccess: (result) => {
+        void navigate({
+          to: "/agents/$threadId",
+          params: { threadId: result.thread_id },
+        })
+      },
+    })
+  }
 
   const onToggle = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
+    if (isTesting || isToggling) return
     updateSchedule.mutate({
       scheduleId: schedule.id,
       body: { enabled: !schedule.enabled },
@@ -157,45 +181,60 @@ function AutomationRow({ schedule }: { schedule: AgentSchedule }) {
   }
 
   return (
-    <Link
-      to="/agents/automations/$scheduleId"
-      params={{ scheduleId: schedule.id }}
-      className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:border-muted-foreground/70"
-    >
-      <span
-        className={cn(
-          "size-2 shrink-0 rounded-full",
-          schedule.enabled ? "bg-success" : "bg-border"
-        )}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-sm font-medium text-foreground">
-            {schedule.name}
-          </span>
-          {schedule.lastError && (
-            <WarningCircleIcon
-              className="size-3.5 shrink-0 text-destructive"
-              aria-label="Last run failed"
-            >
-              <title>Last run failed</title>
-            </WarningCircleIcon>
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:border-muted-foreground/70">
+      <Link
+        to="/agents/automations/$scheduleId"
+        params={{ scheduleId: schedule.id }}
+        className="flex min-w-0 flex-1 items-center gap-3"
+      >
+        <span
+          className={cn(
+            "size-2 shrink-0 rounded-full",
+            schedule.enabled ? "bg-success" : "bg-border"
+          )}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-medium text-foreground">
+              {schedule.name}
+            </span>
+            {schedule.lastError && (
+              <WarningCircleIcon
+                className="size-3.5 shrink-0 text-destructive"
+                aria-label="Last run failed"
+              >
+                <title>Last run failed</title>
+              </WarningCircleIcon>
+            )}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground/70">
+            <span className="flex items-center gap-1">
+              <ClockIcon className="size-3.5" />
+              {describeCron(schedule.schedule)}
+            </span>
+            {schedule.repo && <span>{schedule.repo}</span>}
+            {schedule.slackChannelId && <span>{schedule.slackChannelId}</span>}
+            <span>Last run: {formatDate(schedule.lastTriggeredAt)}</span>
+          </div>
+          {testError && (
+            <p className="mt-1 text-xs text-destructive">{testError}</p>
           )}
         </div>
-        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground/70">
-          <span className="flex items-center gap-1">
-            <ClockIcon className="size-3.5" />
-            {describeCron(schedule.schedule)}
-          </span>
-          {schedule.repo && <span>{schedule.repo}</span>}
-          {schedule.slackChannelId && <span>{schedule.slackChannelId}</span>}
-          <span>Last run: {formatDate(schedule.lastTriggeredAt)}</span>
-        </div>
-      </div>
+      </Link>
+      <button
+        type="button"
+        onClick={onTest}
+        disabled={isTesting || isToggling}
+        aria-label="Test automation"
+        className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
+      >
+        <LightningIcon className="size-3.5" />
+        {isTesting ? "Starting…" : "Test"}
+      </button>
       <button
         type="button"
         onClick={onToggle}
-        disabled={isToggling}
+        disabled={isTesting || isToggling}
         aria-label={schedule.enabled ? "Pause automation" : "Resume automation"}
         className="shrink-0 rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
       >
@@ -205,6 +244,6 @@ function AutomationRow({ schedule }: { schedule: AgentSchedule }) {
           <PlayIcon className="size-4" />
         )}
       </button>
-    </Link>
+    </div>
   )
 }


### PR DESCRIPTION
## Description
Adds an authenticated Test action for dashboard automations, including paused automations, and opens the fresh agent thread after launch. Run state is stored separately so test launches cannot overwrite concurrent schedule edits.

## Test Plan
- [x] `uv run pytest -q tests/agent/test_agent_schedules.py`; Ruff and focused basedpyright
- [x] UI TypeScript and Prettier checks (UI ESLint is unavailable because the repo script cannot find an ESLint binary)

Made by [Open SWE](https://openswe.vercel.app/agents/e1fffff4-4956-dabc-2733-e91eaf738fdd)