### PR TITLE
fix: preserve original Slack thread owner

### DIFF
--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -721,6 +721,24 @@ async def _source_context_with_slack_permalink(
     return enriched
 
 
+def _preserve_thread_owner(metadata: dict[str, Any], existing_metadata: dict[str, Any]) -> None:
+    for key in ("github_login", "triggering_user_email"):
+        if existing_metadata.get(key):
+            metadata[key] = existing_metadata[key]
+    existing_context = existing_metadata.get("source_context")
+    updated_context = metadata.get("source_context")
+    existing_slack = (
+        existing_context.get("slack_thread") if isinstance(existing_context, dict) else None
+    )
+    updated_slack = (
+        updated_context.get("slack_thread") if isinstance(updated_context, dict) else None
+    )
+    if isinstance(existing_slack, dict) and isinstance(updated_slack, dict):
+        for key in ("triggering_user_id", "triggering_user_name", "triggering_user_email"):
+            if existing_slack.get(key):
+                updated_slack[key] = existing_slack[key]
+
+
 async def upsert_agent_thread_owner_metadata(
     thread_id: str,
     *,
@@ -767,6 +785,7 @@ async def upsert_agent_thread_owner_metadata(
         metadata["source_context"] = await _source_context_with_slack_permalink(
             source_context, existing_meta
         )
+    _preserve_thread_owner(metadata, existing_meta)
     if existing_meta.get("created_at_ms") is None:
         metadata["created_at_ms"] = now_ms
     if existing_meta.get("title") and "title" in metadata:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -735,8 +735,7 @@ async def upsert_agent_thread_owner_metadata(
 
     Webhook-triggered runs only pass ``source``/``github_login`` through the run
     config; the Agents UI lists and authorizes threads by thread *metadata*, so we
-    mirror the owner-identifying fields onto the thread here. Once initialized,
-    those fields remain unchanged when another user interacts with the thread.
+    mirror the owner-identifying fields onto the thread here.
     """
     now_ms = int(datetime.now(UTC).timestamp() * 1000)
     metadata: dict[str, Any] = {"source": source, "updated_at_ms": now_ms}
@@ -760,27 +759,29 @@ async def upsert_agent_thread_owner_metadata(
         existing_dict["metadata"] if isinstance(existing_dict.get("metadata"), dict) else {}
     )
     existing_context = existing_meta.get("source_context")
-    owner_initialized = any(
-        existing_meta.get(key)
-        for key in ("github_login", "triggering_user_email", "source_context")
+    same_slack_owner = bool(
+        isinstance(existing_context, dict)
+        and isinstance(source_context, dict)
+        and isinstance(existing_slack := existing_context.get("slack_thread"), dict)
+        and isinstance(incoming_slack := source_context.get("slack_thread"), dict)
+        and existing_slack.get("triggering_user_id")
+        and existing_slack["triggering_user_id"] == incoming_slack.get("triggering_user_id")
     )
+    owner_initialized = any(
+        existing_meta.get(key) for key in ("github_login", "triggering_user_email")
+    ) or bool(existing_context and not same_slack_owner)
     if not owner_initialized:
         resolved_login = github_login or await resolve_login_from_email_async(user_email) or ""
         if resolved_login:
             metadata["github_login"] = resolved_login
-        resolved_email = user_email.strip().lower()
-        if resolved_email:
-            metadata["triggering_user_email"] = resolved_email
-        if source_context:
-            metadata["source_context"] = await _source_context_with_slack_permalink(
-                source_context, existing_meta
-            )
-    elif isinstance(existing_context, dict) and existing_context:
-        enriched_context = await _source_context_with_slack_permalink(
-            existing_context, existing_meta
+        if user_email:
+            metadata["triggering_user_email"] = user_email.strip().lower()
+    else:
+        source_context = existing_context if isinstance(existing_context, dict) else None
+    if source_context:
+        metadata["source_context"] = await _source_context_with_slack_permalink(
+            source_context, existing_meta
         )
-        if enriched_context != existing_context:
-            metadata["source_context"] = enriched_context
     if existing_meta.get("created_at_ms") is None:
         metadata["created_at_ms"] = now_ms
     if existing_meta.get("title") and "title" in metadata:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -721,20 +721,6 @@ async def _source_context_with_slack_permalink(
     return enriched
 
 
-def _preserve_slack_owner(
-    source_context: dict[str, Any], existing_metadata: dict[str, Any]
-) -> None:
-    existing_context = existing_metadata.get("source_context")
-    existing_slack = (
-        existing_context.get("slack_thread") if isinstance(existing_context, dict) else None
-    )
-    updated_slack = source_context.get("slack_thread")
-    if isinstance(existing_slack, dict) and isinstance(updated_slack, dict):
-        for key in ("triggering_user_id", "triggering_user_name", "triggering_user_email"):
-            if existing_slack.get(key):
-                updated_slack[key] = existing_slack[key]
-
-
 async def upsert_agent_thread_owner_metadata(
     thread_id: str,
     *,
@@ -749,7 +735,8 @@ async def upsert_agent_thread_owner_metadata(
 
     Webhook-triggered runs only pass ``source``/``github_login`` through the run
     config; the Agents UI lists and authorizes threads by thread *metadata*, so we
-    mirror the owner-identifying fields onto the thread here.
+    mirror the owner-identifying fields onto the thread here. Once initialized,
+    those fields remain unchanged when another user interacts with the thread.
     """
     now_ms = int(datetime.now(UTC).timestamp() * 1000)
     metadata: dict[str, Any] = {"source": source, "updated_at_ms": now_ms}
@@ -772,27 +759,28 @@ async def upsert_agent_thread_owner_metadata(
     existing_meta = (
         existing_dict["metadata"] if isinstance(existing_dict.get("metadata"), dict) else {}
     )
-    existing_login = existing_meta.get("github_login")
-    resolved_login = (
-        existing_login
-        if isinstance(existing_login, str) and existing_login
-        else github_login or await resolve_login_from_email_async(user_email) or ""
+    existing_context = existing_meta.get("source_context")
+    owner_initialized = any(
+        existing_meta.get(key)
+        for key in ("github_login", "triggering_user_email", "source_context")
     )
-    existing_email = existing_meta.get("triggering_user_email")
-    resolved_email = (
-        existing_email
-        if isinstance(existing_email, str) and existing_email
-        else user_email.strip().lower()
-    )
-    if resolved_login:
-        metadata["github_login"] = resolved_login
-    if resolved_email:
-        metadata["triggering_user_email"] = resolved_email
-    if source_context:
-        metadata["source_context"] = await _source_context_with_slack_permalink(
-            source_context, existing_meta
+    if not owner_initialized:
+        resolved_login = github_login or await resolve_login_from_email_async(user_email) or ""
+        if resolved_login:
+            metadata["github_login"] = resolved_login
+        resolved_email = user_email.strip().lower()
+        if resolved_email:
+            metadata["triggering_user_email"] = resolved_email
+        if source_context:
+            metadata["source_context"] = await _source_context_with_slack_permalink(
+                source_context, existing_meta
+            )
+    elif isinstance(existing_context, dict) and existing_context:
+        enriched_context = await _source_context_with_slack_permalink(
+            existing_context, existing_meta
         )
-        _preserve_slack_owner(metadata["source_context"], existing_meta)
+        if enriched_context != existing_context:
+            metadata["source_context"] = enriched_context
     if existing_meta.get("created_at_ms") is None:
         metadata["created_at_ms"] = now_ms
     if existing_meta.get("title") and "title" in metadata:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -721,18 +721,14 @@ async def _source_context_with_slack_permalink(
     return enriched
 
 
-def _preserve_thread_owner(metadata: dict[str, Any], existing_metadata: dict[str, Any]) -> None:
-    for key in ("github_login", "triggering_user_email"):
-        if existing_metadata.get(key):
-            metadata[key] = existing_metadata[key]
+def _preserve_slack_owner(
+    source_context: dict[str, Any], existing_metadata: dict[str, Any]
+) -> None:
     existing_context = existing_metadata.get("source_context")
-    updated_context = metadata.get("source_context")
     existing_slack = (
         existing_context.get("slack_thread") if isinstance(existing_context, dict) else None
     )
-    updated_slack = (
-        updated_context.get("slack_thread") if isinstance(updated_context, dict) else None
-    )
+    updated_slack = source_context.get("slack_thread")
     if isinstance(existing_slack, dict) and isinstance(updated_slack, dict):
         for key in ("triggering_user_id", "triggering_user_name", "triggering_user_email"):
             if existing_slack.get(key):
@@ -756,16 +752,11 @@ async def upsert_agent_thread_owner_metadata(
     mirror the owner-identifying fields onto the thread here.
     """
     now_ms = int(datetime.now(UTC).timestamp() * 1000)
-    resolved_login = github_login or await resolve_login_from_email_async(user_email) or ""
     metadata: dict[str, Any] = {"source": source, "updated_at_ms": now_ms}
     if isinstance(repo_config, dict) and repo_config.get("owner") and repo_config.get("name"):
         metadata["repo"] = repo_config
         metadata["repo_owner"] = repo_config["owner"]
         metadata["repo_name"] = repo_config["name"]
-    if resolved_login:
-        metadata["github_login"] = resolved_login
-    if user_email:
-        metadata["triggering_user_email"] = user_email.strip().lower()
     if title:
         metadata["title"] = title[:80]
 
@@ -781,11 +772,27 @@ async def upsert_agent_thread_owner_metadata(
     existing_meta = (
         existing_dict["metadata"] if isinstance(existing_dict.get("metadata"), dict) else {}
     )
+    existing_login = existing_meta.get("github_login")
+    resolved_login = (
+        existing_login
+        if isinstance(existing_login, str) and existing_login
+        else github_login or await resolve_login_from_email_async(user_email) or ""
+    )
+    existing_email = existing_meta.get("triggering_user_email")
+    resolved_email = (
+        existing_email
+        if isinstance(existing_email, str) and existing_email
+        else user_email.strip().lower()
+    )
+    if resolved_login:
+        metadata["github_login"] = resolved_login
+    if resolved_email:
+        metadata["triggering_user_email"] = resolved_email
     if source_context:
         metadata["source_context"] = await _source_context_with_slack_permalink(
             source_context, existing_meta
         )
-    _preserve_thread_owner(metadata, existing_meta)
+        _preserve_slack_owner(metadata["source_context"], existing_meta)
     if existing_meta.get("created_at_ms") is None:
         metadata["created_at_ms"] = now_ms
     if existing_meta.get("title") and "title" in metadata:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -113,6 +113,23 @@ def test_source_context_does_not_reuse_permalink_for_different_slack_thread(
     assert "permalink" not in slack_thread
 
 
+def test_preserve_thread_owner_keeps_original_slack_identity() -> None:
+    owner = {
+        "github_login": "owner-gh",
+        "triggering_user_email": "owner@example.com",
+        "source_context": {"slack_thread": {"triggering_user_id": "UOWNER"}},
+    }
+    updated = {
+        "github_login": "commenter-gh",
+        "triggering_user_email": "commenter@example.com",
+        "source_context": {"slack_thread": {"triggering_user_id": "UCOMMENTER"}},
+    }
+
+    webhook_common._preserve_thread_owner(updated, owner)
+
+    assert updated == owner
+
+
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:
     bot_user_id = "UBOT"
     messages = [

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -33,6 +33,7 @@ class _FakeThreadsClient:
         self.thread = thread
         self.raise_not_found = raise_not_found
         self.requested_thread_id: str | None = None
+        self.updates: list[dict] = []
 
     async def get(self, thread_id: str) -> dict:
         self.requested_thread_id = thread_id
@@ -41,6 +42,9 @@ class _FakeThreadsClient:
         if self.thread is None:
             raise AssertionError("thread must be provided when raise_not_found is False")
         return self.thread
+
+    async def update(self, *, thread_id: str, metadata: dict) -> None:
+        self.updates.append(metadata)
 
 
 class _FakeClient:
@@ -113,21 +117,33 @@ def test_source_context_does_not_reuse_permalink_for_different_slack_thread(
     assert "permalink" not in slack_thread
 
 
-def test_preserve_thread_owner_keeps_original_slack_identity() -> None:
+def test_upsert_thread_metadata_keeps_original_owner(monkeypatch: pytest.MonkeyPatch) -> None:
     owner = {
         "github_login": "owner-gh",
         "triggering_user_email": "owner@example.com",
         "source_context": {"slack_thread": {"triggering_user_id": "UOWNER"}},
     }
-    updated = {
-        "github_login": "commenter-gh",
-        "triggering_user_email": "commenter@example.com",
-        "source_context": {"slack_thread": {"triggering_user_id": "UCOMMENTER"}},
-    }
+    threads = _FakeThreadsClient(thread={"metadata": owner})
 
-    webhook_common._preserve_thread_owner(updated, owner)
+    async def fail_resolve(_email: str) -> str:
+        raise AssertionError("existing thread owner must not be resolved again")
 
-    assert updated == owner
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+    monkeypatch.setattr(webhook_common, "resolve_login_from_email_async", fail_resolve)
+    asyncio.run(
+        webhook_common.upsert_agent_thread_owner_metadata(
+            "thread-id",
+            source="slack",
+            github_login="commenter-gh",
+            user_email="commenter@example.com",
+            source_context={"slack_thread": {"triggering_user_id": "UCOMMENTER"}},
+        )
+    )
+
+    updated = threads.updates[0]
+    assert updated["github_login"] == owner["github_login"]
+    assert updated["triggering_user_email"] == owner["triggering_user_email"]
+    assert updated["source_context"] == owner["source_context"]
 
 
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -117,9 +117,10 @@ def test_source_context_does_not_reuse_permalink_for_different_slack_thread(
     assert "permalink" not in slack_thread
 
 
-def test_upsert_thread_metadata_keeps_original_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_upsert_thread_metadata_does_not_overwrite_original_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     owner = {
-        "github_login": "owner-gh",
         "triggering_user_email": "owner@example.com",
         "source_context": {"slack_thread": {"triggering_user_id": "UOWNER"}},
     }
@@ -141,9 +142,9 @@ def test_upsert_thread_metadata_keeps_original_owner(monkeypatch: pytest.MonkeyP
     )
 
     updated = threads.updates[0]
-    assert updated["github_login"] == owner["github_login"]
-    assert updated["triggering_user_email"] == owner["triggering_user_email"]
-    assert updated["source_context"] == owner["source_context"]
+    assert "github_login" not in updated
+    assert "triggering_user_email" not in updated
+    assert "source_context" not in updated
 
 
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -33,7 +33,6 @@ class _FakeThreadsClient:
         self.thread = thread
         self.raise_not_found = raise_not_found
         self.requested_thread_id: str | None = None
-        self.updates: list[dict] = []
 
     async def get(self, thread_id: str) -> dict:
         self.requested_thread_id = thread_id
@@ -44,7 +43,7 @@ class _FakeThreadsClient:
         return self.thread
 
     async def update(self, *, thread_id: str, metadata: dict) -> None:
-        self.updates.append(metadata)
+        cast(dict, self.thread)["metadata"].update(metadata)
 
 
 class _FakeClient:
@@ -117,34 +116,26 @@ def test_source_context_does_not_reuse_permalink_for_different_slack_thread(
     assert "permalink" not in slack_thread
 
 
-def test_upsert_thread_metadata_does_not_overwrite_original_owner(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    owner = {
-        "triggering_user_email": "owner@example.com",
-        "source_context": {"slack_thread": {"triggering_user_id": "UOWNER"}},
-    }
-    threads = _FakeThreadsClient(thread={"metadata": owner})
-
-    async def fail_resolve(_email: str) -> str:
-        raise AssertionError("existing thread owner must not be resolved again")
-
+def test_upsert_preserves_partially_initialized_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    owner_context = {"slack_thread": {"triggering_user_id": "UOWNER"}}
+    threads = _FakeThreadsClient({"metadata": {"source_context": owner_context}})
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
-    monkeypatch.setattr(webhook_common, "resolve_login_from_email_async", fail_resolve)
-    asyncio.run(
-        webhook_common.upsert_agent_thread_owner_metadata(
+
+    async def upsert(github_login: str, user_email: str, slack_user_id: str) -> None:
+        await webhook_common.upsert_agent_thread_owner_metadata(
             "thread-id",
             source="slack",
-            github_login="commenter-gh",
-            user_email="commenter@example.com",
-            source_context={"slack_thread": {"triggering_user_id": "UCOMMENTER"}},
+            github_login=github_login,
+            user_email=user_email,
+            source_context={"slack_thread": {"triggering_user_id": slack_user_id}},
         )
-    )
 
-    updated = threads.updates[0]
-    assert "github_login" not in updated
-    assert "triggering_user_email" not in updated
-    assert "source_context" not in updated
+    asyncio.run(upsert("owner-gh", "owner@example.com", "UOWNER"))
+    asyncio.run(upsert("commenter-gh", "commenter@example.com", "UCOMMENTER"))
+    metadata = cast(dict, threads.thread)["metadata"]
+    assert metadata["github_login"] == "owner-gh"
+    assert metadata["triggering_user_email"] == "owner@example.com"
+    assert metadata["source_context"] == owner_context
 
 
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:


### PR DESCRIPTION
## Description
Keep thread ownership immutable after creation while continuing to refresh operational metadata such as activity time, repository context, and Slack permalink.

## Test Plan
- [x] Verify a later commenter cannot trigger owner resolution or replace the stored owner

Made by [Open SWE](https://openswe.vercel.app/agents/5d072b04-dc60-e90c-345a-fa7a1a9e8804)