### PR TITLE
feat: add defined chat header bar

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -215,21 +215,33 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
         className="flex min-w-0 flex-1 flex-col"
         style={isMobile ? undefined : { minWidth: PANEL_MIN_CHAT_WIDTH }}
       >
-        {thread.repoFullName && (
+        <header className="relative z-10 h-14 shrink-0 border-b border-border/60 bg-background/80 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-4 after:bg-linear-to-b after:from-background/60 after:to-transparent">
           <div
             className={cn(
-              "mx-auto flex w-full max-w-3xl shrink-0 items-center gap-2 px-4 pt-3 text-xs text-muted-foreground",
+              "mx-auto flex h-full w-full max-w-3xl items-center gap-3 px-4",
               sidebarCollapsed && "pl-14",
               panelCollapsed && "pr-14"
             )}
           >
-            <FolderOpen className="size-3.5" />
-            <span className="truncate" title={thread.repoFullName}>
-              {thread.repoFullName}
+            <span
+              className="min-w-0 flex-1 truncate text-sm font-medium"
+              title={thread.title}
+            >
+              {thread.title}
             </span>
-            <span className="ml-auto shrink-0">Cloud</span>
+            {thread.repoFullName && (
+              <span className="hidden min-w-0 items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+                <FolderOpen className="size-3.5 shrink-0" />
+                <span className="truncate" title={thread.repoFullName}>
+                  {thread.repoFullName}
+                </span>
+              </span>
+            )}
+            <span className="shrink-0 text-xs text-muted-foreground">
+              Cloud
+            </span>
           </div>
-        )}
+        </header>
         {thread.status === "error" && (
           <div className="mx-auto w-full max-w-3xl shrink-0 px-4 pt-3">
             <Alert variant="error" controlAlignment="first-line">

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -223,21 +223,15 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
               panelCollapsed && "pr-14"
             )}
           >
-            <span
-              className="min-w-0 flex-1 truncate text-sm font-medium"
-              title={thread.title}
-            >
-              {thread.title}
-            </span>
             {thread.repoFullName && (
-              <span className="hidden min-w-0 items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+              <span className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
                 <FolderOpen className="size-3.5 shrink-0" />
                 <span className="truncate" title={thread.repoFullName}>
                   {thread.repoFullName}
                 </span>
               </span>
             )}
-            <span className="shrink-0 text-xs text-muted-foreground">
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
               Cloud
             </span>
           </div>


### PR DESCRIPTION
## Description
Give the chat panel a defined header with repository context, environment, and a subtle lower fade. This also creates a stable home for future thread controls.

## Release Note
Chat threads now have a distinct top header.

## Test Plan
- [x] Verify the production UI build succeeds

Made by [Open SWE](https://openswe.vercel.app/agents/019ff6c9-119b-76ef-95c5-866321d4470b)