### PR TITLE
fix: load git diff from pull request repository

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -26,7 +26,11 @@ from ..utils.json_types import (
     thread_metadata,
 )
 from ..utils.langsmith import get_langsmith_trace_url
-from ..utils.slack import lookup_slack_thread_run_mapping, update_slack_trace_reply_for_web_handoff
+from ..utils.slack import (
+    lookup_slack_thread_run_mapping,
+    parse_github_pr_url,
+    update_slack_trace_reply_for_web_handoff,
+)
 from ..utils.thread_ops import (
     get_thread_active_status,
     langgraph_client,
@@ -1972,7 +1976,10 @@ async def get_dashboard_thread_pr_diff(
 ) -> dict[str, Any]:
     metadata = await _readable_thread_metadata(thread_id, login=login, email=email)
     pr_number = metadata.get("pr_number")
+    pr_ref = parse_github_pr_url(str(metadata.get("pr_url") or ""))
     _, _, full_name = _metadata_repo(metadata)
+    if pr_ref and pr_ref.number == pr_number:
+        full_name = f"{pr_ref.owner}/{pr_ref.repo}"
     if not isinstance(pr_number, int) or not full_name:
         raise HTTPException(404, "thread has no pull request")
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1779,6 +1779,25 @@ async def test_options_gates_stale_fable_default_when_disabled() -> None:
     assert payload["default_agent_subagent_model"] in model_ids
 
 
+async def test_pr_diff_uses_repository_from_pr_url(monkeypatch) -> None:
+    metadata = {
+        "repo_owner": "langchain-ai",
+        "repo_name": "deepagents",
+        "pr_number": 1925,
+        "pr_url": "https://github.com/langchain-ai/open-swe/pull/1925",
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    monkeypatch.setattr(thread_api, "_github_token_for_login", AsyncMock(return_value="token"))
+    build_diff = AsyncMock(
+        return_value={"base_sha": "base", "head_sha": "head", "truncated": False, "files": []}
+    )
+    monkeypatch.setattr(thread_api, "build_pr_diff_files", build_diff)
+
+    await thread_api.get_dashboard_thread_pr_diff("thread-1", "owner")
+
+    assert build_diff.await_args.args[1:] == ("langchain-ai/open-swe", 1925)
+
+
 async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypatch) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
     thread = {


### PR DESCRIPTION
## Description
Use the persisted PR URL as the repository source for agent git diffs, preventing same-numbered PRs from the thread's configured repository from appearing instead.

## Release Note
Fixed agent git diffs occasionally showing unrelated pull request changes.

## Test Plan
- [x] Reproduce mismatched thread and PR repositories

Made by [Open SWE](https://openswe.vercel.app/agents/019ff6d4-a354-756e-9786-3cbb2cfea3fe)