### PR TITLE
feat: add user-scoped LangSmith credentials

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -203,12 +203,22 @@ from .thread_api import (
 )
 from .user_credentials import (
     CurrentsCredentialsUpdate,
+    UserLangSmithCredentialsUpdate,
     connect_currents,
     connect_notion,
     disconnect_currents,
     disconnect_notion,
     get_currents_status,
     get_notion_status,
+)
+from .user_credentials import (
+    connect_langsmith as connect_user_langsmith,
+)
+from .user_credentials import (
+    disconnect_langsmith as disconnect_user_langsmith,
+)
+from .user_credentials import (
+    get_langsmith_status as get_user_langsmith_status,
 )
 from .user_instructions import (
     UserInstructionsUpdate,
@@ -588,6 +598,31 @@ async def disconnect_my_currents(
 ) -> dict[str, Any]:
     status = await disconnect_currents(session["sub"])
     return status.get("currents", {"connected": False})
+
+
+@router.get("/my-credentials/langsmith")
+async def get_my_langsmith_status(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    status = await get_user_langsmith_status(session["sub"])
+    return status.get("langsmith", {"connected": False})
+
+
+@router.put("/my-credentials/langsmith")
+async def connect_my_langsmith(
+    update: UserLangSmithCredentialsUpdate,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    status = await connect_user_langsmith(session["sub"], update)
+    return status.get("langsmith", {"connected": False})
+
+
+@router.delete("/my-credentials/langsmith")
+async def disconnect_my_langsmith(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    status = await disconnect_user_langsmith(session["sub"])
+    return status.get("langsmith", {"connected": False})
 
 
 @router.get("/my-credentials/notion")

--- a/agent/dashboard/user_credentials.py
+++ b/agent/dashboard/user_credentials.py
@@ -9,15 +9,17 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from langgraph_sdk import get_client
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from ..encryption import decrypt_token, encrypt_token
 from .notion_oauth import is_reauth_required_error, refresh_notion_access_token
+from .team_credentials import DEFAULT_LANGSMITH_ENDPOINT, LangSmithCredentials
 
 logger = logging.getLogger(__name__)
 
 USER_CREDENTIALS_NAMESPACE: list[str] = ["user_credentials"]
 CURRENTS_KEY = "currents"
+LANGSMITH_KEY = "langsmith"
 NOTION_KEY = "notion"
 
 CURRENTS_API_BASE = "https://api.currents.dev/v1"
@@ -66,6 +68,19 @@ class CurrentsCredentialsUpdate(BaseModel):
         if not isinstance(v, str) or not v.strip():
             raise ValueError("api_key must be a non-empty string")
         return v.strip()
+
+
+class UserLangSmithCredentialsUpdate(CurrentsCredentialsUpdate):
+    """Connect LangSmith with an API key."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("api_key")
+    @classmethod
+    def _require_redactable(cls, value: str) -> str:
+        if len(value) < 5:
+            raise ValueError("api_key must be at least 5 characters")
+        return value
 
 
 @dataclass(frozen=True)
@@ -349,3 +364,46 @@ async def get_currents_api_key(login: str) -> str | None:
         return None
     api_key = decrypt_token(currents.get("encrypted_api_key", ""))
     return api_key or None
+
+
+async def get_langsmith_status(login: str) -> dict[str, Any]:
+    """Return a redacted, dashboard-safe view of the user's LangSmith key."""
+    langsmith = await _get_provider(login, LANGSMITH_KEY)
+    return {
+        "langsmith": {
+            "connected": True,
+            "api_key_last4": langsmith.get("api_key_last4", ""),
+            "updated_at": langsmith.get("updated_at"),
+        }
+        if langsmith
+        else {"connected": False},
+    }
+
+
+async def connect_langsmith(login: str, update: UserLangSmithCredentialsUpdate) -> dict[str, Any]:
+    await _put_provider(
+        login,
+        LANGSMITH_KEY,
+        {
+            "encrypted_api_key": encrypt_token(update.api_key),
+            "api_key_last4": _last4(update.api_key),
+            "updated_at": datetime.now(UTC).isoformat(),
+        },
+    )
+    return await get_langsmith_status(login)
+
+
+async def disconnect_langsmith(login: str) -> dict[str, Any]:
+    await _delete_provider(login, LANGSMITH_KEY)
+    return await get_langsmith_status(login)
+
+
+async def get_langsmith_credentials(login: str) -> LangSmithCredentials | None:
+    """Return decrypted LangSmith credentials, or ``None`` when not connected."""
+    langsmith = await _get_provider(login, LANGSMITH_KEY)
+    if not isinstance(langsmith, dict):
+        return None
+    api_key = decrypt_token(langsmith.get("encrypted_api_key", ""))
+    if not api_key:
+        return None
+    return LangSmithCredentials(api_key=api_key, endpoint=DEFAULT_LANGSMITH_ENDPOINT)

--- a/agent/integrations/langsmith_tools.py
+++ b/agent/integrations/langsmith_tools.py
@@ -1,9 +1,9 @@
 """Server-side, read-only LangSmith tools.
 
-Credentials live in team settings (encrypted at rest). The tools run in the
-LangGraph server process and call the LangSmith API directly — the sandbox never
-holds a LangSmith key. The surface is intentionally read-only: fetch a single
-run/trace and list recent runs in a project.
+Credentials are encrypted at rest. The tools run in the LangGraph server process
+and call the LangSmith API directly — the sandbox never holds a LangSmith key.
+The surface is intentionally read-only: fetch a single run/trace and list recent
+runs in a project.
 """
 
 from __future__ import annotations
@@ -14,7 +14,13 @@ from typing import Any
 
 from langchain_core.tools import BaseTool, StructuredTool
 
-from ..dashboard.team_credentials import LangSmithCredentials, get_langsmith_credentials
+from ..dashboard.team_credentials import (
+    LangSmithCredentials,
+)
+from ..dashboard.team_credentials import (
+    get_langsmith_credentials as get_team_langsmith_credentials,
+)
+from ..dashboard.user_credentials import get_langsmith_credentials as get_user_langsmith_credentials
 from ..utils.langsmith import async_langsmith_client, sync_langsmith_client
 
 logger = logging.getLogger(__name__)
@@ -108,9 +114,11 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
     ]
 
 
-async def load_langsmith_tools() -> list[BaseTool]:
-    """Return read-only LangSmith tools when the team has connected LangSmith."""
-    creds = await get_langsmith_credentials()
-    if creds is None:
-        return []
-    return _make_tools(creds)
+async def load_langsmith_tools(
+    login: str | None = None, *, allow_team: bool = True
+) -> list[BaseTool]:
+    """Return read-only LangSmith tools for the user or authorized team fallback."""
+    creds = await get_user_langsmith_credentials(login) if login else None
+    if creds is None and allow_team:
+        creds = await get_team_langsmith_credentials()
+    return _make_tools(creds) if creds else []

--- a/agent/integrations/langsmith_tools.py
+++ b/agent/integrations/langsmith_tools.py
@@ -13,6 +13,8 @@ import logging
 from typing import Any
 
 from langchain_core.tools import BaseTool, StructuredTool
+from langsmith import AsyncClient as AsyncLangSmithClient
+from langsmith import Client as LangSmithClient
 
 from ..dashboard.team_credentials import (
     LangSmithCredentials,
@@ -21,7 +23,6 @@ from ..dashboard.team_credentials import (
     get_langsmith_credentials as get_team_langsmith_credentials,
 )
 from ..dashboard.user_credentials import get_langsmith_credentials as get_user_langsmith_credentials
-from ..utils.langsmith import async_langsmith_client, sync_langsmith_client
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,15 @@ _MAX_LIST_RUNS = 50
 
 
 def _client(creds: LangSmithCredentials):
-    return async_langsmith_client(creds.api_key, creds.endpoint)
+    return AsyncLangSmithClient(api_key=creds.api_key, api_url=creds.endpoint)
+
+
+def _read_run_with_children(creds: LangSmithCredentials, run_id: str):
+    client = LangSmithClient(api_key=creds.api_key, api_url=creds.endpoint)
+    try:
+        return client.read_run(run_id, load_child_runs=True)
+    finally:
+        client.close()
 
 
 def _serialize_run(run: Any) -> dict[str, Any]:
@@ -65,13 +74,10 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
         try:
             if load_child_runs:
                 # AsyncClient.read_run has no load_child_runs; the sync one runs off-loop.
-                run = await asyncio.to_thread(
-                    sync_langsmith_client(creds.api_key, creds.endpoint).read_run,
-                    run_id,
-                    load_child_runs=True,
-                )
+                run = await asyncio.to_thread(_read_run_with_children, creds, run_id)
             else:
-                run = await _client(creds).read_run(run_id)
+                async with _client(creds) as client:
+                    run = await client.read_run(run_id)
         except Exception as e:  # noqa: BLE001
             logger.warning("langsmith_get_trace failed", exc_info=True)
             return {"success": False, "error": f"{type(e).__name__}: {e}"}
@@ -95,14 +101,15 @@ def _make_tools(creds: LangSmithCredentials) -> list[BaseTool]:
         capped = max(1, min(limit, _MAX_LIST_RUNS))
 
         try:
-            runs = [
-                run
-                async for run in _client(creds).list_runs(
-                    project_name=project_name,
-                    filter=filter,
-                    limit=capped,
-                )
-            ]
+            async with _client(creds) as client:
+                runs = [
+                    run
+                    async for run in client.list_runs(
+                        project_name=project_name,
+                        filter=filter,
+                        limit=capped,
+                    )
+                ]
         except Exception as e:  # noqa: BLE001
             logger.warning("langsmith_list_runs failed", exc_info=True)
             return {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/agent/server.py
+++ b/agent/server.py
@@ -734,21 +734,13 @@ async def _cached_tool_loader(key: str, ttl_seconds: float, loader: Any) -> list
         return []
 
 
-async def _load_observability_tools(authorized: bool) -> list[Any]:
-    """Datadog (MCP) + LangSmith read tools when the team has connected them.
-
-    Credentials live server-side in team settings; the sandbox never holds them.
-    Only loaded for authorized (admin / allow-listed) triggering users so an
-    untrusted run cannot exfiltrate team observability data. Failures degrade to
-    no tools so the agent still starts.
-    """
+async def _load_observability_tools(authorized: bool, profile_login: str | None) -> list[Any]:
+    """Load team observability tools for an authorized triggering user."""
     if not authorized:
         return []
     datadog_tools, langsmith_tools = await asyncio.gather(
         _cached_tool_loader(f"tools:datadog:{id(load_datadog_tools)}", 600, load_datadog_tools),
-        _cached_tool_loader(
-            f"tools:langsmith:{id(load_langsmith_tools)}", 600, load_langsmith_tools
-        ),
+        load_langsmith_tools(profile_login),
     )
     return [*datadog_tools, *langsmith_tools]
 
@@ -1102,13 +1094,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
     observability_authorized = await _observability_authorized(config, profile_login)
     if observability_authorized:
-        observability_tools = await _load_observability_tools(True)
+        observability_tools = await _load_observability_tools(True, profile_login)
     elif await _allowed_org_member(config, profile_login):
-        observability_tools = await _cached_tool_loader(
-            f"tools:langsmith:{id(load_langsmith_tools)}", 600, load_langsmith_tools
-        )
+        observability_tools = await load_langsmith_tools(profile_login)
     else:
-        observability_tools = []
+        observability_tools = await load_langsmith_tools(profile_login, allow_team=False)
     corridor_tools = await _load_corridor_mcp_tools()
     browser_tools = load_browser_tools()
 

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
 import os
 import uuid
@@ -18,19 +17,18 @@ from .tracing import AGENT_TRACING_PROJECT
 logger = logging.getLogger(__name__)
 
 _PROJECT_ID_CACHE: dict[str, str] = {}
-_ASYNC_CLIENTS: dict[tuple[bytes, str], AsyncLangSmithClient] = {}
-_SYNC_CLIENTS: dict[tuple[bytes, str], LangSmithClient] = {}
+_ASYNC_CLIENTS: dict[tuple[str, str], AsyncLangSmithClient] = {}
+_SYNC_CLIENTS: dict[tuple[str, str], LangSmithClient] = {}
 
 
 def async_langsmith_client(api_key: str, api_url: str) -> AsyncLangSmithClient:
     """Return a pooled ``AsyncClient`` for these credentials.
 
     Each client owns an ``httpx`` connection pool bound to the event loop that
-    built it, so this assumes one loop per process. Keyed on a credential digest
-    so a test that repoints the env gets a fresh client without retaining raw keys
-    as cache identifiers.
+    built it, so this assumes one loop per process. Keyed on the credentials so
+    a test that repoints the env gets a fresh client instead of a stale pool.
     """
-    key = (hashlib.sha256(api_key.encode()).digest(), api_url)
+    key = (api_key, api_url)
     client = _ASYNC_CLIENTS.get(key)
     if client is None:
         client = _ASYNC_CLIENTS[key] = AsyncLangSmithClient(api_key=api_key, api_url=api_url)
@@ -39,7 +37,7 @@ def async_langsmith_client(api_key: str, api_url: str) -> AsyncLangSmithClient:
 
 def sync_langsmith_client(api_key: str, api_url: str) -> LangSmithClient:
     """Return a pooled sync ``Client``, for the few endpoints AsyncClient lacks."""
-    key = (hashlib.sha256(api_key.encode()).digest(), api_url)
+    key = (api_key, api_url)
     client = _SYNC_CLIENTS.get(key)
     if client is None:
         client = _SYNC_CLIENTS[key] = LangSmithClient(api_key=api_key, api_url=api_url)

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import uuid
@@ -17,18 +18,19 @@ from .tracing import AGENT_TRACING_PROJECT
 logger = logging.getLogger(__name__)
 
 _PROJECT_ID_CACHE: dict[str, str] = {}
-_ASYNC_CLIENTS: dict[tuple[str, str], AsyncLangSmithClient] = {}
-_SYNC_CLIENTS: dict[tuple[str, str], LangSmithClient] = {}
+_ASYNC_CLIENTS: dict[tuple[bytes, str], AsyncLangSmithClient] = {}
+_SYNC_CLIENTS: dict[tuple[bytes, str], LangSmithClient] = {}
 
 
 def async_langsmith_client(api_key: str, api_url: str) -> AsyncLangSmithClient:
     """Return a pooled ``AsyncClient`` for these credentials.
 
     Each client owns an ``httpx`` connection pool bound to the event loop that
-    built it, so this assumes one loop per process. Keyed on the credentials so
-    a test that repoints the env gets a fresh client instead of a stale pool.
+    built it, so this assumes one loop per process. Keyed on a credential digest
+    so a test that repoints the env gets a fresh client without retaining raw keys
+    as cache identifiers.
     """
-    key = (api_key, api_url)
+    key = (hashlib.sha256(api_key.encode()).digest(), api_url)
     client = _ASYNC_CLIENTS.get(key)
     if client is None:
         client = _ASYNC_CLIENTS[key] = AsyncLangSmithClient(api_key=api_key, api_url=api_url)
@@ -37,7 +39,7 @@ def async_langsmith_client(api_key: str, api_url: str) -> AsyncLangSmithClient:
 
 def sync_langsmith_client(api_key: str, api_url: str) -> LangSmithClient:
     """Return a pooled sync ``Client``, for the few endpoints AsyncClient lacks."""
-    key = (api_key, api_url)
+    key = (hashlib.sha256(api_key.encode()).digest(), api_url)
     client = _SYNC_CLIENTS.get(key)
     if client is None:
         client = _SYNC_CLIENTS[key] = LangSmithClient(api_key=api_key, api_url=api_url)

--- a/tests/auth/test_user_credentials.py
+++ b/tests/auth/test_user_credentials.py
@@ -88,6 +88,39 @@ async def test_currents_isolation_between_users(fake_store: _FakeStore) -> None:
 
 
 @pytest.mark.asyncio
+async def test_langsmith_roundtrip_redaction_and_isolation(fake_store: _FakeStore) -> None:
+    with pytest.raises(ValidationError):
+        uc.UserLangSmithCredentialsUpdate(api_key="key")
+    with pytest.raises(ValidationError):
+        uc.UserLangSmithCredentialsUpdate.model_validate(
+            {"api_key": "valid-key", "endpoint": "https://x"}
+        )
+
+    await uc.connect_langsmith(
+        "alice", uc.UserLangSmithCredentialsUpdate(api_key="alice-langsmith-abcd")
+    )
+    await uc.connect_langsmith(
+        "bob", uc.UserLangSmithCredentialsUpdate(api_key="bob-langsmith-wxyz")
+    )
+
+    status = await uc.get_langsmith_status("alice")
+    assert status["langsmith"]["api_key_last4"] == "abcd"
+    record = fake_store.items[(("user_credentials", "alice"), "langsmith")]
+    assert record["encrypted_api_key"] != "alice-langsmith-abcd"
+    assert "alice-langsmith-abcd" not in str(status)
+
+    alice = await uc.get_langsmith_credentials("alice")
+    bob = await uc.get_langsmith_credentials("bob")
+    assert alice and alice.api_key == "alice-langsmith-abcd"
+    assert alice.endpoint == uc.DEFAULT_LANGSMITH_ENDPOINT
+    assert bob and bob.api_key == "bob-langsmith-wxyz"
+
+    await uc.disconnect_langsmith("alice")
+    assert await uc.get_langsmith_credentials("alice") is None
+    assert await uc.get_langsmith_credentials("bob") == bob
+
+
+@pytest.mark.asyncio
 async def test_currents_status_when_not_connected(fake_store: _FakeStore) -> None:
     status = await uc.get_currents_status("nobody")
     assert status["currents"]["connected"] is False

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -138,16 +138,30 @@ async def test_notion_wrapper_fails_when_token_missing_at_call_time() -> None:
 
 @pytest.mark.asyncio
 async def test_load_langsmith_tools_empty_when_not_connected() -> None:
-    with patch.object(langsmith_tools, "get_langsmith_credentials", AsyncMock(return_value=None)):
-        assert await langsmith_tools.load_langsmith_tools() == []
+    with (
+        patch.object(
+            langsmith_tools, "get_user_langsmith_credentials", AsyncMock(return_value=None)
+        ),
+        patch.object(
+            langsmith_tools, "get_team_langsmith_credentials", AsyncMock(return_value=None)
+        ),
+    ):
+        assert await langsmith_tools.load_langsmith_tools("alice") == []
 
 
 @pytest.mark.asyncio
 async def test_load_langsmith_tools_names() -> None:
     creds = LangSmithCredentials(api_key="k", endpoint="https://api.smith.langchain.com")
-    with patch.object(langsmith_tools, "get_langsmith_credentials", AsyncMock(return_value=creds)):
-        tools = await langsmith_tools.load_langsmith_tools()
+    team_credentials = AsyncMock()
+    with (
+        patch.object(
+            langsmith_tools, "get_user_langsmith_credentials", AsyncMock(return_value=creds)
+        ),
+        patch.object(langsmith_tools, "get_team_langsmith_credentials", team_credentials),
+    ):
+        tools = await langsmith_tools.load_langsmith_tools("alice")
     assert {t.name for t in tools} == {"langsmith_get_trace", "langsmith_list_runs"}
+    team_credentials.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -218,7 +232,7 @@ async def test_load_observability_tools_skipped_when_unauthorized() -> None:
         patch.object(server, "load_datadog_tools", AsyncMock(return_value=["dd"])),
         patch.object(server, "load_langsmith_tools", AsyncMock(return_value=["ls"])),
     ):
-        assert await server._load_observability_tools(authorized=False) == []
+        assert await server._load_observability_tools(authorized=False, profile_login=None) == []
 
 
 @pytest.mark.asyncio
@@ -227,7 +241,10 @@ async def test_load_observability_tools_loaded_when_authorized() -> None:
         patch.object(server, "load_datadog_tools", AsyncMock(return_value=["dd"])),
         patch.object(server, "load_langsmith_tools", AsyncMock(return_value=["ls"])),
     ):
-        assert await server._load_observability_tools(authorized=True) == ["dd", "ls"]
+        assert await server._load_observability_tools(authorized=True, profile_login="alice") == [
+            "dd",
+            "ls",
+        ]
 
 
 @pytest.mark.asyncio

--- a/ui/src/features/settings/components/ConnectionsSection.tsx
+++ b/ui/src/features/settings/components/ConnectionsSection.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import { IoLogoSlack } from "react-icons/io5"
 import { SiNotion } from "react-icons/si"
 
-import type { SessionUser } from "@/lib/api"
+import type { ApiKeyCredentialStatus, SessionUser } from "@/lib/api"
 import { SettingsRow, SettingsSection } from "@/components/AppShell"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -135,41 +135,52 @@ function NotionRow({ setError }: { setError: SetError }) {
   )
 }
 
-function CurrentsRow({ setError }: { setError: SetError }) {
+interface ApiKeyRowProps {
+  queryKey: string
+  label: string
+  description: string
+  placeholder: string
+  load: () => Promise<ApiKeyCredentialStatus>
+  connect: (apiKey: string) => Promise<ApiKeyCredentialStatus>
+  disconnect: () => Promise<ApiKeyCredentialStatus>
+  setError: SetError
+}
+
+function ApiKeyRow({
+  queryKey,
+  label,
+  description,
+  placeholder,
+  load,
+  connect: save,
+  disconnect: remove,
+  setError,
+}: ApiKeyRowProps) {
   const qc = useQueryClient()
-  const creds = useQuery({
-    queryKey: ["myCurrents"],
-    queryFn: api.getMyCurrentsStatus,
-  })
+  const creds = useQuery({ queryKey: [queryKey], queryFn: load })
   const [apiKey, setApiKey] = useState("")
 
   const onSuccess = () => {
-    void qc.invalidateQueries({ queryKey: ["myCurrents"] })
+    void qc.invalidateQueries({ queryKey: [queryKey] })
     setApiKey("")
     setError(null)
   }
   const onError = (e: Error) => setError(e.message)
-
   const connect = useMutation({
-    mutationFn: () => api.connectCurrents({ api_key: apiKey.trim() }),
+    mutationFn: () => save(apiKey.trim()),
     onSuccess,
     onError,
   })
-  const disconnect = useMutation({
-    mutationFn: () => api.disconnectCurrents(),
-    onSuccess,
-    onError,
-  })
-
+  const disconnect = useMutation({ mutationFn: remove, onSuccess, onError })
   const connected = !!creds.data?.connected
 
   return (
     <SettingsRow
-      label="Currents.dev"
+      label={label}
       description={
         connected
           ? `Connected · key ••••${creds.data?.api_key_last4 ?? ""}`
-          : "Add your API key (Currents → Organization → API & Record Keys) to let runs inspect e2e test results. Encrypted at rest and scoped to your account."
+          : description
       }
       control={
         connected ? (
@@ -188,7 +199,7 @@ function CurrentsRow({ setError }: { setError: SetError }) {
           <div className="flex items-center gap-2">
             <Input
               className="w-48"
-              placeholder="Currents API key"
+              placeholder={placeholder}
               type="password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
@@ -218,7 +229,26 @@ export function ConnectionsSection({ user }: { user: SessionUser }) {
     >
       <SlackRow user={user} />
       <NotionRow setError={setError} />
-      <CurrentsRow setError={setError} />
+      <ApiKeyRow
+        queryKey="myLangSmith"
+        label="LangSmith"
+        description="Add your API key to let runs inspect LangSmith traces. Encrypted at rest and scoped to your account."
+        placeholder="LangSmith API key"
+        load={api.getMyLangSmithStatus}
+        connect={(apiKey) => api.connectMyLangSmith({ api_key: apiKey })}
+        disconnect={api.disconnectMyLangSmith}
+        setError={setError}
+      />
+      <ApiKeyRow
+        queryKey="myCurrents"
+        label="Currents.dev"
+        description="Add your API key (Currents → Organization → API & Record Keys) to let runs inspect e2e test results. Encrypted at rest and scoped to your account."
+        placeholder="Currents API key"
+        load={api.getMyCurrentsStatus}
+        connect={(apiKey) => api.connectCurrents({ api_key: apiKey })}
+        disconnect={api.disconnectCurrents}
+        setError={setError}
+      />
       {error && <p className="px-4 py-2 text-xs text-destructive">{error}</p>}
     </SettingsSection>
   )

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -215,11 +215,13 @@ export interface LangSmithConnectBody {
   endpoint?: string | null
 }
 
-export interface CurrentsCredentialStatus {
+export interface ApiKeyCredentialStatus {
   connected: boolean
   api_key_last4?: string
   updated_at?: string | null
 }
+
+export type CurrentsCredentialStatus = ApiKeyCredentialStatus
 
 export interface CurrentsConnectBody {
   api_key: string
@@ -797,6 +799,17 @@ export const api = {
     }),
   disconnectCurrents: () =>
     request<CurrentsCredentialStatus>("/my-credentials/currents", {
+      method: "DELETE",
+    }),
+  getMyLangSmithStatus: () =>
+    request<ApiKeyCredentialStatus>("/my-credentials/langsmith"),
+  connectMyLangSmith: (body: CurrentsConnectBody) =>
+    request<ApiKeyCredentialStatus>("/my-credentials/langsmith", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  disconnectMyLangSmith: () =>
+    request<ApiKeyCredentialStatus>("/my-credentials/langsmith", {
       method: "DELETE",
     }),
   getMyNotionStatus: () =>


### PR DESCRIPTION
## Description
Let users securely connect an encrypted LangSmith API key and prefer it for their read-only trace tools while preserving gated team fallback.
## Release Note
Added user-scoped LangSmith credentials in Profile Settings.
## Test Plan
- [x] Verified encrypted isolation, user-first loading, formatting, lint, and type checking.

Made by [Open SWE](https://openswe.vercel.app/agents/4b3f608f-ac0f-afe5-d975-8e2664a0f0d3)

## References
- Plan: https://openswe.vercel.app/agents/4b3f608f-ac0f-afe5-d975-8e2664a0f0d3/plan