### PR TITLE
fix(slack): dedupe mention event deliveries

### DIFF
--- a/agent/utils/slack_events.py
+++ b/agent/utils/slack_events.py
@@ -1,0 +1,76 @@
+"""Deduplication of Slack Event API deliveries.
+
+Slack redelivers an event up to three times when it doesn't get a 2xx within
+three seconds, so every delivery that can start an agent run has to be claimed
+exactly once.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import OrderedDict
+
+from langgraph_sdk import get_client
+
+logger = logging.getLogger(__name__)
+
+LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
+    "LANGGRAPH_URL_PROD", "http://localhost:2024"
+)
+
+_EVENT_NAMESPACE = "slack_mention_events"
+_LOCAL_CLAIM_LIMIT = 2048
+
+_claimed_event_ids: OrderedDict[str, None] = OrderedDict()
+
+
+def _namespace(channel_id: str) -> tuple[str, str]:
+    return (_EVENT_NAMESPACE, channel_id or "unknown")
+
+
+def _claim_locally(event_id: str) -> None:
+    _claimed_event_ids[event_id] = None
+    _claimed_event_ids.move_to_end(event_id)
+    while len(_claimed_event_ids) > _LOCAL_CLAIM_LIMIT:
+        _claimed_event_ids.popitem(last=False)
+
+
+def reset_slack_event_claims() -> None:
+    _claimed_event_ids.clear()
+
+
+async def slack_event_already_seen(channel_id: str, event_id: str) -> bool:
+    """Check-only lookup, for short-circuiting a redelivery before any other work."""
+    if not event_id:
+        return False
+    if event_id in _claimed_event_ids:
+        return True
+    try:
+        item = await get_client(url=LANGGRAPH_URL).store.get_item(_namespace(channel_id), event_id)
+    except Exception:
+        logger.warning("Slack event lookup failed for event_id=%s", event_id, exc_info=True)
+        return False
+    return bool(item)
+
+
+async def claim_slack_event(channel_id: str, event_id: str) -> bool:
+    """Claim an event id; False means another delivery already owns this event."""
+    if not event_id:
+        return True
+
+    # Claimed in-process before the first await so concurrent redeliveries on
+    # this instance can't both pass; the store below covers other instances.
+    if event_id in _claimed_event_ids:
+        return False
+    _claim_locally(event_id)
+
+    namespace = _namespace(channel_id)
+    try:
+        client = get_client(url=LANGGRAPH_URL)
+        if await client.store.get_item(namespace, event_id):
+            return False
+        await client.store.put_item(namespace, event_id, {"event_id": event_id})
+    except Exception:
+        logger.warning("Slack event claim failed for event_id=%s", event_id, exc_info=True)
+    return True

--- a/agent/utils/slack_events.py
+++ b/agent/utils/slack_events.py
@@ -1,14 +1,11 @@
-"""Deduplication of Slack Event API deliveries.
-
-Slack redelivers an event up to three times when it doesn't get a 2xx within
-three seconds, so every delivery that can start an agent run has to be claimed
-exactly once.
-"""
+"""Deduplication of Slack Event API deliveries."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+import uuid
 from collections import OrderedDict
 
 from langgraph_sdk import get_client
@@ -19,14 +16,13 @@ LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
     "LANGGRAPH_URL_PROD", "http://localhost:2024"
 )
 
-_EVENT_NAMESPACE = "slack_mention_events"
 _LOCAL_CLAIM_LIMIT = 2048
-
 _claimed_event_ids: OrderedDict[str, None] = OrderedDict()
+_claim_lock = asyncio.Lock()
 
 
-def _namespace(channel_id: str) -> tuple[str, str]:
-    return (_EVENT_NAMESPACE, channel_id or "unknown")
+def _claim_thread_id(event_id: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:slack-event:{event_id}"))
 
 
 def _claim_locally(event_id: str) -> None:
@@ -40,37 +36,32 @@ def reset_slack_event_claims() -> None:
     _claimed_event_ids.clear()
 
 
-async def slack_event_already_seen(channel_id: str, event_id: str) -> bool:
-    """Check-only lookup, for short-circuiting a redelivery before any other work."""
-    if not event_id:
-        return False
-    if event_id in _claimed_event_ids:
-        return True
-    try:
-        item = await get_client(url=LANGGRAPH_URL).store.get_item(_namespace(channel_id), event_id)
-    except Exception:
-        logger.warning("Slack event lookup failed for event_id=%s", event_id, exc_info=True)
-        return False
-    return bool(item)
+async def slack_event_already_seen(event_id: str) -> bool:
+    """Check whether this process has already claimed the event."""
+    return bool(event_id and event_id in _claimed_event_ids)
 
 
-async def claim_slack_event(channel_id: str, event_id: str) -> bool:
-    """Claim an event id; False means another delivery already owns this event."""
+async def claim_slack_event(event_id: str) -> bool:
+    """Atomically claim an event id; fail open when the platform is unavailable."""
     if not event_id:
         return True
 
-    # Claimed in-process before the first await so concurrent redeliveries on
-    # this instance can't both pass; the store below covers other instances.
-    if event_id in _claimed_event_ids:
-        return False
-    _claim_locally(event_id)
-
-    namespace = _namespace(channel_id)
-    try:
-        client = get_client(url=LANGGRAPH_URL)
-        if await client.store.get_item(namespace, event_id):
+    async with _claim_lock:
+        if event_id in _claimed_event_ids:
             return False
-        await client.store.put_item(namespace, event_id, {"event_id": event_id})
-    except Exception:
-        logger.warning("Slack event claim failed for event_id=%s", event_id, exc_info=True)
-    return True
+
+        claim_thread_id = _claim_thread_id(event_id)
+        client = get_client(url=LANGGRAPH_URL)
+        try:
+            await client.threads.create(thread_id=claim_thread_id, if_exists="raise", ttl=10)
+        except Exception:  # noqa: BLE001
+            try:
+                await client.threads.get(claim_thread_id)
+            except Exception:  # noqa: BLE001
+                logger.warning("Slack event claim failed for event_id=%s", event_id)
+                return True
+            _claim_locally(event_id)
+            return False
+
+        _claim_locally(event_id)
+        return True

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -118,6 +118,10 @@ from ..utils.slack import (
     strip_bot_mention,  # noqa: F401
     verify_slack_signature,
 )
+from ..utils.slack_events import (
+    claim_slack_event,
+    slack_event_already_seen,
+)
 from ..utils.slack_feedback import (
     FEEDBACK_REACTIONS,
     process_slack_reaction_added,
@@ -187,6 +191,7 @@ __all__ = [
     "_upsert_slack_thread_repo_metadata",
     "append_finding_interaction",
     "build_pr_prompt",
+    "claim_slack_event",
     "complete_review_check_run",
     "create_review_check_run",
     "dashboard_thread_url",
@@ -251,6 +256,7 @@ __all__ = [
     "sanitize_github_comment_body",
     "select_slack_context_messages",
     "set_reviewer_thread_metadata",
+    "slack_event_already_seen",
     "store_slack_run_mapping",
     "strip_bot_mention",
     "update_agent_thread_pr_state",

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -59,6 +59,16 @@ async def slack_webhook(
             return {"status": "accepted", "message": "Reaction removal queued"}
         return {"status": "ignored", "reason": "Reaction not tracked for feedback"}
 
+    event_id = str(payload.get("event_id") or "")
+    retry_num = request.headers.get("X-Slack-Retry-Num", "")
+    if retry_num and await common.slack_event_already_seen(
+        str(event.get("channel") or ""), event_id
+    ):
+        common.logger.info(
+            "Ignoring Slack retry %s of already-handled event %s", retry_num, event_id
+        )
+        return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
+
     bot_user_id = common.SLACK_BOT_USER_ID
     if not bot_user_id:
         authorizations = payload.get("authorizations", [])
@@ -135,6 +145,10 @@ async def slack_webhook(
 
     if bot_user_id and user_id == bot_user_id:
         return {"status": "ignored", "reason": "Event from this bot user"}
+
+    if not await common.claim_slack_event(channel_id, event_id):
+        common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
+        return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
 
     channel_context = await common._get_slack_channel_context(channel_id)
 

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -61,9 +61,7 @@ async def slack_webhook(
 
     event_id = str(payload.get("event_id") or "")
     retry_num = request.headers.get("X-Slack-Retry-Num", "")
-    if retry_num and await common.slack_event_already_seen(
-        str(event.get("channel") or ""), event_id
-    ):
+    if retry_num and await common.slack_event_already_seen(event_id):
         common.logger.info(
             "Ignoring Slack retry %s of already-handled event %s", retry_num, event_id
         )
@@ -146,39 +144,38 @@ async def slack_webhook(
     if bot_user_id and user_id == bot_user_id:
         return {"status": "ignored", "reason": "Event from this bot user"}
 
-    if not await common.claim_slack_event(channel_id, event_id):
-        common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
-        return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
-
     channel_context = await common._get_slack_channel_context(channel_id)
 
     if await common._is_docs_plz_slack_channel(channel_id, channel_context):
-        background_tasks.add_task(
-            common.post_slack_thread_reply,
-            channel_id,
-            thread_ts,
-            common.DOCS_PLZ_SLACK_GATE_REPLY,
+        if await common.claim_slack_event(event_id):
+            background_tasks.add_task(
+                common.post_slack_thread_reply,
+                channel_id,
+                thread_ts,
+                common.DOCS_PLZ_SLACK_GATE_REPLY,
+            )
+            return {"status": "accepted", "message": "Slack mention gated for docs-plz"}
+    else:
+        event_data = {
+            "channel_id": channel_id,
+            "channel_context": channel_context,
+            "thread_ts": thread_ts,
+            "event_ts": event_ts,
+            "user_id": user_id,
+            "text": text,
+            "attachments": event.get("attachments", []),
+            "bot_user_id": bot_user_id,
+            "treat_all_messages_as_mentions": is_direct_message,
+        }
+        repo_config = await common.get_slack_repo_config(
+            channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
         )
-        return {"status": "accepted", "message": "Slack mention gated for docs-plz"}
+        if await common.claim_slack_event(event_id):
+            background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
+            return {"status": "accepted", "message": "Slack mention queued"}
 
-    event_data = {
-        "channel_id": channel_id,
-        "channel_context": channel_context,
-        "thread_ts": thread_ts,
-        "event_ts": event_ts,
-        "user_id": user_id,
-        "text": text,
-        "attachments": event.get("attachments", []),
-        "bot_user_id": bot_user_id,
-        "treat_all_messages_as_mentions": is_direct_message,
-    }
-    repo_config = await common.get_slack_repo_config(
-        channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
-    )
-
-    background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
-
-    return {"status": "accepted", "message": "Slack mention queued"}
+    common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
+    return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
 
 
 @router.post("/webhooks/slack/interactivity")

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -18,6 +18,7 @@ import json
 import os
 import sys
 import time
+import uuid
 from html import escape
 from pathlib import Path
 from typing import Any
@@ -68,6 +69,12 @@ SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
 STATIC_DIR = Path(__file__).parent / "static"
 
 CURRENT_THREAD: dict[str, str | None] = {"channel": DEMO_CHANNEL, "thread_ts": None}
+LAST_SLACK_EVENT: dict[str, Any] = {"payload": None}
+
+# Message timestamps restart from a fixed base on every boot, but the store the
+# webhook dedupes against is persisted — so event ids need a per-process salt or
+# a rerun's mentions look like redeliveries of the previous run's.
+EVENT_ID_SALT = uuid.uuid4().hex[:8]
 
 fakes.seed_bare_remote()
 
@@ -78,6 +85,7 @@ async def control_reset() -> JSONResponse:
     fakes.reset()
     CURRENT_THREAD["channel"] = DEMO_CHANNEL
     CURRENT_THREAD["thread_ts"] = None
+    LAST_SLACK_EVENT["payload"] = None
     return JSONResponse({"ok": True})
 
 
@@ -116,11 +124,70 @@ async def control_queued(thread_id: str = "") -> JSONResponse:
     return JSONResponse({"queued_count": len(messages) if isinstance(messages, list) else 0})
 
 
+async def _deliver_slack_event(payload: dict[str, Any], retry_num: str = "") -> httpx.Response:
+    """POST a signed Events-API delivery to the real /webhooks/slack route."""
+    raw = json.dumps(payload).encode()
+    req_ts = str(int(time.time()))
+    base = f"v0:{req_ts}:{raw.decode()}".encode()
+    sig = "v0=" + hmac.new(SLACK_SIGNING_SECRET.encode(), base, hashlib.sha256).hexdigest()
+    headers = {
+        "X-Slack-Signature": sig,
+        "X-Slack-Request-Timestamp": req_ts,
+        "Content-Type": "application/json",
+    }
+    if retry_num:
+        headers["X-Slack-Retry-Num"] = retry_num
+        headers["X-Slack-Retry-Reason"] = "http_timeout"
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://harness") as client:
+        return await client.post("/webhooks/slack", content=raw, headers=headers)
+
+
+def _slack_send_result(payload: dict[str, Any], resp: httpx.Response) -> JSONResponse:
+    event = payload["event"]
+    channel = str(event["channel"])
+    thread_ts = str(event["thread_ts"])
+    return JSONResponse(
+        {
+            "thread_ts": thread_ts,
+            "thread_id": generate_thread_id_from_slack_thread(channel, thread_ts),
+            "event_id": payload["event_id"],
+            "webhook_status": resp.status_code,
+            "webhook": resp.json(),
+        }
+    )
+
+
+@app.post("/control/forget-slack-events")
+async def control_forget_slack_events() -> JSONResponse:
+    """Drop the in-process record of handled Slack events.
+
+    A redelivery normally lands on a different instance than the original, which
+    only has the LangGraph store to dedupe on. Clearing the local cache lets the
+    E2E exercise that path instead of the same-process fast path."""
+    from agent.utils.slack_events import reset_slack_event_claims
+
+    reset_slack_event_claims()
+    return JSONResponse({"ok": True})
+
+
 @app.post("/mock/slack/send")
 async def slack_send(request: Request) -> JSONResponse:
     """Simulate a user posting in Slack: store the message, then deliver the
-    signed Events-API webhook to the real /webhooks/slack route."""
+    signed Events-API webhook to the real /webhooks/slack route.
+
+    ``redeliver`` replays the previous delivery verbatim — same ``event_id``, no
+    new Slack message — which is what Slack does when it doesn't get a 2xx in
+    three seconds."""
     form = await request.json()
+    if form.get("redeliver"):
+        payload = LAST_SLACK_EVENT.get("payload")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="No Slack event to redeliver")
+        resp = await _deliver_slack_event(payload, str(form.get("retry_num") or "1"))
+        return _slack_send_result(payload, resp)
+
     text = str(form.get("text", ""))
     mention_bot = bool(form.get("mention_bot", True))
     channel_type = str(form.get("channel_type") or "")
@@ -156,34 +223,12 @@ async def slack_send(request: Request) -> JSONResponse:
         event["channel_type"] = channel_type
     payload = {
         "type": "event_callback",
-        "event_id": f"Ev{event_ts}",
+        "event_id": f"Ev{EVENT_ID_SALT}{event_ts}",
         "authorizations": [{"user_id": BOT_USER_ID}],
         "event": event,
     }
-    raw = json.dumps(payload).encode()
-    req_ts = str(int(time.time()))
-    base = f"v0:{req_ts}:{raw.decode()}".encode()
-    sig = "v0=" + hmac.new(SLACK_SIGNING_SECRET.encode(), base, hashlib.sha256).hexdigest()
-
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://harness") as client:
-        resp = await client.post(
-            "/webhooks/slack",
-            content=raw,
-            headers={
-                "X-Slack-Signature": sig,
-                "X-Slack-Request-Timestamp": req_ts,
-                "Content-Type": "application/json",
-            },
-        )
-    return JSONResponse(
-        {
-            "thread_ts": thread_ts,
-            "thread_id": generate_thread_id_from_slack_thread(channel, thread_ts),
-            "webhook_status": resp.status_code,
-            "webhook": resp.json(),
-        }
-    )
+    LAST_SLACK_EVENT["payload"] = payload
+    return _slack_send_result(payload, await _deliver_slack_event(payload))
 
 
 @app.post("/control/login")

--- a/tests/e2e/tests/slack_event_dedupe.spec.ts
+++ b/tests/e2e/tests/slack_event_dedupe.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+// Feature: Slack redelivers an event when it doesn't get a 2xx within three
+// seconds. Each redelivery carries the same event_id, and must not start a
+// second agent run (which the user sees as two replies to one mention).
+
+type SendResult = {
+  thread_ts: string;
+  thread_id: string;
+  event_id: string;
+  webhook: { status: string; reason?: string };
+};
+
+async function send(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+): Promise<SendResult> {
+  const res = await request.post("/mock/slack/send", { data });
+  return (await res.json()) as SendResult;
+}
+
+async function botTexts(request: APIRequestContext): Promise<string[]> {
+  const res = await request.get("/mock/slack/messages");
+  const msgs = (await res.json()) as Array<{ text: string; is_bot: boolean }>;
+  return msgs.filter((m) => m.is_bot).map((m) => m.text);
+}
+
+async function runCount(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<number> {
+  const res = await request.get(`/threads/${threadId}/runs`);
+  if (!res.ok()) return -1;
+  const runs = (await res.json()) as unknown[];
+  return runs.length;
+}
+
+async function threadStatus(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<string> {
+  const res = await request.get(`/threads/${threadId}`);
+  if (!res.ok()) return "";
+  const thread = (await res.json()) as { status?: string };
+  return thread.status ?? "";
+}
+
+test.describe("Slack event redelivery", () => {
+  test("a redelivered mention starts no second run", async ({ request }) => {
+    await request.post("/control/reset");
+
+    const opened = await send(request, {
+      text: "<@U0BOT> please add a greet() helper and open a PR",
+      mention_bot: true,
+    });
+    expect(opened.webhook.status).toBe("accepted");
+
+    // Slack's first retry — same payload, same event_id, retry header set.
+    const firstRetry = await send(request, { redeliver: true, retry_num: 1 });
+    expect(firstRetry.event_id).toBe(opened.event_id);
+    expect(firstRetry.webhook.status).toBe("ignored");
+
+    // A retry usually lands on an instance that never saw the original, and so
+    // has only the store to dedupe on.
+    await request.post("/control/forget-slack-events");
+    const secondRetry = await send(request, { redeliver: true, retry_num: 2 });
+    expect(secondRetry.webhook.status).toBe("ignored");
+
+    // The one run that was accepted still completes normally.
+    await expect
+      .poll(async () => (await botTexts(request)).join("\n"), {
+        timeout: 60_000,
+      })
+      .toContain("/pull/");
+    await expect
+      .poll(() => threadStatus(request, opened.thread_id), { timeout: 30_000 })
+      .not.toBe("busy");
+
+    expect(await runCount(request, opened.thread_id)).toBe(1);
+  });
+});

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -114,6 +114,25 @@ async def test_redelivered_event_starts_only_one_run() -> None:
     assert [task[0] for task in background_tasks.tasks] == [slack_service.process_slack_mention]
 
 
+async def test_redelivered_event_without_retry_header_is_deduped() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    await _post(_mention_payload(), background_tasks)
+    second = await _post(_mention_payload(), background_tasks)
+
+    assert second["status"] == "ignored"
+    assert len(background_tasks.tasks) == 1
+
+
+async def test_retry_header_alone_does_not_drop_an_unseen_event() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    response = await _post(_mention_payload("EvNew"), background_tasks, {"X-Slack-Retry-Num": "2"})
+
+    assert response["status"] == "accepted"
+    assert len(background_tasks.tasks) == 1
+
+
 async def test_concurrent_cross_instance_redeliveries_start_one_run() -> None:
     background_tasks = _FakeBackgroundTasks()
 

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -1,0 +1,146 @@
+import asyncio
+import json
+from typing import Any, cast
+
+import pytest
+from fastapi import BackgroundTasks
+from starlette.requests import Request
+
+from agent.utils import slack_events
+from agent.webhooks import common as webhook_common
+from agent.webhooks import slack as slack_service
+from agent.webhooks import slack_routes
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.items: dict[tuple[tuple[str, ...], str], dict[str, Any]] = {}
+
+    async def get_item(self, namespace: tuple[str, ...], key: str) -> dict[str, Any] | None:
+        return self.items.get((namespace, key))
+
+    async def put_item(self, namespace: tuple[str, ...], key: str, value: dict[str, Any]) -> None:
+        self.items[(namespace, key)] = {"value": value}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.store = _FakeStore()
+
+
+class _FakeBackgroundTasks:
+    def __init__(self) -> None:
+        self.tasks: list[tuple[Any, tuple[Any, ...]]] = []
+
+    def add_task(self, func: Any, *args: Any) -> None:
+        self.tasks.append((func, args))
+
+
+class _FakeRequest:
+    def __init__(self, payload: dict[str, Any], headers: dict[str, str] | None = None) -> None:
+        self.headers: dict[str, str] = headers or {}
+        self._body = json.dumps(payload).encode()
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+def _mention_payload(event_id: str = "Ev1") -> dict[str, Any]:
+    return {
+        "type": "event_callback",
+        "event_id": event_id,
+        "authorizations": [{"user_id": "BOT"}],
+        "event": {
+            "type": "app_mention",
+            "channel": "C1",
+            "ts": "1786573369.551099",
+            "user": "U1",
+            "text": "<@BOT> hello?",
+        },
+    }
+
+
+async def _post(
+    payload: dict[str, Any],
+    background_tasks: _FakeBackgroundTasks,
+    headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    return await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload, headers)),
+        cast(BackgroundTasks, background_tasks),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_slack_webhook(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    slack_events.reset_slack_event_claims()
+    client = _FakeClient()
+
+    async def channel_context(_channel_id: str) -> dict[str, Any]:
+        return {}
+
+    async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
+        return False
+
+    async def repo_config(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    monkeypatch.setattr(slack_events, "get_client", lambda url: client)
+    monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **_kwargs: True)
+    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
+    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
+    return client
+
+
+async def test_redelivered_event_starts_only_one_run() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    first = await _post(_mention_payload(), background_tasks)
+    second = await _post(_mention_payload(), background_tasks, {"X-Slack-Retry-Num": "1"})
+
+    assert first["status"] == "accepted"
+    assert second["status"] == "ignored"
+    assert [task[0] for task in background_tasks.tasks] == [slack_service.process_slack_mention]
+
+
+async def test_redelivered_event_without_retry_header_is_deduped() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    await _post(_mention_payload(), background_tasks)
+    second = await _post(_mention_payload(), background_tasks)
+
+    assert second["status"] == "ignored"
+    assert len(background_tasks.tasks) == 1
+
+
+async def test_retry_header_alone_does_not_drop_an_unseen_event() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    response = await _post(_mention_payload("EvNew"), background_tasks, {"X-Slack-Retry-Num": "2"})
+
+    assert response["status"] == "accepted"
+    assert len(background_tasks.tasks) == 1
+
+
+async def test_concurrent_redeliveries_start_one_run() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    responses = await asyncio.gather(
+        *(_post(_mention_payload(), background_tasks) for _ in range(3))
+    )
+
+    assert [response["status"] for response in responses].count("accepted") == 1
+    assert len(background_tasks.tasks) == 1
+
+
+async def test_claim_survives_a_restarted_process(_patch_slack_webhook: _FakeClient) -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    await _post(_mention_payload(), background_tasks)
+    # A redelivery landing on another instance only has the store to go on.
+    slack_events.reset_slack_event_claims()
+    second = await _post(_mention_payload(), background_tasks)
+
+    assert second["status"] == "ignored"
+    assert len(background_tasks.tasks) == 1

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -12,20 +12,30 @@ from agent.webhooks import slack as slack_service
 from agent.webhooks import slack_routes
 
 
-class _FakeStore:
+class _ConflictError(Exception):
+    pass
+
+
+class _FakeThreads:
     def __init__(self) -> None:
-        self.items: dict[tuple[tuple[str, ...], str], dict[str, Any]] = {}
+        self.ids: set[str] = set()
+        self.lock = asyncio.Lock()
 
-    async def get_item(self, namespace: tuple[str, ...], key: str) -> dict[str, Any] | None:
-        return self.items.get((namespace, key))
+    async def create(self, *, thread_id: str, **_kwargs: Any) -> None:
+        async with self.lock:
+            if thread_id in self.ids:
+                raise _ConflictError
+            self.ids.add(thread_id)
 
-    async def put_item(self, namespace: tuple[str, ...], key: str, value: dict[str, Any]) -> None:
-        self.items[(namespace, key)] = {"value": value}
+    async def get(self, thread_id: str) -> dict[str, str]:
+        if thread_id not in self.ids:
+            raise KeyError(thread_id)
+        return {"thread_id": thread_id}
 
 
 class _FakeClient:
     def __init__(self) -> None:
-        self.store = _FakeStore()
+        self.threads = _FakeThreads()
 
 
 class _FakeBackgroundTasks:
@@ -104,43 +114,29 @@ async def test_redelivered_event_starts_only_one_run() -> None:
     assert [task[0] for task in background_tasks.tasks] == [slack_service.process_slack_mention]
 
 
-async def test_redelivered_event_without_retry_header_is_deduped() -> None:
+async def test_concurrent_cross_instance_redeliveries_start_one_run() -> None:
     background_tasks = _FakeBackgroundTasks()
 
-    await _post(_mention_payload(), background_tasks)
-    second = await _post(_mention_payload(), background_tasks)
+    async def post() -> dict[str, str]:
+        slack_events.reset_slack_event_claims()
+        return await _post(_mention_payload(), background_tasks)
 
-    assert second["status"] == "ignored"
-    assert len(background_tasks.tasks) == 1
-
-
-async def test_retry_header_alone_does_not_drop_an_unseen_event() -> None:
-    background_tasks = _FakeBackgroundTasks()
-
-    response = await _post(_mention_payload("EvNew"), background_tasks, {"X-Slack-Retry-Num": "2"})
-
-    assert response["status"] == "accepted"
-    assert len(background_tasks.tasks) == 1
-
-
-async def test_concurrent_redeliveries_start_one_run() -> None:
-    background_tasks = _FakeBackgroundTasks()
-
-    responses = await asyncio.gather(
-        *(_post(_mention_payload(), background_tasks) for _ in range(3))
-    )
+    responses = await asyncio.gather(*(post() for _ in range(3)))
 
     assert [response["status"] for response in responses].count("accepted") == 1
     assert len(background_tasks.tasks) == 1
 
 
-async def test_claim_survives_a_restarted_process(_patch_slack_webhook: _FakeClient) -> None:
+async def test_preprocessing_failure_does_not_claim_event(monkeypatch: pytest.MonkeyPatch) -> None:
     background_tasks = _FakeBackgroundTasks()
 
-    await _post(_mention_payload(), background_tasks)
-    # A redelivery landing on another instance only has the store to go on.
-    slack_events.reset_slack_event_claims()
-    second = await _post(_mention_payload(), background_tasks)
+    async def failed_repo_config(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        raise RuntimeError
 
-    assert second["status"] == "ignored"
-    assert len(background_tasks.tasks) == 1
+    original_repo_config = webhook_common.get_slack_repo_config
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", failed_repo_config)
+    with pytest.raises(RuntimeError):
+        await _post(_mention_payload(), background_tasks)
+
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", original_repo_config)
+    assert (await _post(_mention_payload(), background_tasks))["status"] == "accepted"


### PR DESCRIPTION
A single `@openswe` mention could start two agent runs and post two replies (observed on preview: same `thread_ts`, same channel, same text, two replies).

`POST /webhooks/slack` never deduped mention deliveries. The `reaction_added` / `reaction_removed` branches already pass `payload["event_id"]` into the store-backed dedupe in `agent/utils/slack_feedback.py`, but the `app_mention` / DM / untagged-reply path ignored `event_id` entirely, and `X-Slack-Retry-Num` appeared nowhere in `agent/`. Slack retries an event up to three times when it does not get a 2xx within 3 seconds, and the handler does several Slack API round-trips before returning (`_get_slack_channel_context`, `_is_docs_plz_slack_channel`, plus `_slack_thread_allows_untagged_reply` / `_slack_user_can_reply_to_ready_plan` for non-`app_mention` events), so the ack can exceed that budget under load — and a deployment roll drops the in-flight request, making a retry near-certain.

## Changes

`agent/utils/slack_events.py` claims an `event_id` by creating a LangGraph thread whose id is `uuid5(event_id)` with `if_exists="raise"`, which makes the claim atomic across instances rather than a check-then-write with a race window. A conflict is confirmed with a `threads.get` before the delivery is dropped; if neither call succeeds the claim fails open (the mention still runs) and logs. An in-process LRU behind an `asyncio.Lock` short-circuits repeat deliveries on the same instance.

`agent/webhooks/slack_routes.py` claims the event immediately before enqueueing `process_slack_mention`, after the pre-checks — so a delivery whose preprocessing raises never consumes the claim, and ordinary channel chatter never claims at all — and short-circuits earlier when `X-Slack-Retry-Num` is present and this instance already handled the event. The retry header alone never drops a delivery; only a known `event_id` does.

The E2E harness gained a `redeliver` mode on `/mock/slack/send` (replays the previous signed payload verbatim, same `event_id`, with the retry header and no new Slack message) and a `/control/forget-slack-events` control that clears the in-process claim cache, so the single-process harness can exercise the store path a real redelivery would take. Harness event ids also carry a per-process salt now: mock message timestamps restart from a fixed base on every boot while the store the webhook dedupes against is persisted, so without it a rerun's mentions would look like redeliveries of the previous run's.

## Not done

Acking before the slow pre-checks. Moving `_get_slack_channel_context` / `_is_docs_plz_slack_channel` / `get_slack_repo_config` into the background task changes what the endpoint can report (the docs-plz gate currently decides its response synchronously) and the untagged-reply classification decides whether to run at all, so it is a larger refactor than it looks. Dedupe alone fixes the duplicate replies; the 3s budget is no longer what keeps correctness.

## Test Plan

- [x] `tests/slack/test_slack_event_dedupe.py` — a second delivery of the same `event_id` (with and without a retry header) enqueues no second run; three concurrent deliveries that each bypass the local cache still produce one run; a delivery whose preprocessing raises does not consume the claim; a retry header on an unseen `event_id` is processed normally.
- [x] `tests/e2e/tests/slack_event_dedupe.spec.ts` — through the real webhook and a real agent run: one mention, then two redeliveries of that exact signed payload (the second after clearing the in-process cache, so it dedupes via the store). Both are ignored, the accepted run still completes and posts its PR link, and the thread ends with exactly one run.
- [x] Both new tests verified to fail against the unpatched route (4 of 5 unit cases; the E2E at its first redelivery assertion) and to pass with it.
- [x] `make test` — 1721 passed.
- [x] Full Playwright E2E suite — passed.
- [x] `make lint` — clean.
- [x] `make typecheck` — no new errors (the 7 reported are pre-existing on `main`, in files this PR does not touch).
