### PR TITLE
fix: validate reviewer outcomes dataset name

### DIFF
--- a/agent/utils/reviewer_outcomes.py
+++ b/agent/utils/reviewer_outcomes.py
@@ -80,7 +80,8 @@ def _outcomes_credentials() -> tuple[str, str] | None:
 
 async def _find_dataset(client: AsyncLangSmithClient) -> Any:
     async for dataset in client.list_datasets(dataset_name=OUTCOMES_DATASET_NAME):
-        return dataset
+        if dataset.name == OUTCOMES_DATASET_NAME:
+            return dataset
     return None
 
 

--- a/tests/reviewer/test_reviewer_outcomes.py
+++ b/tests/reviewer/test_reviewer_outcomes.py
@@ -55,7 +55,9 @@ def test_example_id_is_deterministic() -> None:
 
 
 class _FakeDataset:
-    id = "ds_123"
+    def __init__(self, dataset_id: str, name: str) -> None:
+        self.id = dataset_id
+        self.name = name
 
 
 class _FakeClient:
@@ -71,7 +73,8 @@ class _FakeClient:
         return None
 
     async def list_datasets(self, dataset_name: str):  # noqa: ANN001
-        yield _FakeDataset()
+        yield _FakeDataset("ds_wrong", "other-dataset")
+        yield _FakeDataset("ds_123", dataset_name)
 
     async def create_example(self, **kwargs: Any) -> None:
         if self.conflict_once:


### PR DESCRIPTION
## Description
Require an exact dataset-name match so an ignored SDK filter cannot route reviewer outcomes into an arbitrary dataset.

## Release Note
Fix reviewer outcomes being written to unrelated LangSmith datasets.

## Test Plan
- [x] Simulate an unfiltered listing with an unrelated dataset first

Made by [Open SWE](https://openswe.vercel.app/agents/019ff83a-b734-760a-a8e6-ec359d2fe57b)