### PR TITLE
fix: compact review diff header

### DIFF
--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -154,6 +154,7 @@ export function AgentGitPanel({
       ),
     [files]
   )
+  const truncated = prDiff.data?.truncated ?? turnDiff.data?.truncated
   const tabLabels = { diff: "Branch", review: "Review", commits: "Committed" }
   const refreshDiff = () => void (pr ? prDiff.refetch() : turnDiff.refetch())
 
@@ -183,16 +184,10 @@ export function AgentGitPanel({
         {files.length > 0 && (
           <span className="flex items-center gap-2 text-sm">
             <span
-              title={
-                prDiff.data?.truncated || turnDiff.data?.truncated
-                  ? "Only the first files are shown"
-                  : undefined
-              }
+              title={truncated ? "Only the first files are shown" : undefined}
               className="text-xs text-muted-foreground"
             >
-              {prDiff.data?.truncated || turnDiff.data?.truncated
-                ? "first "
-                : ""}
+              {truncated ? "first " : ""}
               {files.length} file{files.length === 1 ? "" : "s"}
             </span>
             <span className="text-success-foreground">+{totals.additions}</span>
@@ -284,7 +279,7 @@ export function AgentGitPanel({
                   emptyLabel={
                     prDiff.isLoading ? "Loading PR diff…" : "No diff available."
                   }
-                  truncated={prDiff.data?.truncated ?? turnDiff.data?.truncated}
+                  truncated={truncated}
                 />
               ) : (
                 <div className="flex min-h-0 flex-1">

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -154,8 +154,6 @@ export function AgentGitPanel({
       ),
     [files]
   )
-  const headRef = pr?.headRef ?? thread.branch
-  const baseRef = pr?.baseRef ?? "main"
   const tabLabels = { diff: "Branch", review: "Review", commits: "Committed" }
   const refreshDiff = () => void (pr ? prDiff.refetch() : turnDiff.refetch())
 
@@ -184,6 +182,19 @@ export function AgentGitPanel({
         </Menu>
         {files.length > 0 && (
           <span className="flex items-center gap-2 text-sm">
+            <span
+              title={
+                prDiff.data?.truncated || turnDiff.data?.truncated
+                  ? "Only the first files are shown"
+                  : undefined
+              }
+              className="text-xs text-muted-foreground"
+            >
+              {prDiff.data?.truncated || turnDiff.data?.truncated
+                ? "first "
+                : ""}
+              {files.length} file{files.length === 1 ? "" : "s"}
+            </span>
             <span className="text-success-foreground">+{totals.additions}</span>
             <span className="text-destructive">-{totals.deletions}</span>
           </span>
@@ -269,23 +280,7 @@ export function AgentGitPanel({
                   files={files}
                   revealFilePath={revealFilePath}
                   fullScreen={fullScreen}
-                  leading={
-                    <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                      <span
-                        className="min-w-0 truncate font-mono"
-                        title={headRef}
-                      >
-                        {headRef}
-                      </span>
-                      <span className="shrink-0">→</span>
-                      <span
-                        className="min-w-0 truncate font-mono"
-                        title={baseRef}
-                      >
-                        {baseRef}
-                      </span>
-                    </div>
-                  }
+                  hideHeader
                   emptyLabel={
                     prDiff.isLoading ? "Loading PR diff…" : "No diff available."
                   }

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -240,15 +240,6 @@ export function AgentGitPanel({
           </Menu>
         </div>
       </div>
-      <div className="flex min-w-0 items-center gap-2 px-2 text-xs text-muted-foreground">
-        <span className="min-w-0 truncate font-mono" title={headRef}>
-          {headRef}
-        </span>
-        <span className="shrink-0">→</span>
-        <span className="min-w-0 truncate font-mono" title={baseRef}>
-          {baseRef}
-        </span>
-      </div>
     </div>
   )
 
@@ -278,6 +269,23 @@ export function AgentGitPanel({
                   files={files}
                   revealFilePath={revealFilePath}
                   fullScreen={fullScreen}
+                  leading={
+                    <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                      <span
+                        className="min-w-0 truncate font-mono"
+                        title={headRef}
+                      >
+                        {headRef}
+                      </span>
+                      <span className="shrink-0">→</span>
+                      <span
+                        className="min-w-0 truncate font-mono"
+                        title={baseRef}
+                      >
+                        {baseRef}
+                      </span>
+                    </div>
+                  }
                   emptyLabel={
                     prDiff.isLoading ? "Loading PR diff…" : "No diff available."
                   }

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -132,6 +132,7 @@ interface DiffFilesViewProps {
   emptyLabel: string
   /** The change set was capped, so `files` is not everything that changed. */
   truncated?: boolean
+  hideHeader?: boolean
   /** Rendered at the start of the header row (the panel's own tabs). */
   leading?: React.ReactNode
   /** Rendered in the header row, before the wrap toggle and diff stats. */
@@ -149,6 +150,7 @@ export function DiffFilesView({
   fullScreen,
   emptyLabel,
   truncated,
+  hideHeader,
   leading,
   actions,
 }: DiffFilesViewProps) {
@@ -193,27 +195,31 @@ export function DiffFilesView({
 
   return (
     <>
-      <div className="flex min-h-9 items-center gap-1 border-b border-border px-3 py-1">
-        {leading}
-        <div className="ml-auto flex min-w-0 items-center gap-2">
-          <DiffWrapToggle />
-          {actions}
-          {files.length > 0 && (
-            <span className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
-              <span
-                title={truncated ? "Only the first files are shown" : undefined}
-              >
-                {truncated ? "first " : ""}
-                {files.length} file{files.length === 1 ? "" : "s"}
+      {!hideHeader && (
+        <div className="flex min-h-9 items-center gap-1 border-b border-border px-3 py-1">
+          {leading}
+          <div className="ml-auto flex min-w-0 items-center gap-2">
+            <DiffWrapToggle />
+            {actions}
+            {files.length > 0 && (
+              <span className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
+                <span
+                  title={
+                    truncated ? "Only the first files are shown" : undefined
+                  }
+                >
+                  {truncated ? "first " : ""}
+                  {files.length} file{files.length === 1 ? "" : "s"}
+                </span>
+                <span className="text-success-foreground">
+                  +{totals.additions}
+                </span>
+                <span className="text-destructive">-{totals.deletions}</span>
               </span>
-              <span className="text-success-foreground">
-                +{totals.additions}
-              </span>
-              <span className="text-destructive">-{totals.deletions}</span>
-            </span>
-          )}
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="flex min-h-0 flex-1">
         {files.length > 0 ? (


### PR DESCRIPTION
## Description
Removes the redundant cloud diff toolbar and places the file count beside the top-level diff stats.

## Release Note
Compact review diff headers in the dashboard.

## Test Plan
- [x] Production UI build

Made by [Open SWE](https://openswe.vercel.app/agents/019ff84d-31a7-729f-9431-5198b9611e92)