### PR TITLE
fix: clean stale package installs after workspace migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run:
 	uv run uvicorn agent.webapp:app --reload --port 8000
 
 desktop:
-	cd desktop && pnpm run dev
+	pnpm run dev:desktop
 
 install:
 	uv sync --extra dev

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "packageManager": "pnpm@11.18.0",
   "scripts": {
-    "dev": "turbo run dev --filter=open-swe-dashboard",
-    "dev:desktop": "turbo run dev --filter=open-swe-desktop",
+    "dev": "node scripts/prepare-pnpm-workspace.cjs && turbo run dev --filter=open-swe-dashboard",
+    "dev:desktop": "node scripts/prepare-pnpm-workspace.cjs && turbo run dev --filter=open-swe-desktop",
     "dev:mock": "bash tests/e2e/dev-mock.sh",
-    "build": "turbo run build",
+    "build": "node scripts/prepare-pnpm-workspace.cjs && turbo run build",
     "check": "turbo run check",
     "format:check": "turbo run format:check",
     "lint": "turbo run lint",

--- a/scripts/prepare-pnpm-workspace.cjs
+++ b/scripts/prepare-pnpm-workspace.cjs
@@ -1,0 +1,23 @@
+const fs = require("node:fs")
+const path = require("node:path")
+const { spawnSync } = require("node:child_process")
+
+const root = path.resolve(__dirname, "..")
+const legacyInstalls = ["ui", "desktop"]
+  .map((workspace) => path.join(root, workspace, "node_modules"))
+  .filter((nodeModules) => fs.existsSync(path.join(nodeModules, ".modules.yaml")))
+
+if (legacyInstalls.length > 0) {
+  for (const nodeModules of legacyInstalls) {
+    console.log(`Removing legacy ${path.relative(root, nodeModules)}`)
+    fs.rmSync(nodeModules, { recursive: true, force: true })
+  }
+
+  const result = spawnSync("pnpm", ["install", "--frozen-lockfile"], {
+    cwd: root,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}


### PR DESCRIPTION
Fixes existing checkouts retaining package-local `node_modules` after the pnpm workspace migration. Stale TanStack packages could shadow root-lockfile versions and break SSR builds.

- clean legacy package installs before root dev/build commands
- route `make desktop` through the root Turborepo command

Test: `pnpm run build`
