### PR TITLE
fix(cache): stop keying TTL cache entries on callable addresses

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -102,7 +102,7 @@ async def _configure_sandbox_github_proxy(
 
 async def _cached_gateway_enabled() -> bool:
     return await ttl_cache.cached(
-        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        "team:gateway-enabled",
         60,
         get_effective_gateway_enabled,
     )

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -132,7 +132,7 @@ Guidance:
 
 async def _cached_gateway_enabled() -> bool:
     return await ttl_cache.cached(
-        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        "team:gateway-enabled",
         60,
         get_effective_gateway_enabled,
     )
@@ -140,7 +140,7 @@ async def _cached_gateway_enabled() -> bool:
 
 async def _cached_team_chat_model() -> tuple[str, str]:
     return await ttl_cache.cached(
-        f"team-default-model:chat:{id(get_team_default_model)}",
+        "team-default-model:chat",
         60,
         lambda: get_team_default_model("chat"),
     )

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -890,7 +890,7 @@ async def _resolve_grouping_model(
 
 async def _cached_reviewer_team_defaults():
     return await ttl_cache.cached(
-        f"team-default-model-pair:reviewer:{id(get_team_default_model_pair)}",
+        "team-default-model-pair:reviewer",
         60,
         lambda: get_team_default_model_pair("reviewer"),
     )
@@ -898,7 +898,7 @@ async def _cached_reviewer_team_defaults():
 
 async def _cached_gateway_enabled() -> bool:
     return await ttl_cache.cached(
-        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        "team:gateway-enabled",
         60,
         get_effective_gateway_enabled,
     )
@@ -906,7 +906,7 @@ async def _cached_gateway_enabled() -> bool:
 
 async def _cached_org_review_guidelines() -> str | None:
     return await ttl_cache.cached(
-        f"reviewer:org-guidelines:{id(get_org_review_guidelines)}",
+        "reviewer:org-guidelines",
         300,
         get_org_review_guidelines,
     )
@@ -914,7 +914,7 @@ async def _cached_org_review_guidelines() -> str | None:
 
 async def _cached_api_standards_skill() -> str | None:
     return await ttl_cache.cached(
-        f"reviewer:api-standards-skill:{id(fetch_api_standards_skill)}",
+        "reviewer:api-standards-skill",
         300,
         fetch_api_standards_skill,
     )

--- a/agent/server.py
+++ b/agent/server.py
@@ -738,7 +738,7 @@ async def _load_observability_tools(authorized: bool, profile_login: str | None)
     if not authorized:
         return []
     datadog_tools, langsmith_tools = await asyncio.gather(
-        _cached_tool_loader(f"tools:datadog:{id(load_datadog_tools)}", 600, load_datadog_tools),
+        _cached_tool_loader("tools:datadog", 600, load_datadog_tools),
         load_langsmith_tools(profile_login),
     )
     return [*datadog_tools, *langsmith_tools]
@@ -746,14 +746,12 @@ async def _load_observability_tools(authorized: bool, profile_login: str | None)
 
 async def _load_corridor_mcp_tools() -> list[Any]:
     """Corridor MCP tools when the deployment environment has configured them."""
-    return await _cached_tool_loader(
-        f"tools:corridor:{id(load_corridor_tools)}", 600, load_corridor_tools
-    )
+    return await _cached_tool_loader("tools:corridor", 600, load_corridor_tools)
 
 
 async def _cached_team_default_model_pair(kind: Literal["agent", "reviewer"]):
     return await ttl_cache.cached(
-        f"team-default-model-pair:{kind}:{id(get_team_default_model_pair)}",
+        f"team-default-model-pair:{kind}",
         60,
         lambda: get_team_default_model_pair(kind),
     )
@@ -761,7 +759,7 @@ async def _cached_team_default_model_pair(kind: Literal["agent", "reviewer"]):
 
 async def _cached_gateway_enabled() -> bool:
     return await ttl_cache.cached(
-        f"team:gateway-enabled:{id(get_effective_gateway_enabled)}",
+        "team:gateway-enabled",
         60,
         get_effective_gateway_enabled,
     )
@@ -769,7 +767,7 @@ async def _cached_gateway_enabled() -> bool:
 
 async def _cached_fable_enabled() -> bool:
     return await ttl_cache.cached(
-        f"team:fable-enabled:{id(get_team_fable_enabled)}",
+        "team:fable-enabled",
         60,
         get_team_fable_enabled,
     )
@@ -779,7 +777,7 @@ async def _cached_profile(profile_login: str | None):
     if not profile_login:
         return None
     return await ttl_cache.cached(
-        f"profile:{profile_login}:{id(load_profile)}", 30, lambda: load_profile(profile_login)
+        f"profile:{profile_login}", 30, lambda: load_profile(profile_login)
     )
 
 
@@ -1106,12 +1104,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if profile_login:
         currents_tools, notion_tools = await asyncio.gather(
             _cached_tool_loader(
-                f"tools:currents:{profile_login}:{id(load_currents_tools)}",
+                f"tools:currents:{profile_login}",
                 300,
                 lambda: load_currents_tools(profile_login),
             ),
             _cached_tool_loader(
-                f"tools:notion:{profile_login}:{id(load_notion_tools)}",
+                f"tools:notion:{profile_login}",
                 300,
                 lambda: load_notion_tools(profile_login),
             ),

--- a/agent/utils/ttl_cache.py
+++ b/agent/utils/ttl_cache.py
@@ -117,5 +117,8 @@ def clear() -> None:
     _CACHE.clear()
     _LOCKS.clear()
     for task in _REFRESH_TASKS.values():
-        task.cancel()
+        try:
+            task.cancel()
+        except RuntimeError:
+            pass
     _REFRESH_TASKS.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
+from agent.utils import ttl_cache
 from agent.webhooks import common as webhook_common
+
+
+@pytest.fixture(autouse=True)
+def _reset_ttl_cache() -> Iterator[None]:
+    """Keep the process-global TTL cache from leaking team settings between tests."""
+    ttl_cache.clear()
+    yield
+    ttl_cache.clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
TTL cache keys embedded `id(some_callable)` so that patching the callable in tests would produce a different key. CPython reuses memory addresses after an object is collected, so two different tests' mocks could land on the same key inside the 60s TTL — the second test then read the first test's cached value.

Symptom: `tests/models/test_agent_subagent_models.py::test_agent_gate_swaps_disabled_fable_profile_to_opus` failed in roughly 2 of 3 full-suite runs with `assert ('openai:gpt-5.6-sol',) == ('anthropic:claude-opus-5',)`, and passed in isolation.

- All 12 cache keys across `server.py`, `reviewer.py`, `chat.py`, and `analyzer.py` are now stable strings with no address component.
- An autouse fixture in `tests/conftest.py` calls the existing `ttl_cache.clear()` around every test, so no test can inherit another's cached team settings.
- `ttl_cache.clear()` tolerates cancelling refresh tasks whose event loop is already closed.

## Test Plan

- [x] 5 consecutive full `pytest tests/` runs green (3 with random ordering, 2 with `-p no:randomly`) — 1722 passed each time
- [x] `make lint` clean
- [x] `make typecheck` shows the same 7 pre-existing errors as the base commit, none in touched files
