### PR TITLE
fix: drop unreplayable OpenAI reasoning items

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -37,6 +37,7 @@ from .integrations.langsmith import _configure_github_proxy
 from .middleware import (
     BasePrepareRunMiddleware,
     PrepareRunState,
+    SanitizeOpenAIResponsesMiddleware,
     SanitizeToolInputsMiddleware,
     TimeoutWrapupMiddleware,
     ToolErrorMiddleware,
@@ -202,6 +203,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
                 ),
                 ToolErrorMiddleware(),
                 TimeoutWrapupMiddleware(),
+                SanitizeOpenAIResponsesMiddleware(),
             ],
         ),
     ).with_config(config)

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -50,6 +50,7 @@ from .middleware import (
     ExcludeToolsMiddleware,
     ModelCallTimeoutMiddleware,
     SanitizeFireworksMessagesMiddleware,
+    SanitizeOpenAIResponsesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     ToolErrorMiddleware,
@@ -96,6 +97,7 @@ def _chat_general_purpose_subagent() -> SubAgent:
             list[AgentMiddleware[Any, Any, Any]],
             [
                 FilesystemMiddleware(tools=["read_file", "ls", "glob", "grep"]),
+                SanitizeOpenAIResponsesMiddleware(),
                 ModelCallTimeoutMiddleware(),
             ],
         ),
@@ -254,6 +256,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
                 ToolErrorMiddleware(),
                 ExcludeToolsMiddleware(excluded=_EXCLUDED_TOOLS),
                 SanitizeFireworksMessagesMiddleware(),
+                SanitizeOpenAIResponsesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
                 ModelCallTimeoutMiddleware(),
             ],

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -18,6 +18,7 @@ _MIDDLEWARE_MODULES = {
     "RepairOrphanedToolCallsMiddleware": ".repair_orphaned_tool_calls",
     "SandboxCircuitBreakerMiddleware": ".sandbox_circuit_breaker",
     "SanitizeFireworksMessagesMiddleware": ".sanitize_fireworks_messages",
+    "SanitizeOpenAIResponsesMiddleware": ".sanitize_openai_responses",
     "SanitizeThinkingBlocksMiddleware": ".sanitize_thinking_blocks",
     "SanitizeToolInputsMiddleware": ".sanitize_tool_inputs",
     "settle_review_check_on_exit": ".settle_review_check",
@@ -40,6 +41,7 @@ __all__ = [
     "PullRequestCreationGuardMiddleware",
     "RepairOrphanedToolCallsMiddleware",
     "SanitizeFireworksMessagesMiddleware",
+    "SanitizeOpenAIResponsesMiddleware",
     "SanitizeThinkingBlocksMiddleware",
     "SanitizeToolInputsMiddleware",
     "SubdirAgentsReadMiddleware",
@@ -71,6 +73,7 @@ if TYPE_CHECKING:
     from .repair_orphaned_tool_calls import RepairOrphanedToolCallsMiddleware
     from .sandbox_circuit_breaker import SandboxCircuitBreakerMiddleware
     from .sanitize_fireworks_messages import SanitizeFireworksMessagesMiddleware
+    from .sanitize_openai_responses import SanitizeOpenAIResponsesMiddleware
     from .sanitize_thinking_blocks import SanitizeThinkingBlocksMiddleware
     from .sanitize_tool_inputs import SanitizeToolInputsMiddleware
     from .settle_review_check import settle_review_check_on_exit

--- a/agent/middleware/sanitize_openai_responses.py
+++ b/agent/middleware/sanitize_openai_responses.py
@@ -1,0 +1,66 @@
+"""Remove non-replayable reasoning items from stateless OpenAI history."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, AnyMessage
+from langchain_openai import ChatOpenAI
+
+
+def _is_stateless_chat_openai(model: object) -> bool:
+    seen: set[int] = set()
+    current = model
+    for _ in range(10):
+        if isinstance(current, ChatOpenAI):
+            return current.store is False
+        current_id = id(current)
+        if current_id in seen:
+            return False
+        seen.add(current_id)
+        bound = getattr(current, "bound", None)
+        if bound is None or bound is current:
+            return False
+        current = bound
+    return False
+
+
+def _sanitize_messages(messages: list[AnyMessage]) -> list[AnyMessage]:
+    sanitized: list[AnyMessage] = []
+    for message in messages:
+        if not isinstance(message, AIMessage) or not isinstance(message.content, list):
+            sanitized.append(message)
+            continue
+        content = [
+            block
+            for block in message.content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "reasoning"
+                and isinstance(block.get("id"), str)
+                and block["id"].startswith("rs_")
+                and not block.get("encrypted_content")
+            )
+        ]
+        sanitized.append(
+            message
+            if len(content) == len(message.content)
+            else message.model_copy(update={"content": content})
+        )
+    return sanitized
+
+
+class SanitizeOpenAIResponsesMiddleware(AgentMiddleware):
+    """Drop reasoning item IDs that OpenAI cannot resolve with ``store=False``."""
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> Any:
+        if _is_stateless_chat_openai(request.model):
+            request = request.override(messages=_sanitize_messages(request.messages))
+        return await handler(request)

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -52,6 +52,7 @@ from .middleware import (
     ModelCallTimeoutMiddleware,
     RepairOrphanedToolCallsMiddleware,
     SanitizeFireworksMessagesMiddleware,
+    SanitizeOpenAIResponsesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     TimeoutWrapupMiddleware,
@@ -359,7 +360,10 @@ def _reviewer_subagent(model: BaseChatModel) -> SubAgent:
         "model": model,
         # Subagents compile into their own graphs, so the reviewer's own
         # middleware never wraps their model calls.
-        "middleware": cast(list[AgentMiddleware[Any, Any, Any]], [ModelCallTimeoutMiddleware()]),
+        "middleware": cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [SanitizeOpenAIResponsesMiddleware(), ModelCallTimeoutMiddleware()],
+        ),
     }
 
 
@@ -1430,6 +1434,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
                 check_message_queue_before_model,
                 TimeoutWrapupMiddleware(),
                 SanitizeFireworksMessagesMiddleware(),
+                SanitizeOpenAIResponsesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
                 RepairOrphanedToolCallsMiddleware(),
                 ModelCallTimeoutMiddleware(),

--- a/agent/server.py
+++ b/agent/server.py
@@ -82,6 +82,7 @@ from .middleware import (
     PlanModeMiddleware,
     PullRequestCreationGuardMiddleware,
     SanitizeFireworksMessagesMiddleware,
+    SanitizeOpenAIResponsesMiddleware,
     SanitizeThinkingBlocksMiddleware,
     SanitizeToolInputsMiddleware,
     SubdirAgentsReadMiddleware,
@@ -592,15 +593,15 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
 )
 
 
-def _subagent_model_timeout_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
-    """Deadline for a subagent's own model calls.
+def _subagent_model_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
+    """Provider guards for subagent model calls.
 
-    Subagents are compiled into their own graphs, so the parent's middleware
-    never wraps them — while a delegated `task` runs, the parent is only waiting
-    on tool execution. Without this a stalled provider call inside a subagent
-    hangs the run exactly like it did in the parent.
+    Subagents compile into their own graphs, so parent middleware never wraps them.
     """
-    return cast(list[AgentMiddleware[Any, Any, Any]], [ModelCallTimeoutMiddleware()])
+    return cast(
+        list[AgentMiddleware[Any, Any, Any]],
+        [SanitizeOpenAIResponsesMiddleware(), ModelCallTimeoutMiddleware()],
+    )
 
 
 def _general_purpose_subagent(
@@ -618,7 +619,7 @@ def _general_purpose_subagent(
         "model": model,
         "middleware": [
             *([dynamic_tools] if dynamic_tools else []),
-            *_subagent_model_timeout_middleware(),
+            *_subagent_model_middleware(),
         ],
     }
     if skills:
@@ -665,7 +666,7 @@ def _browser_subagent(model: BaseChatModel, tools: list[Any]) -> SubAgent:
         "system_prompt": BROWSER_SUBAGENT_SYSTEM_PROMPT,
         "tools": tools,
         "model": model,
-        "middleware": _subagent_model_timeout_middleware(),
+        "middleware": _subagent_model_middleware(),
     }
 
 
@@ -1228,6 +1229,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 *fallback_middleware,
                 *plan_mode_middleware,
                 SanitizeFireworksMessagesMiddleware(),
+                SanitizeOpenAIResponsesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
                 # Innermost, so the deadline covers the provider call itself and a
                 # timeout escalates outward to the fallback model.

--- a/tests/test_openai_responses_replay.py
+++ b/tests/test_openai_responses_replay.py
@@ -4,12 +4,20 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_openai import ChatOpenAI
 from pydantic import SecretStr
 
+from agent.middleware.sanitize_openai_responses import _sanitize_messages
+
 
 def test_stateless_responses_replay_preserves_tool_history_without_mutation() -> None:
     messages = [
         HumanMessage("test the todo middleware"),
         AIMessage(
             content=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_unstored",
+                    "summary": [],
+                    "encrypted_content": None,
+                },
                 {
                     "type": "reasoning",
                     "id": "rs_reasoning",
@@ -50,8 +58,8 @@ def test_stateless_responses_replay_preserves_tool_history_without_mutation() ->
         output_version="responses/v1",
     )
 
-    first_payload = model._get_request_payload(messages)
-    second_payload = model._get_request_payload(messages)
+    first_payload = model._get_request_payload(_sanitize_messages(messages))
+    second_payload = model._get_request_payload(_sanitize_messages(messages))
 
     expected_call = {
         "type": "function_call",
@@ -65,6 +73,7 @@ def test_stateless_responses_replay_preserves_tool_history_without_mutation() ->
         "output": "/workspace/open-swe",
         "call_id": "call_execute",
     }
+    assert not any(item.get("id") == "rs_unstored" for item in first_payload["input"])
     assert expected_call in first_payload["input"]
     assert expected_output in first_payload["input"]
     assert second_payload["input"] == first_payload["input"]


### PR DESCRIPTION
Fixes OpenAI Responses runs that replay `rs_*` reasoning IDs without encrypted payloads while `store=False`.

- Drop only non-replayable reasoning blocks from stateless OpenAI history.
- Preserve encrypted reasoning and tool-call history.
- Apply the guard to parent and subagent model paths.

Test: `uv run pytest -q tests/test_openai_responses_replay.py`
