### PR TITLE
test: expect OpenAI replay sanitizer

### DIFF
--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -112,7 +112,7 @@ async def test_agent_does_not_add_custom_repair_middleware() -> None:
     names = {type(m).__name__ for m in middleware}
     # Built-in PatchToolCallsMiddleware (added by create_deep_agent) replaces it.
     assert "RepairOrphanedToolCallsMiddleware" not in names
-    assert "SanitizeOpenAIResponsesMiddleware" not in names
+    assert "SanitizeOpenAIResponsesMiddleware" in names
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Updates the existing assembly assertion after #1941 added the replay sanitizer.

Test: `uv run pytest -q tests/agent/test_agent_assembly_context.py::test_agent_does_not_add_custom_repair_middleware`