### PR TITLE
fix: honor forwarded scheme for desktop OAuth

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -418,7 +418,11 @@ async def auth_login(
         redirect_to=safe_redirect,
         nonce_hash=hash_state_nonce(nonce),
     )
-    api_base_url = str(request.base_url).rstrip("/") if desktop else _api_base_url()
+    api_base_url = _api_base_url()
+    if desktop:
+        forwarded_proto = request.headers.get("x-forwarded-proto", "").partition(",")[0].strip()
+        scheme = forwarded_proto if forwarded_proto in {"http", "https"} else request.url.scheme
+        api_base_url = str(request.base_url.replace(scheme=scheme)).rstrip("/")
     redirect_uri = f"{api_base_url}/dashboard/api/auth/callback"
     query = urlencode(
         {

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -67,10 +67,11 @@ def test_desktop_login_uses_the_requested_backend_callback(monkeypatch) -> None:
 
     app = FastAPI()
     app.include_router(routes.router)
-    with TestClient(app, base_url="https://backend.example") as client:
+    with TestClient(app, base_url="http://backend.example") as client:
         response = client.get(
             "/dashboard/api/auth/login",
             params={"desktop": "true"},
+            headers={"x-forwarded-proto": "https"},
             follow_redirects=False,
         )
 


### PR DESCRIPTION
Fix desktop GitHub OAuth behind HTTPS reverse proxies by using the validated forwarded scheme when building the backend callback URL.

Test: `uv run pytest -q tests/dashboard/test_dashboard_oauth_redirect.py`
