### PR TITLE
fix: keep GitHub SAML login in desktop

### DIFF
--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -79,12 +79,16 @@ function isTrustedProxyRequest(method, pageUrl, requestUrl) {
 function isGithubOAuthUrl(value) {
   try {
     const url = new URL(value)
+    const pathSegments = url.pathname.split("/").filter(Boolean)
+    const loginPage = ["login", "session", "sessions"].includes(pathSegments[0])
+    const organizationSsoPage =
+      pathSegments[0] === "orgs" &&
+      Boolean(pathSegments[1]) &&
+      ["saml", "sso"].includes(pathSegments[2])
     return (
       url.protocol === "https:" &&
       url.hostname === "github.com" &&
-      ["/login", "/session", "/sessions"].some(
-        (path) => url.pathname === path || url.pathname.startsWith(`${path}/`)
-      )
+      (loginPage || organizationSsoPage)
     )
   } catch {
     return false

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -76,6 +76,7 @@ protocol.registerSchemesAsPrivileged([
 let backendUrl = null;
 let mainWindow = null;
 let setupWindow = null;
+let oauthNavigationActive = false;
 let quitting = false;
 const acpSessions = new Map();
 // sessionId -> { repo, ref }: the worktree snapshot a local session started from, so
@@ -523,6 +524,7 @@ async function serveBundledUi(request) {
 }
 
 async function loadApp(window) {
+  oauthNavigationActive = false;
   if (!backendUrl) return;
   try {
     await window.loadURL(APP_URL);
@@ -620,13 +622,22 @@ function createMenu() {
 function handleNavigation(window, event, url) {
   const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null;
   if (callback) {
+    oauthNavigationActive = false;
     event.preventDefault();
     void window.loadURL(callback);
     return;
   }
-  if (isAppUrl(url) || isGithubOAuthUrl(url)) return;
-  event.preventDefault();
+  if (isAppUrl(url)) {
+    oauthNavigationActive = false;
+    return;
+  }
+  if (isGithubOAuthUrl(url)) {
+    oauthNavigationActive = true;
+    return;
+  }
   const target = new URL(url);
+  if (oauthNavigationActive && target.protocol === "https:") return;
+  event.preventDefault();
   if (["http:", "https:", "mailto:"].includes(target.protocol)) {
     void shell.openExternal(url);
   }
@@ -663,7 +674,14 @@ function createWindow() {
     if (mainWindow === window) mainWindow = null;
   });
   window.webContents.setWindowOpenHandler(({ url }) => {
-    if (["http:", "https:", "mailto:"].includes(new URL(url).protocol)) {
+    const protocol = new URL(url).protocol;
+    if (
+      isGithubOAuthUrl(url) ||
+      (oauthNavigationActive && protocol === "https:")
+    ) {
+      oauthNavigationActive = true;
+      void window.loadURL(url);
+    } else if (["http:", "https:", "mailto:"].includes(protocol)) {
       void shell.openExternal(url);
     }
     return { action: "deny" };

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -76,7 +76,7 @@ protocol.registerSchemesAsPrivileged([
 let backendUrl = null;
 let mainWindow = null;
 let setupWindow = null;
-let oauthNavigationActive = false;
+let authWindow = null;
 let quitting = false;
 const acpSessions = new Map();
 // sessionId -> { repo, ref }: the worktree snapshot a local session started from, so
@@ -524,7 +524,6 @@ async function serveBundledUi(request) {
 }
 
 async function loadApp(window) {
-  oauthNavigationActive = false;
   if (!backendUrl) return;
   try {
     await window.loadURL(APP_URL);
@@ -619,25 +618,95 @@ function createMenu() {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
-function handleNavigation(window, event, url) {
+function handleAuthNavigation(window, event, url) {
   const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null;
   if (callback) {
-    oauthNavigationActive = false;
     event.preventDefault();
     void window.loadURL(callback);
     return;
   }
   if (isAppUrl(url)) {
-    oauthNavigationActive = false;
-    return;
-  }
-  if (isGithubOAuthUrl(url)) {
-    oauthNavigationActive = true;
+    event.preventDefault();
+    window.close();
+    if (mainWindow && !mainWindow.isDestroyed()) void loadApp(mainWindow);
     return;
   }
   const target = new URL(url);
-  if (oauthNavigationActive && target.protocol === "https:") return;
+  if (target.protocol === "https:") return;
   event.preventDefault();
+  if (["http:", "mailto:"].includes(target.protocol)) {
+    void shell.openExternal(url);
+  }
+}
+
+function createAuthWindow(url) {
+  if (authWindow && !authWindow.isDestroyed()) {
+    authWindow.show();
+    authWindow.focus();
+    void authWindow.loadURL(url);
+    return;
+  }
+  const window = new BrowserWindow({
+    title: "Sign in to Open SWE",
+    parent: mainWindow,
+    width: 1000,
+    height: 800,
+    minWidth: 640,
+    minHeight: 480,
+    backgroundColor: "#ffffff",
+    icon: iconPath(),
+    show: false,
+    webPreferences: {
+      contextIsolation: true,
+      navigateOnDragDrop: false,
+      nodeIntegration: false,
+      sandbox: true,
+      session: session.defaultSession,
+    },
+  });
+
+  window.once("ready-to-show", () => window.show());
+  window.on("closed", () => {
+    if (authWindow === window) authWindow = null;
+  });
+  window.webContents.setWindowOpenHandler(({ url: popupUrl }) => {
+    const target = new URL(popupUrl);
+    if (target.protocol === "https:") {
+      void window.loadURL(popupUrl);
+    } else if (["http:", "mailto:"].includes(target.protocol)) {
+      void shell.openExternal(popupUrl);
+    }
+    return { action: "deny" };
+  });
+  window.webContents.on("will-navigate", (event, navigationUrl) =>
+    handleAuthNavigation(window, event, navigationUrl),
+  );
+  window.webContents.on("will-redirect", (event, navigationUrl) =>
+    handleAuthNavigation(window, event, navigationUrl),
+  );
+  window.webContents.on("will-attach-webview", (event) =>
+    event.preventDefault(),
+  );
+
+  authWindow = window;
+  void window.loadURL(url);
+}
+
+function handleNavigation(window, event, url) {
+  const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null;
+  if (callback) {
+    event.preventDefault();
+    void window.loadURL(callback);
+    return;
+  }
+  if (isAppUrl(url)) return;
+  if (isGithubOAuthUrl(url)) {
+    event.preventDefault();
+    createAuthWindow(url);
+    return;
+  }
+  event.preventDefault();
+  const target = new URL(url);
   if (["http:", "https:", "mailto:"].includes(target.protocol)) {
     void shell.openExternal(url);
   }
@@ -675,12 +744,8 @@ function createWindow() {
   });
   window.webContents.setWindowOpenHandler(({ url }) => {
     const protocol = new URL(url).protocol;
-    if (
-      isGithubOAuthUrl(url) ||
-      (oauthNavigationActive && protocol === "https:")
-    ) {
-      oauthNavigationActive = true;
-      void window.loadURL(url);
+    if (isGithubOAuthUrl(url)) {
+      createAuthWindow(url);
     } else if (["http:", "https:", "mailto:"].includes(protocol)) {
       void shell.openExternal(url);
     }

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -141,6 +141,12 @@ test("only keeps GitHub login pages in the app window", () => {
   assert.equal(isGithubOAuthUrl("https://github.com/login?return_to=%2Flogin%2Foauth"), true)
   assert.equal(isGithubOAuthUrl("https://github.com/session"), true)
   assert.equal(isGithubOAuthUrl("https://github.com/sessions/two-factor"), true)
+  assert.equal(
+    isGithubOAuthUrl(
+      "https://github.com/orgs/langchain-ai/saml/initiate?return_to=%2Flogin%2Foauth"
+    ),
+    true
+  )
   assert.equal(isGithubOAuthUrl("https://github.com/langchain-ai/open-swe"), false)
   assert.equal(isGithubOAuthUrl("https://evil.example/login/oauth/authorize"), false)
 })


### PR DESCRIPTION
Keep GitHub organization SAML and identity-provider redirects in the same Electron window so OAuth state is not split with the system browser.

Test:
- `pnpm --dir desktop check`
- Manual GitHub login against the hosted backend with organization SSO
