### PR TITLE
fix: make prompts and tools source-aware

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1356,7 +1356,10 @@ async def _enrich_run_start_command(
         if metadata.get("source") == "slack":
             content = _prepend_message_content_block(content, DASHBOARD_HANDOFF_INSTRUCTION)
         _set_command_last_message_content(params, content)
-        metadata_update: dict[str, Any] = {"plan_mode": plan_mode_requested}
+        metadata_update: dict[str, Any] = {
+            "source": _DASHBOARD_SOURCE,
+            "plan_mode": plan_mode_requested,
+        }
         if command_images and run_model and run_effort:
             overrides["agent_model_id"] = run_model
             overrides["agent_effort"] = run_effort

--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -18,6 +18,7 @@ from langgraph.store.base import BaseStore
 from langgraph_sdk import get_client
 
 from ..dashboard.options import model_supports_images
+from ..prompt import replace_source_guidance
 from ..utils.dashboard_handoff import (  # noqa: F401
     DASHBOARD_HANDOFF_INSTRUCTION,
     DASHBOARD_HANDOFF_MARKER,
@@ -33,6 +34,7 @@ class LinearNotifyState(AgentState):
 
     linear_messages_sent_count: int
     plan_approval_blocked: NotRequired[bool]
+    rendered_system_prompt: NotRequired[str | None]
 
 
 async def _resolve_thread_model_id(thread_id: str) -> str | None:
@@ -99,6 +101,7 @@ def _message_update(
     thread_id: str,
     *,
     plan_approval_blocked: bool | None = None,
+    rendered_system_prompt: str | None = None,
 ) -> dict[str, Any] | None:
     if not content_blocks:
         return None
@@ -110,6 +113,8 @@ def _message_update(
     update: dict[str, Any] = {"messages": [{"role": "user", "content": content_blocks}]}
     if plan_approval_blocked is not None:
         update["plan_approval_blocked"] = plan_approval_blocked
+    if rendered_system_prompt is not None:
+        update["rendered_system_prompt"] = rendered_system_prompt
     return update
 
 
@@ -178,6 +183,7 @@ async def check_message_queue_before_model(  # noqa: PLR0911
 
         content_blocks: list[dict[str, Any]] = []
         plan_approval_blocked: bool | None = None
+        dashboard_handoff = False
         pending_autofix = await _consume_pending_autofix_event(store, thread_id)
         if pending_autofix:
             content_blocks.append({"type": "text", "text": pending_autofix})
@@ -220,6 +226,7 @@ async def check_message_queue_before_model(  # noqa: PLR0911
         for msg in queued_messages:
             content = msg.get("content")
             if _is_dashboard_queued_message(content):
+                dashboard_handoff = True
                 content_blocks.append({"type": "text", "text": DASHBOARD_HANDOFF_INSTRUCTION})
                 if _dashboard_queued_message_from_owner(content):
                     plan_approval_blocked = False
@@ -240,8 +247,16 @@ async def check_message_queue_before_model(  # noqa: PLR0911
                 logger.debug("Queued message contains text content")
                 content_blocks.append({"type": "text", "text": content})
 
+        rendered_prompt = state.get("rendered_system_prompt")
+        if dashboard_handoff and isinstance(rendered_prompt, str):
+            rendered_prompt = replace_source_guidance(rendered_prompt, "dashboard")
+        else:
+            rendered_prompt = None
         return _message_update(
-            content_blocks, thread_id, plan_approval_blocked=plan_approval_blocked
+            content_blocks,
+            thread_id,
+            plan_approval_blocked=plan_approval_blocked,
+            rendered_system_prompt=rendered_prompt,
         )  # noqa: TRY300
     except Exception:
         logger.exception("Error in check_message_queue_before_model")

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -50,7 +50,7 @@ def _load_default_prompt() -> str:
 # Static, run-invariant guidance for the main agent. The per-thread,
 # main-agent-specific prompt (working dir, repo setup, PR workflow,
 # source-channel reply) is layered in front of this via `construct_system_prompt`.
-OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on LangGraph and Deep Agents, operating in a remote, git-backed Linux sandbox invoked from Slack, Linear, or GitHub.
+OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on LangGraph and Deep Agents, operating in a remote, git-backed Linux sandbox invoked from the dashboard or an external integration.
 
 ### Core Behavior
 
@@ -81,13 +81,7 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 
 - Focus on the substance and keep summaries brief. Use light markdown (`###`/`####` headings, bold, code) — avoid `#`/`##` titles.
 - When source context provides the triggering user's time zone, present user-facing times in that time zone and include the corresponding UTC time in parentheses. Do not guess a time zone when none is provided.
-- Whenever calling `slack_thread_reply`, make `message` as concise as possible while still conveying all necessary information. Default to one sentence containing only the outcome/status and link, or one blocking question. Omit greetings, preambles, headings, recaps, implementation details, and redundant context; use bullets only when multiple items are essential.
-- For every initial Slack-triggered request handled by the main agent (not a delegated subagent), immediately send a brief first reply that rephrases your understanding of the request; never use only a generic acknowledgement such as `On it!`. Make `slack_thread_reply` your first tool call: do not call investigative tools or run shell commands before sending this reply.
-- Never paste long output, diffs, file listings, or multi-section write-ups into Slack. When detail is necessary, write it to a Markdown file under `/workspace/plans/`, publish it with `save_plan`, and send only a one-line summary plus the plan-review link. This non-plan share path does not enter plan mode.
-- Be extremely conservative with top-level Slack channel messages: almost always post only a short headline there and put all supporting context and details in the thread.
-- In Slack, when a user asks to “break out,” “split out,” or “start a separate thread” for part of the work, use a headline-only title, summarize the requested aspect and relevant context into self-contained instructions, then call `slack_start_new_thread`; the tool puts those instructions in the first thread reply.
-- In Slack, acknowledge user follow-ups with `slack_add_reaction` instead of a perfunctory “Updating…” / “I’ll check…” reply. Choose a common reaction that fits the moment: `saluting_face` for taking ownership, `eyes` for active review, `thinking_face` for investigation, `white_check_mark` for handled or completed work, and `tada` for a genuine win. Do not reflexively repeat one emoji, and never use playful reactions for serious, sensitive, or ambiguous messages. Never react to a root-level Slack post containing a pull request link with `white_check_mark`, because it can imply that the PR has been approved; use a neutral context-appropriate reaction instead.
-- For Slack-triggered runs, `slack_thread_reply` is the canonical user-facing output and is also visible in the Web UI. For information-only requests, send the complete answer there — not merely a summary — and do not repeat it in the final assistant response. If a final assistant response needs additional content, include only material not already sent to Slack.
+- Follow the Source Context section for acknowledgements, progress updates, plan review, and final delivery. Do not communicate through a different surface unless the user explicitly asks.
 - When delegated work to a subagent: the calling agent only sees your final message, so make it the complete answer.
 
 IMPORTANT: You must ALWAYS call a tool in EVERY SINGLE TURN. If you don't call a tool, the session will end and you won't be able to resume without the user manually restarting you.
@@ -108,11 +102,82 @@ The active dashboard base URL for this deployment is `{dashboard_base_url}`. Use
 """
 
 
+SOURCE_GUIDANCE_OPEN_TAG = "<open_swe_source_context>"
+SOURCE_GUIDANCE_CLOSE_TAG = "</open_swe_source_context>"
+
+DASHBOARD_SOURCE_GUIDANCE = """This run is being handled in the dashboard/Web UI.
+- Communicate through normal assistant responses; do not use source-channel messaging tools unless the user explicitly asks you to act there.
+- For information-only requests, put the complete answer in the normal assistant response.
+- When a plan is ready, share its review link in the normal assistant response and ask the user to approve it or request changes.
+- After completing requested work, report the concise outcome and link in the normal assistant response."""
+
+SLACK_SOURCE_GUIDANCE = """This run was triggered from Slack.
+- Immediately send a brief first reply that rephrases your understanding of the request. Make `slack_thread_reply` your first tool call before investigation; never use only a generic acknowledgement such as `On it!`.
+- `slack_thread_reply` is the canonical user-facing output. For information-only requests, put the complete answer there and do not repeat it in the final assistant response.
+- Keep every `slack_thread_reply` as concise as possible: default to one sentence with only the outcome/status and link, or one blocking question. Omit greetings, preambles, headings, recaps, implementation details, and redundant context; use bullets only when multiple items are essential.
+- Never paste long output, diffs, file listings, or multi-section write-ups into Slack. Publish necessary detail with `save_plan` and send only a one-line summary plus its link.
+- For follow-ups, use `slack_add_reaction` instead of a perfunctory status reply. Never react to a root post containing a pull request link with `white_check_mark`.
+- When asked to break out work, use `slack_start_new_thread` with a headline-only title and self-contained instructions.
+- When a plan is ready, send its review link with `slack_thread_reply` and ask the owner to reply in the thread to approve or request changes; do not send approval buttons."""
+
+LINEAR_SOURCE_GUIDANCE = """This run was triggered from Linear.
+- Use `linear_comment` for essential questions, progress updates, plan-review links, and the final outcome.
+- For information-only requests, put the complete answer in the Linear comment and do not duplicate it in the final assistant response."""
+
+GITHUB_SOURCE_GUIDANCE = """This run was triggered from GitHub.
+- Use `gh issue comment` or `gh pr comment`, as appropriate, for essential questions, plan-review links, and the final outcome.
+- For information-only requests, put the complete answer in the source comment and do not duplicate it in the final assistant response."""
+
+SCHEDULE_SOURCE_GUIDANCE = """This is a scheduled automation run with no interactive source channel.
+- Do not send an initial acknowledgement.
+- After a concrete requested action, call `notify_automation_channel` once with a concise outcome and link."""
+
+SCHEDULE_SLACK_SOURCE_GUIDANCE = """This is a scheduled automation run with a validated Slack destination.
+- Do not send an initial acknowledgement.
+- After a concrete requested action, call `notify_automation_channel` once with a concise outcome and link.
+- Use Slack thread tools only when the scheduled task explicitly requires interaction in that destination."""
+
+GENERIC_SOURCE_GUIDANCE = """No interactive source channel is available.
+- Communicate through normal assistant responses and include the complete answer or final outcome there.
+- When a plan is ready, share its review link in the normal assistant response."""
+
+SOURCE_GUIDANCE_SECTION = """---
+
+### Source Context
+
+{source_guidance}"""
+
+
+def _render_source_guidance(source: str, slack_context: bool) -> str:
+    if source == "slack" and slack_context:
+        guidance = SLACK_SOURCE_GUIDANCE
+    elif source == "linear":
+        guidance = LINEAR_SOURCE_GUIDANCE
+    elif source == "github":
+        guidance = GITHUB_SOURCE_GUIDANCE
+    elif source == "schedule":
+        guidance = SCHEDULE_SLACK_SOURCE_GUIDANCE if slack_context else SCHEDULE_SOURCE_GUIDANCE
+    elif source == "dashboard":
+        guidance = DASHBOARD_SOURCE_GUIDANCE
+    else:
+        guidance = GENERIC_SOURCE_GUIDANCE
+    return f"{SOURCE_GUIDANCE_OPEN_TAG}\n{guidance}\n{SOURCE_GUIDANCE_CLOSE_TAG}"
+
+
+def replace_source_guidance(prompt: str, source: str, *, slack_context: bool = False) -> str:
+    start = prompt.find(SOURCE_GUIDANCE_OPEN_TAG)
+    end = prompt.find(SOURCE_GUIDANCE_CLOSE_TAG, start)
+    if start < 0 or end < 0:
+        return prompt
+    end += len(SOURCE_GUIDANCE_CLOSE_TAG)
+    return prompt[:start] + _render_source_guidance(source, slack_context) + prompt[end:]
+
+
 PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link according to the Source Context section. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -128,7 +193,7 @@ You are in a read-only research-and-planning phase for the target repo. Your sin
 
 Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside the target repo, run state-changing `execute` commands except creating `/workspace/plans` (no `git commit`/`push`/`checkout -b`, installs, code generators, or file-rewriting formatters), commit, push, open/update a PR, call `request_pr_review`, or mutate Linear/external systems. The `task` subagent is disabled here (subagents wouldn't inherit these restrictions) — research directly.
 
-**You MAY:** clone and read the repo (`read_file`, `ls`, `glob`, `grep`, read-only `execute` like `git clone`/`status`/`log`/`diff`, `cat`, `rg`), research with `web_search`/`fetch_url`, ask clarifying questions via `slack_thread_reply` / `linear_comment`, use `execute` only if needed to create `/workspace/plans`, and use `write_file` / `edit_file` only to create or revise the plan file outside any repo under `/workspace/plans/`.
+**You MAY:** clone and read the repo (`read_file`, `ls`, `glob`, `grep`, read-only `execute` like `git clone`/`status`/`log`/`diff`, `cat`, `rg`), research with `web_search`/`fetch_url`, ask clarifying questions through the response path in Source Context, use `execute` only if needed to create `/workspace/plans`, and use `write_file` / `edit_file` only to create or revise the plan file outside any repo under `/workspace/plans/`.
 
 **Workflow:** explore the relevant code enough to choose a sound approach, clarify ambiguity, choose a dated, descriptive plan path like `/workspace/plans/YYYY-MM-DD-short-task-slug.md`, create it with ONE recommended plan, refine it with normal file-editing tools if needed, then publish it with `save_plan` by passing that exact `plan_file_path`. Keep it high level: focus on desired behavior, architecture boundaries, product decisions, tradeoffs, rollout/migration concerns, and verification. Avoid file/function-level details and exhaustive file lists unless a specific implementation detail is unusually tricky, risky, or controversial. Aim for about one page or less unless the task truly requires more. If the user approves the current plan, asks to exit plan mode, or asks to implement the plan, call `approve_plan` before implementation. After `approve_plan` succeeds, plan mode is inactive for this run and you should implement the approved plan. Use this structure:
 
@@ -149,7 +214,7 @@ Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside 
 - <targeted tests or manual checks that prove the behavior>
 ```
 
-After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, use plain text and tell the plan owner to reply in the thread to approve or request changes; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
+After saving, follow the Source Context section to share the plan-review link and invite the user to review, approve, or request changes, then stop. Do not implement — you will be re-invoked with the approval and any feedback."""
 
 
 SELF_AWARENESS_SECTION = """---
@@ -186,11 +251,11 @@ TASK_EXECUTION_SECTION = """---
 
 First decide: is the user asking for code/repository changes, or for information only? Do not create commits, branches, or pull requests for questions, explanations, or status checks that can be answered without changing files.
 
-Call `request_pr_review` only when the user explicitly asks to review a GitHub pull request or explicitly asks to start/run the reviewer agent. Requests to analyze, inspect, explain, or assess a PR or diff are information-only requests, not review requests, and must not invoke the reviewer. For an explicit Slack- or GitHub-triggered review request, do not clone/edit/commit/push/open a PR — call `request_pr_review` once with the PR URL, reply in the source channel saying whether the review started or why not, and stop.
+Call `request_pr_review` only when the user explicitly asks to review a GitHub pull request or explicitly asks to start/run the reviewer agent. Requests to analyze, inspect, explain, or assess a PR or diff are information-only requests, not review requests, and must not invoke the reviewer. For an explicit review request, do not clone/edit/commit/push/open a PR — call `request_pr_review` once with the PR URL, report whether the review started through the response path in Source Context, and stop.
 
 **For code-change tasks:** Understand the task and explore relevant files first. Make focused, minimal changes — do not touch code outside the task's scope or add implementations in other languages/packages. Verify with linters and only the tests related to your changes. Then commit, push, and (when a PR is warranted) open/update the draft PR — see Committing below.
 
-**For information-only requests:** First identify any relevant git repositories and check them out before answering, so your response is grounded in current repo state. Gather what you need and answer fully. For Slack-triggered requests, send the complete answer through `slack_thread_reply` and do not repeat it in the final assistant response; for other sources, answer in the normal assistant response. Never leave a question unanswered. Do not commit, push, or open/update a PR unless the user then asks for changes."""
+**For information-only requests:** First identify any relevant git repositories and check them out before answering, so your response is grounded in current repo state. Gather what you need and answer fully through the response path in Source Context. Never leave a question unanswered. Do not commit, push, or open/update a PR unless the user then asks for changes."""
 
 
 CORRIDOR_PROMPT = """---
@@ -213,7 +278,7 @@ Install dependencies only if the task requires it, using the project's package m
 - If a focused verification command fails because a declared tool or dependency is missing (for example: `command not found`, `ModuleNotFoundError`, or a missing test runner/linter), try the appropriate project install/sync command once, then rerun the same focused verification. If installation still fails, report the blocker instead of silently skipping verification.
 - Before ADDING a dependency the project doesn't already declare, confirm the task can't be solved with the standard library or a package already in the project's manifest/lockfile — prefer what's there.
 - Vet any genuinely new package before adding it: actively maintained (recent release, responsive issues, more than a single maintainer, steady downloads), free of known unpatched CVEs (`npm audit` / `pip-audit` or the GitHub advisory DB), and under a permissive license (MIT, Apache-2.0, BSD). Do not add abandoned, single-source, or unlicensed packages. Pin or bound every newly added dependency to a specific version; never add a floating or unpinned dependency.
-- For any dependency you add, surface it for human review. You can stop to ask: post a question or note in the source Slack thread (or, for non-Slack tasks, the PR description) and end your turn without making a tool call — the user can reply and the run will resume. This is an exception to the autonomy rule. List the package name, why it is needed, its maintenance/security status, and the alternatives you considered, in the PR description too so a reviewer can veto it."""
+- For any dependency you add, surface it for human review through the response path in Source Context, then end your turn so the user can reply and the run can resume. This is an exception to the autonomy rule. List the package name, why it is needed, its maintenance/security status, and the alternatives you considered in the PR description too so a reviewer can veto it."""
 
 
 EXTERNAL_UNTRUSTED_COMMENTS_SECTION = f"""---
@@ -250,9 +315,9 @@ Steps, in order:
    ## Test Plan
    - [ ] <new/novel verification steps only — not "run existing tests">
    ```
-   `open_pull_request` appends a `## References` section automatically for plans, and for originating Slack/Linear/GitHub source references only on private repos. For public repos, don't manually reference private repos, Slack threads, or PR/issue numbers. Commit messages: concise, focused on the "why"; default to the PR title.
+   `open_pull_request` appends a `## References` section automatically for plans and private originating-source references. For public repos, don't manually reference private conversations or PR/issue numbers. Commit messages: concise, focused on the "why"; default to the PR title.
 
-3. **Notify the source** right after pushing (and PR open/update) succeeds, with a brief summary plus the PR link (or branch URL if no PR): `linear_comment` (with an `@mention`) for Linear, `slack_thread_reply` for Slack, `gh issue comment`/`pr comment` for GitHub. Skip if there is no known source channel.
+3. **Notify the source** right after pushing (and PR open/update) succeeds, with a brief summary plus the PR link (or branch URL if no PR), using the response path in Source Context.
 
 **Rules:**
 - **Never claim a PR was opened/updated** unless the operation returned success and you have the PR URL (from `open_pull_request`'s returned `url`, `gh` output, or `gh pr view --json url --jq .url`). If push or PR creation fails, or there are no changes, say so explicitly. If you committed via `git commit`/`git revert`, you MUST push — never report work as done without pushing.
@@ -340,6 +405,7 @@ def _render_user_instructions_section(instructions: str | None) -> str:
 SYSTEM_PROMPT_TEMPLATE = (
     WORKING_ENV_SECTION
     + DASHBOARD_CONTEXT_SECTION
+    + SOURCE_GUIDANCE_SECTION
     + PLAN_MODE_GUIDANCE_SECTION
     + "{plan_mode_section}"
     + SELF_AWARENESS_SECTION
@@ -373,6 +439,8 @@ def construct_system_prompt(
     user_custom_instructions: str | None = None,
     thread_url: str | None = None,
     corridor_enabled: bool = False,
+    source: str = "dashboard",
+    slack_context: bool = False,
 ) -> str:
     default_prompt_section = _load_default_prompt()
     if default_repo and default_repo.get("owner") and default_repo.get("name"):
@@ -392,6 +460,7 @@ def construct_system_prompt(
     return SYSTEM_PROMPT_TEMPLATE.format(
         working_dir=working_dir,
         dashboard_base_url=dashboard_base_url or "(dashboard URL unavailable)",
+        source_guidance=_render_source_guidance(source, slack_context),
         linear_project_id=linear_project_id or "<PROJECT_ID>",
         linear_issue_number=linear_issue_number or "<ISSUE_NUMBER>",
         plan_review_url=plan_url or "(the dashboard plan-review page)",

--- a/agent/server.py
+++ b/agent/server.py
@@ -960,6 +960,8 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 user_custom_instructions=user_custom_instructions,
                 thread_url=dashboard_thread_url(self._thread_id),
                 corridor_enabled=self._corridor_enabled,
+                source=self._source,
+                slack_context=_slack_tools_enabled(configurable),
             ),
         }
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -1162,8 +1162,14 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         recreate_sandbox,
         report_platform_issue,
         schedule_thread_wakeup,
-        *(slack_tools if _slack_tools_enabled(configurable) else []),
+        slack_add_reaction,
+        slack_read_thread_messages,
+        slack_start_new_thread,
+        slack_thread_reply,
     ]
+    reserved_tool_names = {tool.__name__ for tool in static_tools}
+    if not _slack_tools_enabled(configurable):
+        static_tools = [tool for tool in static_tools if tool not in slack_tools]
     dynamic_tool_middleware: DynamicToolMiddleware | None = None
     integration_tool_groups = {
         "Corridor": corridor_tools,
@@ -1174,10 +1180,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if any(integration_tool_groups.values()):
         dynamic_tool_middleware = DynamicToolMiddleware(
             integration_tool_groups,
-            reserved_names={
-                *DEEP_AGENT_TOOL_NAMES,
-                *(tool.__name__ for tool in [*static_tools, *slack_tools]),
-            },
+            reserved_names={*DEEP_AGENT_TOOL_NAMES, *reserved_tool_names},
         )
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)

--- a/agent/server.py
+++ b/agent/server.py
@@ -785,6 +785,19 @@ async def _cached_profile(profile_login: str | None):
     )
 
 
+def _slack_tools_enabled(configurable: dict[str, Any]) -> bool:
+    """Return whether the run has trusted Slack source context."""
+    if configurable.get("source") not in {"slack", "schedule"}:
+        return False
+    slack_thread = configurable.get("slack_thread")
+    if not isinstance(slack_thread, dict):
+        return False
+    return all(
+        isinstance(slack_thread.get(key), str) and bool(slack_thread[key].strip())
+        for key in ("channel_id", "thread_ts")
+    )
+
+
 def _make_model_or_defer(
     model_id: str,
     *,
@@ -1119,6 +1132,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             ),
         )
 
+    slack_tools = [
+        slack_add_reaction,
+        slack_read_thread_messages,
+        slack_start_new_thread,
+        slack_thread_reply,
+    ]
     static_tools = [
         http_request,
         fetch_url,
@@ -1143,10 +1162,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         recreate_sandbox,
         report_platform_issue,
         schedule_thread_wakeup,
-        slack_add_reaction,
-        slack_read_thread_messages,
-        slack_start_new_thread,
-        slack_thread_reply,
+        *(slack_tools if _slack_tools_enabled(configurable) else []),
     ]
     dynamic_tool_middleware: DynamicToolMiddleware | None = None
     integration_tool_groups = {
@@ -1158,7 +1174,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if any(integration_tool_groups.values()):
         dynamic_tool_middleware = DynamicToolMiddleware(
             integration_tool_groups,
-            reserved_names={*DEEP_AGENT_TOOL_NAMES, *(tool.__name__ for tool in static_tools)},
+            reserved_names={
+                *DEEP_AGENT_TOOL_NAMES,
+                *(tool.__name__ for tool in [*static_tools, *slack_tools]),
+            },
         )
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -38,14 +38,18 @@ def _base_config() -> RunnableConfig:
     }
 
 
-async def _capture_create_deep_agent_kwargs() -> dict[str, object]:
+async def _capture_create_deep_agent_kwargs(
+    config: RunnableConfig | None = None,
+) -> dict[str, object]:
     captured: dict[str, object] = {}
+    config = config or _base_config()
+    thread_id = "thread-ctx"
 
     def fake_create_deep_agent(**kwargs: object) -> _DummyAgent:
         captured.update(kwargs)
         return _DummyAgent()
 
-    clear_sandbox_backend("thread-ctx")
+    clear_sandbox_backend(thread_id)
     with (
         patch(
             "agent.server.resolve_github_token",
@@ -74,9 +78,9 @@ async def _capture_create_deep_agent_kwargs() -> dict[str, object]:
         patch("agent.server.construct_system_prompt", return_value="prompt"),
         patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
-        await get_agent(_base_config())
+        await get_agent(config)
 
-    clear_sandbox_backend("thread-ctx")
+    clear_sandbox_backend(thread_id)
     return captured
 
 
@@ -188,6 +192,59 @@ async def test_agent_includes_recreate_sandbox_tool() -> None:
     tools = captured["tools"]
     assert isinstance(tools, list)
     assert recreate_sandbox in tools
+
+
+@pytest.mark.asyncio
+async def test_dashboard_agent_excludes_slack_tools() -> None:
+    config = _base_config()
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    configurable.update(
+        {
+            "source": "dashboard",
+            "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"},
+        }
+    )
+
+    captured = await _capture_create_deep_agent_kwargs(config)
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+
+    tool_names = {getattr(tool, "name", None) or getattr(tool, "__name__", None) for tool in tools}
+    assert tool_names.isdisjoint(
+        {
+            "slack_add_reaction",
+            "slack_read_thread_messages",
+            "slack_start_new_thread",
+            "slack_thread_reply",
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["slack", "schedule"])
+async def test_slack_source_context_includes_slack_tools(source: str) -> None:
+    config = _base_config()
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    configurable.update(
+        {
+            "source": source,
+            "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"},
+        }
+    )
+
+    captured = await _capture_create_deep_agent_kwargs(config)
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+
+    tool_names = {getattr(tool, "name", None) or getattr(tool, "__name__", None) for tool in tools}
+    assert {
+        "slack_add_reaction",
+        "slack_read_thread_messages",
+        "slack_start_new_thread",
+        "slack_thread_reply",
+    } <= tool_names
 
 
 @pytest.mark.asyncio

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -610,6 +610,7 @@ async def test_enrich_run_start_command_adds_web_handoff_for_slack_thread(monkey
     assert content[1] == {"type": "text", "text": "@teammate: continue here"}
     assert content[0]["text"].startswith("<open_swe_web_handoff>\n")
     assert content[0]["text"].endswith("\n</open_swe_web_handoff>")
+    assert enriched["params"]["config"]["configurable"]["source"] == "dashboard"
 
 
 async def test_enrich_run_start_command_adds_web_handoff_before_image_blocks(monkeypatch) -> None:

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -93,16 +93,41 @@ def test_construct_system_prompt_includes_operational_safeguards() -> None:
 def test_slack_information_only_response_uses_single_output_path() -> None:
     from agent.tools.slack_thread_reply import slack_thread_reply
 
-    prompt = construct_system_prompt(working_dir="/workspace")
+    prompt = construct_system_prompt(working_dir="/workspace", source="slack", slack_context=True)
     tool_guidance = " ".join((slack_thread_reply.__doc__ or "").split())
 
-    assert "send the complete answer there" in prompt
-    assert "send the complete answer through `slack_thread_reply`" in prompt
+    assert "`slack_thread_reply` is the canonical user-facing output" in prompt
+    assert "put the complete answer there" in prompt
     assert "complete answer in `message`, not merely a summary" in tool_guidance
     assert "do not repeat it in the final assistant response" in prompt
     assert "do not repeat it in the final assistant response" in tool_guidance
-    assert "answer fully inline" not in prompt
-    assert "not normal web UI assistant messages" not in tool_guidance
+
+
+def test_dashboard_prompt_uses_normal_assistant_responses() -> None:
+    prompt = construct_system_prompt(working_dir="/workspace")
+
+    assert "This run is being handled in the dashboard/Web UI" in prompt
+    assert "put the complete answer in the normal assistant response" in prompt
+    assert "slack_thread_reply" not in prompt
+    assert "slack_add_reaction" not in prompt
+
+
+def test_non_web_source_prompts_use_their_own_delivery_paths() -> None:
+    expected = {
+        "linear": "Use `linear_comment`",
+        "github": "Use `gh issue comment` or `gh pr comment`",
+        "schedule": "call `notify_automation_channel` once",
+    }
+
+    for source, guidance in expected.items():
+        prompt = construct_system_prompt(working_dir="/workspace", source=source)
+        assert guidance in prompt
+        assert "Make `slack_thread_reply` your first tool call" not in prompt
+
+    scheduled_slack = construct_system_prompt(
+        working_dir="/workspace", source="schedule", slack_context=True
+    )
+    assert "validated Slack destination" in scheduled_slack
 
 
 def test_construct_system_prompt_includes_shared_base_explicitly() -> None:

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -11,6 +11,7 @@ from agent.middleware.check_message_queue import (
     _build_blocks_from_payload,
     check_message_queue_before_model,
 )
+from agent.prompt import construct_system_prompt
 
 
 class _QueuedItem:
@@ -43,6 +44,9 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         }
     )
 
+    slack_prompt = construct_system_prompt(
+        working_dir="/workspace", source="slack", slack_context=True
+    )
     with (
         patch(
             "agent.middleware.check_message_queue.get_config",
@@ -51,7 +55,11 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         patch("agent.middleware.check_message_queue.get_store", return_value=store),
     ):
         result = await check_message_queue_before_model.abefore_model(
-            cast(LinearNotifyState, {"messages": []}), MagicMock()
+            cast(
+                LinearNotifyState,
+                {"messages": [], "rendered_system_prompt": slack_prompt},
+            ),
+            MagicMock(),
         )
 
     assert result is not None
@@ -60,6 +68,8 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
     assert DASHBOARD_HANDOFF_MARKER in message["content"][0]["text"]
     assert message["content"][1] == {"type": "text", "text": "continue in web"}
     assert result["plan_approval_blocked"] is True
+    assert "dashboard/Web UI" in result["rendered_system_prompt"]
+    assert "Make `slack_thread_reply` your first tool call" not in result["rendered_system_prompt"]
     assert store.deleted == [(("queue", "thread-1"), "pending_messages")]
 
 


### PR DESCRIPTION
## Description
Dashboard runs no longer inherit Slack tools or instructions. Prompt guidance now follows the active source and hot-swaps to web behavior when a Slack thread continues in the dashboard.

## Release Note
Fixed dashboard agents replying in Slack after a conversation moves to Web.

## Test Plan
- [x] Verify source-specific prompt/tool gating and Slack-to-Web handoffs.

Made by [Open SWE](https://openswe.vercel.app/agents/a226bcc7-17ef-00d8-9e21-bbc092369563)