### PR TITLE
feat: add Slack buttons for plan approvals

### DIFF
--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -202,9 +202,9 @@ async def approve_plan_for_thread(
     await set_plan_status(thread_id, PLAN_STATUS_APPROVED, plan_mode=False)
     if plan_markdown:
         text = (
-            "The plan has been approved. Implement it now exactly as written "
-            "below (it may have been edited by the reviewer, so treat this as "
-            f"the source of truth):\n\n{plan_markdown}"
+            "The plan has been approved. Use the reviewed plan below as the implementation "
+            "guide. Apply reasonable engineering judgment where details need adjustment while "
+            f"preserving its goals and reviewer edits:\n\n{plan_markdown}"
         )
     else:
         text = "The plan has been approved. Implement it now as described in the plan."

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -112,7 +112,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to reply in the thread to approve the plan or request changes; do not send plan-approval buttons. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
+If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link with the user. In Slack, ask the plan owner to choose from `options=["Approve & implement", "Request changes"]` in `slack_thread_reply`; they can still reply manually with feedback. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
 
@@ -149,7 +149,7 @@ Until `approve_plan` succeeds, **you MUST NOT** edit/create/delete files inside 
 - <targeted tests or manual checks that prove the behavior>
 ```
 
-After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, use plain text and tell the plan owner to reply in the thread to approve or request changes; do not use Block Kit or approval buttons. Do not implement — you will be re-invoked with the approval and any feedback."""
+After saving, post a brief completion message with the plan-review link via `slack_thread_reply` (Slack) or `linear_comment` (Linear), invite the user to review/comment/approve, then stop. For Slack, pass `options=["Approve & implement", "Request changes"]` to `slack_thread_reply` and invite manual feedback too; use these options rather than constructing custom Block Kit. Do not implement — you will be re-invoked with the approval and any feedback."""
 
 
 SELF_AWARENESS_SECTION = """---

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -132,8 +132,9 @@ def _format_comments(comments: list[dict[str, Any]]) -> str:
 def _approved_message(plan_markdown: str, feedback: str) -> str:
     if plan_markdown:
         message = (
-            "Plan mode is now inactive because the plan was approved. "
-            "Implement the approved plan now. Treat this published plan as the source of truth:\n\n"
+            "Plan mode is now inactive because the plan was approved. Use the reviewed plan "
+            "below as the implementation guide. Apply reasonable engineering judgment where "
+            "details need adjustment while preserving its goals and reviewer edits:\n\n"
             f"{plan_markdown}"
         )
     else:

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -101,9 +101,9 @@ def _build_option_blocks(message: str, options: list[str] | None) -> list[dict[s
                     "type": "button",
                     "text": {"type": "plain_text", "text": option[:75], "emoji": True},
                     "value": json.dumps({"type": "open_swe_option", "response": option}),
-                    "action_id": "open_swe_option_select",
+                    "action_id": f"open_swe_option_select_{index}",
                 }
-                for option in clean_options[:5]
+                for index, option in enumerate(clean_options[:5])
             ],
         },
     ]
@@ -126,7 +126,7 @@ def build_workflow_approval_blocks(message: str, fingerprint: str) -> list[dict[
                             "fingerprint": fingerprint,
                         }
                     ),
-                    "action_id": "open_swe_option_select",
+                    "action_id": "open_swe_option_select_approve",
                 },
                 {
                     "type": "button",
@@ -139,7 +139,7 @@ def build_workflow_approval_blocks(message: str, fingerprint: str) -> list[dict[
                             "fingerprint": fingerprint,
                         }
                     ),
-                    "action_id": "open_swe_option_select",
+                    "action_id": "open_swe_option_select_reject",
                 },
             ],
         },

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -44,8 +44,9 @@ async def slack_thread_reply(
     render interactive buttons and the web UI will render the same choices.
     The user can still reply manually in the Slack thread.
 
-    When a plan is ready, post a plain-text summary with the dashboard review link
-    and ask the user to reply in the thread to approve it or request changes.
+    When a plan is ready, post a concise summary with the dashboard review link and
+    pass `options=["Approve & implement", "Request changes"]`. The user can still
+    reply manually with feedback.
 
     To mention/tag a user, use Slack's mention format: <@USER_ID>.
     You can find user IDs in the conversation context (e.g. @Name(U06KD8BFY95)).

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -383,7 +383,10 @@ def _first_open_swe_option_action(actions: common.Any) -> dict[str, common.Any] 
     if not isinstance(actions, list):
         return None
     for action in actions:
-        if isinstance(action, dict) and action.get("action_id") == "open_swe_option_select":
+        action_id = action.get("action_id") if isinstance(action, dict) else None
+        if isinstance(action_id, str) and (
+            action_id == "open_swe_option_select" or action_id.startswith("open_swe_option_select_")
+        ):
             return action
     return None
 

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -17,6 +17,13 @@ def test_construct_system_prompt_gates_active_plan_mode(enabled: bool) -> None:
     assert ("### Plan Mode (ACTIVE)" in prompt) is enabled
 
 
+def test_plan_mode_prompt_requests_slack_approval_options() -> None:
+    prompt = construct_system_prompt(working_dir="/work", plan_mode=True)
+
+    assert 'options=["Approve & implement", "Request changes"]' in prompt
+    assert "do not use Block Kit or approval buttons" not in prompt
+
+
 def test_plan_mode_excluded_tools_cover_mutating_tools() -> None:
     excluded = server.PLAN_MODE_EXCLUDED_TOOLS
     for tool in (
@@ -254,6 +261,8 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
     assert messages[0].tool_call_id == "call-1"
     assert "# Plan" in messages[0].content
     assert "add tests" in messages[0].content
+    assert "reasonable engineering judgment" in messages[0].content
+    assert "source of truth" not in messages[0].content
 
 
 async def test_approve_plan_tool_rejects_non_owner_followup(
@@ -338,6 +347,7 @@ async def test_approve_plan_tool_rejects_non_owner(monkeypatch: pytest.MonkeyPat
     "reply",
     [
         "approve",
+        "Approve & implement",
         "Approved!",
         "Looks good to me.",
         "go ahead",

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -711,9 +711,10 @@ async def test_approve_plan_dispatches_published_markdown(
 
     result = await plan_api.approve_plan("t1", session={"sub": "a", "email": None})
     assert result == {"status": "approved", "run_id": "run-1"}
-    # The (possibly edited) published plan is the source of truth, plus feedback.
     assert "# Edited plan" in dispatched["text"]
     assert "use snake_case" in dispatched["text"]
+    assert "reasonable engineering judgment" in dispatched["text"]
+    assert "exactly as written" not in dispatched["text"]
     assert dispatched["plan_mode"] is False
 
 

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -250,7 +250,8 @@ def _plan_complete_step(messages: list[BaseMessage]) -> AIMessage:
                 "name": "slack_thread_reply",
                 "args": {
                     "message": f"✅ The plan is ready for review: <{url}|open the plan>. "
-                    "Take a look, leave comments, and approve it when you're happy."
+                    "Take a look, leave comments, and choose what to do next.",
+                    "options": ["Approve & implement", "Request changes"],
                 },
                 "id": "call-plan-done",
             }

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -22,7 +22,7 @@ import uuid
 from html import escape
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -144,6 +144,21 @@ async def _deliver_slack_event(payload: dict[str, Any], retry_num: str = "") -> 
         return await client.post("/webhooks/slack", content=raw, headers=headers)
 
 
+async def _deliver_slack_interaction(payload: dict[str, Any]) -> httpx.Response:
+    raw = urlencode({"payload": json.dumps(payload)}).encode()
+    req_ts = str(int(time.time()))
+    base = f"v0:{req_ts}:{raw.decode()}".encode()
+    sig = "v0=" + hmac.new(SLACK_SIGNING_SECRET.encode(), base, hashlib.sha256).hexdigest()
+    headers = {
+        "X-Slack-Signature": sig,
+        "X-Slack-Request-Timestamp": req_ts,
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://harness") as client:
+        return await client.post("/webhooks/slack/interactivity", content=raw, headers=headers)
+
+
 def _slack_send_result(payload: dict[str, Any], resp: httpx.Response) -> JSONResponse:
     event = payload["event"]
     channel = str(event["channel"])
@@ -229,6 +244,33 @@ async def slack_send(request: Request) -> JSONResponse:
     }
     LAST_SLACK_EVENT["payload"] = payload
     return _slack_send_result(payload, await _deliver_slack_event(payload))
+
+
+@app.post("/mock/slack/action")
+async def slack_action(request: Request) -> JSONResponse:
+    body = await request.json()
+    action = body.get("action")
+    channel_id = str(CURRENT_THREAD.get("channel") or "")
+    thread_ts = str(body.get("thread_ts") or CURRENT_THREAD.get("thread_ts") or "")
+    message_ts = str(body.get("message_ts") or "")
+    user_id = str(body.get("user") or TEST_USERS[0]["slack_id"])
+    if not isinstance(action, dict) or not channel_id or not thread_ts or not message_ts:
+        raise HTTPException(status_code=400, detail="Missing Slack action context")
+
+    payload = {
+        "type": "block_actions",
+        "user": {"id": user_id},
+        "channel": {"id": channel_id},
+        "container": {
+            "channel_id": channel_id,
+            "message_ts": message_ts,
+            "thread_ts": thread_ts,
+        },
+        "message": {"ts": message_ts, "thread_ts": thread_ts},
+        "actions": [{**action, "action_ts": fakes.next_slack_ts()}],
+    }
+    response = await _deliver_slack_interaction(payload)
+    return JSONResponse(response.json(), status_code=response.status_code)
 
 
 @app.post("/control/login")
@@ -474,6 +516,7 @@ async def slack_messages() -> JSONResponse:
                 "is_bot": m["is_bot"],
                 "ts": m["ts"],
                 "thread_ts": m["thread_ts"],
+                "blocks": m["blocks"],
             }
             for m in msgs
         ]

--- a/tests/e2e/static/slack.html
+++ b/tests/e2e/static/slack.html
@@ -42,15 +42,45 @@
         } catch (_) {}
       }
 
+      async function sendAction(message, action, button) {
+        button.disabled = true;
+        const response = await fetch("/mock/slack/action", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action,
+            message_ts: message.ts,
+            thread_ts: message.thread_ts,
+            user: $("user").value,
+          }),
+        });
+        if (!response.ok) button.disabled = false;
+        poll();
+      }
+
       function render(messages) {
         const html = messages
-          .map((m) => {
+          .map((m, index) => {
             const who = m.is_bot ? "open-swe (bot)" : userNames[m.user] || m.user;
             const linked = m.text.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '<a href="$1">$2</a>');
-            return `<div class="msg ${m.is_bot ? "bot" : ""}" data-bot="${m.is_bot}" data-thread-ts="${m.thread_ts || ""}"><div class="who">${who}</div><div class="text">${linked}</div></div>`;
+            return `<div class="msg ${m.is_bot ? "bot" : ""}" data-bot="${m.is_bot}" data-thread-ts="${m.thread_ts || ""}" data-message-index="${index}"><div class="who">${who}</div><div class="text">${linked}</div><div class="actions"></div></div>`;
           })
           .join("");
         $("thread").innerHTML = html || "<p style='color:#888'>No messages yet.</p>";
+        messages.forEach((message, index) => {
+          const actions = (message.blocks || [])
+            .filter((block) => block.type === "actions")
+            .flatMap((block) => block.elements || []);
+          const container = document.querySelector(`[data-message-index="${index}"] .actions`);
+          for (const action of actions) {
+            const button = document.createElement("button");
+            button.type = "button";
+            button.textContent = action.text?.text || "Choose";
+            if (action.style === "primary") button.classList.add("primary");
+            button.addEventListener("click", () => sendAction(message, action, button));
+            container.appendChild(button);
+          }
+        });
       }
 
       async function poll() {

--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -54,6 +54,43 @@ async function addComment(
 }
 
 test.describe("Plan review (HTTP comments)", () => {
+  test("Slack plan approval button starts implementation", async ({ page }) => {
+    test.setTimeout(180_000);
+    await page.goto("/mock/slack");
+    await page.locator("#reset").click();
+    await expect(page.locator("#thread")).toContainText("No messages yet");
+
+    await page
+      .locator("#text")
+      .fill("<@U0BOT> plan how to add a greet() helper");
+    await page.locator("#send").click();
+
+    const ready = page
+      .locator(".msg.bot")
+      .filter({ hasText: /plan is ready for review/i });
+    await expect(ready).toBeVisible({ timeout: 60_000 });
+    const approve = ready.getByRole("button", {
+      name: "Approve & implement",
+    });
+    await expect(approve).toBeVisible();
+    await expect(
+      ready.getByRole("button", { name: "Request changes" }),
+    ).toBeVisible();
+
+    await approve.click();
+
+    const reply = page
+      .locator(".msg.bot")
+      .filter({ has: page.locator('a[href*="/pull/"]') });
+    await expect(reply).toBeVisible({ timeout: 90_000 });
+    await expect(reply).toContainText("Add greet() helper");
+
+    await page.goto("/mock/github");
+    await expect(page.locator('.pr[data-pr="1"]')).toContainText(
+      "Add greet() helper",
+    );
+  });
+
   test("Slack plan request → comments → owner approves → PR", async ({
     browser,
     request,

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -195,7 +195,21 @@ async def test_slack_thread_reply_builds_option_blocks(monkeypatch: pytest.Monke
     actions = captured["blocks"][1]
     assert actions["type"] == "actions"
     assert [button["text"]["text"] for button in actions["elements"]] == ["A", "B"]
-    assert actions["elements"][0]["action_id"] == "open_swe_option_select"
+    action_ids = [button["action_id"] for button in actions["elements"]]
+    assert action_ids == ["open_swe_option_select_0", "open_swe_option_select_1"]
+    assert len(action_ids) == len(set(action_ids))
+
+
+def test_slack_action_ids_are_unique_and_recognized() -> None:
+    slack_routes = importlib.import_module("agent.webhooks.slack_routes")
+    blocks = slack_reply_tool.build_workflow_approval_blocks("Review", "abc")
+    actions = blocks[1]["elements"]
+
+    assert len({action["action_id"] for action in actions}) == len(actions)
+    assert slack_routes._first_open_swe_option_action(actions) is actions[0]
+    legacy = {"action_id": "open_swe_option_select"}
+    assert slack_routes._first_open_swe_option_action([legacy]) is legacy
+    assert slack_routes._first_open_swe_option_action([{"action_id": "unrelated"}]) is None
 
 
 async def test_slack_thread_reply_passes_model_reported_usage(


### PR DESCRIPTION
## Description
Plan-ready Slack messages now offer “Approve & implement” and “Request changes” buttons through the existing options flow. Approved-plan follow-ups also treat the reviewed plan as guidance and allow reasonable engineering judgment instead of requiring exact adherence.

## Test Plan
- [x] Verify the plan prompt requests Slack approval options and recognizes the approval button text.
- [x] Verify both approval paths preserve the reviewed plan and feedback while allowing implementation judgment.
- [x] Drive the Slack buttons through the signed interactivity flow in Playwright and confirm approval opens a PR.

Made by [Open SWE](https://openswe.vercel.app/agents/c43eb11c-dec6-753c-0ffa-ffbd2d785667)