### PR TITLE
fix: exclude plan setup from turn diffs

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1962,11 +1962,16 @@ async def get_dashboard_thread_turn_diff(
         return {"status": "missing", "files": [], "truncated": False}
 
     checkpoint = checkpoints[index]
-    if turn_key is not None and checkpoint.get("plan_mode") is True:
+    plan_ref = checkpoint.get("plan_ref")
+    if (
+        turn_key is not None
+        and checkpoint.get("plan_mode") is True
+        and (not isinstance(plan_ref, str) or plan_ref == checkpoint.get("ref"))
+    ):
         return {"status": "ready", "files": [], "truncated": False}
 
-    head = None
-    if turn_key and index + 1 < len(checkpoints):
+    head = plan_ref if turn_key is not None and isinstance(plan_ref, str) else None
+    if head is None and turn_key and index + 1 < len(checkpoints):
         next_checkpoint = checkpoints[index + 1]
         repo_path = checkpoint.get("repo_path")
         next_repo_path = next_checkpoint.get("repo_path")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1961,14 +1961,37 @@ async def get_dashboard_thread_turn_diff(
     if index < 0 or not checkpoints or not isinstance(sandbox_id, str) or not sandbox_id:
         return {"status": "missing", "files": [], "truncated": False}
 
+    checkpoint = checkpoints[index]
+    if turn_key is not None and checkpoint.get("plan_mode") is True:
+        return {"status": "ready", "files": [], "truncated": False}
+
+    head = None
+    if turn_key and index + 1 < len(checkpoints):
+        next_checkpoint = checkpoints[index + 1]
+        repo_path = checkpoint.get("repo_path")
+        next_repo_path = next_checkpoint.get("repo_path")
+        if (
+            isinstance(repo_path, str)
+            and isinstance(next_repo_path, str)
+            and repo_path != next_repo_path
+        ):
+            return {"status": "missing", "files": [], "truncated": False}
+        head = next_checkpoint["ref"]
+
     try:
         sandbox = await create_sandbox(sandbox_id)
     except Exception:  # noqa: BLE001
         logger.debug("Could not connect to sandbox %s for turn diff", sandbox_id, exc_info=True)
         return {"status": "missing", "files": [], "truncated": False}
 
-    head = checkpoints[index + 1]["ref"] if turn_key and index + 1 < len(checkpoints) else None
-    return await read_turn_diff(sandbox, None, str(checkpoints[index]["ref"]), head)
+    repo_path = checkpoint.get("repo_path")
+    return await read_turn_diff(
+        sandbox,
+        None,
+        str(checkpoint["ref"]),
+        head,
+        repo_path=repo_path if isinstance(repo_path, str) else None,
+    )
 
 
 async def get_dashboard_thread_pr_diff(

--- a/agent/server.py
+++ b/agent/server.py
@@ -10,6 +10,7 @@ the agent itself is stateless.
 
 import logging
 import os
+import posixpath
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
@@ -844,8 +845,12 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         }
 
     async def _record_turn_checkpoint(
-        self, state: PrepareRunState, sandbox_backend: Any, work_dir: str
-    ) -> list[dict[str, str]] | None:
+        self,
+        state: PrepareRunState,
+        sandbox_backend: Any,
+        work_dir: str,
+        preferred_repo_path: str | None,
+    ) -> list[dict[str, Any]] | None:
         """Snapshot the worktree so the dashboard can diff this turn from git.
 
         Keyed by the user message that opened the turn, which is the same id the
@@ -861,16 +866,29 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         )
         if not turn_key:
             return None
-        ref = await record_turn_checkpoint(sandbox_backend, work_dir, turn_key)
-        if ref is None:
+        checkpoint = await record_turn_checkpoint(
+            sandbox_backend,
+            work_dir,
+            turn_key,
+            repo_path=preferred_repo_path,
+        )
+        if checkpoint is None:
             return None
+        ref, repo_path = checkpoint
         try:
             thread = await client.threads.get(thread_id=self._thread_id)
             existing = (thread.get("metadata") or {}).get("turn_checkpoints")
         except Exception:
             logger.debug("Could not read turn checkpoints for %s", self._thread_id, exc_info=True)
             existing = None
-        return merge_checkpoint(existing, turn_key, ref, datetime.now(UTC).isoformat())
+        return merge_checkpoint(
+            existing,
+            turn_key,
+            ref,
+            datetime.now(UTC).isoformat(),
+            repo_path=repo_path,
+            plan_mode=self._plan_mode,
+        )
 
     async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
         github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
@@ -903,7 +921,17 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             _resolve_repo_custom_instructions(prompt_default_repo),
             _resolve_user_custom_instructions(self._profile_login),
         )
-        turn_checkpoints = await self._record_turn_checkpoint(state, sandbox_backend, work_dir)
+        preferred_repo_path = (
+            posixpath.join(work_dir, prompt_default_repo["name"])
+            if prompt_default_repo and prompt_default_repo.get("name")
+            else None
+        )
+        turn_checkpoints = await self._record_turn_checkpoint(
+            state,
+            sandbox_backend,
+            work_dir,
+            preferred_repo_path,
+        )
 
         try:
             await client.threads.update(

--- a/agent/tools/enter_plan_mode.py
+++ b/agent/tools/enter_plan_mode.py
@@ -13,7 +13,8 @@ from langgraph.types import Command
 from langgraph_sdk import get_client
 
 from ..dashboard.plan_store import PLAN_STATUS_PLANNING, set_plan_status
-from ..utils.turn_checkpoint import mark_checkpoint_plan_mode
+from ..utils.sandbox_state import get_sandbox_backend
+from ..utils.turn_checkpoint import mark_checkpoint_plan_mode, record_plan_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +80,25 @@ async def _mark_turn_checkpoint(thread_id: str, turn_key: str) -> None:
     )
     metadata = metadata if isinstance(metadata, dict) else {}
     existing = metadata.get("turn_checkpoints")
-    updated = mark_checkpoint_plan_mode(existing, turn_key)
+    checkpoint = next(
+        (
+            entry
+            for entry in (existing if isinstance(existing, list) else [])
+            if isinstance(entry, dict) and entry.get("key") == turn_key
+        ),
+        None,
+    )
+    plan_ref = None
+    if checkpoint:
+        backend = await get_sandbox_backend(thread_id)
+        repo_path = checkpoint.get("repo_path")
+        plan_ref = await record_plan_checkpoint(
+            backend,
+            None,
+            turn_key,
+            repo_path=repo_path if isinstance(repo_path, str) else None,
+        )
+    updated = mark_checkpoint_plan_mode(existing, turn_key, plan_ref)
     if updated != existing:
         await client.threads.update(
             thread_id=thread_id,

--- a/agent/tools/enter_plan_mode.py
+++ b/agent/tools/enter_plan_mode.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import InjectedToolCallId
 from langgraph.config import get_config
+from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
+from langgraph_sdk import get_client
 
 from ..dashboard.plan_store import PLAN_STATUS_PLANNING, set_plan_status
+from ..utils.turn_checkpoint import mark_checkpoint_plan_mode
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +26,10 @@ _ENTERED_MESSAGE = (
 )
 
 
-async def enter_plan_mode(tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+async def enter_plan_mode(
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    state: Annotated[dict[str, Any] | None, InjectedState] = None,
+) -> Command:
     """Activate plan mode mid-run.
 
     Call this when you believe the task would benefit from a structured
@@ -43,6 +49,9 @@ async def enter_plan_mode(tool_call_id: Annotated[str, InjectedToolCallId]) -> C
     if thread_id:
         try:
             await set_plan_status(thread_id, PLAN_STATUS_PLANNING, plan_mode=True)
+            turn_key = _latest_human_message_id(state)
+            if turn_key:
+                await _mark_turn_checkpoint(thread_id, turn_key)
         except Exception:
             logger.warning("Failed to persist plan-mode entry for %s", thread_id, exc_info=True)
     return Command(
@@ -51,6 +60,31 @@ async def enter_plan_mode(tool_call_id: Annotated[str, InjectedToolCallId]) -> C
             "messages": [ToolMessage(content=_ENTERED_MESSAGE, tool_call_id=tool_call_id)],
         }
     )
+
+
+def _latest_human_message_id(state: dict[str, Any] | None) -> str | None:
+    if not isinstance(state, dict):
+        return None
+    for message in reversed(state.get("messages") or []):
+        if isinstance(message, HumanMessage) and message.id:
+            return message.id
+    return None
+
+
+async def _mark_turn_checkpoint(thread_id: str, turn_key: str) -> None:
+    client = get_client()
+    thread = await client.threads.get(thread_id)
+    metadata = (
+        thread.get("metadata") if isinstance(thread, dict) else getattr(thread, "metadata", None)
+    )
+    metadata = metadata if isinstance(metadata, dict) else {}
+    existing = metadata.get("turn_checkpoints")
+    updated = mark_checkpoint_plan_mode(existing, turn_key)
+    if updated != existing:
+        await client.threads.update(
+            thread_id=thread_id,
+            metadata={"turn_checkpoints": updated},
+        )
 
 
 def _thread_id_from_config() -> str | None:

--- a/agent/utils/turn_checkpoint.py
+++ b/agent/utils/turn_checkpoint.py
@@ -47,6 +47,10 @@ def checkpoint_ref(turn_key: str) -> str:
     return f"refs/open-swe/turns/{_UNSAFE_KEY.sub('-', turn_key)[:100]}"
 
 
+def plan_checkpoint_ref(turn_key: str) -> str:
+    return f"{checkpoint_ref(turn_key)}-plan"
+
+
 def _cd_repo(work_dir: str | None, repo_path: str | None = None) -> str:
     roots = " ".join(
         shlex.quote(root) for root in ([work_dir] if work_dir else []) + ["/workspace"]
@@ -231,6 +235,8 @@ def _checkpoint_entries(existing: Any) -> list[dict[str, Any]]:
         }
         if isinstance(value.get("repo_path"), str) and value["repo_path"]:
             entry["repo_path"] = value["repo_path"]
+        if isinstance(value.get("plan_ref"), str) and value["plan_ref"]:
+            entry["plan_ref"] = value["plan_ref"]
         if value.get("plan_mode") is True:
             entry["plan_mode"] = True
         entries.append(entry)
@@ -255,18 +261,43 @@ def merge_checkpoint(
         entry["repo_path"] = repo_path
     if plan_mode:
         entry["plan_mode"] = True
+        entry["plan_ref"] = ref
     entries.append(entry)
     return entries[-MAX_CHECKPOINTS:]
 
 
-def mark_checkpoint_plan_mode(existing: Any, key: str) -> list[dict[str, Any]]:
+def mark_checkpoint_plan_mode(
+    existing: Any, key: str, plan_ref: str | None = None
+) -> list[dict[str, Any]]:
     """Mark one existing turn checkpoint as read-only planning."""
     entries = _checkpoint_entries(existing)
     for entry in entries:
         if entry["key"] == key:
             entry["plan_mode"] = True
+            entry["plan_ref"] = plan_ref or entry["ref"]
             break
     return entries
+
+
+async def record_plan_checkpoint(
+    sandbox: Any,
+    work_dir: str | None,
+    turn_key: str,
+    *,
+    repo_path: str | None = None,
+) -> str | None:
+    """Snapshot the worktree where a turn enters plan mode."""
+    ref = plan_checkpoint_ref(turn_key)
+    try:
+        response = await _execute(
+            sandbox,
+            _checkpoint_command(work_dir, ref, repo_path),
+            CHECKPOINT_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        logger.debug("plan checkpoint failed for %s", turn_key, exc_info=True)
+        return None
+    return ref if _ok(response) else None
 
 
 async def record_turn_checkpoint(

--- a/agent/utils/turn_checkpoint.py
+++ b/agent/utils/turn_checkpoint.py
@@ -47,38 +47,53 @@ def checkpoint_ref(turn_key: str) -> str:
     return f"refs/open-swe/turns/{_UNSAFE_KEY.sub('-', turn_key)[:100]}"
 
 
-def _cd_repo(work_dir: str | None) -> str:
+def _cd_repo(work_dir: str | None, repo_path: str | None = None) -> str:
     roots = " ".join(
         shlex.quote(root) for root in ([work_dir] if work_dir else []) + ["/workspace"]
     )
+    preferred = shlex.quote(repo_path) if repo_path else '""'
     return (
-        f'R=""; for w in {roots} "$PWD"; do for d in "$w" "$w"/*; do '
-        'if [ -e "$d/.git" ]; then R="$d"; break 2; fi; done; done; '
+        f"R={preferred}; "
+        'if [ -z "$R" ] || [ ! -e "$R/.git" ]; then R=""; '
+        f'for w in {roots} "$PWD"; do for d in "$w" "$w"/*; do '
+        'if [ -e "$d/.git" ]; then R="$d"; break 2; fi; done; done; fi; '
         '[ -n "$R" ] || exit 3; cd "$R"'
     )
 
 
-def _checkpoint_command(work_dir: str | None, ref: str) -> str:
+def _checkpoint_command(work_dir: str | None, ref: str, repo_path: str | None = None) -> str:
+    quoted_ref = shlex.quote(ref)
     return (
-        f"{_cd_repo(work_dir)}; {_WRITE_WORKTREE_TREE}; "
+        f"{_cd_repo(work_dir, repo_path)}; R=$(git rev-parse --show-toplevel); "
+        f"if C=$(git rev-parse --verify -q {quoted_ref}); then :; else "
+        f"{_WRITE_WORKTREE_TREE}; "
         "if git rev-parse --verify -q HEAD >/dev/null; then "
         'C=$(git commit-tree "$T" -p HEAD -m open-swe-turn); '
         'else C=$(git commit-tree "$T" -m open-swe-turn); fi; '
-        f'git update-ref {shlex.quote(ref)} "$C" && echo "$C"'
+        f'git update-ref {quoted_ref} "$C" || exit; fi; printf \'%s\\n%s\' "$C" "$R"'
     )
 
 
-def _diff_command(work_dir: str | None, base: str, head: str | None) -> str:
+def _diff_command(
+    work_dir: str | None, base: str, head: str | None, repo_path: str | None = None
+) -> str:
     resolve_head = f"H={shlex.quote(head)}" if head else f"{_WRITE_WORKTREE_TREE}; H=$T"
     rng = f"{shlex.quote(base)} $H"
     return (
-        f"{_cd_repo(work_dir)}; {resolve_head}; "
-        f"git diff --numstat -z --no-renames {rng}; printf '{_SECTION}'; "
-        f"git diff --name-status -z --no-renames {rng}; printf '{_SECTION}%s' \"$H\""
+        f"{_cd_repo(work_dir, repo_path)}; {resolve_head}; "
+        f"git diff --numstat -z --no-renames {rng} || exit; printf '{_SECTION}'; "
+        f"git diff --name-status -z --no-renames {rng} || exit; "
+        f"printf '{_SECTION}%s' \"$H\""
     )
 
 
-def _contents_command(work_dir: str | None, base: str, head: str, paths: Sequence[str]) -> str:
+def _contents_command(
+    work_dir: str | None,
+    base: str,
+    head: str,
+    paths: Sequence[str],
+    repo_path: str | None = None,
+) -> str:
     payload = base64.b64encode(
         json.dumps({"base": base, "head": head, "paths": list(paths)}).encode()
     ).decode()
@@ -113,7 +128,7 @@ print(json.dumps({
 }))
 PY"""
     script = script.replace("__PAYLOAD__", payload).replace("__MAX__", str(_MAX_FILE_BYTES))
-    return f"{_cd_repo(work_dir)}; {script}"
+    return f"{_cd_repo(work_dir, repo_path)}; {script}"
 
 
 def _output(response: Any) -> str:
@@ -204,33 +219,70 @@ def build_diff_files(
     return files
 
 
-def merge_checkpoint(existing: Any, key: str, ref: str, started_at: str) -> list[dict[str, str]]:
-    """Append a checkpoint to the thread's bounded list; the earliest wins per key.
-
-    A resumed or re-dispatched run for the same user message must not move the
-    turn's base forward — the first snapshot is the real turn start.
-    """
-    entries = [
-        {
-            "key": str(entry["key"]),
-            "ref": str(entry.get("ref", "")),
-            "started_at": str(entry.get("started_at", "")),
+def _checkpoint_entries(existing: Any) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for value in existing if isinstance(existing, list) else []:
+        if not isinstance(value, Mapping) or not isinstance(value.get("key"), str):
+            continue
+        entry: dict[str, Any] = {
+            "key": str(value["key"]),
+            "ref": str(value.get("ref", "")),
+            "started_at": str(value.get("started_at", "")),
         }
-        for entry in (existing if isinstance(existing, list) else [])
-        if isinstance(entry, Mapping) and isinstance(entry.get("key"), str)
-    ]
+        if isinstance(value.get("repo_path"), str) and value["repo_path"]:
+            entry["repo_path"] = value["repo_path"]
+        if value.get("plan_mode") is True:
+            entry["plan_mode"] = True
+        entries.append(entry)
+    return entries
+
+
+def merge_checkpoint(
+    existing: Any,
+    key: str,
+    ref: str,
+    started_at: str,
+    *,
+    repo_path: str | None = None,
+    plan_mode: bool = False,
+) -> list[dict[str, Any]]:
+    """Append a checkpoint to the thread's bounded list; the earliest wins per key."""
+    entries = _checkpoint_entries(existing)
     if any(entry["key"] == key for entry in entries):
         return entries
-    entries.append({"key": key, "ref": ref, "started_at": started_at})
+    entry: dict[str, Any] = {"key": key, "ref": ref, "started_at": started_at}
+    if repo_path:
+        entry["repo_path"] = repo_path
+    if plan_mode:
+        entry["plan_mode"] = True
+    entries.append(entry)
     return entries[-MAX_CHECKPOINTS:]
 
 
-async def record_turn_checkpoint(sandbox: Any, work_dir: str | None, turn_key: str) -> str | None:
-    """Snapshot the worktree for ``turn_key``; returns the ref, or ``None``."""
+def mark_checkpoint_plan_mode(existing: Any, key: str) -> list[dict[str, Any]]:
+    """Mark one existing turn checkpoint as read-only planning."""
+    entries = _checkpoint_entries(existing)
+    for entry in entries:
+        if entry["key"] == key:
+            entry["plan_mode"] = True
+            break
+    return entries
+
+
+async def record_turn_checkpoint(
+    sandbox: Any,
+    work_dir: str | None,
+    turn_key: str,
+    *,
+    repo_path: str | None = None,
+) -> tuple[str, str] | None:
+    """Snapshot the worktree for ``turn_key``; returns its ref and repository."""
     ref = checkpoint_ref(turn_key)
     try:
         response = await _execute(
-            sandbox, _checkpoint_command(work_dir, ref), CHECKPOINT_TIMEOUT_SECONDS
+            sandbox,
+            _checkpoint_command(work_dir, ref, repo_path),
+            CHECKPOINT_TIMEOUT_SECONDS,
         )
     except Exception:
         logger.debug("turn checkpoint failed for %s", turn_key, exc_info=True)
@@ -238,16 +290,27 @@ async def record_turn_checkpoint(sandbox: Any, work_dir: str | None, turn_key: s
     if not _ok(response):
         logger.debug("turn checkpoint command failed for %s: %s", turn_key, _output(response))
         return None
-    return ref
+    lines = _output(response).strip().splitlines()
+    if len(lines) < 2 or not lines[-2] or not lines[-1].startswith("/"):
+        logger.debug("turn checkpoint returned invalid output for %s: %s", turn_key, lines)
+        return None
+    return ref, lines[-1]
 
 
 async def read_turn_diff(
-    sandbox: Any, work_dir: str | None, base: str, head: str | None
+    sandbox: Any,
+    work_dir: str | None,
+    base: str,
+    head: str | None,
+    *,
+    repo_path: str | None = None,
 ) -> dict[str, Any]:
     """Files changed between ``base`` and ``head`` (or the live worktree)."""
     try:
         response = await _execute(
-            sandbox, _diff_command(work_dir, base, head), DIFF_TIMEOUT_SECONDS
+            sandbox,
+            _diff_command(work_dir, base, head, repo_path),
+            DIFF_TIMEOUT_SECONDS,
         )
     except Exception:
         logger.debug("turn diff failed for %s", base, exc_info=True)
@@ -267,7 +330,7 @@ async def read_turn_diff(
         try:
             blobs = await _execute(
                 sandbox,
-                _contents_command(work_dir, base, head_tree.strip(), paths),
+                _contents_command(work_dir, base, head_tree.strip(), paths, repo_path),
                 DIFF_TIMEOUT_SECONDS,
             )
             decoded = json.loads(_output(blobs).strip().splitlines()[-1])

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -179,6 +179,58 @@ async def test_enter_plan_mode_tool_returns_command() -> None:
     assert messages[0].tool_call_id == "call-1"
 
 
+async def test_mark_turn_checkpoint_records_the_plan_transition(monkeypatch) -> None:
+    import importlib
+
+    enter_plan_mode_module = importlib.import_module("agent.tools.enter_plan_mode")
+    metadata = {
+        "turn_checkpoints": [
+            {
+                "key": "msg-1",
+                "ref": "refs/open-swe/turns/msg-1",
+                "started_at": "t0",
+                "repo_path": "/workspace/repo",
+            }
+        ]
+    }
+
+    class Threads:
+        def __init__(self) -> None:
+            self.get = AsyncMock(return_value={"metadata": metadata})
+            self.update = AsyncMock()
+
+    threads = Threads()
+    client = type("Client", (), {"threads": threads})()
+    backend = object()
+    monkeypatch.setattr(enter_plan_mode_module, "get_client", lambda: client)
+    monkeypatch.setattr(
+        enter_plan_mode_module, "get_sandbox_backend", AsyncMock(return_value=backend)
+    )
+    record_plan = AsyncMock(return_value="refs/open-swe/turns/msg-1-plan")
+    monkeypatch.setattr(enter_plan_mode_module, "record_plan_checkpoint", record_plan)
+
+    await enter_plan_mode_module._mark_turn_checkpoint("thread-1", "msg-1")
+
+    record_plan.assert_awaited_once_with(
+        backend,
+        None,
+        "msg-1",
+        repo_path="/workspace/repo",
+    )
+    threads.update.assert_awaited_once_with(
+        thread_id="thread-1",
+        metadata={
+            "turn_checkpoints": [
+                {
+                    **metadata["turn_checkpoints"][0],
+                    "plan_mode": True,
+                    "plan_ref": "refs/open-swe/turns/msg-1-plan",
+                }
+            ]
+        },
+    )
+
+
 async def test_enter_plan_mode_marks_the_current_turn_checkpoint(monkeypatch) -> None:
     import importlib
 

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -176,6 +177,27 @@ async def test_enter_plan_mode_tool_returns_command() -> None:
     assert len(messages) == 1
     assert isinstance(messages[0], ToolMessage)
     assert messages[0].tool_call_id == "call-1"
+
+
+async def test_enter_plan_mode_marks_the_current_turn_checkpoint(monkeypatch) -> None:
+    import importlib
+
+    from langchain_core.messages import HumanMessage
+
+    enter_plan_mode_module = importlib.import_module("agent.tools.enter_plan_mode")
+    set_plan_status = AsyncMock()
+    mark_checkpoint = AsyncMock()
+    monkeypatch.setattr(enter_plan_mode_module, "_thread_id_from_config", lambda: "thread-1")
+    monkeypatch.setattr(enter_plan_mode_module, "set_plan_status", set_plan_status)
+    monkeypatch.setattr(enter_plan_mode_module, "_mark_turn_checkpoint", mark_checkpoint)
+
+    await enter_plan_mode_module.enter_plan_mode(
+        tool_call_id="call-1",
+        state={"messages": [HumanMessage(content="plan it", id="msg-1")]},
+    )
+
+    set_plan_status.assert_awaited_once_with("thread-1", "planning", plan_mode=True)
+    mark_checkpoint.assert_awaited_once_with("thread-1", "msg-1")
 
 
 def test_enter_plan_mode_exported() -> None:

--- a/tests/agent/test_turn_checkpoint.py
+++ b/tests/agent/test_turn_checkpoint.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import base64
+import subprocess
+from types import SimpleNamespace
 
 from agent.utils.file_diff import build_file_diff
-from agent.utils.turn_checkpoint import build_diff_files, merge_checkpoint
+from agent.utils.turn_checkpoint import (
+    build_diff_files,
+    mark_checkpoint_plan_mode,
+    merge_checkpoint,
+    record_turn_checkpoint,
+)
 
 
 def test_build_diff_files_maps_numstat_status_and_contents() -> None:
@@ -39,6 +46,96 @@ def test_merge_checkpoint_keeps_the_first_snapshot_for_a_turn() -> None:
 
     assert resumed == first
     assert [entry["key"] for entry in second] == ["msg-1", "msg-2"]
+
+
+def test_merge_checkpoint_preserves_repository_and_plan_mode() -> None:
+    entries = merge_checkpoint(
+        None,
+        "msg-1",
+        "refs/open-swe/turns/msg-1",
+        "t0",
+        repo_path="/workspace/repo",
+        plan_mode=True,
+    )
+
+    assert entries == [
+        {
+            "key": "msg-1",
+            "ref": "refs/open-swe/turns/msg-1",
+            "started_at": "t0",
+            "repo_path": "/workspace/repo",
+            "plan_mode": True,
+        }
+    ]
+    assert merge_checkpoint(entries, "msg-1", "other", "t1") == entries
+
+
+def test_mark_checkpoint_plan_mode_marks_only_the_requested_turn() -> None:
+    entries = [
+        {"key": "msg-1", "ref": "ref-1", "started_at": "t0"},
+        {
+            "key": "msg-2",
+            "ref": "ref-2",
+            "started_at": "t1",
+            "repo_path": "/workspace/repo",
+        },
+    ]
+
+    marked = mark_checkpoint_plan_mode(entries, "msg-2")
+
+    assert "plan_mode" not in marked[0]
+    assert marked[1]["plan_mode"] is True
+    assert marked[1]["repo_path"] == "/workspace/repo"
+
+
+async def test_record_turn_checkpoint_uses_preferred_repo_and_keeps_first_snapshot(
+    tmp_path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+    (repo / "file.txt").write_text("first\n")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "initial"], check=True)
+
+    class Sandbox:
+        async def aexecute(self, command: str, *, timeout: int):
+            result = subprocess.run(
+                ["bash", "-lc", command],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return SimpleNamespace(
+                exit_code=result.returncode, output=result.stdout + result.stderr
+            )
+
+    sandbox = Sandbox()
+    first = await record_turn_checkpoint(
+        sandbox,
+        str(tmp_path),
+        "msg-1",
+        repo_path=str(repo),
+    )
+    (repo / "file.txt").write_text("second\n")
+    resumed = await record_turn_checkpoint(
+        sandbox,
+        str(tmp_path),
+        "msg-1",
+        repo_path=str(repo),
+    )
+
+    assert first == resumed == ("refs/open-swe/turns/msg-1", str(repo))
+    snapshot = subprocess.run(
+        ["git", "-C", str(repo), "show", "refs/open-swe/turns/msg-1:file.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert snapshot.stdout == "first\n"
 
 
 def test_build_file_diff_applies_the_edit_to_the_before_image() -> None:

--- a/tests/agent/test_turn_checkpoint.py
+++ b/tests/agent/test_turn_checkpoint.py
@@ -65,6 +65,7 @@ def test_merge_checkpoint_preserves_repository_and_plan_mode() -> None:
             "started_at": "t0",
             "repo_path": "/workspace/repo",
             "plan_mode": True,
+            "plan_ref": "refs/open-swe/turns/msg-1",
         }
     ]
     assert merge_checkpoint(entries, "msg-1", "other", "t1") == entries
@@ -85,6 +86,7 @@ def test_mark_checkpoint_plan_mode_marks_only_the_requested_turn() -> None:
 
     assert "plan_mode" not in marked[0]
     assert marked[1]["plan_mode"] is True
+    assert marked[1]["plan_ref"] == "ref-2"
     assert marked[1]["repo_path"] == "/workspace/repo"
 
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1779,6 +1779,92 @@ async def test_options_gates_stale_fable_default_when_disabled() -> None:
     assert payload["default_agent_subagent_model"] in model_ids
 
 
+async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [
+            {
+                "key": "msg-1",
+                "ref": "refs/open-swe/turns/msg-1",
+                "started_at": "t0",
+                "repo_path": "/workspace/repo",
+                "plan_mode": True,
+            }
+        ],
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    create_sandbox = AsyncMock()
+    monkeypatch.setattr(thread_api, "create_sandbox", create_sandbox)
+
+    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+
+    assert result == {"status": "ready", "files": [], "truncated": False}
+    create_sandbox.assert_not_awaited()
+
+
+async def test_turn_diff_reads_the_checkpoint_repository(monkeypatch) -> None:
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [
+            {
+                "key": "msg-1",
+                "ref": "refs/open-swe/turns/msg-1",
+                "started_at": "t0",
+                "repo_path": "/workspace/repo",
+            },
+            {
+                "key": "msg-2",
+                "ref": "refs/open-swe/turns/msg-2",
+                "started_at": "t1",
+                "repo_path": "/workspace/repo",
+            },
+        ],
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    sandbox = object()
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=sandbox))
+    read_diff = AsyncMock(return_value={"status": "ready", "files": [], "truncated": False})
+    monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
+
+    await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+
+    read_diff.assert_awaited_once_with(
+        sandbox,
+        None,
+        "refs/open-swe/turns/msg-1",
+        "refs/open-swe/turns/msg-2",
+        repo_path="/workspace/repo",
+    )
+
+
+async def test_turn_diff_rejects_checkpoints_from_different_repositories(monkeypatch) -> None:
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [
+            {
+                "key": "msg-1",
+                "ref": "refs/open-swe/turns/msg-1",
+                "started_at": "t0",
+                "repo_path": "/workspace/one",
+            },
+            {
+                "key": "msg-2",
+                "ref": "refs/open-swe/turns/msg-2",
+                "started_at": "t1",
+                "repo_path": "/workspace/two",
+            },
+        ],
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    create_sandbox = AsyncMock()
+    monkeypatch.setattr(thread_api, "create_sandbox", create_sandbox)
+
+    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+
+    assert result == {"status": "missing", "files": [], "truncated": False}
+    create_sandbox.assert_not_awaited()
+
+
 async def test_pr_diff_uses_repository_from_pr_url(monkeypatch) -> None:
     metadata = {
         "repo_owner": "langchain-ai",

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1789,6 +1789,7 @@ async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:
                 "started_at": "t0",
                 "repo_path": "/workspace/repo",
                 "plan_mode": True,
+                "plan_ref": "refs/open-swe/turns/msg-1",
             }
         ],
     }
@@ -1800,6 +1801,37 @@ async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:
 
     assert result == {"status": "ready", "files": [], "truncated": False}
     create_sandbox.assert_not_awaited()
+
+
+async def test_turn_diff_preserves_changes_before_mid_run_plan_mode(monkeypatch) -> None:
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [
+            {
+                "key": "msg-1",
+                "ref": "refs/open-swe/turns/msg-1",
+                "started_at": "t0",
+                "repo_path": "/workspace/repo",
+                "plan_mode": True,
+                "plan_ref": "refs/open-swe/turns/msg-1-plan",
+            }
+        ],
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    sandbox = object()
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=sandbox))
+    read_diff = AsyncMock(return_value={"status": "ready", "files": [], "truncated": False})
+    monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
+
+    await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+
+    read_diff.assert_awaited_once_with(
+        sandbox,
+        None,
+        "refs/open-swe/turns/msg-1",
+        "refs/open-swe/turns/msg-1-plan",
+        repo_path="/workspace/repo",
+    )
 
 
 async def test_turn_diff_reads_the_checkpoint_repository(monkeypatch) -> None:


### PR DESCRIPTION
## Description
Plan-mode repository setup could appear as hundreds of authored file changes because turn checkpoints rediscovered the live checkout independently. Checkpoints now retain their exact repository and plan transitions, excluding setup-only noise while preserving edits made before mid-run planning.

## Test Plan
- [x] Verify plan turns omit setup noise while retaining pre-plan edits.
- [x] Verify resumed turns preserve their first snapshot; 107 focused tests and lint pass.

Made by [Open SWE](https://openswe.vercel.app/agents/1ba65d53-7ebd-8f5a-55b6-cf2d411e3061)