### PR TITLE
feat(environments): named prompt + captured snapshot per environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Webhooks compute deterministic thread ids so the same Linear issue / Slack threa
 - New dashboard endpoints: add to `agent/dashboard/routes.py`. The router is auto-mounted on the FastAPI app.
 - New graphs: register the entrypoint in `langgraph.json` under `graphs`.
 - Minimal-to-no code comments — only when the *why* isn't obvious from the code.
+- Do not add feature documentation to this file. Shipping a feature earns it **no** line here — not a section, not a pointer, not a resolution order or a list of which module wins. Anyone can read that from the code. Feature detail belongs in the code, its docstrings, and the PR description. Only edit this file when asked to, or when something it already claims has become wrong.
 
 <!-- OPENWIKI:START -->
 

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -1,0 +1,429 @@
+"""Named environments: a custom prompt plus a sandbox snapshot.
+
+An environment bundles the two things a team needs to make runs start warm: a
+prompt appended to the agent's system prompt, and a LangSmith snapshot new
+sandboxes boot from. It may cover several repositories — the snapshot is captured
+from a live sandbox after the agent has cloned and provisioned whatever the
+environment needs, so its contents are whatever was set up in that sandbox.
+
+Snapshots are captured (not built from a Dockerfile) so the setup steps are
+ordinary sandbox commands an admin can iterate on in an admin thread. Each
+capture is named ``<prefix>-environment-<slug>:latest`` (prefix from
+``ENVIRONMENT_SNAPSHOT_PREFIX``) and the previous snapshot is deleted once the
+new one is ready, so an environment resolves to exactly one live snapshot.
+
+A run uses the environment it selected — from the dashboard picker, or an
+``env:<name>`` tag on the Slack message that opened the thread — and otherwise
+the one named ``default``. Nothing here is required: with no environment, or one
+whose snapshot is not ready, runs fall back to the per-repo snapshot and then to
+the configured base snapshot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from langgraph_sdk import get_client
+from pydantic import BaseModel, Field, field_validator
+
+from .review_styles import normalize_repo_full_name
+
+logger = logging.getLogger(__name__)
+
+ENVIRONMENTS_NAMESPACE: list[str] = ["environments"]
+DEFAULT_ENVIRONMENT_SLUG = "default"
+
+SnapshotStatus = Literal["none", "capturing", "ready", "failed"]
+
+NAME_MAX_CHARS = 80
+PROMPT_MAX_CHARS = 20_000
+MAX_REPOS = 50
+SNAPSHOT_TAG = "latest"
+CAPTURE_NAME_ATTEMPTS = 5
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+# `env:my-box` anywhere in a message, as a whole word.
+_ENV_TAG_RE = re.compile(r"(?:(?<=\s)|^)env:([A-Za-z0-9][A-Za-z0-9._-]*)(?=\s|$)")
+
+
+def slugify(name: str) -> str:
+    """Return the storage key for an environment name.
+
+    Also the snapshot name stem, so it is restricted to what a Docker-style tag
+    accepts: lowercase alphanumerics and single hyphens.
+    """
+    slug = _SLUG_RE.sub("-", (name or "").strip().lower()).strip("-")
+    if not slug:
+        raise ValueError("name must contain at least one letter or digit")
+    return slug[:NAME_MAX_CHARS]
+
+
+def snapshot_name_prefix() -> str:
+    """Prefix for captured snapshot names, so one workspace can host several deployments."""
+    return os.environ.get("ENVIRONMENT_SNAPSHOT_PREFIX", "").strip() or "openswe"
+
+
+def snapshot_name_for(slug: str, attempt: int = 1) -> str:
+    """``<prefix>-environment-<slug>:latest``, with ``-2``, ``-3``, … past the first attempt.
+
+    The suffix only exists because a capture can collide with a name the platform
+    still holds (a prior snapshot mid-delete, a concurrent capture); the record
+    stores whichever name won.
+    """
+    stem = f"{snapshot_name_prefix()}-environment-{slug}"
+    if attempt > 1:
+        stem = f"{stem}-{attempt}"
+    return f"{stem}:{SNAPSHOT_TAG}"
+
+
+def _validate_name(value: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("name must not be empty")
+    if len(text) > NAME_MAX_CHARS:
+        raise ValueError(f"name must be at most {NAME_MAX_CHARS} characters")
+    slugify(text)
+    return text
+
+
+def _validate_prompt(value: str | None) -> str:
+    text = (value or "").strip()
+    if len(text) > PROMPT_MAX_CHARS:
+        raise ValueError(f"prompt must be at most {PROMPT_MAX_CHARS} characters")
+    return text
+
+
+def _validate_repos(value: list[str] | None) -> list[str]:
+    if not value:
+        return []
+    if len(value) > MAX_REPOS:
+        raise ValueError(f"at most {MAX_REPOS} repositories per environment")
+    return list(dict.fromkeys(normalize_repo_full_name(entry) for entry in value))
+
+
+class EnvironmentCreate(BaseModel):
+    name: str
+    prompt: str = ""
+    repos: list[str] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+    @field_validator("prompt")
+    @classmethod
+    def _check_prompt(cls, v: str) -> str:
+        return _validate_prompt(v)
+
+    @field_validator("repos")
+    @classmethod
+    def _check_repos(cls, v: list[str]) -> list[str]:
+        return _validate_repos(v)
+
+
+class EnvironmentUpdate(BaseModel):
+    """Partial update: only the fields present are written."""
+
+    name: str | None = None
+    prompt: str | None = None
+    repos: list[str] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: str | None) -> str | None:
+        return None if v is None else _validate_name(v)
+
+    @field_validator("prompt")
+    @classmethod
+    def _check_prompt(cls, v: str | None) -> str | None:
+        return None if v is None else _validate_prompt(v)
+
+    @field_validator("repos")
+    @classmethod
+    def _check_repos(cls, v: list[str] | None) -> list[str] | None:
+        return None if v is None else _validate_repos(v)
+
+
+def _client():
+    return get_client()
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _item_value(item: Any) -> dict[str, Any] | None:
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def get_environment(slug: str) -> dict[str, Any] | None:
+    try:
+        item = await _client().store.get_item(ENVIRONMENTS_NAMESPACE, slug)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("environment lookup failed for %s: %s", slug, e)
+        return None
+    return _item_value(item)
+
+
+async def list_environments() -> list[dict[str, Any]]:
+    try:
+        result = await _client().store.search_items(ENVIRONMENTS_NAMESPACE, limit=1000)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("environment search failed: %s", e)
+        return []
+    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+    out = [value for item in items or [] if (value := _item_value(item)) is not None]
+    out.sort(key=lambda record: record.get("name", ""))
+    return out
+
+
+async def create_environment(create: EnvironmentCreate, created_by: str) -> dict[str, Any]:
+    slug = slugify(create.name)
+    existing = await get_environment(slug)
+    if existing is not None:
+        raise ValueError(f"environment {create.name!r} already exists")
+    record = {
+        "slug": slug,
+        "name": create.name.strip(),
+        "prompt": create.prompt,
+        "repos": create.repos,
+        "snapshot_id": None,
+        "snapshot_name": None,
+        "snapshot_status": "none",
+        "status_message": None,
+        "source_sandbox_id": None,
+        "last_captured_at": None,
+        "created_by": created_by,
+        "created_at": _now_iso(),
+        "updated_at": _now_iso(),
+    }
+    await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
+    return record
+
+
+async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, Any]:
+    existing = await get_environment(slug)
+    if existing is None:
+        raise ValueError(f"no environment named {slug!r}")
+    if update.name is not None and slugify(update.name) != slug:
+        raise ValueError("renaming an environment across slugs is not supported; create a new one")
+    record = {**existing, "updated_at": _now_iso()}
+    if update.name is not None:
+        record["name"] = update.name.strip()
+    if update.prompt is not None:
+        record["prompt"] = update.prompt
+    if update.repos is not None:
+        record["repos"] = update.repos
+    await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
+    return record
+
+
+async def delete_environment(slug: str) -> bool:
+    existing = await get_environment(slug)
+    if existing is None:
+        return False
+    try:
+        await _client().store.delete_item(ENVIRONMENTS_NAMESPACE, slug)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("failed to delete environment %s: %s", slug, e)
+        return False
+    await _delete_snapshot(existing.get("snapshot_id"))
+    return True
+
+
+async def resolve_default_environment() -> dict[str, Any] | None:
+    """Return the environment named ``default``, or ``None``.
+
+    Never raises: a store failure resolves to ``None`` so runs fall back to the
+    per-repo and base snapshots with no environment prompt.
+    """
+    try:
+        return await get_environment(DEFAULT_ENVIRONMENT_SLUG)
+    except Exception:  # noqa: BLE001
+        logger.debug("default environment resolution failed", exc_info=True)
+        return None
+
+
+async def resolve_environment(slug: str | None) -> dict[str, Any] | None:
+    """Return the environment a run uses: the one it selected, else ``default``.
+
+    Never raises, and a selection that no longer exists falls back to ``default``
+    rather than failing the run.
+    """
+    if not slug or slug == DEFAULT_ENVIRONMENT_SLUG:
+        return await resolve_default_environment()
+    try:
+        record = await get_environment(slug)
+    except Exception:  # noqa: BLE001
+        logger.debug("environment resolution failed for %s", slug, exc_info=True)
+        record = None
+    if record is None:
+        logger.info("Environment %s is not configured; falling back to the default", slug)
+        return await resolve_default_environment()
+    return record
+
+
+async def list_environment_options() -> list[dict[str, Any]]:
+    """Name/slug/snapshot-state only, for the non-admin environment picker.
+
+    Prompts and snapshot ids stay admin-only; picking an environment needs
+    neither.
+    """
+    return [
+        {
+            "slug": record.get("slug"),
+            "name": record.get("name"),
+            "has_snapshot": record.get("snapshot_status") == "ready",
+        }
+        for record in await list_environments()
+        if isinstance(record.get("slug"), str)
+    ]
+
+
+def parse_environment_tag(text: str) -> tuple[str | None, str]:
+    """Split a leading-or-inline ``env:<name>`` tag off a message.
+
+    Returns ``(slug, text_without_the_tag)``; ``(None, text)`` when there is no
+    tag. The caller decides whether the slug names a real environment — an
+    unresolvable tag should be left in the text rather than silently dropped.
+    """
+    match = _ENV_TAG_RE.search(text or "")
+    if match is None:
+        return None, text
+    try:
+        slug = slugify(match.group(1))
+    except ValueError:
+        return None, text
+    before, after = text[: match.start()].rstrip(), text[match.end() :].lstrip()
+    return slug, f"{before} {after}".strip() if before and after else f"{before}{after}".strip()
+
+
+def environment_snapshot_id(record: dict[str, Any] | None) -> str | None:
+    """The snapshot new sandboxes boot from, or ``None`` when not captured yet."""
+    if not record or record.get("snapshot_status") != "ready":
+        return None
+    snapshot_id = record.get("snapshot_id")
+    return snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None
+
+
+def environment_prompt(record: dict[str, Any] | None) -> str | None:
+    if not record:
+        return None
+    prompt = record.get("prompt")
+    return prompt.strip() or None if isinstance(prompt, str) else None
+
+
+async def _set_snapshot_state(
+    slug: str,
+    status: SnapshotStatus,
+    *,
+    status_message: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    existing = await get_environment(slug)
+    if existing is None:
+        return None
+    record = {
+        **existing,
+        "snapshot_status": status,
+        "status_message": status_message,
+        "updated_at": _now_iso(),
+        **(extra or {}),
+    }
+    await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
+    return record
+
+
+async def _delete_snapshot(snapshot_id: object) -> None:
+    """Best-effort delete of a superseded snapshot."""
+    if not isinstance(snapshot_id, str) or not snapshot_id:
+        return
+    from agent.integrations.langsmith import get_async_sandbox_client
+
+    try:
+        async with get_async_sandbox_client() as client:
+            await client.delete_snapshot(snapshot_id)
+    except Exception:  # noqa: BLE001
+        logger.warning("failed to delete superseded snapshot %s", snapshot_id, exc_info=True)
+
+
+def _is_name_conflict(exc: BaseException) -> bool:
+    if exc.__class__.__name__ in {"ResourceAlreadyExistsError", "ResourceNameConflictError"}:
+        return True
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None) or getattr(exc, "status_code", None)
+    return status_code == 409
+
+
+async def _capture_with_name_retry(
+    client: Any, sandbox_id: str, slug: str, timeout: int
+) -> tuple[Any, str]:
+    """Capture, walking the name suffix forward past whatever the platform still holds."""
+    for attempt in range(1, CAPTURE_NAME_ATTEMPTS + 1):
+        snapshot_name = snapshot_name_for(slug, attempt)
+        try:
+            snapshot = await client.capture_snapshot(sandbox_id, snapshot_name, timeout=timeout)
+        except Exception as exc:
+            if attempt == CAPTURE_NAME_ATTEMPTS or not _is_name_conflict(exc):
+                raise
+            logger.info(
+                "Snapshot name %s is taken; retrying environment %s with the next suffix",
+                snapshot_name,
+                slug,
+            )
+            continue
+        return snapshot, snapshot_name
+    raise RuntimeError("unreachable snapshot capture retry state")
+
+
+async def capture_environment_snapshot(
+    slug: str,
+    sandbox_id: str,
+    *,
+    timeout: int = 600,
+) -> dict[str, Any]:
+    """Capture ``sandbox_id``'s filesystem as this environment's snapshot.
+
+    The previous snapshot is deleted only after the new one is ready, so a failed
+    capture leaves the environment booting from what it had before.
+    """
+    from agent.integrations.langsmith import get_async_sandbox_client
+
+    record = await get_environment(slug)
+    if record is None:
+        raise ValueError(f"no environment named {slug!r}")
+
+    previous_snapshot_id = record.get("snapshot_id")
+    await _set_snapshot_state(slug, "capturing")
+    try:
+        async with get_async_sandbox_client() as client:
+            snapshot, snapshot_name = await _capture_with_name_retry(
+                client, sandbox_id, slug, timeout
+            )
+    except Exception as exc:
+        logger.warning("snapshot capture failed for environment %s", slug, exc_info=True)
+        await _set_snapshot_state(slug, "failed", status_message=str(exc)[:1000])
+        raise
+
+    updated = await _set_snapshot_state(
+        slug,
+        "ready",
+        extra={
+            "snapshot_id": snapshot.id,
+            "snapshot_name": snapshot_name,
+            "source_sandbox_id": sandbox_id,
+            "last_captured_at": _now_iso(),
+        },
+    )
+    if previous_snapshot_id != snapshot.id:
+        await _delete_snapshot(previous_snapshot_id)
+    logger.info("Captured snapshot %s (%s) for environment %s", snapshot.id, snapshot_name, slug)
+    return updated or record

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -342,6 +342,15 @@ async def _set_snapshot_state(
     return record
 
 
+def _require_capture_support() -> None:
+    """Only the langsmith provider has a snapshot API to capture into."""
+    sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
+    if sandbox_type != "langsmith":
+        raise RuntimeError(
+            f"capturing an environment snapshot needs SANDBOX_TYPE=langsmith, not {sandbox_type!r}"
+        )
+
+
 async def _delete_snapshot(snapshot_id: object) -> None:
     """Best-effort delete of a superseded snapshot."""
     if not isinstance(snapshot_id, str) or not snapshot_id:
@@ -392,16 +401,23 @@ async def capture_environment_snapshot(
 ) -> dict[str, Any]:
     """Capture ``sandbox_id``'s filesystem as this environment's snapshot.
 
-    The previous snapshot is deleted only after the new one is ready, so a failed
-    capture leaves the environment booting from what it had before.
+    The previous snapshot survives a failed capture, in both senses: it is deleted
+    only once the new one is ready, and the record stays ``ready`` so runs keep
+    booting from it instead of dropping to the base image.
+
+    Only the langsmith provider can capture; other providers have no snapshot API
+    to capture into, so this raises rather than failing deep in the SDK.
     """
     from agent.integrations.langsmith import get_async_sandbox_client
+
+    _require_capture_support()
 
     record = await get_environment(slug)
     if record is None:
         raise ValueError(f"no environment named {slug!r}")
 
     previous_snapshot_id = record.get("snapshot_id")
+    previous_was_ready = bool(previous_snapshot_id) and record.get("snapshot_status") == "ready"
     await _set_snapshot_state(slug, "capturing")
     try:
         async with get_async_sandbox_client() as client:
@@ -410,7 +426,11 @@ async def capture_environment_snapshot(
             )
     except Exception as exc:
         logger.warning("snapshot capture failed for environment %s", slug, exc_info=True)
-        await _set_snapshot_state(slug, "failed", status_message=str(exc)[:1000])
+        await _set_snapshot_state(
+            slug,
+            "ready" if previous_was_ready else "failed",
+            status_message=str(exc)[:1000],
+        )
         raise
 
     updated = await _set_snapshot_state(

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -33,6 +33,18 @@ from .enabled_repos import (
     list_enabled_review_repos,
     set_review_repo_enabled,
 )
+from .environments import (
+    DEFAULT_ENVIRONMENT_SLUG,
+    EnvironmentCreate,
+    EnvironmentUpdate,
+    create_environment,
+    delete_environment,
+    get_environment,
+    list_environment_options,
+    list_environments,
+    slugify,
+    update_environment,
+)
 from .eval_jobs import (
     get_reviewer_eval_status,
 )
@@ -943,6 +955,78 @@ async def api_delete_repo_snapshot(
     if not record:
         raise HTTPException(404, "repo snapshot not found")
     await delete_repo_snapshot(full_name)
+    return Response(status_code=204)
+
+
+def _normalized_slug(raw: str) -> str:
+    try:
+        return slugify(raw)
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+
+
+@router.get("/environments")
+async def api_list_environments(
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    return {
+        "environments": await list_environments(),
+        "default_slug": DEFAULT_ENVIRONMENT_SLUG,
+    }
+
+
+@router.post("/environments")
+async def api_create_environment(
+    body: EnvironmentCreate,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    try:
+        return await create_environment(body, _admin["sub"])
+    except ValueError as e:
+        raise HTTPException(409, str(e)) from e
+
+
+@router.get("/environments/options")
+async def api_environment_options(
+    _session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    """Pickable environments for any signed-in user: names only, no prompts."""
+    return {
+        "environments": await list_environment_options(),
+        "default_slug": DEFAULT_ENVIRONMENT_SLUG,
+    }
+
+
+@router.get("/environments/{slug}")
+async def api_get_environment(
+    slug: str,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    record = await get_environment(_normalized_slug(slug))
+    if not record:
+        raise HTTPException(404, "environment not found")
+    return record
+
+
+@router.put("/environments/{slug}")
+async def api_update_environment(
+    slug: str,
+    body: EnvironmentUpdate,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    try:
+        return await update_environment(_normalized_slug(slug), body)
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+
+
+@router.delete("/environments/{slug}")
+async def api_delete_environment(
+    slug: str,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> Response:
+    if not await delete_environment(_normalized_slug(slug)):
+        raise HTTPException(404, "environment not found")
     return Response(status_code=204)
 
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -37,7 +37,9 @@ from ..utils.thread_ops import (
     langgraph_url,
     queue_message_for_thread,
 )
+from .admin import is_admin
 from .agent_overrides import normalize_profile_overrides
+from .environments import get_environment, slugify
 from .options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
@@ -441,6 +443,8 @@ async def _thread_summary(
         "model": model,
         "effort": effort,
         "planMode": metadata.get("plan_mode") is True,
+        "adminThread": metadata.get("admin_thread") is True,
+        "environment": metadata.get("environment"),
         "planStatus": metadata.get("plan_status"),
         "source": _thread_source(metadata),
         "status": status,
@@ -1059,6 +1063,21 @@ async def get_dashboard_thread(
     )
 
 
+async def _resolve_requested_environment(requested: Any) -> str | None:
+    """Normalize a requested environment slug, dropping one that does not exist.
+
+    The picker only offers configured environments, so a miss means a stale client
+    — the thread falls back to the default rather than booting from nothing.
+    """
+    if not isinstance(requested, str) or not requested.strip():
+        return None
+    try:
+        slug = slugify(requested)
+    except ValueError:
+        return None
+    return slug if await get_environment(slug) is not None else None
+
+
 def _resolve_repo_config(repo: str | None) -> dict[str, str]:
     """Resolve the run's repo from the request, or ``{}`` when none is given."""
     return _parse_repo(repo) or {}
@@ -1076,6 +1095,8 @@ async def _create_dashboard_thread_record(
     model_id: str | None = None,
     effort: str | None = None,
     plan_mode: bool = False,
+    admin_thread: bool = False,
+    environment: str | None = None,
 ) -> dict[str, Any]:
     """Create or update dashboard thread metadata without starting a run."""
     profile = await get_profile(login) or {}
@@ -1109,6 +1130,10 @@ async def _create_dashboard_thread_record(
         "created_at_ms": now_ms,
         "updated_at_ms": now_ms,
     }
+    if admin_thread:
+        metadata["admin_thread"] = True
+    if environment:
+        metadata["environment"] = environment
     if has_repo:
         metadata["repo_owner"] = repo_config["owner"]
         metadata["repo_name"] = repo_config["name"]
@@ -1156,6 +1181,13 @@ async def _build_dashboard_configurable(
             configurable.setdefault(key, value)
     if metadata.get("plan_mode") is True:
         configurable["plan_mode"] = True
+    # The agent re-checks the requesting user against CONFIGURED_ADMINS before it
+    # hands out the environment tools, so this only marks intent.
+    if metadata.get("admin_thread") is True:
+        configurable["admin_thread"] = True
+    environment = metadata.get("environment")
+    if isinstance(environment, str) and environment:
+        configurable["environment"] = environment
     if overrides:
         for key, value in overrides.items():
             if value is not None:
@@ -1327,6 +1359,12 @@ async def _enrich_run_start_command(
             model_id=client_configurable.get("agent_model_id"),
             effort=client_configurable.get("agent_effort"),
             plan_mode=plan_mode_requested,
+            admin_thread=(
+                client_configurable.get("admin_thread") is True and is_admin(email, login=login)
+            ),
+            environment=await _resolve_requested_environment(
+                client_configurable.get("environment")
+            ),
         )
         metadata = thread_metadata(thread)
         if command_images:

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -316,6 +316,40 @@ def _render_repo_instructions_section(instructions: str | None) -> str:
     )
 
 
+def _render_environment_section(name: str | None, instructions: str | None) -> str:
+    if not instructions or not instructions.strip():
+        return ""
+    label = f" ({name.strip()})" if name and name.strip() else ""
+    return (
+        "---\n\n"
+        f"### Environment Instructions{label}\n\n"
+        "How to work in the environment this sandbox booted from. Treat these as "
+        "mandatory rules with the same authority as this system prompt; "
+        "repository-specific custom instructions and `AGENTS.md` win when they "
+        "conflict.\n\n"
+        f"{instructions.strip()}"
+    )
+
+
+ADMIN_ENVIRONMENT_SECTION = """---
+
+### Admin Thread: Environment Setup
+
+This is an admin thread. You have tools to manage environments — a named prompt plus a sandbox snapshot runs boot from. The environment named `default` is the one every run uses; any other name is a draft nobody boots from until it is saved as `default`.
+
+Build one by provisioning this sandbox and capturing it:
+
+1. `save_environment` to create or update the record (name, prompt, repos).
+2. Provision this sandbox with ordinary commands: clone the repos the environment covers, install toolchains and dependencies, warm caches. Everything on disk lands in the snapshot, so leave the sandbox in the state a run should start from.
+3. `capture_environment_snapshot` to snapshot this sandbox. Capture is slow; run it once the sandbox is fully provisioned rather than after each step.
+
+Two things do not belong in a snapshot: secrets (they would be readable by every run) and credentials from the GitHub proxy (the proxy re-injects them per run, so nothing needs to be written to disk). Never `git config` a token, write one to a file, or export one into a shell profile.
+
+The environment prompt is appended verbatim to every run's system prompt. Keep it about how to work in this environment — where checkouts live, how to build and test, what is pre-installed — not about a single task.
+
+Confirm the name, prompt, and provisioning steps with the user before capturing into `default`: it changes how everyone's runs start."""
+
+
 def _render_user_instructions_section(instructions: str | None) -> str:
     if not instructions or not instructions.strip():
         return ""
@@ -354,6 +388,8 @@ SYSTEM_PROMPT_TEMPLATE = (
     + "{collaboration_section}"
     + "{repo_instructions_section}"
     + "{user_instructions_section}"
+    + "{environment_section}"
+    + "{admin_environment_section}"
     + "\n\n{shared_base_section}"
 )
 
@@ -373,6 +409,9 @@ def construct_system_prompt(
     user_custom_instructions: str | None = None,
     thread_url: str | None = None,
     corridor_enabled: bool = False,
+    environment_name: str | None = None,
+    environment_instructions: str | None = None,
+    admin_environments: bool = False,
 ) -> str:
     default_prompt_section = _load_default_prompt()
     if default_repo and default_repo.get("owner") and default_repo.get("name"):
@@ -409,6 +448,8 @@ def construct_system_prompt(
         collaboration_section=_render_collaboration_section(triggering_user_identity, thread_url),
         repo_instructions_section=_render_repo_instructions_section(repo_custom_instructions),
         user_instructions_section=_render_user_instructions_section(user_custom_instructions),
+        environment_section=_render_environment_section(environment_name, environment_instructions),
+        admin_environment_section=ADMIN_ENVIRONMENT_SECTION if admin_environments else "",
         shared_base_section=OPEN_SWE_SHARED_BASE,
         commit_identity_name=commit_identity_name,
         commit_identity_email=commit_identity_email,

--- a/agent/server.py
+++ b/agent/server.py
@@ -1158,6 +1158,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         PlanModeMiddleware(excluded=PLAN_MODE_EXCLUDED_TOOLS, initial=plan_mode)
     ]
 
+    admin_environments = _admin_thread(config, profile_login)
+    if admin_environments:
+        logger.info("Admin thread %s: adding environment management tools", thread_id)
+
     observability_authorized = await _observability_authorized(config, profile_login)
     if observability_authorized:
         observability_tools = await _load_observability_tools(True, profile_login)
@@ -1184,9 +1188,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             ),
         )
 
-    admin_environments = _admin_thread(config, profile_login)
-    if admin_environments:
-        logger.info("Admin thread %s: adding environment management tools", thread_id)
     static_tools = [
         http_request,
         fetch_url,

--- a/agent/server.py
+++ b/agent/server.py
@@ -11,7 +11,7 @@ the agent itself is stateless.
 import logging
 import os
 import warnings
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any, Literal, cast
 
@@ -41,7 +41,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langsmith.sandbox import SandboxClientError
 
-from .dashboard.admin import is_observability_authorized
+from .dashboard.admin import is_admin, is_observability_authorized
 from .dashboard.agent_overrides import (
     load_profile,
     normalize_profile_overrides,
@@ -51,6 +51,11 @@ from .dashboard.agent_overrides import (
     resolve_github_login,
 )
 from .dashboard.agent_usage import record_agent_thread_usage
+from .dashboard.environments import (
+    environment_prompt,
+    environment_snapshot_id,
+    resolve_environment,
+)
 from .dashboard.options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
@@ -108,6 +113,8 @@ from .runtime.constants import (
 from .runtime.execution import graph_loaded_for_execution
 from .tools import (
     approve_plan,
+    capture_environment_snapshot,
+    delete_environment,
     delete_user_skill,
     enter_plan_mode,
     fetch_url,
@@ -120,11 +127,13 @@ from .tools import (
     linear_list_teams,
     linear_search_issues,
     linear_update_issue,
+    list_environments,
     notify_automation_channel,
     open_pull_request,
     recreate_sandbox,
     report_platform_issue,
     request_pr_review,
+    save_environment,
     save_plan,
     save_user_instructions,
     save_user_skill,
@@ -282,13 +291,20 @@ async def _resolve_proxy_token(
     return token, expires_at, None
 
 
-async def _resolve_snapshot_id(repo: dict[str, str] | None) -> str | None:
+async def _resolve_snapshot_id(
+    repo: dict[str, str] | None,
+    environment_slug: str | None = None,
+) -> str | None:
     """Resolve the snapshot a new sandbox boots from.
 
-    A repo's ready snapshot wins, then the admin-configured base snapshot.
-    Never raises: any failure resolves to ``None`` so sandbox creation falls
-    back to the configured ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
+    The run's environment (its selection, else ``default``) wins, then the repo's
+    built snapshot, then the admin-configured base snapshot. Never raises: any
+    failure resolves to ``None`` so sandbox creation falls back to the configured
+    ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
     """
+    environment_snapshot = environment_snapshot_id(await resolve_environment(environment_slug))
+    if environment_snapshot:
+        return environment_snapshot
     if repo:
         try:
             repo_snapshot_id = await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
@@ -306,9 +322,10 @@ async def _create_sandbox_with_proxy(
     thread_id: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     repo: dict[str, str] | None = None,
+    environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
-    snapshot_id = await _resolve_snapshot_id(repo)
+    snapshot_id = await _resolve_snapshot_id(repo, environment_slug)
     sandbox_backend = await create_sandbox(snapshot_id=snapshot_id)
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
@@ -436,6 +453,7 @@ async def ensure_sandbox_for_thread(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     repo: dict[str, str] | None = None,
+    environment_slug: str | None = None,
     allow_replacement: bool = False,
 ) -> SandboxBackendProtocol:
     """Get-or-create a healthy sandbox bound to ``thread_id``.
@@ -483,6 +501,7 @@ async def ensure_sandbox_for_thread(
             thread_id=thread_id,
             github_proxy_repositories=github_proxy_repositories,
             repo=repo,
+            environment_slug=environment_slug,
         )
         logger.info("Sandbox created: %s", sandbox_backend.id)
     else:
@@ -539,6 +558,7 @@ async def recreate_sandbox_for_thread(
     thread_id: str,
     *,
     repo: dict[str, str] | None = None,
+    environment_slug: str | None = None,
 ) -> tuple[str, str]:
     """Bind a thread to a fresh sandbox while preserving its previous sandbox."""
     cached = SANDBOX_BACKENDS.get(thread_id)
@@ -550,6 +570,7 @@ async def recreate_sandbox_for_thread(
     new_sandbox = await _create_sandbox_with_proxy(
         thread_id=thread_id,
         repo=repo,
+        environment_slug=environment_slug,
     )
     if new_sandbox.id == old_sandbox_id:
         raise RuntimeError("Sandbox provider did not create a distinct sandbox")
@@ -592,6 +613,9 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
         "linear_create_issue",
         "linear_update_issue",
         "linear_delete_issue",
+        "save_environment",
+        "capture_environment_snapshot",
+        "delete_environment",
     }
 )
 
@@ -706,6 +730,28 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
     )
 
 
+def _environment_slug(configurable: Mapping[str, Any] | None) -> str | None:
+    """The environment this thread selected, if any."""
+    slug = (configurable or {}).get("environment")
+    return slug.strip() or None if isinstance(slug, str) else None
+
+
+def _admin_thread(config: RunnableConfig, profile_login: str | None) -> bool:
+    """Whether this run may manage environments.
+
+    The dashboard only stamps ``admin_thread`` for an admin session, but the flag
+    is re-checked here against ``CONFIGURED_ADMINS`` so a thread cannot carry the
+    capability to a non-admin who later messages it.
+    """
+    configurable = (config or {}).get("configurable") or {}
+    if configurable.get("admin_thread") is not True:
+        return False
+    config_login = configurable.get("github_login")
+    login = profile_login or (config_login if isinstance(config_login, str) else None)
+    email = configurable.get("user_email")
+    return is_admin(email if isinstance(email, str) else None, login=login)
+
+
 async def _allowed_org_member(config: RunnableConfig, profile_login: str | None) -> bool:
     configurable = (config or {}).get("configurable") or {}
     config_login = configurable.get("github_login")
@@ -815,6 +861,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         draft_prs: bool,
         plan_mode: bool,
         corridor_enabled: bool,
+        admin_environments: bool,
     ) -> None:
         self._thread_id = thread_id
         self._config = config
@@ -829,6 +876,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         self._draft_prs = draft_prs
         self._plan_mode = plan_mode
         self._corridor_enabled = corridor_enabled
+        self._admin_environments = admin_environments
 
     def _prepare_config_fingerprint(self) -> Any:
         configurable = (self._config or {}).get("configurable") or {}
@@ -899,9 +947,10 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             raise
         del github_token
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
-        repo_custom_instructions, user_custom_instructions = await asyncio.gather(
+        repo_custom_instructions, user_custom_instructions, environment = await asyncio.gather(
             _resolve_repo_custom_instructions(prompt_default_repo),
             _resolve_user_custom_instructions(self._profile_login),
+            resolve_environment(_environment_slug(configurable)),
         )
         turn_checkpoints = await self._record_turn_checkpoint(state, sandbox_backend, work_dir)
 
@@ -947,6 +996,9 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 user_custom_instructions=user_custom_instructions,
                 thread_url=dashboard_thread_url(self._thread_id),
                 corridor_enabled=self._corridor_enabled,
+                environment_name=(environment or {}).get("name"),
+                environment_instructions=environment_prompt(environment),
+                admin_environments=self._admin_environments,
             ),
         }
 
@@ -970,7 +1022,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         _configurable: dict[str, Any] = configurable,
     ) -> SandboxBackendProtocol:
         prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
-        return await ensure_sandbox_for_thread(_thread_id, repo=prompt_default_repo)
+        return await ensure_sandbox_for_thread(
+            _thread_id,
+            repo=prompt_default_repo,
+            environment_slug=_environment_slug(_configurable),
+        )
 
     backend = _get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
     backend.start()
@@ -1148,6 +1204,15 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         slack_start_new_thread,
         slack_thread_reply,
     ]
+    admin_environments = _admin_thread(config, profile_login)
+    if admin_environments:
+        logger.info("Admin thread %s: adding environment management tools", thread_id)
+        static_tools += [
+            list_environments,
+            save_environment,
+            capture_environment_snapshot,
+            delete_environment,
+        ]
     dynamic_tool_middleware: DynamicToolMiddleware | None = None
     integration_tool_groups = {
         "Corridor": corridor_tools,
@@ -1209,6 +1274,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     draft_prs=draft_prs,
                     plan_mode=plan_mode,
                     corridor_enabled=bool(corridor_tools),
+                    admin_environments=admin_environments,
                 ),
                 *([dynamic_tool_middleware] if dynamic_tool_middleware else []),
                 SanitizeToolInputsMiddleware(),

--- a/agent/server.py
+++ b/agent/server.py
@@ -730,6 +730,15 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
     )
 
 
+# Added to an admin thread's tools; see the admin-thread section of the prompt.
+ENVIRONMENT_TOOLS = (
+    list_environments,
+    save_environment,
+    capture_environment_snapshot,
+    delete_environment,
+)
+
+
 def _environment_slug(configurable: Mapping[str, Any] | None) -> str | None:
     """The environment this thread selected, if any."""
     slug = (configurable or {}).get("environment")
@@ -1175,6 +1184,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             ),
         )
 
+    admin_environments = _admin_thread(config, profile_login)
+    if admin_environments:
+        logger.info("Admin thread %s: adding environment management tools", thread_id)
     static_tools = [
         http_request,
         fetch_url,
@@ -1203,16 +1215,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         slack_read_thread_messages,
         slack_start_new_thread,
         slack_thread_reply,
+        *(ENVIRONMENT_TOOLS if admin_environments else ()),
     ]
-    admin_environments = _admin_thread(config, profile_login)
-    if admin_environments:
-        logger.info("Admin thread %s: adding environment management tools", thread_id)
-        static_tools += [
-            list_environments,
-            save_environment,
-            capture_environment_snapshot,
-            delete_environment,
-        ]
     dynamic_tool_middleware: DynamicToolMiddleware | None = None
     integration_tool_groups = {
         "Corridor": corridor_tools,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any
 _TOOL_MODULES = {
     "add_finding": ".add_finding",
     "approve_plan": ".approve_plan",
+    "capture_environment_snapshot": ".environments",
+    "delete_environment": ".environments",
     "enter_plan_mode": ".enter_plan_mode",
     "fetch_review_diff": ".fetch_review_diff",
     "fetch_url": ".fetch_url",
@@ -17,6 +19,7 @@ _TOOL_MODULES = {
     "linear_list_teams": ".linear_list_teams",
     "linear_search_issues": ".linear_search_issues",
     "linear_update_issue": ".linear_update_issue",
+    "list_environments": ".environments",
     "list_findings": ".list_findings",
     "list_review_findings": ".list_review_findings",
     "notify_automation_channel": ".notify_automation_channel",
@@ -28,6 +31,7 @@ _TOOL_MODULES = {
     "request_pr_review": ".request_pr_review",
     "reply_to_finding_thread": ".reply_to_finding_thread",
     "resolve_finding_thread": ".resolve_finding_thread",
+    "save_environment": ".environments",
     "save_plan": ".save_plan",
     "save_user_instructions": ".save_user_instructions",
     "save_user_skill": ".user_skills",
@@ -45,6 +49,8 @@ _TOOL_MODULES = {
 __all__ = [
     "add_finding",
     "approve_plan",
+    "capture_environment_snapshot",
+    "delete_environment",
     "enter_plan_mode",
     "fetch_review_diff",
     "fetch_url",
@@ -57,6 +63,7 @@ __all__ = [
     "linear_list_teams",
     "linear_search_issues",
     "linear_update_issue",
+    "list_environments",
     "list_findings",
     "list_review_findings",
     "notify_automation_channel",
@@ -68,6 +75,7 @@ __all__ = [
     "request_pr_review",
     "reply_to_finding_thread",
     "resolve_finding_thread",
+    "save_environment",
     "save_plan",
     "save_user_instructions",
     "save_user_skill",
@@ -86,6 +94,12 @@ if TYPE_CHECKING:
     from .add_finding import add_finding
     from .approve_plan import approve_plan
     from .enter_plan_mode import enter_plan_mode
+    from .environments import (
+        capture_environment_snapshot,
+        delete_environment,
+        list_environments,
+        save_environment,
+    )
     from .fetch_review_diff import fetch_review_diff
     from .fetch_url import fetch_url
     from .http_request import http_request

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -1,0 +1,201 @@
+"""Admin-thread tools for managing environments.
+
+Wired into the agent only for admin threads (see ``agent/server.py``). Every tool
+re-checks the triggering user against ``CONFIGURED_ADMINS`` so a thread whose
+metadata says "admin" cannot act on behalf of someone who is not one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..dashboard import environments as store
+from ..dashboard.admin import is_admin
+
+logger = logging.getLogger(__name__)
+
+_NOT_ADMIN = "Only workspace admins can manage environments."
+
+
+def _configurable() -> dict[str, Any]:
+    try:
+        config = get_config()
+    except Exception:
+        return {}
+    configurable = config.get("configurable") if isinstance(config, dict) else None
+    return configurable if isinstance(configurable, dict) else {}
+
+
+def _require_admin() -> str | None:
+    """Return an error message when the triggering user is not an admin."""
+    configurable = _configurable()
+    login = configurable.get("github_login")
+    email = configurable.get("user_email")
+    if is_admin(
+        email if isinstance(email, str) else None,
+        login=login if isinstance(login, str) else None,
+    ):
+        return None
+    return _NOT_ADMIN
+
+
+def _summary(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": record.get("name"),
+        "slug": record.get("slug"),
+        "prompt": record.get("prompt"),
+        "repos": record.get("repos") or [],
+        "snapshot_status": record.get("snapshot_status"),
+        "snapshot_id": record.get("snapshot_id"),
+        "snapshot_name": record.get("snapshot_name"),
+        "status_message": record.get("status_message"),
+        "last_captured_at": record.get("last_captured_at"),
+    }
+
+
+async def list_environments() -> dict[str, Any]:
+    """List every environment with its snapshot state.
+
+    The one named ``default`` is what runs boot from; the rest are drafts.
+
+    Returns:
+        ``{"ok": True, "environments": [...]}``.
+    """
+    if error := _require_admin():
+        return {"ok": False, "error": error}
+    records = await store.list_environments()
+    return {
+        "ok": True,
+        "environments": [
+            {**_summary(record), "is_default": record.get("slug") == store.DEFAULT_ENVIRONMENT_SLUG}
+            for record in records
+        ],
+    }
+
+
+async def save_environment(
+    name: str,
+    prompt: str,
+    repos: list[str] | None = None,
+) -> dict[str, Any]:
+    """Create an environment, or replace the prompt and repo list of an existing one.
+
+    Does not touch the environment's snapshot: capture that separately with
+    ``capture_environment_snapshot`` once this sandbox is provisioned.
+
+    Args:
+        name: Display name. Also the snapshot name stem, so keep it short and
+            hyphenated (``langsmith-monorepo``). Saving under an existing name
+            updates that environment rather than creating a second one. The name
+            ``default`` is the environment every run boots from; any other name
+            is a draft nobody boots from.
+        prompt: The complete instruction text appended to every run's system
+            prompt in this environment. This is a full replacement — pass the
+            whole text, not a delta. Empty string clears it.
+        repos: Optional ``owner/repo`` list this environment covers, for the
+            dashboard. Does not clone anything by itself.
+
+    Returns:
+        ``{"ok": True, "environment": {...}, "created": bool}``.
+    """
+    if error := _require_admin():
+        return {"ok": False, "error": error}
+    try:
+        slug = store.slugify(name)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    existing = await store.get_environment(slug)
+    try:
+        if existing is None:
+            login = _configurable().get("github_login")
+            record = await store.create_environment(
+                store.EnvironmentCreate(name=name, prompt=prompt, repos=repos or []),
+                login if isinstance(login, str) else "open-swe",
+            )
+        else:
+            record = await store.update_environment(
+                slug,
+                store.EnvironmentUpdate(name=name, prompt=prompt, repos=repos),
+            )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    except Exception as exc:
+        logger.exception("Failed to save environment %s", slug)
+        return {"ok": False, "error": f"failed to save environment: {exc}"}
+
+    return {"ok": True, "environment": _summary(record), "created": existing is None}
+
+
+async def capture_environment_snapshot(name: str) -> dict[str, Any]:
+    """Snapshot this sandbox as the named environment's image.
+
+    Everything currently on this sandbox's filesystem is captured, so provision it
+    fully first (clone the repos, install toolchains, warm caches) and leave no
+    secrets or tokens on disk. The snapshot replaces the environment's previous
+    one once it is ready. Capture takes minutes on a large filesystem.
+
+    New sandboxes boot from it only for the environment named ``default``.
+
+    Args:
+        name: Name of an environment already saved with ``save_environment``.
+
+    Returns:
+        ``{"ok": True, "environment": {...}}`` with the new snapshot id.
+    """
+    if error := _require_admin():
+        return {"ok": False, "error": error}
+    try:
+        slug = store.slugify(name)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    if await store.get_environment(slug) is None:
+        return {"ok": False, "error": f"no environment named {name!r}; call save_environment first"}
+
+    thread_id = _configurable().get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        return {"ok": False, "error": "no thread_id in the current run config"}
+
+    try:
+        from ..server import _start_langsmith_sandbox_if_needed
+        from ..utils.sandbox_state import get_sandbox_backend, unwrap_sandbox_backend
+
+        backend = unwrap_sandbox_backend(await get_sandbox_backend(thread_id))
+        await _start_langsmith_sandbox_if_needed(backend)
+        record = await store.capture_environment_snapshot(slug, backend.id)
+    except Exception as exc:
+        logger.exception("Failed to capture snapshot for environment %s", slug)
+        return {"ok": False, "error": f"snapshot capture failed: {exc}"}
+
+    return {"ok": True, "environment": _summary(record)}
+
+
+async def delete_environment(name: str) -> dict[str, Any]:
+    """Delete an environment and its snapshot.
+
+    Deleting ``default`` sends runs back to the per-repo and base snapshots.
+    Confirm with the user first: the snapshot cannot be recovered, only rebuilt.
+
+    Args:
+        name: Environment to delete.
+
+    Returns:
+        ``{"ok": True, "deleted": bool}``.
+    """
+    if error := _require_admin():
+        return {"ok": False, "error": error}
+    try:
+        slug = store.slugify(name)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    try:
+        deleted = await store.delete_environment(slug)
+    except Exception as exc:
+        logger.exception("Failed to delete environment %s", slug)
+        return {"ok": False, "error": f"failed to delete environment: {exc}"}
+    if not deleted:
+        return {"ok": False, "error": f"no environment named {name!r}"}
+    return {"ok": True, "deleted": True}

--- a/agent/tools/recreate_sandbox.py
+++ b/agent/tools/recreate_sandbox.py
@@ -30,12 +30,17 @@ async def recreate_sandbox() -> dict[str, Any]:
         return {"success": False, "error": "No thread_id in current run config"}
 
     try:
-        from ..server import _resolve_prompt_default_repo, recreate_sandbox_for_thread
+        from ..server import (
+            _environment_slug,
+            _resolve_prompt_default_repo,
+            recreate_sandbox_for_thread,
+        )
 
         repo = await _resolve_prompt_default_repo(configurable)
         old_sandbox_id, new_sandbox_id = await recreate_sandbox_for_thread(
             thread_id,
             repo=repo,
+            environment_slug=_environment_slug(configurable),
         )
     except Exception as exc:
         logger.exception("Failed to recreate sandbox for thread %s", thread_id)

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -168,6 +168,7 @@ __all__ = [
     "_get_or_resolve_thread_github_token",
     "_get_slack_channel_context",
     "_get_thread_metadata_safe",
+    "_get_thread_environment",
     "_get_thread_plan_mode",
     "_is_docs_plz_slack_channel",
     "_is_not_found_error",
@@ -734,6 +735,7 @@ async def upsert_agent_thread_owner_metadata(
     user_email: str = "",
     title: str = "",
     source_context: dict[str, Any] | None = None,
+    environment: str | None = None,
 ) -> None:
     """Persist owner/source metadata so the dashboard can surface non-dashboard threads.
 
@@ -749,6 +751,8 @@ async def upsert_agent_thread_owner_metadata(
         metadata["repo_name"] = repo_config["name"]
     if title:
         metadata["title"] = title[:80]
+    if environment:
+        metadata["environment"] = environment
 
     langgraph_client = get_client(url=LANGGRAPH_URL)
     try:
@@ -956,6 +960,22 @@ async def _get_thread_plan_mode(thread_id: str) -> bool | None:
         return None
     value = metadata.get("plan_mode")
     return value if isinstance(value, bool) else None
+
+
+async def _get_thread_environment(thread_id: str) -> str | None:
+    """Return the environment slug persisted for a thread, or ``None`` if unset."""
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    try:
+        thread = await langgraph_client.threads.get(thread_id)
+    except Exception as exc:  # noqa: BLE001
+        if not _is_not_found_error(exc):
+            logger.warning("Failed to fetch environment metadata for thread %s", thread_id)
+        return None
+    metadata = thread.get("metadata") if isinstance(thread, dict) else None
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("environment")
+    return value.strip() or None if isinstance(value, str) else None
 
 
 async def _set_thread_plan_mode(thread_id: str, enabled: bool) -> None:

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 import httpx
 from langchain_core.messages.content import create_text_block
 
+from agent.dashboard.environments import get_environment, parse_environment_tag
 from agent.utils.json_types import as_json_object
 from agent.utils.langsmith import get_langsmith_trace_url
 
@@ -425,6 +426,24 @@ async def _process_slack_mention_impl(
         common.strip_bot_mention(text, bot_user_id, bot_username=common.SLACK_BOT_USERNAME)
         or "(no text in mention)"
     )
+    is_first_mention = not await common._thread_exists(thread_id)
+    # `env:<name>` on the message that opens a thread picks the environment its
+    # sandbox boots from. Only the opening message can: the sandbox is created
+    # once, so honoring a later tag would change the prompt but not the image. The
+    # tag is stripped only when it resolves, so a typo stays visible in the
+    # transcript instead of vanishing.
+    environment_slug: str | None = None
+    if is_first_mention:
+        tagged_slug, text_without_tag = parse_environment_tag(clean_text)
+        if tagged_slug and await get_environment(tagged_slug) is not None:
+            environment_slug = tagged_slug
+            clean_text = text_without_tag or "(no text in mention)"
+        elif tagged_slug:
+            common.logger.info(
+                "Slack thread %s tagged unknown environment %s; using the default",
+                thread_id,
+                tagged_slug,
+            )
     trigger_user = user_name or (f"<@{user_id}>" if user_id else "Unknown user")
     trigger_user_timezone_section = (
         f"## Triggering User Time Zone\n{user_timezone}\n\n" if user_timezone else ""
@@ -561,6 +580,8 @@ async def _process_slack_mention_impl(
     }
     if mapped_login:
         configurable["github_login"] = mapped_login
+    if environment_slug:
+        configurable["environment"] = environment_slug
     if image_model_override:
         configurable["agent_model_id"] = image_model_override[0]
         configurable["agent_effort"] = image_model_override[1]
@@ -570,7 +591,6 @@ async def _process_slack_mention_impl(
         configurable["plan_mode"] = thread_plan_mode
 
     langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
-    is_first_mention = not await common._thread_exists(thread_id)
     await common._upsert_slack_thread_repo_metadata(thread_id, repo_config, langgraph_client)
     # Pass the login resolved above (from the stable Slack user id) so the thread is
     # always tagged with github_login — the key the dashboard searches by. Without

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -580,8 +580,12 @@ async def _process_slack_mention_impl(
     }
     if mapped_login:
         configurable["github_login"] = mapped_login
-    if environment_slug:
-        configurable["environment"] = environment_slug
+    # Later mentions carry no tag, so the thread's environment comes back from
+    # metadata — a follow-up must not be told about `default` while its sandbox
+    # was built from the environment the opening message picked.
+    thread_environment = environment_slug or await common._get_thread_environment(thread_id)
+    if thread_environment:
+        configurable["environment"] = thread_environment
     if image_model_override:
         configurable["agent_model_id"] = image_model_override[0]
         configurable["agent_effort"] = image_model_override[1]
@@ -603,6 +607,7 @@ async def _process_slack_mention_impl(
         user_email=user_email or "",
         title=clean_text if is_first_mention else "",
         source_context={"slack_thread": configurable["slack_thread"]},
+        environment=environment_slug,
     )
 
     # A DM (treat_all_messages_as_mentions) is inherently directed at the bot, so

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -222,6 +222,14 @@ REPO_SNAPSHOT_BASE_IMAGE="<your-docker-hub>/<name-of-your-image>"
 
 A base snapshot is required when `SANDBOX_TYPE=langsmith` — either `DEFAULT_SANDBOX_SNAPSHOT_ID` or the runtime setting described below. The server logs a warning at startup when neither the env var nor a stored setting is present, and sandbox creation fails until one is. The snapshot should include the GitHub CLI from `Dockerfile.sandbox`; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
 
+### Environments
+
+An **environment** pairs a prompt with a snapshot every run boots from, and can span several repos. Admins build one from an **admin thread** (the **Admin** toggle in the composer, available when their login or email is in `CONFIGURED_ADMINS`): the agent provisions its own sandbox — cloning repos, installing toolchains, warming caches — and then captures it. The environment named `default` is the one runs use; any other name is a draft. Records are managed on the admin **Environments** page.
+
+With more than one environment configured, a picker appears in the dashboard composer (any signed-in user, names only), and a Slack thread can pick one with an `env:<name>` tag on the message that opens it — `@Open SWE env:staging fix the flaky test`. Only the opening message can: the sandbox is created once, so a later tag would change the prompt but not the image. A run with no selection uses `default`.
+
+Captures are named `openswe-environment-<name>:latest`; set `ENVIRONMENT_SNAPSHOT_PREFIX` to replace the `openswe` prefix when several deployments share one LangSmith workspace. Snapshot resolution for a new sandbox is: the run's environment, then the repo's snapshot, then the base snapshot below.
+
 ### Changing the base snapshot without a redeploy
 
 Admins can override `DEFAULT_SANDBOX_SNAPSHOT_ID` at runtime from the **Repository Snapshots** page (**Base snapshot** field). The stored value wins; clearing it falls back to the env var. Per-repo snapshots still take precedence for runs targeting a repo with a ready snapshot.
@@ -570,6 +578,7 @@ DEFAULT_SANDBOX_VCPUS=""               # vCPUs per sandbox (default: 4)
 DEFAULT_SANDBOX_MEM_BYTES=""           # Memory in bytes per sandbox (default: 16 GiB)
 DEFAULT_SANDBOX_IDLE_TTL_SECONDS=""    # Auto-stop after N seconds idle (default: 7200; 0 disables)
 DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS=""  # Delete N seconds after stop (default: 2592000; 0 disables)
+ENVIRONMENT_SNAPSHOT_PREFIX=""         # Prefix for environment snapshot names (default: openswe)
 
 # === Token Encryption ===
 TOKEN_ENCRYPTION_KEY=""                # Generate with: openssl rand -base64 32

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent import server
+from agent.prompt import construct_system_prompt
+from agent.tools import environments as env_tools
+
+_READY = {"slug": "base", "name": "Base", "snapshot_status": "ready", "snapshot_id": "env-snap"}
+
+
+def _config(**configurable: object) -> dict[str, object]:
+    return {"configurable": configurable}
+
+
+# --- snapshot precedence ---
+
+
+@pytest.mark.asyncio
+async def test_default_environment_snapshot_wins_over_repo_and_base() -> None:
+    with (
+        patch.object(server, "resolve_environment", new_callable=AsyncMock, return_value=_READY),
+        patch.object(
+            server, "resolve_repo_snapshot_id", new_callable=AsyncMock, return_value="repo-snap"
+        ),
+        patch.object(
+            server, "get_admin_base_snapshot_id", new_callable=AsyncMock, return_value="admin-snap"
+        ),
+    ):
+        assert await server._resolve_snapshot_id({"owner": "acme", "name": "repo"}) == "env-snap"
+
+
+@pytest.mark.asyncio
+async def test_environment_without_ready_snapshot_falls_back_to_repo() -> None:
+    capturing = {**_READY, "snapshot_status": "capturing"}
+    with (
+        patch.object(server, "resolve_environment", new_callable=AsyncMock, return_value=capturing),
+        patch.object(
+            server, "resolve_repo_snapshot_id", new_callable=AsyncMock, return_value="repo-snap"
+        ),
+        patch.object(
+            server, "get_admin_base_snapshot_id", new_callable=AsyncMock, return_value="admin-snap"
+        ),
+    ):
+        assert await server._resolve_snapshot_id({"owner": "acme", "name": "repo"}) == "repo-snap"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_resolution_passes_the_threads_environment() -> None:
+    resolve = AsyncMock(return_value={**_READY, "slug": "staging", "snapshot_id": "staging-snap"})
+    with (
+        patch.object(server, "resolve_environment", resolve),
+        patch.object(
+            server, "resolve_repo_snapshot_id", new_callable=AsyncMock, return_value="repo-snap"
+        ),
+        patch.object(
+            server, "get_admin_base_snapshot_id", new_callable=AsyncMock, return_value="admin-snap"
+        ),
+    ):
+        snapshot_id = await server._resolve_snapshot_id(None, "staging")
+
+    assert snapshot_id == "staging-snap"
+    resolve.assert_awaited_once_with("staging")
+
+
+def test_environment_slug_reads_the_run_config() -> None:
+    assert server._environment_slug({"environment": "staging"}) == "staging"
+    assert server._environment_slug({"environment": "  "}) is None
+    assert server._environment_slug({}) is None
+    assert server._environment_slug(None) is None
+
+
+# --- admin thread gate ---
+
+
+def test_admin_thread_requires_flag_and_configured_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramon.nogueira@langchain.dev")
+    admin_config = _config(admin_thread=True, user_email="ramon.nogueira@langchain.dev")
+
+    assert server._admin_thread(admin_config, None) is True
+    # Same user, no flag: an ordinary thread never gets the tools.
+    assert server._admin_thread(_config(user_email="ramon.nogueira@langchain.dev"), None) is False
+    # Flag set by a thread whose current requester is not an admin.
+    non_admin = _config(admin_thread=True, user_email="someone@else.dev")
+    assert server._admin_thread(non_admin, None) is False
+
+
+def test_admin_thread_accepts_configured_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    assert server._admin_thread(_config(admin_thread=True), "ramonn") is True
+
+
+# --- tool gate ---
+
+
+@pytest.mark.asyncio
+async def test_tools_refuse_non_admins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    with patch.object(env_tools, "get_config", return_value=_config(github_login="someone-else")):
+        assert await env_tools.list_environments() == {
+            "ok": False,
+            "error": "Only workspace admins can manage environments.",
+        }
+        result = await env_tools.save_environment("base", "prompt")
+        assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_capture_tool_requires_a_saved_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    with (
+        patch.object(
+            env_tools,
+            "get_config",
+            return_value=_config(github_login="ramonn", thread_id="t-1"),
+        ),
+        patch.object(env_tools.store, "get_environment", new_callable=AsyncMock, return_value=None),
+    ):
+        result = await env_tools.capture_environment_snapshot("base")
+
+    assert result["ok"] is False
+    assert "save_environment" in result["error"]
+
+
+# --- prompt wiring ---
+
+
+def test_environment_instructions_render_in_system_prompt() -> None:
+    prompt = construct_system_prompt(
+        working_dir="/workspace",
+        environment_name="Base",
+        environment_instructions="Checkouts live in /workspace/repos.",
+    )
+    assert "### Environment Instructions (Base)" in prompt
+    assert "Checkouts live in /workspace/repos." in prompt
+    assert "### Admin Thread: Environment Setup" not in prompt
+
+
+def test_admin_section_only_for_admin_threads() -> None:
+    assert "### Admin Thread: Environment Setup" in construct_system_prompt(
+        working_dir="/workspace", admin_environments=True
+    )
+
+
+def test_blank_environment_prompt_renders_nothing() -> None:
+    prompt = construct_system_prompt(
+        working_dir="/workspace", environment_name="Base", environment_instructions="   "
+    )
+    assert "Environment Instructions" not in prompt

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from langgraph.graph.state import RunnableConfig
 
 from agent import server
 from agent.prompt import construct_system_prompt
@@ -11,8 +13,8 @@ from agent.tools import environments as env_tools
 _READY = {"slug": "base", "name": "Base", "snapshot_status": "ready", "snapshot_id": "env-snap"}
 
 
-def _config(**configurable: object) -> dict[str, object]:
-    return {"configurable": configurable}
+def _config(**configurable: object) -> RunnableConfig:
+    return cast(RunnableConfig, {"configurable": configurable})
 
 
 # --- snapshot precedence ---

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.dashboard import environments as env_store
+from agent.dashboard.environments import (
+    EnvironmentCreate,
+    EnvironmentUpdate,
+    environment_prompt,
+    environment_snapshot_id,
+    slugify,
+    snapshot_name_for,
+)
+
+
+def _fake_client() -> tuple[MagicMock, dict[tuple[Any, ...], Any]]:
+    store: dict[tuple[Any, ...], Any] = {}
+    client = MagicMock()
+
+    async def put_item(ns: list[str], key: str, value: dict[str, Any]) -> None:
+        store[(tuple(ns), key)] = value
+
+    async def get_item(ns: list[str], key: str) -> dict[str, Any] | None:
+        value = store.get((tuple(ns), key))
+        return {"value": value} if value is not None else None
+
+    async def delete_item(ns: list[str], key: str) -> None:
+        store.pop((tuple(ns), key), None)
+
+    async def search_items(ns: list[str], limit: int = 100) -> dict[str, Any]:
+        items = [
+            {"value": value} for (namespace, _key), value in store.items() if namespace == tuple(ns)
+        ]
+        return {"items": items[:limit]}
+
+    client.store.put_item = AsyncMock(side_effect=put_item)
+    client.store.get_item = AsyncMock(side_effect=get_item)
+    client.store.delete_item = AsyncMock(side_effect=delete_item)
+    client.store.search_items = AsyncMock(side_effect=search_items)
+    return client, store
+
+
+# --- slug + snapshot naming (sync) ---
+
+
+def test_slugify_normalizes_to_tag_safe_token() -> None:
+    assert slugify("  LangSmith Monorepo!  ") == "langsmith-monorepo"
+
+
+def test_slugify_rejects_names_without_alphanumerics() -> None:
+    with pytest.raises(ValueError, match="at least one letter or digit"):
+        slugify("---")
+
+
+def test_snapshot_name_is_prefixed_and_tagged_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ENVIRONMENT_SNAPSHOT_PREFIX", raising=False)
+    assert snapshot_name_for("monorepo") == "openswe-environment-monorepo:latest"
+    assert snapshot_name_for("monorepo", 3) == "openswe-environment-monorepo-3:latest"
+
+
+def test_snapshot_name_prefix_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT_SNAPSHOT_PREFIX", "acme")
+    assert snapshot_name_for("default") == "acme-environment-default:latest"
+
+
+def test_create_validates_repo_full_names() -> None:
+    create = EnvironmentCreate(
+        name="env", repos=["https://github.com/owner/repo.git", "owner/repo"]
+    )
+    assert create.repos == ["owner/repo"]
+
+
+def test_snapshot_id_only_resolves_when_ready() -> None:
+    assert environment_snapshot_id({"snapshot_status": "capturing", "snapshot_id": "s-1"}) is None
+    assert environment_snapshot_id({"snapshot_status": "ready", "snapshot_id": "s-1"}) == "s-1"
+    assert environment_snapshot_id(None) is None
+
+
+def test_environment_prompt_blank_is_none() -> None:
+    assert environment_prompt({"prompt": "   "}) is None
+    assert environment_prompt({"prompt": " build with make "}) == "build with make"
+
+
+# --- CRUD (patched store) ---
+
+
+@pytest.mark.asyncio
+async def test_only_the_environment_named_default_is_resolved() -> None:
+    client, _ = _fake_client()
+    with patch.object(env_store, "get_client", return_value=client):
+        await env_store.create_environment(EnvironmentCreate(name="Draft"), "ramon")
+        assert await env_store.resolve_default_environment() is None
+
+        await env_store.create_environment(EnvironmentCreate(name="Default"), "ramon")
+        resolved = await env_store.resolve_default_environment()
+
+    assert resolved is not None
+    assert resolved["slug"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_duplicate_name() -> None:
+    client, _ = _fake_client()
+    with patch.object(env_store, "get_client", return_value=client):
+        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+        with pytest.raises(ValueError, match="already exists"):
+            await env_store.create_environment(EnvironmentCreate(name="Base"), "ramon")
+
+
+@pytest.mark.asyncio
+async def test_update_writes_only_provided_fields() -> None:
+    client, _ = _fake_client()
+    with patch.object(env_store, "get_client", return_value=client):
+        await env_store.create_environment(
+            EnvironmentCreate(name="base", prompt="original", repos=["o/r"]), "ramon"
+        )
+        updated = await env_store.update_environment("base", EnvironmentUpdate(prompt="replaced"))
+        assert updated["prompt"] == "replaced"
+        assert updated["repos"] == ["o/r"]
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_a_rename_across_slugs() -> None:
+    client, _ = _fake_client()
+    with patch.object(env_store, "get_client", return_value=client):
+        await env_store.create_environment(EnvironmentCreate(name="draft"), "ramon")
+        with pytest.raises(ValueError, match="renaming an environment"):
+            await env_store.update_environment("draft", EnvironmentUpdate(name="default"))
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_record_and_snapshot() -> None:
+    client, _ = _fake_client()
+    delete_snapshot = AsyncMock()
+    with (
+        patch.object(env_store, "get_client", return_value=client),
+        patch.object(env_store, "_delete_snapshot", delete_snapshot),
+    ):
+        await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
+        await env_store._set_snapshot_state("default", "ready", extra={"snapshot_id": "snap-1"})
+
+        assert await env_store.delete_environment("default") is True
+        assert await env_store.resolve_default_environment() is None
+        delete_snapshot.assert_awaited_once_with("snap-1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_default_environment_swallows_store_failures() -> None:
+    client = MagicMock()
+    client.store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
+    with patch.object(env_store, "get_client", return_value=client):
+        assert await env_store.resolve_default_environment() is None
+
+
+# --- capture ---
+
+
+class _FakeSnapshot:
+    def __init__(self, snapshot_id: str) -> None:
+        self.id = snapshot_id
+
+
+def _sandbox_client(capture: AsyncMock) -> MagicMock:
+    client = MagicMock()
+    client.capture_snapshot = capture
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=client)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return context
+
+
+@pytest.mark.asyncio
+async def test_capture_tags_latest_and_replaces_previous_snapshot() -> None:
+    client, _ = _fake_client()
+    capture = AsyncMock(return_value=_FakeSnapshot("snap-2"))
+    delete_snapshot = AsyncMock()
+    with (
+        patch.object(env_store, "get_client", return_value=client),
+        patch.object(env_store, "_delete_snapshot", delete_snapshot),
+        patch(
+            "agent.integrations.langsmith.get_async_sandbox_client",
+            return_value=_sandbox_client(capture),
+        ),
+    ):
+        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+        await env_store._set_snapshot_state("base", "ready", extra={"snapshot_id": "snap-1"})
+
+        record = await env_store.capture_environment_snapshot("base", "sb-123")
+
+    assert capture.await_args is not None
+    assert capture.await_args.args == ("sb-123", "openswe-environment-base:latest")
+    assert record["snapshot_status"] == "ready"
+    assert record["snapshot_id"] == "snap-2"
+    assert record["snapshot_name"] == "openswe-environment-base:latest"
+    assert record["source_sandbox_id"] == "sb-123"
+    delete_snapshot.assert_awaited_once_with("snap-1")
+
+
+class _NameConflict(Exception):
+    """Stands in for the SDK's ResourceAlreadyExistsError (matched by class name)."""
+
+
+_NameConflict.__name__ = "ResourceAlreadyExistsError"
+
+
+@pytest.mark.asyncio
+async def test_capture_walks_the_name_suffix_past_a_conflict() -> None:
+    client, _ = _fake_client()
+    capture = AsyncMock(side_effect=[_NameConflict("taken"), _FakeSnapshot("snap-2")])
+    with (
+        patch.object(env_store, "get_client", return_value=client),
+        patch.object(env_store, "_delete_snapshot", AsyncMock()),
+        patch(
+            "agent.integrations.langsmith.get_async_sandbox_client",
+            return_value=_sandbox_client(capture),
+        ),
+    ):
+        await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
+        record = await env_store.capture_environment_snapshot("default", "sb-123")
+
+    assert [call.args[1] for call in capture.await_args_list] == [
+        "openswe-environment-default:latest",
+        "openswe-environment-default-2:latest",
+    ]
+    assert record["snapshot_status"] == "ready"
+    assert record["snapshot_name"] == "openswe-environment-default-2:latest"
+
+
+@pytest.mark.asyncio
+async def test_failed_capture_keeps_previous_snapshot() -> None:
+    client, _ = _fake_client()
+    capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
+    delete_snapshot = AsyncMock()
+    with (
+        patch.object(env_store, "get_client", return_value=client),
+        patch.object(env_store, "_delete_snapshot", delete_snapshot),
+        patch(
+            "agent.integrations.langsmith.get_async_sandbox_client",
+            return_value=_sandbox_client(capture),
+        ),
+    ):
+        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+        await env_store._set_snapshot_state("base", "ready", extra={"snapshot_id": "snap-1"})
+
+        with pytest.raises(RuntimeError, match="capture exploded"):
+            await env_store.capture_environment_snapshot("base", "sb-123")
+
+        record = await env_store.get_environment("base")
+
+    assert record is not None
+    assert record["snapshot_status"] == "failed"
+    assert record["status_message"] == "capture exploded"
+    # The environment still boots from what it had, and nothing was deleted.
+    assert record["snapshot_id"] == "snap-1"
+    delete_snapshot.assert_not_awaited()
+
+
+# --- per-thread selection ---
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_slug", "expected_text"),
+    [
+        ("env:staging please fix the bug", "staging", "please fix the bug"),
+        ("please fix the bug env:staging", "staging", "please fix the bug"),
+        ("please fix the bug", None, "please fix the bug"),
+        # Not a tag: no word boundary before it.
+        ("see env:staging/notes.md", None, "see env:staging/notes.md"),
+        ("open env:Staging-Box now", "staging-box", "open now"),
+    ],
+)
+def test_parse_environment_tag(text: str, expected_slug: str | None, expected_text: str) -> None:
+    assert env_store.parse_environment_tag(text) == (expected_slug, expected_text)
+
+
+@pytest.mark.asyncio
+async def test_resolve_environment_prefers_the_selection() -> None:
+    client, _ = _fake_client()
+    with patch.object(env_store, "get_client", return_value=client):
+        await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
+        await env_store.create_environment(EnvironmentCreate(name="staging"), "ramon")
+
+        selected = await env_store.resolve_environment("staging")
+        assert selected is not None
+        assert selected["slug"] == "staging"
+
+        assert (await env_store.resolve_environment(None))["slug"] == "default"
+        # A selection that no longer exists falls back rather than failing the run.
+        assert (await env_store.resolve_environment("deleted"))["slug"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_environment_options_omit_prompts() -> None:
+    client, _ = _fake_client()
+    with patch.object(env_store, "get_client", return_value=client):
+        await env_store.create_environment(
+            EnvironmentCreate(name="default", prompt="secret-ish prompt"), "ramon"
+        )
+        await env_store._set_snapshot_state("default", "ready", extra={"snapshot_id": "snap-1"})
+        options = await env_store.list_environment_options()
+
+    assert options == [{"slug": "default", "name": "default", "has_snapshot": True}]

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -331,9 +331,14 @@ async def test_resolve_environment_prefers_the_selection() -> None:
         assert selected is not None
         assert selected["slug"] == "staging"
 
-        assert (await env_store.resolve_environment(None))["slug"] == "default"
+        unselected = await env_store.resolve_environment(None)
+        assert unselected is not None
+        assert unselected["slug"] == "default"
+
         # A selection that no longer exists falls back rather than failing the run.
-        assert (await env_store.resolve_environment("deleted"))["slug"] == "default"
+        stale = await env_store.resolve_environment("deleted")
+        assert stale is not None
+        assert stale["slug"] == "default"
 
 
 @pytest.mark.asyncio

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -230,7 +230,7 @@ async def test_capture_walks_the_name_suffix_past_a_conflict() -> None:
 
 
 @pytest.mark.asyncio
-async def test_failed_capture_keeps_previous_snapshot() -> None:
+async def test_failed_recapture_keeps_booting_from_the_previous_snapshot() -> None:
     client, _ = _fake_client()
     capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
     delete_snapshot = AsyncMock()
@@ -251,11 +251,55 @@ async def test_failed_capture_keeps_previous_snapshot() -> None:
         record = await env_store.get_environment("base")
 
     assert record is not None
-    assert record["snapshot_status"] == "failed"
+    # Still ready, so runs keep booting from snap-1 instead of dropping to the
+    # base image; the error rides along in status_message.
+    assert record["snapshot_status"] == "ready"
+    assert environment_snapshot_id(record) == "snap-1"
     assert record["status_message"] == "capture exploded"
-    # The environment still boots from what it had, and nothing was deleted.
-    assert record["snapshot_id"] == "snap-1"
     delete_snapshot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_first_capture_failure_marks_the_environment_failed() -> None:
+    client, _ = _fake_client()
+    capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
+    with (
+        patch.object(env_store, "get_client", return_value=client),
+        patch(
+            "agent.integrations.langsmith.get_async_sandbox_client",
+            return_value=_sandbox_client(capture),
+        ),
+    ):
+        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+
+        with pytest.raises(RuntimeError, match="capture exploded"):
+            await env_store.capture_environment_snapshot("base", "sb-123")
+
+        record = await env_store.get_environment("base")
+
+    # Nothing to fall back to, so the record says so rather than claiming ready.
+    assert record is not None
+    assert record["snapshot_status"] == "failed"
+    assert environment_snapshot_id(record) is None
+
+
+@pytest.mark.asyncio
+async def test_capture_requires_the_langsmith_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SANDBOX_TYPE", "local")
+    client, _ = _fake_client()
+    capture = AsyncMock()
+    with (
+        patch.object(env_store, "get_client", return_value=client),
+        patch(
+            "agent.integrations.langsmith.get_async_sandbox_client",
+            return_value=_sandbox_client(capture),
+        ),
+    ):
+        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+        with pytest.raises(RuntimeError, match="SANDBOX_TYPE=langsmith"):
+            await env_store.capture_environment_snapshot("base", "sb-123")
+
+    capture.assert_not_awaited()
 
 
 # --- per-thread selection ---

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -22,6 +22,8 @@ code runs for real.
 | The LLM                                                          | **fake** — a scripted model (`fake_llm.py`) emitting a fixed tool sequence |
 | `api.github.com` REST (PR create) + dashboard GitHub OAuth login | **fake** (`/fake-gh/...`), state rendered at `/mock/github`                |
 | `slack.com/api` (post message, etc.)                             | **fake** (`/fake-slack/...`), thread rendered at `/mock/slack`             |
+| Environment tools, store records, snapshot naming + status       | **real**                                                                   |
+| LangSmith snapshot service (capture/delete)                      | **fake** (`patches.py`) — the local sandbox has nothing to snapshot         |
 | GitHub App token mint, `api.github.com/user` identity            | stubbed (offline)                                                          |
 
 The fake GitHub/Slack stores are the single source of truth the mock UIs render,

--- a/tests/e2e/e2e_env.py
+++ b/tests/e2e/e2e_env.py
@@ -77,6 +77,11 @@ TEST_USERS = [
     {"name": "Bob", "slack_id": "U_BOB", "login": "bob", "email": "bob@example.com"},
 ]
 
+# Alice is the workspace admin (so admin threads + the environments dashboard are
+# reachable); Bob is a plain member, which is what the deny-side assertions use.
+ADMIN_USER = TEST_USERS[0]
+_DEFAULTS["CONFIGURED_ADMINS"] = ADMIN_USER["email"]
+
 # The default Slack sender / thread owner; a session with this email may continue
 # the thread on the web. Any other logged-in user is read-only.
 SAME_USER = {"login": TEST_USERS[0]["login"], "email": TEST_USERS[0]["email"]}

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -26,7 +26,13 @@ from e2e_env import (
 )
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.outputs import ChatGeneration, ChatResult
 
 # One shell command that does the whole git workflow. Each execute() runs in a
@@ -49,6 +55,10 @@ git commit -m "{PR_TITLE}"
 git push origin {FEATURE_BRANCH}
 echo PUSHED_OK
 """.strip()
+
+# The system prompt of the most recent model call, so specs can assert what the
+# agent was actually told (e.g. the environment section) rather than infer it.
+LAST_SYSTEM_PROMPT: dict[str, str] = {"text": ""}
 
 _PLAN_URL_RE = re.compile(r"https?://[^\s\"'<>)\]|]+/plan\b")
 _ATTRIBUTION_RE = re.compile(r"@([A-Za-z0-9-]+):")
@@ -258,6 +268,12 @@ def _plan_complete_step(messages: list[BaseMessage]) -> AIMessage:
     )
 
 
+ENVIRONMENT_NAME = "default"
+ENVIRONMENT_PROMPT = (
+    "Checkouts live in /workspace/repos. Build with `make build`, test with `make test`."
+)
+ENVIRONMENT_PROVISION_SCRIPT = "mkdir -p repos && echo provisioned > repos/.provisioned && ls repos"
+
 FOLLOW_UP_REPLY = "Thanks! The PR is ready for review — anything else you'd like changed?"
 
 
@@ -342,12 +358,41 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
         _dynamic_step(_plan_complete_step),
         StepSpec(content="I'll wait for your review and approval before implementing."),
     ),
+    "environment": (
+        _tool_step(
+            "Provisioning this sandbox before capturing it.",
+            "execute",
+            {"command": ENVIRONMENT_PROVISION_SCRIPT},
+            "call-env-provision",
+        ),
+        _tool_step(
+            "Saving the environment record.",
+            "save_environment",
+            {
+                "name": ENVIRONMENT_NAME,
+                "prompt": ENVIRONMENT_PROMPT,
+                "repos": [f"{OWNER}/{REPO}"],
+            },
+            "call-env-save",
+        ),
+        _tool_step(
+            "Capturing this sandbox as the environment snapshot.",
+            "capture_environment_snapshot",
+            {"name": ENVIRONMENT_NAME},
+            "call-env-capture",
+        ),
+        StepSpec(content=f"The `{ENVIRONMENT_NAME}` environment is captured and live."),
+    ),
     "followup": (_dynamic_step(_followup_step),),
 }
 
 
 def _is_plan_request(text: str) -> bool:
     return "plan" in text.lower()
+
+
+def _is_environment_request(text: str) -> bool:
+    return "environment" in text.lower()
 
 
 def _is_breakout_request(text: str) -> bool:
@@ -366,6 +411,9 @@ def _is_revision(text: str) -> bool:
 
 
 SCRIPT_RULES: tuple[ScriptRule, ...] = (
+    ScriptRule(
+        "environment", lambda ctx: ctx.human_count <= 1 and _is_environment_request(ctx.first_text)
+    ),
     ScriptRule("implement", lambda ctx: _is_approval(ctx.last_text)),
     ScriptRule("plan", lambda ctx: _is_revision(ctx.last_text)),
     ScriptRule("plan", lambda ctx: ctx.human_count <= 1 and _is_plan_request(ctx.first_text)),
@@ -407,6 +455,10 @@ class FakeScriptedChatModel(BaseChatModel):
         run_manager: CallbackManagerForLLMRun | None = None,  # noqa: ARG002
         **kwargs: Any,
     ) -> ChatResult:
+        for message in messages:
+            if isinstance(message, SystemMessage):
+                LAST_SYSTEM_PROMPT["text"] = _text(message.content)
+                break
         humans = [m for m in messages if isinstance(m, HumanMessage)]
         context = ScriptContext(
             first_text=_text(humans[0].content) if humans else "",

--- a/tests/e2e/fakes.py
+++ b/tests/e2e/fakes.py
@@ -172,9 +172,31 @@ def repo_private() -> bool:
     return REPO_PRIVATE[0]
 
 
+# --- LangSmith snapshots ---------------------------------------------------
+# Captures the environment tools asked for: {"snapshot_id", "name", "sandbox_id"}.
+# The E2E sandbox is the local provider, so there is no real snapshot service —
+# this store stands in for it and is what the specs assert on.
+SNAPSHOTS: list[dict[str, Any]] = []
+DELETED_SNAPSHOTS: list[str] = []
+_snapshot_seq = [0]
+
+
+def record_snapshot_capture(sandbox_id: str, name: str) -> str:
+    _snapshot_seq[0] += 1
+    snapshot_id = f"snap-{_snapshot_seq[0]}"
+    SNAPSHOTS.append({"snapshot_id": snapshot_id, "name": name, "sandbox_id": sandbox_id})
+    return snapshot_id
+
+
+def record_snapshot_delete(snapshot_id: str) -> None:
+    DELETED_SNAPSHOTS.append(snapshot_id)
+
+
 def reset() -> None:
     SLACK_MESSAGES.clear()
     PULLS.clear()
+    SNAPSHOTS.clear()
+    DELETED_SNAPSHOTS.clear()
     REPO_PRIVATE[0] = False
     _pr_seq[0] = 0
     seed_bare_remote()

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -96,6 +96,20 @@ async def control_state() -> JSONResponse:
     )
 
 
+@app.get("/control/snapshots")
+async def control_snapshots() -> JSONResponse:
+    """Snapshot captures/deletes the environment tools asked the platform for."""
+    return JSONResponse({"captured": fakes.SNAPSHOTS, "deleted": fakes.DELETED_SNAPSHOTS})
+
+
+@app.get("/control/last-system-prompt")
+async def control_last_system_prompt() -> JSONResponse:
+    """The system prompt of the most recent model call (what the agent was told)."""
+    from fake_llm import LAST_SYSTEM_PROMPT
+
+    return JSONResponse({"text": LAST_SYSTEM_PROMPT["text"]})
+
+
 @app.post("/control/repo-private")
 async def control_repo_private(request: Request) -> JSONResponse:
     body = await request.json()

--- a/tests/e2e/patches.py
+++ b/tests/e2e/patches.py
@@ -86,9 +86,13 @@ def apply() -> None:
     # provider, so there is nothing to capture from — record the request in the
     # fake store instead. The environment tools, store writes, name/tag scheme
     # and status transitions all still run for real.
+    from agent.dashboard import environments as environments_store
     from agent.integrations import langsmith as langsmith_integration
 
     langsmith_integration.get_async_sandbox_client = _FakeSandboxClient
+    # The capture path refuses to run off the langsmith provider; with that
+    # provider's snapshot API faked above, the E2E's local sandbox is capturable.
+    environments_store._require_capture_support = lambda: None
 
     _applied = True
 

--- a/tests/e2e/patches.py
+++ b/tests/e2e/patches.py
@@ -82,4 +82,46 @@ def apply() -> None:
     profiles.get_valid_access_token = _dummy_user_token
     thread_api.get_valid_access_token = _dummy_user_token
 
+    # Snapshot service: another external boundary. The E2E runs the local sandbox
+    # provider, so there is nothing to capture from — record the request in the
+    # fake store instead. The environment tools, store writes, name/tag scheme
+    # and status transitions all still run for real.
+    from agent.integrations import langsmith as langsmith_integration
+
+    langsmith_integration.get_async_sandbox_client = _FakeSandboxClient
+
     _applied = True
+
+
+class _FakeSnapshot:
+    def __init__(self, snapshot_id: str, name: str) -> None:
+        self.id = snapshot_id
+        self.name = name
+        self.status = "ready"
+
+
+class _FakeSandboxClient:
+    """Stands in for ``AsyncSandboxClient`` for snapshot calls only."""
+
+    async def __aenter__(self) -> _FakeSandboxClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def capture_snapshot(
+        self,
+        sandbox_name: str,
+        name: str,
+        *,
+        timeout: int = 60,  # noqa: ARG002
+        **_kwargs: object,
+    ) -> _FakeSnapshot:
+        import fakes
+
+        return _FakeSnapshot(fakes.record_snapshot_capture(sandbox_name, name), name)
+
+    async def delete_snapshot(self, snapshot_id: str) -> None:
+        import fakes
+
+        fakes.record_snapshot_delete(snapshot_id)

--- a/tests/e2e/tests/environments.spec.ts
+++ b/tests/e2e/tests/environments.spec.ts
@@ -1,0 +1,338 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Environments end-to-end: the admin dashboard CRUD, the admin gate, and an
+// admin thread that provisions its own sandbox and captures it. The agent, the
+// tools, the store writes and the prompt injection are all real — only the LLM
+// and the snapshot service are faked (see patches.py).
+const ADMIN = { login: "alice", email: "alice@example.com" };
+const MEMBER = { login: "bob", email: "bob@example.com" };
+
+const DEFAULT_SLUG = "default";
+const DRAFT_NAME = "Staging Box";
+const DRAFT_SLUG = "staging-box";
+const EXPECTED_SNAPSHOT_NAME = "openswe-environment-default:latest";
+const ALT_NAME = "Alt Box";
+const ALT_SLUG = "alt-box";
+const DEFAULT_ENV_PROMPT = "Default environment: run make test.";
+const ALT_ENV_PROMPT = "Alt environment: run pytest -q.";
+// Mirrors fake_llm.py's environment script.
+const ENVIRONMENT_PROMPT =
+  "Checkouts live in /workspace/repos. Build with `make build`, test with `make test`.";
+
+interface Environment {
+  slug: string;
+  name: string;
+  prompt: string;
+  repos: Array<string>;
+  snapshot_id: string | null;
+  snapshot_name: string | null;
+  snapshot_status: string;
+}
+
+async function loginAs(page: Page, user: { login: string; email: string }) {
+  const res = await page.request.post("/control/login", { data: user });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function listEnvironments(page: Page): Promise<Array<Environment>> {
+  const res = await page.request.get("/dashboard/api/environments");
+  expect(res.ok()).toBeTruthy();
+  return ((await res.json()) as { environments: Array<Environment> })
+    .environments;
+}
+
+async function findEnvironment(
+  page: Page,
+  slug: string,
+): Promise<Environment | undefined> {
+  return (await listEnvironments(page)).find((env) => env.slug === slug);
+}
+
+const BASE_URL = `http://127.0.0.1:${process.env.E2E_PORT ?? 2024}`;
+
+// The dashboard's mutating routes enforce same-origin, which a browser sets for
+// itself but APIRequestContext does not.
+const SAME_ORIGIN_HEADERS = { origin: BASE_URL, referer: `${BASE_URL}/` };
+
+async function deleteEnvironment(page: Page, slug: string) {
+  await page.request.delete(`/dashboard/api/environments/${slug}`, {
+    headers: SAME_ORIGIN_HEADERS,
+  });
+}
+
+// Saving a default model retires the first-run onboarding modal, which otherwise
+// covers the composer on the new-agent page.
+async function saveDefaultModel(page: Page) {
+  const options = (await (
+    await page.request.get("/dashboard/api/options")
+  ).json()) as {
+    default_agent_model: string;
+    default_agent_reasoning_effort: string;
+  };
+  const res = await page.request.put("/dashboard/api/profile", {
+    headers: SAME_ORIGIN_HEADERS,
+    data: {
+      default_model: options.default_agent_model,
+      reasoning_effort: options.default_agent_reasoning_effort,
+    },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function capturedSnapshots(
+  page: Page,
+): Promise<Array<{ snapshot_id: string; name: string; sandbox_id: string }>> {
+  const res = await page.request.get("/control/snapshots");
+  expect(res.ok()).toBeTruthy();
+  return (
+    (await res.json()) as {
+      captured: Array<{
+        snapshot_id: string;
+        name: string;
+        sandbox_id: string;
+      }>;
+    }
+  ).captured;
+}
+
+async function lastSystemPrompt(page: Page): Promise<string> {
+  const res = await page.request.get("/control/last-system-prompt");
+  expect(res.ok()).toBeTruthy();
+  return ((await res.json()) as { text: string }).text;
+}
+
+async function openNewAgentHome(page: Page) {
+  await saveDefaultModel(page);
+  await page.goto("/agents");
+  await expect(page.getByTestId("composer-editor")).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+}
+
+async function createEnvironment(
+  page: Page,
+  name: string,
+  prompt: string,
+): Promise<string> {
+  const created = await page.request.post("/dashboard/api/environments", {
+    headers: SAME_ORIGIN_HEADERS,
+    data: { name, prompt },
+  });
+  expect(created.ok()).toBeTruthy();
+  // No snapshot: the prompt applies on its own, and the sandbox falls back to
+  // the base image — which is what these selection specs assert on.
+  return ((await created.json()) as { slug: string }).slug;
+}
+
+async function typeIntoComposer(page: Page, text: string) {
+  const editor = page.getByTestId("composer-editor");
+  await editor.click();
+  await editor.pressSequentially(text);
+  await editor.press("Enter");
+}
+
+test.describe("Environments", () => {
+  test("an admin creates, edits and deletes an environment in the dashboard", async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN);
+    await deleteEnvironment(page, DRAFT_SLUG);
+
+    await page.goto("/agents/environments");
+    await expect(
+      page.getByRole("heading", { name: "Environments" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Add environment").fill(DRAFT_NAME);
+    await page.getByRole("button", { name: "Add" }).click();
+
+    // Selected on create: any name other than `default` is a draft no run boots from.
+    await expect(
+      page.getByText("draft — no run boots from this"),
+    ).toBeVisible();
+    await expect(page.getByText("No snapshot").first()).toBeVisible();
+
+    await page.getByLabel("Repositories").fill("fakeorg/demo, fakeorg/demo");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Deduped and normalized server-side, which is why the spec asserts on the record.
+    await expect
+      .poll(async () => (await findEnvironment(page, DRAFT_SLUG))?.repos)
+      .toEqual(["fakeorg/demo"]);
+
+    page.once("dialog", (dialog) => void dialog.accept());
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect.poll(() => findEnvironment(page, DRAFT_SLUG)).toBeUndefined();
+  });
+
+  test("a non-admin cannot reach the environments page or API", async ({
+    page,
+  }) => {
+    await loginAs(page, MEMBER);
+
+    const res = await page.request.get("/dashboard/api/environments");
+    expect(res.status()).toBe(403);
+
+    await page.goto("/agents/environments");
+    await expect(page).toHaveURL(/\/my-settings/);
+    await expect(
+      page.getByRole("heading", { name: "Environments" }),
+    ).toHaveCount(0);
+
+    // No Admin toggle in the composer, so they cannot start an admin thread.
+    await openNewAgentHome(page);
+    await expect(page.getByTestId("composer-editor")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Admin" })).toHaveCount(0);
+  });
+
+  test("the composer picker appears only with several environments, and the pick reaches the run", async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN);
+    await deleteEnvironment(page, DEFAULT_SLUG);
+    await deleteEnvironment(page, ALT_SLUG);
+    await createEnvironment(page, "default", DEFAULT_ENV_PROMPT);
+
+    // One environment: the choice is already made, so no control is rendered.
+    await openNewAgentHome(page);
+    await expect(page.getByRole("button", { name: "Environment" })).toHaveCount(
+      0,
+    );
+
+    await createEnvironment(page, ALT_NAME, ALT_ENV_PROMPT);
+    await page.reload();
+    const picker = page.getByRole("button", { name: "Environment" });
+    await expect(picker).toBeVisible();
+    // Defaults to the environment named `default`.
+    await expect(picker).toContainText("default");
+
+    await picker.click();
+    await page.getByRole("button", { name: new RegExp(ALT_NAME) }).click();
+    await expect(picker).toContainText(ALT_NAME);
+
+    await typeIntoComposer(page, "Which environment am I in?");
+    await expect(page).toHaveURL(/\/agents\/[^/]+$/);
+    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
+
+    // The thread records the pick, and the run's prompt carries that
+    // environment's instructions — not the default's.
+    await expect
+      .poll(async () => {
+        const res = await page.request.get(
+          `/dashboard/api/threads/${threadId}?mark_viewed=false`,
+        );
+        return res.ok()
+          ? ((await res.json()) as { environment?: string | null }).environment
+          : undefined;
+      })
+      .toBe(ALT_SLUG);
+    await expect
+      .poll(() => lastSystemPrompt(page), { timeout: 30_000 })
+      .toContain(ALT_ENV_PROMPT);
+    expect(await lastSystemPrompt(page)).not.toContain(DEFAULT_ENV_PROMPT);
+
+    await deleteEnvironment(page, ALT_SLUG);
+    await deleteEnvironment(page, DEFAULT_SLUG);
+  });
+
+  test("an env: tag on the opening Slack message selects the environment", async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN);
+    await deleteEnvironment(page, ALT_SLUG);
+    await createEnvironment(page, ALT_NAME, ALT_ENV_PROMPT);
+
+    await page.goto("/mock/slack");
+    await page.locator("#reset").click();
+    await expect(page.locator("#thread")).toContainText("No messages yet");
+    await page
+      .locator("#text")
+      .fill(
+        `<@U0BOT> env:${ALT_SLUG} please add a greet() helper and open a PR`,
+      );
+    await page.locator("#send").click();
+
+    await expect(
+      page.locator(".msg.bot").filter({ hasText: "Add greet() helper" }),
+    ).toBeVisible();
+
+    const systemPrompt = await lastSystemPrompt(page);
+    expect(systemPrompt).toContain(ALT_ENV_PROMPT);
+    // The tag itself is consumed, so the agent never sees it in the request.
+    expect(systemPrompt).not.toContain(`env:${ALT_SLUG}`);
+
+    await deleteEnvironment(page, ALT_SLUG);
+  });
+
+  test("an admin thread provisions its sandbox, captures it, and later runs boot with the environment prompt", async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN);
+    await deleteEnvironment(page, DEFAULT_SLUG);
+    await page.request.post("/control/reset");
+
+    await openNewAgentHome(page);
+    const adminToggle = page.getByRole("button", { name: "Admin" });
+    await expect(adminToggle).toBeVisible();
+    await adminToggle.click();
+    await expect(adminToggle).toHaveAttribute("aria-pressed", "true");
+
+    await typeIntoComposer(
+      page,
+      "Please set up the default environment for this repo and capture it.",
+    );
+    await expect(page).toHaveURL(/\/agents\/[^/]+$/);
+    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(threadId).not.toBe("");
+
+    // The agent's own summary, after the real save + capture tools ran.
+    await expect(
+      page.getByText(/environment is captured and live/),
+    ).toBeVisible();
+
+    // The record the real tools wrote: prompt, repos, and a ready snapshot.
+    const record = await findEnvironment(page, DEFAULT_SLUG);
+    expect(record).toBeDefined();
+    expect(record?.prompt).toBe(ENVIRONMENT_PROMPT);
+    expect(record?.repos).toEqual(["fakeorg/demo"]);
+    expect(record?.snapshot_status).toBe("ready");
+    expect(record?.snapshot_name).toBe(EXPECTED_SNAPSHOT_NAME);
+
+    // The capture went to the platform against this thread's own sandbox.
+    const captures = await capturedSnapshots(page);
+    expect(captures.map((c) => c.name)).toEqual([EXPECTED_SNAPSHOT_NAME]);
+    expect(captures[0]?.snapshot_id).toBe(record?.snapshot_id);
+    const threadRes = await page.request.get(
+      `/dashboard/api/threads/${threadId}?mark_viewed=false`,
+    );
+    expect(threadRes.ok()).toBeTruthy();
+    const thread = (await threadRes.json()) as { sandboxId?: string | null };
+    expect(captures[0]?.sandbox_id).toBe(thread.sandboxId);
+
+    // A later run is told about the environment: the prompt is appended verbatim.
+    await typeIntoComposer(page, "Thanks — anything else needed?");
+    await expect(
+      page.getByText(/anything else you'd like changed/),
+    ).toBeVisible();
+    const systemPrompt = await lastSystemPrompt(page);
+    expect(systemPrompt).toContain("### Environment Instructions (default)");
+    expect(systemPrompt).toContain(ENVIRONMENT_PROMPT);
+    // Admin threads also carry the environment-management instructions.
+    expect(systemPrompt).toContain("### Admin Thread: Environment Setup");
+
+    // The dashboard shows it as the environment runs boot from.
+    await page.goto("/agents/environments");
+    await page
+      .getByRole("button", { name: /default/ })
+      .first()
+      .click();
+    await expect(page.getByText("runs boot from this")).toBeVisible();
+    await expect(page.getByText(EXPECTED_SNAPSHOT_NAME)).toBeVisible();
+
+    // Leave no default behind: later specs' runs would boot from it.
+    page.once("dialog", (dialog) => void dialog.accept());
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect
+      .poll(() => findEnvironment(page, DEFAULT_SLUG))
+      .toBeUndefined();
+  });
+});

--- a/tests/sandbox/test_sandbox_recreation.py
+++ b/tests/sandbox/test_sandbox_recreation.py
@@ -46,6 +46,7 @@ async def test_recreate_sandbox_hands_off_after_metadata_persists() -> None:
     create.assert_awaited_once_with(
         thread_id=thread_id,
         repo={"owner": "langchain-ai", "name": "open-swe"},
+        environment_slug=None,
     )
     configure.assert_awaited_once_with(new_sandbox)
     update.assert_awaited_once_with(

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1343,3 +1343,40 @@ def test_get_slack_permalink_without_token_returns_none(monkeypatch: pytest.Monk
     result = asyncio.run(get_slack_permalink("C123", "1700000000.000100"))
 
     assert result is None
+
+
+def test_thread_environment_round_trips_through_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tagged opening message persists the environment; follow-ups read it back.
+
+    Without this, a follow-up (which carries no `env:` tag) would resolve the
+    default environment while reusing the sandbox built from the tagged one.
+    """
+    threads = _FakeThreadsClient({"metadata": {}})
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+
+    asyncio.run(
+        webhook_common.upsert_agent_thread_owner_metadata(
+            "thread-id",
+            source="slack",
+            environment="staging",
+        )
+    )
+    assert threads.thread is not None
+    assert threads.thread["metadata"]["environment"] == "staging"
+    assert asyncio.run(webhook_common._get_thread_environment("thread-id")) == "staging"
+
+
+def test_thread_environment_is_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    threads = _FakeThreadsClient({"metadata": {}})
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+    assert asyncio.run(webhook_common._get_thread_environment("thread-id")) is None
+
+
+def test_thread_environment_is_none_for_a_missing_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads = _FakeThreadsClient(raise_not_found=True)
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+    assert asyncio.run(webhook_common._get_thread_environment("thread-id")) is None

--- a/tests/tools/test_recreate_sandbox_tool.py
+++ b/tests/tools/test_recreate_sandbox_tool.py
@@ -38,7 +38,7 @@ async def test_recreate_sandbox_returns_old_and_new_ids() -> None:
         "new_sandbox_id": "sandbox-new",
     }
     resolve_repo.assert_awaited_once_with(config["configurable"])
-    recreate.assert_awaited_once_with("thread-1", repo=repo)
+    recreate.assert_awaited_once_with("thread-1", repo=repo, environment_slug=None)
 
 
 @pytest.mark.asyncio

--- a/ui/src/components/EnvironmentsPanel.tsx
+++ b/ui/src/components/EnvironmentsPanel.tsx
@@ -1,0 +1,296 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
+
+import type { Environment, EnvironmentSnapshotStatus } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { InstructionsEditor } from "@/components/InstructionsEditor"
+import { api } from "@/lib/api"
+import { normalizeRepoFullName } from "@/lib/repo"
+
+const STATUS_LABEL: Record<EnvironmentSnapshotStatus, string> = {
+  none: "No snapshot",
+  capturing: "Capturing…",
+  ready: "Ready",
+  failed: "Failed",
+}
+
+const STATUS_CLASS: Record<EnvironmentSnapshotStatus, string> = {
+  none: "text-muted-foreground",
+  capturing: "text-amber-500",
+  ready: "text-emerald-500",
+  failed: "text-destructive",
+}
+
+function parseRepos(value: string): Array<string> {
+  const entries = value
+    .split(/[\s,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  return entries.map((entry) => normalizeRepoFullName(entry) ?? entry)
+}
+
+export function EnvironmentsPanel() {
+  const qc = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [newName, setNewName] = useState("")
+  const [selected, setSelected] = useState<string | null>(null)
+  const [promptDraft, setPromptDraft] = useState("")
+  const [reposDraft, setReposDraft] = useState("")
+
+  const list = useQuery({
+    queryKey: ["environments"],
+    queryFn: api.listEnvironments,
+    // Poll while a capture is running so status updates without a reload.
+    refetchInterval: (query) =>
+      query.state.data?.environments.some(
+        (env) => env.snapshot_status === "capturing"
+      )
+        ? 5000
+        : false,
+  })
+
+  const environments = list.data?.environments ?? []
+  const defaultSlug = list.data?.default_slug ?? "default"
+  const active: Environment | null =
+    environments.find((env) => env.slug === selected) ?? null
+
+  useEffect(() => {
+    if (!active) return
+    setPromptDraft(active.prompt)
+    setReposDraft(active.repos.join("\n"))
+  }, [active?.slug, active?.updated_at])
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ["environments"] })
+  const onError = (e: Error) => setError(e.message)
+
+  const create = useMutation({
+    mutationFn: (name: string) => api.createEnvironment({ name }),
+    onSuccess: (record) => {
+      void invalidate()
+      setSelected(record.slug)
+      setNewName("")
+      setError(null)
+    },
+    onError,
+  })
+
+  const save = useMutation({
+    mutationFn: ({
+      slug,
+      prompt,
+      repos,
+    }: {
+      slug: string
+      prompt: string
+      repos: Array<string>
+    }) => api.saveEnvironment(slug, { prompt, repos }),
+    onSuccess: () => {
+      void invalidate()
+      setError(null)
+    },
+    onError,
+  })
+
+  const remove = useMutation({
+    mutationFn: (slug: string) => api.deleteEnvironment(slug),
+    onSuccess: (_data, slug) => {
+      void invalidate()
+      if (selected === slug) setSelected(null)
+      setError(null)
+    },
+    onError,
+  })
+
+  if (list.isLoading) return <Skeleton className="h-40" />
+
+  const dirty =
+    active != null &&
+    (promptDraft !== active.prompt ||
+      parseRepos(reposDraft).join("\n") !== active.repos.join("\n"))
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <section className="space-y-2">
+        <Label htmlFor="new-environment">Add environment</Label>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <Input
+            id="new-environment"
+            placeholder="monorepo-full"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter") return
+              e.preventDefault()
+              if (newName.trim()) void create.mutateAsync(newName.trim())
+            }}
+            className="sm:flex-1"
+          />
+          <Button
+            size="sm"
+            className="shrink-0 sm:w-auto"
+            disabled={!newName.trim() || create.isPending}
+            onClick={() => void create.mutateAsync(newName.trim())}
+          >
+            Add
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Runs boot from the environment named <code>default</code>; any other
+          name is a draft. Build the snapshot from an admin thread: provision its
+          sandbox, then have the agent capture it.
+        </p>
+      </section>
+
+      <div className="border-t border-border" />
+
+      <section className="space-y-2">
+        <p className="text-xs font-medium text-foreground">Environments</p>
+        {environments.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No environments yet. Runs boot from the per-repo or base snapshot.
+          </p>
+        ) : (
+          <ul className="flex flex-wrap gap-2">
+            {environments.map((env) => (
+              <li key={env.slug}>
+                <button
+                  type="button"
+                  className={`inline-flex max-w-full items-center gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors hover:bg-muted ${
+                    selected === env.slug
+                      ? "border-primary bg-muted font-medium"
+                      : "border-border"
+                  }`}
+                  onClick={() => setSelected(env.slug)}
+                >
+                  <span className="truncate">{env.name}</span>
+                  {env.slug === defaultSlug && (
+                    <span className="text-[10px] text-primary">default</span>
+                  )}
+                  <span
+                    className={`text-[10px] ${STATUS_CLASS[env.snapshot_status]}`}
+                  >
+                    {STATUS_LABEL[env.snapshot_status]}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="border-t border-border" />
+
+      <section className="space-y-3">
+        {!active ? (
+          <p className="text-xs text-muted-foreground">
+            Select an environment to edit its prompt and repositories.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-medium text-foreground">
+                {active.name}
+              </p>
+              {active.slug === defaultSlug ? (
+                <span className="text-[10px] text-primary">
+                  runs boot from this
+                </span>
+              ) : (
+                <span className="text-[10px] text-muted-foreground">
+                  draft — no run boots from this
+                </span>
+              )}
+              <span
+                className={`text-xs ${STATUS_CLASS[active.snapshot_status]}`}
+              >
+                {STATUS_LABEL[active.snapshot_status]}
+              </span>
+              {active.snapshot_name && (
+                <span className="text-[10px] text-muted-foreground">
+                  {active.snapshot_name}
+                </span>
+              )}
+              {active.snapshot_id && (
+                <span className="text-[10px] text-muted-foreground">
+                  snapshot {active.snapshot_id}
+                </span>
+              )}
+              {active.last_captured_at && (
+                <span className="text-[10px] text-muted-foreground">
+                  captured {new Date(active.last_captured_at).toLocaleString()}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                disabled={!dirty || save.isPending}
+                onClick={() =>
+                  void save.mutateAsync({
+                    slug: active.slug,
+                    prompt: promptDraft,
+                    repos: parseRepos(reposDraft),
+                  })
+                }
+              >
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                className="ml-auto"
+                disabled={remove.isPending}
+                onClick={() => {
+                  if (
+                    !window.confirm(
+                      `Delete ${active.name} and its snapshot? Runs fall back to the per-repo or base snapshot.`
+                    )
+                  ) {
+                    return
+                  }
+                  void remove.mutateAsync(active.slug)
+                }}
+              >
+                Delete
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="environment-repos">Repositories</Label>
+              <Input
+                id="environment-repos"
+                placeholder="owner/repo, owner/other-repo"
+                value={reposDraft}
+                onChange={(e) => setReposDraft(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                What this environment&rsquo;s snapshot contains. Documentation
+                only — listing a repo does not clone it.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Environment prompt</Label>
+              <InstructionsEditor
+                value={promptDraft}
+                onChange={setPromptDraft}
+                placeholder="Where checkouts live, how to build and test, what is pre-installed…"
+              />
+            </div>
+
+            {active.snapshot_status === "failed" && active.status_message && (
+              <p className="text-xs text-destructive">
+                {active.status_message}
+              </p>
+            )}
+          </>
+        )}
+        {error && <p className="text-xs text-destructive">{error}</p>}
+      </section>
+    </div>
+  )
+}

--- a/ui/src/components/EnvironmentsPanel.tsx
+++ b/ui/src/components/EnvironmentsPanel.tsx
@@ -282,9 +282,13 @@ export function EnvironmentsPanel() {
               />
             </div>
 
-            {active.snapshot_status === "failed" && active.status_message && (
+            {/* Shown even when Ready: a failed recapture keeps the previous
+                snapshot bootable, so the error is the only sign it happened. */}
+            {active.status_message && (
               <p className="text-xs text-destructive">
-                {active.status_message}
+                {active.snapshot_status === "ready"
+                  ? `Last capture failed, still booting from the previous snapshot: ${active.status_message}`
+                  : active.status_message}
               </p>
             )}
           </>

--- a/ui/src/components/EnvironmentsPanel.tsx
+++ b/ui/src/components/EnvironmentsPanel.tsx
@@ -139,8 +139,8 @@ export function EnvironmentsPanel() {
         </div>
         <p className="text-xs text-muted-foreground">
           Runs boot from the environment named <code>default</code>; any other
-          name is a draft. Build the snapshot from an admin thread: provision its
-          sandbox, then have the agent capture it.
+          name is a draft. Build the snapshot from an admin thread: provision
+          its sandbox, then have the agent capture it.
         </p>
       </section>
 

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -16,6 +16,7 @@ import {
   optimisticThread,
   seedAgentThreadLists,
   useAgentSkills,
+  useEnvironmentOptions,
 } from "@/features/agents/lib/queries"
 import {
   persistModelSelection,
@@ -60,6 +61,19 @@ export function AgentsHome() {
     (model) => model.id === activeSelection?.modelId
   )
   const [planMode, setPlanMode] = useState(false)
+  const [adminThread, setAdminThread] = useState(false)
+  const environmentOptions = useEnvironmentOptions()
+  const environments = environmentOptions.data?.environments ?? []
+  // undefined = untouched, so the run falls back to the default environment.
+  const [environmentOverride, setEnvironmentOverride] = useState<string | null>(
+    null
+  )
+  const defaultEnvironmentSlug = environmentOptions.data?.default_slug ?? null
+  const selectedEnvironment =
+    environmentOverride ??
+    (environments.some((env) => env.slug === defaultEnvironmentSlug)
+      ? defaultEnvironmentSlug
+      : null)
   const [submitting, setSubmitting] = useState(false)
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
@@ -183,6 +197,8 @@ export function AgentsHome() {
     if (repo) configurable.repo = repo
     if (repoOverride === null) configurable.repo_explicitly_none = true
     if (planMode) configurable.plan_mode = true
+    if (adminThread) configurable.admin_thread = true
+    if (selectedEnvironment) configurable.environment = selectedEnvironment
 
     await stream
       .submit(
@@ -230,6 +246,17 @@ export function AgentsHome() {
             onRemoveLocalProject={(cwd) => void handleRemoveLocalProject(cwd)}
             planMode={planMode}
             onPlanModeChange={runTarget === "cloud" ? setPlanMode : undefined}
+            environments={environments}
+            selectedEnvironment={selectedEnvironment}
+            onEnvironmentChange={
+              runTarget === "cloud" ? setEnvironmentOverride : undefined
+            }
+            adminThread={adminThread}
+            onAdminThreadChange={
+              runTarget === "cloud" && session.data?.is_admin
+                ? setAdminThread
+                : undefined
+            }
             skills={skills.data}
             contextUsage={{
               contextWindow:

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -1,5 +1,10 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { ImagePlus, Map as MapIcon, X } from "lucide-react"
+import {
+  ImagePlus,
+  Map as MapIcon,
+  ServerCog as ServerCogIcon,
+  X,
+} from "lucide-react"
 
 import { ComposerCommandMenu } from "./ComposerCommandMenu"
 import { ComposerControl, ComposerControlIcon } from "./ComposerControl"
@@ -9,6 +14,7 @@ import {
   mentionReplacementText,
 } from "./ComposerPromptEditor"
 import { ContextWindowMeter } from "./ContextWindowMeter"
+import { EnvironmentSelector } from "./EnvironmentSelector"
 import { RunTargetSelector } from "./RunTargetSelector"
 import {
   COMPOSER_PATH_DRAG_MIME,
@@ -24,7 +30,7 @@ import type {
 import type { ComposerSlashCommand, ComposerTrigger } from "./composerTrigger"
 import type { RunTarget } from "./RunTargetSelector"
 import type { DesktopProject } from "@/desktop"
-import type { ModelOption, Skill } from "@/lib/api"
+import type { EnvironmentOption, ModelOption, Skill } from "@/lib/api"
 import type { ImageChunk } from "@/features/agents/lib/types"
 import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
 import { ModelPicker } from "@/features/agents/components/ModelPicker"
@@ -97,6 +103,13 @@ export interface ChatComposerProps {
   /** When provided, a Plan mode toggle is shown. Plan mode researches read-only and proposes a plan before editing. */
   planMode?: boolean
   onPlanModeChange?: (next: boolean) => void
+  /** Admins only: when provided, an Admin toggle is shown. Admin threads can manage environments. */
+  adminThread?: boolean
+  onAdminThreadChange?: (next: boolean) => void
+  /** Environments a new thread can boot from. The picker appears only when there are several. */
+  environments?: Array<EnvironmentOption>
+  selectedEnvironment?: string | null
+  onEnvironmentChange?: (slug: string | null) => void
   /** Paths offered by `@` autocomplete — in a thread, the files the agent has touched. */
   mentionPaths?: Array<string>
   skills?: Array<Skill>
@@ -204,6 +217,11 @@ export const ChatComposer = memo(function ChatComposer({
   onRemoveLocalProject,
   planMode = false,
   onPlanModeChange,
+  adminThread = false,
+  onAdminThreadChange,
+  environments = [],
+  selectedEnvironment = null,
+  onEnvironmentChange,
   mentionPaths = [],
   skills = [],
   contextUsage,
@@ -494,13 +512,20 @@ export const ChatComposer = memo(function ChatComposer({
         compact ? "max-w-none" : "max-w-2xl"
       )}
     >
-      {(onRepoChange || onRunTargetChange) && (
+      {(onRepoChange || onRunTargetChange || onEnvironmentChange) && (
         <div className="mb-2 flex items-center gap-2 px-1 text-xs">
           {runTarget !== "local" && onRepoChange && (
             <RepoSelector
               repos={repos}
               selectedRepo={selectedRepo}
               onRepoChange={onRepoChange}
+            />
+          )}
+          {runTarget !== "local" && onEnvironmentChange && (
+            <EnvironmentSelector
+              environments={environments}
+              selectedSlug={selectedEnvironment}
+              onChange={onEnvironmentChange}
             />
           )}
           {runTarget &&
@@ -652,6 +677,33 @@ export const ChatComposer = memo(function ChatComposer({
                 Research read-only and propose a plan before editing{" "}
                 <Kbd>⇧</Kbd>
                 <Kbd>Tab</Kbd>
+              </TooltipPopup>
+            </Tooltip>
+          )}
+
+          {onAdminThreadChange && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <ComposerControl
+                    aria-pressed={adminThread}
+                    className={cn(
+                      adminThread &&
+                        "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
+                    )}
+                    onClick={() => onAdminThreadChange(!adminThread)}
+                    type="button"
+                  />
+                }
+              >
+                <ComposerControlIcon icon={ServerCogIcon} />
+                <span>Admin</span>
+              </TooltipTrigger>
+              <TooltipPopup
+                className="max-w-[18rem] whitespace-normal"
+                side="top"
+              >
+                Provision this sandbox and capture it as an environment snapshot
               </TooltipPopup>
             </Tooltip>
           )}

--- a/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
+++ b/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from "react"
+import { CaretDownIcon, StackIcon } from "@phosphor-icons/react"
+
+import type { EnvironmentOption } from "@/lib/api"
+import { cn } from "@/lib/utils"
+
+interface EnvironmentSelectorProps {
+  environments: Array<EnvironmentOption>
+  selectedSlug: string | null
+  onChange: (slug: string | null) => void
+  disabled?: boolean
+}
+
+/**
+ * Picks the environment a new thread's sandbox boots from.
+ *
+ * Only rendered when there is more than one to choose between — with a single
+ * environment (or none) the choice is already made, so the control would be
+ * noise.
+ */
+export function EnvironmentSelector({
+  environments,
+  selectedSlug,
+  onChange,
+  disabled = false,
+}: EnvironmentSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target as Node
+      if (dropdownRef.current && !dropdownRef.current.contains(target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  if (environments.length < 2) return null
+
+  const selected = environments.find((env) => env.slug === selectedSlug)
+
+  return (
+    <div ref={dropdownRef} className="relative min-w-0 shrink">
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label="Environment"
+        onClick={() => setOpen((value) => !value)}
+        className="flex max-w-[220px] cursor-pointer items-center gap-1 text-muted-foreground transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-60"
+      >
+        <StackIcon className="size-3.5 shrink-0" />
+        <span className="flex-1 truncate text-left">
+          {selected?.name ?? "Default environment"}
+        </span>
+        <CaretDownIcon className="size-3 shrink-0 opacity-70" />
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 z-50 mt-1 flex max-h-72 w-64 flex-col overflow-y-auto rounded border border-border bg-popover text-xs text-popover-foreground shadow-lg">
+          {environments.map((env) => {
+            const isSelected = env.slug === selectedSlug
+            return (
+              <button
+                key={env.slug}
+                type="button"
+                onClick={() => {
+                  onChange(env.slug)
+                  setOpen(false)
+                }}
+                className={cn(
+                  "flex w-full items-center px-2 py-1.5 text-left transition-colors hover:bg-muted",
+                  isSelected ? "text-foreground" : "text-muted-foreground"
+                )}
+              >
+                <span className="truncate">{env.name}</span>
+                {!env.has_snapshot && (
+                  <span className="ml-2 shrink-0 text-[10px] text-muted-foreground">
+                    no snapshot
+                  </span>
+                )}
+                {isSelected && (
+                  <span className="ml-auto pl-3 text-muted-foreground">✓</span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
+++ b/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
@@ -53,7 +53,7 @@ export function EnvironmentSelector({
       >
         <StackIcon className="size-3.5 shrink-0" />
         <span className="flex-1 truncate text-left">
-          {selected?.name ?? "Default environment"}
+          {selected?.name ?? "No environment"}
         </span>
         <CaretDownIcon className="size-3 shrink-0 opacity-70" />
       </button>

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -66,6 +66,19 @@ export const agentSkillKeys = {
   all: ["agent-skills"] as const,
 }
 
+export const environmentOptionKeys = {
+  all: ["environment-options"] as const,
+}
+
+/** Environments a new thread can boot from. Empty when none are configured. */
+export function useEnvironmentOptions() {
+  return useQuery({
+    queryKey: environmentOptionKeys.all,
+    queryFn: api.listEnvironmentOptions,
+    staleTime: 60_000,
+  })
+}
+
 export function useAgentSkills() {
   return useQuery({
     queryKey: agentSkillKeys.all,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -398,6 +398,49 @@ export interface RepoSnapshot {
   updated_at?: string
 }
 
+export type EnvironmentSnapshotStatus =
+  "none" | "capturing" | "ready" | "failed"
+
+export interface Environment {
+  slug: string
+  name: string
+  prompt: string
+  repos: Array<string>
+  snapshot_id: string | null
+  snapshot_name: string | null
+  snapshot_status: EnvironmentSnapshotStatus
+  status_message: string | null
+  source_sandbox_id: string | null
+  last_captured_at: string | null
+  created_by?: string
+  created_at?: string
+  updated_at?: string
+}
+
+export interface EnvironmentList {
+  environments: Array<Environment>
+  /** Slug of the environment runs boot from — the one literally named "default". */
+  default_slug: string
+}
+
+export interface EnvironmentUpdateBody {
+  name?: string
+  prompt?: string
+  repos?: Array<string>
+}
+
+/** What a non-admin needs to pick an environment for a new thread. */
+export interface EnvironmentOption {
+  slug: string
+  name: string
+  has_snapshot: boolean
+}
+
+export interface EnvironmentOptionList {
+  environments: Array<EnvironmentOption>
+  default_slug: string
+}
+
 export interface RepoSnapshotUpdateBody {
   dockerfile: string
   fs_capacity_bytes?: number | null
@@ -757,6 +800,27 @@ export const api = {
     ),
   deleteRepoSnapshot: (full_name: string) =>
     request<void>(`/repo-snapshots/${encodeURIComponent(full_name)}`, {
+      method: "DELETE",
+    }),
+  listEnvironments: () => request<EnvironmentList>("/environments"),
+  listEnvironmentOptions: () =>
+    request<EnvironmentOptionList>("/environments/options"),
+  createEnvironment: (body: {
+    name: string
+    prompt?: string
+    repos?: Array<string>
+  }) =>
+    request<Environment>("/environments", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  saveEnvironment: (slug: string, body: EnvironmentUpdateBody) =>
+    request<Environment>(`/environments/${encodeURIComponent(slug)}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  deleteEnvironment: (slug: string) =>
+    request<void>(`/environments/${encodeURIComponent(slug)}`, {
       method: "DELETE",
     }),
   getTeamSettings: () => request<TeamSettings>("/team-settings"),

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as AgentsIndexRouteImport } from './routes/agents/index'
 import { Route as AgentsThreadIdRouteImport } from './routes/agents/$threadId'
 import { Route as AgentsSkillsRouteImport } from './routes/agents/skills'
 import { Route as AgentsThreadsRouteImport } from './routes/agents/threads'
+import { Route as AgentsEnvironmentsRouteImport } from './routes/agents_.environments'
 import { Route as AgentsInstructionsRouteImport } from './routes/agents_.instructions'
 import { Route as AgentsSnapshotsRouteImport } from './routes/agents_.snapshots'
 import { Route as ReviewStylesRouteImport } from './routes/review_.styles'
@@ -106,6 +107,11 @@ const AgentsThreadsRoute = AgentsThreadsRouteImport.update({
   path: '/threads',
   getParentRoute: () => AgentsRoute,
 } as any)
+const AgentsEnvironmentsRoute = AgentsEnvironmentsRouteImport.update({
+  id: '/agents_/environments',
+  path: '/agents/environments',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AgentsInstructionsRoute = AgentsInstructionsRouteImport.update({
   id: '/agents_/instructions',
   path: '/agents/instructions',
@@ -183,6 +189,7 @@ export interface FileRoutesByFullPath {
   '/agents/$threadId': typeof AgentsThreadIdRoute
   '/agents/skills': typeof AgentsSkillsRoute
   '/agents/threads': typeof AgentsThreadsRoute
+  '/agents/environments': typeof AgentsEnvironmentsRoute
   '/agents/instructions': typeof AgentsInstructionsRoute
   '/agents/snapshots': typeof AgentsSnapshotsRoute
   '/review/styles': typeof ReviewStylesRoute
@@ -210,6 +217,7 @@ export interface FileRoutesByTo {
   '/agents/$threadId': typeof AgentsThreadIdRoute
   '/agents/skills': typeof AgentsSkillsRoute
   '/agents/threads': typeof AgentsThreadsRoute
+  '/agents/environments': typeof AgentsEnvironmentsRoute
   '/agents/instructions': typeof AgentsInstructionsRoute
   '/agents/snapshots': typeof AgentsSnapshotsRoute
   '/review/styles': typeof ReviewStylesRoute
@@ -239,6 +247,7 @@ export interface FileRoutesById {
   '/agents/$threadId': typeof AgentsThreadIdRoute
   '/agents/skills': typeof AgentsSkillsRoute
   '/agents/threads': typeof AgentsThreadsRoute
+  '/agents_/environments': typeof AgentsEnvironmentsRoute
   '/agents_/instructions': typeof AgentsInstructionsRoute
   '/agents_/snapshots': typeof AgentsSnapshotsRoute
   '/review_/styles': typeof ReviewStylesRoute
@@ -269,6 +278,7 @@ export interface FileRouteTypes {
     | '/agents/$threadId'
     | '/agents/skills'
     | '/agents/threads'
+    | '/agents/environments'
     | '/agents/instructions'
     | '/agents/snapshots'
     | '/review/styles'
@@ -296,6 +306,7 @@ export interface FileRouteTypes {
     | '/agents/$threadId'
     | '/agents/skills'
     | '/agents/threads'
+    | '/agents/environments'
     | '/agents/instructions'
     | '/agents/snapshots'
     | '/review/styles'
@@ -324,6 +335,7 @@ export interface FileRouteTypes {
     | '/agents/$threadId'
     | '/agents/skills'
     | '/agents/threads'
+    | '/agents_/environments'
     | '/agents_/instructions'
     | '/agents_/snapshots'
     | '/review_/styles'
@@ -350,6 +362,7 @@ export interface RootRouteChildren {
   ReviewRoute: typeof ReviewRoute
   UsageRoute: typeof UsageRoute
   AdminEvalsRoute: typeof AdminEvalsRoute
+  AgentsEnvironmentsRoute: typeof AgentsEnvironmentsRoute
   AgentsInstructionsRoute: typeof AgentsInstructionsRoute
   AgentsSnapshotsRoute: typeof AgentsSnapshotsRoute
   ReviewStylesRoute: typeof ReviewStylesRoute
@@ -456,6 +469,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/agents/threads'
       preLoaderRoute: typeof AgentsThreadsRouteImport
       parentRoute: typeof AgentsRoute
+    }
+    '/agents_/environments': {
+      id: '/agents_/environments'
+      path: '/agents/environments'
+      fullPath: '/agents/environments'
+      preLoaderRoute: typeof AgentsEnvironmentsRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/agents_/instructions': {
       id: '/agents_/instructions'
@@ -586,6 +606,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReviewRoute: ReviewRoute,
   UsageRoute: UsageRoute,
   AdminEvalsRoute: AdminEvalsRoute,
+  AgentsEnvironmentsRoute: AgentsEnvironmentsRoute,
   AgentsInstructionsRoute: AgentsInstructionsRoute,
   AgentsSnapshotsRoute: AgentsSnapshotsRoute,
   ReviewStylesRoute: ReviewStylesRoute,

--- a/ui/src/routes/agents_.environments.tsx
+++ b/ui/src/routes/agents_.environments.tsx
@@ -1,0 +1,38 @@
+import { Navigate, createFileRoute } from "@tanstack/react-router"
+
+import { AppShell } from "@/components/AppShell"
+import { EnvironmentsPanel } from "@/components/EnvironmentsPanel"
+import { RequireLogin } from "@/lib/auth-redirect"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useSession } from "@/lib/session"
+
+export const Route = createFileRoute("/agents_/environments")({
+  component: EnvironmentsPage,
+})
+
+function EnvironmentsPage() {
+  const session = useSession()
+
+  if (session.isLoading) {
+    return (
+      <main className="p-6">
+        <Skeleton className="h-64 w-full" />
+      </main>
+    )
+  }
+  if (!session.data) return <RequireLogin />
+  if (!session.data.is_admin) return <Navigate to="/my-settings" />
+
+  return (
+    <AppShell
+      user={session.data}
+      title="Environments"
+      description="A named prompt plus a sandbox snapshot every run boots from. Snapshots are captured from an admin thread's sandbox once it is provisioned."
+      backTo={{ to: "/cloud-agents", label: "Back to Open SWE Agent" }}
+    >
+      <div className="rounded-lg border border-border bg-card">
+        <EnvironmentsPanel />
+      </div>
+    </AppShell>
+  )
+}

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -327,11 +327,18 @@ function CloudAgentsPage() {
           description="Per-repo custom instructions injected into the agent's system prompt."
         />
         {session.data.is_admin && (
-          <SettingsNavRow
-            to="/agents/snapshots"
-            label="Repository Snapshots"
-            description="Build a per-repo sandbox image from a custom Dockerfile. Falls back to the default image."
-          />
+          <>
+            <SettingsNavRow
+              to="/agents/environments"
+              label="Environments"
+              description="A named prompt plus a sandbox snapshot every run boots from. Built from admin threads."
+            />
+            <SettingsNavRow
+              to="/agents/snapshots"
+              label="Repository Snapshots"
+              description="Build a per-repo sandbox image from a custom Dockerfile. Falls back to the default image."
+            />
+          </>
         )}
       </SettingsSection>
 


### PR DESCRIPTION
Adds **environments**, in the shape Cursor uses: a name, a prompt injected into the system prompt, and a sandbox snapshot runs boot from. An environment can span several repos, since its snapshot is whatever was set up in the sandbox it was captured from.

Snapshots are **captured from a live sandbox**, not built from a Dockerfile. Setup is therefore ordinary shell an admin iterates on interactively — clone the repos, install toolchains, warm caches — and then captures. Each capture is named `openswe-environment-<name>:latest` (prefix overridable via `ENVIRONMENT_SNAPSHOT_PREFIX`), and the previous snapshot is deleted only after the new one is ready, so a failed capture leaves the environment booting from what it had. A name the platform still holds is retried with a `-2`, `-3` suffix.

**Admin threads** are where environments get built: the composer's Admin toggle (admin sessions only) stamps `admin_thread` on the thread, and the agent gets `list_environments`, `save_environment`, `capture_environment_snapshot` and `delete_environment` plus a prompt section covering the workflow and the two things that must never land in a snapshot (secrets, and proxy-injected GitHub credentials). The flag is re-checked against `CONFIGURED_ADMINS` at run time, so a thread cannot carry the capability to a non-admin who later messages it.

**Selection.** The environment named `default` is what runs use. A thread can pick another: a picker in the dashboard composer (rendered only when more than one exists), or an `env:<name>` tag on the Slack message that opens the thread. Only the opening Slack message counts — the sandbox is created once, so honoring a later tag would change the prompt but not the image — and the tag is stripped only when it resolves, so a typo stays visible in the transcript. The pick lands in thread metadata, so follow-up runs and `recreate_sandbox` stay on the same environment.

Snapshot resolution for a new sandbox becomes: the run's environment, then the repo's Dockerfile-built snapshot, then the configured base. Everything is additive — with no environment configured, nothing changes.

Non-admins can read `GET /environments/options` (names and slugs only) so the picker works without exposing prompts or snapshot ids; the full records stay admin-only.

## Test Plan

- [x] `make lint`
- [x] `make test` — 1722 passed
- [x] `make typecheck` — 13 errors, unchanged from base
- [x] `pnpm run typecheck` (ui)
- [x] `npx playwright test` in `tests/e2e` — 31 passed, including 5 new environment specs: admin CRUD through the real dashboard, the non-admin 403 + redirect + hidden Admin toggle, an admin thread that provisions and captures its own sandbox (asserting the capture hit the platform against that thread's sandbox and that the next run's prompt carries the section), the composer picker's appear-only-when-several behavior with the pick reaching the run, and the Slack `env:` tag
- [x] E2E fakes only the snapshot service (`patches.py`); the tools, store writes, naming/status transitions and prompt injection all run for real
