### PR TITLE
fix(sandbox): rebind proxy asyncio state across isolated loops

### DIFF
--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -73,6 +73,7 @@ class SandboxBackendProxy(BaseSandbox):
         self._reconnect = reconnect
         self._startup_task: asyncio.Task[SandboxBackendProtocol] | None = None
         self._lock: asyncio.Lock | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     @property
     def current(self) -> SandboxBackendProtocol:
@@ -109,6 +110,7 @@ class SandboxBackendProxy(BaseSandbox):
             if self._backend is not None:
                 return
             raise RuntimeError("Cannot start sandbox without a reconnect callback")
+        self._loop = asyncio.get_running_loop()
         self._startup_task = asyncio.create_task(self._reconnect())
         self._startup_task.add_done_callback(self._startup_completed)
 
@@ -136,9 +138,27 @@ class SandboxBackendProxy(BaseSandbox):
     def _get_lock(self) -> asyncio.Lock:
         if self._lock is None:
             self._lock = asyncio.Lock()
+            self._loop = asyncio.get_running_loop()
         return self._lock
 
+    def _rebind_loop(self) -> None:
+        """Drop asyncio state owned by a previous loop.
+
+        ``SANDBOX_BACKENDS`` outlives any single run, and BG_JOB_ISOLATED_LOOPS gives
+        each background run its own loop in the same process. Awaiting a task or lock
+        created on another loop raises "attached to a different loop".
+        """
+        loop = asyncio.get_running_loop()
+        if self._loop is loop:
+            return
+        if self._startup_task is not None and not self._startup_task.done():
+            self._startup_task.cancel()
+        self._startup_task = None
+        self._lock = None
+        self._loop = loop
+
     async def _aget_backend(self) -> SandboxBackendProtocol:
+        self._rebind_loop()
         if self._backend is not None and self._startup_task is None:
             return self._backend
         if not self._thread_id:
@@ -161,6 +181,7 @@ class SandboxBackendProxy(BaseSandbox):
                     logger.info(
                         "Reconnecting sandbox backend for thread %s from metadata", self._thread_id
                     )
+                    self._loop = asyncio.get_running_loop()
                     self._startup_task = asyncio.create_task(create_sandbox(sandbox_id))
                     self._startup_task.add_done_callback(self._startup_completed)
             startup_task = self._startup_task

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -389,6 +389,8 @@ Users can also override the team/project mapping per-comment by including `repo:
             "request_url": "https://<your-ngrok-url>/webhooks/slack",
             "bot_events": [
                 "app_mention",
+                "message.channels",
+                "message.groups",
                 "message.im",
                 "message.mpim"
             ]
@@ -416,6 +418,12 @@ Both Slack URLs must point at the Open SWE backend that serves `agent.webapp:app
 - **Interactivity & Shortcuts → Interactivity Request URL:** `https://<your-backend-url>/webhooks/slack/interactivity`
 
 Slack Block Kit option buttons only work when Interactivity is enabled and pointed at `/webhooks/slack/interactivity`.
+
+**Bot events checklist:**
+
+`app_mention` alone only covers explicit `@`-mentions. The `message.channels` and `message.groups` subscriptions are what let Open SWE reply in a channel thread without being tagged — it answers an untagged follow-up when it has already posted in that thread and exactly one human is participating. Without them Slack never delivers the message, so untagged replies (and plan approvals typed in a channel thread) are silently dropped.
+
+Subscribing to these means the webhook receives every message in every channel the bot is invited to; Open SWE ignores the ones it does not need. Keep the bot out of high-traffic channels where it has no reason to be.
 
 **Credentials you'll need:**
 
@@ -754,7 +762,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - Verify ngrok is running and the URL matches what's configured in GitHub/Linear/Slack
 - Check the ngrok web inspector at `http://localhost:4040` for incoming requests
-- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` for Slack, Issues + Issue comment for GitHub)
+- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` + `message.*` for Slack, Issues + Issue comment for GitHub)
 - **Webhook secrets are required** — if `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or `SLACK_SIGNING_SECRET` is not set, all requests to that endpoint will be rejected with 401
 
 ### GitHub authentication errors
@@ -788,7 +796,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and the commenter has a user mapping (Admin → User mappings; see "Configure triggering surfaces"). Add any missing user with **Add / update** in that section.
 - For Linear: ensure the comment contains `@openswe` (case-insensitive)
-- For Slack: ensure the bot is invited to the channel and the message is an `@mention`
+- For Slack: ensure the bot is invited to the channel and the message is an `@mention`. For untagged follow-ups in a thread, also confirm the app subscribes to `message.channels` / `message.groups` (see "Bot events checklist") and that the thread has only Open SWE and one human in it
 - Check server logs for webhook processing errors
 
 ### Token encryption errors

--- a/tests/sandbox/test_sandbox_proxy_loops.py
+++ b/tests/sandbox/test_sandbox_proxy_loops.py
@@ -1,0 +1,52 @@
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+from agent.utils.sandbox_state import SandboxBackendProxy
+
+
+def _run_on_new_loop(coro_factory: Any) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro_factory())
+    finally:
+        loop.close()
+
+
+def test_proxy_ready_survives_isolated_loops() -> None:
+    """BG_JOB_ISOLATED_LOOPS gives each run its own loop; the cached proxy is shared."""
+    backend = MagicMock()
+
+    async def reconnect() -> Any:
+        await asyncio.sleep(0)
+        return backend
+
+    proxy = SandboxBackendProxy(thread_id="t1", reconnect=reconnect)
+
+    assert _run_on_new_loop(proxy.ready) is backend
+    assert _run_on_new_loop(proxy.ready) is backend
+
+
+def test_proxy_discards_pending_startup_from_a_dead_loop() -> None:
+    backend = MagicMock()
+
+    async def reconnect() -> Any:
+        await asyncio.sleep(0)
+        return backend
+
+    proxy = SandboxBackendProxy(thread_id="t1", reconnect=reconnect)
+
+    loop_a = asyncio.new_event_loop()
+    loop_a.run_until_complete(_seed_pending_startup(proxy, reconnect))
+
+    try:
+        assert _run_on_new_loop(proxy.ready) is backend
+    finally:
+        loop_a.run_until_complete(asyncio.sleep(0))
+        loop_a.close()
+
+
+async def _seed_pending_startup(proxy: SandboxBackendProxy, reconnect: Any) -> None:
+    proxy._loop = asyncio.get_running_loop()
+    proxy._lock = asyncio.Lock()
+    proxy._startup_task = asyncio.create_task(reconnect())


### PR DESCRIPTION
Runs on `open-swe-preview` were failing with:

```
RuntimeError: Task <... SandboxBackendProxy.ready() at agent/utils/sandbox_state.py:128>
got Future <... shield ...> attached to a different loop
```

`SANDBOX_BACKENDS` is a process-global dict keyed by `thread_id`, so a `SandboxBackendProxy` outlives any single run. It cached two objects owned by whichever event loop created them — `_startup_task` (`asyncio.create_task`) and `_lock` (`asyncio.Lock`). The preview deployment sets `BG_JOB_ISOLATED_LOOPS=True`, which gives each background run its own loop inside the same process, so a second run on the same thread awaited the first loop's task and crashed. Users saw the generic "wasn't able to finish that" warning in Slack.

The proxy now records the owning loop at each creation site, and `_aget_backend` discards the stale task and lock when it runs on a different loop instead of awaiting across loops. Prod (`open-swe-v3`) does not set that flag, which is why it never hit this.

Also subscribes `message.channels` and `message.groups` in the documented Slack app manifest. `app_mention` alone never delivers untagged thread replies, so the existing untagged two-party reply path and channel plan approvals could not fire on an app installed from these docs.

## Test Plan

- [x] `tests/sandbox/test_sandbox_proxy_loops.py` drives one cached proxy from two separate event loops; it reproduces the production `RuntimeError` verbatim when the fix is reverted and passes with it
- [x] `uv run pytest tests/sandbox/ tests/slack/` — 262 passed
- [x] `make lint` clean