### PR TITLE
fix(sandbox): keep local sandbox git identity out of ~/.gitconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# local sandbox git identity (never the developer's ~/.gitconfig)
+.gitconfig-sandbox
+
 # local env files
 .env*.local
 .env

--- a/agent/integrations/local.py
+++ b/agent/integrations/local.py
@@ -1,6 +1,23 @@
 import os
+from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
+
+SANDBOX_GITCONFIG = ".gitconfig-sandbox"
+
+
+def _scoped_git_config_env(root_dir: str) -> dict[str, str]:
+    """Point `git config --global` at a sandbox-local file.
+
+    Local sandboxes run on the host, so the bot identity every run writes would
+    otherwise overwrite the developer's own `~/.gitconfig` user.name/email. The
+    scoped file includes the real one so credential helpers and aliases survive.
+    """
+    scoped = Path(root_dir) / SANDBOX_GITCONFIG
+    if not scoped.exists():
+        host = Path.home() / ".gitconfig"
+        scoped.write_text(f"[include]\n\tpath = {host}\n" if host.exists() else "")
+    return {"GIT_CONFIG_GLOBAL": str(scoped)}
 
 
 def create_local_sandbox(sandbox_id: str | None = None):
@@ -22,8 +39,11 @@ def create_local_sandbox(sandbox_id: str | None = None):
     root_dir = os.getenv("LOCAL_SANDBOX_ROOT_DIR", os.getcwd())
     os.makedirs(root_dir, exist_ok=True)
 
+    env = {} if os.getenv("GIT_CONFIG_GLOBAL") else _scoped_git_config_env(root_dir)
+
     return LocalShellBackend(
         root_dir=root_dir,
         virtual_mode=True,
         inherit_env=True,
+        env=env,
     )

--- a/tests/sandbox/test_local_integration.py
+++ b/tests/sandbox/test_local_integration.py
@@ -4,10 +4,11 @@ import agent.integrations.local as local_mod
 
 
 class _StubLocalShellBackend:
-    def __init__(self, *, root_dir, virtual_mode, inherit_env):
+    def __init__(self, *, root_dir, virtual_mode, inherit_env, env=None):
         self.root_dir = root_dir
         self.virtual_mode = virtual_mode
         self.inherit_env = inherit_env
+        self.env = env or {}
 
 
 def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
@@ -34,3 +35,34 @@ def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
     stub = cast(_StubLocalShellBackend, backend)
     assert stub.root_dir == str(tmp_path)
     assert stub.virtual_mode is True
+
+
+def test_create_local_sandbox_scopes_global_git_config(monkeypatch, tmp_path):
+    root = tmp_path / "work"
+    monkeypatch.setenv("LOCAL_SANDBOX_ROOT_DIR", str(root))
+    monkeypatch.delenv("GIT_CONFIG_GLOBAL", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    host_config = tmp_path / "home" / ".gitconfig"
+    host_config.parent.mkdir()
+    host_config.write_text("[user]\n\tname = Dev\n")
+    monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
+
+    backend = local_mod.create_local_sandbox()
+
+    scoped = root / local_mod.SANDBOX_GITCONFIG
+    stub = cast(_StubLocalShellBackend, backend)
+    assert stub.env["GIT_CONFIG_GLOBAL"] == str(scoped)
+    assert str(host_config) in scoped.read_text()
+    assert host_config.read_text() == "[user]\n\tname = Dev\n"
+
+
+def test_create_local_sandbox_keeps_explicit_global_git_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOCAL_SANDBOX_ROOT_DIR", str(tmp_path / "work"))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "chosen-gitconfig"))
+    monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
+
+    backend = local_mod.create_local_sandbox()
+
+    stub = cast(_StubLocalShellBackend, backend)
+    assert "GIT_CONFIG_GLOBAL" not in stub.env
+    assert not (tmp_path / "work" / local_mod.SANDBOX_GITCONFIG).exists()


### PR DESCRIPTION
`_configure_git_identity` runs `git config --global user.name/email` on every sandbox creation and refresh. With `SANDBOX_TYPE=local` (the default for `make dev` and the e2e harness) that command executes on the host, so it overwrote the developer's own `~/.gitconfig` `[user]` section with `open-swe[bot]` — every later commit on that machine, in every repo, was authored as the bot.

`create_local_sandbox` now points `GIT_CONFIG_GLOBAL` at `<sandbox root>/.gitconfig-sandbox`, so the bot identity lands there. The scoped file `[include]`s the real `~/.gitconfig`, so credential helpers, aliases, and LFS filters still resolve inside the sandbox. An explicitly-set `GIT_CONFIG_GLOBAL` (what `tests/e2e/e2e_env.py` already does) is left alone.

## Test Plan

- [x] `uv run pytest tests/sandbox tests/github/test_github_proxy_refresh.py` — 156 passed
- [x] New unit tests: identity redirect + host include, and explicit `GIT_CONFIG_GLOBAL` untouched
- [x] Ran the real `_configure_git_identity` against a local sandbox: `~/.gitconfig` byte-identical afterwards, bot identity written to `.gitconfig-sandbox`, and `git config --get user.email` inside the sandbox resolves the bot while `credential."https://github.com".helper` still resolves the host `gh` helper
- [x] `make lint`
