### PR TITLE
fix: deny Slack tools to subagents

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -607,19 +607,30 @@ def _subagent_model_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
     )
 
 
+def _is_slack_tool(tool: Any) -> bool:
+    """Return whether a tool reaches Slack."""
+    name = getattr(tool, "name", None) or getattr(tool, "__name__", "")
+    return name.startswith("slack_") or name == "notify_automation_channel"
+
+
 def _general_purpose_subagent(
     model: BaseChatModel,
+    tools: Sequence[Any],
     skills: list[str] | None = None,
     dynamic_tools: DynamicToolMiddleware | None = None,
 ) -> SubAgent:
     subagent: SubAgent = {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
-        "description": GENERAL_PURPOSE_SUBAGENT["description"],
+        "description": (
+            GENERAL_PURPOSE_SUBAGENT["description"]
+            + " It cannot access Slack tools; relay all Slack communication from the main agent."
+        ),
         # Deep Agents' default GP prompt covers only task mechanics; the shared
         # base carries the Open SWE identity and conventions (gh proxy usage,
         # tool-call cadence) that delegated work also needs.
         "system_prompt": OPEN_SWE_SHARED_BASE + "\n\n" + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
+        "tools": [tool for tool in tools if not _is_slack_tool(tool)],
         "middleware": [
             *([dynamic_tools] if dynamic_tools else []),
             *_subagent_model_middleware(),
@@ -1187,7 +1198,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         system_prompt="",
         tools=static_tools,
         subagents=[
-            _general_purpose_subagent(subagent_model, skill_sources, dynamic_tool_middleware),
+            _general_purpose_subagent(
+                subagent_model,
+                tools=static_tools,
+                skills=skill_sources,
+                dynamic_tools=dynamic_tool_middleware,
+            ),
             *([_browser_subagent(subagent_model, browser_tools)] if browser_tools else []),
         ],
         skills=skill_sources,

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -212,3 +212,28 @@ async def test_general_purpose_subagent_carries_open_swe_shared_base() -> None:
     assert prompt.startswith(OPEN_SWE_SHARED_BASE)
     # GP task-mechanics guidance still trails the shared base.
     assert "calling agent only sees your final" in prompt
+
+
+@pytest.mark.asyncio
+async def test_general_purpose_subagent_cannot_use_slack_tools() -> None:
+    captured = await _capture_create_deep_agent_kwargs()
+    parent_tools = captured["tools"]
+    subagents = captured["subagents"]
+    assert isinstance(parent_tools, list)
+    assert isinstance(subagents, list)
+
+    gp = next(s for s in subagents if s["name"] == "general-purpose")
+    assert "cannot access Slack tools" in gp["description"]
+    parent_names = {tool.__name__ for tool in parent_tools}
+    subagent_names = {tool.__name__ for tool in gp["tools"]}
+    slack_names = {
+        "notify_automation_channel",
+        "slack_add_reaction",
+        "slack_read_thread_messages",
+        "slack_start_new_thread",
+        "slack_thread_reply",
+    }
+
+    assert slack_names <= parent_names
+    assert slack_names.isdisjoint(subagent_names)
+    assert subagent_names == parent_names - slack_names

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -92,6 +92,6 @@ def test_general_purpose_subagent_includes_dynamic_tools() -> None:
     from agent.server import _general_purpose_subagent
 
     middleware = DynamicToolMiddleware({"Notion": [_tool("notion-search")]})
-    subagent = _general_purpose_subagent(MagicMock(), dynamic_tools=middleware)
+    subagent = _general_purpose_subagent(MagicMock(), tools=[], dynamic_tools=middleware)
 
     assert middleware in subagent.get("middleware", [])

--- a/tests/middleware/test_model_call_timeout.py
+++ b/tests/middleware/test_model_call_timeout.py
@@ -60,7 +60,7 @@ class TestModelCallTimeoutMiddleware:
 
         model = MagicMock()
         specs = [
-            _general_purpose_subagent(model),
+            _general_purpose_subagent(model, tools=[]),
             _browser_subagent(model, []),
             _reviewer_subagent(model),
         ]


### PR DESCRIPTION
## Description
General-purpose subagents inherited every main-agent tool and could post duplicate Slack updates. Give them an explicit non-Slack tool set, including denial of the automation-channel notifier, while keeping Slack tools available to the main agent.

## Test Plan
- [x] Verify agent assembly retains Slack tools only on the main agent.
- [x] Run focused agent assembly and middleware tests.

Made by [Open SWE](https://openswe.vercel.app/agents/b44f70cb-5a70-fffe-8edf-224b98324363)