### PR TITLE
chore(typing): clear basedpyright errors and gate CI on typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Run format check
         run: make format-check
 
+  typecheck:
+    name: Agent typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: uv sync --locked --extra dev
+      - name: Run typecheck
+        run: make typecheck
+
   unit-tests:
     name: Agent unit tests
     runs-on: ubuntu-latest

--- a/agent/server.py
+++ b/agent/server.py
@@ -160,6 +160,7 @@ from .utils.sandbox import create_sandbox
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 from .utils.sandbox_state import (
     SANDBOX_BACKENDS,
+    SandboxBackendProxy,
     SandboxUnreachableError,
     get_or_create_sandbox_backend_proxy,
     get_sandbox_id_from_metadata,
@@ -677,7 +678,7 @@ def _get_cached_sandbox_backend(
     thread_id: str,
     *,
     reconnect: Callable[[], Awaitable[SandboxBackendProtocol]] | None = None,
-) -> SandboxBackendProtocol:
+) -> SandboxBackendProxy:
     return get_or_create_sandbox_backend_proxy(thread_id, reconnect=reconnect)
 
 

--- a/agent/tools/slack_start_new_thread.py
+++ b/agent/tools/slack_start_new_thread.py
@@ -244,6 +244,8 @@ async def slack_start_new_thread(
             "hint": _failure_hint(slack_error),
         }
 
+    details_ts: str | None = None
+    details_error: str | None = None
     for attempt in range(2):
         details_ts, details_error = await post_slack_thread_reply_with_ts(
             clean_channel_id,

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -109,7 +109,7 @@ class SandboxBackendProxy(BaseSandbox):
             if self._backend is not None:
                 return
             raise RuntimeError("Cannot start sandbox without a reconnect callback")
-        self._startup_task = asyncio.create_task(self._reconnect())
+        self._startup_task = asyncio.ensure_future(self._reconnect())
         self._startup_task.add_done_callback(self._startup_completed)
 
     def _startup_completed(self, task: asyncio.Task[SandboxBackendProtocol]) -> None:
@@ -164,6 +164,8 @@ class SandboxBackendProxy(BaseSandbox):
                     self._startup_task = asyncio.create_task(create_sandbox(sandbox_id))
                     self._startup_task.add_done_callback(self._startup_completed)
             startup_task = self._startup_task
+            if startup_task is None:
+                raise RuntimeError(f"Sandbox startup task missing for thread {self._thread_id}")
 
         try:
             sandbox_backend = await asyncio.shield(startup_task)
@@ -179,7 +181,10 @@ class SandboxBackendProxy(BaseSandbox):
                 self._backend = unwrap_sandbox_backend(sandbox_backend)
                 self._startup_task = None
                 SANDBOX_BACKENDS[self._thread_id] = self
-            return self._backend
+            backend = self._backend
+            if backend is None:
+                raise RuntimeError(f"No sandbox backend cached for thread {self._thread_id}")
+            return backend
 
     def ls(self, path: str) -> LsResult:
         raise NotImplementedError(_SYNC_UNSUPPORTED)

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1795,6 +1795,7 @@ async def test_pr_diff_uses_repository_from_pr_url(monkeypatch) -> None:
 
     await thread_api.get_dashboard_thread_pr_diff("thread-1", "owner")
 
+    assert build_diff.await_args is not None
     assert build_diff.await_args.args[1:] == ("langchain-ai/open-swe", 1925)
 
 

--- a/tests/dashboard/test_profile_draft_preference.py
+++ b/tests/dashboard/test_profile_draft_preference.py
@@ -22,6 +22,7 @@ async def test_omitted_draft_preference_preserves_existing_value() -> None:
         profile = await upsert_profile("octocat", "octocat@example.com", update)
 
     assert profile["draft_prs"] is False
+    assert put_item.await_args is not None
     assert put_item.await_args.args[2]["draft_prs"] is False
 
 
@@ -42,4 +43,5 @@ async def test_explicit_draft_preference_is_persisted() -> None:
         profile = await upsert_profile("octocat", "octocat@example.com", update)
 
     assert profile["draft_prs"] is True
+    assert put_item.await_args is not None
     assert put_item.await_args.args[2]["draft_prs"] is True

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -204,7 +204,7 @@ async def test_sandbox_proxy_refreshes_initialized_backend_when_started() -> Non
         return refreshed
 
     proxy = SandboxBackendProxy(
-        _FakeSandboxBackend(),
+        cast(SandboxBackendProtocol, _FakeSandboxBackend()),
         thread_id="thread-1",
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )


### PR DESCRIPTION
`make typecheck` (basedpyright, standard mode) reported 13 errors on `main`, so every PR read "13 errors, unchanged from base" and the check gated nothing. This clears all 13 and adds a blocking `Agent typecheck` job to `Agent CI` — the workflow previously did not run it at all.

Typing-only; no runtime behavior changes.

- `agent/utils/sandbox_state.py`: `SandboxBackendProxy` startup used `asyncio.create_task` on the `Awaitable` reconnect callback (`ensure_future` accepts it and is identical for coroutines), and `_aget_backend` read `_startup_task` / `_backend` as if non-`None` after the lock. Both invariants are now stated with an explicit `raise` so a refactor that breaks them fails loudly instead of type-lying.
- `agent/server.py`: `_get_cached_sandbox_backend` returns `SandboxBackendProxy`, which is what it actually constructs — the callers need `.start()`.
- `agent/tools/slack_start_new_thread.py`: initialize `details_ts` / `details_error` before the retry loop.
- Tests: assert `await_args is not None` before indexing `.args` (pattern already used elsewhere in `tests/`), and cast the protocol-only fake to `SandboxBackendProtocol` at the one call site that missed it — same cast the rest of the file uses. The protocol is unchanged.

Surfaced by a reviewer on #1952, which touches none of these files.

## Test Plan

- [x] `make typecheck` — 0 errors (was 13)
- [x] `make lint` — clean
- [x] `make test` — 1690 passed
