### PR TITLE
fix(sandbox): adopt an orphaned sandbox on name collision

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -271,6 +271,37 @@ def _is_retryable_sandbox_create_error(exc: BaseException) -> bool:
     }
 
 
+def _is_sandbox_name_taken_error(exc: BaseException) -> bool:
+    return "already exists" in str(exc).lower()
+
+
+async def _reuse_existing_sandbox(client: AsyncSandboxClient, sandbox_id: str) -> Any:
+    try:
+        sandbox = await client.get_sandbox(name=sandbox_id)
+    except Exception as e:
+        msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
+        raise RuntimeError(msg) from e
+    status = _status_text(sandbox)
+    if status and status not in SANDBOX_READY_STATUSES:
+        if status in SANDBOX_RECONNECT_STARTABLE_STATUSES:
+            try:
+                logger.info(
+                    "Starting LangSmith sandbox %s before reconnect (status=%s)",
+                    sandbox_id,
+                    status,
+                )
+                await client.start_sandbox(sandbox_id)
+                sandbox = await _wait_for_reconnected_sandbox(client, sandbox_id)
+                status = _status_text(sandbox)
+            except Exception as e:
+                msg = f"Failed to start existing sandbox '{sandbox_id}' ({status})"
+                raise RuntimeError(msg) from e
+        if status not in SANDBOX_READY_STATUSES:
+            msg = f"Existing sandbox '{sandbox_id}' is {status or 'unknown'}, not reusable"
+            raise RuntimeError(msg)
+    return sandbox
+
+
 async def _wait_for_reconnected_sandbox(
     client: AsyncSandboxClient,
     sandbox_id: str,
@@ -648,29 +679,7 @@ class LangSmithProvider(SandboxProvider):
             api_key=self._api_key, api_endpoint=self._api_endpoint
         ) as client:
             if sandbox_id:
-                try:
-                    sandbox = await client.get_sandbox(name=sandbox_id)
-                except Exception as e:
-                    msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
-                    raise RuntimeError(msg) from e
-                status = _status_text(sandbox)
-                if status and status not in SANDBOX_READY_STATUSES:
-                    if status in SANDBOX_RECONNECT_STARTABLE_STATUSES:
-                        try:
-                            logger.info(
-                                "Starting LangSmith sandbox %s before reconnect (status=%s)",
-                                sandbox_id,
-                                status,
-                            )
-                            await client.start_sandbox(sandbox_id)
-                            sandbox = await _wait_for_reconnected_sandbox(client, sandbox_id)
-                            status = _status_text(sandbox)
-                        except Exception as e:
-                            msg = f"Failed to start existing sandbox '{sandbox_id}' ({status})"
-                            raise RuntimeError(msg) from e
-                    if status not in SANDBOX_READY_STATUSES:
-                        msg = f"Existing sandbox '{sandbox_id}' is {status or 'unknown'}, not reusable"
-                        raise RuntimeError(msg)
+                sandbox = await _reuse_existing_sandbox(client, sandbox_id)
                 return TimeoutLangSmithSandbox(sandbox.to_sync())
 
             if not snapshot_id:
@@ -695,7 +704,13 @@ class LangSmithProvider(SandboxProvider):
                     timeout=timeout,
                 )
             except Exception as e:
-                msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
-                raise RuntimeError(msg) from e
+                if not (name and _is_sandbox_name_taken_error(e)):
+                    msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
+                    raise RuntimeError(msg) from e
+                # Sandbox names are deterministic per thread, so the holder is this
+                # thread's own sandbox from a run that died before persisting its id.
+                # Creating is impossible and failing strands the thread forever.
+                logger.warning("Sandbox %s already exists; adopting it instead of creating", name)
+                sandbox = await _reuse_existing_sandbox(client, name)
 
             return TimeoutLangSmithSandbox(sandbox.to_sync())

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -38,11 +38,6 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS = 30 * 24 * 60 * 60  # 30 days
 SANDBOX_CREATE_MAX_ATTEMPTS = 3
 SANDBOX_CREATE_RETRY_DELAYS_SECONDS = (1.0, 3.0)
 SANDBOX_CREATE_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
-SANDBOX_READY_STATUSES = frozenset({"ready", "running"})
-SANDBOX_RECONNECT_STARTABLE_STATUSES = frozenset({"stopped", "paused", "idle"})
-SANDBOX_RECONNECT_PENDING_STATUSES = frozenset({"creating", "pending", "starting", "resuming"})
-SANDBOX_RECONNECT_READY_TIMEOUT_SECONDS = 30.0
-SANDBOX_RECONNECT_READY_POLL_SECONDS = 2.0
 PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
@@ -252,12 +247,6 @@ def _is_retryable_proxy_config_error(exc: BaseException) -> bool:
     return isinstance(exc, httpx.TransportError)
 
 
-def _status_text(sandbox_or_status: Any) -> str:
-    status = getattr(sandbox_or_status, "status", sandbox_or_status)
-    status = getattr(status, "value", status)
-    return str(status or "").lower()
-
-
 def _is_retryable_sandbox_create_error(exc: BaseException) -> bool:
     response = getattr(exc, "response", None)
     status_code = getattr(response, "status_code", None) or getattr(exc, "status_code", None)
@@ -277,50 +266,10 @@ def _is_sandbox_name_taken_error(exc: BaseException) -> bool:
 
 async def _reuse_existing_sandbox(client: AsyncSandboxClient, sandbox_id: str) -> Any:
     try:
-        sandbox = await client.get_sandbox(name=sandbox_id)
+        return await client.get_sandbox(name=sandbox_id)
     except Exception as e:
         msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
         raise RuntimeError(msg) from e
-    status = _status_text(sandbox)
-    if status and status not in SANDBOX_READY_STATUSES:
-        if status in SANDBOX_RECONNECT_STARTABLE_STATUSES:
-            try:
-                logger.info(
-                    "Starting LangSmith sandbox %s before reconnect (status=%s)",
-                    sandbox_id,
-                    status,
-                )
-                await client.start_sandbox(sandbox_id)
-                sandbox = await _wait_for_reconnected_sandbox(client, sandbox_id)
-                status = _status_text(sandbox)
-            except Exception as e:
-                msg = f"Failed to start existing sandbox '{sandbox_id}' ({status})"
-                raise RuntimeError(msg) from e
-        if status not in SANDBOX_READY_STATUSES:
-            msg = f"Existing sandbox '{sandbox_id}' is {status or 'unknown'}, not reusable"
-            raise RuntimeError(msg)
-    return sandbox
-
-
-async def _wait_for_reconnected_sandbox(
-    client: AsyncSandboxClient,
-    sandbox_id: str,
-    *,
-    timeout_seconds: float = SANDBOX_RECONNECT_READY_TIMEOUT_SECONDS,
-    poll_seconds: float = SANDBOX_RECONNECT_READY_POLL_SECONDS,
-) -> Any:
-    deadline = asyncio.get_running_loop().time() + timeout_seconds
-    last_sandbox = await client.get_sandbox(name=sandbox_id)
-    while True:
-        status = _status_text(last_sandbox)
-        if status in SANDBOX_READY_STATUSES or status not in SANDBOX_RECONNECT_PENDING_STATUSES:
-            return last_sandbox
-        if asyncio.get_running_loop().time() >= deadline:
-            return last_sandbox
-        await asyncio.sleep(
-            min(poll_seconds, max(deadline - asyncio.get_running_loop().time(), 0.0))
-        )
-        last_sandbox = await client.get_sandbox(name=sandbox_id)
 
 
 async def _create_sandbox_with_retry(

--- a/agent/server.py
+++ b/agent/server.py
@@ -30,7 +30,6 @@ import asyncio
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
 from deepagents import create_deep_agent
-from deepagents.backends import LangSmithSandbox
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import BackendProtocol, SandboxBackendProtocol
 from deepagents.backends.store import StoreBackend
@@ -70,7 +69,7 @@ from .dashboard.user_mappings import email_for_login
 from .integrations.corridor_mcp import load_corridor_tools
 from .integrations.currents_tools import load_currents_tools
 from .integrations.datadog_mcp import load_datadog_tools
-from .integrations.langsmith import _configure_github_proxy, get_async_sandbox_client
+from .integrations.langsmith import _configure_github_proxy
 from .integrations.langsmith_tools import load_langsmith_tools
 from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
@@ -247,31 +246,6 @@ async def _resolve_user_custom_instructions(login: str | None) -> str | None:
         return None
 
 
-async def _start_langsmith_sandbox_if_needed(sandbox_backend: SandboxBackendProtocol) -> None:
-    """Start a LangSmith sandbox before operations that require it to be running."""
-    if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
-        return
-    current_backend = unwrap_sandbox_backend(sandbox_backend)
-    if not isinstance(current_backend, LangSmithSandbox):
-        return
-
-    name = current_backend.id
-    async with get_async_sandbox_client() as client:
-        status = await client.get_sandbox_status(name)
-        status_name = getattr(status, "status", status)
-        status_name = getattr(status_name, "value", status_name)
-        status_text = str(status_name or "").lower()
-        if status_text in {"running", "ready"}:
-            return
-
-        logger.info(
-            "Starting LangSmith sandbox %s before proxy refresh (status=%s)",
-            name,
-            status_text or "unknown",
-        )
-        await client.start_sandbox(name)
-
-
 async def _resolve_proxy_token(
     github_proxy_token: str | None,
 ) -> tuple[str | None, str | None, None]:
@@ -318,7 +292,6 @@ async def _create_sandbox_with_proxy(
             msg = "Cannot configure proxy: GitHub App installation token is unavailable"
             logger.error(msg)
             raise ValueError(msg)
-        await _start_langsmith_sandbox_if_needed(sandbox_backend)
         await _configure_github_proxy(sandbox_backend.id, token)
         record_proxy_token_expiry(
             thread_id,
@@ -350,7 +323,6 @@ async def _refresh_github_proxy(
         return
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
-    await _start_langsmith_sandbox_if_needed(current_backend)
     await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
         thread_id,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -389,8 +389,6 @@ Users can also override the team/project mapping per-comment by including `repo:
             "request_url": "https://<your-ngrok-url>/webhooks/slack",
             "bot_events": [
                 "app_mention",
-                "message.channels",
-                "message.groups",
                 "message.im",
                 "message.mpim"
             ]
@@ -418,12 +416,6 @@ Both Slack URLs must point at the Open SWE backend that serves `agent.webapp:app
 - **Interactivity & Shortcuts → Interactivity Request URL:** `https://<your-backend-url>/webhooks/slack/interactivity`
 
 Slack Block Kit option buttons only work when Interactivity is enabled and pointed at `/webhooks/slack/interactivity`.
-
-**Bot events checklist:**
-
-`app_mention` alone only covers explicit `@`-mentions. The `message.channels` and `message.groups` subscriptions are what let Open SWE reply in a channel thread without being tagged — it answers an untagged follow-up when it has already posted in that thread and exactly one human is participating. Without them Slack never delivers the message, so untagged replies (and plan approvals typed in a channel thread) are silently dropped.
-
-Subscribing to these means the webhook receives every message in every channel the bot is invited to; Open SWE ignores the ones it does not need. Keep the bot out of high-traffic channels where it has no reason to be.
 
 **Credentials you'll need:**
 
@@ -762,7 +754,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - Verify ngrok is running and the URL matches what's configured in GitHub/Linear/Slack
 - Check the ngrok web inspector at `http://localhost:4040` for incoming requests
-- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` + `message.*` for Slack, Issues + Issue comment for GitHub)
+- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` for Slack, Issues + Issue comment for GitHub)
 - **Webhook secrets are required** — if `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or `SLACK_SIGNING_SECRET` is not set, all requests to that endpoint will be rejected with 401
 
 ### GitHub authentication errors
@@ -796,7 +788,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and the commenter has a user mapping (Admin → User mappings; see "Configure triggering surfaces"). Add any missing user with **Add / update** in that section.
 - For Linear: ensure the comment contains `@openswe` (case-insensitive)
-- For Slack: ensure the bot is invited to the channel and the message is an `@mention`. For untagged follow-ups in a thread, also confirm the app subscribes to `message.channels` / `message.groups` (see "Bot events checklist") and that the thread has only Open SWE and one human in it
+- For Slack: ensure the bot is invited to the channel and the message is an `@mention`
 - Check server logs for webhook processing errors
 
 ### Token encryption errors

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -389,6 +389,8 @@ Users can also override the team/project mapping per-comment by including `repo:
             "request_url": "https://<your-ngrok-url>/webhooks/slack",
             "bot_events": [
                 "app_mention",
+                "message.channels",
+                "message.groups",
                 "message.im",
                 "message.mpim"
             ]
@@ -416,6 +418,12 @@ Both Slack URLs must point at the Open SWE backend that serves `agent.webapp:app
 - **Interactivity & Shortcuts → Interactivity Request URL:** `https://<your-backend-url>/webhooks/slack/interactivity`
 
 Slack Block Kit option buttons only work when Interactivity is enabled and pointed at `/webhooks/slack/interactivity`.
+
+**Bot events checklist:**
+
+`app_mention` alone only covers explicit `@`-mentions. The `message.channels` and `message.groups` subscriptions are what let Open SWE reply in a channel thread without being tagged — it answers an untagged follow-up when it has already posted in that thread and exactly one human is participating. Without them Slack never delivers the message, so untagged replies (and plan approvals typed in a channel thread) are silently dropped.
+
+Subscribing to these means the webhook receives every message in every channel the bot is invited to; Open SWE ignores the ones it does not need. Keep the bot out of high-traffic channels where it has no reason to be.
 
 **Credentials you'll need:**
 
@@ -754,7 +762,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - Verify ngrok is running and the URL matches what's configured in GitHub/Linear/Slack
 - Check the ngrok web inspector at `http://localhost:4040` for incoming requests
-- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` for Slack, Issues + Issue comment for GitHub)
+- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` + `message.*` for Slack, Issues + Issue comment for GitHub)
 - **Webhook secrets are required** — if `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or `SLACK_SIGNING_SECRET` is not set, all requests to that endpoint will be rejected with 401
 
 ### GitHub authentication errors
@@ -788,7 +796,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and the commenter has a user mapping (Admin → User mappings; see "Configure triggering surfaces"). Add any missing user with **Add / update** in that section.
 - For Linear: ensure the comment contains `@openswe` (case-insensitive)
-- For Slack: ensure the bot is invited to the channel and the message is an `@mention`
+- For Slack: ensure the bot is invited to the channel and the message is an `@mention`. For untagged follow-ups in a thread, also confirm the app subscribes to `message.channels` / `message.groups` (see "Bot events checklist") and that the thread has only Open SWE and one human in it
 - Check server logs for webhook processing errors
 
 ### Token encryption errors

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -23,7 +23,6 @@ from agent.integrations.langsmith import (
     _install_create_extra_fields,
     _is_sandbox_name_taken_error,
     _sandbox_name_for_thread,
-    _wait_for_reconnected_sandbox,
 )
 
 
@@ -185,17 +184,6 @@ class _FakeStatusSandbox:
         self.status = status
 
 
-class _FakeReconnectClient:
-    def __init__(self, statuses: list[str]) -> None:
-        self.statuses = statuses
-        self.calls = 0
-
-    async def get_sandbox(self, *, name: str) -> _FakeStatusSandbox:
-        self.calls += 1
-        status = self.statuses[min(self.calls - 1, len(self.statuses) - 1)]
-        return _FakeStatusSandbox(status)
-
-
 @pytest.mark.asyncio
 async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -> None:  # noqa: ANN001
     client = _FakeSandboxClient(failures=2)
@@ -216,24 +204,6 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
     assert result == {"sandbox": "snap-1"}
     assert client.calls == 3
     assert client.last_kwargs["name"] == "openswe-abc"
-
-
-@pytest.mark.asyncio
-async def test_wait_for_reconnected_sandbox_polls_until_ready(monkeypatch) -> None:  # noqa: ANN001
-    client = _FakeReconnectClient(["starting", "starting", "running"])
-    sleep = AsyncMock()
-    monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", sleep)
-
-    sandbox = await _wait_for_reconnected_sandbox(
-        cast(AsyncSandboxClient, client),
-        "sandbox-1",
-        timeout_seconds=30,
-        poll_seconds=2,
-    )
-
-    assert sandbox.status == "running"
-    assert client.calls == 3
-    assert sleep.await_count == 2
 
 
 def test_extra_fields_unset_is_empty() -> None:
@@ -322,16 +292,17 @@ class _NameTakenClient:
 
 
 @pytest.mark.asyncio
-async def test_name_collision_adopts_the_orphaned_sandbox() -> None:
+@pytest.mark.parametrize("status", ["running", "creating", "stopped"])
+async def test_name_collision_adopts_the_orphaned_sandbox(status: str) -> None:
     from agent.integrations.langsmith import _reuse_existing_sandbox
 
-    client = _NameTakenClient()
+    client = _NameTakenClient(status=status)
     try:
         await client.create_sandbox(name="openswe-abc", snapshot_id="snap-1")
     except RuntimeError as exc:
         assert _is_sandbox_name_taken_error(exc)
         adopted = await _reuse_existing_sandbox(cast(AsyncSandboxClient, client), "openswe-abc")
-        assert adopted.status == "running"
+        assert adopted.status == status
         assert client.requested == ["openswe-abc"]
     else:  # pragma: no cover
         pytest.fail("expected a name collision")

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -21,6 +21,7 @@ from agent.integrations.langsmith import (
     _get_sandbox_create_extra_fields,
     _get_sandbox_snapshot_config,
     _install_create_extra_fields,
+    _is_sandbox_name_taken_error,
     _sandbox_name_for_thread,
     _wait_for_reconnected_sandbox,
 )
@@ -301,3 +302,41 @@ async def test_install_create_extra_fields_noop_when_empty() -> None:
     client = _FakeClient()
     _install_create_extra_fields(cast(AsyncSandboxClient, client), {})
     assert client._http.post == "sentinel"
+
+
+class _NameTakenClient:
+    """create_sandbox always collides; get_sandbox returns the orphan by that name."""
+
+    def __init__(self, status: str = "running") -> None:
+        self.create_calls = 0
+        self.status = status
+        self.requested: list[str] = []
+
+    async def create_sandbox(self, **kwargs):  # noqa: ANN003, ANN202
+        self.create_calls += 1
+        raise RuntimeError(f"Sandbox '{kwargs['name']}' already exists")
+
+    async def get_sandbox(self, *, name: str) -> _FakeStatusSandbox:
+        self.requested.append(name)
+        return _FakeStatusSandbox(self.status)
+
+
+@pytest.mark.asyncio
+async def test_name_collision_adopts_the_orphaned_sandbox() -> None:
+    from agent.integrations.langsmith import _reuse_existing_sandbox
+
+    client = _NameTakenClient()
+    try:
+        await client.create_sandbox(name="openswe-abc", snapshot_id="snap-1")
+    except RuntimeError as exc:
+        assert _is_sandbox_name_taken_error(exc)
+        adopted = await _reuse_existing_sandbox(cast(AsyncSandboxClient, client), "openswe-abc")
+        assert adopted.status == "running"
+        assert client.requested == ["openswe-abc"]
+    else:  # pragma: no cover
+        pytest.fail("expected a name collision")
+
+
+def test_unrelated_create_errors_are_not_treated_as_collisions() -> None:
+    assert not _is_sandbox_name_taken_error(RuntimeError("snapshot not found"))
+    assert _is_sandbox_name_taken_error(RuntimeError("Sandbox 'x' already exists"))

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -326,19 +326,6 @@ class TestRefreshProxyOnSandboxReuse:
             },
         )
 
-    @staticmethod
-    def _async_client_mock(status: str) -> MagicMock:
-        """Build an ``httpx``-style async-context-manager mock for the sandbox
-        client whose status/start methods are awaitable."""
-        inner = MagicMock()
-        inner.get_sandbox_status = AsyncMock(return_value=MagicMock(status=status))
-        inner.start_sandbox = AsyncMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(return_value=inner)
-        cm.__aexit__ = AsyncMock(return_value=False)
-        cm._inner = inner
-        return cm
-
     @pytest.mark.asyncio
     async def test_refreshes_proxy_for_cached_langsmith_sandbox(self) -> None:
         """Cached sandboxes should get a fresh proxy token before git operations."""
@@ -495,59 +482,3 @@ class TestRefreshProxyOnSandboxReuse:
             assert excinfo.value.sandbox_id == "sandbox-stale"
             mock_proxy.assert_called_once_with("sandbox-stale", "ghs_fresh")
             mock_create.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_starts_stopped_langsmith_sandbox_before_proxy_refresh(self) -> None:
-        """Proxy config requires a running LangSmith sandbox."""
-        inner_sandbox = MagicMock(name="sandbox-stopped")
-        inner_sandbox.name = "sandbox-stopped"
-        client_cm = self._async_client_mock("stopped")
-
-        with (
-            patch(
-                "agent.server.get_github_app_installation_token_with_expiry",
-                new_callable=AsyncMock,
-                return_value=("ghs_fresh", None),
-            ),
-            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
-            patch("agent.server.get_async_sandbox_client", return_value=client_cm),
-            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
-        ):
-            from agent.server import LangSmithSandbox, _refresh_github_proxy
-
-            sandbox_backend = object.__new__(LangSmithSandbox)
-            sandbox_backend._sandbox = inner_sandbox
-
-            await _refresh_github_proxy(sandbox_backend)
-
-            client_cm._inner.get_sandbox_status.assert_awaited_once_with("sandbox-stopped")
-            client_cm._inner.start_sandbox.assert_awaited_once_with("sandbox-stopped")
-            mock_proxy.assert_called_once_with("sandbox-stopped", "ghs_fresh")
-
-    @pytest.mark.asyncio
-    async def test_skips_start_for_ready_langsmith_sandbox_before_proxy_refresh(self) -> None:
-        """Ready sandboxes can be patched without starting again."""
-        inner_sandbox = MagicMock(name="sandbox-ready")
-        inner_sandbox.name = "sandbox-ready"
-        client_cm = self._async_client_mock("ready")
-
-        with (
-            patch(
-                "agent.server.get_github_app_installation_token_with_expiry",
-                new_callable=AsyncMock,
-                return_value=("ghs_fresh", None),
-            ),
-            patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
-            patch("agent.server.get_async_sandbox_client", return_value=client_cm),
-            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
-        ):
-            from agent.server import LangSmithSandbox, _refresh_github_proxy
-
-            sandbox_backend = object.__new__(LangSmithSandbox)
-            sandbox_backend._sandbox = inner_sandbox
-
-            await _refresh_github_proxy(sandbox_backend)
-
-            client_cm._inner.get_sandbox_status.assert_awaited_once_with("sandbox-ready")
-            client_cm._inner.start_sandbox.assert_not_called()
-            mock_proxy.assert_called_once_with("sandbox-ready", "ghs_fresh")


### PR DESCRIPTION
Runs on `open-swe-preview` were failing with:

```
Failed to create sandbox from snapshot 'fbd31a9b-…': Sandbox 'openswe-7oplswcx3zocdkui5o5werf4km' already exists
```

Sandbox names are deterministic per thread (`openswe-<b32(thread uuid)>`). When a run creates the sandbox but dies before persisting `sandbox_id` to thread metadata, the next run finds no id, takes the create path, and collides with the sandbox it orphaned. `already exists` is not in the retryable set, so it raises. The thread is stranded permanently and every follow-up message gets the generic "wasn't able to finish that" warning.

The common way a run dies mid-create is an interrupt, not a crash: send a second Slack message while the first run is still provisioning and run A gets `Received interrupt signal from gRPC stream`, run B starts, and its create 409s ~600ms later. Datadog shows ~20 of these over the last 11 days, the oldest at the edge of log retention — one thread (`ae966d3b`) collided on the same name twice, 7h apart, confirming that a stranded thread never recovers on its own.

Since the name is derived from the thread id, the sandbox holding it is always that thread's own. Adopt it rather than failing.

Adoption also drops all status gating. Sandboxes autostart, so inspecting status could only ever *reject* a sandbox that would have worked — including an orphan still in `creating`, the exact collision this path exists to recover. Gone: the ready/startable/pending status sets and reconnect timeouts, `_status_text`, `_wait_for_reconnected_sandbox`, and `agent/server.py:_start_langsmith_sandbox_if_needed` with both of its call sites. `_reuse_existing_sandbox` is now `get_sandbox(name=...)` with the failure wrapped, shared by the `sandbox_id` path and the adopt path.

## Test Plan

- [x] `test_name_collision_adopts_the_orphaned_sandbox` covers the adopt path, parametrized over `running` / `creating` / `stopped` so no status is rejected; `test_unrelated_create_errors_are_not_treated_as_collisions` pins the error matcher so unrelated create failures still raise
- [x] `uv run pytest tests/sandbox/ tests/slack/` — 263 passed
- [x] `make lint` clean; `make typecheck` unchanged (13 pre-existing errors, none in the touched files)
