### PR TITLE
feat(slack): drop quiet third parties from the untagged-reply gate

### DIFF
--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -99,6 +99,7 @@ from ..utils.multimodal import (
 from ..utils.repo import extract_repo_from_text
 from ..utils.slack import (
     GitHubPrRef,
+    _parse_ts,  # noqa: F401
     fetch_slack_thread_messages,  # noqa: F401
     format_slack_messages_for_prompt,  # noqa: F401
     get_slack_channel_context,

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -77,13 +77,48 @@ def _is_natural_language_plan_approval(text: str) -> bool:
     return any(f" {phrase} " in padded for phrase in _PLAN_APPROVAL_PHRASES)
 
 
+STALE_PARTICIPANT_SECONDS = 15 * 60
+
+_MENTION_PREAMBLE = "You were mentioned in Slack.\n\n"
+
+_UNTAGGED_REPLY_PREAMBLE = (
+    "A message arrived in a Slack thread you are part of. You were NOT tagged in it — "
+    "you are seeing it because you and the sender are the only active participants.\n\n"
+    "Decide first whether the message is actually addressed to you. Continuations of your "
+    "conversation, answers to your questions, and follow-up instructions are addressed to you. "
+    "Someone thinking out loud, talking to another person, or commenting on the thread without "
+    "expecting you to act is not.\n\n"
+    "If it is not addressed to you, call `no_op` and post nothing. Staying silent is the right "
+    "outcome; an unwanted reply from an untagged message is worse than no reply. If it is "
+    "addressed to you, handle it exactly as you would a direct mention.\n\n"
+)
+
+
+def _slack_prompt_preamble(untagged_reply: bool) -> str:
+    return _UNTAGGED_REPLY_PREAMBLE if untagged_reply else _MENTION_PREAMBLE
+
+
+def _slack_request_heading(untagged_reply: bool) -> str:
+    return "## Untagged Message" if untagged_reply else "## Latest Mention Request"
+
+
 async def _slack_thread_allows_untagged_reply(
-    channel_id: str, thread_ts: str, text: str, bot_user_id: str
+    channel_id: str,
+    thread_ts: str,
+    text: str,
+    bot_user_id: str,
+    sender_id: str = "",
+    now_ts: str = "",
 ) -> bool:
-    """Allow an untagged follow-up when Open SWE and exactly one human share the thread.
+    """Allow an untagged follow-up when the sender and Open SWE are the live participants.
 
     Skipped when the message mentions any user other than Open SWE, so tagging a
     different person still hands the turn to them rather than the agent.
+
+    A third party drops out of the count once they have gone quiet: their last
+    message predates Open SWE's latest reply *and* is older than
+    ``STALE_PARTICIPANT_SECONDS``. Without that, one drive-by emoji would disable
+    untagged replies in the thread permanently.
     """
     if not channel_id or not thread_ts or not bot_user_id:
         return False
@@ -93,20 +128,35 @@ async def _slack_thread_allows_untagged_reply(
         return False
 
     messages = await common.fetch_slack_thread_messages(channel_id, thread_ts)
-    bot_participated = False
-    humans: set[str] = set()
+    bot_last_ts = 0.0
+    latest_ts = common._parse_ts(now_ts)
+    last_message_ts: dict[str, float] = {}
     for message in messages:
+        message_ts = common._parse_ts(message.get("ts"))
+        latest_ts = max(latest_ts, message_ts)
         author = message.get("user")
         if author == bot_user_id:
-            bot_participated = True
+            bot_last_ts = max(bot_last_ts, message_ts)
             continue
         # Skip other apps (GitHub/CI bots) — they are neither Open SWE nor a human participant.
         if message.get("bot_id"):
             continue
+        # Joins, leaves and edits are not someone taking part in the conversation.
+        if message.get("subtype"):
+            continue
         if isinstance(author, str) and author:
-            humans.add(author)
+            last_message_ts[author] = max(last_message_ts.get(author, 0.0), message_ts)
 
-    return bot_participated and len(humans) == 1
+    if not bot_last_ts or not last_message_ts:
+        return False
+
+    # The sender is always a live participant; fall back to whoever spoke last.
+    sender = sender_id or max(last_message_ts, key=lambda author: last_message_ts[author])
+    return not any(
+        author != sender
+        and not (author_ts < bot_last_ts and latest_ts - author_ts > STALE_PARTICIPANT_SECONDS)
+        for author, author_ts in last_message_ts.items()
+    )
 
 
 async def _slack_thread_is_busy(client: Any, thread_id: str) -> bool:
@@ -393,6 +443,7 @@ async def _process_slack_mention_impl(
         current_message["attachments"] = attachments
 
     treat_all_messages_as_mentions = bool(event_data.get("treat_all_messages_as_mentions"))
+    untagged_reply = bool(event_data.get("untagged_reply"))
     context_messages, context_mode = common.select_slack_context_messages(
         thread_messages,
         event_ts,
@@ -439,8 +490,7 @@ async def _process_slack_mention_impl(
         channel_id, thread_ts, context_source, channel_context
     )
     prompt = (
-        "You were mentioned in Slack.\n\n"
-        "## Default Repository Hint\n"
+        _slack_prompt_preamble(untagged_reply) + "## Default Repository Hint\n"
         f"{repo_config.get('owner')}/{repo_config.get('name')}\n"
         "Use this only if the Slack conversation does not identify a different repository.\n\n"
         f"## Triggered by\n{trigger_user}\n\n"
@@ -448,7 +498,7 @@ async def _process_slack_mention_impl(
         f"{slack_thread_section}\n\n"
         f"{await _format_slack_run_links_section(thread_id)}\n\n"
         f"## Conversation Context\n{context_text}\n\n"
-        f"## Latest Mention Request\n{clean_text}"
+        + f"{_slack_request_heading(untagged_reply)}\n{clean_text}"
         + (f"\n\n{resolved_links_section}" if resolved_links_section else "")
     )
     content_blocks: list[dict[str, Any]] = [cast(dict[str, Any], create_text_block(prompt))]

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -112,6 +112,11 @@ async def slack_webhook(
             event.get("type") == "message"
             and not event.get("subtype")
             and not is_direct_message
+            # An explicit tag is never an untagged reply: the gate below admits
+            # messages mentioning only Open SWE, so without this an explicitly
+            # tagged request would tell the agent it was not tagged.
+            and not has_username_mention
+            and not has_id_mention
             and await service._slack_thread_allows_untagged_reply(
                 str(event.get("channel") or ""),
                 str(event.get("thread_ts") or ""),

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -86,6 +86,7 @@ async def slack_webhook(
         and event.get("channel_type") == "im"
         and bool(event.get("user"))
     )
+    is_untagged_two_party_reply = False
     if event.get("type") != "app_mention":
         message_text = event.get("text", "")
         has_username_mention = bool(
@@ -116,6 +117,8 @@ async def slack_webhook(
                 str(event.get("thread_ts") or ""),
                 message_text,
                 bot_user_id,
+                str(event.get("user") or ""),
+                str(event.get("ts") or ""),
             )
         )
         should_handle_message = any(
@@ -166,6 +169,7 @@ async def slack_webhook(
             "attachments": event.get("attachments", []),
             "bot_user_id": bot_user_id,
             "treat_all_messages_as_mentions": is_direct_message,
+            "untagged_reply": is_untagged_two_party_reply,
         }
         repo_config = await common.get_slack_repo_config(
             channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -1,0 +1,111 @@
+"""Route-level cover for the `untagged_reply` flag handed to the agent prompt."""
+
+import json
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import BackgroundTasks
+from starlette.requests import Request
+
+from agent.utils import slack_events
+from agent.webhooks import common as webhook_common
+from agent.webhooks import slack as slack_service
+from agent.webhooks import slack_routes
+
+
+class _FakeThreads:
+    """Every claim succeeds — dedupe is covered in test_slack_event_dedupe.py."""
+
+    async def create(self, *, thread_id: str, **_kwargs: Any) -> None:
+        return None
+
+    async def get(self, thread_id: str) -> dict[str, str]:
+        raise KeyError(thread_id)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.threads = _FakeThreads()
+
+
+class _FakeBackgroundTasks:
+    def __init__(self) -> None:
+        self.tasks: list[tuple[Any, tuple[Any, ...]]] = []
+
+    def add_task(self, func: Any, *args: Any) -> None:
+        self.tasks.append((func, args))
+
+
+class _FakeRequest:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.headers: dict[str, str] = {}
+        self._body = json.dumps(payload).encode()
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+def _message_payload(text: str, event_id: str) -> dict[str, Any]:
+    return {
+        "type": "event_callback",
+        "event_id": event_id,
+        "authorizations": [{"user_id": "BOT"}],
+        "event": {
+            "type": "message",
+            "channel": "C1",
+            "ts": "1786573369.551099",
+            "thread_ts": "1786573300.000000",
+            "user": "U1",
+            "text": text,
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    slack_events.reset_slack_event_claims()
+
+    async def channel_context(_channel_id: str) -> dict[str, Any]:
+        return {}
+
+    async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
+        return False
+
+    async def repo_config(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {"owner": "langchain-ai", "name": "open-swe"}
+
+    monkeypatch.setattr(slack_events, "get_client", lambda url: _FakeClient())
+    monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **_kwargs: True)
+    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
+    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
+    monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "BOT")
+    monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "openswe")
+    # The two-party gate would admit these messages on its own.
+    monkeypatch.setattr(
+        slack_service, "_slack_thread_allows_untagged_reply", AsyncMock(return_value=True)
+    )
+
+
+async def _untagged_flag_for(text: str, event_id: str) -> bool:
+    background_tasks = _FakeBackgroundTasks()
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(_message_payload(text, event_id))),
+        cast(BackgroundTasks, background_tasks),
+    )
+    assert response["status"] == "accepted", response
+    event_data = background_tasks.tasks[0][1][0]
+    return bool(event_data["untagged_reply"])
+
+
+async def test_id_mention_is_not_marked_untagged() -> None:
+    assert await _untagged_flag_for("<@BOT> please fix this", "Ev-id") is False
+
+
+async def test_username_mention_is_not_marked_untagged() -> None:
+    assert await _untagged_flag_for("hey @openswe please fix this", "Ev-name") is False
+
+
+async def test_message_without_a_mention_is_marked_untagged() -> None:
+    assert await _untagged_flag_for("how about now", "Ev-plain") is True

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -277,6 +277,13 @@ async def test_dispatch_or_queue_dispatches_when_idle(
 ) -> None:
     dispatch = AsyncMock(return_value={"run_id": "run-1"})
     queue = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_webhook.common, "is_bot_token_only_mode", lambda: True)
+    monkeypatch.setattr(slack_webhook.common, "login_for_slack_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(slack_webhook.common, "login_for_email", AsyncMock(return_value=None))
+    monkeypatch.setattr(slack_webhook.common, "_thread_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(slack_webhook.common, "upsert_agent_thread_owner_metadata", AsyncMock())
+    monkeypatch.setattr(slack_webhook.common, "get_client", lambda *, url: _FakeClient())
+    monkeypatch.setattr(slack_webhook, "_slack_thread_is_busy", AsyncMock(return_value=False))
     monkeypatch.setattr(slack_webhook.common, "dispatch_agent_run", dispatch)
     monkeypatch.setattr(slack_webhook.common, "queue_message_for_thread", queue)
 
@@ -368,3 +375,119 @@ async def test_dispatch_or_queue_tagged_message_interrupts_even_when_busy(
     assert run == {"run_id": "run-1"}
     queue.assert_not_awaited()
     dispatch.assert_awaited_once()
+
+
+def _msg(ts: float, user: str, **extra: Any) -> dict[str, Any]:
+    return {"ts": f"{ts:.6f}", "user": user, **extra}
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_ignores_a_third_party_who_went_quiet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mukil's drive-by emoji must not disable untagged replies forever."""
+    base = 1786723299.0
+    messages = [
+        _msg(base, "URAMON"),
+        _msg(base + 6, "BOT"),
+        _msg(base + 90, "UMUKIL"),  # went quiet, before the bot's latest reply
+        _msg(base + 1331, "BOT"),
+    ]
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "why do you not see this message", "BOT", "URAMON", f"{base + 1423:.6f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_while_a_third_party_is_still_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = 1786723299.0
+    messages = [
+        _msg(base, "URAMON"),
+        _msg(base + 6, "BOT"),
+        _msg(base + 1400, "UMUKIL"),  # spoke 23s ago — still in the conversation
+    ]
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "how about now", "BOT", "URAMON", f"{base + 1423:.6f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_when_third_party_spoke_after_the_bot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale needs both conditions: older than the bot's last reply AND >15 min."""
+    base = 1786723299.0
+    messages = [
+        _msg(base, "URAMON"),
+        _msg(base + 6, "BOT"),
+        _msg(base + 60, "UMUKIL"),  # after the bot, so never stale however old
+    ]
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "ping", "BOT", "URAMON", f"{base + 9999:.6f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_ignores_joins_and_leaves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = 1786723299.0
+    messages = [
+        _msg(base, "URAMON"),
+        _msg(base + 6, "BOT"),
+        _msg(base + 10, "ULURKER", subtype="channel_join"),
+    ]
+    monkeypatch.setattr(
+        slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
+    )
+
+    assert await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "keep going", "BOT", "URAMON", f"{base + 20:.6f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_untagged_reply_blocked_when_bot_never_posted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = 1786723299.0
+    monkeypatch.setattr(
+        slack_webhook.common,
+        "fetch_slack_thread_messages",
+        AsyncMock(return_value=[_msg(base, "URAMON")]),
+    )
+
+    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+        "C1", "123.45", "hello", "BOT", "URAMON", f"{base + 5:.6f}"
+    )
+
+
+def test_untagged_prompt_tells_the_agent_it_was_not_tagged() -> None:
+    preamble = slack_webhook._slack_prompt_preamble(untagged_reply=True)
+
+    assert "You were NOT tagged" in preamble
+    assert "call `no_op` and post nothing" in preamble
+    assert "Staying silent is the right" in preamble
+    assert slack_webhook._slack_request_heading(untagged_reply=True) == "## Untagged Message"
+
+
+def test_tagged_prompt_keeps_the_mention_wording() -> None:
+    preamble = slack_webhook._slack_prompt_preamble(untagged_reply=False)
+
+    assert preamble == "You were mentioned in Slack.\n\n"
+    assert "NOT tagged" not in preamble
+    assert slack_webhook._slack_request_heading(untagged_reply=False) == "## Latest Mention Request"


### PR DESCRIPTION
Open SWE replies to an untagged message in a thread when it and one human are the only participants. The gate counted every human who had ever posted and required exactly one, so a colleague dropping a single `:sad-spongebob:` into a thread disabled untagged replies there permanently.

A third party is now ignored once they have gone quiet — **both** conditions must hold:

- their last message predates Open SWE's most recent reply, **and**
- their last message is more than 15 minutes old

Either one alone is not enough: someone who spoke after the bot is still in the conversation however long ago it was, and someone who spoke 20 seconds ago is still active even if the bot has replied since. Messages carrying a `subtype` (joins, leaves) never counted as taking part. The sender always counts as live.

Untagged runs also get a different prompt preamble. The agent is told explicitly that it was not tagged, and that it should call `no_op` and stay silent unless it judges the message to be addressed to it — an unwanted reply to an untagged message is worse than no reply. Tagged mentions keep the existing wording.

## Test Plan

- [x] `test_untagged_reply_ignores_a_third_party_who_went_quiet` replays the real thread timings that triggered this (third party quiet 22 min, bot replied since)
- [x] `test_untagged_reply_blocked_while_a_third_party_is_still_active` and `test_untagged_reply_blocked_when_third_party_spoke_after_the_bot` pin that both staleness conditions are required
- [x] `test_untagged_prompt_tells_the_agent_it_was_not_tagged` / `test_tagged_prompt_keeps_the_mention_wording` cover the preamble split
- [x] `uv run pytest tests/slack/` — 129 passed
- [x] `make lint` clean; `make typecheck` shows the same 13 pre-existing errors as `main`