### PR TITLE
fix: display the repository used by an agent

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -405,10 +405,8 @@ async def _thread_summary(
     metadata = thread_metadata(thread)
     owner, name, full_name = _metadata_repo(metadata)
     working_repo = metadata.get("working_repo_full_name")
-    if isinstance(working_repo, str) and working_repo.count("/") == 1:
-        working_owner, working_name = working_repo.split("/", 1)
-        if working_owner and working_name:
-            name, full_name = working_name, working_repo
+    if not isinstance(working_repo, str) or working_repo.count("/") != 1:
+        working_repo = None
     created_at = metadata.get("created_at_ms")
     updated_at = metadata.get("updated_at_ms")
     title = metadata.get("title") if isinstance(metadata.get("title"), str) else "Untitled agent"
@@ -442,6 +440,7 @@ async def _thread_summary(
         "title": title,
         "repo": name,
         "repoFullName": full_name,
+        "workingRepoFullName": working_repo,
         "branch": metadata.get("branch_name") or metadata.get("base_branch") or "main",
         "model": model,
         "effort": effort,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -404,6 +404,11 @@ async def _thread_summary(
 ) -> dict[str, Any]:
     metadata = thread_metadata(thread)
     owner, name, full_name = _metadata_repo(metadata)
+    working_repo = metadata.get("working_repo_full_name")
+    if isinstance(working_repo, str) and working_repo.count("/") == 1:
+        working_owner, working_name = working_repo.split("/", 1)
+        if working_owner and working_name:
+            name, full_name = working_name, working_repo
     created_at = metadata.get("created_at_ms")
     updated_at = metadata.get("updated_at_ms")
     title = metadata.get("title") if isinstance(metadata.get("title"), str) else "Untitled agent"

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -28,6 +28,7 @@ _MIDDLEWARE_MODULES = {
     "TimeoutWrapupMiddleware": ".timeout_wrapup",
     "ToolErrorMiddleware": ".tool_error_handler",
     "WorkflowPushGuardMiddleware": ".workflow_push_guard",
+    "WorkingRepoMiddleware": ".working_repo",
 }
 
 __all__ = [
@@ -48,6 +49,7 @@ __all__ = [
     "ToolErrorMiddleware",
     "TimeoutWrapupMiddleware",
     "WorkflowPushGuardMiddleware",
+    "WorkingRepoMiddleware",
     "SandboxCircuitBreakerMiddleware",
     "check_message_queue_before_model",
     "ensure_no_empty_msg",
@@ -82,6 +84,7 @@ if TYPE_CHECKING:
     from .timeout_wrapup import TimeoutWrapupMiddleware
     from .tool_error_handler import ToolErrorMiddleware
     from .workflow_push_guard import WorkflowPushGuardMiddleware
+    from .working_repo import WorkingRepoMiddleware
 
 
 def _load_export(name: str) -> Any:

--- a/agent/middleware/working_repo.py
+++ b/agent/middleware/working_repo.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from ..utils.sandbox_paths import aresolve_sandbox_work_dir
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_REMOTE = re.compile(
+    r"^(?:https://github\.com/|ssh://git@github\.com/|git@github\.com:)([^/\s]+)/([^/\s]+)$"
+)
+_DISCOVER_TIMEOUT_SECONDS = 15
+
+
+def github_repo_from_remote(remote: str) -> tuple[str, str] | None:
+    value = remote.strip()
+    if value.endswith(".git"):
+        value = value[:-4]
+    match = _GITHUB_REMOTE.fullmatch(value)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _tool_name(request: ToolCallRequest) -> str | None:
+    tool_call = getattr(request, "tool_call", None)
+    if not isinstance(tool_call, Mapping):
+        return None
+    name = tool_call.get("name")
+    return name if isinstance(name, str) else None
+
+
+def _output(response: Any) -> str:
+    output = getattr(response, "output", None)
+    if isinstance(output, str):
+        return output
+    if isinstance(response, Mapping):
+        value = response.get("output")
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _discovery_command(work_dir: str) -> str:
+    root = shlex.quote(work_dir)
+    return (
+        f"for d in {root} {root}/*; do "
+        '[ -d "$d/.git" ] || continue; '
+        'git -C "$d" remote get-url origin 2>/dev/null || true; '
+        "done"
+    )
+
+
+async def discover_working_repo(backend: Any) -> tuple[str, str] | None:
+    try:
+        work_dir = await aresolve_sandbox_work_dir(backend)
+        response = await backend.aexecute(
+            _discovery_command(work_dir), timeout=_DISCOVER_TIMEOUT_SECONDS
+        )
+    except Exception:
+        logger.debug("Failed to inspect the sandbox working repository", exc_info=True)
+        return None
+
+    repos = {
+        repo
+        for line in _output(response).splitlines()
+        if (repo := github_repo_from_remote(line)) is not None
+    }
+    return next(iter(repos)) if len(repos) == 1 else None
+
+
+class WorkingRepoMiddleware(AgentMiddleware):
+    state_schema = AgentState
+
+    def __init__(self, *, thread_id: str, backend: Any, thread_client: Any) -> None:
+        self._thread_id = thread_id
+        self._backend = backend
+        self._thread_client = thread_client
+        self._current_repo: tuple[str, str] | None = None
+
+    async def _sync_repo(self) -> None:
+        repo = await discover_working_repo(self._backend)
+        if repo is None or repo == self._current_repo:
+            return
+        owner, name = repo
+        try:
+            await self._thread_client.threads.update(
+                thread_id=self._thread_id,
+                metadata={
+                    "repo": {"owner": owner, "name": name},
+                    "repo_owner": owner,
+                    "repo_name": name,
+                },
+            )
+        except Exception:
+            logger.debug(
+                "Failed to update working repository for %s", self._thread_id, exc_info=True
+            )
+            return
+        self._current_repo = repo
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        result = await handler(request)
+        if _tool_name(request) == "execute":
+            await self._sync_repo()
+        return result

--- a/agent/middleware/working_repo.py
+++ b/agent/middleware/working_repo.py
@@ -95,11 +95,7 @@ class WorkingRepoMiddleware(AgentMiddleware):
         try:
             await self._thread_client.threads.update(
                 thread_id=self._thread_id,
-                metadata={
-                    "repo": {"owner": owner, "name": name},
-                    "repo_owner": owner,
-                    "repo_name": name,
-                },
+                metadata={"working_repo_full_name": f"{owner}/{name}"},
             )
         except Exception:
             logger.debug(

--- a/agent/middleware/working_repo.py
+++ b/agent/middleware/working_repo.py
@@ -114,6 +114,6 @@ class WorkingRepoMiddleware(AgentMiddleware):
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
     ) -> ToolMessage | Command:
         result = await handler(request)
-        if _tool_name(request) == "execute":
+        if _tool_name(request) in {"execute", "task"}:
             await self._sync_repo()
         return result

--- a/agent/server.py
+++ b/agent/server.py
@@ -87,6 +87,7 @@ from .middleware import (
     SubdirAgentsReadMiddleware,
     TimeoutWrapupMiddleware,
     ToolErrorMiddleware,
+    WorkingRepoMiddleware,
     check_message_queue_before_model,
     notify_step_limit_reached,
     refresh_github_proxy_before_model,
@@ -1187,6 +1188,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 SanitizeToolInputsMiddleware(),
                 ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
                 ToolErrorMiddleware(),
+                WorkingRepoMiddleware(thread_id=thread_id, backend=backend, thread_client=client),
                 SubdirAgentsReadMiddleware(),
                 ToolRetryMiddleware(
                     max_retries=2,

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -329,8 +329,9 @@ async def test_thread_summary_uses_working_repo_for_display_only() -> None:
 
     summary = await thread_api._thread_summary(_thread_with_metadata(metadata))
 
-    assert summary["repo"] == "checkout"
-    assert summary["repoFullName"] == "observed/checkout"
+    assert summary["repo"] == "default"
+    assert summary["repoFullName"] == "trusted/default"
+    assert summary["workingRepoFullName"] == "observed/checkout"
     assert metadata["repo"] == {"owner": "trusted", "name": "default"}
 
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -321,6 +321,19 @@ async def test_thread_summary_includes_pr_and_diff_stats() -> None:
     assert summary["diffStats"] == {"files": 3, "additions": 10, "deletions": 2}
 
 
+async def test_thread_summary_uses_working_repo_for_display_only() -> None:
+    metadata = {
+        "repo": {"owner": "trusted", "name": "default"},
+        "working_repo_full_name": "observed/checkout",
+    }
+
+    summary = await thread_api._thread_summary(_thread_with_metadata(metadata))
+
+    assert summary["repo"] == "checkout"
+    assert summary["repoFullName"] == "observed/checkout"
+    assert metadata["repo"] == {"owner": "trusted", "name": "default"}
+
+
 async def test_thread_summary_defaults_unknown_pr_state_to_open() -> None:
     summary = await thread_api._thread_summary(
         _thread_with_metadata(

--- a/tests/middleware/test_working_repo_middleware.py
+++ b/tests/middleware/test_working_repo_middleware.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from agent.middleware.working_repo import (
+    WorkingRepoMiddleware,
+    discover_working_repo,
+    github_repo_from_remote,
+)
+
+
+class FakeBackend:
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self.commands: list[str] = []
+        self._open_swe_resolved_work_dir = "/workspace"
+
+    async def aexecute(self, command: str, *, timeout: int) -> Any:
+        self.commands.append(command)
+        return SimpleNamespace(output=self.output, exit_code=0)
+
+
+class FakeThreads:
+    def __init__(self) -> None:
+        self.updates: list[dict[str, Any]] = []
+
+    async def update(self, **kwargs: Any) -> None:
+        self.updates.append(kwargs)
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    [
+        ("https://github.com/langchain-ai/open-swe.git", ("langchain-ai", "open-swe")),
+        ("git@github.com:langchain-ai/open-swe.git", ("langchain-ai", "open-swe")),
+        ("ssh://git@github.com/langchain-ai/open-swe", ("langchain-ai", "open-swe")),
+        ("https://gitlab.com/langchain-ai/open-swe", None),
+        ("https://github.com/langchain-ai/open-swe/extra", None),
+    ],
+)
+def test_github_repo_from_remote(remote: str, expected: tuple[str, str] | None) -> None:
+    assert github_repo_from_remote(remote) == expected
+
+
+async def test_discover_working_repo_returns_single_unique_repo() -> None:
+    backend = FakeBackend(
+        "https://github.com/langchain-ai/open-swe.git\ngit@github.com:langchain-ai/open-swe.git\n"
+    )
+
+    assert await discover_working_repo(backend) == ("langchain-ai", "open-swe")
+    assert 'git -C "$d" remote get-url origin' in backend.commands[0]
+
+
+async def test_discover_working_repo_rejects_ambiguous_repos() -> None:
+    backend = FakeBackend(
+        "https://github.com/langchain-ai/open-swe.git\n"
+        "https://github.com/langchain-ai/langchain.git\n"
+    )
+
+    assert await discover_working_repo(backend) is None
+
+
+async def test_execute_updates_thread_repo_metadata_once() -> None:
+    backend = FakeBackend("https://github.com/langchain-ai/open-swe.git\n")
+    threads = FakeThreads()
+    middleware = WorkingRepoMiddleware(
+        thread_id="thread-1",
+        backend=backend,
+        thread_client=SimpleNamespace(threads=threads),
+    )
+    request: Any = SimpleNamespace(tool_call={"name": "execute", "args": {}, "id": "call-1"})
+
+    async def handler(_request: Any) -> ToolMessage:
+        return ToolMessage(content="ok", tool_call_id="call-1")
+
+    await middleware.awrap_tool_call(request, handler)
+    await middleware.awrap_tool_call(request, handler)
+
+    assert threads.updates == [
+        {
+            "thread_id": "thread-1",
+            "metadata": {
+                "repo": {"owner": "langchain-ai", "name": "open-swe"},
+                "repo_owner": "langchain-ai",
+                "repo_name": "open-swe",
+            },
+        }
+    ]

--- a/tests/middleware/test_working_repo_middleware.py
+++ b/tests/middleware/test_working_repo_middleware.py
@@ -64,7 +64,8 @@ async def test_discover_working_repo_rejects_ambiguous_repos() -> None:
     assert await discover_working_repo(backend) is None
 
 
-async def test_execute_updates_thread_repo_metadata_once() -> None:
+@pytest.mark.parametrize("tool_name", ["execute", "task"])
+async def test_sandbox_tool_updates_thread_repo_metadata_once(tool_name: str) -> None:
     backend = FakeBackend("https://github.com/langchain-ai/open-swe.git\n")
     threads = FakeThreads()
     middleware = WorkingRepoMiddleware(
@@ -72,7 +73,7 @@ async def test_execute_updates_thread_repo_metadata_once() -> None:
         backend=backend,
         thread_client=SimpleNamespace(threads=threads),
     )
-    request: Any = SimpleNamespace(tool_call={"name": "execute", "args": {}, "id": "call-1"})
+    request: Any = SimpleNamespace(tool_call={"name": tool_name, "args": {}, "id": "call-1"})
 
     async def handler(_request: Any) -> ToolMessage:
         return ToolMessage(content="ok", tool_call_id="call-1")
@@ -83,10 +84,6 @@ async def test_execute_updates_thread_repo_metadata_once() -> None:
     assert threads.updates == [
         {
             "thread_id": "thread-1",
-            "metadata": {
-                "repo": {"owner": "langchain-ai", "name": "open-swe"},
-                "repo_owner": "langchain-ai",
-                "repo_name": "open-swe",
-            },
+            "metadata": {"working_repo_full_name": "langchain-ai/open-swe"},
         }
     ]

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -191,6 +191,7 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   // this thread. Those are also the paths a follow-up is most likely about.
   const mentionPaths = useMemo(() => editedPaths(baseMessages), [baseMessages])
   const isThinking = stream.isLoading
+  const displayRepo = thread.workingRepoFullName || thread.repoFullName
   const settingUpSandbox = isThinking && baseMessages.length === 0
   // The transcript hydrates from the SDK (`GET …/state` → `stream.messages`).
   // Show a loading state during that one-time fetch instead of the empty state.
@@ -225,11 +226,11 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
               panelCollapsed && "pr-14"
             )}
           >
-            {thread.repoFullName && (
+            {displayRepo && (
               <span className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
                 <FolderOpen className="size-3.5 shrink-0" />
-                <span className="truncate" title={thread.repoFullName}>
-                  {thread.repoFullName}
+                <span className="truncate" title={displayRepo}>
+                  {displayRepo}
                 </span>
               </span>
             )}

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -220,6 +220,7 @@ export interface AgentThread {
   title: string
   repo: string
   repoFullName: string
+  workingRepoFullName?: string | null
   branch: string
   model: string
   effort?: string | null


### PR DESCRIPTION
## Description
The Agents UI currently keeps showing the repository hint captured when a thread starts, even after the agent checks out a different repository. Detect the unique GitHub checkout after sandbox commands and persist it to thread metadata so the web header and follow-up runs reflect the repository actually in use.

## Test Plan
- [x] Verify HTTPS and SSH remotes resolve to the same repository while ambiguous checkouts are ignored.
- [x] Verify repeated sandbox commands update thread repository metadata only once.

Made by [Open SWE](https://openswe.vercel.app/agents/c8fc0919-2bb9-b582-e06f-d8cd869b5017)