### PR TITLE
feat: add macOS desktop install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev desktop
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev desktop install-desktop
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -15,6 +15,12 @@ run:
 
 desktop:
 	cd desktop && pnpm run dev
+
+install-desktop:
+	@test -z "$$(git status --porcelain)" || { echo 'Commit or stash repository changes first.' >&2; exit 1; }
+	@git switch main
+	@git pull --ff-only origin main
+	@./scripts/install_desktop.sh
 
 install:
 	uv sync --extra dev
@@ -68,6 +74,7 @@ help:
 	@echo 'dev                          - run LangGraph dev server'
 	@echo 'run                          - run webhook server'
 	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
+	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ This is an area where you can extend Open SWE for your org: add deterministic CI
 ## Getting Started
 
 - **[Installation Guide](docs/INSTALLATION.md)** — local dev (backend + dashboard), GitHub App creation, LangSmith, Linear/Slack/GitHub triggers, and production deployment
+- **macOS Desktop beta** — clone this repository and run `make install-desktop` from the root to install or update the app
 - **[Customization Guide](docs/CUSTOMIZATION.md)** — swap the sandbox, model, tools, triggers, system prompt, and middleware for your org
 
 ## License

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -35,6 +35,18 @@ The backend's GitHub App must allow `<backend-url>/dashboard/api/auth/callback` 
 Set `ALLOWED_GITHUB_ORGS` on the backend to prevent GitHub users outside the organization from
 creating dashboard sessions.
 
+## Install on macOS
+
+Install Git and Node.js 22, clone this repository, then run this from its root:
+
+```bash
+make install-desktop
+```
+
+The command fast-forwards to the latest `main`, builds Open SWE Desktop, and installs it in
+`/Applications` (or `~/Applications` when needed). Run it again to update and replace the app; saved
+backend settings, login sessions, and projects are preserved.
+
 ## Local development
 
 Install both packages, run the backend at `http://localhost:2024`, then start Electron:

--- a/scripts/install_desktop.sh
+++ b/scripts/install_desktop.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Open SWE Desktop can only be installed with this command on macOS." >&2
+  exit 1
+fi
+
+for command in node corepack ditto; do
+  command -v "$command" >/dev/null || {
+    echo "Missing $command. Install Node.js 22, then try again." >&2
+    exit 1
+  }
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+corepack pnpm install --frozen-lockfile
+rm -rf desktop/dist
+corepack pnpm --dir desktop run pack
+
+apps=(desktop/dist/mac*/"Open SWE.app")
+if [[ ${#apps[@]} -ne 1 || ! -d "${apps[0]}" ]]; then
+  echo "Could not find the packaged Open SWE application." >&2
+  exit 1
+fi
+
+system_app="/Applications/Open SWE.app"
+user_app="$HOME/Applications/Open SWE.app"
+if [[ -e "$system_app" && -w "$system_app" || ! -e "$system_app" && -w /Applications ]]; then
+  target="$system_app"
+else
+  mkdir -p "$HOME/Applications"
+  target="$user_app"
+fi
+
+staged="${target}.installing.$$"
+trap 'rm -rf "$staged"' EXIT
+ditto "${apps[0]}" "$staged"
+osascript -e 'tell application id "com.langchain.openswe" to quit' >/dev/null 2>&1 || true
+rm -rf "$target"
+mv "$staged" "$target"
+trap - EXIT
+open "$target"
+echo "Open SWE Desktop installed at $target"

--- a/scripts/install_desktop.sh
+++ b/scripts/install_desktop.sh
@@ -28,7 +28,7 @@ fi
 
 system_app="/Applications/Open SWE.app"
 user_app="$HOME/Applications/Open SWE.app"
-if [[ -e "$system_app" && -w "$system_app" || ! -e "$system_app" && -w /Applications ]]; then
+if [[ -w /Applications ]]; then
   target="$system_app"
 else
   mkdir -p "$HOME/Applications"


### PR DESCRIPTION
## Description
Give beta testers one command to build the latest `main` and replace their installed macOS desktop app.

## Release Note
Add `make install-desktop` for installing or updating Open SWE Desktop from source.

## Test Plan
- [x] Smoke-test app packaging and user Applications fallback with stubbed macOS tools

Made by [Open SWE](https://openswe.vercel.app/agents/01a0019b-b907-77cf-811d-0de879a67524)