### PR TITLE
fix(slack): dedupe on the message, not the delivery

### DIFF
--- a/agent/utils/slack_events.py
+++ b/agent/utils/slack_events.py
@@ -26,14 +26,25 @@ def _claim_thread_id(claim_key: str) -> str:
 
 
 def slack_message_claim_key(event_id: str, channel_id: str = "", event_ts: str = "") -> str:
-    """Key a claim on the message itself, not the delivery.
-
-    Slack fans one tagged channel post out as both `app_mention` and `message`, each
-    with its own event id, so an event-id claim lets the same message start two runs.
-    """
+    """Key a claim on the message itself, not the delivery."""
     if channel_id and event_ts:
         return f"{channel_id}:{event_ts}"
     return event_id
+
+
+async def _claim_remotely(claim_key: str) -> bool | None:
+    client = get_client(url=LANGGRAPH_URL)
+    claim_thread_id = _claim_thread_id(claim_key)
+    try:
+        await client.threads.create(thread_id=claim_thread_id, if_exists="raise", ttl=10)
+    except Exception:  # noqa: BLE001
+        try:
+            await client.threads.get(claim_thread_id)
+        except Exception:  # noqa: BLE001
+            logger.warning("Slack event claim failed for key=%s", claim_key)
+            return None
+        return False
+    return True
 
 
 def _claim_locally(claim_key: str) -> None:
@@ -64,20 +75,19 @@ async def claim_slack_event(event_id: str, channel_id: str = "", event_ts: str =
         if claim_key in _claimed_keys or (event_id and event_id in _claimed_keys):
             return False
 
-        claim_thread_id = _claim_thread_id(claim_key)
-        client = get_client(url=LANGGRAPH_URL)
-        try:
-            await client.threads.create(thread_id=claim_thread_id, if_exists="raise", ttl=10)
-        except Exception:  # noqa: BLE001
-            try:
-                await client.threads.get(claim_thread_id)
-            except Exception:  # noqa: BLE001
-                logger.warning("Slack event claim failed for key=%s", claim_key)
-                return True
-            _claim_locally(claim_key)
+        claimed = await _claim_remotely(event_id)
+        if claimed is False:
             _claim_locally(event_id)
             return False
+        if claim_key != event_id:
+            message_claimed = await _claim_remotely(claim_key)
+            if message_claimed is False:
+                _claim_locally(claim_key)
+                _claim_locally(event_id)
+                return False
+            claimed = claimed or message_claimed
 
-        _claim_locally(claim_key)
-        _claim_locally(event_id)
+        if claimed:
+            _claim_locally(claim_key)
+            _claim_locally(event_id)
         return True

--- a/agent/utils/slack_events.py
+++ b/agent/utils/slack_events.py
@@ -17,40 +17,54 @@ LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
 )
 
 _LOCAL_CLAIM_LIMIT = 2048
-_claimed_event_ids: OrderedDict[str, None] = OrderedDict()
+_claimed_keys: OrderedDict[str, None] = OrderedDict()
 _claim_lock = asyncio.Lock()
 
 
-def _claim_thread_id(event_id: str) -> str:
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:slack-event:{event_id}"))
+def _claim_thread_id(claim_key: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:slack-event:{claim_key}"))
 
 
-def _claim_locally(event_id: str) -> None:
-    _claimed_event_ids[event_id] = None
-    _claimed_event_ids.move_to_end(event_id)
-    while len(_claimed_event_ids) > _LOCAL_CLAIM_LIMIT:
-        _claimed_event_ids.popitem(last=False)
+def slack_message_claim_key(event_id: str, channel_id: str = "", event_ts: str = "") -> str:
+    """Key a claim on the message itself, not the delivery.
+
+    Slack fans one tagged channel post out as both `app_mention` and `message`, each
+    with its own event id, so an event-id claim lets the same message start two runs.
+    """
+    if channel_id and event_ts:
+        return f"{channel_id}:{event_ts}"
+    return event_id
+
+
+def _claim_locally(claim_key: str) -> None:
+    if not claim_key:
+        return
+    _claimed_keys[claim_key] = None
+    _claimed_keys.move_to_end(claim_key)
+    while len(_claimed_keys) > _LOCAL_CLAIM_LIMIT:
+        _claimed_keys.popitem(last=False)
 
 
 def reset_slack_event_claims() -> None:
-    _claimed_event_ids.clear()
+    _claimed_keys.clear()
 
 
 async def slack_event_already_seen(event_id: str) -> bool:
     """Check whether this process has already claimed the event."""
-    return bool(event_id and event_id in _claimed_event_ids)
+    return bool(event_id and event_id in _claimed_keys)
 
 
-async def claim_slack_event(event_id: str) -> bool:
-    """Atomically claim an event id; fail open when the platform is unavailable."""
-    if not event_id:
+async def claim_slack_event(event_id: str, channel_id: str = "", event_ts: str = "") -> bool:
+    """Atomically claim a Slack message; fail open when the platform is unavailable."""
+    claim_key = slack_message_claim_key(event_id, channel_id, event_ts)
+    if not claim_key:
         return True
 
     async with _claim_lock:
-        if event_id in _claimed_event_ids:
+        if claim_key in _claimed_keys or (event_id and event_id in _claimed_keys):
             return False
 
-        claim_thread_id = _claim_thread_id(event_id)
+        claim_thread_id = _claim_thread_id(claim_key)
         client = get_client(url=LANGGRAPH_URL)
         try:
             await client.threads.create(thread_id=claim_thread_id, if_exists="raise", ttl=10)
@@ -58,10 +72,12 @@ async def claim_slack_event(event_id: str) -> bool:
             try:
                 await client.threads.get(claim_thread_id)
             except Exception:  # noqa: BLE001
-                logger.warning("Slack event claim failed for event_id=%s", event_id)
+                logger.warning("Slack event claim failed for key=%s", claim_key)
                 return True
+            _claim_locally(claim_key)
             _claim_locally(event_id)
             return False
 
+        _claim_locally(claim_key)
         _claim_locally(event_id)
         return True

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -147,7 +147,7 @@ async def slack_webhook(
     channel_context = await common._get_slack_channel_context(channel_id)
 
     if await common._is_docs_plz_slack_channel(channel_id, channel_context):
-        if await common.claim_slack_event(event_id):
+        if await common.claim_slack_event(event_id, channel_id, event_ts):
             background_tasks.add_task(
                 common.post_slack_thread_reply,
                 channel_id,
@@ -170,7 +170,7 @@ async def slack_webhook(
         repo_config = await common.get_slack_repo_config(
             channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
         )
-        if await common.claim_slack_event(event_id):
+        if await common.claim_slack_event(event_id, channel_id, event_ts):
             background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
             return {"status": "accepted", "message": "Slack mention queued"}
 

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -132,16 +132,23 @@ async def test_redelivered_event_without_retry_header_is_deduped() -> None:
 
 async def test_mention_and_message_deliveries_start_one_run(
     monkeypatch: pytest.MonkeyPatch,
+    _patch_slack_webhook: _FakeClient,
 ) -> None:
     background_tasks = _FakeBackgroundTasks()
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "BOT")
 
     first = await _post(_mention_payload("Ev1"), background_tasks)
+    slack_events.reset_slack_event_claims()
     second = await _post(_channel_message_payload("Ev2"), background_tasks)
 
     assert first["status"] == "accepted"
     assert second["status"] == "ignored"
     assert len(background_tasks.tasks) == 1
+    assert _patch_slack_webhook.threads.ids == {
+        slack_events._claim_thread_id("Ev1"),
+        slack_events._claim_thread_id("Ev2"),
+        slack_events._claim_thread_id("C1:1786573369.551099"),
+    }
 
 
 async def test_distinct_messages_in_one_channel_both_run() -> None:

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -70,6 +70,12 @@ def _mention_payload(event_id: str = "Ev1") -> dict[str, Any]:
     }
 
 
+def _channel_message_payload(event_id: str = "Ev2") -> dict[str, Any]:
+    payload = _mention_payload(event_id)
+    payload["event"] = {**payload["event"], "type": "message", "channel_type": "channel"}
+    return payload
+
+
 async def _post(
     payload: dict[str, Any],
     background_tasks: _FakeBackgroundTasks,
@@ -122,6 +128,33 @@ async def test_redelivered_event_without_retry_header_is_deduped() -> None:
 
     assert second["status"] == "ignored"
     assert len(background_tasks.tasks) == 1
+
+
+async def test_mention_and_message_deliveries_start_one_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    background_tasks = _FakeBackgroundTasks()
+    monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "BOT")
+
+    first = await _post(_mention_payload("Ev1"), background_tasks)
+    second = await _post(_channel_message_payload("Ev2"), background_tasks)
+
+    assert first["status"] == "accepted"
+    assert second["status"] == "ignored"
+    assert len(background_tasks.tasks) == 1
+
+
+async def test_distinct_messages_in_one_channel_both_run() -> None:
+    background_tasks = _FakeBackgroundTasks()
+
+    second_message = _mention_payload("Ev2")
+    second_message["event"] = {**second_message["event"], "ts": "1786573999.111222"}
+
+    first = await _post(_mention_payload("Ev1"), background_tasks)
+    second = await _post(second_message, background_tasks)
+
+    assert [first["status"], second["status"]] == ["accepted", "accepted"]
+    assert len(background_tasks.tasks) == 2
 
 
 async def test_retry_header_alone_does_not_drop_an_unseen_event() -> None:


### PR DESCRIPTION
## Description
Dedupe Slack's paired `app_mention` and `message` deliveries by message identity while preserving the legacy event claim during rolling deploys.

## Release Note
Fixed duplicate runs for tagged Slack channel messages.

## Test Plan
- [x] Focused Slack dedupe and agent assembly regression tests
- [x] `make lint && make typecheck`

Made by [Open SWE](https://openswe.vercel.app/agents/01a00b26-3f5f-755a-b64c-d856e366fc31)
