### PR TITLE
fix: inherit shell auth for desktop ACP

### DIFF
--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -28,6 +28,7 @@ const {
 const {
   closeAllTerminals,
   configureTerminalIpc,
+  getUserShellEnv,
 } = require("./terminal-manager.cjs");
 const {
   addProject,
@@ -230,10 +231,11 @@ function registeredProject(cwd) {
 }
 
 function createAcpSession({ cwd, modelId, effort, restored }) {
+  const env = getUserShellEnv({ cwd });
   return new AcpSession({
     cwd,
-    target: dcodeTarget({ modelId, effort }),
-    env: process.env,
+    target: dcodeTarget({ env, modelId, effort }),
+    env,
     onEvent: sendAcpEvent,
     onChange: persistAcpSession,
     requestPermission: async () => true,

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -28,7 +28,7 @@ const {
 const {
   closeAllTerminals,
   configureTerminalIpc,
-  getUserShellEnv,
+  getProjectShellEnv,
 } = require("./terminal-manager.cjs");
 const {
   addProject,
@@ -230,8 +230,8 @@ function registeredProject(cwd) {
   }
 }
 
-function createAcpSession({ cwd, modelId, effort, restored }) {
-  const env = getUserShellEnv({ cwd });
+async function createAcpSession({ cwd, modelId, effort, restored }) {
+  const env = await getProjectShellEnv({ cwd });
   return new AcpSession({
     cwd,
     target: dcodeTarget({ env, modelId, effort }),
@@ -256,7 +256,7 @@ async function restoreAcpSession(sessionId) {
       ((await repoRoot(cwd)) === stored.checkpoint.repo &&
         stored.checkpoint.ref === checkpointRef(stored.id));
     if (!checkpointValid) acpCheckpoints.delete(sessionId);
-    const localSession = createAcpSession({
+    const localSession = await createAcpSession({
       cwd,
       modelId: stored.modelId,
       effort: stored.effort,
@@ -365,7 +365,7 @@ function configureDesktopIpc() {
     const modelId =
       typeof input.modelId === "string" ? input.modelId : undefined;
     const effort = typeof input.effort === "string" ? input.effort : undefined;
-    const localSession = createAcpSession({ cwd, modelId, effort });
+    const localSession = await createAcpSession({ cwd, modelId, effort });
     persistedAcpSessions.set(localSession.id, {
       ...sessionRecord(localSession),
       ...(modelId ? { modelId } : {}),

--- a/desktop/src/terminal-manager.cjs
+++ b/desktop/src/terminal-manager.cjs
@@ -47,30 +47,50 @@ function ensurePtySpawnHelperExecutable(options = {}) {
   } catch {}
 }
 
-function getUserShellEnv() {
-  if (shellEnv) return shellEnv
-  const shell = process.env.SHELL || "/bin/zsh"
-  for (const args of [["-il", "-c"], ["-l", "-c"], ["-i", "-c"]]) {
+function getUserShellEnv(options = {}) {
+  const baseEnv = options.env || process.env
+  const run = options.execFileSync || execFileSync
+  const cache =
+    options.cwd === undefined && options.env === undefined && options.execFileSync === undefined
+  if (cache && shellEnv) return shellEnv
+  const shell = baseEnv.SHELL || "/bin/zsh"
+  const attempts = [
+    { args: ["-il"], stdin: true },
+    { args: ["-il", "-c"] },
+    { args: ["-l", "-c"] },
+    { args: ["-i", "-c"] },
+  ]
+  for (const attempt of attempts) {
     try {
       const mark = randomBytes(8).toString("hex")
-      const result = execFileSync(shell, [...args, `echo '${mark}'; env; echo '${mark}'`], {
-        encoding: "utf8",
-        timeout: 10_000,
-        stdio: ["pipe", "pipe", "pipe"],
-      })
+      const command = `echo '${mark}'; env; echo '${mark}'`
+      const result = run(
+        shell,
+        attempt.stdin ? attempt.args : [...attempt.args, command],
+        {
+          encoding: "utf8",
+          timeout: 10_000,
+          stdio: ["pipe", "pipe", "pipe"],
+          env: baseEnv,
+          ...(options.cwd ? { cwd: options.cwd } : {}),
+          ...(attempt.stdin ? { input: `${command}\nexit\n` } : {}),
+        }
+      )
       const start = result.indexOf(mark)
       const end = result.lastIndexOf(mark)
       if (start === -1 || start === end) continue
-      shellEnv = { ...process.env }
+      const resolved = { ...baseEnv }
       for (const line of result.slice(start + mark.length, end).split("\n")) {
         const separator = line.indexOf("=")
-        if (separator > 0) shellEnv[line.slice(0, separator)] = line.slice(separator + 1)
+        if (separator > 0) resolved[line.slice(0, separator)] = line.slice(separator + 1)
       }
-      return shellEnv
+      if (cache) shellEnv = resolved
+      return resolved
     } catch {}
   }
-  shellEnv = { ...process.env }
-  return shellEnv
+  const fallback = { ...baseEnv }
+  if (cache) shellEnv = fallback
+  return fallback
 }
 
 function shellCandidates(env, platform = process.platform) {
@@ -978,5 +998,6 @@ module.exports = {
   configureTerminalIpc,
   createTerminalManager,
   ensurePtySpawnHelperExecutable,
+  getUserShellEnv,
   sanitizeHistoryChunk,
 }

--- a/desktop/src/terminal-manager.cjs
+++ b/desktop/src/terminal-manager.cjs
@@ -47,12 +47,55 @@ function ensurePtySpawnHelperExecutable(options = {}) {
   } catch {}
 }
 
-function getUserShellEnv(options = {}) {
+function shellEnvFromOutput(result, mark, baseEnv) {
+  const start = result.indexOf(mark)
+  const end = result.lastIndexOf(mark)
+  if (start === -1 || start === end) return null
+  const resolved = { ...baseEnv }
+  for (const line of result.slice(start + mark.length, end).split("\n")) {
+    const separator = line.indexOf("=")
+    if (separator > 0) resolved[line.slice(0, separator)] = line.slice(separator + 1)
+  }
+  return resolved
+}
+
+function getUserShellEnv() {
+  if (shellEnv) return shellEnv
+  const shell = process.env.SHELL || "/bin/zsh"
+  for (const args of [["-il", "-c"], ["-l", "-c"], ["-i", "-c"]]) {
+    try {
+      const mark = randomBytes(8).toString("hex")
+      const result = execFileSync(shell, [...args, `echo '${mark}'; env; echo '${mark}'`], {
+        encoding: "utf8",
+        timeout: 10_000,
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+      const resolved = shellEnvFromOutput(result, mark, process.env)
+      if (!resolved) continue
+      shellEnv = resolved
+      return shellEnv
+    } catch {}
+  }
+  shellEnv = { ...process.env }
+  return shellEnv
+}
+
+function runShell(shell, args, options, input) {
+  return new Promise((resolve, reject) => {
+    const child = execFile(shell, args, options, (error, stdout) => {
+      if (error) reject(error)
+      else resolve(stdout)
+    })
+    if (input && child.stdin) {
+      child.stdin.on("error", () => {})
+      child.stdin.end(input)
+    }
+  })
+}
+
+async function getProjectShellEnv(options = {}) {
   const baseEnv = options.env || process.env
-  const run = options.execFileSync || execFileSync
-  const cache =
-    options.cwd === undefined && options.env === undefined && options.execFileSync === undefined
-  if (cache && shellEnv) return shellEnv
+  const run = options.run || runShell
   const shell = baseEnv.SHELL || "/bin/zsh"
   const attempts = [
     { args: ["-il"], stdin: true },
@@ -64,33 +107,22 @@ function getUserShellEnv(options = {}) {
     try {
       const mark = randomBytes(8).toString("hex")
       const command = `echo '${mark}'; env; echo '${mark}'`
-      const result = run(
+      const result = await run(
         shell,
         attempt.stdin ? attempt.args : [...attempt.args, command],
         {
           encoding: "utf8",
           timeout: 10_000,
-          stdio: ["pipe", "pipe", "pipe"],
           env: baseEnv,
           ...(options.cwd ? { cwd: options.cwd } : {}),
-          ...(attempt.stdin ? { input: `${command}\nexit\n` } : {}),
-        }
+        },
+        attempt.stdin ? `${command}\nexit\n` : undefined
       )
-      const start = result.indexOf(mark)
-      const end = result.lastIndexOf(mark)
-      if (start === -1 || start === end) continue
-      const resolved = { ...baseEnv }
-      for (const line of result.slice(start + mark.length, end).split("\n")) {
-        const separator = line.indexOf("=")
-        if (separator > 0) resolved[line.slice(0, separator)] = line.slice(separator + 1)
-      }
-      if (cache) shellEnv = resolved
-      return resolved
+      const resolved = shellEnvFromOutput(result, mark, baseEnv)
+      if (resolved) return resolved
     } catch {}
   }
-  const fallback = { ...baseEnv }
-  if (cache) shellEnv = fallback
-  return fallback
+  return { ...baseEnv }
 }
 
 function shellCandidates(env, platform = process.platform) {
@@ -998,6 +1030,6 @@ module.exports = {
   configureTerminalIpc,
   createTerminalManager,
   ensurePtySpawnHelperExecutable,
-  getUserShellEnv,
+  getProjectShellEnv,
   sanitizeHistoryChunk,
 }

--- a/desktop/test/terminal-manager.test.cjs
+++ b/desktop/test/terminal-manager.test.cjs
@@ -6,7 +6,7 @@ const test = require("node:test")
 const {
   createTerminalManager,
   ensurePtySpawnHelperExecutable,
-  getUserShellEnv,
+  getProjectShellEnv,
 } = require("../src/terminal-manager.cjs")
 
 class FakeProcess {
@@ -92,14 +92,14 @@ function tick() {
   return new Promise((resolve) => setImmediate(resolve))
 }
 
-test("loads environment set by interactive shell prompt hooks", () => {
-  const env = getUserShellEnv({
+test("loads environment set by interactive shell prompt hooks", async () => {
+  const env = await getProjectShellEnv({
     cwd: "/project",
     env: { SHELL: "/bin/zsh", EXISTING: "kept" },
-    execFileSync: (_shell, args, options) => {
+    run: async (_shell, args, options, input) => {
       assert.deepEqual(args, ["-il"])
       assert.equal(options.cwd, "/project")
-      const mark = /echo '([0-9a-f]+)'/.exec(options.input)[1]
+      const mark = /echo '([0-9a-f]+)'/.exec(input)[1]
       return `${mark}\nOPENAI_BASE_URL=https://gateway.example/openai/v1\n${mark}\n`
     },
   })

--- a/desktop/test/terminal-manager.test.cjs
+++ b/desktop/test/terminal-manager.test.cjs
@@ -6,6 +6,7 @@ const test = require("node:test")
 const {
   createTerminalManager,
   ensurePtySpawnHelperExecutable,
+  getUserShellEnv,
 } = require("../src/terminal-manager.cjs")
 
 class FakeProcess {
@@ -90,6 +91,22 @@ function request(cwd, extra = {}) {
 function tick() {
   return new Promise((resolve) => setImmediate(resolve))
 }
+
+test("loads environment set by interactive shell prompt hooks", () => {
+  const env = getUserShellEnv({
+    cwd: "/project",
+    env: { SHELL: "/bin/zsh", EXISTING: "kept" },
+    execFileSync: (_shell, args, options) => {
+      assert.deepEqual(args, ["-il"])
+      assert.equal(options.cwd, "/project")
+      const mark = /echo '([0-9a-f]+)'/.exec(options.input)[1]
+      return `${mark}\nOPENAI_BASE_URL=https://gateway.example/openai/v1\n${mark}\n`
+    },
+  })
+
+  assert.equal(env.EXISTING, "kept")
+  assert.equal(env.OPENAI_BASE_URL, "https://gateway.example/openai/v1")
+})
 
 test("keeps terminal identity scoped to the ACP session and validates launch boundaries", async (t) => {
   const value = fixture()

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -273,7 +273,16 @@ async def test_general_purpose_subagent_carries_open_swe_shared_base() -> None:
 
 @pytest.mark.asyncio
 async def test_general_purpose_subagent_cannot_use_slack_tools() -> None:
-    captured = await _capture_create_deep_agent_kwargs()
+    config = _base_config()
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    configurable.update(
+        {
+            "source": "slack",
+            "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"},
+        }
+    )
+    captured = await _capture_create_deep_agent_kwargs(config)
     parent_tools = captured["tools"]
     subagents = captured["subagents"]
     assert isinstance(parent_tools, list)


### PR DESCRIPTION
Fix packaged Desktop ACP launches dropping dcode's shell-provided auth.

- Resolve the fully interactive shell environment asynchronously in the selected project so prompt hooks run without blocking Electron.
- Pass that environment to dcode and refresh it for each local session.
- Scope the newly merged Slack subagent test to Slack source context, fixing the unit-test failure inherited from `main`.

Tested:
- `pnpm --dir desktop test`
- `uv run pytest -q tests/agent/test_agent_assembly_context.py::test_general_purpose_subagent_cannot_use_slack_tools`
- Packaged app resolved the LangSmith gateway endpoint and credential from an empty launch environment.
- Real packaged ACP prompt returned `OK` without a 401.
