### PR TITLE
fix: keep sidebar section headers visible

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -208,9 +208,18 @@ export function AgentsSidebar({
         })}
       </nav>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
+      <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
         {isDesktop && (
-          <div className="mb-3">
+          <div
+            className={cn(
+              "mb-3 flex min-h-0 flex-col",
+              prefs.collapsed.local
+                ? "shrink-0"
+                : cloudCollapsed
+                  ? "flex-1"
+                  : "max-h-1/2 shrink-0"
+            )}
+          >
             <SectionHeader
               label="Local"
               count={localSessionCount}
@@ -228,7 +237,7 @@ export function AgentsSidebar({
               </button>
             </SectionHeader>
             {!prefs.collapsed.local && (
-              <>
+              <div className="min-h-0 overflow-y-auto">
                 {localGroups.map((group) => (
                   <LocalThreadGroup
                     key={group.project.cwd}
@@ -245,7 +254,7 @@ export function AgentsSidebar({
                     No projects yet
                   </p>
                 )}
-              </>
+              </div>
             )}
           </div>
         )}
@@ -261,7 +270,7 @@ export function AgentsSidebar({
           />
         )}
         {!cloudCollapsed && (
-          <>
+          <div className="min-h-0 flex-1 overflow-y-auto">
             {prefs.group === "none"
               ? sections[0]?.threads.map((thread) => (
                   <ThreadRow
@@ -297,7 +306,7 @@ export function AgentsSidebar({
                 No threads match these filters.
               </p>
             )}
-          </>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Description
Keep Local and Cloud headers outside their independently scrollable thread lists.

## Release Note
Fixed desktop sidebar section headers scrolling out of view.

## Test Plan
- [x] Verify UI build, typecheck, lint, and formatting

Made by [Open SWE](https://openswe.vercel.app/agents/01a00220-a7af-7798-a6f1-dbc681738d05)