### PR TITLE
feat: switch models in desktop threads

### DIFF
--- a/desktop/src/acp-client.cjs
+++ b/desktop/src/acp-client.cjs
@@ -314,8 +314,6 @@ class AcpSession {
   }) {
     this.id = restored?.id || randomUUID()
     this.cwd = cwd
-    this.target = target
-    this.env = env
     this.title = restored?.title || "New local agent"
     this.createdAt = restored?.createdAt || Date.now()
     this.updatedAt = restored?.updatedAt || this.createdAt
@@ -336,6 +334,8 @@ class AcpSession {
   }
 
   connect(target, env) {
+    this.target = target
+    this.env = env
     this.rpc = new NdJsonRpcClient(target.command, target.args, this.cwd, env)
     this.rpc.onNotification = (method, params) =>
       this.handleNotification(method, params)

--- a/desktop/src/acp-client.cjs
+++ b/desktop/src/acp-client.cjs
@@ -251,6 +251,8 @@ class AcpSession {
     onChange,
     requestPermission,
     restored,
+    modelId,
+    effort,
   }) {
     this.id = restored?.id || randomUUID()
     this.cwd = cwd
@@ -258,6 +260,8 @@ class AcpSession {
     this.createdAt = restored?.createdAt || Date.now()
     this.updatedAt = restored?.updatedAt || this.createdAt
     this.acpSessionId = restored?.acpSessionId
+    this.modelId = modelId
+    this.effort = effort
     this.status = "starting"
     this.events = []
     this.onEvent = onEvent
@@ -265,7 +269,12 @@ class AcpSession {
     this.requestPermission = requestPermission
     this.tools = new Map()
     this.replayUsers = new Map()
-    this.rpc = new NdJsonRpcClient(target.command, target.args, cwd, env)
+    this.suppressUpdates = false
+    this.connect(target, env)
+  }
+
+  connect(target, env) {
+    this.rpc = new NdJsonRpcClient(target.command, target.args, this.cwd, env)
     this.rpc.onNotification = (method, params) =>
       this.handleNotification(method, params)
     this.rpc.onRequest = (method, params) => this.handleRequest(method, params)
@@ -302,7 +311,7 @@ class AcpSession {
     }
   }
 
-  async initialize() {
+  async initialize(persist = true) {
     const initialized = await this.rpc.request("initialize", {
       protocolVersion: ACP_PROTOCOL_VERSION,
       clientCapabilities: {
@@ -339,7 +348,26 @@ class AcpSession {
       this.acpSessionId = result.sessionId
     }
     this.status = "idle"
-    this.notifyChange()
+    if (persist) this.notifyChange()
+  }
+
+  async configure(modelId, effort, target, env) {
+    if (modelId === this.modelId && effort === this.effort) return
+    if (this.status === "running")
+      throw new Error("Deep Agents Code is already running")
+    this.rpc.close()
+    this.status = "starting"
+    this.replayUsers.clear()
+    this.connect(target, env)
+    this.suppressUpdates = true
+    try {
+      await this.initialize(false)
+      this.modelId = modelId
+      this.effort = effort
+      this.notifyChange()
+    } finally {
+      this.suppressUpdates = false
+    }
   }
 
   async prompt(text, images) {
@@ -373,6 +401,7 @@ class AcpSession {
 
   handleNotification(method, params) {
     if (
+      this.suppressUpdates ||
       method !== "session/update" ||
       !isRecord(params) ||
       !isRecord(params.update)
@@ -467,6 +496,8 @@ class AcpSession {
       status: this.status,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
+      modelId: this.modelId,
+      effort: this.effort,
     }
   }
 

--- a/desktop/src/acp-client.cjs
+++ b/desktop/src/acp-client.cjs
@@ -365,6 +365,11 @@ class AcpSession {
       this.modelId = modelId
       this.effort = effort
       this.notifyChange()
+    } catch (error) {
+      this.rpc.close()
+      this.status = "error"
+      this.emit({ type: "error", message: String(error?.message || error) })
+      throw error
     } finally {
       this.suppressUpdates = false
     }

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -133,7 +133,6 @@ function acpSessionsPath() {
 }
 
 function sessionRecord(localSession) {
-  const previous = persistedAcpSessions.get(localSession.id) || {};
   return {
     id: localSession.id,
     acpSessionId: localSession.acpSessionId,
@@ -141,8 +140,8 @@ function sessionRecord(localSession) {
     title: localSession.title,
     createdAt: localSession.createdAt,
     updatedAt: localSession.updatedAt,
-    ...(previous.modelId ? { modelId: previous.modelId } : {}),
-    ...(previous.effort ? { effort: previous.effort } : {}),
+    ...(localSession.modelId ? { modelId: localSession.modelId } : {}),
+    ...(localSession.effort ? { effort: localSession.effort } : {}),
     ...(acpCheckpoints.get(localSession.id)
       ? { checkpoint: acpCheckpoints.get(localSession.id) }
       : {}),
@@ -163,6 +162,8 @@ function sessionSummary(record) {
     status: "idle",
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
+    modelId: record.modelId,
+    effort: record.effort,
   };
 }
 
@@ -240,6 +241,8 @@ async function createAcpSession({ cwd, modelId, effort, restored }) {
     onChange: persistAcpSession,
     requestPermission: async () => true,
     restored,
+    modelId,
+    effort,
   });
 }
 
@@ -393,6 +396,18 @@ function configureDesktopIpc() {
     const localSession = await restoreAcpSession(input?.sessionId);
     if (!localSession)
       throw new Error("Local Deep Agents Code session not found");
+    const modelId =
+      typeof input.modelId === "string" ? input.modelId : undefined;
+    const effort = typeof input.effort === "string" ? input.effort : undefined;
+    if (modelId !== localSession.modelId || effort !== localSession.effort) {
+      const env = await getProjectShellEnv({ cwd: localSession.cwd });
+      await localSession.configure(
+        modelId,
+        effort,
+        dcodeTarget({ env, modelId, effort }),
+        env,
+      );
+    }
     await localSession.prompt(input.prompt || "", input.images || []);
     return localSession.snapshot();
   });

--- a/desktop/test/acp-client.test.cjs
+++ b/desktop/test/acp-client.test.cjs
@@ -86,6 +86,7 @@ test("builds ACP text and image prompt blocks", () => {
 test("switches model before continuing an ACP session", async () => {
   let closed = false
   let initialized = false
+  let emitted
   const session = Object.assign(Object.create(AcpSession.prototype), {
     status: "idle",
     modelId: "old:model",
@@ -95,6 +96,7 @@ test("switches model before continuing an ACP session", async () => {
     connect() {},
     initialize: async () => (initialized = true),
     notifyChange() {},
+    emit: (event) => (emitted = event),
   })
 
   await session.configure("new:model", "high", {}, {})
@@ -103,6 +105,13 @@ test("switches model before continuing an ACP session", async () => {
   assert.equal(initialized, true)
   assert.equal(session.modelId, "new:model")
   assert.equal(session.effort, "high")
+
+  session.initialize = async () => {
+    throw new Error("load failed")
+  }
+  await assert.rejects(session.configure("other:model", "low", {}, {}))
+  assert.equal(session.status, "error")
+  assert.deepEqual(emitted, { type: "error", message: "load failed" })
 })
 
 test("combines chunked user messages when replaying an ACP session", () => {

--- a/desktop/test/acp-client.test.cjs
+++ b/desktop/test/acp-client.test.cjs
@@ -83,6 +83,28 @@ test("builds ACP text and image prompt blocks", () => {
   )
 })
 
+test("switches model before continuing an ACP session", async () => {
+  let closed = false
+  let initialized = false
+  const session = Object.assign(Object.create(AcpSession.prototype), {
+    status: "idle",
+    modelId: "old:model",
+    effort: "low",
+    replayUsers: new Map(),
+    rpc: { close: () => (closed = true) },
+    connect() {},
+    initialize: async () => (initialized = true),
+    notifyChange() {},
+  })
+
+  await session.configure("new:model", "high", {}, {})
+
+  assert.equal(closed, true)
+  assert.equal(initialized, true)
+  assert.equal(session.modelId, "new:model")
+  assert.equal(session.effort, "high")
+})
+
 test("combines chunked user messages when replaying an ACP session", () => {
   const session = Object.assign(Object.create(AcpSession.prototype), {
     id: "session",

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -21,6 +21,8 @@ export interface DesktopAcpSessionSummary {
   status: "starting" | "idle" | "running" | "error"
   createdAt: number
   updatedAt: number
+  modelId?: string
+  effort?: string
 }
 
 export interface DesktopAcpSession extends DesktopAcpSessionSummary {
@@ -168,7 +170,11 @@ declare global {
         }
       ) => Promise<DesktopAcpSession>
       promptAcpSession: (
-        input: DesktopAcpPromptInput & { sessionId: string }
+        input: DesktopAcpPromptInput & {
+          sessionId: string
+          modelId?: string
+          effort?: string
+        }
       ) => Promise<DesktopAcpSession>
       cancelAcpSession: (sessionId: string) => Promise<void>
       getAcpSession: (sessionId: string) => Promise<DesktopAcpSession | null>

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -44,6 +44,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const { session, messages, loaded } = useDesktopAcpSession(sessionId)
   const { models, defaultSelection } = useModelOptions()
   const [selection, setSelection] = useState<ModelSelection | null>(null)
+  useEffect(() => setSelection(null), [sessionId])
   const sessionSelection = useMemo<ModelSelection | null>(() => {
     const modelId = session?.modelId
     const effort = session?.effort

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -3,6 +3,7 @@ import { CircleAlert, FolderOpen, X } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
 import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
+import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useSidebarCollapsed } from "@/components/sidebar-layout"
@@ -19,6 +20,7 @@ import {
 import { Messages } from "@/features/agents/components/messages"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
 import { usePanelTabs } from "@/features/agents/lib/panelTabs"
+import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import {
   readStoredPanelCollapsed,
@@ -40,6 +42,19 @@ const LOCAL_PANEL_KINDS: ReadonlyArray<PanelTabKind> = [
 
 export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const { session, messages, loaded } = useDesktopAcpSession(sessionId)
+  const { models, defaultSelection } = useModelOptions()
+  const [selection, setSelection] = useState<ModelSelection | null>(null)
+  const sessionSelection = useMemo<ModelSelection | null>(() => {
+    const modelId = session?.modelId
+    const effort = session?.effort
+    if (!modelId || !effort) return null
+    return models.some(
+      (model) => model.id === modelId && model.efforts.includes(effort)
+    )
+      ? { modelId, effort }
+      : null
+  }, [models, session?.effort, session?.modelId])
+  const activeSelection = selection ?? sessionSelection ?? defaultSelection
   const isMobile = useIsMobile()
   const sidebarCollapsed = useSidebarCollapsed()
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
@@ -223,8 +238,13 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
                       ? `${prompt}\n\nTerminal selection:\n\`\`\`\n${terminalContext}\n\`\`\``
                       : prompt,
                     images,
+                    modelId: activeSelection?.modelId,
+                    effort: activeSelection?.effort,
                   })
                 }}
+                models={models}
+                selection={activeSelection}
+                onSelectionChange={setSelection}
                 placeholder="Add a follow up"
               />
             </div>


### PR DESCRIPTION
## Description
Add the existing model picker to local Desktop threads and apply model or effort changes before the next follow-up while preserving the ACP session.

## Release Note
Desktop users can switch model and reasoning effort in an active local thread.

## Test Plan
- [x] Continue an ACP session after changing its model

Made by [Open SWE](https://openswe.vercel.app/agents/01a00226-d183-723c-8b5c-ba5e2a53471b)