### PR TITLE
feat: delete local desktop sessions

### DIFF
--- a/desktop/src/acp-client.cjs
+++ b/desktop/src/acp-client.cjs
@@ -39,6 +39,47 @@ function dcodeTarget({
   return { command: "dcode", args }
 }
 
+function deleteDcodeSession({ target, cwd, env, sessionId }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(target.command, ["threads", "delete", sessionId], {
+      cwd,
+      env: { ...env, PWD: cwd, PYTHONUNBUFFERED: "1" },
+      stdio: ["ignore", "ignore", "pipe"],
+    })
+    let stderr = ""
+    let settled = false
+    const finish = (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (error) reject(error)
+      else resolve()
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL")
+      } catch {}
+      finish(new Error("Deep Agents Code session deletion timed out"))
+    }, 15_000)
+    child.stderr.on("data", (chunk) => {
+      stderr = `${stderr}${chunk.toString("utf8")}`.slice(-8_000)
+    })
+    child.once("error", finish)
+    child.once("exit", (code, signal) => {
+      if (code === 0) finish()
+      else {
+        const reason = signal ? `signal ${signal}` : `exit code ${code}`
+        const detail = stderr.trim()
+        finish(
+          new Error(
+            `Deep Agents Code could not delete the session (${reason})${detail ? `: ${detail}` : ""}`
+          )
+        )
+      }
+    })
+  })
+}
+
 function sessionTitle(text) {
   const value = text.trim().replace(/\s+/g, " ")
   return value.slice(0, 80) || "New local agent"
@@ -254,11 +295,15 @@ class AcpSession {
   }) {
     this.id = restored?.id || randomUUID()
     this.cwd = cwd
+    this.target = target
+    this.env = env
     this.title = restored?.title || "New local agent"
     this.createdAt = restored?.createdAt || Date.now()
     this.updatedAt = restored?.updatedAt || this.createdAt
     this.acpSessionId = restored?.acpSessionId
     this.status = "starting"
+    this.closed = false
+    this.deleteSupported = false
     this.events = []
     this.onEvent = onEvent
     this.onChange = onChange
@@ -315,6 +360,11 @@ class AcpSession {
         version: "0.1.0",
       },
     })
+    const sessionCapabilities = isRecord(initialized?.agentCapabilities)
+      ? initialized.agentCapabilities.sessionCapabilities
+      : null
+    this.deleteSupported =
+      isRecord(sessionCapabilities) && isRecord(sessionCapabilities.delete)
     if (this.acpSessionId) {
       if (
         !isRecord(initialized) ||
@@ -356,6 +406,7 @@ class AcpSession {
       this.status = "idle"
       this.emit({ type: "run-end" })
     } catch (error) {
+      if (this.closed) throw error
       if (this.status !== "error") {
         this.status = "idle"
         this.emit({ type: "error", message: String(error?.message || error) })
@@ -363,6 +414,12 @@ class AcpSession {
       }
       throw error
     }
+  }
+
+  async delete() {
+    if (!this.deleteSupported || !this.acpSessionId) return false
+    await this.rpc.request("session/delete", { sessionId: this.acpSessionId })
+    return true
   }
 
   cancel() {
@@ -471,6 +528,8 @@ class AcpSession {
   }
 
   close() {
+    this.closed = true
+    this.onChange = null
     this.rpc.close()
   }
 }
@@ -478,6 +537,7 @@ class AcpSession {
 module.exports = {
   AcpSession,
   dcodeTarget,
+  deleteDcodeSession,
   promptBlocks,
   sessionTitle,
 }

--- a/desktop/src/acp-client.cjs
+++ b/desktop/src/acp-client.cjs
@@ -5,6 +5,7 @@ const readline = require("node:readline")
 const { randomUUID } = require("node:crypto")
 
 const ACP_PROTOCOL_VERSION = 1
+const DELETE_TIMEOUT_MS = 15_000
 
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -183,14 +184,26 @@ class NdJsonRpcClient {
     })
   }
 
-  request(method, params) {
+  request(method, params, timeoutMs) {
     if (this.closed)
       return Promise.reject(new Error("Deep Agents Code is not running"))
     const id = this.nextId++
-    this.write({ jsonrpc: "2.0", id, method, params })
-    return new Promise((resolve, reject) =>
-      this.pending.set(id, { method, resolve, reject })
-    )
+    return new Promise((resolve, reject) => {
+      const timer = timeoutMs
+        ? setTimeout(() => {
+            if (!this.pending.delete(id)) return
+            reject(new Error(`[acp:${method}] Request timed out`))
+          }, timeoutMs)
+        : null
+      this.pending.set(id, { method, resolve, reject, timer })
+      try {
+        this.write({ jsonrpc: "2.0", id, method, params })
+      } catch (error) {
+        this.pending.delete(id)
+        clearTimeout(timer)
+        reject(error)
+      }
+    })
   }
 
   notify(method, params) {
@@ -224,6 +237,7 @@ class NdJsonRpcClient {
       const pending = this.pending.get(message.id)
       if (!pending) return
       this.pending.delete(message.id)
+      clearTimeout(pending.timer)
       if ("error" in message) {
         const rpcError = isRecord(message.error) ? message.error : {}
         const detail =
@@ -270,7 +284,10 @@ class NdJsonRpcClient {
   rejectPending(error) {
     const pending = [...this.pending.values()]
     this.pending.clear()
-    for (const request of pending) request.reject(error)
+    for (const request of pending) {
+      clearTimeout(request.timer)
+      request.reject(error)
+    }
   }
 
   close() {
@@ -418,7 +435,11 @@ class AcpSession {
 
   async delete() {
     if (!this.deleteSupported || !this.acpSessionId) return false
-    await this.rpc.request("session/delete", { sessionId: this.acpSessionId })
+    await this.rpc.request(
+      "session/delete",
+      { sessionId: this.acpSessionId },
+      DELETE_TIMEOUT_MS
+    )
     return true
   }
 

--- a/desktop/src/acp-session-store.cjs
+++ b/desktop/src/acp-session-store.cjs
@@ -22,6 +22,7 @@ function validRecord(value) {
   }
   if (value.modelId !== undefined && !validString(value.modelId)) return false
   if (value.effort !== undefined && !validString(value.effort)) return false
+  if (value.dcodeCommand !== undefined && !validString(value.dcodeCommand)) return false
   return (
     value.checkpoint === undefined ||
     (value.checkpoint &&

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -12,7 +12,11 @@ const {
   session,
   shell,
 } = require("electron");
-const { AcpSession, dcodeTarget } = require("./acp-client.cjs");
+const {
+  AcpSession,
+  dcodeTarget,
+  deleteDcodeSession,
+} = require("./acp-client.cjs");
 const {
   readAcpSessions,
   writeAcpSessions,
@@ -28,6 +32,7 @@ const {
 const {
   closeAllTerminals,
   configureTerminalIpc,
+  deleteSessionTerminals,
   getProjectShellEnv,
 } = require("./terminal-manager.cjs");
 const {
@@ -85,6 +90,7 @@ let authWindow = null;
 let quitting = false;
 const acpSessions = new Map();
 const acpRestores = new Map();
+const deletingAcpSessions = new Set();
 const persistedAcpSessions = new Map();
 // sessionId -> { repo, ref }: the worktree snapshot a local session started from, so
 // the diff panel can show what the agent changed rather than the repo's prior state.
@@ -141,6 +147,7 @@ function sessionRecord(localSession) {
     title: localSession.title,
     createdAt: localSession.createdAt,
     updatedAt: localSession.updatedAt,
+    dcodeCommand: localSession.target.command,
     ...(previous.modelId ? { modelId: previous.modelId } : {}),
     ...(previous.effort ? { effort: previous.effort } : {}),
     ...(acpCheckpoints.get(localSession.id)
@@ -150,7 +157,11 @@ function sessionRecord(localSession) {
 }
 
 function persistAcpSession(localSession) {
-  if (!localSession.acpSessionId) return;
+  if (
+    !localSession.acpSessionId ||
+    deletingAcpSessions.has(localSession.id)
+  )
+    return;
   persistedAcpSessions.set(localSession.id, sessionRecord(localSession));
   writeAcpSessions(acpSessionsPath(), [...persistedAcpSessions.values()]);
 }
@@ -244,6 +255,7 @@ async function createAcpSession({ cwd, modelId, effort, restored }) {
 }
 
 async function restoreAcpSession(sessionId) {
+  if (deletingAcpSessions.has(sessionId)) return null;
   if (acpSessions.has(sessionId)) return acpSessions.get(sessionId);
   if (acpRestores.has(sessionId)) return acpRestores.get(sessionId);
   const stored = persistedAcpSessions.get(sessionId);
@@ -280,6 +292,56 @@ async function restoreAcpSession(sessionId) {
     return await restore;
   } finally {
     acpRestores.delete(sessionId);
+  }
+}
+
+async function deleteAcpSession(sessionId) {
+  if (typeof sessionId !== "string") return false;
+  const stored = persistedAcpSessions.get(sessionId);
+  if (!stored || deletingAcpSessions.has(sessionId)) return false;
+
+  deletingAcpSessions.add(sessionId);
+  try {
+    await acpRestores.get(sessionId)?.catch(() => null);
+    const localSession = acpSessions.get(sessionId);
+    localSession?.cancel();
+
+    let deletedThroughAcp = false;
+    if (localSession) {
+      try {
+        deletedThroughAcp = await localSession.delete();
+      } catch {}
+      localSession.close();
+      acpSessions.delete(sessionId);
+    }
+
+    if (!deletedThroughAcp) {
+      const env = localSession?.env || process.env;
+      const target =
+        localSession?.target ||
+        (stored.dcodeCommand
+          ? { command: stored.dcodeCommand, args: [] }
+          : dcodeTarget({ env }));
+      await deleteDcodeSession({
+        target,
+        cwd: stored.cwd,
+        env,
+        sessionId: stored.acpSessionId,
+      });
+    }
+
+    await deleteSessionTerminals(sessionId);
+    const checkpoint = acpCheckpoints.get(sessionId) || stored.checkpoint;
+    if (checkpoint?.ref === checkpointRef(sessionId)) {
+      deleteRefs(checkpoint.repo, [checkpoint.ref]);
+    }
+    acpSessions.delete(sessionId);
+    acpCheckpoints.delete(sessionId);
+    persistedAcpSessions.delete(sessionId);
+    writeAcpSessions(acpSessionsPath(), [...persistedAcpSessions.values()]);
+    return true;
+  } finally {
+    deletingAcpSessions.delete(sessionId);
   }
 }
 
@@ -366,14 +428,15 @@ function configureDesktopIpc() {
       typeof input.modelId === "string" ? input.modelId : undefined;
     const effort = typeof input.effort === "string" ? input.effort : undefined;
     const localSession = await createAcpSession({ cwd, modelId, effort });
-    persistedAcpSessions.set(localSession.id, {
-      ...sessionRecord(localSession),
-      ...(modelId ? { modelId } : {}),
-      ...(effort ? { effort } : {}),
-    });
     acpSessions.set(localSession.id, localSession);
     try {
       await localSession.initialize();
+      persistedAcpSessions.set(localSession.id, {
+        ...sessionRecord(localSession),
+        ...(modelId ? { modelId } : {}),
+        ...(effort ? { effort } : {}),
+      });
+      writeAcpSessions(acpSessionsPath(), [...persistedAcpSessions.values()]);
     } catch (error) {
       acpSessions.delete(localSession.id);
       persistedAcpSessions.delete(localSession.id);
@@ -400,6 +463,11 @@ function configureDesktopIpc() {
   ipcMain.handle("desktop:acp-cancel", (event, sessionId) => {
     requireTrustedDesktopIpc(event);
     acpSessions.get(sessionId)?.cancel();
+  });
+
+  ipcMain.handle("desktop:acp-delete", async (event, sessionId) => {
+    requireTrustedDesktopIpc(event);
+    return deleteAcpSession(sessionId);
   });
 
   ipcMain.handle("desktop:acp-session", async (event, sessionId) => {

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -16,6 +16,7 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   startAcpSession: (input) => ipcRenderer.invoke("desktop:acp-start", input),
   promptAcpSession: (input) => ipcRenderer.invoke("desktop:acp-prompt", input),
   cancelAcpSession: (sessionId) => ipcRenderer.invoke("desktop:acp-cancel", sessionId),
+  deleteAcpSession: (sessionId) => ipcRenderer.invoke("desktop:acp-delete", sessionId),
   getAcpSession: (sessionId) => ipcRenderer.invoke("desktop:acp-session", sessionId),
   listAcpSessions: () => ipcRenderer.invoke("desktop:acp-sessions"),
   getAcpDiff: (sessionId) => ipcRenderer.invoke("desktop:acp-diff", sessionId),

--- a/desktop/src/terminal-manager.cjs
+++ b/desktop/src/terminal-manager.cjs
@@ -888,6 +888,25 @@ function createTerminalManager(options) {
     emit(session, "closed")
   }
 
+  async function deleteSession(localSessionId) {
+    cleanId(localSessionId, "local session ID")
+    return locked(localSessionId, () => {
+      for (const session of [...sessions.values()]) {
+        if (session.localSessionId === localSessionId) {
+          closeOne(localSessionId, session.terminalId, true)
+        }
+      }
+      const prefix = `terminal_${safePart(localSessionId)}_`
+      try {
+        for (const name of fileSystem.readdirSync(logsDir)) {
+          if (name.startsWith(prefix) && name.endsWith(".log")) {
+            fileSystem.rmSync(path.join(logsDir, name), { force: true })
+          }
+        }
+      } catch {}
+    })
+  }
+
   function list(localSessionId) {
     cleanId(localSessionId, "local session ID")
     if (!getAcpSession(localSessionId)) throw new Error("Local Deep Agents Code session not found")
@@ -938,6 +957,7 @@ function createTerminalManager(options) {
     attach,
     clear,
     close,
+    deleteSession,
     list,
     open,
     resize,
@@ -1024,10 +1044,15 @@ function closeAllTerminals() {
   return configuredManager?.shutdown() || Promise.resolve()
 }
 
+function deleteSessionTerminals(localSessionId) {
+  return configuredManager?.deleteSession(localSessionId) || Promise.resolve()
+}
+
 module.exports = {
   capHistory,
   closeAllTerminals,
   configureTerminalIpc,
+  deleteSessionTerminals,
   createTerminalManager,
   ensurePtySpawnHelperExecutable,
   getProjectShellEnv,

--- a/desktop/test/acp-session-store.test.cjs
+++ b/desktop/test/acp-session-store.test.cjs
@@ -22,6 +22,7 @@ test("persists valid ACP session metadata and ignores malformed records", (t) =>
     updatedAt: 456,
     modelId: "provider:model",
     effort: "high",
+    dcodeCommand: "/opt/bin/dcode",
     checkpoint: { repo: root, ref: "refs/open-swe/local/desktop-id" },
   }
 

--- a/desktop/test/terminal-manager.test.cjs
+++ b/desktop/test/terminal-manager.test.cjs
@@ -192,6 +192,21 @@ test("persists bounded sanitized history and supports clear, restart, detach, an
 })
 
 
+test("deleting a local session stops its terminals and removes their history", async (t) => {
+  const value = fixture()
+  t.after(() => value.manager.shutdown())
+  await value.manager.open(request(value.root))
+  value.processes[0].data("saved output\n")
+
+  await value.manager.deleteSession("acp-1")
+
+  assert.deepEqual(value.manager.list("acp-1"), [])
+  assert.equal(value.processes[0].kills[0], "SIGTERM")
+  const attached = await value.manager.attach(request(value.root), () => {})
+  assert.equal(attached.snapshot.history, "")
+  attached.detach()
+})
+
 test("drains queued and trailing PTY output before publishing exit", async (t) => {
   const value = fixture()
   t.after(() => value.manager.shutdown())

--- a/ui/src/client.tsx
+++ b/ui/src/client.tsx
@@ -1,4 +1,6 @@
 import { StartClient } from "@tanstack/react-start/client"
-import { hydrateRoot } from "react-dom/client"
+import { createRoot, hydrateRoot } from "react-dom/client"
 
-hydrateRoot(document, <StartClient />)
+const app = <StartClient />
+if (window.openSweDesktop) createRoot(document).render(app)
+else hydrateRoot(document, app)

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -171,6 +171,7 @@ declare global {
         input: DesktopAcpPromptInput & { sessionId: string }
       ) => Promise<DesktopAcpSession>
       cancelAcpSession: (sessionId: string) => Promise<void>
+      deleteAcpSession: (sessionId: string) => Promise<boolean>
       getAcpSession: (sessionId: string) => Promise<DesktopAcpSession | null>
       listAcpSessions: () => Promise<Array<DesktopAcpSessionSummary>>
       getAcpDiff: (sessionId: string) => Promise<DesktopAcpDiff>

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -1,6 +1,6 @@
 import { Menu } from "@base-ui/react/menu"
 import { Dialog } from "@base-ui/react/dialog"
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import {
   ArrowCounterClockwiseIcon,
   CalendarBlankIcon,
@@ -127,7 +127,8 @@ export function AgentsSidebar({
     resetFilters,
   } = useSidebarPrefs()
   const sidebar = useSidebarThreads(RESOLVED_SIDEBAR_LIMIT, activeThreadId)
-  const localSessions = useDesktopAcpSessions()
+  const { sessions: localSessions, deleteSession: deleteLocalSession } =
+    useDesktopAcpSessions()
   const {
     projects: localProjects,
     addProject: addLocalProject,
@@ -236,6 +237,7 @@ export function AgentsSidebar({
                     sessions={group.sessions}
                     activeSessionId={activeLocalSessionId}
                     onNavigate={layout.closeOnMobile}
+                    onDelete={deleteLocalSession}
                     onRemove={() => void removeLocalProject(group.project.cwd)}
                     compact={prefs.compact}
                   />
@@ -349,6 +351,61 @@ function SectionHeader({
   )
 }
 
+function DeleteThreadDialog({
+  open,
+  onOpenChange,
+  threadTitle,
+  isDeleting,
+  onConfirm,
+  detail = "This cannot be undone.",
+  error,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  threadTitle: string
+  isDeleting: boolean
+  onConfirm: () => void
+  detail?: string
+  error?: string | null
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <Dialog.Popup className="fixed top-1/2 left-1/2 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-popover p-6 text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+          <div className="flex flex-col gap-4">
+            <Dialog.Title className="text-sm font-medium">
+              Delete thread
+            </Dialog.Title>
+            <Dialog.Description className="text-xs text-muted-foreground">
+              Delete "{threadTitle}"? {detail}
+            </Dialog.Description>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+            <div className="mt-2 flex justify-end gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onOpenChange(false)}
+                disabled={isDeleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={onConfirm}
+                disabled={isDeleting}
+              >
+                {isDeleting ? "Deleting..." : "Delete"}
+              </Button>
+            </div>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
 function groupLocalProjects(
   projects: Array<DesktopProject>,
   sessions: Array<DesktopAcpSessionSummary>
@@ -380,6 +437,7 @@ function LocalThreadGroup({
   sessions,
   activeSessionId,
   onNavigate,
+  onDelete,
   onRemove,
   compact = false,
 }: {
@@ -387,6 +445,7 @@ function LocalThreadGroup({
   sessions: Array<DesktopAcpSessionSummary>
   activeSessionId?: string
   onNavigate?: () => void
+  onDelete: (sessionId: string) => Promise<boolean>
   onRemove: () => void
   compact?: boolean
 }) {
@@ -425,6 +484,7 @@ function LocalThreadGroup({
             session={session}
             isActive={session.id === activeSessionId}
             onNavigate={onNavigate}
+            onDelete={onDelete}
             compact={compact}
           />
         ))}
@@ -436,39 +496,115 @@ function LocalThreadRow({
   session,
   isActive,
   onNavigate,
+  onDelete,
   compact = false,
 }: {
   session: DesktopAcpSessionSummary
   isActive: boolean
   onNavigate?: () => void
+  onDelete: (sessionId: string) => Promise<boolean>
   compact?: boolean
 }) {
+  const navigate = useNavigate()
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const running = session.status === "running" || session.status === "starting"
+
+  const confirmDelete = async () => {
+    if (isDeleting) return
+    setIsDeleting(true)
+    setDeleteError(null)
+    try {
+      if (!(await onDelete(session.id))) {
+        throw new Error("Local Deep Agents Code session not found")
+      }
+      setDeleteOpen(false)
+      if (isActive) {
+        onNavigate?.()
+        void navigate({ to: "/agents" })
+      }
+    } catch (error) {
+      setDeleteError(
+        error instanceof Error ? error.message : "Could not delete local thread"
+      )
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   return (
-    <Link
-      to="/agents/local/$sessionId"
-      params={{ sessionId: session.id }}
-      onClick={onNavigate}
-      className={cn(
-        "mb-0.5 flex items-center gap-2 rounded-lg px-2.5 transition-colors",
-        compact ? "h-7 gap-1.5" : "h-8",
-        isActive
-          ? "bg-accent text-foreground"
-          : "text-muted-foreground hover:bg-sidebar-row-hover"
-      )}
-    >
-      {running ? (
-        <CircleNotchIcon
-          className="size-3 shrink-0 animate-spin text-primary"
-          aria-label="Local thread running"
-        />
-      ) : (
-        <span className="size-2 shrink-0 rounded-full bg-border" />
-      )}
-      <span className="min-w-0 flex-1 truncate text-[13px]">
-        {session.title}
-      </span>
-    </Link>
+    <>
+      <div className={cn("group relative mb-0.5", isDeleting && "opacity-50")}>
+        <Link
+          to="/agents/local/$sessionId"
+          params={{ sessionId: session.id }}
+          onClick={onNavigate}
+          className={cn(
+            "flex items-center gap-2 rounded-lg px-2.5 transition-colors group-hover:pr-8 [@media(hover:none)]:pr-8",
+            compact ? "h-7 gap-1.5" : "h-8",
+            isActive
+              ? "bg-accent text-foreground"
+              : "text-muted-foreground group-hover:bg-sidebar-row-hover"
+          )}
+        >
+          {running ? (
+            <CircleNotchIcon
+              className="size-3 shrink-0 animate-spin text-primary"
+              aria-label="Local thread running"
+            />
+          ) : (
+            <span className="size-2 shrink-0 rounded-full bg-border" />
+          )}
+          <span className="min-w-0 flex-1 truncate text-[13px]">
+            {session.title}
+          </span>
+        </Link>
+        <Menu.Root>
+          <Menu.Trigger
+            render={
+              <button
+                type="button"
+                aria-label="Local thread actions"
+                className="absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/70 group-hover:flex hover:bg-accent hover:text-foreground data-popup-open:flex [@media(hover:none)]:flex"
+              >
+                <DotsThreeVerticalIcon className="size-4" weight="bold" />
+              </button>
+            }
+          />
+          <Menu.Portal>
+            <Menu.Positioner
+              align="end"
+              sideOffset={4}
+              className="z-50 outline-none"
+            >
+              <Menu.Popup className="min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+                <Menu.Item
+                  onClick={() => setDeleteOpen(true)}
+                  disabled={isDeleting}
+                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
+                >
+                  <TrashIcon className="size-3.5" />
+                  Delete thread
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </div>
+      <DeleteThreadDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleteError(null)
+        }}
+        threadTitle={session.title}
+        isDeleting={isDeleting}
+        onConfirm={() => void confirmDelete()}
+        detail="This removes its dcode history but does not revert changes made to your project."
+        error={deleteError}
+      />
+    </>
   )
 }
 
@@ -783,39 +919,13 @@ function ThreadRow({
           </Menu.Portal>
         </Menu.Root>
       </div>
-      <Dialog.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <Dialog.Portal>
-          <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
-          <Dialog.Popup className="fixed top-1/2 left-1/2 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-popover p-6 text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
-            <div className="flex flex-col gap-4">
-              <Dialog.Title className="text-sm font-medium">
-                Delete thread
-              </Dialog.Title>
-              <Dialog.Description className="text-xs text-muted-foreground">
-                Delete "{thread.title}"? This cannot be undone.
-              </Dialog.Description>
-              <div className="mt-2 flex justify-end gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setDeleteOpen(false)}
-                  disabled={isDeleting}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={onConfirmDelete}
-                  disabled={isDeleting}
-                >
-                  {isDeleting ? "Deleting..." : "Delete"}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Popup>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <DeleteThreadDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        threadTitle={thread.title}
+        isDeleting={isDeleting}
+        onConfirm={onConfirmDelete}
+      />
     </>
   )
 }

--- a/ui/src/features/agents/lib/desktopAcp.test.ts
+++ b/ui/src/features/agents/lib/desktopAcp.test.ts
@@ -3,7 +3,7 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { useDesktopAcpSession } from "./desktopAcp"
+import { useDesktopAcpSession, useDesktopAcpSessions } from "./desktopAcp"
 import { desktopAcpMessages } from "./desktopAcpMessages"
 import type {
   DesktopAcpEvent,
@@ -185,5 +185,44 @@ describe("useDesktopAcpSession", () => {
 
     await waitFor(() => expect(result.current.session?.status).toBe("idle"))
     expect(result.current.session?.events).toHaveLength(2)
+  })
+})
+
+describe("useDesktopAcpSessions", () => {
+  it("does not restore a deleted session from stale events or listing", async () => {
+    const listing = deferred<Array<DesktopAcpSessionSummary>>()
+    let emit!: (payload: {
+      sessionId: string
+      event: DesktopAcpEvent
+      session: DesktopAcpSessionSummary
+    }) => void
+    window.openSweDesktop = {
+      listAcpSessions: () => listing.promise,
+      deleteAcpSession: async () => true,
+      onAcpEvent: (callback) => {
+        emit = callback
+        return vi.fn()
+      },
+    } as Window["openSweDesktop"]
+    const { result } = renderHook(() => useDesktopAcpSessions())
+    const summary = session("local")
+    const event: DesktopAcpEvent = {
+      sequence: 0,
+      timestamp: "2026-08-05T20:00:00Z",
+      type: "run-end",
+    }
+
+    act(() => emit({ sessionId: "local", event, session: summary }))
+    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
+    await act(async () => {
+      expect(await result.current.deleteSession("local")).toBe(true)
+    })
+    act(() => emit({ sessionId: "local", event, session: summary }))
+    await act(async () => {
+      listing.resolve([summary])
+      await listing.promise
+    })
+
+    expect(result.current.sessions).toEqual([])
   })
 })

--- a/ui/src/features/agents/lib/desktopAcp.ts
+++ b/ui/src/features/agents/lib/desktopAcp.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 
 import { desktopAcpMessages } from "./desktopAcpMessages"
@@ -139,18 +139,39 @@ function mergeSummaries(
 
 export function useDesktopAcpSessions() {
   const [sessions, setSessions] = useState<Array<DesktopAcpSessionSummary>>([])
+  const deletedSessionIds = useRef(new Set<string>())
 
   useEffect(() => {
     const desktop = window.openSweDesktop
     if (!desktop) return
     const unsubscribe = desktop.onAcpEvent(({ session }) => {
+      if (deletedSessionIds.current.has(session.id)) return
       setSessions((current) => mergeSummaries(current, [session]))
     })
     void desktop.listAcpSessions().then((incoming) => {
-      setSessions((current) => mergeSummaries(current, incoming))
+      setSessions((current) =>
+        mergeSummaries(
+          current,
+          incoming.filter(
+            (session) => !deletedSessionIds.current.has(session.id)
+          )
+        )
+      )
     })
     return unsubscribe
   }, [])
 
-  return sessions
+  const deleteSession = useCallback(async (sessionId: string) => {
+    const deleted =
+      (await window.openSweDesktop?.deleteAcpSession(sessionId)) ?? false
+    if (deleted) {
+      deletedSessionIds.current.add(sessionId)
+      setSessions((current) =>
+        current.filter((session) => session.id !== sessionId)
+      )
+    }
+    return deleted
+  }, [])
+
+  return { sessions, deleteSession }
 }


### PR DESCRIPTION
Adds per-session deletion for local Desktop dcode threads, including confirmation UI and cleanup of dcode history, terminal history, checkpoint refs, and persisted metadata. ACP deletion and CLI fallback are bounded, and custom dcode command paths survive restarts. Also mounts Desktop's client-only shell without SSR hydration.\n\nTests: desktop test suite, targeted Desktop ACP UI tests, production UI build, and manual ACP create/close/delete verification.