### PR TITLE
feat: shimmer the conversation loader

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -352,10 +352,12 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
             </div>
           </div>
         ) : isHydrating ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
-            <p className="text-xs text-muted-foreground/70">
-              Loading conversation…
-            </p>
+          <div className="flex flex-1 items-center justify-center px-6">
+            <img
+              src="/logo-mark.png"
+              alt="Loading conversation"
+              className="size-12 animate-pulse"
+            />
           </div>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -121,9 +121,15 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   if (!session) {
     return (
       <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 text-xs text-muted-foreground">
-        {loaded
-          ? "This local session is no longer running."
-          : "Loading local Deep Agents Code session…"}
+        {loaded ? (
+          "This local session is no longer running."
+        ) : (
+          <img
+            src="/logo-mark.png"
+            alt="Loading local Deep Agents Code session"
+            className="size-12 animate-pulse"
+          />
+        )}
         {loaded && (
           <Link
             className="text-foreground underline underline-offset-4"


### PR DESCRIPTION
## Description
Replace cloud conversation and local ACP session loading text with the existing Open SWE mark and a subtle pulse animation.

## Release Note
Conversation loading now uses a shimmering Open SWE logo.

## Test Plan
- [x] Build the dashboard

Made by [Open SWE](https://openswe.vercel.app/agents/01a00278-a89a-7750-b61f-596795cf340a)