### PR TITLE
feat: Enable terminals on the Desktop new-agent screen

### DIFF
--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -203,6 +203,20 @@ function localSessionContext(localSessionId) {
   return acpSessions.get(localSessionId) || acpDrafts.get(localSessionId);
 }
 
+async function deleteAcpDrafts(ownerId, sessionId) {
+  for (const draft of acpDrafts.values()) {
+    if (draft.ownerId !== ownerId || (sessionId && draft.id !== sessionId)) {
+      continue;
+    }
+    if (draft.starting) {
+      draft.deleteRequested = true;
+      continue;
+    }
+    acpDrafts.delete(draft.id);
+    await deleteSessionTerminals(draft.id);
+  }
+}
+
 function resolveAcpProjectPath(localSessionId, value) {
   const localSession = localSessionContext(localSessionId);
   if (!localSession || typeof value !== "string" || value.length === 0) {
@@ -420,6 +434,7 @@ function configureDesktopIpc() {
     const draft = {
       id: randomUUID(),
       cwd,
+      ownerId: event.sender.id,
       starting: false,
       deleteRequested: false,
     };
@@ -431,13 +446,8 @@ function configureDesktopIpc() {
     requireTrustedDesktopIpc(event);
     const draft =
       typeof sessionId === "string" ? acpDrafts.get(sessionId) : null;
-    if (!draft) return false;
-    if (draft.starting) {
-      draft.deleteRequested = true;
-      return true;
-    }
-    acpDrafts.delete(sessionId);
-    await deleteSessionTerminals(sessionId);
+    if (!draft || draft.ownerId !== event.sender.id) return false;
+    await deleteAcpDrafts(event.sender.id, sessionId);
     return true;
   });
 
@@ -466,7 +476,13 @@ function configureDesktopIpc() {
         ? input.draftSessionId
         : undefined;
     const draft = draftSessionId ? acpDrafts.get(draftSessionId) : null;
-    if (draftSessionId && (!draft || draft.cwd !== cwd || draft.starting)) {
+    if (
+      draftSessionId &&
+      (!draft ||
+        draft.ownerId !== event.sender.id ||
+        draft.cwd !== cwd ||
+        draft.starting)
+    ) {
       throw new Error("Local agent draft is no longer available");
     }
     if (draft) draft.starting = true;
@@ -1009,6 +1025,11 @@ function createWindow() {
   window.webContents.on("will-attach-webview", (event) =>
     event.preventDefault(),
   );
+  const ownerId = window.webContents.id;
+  const deleteDrafts = () => void deleteAcpDrafts(ownerId);
+  window.webContents.on("did-start-navigation", deleteDrafts);
+  window.webContents.on("render-process-gone", deleteDrafts);
+  window.webContents.on("destroyed", deleteDrafts);
 
   mainWindow = window;
   void loadApp(window);

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -1,5 +1,6 @@
 const fs = require("node:fs");
 const path = require("node:path");
+const { randomUUID } = require("node:crypto");
 const { pathToFileURL } = require("node:url");
 const {
   app,
@@ -89,6 +90,7 @@ let setupWindow = null;
 let authWindow = null;
 let quitting = false;
 const acpSessions = new Map();
+const acpDrafts = new Map();
 const acpRestores = new Map();
 const deletingAcpSessions = new Set();
 const persistedAcpSessions = new Map();
@@ -197,8 +199,12 @@ function pathIsInside(root, candidate) {
   );
 }
 
+function localSessionContext(localSessionId) {
+  return acpSessions.get(localSessionId) || acpDrafts.get(localSessionId);
+}
+
 function resolveAcpProjectPath(localSessionId, value) {
-  const localSession = acpSessions.get(localSessionId);
+  const localSession = localSessionContext(localSessionId);
   if (!localSession || typeof value !== "string" || value.length === 0) {
     return null;
   }
@@ -407,6 +413,34 @@ function configureDesktopIpc() {
     return resolveAcpProjectPath(input?.localSessionId, input?.path);
   });
 
+  ipcMain.handle("desktop:acp-draft-create", (event, value) => {
+    requireTrustedDesktopIpc(event);
+    const cwd = typeof value === "string" ? registeredProject(value) : null;
+    if (!cwd) throw new Error("Choose a valid local project directory");
+    const draft = {
+      id: randomUUID(),
+      cwd,
+      starting: false,
+      deleteRequested: false,
+    };
+    acpDrafts.set(draft.id, draft);
+    return { id: draft.id, cwd: draft.cwd };
+  });
+
+  ipcMain.handle("desktop:acp-draft-delete", async (event, sessionId) => {
+    requireTrustedDesktopIpc(event);
+    const draft =
+      typeof sessionId === "string" ? acpDrafts.get(sessionId) : null;
+    if (!draft) return false;
+    if (draft.starting) {
+      draft.deleteRequested = true;
+      return true;
+    }
+    acpDrafts.delete(sessionId);
+    await deleteSessionTerminals(sessionId);
+    return true;
+  });
+
   ipcMain.handle("desktop:acp-start", async (event, input) => {
     requireTrustedDesktopIpc(event);
     if (
@@ -427,9 +461,25 @@ function configureDesktopIpc() {
     const modelId =
       typeof input.modelId === "string" ? input.modelId : undefined;
     const effort = typeof input.effort === "string" ? input.effort : undefined;
-    const localSession = await createAcpSession({ cwd, modelId, effort });
-    acpSessions.set(localSession.id, localSession);
+    const draftSessionId =
+      typeof input.draftSessionId === "string"
+        ? input.draftSessionId
+        : undefined;
+    const draft = draftSessionId ? acpDrafts.get(draftSessionId) : null;
+    if (draftSessionId && (!draft || draft.cwd !== cwd || draft.starting)) {
+      throw new Error("Local agent draft is no longer available");
+    }
+    if (draft) draft.starting = true;
+
+    let localSession;
     try {
+      localSession = await createAcpSession({
+        cwd,
+        modelId,
+        effort,
+        restored: draft ? { id: draft.id } : undefined,
+      });
+      acpSessions.set(localSession.id, localSession);
       await localSession.initialize();
       persistedAcpSessions.set(localSession.id, {
         ...sessionRecord(localSession),
@@ -437,11 +487,21 @@ function configureDesktopIpc() {
         ...(effort ? { effort } : {}),
       });
       writeAcpSessions(acpSessionsPath(), [...persistedAcpSessions.values()]);
+      if (draft) acpDrafts.delete(draft.id);
     } catch (error) {
-      acpSessions.delete(localSession.id);
-      persistedAcpSessions.delete(localSession.id);
-      writeAcpSessions(acpSessionsPath(), [...persistedAcpSessions.values()]);
-      localSession.close();
+      if (localSession) {
+        acpSessions.delete(localSession.id);
+        persistedAcpSessions.delete(localSession.id);
+        writeAcpSessions(acpSessionsPath(), [...persistedAcpSessions.values()]);
+        localSession.close();
+      }
+      if (draft) {
+        draft.starting = false;
+        if (draft.deleteRequested) {
+          acpDrafts.delete(draft.id);
+          await deleteSessionTerminals(draft.id);
+        }
+      }
       throw error;
     }
     await recordAcpCheckpoint(localSession);
@@ -1032,7 +1092,12 @@ const hasSingleInstanceLock = app.requestSingleInstanceLock();
 if (!hasSingleInstanceLock) {
   app.quit();
 } else {
-  app.on("second-instance", () => {
+  app.on("second-instance", (_event, commandLine) => {
+    if (isDevelopment) {
+      app.relaunch({ args: commandLine.slice(1) });
+      app.quit();
+      return;
+    }
     const window = mainWindow || setupWindow || createWindow();
     if (window.isMinimized()) window.restore();
     window.show();
@@ -1071,7 +1136,7 @@ if (!hasSingleInstanceLock) {
       requireTrusted: requireTrustedDesktopIpc,
       getWindow: () => mainWindow,
       listProjects,
-      getAcpSession: (sessionId) => acpSessions.get(sessionId),
+      getAcpSession: localSessionContext,
       userDataPath: app.getPath("userData"),
     });
 

--- a/desktop/src/preload.cjs
+++ b/desktop/src/preload.cjs
@@ -13,6 +13,10 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
     ipcRenderer.on("desktop:projects-changed", listener)
     return () => ipcRenderer.removeListener("desktop:projects-changed", listener)
   },
+  createAcpDraftSession: (cwd) =>
+    ipcRenderer.invoke("desktop:acp-draft-create", cwd),
+  deleteAcpDraftSession: (sessionId) =>
+    ipcRenderer.invoke("desktop:acp-draft-delete", sessionId),
   startAcpSession: (input) => ipcRenderer.invoke("desktop:acp-start", input),
   promptAcpSession: (input) => ipcRenderer.invoke("desktop:acp-prompt", input),
   cancelAcpSession: (sessionId) => ipcRenderer.invoke("desktop:acp-cancel", sessionId),

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -27,6 +27,11 @@ export interface DesktopAcpSession extends DesktopAcpSessionSummary {
   events: Array<DesktopAcpEvent>
 }
 
+export interface DesktopAcpDraftSession {
+  id: string
+  cwd: string
+}
+
 export interface DesktopAcpDiff {
   status: "ready" | "missing" | "error"
   truncated: boolean
@@ -160,9 +165,12 @@ declare global {
         localSessionId: string
         path: string
       }) => Promise<string | null>
+      createAcpDraftSession?: (cwd: string) => Promise<DesktopAcpDraftSession>
+      deleteAcpDraftSession?: (sessionId: string) => Promise<boolean>
       startAcpSession: (
         input: DesktopAcpPromptInput & {
           cwd: string
+          draftSessionId?: string
           modelId?: string
           effort?: string
         }

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -8,6 +8,7 @@ import type { CreateAgentThreadVariables } from "@/features/agents/lib/queries"
 import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
 import type { RunTarget } from "@/features/agents/components/composer/RunTargetSelector"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
+import { NewAgentTerminalPanel } from "@/features/agents/components/NewAgentTerminalPanel"
 import { OnboardingDialog } from "@/features/agents/components/OnboardingDialog"
 import { Logo } from "@/features/agents/components/chat/Logo"
 import {
@@ -23,12 +24,18 @@ import {
   useModelOptions,
 } from "@/features/agents/lib/provider/useModelOptions"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
+import {
+  readStoredPanelCollapsed,
+  writeStoredPanelCollapsed,
+} from "@/features/agents/lib/gitPanelPreferences"
 import { useProfile, useRepos } from "@/lib/profile"
 import { useSession } from "@/lib/session"
 import {
   requestNotificationPermission,
   setNotificationsPref,
 } from "@/lib/notifications"
+
+const NEW_AGENT_PANEL_ID = "new-agent"
 
 function promptContent(text: string, images: Array<ImageChunk>) {
   const trimmed = text.trim()
@@ -77,9 +84,21 @@ export function AgentsHome() {
   const [submitting, setSubmitting] = useState(false)
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
-  const [runTarget, setRunTarget] = useState<RunTarget>("cloud")
+  const [runTarget, setRunTarget] = useState<RunTarget>(() =>
+    isDesktop ? "local" : "cloud"
+  )
   const [localProjectPath, setLocalProjectPath] = useState<string | null>(null)
   const [localError, setLocalError] = useState<string | null>(null)
+  const [localDraftSessionId, setLocalDraftSessionId] = useState<string | null>(
+    null
+  )
+  const localDraftRef = useRef<{
+    cwd: string
+    promise: Promise<string>
+  } | null>(null)
+  const [panelCollapsed, setPanelCollapsed] = useState(() =>
+    readStoredPanelCollapsed(NEW_AGENT_PANEL_ID)
+  )
   const {
     projects: localProjects,
     addProject,
@@ -123,6 +142,69 @@ export function AgentsHome() {
     }
   }, [localProjectPath, localProjects])
 
+  useEffect(() => {
+    if (!isDesktop || localProjectPath || localProjects.length === 0) return
+    setLocalProjectPath(localProjects[0]!.cwd)
+  }, [isDesktop, localProjectPath, localProjects])
+
+  useEffect(() => {
+    const desktop = window.openSweDesktop
+    const createDraft = desktop?.createAcpDraftSession
+    const deleteDraft = desktop?.deleteAcpDraftSession
+    setLocalDraftSessionId(null)
+    if (
+      !createDraft ||
+      !deleteDraft ||
+      runTarget !== "local" ||
+      !localProjectPath
+    ) {
+      localDraftRef.current = null
+      return
+    }
+
+    let active = true
+    const request = {
+      cwd: localProjectPath,
+      promise: createDraft(localProjectPath).then((draft) => draft.id),
+    }
+    localDraftRef.current = request
+    void request.promise
+      .then((sessionId) => {
+        if (active) setLocalDraftSessionId(sessionId)
+      })
+      .catch((error: unknown) => {
+        if (active) {
+          setLocalError(
+            error instanceof Error
+              ? error.message
+              : "Could not prepare the local terminal"
+          )
+        }
+      })
+
+    return () => {
+      active = false
+      if (localDraftRef.current === request) localDraftRef.current = null
+      void request.promise
+        .then((sessionId) => deleteDraft(sessionId))
+        .catch(() => {})
+    }
+  }, [localProjectPath, runTarget])
+
+  useEffect(() => {
+    if (localDraftSessionId) {
+      writeStoredPanelCollapsed(localDraftSessionId, panelCollapsed)
+    }
+  }, [localDraftSessionId, panelCollapsed])
+
+  const handlePanelCollapsedChange = (next: boolean) => {
+    setPanelCollapsed(next)
+    writeStoredPanelCollapsed(NEW_AGENT_PANEL_ID, next)
+    if (localDraftSessionId) {
+      writeStoredPanelCollapsed(localDraftSessionId, next)
+    }
+  }
+
   const handleRunTargetChange = (next: RunTarget) => {
     setRunTarget(next)
     setLocalError(null)
@@ -157,10 +239,16 @@ export function AgentsHome() {
       setSubmitting(true)
       setLocalError(null)
       try {
+        const draftRequest = localDraftRef.current
+        const draftSessionId =
+          draftRequest?.cwd === localProjectPath
+            ? await draftRequest.promise
+            : undefined
         const session = await desktop.startAcpSession({
           cwd: localProjectPath,
           prompt,
           images,
+          draftSessionId,
           modelId: activeSelection?.modelId,
           effort: activeSelection?.effort,
         })
@@ -217,56 +305,66 @@ export function AgentsHome() {
   }
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-6 py-8">
-      <OnboardingDialog />
-      <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center">
-        <div className="flex w-full flex-col items-center gap-6">
-          <Logo />
-          {localError && (
-            <div className="w-full rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-              {localError}
-            </div>
-          )}
-          <AgentPromptBar
-            autoFocus
-            onSubmit={handleSubmit}
-            disabled={submitting}
-            models={models}
-            selection={activeSelection}
-            onSelectionChange={handleSelectionChange}
-            repos={reposQuery.data?.repositories}
-            selectedRepo={repo}
-            onRepoChange={setRepoOverride}
-            runTarget={isDesktop ? runTarget : undefined}
-            onRunTargetChange={isDesktop ? handleRunTargetChange : undefined}
-            localProjects={localProjects}
-            selectedLocalProjectPath={localProjectPath}
-            onSelectLocalProject={handleSelectLocalProject}
-            onAddLocalProject={() => void handleAddLocalProject()}
-            onRemoveLocalProject={(cwd) => void handleRemoveLocalProject(cwd)}
-            planMode={planMode}
-            onPlanModeChange={runTarget === "cloud" ? setPlanMode : undefined}
-            environments={environments}
-            selectedEnvironment={selectedEnvironment}
-            onEnvironmentChange={
-              runTarget === "cloud" ? setEnvironmentOverride : undefined
-            }
-            adminThread={adminThread}
-            onAdminThreadChange={
-              runTarget === "cloud" && session.data?.is_admin
-                ? setAdminThread
-                : undefined
-            }
-            skills={skills.data}
-            contextUsage={{
-              contextWindow:
-                runTarget === "cloud"
-                  ? (activeModel?.context_window ?? null)
-                  : null,
-            }}
-          />
+    <>
+      <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-6 py-8">
+        <OnboardingDialog />
+        <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center">
+          <div className="flex w-full flex-col items-center gap-6">
+            <Logo />
+            {localError && (
+              <div className="w-full rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                {localError}
+              </div>
+            )}
+            <AgentPromptBar
+              autoFocus
+              onSubmit={handleSubmit}
+              disabled={submitting}
+              models={models}
+              selection={activeSelection}
+              onSelectionChange={handleSelectionChange}
+              repos={reposQuery.data?.repositories}
+              selectedRepo={repo}
+              onRepoChange={setRepoOverride}
+              runTarget={isDesktop ? runTarget : undefined}
+              onRunTargetChange={isDesktop ? handleRunTargetChange : undefined}
+              localProjects={localProjects}
+              selectedLocalProjectPath={localProjectPath}
+              onSelectLocalProject={handleSelectLocalProject}
+              onAddLocalProject={() => void handleAddLocalProject()}
+              onRemoveLocalProject={(cwd) => void handleRemoveLocalProject(cwd)}
+              planMode={planMode}
+              onPlanModeChange={runTarget === "cloud" ? setPlanMode : undefined}
+              environments={environments}
+              selectedEnvironment={selectedEnvironment}
+              onEnvironmentChange={
+                runTarget === "cloud" ? setEnvironmentOverride : undefined
+              }
+              adminThread={adminThread}
+              onAdminThreadChange={
+                runTarget === "cloud" && session.data?.is_admin
+                  ? setAdminThread
+                  : undefined
+              }
+              skills={skills.data}
+              contextUsage={{
+                contextWindow:
+                  runTarget === "cloud"
+                    ? (activeModel?.context_window ?? null)
+                    : null,
+              }}
+            />
+          </div>
         </div>
       </div>
-    </div>
+      {runTarget === "local" && localProjectPath && localDraftSessionId && (
+        <NewAgentTerminalPanel
+          sessionId={localDraftSessionId}
+          cwd={localProjectPath}
+          collapsed={panelCollapsed}
+          onCollapsedChange={handlePanelCollapsedChange}
+        />
+      )}
+    </>
   )
 }

--- a/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
+++ b/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect } from "react"
+
+import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
+import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
+import { AgentPanelShell } from "@/features/agents/components/AgentPanelShell"
+import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
+import { usePanelTabs } from "@/features/agents/lib/panelTabs"
+import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
+import { cn } from "@/lib/utils"
+
+const NEW_AGENT_PANEL_KINDS: ReadonlyArray<PanelTabKind> = ["terminal"]
+
+export function NewAgentTerminalPanel({
+  sessionId,
+  cwd,
+  collapsed,
+  onCollapsedChange,
+}: {
+  sessionId: string
+  cwd: string
+  collapsed: boolean
+  onCollapsedChange: (next: boolean) => void
+}) {
+  const panel = usePanelTabs(sessionId)
+  const terminals = useTerminalGroups(sessionId, cwd)
+
+  const handleOpenKind = useCallback(() => {
+    panel.open({ id: terminals.addGroup(), kind: "terminal" })
+  }, [panel, terminals])
+  const handleSelectTab = useCallback(
+    (id: string) => {
+      panel.select(id)
+      const terminalId = terminals.state.terminalGroups.find(
+        (group) => group.id === id
+      )?.terminalIds[0]
+      if (terminalId) terminals.focus(terminalId)
+    },
+    [panel, terminals]
+  )
+  const handleCloseTab = useCallback(
+    async (id: string) => {
+      if (!(await terminals.closeGroup(id))) return
+      panel.close(id)
+    },
+    [panel, terminals]
+  )
+
+  const terminalGroupIds = terminals.state.terminalGroups
+    .map((group) => group.id)
+    .join(",")
+  const syncTerminals = panel.syncTerminals
+  useEffect(() => {
+    syncTerminals(terminalGroupIds ? terminalGroupIds.split(",") : [])
+  }, [syncTerminals, terminalGroupIds])
+
+  return (
+    <AgentPanelShell
+      tabs={panel.tabs.map((tab) => ({
+        ...tab,
+        title: terminalTabTitle(terminals, tab.id),
+      }))}
+      activeTabId={panel.activeTabId}
+      onSelectTab={handleSelectTab}
+      onCloseTab={handleCloseTab}
+      onOpenKind={handleOpenKind}
+      menuKinds={NEW_AGENT_PANEL_KINDS}
+      collapsed={collapsed}
+      onCollapsedChange={onCollapsedChange}
+    >
+      {() => (
+        <>
+          {panel.tabs.map((tab) => (
+            <div
+              key={tab.id}
+              className={cn(
+                "min-h-0 flex-1",
+                tab.id !== panel.activeTabId && "hidden"
+              )}
+            >
+              <TerminalPanel
+                localSessionId={sessionId}
+                cwd={cwd}
+                groupId={tab.id}
+                terminals={terminals}
+              />
+            </div>
+          ))}
+        </>
+      )}
+    </AgentPanelShell>
+  )
+}
+
+function terminalTabTitle(
+  terminals: TerminalGroupsController,
+  groupId: string
+): string {
+  const group = terminals.state.terminalGroups.find(
+    (candidate) => candidate.id === groupId
+  )
+  const terminalId = group?.terminalIds.includes(
+    terminals.state.activeTerminalId
+  )
+    ? terminals.state.activeTerminalId
+    : group?.terminalIds[0]
+  return (
+    (terminalId ? terminals.metadataById.get(terminalId)?.label : null) ||
+    "Terminal"
+  )
+}

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -21,8 +21,8 @@ interface TerminalPanelProps {
   /** The terminal group this tab renders; splits live inside it. */
   groupId: string
   terminals: TerminalGroupsController
-  onOpenFile: (path: string) => void
-  onAddToChat: (text: string) => void
+  onOpenFile?: (path: string) => void
+  onAddToChat?: (text: string) => void
 }
 
 interface TerminalViewportProps {
@@ -32,8 +32,8 @@ interface TerminalViewportProps {
   active: boolean
   focusRequest: number
   onFocus: () => void
-  onOpenFile: (path: string) => void
-  onAddToChat: (text: string) => void
+  onOpenFile?: (path: string) => void
+  onAddToChat?: (text: string) => void
 }
 
 function terminalTheme() {
@@ -112,6 +112,7 @@ function TerminalViewport({
           void desktop.openExternal(text)
           return
         }
+        if (!onOpenFile) return
         const path = text.replace(/:\d+(?::\d+)?$/, "")
         void desktop
           .resolveAcpProjectPath({ localSessionId, path })
@@ -188,20 +189,25 @@ function TerminalViewport({
       <div ref={mountRef} className="h-full w-full overflow-hidden" />
       {selection && (
         <div className="absolute right-2 bottom-2 z-10 flex overflow-hidden rounded-md border border-border bg-background shadow-sm">
-          <button
-            type="button"
-            className="flex items-center gap-1 px-2 py-1 text-[11px] hover:bg-accent"
-            onClick={() => {
-              onAddToChat(selection)
-              surfaceRef.current?.clearSelection()
-            }}
-          >
-            <Plus className="size-3" /> Add to chat
-          </button>
+          {onAddToChat && (
+            <button
+              type="button"
+              className="flex items-center gap-1 px-2 py-1 text-[11px] hover:bg-accent"
+              onClick={() => {
+                onAddToChat(selection)
+                surfaceRef.current?.clearSelection()
+              }}
+            >
+              <Plus className="size-3" /> Add to chat
+            </button>
+          )}
           <button
             type="button"
             aria-label="Copy selection"
-            className="border-l border-border p-1.5 hover:bg-accent"
+            className={cn(
+              "p-1.5 hover:bg-accent",
+              onAddToChat && "border-l border-border"
+            )}
             onClick={() => {
               void navigator.clipboard.writeText(selection)
               surfaceRef.current?.clearSelection()


### PR DESCRIPTION
Defaults the Desktop new-agent screen to This Mac and selects the most recently added project. Enables the right panel before an agent starts, with terminals launched in the selected directory and transferred into the resulting local session.

Also restarts a stale development main process when make desktop is launched again, preventing renderer/preload IPC mismatches.

Tested with the targeted terminal-manager tests, production UI build, Electron preload smoke test, and consecutive make desktop launches.

Made by [Open SWE](https://openswe.vercel.app/agents/01a0029e-f420-7746-bc2b-1dc69f142009)
