### PR TITLE
fix: preserve reviews with unresolved paths

### DIFF
--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -97,7 +97,9 @@ async def publish_review(
           claim publication.
 
         Only a numeric ``review_id`` (with neither flag set) confirms a real
-        GitHub Review was created.
+        GitHub Review was created. Findings listed in ``unresolvable_findings``
+        were preserved in the review summary because GitHub rejected their
+        inline anchors; do not retry them.
     """
     if severity_threshold not in {"low", "medium", "high", "critical"}:
         return {"success": False, "error": f"Invalid severity_threshold: {severity_threshold}"}
@@ -367,6 +369,7 @@ async def _publish_review_async(
         additional_findings_count=additional_findings_count,
     )
 
+    demoted_findings: list[Finding] = []
     review_response = await post_pull_request_review(
         owner=owner,
         repo=repo,
@@ -432,19 +435,33 @@ async def _publish_review_async(
                     ),
                 }
         else:
-            # Either nothing to drop (no diff_line_set available, so we can't
-            # tell which findings are bad) or everything would be dropped.
-            # Either way, do not retry — surface the structural signal so the
-            # agent stops retrying with the same args.
-            return {
-                "success": False,
-                "error": f"Failed to POST PR review: {review_response['_error']}",
-                "unresolvable_findings": dropped_ids,
-                "hint": (
-                    "Call update_finding(status='resolved') on these ids "
-                    "or fix their file/line before retrying."
+            # GitHub does not identify the bad comment in this 422. Preserve the
+            # findings in the review body and retry without inline anchors.
+            demoted_findings = [finding for finding, _ in eligible_with_payload]
+            dropped_ids = [
+                finding_id
+                for finding in demoted_findings
+                if isinstance((finding_id := finding.get("id")), str)
+            ]
+            review_response = await post_pull_request_review(
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                body=render_review_body(
+                    pr_number=pr_number,
+                    surfaced_count=0,
+                    trace_url=review_trace_url,
+                    ui_url=review_ui_url,
+                    out_of_diff_findings=demoted_findings,
+                    additional_findings_count=additional_findings_count,
                 ),
-            }
+                inline_comments=[],
+                token=token,
+            )
+            inline_comments = []
+            eligible_with_payload = []
+            unresolvable_findings = dropped_ids
     if isinstance(review_response, dict) and "_error" in review_response:
         return {
             "success": False,
@@ -514,6 +531,7 @@ async def _publish_review_async(
         findings=await list_findings_async(thread_id),
     )
 
+    surfaced_count = len(inline_comments) + len(demoted_findings)
     if not is_re_review:
         await _maybe_post_slack_completion_reply(
             thread_id=thread_id,
@@ -521,12 +539,12 @@ async def _publish_review_async(
             repo=repo,
             pr_number=pr_number,
             review_id=review_id,
-            surfaced_count=len(inline_comments),
+            surfaced_count=surfaced_count,
         )
 
     await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
     await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
-    conclusion, check_title, check_summary = review_check_conclusion(len(inline_comments))
+    conclusion, check_title, check_summary = review_check_conclusion(surfaced_count)
     await settle_review_check_run(
         thread_id=thread_id,
         owner=owner,
@@ -540,15 +558,15 @@ async def _publish_review_async(
     result: dict[str, Any] = {
         "success": True,
         "review_id": review_id,
-        "surfaced_count": len(inline_comments),
-        "hidden_count": max(len(open_unpublished) - len(inline_comments), 0),
+        "surfaced_count": surfaced_count,
+        "hidden_count": max(len(open_unpublished) - surfaced_count, 0),
         "resolved_thread_count": resolved_thread_count,
     }
     if unresolvable_findings:
         result["unresolvable_findings"] = unresolvable_findings
         result["hint"] = (
-            "Some findings had anchors not in the PR diff; "
-            "call update_finding to fix or resolve them."
+            "These findings were preserved in the review summary because GitHub rejected "
+            "their inline anchors; use update_finding before a future publish, not a retry."
         )
     return result
 

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -2137,24 +2137,19 @@ async def test_publish_review_reports_unresolvable_when_retry_still_fails() -> N
 
 
 @pytest.mark.asyncio
-async def test_publish_review_does_not_retry_when_no_findings_can_be_dropped() -> None:
-    """When the unresolved_anchor 422 fires but the diff_line_set rules out
-    no findings (e.g., diff data unavailable), the tool must NOT retry — it
-    must surface the structured error so the agent stops looping."""
+async def test_publish_review_demotes_all_findings_when_bad_anchor_is_unknown() -> None:
     from agent.tools.publish_review import _publish_review_async
 
     findings = [
         _f(id="f_only", severity="high", file="in_diff.py", start_line=10, end_line=10),
     ]
-    # No cached diff_line_set, and the on-demand fetch fails — no way to tell
-    # which finding is bad.
     first_response = {
         "_error": "HTTP 422: ...",
         "_error_kind": "unresolved_anchor",
         "_raw_errors": ["Path could not be resolved"],
         "_status": 422,
     }
-    post_review = AsyncMock(return_value=first_response)
+    post_review = AsyncMock(side_effect=[first_response, {"id": 7777}])
 
     with (
         patch(
@@ -2162,10 +2157,7 @@ async def test_publish_review_does_not_retry_when_no_findings_can_be_dropped() -
             return_value={"configurable": {"thread_id": "tid"}},
         ),
         patch("agent.tools.publish_review.get_thread_id_from_runtime", return_value="tid"),
-        patch(
-            "agent.tools.publish_review.list_findings_async",
-            AsyncMock(return_value=findings),
-        ),
+        patch("agent.tools.publish_review.list_findings_async", AsyncMock(return_value=findings)),
         patch("agent.tools.publish_review.post_pull_request_review", post_review),
         patch(
             "agent.tools.publish_review._resolve_diff_line_set",
@@ -2178,6 +2170,9 @@ async def test_publish_review_does_not_retry_when_no_findings_can_be_dropped() -
             return_value=0,
         ),
         patch("agent.tools.publish_review.set_reviewer_thread_metadata", new_callable=AsyncMock),
+        patch(
+            "agent.tools.publish_review._maybe_post_slack_completion_reply", new_callable=AsyncMock
+        ),
     ):
         result = await _publish_review_async(
             owner="o",
@@ -2190,11 +2185,13 @@ async def test_publish_review_does_not_retry_when_no_findings_can_be_dropped() -
             is_re_review=False,
         )
 
-    # Only one attempt — never retry blindly.
-    assert post_review.await_count == 1
-    assert result["success"] is False
-    assert result["unresolvable_findings"] == []
-    assert "update_finding" in result["hint"]
+    retry = post_review.await_args_list[1].kwargs
+    assert retry["inline_comments"] == []
+    assert "`in_diff.py line 10`" in retry["body"]
+    assert result["success"] is True
+    assert result["review_id"] == 7777
+    assert result["surfaced_count"] == 1
+    assert result["unresolvable_findings"] == ["f_only"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
GitHub can reject a review batch with a generic unresolved-path 422 while providing no offending finding IDs. Retry without inline anchors and preserve every finding in the review summary instead of failing with an empty recovery hint.

## Release Note
Fix review publishing when GitHub cannot resolve an inline path.

## Test Plan
- [x] Verify the unresolved-anchor fallback publishes a summary-only review

Made by [Open SWE](https://openswe.vercel.app/agents/01a002d4-20a5-7448-aa96-27b10e35e317)