### PR TITLE
feat: show local branch pull requests

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -18,7 +18,8 @@ dcode runs are ephemeral: their sessions remain available only for the lifetime 
 process and cannot be resumed after it exits.
 
 The side panel's **Changes** tab diffs the project against a git snapshot taken when the session
-started, so it shows what the agent changed and not the working tree's prior state.
+started, so it shows what the agent changed and not the working tree's prior state. It also shows
+the current branch and discovers its pull request when the GitHub CLI is installed and authenticated.
 
 ## How it connects
 

--- a/desktop/src/git-diff.cjs
+++ b/desktop/src/git-diff.cjs
@@ -7,6 +7,7 @@ const MAX_FILES = 200
 const MAX_FILE_BYTES = 400_000
 const MAX_CONTENT_BYTES = 16 * 1024 * 1024
 const MAX_OUTPUT_BYTES = 64 * 1024 * 1024
+const MAX_GH_OUTPUT_BYTES = 1024 * 1024
 const CHECKPOINT_NAMESPACE = "refs/open-swe/local"
 
 // The project is whatever directory the user picked, so never let its git config
@@ -36,6 +37,70 @@ async function currentBranch(cwd) {
   } catch {
     return null
   }
+}
+
+function parsePullRequest(raw) {
+  try {
+    const value = JSON.parse(raw)
+    const url = new URL(value.url)
+    if (
+      !Number.isInteger(value.number) ||
+      value.number < 1 ||
+      typeof value.title !== "string" ||
+      !["OPEN", "CLOSED", "MERGED"].includes(value.state) ||
+      typeof value.isDraft !== "boolean" ||
+      typeof value.headRefName !== "string" ||
+      typeof value.baseRefName !== "string" ||
+      !["http:", "https:"].includes(url.protocol)
+    ) {
+      return null
+    }
+    return {
+      number: value.number,
+      title: value.title,
+      state:
+        value.state === "OPEN" && value.isDraft
+          ? "draft"
+          : value.state.toLowerCase(),
+      headRef: value.headRefName,
+      baseRef: value.baseRefName,
+      url: url.href,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function pullRequest(repo, env) {
+  try {
+    const output = await new Promise((resolve, reject) => {
+      execFile(
+        "gh",
+        [
+          "pr",
+          "view",
+          "--json",
+          "number,title,state,isDraft,headRefName,baseRefName,url",
+        ],
+        {
+          cwd: repo,
+          env: { ...(env || process.env), GH_PROMPT_DISABLED: "1" },
+          encoding: "utf8",
+          maxBuffer: MAX_GH_OUTPUT_BYTES,
+          timeout: 5_000,
+        },
+        (error, stdout) => (error ? reject(error) : resolve(stdout))
+      )
+    })
+    return parsePullRequest(output)
+  } catch {
+    return null
+  }
+}
+
+async function repositoryMetadata(repo, env) {
+  const branch = await currentBranch(repo)
+  return { branch, pr: branch ? await pullRequest(repo, env) : null }
 }
 
 function gitStdin(cwd, args, input) {
@@ -261,7 +326,9 @@ module.exports = {
   checkpointRef,
   currentBranch,
   deleteRefs,
+  parsePullRequest,
   readDiff,
   repoRoot,
+  repositoryMetadata,
   staleRefs,
 }

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -29,6 +29,7 @@ const {
   deleteRefs,
   readDiff,
   repoRoot,
+  repositoryMetadata,
   staleRefs,
 } = require("./git-diff.cjs");
 const {
@@ -593,7 +594,11 @@ function configureDesktopIpc() {
       return { status: "missing", files: [], truncated: false };
     }
     try {
-      return await readDiff(checkpoint.repo, checkpoint.ref);
+      const [diff, repository] = await Promise.all([
+        readDiff(checkpoint.repo, checkpoint.ref),
+        repositoryMetadata(checkpoint.repo, localSession?.env),
+      ]);
+      return { ...diff, repository };
     } catch {
       return { status: "error", files: [], truncated: false };
     }

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -9,6 +9,7 @@ const {
   captureCheckpoint,
   checkpointRef,
   currentBranch,
+  parsePullRequest,
   readDiff,
   repoRoot,
 } = require("../src/git-diff.cjs")
@@ -16,6 +17,43 @@ const {
 function git(cwd, args) {
   execFileSync("git", args, { cwd, stdio: "ignore" })
 }
+
+test("normalizes validated pull request metadata", () => {
+  const pr = parsePullRequest(
+    JSON.stringify({
+      number: 12,
+      title: "Draft change",
+      state: "OPEN",
+      isDraft: true,
+      headRefName: "feature",
+      baseRefName: "main",
+      url: "https://github.com/example/repo/pull/12",
+    })
+  )
+  assert.deepEqual(pr, {
+    number: 12,
+    title: "Draft change",
+    state: "draft",
+    headRef: "feature",
+    baseRef: "main",
+    url: "https://github.com/example/repo/pull/12",
+  })
+  assert.equal(
+    parsePullRequest(
+      JSON.stringify({
+        number: 12,
+        title: "Closed draft",
+        state: "CLOSED",
+        isDraft: true,
+        headRefName: "feature",
+        baseRefName: "main",
+        url: "https://github.com/example/repo/pull/12",
+      })
+    ).state,
+    "closed"
+  )
+  assert.equal(parsePullRequest('{"url":"javascript:alert(1)"}'), null)
+})
 
 test("diffs the worktree against a session checkpoint", async (t) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "open-swe-git-"))

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -1,5 +1,5 @@
 import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
-import type { ImageChunk } from "@/features/agents/lib/types"
+import type { AgentThread, ImageChunk } from "@/features/agents/lib/types"
 
 export interface DesktopProject {
   cwd: string
@@ -38,6 +38,10 @@ export interface DesktopAcpDiff {
   status: "ready" | "missing" | "error"
   truncated: boolean
   files: Array<ThreadPrDiffFile>
+  repository?: {
+    branch: string | null
+    pr: AgentThread["pr"] | null
+  }
 }
 
 export interface DesktopAcpPromptInput {

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { CircleAlert, FolderOpen, X } from "lucide-react"
+import {
+  CircleAlert,
+  FolderOpen,
+  GitPullRequestIcon,
+  RefreshCwIcon,
+  X,
+} from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
 import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
@@ -132,6 +138,32 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const files = useMemo(
     () => toPanelFiles(diff.data?.files ?? []),
     [diff.data?.files]
+  )
+  const repository = diff.data?.repository
+  const pr = repository?.pr
+  const diffActions = (
+    <>
+      <button
+        type="button"
+        aria-label="Refresh changes"
+        title="Refresh changes"
+        onClick={() => void diff.refetch()}
+        className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <RefreshCwIcon className="size-3.5" />
+      </button>
+      {pr && (
+        <a
+          href={pr.url}
+          target="_blank"
+          rel="noreferrer"
+          className="flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          <GitPullRequestIcon className="size-3.5" />
+          View PR
+        </a>
+      )}
+    </>
   )
 
   if (!session) {
@@ -288,6 +320,12 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
                   diff.isPending
                 )}
                 truncated={diff.data?.truncated}
+                leading={
+                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                    Branch{repository?.branch ? ` · ${repository.branch}` : ""}
+                  </span>
+                }
+                actions={diffActions}
               />
             )}
             {(panel.activeTab?.kind === "browser" ||

--- a/ui/src/features/agents/lib/desktopAcp.test.ts
+++ b/ui/src/features/agents/lib/desktopAcp.test.ts
@@ -203,7 +203,9 @@ describe("useDesktopAcpSessions", () => {
         emit = callback
         return vi.fn()
       },
-    } as Window["openSweDesktop"]
+    } as Partial<
+      NonNullable<Window["openSweDesktop"]>
+    > as Window["openSweDesktop"]
     const { result } = renderHook(() => useDesktopAcpSessions())
     const summary = session("local")
     const event: DesktopAcpEvent = {


### PR DESCRIPTION
## Description
Bring the Desktop local Changes panel in line with cloud threads by showing branch metadata, refresh controls, and the current branch's pull request when authenticated GitHub CLI discovery succeeds.

## Release Note
Desktop local Changes now show branch metadata and link the current pull request.

## Test Plan
- [x] Verify authenticated, unavailable, and detached-HEAD PR discovery states

Made by [Open SWE](https://openswe.vercel.app/agents/01a002c9-86a9-72ff-a278-84f6be5e2b86)

## References
- Plan: https://openswe.vercel.app/agents/01a002c9-86a9-72ff-a278-84f6be5e2b86/plan