### PR TITLE
feat: add cloud sandbox terminals

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -14,7 +14,8 @@ from urllib.parse import urlparse
 
 import httpx
 import jwt
-from fastapi import HTTPException, Request
+from fastapi import HTTPException
+from starlette.requests import HTTPConnection
 
 from agent.utils.github_org_membership import is_user_active_org_member
 
@@ -217,14 +218,14 @@ def build_settings_url() -> str | None:
     return f"{frontend_base}{PROFILE_SETTINGS_PATH}"
 
 
-def require_session(request: Request) -> dict[str, Any]:
+def require_session(request: HTTPConnection) -> dict[str, Any]:
     token = request.cookies.get(COOKIE_NAME)
     if not token:
         raise HTTPException(401, "not authenticated")
     return decode_session(token)
 
 
-def request_origin(request: Request) -> str | None:
+def request_origin(request: HTTPConnection) -> str | None:
     """Return the request's origin (scheme + host + port), if present and valid."""
     raw_origin = request.headers.get("origin")
     if raw_origin is not None:
@@ -239,7 +240,7 @@ def request_origin(request: Request) -> str | None:
     return None
 
 
-def require_same_origin(request: Request) -> None:
+def require_same_origin(request: HTTPConnection) -> None:
     """Reject cross-site cookie-authenticated mutations (CSRF defense).
 
     No-op when no dashboard origins are configured (local setups without
@@ -256,15 +257,18 @@ def require_same_origin(request: Request) -> None:
     if not origin or origin not in allowed:
         logger.warning(
             "Rejected %s %s — origin %r not in allowlist",
-            request.method,
+            request.scope.get("method", "WEBSOCKET"),
             request.url.path,
             origin,
         )
         raise HTTPException(403, "CSRF check failed")
 
 
-def require_same_origin_for_mutations(request: Request) -> None:
-    if request.method in {"GET", "HEAD", "OPTIONS"}:
+def require_same_origin_for_mutations(request: HTTPConnection) -> None:
+    if request.scope["type"] == "websocket":
+        require_same_origin(request)
+        return
+    if request.scope.get("method") in {"GET", "HEAD", "OPTIONS"}:
         return
     # The origin allowlist defends the ambient session cookie. A request whose
     # only credential is an explicit bearer header can't be forged by a browser,

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 import httpx
 import jwt
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from starlette.requests import HTTPConnection
 
 from agent.utils.github_org_membership import is_user_active_org_member
@@ -273,6 +273,8 @@ def require_same_origin_for_mutations(request: HTTPConnection) -> None:
     # The origin allowlist defends the ambient session cookie. A request whose
     # only credential is an explicit bearer header can't be forged by a browser,
     # so it has nothing to defend.
+    if not isinstance(request, Request):
+        raise HTTPException(400, "invalid request")
     if bearer_github_token(request) and not request.cookies.get(COOKIE_NAME):
         return
     require_same_origin(request)

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -2,14 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import hmac
+import json
 import logging
 import os
+import posixpath
+import shlex
 from typing import Any, Literal
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.responses import RedirectResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
@@ -198,6 +211,7 @@ from .thread_api import (
     admin_cancel_dashboard_thread,
     cancel_dashboard_thread,
     delete_dashboard_thread,
+    get_dashboard_terminal_sandbox,
     get_dashboard_thread,
     get_dashboard_thread_pr_diff,
     get_dashboard_thread_recovery_patch,
@@ -254,6 +268,7 @@ router = APIRouter(
     dependencies=[Depends(require_same_origin_for_mutations)],
 )
 _GITHUB_API_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
+_CLOUD_TERMINAL_SLOTS = asyncio.Semaphore(20)
 _SKIPPABLE_INSTALLATION_REPO_STATUS_CODES = frozenset({403, 404})
 
 
@@ -1843,6 +1858,97 @@ async def api_get_thread(
         email=session.get("email"),
         mark_viewed=mark_viewed,
     )
+
+
+async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[str, Any]) -> None:
+    if os.environ.get("SANDBOX_TYPE", "langsmith") != "langsmith":
+        await websocket.close(code=1008, reason="Cloud terminal requires a LangSmith sandbox")
+        return
+    try:
+        sandbox_id, repo_name = await get_dashboard_terminal_sandbox(
+            thread_id, session["sub"], email=session.get("email")
+        )
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=str(exc.detail)[:123])
+        return
+
+    await websocket.accept()
+    client = handle = None
+    try:
+        await asyncio.wait_for(_CLOUD_TERMINAL_SLOTS.acquire(), timeout=0.01)
+    except TimeoutError:
+        await websocket.close(code=1013, reason="Cloud terminal capacity reached")
+        return
+    try:
+        from ..integrations.langsmith import connect_async_langsmith_sandbox
+
+        client, sandbox = await connect_async_langsmith_sandbox(sandbox_id)
+        cwd = posixpath.join("/workspace", repo_name) if repo_name else "/workspace"
+        if not (await sandbox.run(f"test -d {shlex.quote(cwd)}")).success:
+            cwd = "/workspace"
+        handle = await sandbox.run(
+            "exec ${SHELL:-/bin/bash} -l",
+            cwd=cwd,
+            timeout=0,
+            idle_timeout=300,
+            kill_on_disconnect=True,
+            pty=True,
+            wait=False,
+        )
+
+        async def output() -> None:
+            assert handle is not None
+            async for chunk in handle:
+                await websocket.send_text(json.dumps({"type": "output", "data": chunk.data}))
+            result = await handle.result
+            await websocket.send_text(json.dumps({"type": "exit", "exitCode": result.exit_code}))
+
+        async def input_() -> None:
+            assert handle is not None
+            while True:
+                message = await websocket.receive_json()
+                if not isinstance(message, dict):
+                    continue
+                if message.get("type") == "input" and isinstance(message.get("data"), str):
+                    data = message["data"]
+                    if len(data.encode()) <= 64 * 1024:
+                        await handle.send_input(data)
+
+        output_task = asyncio.create_task(output())
+        input_task = asyncio.create_task(input_())
+        done, pending = await asyncio.wait(
+            {output_task, input_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        for task in done:
+            task.result()
+    except WebSocketDisconnect:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Cloud terminal failed for thread %s: %s", thread_id, type(exc).__name__)
+        try:
+            await websocket.send_text(
+                json.dumps({"type": "error", "message": "Cloud terminal disconnected"})
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    finally:
+        if handle is not None:
+            await handle.kill()
+        if client is not None:
+            await client.aclose()
+        _CLOUD_TERMINAL_SLOTS.release()
+
+
+@router.websocket("/threads/{thread_id}/terminal")
+async def api_thread_terminal(
+    websocket: WebSocket,
+    thread_id: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> None:
+    await _cloud_terminal(websocket, thread_id, session)
 
 
 @router.get("/threads/{thread_id}/recovery.patch")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -1913,6 +1913,18 @@ async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[st
                     data = message["data"]
                     if len(data.encode()) <= 64 * 1024:
                         await handle.send_input(data)
+                elif message.get("type") == "resize":
+                    cols, rows = message.get("cols"), message.get("rows")
+                    if (
+                        isinstance(cols, int)
+                        and not isinstance(cols, bool)
+                        and 1 <= cols <= 500
+                        and isinstance(rows, int)
+                        and not isinstance(rows, bool)
+                        and 1 <= rows <= 500
+                        and handle.pid is not None
+                    ):
+                        await sandbox.run(f"stty cols {cols} rows {rows} < /proc/{handle.pid}/fd/0")
 
         output_task = asyncio.create_task(output())
         input_task = asyncio.create_task(input_())

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -8,6 +8,7 @@ import binascii
 import json
 import logging
 import os
+import posixpath
 from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime
 from typing import Any
@@ -80,6 +81,7 @@ _SURFACED_SOURCES: tuple[str, ...] = ("dashboard", "github", "slack", "linear", 
 _PR_STATES: frozenset[str] = frozenset({"draft", "open", "merged", "closed"})
 _RECOVERY_PATCH_LIMIT_BYTES = 25 * 1024 * 1024
 _RECOVERY_PATCH_TIMEOUT_SECONDS = 120
+_SANDBOX_CREATING_SENTINEL = "__creating__"
 
 
 async def create_sandbox(*args: Any, **kwargs: Any) -> Any:
@@ -427,10 +429,11 @@ async def _thread_summary(
     trace_url = await get_langsmith_trace_url(thread_id) if isinstance(thread_id, str) else None
 
     raw_sandbox_id = metadata.get("sandbox_id")
-    # "__creating__" is the in-flight sentinel written before the real id lands.
     sandbox_id = (
         raw_sandbox_id
-        if isinstance(raw_sandbox_id, str) and raw_sandbox_id and raw_sandbox_id != "__creating__"
+        if isinstance(raw_sandbox_id, str)
+        and raw_sandbox_id
+        and raw_sandbox_id != _SANDBOX_CREATING_SENTINEL
         else None
     )
 
@@ -1015,6 +1018,29 @@ async def _mark_thread_viewed(
         logger.debug("Could not mark thread %s viewed", thread_id, exc_info=True)
         return metadata
     return {**metadata, **metadata_update}
+
+
+async def get_dashboard_terminal_sandbox(
+    thread_id: str, login: str, *, email: str | None = None
+) -> tuple[str, str | None]:
+    client = langgraph_client()
+    try:
+        thread = await client.threads.get(thread_id)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(404, "thread not found") from exc
+    metadata = thread_metadata(thread)
+    _assert_thread_owner(metadata, login, email)
+    sandbox_id = metadata.get("sandbox_id")
+    if (
+        not isinstance(sandbox_id, str)
+        or not sandbox_id
+        or sandbox_id == _SANDBOX_CREATING_SENTINEL
+    ):
+        raise HTTPException(404, "thread sandbox is not ready")
+    repo_name = metadata.get("repo_name")
+    if not isinstance(repo_name, str) or posixpath.basename(repo_name) != repo_name:
+        repo_name = None
+    return sandbox_id, repo_name
 
 
 async def get_dashboard_thread(

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -374,6 +374,15 @@ def get_async_sandbox_client() -> AsyncSandboxClient:
     )
 
 
+async def connect_async_langsmith_sandbox(sandbox_id: str) -> tuple[AsyncSandboxClient, Any]:
+    client = get_async_sandbox_client()
+    try:
+        return client, await client.get_sandbox(name=sandbox_id)
+    except Exception:
+        await client.aclose()
+        raise
+
+
 async def create_langsmith_sandbox(
     sandbox_id: str | None = None,
     github_token: str | None = None,

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -356,6 +356,37 @@ async def test_thread_summary_hides_creating_sandbox_sentinel() -> None:
     assert summary["sandboxId"] is None
 
 
+async def test_terminal_sandbox_requires_owner_and_existing_sandbox(monkeypatch) -> None:
+    metadata = {
+        "source": "dashboard",
+        "github_login": "owner",
+        "sandbox_id": "sandbox-123",
+        "repo_name": "repo",
+    }
+
+    class FakeThreads:
+        async def get(self, thread_id: str):
+            return {"thread_id": thread_id, "metadata": metadata}
+
+    class FakeClient:
+        threads = FakeThreads()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    assert await thread_api.get_dashboard_terminal_sandbox("tid", "owner") == (
+        "sandbox-123",
+        "repo",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.get_dashboard_terminal_sandbox("tid", "intruder")
+    assert exc_info.value.status_code == 404
+
+    metadata["sandbox_id"] = "__creating__"
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.get_dashboard_terminal_sandbox("tid", "owner")
+    assert exc_info.value.status_code == 404
+
+
 async def test_thread_summary_includes_slack_source_url_for_private_repo() -> None:
     summary = await thread_api._thread_summary(
         _thread_with_metadata(

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { useQueryClient } from "@tanstack/react-query"
 import {
@@ -12,6 +12,7 @@ import {
 } from "lucide-react"
 
 import type { AgentThread } from "@/features/agents/lib/types"
+import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
 import { agentsApi } from "@/features/agents/lib/api"
 import {
   agentThreadKeys,
@@ -34,6 +35,11 @@ import {
   toPanelFiles,
 } from "@/features/agents/components/DiffFilesView"
 import { PlanView } from "@/features/agents/components/PlanView"
+import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
+import { usePanelTabs } from "@/features/agents/lib/panelTabs"
+import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
+import { terminalTabTitle } from "@/features/agents/lib/terminalTabTitle"
+import { cn } from "@/lib/utils"
 
 export type AgentPanelTab = "git" | "plan"
 
@@ -59,13 +65,63 @@ export function AgentGitPanel({
   const stream = useAgentThreadStream()
   const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
   const [wrap, setWrap] = useDiffWrap()
+  const panel = usePanelTabs(`cloud:${thread.id}`)
+  const terminals = useTerminalGroups(
+    { kind: "cloud", threadId: thread.id },
+    ""
+  )
   const hasPlan = Boolean(
     thread.planStatus &&
     thread.planStatus !== "approved" &&
     thread.planStatus !== "cancelled"
   )
 
-  const topTab = hasPlan || requestedTab !== "plan" ? requestedTab : "git"
+  const topTab =
+    requestedTab === "plan" && hasPlan
+      ? "plan"
+      : panel.activeTab?.kind === "terminal"
+        ? panel.activeTab.id
+        : "git"
+  const handleOpenKind = useCallback(
+    (kind: PanelTabKind) => {
+      if (kind !== "terminal") return
+      onTabChange("git")
+      panel.open({ id: terminals.addGroup(), kind })
+    },
+    [onTabChange, panel, terminals]
+  )
+  const handleSelectTab = useCallback(
+    (id: string) => {
+      if (id === "git" || id === "plan") {
+        onTabChange(id)
+        panel.select("")
+        return
+      }
+      panel.select(id)
+      const terminalId = terminals.state.terminalGroups.find(
+        (group) => group.id === id
+      )?.terminalIds[0]
+      if (terminalId) terminals.focus(terminalId)
+    },
+    [onTabChange, panel, terminals]
+  )
+  const handleCloseTab = useCallback(
+    async (id: string) => {
+      if (id === "git" || id === "plan") {
+        onCollapsedChange(true)
+        return
+      }
+      if (await terminals.closeGroup(id)) panel.close(id)
+    },
+    [onCollapsedChange, panel, terminals]
+  )
+  const terminalGroupIds = terminals.state.terminalGroups
+    .map((group) => group.id)
+    .join(",")
+  const syncTerminals = panel.syncTerminals
+  useEffect(() => {
+    syncTerminals(terminalGroupIds ? terminalGroupIds.split(",") : [])
+  }, [syncTerminals, terminalGroupIds])
   const onPlanApproved = useCallback(
     (runId: string) => {
       queryClient.setQueryData<AgentThread>(
@@ -77,6 +133,7 @@ export function AgentGitPanel({
       )
       void queryClient.invalidateQueries({ queryKey: ["plan", thread.id] })
       invalidateAgentThreadLists(queryClient)
+      panel.select("")
       onTabChange("git")
       void stream.client.runs.join(thread.id, runId).finally(() => {
         void queryClient.invalidateQueries({
@@ -84,7 +141,7 @@ export function AgentGitPanel({
         })
       })
     },
-    [onTabChange, queryClient, stream, thread.id]
+    [onTabChange, panel, queryClient, stream, thread.id]
   )
 
   // Collapsed state is owned by the parent (so the plan banner can reserve space
@@ -252,13 +309,26 @@ export function AgentGitPanel({
   return (
     <AgentPanelShell
       tabs={[
-        { id: "git", kind: "review" as const },
-        ...(hasPlan ? [{ id: "plan", kind: "plan" as const }] : []),
+        { id: "git", kind: "review" as const, closable: false },
+        ...(hasPlan
+          ? [{ id: "plan", kind: "plan" as const, closable: false }]
+          : []),
+        ...panel.tabs.map((panelTab) => ({
+          ...panelTab,
+          title: terminalTabTitle(terminals, panelTab.id),
+        })),
       ]}
       activeTabId={topTab}
-      onSelectTab={(id) => onTabChange(id as AgentPanelTab)}
-      onCloseTab={() => setCollapsed(true)}
-      menuKinds={[]}
+      onSelectTab={handleSelectTab}
+      onCloseTab={handleCloseTab}
+      onOpenKind={
+        thread.isOwner !== false && thread.sandboxId
+          ? handleOpenKind
+          : undefined
+      }
+      menuKinds={
+        thread.isOwner !== false && thread.sandboxId ? ["terminal"] : []
+      }
       collapsed={collapsed}
       onCollapsedChange={setCollapsed}
       seamlessHeader={topTab === "git"}
@@ -267,7 +337,7 @@ export function AgentGitPanel({
         <>
           {topTab === "plan" ? (
             <PlanView threadId={thread.id} onApprove={onPlanApproved} />
-          ) : (
+          ) : topTab === "git" ? (
             <>
               {reviewHeader}
               {tab === "diff" ? (
@@ -293,7 +363,23 @@ export function AgentGitPanel({
                 </div>
               )}
             </>
-          )}
+          ) : null}
+          {panel.tabs.map((terminalTab) => (
+            <div
+              key={terminalTab.id}
+              className={cn(
+                "min-h-0 flex-1",
+                terminalTab.id !== topTab && "hidden"
+              )}
+            >
+              <TerminalPanel
+                target={{ kind: "cloud", threadId: thread.id }}
+                cwd=""
+                groupId={terminalTab.id}
+                terminals={terminals}
+              />
+            </div>
+          ))}
         </>
       )}
     </AgentPanelShell>

--- a/ui/src/features/agents/components/AgentPanelShell.tsx
+++ b/ui/src/features/agents/components/AgentPanelShell.tsx
@@ -368,7 +368,7 @@ export function AgentPanelShell({
                     <Icon className="size-3.5 shrink-0" />
                     <span className="max-w-28 truncate">{title}</span>
                   </button>
-                  {active && onCloseTab && (
+                  {active && onCloseTab && tab.closable !== false && (
                     <button
                       type="button"
                       aria-label={`Close ${title}`}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -62,7 +62,10 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     readStoredPanelCollapsed(sessionId)
   )
   const panel = usePanelTabs(sessionId)
-  const terminals = useTerminalGroups(sessionId, session?.cwd ?? "")
+  const terminals = useTerminalGroups(
+    { kind: "local", sessionId },
+    session?.cwd ?? ""
+  )
   const [revealFilePath, setRevealFilePath] = useState<string | null>(null)
   const [terminalContexts, setTerminalContexts] = useState<Array<string>>([])
   const handlePanelCollapsedChange = useCallback(
@@ -304,7 +307,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
                   )}
                 >
                   <TerminalPanel
-                    localSessionId={session.id}
+                    target={{ kind: "local", sessionId: session.id }}
                     cwd={session.cwd}
                     groupId={tab.id}
                     terminals={terminals}

--- a/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
+++ b/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
@@ -22,7 +22,7 @@ export function NewAgentTerminalPanel({
   onCollapsedChange: (next: boolean) => void
 }) {
   const panel = usePanelTabs(sessionId)
-  const terminals = useTerminalGroups(sessionId, cwd)
+  const terminals = useTerminalGroups({ kind: "local", sessionId }, cwd)
 
   const handleOpenKind = useCallback(() => {
     panel.open({ id: terminals.addGroup(), kind: "terminal" })
@@ -78,7 +78,7 @@ export function NewAgentTerminalPanel({
               )}
             >
               <TerminalPanel
-                localSessionId={sessionId}
+                target={{ kind: "local", sessionId }}
                 cwd={cwd}
                 groupId={tab.id}
                 terminals={terminals}

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -10,13 +10,14 @@ import {
 } from "lucide-react"
 
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
-import { cn } from "@/lib/utils"
+import type { TerminalTarget } from "@/features/agents/lib/terminalSession"
 import { MAX_TERMINALS_PER_GROUP } from "@/features/agents/lib/terminalState"
+import { cn } from "@/lib/utils"
 import { useAttachedTerminal } from "@/features/agents/lib/terminalSession"
 import { GhosttyTerminalSurface } from "@/features/agents/terminal/ghostty/surface"
 
 interface TerminalPanelProps {
-  localSessionId: string
+  target: TerminalTarget
   cwd: string
   /** The terminal group this tab renders; splits live inside it. */
   groupId: string
@@ -26,7 +27,7 @@ interface TerminalPanelProps {
 }
 
 interface TerminalViewportProps {
-  localSessionId: string
+  target: TerminalTarget
   terminalId: string
   cwd: string
   active: boolean
@@ -34,6 +35,8 @@ interface TerminalViewportProps {
   onFocus: () => void
   onOpenFile?: (path: string) => void
   onAddToChat?: (text: string) => void
+  clearRequest: number
+  restartRequest: number
 }
 
 function terminalTheme() {
@@ -54,7 +57,7 @@ function terminalTheme() {
 }
 
 function TerminalViewport({
-  localSessionId,
+  target,
   terminalId,
   cwd,
   active,
@@ -62,20 +65,28 @@ function TerminalViewport({
   onFocus,
   onOpenFile,
   onAddToChat,
+  clearRequest,
+  restartRequest,
 }: TerminalViewportProps) {
   const mountRef = useRef<HTMLDivElement>(null)
   const surfaceRef = useRef<GhosttyTerminalSurface | null>(null)
   const previousRef = useRef({ buffer: "", version: 0 })
   const [error, setError] = useState<string | null>(null)
   const [selection, setSelection] = useState<string | null>(null)
-  const state = useAttachedTerminal(localSessionId, terminalId, cwd)
+  const targetId = target.kind === "local" ? target.sessionId : target.threadId
+  const state = useAttachedTerminal(
+    target,
+    terminalId,
+    cwd,
+    clearRequest,
+    restartRequest
+  )
   const latestStateRef = useRef(state)
   latestStateRef.current = state
 
   useEffect(() => {
     const mount = mountRef.current
-    const bridge = window.openSweDesktop?.terminal
-    if (!mount || !bridge) return
+    if (!mount) return
     let disposed = false
     let surface: GhosttyTerminalSurface | null = null
 
@@ -87,17 +98,15 @@ function TerminalViewport({
         size: 13,
       },
       onData: (data) => {
-        void bridge
-          .write({ localSessionId, terminalId, data })
+        void latestStateRef.current
+          .write(data)
           .catch((cause) =>
             setError(
               cause instanceof Error ? cause.message : "Terminal write failed"
             )
           )
       },
-      onResize: (cols, rows) => {
-        void bridge.resize({ localSessionId, terminalId, cols, rows })
-      },
+      onResize: (cols, rows) => latestStateRef.current.resize(cols, rows),
       onSelectionChange: () => {
         const text = surfaceRef.current?.getSelection().trim() ?? ""
         setSelection(text || null)
@@ -106,16 +115,16 @@ function TerminalViewport({
       beforeKey: () => true,
       onLinkActivate: (text, event) => {
         if (!(event.metaKey || event.ctrlKey)) return
-        const desktop = window.openSweDesktop
-        if (!desktop) return
         if (/^https?:\/\//i.test(text)) {
-          void desktop.openExternal(text)
+          if (target.kind === "local")
+            void window.openSweDesktop?.openExternal(text)
+          else window.open(text, "_blank", "noopener,noreferrer")
           return
         }
-        if (!onOpenFile) return
+        if (target.kind !== "local" || !onOpenFile) return
         const path = text.replace(/:\d+(?::\d+)?$/, "")
-        void desktop
-          .resolveAcpProjectPath({ localSessionId, path })
+        void window.openSweDesktop
+          ?.resolveAcpProjectPath({ localSessionId: target.sessionId, path })
           .then((relativePath) => {
             if (relativePath) onOpenFile(relativePath)
           })
@@ -161,7 +170,7 @@ function TerminalViewport({
       if (surfaceRef.current === surface) surfaceRef.current = null
       surface?.dispose()
     }
-  }, [cwd, localSessionId, terminalId])
+  }, [cwd, target.kind, targetId, terminalId])
 
   useEffect(() => {
     const surface = surfaceRef.current
@@ -252,7 +261,7 @@ function ActionButton({
 }
 
 export function TerminalPanel({
-  localSessionId,
+  target,
   cwd,
   groupId,
   terminals,
@@ -340,7 +349,7 @@ export function TerminalPanel({
             )}
           >
             <TerminalViewport
-              localSessionId={localSessionId}
+              target={target}
               terminalId={terminalId}
               cwd={terminals.metadataById.get(terminalId)?.cwd ?? cwd}
               active={activeTerminalId === terminalId}
@@ -351,6 +360,8 @@ export function TerminalPanel({
               }}
               onOpenFile={onOpenFile}
               onAddToChat={onAddToChat}
+              clearRequest={terminals.clearRequests.get(terminalId) ?? 0}
+              restartRequest={terminals.restartRequests.get(terminalId) ?? 0}
             />
           </div>
         ))}

--- a/ui/src/features/agents/lib/panelTabs.ts
+++ b/ui/src/features/agents/lib/panelTabs.ts
@@ -7,6 +7,7 @@ export interface PanelTab {
   kind: PanelTabKind
   /** Overrides the kind's default label (terminal tabs use the shell label). */
   title?: string
+  closable?: boolean
 }
 
 export interface PanelTabsState {

--- a/ui/src/features/agents/lib/terminalGroups.ts
+++ b/ui/src/features/agents/lib/terminalGroups.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type { DesktopTerminalBridge, DesktopTerminalSummary } from "@/desktop"
+import type { TerminalTarget } from "@/features/agents/lib/terminalSession"
 import type {
   TerminalSplitDirection,
   TerminalUiState,
@@ -28,17 +29,30 @@ export interface TerminalGroupsController {
   split: (direction: TerminalSplitDirection) => void
   clear: (terminalId: string) => void
   restart: (terminalId: string) => void
+  clearRequests: ReadonlyMap<string, number>
+  restartRequests: ReadonlyMap<string, number>
 }
 
 export function useTerminalGroups(
-  localSessionId: string,
+  target: TerminalTarget,
   cwd: string
 ): TerminalGroupsController {
+  const localSessionId =
+    target.kind === "local" ? target.sessionId : target.threadId
   const [state, setState] = useState<TerminalUiState>(() =>
     readTerminalState(localSessionId)
   )
   const [error, setError] = useState<string | null>(null)
-  const metadata = useDesktopTerminalMetadata(localSessionId)
+  const [clearRequests, setClearRequests] = useState<
+    ReadonlyMap<string, number>
+  >(new Map())
+  const [restartRequests, setRestartRequests] = useState<
+    ReadonlyMap<string, number>
+  >(new Map())
+  const metadata = useDesktopTerminalMetadata(
+    localSessionId,
+    target.kind === "local"
+  )
   const stateRef = useRef(state)
   stateRef.current = state
 
@@ -93,6 +107,10 @@ export function useTerminalGroups(
 
   const closeTerminals = useCallback(
     (terminalIds: ReadonlyArray<string>) => {
+      if (target.kind === "cloud") {
+        commit(terminalIds.reduce(closeTerminal, stateRef.current))
+        return Promise.resolve(true)
+      }
       return run("Unable to close terminal", async (bridge) => {
         for (const terminalId of terminalIds) {
           await bridge.close({
@@ -104,7 +122,7 @@ export function useTerminalGroups(
         commit(terminalIds.reduce(closeTerminal, stateRef.current))
       })
     },
-    [commit, localSessionId, run]
+    [commit, localSessionId, run, target.kind]
   )
 
   return useMemo(
@@ -124,28 +142,51 @@ export function useTerminalGroups(
         commit(focusTerminal(stateRef.current, terminalId)),
       split: (direction: TerminalSplitDirection) =>
         commit(splitTerminal(stateRef.current, direction)),
-      clear: (terminalId: string) =>
-        run("Unable to clear terminal", (bridge) =>
+      clear: (terminalId: string) => {
+        if (target.kind === "cloud") {
+          setClearRequests((current) => {
+            const next = new Map(current)
+            next.set(terminalId, (next.get(terminalId) ?? 0) + 1)
+            return next
+          })
+          return
+        }
+        void run("Unable to clear terminal", (bridge) =>
           bridge.clear({ localSessionId, terminalId })
-        ),
-      restart: (terminalId: string) =>
-        run("Unable to restart terminal", async (bridge) => {
+        )
+      },
+      restart: (terminalId: string) => {
+        if (target.kind === "cloud") {
+          setRestartRequests((current) => {
+            const next = new Map(current)
+            next.set(terminalId, (next.get(terminalId) ?? 0) + 1)
+            return next
+          })
+          return
+        }
+        void run("Unable to restart terminal", async (bridge) => {
           await bridge.restart({
             localSessionId,
             terminalId,
             cwd: metadataById.get(terminalId)?.cwd ?? cwd,
           })
-        }),
+        })
+      },
+      clearRequests,
+      restartRequests,
     }),
     [
+      clearRequests,
       closeTerminals,
       commit,
       cwd,
       error,
       localSessionId,
       metadataById,
+      restartRequests,
       run,
       state,
+      target.kind,
     ]
   )
 }

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -1,10 +1,14 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type {
   DesktopTerminalAttachEvent,
   DesktopTerminalSessionSnapshot,
   DesktopTerminalSummary,
 } from "@/desktop"
+import { dashboardApiUrl } from "@/lib/dashboard-fetch"
+
+export type TerminalTarget =
+  { kind: "local"; sessionId: string } | { kind: "cloud"; threadId: string }
 
 export interface TerminalSessionState {
   buffer: string
@@ -142,12 +146,15 @@ export function applyTerminalEvent(
   }
 }
 
-export function useDesktopTerminalMetadata(localSessionId: string) {
+export function useDesktopTerminalMetadata(
+  localSessionId: string,
+  enabled = true
+) {
   const [terminals, setTerminals] = useState<Array<DesktopTerminalSummary>>([])
 
   useEffect(() => {
     const bridge = window.openSweDesktop?.terminal
-    if (!bridge) return
+    if (!enabled || !bridge) return
     let disposed = false
     const pending: Array<
       | { type: "upsert"; terminal: DesktopTerminalSummary }
@@ -200,7 +207,7 @@ export function useDesktopTerminalMetadata(localSessionId: string) {
       remove()
       void bridge.detachMetadata(localSessionId)
     }
-  }, [localSessionId])
+  }, [enabled, localSessionId])
 
   return useMemo(
     () =>
@@ -213,30 +220,139 @@ export function useDesktopTerminalMetadata(localSessionId: string) {
   )
 }
 
+export interface AttachedTerminal extends TerminalSessionState {
+  write: (data: string) => Promise<void>
+  resize: (cols: number, rows: number) => void
+}
+
+function cloudTerminalUrl(threadId: string): string {
+  const base = dashboardApiUrl(
+    `/threads/${encodeURIComponent(threadId)}/terminal`
+  )
+  const url = new URL(base, window.location.href)
+  if (!/^https?:$/.test(url.protocol)) {
+    throw new Error("Cloud terminal requires an HTTP dashboard API")
+  }
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
+  return url.toString()
+}
+
 export function useAttachedTerminal(
-  localSessionId: string,
+  target: TerminalTarget,
   terminalId: string,
-  cwd: string
-): TerminalSessionState {
+  cwd: string,
+  clearRequest = 0,
+  restartRequest = 0
+): AttachedTerminal {
   const [state, setState] = useState<TerminalSessionState>(
     EMPTY_TERMINAL_SESSION
   )
+  const socketRef = useRef<WebSocket | null>(null)
+  const sessionId = target.kind === "local" ? target.sessionId : target.threadId
 
   useEffect(() => {
-    const bridge = window.openSweDesktop?.terminal
-    if (!bridge) {
-      setState({
-        ...EMPTY_TERMINAL_SESSION,
-        status: "error",
-        error: "Local terminal is only available in the desktop app.",
-      })
-      return
+    if (target.kind === "cloud") {
+      let disposed = false
+      let sequence = 0
+      let socket: WebSocket
+      try {
+        socket = new WebSocket(cloudTerminalUrl(target.threadId))
+      } catch (error) {
+        setState({
+          ...EMPTY_TERMINAL_SESSION,
+          status: "error",
+          error: error instanceof Error ? error.message : "Unable to connect",
+        })
+        return
+      }
+      socketRef.current = socket
+      setState({ ...EMPTY_TERMINAL_SESSION, status: "starting" })
+      socket.onopen = () => {
+        if (socketRef.current === socket && !disposed) {
+          setState((current) => ({
+            ...current,
+            status: "running",
+            error: null,
+          }))
+        }
+      }
+      socket.onmessage = (event) => {
+        if (
+          disposed ||
+          socketRef.current !== socket ||
+          typeof event.data !== "string"
+        )
+          return
+        let message: {
+          type: string
+          data?: string
+          exitCode?: number
+          message?: string
+        }
+        try {
+          message = JSON.parse(event.data)
+        } catch {
+          return
+        }
+        if (message.type === "output" && typeof message.data === "string") {
+          setState((current) => ({
+            ...current,
+            buffer: trimBuffer(`${current.buffer}${message.data}`),
+            status: "running",
+            error: null,
+            version: current.version + 1,
+            sequence: ++sequence,
+          }))
+        } else if (message.type === "exit") {
+          setState((current) => ({
+            ...current,
+            status: "exited",
+            version: current.version + 1,
+            sequence: ++sequence,
+          }))
+        } else if (message.type === "error") {
+          setState((current) => ({
+            ...current,
+            status: "error",
+            error: message.message ?? "Cloud terminal disconnected",
+            version: current.version + 1,
+          }))
+        }
+      }
+      socket.onerror = () => {
+        if (socketRef.current !== socket || disposed) return
+        setState((current) => ({
+          ...current,
+          status: "error",
+          error: "Unable to connect to cloud terminal",
+          version: current.version + 1,
+        }))
+      }
+      socket.onclose = () => {
+        const active = socketRef.current === socket
+        if (active) socketRef.current = null
+        if (active && !disposed) {
+          setState((current) =>
+            current.status === "error"
+              ? current
+              : { ...current, status: "closed", version: current.version + 1 }
+          )
+        }
+      }
+      return () => {
+        disposed = true
+        socket.close()
+        if (socketRef.current === socket) socketRef.current = null
+      }
     }
+
+    const bridge = window.openSweDesktop?.terminal
+    if (!bridge) return
     let disposed = false
     setState(EMPTY_TERMINAL_SESSION)
     const remove = bridge.onEvent((event) => {
       if (
-        event.localSessionId === localSessionId &&
+        event.localSessionId === target.sessionId &&
         event.terminalId === terminalId &&
         !disposed
       ) {
@@ -244,15 +360,10 @@ export function useAttachedTerminal(
       }
     })
     void bridge
-      .attach({
-        localSessionId,
-        terminalId,
-        cwd,
-      })
+      .attach({ localSessionId: target.sessionId, terminalId, cwd })
       .then((snapshot) => {
-        if (!disposed) {
+        if (!disposed)
           setState((current) => applyTerminalSnapshot(current, snapshot))
-        }
       })
       .catch((error: unknown) => {
         if (!disposed) {
@@ -267,13 +378,49 @@ export function useAttachedTerminal(
           }))
         }
       })
-
     return () => {
       disposed = true
       remove()
-      void bridge.detach({ localSessionId, terminalId })
+      void bridge.detach({ localSessionId: target.sessionId, terminalId })
     }
-  }, [cwd, localSessionId, terminalId])
+  }, [cwd, restartRequest, sessionId, target.kind, terminalId])
 
-  return state
+  useEffect(() => {
+    if (!clearRequest || target.kind === "local") return
+    setState((current) => ({
+      ...current,
+      buffer: "",
+      version: current.version + 1,
+    }))
+  }, [clearRequest, target.kind])
+
+  const send = useCallback((message: object) => {
+    if (socketRef.current?.readyState === WebSocket.OPEN) {
+      socketRef.current.send(JSON.stringify(message))
+    }
+  }, [])
+
+  return {
+    ...state,
+    write: (data) =>
+      target.kind === "local"
+        ? (window.openSweDesktop?.terminal.write({
+            localSessionId: target.sessionId,
+            terminalId,
+            data,
+          }) ?? Promise.reject(new Error("Local terminal unavailable")))
+        : Promise.resolve(send({ type: "input", data })),
+    resize: (cols, rows) => {
+      if (target.kind === "local") {
+        void window.openSweDesktop?.terminal.resize({
+          localSessionId: target.sessionId,
+          terminalId,
+          cols,
+          rows,
+        })
+      } else {
+        send({ type: "resize", cols, rows })
+      }
+    },
+  }
 }

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -255,6 +255,7 @@ export function useAttachedTerminal(
     if (target.kind === "cloud") {
       let disposed = false
       let sequence = 0
+      pendingRef.current = []
       let socket: WebSocket
       try {
         socket = new WebSocket(cloudTerminalUrl(target.threadId))
@@ -353,6 +354,7 @@ export function useAttachedTerminal(
       }
       return () => {
         disposed = true
+        pendingRef.current = []
         socket.close()
         if (socketRef.current === socket) socketRef.current = null
       }

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -248,6 +248,7 @@ export function useAttachedTerminal(
     EMPTY_TERMINAL_SESSION
   )
   const socketRef = useRef<WebSocket | null>(null)
+  const pendingRef = useRef<Array<object>>([])
   const sessionId = target.kind === "local" ? target.sessionId : target.threadId
 
   useEffect(() => {
@@ -274,6 +275,9 @@ export function useAttachedTerminal(
             status: "running",
             error: null,
           }))
+          for (const message of pendingRef.current.splice(0)) {
+            socket.send(JSON.stringify(message))
+          }
         }
       }
       socket.onmessage = (event) => {
@@ -328,14 +332,22 @@ export function useAttachedTerminal(
           version: current.version + 1,
         }))
       }
-      socket.onclose = () => {
+      socket.onclose = (event) => {
         const active = socketRef.current === socket
         if (active) socketRef.current = null
         if (active && !disposed) {
+          pendingRef.current = []
           setState((current) =>
-            current.status === "error"
-              ? current
-              : { ...current, status: "closed", version: current.version + 1 }
+            event.code !== 1000
+              ? {
+                  ...current,
+                  status: "error",
+                  error: event.reason || "Cloud terminal disconnected",
+                  version: current.version + 1,
+                }
+              : current.status === "error"
+                ? current
+                : { ...current, status: "closed", version: current.version + 1 }
           )
         }
       }
@@ -394,10 +406,18 @@ export function useAttachedTerminal(
     }))
   }, [clearRequest, target.kind])
 
-  const send = useCallback((message: object) => {
-    if (socketRef.current?.readyState === WebSocket.OPEN) {
-      socketRef.current.send(JSON.stringify(message))
+  const send = useCallback((message: object): boolean => {
+    const socket = socketRef.current
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(message))
+      return true
     }
+    if (socket?.readyState === WebSocket.CONNECTING) {
+      if (pendingRef.current.length >= 100) return false
+      pendingRef.current.push(message)
+      return true
+    }
+    return false
   }, [])
 
   return {
@@ -409,7 +429,9 @@ export function useAttachedTerminal(
             terminalId,
             data,
           }) ?? Promise.reject(new Error("Local terminal unavailable")))
-        : Promise.resolve(send({ type: "input", data })),
+        : send({ type: "input", data })
+          ? Promise.resolve()
+          : Promise.reject(new Error("Cloud terminal is disconnected")),
     resize: (cols, rows) => {
       if (target.kind === "local") {
         void window.openSweDesktop?.terminal.resize({
@@ -419,6 +441,9 @@ export function useAttachedTerminal(
           rows,
         })
       } else {
+        pendingRef.current = pendingRef.current.filter(
+          (message) => (message as { type?: string }).type !== "resize"
+        )
         send({ type: "resize", cols, rows })
       }
     },

--- a/ui/src/features/agents/lib/terminalTabTitle.ts
+++ b/ui/src/features/agents/lib/terminalTabTitle.ts
@@ -1,0 +1,19 @@
+import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
+
+export function terminalTabTitle(
+  terminals: TerminalGroupsController,
+  groupId: string
+): string {
+  const group = terminals.state.terminalGroups.find(
+    (candidate) => candidate.id === groupId
+  )
+  const terminalId = group?.terminalIds.includes(
+    terminals.state.activeTerminalId
+  )
+    ? terminals.state.activeTerminalId
+    : group?.terminalIds[0]
+  return (
+    (terminalId ? terminals.metadataById.get(terminalId)?.label : null) ||
+    "Terminal"
+  )
+}


### PR DESCRIPTION
## Description
Adds owner-authenticated cloud terminal tabs backed by each thread’s existing LangSmith sandbox PTY. Reuses the local terminal UI while keeping sandbox credentials server-side.

## Release Note
Cloud agent threads now support interactive sandbox terminals.

## Test Plan
- [x] Verify focused dashboard thread API and terminal UI tests

Made by [Open SWE](https://openswe.vercel.app/agents/01a002cd-ac16-72aa-a05c-5528f7cfa7a6)

## References
- Plan: https://openswe.vercel.app/agents/01a002cd-ac16-72aa-a05c-5528f7cfa7a6/plan