### PR TITLE
feat(desktop): sign in through the user's own browser

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import logging
 import os
+import re
 import secrets
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 import jwt
@@ -28,6 +30,7 @@ STATE_COOKIE_NAME = "osw_oauth_state"
 _DESKTOP_APP_ORIGIN = "open-swe://app"
 SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
 STATE_TTL_SECONDS = 600
+HANDOFF_TTL_SECONDS = 120
 JWT_ALG = "HS256"
 
 GITHUB_APP_CLIENT_ID = os.environ.get("GITHUB_APP_CLIENT_ID", "")
@@ -182,7 +185,13 @@ def hash_state_nonce(nonce: str) -> str:
     return hmac.new(_secret().encode(), nonce.encode(), hashlib.sha256).hexdigest()
 
 
-def issue_state(*, redirect_to: str, nonce_hash: str) -> str:
+def issue_state(
+    *,
+    redirect_to: str,
+    nonce_hash: str,
+    handoff_challenge: str | None = None,
+    handoff_port: int | None = None,
+) -> str:
     now = int(time.time())
     payload: dict[str, Any] = {
         "nonce_hash": nonce_hash,
@@ -190,6 +199,9 @@ def issue_state(*, redirect_to: str, nonce_hash: str) -> str:
         "iat": now,
         "exp": now + STATE_TTL_SECONDS,
     }
+    if handoff_challenge and handoff_port:
+        payload["handoff_challenge"] = handoff_challenge
+        payload["handoff_port"] = handoff_port
     return jwt.encode(payload, _secret(), algorithm=JWT_ALG)
 
 
@@ -198,6 +210,63 @@ def decode_state(state: str) -> dict[str, Any]:
         return jwt.decode(state, _secret(), algorithms=[JWT_ALG])
     except jwt.PyJWTError as e:
         raise HTTPException(400, f"invalid state: {e}") from e
+
+
+_S256_CHALLENGE = re.compile(r"[A-Za-z0-9_-]{43}")
+
+
+def _s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def valid_handoff_challenge(value: str | None) -> str | None:
+    """Return the desktop app's PKCE S256 challenge, or ``None`` when absent."""
+    if not value:
+        return None
+    if not _S256_CHALLENGE.fullmatch(value):
+        raise HTTPException(400, "invalid desktop handoff challenge")
+    return value
+
+
+def desktop_callback_url(port: int, code: str) -> str:
+    """Loopback redirect target for the desktop app's local login listener.
+
+    Only the port crosses the wire; the host and path are fixed here so this
+    can never be steered into an open redirect.
+    """
+    return f"http://127.0.0.1:{port}/callback?code={quote(code, safe='')}"
+
+
+def issue_desktop_handoff(*, session_jwt: str, challenge: str) -> str:
+    now = int(time.time())
+    payload = {
+        "session": session_jwt,
+        "challenge": challenge,
+        "iat": now,
+        "exp": now + HANDOFF_TTL_SECONDS,
+    }
+    return jwt.encode(payload, _secret(), algorithm=JWT_ALG)
+
+
+def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
+    """Return the session JWT carried by a desktop handoff code.
+
+    The code travels over the ``open-swe://`` scheme, which any locally
+    installed app can claim, so redeeming it also requires the verifier the
+    challenge committed to — and that never leaves the desktop app.
+    """
+    try:
+        payload = jwt.decode(code, _secret(), algorithms=[JWT_ALG])
+    except jwt.PyJWTError as e:
+        raise HTTPException(400, f"invalid handoff code: {e}") from e
+    challenge = payload.get("challenge")
+    session_jwt = payload.get("session")
+    if not isinstance(challenge, str) or not isinstance(session_jwt, str):
+        raise HTTPException(400, "malformed handoff code")
+    if not hmac.compare_digest(_s256(verifier), challenge):
+        raise HTTPException(400, "handoff verifier mismatch")
+    return session_jwt
 
 
 # Dashboard route where users manage their GitHub↔Slack link.

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -238,10 +238,21 @@ def desktop_callback_url(port: int, code: str) -> str:
     return f"http://127.0.0.1:{port}/callback?code={quote(code, safe='')}"
 
 
-def issue_desktop_handoff(*, session_jwt: str, challenge: str) -> str:
+def issue_desktop_handoff(
+    *, login: str, email: str | None, avatar_url: str | None, challenge: str
+) -> str:
+    """Mint the code the browser hands back to the desktop app.
+
+    Carries the identity a session will be minted from, never a session
+    itself: a JWT is signed but not encrypted, so anything that sees the
+    loopback URL — browser history, an extension — can read the payload, and a
+    session in there would be a bearer token that makes the verifier pointless.
+    """
     now = int(time.time())
     payload = {
-        "session": session_jwt,
+        "sub": login,
+        "email": email,
+        "avatar_url": avatar_url,
         "challenge": challenge,
         "iat": now,
         "exp": now + HANDOFF_TTL_SECONDS,
@@ -250,23 +261,29 @@ def issue_desktop_handoff(*, session_jwt: str, challenge: str) -> str:
 
 
 def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
-    """Return the session JWT carried by a desktop handoff code.
+    """Mint the session a desktop handoff code was issued for.
 
-    The code travels over the ``open-swe://`` scheme, which any locally
-    installed app can claim, so redeeming it also requires the verifier the
-    challenge committed to — and that never leaves the desktop app.
+    The code reaches a loopback port through the user's browser, so redeeming
+    it also requires the verifier the challenge committed to — and that never
+    leaves the desktop app.
     """
     try:
         payload = jwt.decode(code, _secret(), algorithms=[JWT_ALG])
     except jwt.PyJWTError as e:
         raise HTTPException(400, f"invalid handoff code: {e}") from e
     challenge = payload.get("challenge")
-    session_jwt = payload.get("session")
-    if not isinstance(challenge, str) or not isinstance(session_jwt, str):
+    login = payload.get("sub")
+    if not isinstance(challenge, str) or not isinstance(login, str) or not login:
         raise HTTPException(400, "malformed handoff code")
     if not hmac.compare_digest(_s256(verifier), challenge):
         raise HTTPException(400, "handoff verifier mismatch")
-    return session_jwt
+    email = payload.get("email")
+    avatar_url = payload.get("avatar_url")
+    return issue_session(
+        login=login,
+        email=email if isinstance(email, str) else None,
+        avatar_url=avatar_url if isinstance(avatar_url, str) else None,
+    )
 
 
 # Dashboard route where users manage their GitHub↔Slack link.

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -62,16 +62,20 @@ from .oauth import (
     STATE_COOKIE_NAME,
     STATE_TTL_SECONDS,
     decode_state,
+    desktop_callback_url,
     enforce_org_login_gate,
     exchange_code,
     fetch_github_user,
     hash_state_nonce,
+    issue_desktop_handoff,
     issue_session,
     issue_state,
     new_state_nonce,
+    redeem_desktop_handoff,
     require_same_origin_for_mutations,
     require_session,
     sanitize_redirect_to,
+    valid_handoff_challenge,
 )
 from .oidc_auth import admin_session_for_actions_oidc, is_actions_oidc_token
 from .options import (
@@ -419,6 +423,8 @@ async def auth_login(
     request: Request,
     redirect_to: str | None = None,
     desktop: bool = False,
+    desktop_handoff: str | None = None,
+    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
 ) -> RedirectResponse:
     client_id = os.environ.get("GITHUB_APP_CLIENT_ID", "")
     if not client_id:
@@ -429,6 +435,8 @@ async def auth_login(
     state = issue_state(
         redirect_to=safe_redirect,
         nonce_hash=hash_state_nonce(nonce),
+        handoff_challenge=valid_handoff_challenge(desktop_handoff),
+        handoff_port=desktop_port,
     )
     api_base_url = _api_base_url()
     if desktop:
@@ -450,7 +458,7 @@ async def auth_login(
 
 
 @router.get("/auth/callback")
-async def auth_callback(request: Request, code: str, state: str) -> RedirectResponse:
+async def auth_callback(request: Request, code: str, state: str) -> Response:
     state_payload = decode_state(state)
     state_nonce_hash = state_payload.get("nonce_hash")
     cookie_nonce = request.cookies.get(STATE_COOKIE_NAME)
@@ -479,10 +487,35 @@ async def auth_callback(request: Request, code: str, state: str) -> RedirectResp
     await upsert_access_token_from_github_response(login, email or "", token_data)
 
     session_jwt = issue_session(login=login, email=email, avatar_url=user.get("avatar_url"))
+
+    challenge = state_payload.get("handoff_challenge")
+    port = state_payload.get("handoff_port")
+    if isinstance(challenge, str) and isinstance(port, int):
+        # Desktop login runs in the user's own browser, so the session belongs to
+        # the app rather than to this browser: hand back a PKCE-bound code the
+        # app redeems, and leave no session cookie behind here.
+        handoff = issue_desktop_handoff(session_jwt=session_jwt, challenge=challenge)
+        response = RedirectResponse(desktop_callback_url(port, handoff), status_code=302)
+        _clear_state_cookie(response)
+        return response
+
     response = RedirectResponse(redirect_to, status_code=302)
     _set_session_cookie(response, session_jwt)
     _clear_state_cookie(response)
     return response
+
+
+class DesktopHandoffExchange(BaseModel):
+    code: str
+    verifier: str
+
+
+@router.post("/auth/desktop/exchange")
+async def auth_desktop_exchange(body: DesktopHandoffExchange) -> dict[str, Any]:
+    return {
+        "session": redeem_desktop_handoff(code=body.code, verifier=body.verifier),
+        "expires_in": SESSION_TTL_SECONDS,
+    }
 
 
 @router.post("/auth/logout")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hmac
 import logging
 import os
-import re
 from typing import Any, Literal
 from urllib.parse import urlencode
 
@@ -419,33 +418,6 @@ def _clear_notion_state_cookie(response: Response) -> None:
     )
 
 
-_FORWARDED_HOST = re.compile(r"[A-Za-z0-9.\-]+(?::\d{1,5})?")
-
-
-def _forwarded_base_url(request: Request) -> str:
-    """The origin the client actually reached, as seen from outside any proxy.
-
-    A desktop client can point at any deployment, so its OAuth callback has to
-    come back to the host the browser started on. Behind a rewrite that host
-    only survives in the forwarded headers — ``request.base_url`` is whatever
-    the proxy dialled — and a callback on the wrong origin loses the state
-    cookie set on the first hop.
-    """
-    headers = request.headers
-
-    def forwarded(name: str) -> str:
-        return headers.get(name, "").partition(",")[0].strip()
-
-    proto = forwarded("x-forwarded-proto")
-    base = request.base_url.replace(
-        scheme=proto if proto in {"http", "https"} else request.url.scheme
-    )
-    host = forwarded("x-forwarded-host")
-    if host and _FORWARDED_HOST.fullmatch(host):
-        base = base.replace(netloc=host)
-    return str(base).rstrip("/")
-
-
 @router.get("/auth/login")
 async def auth_login(
     request: Request,
@@ -468,7 +440,9 @@ async def auth_login(
     )
     api_base_url = _api_base_url()
     if desktop:
-        api_base_url = _forwarded_base_url(request)
+        forwarded_proto = request.headers.get("x-forwarded-proto", "").partition(",")[0].strip()
+        scheme = forwarded_proto if forwarded_proto in {"http", "https"} else request.url.scheme
+        api_base_url = str(request.base_url.replace(scheme=scheme)).rstrip("/")
     redirect_uri = f"{api_base_url}/dashboard/api/auth/callback"
     query = urlencode(
         {

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -258,6 +258,9 @@ router = APIRouter(
     dependencies=[Depends(require_same_origin_for_mutations)],
 )
 _GITHUB_API_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
+# Module-level so a local harness can point the browser leg at a fake consent
+# page and still run the real login/callback code.
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 _SKIPPABLE_INSTALLATION_REPO_STATUS_CODES = frozenset({403, 404})
 
 
@@ -451,7 +454,7 @@ async def auth_login(
             "state": state,
         }
     )
-    url = f"https://github.com/login/oauth/authorize?{query}"
+    url = f"{GITHUB_AUTHORIZE_URL}?{query}"
     response = RedirectResponse(url, status_code=302)
     _set_state_cookie(response, nonce)
     return response

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -486,19 +486,23 @@ async def auth_callback(request: Request, code: str, state: str) -> Response:
 
     await upsert_access_token_from_github_response(login, email or "", token_data)
 
-    session_jwt = issue_session(login=login, email=email, avatar_url=user.get("avatar_url"))
-
     challenge = state_payload.get("handoff_challenge")
     port = state_payload.get("handoff_port")
     if isinstance(challenge, str) and isinstance(port, int):
         # Desktop login runs in the user's own browser, so the session belongs to
         # the app rather than to this browser: hand back a PKCE-bound code the
-        # app redeems, and leave no session cookie behind here.
-        handoff = issue_desktop_handoff(session_jwt=session_jwt, challenge=challenge)
+        # app redeems for one, and leave no session cookie behind here.
+        handoff = issue_desktop_handoff(
+            login=login,
+            email=email,
+            avatar_url=user.get("avatar_url"),
+            challenge=challenge,
+        )
         response = RedirectResponse(desktop_callback_url(port, handoff), status_code=302)
         _clear_state_cookie(response)
         return response
 
+    session_jwt = issue_session(login=login, email=email, avatar_url=user.get("avatar_url"))
     response = RedirectResponse(redirect_to, status_code=302)
     _set_session_cookie(response, session_jwt)
     _clear_state_cookie(response)

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hmac
 import logging
 import os
+import re
 from typing import Any, Literal
 from urllib.parse import urlencode
 
@@ -418,6 +419,33 @@ def _clear_notion_state_cookie(response: Response) -> None:
     )
 
 
+_FORWARDED_HOST = re.compile(r"[A-Za-z0-9.\-]+(?::\d{1,5})?")
+
+
+def _forwarded_base_url(request: Request) -> str:
+    """The origin the client actually reached, as seen from outside any proxy.
+
+    A desktop client can point at any deployment, so its OAuth callback has to
+    come back to the host the browser started on. Behind a rewrite that host
+    only survives in the forwarded headers — ``request.base_url`` is whatever
+    the proxy dialled — and a callback on the wrong origin loses the state
+    cookie set on the first hop.
+    """
+    headers = request.headers
+
+    def forwarded(name: str) -> str:
+        return headers.get(name, "").partition(",")[0].strip()
+
+    proto = forwarded("x-forwarded-proto")
+    base = request.base_url.replace(
+        scheme=proto if proto in {"http", "https"} else request.url.scheme
+    )
+    host = forwarded("x-forwarded-host")
+    if host and _FORWARDED_HOST.fullmatch(host):
+        base = base.replace(netloc=host)
+    return str(base).rstrip("/")
+
+
 @router.get("/auth/login")
 async def auth_login(
     request: Request,
@@ -440,9 +468,7 @@ async def auth_login(
     )
     api_base_url = _api_base_url()
     if desktop:
-        forwarded_proto = request.headers.get("x-forwarded-proto", "").partition(",")[0].strip()
-        scheme = forwarded_proto if forwarded_proto in {"http", "https"} else request.url.scheme
-        api_base_url = str(request.base_url.replace(scheme=scheme)).rstrip("/")
+        api_base_url = _forwarded_base_url(request)
     redirect_uri = f"{api_base_url}/dashboard/api/auth/callback"
     query = urlencode(
         {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "dev": "pnpm run build:ui && electron . --dev",
     "start": "pnpm run build:ui && electron .",
     "test": "node --test test/*.test.cjs",
-    "check": "node --check src/config.cjs && node --check src/acp-client.cjs && node --check src/acp-session-store.cjs && node --check src/git-diff.cjs && node --check src/project-store.cjs && node --check src/terminal-manager.cjs && node --check src/main.cjs && node --check src/preload.cjs && pnpm run test && pnpm run build:ui",
+    "check": "node --check src/config.cjs && node --check src/login-server.cjs && node --check src/acp-client.cjs && node --check src/acp-session-store.cjs && node --check src/git-diff.cjs && node --check src/project-store.cjs && node --check src/terminal-manager.cjs && node --check src/main.cjs && node --check src/preload.cjs && pnpm run test && pnpm run build:ui",
     "pack": "pnpm run build:ui && electron-builder --dir",
     "dist": "pnpm run build:ui && electron-builder"
   },

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -75,6 +75,10 @@ function isAppLoginUrl(value) {
 
 function desktopLoginUrl(backendUrl, { challenge, port }) {
   const target = new URL(LOGIN_PATH, backendUrl)
+  // Pin the OAuth callback to the backend this app was pointed at; otherwise
+  // the deployment's own DASHBOARD_API_BASE_URL wins and a preview login can
+  // land on production.
+  target.searchParams.set("desktop", "true")
   target.searchParams.set("desktop_handoff", challenge)
   target.searchParams.set("desktop_port", String(port))
   return target.toString()
@@ -95,11 +99,7 @@ function isTrustedProxyRequest(pageUrl) {
 function backendRequestUrl(backendUrl, appRequestUrl) {
   if (!isAppUrl(appRequestUrl)) throw new Error("Invalid desktop request URL")
   const source = new URL(appRequestUrl)
-  const target = new URL(`${source.pathname}${source.search}`, backendUrl)
-  if (source.pathname === "/dashboard/api/auth/login") {
-    target.searchParams.set("desktop", "true")
-  }
-  return target.toString()
+  return new URL(`${source.pathname}${source.search}`, backendUrl).toString()
 }
 
 function localCallbackUrl(navigationUrl, backendUrl) {

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -9,6 +9,9 @@ const DEVELOPMENT_APP_USER_MODEL_ID = "com.langchain.openswe.dev"
 const DEVELOPMENT_USER_DATA_DIRECTORY = "Open SWE Development"
 const DEFAULT_DEVELOPMENT_BACKEND_URL = "http://localhost:2024"
 const ALLOWED_PERMISSIONS = new Set(["clipboard-sanitized-write", "notifications"])
+const SESSION_COOKIE_NAME = "osw_session"
+const LOGIN_PATH = "/dashboard/api/auth/login"
+const DESKTOP_EXCHANGE_PATH = "/dashboard/api/auth/desktop/exchange"
 
 function resolveAppRuntime({ argv, isPackaged, appDataPath }) {
   const isDevelopment = !isPackaged || argv.includes("--dev")
@@ -62,37 +65,31 @@ function isAppUrl(value) {
   }
 }
 
+function isAppLoginUrl(value) {
+  try {
+    return isAppUrl(value) && new URL(value).pathname === LOGIN_PATH
+  } catch {
+    return false
+  }
+}
+
+function desktopLoginUrl(backendUrl, { challenge, port }) {
+  const target = new URL(LOGIN_PATH, backendUrl)
+  target.searchParams.set("desktop_handoff", challenge)
+  target.searchParams.set("desktop_port", String(port))
+  return target.toString()
+}
+
+function desktopExchangeUrl(backendUrl) {
+  return new URL(DESKTOP_EXCHANGE_PATH, backendUrl).toString()
+}
+
 function isTrustedPermissionRequest(permission, requestingUrl) {
   return ALLOWED_PERMISSIONS.has(permission) && isAppUrl(requestingUrl)
 }
 
-function isTrustedProxyRequest(method, pageUrl, requestUrl) {
-  if (isAppUrl(pageUrl)) return true
-  if (method !== "GET" || !isGithubOAuthUrl(pageUrl)) return false
-  try {
-    return new URL(requestUrl).pathname === "/dashboard/api/auth/callback"
-  } catch {
-    return false
-  }
-}
-
-function isGithubOAuthUrl(value) {
-  try {
-    const url = new URL(value)
-    const pathSegments = url.pathname.split("/").filter(Boolean)
-    const loginPage = ["login", "session", "sessions"].includes(pathSegments[0])
-    const organizationSsoPage =
-      pathSegments[0] === "orgs" &&
-      Boolean(pathSegments[1]) &&
-      ["saml", "sso"].includes(pathSegments[2])
-    return (
-      url.protocol === "https:" &&
-      url.hostname === "github.com" &&
-      (loginPage || organizationSsoPage)
-    )
-  } catch {
-    return false
-  }
+function isTrustedProxyRequest(pageUrl) {
+  return isAppUrl(pageUrl)
 }
 
 function backendRequestUrl(backendUrl, appRequestUrl) {
@@ -141,11 +138,14 @@ module.exports = {
   APP_ORIGIN,
   APP_URL,
   DEFAULT_DEVELOPMENT_BACKEND_URL,
+  SESSION_COOKIE_NAME,
   appRedirectUrl,
+  desktopExchangeUrl,
+  desktopLoginUrl,
   resolveAppRuntime,
   backendRequestUrl,
+  isAppLoginUrl,
   isAppUrl,
-  isGithubOAuthUrl,
   isTrustedPermissionRequest,
   isTrustedProxyRequest,
   localCallbackUrl,

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -75,10 +75,6 @@ function isAppLoginUrl(value) {
 
 function desktopLoginUrl(backendUrl, { challenge, port }) {
   const target = new URL(LOGIN_PATH, backendUrl)
-  // Pin the OAuth callback to the backend this app was pointed at; otherwise
-  // the deployment's own DASHBOARD_API_BASE_URL wins and a preview login can
-  // land on production.
-  target.searchParams.set("desktop", "true")
   target.searchParams.set("desktop_handoff", challenge)
   target.searchParams.set("desktop_port", String(port))
   return target.toString()
@@ -99,7 +95,11 @@ function isTrustedProxyRequest(pageUrl) {
 function backendRequestUrl(backendUrl, appRequestUrl) {
   if (!isAppUrl(appRequestUrl)) throw new Error("Invalid desktop request URL")
   const source = new URL(appRequestUrl)
-  return new URL(`${source.pathname}${source.search}`, backendUrl).toString()
+  const target = new URL(`${source.pathname}${source.search}`, backendUrl)
+  if (source.pathname === "/dashboard/api/auth/login") {
+    target.searchParams.set("desktop", "true")
+  }
+  return target.toString()
 }
 
 function localCallbackUrl(navigationUrl, backendUrl) {

--- a/desktop/src/login-server.cjs
+++ b/desktop/src/login-server.cjs
@@ -1,0 +1,94 @@
+const http = require("node:http")
+const { createHash, randomBytes } = require("node:crypto")
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000
+
+function page(heading, detail) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Open SWE</title>
+<style>
+  :root { color-scheme: light dark }
+  body {
+    font: 16px/1.5 system-ui, -apple-system, sans-serif;
+    margin: 0; min-height: 100vh;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    text-align: center; padding: 2rem;
+  }
+  h1 { font-size: 1.25rem; margin: 0 0 .5rem }
+  p { margin: 0; opacity: .7 }
+</style>
+</head>
+<body>
+<h1>${heading}</h1>
+<p>${detail}</p>
+</body>
+</html>
+`
+}
+
+const SIGNED_IN_PAGE = page("You're signed in", "You can close this tab and return to Open SWE.")
+const FAILED_PAGE = page("Sign-in failed", "Open SWE did not receive a sign-in code. Try again from the app.")
+
+/**
+ * Bind a loopback listener for one GitHub sign-in, so the login itself can run
+ * in the user's own browser and hand the result back to the app.
+ *
+ * Resolves to the flow's PKCE material, the bound port, and a `code` promise
+ * that yields the handoff code — or `null` if the flow timed out or was
+ * superseded by `cancel()`.
+ */
+async function beginLogin() {
+  const verifier = randomBytes(32).toString("base64url")
+  const challenge = createHash("sha256").update(verifier).digest("base64url")
+
+  let resolveCode = () => {}
+  const code = new Promise((resolve) => {
+    resolveCode = resolve
+  })
+
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1")
+    if (url.pathname !== "/callback") {
+      response.writeHead(404).end()
+      return
+    }
+    const value = url.searchParams.get("code")
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+    response.end(value ? SIGNED_IN_PAGE : FAILED_PAGE)
+    finish(value || null)
+  })
+
+  let timer = null
+  function finish(value) {
+    if (timer) clearTimeout(timer)
+    timer = null
+    server.closeAllConnections()
+    server.close()
+    resolveCode(value)
+  }
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject)
+      resolve()
+    })
+  })
+
+  timer = setTimeout(() => finish(null), LOGIN_TIMEOUT_MS)
+  timer.unref()
+
+  return {
+    challenge,
+    verifier,
+    port: server.address().port,
+    code,
+    cancel: () => finish(null),
+  }
+}
+
+module.exports = { beginLogin }

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -42,13 +42,17 @@ const {
   readProjects,
   removeProject,
 } = require("./project-store.cjs");
+const { beginLogin } = require("./login-server.cjs");
 const {
   APP_ORIGIN,
   APP_URL,
+  SESSION_COOKIE_NAME,
   appRedirectUrl,
   backendRequestUrl,
+  desktopExchangeUrl,
+  desktopLoginUrl,
+  isAppLoginUrl,
   isAppUrl,
-  isGithubOAuthUrl,
   isTrustedPermissionRequest,
   isTrustedProxyRequest,
   localCallbackUrl,
@@ -88,7 +92,7 @@ protocol.registerSchemesAsPrivileged([
 let backendUrl = null;
 let mainWindow = null;
 let setupWindow = null;
-let authWindow = null;
+let loginFlow = null;
 let quitting = false;
 const acpSessions = new Map();
 const acpDrafts = new Map();
@@ -690,7 +694,7 @@ async function proxyBackendRequest(request) {
   const source = new URL(request.url);
   const headers = new Headers(request.headers);
   const pageUrl = mainWindow?.webContents.getURL() || "";
-  if (!isTrustedProxyRequest(request.method, pageUrl, request.url)) {
+  if (!isTrustedProxyRequest(pageUrl)) {
     return new Response("Forbidden", { status: 403 });
   }
   headers.delete("host");
@@ -905,81 +909,74 @@ function createMenu() {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
-function handleAuthNavigation(window, event, url) {
-  const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null;
-  if (callback) {
-    event.preventDefault();
-    void window.loadURL(callback);
+async function startExternalLogin() {
+  if (!backendUrl) return;
+  loginFlow?.cancel();
+  loginFlow = null;
+
+  let flow;
+  try {
+    flow = await beginLogin();
+  } catch (error) {
+    dialog.showErrorBox(
+      `${appRuntime.name} sign-in failed`,
+      `Could not open a local sign-in listener: ${error.message}`,
+    );
     return;
   }
-  if (isAppUrl(url)) {
-    event.preventDefault();
-    window.close();
-    if (mainWindow && !mainWindow.isDestroyed()) void loadApp(mainWindow);
-    return;
-  }
-  const target = new URL(url);
-  if (target.protocol === "https:") return;
-  event.preventDefault();
-  if (["http:", "mailto:"].includes(target.protocol)) {
-    void shell.openExternal(url);
+  loginFlow = flow;
+  void shell.openExternal(desktopLoginUrl(backendUrl, flow));
+
+  const code = await flow.code;
+  if (loginFlow !== flow) return;
+  loginFlow = null;
+  if (!code) return;
+
+  try {
+    await completeExternalLogin(flow.verifier, code);
+  } catch (error) {
+    dialog.showErrorBox(`${appRuntime.name} sign-in failed`, error.message);
   }
 }
 
-function createAuthWindow(url) {
-  if (authWindow && !authWindow.isDestroyed()) {
-    authWindow.show();
-    authWindow.focus();
-    void authWindow.loadURL(url);
-    return;
+async function completeExternalLogin(verifier, code) {
+  const response = await fetch(desktopExchangeUrl(backendUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: APP_ORIGIN },
+    body: JSON.stringify({ code, verifier }),
+  });
+  if (!response.ok) {
+    throw new Error(`Backend rejected the sign-in (${response.status})`);
   }
-  const window = new BrowserWindow({
-    title: "Sign in to Open SWE",
-    parent: mainWindow,
-    width: 1000,
-    height: 800,
-    minWidth: 640,
-    minHeight: 480,
-    backgroundColor: "#ffffff",
-    icon: iconPath(),
-    show: false,
-    webPreferences: {
-      contextIsolation: true,
-      navigateOnDragDrop: false,
-      nodeIntegration: false,
-      sandbox: true,
-      session: session.defaultSession,
-    },
+  const payload = await response.json();
+  if (typeof payload?.session !== "string") {
+    throw new Error("Backend returned no session");
+  }
+  await session.defaultSession.cookies.set({
+    url: backendUrl,
+    name: SESSION_COOKIE_NAME,
+    value: payload.session,
+    path: "/",
+    httpOnly: true,
+    secure: new URL(backendUrl).protocol === "https:",
+    expirationDate: Date.now() / 1000 + Number(payload.expires_in),
   });
 
-  window.once("ready-to-show", () => window.show());
-  window.on("closed", () => {
-    if (authWindow === window) authWindow = null;
-  });
-  window.webContents.setWindowOpenHandler(({ url: popupUrl }) => {
-    const target = new URL(popupUrl);
-    if (target.protocol === "https:") {
-      void window.loadURL(popupUrl);
-    } else if (["http:", "mailto:"].includes(target.protocol)) {
-      void shell.openExternal(popupUrl);
-    }
-    return { action: "deny" };
-  });
-  window.webContents.on("will-navigate", (event, navigationUrl) =>
-    handleAuthNavigation(window, event, navigationUrl),
-  );
-  window.webContents.on("will-redirect", (event, navigationUrl) =>
-    handleAuthNavigation(window, event, navigationUrl),
-  );
-  window.webContents.on("will-attach-webview", (event) =>
-    event.preventDefault(),
-  );
-
-  authWindow = window;
-  void window.loadURL(url);
+  const window =
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow : createWindow();
+  if (window.isMinimized()) window.restore();
+  window.show();
+  window.focus();
+  app.focus({ steal: true });
+  await loadApp(window);
 }
 
 function handleNavigation(window, event, url) {
+  if (isAppLoginUrl(url)) {
+    event.preventDefault();
+    void startExternalLogin();
+    return;
+  }
   const callback = backendUrl ? localCallbackUrl(url, backendUrl) : null;
   if (callback) {
     event.preventDefault();
@@ -987,11 +984,6 @@ function handleNavigation(window, event, url) {
     return;
   }
   if (isAppUrl(url)) return;
-  if (isGithubOAuthUrl(url)) {
-    event.preventDefault();
-    createAuthWindow(url);
-    return;
-  }
   event.preventDefault();
   const target = new URL(url);
   if (["http:", "https:", "mailto:"].includes(target.protocol)) {
@@ -1031,8 +1023,8 @@ function createWindow() {
   });
   window.webContents.setWindowOpenHandler(({ url }) => {
     const protocol = new URL(url).protocol;
-    if (isGithubOAuthUrl(url)) {
-      createAuthWindow(url);
+    if (isAppLoginUrl(url)) {
+      void startExternalLogin();
     } else if (["http:", "https:", "mailto:"].includes(protocol)) {
       void shell.openExternal(url);
     }

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -6,7 +6,9 @@ const {
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   appRedirectUrl,
   backendRequestUrl,
-  isGithubOAuthUrl,
+  desktopExchangeUrl,
+  desktopLoginUrl,
+  isAppLoginUrl,
   isTrustedPermissionRequest,
   isTrustedProxyRequest,
   localCallbackUrl,
@@ -112,43 +114,27 @@ test("only grants expected permissions to the bundled app", () => {
 })
 
 test("only proxies requests from the bundled app window", () => {
-  const requestUrl = `${APP_URL}dashboard/api/threads/thread-id/commands`
-  assert.equal(isTrustedProxyRequest("POST", APP_URL, requestUrl), true)
-  assert.equal(
-    isTrustedProxyRequest("POST", "https://evil.example", requestUrl),
-    false
-  )
-  assert.equal(
-    isTrustedProxyRequest(
-      "GET",
-      "https://github.com/login/oauth/authorize",
-      `${APP_URL}dashboard/api/auth/callback?code=123`
-    ),
-    true
-  )
-  assert.equal(
-    isTrustedProxyRequest(
-      "GET",
-      "https://github.com/login/oauth/authorize",
-      `${APP_URL}dashboard/api/me`
-    ),
-    false
-  )
+  assert.equal(isTrustedProxyRequest(APP_URL), true)
+  assert.equal(isTrustedProxyRequest("https://evil.example"), false)
+  assert.equal(isTrustedProxyRequest("https://github.com/login/oauth/authorize"), false)
 })
 
-test("only keeps GitHub login pages in the app window", () => {
-  assert.equal(isGithubOAuthUrl("https://github.com/login/oauth/authorize?client_id=1"), true)
-  assert.equal(isGithubOAuthUrl("https://github.com/login?return_to=%2Flogin%2Foauth"), true)
-  assert.equal(isGithubOAuthUrl("https://github.com/session"), true)
-  assert.equal(isGithubOAuthUrl("https://github.com/sessions/two-factor"), true)
+test("sends login to the user's browser instead of the app window", () => {
+  assert.equal(isAppLoginUrl(`${APP_URL}dashboard/api/auth/login`), true)
+  assert.equal(isAppLoginUrl(`${APP_URL}dashboard/api/auth/login?redirect_to=%2F`), true)
+  assert.equal(isAppLoginUrl(`${APP_URL}dashboard/api/auth/callback`), false)
+  assert.equal(isAppLoginUrl("https://backend.example/dashboard/api/auth/login"), false)
+})
+
+test("carries the loopback port and PKCE challenge into the browser login", () => {
   assert.equal(
-    isGithubOAuthUrl(
-      "https://github.com/orgs/langchain-ai/saml/initiate?return_to=%2Flogin%2Foauth"
-    ),
-    true
+    desktopLoginUrl("https://backend.example", { challenge: "abc", port: 51234 }),
+    "https://backend.example/dashboard/api/auth/login?desktop_handoff=abc&desktop_port=51234"
   )
-  assert.equal(isGithubOAuthUrl("https://github.com/langchain-ai/open-swe"), false)
-  assert.equal(isGithubOAuthUrl("https://evil.example/login/oauth/authorize"), false)
+  assert.equal(
+    desktopExchangeUrl("https://backend.example/base/"),
+    "https://backend.example/dashboard/api/auth/desktop/exchange"
+  )
 })
 
 test("maps desktop API requests to the selected backend", () => {

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -127,11 +127,9 @@ test("sends login to the user's browser instead of the app window", () => {
 })
 
 test("carries the loopback port and PKCE challenge into the browser login", () => {
-  // desktop=true keeps the OAuth callback on the configured backend, so a
-  // preview login cannot be redirected to production.
   assert.equal(
     desktopLoginUrl("https://backend.example", { challenge: "abc", port: 51234 }),
-    "https://backend.example/dashboard/api/auth/login?desktop=true&desktop_handoff=abc&desktop_port=51234"
+    "https://backend.example/dashboard/api/auth/login?desktop_handoff=abc&desktop_port=51234"
   )
   assert.equal(
     desktopExchangeUrl("https://backend.example/base/"),
@@ -148,8 +146,8 @@ test("maps desktop API requests to the selected backend", () => {
     "https://backend.example/dashboard/api/threads?limit=20"
   )
   assert.equal(
-    backendRequestUrl("https://backend.example", `${APP_URL}dashboard/api/me`),
-    "https://backend.example/dashboard/api/me"
+    backendRequestUrl("https://backend.example", `${APP_URL}dashboard/api/auth/login`),
+    "https://backend.example/dashboard/api/auth/login?desktop=true"
   )
 })
 

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -127,9 +127,11 @@ test("sends login to the user's browser instead of the app window", () => {
 })
 
 test("carries the loopback port and PKCE challenge into the browser login", () => {
+  // desktop=true keeps the OAuth callback on the configured backend, so a
+  // preview login cannot be redirected to production.
   assert.equal(
     desktopLoginUrl("https://backend.example", { challenge: "abc", port: 51234 }),
-    "https://backend.example/dashboard/api/auth/login?desktop_handoff=abc&desktop_port=51234"
+    "https://backend.example/dashboard/api/auth/login?desktop=true&desktop_handoff=abc&desktop_port=51234"
   )
   assert.equal(
     desktopExchangeUrl("https://backend.example/base/"),
@@ -146,8 +148,8 @@ test("maps desktop API requests to the selected backend", () => {
     "https://backend.example/dashboard/api/threads?limit=20"
   )
   assert.equal(
-    backendRequestUrl("https://backend.example", `${APP_URL}dashboard/api/auth/login`),
-    "https://backend.example/dashboard/api/auth/login?desktop=true"
+    backendRequestUrl("https://backend.example", `${APP_URL}dashboard/api/me`),
+    "https://backend.example/dashboard/api/me"
   )
 })
 

--- a/desktop/test/login-server.test.cjs
+++ b/desktop/test/login-server.test.cjs
@@ -1,0 +1,45 @@
+const assert = require("node:assert/strict")
+const { createHash } = require("node:crypto")
+const test = require("node:test")
+
+const { beginLogin } = require("../src/login-server.cjs")
+
+test("receives the handoff code on the loopback listener", async () => {
+  const flow = await beginLogin()
+  assert.equal(
+    createHash("sha256").update(flow.verifier).digest("base64url"),
+    flow.challenge
+  )
+
+  const response = await fetch(`http://127.0.0.1:${flow.port}/callback?code=handoff-123`)
+  assert.equal(response.status, 200)
+  assert.match(await response.text(), /You're signed in/)
+  assert.equal(await flow.code, "handoff-123")
+})
+
+test("yields no code when the callback carries none", async () => {
+  const flow = await beginLogin()
+  const response = await fetch(`http://127.0.0.1:${flow.port}/callback`)
+  assert.equal(response.status, 200)
+  assert.match(await response.text(), /Sign-in failed/)
+  assert.equal(await flow.code, null)
+})
+
+test("ignores other paths and yields no code when cancelled", async () => {
+  const flow = await beginLogin()
+  const stray = await fetch(`http://127.0.0.1:${flow.port}/favicon.ico`)
+  assert.equal(stray.status, 404)
+
+  flow.cancel()
+  assert.equal(await flow.code, null)
+  await assert.rejects(fetch(`http://127.0.0.1:${flow.port}/callback?code=late`))
+})
+
+test("uses a fresh port and verifier per login", async () => {
+  const first = await beginLogin()
+  const second = await beginLogin()
+  assert.notEqual(first.port, second.port)
+  assert.notEqual(first.verifier, second.verifier)
+  first.cancel()
+  second.cancel()
+})

--- a/desktop/test/manual/stub-backend.cjs
+++ b/desktop/test/manual/stub-backend.cjs
@@ -61,9 +61,11 @@ const server = http.createServer(async (request, response) => {
 
   if (url.pathname === "/dashboard/api/auth/login") {
     const challenge = url.searchParams.get("desktop_handoff")
-    const loopback = url.searchParams.get("desktop_port")
-    if (!challenge || !loopback) {
-      console.log("  ✗ login is missing desktop_handoff/desktop_port")
+    // Mirror the backend: only a port number crosses the wire, so the redirect
+    // target can never be steered off loopback.
+    const loopback = Number(url.searchParams.get("desktop_port"))
+    if (!challenge || !Number.isInteger(loopback) || loopback < 1024 || loopback > 65535) {
+      console.log("  ✗ login is missing a valid desktop_handoff/desktop_port")
       return send(response, 400, { error: "not a desktop login" })
     }
     const code = randomBytes(24).toString("base64url")

--- a/desktop/test/manual/stub-backend.cjs
+++ b/desktop/test/manual/stub-backend.cjs
@@ -1,0 +1,108 @@
+/**
+ * Stub backend for exercising desktop browser login without GitHub or a real
+ * server. Skips straight from /auth/login to the loopback redirect, then logs
+ * every proxied request so you can see the session cookie arrive.
+ *
+ *   node desktop/test/manual/stub-backend.cjs 4999
+ *   OPEN_SWE_BACKEND_URL=http://127.0.0.1:4999 pnpm --dir desktop run dev
+ */
+const http = require("node:http")
+const { createHash, randomBytes } = require("node:crypto")
+
+const port = Number(process.argv[2] || 4999)
+const handoffs = new Map()
+
+const MODEL = {
+  id: "anthropic:claude-opus-5",
+  label: "Opus 5",
+  efforts: ["low", "medium", "high", "xhigh", "max"],
+  default_effort: "high",
+  supports_images: true,
+}
+
+// Enough shape for the dashboard to render once signed in; everything else
+// falls through to an empty list.
+const SIGNED_IN_ROUTES = {
+  "/dashboard/api/me": {
+    login: "stub-user",
+    email: "stub@example.com",
+    avatar_url: null,
+    is_admin: false,
+    slack_oauth_enabled: false,
+  },
+  "/dashboard/api/threads/sidebar": {
+    active: { items: [], limit: 50, hasMore: false },
+    resolved: { items: [], limit: 20, hasMore: false },
+  },
+  "/dashboard/api/my-mapping": {},
+  "/dashboard/api/profile": {},
+  "/dashboard/api/environments/options": { environments: [], default_slug: "default" },
+  "/dashboard/api/options": {
+    models: [MODEL],
+    default_agent_model: MODEL.id,
+    default_agent_reasoning_effort: "high",
+    default_agent_subagent_model: MODEL.id,
+    default_agent_subagent_reasoning_effort: "high",
+  },
+  "/dashboard/api/repos": { installations: [], repositories: [] },
+  "/dashboard/api/skills": { items: [], next_offset: null },
+}
+
+function send(response, status, body, headers = {}) {
+  const payload = typeof body === "string" ? body : JSON.stringify(body)
+  response.writeHead(status, { "content-type": "application/json", ...headers })
+  response.end(payload)
+}
+
+const server = http.createServer(async (request, response) => {
+  const url = new URL(request.url, `http://127.0.0.1:${port}`)
+  const cookie = request.headers.cookie || "—"
+  console.log(`${request.method} ${url.pathname}${url.search}  cookie: ${cookie}`)
+
+  if (url.pathname === "/dashboard/api/auth/login") {
+    const challenge = url.searchParams.get("desktop_handoff")
+    const loopback = url.searchParams.get("desktop_port")
+    if (!challenge || !loopback) {
+      console.log("  ✗ login is missing desktop_handoff/desktop_port")
+      return send(response, 400, { error: "not a desktop login" })
+    }
+    const code = randomBytes(24).toString("base64url")
+    handoffs.set(code, { challenge, session: `stub-session-${randomBytes(6).toString("hex")}` })
+    const target = `http://127.0.0.1:${loopback}/callback?code=${code}`
+    console.log(`  → ${target}`)
+    response.writeHead(302, { location: target })
+    return response.end()
+  }
+
+  if (url.pathname === "/dashboard/api/auth/desktop/exchange" && request.method === "POST") {
+    const chunks = []
+    for await (const chunk of request) chunks.push(chunk)
+    const { code, verifier } = JSON.parse(Buffer.concat(chunks).toString() || "{}")
+    const pending = handoffs.get(code)
+    if (!pending) {
+      console.log("  ✗ unknown handoff code")
+      return send(response, 400, { error: "unknown handoff code" })
+    }
+    handoffs.delete(code)
+    if (createHash("sha256").update(verifier || "").digest("base64url") !== pending.challenge) {
+      console.log("  ✗ verifier does not match the challenge")
+      return send(response, 400, { error: "verifier mismatch" })
+    }
+    console.log("  ✓ verifier matched — handing back a session")
+    return send(response, 200, { session: pending.session, expires_in: 3600 })
+  }
+
+  const signedIn = (request.headers.cookie || "").includes("osw_session=")
+  if (!signedIn) {
+    if (url.pathname === "/dashboard/api/me") console.log("  ✗ /me without a session cookie")
+    return send(response, 401, { detail: "not authenticated" })
+  }
+  if (url.pathname === "/dashboard/api/me") {
+    console.log("  ✓ /me carried the session cookie — desktop login works")
+  }
+  send(response, 200, SIGNED_IN_ROUTES[url.pathname] ?? [])
+})
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`stub backend on http://127.0.0.1:${port}`)
+})

--- a/scripts/install_desktop.sh
+++ b/scripts/install_desktop.sh
@@ -6,9 +6,9 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 1
 fi
 
-for command in node corepack ditto; do
+for command in node pnpm ditto; do
   command -v "$command" >/dev/null || {
-    echo "Missing $command. Install Node.js 22, then try again." >&2
+    echo "Missing $command. Install Node.js and pnpm, then try again." >&2
     exit 1
   }
 done
@@ -16,9 +16,9 @@ done
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-corepack pnpm install --frozen-lockfile
+pnpm install --frozen-lockfile
 rm -rf desktop/dist
-corepack pnpm --dir desktop run pack
+pnpm --dir desktop run pack
 
 apps=(desktop/dist/mac*/"Open SWE.app")
 if [[ ${#apps[@]} -ne 1 || ! -d "${apps[0]}" ]]; then

--- a/scripts/install_desktop.sh
+++ b/scripts/install_desktop.sh
@@ -6,19 +6,29 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 1
 fi
 
-for command in node pnpm ditto; do
+for command in node ditto; do
   command -v "$command" >/dev/null || {
-    echo "Missing $command. Install Node.js and pnpm, then try again." >&2
+    echo "Missing $command. Install Node.js, then try again." >&2
     exit 1
   }
 done
 
+# Node 25 dropped the bundled corepack shim, so neither launcher is guaranteed.
+if command -v pnpm >/dev/null; then
+  pnpm=(pnpm)
+elif command -v corepack >/dev/null; then
+  pnpm=(corepack pnpm)
+else
+  echo "Missing pnpm. Install it with 'npm install -g pnpm', then try again." >&2
+  exit 1
+fi
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-pnpm install --frozen-lockfile
+"${pnpm[@]}" install --frozen-lockfile
 rm -rf desktop/dist
-pnpm --dir desktop run pack
+"${pnpm[@]}" --dir desktop run pack
 
 apps=(desktop/dist/mac*/"Open SWE.app")
 if [[ ${#apps[@]} -ne 1 || ! -d "${apps[0]}" ]]; then

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -198,16 +198,9 @@ def test_auth_callback_cross_origin_redirect(monkeypatch) -> None:
         assert not callback_response.headers["location"].startswith("http://localhost:2024")
 
 
-DESKTOP_PREVIEW_HOST = "https://preview.example"
-# Mirrors desktopLoginUrl in desktop/src/config.cjs; keep both in step.
-DESKTOP_LOGIN_PARAMS = {"desktop": "true", "desktop_handoff": "", "desktop_port": 51234}
-
-
 def _desktop_login_env(monkeypatch) -> None:
-    # Deliberately unequal: the desktop app can point at any deployment, so a
-    # test that sets these to the same host cannot tell which one wins.
-    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://production.example")
-    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://production.example")
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://dashboard.example")
     monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret")
     monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "client-id")
 
@@ -244,16 +237,19 @@ def test_desktop_login_hands_the_session_back_over_loopback(monkeypatch) -> None
 
     app = FastAPI()
     app.include_router(routes.router)
-    with TestClient(app, base_url=DESKTOP_PREVIEW_HOST) as client:
+    # Not the same host as DASHBOARD_API_BASE_URL: browser login only works when
+    # the callback lands back on the configured API origin, where the state
+    # cookie was set, and equal hosts here would hide a regression.
+    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
         login_response = client.get(
             "/dashboard/api/auth/login",
-            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": challenge},
+            params={"desktop_handoff": challenge, "desktop_port": 51234},
             follow_redirects=False,
         )
         authorize = parse_qs(urlparse(login_response.headers["location"]).query)
-        # GitHub must come back to the deployment the app targeted, not to
-        # whatever DASHBOARD_API_BASE_URL that deployment was configured with.
-        assert authorize["redirect_uri"] == [f"{DESKTOP_PREVIEW_HOST}/dashboard/api/auth/callback"]
+        assert authorize["redirect_uri"] == [
+            "https://dashboard.example/dashboard/api/auth/callback"
+        ]
         state = authorize["state"][0]
 
         callback_response = client.get(
@@ -288,64 +284,22 @@ def test_desktop_login_hands_the_session_back_over_loopback(monkeypatch) -> None
         assert forged.status_code == 400
 
 
-def test_desktop_login_callback_follows_the_forwarded_host(monkeypatch) -> None:
-    """A rewrite in front of the API replaces the Host the app dialled.
-
-    The browser starts the login on the proxy's host and keeps the state
-    cookie there, so the callback has to come back to that host and not to the
-    upstream one the request arrived with.
-    """
-    _desktop_login_env(monkeypatch)
-
-    app = FastAPI()
-    app.include_router(routes.router)
-    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
-        response = client.get(
-            "/dashboard/api/auth/login",
-            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "a" * 43},
-            headers={"x-forwarded-proto": "https", "x-forwarded-host": "preview.example"},
-            follow_redirects=False,
-        )
-
-    query = parse_qs(urlparse(response.headers["location"]).query)
-    assert query["redirect_uri"] == [f"{DESKTOP_PREVIEW_HOST}/dashboard/api/auth/callback"]
-
-
-def test_desktop_login_ignores_a_malformed_forwarded_host(monkeypatch) -> None:
-    _desktop_login_env(monkeypatch)
-
-    app = FastAPI()
-    app.include_router(routes.router)
-    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
-        response = client.get(
-            "/dashboard/api/auth/login",
-            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "a" * 43},
-            headers={"x-forwarded-host": "evil.example/path?x=1"},
-            follow_redirects=False,
-        )
-
-    query = parse_qs(urlparse(response.headers["location"]).query)
-    assert query["redirect_uri"] == [
-        "https://upstream.langgraph.example/dashboard/api/auth/callback"
-    ]
-
-
 def test_desktop_login_rejects_a_malformed_handoff_challenge(monkeypatch) -> None:
     _desktop_login_env(monkeypatch)
 
     app = FastAPI()
     app.include_router(routes.router)
-    with TestClient(app, base_url=DESKTOP_PREVIEW_HOST) as client:
+    with TestClient(app, base_url="https://dashboard.example") as client:
         response = client.get(
             "/dashboard/api/auth/login",
-            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "../evil"},
+            params={"desktop_handoff": "../evil", "desktop_port": 51234},
             follow_redirects=False,
         )
         assert response.status_code == 400
 
         out_of_range = client.get(
             "/dashboard/api/auth/login",
-            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "a" * 43, "desktop_port": 80},
+            params={"desktop_handoff": "a" * 43, "desktop_port": 80},
             follow_redirects=False,
         )
         assert out_of_range.status_code == 422

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -5,6 +5,7 @@ import hashlib
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+import jwt
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -303,3 +304,40 @@ def test_desktop_login_rejects_a_malformed_handoff_challenge(monkeypatch) -> Non
             follow_redirects=False,
         )
         assert out_of_range.status_code == 422
+
+
+def test_desktop_handoff_code_carries_no_session(monkeypatch) -> None:
+    """The handoff code rides in a URL the browser records and extensions can read.
+
+    A JWT is signed, not encrypted, so anything in its payload is readable
+    without the verifier — a session in there would make the PKCE check moot.
+    """
+    _desktop_login_env(monkeypatch)
+    verifier = "desktop-verifier"
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    )
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://dashboard.example") as client:
+        login_response = client.get(
+            "/dashboard/api/auth/login",
+            params={"desktop_handoff": challenge, "desktop_port": 51234},
+            follow_redirects=False,
+        )
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        callback_response = client.get(
+            "/dashboard/api/auth/callback",
+            params={"code": "oauth-code", "state": state},
+            follow_redirects=False,
+        )
+        location = urlparse(callback_response.headers["location"])
+        handoff = parse_qs(location.query)["code"][0]
+
+    payload = jwt.decode(handoff, "test-secret", algorithms=["HS256"])
+    assert "session" not in payload
+    assert not any(
+        isinstance(v, str) and v.count(".") == 2 and len(v) > 60 for v in payload.values()
+    ), f"handoff payload looks like it embeds a token: {payload}"
+    assert payload["sub"] == "alice"

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -288,6 +288,48 @@ def test_desktop_login_hands_the_session_back_over_loopback(monkeypatch) -> None
         assert forged.status_code == 400
 
 
+def test_desktop_login_callback_follows_the_forwarded_host(monkeypatch) -> None:
+    """A rewrite in front of the API replaces the Host the app dialled.
+
+    The browser starts the login on the proxy's host and keeps the state
+    cookie there, so the callback has to come back to that host and not to the
+    upstream one the request arrived with.
+    """
+    _desktop_login_env(monkeypatch)
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
+        response = client.get(
+            "/dashboard/api/auth/login",
+            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "a" * 43},
+            headers={"x-forwarded-proto": "https", "x-forwarded-host": "preview.example"},
+            follow_redirects=False,
+        )
+
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["redirect_uri"] == [f"{DESKTOP_PREVIEW_HOST}/dashboard/api/auth/callback"]
+
+
+def test_desktop_login_ignores_a_malformed_forwarded_host(monkeypatch) -> None:
+    _desktop_login_env(monkeypatch)
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
+        response = client.get(
+            "/dashboard/api/auth/login",
+            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "a" * 43},
+            headers={"x-forwarded-host": "evil.example/path?x=1"},
+            follow_redirects=False,
+        )
+
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["redirect_uri"] == [
+        "https://upstream.langgraph.example/dashboard/api/auth/callback"
+    ]
+
+
 def test_desktop_login_rejects_a_malformed_handoff_challenge(monkeypatch) -> None:
     _desktop_login_env(monkeypatch)
 

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -198,9 +198,16 @@ def test_auth_callback_cross_origin_redirect(monkeypatch) -> None:
         assert not callback_response.headers["location"].startswith("http://localhost:2024")
 
 
+DESKTOP_PREVIEW_HOST = "https://preview.example"
+# Mirrors desktopLoginUrl in desktop/src/config.cjs; keep both in step.
+DESKTOP_LOGIN_PARAMS = {"desktop": "true", "desktop_handoff": "", "desktop_port": 51234}
+
+
 def _desktop_login_env(monkeypatch) -> None:
-    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
-    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://dashboard.example")
+    # Deliberately unequal: the desktop app can point at any deployment, so a
+    # test that sets these to the same host cannot tell which one wins.
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://production.example")
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://production.example")
     monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret")
     monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "client-id")
 
@@ -237,13 +244,17 @@ def test_desktop_login_hands_the_session_back_over_loopback(monkeypatch) -> None
 
     app = FastAPI()
     app.include_router(routes.router)
-    with TestClient(app, base_url="https://dashboard.example") as client:
+    with TestClient(app, base_url=DESKTOP_PREVIEW_HOST) as client:
         login_response = client.get(
             "/dashboard/api/auth/login",
-            params={"desktop_handoff": challenge, "desktop_port": 51234},
+            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": challenge},
             follow_redirects=False,
         )
-        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        authorize = parse_qs(urlparse(login_response.headers["location"]).query)
+        # GitHub must come back to the deployment the app targeted, not to
+        # whatever DASHBOARD_API_BASE_URL that deployment was configured with.
+        assert authorize["redirect_uri"] == [f"{DESKTOP_PREVIEW_HOST}/dashboard/api/auth/callback"]
+        state = authorize["state"][0]
 
         callback_response = client.get(
             "/dashboard/api/auth/callback",
@@ -282,17 +293,17 @@ def test_desktop_login_rejects_a_malformed_handoff_challenge(monkeypatch) -> Non
 
     app = FastAPI()
     app.include_router(routes.router)
-    with TestClient(app, base_url="https://dashboard.example") as client:
+    with TestClient(app, base_url=DESKTOP_PREVIEW_HOST) as client:
         response = client.get(
             "/dashboard/api/auth/login",
-            params={"desktop_handoff": "../evil", "desktop_port": 51234},
+            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "../evil"},
             follow_redirects=False,
         )
         assert response.status_code == 400
 
         out_of_range = client.get(
             "/dashboard/api/auth/login",
-            params={"desktop_handoff": "a" * 43, "desktop_port": 80},
+            params=DESKTOP_LOGIN_PARAMS | {"desktop_handoff": "a" * 43, "desktop_port": 80},
             follow_redirects=False,
         )
         assert out_of_range.status_code == 422

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -238,10 +238,10 @@ def test_desktop_login_hands_the_session_back_over_loopback(monkeypatch) -> None
 
     app = FastAPI()
     app.include_router(routes.router)
-    # Not the same host as DASHBOARD_API_BASE_URL: browser login only works when
-    # the callback lands back on the configured API origin, where the state
-    # cookie was set, and equal hosts here would hide a regression.
-    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
+    # Same host as DASHBOARD_API_BASE_URL, because that is the only arrangement a
+    # real browser can complete: it carries the state cookie from login to
+    # callback, and the cookie is bound to the origin that set it.
+    with TestClient(app, base_url="https://dashboard.example") as client:
         login_response = client.get(
             "/dashboard/api/auth/login",
             params={"desktop_handoff": challenge, "desktop_port": 51234},
@@ -341,3 +341,57 @@ def test_desktop_handoff_code_carries_no_session(monkeypatch) -> None:
         isinstance(v, str) and v.count(".") == 2 and len(v) > 60 for v in payload.values()
     ), f"handoff payload looks like it embeds a token: {payload}"
     assert payload["sub"] == "alice"
+
+
+def test_desktop_login_callback_follows_the_configured_api_origin(monkeypatch) -> None:
+    """`redirect_uri` comes from DASHBOARD_API_BASE_URL, not the request host.
+
+    Driven from a host that differs from the configured one so the two cannot
+    be confused; the companion test below covers what that costs when a
+    deployment sets the variable to an origin the browser never visits.
+    """
+    _desktop_login_env(monkeypatch)
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://upstream.langgraph.example") as client:
+        response = client.get(
+            "/dashboard/api/auth/login",
+            params={"desktop_handoff": "a" * 43, "desktop_port": 51234},
+            follow_redirects=False,
+        )
+
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["redirect_uri"] == ["https://dashboard.example/dashboard/api/auth/callback"]
+
+
+def test_auth_callback_rejects_a_callback_on_a_different_origin(monkeypatch) -> None:
+    """A callback that lands somewhere other than where login started fails.
+
+    The state nonce lives in a cookie bound to the origin that issued it, so a
+    deployment whose DASHBOARD_API_BASE_URL names a host the browser never
+    visited during login cannot complete sign-in — it dies here rather than
+    somewhere subtler.
+    """
+    _desktop_login_env(monkeypatch)
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://upstream.langgraph.example") as login_client:
+        login_response = login_client.get(
+            "/dashboard/api/auth/login",
+            params={"desktop_handoff": "a" * 43, "desktop_port": 51234},
+            follow_redirects=False,
+        )
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+
+    # A different origin: a fresh client holds none of the login's cookies.
+    with TestClient(app, base_url="https://dashboard.example") as callback_client:
+        callback_response = callback_client.get(
+            "/dashboard/api/auth/callback",
+            params={"code": "oauth-code", "state": state},
+            follow_redirects=False,
+        )
+
+    assert callback_response.status_code == 400
+    assert "oauth state mismatch" in callback_response.json()["detail"]

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -7,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agent.dashboard import routes
-from agent.dashboard.oauth import COOKIE_NAME, sanitize_redirect_to
+from agent.dashboard.oauth import COOKIE_NAME, decode_session, sanitize_redirect_to
 
 
 def test_sanitize_redirect_to_preserves_allowed_dashboard_target(monkeypatch) -> None:
@@ -194,3 +196,103 @@ def test_auth_callback_cross_origin_redirect(monkeypatch) -> None:
         assert callback_response.status_code == 302
         assert callback_response.headers["location"] == f"http://localhost:3000{target}"
         assert not callback_response.headers["location"].startswith("http://localhost:2024")
+
+
+def _desktop_login_env(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://dashboard.example")
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "client-id")
+
+    async def fake_exchange_code(code: str) -> dict[str, Any]:
+        return {"access_token": "gho_test"}
+
+    async def fake_fetch_github_user(access_token: str) -> tuple[dict[str, Any], str | None]:
+        return {"login": "alice", "avatar_url": None}, "alice@example.com"
+
+    async def fake_enforce_org_login_gate(login: str) -> None:
+        pass
+
+    async def fake_upsert_access_token_from_github_response(
+        login: str, email: str, data: dict[str, Any]
+    ) -> None:
+        pass
+
+    monkeypatch.setattr(routes, "exchange_code", fake_exchange_code)
+    monkeypatch.setattr(routes, "fetch_github_user", fake_fetch_github_user)
+    monkeypatch.setattr(routes, "enforce_org_login_gate", fake_enforce_org_login_gate)
+    monkeypatch.setattr(
+        routes,
+        "upsert_access_token_from_github_response",
+        fake_upsert_access_token_from_github_response,
+    )
+
+
+def test_desktop_login_hands_the_session_back_over_loopback(monkeypatch) -> None:
+    _desktop_login_env(monkeypatch)
+    verifier = "desktop-verifier"
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    )
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://dashboard.example") as client:
+        login_response = client.get(
+            "/dashboard/api/auth/login",
+            params={"desktop_handoff": challenge, "desktop_port": 51234},
+            follow_redirects=False,
+        )
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+
+        callback_response = client.get(
+            "/dashboard/api/auth/callback",
+            params={"code": "oauth-code", "state": state},
+            follow_redirects=False,
+        )
+        assert callback_response.status_code == 302
+        location = urlparse(callback_response.headers["location"])
+        assert (location.scheme, location.netloc, location.path) == (
+            "http",
+            "127.0.0.1:51234",
+            "/callback",
+        )
+        # The browser is only a courier here — it must not keep a session.
+        assert not callback_response.cookies.get(COOKIE_NAME)
+
+        handoff = parse_qs(location.query)["code"][0]
+        exchange = client.post(
+            "/dashboard/api/auth/desktop/exchange",
+            json={"code": handoff, "verifier": verifier},
+            headers={"origin": "open-swe://app"},
+        )
+        assert exchange.status_code == 200
+        assert decode_session(exchange.json()["session"])["sub"] == "alice"
+
+        forged = client.post(
+            "/dashboard/api/auth/desktop/exchange",
+            json={"code": handoff, "verifier": "wrong-verifier"},
+            headers={"origin": "open-swe://app"},
+        )
+        assert forged.status_code == 400
+
+
+def test_desktop_login_rejects_a_malformed_handoff_challenge(monkeypatch) -> None:
+    _desktop_login_env(monkeypatch)
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    with TestClient(app, base_url="https://dashboard.example") as client:
+        response = client.get(
+            "/dashboard/api/auth/login",
+            params={"desktop_handoff": "../evil", "desktop_port": 51234},
+            follow_redirects=False,
+        )
+        assert response.status_code == 400
+
+        out_of_range = client.get(
+            "/dashboard/api/auth/login",
+            params={"desktop_handoff": "a" * 43, "desktop_port": 80},
+            follow_redirects=False,
+        )
+        assert out_of_range.status_code == 422

--- a/tests/e2e/local_desktop_login.py
+++ b/tests/e2e/local_desktop_login.py
@@ -1,0 +1,90 @@
+"""Real dashboard login against a fake GitHub, for testing desktop sign-in locally.
+
+Runs the actual `/auth/login`, `/auth/callback`, handoff and exchange code —
+only GitHub itself is faked, so the loopback flow is exercised end to end.
+
+    uv run python tests/e2e/local_desktop_login.py
+
+Then point the desktop app at http://127.0.0.1:8765 (Open SWE -> Backend URL...)
+and sign in. Endpoints other than /auth/* and /me need a real backend and will
+error; login is what this harness covers.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import quote
+
+PORT = int(os.environ.get("PORT", "8765"))
+BASE_URL = f"http://127.0.0.1:{PORT}"
+os.environ.setdefault("DASHBOARD_JWT_SECRET", "local-desktop-login-secret")
+os.environ.setdefault("GITHUB_APP_CLIENT_ID", "local-client-id")
+os.environ.setdefault("GITHUB_APP_CLIENT_SECRET", "local-client-secret")
+os.environ.setdefault("DASHBOARD_BASE_URL", BASE_URL)
+os.environ.setdefault("DASHBOARD_API_BASE_URL", BASE_URL)
+os.environ.setdefault("DASHBOARD_ALLOWED_ORIGINS", BASE_URL)
+os.environ.setdefault("ALLOWED_GITHUB_ORGS", "")
+
+import uvicorn  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.responses import HTMLResponse, RedirectResponse  # noqa: E402
+
+from agent.dashboard import routes  # noqa: E402
+
+LOGIN = os.environ.get("FAKE_GITHUB_LOGIN", "local-tester")
+EMAIL = os.environ.get("FAKE_GITHUB_EMAIL", "local-tester@example.com")
+
+routes.GITHUB_AUTHORIZE_URL = f"{BASE_URL}/fake-gh/login/oauth/authorize"
+
+
+async def fake_exchange_code(code: str) -> dict[str, Any]:
+    return {"access_token": "gho_local", "token_type": "bearer"}
+
+
+async def fake_fetch_github_user(access_token: str) -> tuple[dict[str, Any], str | None]:
+    return {"login": LOGIN, "avatar_url": None}, EMAIL
+
+
+async def fake_enforce_org_login_gate(login: str) -> None:
+    return None
+
+
+async def fake_upsert(login: str, email: str, data: dict[str, Any]) -> None:
+    return None
+
+
+routes.exchange_code = fake_exchange_code
+routes.fetch_github_user = fake_fetch_github_user
+routes.enforce_org_login_gate = fake_enforce_org_login_gate
+routes.upsert_access_token_from_github_response = fake_upsert
+
+app = FastAPI()
+app.include_router(routes.router)
+
+
+@app.get("/fake-gh/login/oauth/authorize")
+async def fake_github_authorize(redirect_uri: str, state: str, client_id: str = "") -> HTMLResponse:
+    """Stand-in for GitHub's consent screen."""
+    target = f"{redirect_uri}?code=fake-oauth-code&state={quote(state, safe='')}"
+    return HTMLResponse(
+        f"""<!doctype html><meta charset=utf-8><title>Fake GitHub</title>
+        <body style="font:16px system-ui;max-width:30rem;margin:4rem auto;text-align:center">
+        <h1 style="font-size:1.1rem">Authorize Open SWE</h1>
+        <p style="opacity:.7">Signing in as <b>{LOGIN}</b> — this is a local fake, not GitHub.</p>
+        <p><a href="{target}"
+              style="display:inline-block;padding:.6rem 1rem;border:1px solid;border-radius:.4rem">
+           Authorize</a></p>
+        </body>"""
+    )
+
+
+@app.get("/")
+async def index() -> RedirectResponse:
+    return RedirectResponse("/dashboard/api/me")
+
+
+if __name__ == "__main__":
+    print(f"\n  Fake-GitHub login harness on {BASE_URL}")
+    print(f"  Point the desktop app at {BASE_URL} and sign in.\n")
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="info")

--- a/tests/e2e/local_desktop_login.py
+++ b/tests/e2e/local_desktop_login.py
@@ -13,6 +13,7 @@ error; login is what this harness covers.
 from __future__ import annotations
 
 import os
+from html import escape
 from typing import Any
 from urllib.parse import quote
 
@@ -27,7 +28,7 @@ os.environ.setdefault("DASHBOARD_ALLOWED_ORIGINS", BASE_URL)
 os.environ.setdefault("ALLOWED_GITHUB_ORGS", "")
 
 import uvicorn  # noqa: E402
-from fastapi import FastAPI  # noqa: E402
+from fastapi import FastAPI, HTTPException  # noqa: E402
 from fastapi.responses import HTMLResponse, RedirectResponse  # noqa: E402
 
 from agent.dashboard import routes  # noqa: E402
@@ -66,12 +67,17 @@ app.include_router(routes.router)
 @app.get("/fake-gh/login/oauth/authorize")
 async def fake_github_authorize(redirect_uri: str, state: str, client_id: str = "") -> HTMLResponse:
     """Stand-in for GitHub's consent screen."""
-    target = f"{redirect_uri}?code=fake-oauth-code&state={quote(state, safe='')}"
+    # Both values arrive in the query string, so pin the target to this
+    # harness's own callback and escape what reaches the page.
+    callback = f"{BASE_URL}/dashboard/api/auth/callback"
+    if redirect_uri != callback:
+        raise HTTPException(400, "unexpected redirect_uri")
+    target = escape(f"{callback}?code=fake-oauth-code&state={quote(state, safe='')}", quote=True)
     return HTMLResponse(
         f"""<!doctype html><meta charset=utf-8><title>Fake GitHub</title>
         <body style="font:16px system-ui;max-width:30rem;margin:4rem auto;text-align:center">
         <h1 style="font-size:1.1rem">Authorize Open SWE</h1>
-        <p style="opacity:.7">Signing in as <b>{LOGIN}</b> — this is a local fake, not GitHub.</p>
+        <p style="opacity:.7">Signing in as <b>{escape(LOGIN)}</b> — a local fake, not GitHub.</p>
         <p><a href="{target}"
               style="display:inline-block;padding:.6rem 1rem;border:1px solid;border-radius:.4rem">
            Authorize</a></p>


### PR DESCRIPTION
Two desktop changes.

## Sign in through the user's own browser

Desktop sign-in opened GitHub inside an embedded Electron window. This moves it to the user's default browser using the RFC 8252 loopback flow.

The app binds an ephemeral `127.0.0.1` listener, opens the login URL with `shell.openExternal`, and the backend redirects the finished login back to that port. Because the login now runs in a browser the app doesn't control, the session belongs to the app rather than to that browser: `/auth/callback` hands back a PKCE-bound handoff code instead of setting a cookie, and the app redeems it at `POST /auth/desktop/exchange` with the verifier — which never leaves the process — before storing the session itself. Only the port number crosses the wire; the loopback host and path are built server-side, so it can't be steered into an open redirect.

Loopback rather than an `open-swe://` deep link: no OS scheme registration, no "allow this page to open Open SWE?" prompt, no collision between the dev and packaged builds, and no other installed app can claim the callback.

Also drops the embedded auth window and, with it, the proxy carve-out that let a `github.com` page issue callback requests through the app's protocol handler.

## Install without corepack

`make install-desktop` fails on current Node with `Missing corepack. Install Node.js 22, then try again.` — Node 25 dropped the bundled corepack shim, so the check fails even when pnpm is installed and on PATH. Nothing in the repo pins Node (no `engines`, no `.nvmrc`), and corepack's only job here was launching pnpm. Call `pnpm` directly; the `packageManager` pin still selects the version.

## Test Plan

- [x] `desktop`: 40 unit tests pass, covering the loopback listener (code delivery, empty callback, cancellation, fresh port/verifier per login) and the new login-URL helpers
- [x] `tests/dashboard/test_dashboard_oauth_redirect.py`: end-to-end handoff — login carries the challenge and port, callback redirects to loopback and sets no browser cookie, exchange returns the session, a wrong verifier is rejected, malformed challenge/port are rejected
- [x] Full suite green: 1754 Python tests, `ruff check`, `ruff format --diff`, `basedpyright`
- [x] Manual end-to-end against `desktop/test/manual/stub-backend.cjs`: clicking sign-in opened the default browser, the browser handed the code to the app's loopback listener, the exchange succeeded, and the app reloaded authenticated (`/me` carried the session cookie)
- [x] `./scripts/install_desktop.sh` on Node 26 with pnpm 11.18.0: built and installed `Open SWE.app` to `/Applications`