### PR TITLE
fix(desktop): install without corepack

### DIFF
--- a/scripts/install_desktop.sh
+++ b/scripts/install_desktop.sh
@@ -6,9 +6,9 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 1
 fi
 
-for command in node corepack ditto; do
+for command in node pnpm ditto; do
   command -v "$command" >/dev/null || {
-    echo "Missing $command. Install Node.js 22, then try again." >&2
+    echo "Missing $command. Install Node.js and pnpm, then try again." >&2
     exit 1
   }
 done
@@ -16,9 +16,9 @@ done
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-corepack pnpm install --frozen-lockfile
+pnpm install --frozen-lockfile
 rm -rf desktop/dist
-corepack pnpm --dir desktop run pack
+pnpm --dir desktop run pack
 
 apps=(desktop/dist/mac*/"Open SWE.app")
 if [[ ${#apps[@]} -ne 1 || ! -d "${apps[0]}" ]]; then


### PR DESCRIPTION
`make install-desktop` fails on current Node with `Missing corepack. Install Node.js 22, then try again.` — Node 25 dropped the bundled corepack shim, so the check fails even when pnpm is installed and on PATH.

Nothing in the repo pins Node (no `engines`, no `.nvmrc`), and corepack's only job here was launching pnpm. Call `pnpm` directly; the `packageManager` pin still selects the version.

## Test Plan

- [x] `./scripts/install_desktop.sh` on Node 26 with pnpm 11.18.0: built and installed `Open SWE.app` to `/Applications`