### PR TITLE
fix(ui): allow the prod branch to deploy the production dashboard

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -6,7 +6,8 @@
     "deploymentEnabled": {
       "**": false,
       "main": true,
-      "preview": true
+      "preview": true,
+      "prod": true
     }
   }
 }


### PR DESCRIPTION
The production dashboard has been serving a days-old bundle while its backend deployed normally — new API endpoints answer, but the UI that calls them isn't there. Adding `prod` to the deployment allowlist restores production builds.

`ui/vercel.json` gained a `git.deploymentEnabled` allowlist in #1946:

```json
{ "**": false, "main": true, "preview": true }
```

The intent was to stop feature branches (`user/slug`) from building the dashboard on either project, and that part works. But the production project builds from the **`prod`** branch — promoted from `main` daily by `promote_main_to_prod.yml`, as documented in `docs/PREVIEW_ENV.md` — and `prod` was not on the list, so every production build has been canceled since #1946 merged.

Evidence from the Vercel CLI:

- `langchain/open-swe` — the last 8 deployments are all `Canceled`, all `Environment: Preview`, from feature branches. **Zero Production deployments**; the project last updated 2 days ago.
- `langchain/open-swe-preview` — `Ready`, `Environment: Production`, one every few minutes. The `preview` branch is on the allowlist, so that project was never affected.

And the resulting split on production: `GET /dashboard/api/environments/options` (added by #1952) returns `{"environments":[],"default_slug":"default"}`, while all 9 JS bundles served by `openswe.vercel.app/agents` contain neither `environments/options` nor the Admin-toggle string from the same PR.

## Test Plan

- [x] `ui/vercel.json` parses and the allowlist reads `{"**": false, "main": true, "preview": true, "prod": true}`
- [x] Confirmed a `prod` branch exists on the remote and currently points at the same commit as `main`
- [x] Confirmed via `vercel ls open-swe` that recent production-project deployments are all `Canceled`, and via `vercel ls open-swe-preview` that the preview project is deploying normally
- [x] Feature branches remain blocked: the `**: false` rule is unchanged, and the canceled deployments above are branch builds it is meant to cancel

## Follow-up

A canceled build reports as a green check, which is why this went unnoticed for days. Making a skipped frontend build visibly distinct from a real one is worth doing separately — this PR is kept to the one-line unblock.
