### PR TITLE
fix(dashboard): keep thread-title generation out of the run's stream

### DIFF
--- a/agent/thread_title.py
+++ b/agent/thread_title.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -85,7 +86,10 @@ async def generate_and_store_thread_title(
             [
                 SystemMessage(content=_TITLE_SYSTEM_PROMPT),
                 HumanMessage(content=user_message),
-            ]
+            ],
+            # Empty callbacks, so this call cannot inherit the run's handlers and
+            # stream its tokens into the thread the user is watching.
+            config={"callbacks": [], "run_name": "thread-title"},
         )
     if not isinstance(result, _ThreadTitle):
         return
@@ -131,6 +135,10 @@ def schedule_thread_title_generation(
         finally:
             _inflight_thread_ids.discard(thread_id)
 
-    task = asyncio.get_running_loop().create_task(run())
+    # A fresh context, not the caller's: an inherited context carries LangGraph's
+    # stream writer, and this call's structured-output chunks would then be
+    # emitted into the run's message stream — rendering as a bogus assistant
+    # message and derailing the client's assembly of every later chunk.
+    task = asyncio.get_running_loop().create_task(run(), context=contextvars.Context())
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -1,22 +1,43 @@
 from __future__ import annotations
 
+import asyncio
+import contextvars
 from typing import Any, cast
 
 import pytest
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage
 
-from agent.thread_title import _ThreadTitle, generate_and_store_thread_title
+from agent.thread_title import (
+    _ThreadTitle,
+    generate_and_store_thread_title,
+    schedule_thread_title_generation,
+)
+
+# Stands in for LangGraph's stream writer, which travels in a contextvar. A title
+# call that sees a non-default value here is running inside the agent run, and
+# would stream its tokens into the thread the user is watching.
+_RUN_STREAM: contextvars.ContextVar[str] = contextvars.ContextVar("run_stream", default="none")
 
 
 class _StructuredModel:
-    async def ainvoke(self, messages: list[Any]) -> _ThreadTitle:
+    def __init__(self, recorder: dict[str, Any] | None = None) -> None:
+        self._recorder = recorder if recorder is not None else {}
+
+    async def ainvoke(self, messages: list[Any], config: Any = None, **_: Any) -> _ThreadTitle:
+        self._recorder["stream"] = _RUN_STREAM.get()
+        self._recorder["config"] = config
+        self._recorder["messages"] = messages
         return _ThreadTitle(title="Review thread title generation")
 
 
 class _Model:
+    def __init__(self, recorder: dict[str, Any] | None = None) -> None:
+        self._recorder = recorder if recorder is not None else {}
+
     def with_structured_output(self, schema: type[_ThreadTitle]) -> _StructuredModel:
         assert schema is _ThreadTitle
-        return _StructuredModel()
+        return _StructuredModel(self._recorder)
 
 
 class _Threads:
@@ -68,3 +89,93 @@ async def test_generate_and_store_thread_title_only_replaces_explicit_seed(
     )
 
     assert threads.metadata == expected
+
+
+@pytest.mark.asyncio
+async def test_title_generation_never_inherits_the_runs_context() -> None:
+    """The background task must not run inside the caller's context.
+
+    An inherited context carries the run's stream writer, so the structured
+    output is emitted into the run's message stream: it renders as a bogus
+    `{"title": ...}` assistant message and derails the client's assembly of every
+    chunk after it, freezing the transcript until the page is reloaded.
+    """
+    recorder: dict[str, Any] = {}
+    threads = _Threads(
+        {
+            "source": "dashboard",
+            "title": "please review title generation",
+            "title_seed": "please review title generation",
+        }
+    )
+    client = type("Client", (), {"threads": threads})()
+
+    token = _RUN_STREAM.set("agent-run-stream")
+    try:
+        schedule_thread_title_generation(
+            thread_id="thread-123",
+            messages=[HumanMessage(content="please review title generation")],
+            model=cast(BaseChatModel, _Model(recorder)),
+            client=client,
+        )
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if "stream" in recorder:
+                break
+    finally:
+        _RUN_STREAM.reset(token)
+
+    assert recorder["stream"] == "none"
+    assert threads.metadata["title"] == "Review thread title generation"
+
+
+@pytest.mark.asyncio
+async def test_title_generation_disables_inherited_callbacks() -> None:
+    """Belt and braces: callbacks bound to the model itself must not stream either."""
+    recorder: dict[str, Any] = {}
+    threads = _Threads(
+        {
+            "source": "dashboard",
+            "title": "please review title generation",
+            "title_seed": "please review title generation",
+        }
+    )
+    client = type("Client", (), {"threads": threads})()
+
+    await generate_and_store_thread_title(
+        thread_id="thread-123",
+        user_message="please review title generation",
+        model=cast(BaseChatModel, _Model(recorder)),
+        client=client,
+    )
+
+    assert recorder["config"]["callbacks"] == []
+
+
+@pytest.mark.asyncio
+async def test_title_generation_skips_threads_past_the_first_message() -> None:
+    """Only the opening message seeds a title; later turns leave it alone."""
+    recorder: dict[str, Any] = {}
+    threads = _Threads(
+        {
+            "source": "dashboard",
+            "title": "please review title generation",
+            "title_seed": "please review title generation",
+        }
+    )
+    client = type("Client", (), {"threads": threads})()
+
+    schedule_thread_title_generation(
+        thread_id="thread-123",
+        messages=[
+            HumanMessage(content="first"),
+            AIMessage(content="reply"),
+            HumanMessage(content="second"),
+        ],
+        model=cast(BaseChatModel, _Model(recorder)),
+        client=client,
+    )
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert recorder == {}


### PR DESCRIPTION
A dashboard thread stops rendering mid-run: tool calls and replies stop appearing, and the transcript only catches up when the page is reloaded. The agent is fine the whole time — the stream is broken, not the run.

`schedule_thread_title_generation` created its task with `asyncio.create_task` from inside the run, so the task inherited the caller's context — which carries LangGraph's stream writer. The title model's structured-output chunks were therefore emitted into the same `messages` stream the dashboard was assembling. Two consequences, both observed in production:

1. A `{"title":"…"}` bubble appears in the transcript. It is never persisted — the thread state has no such message — so it vanishes on reload.
2. Everything after that point stops rendering live. The client maps chunks to messages by id, and the foreign stream derails that assembly for the rest of the run.

Observed on `openswe.vercel.app` before this fix: the live transcript ended at four `Shell` clone calls followed by `{"title":"Set Up Default Environment"}`; after a reload, the same thread showed the work that had continued past it (`Read /workspace/langgraph-api/AGENTS.md`, then `make install` / `uv sync` across four repos).

The fix is at the scheduling site: run the task in a fresh `contextvars.Context()` so it cannot inherit the stream writer, and pass `config={"callbacks": []}` so a handler bound to the model itself cannot stream either.

## Test Plan

- [x] `test_title_generation_never_inherits_the_runs_context` — sets a contextvar standing in for the run's stream writer, schedules title generation, and asserts the model call sees the default value rather than the run's
- [x] `test_title_generation_disables_inherited_callbacks` — asserts the call passes `callbacks: []`
- [x] `test_title_generation_skips_threads_past_the_first_message` — only the opening message seeds a title
- [x] Confirmed both new assertions FAIL without the fix (`assert 'agent-run-stream' == 'none'`) and pass with it
- [x] `make test` — 1760 passed
- [x] `make lint`, `make typecheck` — 0 errors
