### PR TITLE
test(e2e): drop the blanket 8s stall from the fake implement script

### DIFF
--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -39,7 +39,6 @@ from langchain_core.outputs import ChatGeneration, ChatResult
 # fresh shell rooted at the sandbox dir, so the clone+commit+push is bundled.
 _IMPLEMENT_SCRIPT = f"""
 set -e
-sleep 8
 rm -rf repo
 git clone "$E2E_REMOTE" repo
 cd repo
@@ -60,6 +59,7 @@ echo PUSHED_OK
 # agent was actually told (e.g. the environment section) rather than infer it.
 LAST_SYSTEM_PROMPT: dict[str, str] = {"text": ""}
 
+_BUSY_HOLD_RE = re.compile(r"E2E_BUSY_HOLD(?::(\d+(?:\.\d+)?))?")
 _PLAN_URL_RE = re.compile(r"https?://[^\s\"'<>)\]|]+/plan\b")
 _ATTRIBUTION_RE = re.compile(r"@([A-Za-z0-9-]+):")
 
@@ -475,8 +475,11 @@ class FakeScriptedChatModel(BaseChatModel):
 
         # Keep a run busy on demand so E2E can land follow-ups mid-run (exercising
         # the interrupt-debounce path). Only the triggering message carries the
-        # marker, and only the first model call of that run blocks.
-        if step_index == 0 and "E2E_BUSY_HOLD" in context.last_text:
-            time.sleep(float(os.environ.get("E2E_BUSY_HOLD_SECONDS", "10")))
+        # marker, and only the first model call of that run blocks. `E2E_BUSY_HOLD:<n>`
+        # overrides the window so a spec needing a short hold does not leave a run
+        # in flight for the specs that follow it.
+        hold = _BUSY_HOLD_RE.search(context.last_text) if step_index == 0 else None
+        if hold:
+            time.sleep(float(hold.group(1) or os.environ.get("E2E_BUSY_HOLD_SECONDS", "10")))
         step = script[step_index] if step_index < len(script) else SCRIPT_LIBRARY["followup"][0]
         return ChatResult(generations=[ChatGeneration(message=_render_step(step, messages))])

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -475,10 +475,12 @@ class FakeScriptedChatModel(BaseChatModel):
 
         # Keep a run busy on demand so E2E can land follow-ups mid-run (exercising
         # the interrupt-debounce path). Only the triggering message carries the
-        # marker, and only the first model call of that run blocks. `E2E_BUSY_HOLD:<n>`
-        # overrides the window so a spec needing a short hold does not leave a run
-        # in flight for the specs that follow it.
-        hold = _BUSY_HOLD_RE.search(context.last_text) if step_index == 0 else None
+        # marker. The block lands on the second model call so the Slack
+        # acknowledgement — and the web link a spec may need to click — is already
+        # out by the time the run stalls. `E2E_BUSY_HOLD:<n>` overrides the window
+        # so a spec needing a short hold does not leave a run in flight for the
+        # specs that follow it.
+        hold = _BUSY_HOLD_RE.search(context.last_text) if step_index == 1 else None
         if hold:
             time.sleep(float(hold.group(1) or os.environ.get("E2E_BUSY_HOLD_SECONDS", "10")))
         step = script[step_index] if step_index < len(script) else SCRIPT_LIBRARY["followup"][0]

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -38,13 +38,15 @@ async function setRepoPrivate(page: Page, value: boolean) {
   expect(res.ok()).toBeTruthy();
 }
 
+// E2E_BUSY_HOLD:8 makes the fake LLM hold the run open for 8s, so the thread is
+// still running by the time the browser lands on it.
 async function openRunningThreadViaSlackLink(page: Page) {
   await page.goto("/mock/slack");
   await page.locator("#reset").click();
   await expect(page.locator("#thread")).toContainText("No messages yet");
   await page
     .locator("#text")
-    .fill("<@U0BOT> please add a greet() helper and open a PR");
+    .fill("<@U0BOT> E2E_BUSY_HOLD:8 please add a greet() helper and open a PR");
   await page.locator("#send").click();
 
   const webLink = page.locator('.msg.bot a[href*="/agents/"]').first();


### PR DESCRIPTION
The fake LLM's `_IMPLEMENT_SCRIPT` opened with `sleep 8`, so every spec that sent a plain Slack request paid it — roughly 22 runs across the suite, ~3 minutes of the 5.8-minute Playwright job.

Only one spec actually needs the run held open: `openRunningThreadViaSlackLink` clicks the bot's "Open in Web" link and expects to land on a still-running thread. That helper now uses the `E2E_BUSY_HOLD` marker the other busy specs already use. The marker takes an optional window (`E2E_BUSY_HOLD:8`) so it holds for 8s instead of the 20s the debounce spec relies on — a longer hold would leave a run in flight for the specs that follow.

Everything else in the suite polls for the bot's replies, so removing the stall does not change what any assertion observes.

Locally the first five dashboard specs drop from 13.5s/11.9s/11.9s/11.5s/11.9s to 4.8s/3.0s/4.0s/2.7s/2.9s.

## Test Plan

- [x] Full `pnpm run test:e2e` suite locally
- [x] Playwright E2E job in CI