### PR TITLE
feat(ui): stop the running turn with Escape

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -107,6 +107,19 @@ async function waitForThreadIdle(page: Page, threadId: string) {
     .not.toBe("running");
 }
 
+async function waitForThreadNotBusy(page: Page, threadId: string) {
+  await expect
+    .poll(
+      async () => {
+        const res = await page.request.get(`/threads/${threadId}`);
+        if (!res.ok()) return "unknown";
+        return ((await res.json()) as { status?: string }).status ?? "unknown";
+      },
+      { timeout: 30_000, intervals: [500] },
+    )
+    .not.toBe("busy");
+}
+
 async function latestPrBody(page: Page): Promise<string> {
   const res = await page.request.get("/mock/github/data");
   expect(res.ok()).toBeTruthy();
@@ -258,6 +271,46 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect.poll(() => latestPrBody(page)).toContain("Slack thread");
   });
 
+  // The queued card is optimistic, so a regression shows up as a flash the DOM
+  // holds for only the length of one request — too short for a locator poll.
+  test("never flashes a queued card when no run is in progress", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page);
+    const threadId = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(threadId).not.toBe("");
+    await waitForThreadIdle(page, threadId);
+    // The dashboard's status can report a finished run before LangGraph drops
+    // the thread out of `busy`, and `busy` is the exact condition the queue
+    // endpoint accepts on. Wait for it, or the send legitimately queues.
+    await waitForThreadNotBusy(page, threadId);
+
+    await page.evaluate(() => {
+      const seen = { value: false };
+      (window as unknown as Record<string, unknown>).__queuedCardSeen = seen;
+      new MutationObserver(() => {
+        if (document.querySelector('[data-testid="queued-message"]'))
+          seen.value = true;
+      }).observe(document.body, { childList: true, subtree: true });
+    });
+
+    await typeIntoComposer(page, "Can you also add a docstring?");
+    await expect(
+      page.getByText(/anything else you'd like changed/),
+    ).toBeVisible();
+
+    const flashed = await page.evaluate(
+      () =>
+        (
+          (window as unknown as Record<string, unknown>).__queuedCardSeen as {
+            value: boolean;
+          }
+        ).value,
+    );
+    expect(flashed).toBe(false);
+  });
+
   test("keeps follow-ups visible while queued during a running agent", async ({
     page,
   }, testInfo) => {
@@ -326,6 +379,49 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       );
     });
     await stopButton.click();
+
+    const cancelResponse = await cancelResponsePromise;
+    expect(cancelResponse.ok()).toBeTruthy();
+    await expect(cancelResponse.json()).resolves.toMatchObject({
+      id: threadId,
+      status: "interrupted",
+    });
+    await expect(
+      page.getByRole("button", { name: "Send message" }),
+    ).toBeVisible();
+    await expect(stopButton).toHaveCount(0);
+  });
+
+  // Escape has to survive the composer's own editor, which registers a Lexical
+  // escape command of its own — hence pressing it with the editor focused.
+  test("stops a run with Escape from inside the composer", async ({ page }) => {
+    await loginAs(page, SAME_USER);
+    await page.goto("/mock/slack");
+    await page.locator("#reset").click();
+
+    const send = await page.request.post("/mock/slack/send", {
+      data: {
+        text: "<@U0BOT> E2E_BUSY_HOLD please add a greet() helper and open a PR",
+      },
+    });
+    expect(send.ok()).toBeTruthy();
+    const { thread_id: threadId } = (await send.json()) as {
+      thread_id: string;
+    };
+
+    await page.goto(`/agents/${threadId}`);
+    const stopButton = page.getByRole("button", { name: "Stop run" });
+    await expect(stopButton).toBeVisible();
+
+    const cancelResponsePromise = page.waitForResponse((response) => {
+      const path = new URL(response.url()).pathname;
+      return (
+        response.request().method() === "POST" &&
+        path === `/dashboard/api/threads/${threadId}/cancel`
+      );
+    });
+    await page.getByTestId("composer-editor").click();
+    await page.keyboard.press("Escape");
 
     const cancelResponse = await cancelResponsePromise;
     expect(cancelResponse.ok()).toBeTruthy();

--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -89,6 +89,33 @@ describe("ChatComposer stop button", () => {
     expect(screen.getByRole("button", { name: "Stop run" })).toBeTruthy()
   })
 
+  it("stops the run on Escape", async () => {
+    renderComposer(true)
+
+    fireEvent.keyDown(document.body, { key: "Escape" })
+
+    await waitFor(() => expect(cancelThread).toHaveBeenCalledWith("thread-1"))
+  })
+
+  it("leaves Escape to an open overlay", () => {
+    renderComposer(true)
+    const dialog = document.createElement("div")
+    dialog.setAttribute("role", "dialog")
+    document.body.appendChild(dialog)
+
+    fireEvent.keyDown(dialog, { key: "Escape" })
+
+    expect(cancelThread).not.toHaveBeenCalled()
+  })
+
+  it("ignores Escape when no run is live", () => {
+    renderComposer(false)
+
+    fireEvent.keyDown(document.body, { key: "Escape" })
+
+    expect(cancelThread).not.toHaveBeenCalled()
+  })
+
   it("shows the send button when no run is live", () => {
     renderComposer(false)
 

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -745,6 +745,7 @@ export const ChatComposer = memo(function ChatComposer({
             canSubmit={canSubmit}
             onSubmit={() => void handleSubmit()}
             onStop={onStop}
+            stopOnEscape={!menuOpen && !modelPickerOpen}
             submitting={isSubmitting}
           />
         </div>

--- a/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { LoaderCircle } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
@@ -25,6 +25,37 @@ export interface ComposerPrimaryActionsProps {
   activeRun?: ActiveRun
   /** Direct stop handler for non-LangGraph runtimes such as desktop ACP. */
   onStop?: () => void | Promise<void>
+  /** Set false while the composer owns Escape (an open command menu or model picker). */
+  stopOnEscape?: boolean
+}
+
+function useEscapeToStop(enabled: boolean, onStop: () => void) {
+  const onStopRef = useRef(onStop)
+  useEffect(() => {
+    onStopRef.current = onStop
+  })
+
+  useEffect(() => {
+    if (!enabled) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented || event.isComposing)
+        return
+      // Escape belongs to whatever overlay is open and focused; only a bare
+      // Escape on the page reaches the run.
+      const target = event.target
+      if (
+        target instanceof Element &&
+        target.closest(
+          '[role="dialog"],[role="alertdialog"],[role="menu"],[role="listbox"]'
+        )
+      )
+        return
+      event.preventDefault()
+      onStopRef.current()
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [enabled])
 }
 
 function SendIcon() {
@@ -75,11 +106,15 @@ function SendButton({
 
 function StopButton({
   disabled,
+  stopOnEscape = true,
   onStop,
 }: {
   disabled: boolean
+  stopOnEscape?: boolean
   onStop: () => void
 }) {
+  useEscapeToStop(stopOnEscape && !disabled, onStop)
+
   return (
     <button
       aria-label="Stop run"
@@ -90,7 +125,7 @@ function StopButton({
       )}
       disabled={disabled}
       onClick={onStop}
-      title="Stop run"
+      title="Stop run (Esc)"
       type="button"
     >
       {disabled ? (
@@ -152,7 +187,13 @@ function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
   if (!stream.isLoading && !props.activeRun?.running)
     return <SendButton {...props} />
 
-  return <StopButton disabled={stopping} onStop={() => void handleStop()} />
+  return (
+    <StopButton
+      disabled={stopping}
+      onStop={() => void handleStop()}
+      stopOnEscape={props.stopOnEscape}
+    />
+  )
 }
 
 function DirectPrimaryActions(props: ComposerPrimaryActionsProps) {
@@ -167,7 +208,13 @@ function DirectPrimaryActions(props: ComposerPrimaryActionsProps) {
       setStopping(false)
     }
   }
-  return <StopButton disabled={stopping} onStop={() => void stop()} />
+  return (
+    <StopButton
+      disabled={stopping}
+      onStop={() => void stop()}
+      stopOnEscape={props.stopOnEscape}
+    />
+  )
 }
 
 /** The composer's send button, which becomes a stop button while a run is live. */

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useSubmitAgentMessage } from "./useSubmitAgentMessage"
+import type { AgentThread } from "@/features/agents/lib/types"
+import { AgentsApiError } from "@/features/agents/lib/api"
+import { agentThreadKeys } from "@/features/agents/lib/queries"
+
+const stream = { isLoading: false, submit: vi.fn(async () => undefined) }
+
+vi.mock("@langchain/react", () => ({
+  useStreamContext: () => stream,
+}))
+
+const queueMessage = vi.fn()
+
+vi.mock("@/features/agents/lib/api", () => ({
+  agentsApi: { queueMessage: () => queueMessage() },
+  AgentsApiError: class extends Error {
+    constructor(
+      public readonly status: number,
+      message: string
+    ) {
+      super(message)
+    }
+  },
+}))
+
+const THREAD_ID = "thread-1"
+
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+  client.setQueryData(agentThreadKeys.detail(THREAD_ID), {
+    id: THREAD_ID,
+    status: "idle",
+    messages: [],
+  } as unknown as AgentThread)
+  const queuedCounts: Array<number> = []
+  client.getQueryCache().subscribe(() => {
+    const thread = client.getQueryData<AgentThread>(
+      agentThreadKeys.detail(THREAD_ID)
+    )
+    queuedCounts.push(thread?.queuedMessages?.length ?? 0)
+  })
+  const { result } = renderHook(() => useSubmitAgentMessage(THREAD_ID), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  })
+  return { client, queuedCounts, result }
+}
+
+function queuedMessages(client: QueryClient) {
+  return client.getQueryData<AgentThread>(agentThreadKeys.detail(THREAD_ID))
+    ?.queuedMessages
+}
+
+beforeEach(() => {
+  stream.isLoading = false
+  stream.submit.mockClear()
+  queueMessage.mockReset()
+  queueMessage.mockResolvedValue(undefined)
+})
+
+describe("useSubmitAgentMessage", () => {
+  it("never flashes a queued bubble when the send starts a new run", async () => {
+    queueMessage.mockRejectedValueOnce(new AgentsApiError(409, "no active run"))
+    const { queuedCounts, result } = setup()
+
+    await result.current.mutateAsync({ content: "hi", images: [] })
+
+    await waitFor(() => expect(stream.submit).toHaveBeenCalled())
+    expect(queuedCounts.every((count) => count === 0)).toBe(true)
+  })
+
+  it("shows the queued bubble once a run this client never joined accepts it", async () => {
+    const { client, result } = setup()
+
+    await result.current.mutateAsync({ content: "hi", images: [] })
+
+    expect(queuedMessages(client)).toHaveLength(1)
+    expect(stream.submit).not.toHaveBeenCalled()
+  })
+
+  it("shows the queued bubble immediately while this client streams", async () => {
+    stream.isLoading = true
+    let acceptQueue: () => void = () => {}
+    queueMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          acceptQueue = () => resolve(undefined)
+        })
+    )
+    const { client, result } = setup()
+
+    const pending = result.current.mutateAsync({ content: "hi", images: [] })
+    await waitFor(() => expect(queuedMessages(client)).toHaveLength(1))
+    acceptQueue()
+    await pending
+  })
+})

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
@@ -76,14 +76,20 @@ export function useSubmitAgentMessage(threadId: string) {
 
   return useMutation({
     mutationFn: async (vars: SendAgentMessageVariables) => {
-      const queue = async () => {
+      // `optimistic` is only safe when a run is known to be in flight. Idle
+      // sends still probe `/messages` first (a run may have started elsewhere),
+      // and that probe answers 409 — showing the bubble up front would flash a
+      // "Queued next" card for the length of the round trip.
+      const queue = async (optimistic: boolean) => {
         const queuedAt = Date.now()
         const queuedId = `queued-${queuedAt}-${Math.random().toString(36).slice(2)}`
-        queryClient.setQueryData<AgentThread>(
-          agentThreadKeys.detail(threadId),
-          (prev) =>
-            prev ? appendQueuedMessage(prev, vars, queuedId, queuedAt) : prev
-        )
+        const showQueued = () =>
+          queryClient.setQueryData<AgentThread>(
+            agentThreadKeys.detail(threadId),
+            (prev) =>
+              prev ? appendQueuedMessage(prev, vars, queuedId, queuedAt) : prev
+          )
+        if (optimistic) showQueued()
         try {
           await agentsApi.queueMessage(threadId, {
             content: vars.content,
@@ -93,21 +99,24 @@ export function useSubmitAgentMessage(threadId: string) {
             plan_mode: vars.plan_mode,
           })
         } catch (error) {
-          queryClient.setQueryData<AgentThread>(
-            agentThreadKeys.detail(threadId),
-            (prev) => (prev ? removeQueuedMessage(prev, queuedId) : prev)
-          )
+          if (optimistic) {
+            queryClient.setQueryData<AgentThread>(
+              agentThreadKeys.detail(threadId),
+              (prev) => (prev ? removeQueuedMessage(prev, queuedId) : prev)
+            )
+          }
           throw error
         }
+        if (!optimistic) showQueued()
       }
 
       if (stream.isLoading) {
-        await queue()
+        await queue(true)
         return
       }
 
       try {
-        await queue()
+        await queue(false)
         return
       } catch (error) {
         if (!(error instanceof AgentsApiError) || error.status !== 409) {


### PR DESCRIPTION
Escape now cancels the live run from anywhere on the page, exactly as clicking the composer's stop button does — same handler, same spinner. The listener only exists while a run is live, and it stands down when:

- an overlay owns the key (target inside `role=dialog/alertdialog/menu/listbox`, or `defaultPrevented`)
- the composer's `/`-command menu or model picker is open
- a stop is already in flight

Works in both the LangGraph stream path and the desktop ACP path.

Separately, this fixes a "Queued next" card flashing on sends with no generation in progress. Every send POSTs `/messages` first (a run may have started from Slack/Linear/GitHub), and the optimistic card was painted *before* that request. On an idle thread the server answers 409 and the card is removed — visible for the length of the round trip. The optimistic paint now happens only when a run is genuinely in flight; the idle probe paints only if the server actually accepts the queue.

## Test Plan

- [x] `pnpm vitest run src/features/agents/components/composer/ChatComposer.test.tsx src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx` — new coverage for Escape (stops, defers to an open overlay, ignored when idle) and for the queue paint timing
- [x] Manually: sent a message on an idle thread with no flash, then hit Escape mid-generation and the run stopped