### PR TITLE
fix(environments): drop the tag from captured snapshot names

### DIFF
--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -8,9 +8,10 @@ environment needs, so its contents are whatever was set up in that sandbox.
 
 Snapshots are captured (not built from a Dockerfile) so the setup steps are
 ordinary sandbox commands an admin can iterate on in an admin thread. Each
-capture is named ``<prefix>-environment-<slug>:latest`` (prefix from
-``ENVIRONMENT_SNAPSHOT_PREFIX``) and the previous snapshot is deleted once the
-new one is ready, so an environment resolves to exactly one live snapshot.
+capture is named ``<prefix>-environment-<slug>`` (prefix from
+``ENVIRONMENT_SNAPSHOT_PREFIX``); the platform appends its own ``:latest`` tag and
+rejects a name that carries one. The previous snapshot is deleted once the new one
+is ready, so an environment resolves to exactly one live snapshot.
 
 A run uses the environment it selected — from the dashboard picker, or an
 ``env:<name>`` tag on the Slack message that opened the thread — and otherwise
@@ -42,7 +43,6 @@ SnapshotStatus = Literal["none", "capturing", "ready", "failed"]
 NAME_MAX_CHARS = 80
 PROMPT_MAX_CHARS = 20_000
 MAX_REPOS = 50
-SNAPSHOT_TAG = "latest"
 CAPTURE_NAME_ATTEMPTS = 5
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
@@ -63,21 +63,32 @@ def slugify(name: str) -> str:
 
 
 def snapshot_name_prefix() -> str:
-    """Prefix for captured snapshot names, so one workspace can host several deployments."""
-    return os.environ.get("ENVIRONMENT_SNAPSHOT_PREFIX", "").strip() or "openswe"
+    """Prefix for captured snapshot names, so one workspace can host several deployments.
+
+    A configured prefix carrying a colon would produce a name the platform
+    rejects, so it is dropped rather than passed through.
+    """
+    prefix = os.environ.get("ENVIRONMENT_SNAPSHOT_PREFIX", "").strip()
+    if ":" in prefix:
+        logger.warning(
+            "ENVIRONMENT_SNAPSHOT_PREFIX %r contains a colon, which snapshot names "
+            "may not; falling back to the default prefix",
+            prefix,
+        )
+        prefix = ""
+    return prefix or "openswe"
 
 
 def snapshot_name_for(slug: str, attempt: int = 1) -> str:
-    """``<prefix>-environment-<slug>:latest``, with ``-2``, ``-3``, … past the first attempt.
+    """``<prefix>-environment-<slug>``, with ``-2``, ``-3``, … past the first attempt.
 
-    The suffix only exists because a capture can collide with a name the platform
-    still holds (a prior snapshot mid-delete, a concurrent capture); the record
-    stores whichever name won.
+    No tag: the platform rejects a colon in the name and appends ``:latest``
+    itself. The numeric suffix exists because a capture can collide with a name
+    the platform still holds (a prior snapshot mid-delete, a concurrent capture);
+    the record stores whichever name won.
     """
     stem = f"{snapshot_name_prefix()}-environment-{slug}"
-    if attempt > 1:
-        stem = f"{stem}-{attempt}"
-    return f"{stem}:{SNAPSHOT_TAG}"
+    return stem if attempt == 1 else f"{stem}-{attempt}"
 
 
 def _validate_name(value: str) -> str:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -228,7 +228,7 @@ An **environment** pairs a prompt with a snapshot every run boots from, and can 
 
 With more than one environment configured, a picker appears in the dashboard composer (any signed-in user, names only), and a Slack thread can pick one with an `env:<name>` tag on the message that opens it — `@Open SWE env:staging fix the flaky test`. Only the opening message can: the sandbox is created once, so a later tag would change the prompt but not the image. A run with no selection uses `default`.
 
-Captures are named `openswe-environment-<name>:latest`; set `ENVIRONMENT_SNAPSHOT_PREFIX` to replace the `openswe` prefix when several deployments share one LangSmith workspace. Snapshot resolution for a new sandbox is: the run's environment, then the repo's snapshot, then the base snapshot below.
+Captures are named `openswe-environment-<name>` (the platform appends its own `:latest` tag, and rejects a name that carries one); set `ENVIRONMENT_SNAPSHOT_PREFIX` to replace the `openswe` prefix when several deployments share one LangSmith workspace. Snapshot resolution for a new sandbox is: the run's environment, then the repo's snapshot, then the base snapshot below.
 
 ### Changing the base snapshot without a redeploy
 

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -55,15 +55,23 @@ def test_slugify_rejects_names_without_alphanumerics() -> None:
         slugify("---")
 
 
-def test_snapshot_name_is_prefixed_and_tagged_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_snapshot_name_carries_no_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The platform rejects a colon and appends its own `:latest`."""
     monkeypatch.delenv("ENVIRONMENT_SNAPSHOT_PREFIX", raising=False)
-    assert snapshot_name_for("monorepo") == "openswe-environment-monorepo:latest"
-    assert snapshot_name_for("monorepo", 3) == "openswe-environment-monorepo-3:latest"
+    assert snapshot_name_for("monorepo") == "openswe-environment-monorepo"
+    assert snapshot_name_for("monorepo", 3) == "openswe-environment-monorepo-3"
 
 
 def test_snapshot_name_prefix_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ENVIRONMENT_SNAPSHOT_PREFIX", "acme")
-    assert snapshot_name_for("default") == "acme-environment-default:latest"
+    assert snapshot_name_for("default") == "acme-environment-default"
+
+
+def test_no_generated_snapshot_name_contains_a_colon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A colon anywhere in the name is rejected by the platform, so never emit one."""
+    monkeypatch.setenv("ENVIRONMENT_SNAPSHOT_PREFIX", "acme:v2")
+    for attempt in range(1, env_store.CAPTURE_NAME_ATTEMPTS + 1):
+        assert ":" not in snapshot_name_for("default", attempt)
 
 
 def test_create_validates_repo_full_names() -> None:
@@ -191,10 +199,10 @@ async def test_capture_tags_latest_and_replaces_previous_snapshot() -> None:
         record = await env_store.capture_environment_snapshot("base", "sb-123")
 
     assert capture.await_args is not None
-    assert capture.await_args.args == ("sb-123", "openswe-environment-base:latest")
+    assert capture.await_args.args == ("sb-123", "openswe-environment-base")
     assert record["snapshot_status"] == "ready"
     assert record["snapshot_id"] == "snap-2"
-    assert record["snapshot_name"] == "openswe-environment-base:latest"
+    assert record["snapshot_name"] == "openswe-environment-base"
     assert record["source_sandbox_id"] == "sb-123"
     delete_snapshot.assert_awaited_once_with("snap-1")
 
@@ -222,11 +230,11 @@ async def test_capture_walks_the_name_suffix_past_a_conflict() -> None:
         record = await env_store.capture_environment_snapshot("default", "sb-123")
 
     assert [call.args[1] for call in capture.await_args_list] == [
-        "openswe-environment-default:latest",
-        "openswe-environment-default-2:latest",
+        "openswe-environment-default",
+        "openswe-environment-default-2",
     ]
     assert record["snapshot_status"] == "ready"
-    assert record["snapshot_name"] == "openswe-environment-default-2:latest"
+    assert record["snapshot_name"] == "openswe-environment-default-2"
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/tests/environments.spec.ts
+++ b/tests/e2e/tests/environments.spec.ts
@@ -10,7 +10,7 @@ const MEMBER = { login: "bob", email: "bob@example.com" };
 const DEFAULT_SLUG = "default";
 const DRAFT_NAME = "Staging Box";
 const DRAFT_SLUG = "staging-box";
-const EXPECTED_SNAPSHOT_NAME = "openswe-environment-default:latest";
+const EXPECTED_SNAPSHOT_NAME = "openswe-environment-default";
 const ALT_NAME = "Alt Box";
 const ALT_SLUG = "alt-box";
 const DEFAULT_ENV_PROMPT = "Default environment: run make test.";
@@ -273,8 +273,14 @@ test.describe("Environments", () => {
     await openNewAgentHome(page);
     const adminToggle = page.getByRole("button", { name: "Admin" });
     await expect(adminToggle).toBeVisible();
-    await adminToggle.click();
-    await expect(adminToggle).toHaveAttribute("aria-pressed", "true");
+    // Retry the click: a click landing before hydration attaches the handler is
+    // silently dropped, and the toggle stays unpressed.
+    await expect(async () => {
+      await adminToggle.click();
+      await expect(adminToggle).toHaveAttribute("aria-pressed", "true", {
+        timeout: 2000,
+      });
+    }).toPass({ timeout: 20_000 });
 
     await typeIntoComposer(
       page,


### PR DESCRIPTION
Environment snapshot capture fails 100% of the time in production:

```
snapshot name must not contain a colon. Got: "openswe-environment-default:latest"
```

The platform appends its own `:latest` tag and rejects a name that already carries one — the tag was never ours to pass. Captured names are now `<prefix>-environment-<slug>` (`openswe-environment-default`), and the retry suffix stays `-2`, `-3`, … for name collisions.

Because a colon anywhere in the name is fatal, `ENVIRONMENT_SNAPSHOT_PREFIX` is now sanitized too: a prefix containing one is dropped with a warning instead of producing a name the platform will reject.

Also makes the Admin-toggle step in the environments E2E retry its click — a click landing before hydration attaches the handler is silently dropped, which made that spec flake.

## Test Plan

- [x] `test_snapshot_name_carries_no_tag` — `openswe-environment-monorepo`, and `openswe-environment-monorepo-3` on the third attempt
- [x] `test_no_generated_snapshot_name_contains_a_colon` — with `ENVIRONMENT_SNAPSHOT_PREFIX=acme:v2`, no generated name across every retry attempt contains a colon
- [x] Existing capture tests updated to assert the untagged name reaches `capture_snapshot`, including the collision-retry sequence
- [x] `make test` — 1761 passed; `make lint`, `make typecheck` — 0 errors
- [x] `npx playwright test tests/environments.spec.ts` — 5 passed, including the admin-thread capture path end to end
