### PR TITLE
test(e2e): stop recording traces and video for passing CI runs

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -20,10 +20,12 @@ export default defineConfig({
     baseURL,
     // Locally, always capture the replayable artifacts: a trace (DOM snapshots,
     // network, console, source — open with `npx playwright show-trace`) and a
-    // screen recording. Recording both costs ~20% of the run, so CI captures
-    // them only for the failures it actually uploads.
+    // screen recording. Recording costs real time per spec, so CI records
+    // nothing on the first attempt and captures both on the retry a failure
+    // gets. `retain-on-failure` would not do: it still records everything and
+    // only discards the files afterwards.
     trace: process.env.CI ? "on-first-retry" : "on",
-    video: process.env.CI ? "retain-on-failure" : "on",
+    video: process.env.CI ? "on-first-retry" : "on",
     screenshot: "only-on-failure",
     // SLOW_MO=700 npx playwright test --headed  → watch it run in human time.
     launchOptions: { slowMo: Number(process.env.SLOW_MO ?? 0) },

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -18,11 +18,12 @@ export default defineConfig({
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL,
-    // Always capture the replayable artifacts: a trace (DOM snapshots, network,
-    // console, source — open with `npx playwright show-trace`) and a screen
-    // recording, plus a screenshot on failure. The CI job uploads them.
-    trace: "on",
-    video: "on",
+    // Locally, always capture the replayable artifacts: a trace (DOM snapshots,
+    // network, console, source — open with `npx playwright show-trace`) and a
+    // screen recording. Recording both costs ~20% of the run, so CI captures
+    // them only for the failures it actually uploads.
+    trace: process.env.CI ? "on-first-retry" : "on",
+    video: process.env.CI ? "retain-on-failure" : "on",
     screenshot: "only-on-failure",
     // SLOW_MO=700 npx playwright test --headed  → watch it run in human time.
     launchOptions: { slowMo: Number(process.env.SLOW_MO ?? 0) },

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -38,16 +38,16 @@ async function setRepoPrivate(page: Page, value: boolean) {
   expect(res.ok()).toBeTruthy();
 }
 
-// E2E_BUSY_HOLD:5 makes the fake LLM hold the run open for 5s. The window has to
-// outlast the click through to the thread plus one reload — once the run
-// finishes the retry loop below can never pass — so it keeps a wide margin.
+// E2E_BUSY_HOLD:8 makes the fake LLM hold the run open for 8s. The window has to
+// outlast the click through to the thread plus one reload, which takes over 5s
+// on a CI runner; once the run finishes the retry loop below can never pass.
 async function openRunningThreadViaSlackLink(page: Page) {
   await page.goto("/mock/slack");
   await page.locator("#reset").click();
   await expect(page.locator("#thread")).toContainText("No messages yet");
   await page
     .locator("#text")
-    .fill("<@U0BOT> E2E_BUSY_HOLD:5 please add a greet() helper and open a PR");
+    .fill("<@U0BOT> E2E_BUSY_HOLD:8 please add a greet() helper and open a PR");
   await page.locator("#send").click();
 
   const webLink = page.locator('.msg.bot a[href*="/agents/"]').first();

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -38,15 +38,16 @@ async function setRepoPrivate(page: Page, value: boolean) {
   expect(res.ok()).toBeTruthy();
 }
 
-// E2E_BUSY_HOLD:8 makes the fake LLM hold the run open for 8s, so the thread is
-// still running by the time the browser lands on it.
+// E2E_BUSY_HOLD:5 makes the fake LLM hold the run open for 5s. The window has to
+// outlast the click through to the thread plus one reload — once the run
+// finishes the retry loop below can never pass — so it keeps a wide margin.
 async function openRunningThreadViaSlackLink(page: Page) {
   await page.goto("/mock/slack");
   await page.locator("#reset").click();
   await expect(page.locator("#thread")).toContainText("No messages yet");
   await page
     .locator("#text")
-    .fill("<@U0BOT> E2E_BUSY_HOLD:8 please add a greet() helper and open a PR");
+    .fill("<@U0BOT> E2E_BUSY_HOLD:5 please add a greet() helper and open a PR");
   await page.locator("#send").click();
 
   const webLink = page.locator('.msg.bot a[href*="/agents/"]').first();


### PR DESCRIPTION
Follow-up to #1982.

`trace: "on"` and `video: "on"` record every one of the 32 specs. Measured on `dashboard.spec.ts`, that costs about 20% of the run: 37s with recording, 29.5s without. Per test: 5.7s → 3.8s, 9.2s → 8.2s.

CI only ever opens these artifacts for a failure, so it now records the trace on retry and keeps the video only when a test fails. Local runs are unchanged — both stay on, so `npx playwright show-trace` works without having to reproduce a failure first.

## Test Plan

- [x] Full suite under `CI=1` locally: 32 passed
- [x] Playwright E2E job in CI