### PR TITLE
feat: tint admin threads red

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -214,7 +214,10 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   return (
     <div className="flex min-w-0 flex-1">
       <div
-        className="flex min-w-0 flex-1 flex-col"
+        className={cn(
+          "flex min-w-0 flex-1 flex-col",
+          thread.adminThread && "bg-destructive/4"
+        )}
         style={isMobile ? undefined : { minWidth: PANEL_MIN_CHAT_WIDTH }}
       >
         <header className="relative z-10 h-11 shrink-0 border-b border-border/60 bg-background/80 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-4 after:bg-linear-to-b after:from-background/60 after:to-transparent">

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -803,8 +803,12 @@ function ThreadRow({
             "flex items-center gap-2 rounded-lg px-2.5 transition-colors group-hover:pr-8 [@media(hover:none)]:pr-8",
             compact ? "h-7 gap-1.5" : "h-8",
             isActive
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground group-hover:bg-sidebar-row-hover"
+              ? thread.adminThread
+                ? "bg-destructive/10 text-foreground"
+                : "bg-accent text-foreground"
+              : thread.adminThread
+                ? "bg-destructive/5 text-muted-foreground group-hover:bg-destructive/10"
+                : "text-muted-foreground group-hover:bg-sidebar-row-hover"
           )}
         >
           {thread.status === "running" ? (

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -225,6 +225,7 @@ export interface AgentThread {
   effort?: string | null
   planMode?: boolean
   planStatus?: string | null
+  adminThread?: boolean
   source?: AgentSource
   status: AgentStatus
   viewed: boolean


### PR DESCRIPTION
## Description
Give admin threads a subtle red tint in the main conversation pane and sidebar so they are easy to distinguish.

## Release Note
Admin threads now have a subtle red background in chat and the sidebar.

## Test Plan
- [x] Build the dashboard production bundle

Made by [Open SWE](https://openswe.vercel.app/agents/01a00760-926b-7579-a397-0cfb2d691430)