### PR TITLE
feat: add voice dictation to the composer

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -249,6 +249,7 @@ from .user_mappings import (
     list_mappings,
     upsert_mapping,
 )
+from .voice import transcribe_audio
 
 logger = logging.getLogger(__name__)
 
@@ -1926,6 +1927,13 @@ async def api_get_thread_pr_diff(
         session["sub"],
         email=session.get("email"),
     )
+
+
+@router.post("/voice/transcriptions")
+async def create_voice_transcription(
+    request: Request, session: dict[str, Any] = _SESSION_DEP
+) -> dict[str, str]:
+    return {"text": await transcribe_audio(request)}
 
 
 @router.post("/threads/{thread_id}/messages")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -190,10 +190,12 @@ from .team_credentials import (
 )
 from .team_settings import (
     TeamSettingsUpdate,
+    TranscriptionSettingsUpdate,
     get_team_default_model,
     get_team_default_subagent_model,
     get_team_fable_enabled,
     get_team_settings,
+    update_team_transcription_model,
     upsert_team_settings,
 )
 from .thread_api import (
@@ -835,6 +837,14 @@ async def api_get_team_settings(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     return await get_team_settings()
+
+
+@router.put("/team-settings/transcription")
+async def api_put_transcription_settings(
+    update: TranscriptionSettingsUpdate,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    return await update_team_transcription_model(update.transcription_model)
 
 
 @router.put("/team-settings")

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -37,6 +37,12 @@ ORG_GUIDELINES_MAX_CHARS = 10_000
 REVIEW_TRACING_PROJECT_MAX_CHARS = 256
 DEFAULT_THREAD_TITLE_MODEL = "openai:gpt-5.6-luna"
 DEFAULT_THREAD_TITLE_REASONING_EFFORT = "low"
+DEFAULT_TRANSCRIPTION_MODEL = "gpt-transcribe"
+SUPPORTED_TRANSCRIPTION_MODELS = {
+    DEFAULT_TRANSCRIPTION_MODEL,
+    "gpt-4o-transcribe",
+    "gpt-4o-mini-transcribe",
+}
 
 
 class TeamSettingsUpdate(BaseModel):
@@ -46,6 +52,7 @@ class TeamSettingsUpdate(BaseModel):
     # Tri-state LLM Gateway toggle: True/False is authoritative, None inherits the
     # LANGSMITH_GATEWAY_ENABLED deployment default.
     gateway_enabled: bool | None = None
+    transcription_model: str = DEFAULT_TRANSCRIPTION_MODEL
     fable_enabled: bool = False
     review_tracing_project: str | None = None
     org_guidelines: str | None = None
@@ -64,6 +71,13 @@ class TeamSettingsUpdate(BaseModel):
     default_chat_reasoning_effort: str | None = None
     default_thread_title_model: str | None = None
     default_thread_title_reasoning_effort: str | None = None
+
+    @field_validator("transcription_model")
+    @classmethod
+    def _validate_transcription_model(cls, value: str) -> str:
+        if value not in SUPPORTED_TRANSCRIPTION_MODELS:
+            raise ValueError("unsupported transcription model")
+        return value
 
     @field_validator("org_guidelines", mode="before")
     @classmethod
@@ -264,6 +278,7 @@ def _default_settings() -> dict[str, Any]:
         "pr_summaries": True,
         "review_trace_links": True,
         "gateway_enabled": None,
+        "transcription_model": DEFAULT_TRANSCRIPTION_MODEL,
         "fable_enabled": False,
         "review_tracing_project": None,
         "org_guidelines": None,
@@ -322,6 +337,7 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "pr_summaries": update.pr_summaries,
         "review_trace_links": update.review_trace_links,
         "gateway_enabled": update.gateway_enabled,
+        "transcription_model": update.transcription_model,
         "fable_enabled": update.fable_enabled,
         "review_tracing_project": update.review_tracing_project,
         "org_guidelines": update.org_guidelines,
@@ -457,6 +473,12 @@ async def get_team_review_trace_links_enabled() -> bool:
     """Return whether GitHub review bodies should include a LangSmith trace link."""
     settings = await get_team_settings()
     return bool(settings.get("review_trace_links", True))
+
+
+async def get_team_transcription_model() -> str:
+    settings = await get_team_settings()
+    value = settings.get("transcription_model")
+    return value if value in SUPPORTED_TRANSCRIPTION_MODELS else DEFAULT_TRANSCRIPTION_MODEL
 
 
 async def get_team_gateway_enabled() -> bool | None:

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import UTC, datetime
 from typing import Any, Literal
 
@@ -38,14 +39,22 @@ REVIEW_TRACING_PROJECT_MAX_CHARS = 256
 DEFAULT_THREAD_TITLE_MODEL = "openai:gpt-5.6-luna"
 DEFAULT_THREAD_TITLE_REASONING_EFFORT = "low"
 DEFAULT_TRANSCRIPTION_MODEL = "gpt-transcribe"
-SUPPORTED_TRANSCRIPTION_MODELS = {
-    DEFAULT_TRANSCRIPTION_MODEL,
-    "gpt-4o-transcribe",
-    "gpt-4o-mini-transcribe",
-}
+TRANSCRIPTION_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 
 
-class TeamSettingsUpdate(BaseModel):
+class TranscriptionSettingsUpdate(BaseModel):
+    transcription_model: str = DEFAULT_TRANSCRIPTION_MODEL
+
+    @field_validator("transcription_model")
+    @classmethod
+    def _validate_transcription_model(cls, value: str) -> str:
+        value = value.strip()
+        if not TRANSCRIPTION_MODEL_RE.fullmatch(value):
+            raise ValueError("invalid transcription model")
+        return value
+
+
+class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     review_draft_prs: bool = False
     pr_summaries: bool = True
     review_trace_links: bool = True
@@ -71,13 +80,6 @@ class TeamSettingsUpdate(BaseModel):
     default_chat_reasoning_effort: str | None = None
     default_thread_title_model: str | None = None
     default_thread_title_reasoning_effort: str | None = None
-
-    @field_validator("transcription_model")
-    @classmethod
-    def _validate_transcription_model(cls, value: str) -> str:
-        if value not in SUPPORTED_TRANSCRIPTION_MODELS:
-            raise ValueError("unsupported transcription model")
-        return value
 
     @field_validator("org_guidelines", mode="before")
     @classmethod
@@ -476,9 +478,21 @@ async def get_team_review_trace_links_enabled() -> bool:
 
 
 async def get_team_transcription_model() -> str:
+    value = (await get_team_settings()).get("transcription_model")
+    return (
+        value
+        if isinstance(value, str) and TRANSCRIPTION_MODEL_RE.fullmatch(value)
+        else DEFAULT_TRANSCRIPTION_MODEL
+    )
+
+
+async def update_team_transcription_model(model: str) -> dict[str, Any]:
     settings = await get_team_settings()
-    value = settings.get("transcription_model")
-    return value if value in SUPPORTED_TRANSCRIPTION_MODELS else DEFAULT_TRANSCRIPTION_MODEL
+    settings["transcription_model"] = TranscriptionSettingsUpdate(
+        transcription_model=model
+    ).transcription_model
+    settings.pop("updated_at", None)
+    return await upsert_team_settings(TeamSettingsUpdate.model_validate(settings))
 
 
 async def get_team_gateway_enabled() -> bool | None:

--- a/agent/dashboard/voice.py
+++ b/agent/dashboard/voice.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+from fastapi import HTTPException, Request
+
+MAX_AUDIO_BYTES = 10 * 1024 * 1024
+SUPPORTED_AUDIO_TYPES = {
+    "audio/mp4": "audio.m4a",
+    "audio/mpeg": "audio.mp3",
+    "audio/ogg": "audio.ogg",
+    "audio/wav": "audio.wav",
+    "audio/webm": "audio.webm",
+}
+
+
+async def transcribe_audio(request: Request) -> str:
+    content_type = request.headers.get("content-type", "").partition(";")[0].lower()
+    filename = SUPPORTED_AUDIO_TYPES.get(content_type)
+    if not filename:
+        raise HTTPException(415, "Unsupported audio format")
+
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in request.stream():
+        size += len(chunk)
+        if size > MAX_AUDIO_BYTES:
+            raise HTTPException(413, "Audio recording is too large")
+        chunks.append(chunk)
+    if not size:
+        raise HTTPException(400, "Audio recording is empty")
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(503, "Voice dictation is not configured")
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1").rstrip("/")
+    model = os.environ.get("OPEN_SWE_TRANSCRIPTION_MODEL", "gpt-4o-mini-transcribe")
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30, connect=5)) as client:
+            response = await client.post(
+                f"{base_url}/audio/transcriptions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                data={"model": model},
+                files={"file": (filename, b"".join(chunks), content_type)},
+            )
+        response.raise_for_status()
+        text = response.json().get("text", "").strip()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise HTTPException(502, "Voice transcription failed") from exc
+    if not text:
+        raise HTTPException(422, "No speech was detected")
+    return text

--- a/agent/dashboard/voice.py
+++ b/agent/dashboard/voice.py
@@ -5,6 +5,8 @@ import os
 import httpx
 from fastapi import HTTPException, Request
 
+from .team_settings import get_team_transcription_model
+
 MAX_AUDIO_BYTES = 10 * 1024 * 1024
 SUPPORTED_AUDIO_TYPES = {
     "audio/mp4": "audio.m4a",
@@ -31,11 +33,11 @@ async def transcribe_audio(request: Request) -> str:
     if not size:
         raise HTTPException(400, "Audio recording is empty")
 
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
     if not api_key:
         raise HTTPException(503, "Voice dictation is not configured")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1").rstrip("/")
-    model = os.environ.get("OPEN_SWE_TRANSCRIPTION_MODEL", "gpt-4o-mini-transcribe")
+    base_url = (os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1").rstrip("/")
+    model = await get_team_transcription_model()
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(30, connect=5)) as client:
             response = await client.post(

--- a/desktop/entitlements.mac.plist
+++ b/desktop/entitlements.mac.plist
@@ -8,6 +8,8 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
   <key>com.apple.security.network.client</key>
   <true/>
   <key>com.apple.security.network.server</key>

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -57,6 +57,9 @@
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "Open SWE uses the microphone for message dictation."
+      },
       "icon": "resources/icon.icns",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -87,10 +87,11 @@ function desktopExchangeUrl(backendUrl) {
 function isTrustedPermissionRequest(permission, requestingUrl, details = {}) {
   if (!isAppUrl(requestingUrl)) return false
   if (ALLOWED_PERMISSIONS.has(permission)) return true
+  const mediaTypes = details.mediaTypes ?? [details.mediaType]
   return (
     permission === "media" &&
-    details.mediaTypes?.includes("audio") &&
-    !details.mediaTypes.includes("video")
+    mediaTypes.includes("audio") &&
+    !mediaTypes.includes("video")
   )
 }
 

--- a/desktop/src/config.cjs
+++ b/desktop/src/config.cjs
@@ -84,8 +84,14 @@ function desktopExchangeUrl(backendUrl) {
   return new URL(DESKTOP_EXCHANGE_PATH, backendUrl).toString()
 }
 
-function isTrustedPermissionRequest(permission, requestingUrl) {
-  return ALLOWED_PERMISSIONS.has(permission) && isAppUrl(requestingUrl)
+function isTrustedPermissionRequest(permission, requestingUrl, details = {}) {
+  if (!isAppUrl(requestingUrl)) return false
+  if (ALLOWED_PERMISSIONS.has(permission)) return true
+  return (
+    permission === "media" &&
+    details.mediaTypes?.includes("audio") &&
+    !details.mediaTypes.includes("video")
+  )
 }
 
 function isTrustedProxyRequest(pageUrl) {

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -1113,13 +1113,14 @@ function configurePermissions() {
         isTrustedPermissionRequest(
           permission,
           details.requestingUrl || webContents.getURL(),
+          details,
         ),
       );
     },
   );
   session.defaultSession.setPermissionCheckHandler(
-    (_webContents, permission, requestingOrigin) =>
-      isTrustedPermissionRequest(permission, requestingOrigin),
+    (_webContents, permission, requestingOrigin, details) =>
+      isTrustedPermissionRequest(permission, requestingOrigin, details),
   );
 }
 

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -106,6 +106,14 @@ test("rejects non-web backend URLs", () => {
 
 test("only grants expected permissions to the bundled app", () => {
   assert.equal(isTrustedPermissionRequest("notifications", `${APP_URL}settings`), true)
+  assert.equal(
+    isTrustedPermissionRequest("media", APP_URL, { mediaTypes: ["audio"] }),
+    true
+  )
+  assert.equal(
+    isTrustedPermissionRequest("media", APP_URL, { mediaTypes: ["audio", "video"] }),
+    false
+  )
   assert.equal(isTrustedPermissionRequest("camera", APP_URL), false)
   assert.equal(
     isTrustedPermissionRequest("notifications", "https://dashboard.example"),

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -110,6 +110,7 @@ test("only grants expected permissions to the bundled app", () => {
     isTrustedPermissionRequest("media", APP_URL, { mediaTypes: ["audio"] }),
     true
   )
+  assert.equal(isTrustedPermissionRequest("media", APP_URL, { mediaType: "audio" }), true)
   assert.equal(
     isTrustedPermissionRequest("media", APP_URL, { mediaTypes: ["audio", "video"] }),
     false

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -462,10 +462,11 @@ LANGSMITH_URL_PROD="https://smith.langchain.com"
 # === LLM ===
 ANTHROPIC_API_KEY=""                   # Anthropic API key
 OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dictation
-OPENAI_BASE_URL=""                     # Optional OpenAI-compatible API base URL
-OPEN_SWE_TRANSCRIPTION_MODEL=""        # Optional dictation model (default: gpt-4o-mini-transcribe)
+# OPENAI_BASE_URL="https://api.openai.com/v1"  # Optional OpenAI-compatible API base URL
 GOOGLE_API_KEY=""                      # Google AI API key (when using google_genai: models)
 FIREWORKS_API_KEY=""                   # Fireworks API key (when using fireworks: models)
+# Voice dictation uses this OpenAI configuration.
+# Admins choose its transcription model in the dashboard Admin page.
 
 # === GitHub App (required) ===
 GITHUB_APP_ID=""                       # From step 3c

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -461,7 +461,9 @@ LANGSMITH_URL_PROD="https://smith.langchain.com"
 
 # === LLM ===
 ANTHROPIC_API_KEY=""                   # Anthropic API key
-OPENAI_API_KEY=""                      # OpenAI API key (when using openai: models)
+OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dictation
+OPENAI_BASE_URL=""                     # Optional OpenAI-compatible API base URL
+OPEN_SWE_TRANSCRIPTION_MODEL=""        # Optional dictation model (default: gpt-4o-mini-transcribe)
 GOOGLE_API_KEY=""                      # Google AI API key (when using google_genai: models)
 FIREWORKS_API_KEY=""                   # Fireworks API key (when using fireworks: models)
 

--- a/tests/dashboard/test_team_settings_transcription.py
+++ b/tests/dashboard/test_team_settings_transcription.py
@@ -14,14 +14,18 @@ from agent.dashboard.team_settings import (
 
 def test_transcription_model_defaults_to_recommended_model() -> None:
     assert TeamSettingsUpdate().transcription_model == DEFAULT_TRANSCRIPTION_MODEL
+    assert (
+        TeamSettingsUpdate(transcription_model=" provider/deployment:v2 ").transcription_model
+        == "provider/deployment:v2"
+    )
     with pytest.raises(ValidationError):
-        TeamSettingsUpdate(transcription_model="retired-model")
+        TeamSettingsUpdate(transcription_model="bad model")
 
 
 async def test_invalid_stored_transcription_model_uses_default() -> None:
     with patch(
         "agent.dashboard.team_settings.get_team_settings",
         new_callable=AsyncMock,
-        return_value={"transcription_model": "retired-model"},
+        return_value={"transcription_model": "bad model"},
     ):
         assert await get_team_transcription_model() == DEFAULT_TRANSCRIPTION_MODEL

--- a/tests/dashboard/test_team_settings_transcription.py
+++ b/tests/dashboard/test_team_settings_transcription.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from agent.dashboard.team_settings import (
+    DEFAULT_TRANSCRIPTION_MODEL,
+    TeamSettingsUpdate,
+    get_team_transcription_model,
+)
+
+
+def test_transcription_model_defaults_to_recommended_model() -> None:
+    assert TeamSettingsUpdate().transcription_model == DEFAULT_TRANSCRIPTION_MODEL
+    with pytest.raises(ValidationError):
+        TeamSettingsUpdate(transcription_model="retired-model")
+
+
+async def test_invalid_stored_transcription_model_uses_default() -> None:
+    with patch(
+        "agent.dashboard.team_settings.get_team_settings",
+        new_callable=AsyncMock,
+        return_value={"transcription_model": "retired-model"},
+    ):
+        assert await get_team_transcription_model() == DEFAULT_TRANSCRIPTION_MODEL

--- a/tests/dashboard/test_voice.py
+++ b/tests/dashboard/test_voice.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from agent.dashboard import routes, voice
+
+
+def _request(body: bytes, content_type: str = "audio/webm") -> Request:
+    sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/dashboard/api/voice/transcriptions",
+            "headers": [(b"content-type", content_type.encode())],
+        },
+        receive,
+    )
+
+
+def test_voice_route_requires_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://testserver")
+    app = FastAPI()
+    app.include_router(routes.router)
+    response = TestClient(app).post(
+        "/dashboard/api/voice/transcriptions",
+        content=b"audio",
+        headers={"content-type": "audio/webm", "origin": "http://testserver"},
+    )
+    assert response.status_code == 401
+
+
+async def test_transcribe_audio_validates_and_forwards(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(HTTPException, match="Unsupported audio format"):
+        await voice.transcribe_audio(_request(b"audio", "text/plain"))
+
+    monkeypatch.setattr(voice, "MAX_AUDIO_BYTES", 4)
+    with pytest.raises(HTTPException, match="too large"):
+        await voice.transcribe_audio(_request(b"audio"))
+
+    monkeypatch.setattr(voice, "MAX_AUDIO_BYTES", 100)
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://api.openai.com/v1/audio/transcriptions"
+        assert request.headers["authorization"] == "Bearer secret"
+        assert b"gpt-4o-mini-transcribe" in request.content
+        assert b"audio" in request.content
+        return httpx.Response(200, json={"text": " dictated text "})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: client)
+    assert await voice.transcribe_audio(_request(b"audio")) == "dictated text"

--- a/tests/dashboard/test_voice.py
+++ b/tests/dashboard/test_voice.py
@@ -53,10 +53,15 @@ async def test_transcribe_audio_validates_and_forwards(monkeypatch: pytest.Monke
     monkeypatch.setattr(voice, "MAX_AUDIO_BYTES", 100)
     monkeypatch.setenv("OPENAI_API_KEY", "secret")
 
+    async def model() -> str:
+        return "gpt-transcribe"
+
+    monkeypatch.setattr(voice, "get_team_transcription_model", model)
+
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url == "https://api.openai.com/v1/audio/transcriptions"
         assert request.headers["authorization"] == "Bearer secret"
-        assert b"gpt-4o-mini-transcribe" in request.content
+        assert b"gpt-transcribe" in request.content
         assert b"audio" in request.content
         return httpx.Response(200, json={"text": " dictated text "})
 

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -256,6 +256,7 @@ export const ChatComposer = memo(function ChatComposer({
   const recorderRef = useRef<MediaRecorder | null>(null)
   const audioChunksRef = useRef<Array<Blob>>([])
   const mountedRef = useRef(true)
+  const requestingMicrophoneRef = useRef(false)
 
   useEffect(() => {
     if (autoFocus) editorRef.current?.focus()
@@ -318,10 +319,15 @@ export const ChatComposer = memo(function ChatComposer({
       recorderRef.current?.stop()
       return
     }
-    if (dictationState !== "idle") return
+    if (dictationState !== "idle" || requestingMicrophoneRef.current) return
+    requestingMicrophoneRef.current = true
     setDictationError(null)
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      if (!mountedRef.current) {
+        stream.getTracks().forEach((track) => track.stop())
+        return
+      }
       const mimeType = [
         "audio/webm;codecs=opus",
         "audio/webm",
@@ -375,6 +381,8 @@ export const ChatComposer = memo(function ChatComposer({
       setDictationError(
         error instanceof Error ? error.message : "Microphone access failed"
       )
+    } finally {
+      requestingMicrophoneRef.current = false
     }
   }, [applyPrompt, dictationState, value])
 

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -1,8 +1,11 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   ImagePlus,
+  LoaderCircle,
   Map as MapIcon,
+  Mic,
   ServerCog as ServerCogIcon,
+  Square,
   X,
 } from "lucide-react"
 
@@ -37,12 +40,14 @@ import { ModelPicker } from "@/features/agents/components/ModelPicker"
 import { RepoSelector } from "@/features/settings/components/RepoSelector"
 import { Kbd } from "@/components/ui/kbd"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+import { transcribeAudio } from "@/lib/api"
 import { cn } from "@/lib/utils"
 
 export type { ActiveRun }
 
 const MAX_IMAGE_COUNT = 5
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+const MAX_AUDIO_BYTES = 10 * 1024 * 1024
 const MAX_MENTION_SUGGESTIONS = 8
 const SUPPORTED_IMAGE_TYPES = new Set([
   "image/png",
@@ -240,10 +245,17 @@ export const ChatComposer = memo(function ChatComposer({
     null
   )
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
+  const [dictationState, setDictationState] = useState<
+    "idle" | "recording" | "transcribing"
+  >("idle")
+  const [dictationError, setDictationError] = useState<string | null>(null)
 
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const dragDepthRef = useRef(0)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const audioChunksRef = useRef<Array<Blob>>([])
+  const mountedRef = useRef(true)
 
   useEffect(() => {
     if (autoFocus) editorRef.current?.focus()
@@ -253,6 +265,14 @@ export const ChatComposer = memo(function ChatComposer({
   // click, or two rapid Enters) before React re-renders. Scoped to the send
   // request only — never the run lifecycle.
   const submittingRef = useRef(false)
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+      recorderRef.current?.stream.getTracks().forEach((track) => track.stop())
+    },
+    []
+  )
 
   const trigger = useMemo(
     () => detectComposerTrigger(value, cursor),
@@ -292,6 +312,71 @@ export const ChatComposer = memo(function ChatComposer({
     setDismissedTriggerKey(null)
     setActiveItemId(null)
   }, [])
+
+  const handleDictation = useCallback(async () => {
+    if (dictationState === "recording") {
+      recorderRef.current?.stop()
+      return
+    }
+    if (dictationState !== "idle") return
+    setDictationError(null)
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const mimeType = [
+        "audio/webm;codecs=opus",
+        "audio/webm",
+        "audio/mp4",
+      ].find((type) => MediaRecorder.isTypeSupported(type))
+      if (!mimeType) {
+        stream.getTracks().forEach((track) => track.stop())
+        throw new Error("Audio recording is not supported")
+      }
+      const recorder = new MediaRecorder(stream, { mimeType })
+      recorderRef.current = recorder
+      audioChunksRef.current = []
+      recorder.ondataavailable = (event) => {
+        if (event.data.size) audioChunksRef.current.push(event.data)
+      }
+      recorder.onstop = async () => {
+        stream.getTracks().forEach((track) => track.stop())
+        if (!mountedRef.current) return
+        setDictationState("transcribing")
+        try {
+          const audio = new Blob(audioChunksRef.current, {
+            type: recorder.mimeType,
+          })
+          if (!audio.size) throw new Error("No audio was recorded")
+          if (audio.size > MAX_AUDIO_BYTES)
+            throw new Error("Recording is too long")
+          const transcript = await transcribeAudio(audio)
+          const snapshot = editorRef.current?.readSnapshot() ?? {
+            value,
+            cursor: value.length,
+          }
+          const separator =
+            snapshot.value && !/\s$/.test(snapshot.value) ? " " : ""
+          const next = `${snapshot.value}${separator}${transcript}`
+          applyPrompt(next, next.length)
+          queueMicrotask(() => editorRef.current?.focusAtEnd())
+        } catch (error) {
+          setDictationError(
+            error instanceof Error
+              ? error.message
+              : "Voice transcription failed"
+          )
+        } finally {
+          recorderRef.current = null
+          setDictationState("idle")
+        }
+      }
+      recorder.start()
+      setDictationState("recording")
+    } catch (error) {
+      setDictationError(
+        error instanceof Error ? error.message : "Microphone access failed"
+      )
+    }
+  }, [applyPrompt, dictationState, value])
 
   const handleSubmit = useCallback(async () => {
     if (submittingRef.current || disabled) return
@@ -554,6 +639,12 @@ export const ChatComposer = memo(function ChatComposer({
         </div>
       )}
 
+      {dictationError && (
+        <div className="mb-2 px-1 text-xs text-destructive" role="alert">
+          {dictationError}
+        </div>
+      )}
+
       {!selectedModelSupportsImages && (
         <div className="dropdown-glass mb-2 rounded-xl border border-warning/30 px-3 py-2 text-xs text-muted-foreground">
           The selected model does not accept image input. Remove the image
@@ -722,6 +813,45 @@ export const ChatComposer = memo(function ChatComposer({
             hasMessages={contextUsage?.hasMessages}
             usedTokens={contextUsage?.usedTokens}
           />
+
+          {typeof navigator !== "undefined" &&
+            "mediaDevices" in navigator &&
+            typeof MediaRecorder !== "undefined" && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <ComposerControl
+                      aria-label={
+                        dictationState === "recording"
+                          ? "Stop dictation"
+                          : "Start dictation"
+                      }
+                      aria-pressed={dictationState === "recording"}
+                      className={cn(
+                        "size-7 px-0",
+                        dictationState === "recording" && "text-destructive"
+                      )}
+                      disabled={disabled || dictationState === "transcribing"}
+                      onClick={() => void handleDictation()}
+                      type="button"
+                    />
+                  }
+                >
+                  {dictationState === "transcribing" ? (
+                    <LoaderCircle className="size-4 animate-spin" />
+                  ) : dictationState === "recording" ? (
+                    <Square className="size-3 fill-current" />
+                  ) : (
+                    <Mic className="size-4" />
+                  )}
+                </TooltipTrigger>
+                <TooltipPopup side="top">
+                  {dictationState === "recording"
+                    ? "Stop dictation"
+                    : "Dictate message"}
+                </TooltipPopup>
+              </Tooltip>
+            )}
 
           <Tooltip>
             <TooltipTrigger

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -841,6 +841,11 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(body),
     }),
+  saveTranscriptionModel: (transcription_model: string) =>
+    request<TeamSettings>("/team-settings/transcription", {
+      method: "PUT",
+      body: JSON.stringify({ transcription_model }),
+    }),
   getTeamCredentials: () => request<TeamCredentialsStatus>("/team-credentials"),
   connectDatadog: (body: DatadogConnectBody) =>
     request<TeamCredentialsStatus>("/team-credentials/datadog", {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -175,6 +175,7 @@ export interface TeamSettings {
   review_trace_links: boolean
   /** Tri-state LLM Gateway toggle; null inherits the LANGSMITH_GATEWAY_ENABLED default. */
   gateway_enabled?: boolean | null
+  transcription_model?: string
   fable_enabled?: boolean
   review_tracing_project?: string | null
   org_guidelines?: string | null

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -91,6 +91,15 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   return (await res.json()) as T
 }
 
+export async function transcribeAudio(audio: Blob): Promise<string> {
+  const response = await request<{ text: string }>("/voice/transcriptions", {
+    method: "POST",
+    body: audio,
+    headers: { "Content-Type": audio.type },
+  })
+  return response.text
+}
+
 export interface PRTraceResolutionResult {
   resolved: boolean
   detail: string

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -764,8 +764,13 @@ function DictationSection() {
     queryFn: api.getTeamSettings,
   })
   const [error, setError] = useState<string | null>(null)
+  const [customModel, setCustomModel] = useState<string | null>(null)
+  const selectedModel = settings.data?.transcription_model ?? "gpt-transcribe"
+  const preset = TRANSCRIPTION_MODELS.some(
+    (model) => model.value === selectedModel
+  )
   const save = useMutation({
-    mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
+    mutationFn: api.saveTranscriptionModel,
     onSuccess: (saved) => {
       qc.setQueryData(["teamSettings"], saved)
       setError(null)
@@ -783,11 +788,15 @@ function DictationSection() {
         description="GPT Transcribe is OpenAI's recommended model for recorded speech."
         control={
           <Select
-            value={settings.data?.transcription_model ?? "gpt-transcribe"}
-            onValueChange={(transcription_model) =>
-              settings.data &&
-              save.mutate({ ...settings.data, transcription_model })
-            }
+            value={preset && customModel === null ? selectedModel : "custom"}
+            onValueChange={(model) => {
+              if (model === "custom")
+                setCustomModel(preset ? "" : selectedModel)
+              else {
+                setCustomModel(null)
+                save.mutate(model)
+              }
+            }}
             disabled={!settings.data || save.isPending}
           >
             <SelectTrigger className="w-56">
@@ -799,10 +808,33 @@ function DictationSection() {
                   {model.label}
                 </SelectItem>
               ))}
+              <SelectItem value="custom">Custom model</SelectItem>
             </SelectContent>
           </Select>
         }
       />
+      {(!preset || customModel !== null) && (
+        <SettingsRow
+          label="Custom model ID"
+          control={
+            <div className="flex items-center gap-2">
+              <Input
+                className="w-56"
+                value={customModel ?? selectedModel}
+                onChange={(event) => setCustomModel(event.target.value)}
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={!customModel?.trim() || save.isPending}
+                onClick={() => customModel && save.mutate(customModel.trim())}
+              >
+                Save
+              </Button>
+            </div>
+          }
+        />
+      )}
       {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
     </SettingsSection>
   )

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -62,6 +62,8 @@ function AdminPage() {
 
       <LLMGatewaySection />
 
+      <DictationSection />
+
       <FableSection />
 
       <TriggerReviewSection />
@@ -744,6 +746,63 @@ function LLMGatewaySection() {
           }
         />
       </div>
+      {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
+    </SettingsSection>
+  )
+}
+
+const TRANSCRIPTION_MODELS = [
+  { value: "gpt-transcribe", label: "GPT Transcribe (recommended)" },
+  { value: "gpt-4o-transcribe", label: "GPT-4o Transcribe (legacy)" },
+  { value: "gpt-4o-mini-transcribe", label: "GPT-4o Mini Transcribe (legacy)" },
+]
+
+function DictationSection() {
+  const qc = useQueryClient()
+  const settings = useQuery({
+    queryKey: ["teamSettings"],
+    queryFn: api.getTeamSettings,
+  })
+  const [error, setError] = useState<string | null>(null)
+  const save = useMutation({
+    mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
+    onSuccess: (saved) => {
+      qc.setQueryData(["teamSettings"], saved)
+      setError(null)
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  return (
+    <SettingsSection
+      title="Voice dictation"
+      description="Configure speech-to-text for the web and desktop message composer. Uses the same OpenAI API key and base URL as OpenAI LLMs."
+    >
+      <SettingsRow
+        label="Transcription model"
+        description="GPT Transcribe is OpenAI's recommended model for recorded speech."
+        control={
+          <Select
+            value={settings.data?.transcription_model ?? "gpt-transcribe"}
+            onValueChange={(transcription_model) =>
+              settings.data &&
+              save.mutate({ ...settings.data, transcription_model })
+            }
+            disabled={!settings.data || save.isPending}
+          >
+            <SelectTrigger className="w-56">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TRANSCRIPTION_MODELS.map((model) => (
+                <SelectItem key={model.value} value={model.value}>
+                  {model.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
       {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
     </SettingsSection>
   )


### PR DESCRIPTION
## Description
Add push-to-talk dictation to the shared web/desktop composer using authenticated server-side transcription. Desktop microphone access remains restricted to audio from the bundled app origin.

## Release Note
Add microphone dictation to agent message composers.

## Test Plan
- [x] Verify focused transcription, composer, and desktop permission tests

Made by [Open SWE](https://openswe.vercel.app/agents/01a008e4-b67c-707c-bd82-650eb8bb497a)

## References
- Plan: https://openswe.vercel.app/agents/01a008e4-b67c-707c-bd82-650eb8bb497a/plan