### PR TITLE
fix: shorten tool call file paths

### DIFF
--- a/ui/src/features/agents/components/chat/ToolExecution.test.ts
+++ b/ui/src/features/agents/components/chat/ToolExecution.test.ts
@@ -1,30 +1,47 @@
 import { describe, expect, it } from "vitest"
 
-import { formatToolDisplay } from "./toolExecutionDisplay"
+import {
+  formatToolDisplay,
+  formatToolDisplayParts,
+} from "./toolExecutionDisplay"
 
 describe("formatToolDisplay", () => {
   const projectPath = "/workspace/open-swe"
 
-  it("renders read_file with the file_path alias consistently", () => {
+  it("renders only the read file name and retains its full path", () => {
+    const fullPath = "/workspace/open-swe/ui/src/AGENTS.md"
+
     expect(
       formatToolDisplay(
-        "read_file /workspace/open-swe/AGENTS.md",
+        `read_file ${fullPath}`,
         "read",
-        { file_path: "/workspace/open-swe/AGENTS.md" },
+        { file_path: fullPath },
         projectPath
       )
     ).toBe("Read AGENTS.md")
-  })
-
-  it("renders ls as a list operation with a relative path", () => {
     expect(
-      formatToolDisplay(
-        "ls /workspace/open-swe/ui",
+      formatToolDisplayParts(
+        `read_file ${fullPath}`,
         "read",
-        { path: "/workspace/open-swe/ui" },
+        { file_path: fullPath },
         projectPath
       )
-    ).toBe("List ui")
+    ).toEqual({
+      heading: "Read",
+      preview: "AGENTS.md",
+      previewTooltip: fullPath,
+    })
+  })
+
+  it("renders ls with only the target directory name", () => {
+    expect(
+      formatToolDisplay(
+        "ls /workspace/open-swe/ui/src",
+        "read",
+        { path: "/workspace/open-swe/ui/src" },
+        projectPath
+      )
+    ).toBe("List src")
   })
 
   it("renders search tools with their pattern", () => {

--- a/ui/src/features/agents/components/chat/toolExecutionDisplay.ts
+++ b/ui/src/features/agents/components/chat/toolExecutionDisplay.ts
@@ -1,10 +1,21 @@
 import type { AcpToolKind } from "@/features/agents/lib/types"
 import { humanizeToolName } from "@/features/agents/lib/toolNames"
 
-function stripProjectPath(path: string, projectPath?: string): string {
-  if (!projectPath || !path.startsWith(projectPath)) return path
-  const relative = path.slice(projectPath.length)
-  return relative.replace(/^\/+/, "") || "."
+function pathName(path: string): string {
+  const withoutTrailingSeparators = path.replace(/[\\/]+$/, "")
+  if (!withoutTrailingSeparators) return path
+  return withoutTrailingSeparators.split(/[\\/]/).at(-1) || path
+}
+
+export function formatPathDisplayParts(
+  heading: string,
+  path: string
+): ToolDisplayParts {
+  return {
+    heading,
+    preview: pathName(path),
+    previewTooltip: path,
+  }
 }
 
 function firstStringArg(
@@ -48,13 +59,14 @@ function humanizeToolTitle(title: string): string {
 export interface ToolDisplayParts {
   heading: string
   preview: string | null
+  previewTooltip?: string
 }
 
 export function formatToolDisplayParts(
   title: string,
   toolKind: AcpToolKind,
   input: Record<string, unknown> | undefined,
-  projectPath?: string
+  _projectPath?: string
 ): ToolDisplayParts {
   const toolName = normalizedToolName(title)
   const path = firstStringArg(input, ["path", "file_path", "target_file"])
@@ -70,11 +82,7 @@ export function formatToolDisplayParts(
   switch (toolKind) {
     case "read": {
       if (path) {
-        const displayPath = stripProjectPath(path, projectPath)
-        return {
-          heading: toolName === "ls" ? "List" : "Read",
-          preview: displayPath,
-        }
+        return formatPathDisplayParts(toolName === "ls" ? "List" : "Read", path)
       }
       return plain(humanizeToolTitle(title))
     }
@@ -86,11 +94,7 @@ export function formatToolDisplayParts(
         }
       if (query)
         return { heading: "Search", preview: `"${truncateMiddle(query, 40)}"` }
-      if (path)
-        return {
-          heading: "Search",
-          preview: stripProjectPath(path, projectPath),
-        }
+      if (path) return formatPathDisplayParts("Search", path)
       return plain(humanizeToolTitle(title))
     }
     case "fetch": {
@@ -103,8 +107,13 @@ export function formatToolDisplayParts(
       return plain(humanizeToolTitle(title))
     }
     case "edit":
+      if (path) return formatPathDisplayParts("Edit", path)
+      return plain(humanizeToolTitle(title))
     case "delete":
+      if (path) return formatPathDisplayParts("Delete", path)
+      return plain(humanizeToolTitle(title))
     case "move":
+      if (path) return formatPathDisplayParts("Move", path)
       return plain(humanizeToolTitle(title))
     case "think":
       return plain("Thinking...")
@@ -116,7 +125,7 @@ export function formatToolDisplayParts(
         return plain("Update todos")
       }
       if (toolName === "ls" && path) {
-        return { heading: "List", preview: stripProjectPath(path, projectPath) }
+        return formatPathDisplayParts("List", path)
       }
       return plain(humanizeToolTitle(title))
     }

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -203,6 +203,17 @@ export function WorkEntryRow({
                     {entry.preview}
                   </span>
                 ))}
+              {entry.diffStats && (
+                <span className="flex shrink-0 items-center gap-1 font-mono text-[11px] text-muted-foreground tabular-nums">
+                  <span className="transition-colors group-focus-within/entry:text-success-foreground group-hover/entry:text-success-foreground">
+                    +{entry.diffStats.additions}
+                  </span>
+                  <span aria-hidden>/</span>
+                  <span className="transition-colors group-focus-within/entry:text-destructive group-hover/entry:text-destructive">
+                    -{entry.diffStats.deletions}
+                  </span>
+                </span>
+              )}
             </p>
           </div>
 

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -184,11 +184,25 @@ export function WorkEntryRow({
               >
                 {entry.heading}
               </span>
-              {entry.preview && (
-                <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                  {entry.preview}
-                </span>
-              )}
+              {entry.preview &&
+                (entry.previewTooltip ? (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <span className="min-w-0 flex-1 truncate text-muted-foreground" />
+                      }
+                    >
+                      {entry.preview}
+                    </TooltipTrigger>
+                    <TooltipPopup className="max-w-md break-all">
+                      {entry.previewTooltip}
+                    </TooltipPopup>
+                  </Tooltip>
+                ) : (
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                    {entry.preview}
+                  </span>
+                ))}
             </p>
           </div>
 

--- a/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
@@ -54,6 +54,7 @@ describe("describeWorkEntry", () => {
     expect(entry.heading).toBe("Edited")
     expect(entry.preview).toBe("app.tsx")
     expect(entry.previewTooltip).toBe(`${projectPath}/ui/src/app.tsx`)
+    expect(entry.diffStats).toEqual({ additions: 1, deletions: 1 })
     expect(entry.icon).toBe("square-pen")
     // The diff is rendered as the row body, so there is no text fallback.
     expect(entry.expandedText).toBeNull()

--- a/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
@@ -32,14 +32,16 @@ function diff(overrides: Partial<DiffData> = {}): DiffData {
 }
 
 describe("describeWorkEntry", () => {
-  it("splits a read into a verb heading and a project-relative preview", () => {
+  it("splits a read into a verb, file name, and full-path tooltip", () => {
+    const fullPath = `${projectPath}/ui/src/AGENTS.md`
     const entry = describeWorkEntry(
-      chunk({ input: { file_path: `${projectPath}/AGENTS.md` } }),
+      chunk({ input: { file_path: fullPath } }),
       projectPath
     )
 
     expect(entry.heading).toBe("Read")
     expect(entry.preview).toBe("AGENTS.md")
+    expect(entry.previewTooltip).toBe(fullPath)
     expect(entry.icon).toBe("eye")
   })
 
@@ -50,7 +52,8 @@ describe("describeWorkEntry", () => {
     )
 
     expect(entry.heading).toBe("Edited")
-    expect(entry.preview).toBe("ui/src/app.tsx")
+    expect(entry.preview).toBe("app.tsx")
+    expect(entry.previewTooltip).toBe(`${projectPath}/ui/src/app.tsx`)
     expect(entry.icon).toBe("square-pen")
     // The diff is rendered as the row body, so there is no text fallback.
     expect(entry.expandedText).toBeNull()

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -6,6 +6,7 @@ import {
   formatPathDisplayParts,
   formatToolDisplayParts,
 } from "@/features/agents/components/chat/toolExecutionDisplay"
+import { countLineChanges } from "@/features/agents/utils/diffStats"
 
 export type WorkEntryIconName =
   | "bot"
@@ -28,6 +29,7 @@ export interface WorkEntryView {
   /** Dimmed argument shown after the heading; null when it would just repeat it. */
   preview: string | null
   previewTooltip?: string
+  diffStats?: { additions: number; deletions: number }
   tone: WorkEntryTone
   status: AcpToolStatus
   /** Plain-text detail for rows that have no richer renderer of their own. */
@@ -148,6 +150,11 @@ export function describeWorkEntry(
     return {
       icon: "square-pen",
       ...pathDisplay,
+      diffStats: countLineChanges(
+        diff.originalContent,
+        diff.newContent,
+        diff.filePath
+      ),
       tone: toneForChunk(chunk),
       status: chunk.status,
       // The diff itself is the body; a text dump alongside it would be noise.

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -2,7 +2,10 @@ import type {
   AcpToolStatus,
   ToolExecutionChunk,
 } from "@/features/agents/lib/types"
-import { formatToolDisplayParts } from "@/features/agents/components/chat/toolExecutionDisplay"
+import {
+  formatPathDisplayParts,
+  formatToolDisplayParts,
+} from "@/features/agents/components/chat/toolExecutionDisplay"
 
 export type WorkEntryIconName =
   | "bot"
@@ -24,6 +27,7 @@ export interface WorkEntryView {
   heading: string
   /** Dimmed argument shown after the heading; null when it would just repeat it. */
   preview: string | null
+  previewTooltip?: string
   tone: WorkEntryTone
   status: AcpToolStatus
   /** Plain-text detail for rows that have no richer renderer of their own. */
@@ -140,10 +144,10 @@ export function describeWorkEntry(
             ? "Created"
             : "Edited"
           : "Editing"
+    const pathDisplay = formatPathDisplayParts(heading, diff.filePath)
     return {
       icon: "square-pen",
-      heading,
-      preview: stripProjectPath(diff.filePath, projectPath),
+      ...pathDisplay,
       tone: toneForChunk(chunk),
       status: chunk.status,
       // The diff itself is the body; a text dump alongside it would be noise.
@@ -151,7 +155,7 @@ export function describeWorkEntry(
     }
   }
 
-  const { heading, preview } = formatToolDisplayParts(
+  const { heading, preview, previewTooltip } = formatToolDisplayParts(
     chunk.title,
     chunk.toolKind,
     chunk.input,
@@ -167,6 +171,7 @@ export function describeWorkEntry(
       normalizeForCompare(resolvedPreview) !== normalizeForCompare(heading)
         ? resolvedPreview
         : null,
+    previewTooltip,
     tone: toneForChunk(chunk),
     status: chunk.status,
     expandedText: expandedTextForChunk(chunk, projectPath),

--- a/ui/src/features/agents/lib/desktopAcp.test.ts
+++ b/ui/src/features/agents/lib/desktopAcp.test.ts
@@ -198,12 +198,12 @@ describe("useDesktopAcpSessions", () => {
     }) => void
     window.openSweDesktop = {
       listAcpSessions: () => listing.promise,
-      deleteAcpSession: async () => true,
-      onAcpEvent: (callback) => {
+      deleteAcpSession: () => Promise.resolve(true),
+      onAcpEvent: (callback: typeof emit) => {
         emit = callback
         return vi.fn()
       },
-    } as Window["openSweDesktop"]
+    } as unknown as Window["openSweDesktop"]
     const { result } = renderHook(() => useDesktopAcpSessions())
     const summary = session("local")
     const event: DesktopAcpEvent = {


### PR DESCRIPTION
## Description
Tool-call rows now show only the target file or directory name, preserving the full path in an accessible hover tooltip. Edit rows also show `+N / -M` diffstats in muted text, transitioning to green/red on hover or keyboard focus; the desktop ACP test mock typing is aligned so UI typecheck remains clean.

## Release Note
Dashboard tool calls display concise file names, full paths on hover, and edit diffstats.

## Test Plan
- [x] Verify focused tool display, work-entry, and desktop ACP tests
- [x] Verify touched files with ESLint
- [x] Run the complete UI typecheck

Made by [Open SWE](https://openswe.vercel.app/agents/01a00ae5-7c83-7288-a6fa-6ebff92c05ed)