### PR TITLE
feat: require platform issue details

### DIFF
--- a/agent/tools/report_platform_issue.py
+++ b/agent/tools/report_platform_issue.py
@@ -13,7 +13,7 @@ def _uuid7() -> str:
 
 async def report_platform_issue(
     problem_description: str,
-    keywords: str,
+    keywords: list[str],
 ) -> dict[str, str]:
     """Report an issue with the sandbox or execution environment."""
     return {"report_id": _uuid7()}

--- a/agent/tools/report_platform_issue.py
+++ b/agent/tools/report_platform_issue.py
@@ -11,6 +11,9 @@ def _uuid7() -> str:
     return str(uuid.UUID(int=uuid_int))
 
 
-async def report_platform_issue() -> dict[str, str]:
+async def report_platform_issue(
+    problem_description: str,
+    keywords: str,
+) -> dict[str, str]:
     """Report an issue with the sandbox or execution environment."""
     return {"report_id": _uuid7()}

--- a/tests/tools/test_report_platform_issue_tool.py
+++ b/tests/tools/test_report_platform_issue_tool.py
@@ -10,7 +10,7 @@ async def test_report_platform_issue_returns_uuid7_report_id() -> None:
 
     result = await report_platform_issue(
         problem_description="The sandbox command timed out",
-        keywords="sandbox,timeout",
+        keywords=["sandbox", "timeout"],
     )
 
     assert set(result) == {"report_id"}
@@ -29,7 +29,8 @@ def test_report_platform_issue_requires_description_and_keywords() -> None:
         parameter.default is inspect.Parameter.empty for parameter in signature.parameters.values()
     )
     type_hints = get_type_hints(report_platform_issue)
-    assert all(type_hints[name] is str for name in signature.parameters)
+    assert type_hints["problem_description"] is str
+    assert type_hints["keywords"] == list[str]
 
 
 def test_report_platform_issue_exported() -> None:

--- a/tests/tools/test_report_platform_issue_tool.py
+++ b/tests/tools/test_report_platform_issue_tool.py
@@ -1,17 +1,35 @@
 from __future__ import annotations
 
+import inspect
 import uuid
+from typing import get_type_hints
 
 
 async def test_report_platform_issue_returns_uuid7_report_id() -> None:
     from agent.tools.report_platform_issue import report_platform_issue
 
-    result = await report_platform_issue()
+    result = await report_platform_issue(
+        problem_description="The sandbox command timed out",
+        keywords="sandbox,timeout",
+    )
 
     assert set(result) == {"report_id"}
     report_id = uuid.UUID(result["report_id"])
     assert report_id.version == 7
     assert report_id.variant == uuid.RFC_4122
+
+
+def test_report_platform_issue_requires_description_and_keywords() -> None:
+    from agent.tools.report_platform_issue import report_platform_issue
+
+    signature = inspect.signature(report_platform_issue)
+
+    assert list(signature.parameters) == ["problem_description", "keywords"]
+    assert all(
+        parameter.default is inspect.Parameter.empty for parameter in signature.parameters.values()
+    )
+    type_hints = get_type_hints(report_platform_issue)
+    assert all(type_hints[name] is str for name in signature.parameters)
 
 
 def test_report_platform_issue_exported() -> None:


### PR DESCRIPTION
## Description
Require `problem_description` and a `keywords` string array when reporting sandbox or execution-environment issues, giving reports actionable context.

## Release Note
Platform issue reports now require a problem description and keyword array.

## Test Plan
- [x] Verify the tool signature exposes both fields with required types.

Made by [Open SWE](https://openswe.vercel.app/agents/01a00be0-2b55-76fc-8098-7fd26828ebc0)