### PR TITLE
fix: style plan approval as Slack status

### DIFF
--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -265,7 +265,11 @@ def _slack_thread_from_metadata(metadata: dict[str, Any]) -> tuple[str, str] | N
 
 
 def _plan_approved_slack_text(comment_count: int, actor: str) -> str:
-    return f"Plan approved with {comment_count} comments by {actor}\nbeginning implementation"
+    return f"Plan approved with {comment_count} comments by {actor}"
+
+
+def _plan_approved_slack_blocks(text: str) -> list[dict[str, Any]]:
+    return [{"type": "context", "elements": [{"type": "mrkdwn", "text": f"_{text}_"}]}]
 
 
 async def _maybe_post_plan_approved_to_slack(
@@ -275,11 +279,13 @@ async def _maybe_post_plan_approved_to_slack(
     if slack_thread is None:
         return
     channel_id, thread_ts = slack_thread
+    text = _plan_approved_slack_text(comment_count, actor)
     try:
         ok = await post_slack_thread_reply(
             channel_id,
             thread_ts,
-            _plan_approved_slack_text(comment_count, actor),
+            text,
+            blocks=_plan_approved_slack_blocks(text),
         )
     except Exception:
         logger.warning("Could not post plan approval Slack reply", exc_info=True)

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -585,9 +585,17 @@ async def update_slack_message(
             return False, f"http_error: {type(exc).__name__}"
 
 
-async def post_slack_thread_reply(channel_id: str, thread_ts: str, text: str) -> bool:
+async def post_slack_thread_reply(
+    channel_id: str,
+    thread_ts: str,
+    text: str,
+    *,
+    blocks: list[dict[str, Any]] | None = None,
+) -> bool:
     """Post a reply in a Slack thread."""
-    message_ts, _ = await post_slack_thread_reply_with_ts(channel_id, thread_ts, text)
+    message_ts, _ = await post_slack_thread_reply_with_ts(
+        channel_id, thread_ts, text, blocks=blocks
+    )
     return message_ts is not None
 
 

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -39,13 +39,18 @@ def test_format_comments_empty() -> None:
     assert _format_comments([]) == ""
 
 
-def test_plan_approved_slack_text_mentions_comments_actor_and_start() -> None:
-    from agent.dashboard.plan_api import _plan_approved_slack_text
+def test_plan_approved_slack_text_mentions_comments_and_actor() -> None:
+    from agent.dashboard.plan_api import _plan_approved_slack_blocks, _plan_approved_slack_text
 
-    assert (
-        _plan_approved_slack_text(2, "Alice")
-        == "Plan approved with 2 comments by Alice\nbeginning implementation"
-    )
+    text = _plan_approved_slack_text(2, "Alice")
+
+    assert text == "Plan approved with 2 comments by Alice"
+    assert _plan_approved_slack_blocks(text) == [
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "_Plan approved with 2 comments by Alice_"}],
+        }
+    ]
 
 
 def test_plan_comment_helpers_exported() -> None:
@@ -744,8 +749,14 @@ async def test_approve_plan_posts_slack_approval_notice(
     async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
         return None
 
-    async def fake_post(channel_id: str, thread_ts: str, text: str) -> bool:
-        posted.update(channel_id=channel_id, thread_ts=thread_ts, text=text)
+    async def fake_post(
+        channel_id: str,
+        thread_ts: str,
+        text: str,
+        *,
+        blocks: list[dict[str, Any]] | None = None,
+    ) -> bool:
+        posted.update(channel_id=channel_id, thread_ts=thread_ts, text=text, blocks=blocks)
         return True
 
     async def fake_dispatch(
@@ -770,7 +781,18 @@ async def test_approve_plan_posts_slack_approval_notice(
     assert posted == {
         "channel_id": "C1",
         "thread_ts": "123.45",
-        "text": "Plan approved with 2 comments by Alice Example\nbeginning implementation",
+        "text": "Plan approved with 2 comments by Alice Example",
+        "blocks": [
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "_Plan approved with 2 comments by Alice Example_",
+                    }
+                ],
+            }
+        ],
     }
     assert dispatched["plan_mode"] is False
 

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -205,3 +205,14 @@ async def test_post_slack_thread_reply_preserves_bool_return_on_error(
         ok = await slack_utils.post_slack_thread_reply("C1", "1.0", "hello")
 
     assert ok is False
+
+
+async def test_post_slack_thread_reply_forwards_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_with_ts = AsyncMock(return_value=("1.1", None))
+    monkeypatch.setattr(slack_utils, "post_slack_thread_reply_with_ts", post_with_ts)
+    blocks = [{"type": "context", "elements": [{"type": "mrkdwn", "text": "_Status_"}]}]
+
+    ok = await slack_utils.post_slack_thread_reply("C1", "1.0", "Status", blocks=blocks)
+
+    assert ok is True
+    post_with_ts.assert_awaited_once_with("C1", "1.0", "Status", blocks=blocks)


### PR DESCRIPTION
## Description
Formats dashboard plan-approval notifications as italic Slack context blocks so they read as muted status events, and removes the “beginning implementation” wording.

## Test Plan
- [x] Verify the generated approval text and exact Slack block payload in focused unit tests.

Made by [Open SWE](https://openswe.vercel.app/agents/5ab99135-541c-e081-d8c6-e3241ef32195)