### PR TITLE
fix: require admin threads to create environments

### DIFF
--- a/tests/e2e/tests/environments.spec.ts
+++ b/tests/e2e/tests/environments.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, type Page } from "@playwright/test";
 
-// Environments end-to-end: the admin dashboard CRUD, the admin gate, and an
-// admin thread that provisions its own sandbox and captures it. The agent, the
-// tools, the store writes and the prompt injection are all real — only the LLM
-// and the snapshot service are faked (see patches.py).
+// Environments end-to-end: dashboard management, the admin gate, and an admin
+// thread that creates, provisions, and captures its own sandbox. The agent, the
+// tools, store writes, and prompt injection are real; only the LLM and snapshot
+// service are faked (see patches.py).
 const ADMIN = { login: "alice", email: "alice@example.com" };
 const MEMBER = { login: "bob", email: "bob@example.com" };
 
@@ -131,21 +131,23 @@ async function typeIntoComposer(page: Page, text: string) {
 }
 
 test.describe("Environments", () => {
-  test("an admin creates, edits and deletes an environment in the dashboard", async ({
+  test("an admin edits and deletes an environment in the dashboard", async ({
     page,
   }) => {
     await loginAs(page, ADMIN);
     await deleteEnvironment(page, DRAFT_SLUG);
+    await createEnvironment(page, DRAFT_NAME, "");
 
     await page.goto("/agents/environments");
     await expect(
       page.getByRole("heading", { name: "Environments" }),
     ).toBeVisible();
+    await expect(page.getByLabel("Add environment")).toHaveCount(0);
+    await expect(
+      page.getByText(/Create environments from an admin thread/),
+    ).toBeVisible();
 
-    await page.getByLabel("Add environment").fill(DRAFT_NAME);
-    await page.getByRole("button", { name: "Add" }).click();
-
-    // Selected on create: any name other than `default` is a draft no run boots from.
+    await page.getByRole("button", { name: new RegExp(DRAFT_NAME) }).click();
     await expect(
       page.getByText("draft — no run boots from this"),
     ).toBeVisible();
@@ -154,7 +156,6 @@ test.describe("Environments", () => {
     await page.getByLabel("Repositories").fill("fakeorg/demo, fakeorg/demo");
     await page.getByRole("button", { name: "Save" }).click();
 
-    // Deduped and normalized server-side, which is why the spec asserts on the record.
     await expect
       .poll(async () => (await findEnvironment(page, DRAFT_SLUG))?.repos)
       .toEqual(["fakeorg/demo"]);

--- a/ui/src/components/EnvironmentsPanel.tsx
+++ b/ui/src/components/EnvironmentsPanel.tsx
@@ -35,7 +35,6 @@ function parseRepos(value: string): Array<string> {
 export function EnvironmentsPanel() {
   const qc = useQueryClient()
   const [error, setError] = useState<string | null>(null)
-  const [newName, setNewName] = useState("")
   const [selected, setSelected] = useState<string | null>(null)
   const [promptDraft, setPromptDraft] = useState("")
   const [reposDraft, setReposDraft] = useState("")
@@ -65,17 +64,6 @@ export function EnvironmentsPanel() {
 
   const invalidate = () => qc.invalidateQueries({ queryKey: ["environments"] })
   const onError = (e: Error) => setError(e.message)
-
-  const create = useMutation({
-    mutationFn: (name: string) => api.createEnvironment({ name }),
-    onSuccess: (record) => {
-      void invalidate()
-      setSelected(record.slug)
-      setNewName("")
-      setError(null)
-    },
-    onError,
-  })
 
   const save = useMutation({
     mutationFn: ({
@@ -114,33 +102,11 @@ export function EnvironmentsPanel() {
   return (
     <div className="flex flex-col gap-6 p-4">
       <section className="space-y-2">
-        <Label htmlFor="new-environment">Add environment</Label>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-          <Input
-            id="new-environment"
-            placeholder="monorepo-full"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key !== "Enter") return
-              e.preventDefault()
-              if (newName.trim()) void create.mutateAsync(newName.trim())
-            }}
-            className="sm:flex-1"
-          />
-          <Button
-            size="sm"
-            className="shrink-0 sm:w-auto"
-            disabled={!newName.trim() || create.isPending}
-            onClick={() => void create.mutateAsync(newName.trim())}
-          >
-            Add
-          </Button>
-        </div>
         <p className="text-xs text-muted-foreground">
-          Runs boot from the environment named <code>default</code>; any other
-          name is a draft. Build the snapshot from an admin thread: provision
-          its sandbox, then have the agent capture it.
+          Create environments from an admin thread: enable Admin in the
+          new-agent composer, provision its sandbox, then ask the agent to save
+          and capture it. Runs without an explicit selection use the environment
+          named <code>default</code>.
         </p>
       </section>
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -807,15 +807,6 @@ export const api = {
   listEnvironments: () => request<EnvironmentList>("/environments"),
   listEnvironmentOptions: () =>
     request<EnvironmentOptionList>("/environments/options"),
-  createEnvironment: (body: {
-    name: string
-    prompt?: string
-    repos?: Array<string>
-  }) =>
-    request<Environment>("/environments", {
-      method: "POST",
-      body: JSON.stringify(body),
-    }),
   saveEnvironment: (slug: string, body: EnvironmentUpdateBody) =>
     request<Environment>(`/environments/${encodeURIComponent(slug)}`, {
       method: "PUT",


### PR DESCRIPTION
## Description
Removes environment creation from the admin dashboard and directs admins to create, provision, and capture environments through Admin threads. Existing environment editing and deletion remain available in the dashboard.

## Test Plan
- [x] `pnpm --dir ui run typecheck`
- [x] `pnpm --dir ui run format:check`
- [x] `npm --prefix tests/e2e test -- environments.spec.ts --reporter=line` (5 passed)
- [ ] `pnpm --dir ui run lint` — blocked because `eslint` is not installed after `pnpm install --frozen-lockfile`

Made by [Open SWE](https://openswe.vercel.app/agents/6a4a1950-dddf-71f3-e92f-9b2834c960e9)