### PR TITLE
feat: show inline diffs for edit tool calls

### DIFF
--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -35,9 +35,7 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-# One shell command that does the whole git workflow. Each execute() runs in a
-# fresh shell rooted at the sandbox dir, so the clone+commit+push is bundled.
-_IMPLEMENT_SCRIPT = f"""
+_SETUP_SCRIPT = f"""
 set -e
 rm -rf repo
 git clone "$E2E_REMOTE" repo
@@ -47,8 +45,13 @@ git config user.name "Dev User"
 git checkout -b {FEATURE_BRANCH}
 cat > {FEATURE_FILE} <<'EOF'
 def greet(name):
-    return f"Hello, {{name}}!"
+    return "Hello!"
 EOF
+""".strip()
+
+_COMMIT_SCRIPT = f"""
+set -e
+cd repo
 git add -A
 git commit -m "{PR_TITLE}"
 git push origin {FEATURE_BRANCH}
@@ -307,10 +310,26 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
             "call-ack",
         ),
         _tool_step(
-            "Setting up the repo and implementing the change.",
+            "Setting up the repository.",
             "execute",
-            {"command": _IMPLEMENT_SCRIPT},
-            "call-impl",
+            {"command": _SETUP_SCRIPT},
+            "call-setup",
+        ),
+        _tool_step(
+            "Implementing the greeting.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'def greet(name):\n    return "Hello!"',
+                "new_string": 'def greet(name):\n    return f"Hello, {name}!"',
+            },
+            "call-edit",
+        ),
+        _tool_step(
+            "Committing and pushing the change.",
+            "execute",
+            {"command": _COMMIT_SCRIPT},
+            "call-commit",
         ),
         _tool_step(
             "Opening a pull request.",

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -44,8 +44,14 @@ git config user.email "dev@example.com"
 git config user.name "Dev User"
 git checkout -b {FEATURE_BRANCH}
 cat > {FEATURE_FILE} <<'EOF'
+def normalize(name):
+    return name.strip()
+
 def greet(name):
     return "Hello!"
+
+def farewell(name):
+    return f"Goodbye, {{name}}!"
 EOF
 """.strip()
 

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -231,6 +231,9 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect(
       inlineDiff.locator('[data-line][data-line-type="change-addition"]'),
     ).toContainText('return f"Hello, {name}!"');
+    await expect(inlineDiff).toHaveAttribute("data-disable-line-numbers");
+    await expect(inlineDiff).not.toContainText("normalize");
+    await expect(inlineDiff).not.toContainText("farewell");
     await expect
       .poll(() => inlineDiff.locator("[data-line] span").count())
       .toBeGreaterThan(2);

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -207,6 +207,35 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     ).toHaveCount(0);
   });
 
+  test("expands an Edit call into a highlighted inline diff", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page);
+    await expectTranscriptVisible(page);
+
+    const worked = page.getByRole("button", { name: /^Worked(?: for .+)?$/ });
+    await expect(worked).toBeVisible();
+    await worked.click();
+
+    const edit = page.getByRole("button", { name: "Edited greet.py" });
+    await expect(edit).toHaveAttribute("aria-expanded", "false");
+    await edit.click();
+    await expect(edit).toHaveAttribute("aria-expanded", "true");
+
+    const inlineDiff = edit.locator("[data-diff]");
+    await expect(inlineDiff).toBeVisible();
+    await expect(
+      inlineDiff.locator('[data-line][data-line-type="change-deletion"]'),
+    ).toContainText('return "Hello!"');
+    await expect(
+      inlineDiff.locator('[data-line][data-line-type="change-addition"]'),
+    ).toContainText('return f"Hello, {name}!"');
+    await expect
+      .poll(() => inlineDiff.locator("[data-line] span").count())
+      .toBeGreaterThan(2);
+  });
+
   test("streams after thread navigation and foreground recovery", async ({
     page,
   }) => {

--- a/ui/src/features/agents/components/chat/DiffView.tsx
+++ b/ui/src/features/agents/components/chat/DiffView.tsx
@@ -6,10 +6,16 @@ import { countLineChanges } from "@/features/agents/utils/diffStats"
 
 interface DiffViewProps {
   diffData: DiffData
+  snippet?: boolean
 }
 
-export function DiffView({ diffData }: DiffViewProps) {
+export function DiffView({ diffData, snippet = false }: DiffViewProps) {
   const diffOptions = useDiffOptions()
+  const options = useMemo(
+    () =>
+      snippet ? { ...diffOptions, disableLineNumbers: true } : diffOptions,
+    [diffOptions, snippet]
+  )
   const { originalContent, newContent, filePath, isBinary } = diffData
   const displayPath = filePath.split("/").pop() || filePath
   const stats = useMemo(
@@ -35,7 +41,7 @@ export function DiffView({ diffData }: DiffViewProps) {
     <div className="mt-2 font-mono text-xs">
       <div className="mb-1 flex items-center gap-2 text-gray-500">
         <span className="text-gray-400">{displayPath}</span>
-        {diffData.isNewFile && <span>(new)</span>}
+        {diffData.isNewFile && !snippet && <span>(new)</span>}
         <span className="text-green-400">+{stats.additions}</span>
         <span className="text-red-400">-{stats.deletions}</span>
       </div>
@@ -43,7 +49,7 @@ export function DiffView({ diffData }: DiffViewProps) {
         <MultiFileDiff
           oldFile={{ name: displayPath, contents: originalContent ?? "" }}
           newFile={{ name: displayPath, contents: newContent }}
-          options={diffOptions}
+          options={options}
         />
       </div>
     </div>

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -63,7 +63,7 @@ function EditWorkEntry({
     <WorkEntryRow
       entry={describeWorkEntry(chunk, projectPath)}
       timestamp={chunk.timestamp}
-      body={diff ? <DiffView diffData={diff} /> : undefined}
+      body={diff ? <DiffView diffData={diff} snippet /> : undefined}
     />
   )
 }

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
+import { DiffView } from "../../chat/DiffView"
 import { ChunkRenderer } from "../ChunkRenderer"
 import { MessageTimestamp } from "../MessageTimestamp"
 import { ReasoningBlock } from "../ReasoningBlock"
@@ -50,28 +51,19 @@ function splitWorkAndReply(items: Array<RenderItem>): {
   }
 }
 
-/**
- * One row per edit call, showing only what the call targeted. The diff lives in
- * the turn's changed-files card and the side panel, both of which read git —
- * rendering a per-call diff here made repeated edits of one file look duplicated.
- */
 function EditWorkEntry({
   chunk,
   projectPath,
-  onOpenFile,
 }: {
   chunk: ToolExecutionChunk
   projectPath?: string
-  onOpenFile?: (filePath: string) => void
 }) {
-  const filePath = latestDiff(chunk)?.filePath
+  const diff = latestDiff(chunk)
   return (
     <WorkEntryRow
       entry={describeWorkEntry(chunk, projectPath)}
       timestamp={chunk.timestamp}
-      onActivate={
-        filePath && onOpenFile ? () => onOpenFile(filePath) : undefined
-      }
+      body={diff ? <DiffView diffData={diff} /> : undefined}
     />
   )
 }
@@ -241,7 +233,6 @@ export function AgentTurn({
             key={item.key}
             chunk={item.chunk}
             projectPath={projectPath}
-            onOpenFile={callbacks.onOpenFile}
           />
         )
 


### PR DESCRIPTION
## Description
Edit tool rows now expand into highlighted per-call source diffs using the existing Pierre renderer, while the turn-level git diff remains unchanged. The E2E scripted flow now performs a real `edit_file` call so the interaction is covered end to end.

## Test Plan
- [x] Focused Playwright dashboard spec (1 passed)
- [x] UI TypeScript typecheck
- [x] Focused timeline Vitest spec (8 passed)

Made by [Open SWE](https://openswe.vercel.app/agents/b6887323-ab4e-6b91-0435-fecc3bcb43ed)