### PR TITLE
feat: scope user settings reads to thread participants

### DIFF
--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -16,6 +16,7 @@ from ..dispatch import create_durable_run
 from ..utils.slack import post_slack_top_level_message_with_ts, store_slack_run_mapping
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
 from ..utils.thread_ops import langgraph_client
+from ..utils.thread_participants import PARTICIPANT_LOGINS_KEY
 from .options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
@@ -496,6 +497,7 @@ def _agent_run_metadata(
         "schedule_name": record.get("name"),
         "schedule_test": test_run,
         "github_login": record.get("created_by"),
+        PARTICIPANT_LOGINS_KEY: [record["created_by"]] if record.get("created_by") else [],
         "triggering_user_email": record.get("user_email"),
         "title": f"{title_prefix}: {record.get('name') or 'Agent'}",
         "base_branch": record.get("base_branch") or "main",

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -38,6 +38,7 @@ from ..utils.thread_ops import (
     langgraph_url,
     queue_message_for_thread,
 )
+from ..utils.thread_participants import PARTICIPANT_LOGINS_KEY, merge_participant_logins
 from .admin import is_admin
 from .agent_overrides import normalize_profile_overrides
 from .environments import get_environment, slugify
@@ -1150,6 +1151,7 @@ async def _create_dashboard_thread_record(
     metadata: dict[str, Any] = {
         "source": _DASHBOARD_SOURCE,
         "github_login": login,
+        PARTICIPANT_LOGINS_KEY: [login],
         "title": initial_title,
         "base_branch": profile.get("base_branch") or "main",
         "branch_prefix": profile.get("branch_prefix"),
@@ -1430,6 +1432,9 @@ async def _enrich_run_start_command(
         metadata_update: dict[str, Any] = {
             "source": _DASHBOARD_SOURCE,
             "plan_mode": plan_mode_requested,
+            PARTICIPANT_LOGINS_KEY: merge_participant_logins(
+                metadata.get(PARTICIPANT_LOGINS_KEY), login
+            ),
         }
         if command_images and run_model and run_effort:
             overrides["agent_model_id"] = run_model
@@ -1531,6 +1536,9 @@ async def send_dashboard_message(
         "source": _DASHBOARD_SOURCE,
         "updated_at_ms": now_ms,
         "plan_mode": body.plan_mode,
+        PARTICIPANT_LOGINS_KEY: merge_participant_logins(
+            metadata.get(PARTICIPANT_LOGINS_KEY), login
+        ),
     }
     if chosen_model and chosen_effort:
         metadata_update["model"] = chosen_model

--- a/agent/server.py
+++ b/agent/server.py
@@ -133,6 +133,7 @@ from .tools import (
     list_environments,
     notify_automation_channel,
     open_pull_request,
+    read_user_settings,
     recreate_sandbox,
     report_platform_issue,
     request_pr_review,
@@ -608,10 +609,13 @@ def _subagent_model_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
     )
 
 
-def _is_slack_tool(tool: Any) -> bool:
-    """Return whether a tool reaches Slack."""
+def _is_subagent_excluded_tool(tool: Any) -> bool:
+    """Return whether a tool depends on parent-only source context."""
     name = getattr(tool, "name", None) or getattr(tool, "__name__", "")
-    return name.startswith("slack_") or name == "notify_automation_channel"
+    return name.startswith("slack_") or name in {
+        "notify_automation_channel",
+        "read_user_settings",
+    }
 
 
 def _general_purpose_subagent(
@@ -631,7 +635,7 @@ def _general_purpose_subagent(
         # tool-call cadence) that delegated work also needs.
         "system_prompt": OPEN_SWE_SHARED_BASE + "\n\n" + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
-        "tools": [tool for tool in tools if not _is_slack_tool(tool)],
+        "tools": [tool for tool in tools if not _is_subagent_excluded_tool(tool)],
         "middleware": [
             *([dynamic_tools] if dynamic_tools else []),
             *_subagent_model_middleware(),
@@ -1270,6 +1274,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         linear_update_issue,
         notify_automation_channel,
         open_pull_request,
+        read_user_settings,
         request_pr_review,
         recreate_sandbox,
         report_platform_issue,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -26,6 +26,7 @@ _TOOL_MODULES = {
     "open_pull_request": ".open_pull_request",
     "publish_review": ".publish_review",
     "read_repo_file": ".read_repo_file",
+    "read_user_settings": ".read_user_settings",
     "recreate_sandbox": ".recreate_sandbox",
     "report_platform_issue": ".report_platform_issue",
     "request_pr_review": ".request_pr_review",
@@ -70,6 +71,7 @@ __all__ = [
     "open_pull_request",
     "publish_review",
     "read_repo_file",
+    "read_user_settings",
     "recreate_sandbox",
     "report_platform_issue",
     "request_pr_review",
@@ -117,6 +119,7 @@ if TYPE_CHECKING:
     from .open_pull_request import open_pull_request
     from .publish_review import publish_review
     from .read_repo_file import read_repo_file
+    from .read_user_settings import read_user_settings
     from .recreate_sandbox import recreate_sandbox
     from .reply_to_finding_thread import reply_to_finding_thread
     from .report_platform_issue import report_platform_issue

--- a/agent/tools/read_user_settings.py
+++ b/agent/tools/read_user_settings.py
@@ -17,6 +17,24 @@ from ..dashboard.user_credentials import (
 from ..dashboard.user_instructions import get_user_instructions
 from ..utils.thread_participants import resolve_thread_participant_logins
 
+_PROFILE_SETTING_KEYS = (
+    "default_model",
+    "reasoning_effort",
+    "default_subagent_model",
+    "subagent_reasoning_effort",
+    "auto_fix_ci",
+    "create_prs",
+    "draft_prs",
+    "review_draft_prs",
+)
+
+
+def _safe_profile_settings(profile: dict[str, Any] | None) -> dict[str, Any]:
+    if not profile:
+        return {}
+    normalized = normalize_profile_for_response(profile)
+    return {key: normalized[key] for key in _PROFILE_SETTING_KEYS if key in normalized}
+
 
 async def _settings_for_login(login: str) -> dict[str, Any]:
     profile, instruction_record, notion, langsmith, currents = await asyncio.gather(
@@ -29,7 +47,7 @@ async def _settings_for_login(login: str) -> dict[str, Any]:
     instructions = instruction_record.get("instructions") if instruction_record else ""
     return {
         "login": login,
-        "profile": normalize_profile_for_response(profile) if profile else {},
+        "profile": _safe_profile_settings(profile),
         "instructions": instructions if isinstance(instructions, str) else "",
         "connections": {
             "notion": notion.get("notion", {"connected": False}),

--- a/agent/tools/read_user_settings.py
+++ b/agent/tools/read_user_settings.py
@@ -1,0 +1,61 @@
+"""Read safe settings for verified participants in the active thread."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..dashboard.profiles import get_profile, normalize_profile_for_response
+from ..dashboard.user_credentials import (
+    get_currents_status,
+    get_langsmith_status,
+    get_notion_status,
+)
+from ..dashboard.user_instructions import get_user_instructions
+from ..utils.thread_participants import resolve_thread_participant_logins
+
+
+async def _settings_for_login(login: str) -> dict[str, Any]:
+    profile, instruction_record, notion, langsmith, currents = await asyncio.gather(
+        get_profile(login),
+        get_user_instructions(login),
+        get_notion_status(login),
+        get_langsmith_status(login),
+        get_currents_status(login),
+    )
+    instructions = instruction_record.get("instructions") if instruction_record else ""
+    return {
+        "login": login,
+        "profile": normalize_profile_for_response(profile) if profile else {},
+        "instructions": instructions if isinstance(instructions, str) else "",
+        "connections": {
+            "notion": notion.get("notion", {"connected": False}),
+            "langsmith": langsmith.get("langsmith", {"connected": False}),
+            "currents": currents.get("currents", {"connected": False}),
+        },
+    }
+
+
+async def read_user_settings() -> dict[str, Any]:
+    """Read server-backed settings for every verified participant in this thread.
+
+    This tool accepts no user, thread, or source identifiers. It derives the active
+    thread from trusted runtime context and returns only mapped human participants.
+    Connection data is redacted status metadata; credentials and tokens are never
+    returned. Browser-local theme and notification preferences are not server-backed.
+    """
+    config = get_config()
+    if not isinstance(config, Mapping):
+        return {"success": False, "error": "Missing run config"}
+    logins, unresolved_count, error = await resolve_thread_participant_logins(config)
+    if error or not logins:
+        return {"success": False, "error": error or "No verified participants found"}
+    participants = await asyncio.gather(*(_settings_for_login(login) for login in sorted(logins)))
+    return {
+        "success": True,
+        "participants": list(participants),
+        "unresolved_participant_count": unresolved_count,
+    }

--- a/agent/utils/github_comments.py
+++ b/agent/utils/github_comments.py
@@ -23,6 +23,7 @@ __all__ = [
     "build_pr_prompt",
     "describe_open_swe_tags",
     "extract_pr_context",
+    "fetch_github_thread_participants",
     "fetch_issue_comments",
     "fetch_pr_branch",
     "fetch_pr_comments_since_last_tag",
@@ -259,6 +260,66 @@ async def post_github_comment(
         except httpx.HTTPError:
             logger.exception("Failed to post comment to GitHub issue/PR #%s", issue_number)
             return False
+
+
+async def fetch_github_thread_participants(
+    repo_config: dict[str, str], issue_number: int, *, token: str
+) -> set[str] | None:
+    """Return mapped-candidate GitHub logins that authored an issue or PR thread."""
+    owner = repo_config.get("owner", "")
+    repo = repo_config.get("name", "")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
+            issue_response = await http_client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}",
+                headers=headers,
+            )
+            if issue_response.status_code == 401:
+                raise GitHubAuthError(f"GitHub returned 401 fetching issue {issue_number}")
+            if issue_response.status_code != 200:  # noqa: PLR2004
+                return None
+            issue = issue_response.json()
+            comments, review_comments, reviews = await asyncio.gather(
+                _fetch_paginated(
+                    http_client,
+                    f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments",
+                    headers,
+                ),
+                _fetch_paginated(
+                    http_client,
+                    f"https://api.github.com/repos/{owner}/{repo}/pulls/{issue_number}/comments",
+                    headers,
+                ),
+                _fetch_paginated(
+                    http_client,
+                    f"https://api.github.com/repos/{owner}/{repo}/pulls/{issue_number}/reviews",
+                    headers,
+                ),
+            )
+    except GitHubAuthError:
+        return None
+    except Exception:
+        logger.exception(
+            "Failed to fetch GitHub participants for %s/%s#%s", owner, repo, issue_number
+        )
+        return None
+
+    users = [issue.get("user")]
+    users.extend(item.get("user") for item in [*comments, *review_comments, *reviews])
+    return {
+        login.strip()
+        for user in users
+        if isinstance(user, dict)
+        and user.get("type") != "Bot"
+        and isinstance(login := user.get("login"), str)
+        and login.strip()
+        and not login.lower().endswith("[bot]")
+    }
 
 
 async def fetch_issue_comments(

--- a/agent/utils/linear.py
+++ b/agent/utils/linear.py
@@ -104,6 +104,40 @@ async def list_teams() -> dict[str, Any]:
     return {"teams": result.get("teams", {}).get("nodes", [])}
 
 
+async def fetch_linear_issue_participant_emails(issue_id: str) -> set[str] | None:
+    """Return verified participant emails for a Linear issue."""
+    query = """
+    query GetIssueParticipants($id: String!) {
+        issue(id: $id) {
+            creator { email }
+            assignee { email }
+            comments {
+                nodes { user { email } }
+            }
+        }
+    }
+    """
+    result = await _graphql_request(query, {"id": issue_id})
+    if "error" in result:
+        return None
+    issue = result.get("issue")
+    if not isinstance(issue, dict):
+        return None
+    identities = [issue.get("creator"), issue.get("assignee")]
+    comments = issue.get("comments")
+    if isinstance(comments, dict):
+        for comment in comments.get("nodes") or []:
+            if isinstance(comment, dict):
+                identities.append(comment.get("user"))
+    return {
+        email.strip().lower()
+        for identity in identities
+        if isinstance(identity, dict)
+        and isinstance(email := identity.get("email"), str)
+        and email.strip()
+    }
+
+
 async def get_issue(issue_id: str) -> dict[str, Any]:
     """Get a Linear issue by ID."""
     query = """

--- a/agent/utils/thread_participants.py
+++ b/agent/utils/thread_participants.py
@@ -16,6 +16,23 @@ from .linear import fetch_linear_issue_participant_emails
 from .slack import fetch_slack_thread_messages
 
 PARTICIPANT_LOGINS_KEY = "participant_logins"
+_SLACK_SYSTEM_MESSAGE_SUBTYPES = {
+    "bot_message",
+    "channel_archive",
+    "channel_join",
+    "channel_leave",
+    "channel_name",
+    "channel_purpose",
+    "channel_topic",
+    "channel_unarchive",
+    "group_join",
+    "group_leave",
+    "message_changed",
+    "message_deleted",
+    "pinned_item",
+    "slackbot_response",
+    "unpinned_item",
+}
 
 
 def merge_participant_logins(existing: Any, *logins: Any) -> list[str]:
@@ -46,7 +63,7 @@ async def _mapped_slack_logins(messages: list[dict[str, Any]]) -> tuple[set[str]
         for message in messages
         if not message.get("bot_id")
         and not message.get("bot_profile")
-        and not message.get("subtype")
+        and message.get("subtype") not in _SLACK_SYSTEM_MESSAGE_SUBTYPES
         and isinstance(user_id := message.get("user"), str)
         and user_id
     }

--- a/agent/utils/thread_participants.py
+++ b/agent/utils/thread_participants.py
@@ -1,0 +1,176 @@
+"""Resolve verified participants for the active agent thread."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from langgraph_sdk import get_client
+
+from ..dashboard.user_mappings import get_mapping, login_for_email, login_for_slack_id
+from .github_comments import fetch_github_thread_participants
+from .github_token import get_github_token
+from .json_types import as_json_object, thread_metadata
+from .linear import fetch_linear_issue_participant_emails
+from .slack import fetch_slack_thread_messages
+
+PARTICIPANT_LOGINS_KEY = "participant_logins"
+
+
+def merge_participant_logins(existing: Any, *logins: Any) -> list[str]:
+    merged: dict[str, str] = {}
+    if isinstance(existing, list):
+        for value in existing:
+            if isinstance(value, str) and value.strip():
+                merged[value.strip().lower()] = value.strip()
+    for value in logins:
+        if isinstance(value, str) and value.strip():
+            merged[value.strip().lower()] = value.strip()
+    return [merged[key] for key in sorted(merged)]
+
+
+async def _active_mapping_login(login: str | None) -> str | None:
+    if not isinstance(login, str) or not login.strip():
+        return None
+    record = await get_mapping(login.strip())
+    if not record or record.get("status", "active") != "active":
+        return None
+    value = record.get("github_login")
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+async def _mapped_slack_logins(messages: list[dict[str, Any]]) -> tuple[set[str], int]:
+    user_ids = {
+        user_id
+        for message in messages
+        if not message.get("bot_id")
+        and not message.get("bot_profile")
+        and not message.get("subtype")
+        and isinstance(user_id := message.get("user"), str)
+        and user_id
+    }
+    resolved = await asyncio.gather(*(login_for_slack_id(user_id) for user_id in user_ids))
+    mapped = await asyncio.gather(*(_active_mapping_login(login) for login in resolved))
+    return {login for login in mapped if login}, sum(login is None for login in mapped)
+
+
+async def _mapped_email_logins(emails: set[str]) -> tuple[set[str], int]:
+    resolved = await asyncio.gather(*(login_for_email(email) for email in emails))
+    mapped = await asyncio.gather(*(_active_mapping_login(login) for login in resolved))
+    return {login for login in mapped if login}, sum(login is None for login in mapped)
+
+
+async def _mapped_github_logins(logins: set[str]) -> tuple[set[str], int]:
+    mapped = await asyncio.gather(*(_active_mapping_login(login) for login in logins))
+    return {login for login in mapped if login}, sum(login is None for login in mapped)
+
+
+def _context_value(configurable: dict[str, Any], metadata: dict[str, Any], key: str) -> Any:
+    value = configurable.get(key)
+    if value is not None:
+        return value
+    source_context = metadata.get("source_context")
+    if isinstance(source_context, dict):
+        return source_context.get(key)
+    return None
+
+
+def _repo_config(configurable: dict[str, Any], metadata: dict[str, Any]) -> dict[str, str] | None:
+    repo = configurable.get("repo") or metadata.get("repo")
+    if (
+        isinstance(repo, dict)
+        and isinstance(repo.get("owner"), str)
+        and isinstance(repo.get("name"), str)
+    ):
+        if repo["owner"] and repo["name"]:
+            return {"owner": repo["owner"], "name": repo["name"]}
+    owner = metadata.get("repo_owner")
+    name = metadata.get("repo_name")
+    if isinstance(owner, str) and owner and isinstance(name, str) and name:
+        return {"owner": owner, "name": name}
+    return None
+
+
+async def resolve_thread_participant_logins(
+    config: Mapping[str, Any],
+) -> tuple[set[str] | None, int, str | None]:
+    configurable = as_json_object(config.get("configurable"))
+    thread_id = configurable.get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        return None, 0, "Missing thread_id in run config"
+
+    try:
+        thread = await get_client().threads.get(thread_id)
+    except Exception:
+        return None, 0, "Could not verify the active thread"
+    metadata = thread_metadata(thread)
+
+    candidate_logins = set(
+        merge_participant_logins(
+            metadata.get(PARTICIPANT_LOGINS_KEY),
+            metadata.get("github_login"),
+            configurable.get("github_login"),
+        )
+    )
+    logins, unresolved_count = await _mapped_github_logins(candidate_logins)
+
+    slack_thread = _context_value(configurable, metadata, "slack_thread")
+    linear_issue = _context_value(configurable, metadata, "linear_issue")
+    github_issue = _context_value(configurable, metadata, "github_issue")
+    source = configurable.get("source") or metadata.get("source")
+
+    if isinstance(slack_thread, dict):
+        channel_id = slack_thread.get("channel_id")
+        thread_ts = slack_thread.get("thread_ts")
+        if not isinstance(channel_id, str) or not channel_id or not isinstance(thread_ts, str):
+            return None, 0, "Slack thread context is incomplete"
+        messages = await fetch_slack_thread_messages(channel_id, thread_ts)
+        if not messages:
+            return None, 0, "Could not verify Slack thread participants"
+        mapped, source_unresolved = await _mapped_slack_logins(messages)
+        logins.update(mapped)
+        unresolved_count += source_unresolved
+    elif isinstance(linear_issue, dict):
+        issue_id = linear_issue.get("id")
+        if not isinstance(issue_id, str) or not issue_id:
+            return None, 0, "Linear issue context is incomplete"
+        emails = await fetch_linear_issue_participant_emails(issue_id)
+        if emails is None:
+            return None, 0, "Could not verify Linear issue participants"
+        mapped, source_unresolved = await _mapped_email_logins(emails)
+        logins.update(mapped)
+        unresolved_count += source_unresolved
+    elif isinstance(github_issue, dict) or (
+        source == "github" and _context_value(configurable, metadata, "pr_number") is not None
+    ):
+        issue_number = (
+            github_issue.get("number")
+            if isinstance(github_issue, dict)
+            else configurable.get("pr_number")
+        )
+        if not isinstance(issue_number, int):
+            context_pr_number = _context_value(configurable, metadata, "pr_number")
+            issue_number = context_pr_number if isinstance(context_pr_number, int) else None
+        repo = _repo_config(configurable, metadata)
+        token = get_github_token(config)
+        if not repo or not issue_number or not token:
+            return None, 0, "GitHub thread context is incomplete"
+        participants = await fetch_github_thread_participants(repo, issue_number, token=token)
+        if participants is None:
+            return None, 0, "Could not verify GitHub thread participants"
+        mapped, source_unresolved = await _mapped_github_logins(participants)
+        logins.update(mapped)
+        unresolved_count += source_unresolved
+    elif source == "dashboard":
+        if not metadata.get(PARTICIPANT_LOGINS_KEY):
+            return None, 0, "Dashboard participant metadata is unavailable"
+    elif source == "schedule":
+        if not metadata.get(PARTICIPANT_LOGINS_KEY):
+            return None, 0, "Schedule participant metadata is unavailable"
+    else:
+        return None, 0, "Unsupported or missing thread source"
+
+    if not logins:
+        return None, unresolved_count, "No mapped participants were found for the active thread"
+    return logins, unresolved_count, None

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -130,6 +130,7 @@ from ..utils.slack_feedback import (
 )
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
 from ..utils.thread_ops import queue_message_for_thread  # noqa: F401
+from ..utils.thread_participants import PARTICIPANT_LOGINS_KEY, merge_participant_logins
 
 __all__ = [
     "Any",
@@ -768,6 +769,10 @@ async def upsert_agent_thread_owner_metadata(
         existing_dict["metadata"] if isinstance(existing_dict.get("metadata"), dict) else {}
     )
     existing_context = existing_meta.get("source_context")
+    if github_login:
+        metadata[PARTICIPANT_LOGINS_KEY] = merge_participant_logins(
+            existing_meta.get(PARTICIPANT_LOGINS_KEY), github_login
+        )
     same_slack_owner = bool(
         isinstance(existing_context, dict)
         and isinstance(source_context, dict)

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -185,6 +185,20 @@ async def test_agent_includes_report_platform_issue_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_includes_read_user_settings_only_on_parent() -> None:
+    from agent.tools import read_user_settings
+
+    captured = await _capture_create_deep_agent_kwargs()
+    tools = captured["tools"]
+    subagents = captured["subagents"]
+    assert isinstance(tools, list)
+    assert isinstance(subagents, list)
+    assert read_user_settings in tools
+    general_purpose = next(item for item in subagents if item["name"] == "general-purpose")
+    assert read_user_settings not in general_purpose["tools"]
+
+
+@pytest.mark.asyncio
 async def test_agent_includes_recreate_sandbox_tool() -> None:
     from agent.tools import recreate_sandbox
 
@@ -300,6 +314,7 @@ async def test_general_purpose_subagent_cannot_use_slack_tools() -> None:
         "slack_thread_reply",
     }
 
-    assert slack_names <= parent_names
-    assert slack_names.isdisjoint(subagent_names)
-    assert subagent_names == parent_names - slack_names
+    parent_only_names = {*slack_names, "read_user_settings"}
+    assert parent_only_names <= parent_names
+    assert parent_only_names.isdisjoint(subagent_names)
+    assert subagent_names == parent_names - parent_only_names

--- a/tests/agent/test_read_user_settings.py
+++ b/tests/agent/test_read_user_settings.py
@@ -28,7 +28,14 @@ async def test_read_user_settings_returns_redacted_participant_settings() -> Non
         patch(
             "agent.tools.read_user_settings.get_profile",
             new_callable=AsyncMock,
-            return_value={"default_model": "openai:gpt-5.6-sol", "reasoning_effort": "high"},
+            return_value={
+                "default_model": "openai:gpt-5.6-sol",
+                "reasoning_effort": "high",
+                "email": "private@example.com",
+                "default_repo": "private/internal",
+                "branch_prefix": "secret-prefix",
+                "updated_at": "2026-08-16T00:00:00Z",
+            },
         ),
         patch(
             "agent.tools.read_user_settings.get_user_instructions",
@@ -72,7 +79,12 @@ async def test_read_user_settings_returns_redacted_participant_settings() -> Non
         ],
         "unresolved_participant_count": 1,
     }
-    assert "token" not in repr(result).lower()
+    rendered = repr(result).lower()
+    assert "token" not in rendered
+    assert "private@example.com" not in rendered
+    assert "private/internal" not in rendered
+    assert "secret-prefix" not in rendered
+    assert "updated_at" not in rendered
 
 
 @pytest.mark.asyncio
@@ -97,29 +109,32 @@ async def test_read_user_settings_fails_before_settings_reads() -> None:
 
 
 @pytest.mark.asyncio
-async def test_slack_participants_exclude_bots_subtypes_and_unmapped_users() -> None:
+async def test_slack_participants_include_broadcasts_and_exclude_system_messages() -> None:
     messages = [
         {"user": "U1"},
+        {"user": "UBROADCAST", "subtype": "thread_broadcast"},
         {"user": "UBOT", "bot_id": "B1"},
         {"user": "UEDIT", "subtype": "message_changed"},
         {"user": "U2"},
     ]
 
     async def login_for_slack_id(user_id: str) -> str | None:
-        return {"U1": "octocat", "U2": None}.get(user_id)
+        return {
+            "U1": "octocat",
+            "UBROADCAST": "broadcaster",
+            "U2": None,
+        }.get(user_id)
+
+    async def get_mapping(login: str) -> dict[str, str]:
+        return {"github_login": login, "status": "active"}
 
     with (
         patch.object(participants, "login_for_slack_id", side_effect=login_for_slack_id),
-        patch.object(
-            participants,
-            "get_mapping",
-            new_callable=AsyncMock,
-            return_value={"github_login": "octocat", "status": "active"},
-        ),
+        patch.object(participants, "get_mapping", side_effect=get_mapping),
     ):
         logins, unresolved = await participants._mapped_slack_logins(messages)
 
-    assert logins == {"octocat"}
+    assert logins == {"octocat", "broadcaster"}
     assert unresolved == 1
 
 

--- a/tests/agent/test_read_user_settings.py
+++ b/tests/agent/test_read_user_settings.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.tools.read_user_settings import read_user_settings
+from agent.utils import thread_participants as participants
+
+
+def test_read_user_settings_accepts_no_model_arguments() -> None:
+    assert list(inspect.signature(read_user_settings).parameters) == []
+
+
+@pytest.mark.asyncio
+async def test_read_user_settings_returns_redacted_participant_settings() -> None:
+    with (
+        patch(
+            "agent.tools.read_user_settings.get_config",
+            return_value={"configurable": {"thread_id": "thread-1"}},
+        ),
+        patch(
+            "agent.tools.read_user_settings.resolve_thread_participant_logins",
+            new_callable=AsyncMock,
+            return_value=({"octocat"}, 1, None),
+        ),
+        patch(
+            "agent.tools.read_user_settings.get_profile",
+            new_callable=AsyncMock,
+            return_value={"default_model": "openai:gpt-5.6-sol", "reasoning_effort": "high"},
+        ),
+        patch(
+            "agent.tools.read_user_settings.get_user_instructions",
+            new_callable=AsyncMock,
+            return_value={"instructions": "Be concise."},
+        ),
+        patch(
+            "agent.tools.read_user_settings.get_notion_status",
+            new_callable=AsyncMock,
+            return_value={"notion": {"connected": True}},
+        ),
+        patch(
+            "agent.tools.read_user_settings.get_langsmith_status",
+            new_callable=AsyncMock,
+            return_value={"langsmith": {"connected": True, "api_key_last4": "1234"}},
+        ),
+        patch(
+            "agent.tools.read_user_settings.get_currents_status",
+            new_callable=AsyncMock,
+            return_value={"currents": {"connected": False}},
+        ),
+    ):
+        result = await read_user_settings()
+
+    assert result == {
+        "success": True,
+        "participants": [
+            {
+                "login": "octocat",
+                "profile": {
+                    "default_model": "openai:gpt-5.6-sol",
+                    "reasoning_effort": "high",
+                },
+                "instructions": "Be concise.",
+                "connections": {
+                    "notion": {"connected": True},
+                    "langsmith": {"connected": True, "api_key_last4": "1234"},
+                    "currents": {"connected": False},
+                },
+            }
+        ],
+        "unresolved_participant_count": 1,
+    }
+    assert "token" not in repr(result).lower()
+
+
+@pytest.mark.asyncio
+async def test_read_user_settings_fails_before_settings_reads() -> None:
+    profile = AsyncMock()
+    with (
+        patch(
+            "agent.tools.read_user_settings.get_config",
+            return_value={"configurable": {"thread_id": "thread-1"}},
+        ),
+        patch(
+            "agent.tools.read_user_settings.resolve_thread_participant_logins",
+            new_callable=AsyncMock,
+            return_value=(None, 0, "Could not verify the active thread"),
+        ),
+        patch("agent.tools.read_user_settings.get_profile", profile),
+    ):
+        result = await read_user_settings()
+
+    assert result == {"success": False, "error": "Could not verify the active thread"}
+    profile.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slack_participants_exclude_bots_subtypes_and_unmapped_users() -> None:
+    messages = [
+        {"user": "U1"},
+        {"user": "UBOT", "bot_id": "B1"},
+        {"user": "UEDIT", "subtype": "message_changed"},
+        {"user": "U2"},
+    ]
+
+    async def login_for_slack_id(user_id: str) -> str | None:
+        return {"U1": "octocat", "U2": None}.get(user_id)
+
+    with (
+        patch.object(participants, "login_for_slack_id", side_effect=login_for_slack_id),
+        patch.object(
+            participants,
+            "get_mapping",
+            new_callable=AsyncMock,
+            return_value={"github_login": "octocat", "status": "active"},
+        ),
+    ):
+        logins, unresolved = await participants._mapped_slack_logins(messages)
+
+    assert logins == {"octocat"}
+    assert unresolved == 1
+
+
+@pytest.mark.asyncio
+async def test_linear_participants_use_verified_email_mappings() -> None:
+    async def login_for_email(email: str) -> str | None:
+        return {"octo@example.com": "octocat", "missing@example.com": None}.get(email)
+
+    with (
+        patch.object(participants, "login_for_email", side_effect=login_for_email),
+        patch.object(
+            participants,
+            "get_mapping",
+            new_callable=AsyncMock,
+            return_value={"github_login": "octocat", "status": "active"},
+        ),
+    ):
+        logins, unresolved = await participants._mapped_email_logins(
+            {"octo@example.com", "missing@example.com"}
+        )
+
+    assert logins == {"octocat"}
+    assert unresolved == 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_participants_are_read_from_trusted_metadata() -> None:
+    class Threads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            assert thread_id == "thread-1"
+            return {
+                "metadata": {
+                    "source": "dashboard",
+                    "github_login": "owner",
+                    "participant_logins": ["owner", "teammate"],
+                }
+            }
+
+    class Client:
+        threads = Threads()
+
+    async def get_mapping(login: str) -> dict[str, str]:
+        return {"github_login": login, "status": "active"}
+
+    with (
+        patch.object(participants, "get_client", return_value=Client()),
+        patch.object(participants, "get_mapping", side_effect=get_mapping),
+    ):
+        logins, unresolved, error = await participants.resolve_thread_participant_logins(
+            {"configurable": {"thread_id": "thread-1", "source": "dashboard"}}
+        )
+
+    assert error is None
+    assert unresolved == 0
+    assert logins == {"owner", "teammate"}

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -576,9 +576,12 @@ async def test_proxy_commands_lazily_creates_missing_thread_only_for_run_start(
 
 
 async def test_enrich_run_start_command_attributes_non_owner_message(monkeypatch) -> None:
+    updates: list[dict[str, object]] = []
+
     class FakeThreads:
         async def update(self, *, thread_id: str, metadata: dict[str, object]) -> None:
-            pass
+            assert thread_id == "tid"
+            updates.append(metadata)
 
     class FakeClient:
         threads = FakeThreads()
@@ -606,13 +609,18 @@ async def test_enrich_run_start_command_attributes_non_owner_message(monkeypatch
         "tid",
         "teammate",
         command,
-        metadata={"source": "dashboard", "github_login": "owner"},
+        metadata={
+            "source": "dashboard",
+            "github_login": "owner",
+            "participant_logins": ["owner"],
+        },
         email="teammate@example.com",
     )
 
     # A non-owner's message is forwarded but tagged with their login.
     last = enriched["params"]["input"]["messages"][-1]
     assert last["content"] == "@teammate: fix the bug"
+    assert updates[-1]["participant_logins"] == ["owner", "teammate"]
 
 
 async def test_enrich_run_start_command_adds_web_handoff_for_slack_thread(monkeypatch) -> None:

--- a/tests/utils/test_thread_participants.py
+++ b/tests/utils/test_thread_participants.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.utils import thread_participants as participants
+
+
+class _Threads:
+    def __init__(self, metadata: dict[str, object]) -> None:
+        self._metadata = metadata
+
+    async def get(self, thread_id: str) -> dict[str, object]:
+        assert thread_id == "thread-1"
+        return {"metadata": self._metadata}
+
+
+class _Client:
+    def __init__(self, metadata: dict[str, object]) -> None:
+        self.threads = _Threads(metadata)
+
+
+async def _active_mapping(login: str) -> dict[str, str]:
+    return {"github_login": login, "status": "active"}
+
+
+@pytest.mark.asyncio
+async def test_resolves_slack_participants_from_verified_source_context() -> None:
+    metadata = {
+        "source": "slack",
+        "participant_logins": ["owner"],
+        "source_context": {
+            "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"}
+        },
+    }
+    with (
+        patch.object(participants, "get_client", return_value=_Client(metadata)),
+        patch.object(participants, "get_mapping", side_effect=_active_mapping),
+        patch.object(
+            participants,
+            "fetch_slack_thread_messages",
+            new_callable=AsyncMock,
+            return_value=[{"user": "U2"}],
+        ) as fetch,
+        patch.object(
+            participants,
+            "login_for_slack_id",
+            new_callable=AsyncMock,
+            return_value="teammate",
+        ),
+    ):
+        logins, unresolved, error = await participants.resolve_thread_participant_logins(
+            {"configurable": {"thread_id": "thread-1", "source": "slack"}}
+        )
+
+    assert error is None
+    assert unresolved == 0
+    assert logins == {"owner", "teammate"}
+    fetch.assert_awaited_once_with("C123", "1700000000.000100")
+
+
+@pytest.mark.asyncio
+async def test_resolves_linear_participants_from_issue_context() -> None:
+    metadata = {
+        "source": "linear",
+        "participant_logins": ["owner"],
+        "source_context": {"linear_issue": {"id": "lin-1"}},
+    }
+    with (
+        patch.object(participants, "get_client", return_value=_Client(metadata)),
+        patch.object(participants, "get_mapping", side_effect=_active_mapping),
+        patch.object(
+            participants,
+            "fetch_linear_issue_participant_emails",
+            new_callable=AsyncMock,
+            return_value={"teammate@example.com"},
+        ) as fetch,
+        patch.object(
+            participants,
+            "login_for_email",
+            new_callable=AsyncMock,
+            return_value="teammate",
+        ),
+    ):
+        logins, unresolved, error = await participants.resolve_thread_participant_logins(
+            {"configurable": {"thread_id": "thread-1", "source": "linear"}}
+        )
+
+    assert error is None
+    assert unresolved == 0
+    assert logins == {"owner", "teammate"}
+    fetch.assert_awaited_once_with("lin-1")
+
+
+@pytest.mark.asyncio
+async def test_resolves_github_participants_from_issue_context() -> None:
+    metadata = {
+        "source": "github",
+        "participant_logins": ["owner"],
+        "repo": {"owner": "acme", "name": "widgets"},
+        "source_context": {"github_issue": {"number": 7}},
+    }
+    with (
+        patch.object(participants, "get_client", return_value=_Client(metadata)),
+        patch.object(participants, "get_mapping", side_effect=_active_mapping),
+        patch.object(participants, "get_github_token", return_value="token"),
+        patch.object(
+            participants,
+            "fetch_github_thread_participants",
+            new_callable=AsyncMock,
+            return_value={"owner", "teammate"},
+        ) as fetch,
+    ):
+        logins, unresolved, error = await participants.resolve_thread_participant_logins(
+            {"configurable": {"thread_id": "thread-1", "source": "github"}}
+        )
+
+    assert error is None
+    assert unresolved == 0
+    assert logins == {"owner", "teammate"}
+    fetch.assert_awaited_once_with({"owner": "acme", "name": "widgets"}, 7, token="token")
+
+
+@pytest.mark.asyncio
+async def test_source_fetch_failure_does_not_fall_back_to_metadata_owner() -> None:
+    metadata = {
+        "source": "slack",
+        "participant_logins": ["owner"],
+        "source_context": {
+            "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"}
+        },
+    }
+    with (
+        patch.object(participants, "get_client", return_value=_Client(metadata)),
+        patch.object(participants, "get_mapping", side_effect=_active_mapping),
+        patch.object(
+            participants,
+            "fetch_slack_thread_messages",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        logins, unresolved, error = await participants.resolve_thread_participant_logins(
+            {"configurable": {"thread_id": "thread-1", "source": "slack"}}
+        )
+
+    assert logins is None
+    assert unresolved == 0
+    assert error == "Could not verify Slack thread participants"


### PR DESCRIPTION
## Description
Adds a source-agnostic, no-argument tool that reads safe server-backed settings only for verified participants in the active Slack, Linear, GitHub, dashboard, or scheduled thread. Participant resolution fails closed and connection data uses redacted status helpers only.

## Test Plan
- [x] Verify source-specific participant resolution, participant metadata, tool assembly, and redacted output

Made by [Open SWE](https://openswe.vercel.app/agents/ab9df93e-6a0e-d06b-c8d4-0b76b96e7c47)

## References
- Plan: https://openswe.vercel.app/agents/ab9df93e-6a0e-d06b-c8d4-0b76b96e7c47/plan