### PR TITLE
fix: restore cloud terminal connections

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -32,7 +32,44 @@ _DESKTOP_APP_ORIGIN = "open-swe://app"
 SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
 STATE_TTL_SECONDS = 600
 HANDOFF_TTL_SECONDS = 120
+TERMINAL_TICKET_TTL_SECONDS = 60
+TERMINAL_TICKET_AUDIENCE = "open-swe-cloud-terminal"
 JWT_ALG = "HS256"
+
+
+def issue_terminal_ticket(*, login: str, email: str | None, thread_id: str) -> str:
+    now = int(time.time())
+    payload = {
+        "aud": TERMINAL_TICKET_AUDIENCE,
+        "sub": login,
+        "email": email,
+        "thread_id": thread_id,
+        "iat": now,
+        "exp": now + TERMINAL_TICKET_TTL_SECONDS,
+    }
+    return jwt.encode(payload, _secret(), algorithm=JWT_ALG)
+
+
+def decode_terminal_ticket(token: str, *, thread_id: str) -> dict[str, Any]:
+    try:
+        payload = jwt.decode(
+            token,
+            _secret(),
+            algorithms=[JWT_ALG],
+            audience=TERMINAL_TICKET_AUDIENCE,
+            options={"require": ["aud", "sub", "thread_id", "iat", "exp"]},
+        )
+    except jwt.PyJWTError as exc:
+        raise HTTPException(401, "invalid terminal ticket") from exc
+    login = payload.get("sub")
+    ticket_thread_id = payload.get("thread_id")
+    if not isinstance(login, str) or not login or not isinstance(ticket_thread_id, str):
+        raise HTTPException(401, "invalid terminal ticket")
+    if not hmac.compare_digest(ticket_thread_id, thread_id):
+        raise HTTPException(401, "invalid terminal ticket")
+    email = payload.get("email")
+    return {"sub": login, "email": email if isinstance(email, str) else None}
+
 
 GITHUB_APP_CLIENT_ID = os.environ.get("GITHUB_APP_CLIENT_ID", "")
 GITHUB_APP_CLIENT_SECRET = os.environ.get("GITHUB_APP_CLIENT_SECRET", "")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -10,7 +10,7 @@ import os
 import posixpath
 import shlex
 from typing import Any, Literal
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import (
@@ -26,6 +26,7 @@ from fastapi import (
 from fastapi.responses import RedirectResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
+from ..utils.thread_ops import langgraph_url
 from .admin import is_admin
 from .agent_instructions import (
     AgentInstructionsCreate,
@@ -75,6 +76,7 @@ from .oauth import (
     STATE_COOKIE_NAME,
     STATE_TTL_SECONDS,
     decode_state,
+    decode_terminal_ticket,
     desktop_callback_url,
     enforce_org_login_gate,
     exchange_code,
@@ -83,6 +85,7 @@ from .oauth import (
     issue_desktop_handoff,
     issue_session,
     issue_state,
+    issue_terminal_ticket,
     new_state_nonce,
     redeem_desktop_handoff,
     require_same_origin_for_mutations,
@@ -280,6 +283,7 @@ router = APIRouter(
 )
 _GITHUB_API_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
 _CLOUD_TERMINAL_SLOTS = asyncio.Semaphore(20)
+_CLOUD_TERMINAL_SUBPROTOCOL = "open-swe-terminal"
 # Module-level so a local harness can point the browser leg at a fake consent
 # page and still run the real login/callback code.
 GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
@@ -1950,6 +1954,50 @@ async def api_get_thread(
     )
 
 
+def _cloud_terminal_websocket_url(thread_id: str) -> str:
+    parsed = urlsplit(langgraph_url())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise HTTPException(500, "invalid LangGraph URL for cloud terminal")
+    path = f"{parsed.path.rstrip('/')}/dashboard/api/threads/{quote(thread_id, safe='')}/terminal"
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    return urlunsplit((scheme, parsed.netloc, path, "", ""))
+
+
+def _cloud_terminal_session(websocket: WebSocket, thread_id: str) -> dict[str, Any]:
+    offered = [
+        value.strip()
+        for value in websocket.headers.get("sec-websocket-protocol", "").split(",")
+        if value.strip()
+    ]
+    if len(offered) != 2 or offered[0] != _CLOUD_TERMINAL_SUBPROTOCOL:
+        raise HTTPException(401, "invalid terminal ticket")
+    return decode_terminal_ticket(offered[1], thread_id=thread_id)
+
+
+@router.post("/threads/{thread_id}/terminal/connect")
+async def api_thread_terminal_connection(
+    thread_id: str,
+    response: Response,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, str]:
+    await get_dashboard_terminal_sandbox(thread_id, session["sub"], email=session.get("email"))
+    response.headers["Cache-Control"] = "no-store"
+    return {
+        "url": _cloud_terminal_websocket_url(thread_id),
+        "protocol": _CLOUD_TERMINAL_SUBPROTOCOL,
+        "ticket": issue_terminal_ticket(
+            login=session["sub"], email=session.get("email"), thread_id=thread_id
+        ),
+    }
+
+
 async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[str, Any]) -> None:
     if os.environ.get("SANDBOX_TYPE", "langsmith") != "langsmith":
         await websocket.close(code=1008, reason="Cloud terminal requires a LangSmith sandbox")
@@ -1962,7 +2010,7 @@ async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[st
         await websocket.close(code=1008, reason=str(exc.detail)[:123])
         return
 
-    await websocket.accept()
+    await websocket.accept(subprotocol=_CLOUD_TERMINAL_SUBPROTOCOL)
     client = handle = None
     try:
         await asyncio.wait_for(_CLOUD_TERMINAL_SLOTS.acquire(), timeout=0.01)
@@ -2045,11 +2093,12 @@ async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[st
 
 
 @router.websocket("/threads/{thread_id}/terminal")
-async def api_thread_terminal(
-    websocket: WebSocket,
-    thread_id: str,
-    session: dict[str, Any] = _SESSION_DEP,
-) -> None:
+async def api_thread_terminal(websocket: WebSocket, thread_id: str) -> None:
+    try:
+        session = _cloud_terminal_session(websocket, thread_id)
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=str(exc.detail)[:123])
+        return
     await _cloud_terminal(websocket, thread_id, session)
 
 

--- a/tests/dashboard/test_cloud_terminal.py
+++ b/tests/dashboard/test_cloud_terminal.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, HTTPException, Response, WebSocket
+from fastapi.testclient import TestClient
+
+from agent.dashboard import oauth, routes
+
+
+def test_terminal_ticket_is_short_lived_and_thread_bound(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-with-at-least-32-bytes")
+    ticket = oauth.issue_terminal_ticket(
+        login="alice", email="alice@example.com", thread_id="thread-1"
+    )
+
+    assert oauth.decode_terminal_ticket(ticket, thread_id="thread-1") == {
+        "sub": "alice",
+        "email": "alice@example.com",
+    }
+    with pytest.raises(HTTPException) as exc_info:
+        oauth.decode_terminal_ticket(ticket, thread_id="thread-2")
+    assert exc_info.value.status_code == 401
+
+
+def test_terminal_ticket_rejects_expired_tokens(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-with-at-least-32-bytes")
+    monkeypatch.setattr(oauth.time, "time", lambda: 0)
+    ticket = oauth.issue_terminal_ticket(login="alice", email=None, thread_id="thread-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        oauth.decode_terminal_ticket(ticket, thread_id="thread-1")
+    assert exc_info.value.status_code == 401
+
+
+def test_cloud_terminal_url_uses_direct_langgraph_origin(monkeypatch) -> None:
+    monkeypatch.setenv("LANGGRAPH_URL", "https://agent.example/base")
+
+    assert routes._cloud_terminal_websocket_url("thread/1") == (
+        "wss://agent.example/base/dashboard/api/threads/thread%2F1/terminal"
+    )
+
+
+async def test_terminal_connection_requires_owner_before_issuing_ticket(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-with-at-least-32-bytes")
+    monkeypatch.setenv("LANGGRAPH_URL", "https://agent.example")
+    get_sandbox = AsyncMock(return_value=("sandbox-1", "repo"))
+    monkeypatch.setattr(routes, "get_dashboard_terminal_sandbox", get_sandbox)
+    response = Response()
+
+    connection = await routes.api_thread_terminal_connection(
+        "thread-1",
+        response,
+        {"sub": "alice", "email": "alice@example.com"},
+    )
+
+    get_sandbox.assert_awaited_once_with("thread-1", "alice", email="alice@example.com")
+    assert response.headers["cache-control"] == "no-store"
+    assert connection["url"] == ("wss://agent.example/dashboard/api/threads/thread-1/terminal")
+    assert connection["protocol"] == "open-swe-terminal"
+    assert connection["ticket"] not in connection["url"]
+    assert (
+        oauth.decode_terminal_ticket(connection["ticket"], thread_id="thread-1")["sub"] == "alice"
+    )
+
+
+def test_cloud_terminal_session_reads_ticket_from_subprotocol(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-with-at-least-32-bytes")
+    ticket = oauth.issue_terminal_ticket(login="alice", email=None, thread_id="thread-1")
+    websocket = cast(
+        WebSocket,
+        SimpleNamespace(
+            headers={
+                "sec-websocket-protocol": f"open-swe-terminal, {ticket}",
+            }
+        ),
+    )
+
+    assert routes._cloud_terminal_session(websocket, "thread-1") == {
+        "sub": "alice",
+        "email": None,
+    }
+
+    invalid_websocket = cast(
+        WebSocket,
+        SimpleNamespace(headers={"sec-websocket-protocol": ticket}),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        routes._cloud_terminal_session(invalid_websocket, "thread-1")
+    assert exc_info.value.status_code == 401
+
+
+def test_cloud_terminal_route_accepts_ticket_without_dashboard_cookie(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-with-at-least-32-bytes")
+    ticket = oauth.issue_terminal_ticket(login="alice", email=None, thread_id="thread-1")
+
+    async def fake_cloud_terminal(
+        websocket: WebSocket, thread_id: str, session: dict[str, object]
+    ) -> None:
+        assert thread_id == "thread-1"
+        assert session["sub"] == "alice"
+        await websocket.accept(subprotocol="open-swe-terminal")
+        await websocket.send_json({"type": "ready"})
+        await websocket.close()
+
+    monkeypatch.setattr(routes, "_cloud_terminal", fake_cloud_terminal)
+    app = FastAPI()
+    app.include_router(routes.router)
+
+    with TestClient(app).websocket_connect(
+        "/dashboard/api/threads/thread-1/terminal",
+        subprotocols=["open-swe-terminal", ticket],
+    ) as websocket:
+        assert websocket.accepted_subprotocol == "open-swe-terminal"
+        assert websocket.receive_json() == {"type": "ready"}

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -93,6 +93,12 @@ export interface ThreadRecoveryPatch {
   filename: string
 }
 
+export interface CloudTerminalConnection {
+  url: string
+  protocol: string
+  ticket: string
+}
+
 export interface ThreadsPageParams {
   limit?: number
   offset?: number
@@ -327,6 +333,11 @@ export const agentsApi = {
   downloadThreadRecoveryPatch: (threadId: string) =>
     agentsBlobRequest(
       `/threads/${encodeURIComponent(threadId)}/recovery.patch`
+    ),
+  connectCloudTerminal: (threadId: string) =>
+    agentsRequest<CloudTerminalConnection>(
+      `/threads/${encodeURIComponent(threadId)}/terminal/connect`,
+      { method: "POST" }
     ),
   streamUrl: (threadId: string) =>
     `${API_BASE}/dashboard/api/threads/${encodeURIComponent(threadId)}/stream`,

--- a/ui/src/features/agents/lib/terminalSession.test.ts
+++ b/ui/src/features/agents/lib/terminalSession.test.ts
@@ -4,6 +4,8 @@ import {
   EMPTY_TERMINAL_SESSION,
   applyTerminalEvent,
   applyTerminalSnapshot,
+  cloudTerminalCloseError,
+  cloudTerminalProtocols,
 } from "./terminalSession"
 
 const snapshot = {
@@ -82,5 +84,29 @@ describe("terminal session replay", () => {
     expect(active.summary?.label).toBe("node")
     expect(restarted.buffer).toBe("new")
     expect(restarted.summary?.pid).toBe(2)
+  })
+})
+
+describe("cloud terminal connection", () => {
+  it("passes the short-lived ticket as a WebSocket subprotocol", () => {
+    expect(
+      cloudTerminalProtocols({
+        url: "wss://agent.example/terminal",
+        protocol: "open-swe-terminal",
+        ticket: "signed-ticket",
+      })
+    ).toEqual(["open-swe-terminal", "signed-ticket"])
+  })
+
+  it("keeps the actionable handshake error when close has no reason", () => {
+    expect(
+      cloudTerminalCloseError("", "Unable to connect to cloud terminal")
+    ).toBe("Unable to connect to cloud terminal")
+    expect(cloudTerminalCloseError("capacity reached", "prior error")).toBe(
+      "capacity reached"
+    )
+    expect(cloudTerminalCloseError("", null)).toBe(
+      "Cloud terminal disconnected"
+    )
   })
 })

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -5,7 +5,8 @@ import type {
   DesktopTerminalSessionSnapshot,
   DesktopTerminalSummary,
 } from "@/desktop"
-import { dashboardApiUrl } from "@/lib/dashboard-fetch"
+import { agentsApi } from "@/features/agents/lib/api"
+import type { CloudTerminalConnection } from "@/features/agents/lib/api"
 
 export type TerminalTarget =
   { kind: "local"; sessionId: string } | { kind: "cloud"; threadId: string }
@@ -225,16 +226,17 @@ export interface AttachedTerminal extends TerminalSessionState {
   resize: (cols: number, rows: number) => void
 }
 
-function cloudTerminalUrl(threadId: string): string {
-  const base = dashboardApiUrl(
-    `/threads/${encodeURIComponent(threadId)}/terminal`
-  )
-  const url = new URL(base, window.location.href)
-  if (!/^https?:$/.test(url.protocol)) {
-    throw new Error("Cloud terminal requires an HTTP dashboard API")
-  }
-  url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
-  return url.toString()
+export function cloudTerminalProtocols(
+  connection: CloudTerminalConnection
+): string[] {
+  return [connection.protocol, connection.ticket]
+}
+
+export function cloudTerminalCloseError(
+  reason: string,
+  currentError: string | null
+): string {
+  return reason || currentError || "Cloud terminal disconnected"
 }
 
 export function useAttachedTerminal(
@@ -248,6 +250,7 @@ export function useAttachedTerminal(
     EMPTY_TERMINAL_SESSION
   )
   const socketRef = useRef<WebSocket | null>(null)
+  const cloudConnectingRef = useRef(false)
   const pendingRef = useRef<Array<object>>([])
   const sessionId = target.kind === "local" ? target.sessionId : target.threadId
 
@@ -255,107 +258,136 @@ export function useAttachedTerminal(
     if (target.kind === "cloud") {
       let disposed = false
       let sequence = 0
+      let socket: WebSocket | null = null
       pendingRef.current = []
-      let socket: WebSocket
-      try {
-        socket = new WebSocket(cloudTerminalUrl(target.threadId))
-      } catch (error) {
-        setState({
-          ...EMPTY_TERMINAL_SESSION,
-          status: "error",
-          error: error instanceof Error ? error.message : "Unable to connect",
-        })
-        return
-      }
-      socketRef.current = socket
+      cloudConnectingRef.current = true
       setState({ ...EMPTY_TERMINAL_SESSION, status: "starting" })
-      socket.onopen = () => {
-        if (socketRef.current === socket && !disposed) {
-          setState((current) => ({
-            ...current,
-            status: "running",
-            error: null,
-          }))
-          for (const message of pendingRef.current.splice(0)) {
-            socket.send(JSON.stringify(message))
-          }
-        }
-      }
-      socket.onmessage = (event) => {
-        if (
-          disposed ||
-          socketRef.current !== socket ||
-          typeof event.data !== "string"
-        )
-          return
-        let message: {
-          type: string
-          data?: string
-          exitCode?: number
-          message?: string
-        }
-        try {
-          message = JSON.parse(event.data)
-        } catch {
-          return
-        }
-        if (message.type === "output" && typeof message.data === "string") {
-          setState((current) => ({
-            ...current,
-            buffer: trimBuffer(`${current.buffer}${message.data}`),
-            status: "running",
-            error: null,
-            version: current.version + 1,
-            sequence: ++sequence,
-          }))
-        } else if (message.type === "exit") {
-          setState((current) => ({
-            ...current,
-            status: "exited",
-            version: current.version + 1,
-            sequence: ++sequence,
-          }))
-        } else if (message.type === "error") {
-          setState((current) => ({
-            ...current,
-            status: "error",
-            error: message.message ?? "Cloud terminal disconnected",
-            version: current.version + 1,
-          }))
-        }
-      }
-      socket.onerror = () => {
-        if (socketRef.current !== socket || disposed) return
-        setState((current) => ({
-          ...current,
-          status: "error",
-          error: "Unable to connect to cloud terminal",
-          version: current.version + 1,
-        }))
-      }
-      socket.onclose = (event) => {
-        const active = socketRef.current === socket
-        if (active) socketRef.current = null
-        if (active && !disposed) {
-          pendingRef.current = []
-          setState((current) =>
-            event.code !== 1000
-              ? {
-                  ...current,
-                  status: "error",
-                  error: event.reason || "Cloud terminal disconnected",
-                  version: current.version + 1,
-                }
-              : current.status === "error"
-                ? current
-                : { ...current, status: "closed", version: current.version + 1 }
+
+      void agentsApi
+        .connectCloudTerminal(target.threadId)
+        .then((connection) => {
+          if (disposed) return
+          const createdSocket = new WebSocket(
+            connection.url,
+            cloudTerminalProtocols(connection)
           )
-        }
-      }
+          socket = createdSocket
+          socketRef.current = createdSocket
+          createdSocket.onopen = () => {
+            if (socketRef.current === createdSocket && !disposed) {
+              cloudConnectingRef.current = false
+              setState((current) => ({
+                ...current,
+                status: "running",
+                error: null,
+              }))
+              for (const message of pendingRef.current.splice(0)) {
+                createdSocket.send(JSON.stringify(message))
+              }
+            }
+          }
+          createdSocket.onmessage = (event) => {
+            if (
+              disposed ||
+              socketRef.current !== createdSocket ||
+              typeof event.data !== "string"
+            )
+              return
+            let message: {
+              type: string
+              data?: string
+              exitCode?: number
+              message?: string
+            }
+            try {
+              message = JSON.parse(event.data)
+            } catch {
+              return
+            }
+            if (message.type === "output" && typeof message.data === "string") {
+              setState((current) => ({
+                ...current,
+                buffer: trimBuffer(`${current.buffer}${message.data}`),
+                status: "running",
+                error: null,
+                version: current.version + 1,
+                sequence: ++sequence,
+              }))
+            } else if (message.type === "exit") {
+              setState((current) => ({
+                ...current,
+                status: "exited",
+                version: current.version + 1,
+                sequence: ++sequence,
+              }))
+            } else if (message.type === "error") {
+              setState((current) => ({
+                ...current,
+                status: "error",
+                error: message.message ?? "Cloud terminal disconnected",
+                version: current.version + 1,
+              }))
+            }
+          }
+          createdSocket.onerror = () => {
+            if (socketRef.current !== createdSocket || disposed) return
+            cloudConnectingRef.current = false
+            setState((current) => ({
+              ...current,
+              status: "error",
+              error: "Unable to connect to cloud terminal",
+              version: current.version + 1,
+            }))
+          }
+          createdSocket.onclose = (event) => {
+            const active = socketRef.current === createdSocket
+            if (active) {
+              socketRef.current = null
+              cloudConnectingRef.current = false
+            }
+            if (active && !disposed) {
+              pendingRef.current = []
+              setState((current) =>
+                event.code !== 1000
+                  ? {
+                      ...current,
+                      status: "error",
+                      error: cloudTerminalCloseError(
+                        event.reason,
+                        current.error
+                      ),
+                      version: current.version + 1,
+                    }
+                  : current.status === "error"
+                    ? current
+                    : {
+                        ...current,
+                        status: "closed",
+                        version: current.version + 1,
+                      }
+              )
+            }
+          }
+        })
+        .catch((error: unknown) => {
+          if (disposed) return
+          cloudConnectingRef.current = false
+          pendingRef.current = []
+          setState({
+            ...EMPTY_TERMINAL_SESSION,
+            status: "error",
+            error:
+              error instanceof Error
+                ? error.message
+                : "Unable to connect to cloud terminal",
+          })
+        })
+
       return () => {
         disposed = true
+        cloudConnectingRef.current = false
         pendingRef.current = []
-        socket.close()
+        socket?.close()
         if (socketRef.current === socket) socketRef.current = null
       }
     }
@@ -414,7 +446,10 @@ export function useAttachedTerminal(
       socket.send(JSON.stringify(message))
       return true
     }
-    if (socket?.readyState === WebSocket.CONNECTING) {
+    if (
+      socket?.readyState === WebSocket.CONNECTING ||
+      cloudConnectingRef.current
+    ) {
       if (pendingRef.current.length >= 100) return false
       pendingRef.current.push(message)
       return true


### PR DESCRIPTION
## Description
Cloud terminal upgrades were lost by the Vercel external rewrite and fell into LangGraph auth instead of the terminal route. This uses an authenticated, thread-bound short-lived ticket to connect directly to the backend WebSocket and preserves actionable connection errors.

## Test Plan
- [x] Focused dashboard ticket, authorization, and WebSocket route tests
- [x] Focused terminal session UI tests
- [x] Production UI build

Made by [Open SWE](https://openswe.vercel.app/agents/5db9f81b-f7da-5fcd-576f-6c06c61e7ddc)