### PR TITLE
feat: retitle Slack-started agent threads

### DIFF
--- a/agent/thread_title.py
+++ b/agent/thread_title.py
@@ -74,7 +74,7 @@ async def generate_and_store_thread_title(
     expected_title = metadata.get("title")
     title_seed = metadata.get("title_seed")
     if (
-        metadata.get("source") != "dashboard"
+        metadata.get("source") not in {"dashboard", "slack"}
         or not isinstance(title_seed, str)
         or expected_title != title_seed
     ):

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -751,7 +751,10 @@ async def upsert_agent_thread_owner_metadata(
         metadata["repo_owner"] = repo_config["owner"]
         metadata["repo_name"] = repo_config["name"]
     if title:
-        metadata["title"] = title[:80]
+        initial_title = title[:80]
+        metadata["title"] = initial_title
+        if source == "slack":
+            metadata["title_seed"] = initial_title
     if environment:
         metadata["environment"] = environment
 
@@ -796,6 +799,7 @@ async def upsert_agent_thread_owner_metadata(
     if existing_meta.get("title") and "title" in metadata:
         # Preserve a title that was already chosen (first message wins).
         metadata.pop("title")
+        metadata.pop("title_seed", None)
 
     try:
         if existing is None:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -752,10 +752,7 @@ async def upsert_agent_thread_owner_metadata(
         metadata["repo_owner"] = repo_config["owner"]
         metadata["repo_name"] = repo_config["name"]
     if title:
-        initial_title = title[:80]
-        metadata["title"] = initial_title
-        if source == "slack":
-            metadata["title_seed"] = initial_title
+        metadata["title"] = title[:80]
     if environment:
         metadata["environment"] = environment
 
@@ -804,7 +801,8 @@ async def upsert_agent_thread_owner_metadata(
     if existing_meta.get("title") and "title" in metadata:
         # Preserve a title that was already chosen (first message wins).
         metadata.pop("title")
-        metadata.pop("title_seed", None)
+    elif source == "slack" and "title" in metadata:
+        metadata["title_seed"] = metadata["title"]
 
     try:
         if existing is None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -138,6 +138,32 @@ def test_upsert_preserves_partially_initialized_owner(monkeypatch: pytest.Monkey
     assert metadata["source_context"] == owner_context
 
 
+def test_slack_upsert_seeds_only_the_initial_thread_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads = _FakeThreadsClient({"metadata": {}})
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+
+    asyncio.run(
+        webhook_common.upsert_agent_thread_owner_metadata(
+            "thread-id",
+            source="slack",
+            title="Investigate the deployment failure",
+        )
+    )
+    asyncio.run(
+        webhook_common.upsert_agent_thread_owner_metadata(
+            "thread-id",
+            source="slack",
+            title="Ignore this later title",
+        )
+    )
+
+    metadata = cast(dict, threads.thread)["metadata"]
+    assert metadata["title"] == "Investigate the deployment failure"
+    assert metadata["title_seed"] == "Investigate the deployment failure"
+
+
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:
     bot_user_id = "UBOT"
     messages = [

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -127,6 +127,7 @@ def test_upsert_preserves_partially_initialized_owner(monkeypatch: pytest.Monkey
             source="slack",
             github_login=github_login,
             user_email=user_email,
+            title=github_login,
             source_context={"slack_thread": {"triggering_user_id": slack_user_id}},
         )
 
@@ -136,6 +137,7 @@ def test_upsert_preserves_partially_initialized_owner(monkeypatch: pytest.Monkey
     assert metadata["github_login"] == "owner-gh"
     assert metadata["triggering_user_email"] == "owner@example.com"
     assert metadata["source_context"] == owner_context
+    assert metadata["title"] == metadata["title_seed"] == "owner-gh"
 
 
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -138,32 +138,6 @@ def test_upsert_preserves_partially_initialized_owner(monkeypatch: pytest.Monkey
     assert metadata["source_context"] == owner_context
 
 
-def test_slack_upsert_seeds_only_the_initial_thread_title(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    threads = _FakeThreadsClient({"metadata": {}})
-    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
-
-    asyncio.run(
-        webhook_common.upsert_agent_thread_owner_metadata(
-            "thread-id",
-            source="slack",
-            title="Investigate the deployment failure",
-        )
-    )
-    asyncio.run(
-        webhook_common.upsert_agent_thread_owner_metadata(
-            "thread-id",
-            source="slack",
-            title="Ignore this later title",
-        )
-    )
-
-    metadata = cast(dict, threads.thread)["metadata"]
-    assert metadata["title"] == "Investigate the deployment failure"
-    assert metadata["title_seed"] == "Investigate the deployment failure"
-
-
 def test_select_slack_context_messages_uses_thread_start_when_no_prior_mention() -> None:
     bot_user_id = "UBOT"
     messages = [

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -69,6 +69,18 @@ class _Threads:
             },
         ),
         (
+            {
+                "source": "slack",
+                "title": "please review title generation",
+                "title_seed": "please review title generation",
+            },
+            {
+                "source": "slack",
+                "title": "Review thread title generation",
+                "title_seed": None,
+            },
+        ),
+        (
             {"source": "github", "title": "PR #1947", "title_seed": "PR #1947"},
             {"source": "github", "title": "PR #1947", "title_seed": "PR #1947"},
         ),

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -58,18 +58,6 @@ class _Threads:
     [
         (
             {
-                "source": "dashboard",
-                "title": "please review title generation",
-                "title_seed": "please review title generation",
-            },
-            {
-                "source": "dashboard",
-                "title": "Review thread title generation",
-                "title_seed": None,
-            },
-        ),
-        (
-            {
                 "source": "slack",
                 "title": "please review title generation",
                 "title_seed": "please review title generation",


### PR DESCRIPTION
## Description
Seed Slack-started threads so the existing guarded title generator can replace their raw opening request without changing explicit or non-Slack titles.

## Release Note
Slack-started agent threads now receive concise generated dashboard titles.

## Test Plan
- [x] Verify Slack title generation and webhook context tests

Made by [Open SWE](https://openswe.vercel.app/agents/01a0114a-6279-731a-be4a-a5aea45edc60)
