### PR TITLE
fix: align OpenAI context windows with Codex

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -118,13 +118,17 @@ DEPRECATED_MODEL_REPLACEMENTS: dict[str, str] = {
 ProfileLoader = Callable[[str], Mapping[str, object]]
 
 # LangChain partner packages expose ``_get_default_model_profile`` — the same
-# accessor that populates ``ChatModel.profile`` from bundled models.dev data —
-# so context windows come from LangChain profiles instead of hardcoded numbers.
+# accessor that populates ``ChatModel.profile`` from bundled models.dev data.
 _PROFILE_LOADER_MODULES: dict[str, str] = {
     "anthropic": "langchain_anthropic.chat_models",
     "fireworks": "langchain_fireworks.chat_models",
     "google_genai": "langchain_google_genai.chat_models",
     "openai": "langchain_openai.chat_models.base",
+}
+CODEX_CONTEXT_WINDOW_OVERRIDES: dict[str, int] = {
+    "openai:gpt-5.6-sol": 272_000,
+    "openai:gpt-5.6-terra": 272_000,
+    "openai:gpt-5.6-luna": 272_000,
 }
 _PROFILE_CONTEXT_WINDOW_FALLBACKS: dict[str, int] = {
     "fireworks:accounts/fireworks/models/kimi-k3": 1_048_576,
@@ -146,8 +150,22 @@ def _profile_loader(provider: str) -> ProfileLoader | None:
     return cast(ProfileLoader, loader)
 
 
+def model_profile_with_context_override(model_id: str) -> dict[str, object] | None:
+    context_window = CODEX_CONTEXT_WINDOW_OVERRIDES.get(model_id)
+    if context_window is None:
+        return None
+    provider, _, model_name = model_id.partition(":")
+    loader = _profile_loader(provider)
+    profile = dict(loader(model_name)) if loader is not None else {}
+    profile["max_input_tokens"] = context_window
+    return profile
+
+
 @lru_cache(maxsize=512)
 def model_profile_context_window(model_id: str) -> int | None:
+    context_window = CODEX_CONTEXT_WINDOW_OVERRIDES.get(model_id)
+    if context_window is not None:
+        return context_window
     provider, _, model_name = model_id.partition(":")
     if not provider or not model_name:
         return None

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, TypedDict, Unpack, cast
 
 from langchain.chat_models import init_chat_model
 
-from ..dashboard.options import DEFAULT_MODEL_ID
+from ..dashboard.options import DEFAULT_MODEL_ID, model_profile_with_context_override
 from .gateway import gateway_env_default, gateway_overrides
 
 OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
@@ -148,6 +148,10 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
     if model_id.startswith("openai:"):
         _configure_openai_responses_kwargs(model_kwargs)
         _coerce_openai_chat_completions_kwargs(model_kwargs)
+
+    profile_override = model_profile_with_context_override(model_id)
+    if profile_override is not None:
+        model_kwargs["profile"] = profile_override
 
     max_tokens = model_kwargs.get("max_tokens")
     max_tokens_key = max_tokens if type(max_tokens) is int else None

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1789,8 +1789,8 @@ async def test_options_includes_fable_when_enabled() -> None:
     ):
         payload = await routes.options()
     assert _FABLE in [m["id"] for m in payload["models"]]
-    gpt_5_5 = next(m for m in payload["models"] if m["id"] == _VISION_MODEL)
-    assert gpt_5_5["context_window"] == 1_050_000
+    openai_model = next(m for m in payload["models"] if m["id"] == _VISION_MODEL)
+    assert openai_model["context_window"] == 272_000
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -93,8 +93,8 @@ def test_supported_models_do_not_hardcode_context_windows() -> None:
     assert all("context_window" not in model for model in SUPPORTED_MODELS)
 
 
-def test_model_profile_context_window_uses_langchain_profile() -> None:
-    assert model_profile_context_window(SUPPORTED_OPENAI) == 1_050_000
+def test_model_profile_context_window_uses_codex_override() -> None:
+    assert model_profile_context_window(SUPPORTED_OPENAI) == 272_000
 
 
 def test_model_profile_context_window_uses_fireworks_profile_for_kimi_k3() -> None:
@@ -110,9 +110,9 @@ def test_models_with_profile_context_windows_enriches_copies() -> None:
     enriched = models_with_profile_context_windows(models)
     assert all("context_window" not in model for model in models)
     assert {model["id"]: model.get("context_window") for model in enriched} == {
-        "openai:gpt-5.6-sol": 1_050_000,
-        "openai:gpt-5.6-terra": 1_050_000,
-        "openai:gpt-5.6-luna": 1_050_000,
+        "openai:gpt-5.6-sol": 272_000,
+        "openai:gpt-5.6-terra": 272_000,
+        "openai:gpt-5.6-luna": 272_000,
         SUPPORTED_KIMI: 1_048_576,
     }
 

--- a/tests/models/test_model_request_timeout.py
+++ b/tests/models/test_model_request_timeout.py
@@ -31,10 +31,17 @@ def test_openai_gets_a_default_request_timeout() -> None:
     assert captured["max_retries"] == model.DEFAULT_MAX_RETRIES
 
 
+def test_openai_gets_codex_context_window_profile_override() -> None:
+    captured = _make_model("openai:gpt-5.6-sol")
+    profile = captured["profile"]
+    assert profile["max_input_tokens"] == 272_000
+    assert profile["tool_calling"] is True
+
+
 def test_anthropic_gets_a_default_request_timeout() -> None:
-    assert _make_model("anthropic:claude-opus-5")["timeout"] == (
-        model.DEFAULT_REQUEST_TIMEOUT_SECONDS
-    )
+    captured = _make_model("anthropic:claude-opus-5")
+    assert captured["timeout"] == model.DEFAULT_REQUEST_TIMEOUT_SECONDS
+    assert "profile" not in captured
 
 
 def test_explicit_timeout_wins() -> None:


### PR DESCRIPTION
## Description
Align Sol, Terra, and Luna with Codex's 272k operating context. Apply the override to both dashboard metadata and complete runtime model profiles so Deep Agents compacts against the lower budget while preserving model capabilities.

## Test Plan
- [x] `uv run pytest -q tests/models/test_model_fallback_resolution.py tests/models/test_model_request_timeout.py tests/dashboard/test_dashboard_thread_api.py::test_options_includes_fable_when_enabled`
- [x] `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/d920e01a-9302-5413-2de1-d8372bdd1dc9)