### PR TITLE
feat: allow collaborators to approve plans

### DIFF
--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -7,9 +7,9 @@ are read back here, formatted, and handed to the agent as the instruction for th
 follow-up run. The agent never sees comments during review — only this aggregated
 feedback at the decision point.
 
-Permissions: any authenticated org member can read a surfaced thread, comment, and
-request changes (reject); only the thread owner can approve. A comment can be
-deleted by its author or the thread owner.
+Permissions: any authenticated org member can read a surfaced thread, comment,
+approve, and request changes (reject). A comment can be deleted by its author or
+the thread owner.
 """
 
 import logging
@@ -33,6 +33,7 @@ from .plan_store import (
     delete_plan_comment,
     get_plan_content,
     list_plan_comments,
+    make_plan_approver,
     plan_file_path_for_thread,
     save_plan_content,
     set_plan_status,
@@ -83,11 +84,23 @@ async def get_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -> di
     login = session["sub"]
     email = session.get("email")
     content = await get_plan_content(thread_id) or {}
+    approved_by = content.get("approved_by") or metadata.get("plan_approved_by")
+    if isinstance(approved_by, dict):
+        approved_by = make_plan_approver(
+            actor_id=str(approved_by.get("id") or ""),
+            name=str(approved_by.get("name") or ""),
+            source=str(approved_by.get("source") or ""),
+        )
+    else:
+        approved_by = None
+    approved_at = content.get("approved_at") or metadata.get("plan_approved_at")
     return {
         "threadId": thread_id,
         "status": content.get("status") or metadata.get("plan_status") or "planning",
         "markdown": content.get("markdown", ""),
         "isOwner": _user_owns_thread(metadata, login, email),
+        "approvedBy": approved_by,
+        "approvedAt": approved_at if isinstance(approved_at, str) else None,
         "user": {
             "id": login,
             "login": login,
@@ -182,22 +195,39 @@ async def remove_plan_comment(
 @plan_router.post("/{thread_id}/approve")
 async def approve_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -> dict[str, Any]:
     metadata = await _thread_metadata(thread_id)
-    if not _user_owns_thread(metadata, session["sub"], session.get("email")):
-        raise HTTPException(403, "only the plan owner can approve")
+    if not _thread_is_readable(metadata):
+        raise HTTPException(404, "thread not found")
+    actor_id = str(session.get("sub") or "").strip()
     return await approve_plan_for_thread(
-        thread_id, metadata=metadata, actor=_approval_actor_name(session)
+        thread_id,
+        metadata=metadata,
+        approver=make_plan_approver(
+            actor_id=actor_id,
+            name=_approval_actor_name(session),
+            source="dashboard",
+        ),
     )
 
 
 async def approve_plan_for_thread(
-    thread_id: str, *, metadata: dict[str, Any], actor: str
+    thread_id: str, *, metadata: dict[str, Any], approver: dict[str, str]
 ) -> dict[str, Any]:
+    approver = make_plan_approver(
+        actor_id=str(approver.get("id") or ""),
+        name=str(approver.get("name") or ""),
+        source=str(approver.get("source") or ""),
+    )
     content = await get_plan_content(thread_id, raise_on_error=True) or {}
     _reject_shared_content(content)
     plan_markdown = str(content.get("markdown", "")).strip()
     comments = await list_plan_comments(thread_id, raise_on_error=True)
     feedback = _format_comments(comments)
-    await set_plan_status(thread_id, PLAN_STATUS_APPROVED, plan_mode=False)
+    await set_plan_status(
+        thread_id,
+        PLAN_STATUS_APPROVED,
+        plan_mode=False,
+        approved_by=approver,
+    )
     if plan_markdown:
         text = (
             "The plan has been approved. Use the reviewed plan below as the implementation "
@@ -213,7 +243,7 @@ async def approve_plan_for_thread(
         metadata,
         thread_id=thread_id,
         comment_count=len(comments),
-        actor=actor,
+        actor=approver["name"],
     )
     return {"status": PLAN_STATUS_APPROVED, "run_id": run["run_id"]}
 

--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -249,7 +249,11 @@ async def approve_plan_for_thread(thread_id: str, *, approver: dict[str, str]) -
             text = "The plan has been approved. Implement it now as described in the plan."
         if feedback:
             text += "\n\nAlso take this reviewer feedback into account:\n\n" + feedback
-        run = await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
+        try:
+            run = await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
+        except Exception:
+            await set_plan_status(thread_id, PLAN_STATUS_READY, plan_mode=True)
+            raise
         await _maybe_post_plan_approved_to_slack(
             metadata,
             thread_id=thread_id,

--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -12,6 +12,7 @@ approve, and request changes (reject). A comment can be deleted by its author or
 the thread owner.
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -47,6 +48,7 @@ from .thread_api import (
 )
 
 logger = logging.getLogger(__name__)
+_plan_approval_locks: dict[str, asyncio.Lock] = {}
 
 plan_router = APIRouter(
     prefix="/dashboard/api/plan",
@@ -200,7 +202,6 @@ async def approve_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -
     actor_id = str(session.get("sub") or "").strip()
     return await approve_plan_for_thread(
         thread_id,
-        metadata=metadata,
         approver=make_plan_approver(
             actor_id=actor_id,
             name=_approval_actor_name(session),
@@ -209,43 +210,53 @@ async def approve_plan(thread_id: str, session: dict[str, Any] = _SESSION_DEP) -
     )
 
 
-async def approve_plan_for_thread(
-    thread_id: str, *, metadata: dict[str, Any], approver: dict[str, str]
-) -> dict[str, Any]:
+async def approve_plan_for_thread(thread_id: str, *, approver: dict[str, str]) -> dict[str, Any]:
     approver = make_plan_approver(
         actor_id=str(approver.get("id") or ""),
         name=str(approver.get("name") or ""),
         source=str(approver.get("source") or ""),
     )
-    content = await get_plan_content(thread_id, raise_on_error=True) or {}
-    _reject_shared_content(content)
-    plan_markdown = str(content.get("markdown", "")).strip()
-    comments = await list_plan_comments(thread_id, raise_on_error=True)
-    feedback = _format_comments(comments)
-    await set_plan_status(
-        thread_id,
-        PLAN_STATUS_APPROVED,
-        plan_mode=False,
-        approved_by=approver,
-    )
-    if plan_markdown:
-        text = (
-            "The plan has been approved. Use the reviewed plan below as the implementation "
-            "guide. Apply reasonable engineering judgment where details need adjustment while "
-            f"preserving its goals and reviewer edits:\n\n{plan_markdown}"
+    lock = _plan_approval_locks.setdefault(thread_id, asyncio.Lock())
+    async with lock:
+        metadata = await _thread_metadata(thread_id)
+        content = await get_plan_content(thread_id, raise_on_error=True) or {}
+        _reject_shared_content(content)
+        if (
+            metadata.get("plan_mode") is not True
+            or metadata.get("plan_status") != PLAN_STATUS_READY
+            or content.get("status") != PLAN_STATUS_READY
+        ):
+            return {
+                "status": str(content.get("status") or metadata.get("plan_status") or "planning"),
+                "already_approved": True,
+            }
+        plan_markdown = str(content.get("markdown", "")).strip()
+        comments = await list_plan_comments(thread_id, raise_on_error=True)
+        feedback = _format_comments(comments)
+        await set_plan_status(
+            thread_id,
+            PLAN_STATUS_APPROVED,
+            plan_mode=False,
+            approved_by=approver,
         )
-    else:
-        text = "The plan has been approved. Implement it now as described in the plan."
-    if feedback:
-        text += "\n\nAlso take this reviewer feedback into account:\n\n" + feedback
-    run = await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
-    await _maybe_post_plan_approved_to_slack(
-        metadata,
-        thread_id=thread_id,
-        comment_count=len(comments),
-        actor=approver["name"],
-    )
-    return {"status": PLAN_STATUS_APPROVED, "run_id": run["run_id"]}
+        if plan_markdown:
+            text = (
+                "The plan has been approved. Use the reviewed plan below as the implementation "
+                "guide. Apply reasonable engineering judgment where details need adjustment while "
+                f"preserving its goals and reviewer edits:\n\n{plan_markdown}"
+            )
+        else:
+            text = "The plan has been approved. Implement it now as described in the plan."
+        if feedback:
+            text += "\n\nAlso take this reviewer feedback into account:\n\n" + feedback
+        run = await _dispatch_followup(thread_id, metadata, text, plan_mode=False)
+        await _maybe_post_plan_approved_to_slack(
+            metadata,
+            thread_id=thread_id,
+            comment_count=len(comments),
+            actor=approver["name"],
+        )
+        return {"status": PLAN_STATUS_APPROVED, "run_id": run["run_id"]}
 
 
 @plan_router.post("/{thread_id}/reject")

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -104,11 +104,7 @@ async def save_plan_content(
         except Exception:
             # Best-effort: a failed cleanup must not block publishing the new plan.
             pass
-    metadata: dict[str, Any] = {
-        "plan_status": status,
-        "plan_approved_by": None,
-        "plan_approved_at": None,
-    }
+    metadata: dict[str, Any] = {"plan_status": status}
     if plan_mode is not None:
         metadata["plan_mode"] = plan_mode
     await _merge_thread_metadata(thread_id, metadata)
@@ -172,11 +168,7 @@ async def set_plan_status(
     plan_file_path = existing.get("plan_file_path")
     if not entering_plan_after_share and isinstance(plan_file_path, str) and plan_file_path:
         record["plan_file_path"] = plan_file_path
-    metadata: dict[str, Any] = {
-        "plan_status": status,
-        "plan_approved_by": None,
-        "plan_approved_at": None,
-    }
+    metadata: dict[str, Any] = {"plan_status": status}
     if status == PLAN_STATUS_APPROVED and approved_by is not None:
         approver = make_plan_approver(
             actor_id=str(approved_by.get("id") or ""),

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -12,6 +12,7 @@ store operations (no CRDT/WebSocket).
 import logging
 import re
 import uuid
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
 
@@ -32,6 +33,17 @@ PLAN_STATUS_SHARED = "shared"
 PLAN_STATUS_REVISING = "revising"
 PLAN_STATUS_APPROVED = "approved"
 PLAN_STATUS_CANCELLED = "cancelled"
+
+
+def make_plan_approver(*, actor_id: str, name: str, source: str) -> dict[str, str]:
+    actor_id = actor_id.strip()
+    name = name.strip()
+    source = source.strip()
+    return {
+        "id": actor_id or name or "unknown",
+        "name": name or actor_id or "Unknown user",
+        "source": source or "unknown",
+    }
 
 
 def plan_file_path_for_thread(thread_id: str) -> str:
@@ -92,7 +104,11 @@ async def save_plan_content(
         except Exception:
             # Best-effort: a failed cleanup must not block publishing the new plan.
             pass
-    metadata: dict[str, Any] = {"plan_status": status}
+    metadata: dict[str, Any] = {
+        "plan_status": status,
+        "plan_approved_by": None,
+        "plan_approved_at": None,
+    }
     if plan_mode is not None:
         metadata["plan_mode"] = plan_mode
     await _merge_thread_metadata(thread_id, metadata)
@@ -136,7 +152,13 @@ async def get_plan_content(
     return _item_value(item)
 
 
-async def set_plan_status(thread_id: str, status: str, *, plan_mode: bool | None = None) -> None:
+async def set_plan_status(
+    thread_id: str,
+    status: str,
+    *,
+    plan_mode: bool | None = None,
+    approved_by: Mapping[str, str] | None = None,
+) -> None:
     """Update the plan lifecycle status on both the content record and metadata."""
     existing = await get_plan_content(thread_id) or {}
     entering_plan_after_share = (
@@ -150,12 +172,25 @@ async def set_plan_status(thread_id: str, status: str, *, plan_mode: bool | None
     plan_file_path = existing.get("plan_file_path")
     if not entering_plan_after_share and isinstance(plan_file_path, str) and plan_file_path:
         record["plan_file_path"] = plan_file_path
+    metadata: dict[str, Any] = {
+        "plan_status": status,
+        "plan_approved_by": None,
+        "plan_approved_at": None,
+    }
+    if status == PLAN_STATUS_APPROVED and approved_by is not None:
+        approver = make_plan_approver(
+            actor_id=str(approved_by.get("id") or ""),
+            name=str(approved_by.get("name") or ""),
+            source=str(approved_by.get("source") or ""),
+        )
+        approved_at = datetime.now(UTC).isoformat()
+        record.update(approved_by=approver, approved_at=approved_at)
+        metadata.update(plan_approved_by=approver, plan_approved_at=approved_at)
     await client.store.put_item(
         PLAN_CONTENT_NAMESPACE,
         thread_id,
         record,
     )
-    metadata: dict[str, Any] = {"plan_status": status}
     if plan_mode is not None:
         metadata["plan_mode"] = plan_mode
     await _merge_thread_metadata(thread_id, metadata)

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1613,7 +1613,7 @@ async def send_dashboard_message(
     queue_payload: dict[str, Any] = {
         "text": prompt,
         "source": _DASHBOARD_SOURCE,
-        "from_owner": _user_owns_thread(metadata, login, email),
+        "approver": {"id": login, "name": login, "source": _DASHBOARD_SOURCE},
     }
     if isinstance(content, list):
         queue_payload["images"] = [

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1613,7 +1613,6 @@ async def send_dashboard_message(
     queue_payload: dict[str, Any] = {
         "text": prompt,
         "source": _DASHBOARD_SOURCE,
-        "approver": {"id": login, "name": login, "source": _DASHBOARD_SOURCE},
     }
     if isinstance(content, list):
         queue_payload["images"] = [

--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -31,7 +31,7 @@ class LinearNotifyState(AgentState):
     """Extended agent state for tracking Linear notifications."""
 
     linear_messages_sent_count: int
-    plan_approval_blocked: NotRequired[bool]
+    plan_approver: NotRequired[dict[str, str]]
     rendered_system_prompt: NotRequired[str | None]
 
 
@@ -90,15 +90,24 @@ def _is_dashboard_queued_message(content: object) -> bool:
     return isinstance(content, dict) and content.get("source") == "dashboard"
 
 
-def _dashboard_queued_message_from_owner(content: object) -> bool:
-    return isinstance(content, dict) and content.get("from_owner") is True
+def _dashboard_queued_message_approver(content: object) -> dict[str, str] | None:
+    if not isinstance(content, dict):
+        return None
+    approver = content.get("approver")
+    if not isinstance(approver, dict):
+        return None
+    return {
+        "id": str(approver.get("id") or ""),
+        "name": str(approver.get("name") or ""),
+        "source": str(approver.get("source") or "dashboard"),
+    }
 
 
 def _message_update(
     content_blocks: list[dict[str, Any]],
     thread_id: str,
     *,
-    plan_approval_blocked: bool | None = None,
+    plan_approver: dict[str, str] | None = None,
     rendered_system_prompt: str | None = None,
 ) -> dict[str, Any] | None:
     if not content_blocks:
@@ -109,8 +118,8 @@ def _message_update(
         thread_id,
     )
     update: dict[str, Any] = {"messages": [{"role": "user", "content": content_blocks}]}
-    if plan_approval_blocked is not None:
-        update["plan_approval_blocked"] = plan_approval_blocked
+    if plan_approver is not None:
+        update["plan_approver"] = plan_approver
     if rendered_system_prompt is not None:
         update["rendered_system_prompt"] = rendered_system_prompt
     return update
@@ -180,7 +189,7 @@ async def check_message_queue_before_model(  # noqa: PLR0911
             return None
 
         content_blocks: list[dict[str, Any]] = []
-        plan_approval_blocked: bool | None = None
+        plan_approver: dict[str, str] | None = None
         dashboard_handoff = False
         pending_autofix = await _consume_pending_autofix_event(store, thread_id)
         if pending_autofix:
@@ -226,10 +235,9 @@ async def check_message_queue_before_model(  # noqa: PLR0911
             if _is_dashboard_queued_message(content):
                 dashboard_handoff = True
                 content_blocks.append({"type": "text", "text": DASHBOARD_HANDOFF_INSTRUCTION})
-                if _dashboard_queued_message_from_owner(content):
-                    plan_approval_blocked = False
-                elif plan_approval_blocked is None:
-                    plan_approval_blocked = True
+                queued_approver = _dashboard_queued_message_approver(content)
+                if queued_approver is not None:
+                    plan_approver = queued_approver
             if isinstance(content, dict) and (
                 "text" in content or "image_urls" in content or "images" in content
             ):
@@ -253,7 +261,7 @@ async def check_message_queue_before_model(  # noqa: PLR0911
         return _message_update(
             content_blocks,
             thread_id,
-            plan_approval_blocked=plan_approval_blocked,
+            plan_approver=plan_approver,
             rendered_system_prompt=rendered_prompt,
         )  # noqa: TRY300
     except Exception:

--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -31,7 +31,6 @@ class LinearNotifyState(AgentState):
     """Extended agent state for tracking Linear notifications."""
 
     linear_messages_sent_count: int
-    plan_approver: NotRequired[dict[str, str]]
     rendered_system_prompt: NotRequired[str | None]
 
 
@@ -90,24 +89,10 @@ def _is_dashboard_queued_message(content: object) -> bool:
     return isinstance(content, dict) and content.get("source") == "dashboard"
 
 
-def _dashboard_queued_message_approver(content: object) -> dict[str, str] | None:
-    if not isinstance(content, dict):
-        return None
-    approver = content.get("approver")
-    if not isinstance(approver, dict):
-        return None
-    return {
-        "id": str(approver.get("id") or ""),
-        "name": str(approver.get("name") or ""),
-        "source": str(approver.get("source") or "dashboard"),
-    }
-
-
 def _message_update(
     content_blocks: list[dict[str, Any]],
     thread_id: str,
     *,
-    plan_approver: dict[str, str] | None = None,
     rendered_system_prompt: str | None = None,
 ) -> dict[str, Any] | None:
     if not content_blocks:
@@ -118,8 +103,6 @@ def _message_update(
         thread_id,
     )
     update: dict[str, Any] = {"messages": [{"role": "user", "content": content_blocks}]}
-    if plan_approver is not None:
-        update["plan_approver"] = plan_approver
     if rendered_system_prompt is not None:
         update["rendered_system_prompt"] = rendered_system_prompt
     return update
@@ -189,7 +172,6 @@ async def check_message_queue_before_model(  # noqa: PLR0911
             return None
 
         content_blocks: list[dict[str, Any]] = []
-        plan_approver: dict[str, str] | None = None
         dashboard_handoff = False
         pending_autofix = await _consume_pending_autofix_event(store, thread_id)
         if pending_autofix:
@@ -235,9 +217,6 @@ async def check_message_queue_before_model(  # noqa: PLR0911
             if _is_dashboard_queued_message(content):
                 dashboard_handoff = True
                 content_blocks.append({"type": "text", "text": DASHBOARD_HANDOFF_INSTRUCTION})
-                queued_approver = _dashboard_queued_message_approver(content)
-                if queued_approver is not None:
-                    plan_approver = queued_approver
             if isinstance(content, dict) and (
                 "text" in content or "image_urls" in content or "images" in content
             ):
@@ -261,7 +240,6 @@ async def check_message_queue_before_model(  # noqa: PLR0911
         return _message_update(
             content_blocks,
             thread_id,
-            plan_approver=plan_approver,
             rendered_system_prompt=rendered_prompt,
         )  # noqa: TRY300
     except Exception:

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -17,16 +17,16 @@ from ..dashboard.plan_store import (
     PLAN_STATUS_SHARED,
     get_plan_content,
     list_plan_comments,
+    make_plan_approver,
     set_plan_status,
 )
-from ..dashboard.thread_api import _user_owns_thread
 
 logger = logging.getLogger(__name__)
 
 
 class ApprovePlanState(TypedDict, total=False):
     plan_mode: bool
-    plan_approval_blocked: bool
+    plan_approver: dict[str, str]
 
 
 async def approve_plan(
@@ -51,20 +51,18 @@ async def approve_plan(
         metadata = await _thread_metadata(str(thread_id))
         if not _active_plan_mode(state, configurable, metadata):
             return {"success": False, "error": "plan mode is not active for this thread"}
-        if isinstance(state, dict) and state.get("plan_approval_blocked") is True:
-            return {
-                "success": False,
-                "error": "a non-owner dashboard follow-up cannot approve the plan",
-            }
-        if not _current_user_owns_thread(metadata, configurable):
-            return {"success": False, "error": "only the plan owner can approve the plan"}
         content = await get_plan_content(str(thread_id), raise_on_error=True) or {}
         if content.get("status") == PLAN_STATUS_SHARED:
             return {"success": False, "error": "shared content is not an implementation plan"}
         plan_markdown = str(content.get("markdown", "")).strip()
         comments = await list_plan_comments(str(thread_id), raise_on_error=True)
         feedback = _format_comments(comments)
-        await set_plan_status(str(thread_id), PLAN_STATUS_APPROVED, plan_mode=False)
+        await set_plan_status(
+            str(thread_id),
+            PLAN_STATUS_APPROVED,
+            plan_mode=False,
+            approved_by=_current_approver(state, configurable),
+        )
     except Exception as exc:  # noqa: BLE001
         logger.exception("approve_plan failed for thread %s", thread_id)
         return {"success": False, "error": f"failed to approve plan: {exc}"}
@@ -100,18 +98,29 @@ def _active_plan_mode(
     return metadata.get("plan_mode") is True
 
 
-def _current_user_owns_thread(metadata: Mapping[str, Any], configurable: Any) -> bool:
-    if not isinstance(configurable, dict):
-        return False
-    login = configurable.get("github_login")
-    login = login.strip() if isinstance(login, str) else ""
-    email = configurable.get("user_email")
-    if not isinstance(email, str):
-        slack_thread = configurable.get("slack_thread")
-        if isinstance(slack_thread, dict):
-            email = slack_thread.get("triggering_user_email")
-    email = email.strip().lower() if isinstance(email, str) else None
-    return bool(login or email) and _user_owns_thread(metadata, login, email)
+def _current_approver(state: Mapping[str, Any] | None, configurable: Any) -> dict[str, str]:
+    if isinstance(state, dict):
+        state_approver = state.get("plan_approver")
+        if isinstance(state_approver, dict):
+            return make_plan_approver(
+                actor_id=str(state_approver.get("id") or ""),
+                name=str(state_approver.get("name") or ""),
+                source=str(state_approver.get("source") or ""),
+            )
+    configurable = configurable if isinstance(configurable, dict) else {}
+    source = str(configurable.get("source") or "agent")
+    slack_thread = configurable.get("slack_thread")
+    slack_thread = slack_thread if isinstance(slack_thread, dict) else {}
+    actor_id = str(
+        slack_thread.get("triggering_user_id")
+        or configurable.get("github_login")
+        or configurable.get("user_email")
+        or ""
+    )
+    name = str(
+        slack_thread.get("triggering_user_name") or configurable.get("github_login") or actor_id
+    )
+    return make_plan_approver(actor_id=actor_id, name=name, source=source)
 
 
 def _format_comments(comments: list[dict[str, Any]]) -> str:

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 class ApprovePlanState(TypedDict, total=False):
     plan_mode: bool
-    plan_approver: dict[str, str]
 
 
 async def approve_plan(
@@ -61,7 +60,7 @@ async def approve_plan(
             str(thread_id),
             PLAN_STATUS_APPROVED,
             plan_mode=False,
-            approved_by=_current_approver(state, configurable),
+            approved_by=_current_approver(configurable),
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("approve_plan failed for thread %s", thread_id)
@@ -98,15 +97,7 @@ def _active_plan_mode(
     return metadata.get("plan_mode") is True
 
 
-def _current_approver(state: Mapping[str, Any] | None, configurable: Any) -> dict[str, str]:
-    if isinstance(state, dict):
-        state_approver = state.get("plan_approver")
-        if isinstance(state_approver, dict):
-            return make_plan_approver(
-                actor_id=str(state_approver.get("id") or ""),
-                name=str(state_approver.get("name") or ""),
-                source=str(state_approver.get("source") or ""),
-            )
+def _current_approver(configurable: Any) -> dict[str, str]:
     configurable = configurable if isinstance(configurable, dict) else {}
     source = str(configurable.get("source") or "agent")
     slack_thread = configurable.get("slack_thread")

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -203,11 +203,7 @@ async def _slack_user_can_reply_to_ready_plan(
         # A brand-new thread has no metadata (_thread_metadata raises 404); an
         # untagged message there simply isn't a plan reply — don't abort the gate.
         return False
-    return (
-        metadata.get("plan_mode") is True
-        and metadata.get("plan_status") == "ready"
-        and await common._slack_user_is_thread_owner(thread_id, slack_user_id)
-    )
+    return metadata.get("plan_mode") is True and metadata.get("plan_status") == "ready"
 
 
 def _format_slack_thread_section(
@@ -273,10 +269,9 @@ async def _maybe_approve_ready_plan_reply(
 ) -> bool:
     if not _is_natural_language_plan_approval(text):
         return False
-    if not await common._slack_user_is_thread_owner(thread_id, user_id):
-        return False
 
     from agent.dashboard.plan_api import _thread_metadata, approve_plan_for_thread
+    from agent.dashboard.plan_store import make_plan_approver
 
     lock = _plan_approval_locks.setdefault(thread_id, asyncio.Lock())
     async with lock:
@@ -286,7 +281,11 @@ async def _maybe_approve_ready_plan_reply(
         await approve_plan_for_thread(
             thread_id,
             metadata=metadata,
-            actor=user_name or user_id or "Slack user",
+            approver=make_plan_approver(
+                actor_id=user_id,
+                name=user_name or user_id or "Slack user",
+                source="slack",
+            ),
         )
     return True
 
@@ -473,6 +472,10 @@ async def _process_slack_mention_impl(
         common.strip_bot_mention(text, bot_user_id, bot_username=common.SLACK_BOT_USERNAME)
         or "(no text in mention)"
     )
+    if await _maybe_approve_ready_plan_reply(
+        thread_id, channel_id, thread_ts, user_id, user_name, clean_text
+    ):
+        return
     is_first_mention = not await common._thread_exists(thread_id)
     # `env:<name>` on the message that opens a thread picks the environment its
     # sandbox boots from. Only the opening message can: the sandbox is created
@@ -604,11 +607,6 @@ async def _process_slack_mention_impl(
                 reason=reason,
                 agent_thread_id=thread_id,
             )
-        return
-
-    if await _maybe_approve_ready_plan_reply(
-        thread_id, channel_id, thread_ts, user_id, user_name, clean_text
-    ):
         return
 
     slack_thread_context: dict[str, Any] = {

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -4,7 +4,6 @@ Helpers and constants stay in common.py; they are accessed through the module
 object (``common.X``) so tests that monkeypatch them keep working.
 """
 
-import asyncio
 import re
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -65,7 +64,6 @@ _PLAN_APPROVAL_NEGATIONS = {
     "stop",
     "wait",
 }
-_plan_approval_locks: dict[str, asyncio.Lock] = {}
 
 
 def _is_natural_language_plan_approval(text: str) -> bool:
@@ -273,21 +271,38 @@ async def _maybe_approve_ready_plan_reply(
     from agent.dashboard.plan_api import _thread_metadata, approve_plan_for_thread
     from agent.dashboard.plan_store import make_plan_approver
 
-    lock = _plan_approval_locks.setdefault(thread_id, asyncio.Lock())
-    async with lock:
+    try:
         metadata = await _thread_metadata(thread_id)
-        if metadata.get("plan_mode") is not True or metadata.get("plan_status") != "ready":
-            return False
-        await approve_plan_for_thread(
-            thread_id,
-            metadata=metadata,
-            approver=make_plan_approver(
-                actor_id=user_id,
-                name=user_name or user_id or "Slack user",
-                source="slack",
-            ),
+    except Exception:  # noqa: BLE001
+        return False
+    if metadata.get("plan_mode") is not True or metadata.get("plan_status") != "ready":
+        return False
+    result = await approve_plan_for_thread(
+        thread_id,
+        approver=make_plan_approver(
+            actor_id=user_id,
+            name=user_name or user_id or "Slack user",
+            source="slack",
+        ),
+    )
+    return result.get("already_approved") is not True
+
+
+async def process_slack_plan_approval(
+    event_data: dict[str, Any], repo_config: dict[str, str]
+) -> None:
+    try:
+        await _maybe_approve_ready_plan_reply(
+            str(event_data.get("thread_id") or ""),
+            str(event_data.get("channel_id") or ""),
+            str(event_data.get("thread_ts") or ""),
+            str(event_data.get("user_id") or ""),
+            str(event_data.get("user_name") or ""),
+            "approve",
         )
-    return True
+    except Exception:  # noqa: BLE001
+        common.logger.exception("Unexpected error while processing Slack plan approval")
+        await _notify_slack_processing_error(event_data, repo_config)
 
 
 async def _notify_slack_processing_error(

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -358,38 +358,17 @@ async def slack_interactivity(
             return {"status": "accepted", "message": "Plan cancelled"}
 
         if plan_action == "approve":
-            if not await common._slack_user_is_thread_owner(thread_id, user_id):
-                await common.post_slack_thread_reply(
-                    channel_id=channel_id,
-                    thread_ts=thread_ts,
-                    text="Only the person who requested this plan can approve it. Anyone can reply with feedback or use *Revise Plan*.",
-                    agent_thread_id=thread_id,
-                )
-                return {"status": "ignored", "reason": "approver is not the thread owner"}
-            await common._set_thread_plan_mode(thread_id, False)
-            channel_context = await common._get_slack_channel_context(channel_id)
-            repo_config = await common.get_slack_repo_config(
+            user_name = str(user.get("name") or user.get("username") or user_id)
+            background_tasks.add_task(
+                service._maybe_approve_ready_plan_reply,
+                thread_id,
                 channel_id,
                 thread_ts,
-                slack_user_id=user_id,
-                channel_context=channel_context,
-                thread_id=thread_id,
+                user_id,
+                user_name,
+                "approve",
             )
-            background_tasks.add_task(
-                service.process_slack_mention,
-                {
-                    "channel_id": channel_id,
-                    "channel_context": channel_context,
-                    "thread_ts": thread_ts,
-                    "event_ts": str(message.get("ts") or ""),
-                    "user_id": user_id,
-                    "text": "Proceed with the approved plan. Implement the changes as described in the plan.",
-                    "bot_user_id": common.SLACK_BOT_USER_ID,
-                    "thread_id": thread_id,
-                },
-                repo_config,
-            )
-            return {"status": "accepted", "message": "Plan approved, starting implementation"}
+            return {"status": "accepted", "message": "Plan approval queued"}
 
         return {"status": "accepted", "message": "Reply to revise the plan"}
 

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -359,14 +359,24 @@ async def slack_interactivity(
 
         if plan_action == "approve":
             user_name = str(user.get("name") or user.get("username") or user_id)
+            channel_context = await common._get_slack_channel_context(channel_id)
+            repo_config = await common.get_slack_repo_config(
+                channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
+            )
             background_tasks.add_task(
-                service._maybe_approve_ready_plan_reply,
-                thread_id,
-                channel_id,
-                thread_ts,
-                user_id,
-                user_name,
-                "approve",
+                service.process_slack_plan_approval,
+                {
+                    "thread_id": thread_id,
+                    "channel_id": channel_id,
+                    "channel_context": channel_context,
+                    "thread_ts": thread_ts,
+                    "event_ts": str(message.get("ts") or ""),
+                    "user_id": user_id,
+                    "user_name": user_name,
+                    "text": "approve",
+                    "bot_user_id": common.SLACK_BOT_USER_ID,
+                },
+                repo_config,
             )
             return {"status": "accepted", "message": "Plan approval queued"}
 

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -364,7 +364,7 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
     assert "source of truth" not in messages[0].content
 
 
-async def test_approve_plan_tool_records_dashboard_followup_approver(
+async def test_approve_plan_tool_ignores_stale_state_approver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import importlib
@@ -380,7 +380,8 @@ async def test_approve_plan_tool_records_dashboard_followup_approver(
         lambda: {
             "configurable": {
                 "thread_id": "t1",
-                "github_login": "owner",
+                "github_login": "current-user",
+                "source": "dashboard",
                 "plan_mode": True,
             }
         },
@@ -428,8 +429,8 @@ async def test_approve_plan_tool_records_dashboard_followup_approver(
         "status": "approved",
         "plan_mode": False,
         "approved_by": {
-            "id": "teammate",
-            "name": "Teammate",
+            "id": "current-user",
+            "name": "current-user",
             "source": "dashboard",
         },
     }

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -321,8 +321,19 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
         assert raise_on_error is True
         return [{"author": "Alice", "body": "add tests"}]
 
-    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
-        saved.update(thread_id=thread_id, status=status, plan_mode=plan_mode)
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
+        saved.update(
+            thread_id=thread_id,
+            status=status,
+            plan_mode=plan_mode,
+            approved_by=approved_by,
+        )
 
     monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
     monkeypatch.setattr(approve_plan_tool, "get_plan_content", fake_get_content)
@@ -337,7 +348,12 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
     assert isinstance(result, Command)
     assert result.update is not None
     assert result.update["plan_mode"] is False
-    assert saved == {"thread_id": "t1", "status": "approved", "plan_mode": False}
+    assert saved == {
+        "thread_id": "t1",
+        "status": "approved",
+        "plan_mode": False,
+        "approved_by": {"id": "octo", "name": "octo", "source": "agent"},
+    }
     messages = result.update["messages"]
     assert len(messages) == 1
     assert isinstance(messages[0], ToolMessage)
@@ -348,12 +364,15 @@ async def test_approve_plan_tool_exits_plan_mode(monkeypatch: pytest.MonkeyPatch
     assert "source of truth" not in messages[0].content
 
 
-async def test_approve_plan_tool_rejects_non_owner_followup(
+async def test_approve_plan_tool_records_dashboard_followup_approver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import importlib
 
+    from langgraph.types import Command
+
     approve_plan_tool = importlib.import_module("agent.tools.approve_plan")
+    saved: dict[str, Any] = {}
 
     monkeypatch.setattr(
         approve_plan_tool,
@@ -361,38 +380,70 @@ async def test_approve_plan_tool_rejects_non_owner_followup(
         lambda: {
             "configurable": {
                 "thread_id": "t1",
-                "github_login": "octo",
-                "user_email": "octo@example.com",
+                "github_login": "owner",
                 "plan_mode": True,
             }
         },
     )
 
     async def fake_thread_metadata(thread_id: str) -> dict[str, Any]:
-        return {
-            "source": "dashboard",
-            "github_login": "octo",
-            "triggering_user_email": "octo@example.com",
-            "plan_mode": True,
-        }
+        return {"github_login": "owner", "plan_mode": True}
+
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        return {"markdown": "# Plan", "status": "ready"}
+
+    async def fake_list_comments(
+        thread_id: str, *, raise_on_error: bool = False
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
+        saved.update(status=status, plan_mode=plan_mode, approved_by=approved_by)
 
     monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
+    monkeypatch.setattr(approve_plan_tool, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(approve_plan_tool, "list_plan_comments", fake_list_comments)
+    monkeypatch.setattr(approve_plan_tool, "set_plan_status", fake_set_status)
 
     result = await approve_plan_tool.approve_plan(
-        state={"plan_mode": True, "plan_approval_blocked": True},
+        state={
+            "plan_mode": True,
+            "plan_approver": {
+                "id": "teammate",
+                "name": "Teammate",
+                "source": "dashboard",
+            },
+        },
         tool_call_id="call-1",
     )
 
-    assert isinstance(result, dict)
-    assert result["success"] is False
-    assert "non-owner" in result["error"]
+    assert isinstance(result, Command)
+    assert saved == {
+        "status": "approved",
+        "plan_mode": False,
+        "approved_by": {
+            "id": "teammate",
+            "name": "Teammate",
+            "source": "dashboard",
+        },
+    }
 
 
-async def test_approve_plan_tool_rejects_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_approve_plan_tool_allows_non_owner_configurable_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import importlib
 
-    approve_plan_tool = importlib.import_module("agent.tools.approve_plan")
+    from langgraph.types import Command
 
+    approve_plan_tool = importlib.import_module("agent.tools.approve_plan")
+    saved: dict[str, Any] = {}
     monkeypatch.setattr(
         approve_plan_tool,
         "get_config",
@@ -400,30 +451,41 @@ async def test_approve_plan_tool_rejects_non_owner(monkeypatch: pytest.MonkeyPat
             "configurable": {
                 "thread_id": "t1",
                 "github_login": "other",
-                "user_email": "other@example.com",
+                "source": "linear",
                 "plan_mode": True,
             }
         },
     )
 
     async def fake_thread_metadata(thread_id: str) -> dict[str, Any]:
-        return {
-            "source": "dashboard",
-            "github_login": "octo",
-            "triggering_user_email": "octo@example.com",
-            "plan_mode": True,
-        }
+        return {"github_login": "owner", "plan_mode": True}
+
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        return {"markdown": "# Plan", "status": "ready"}
+
+    async def fake_list_comments(
+        thread_id: str, *, raise_on_error: bool = False
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
+        saved["approved_by"] = approved_by
 
     monkeypatch.setattr(approve_plan_tool, "_thread_metadata", fake_thread_metadata)
+    monkeypatch.setattr(approve_plan_tool, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(approve_plan_tool, "list_plan_comments", fake_list_comments)
+    monkeypatch.setattr(approve_plan_tool, "set_plan_status", fake_set_status)
 
-    result = await approve_plan_tool.approve_plan(
-        state={"plan_mode": True},
-        tool_call_id="call-1",
-    )
+    result = await approve_plan_tool.approve_plan(state={"plan_mode": True}, tool_call_id="call-1")
 
-    assert isinstance(result, dict)
-    assert result["success"] is False
-    assert "owner" in result["error"]
+    assert isinstance(result, Command)
+    assert saved["approved_by"] == {"id": "other", "name": "other", "source": "linear"}
 
 
 @pytest.mark.parametrize(

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -788,7 +789,7 @@ async def test_non_owner_can_approve_and_dispatch_published_markdown(
     dispatched: dict[str, Any] = {}
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
-        return {"source": "slack", "plan_status": "ready"}
+        return {"source": "slack", "plan_mode": True, "plan_status": "ready"}
 
     async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         return {"markdown": "# Edited plan\n\nstep one", "status": "ready"}
@@ -828,6 +829,56 @@ async def test_non_owner_can_approve_and_dispatch_published_markdown(
     assert dispatched["approved_by"] == {"id": "a", "name": "a", "source": "dashboard"}
 
 
+async def test_concurrent_plan_approvals_dispatch_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from agent.dashboard import plan_api
+
+    state = {"source": "dashboard", "plan_mode": True, "plan_status": "ready"}
+    dispatches: list[str] = []
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return dict(state)
+
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        return {"markdown": "# Plan", "status": state["plan_status"]}
+
+    async def fake_list(thread_id: str, *, raise_on_error: bool = False) -> list[dict[str, Any]]:
+        return []
+
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
+        state.update(plan_mode=plan_mode, plan_status=status)
+
+    async def fake_dispatch(
+        thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
+    ) -> dict[str, Any]:
+        dispatches.append(thread_id)
+        return {"run_id": "run-1"}
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+    monkeypatch.setattr(plan_api, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(plan_api, "list_plan_comments", fake_list)
+    monkeypatch.setattr(plan_api, "set_plan_status", fake_set_status)
+    monkeypatch.setattr(plan_api, "_dispatch_followup", fake_dispatch)
+    monkeypatch.setattr(plan_api, "_maybe_post_plan_approved_to_slack", AsyncMock())
+
+    approver = {"id": "reviewer", "name": "Reviewer", "source": "dashboard"}
+    results = await asyncio.gather(
+        plan_api.approve_plan_for_thread("t1", approver=approver),
+        plan_api.approve_plan_for_thread("t1", approver=approver),
+    )
+
+    assert dispatches == ["t1"]
+    assert results[0] == {"status": "approved", "run_id": "run-1"}
+    assert results[1] == {"status": "approved", "already_approved": True}
+
+
 async def test_approve_plan_posts_slack_approval_notice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -839,6 +890,7 @@ async def test_approve_plan_posts_slack_approval_notice(
     async def fake_meta(thread_id: str) -> dict[str, Any]:
         return {
             "source": "slack",
+            "plan_mode": True,
             "plan_status": "ready",
             "source_context": {"slack_thread": {"channel_id": "C1", "thread_ts": "123.45"}},
         }
@@ -925,7 +977,7 @@ async def test_approve_plan_aborts_when_plan_read_fails(
     dispatched: list[Any] = []
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
-        return {"source": "slack", "plan_status": "ready"}
+        return {"source": "slack", "plan_mode": True, "plan_status": "ready"}
 
     async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         # A transient store failure must abort approval, not silently drop the

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -879,6 +879,60 @@ async def test_concurrent_plan_approvals_dispatch_once(monkeypatch: pytest.Monke
     assert results[1] == {"status": "approved", "already_approved": True}
 
 
+async def test_failed_approval_dispatch_rolls_back_and_can_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.dashboard import plan_api
+
+    state = {"source": "dashboard", "plan_mode": True, "plan_status": "ready"}
+    status_updates: list[tuple[str, Any]] = []
+    dispatch_attempts = 0
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return dict(state)
+
+    async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        return {"markdown": "# Plan", "status": state["plan_status"]}
+
+    async def fake_list(thread_id: str, *, raise_on_error: bool = False) -> list[dict[str, Any]]:
+        return []
+
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
+        status_updates.append((status, plan_mode))
+        state.update(plan_mode=plan_mode, plan_status=status)
+
+    async def fake_dispatch(
+        thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
+    ) -> dict[str, Any]:
+        nonlocal dispatch_attempts
+        dispatch_attempts += 1
+        if dispatch_attempts == 1:
+            raise RuntimeError("dispatch unavailable")
+        return {"run_id": "run-2"}
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+    monkeypatch.setattr(plan_api, "get_plan_content", fake_get_content)
+    monkeypatch.setattr(plan_api, "list_plan_comments", fake_list)
+    monkeypatch.setattr(plan_api, "set_plan_status", fake_set_status)
+    monkeypatch.setattr(plan_api, "_dispatch_followup", fake_dispatch)
+    monkeypatch.setattr(plan_api, "_maybe_post_plan_approved_to_slack", AsyncMock())
+
+    approver = {"id": "reviewer", "name": "Reviewer", "source": "dashboard"}
+    with pytest.raises(RuntimeError, match="dispatch unavailable"):
+        await plan_api.approve_plan_for_thread("t1", approver=approver)
+
+    assert status_updates == [("approved", False), ("ready", True)]
+    result = await plan_api.approve_plan_for_thread("t1", approver=approver)
+    assert result == {"status": "approved", "run_id": "run-2"}
+    assert dispatch_attempts == 2
+
+
 async def test_approve_plan_posts_slack_approval_notice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -549,12 +549,7 @@ async def test_set_plan_status_clears_shared_content_when_entering_plan_mode(
     await plan_store.set_plan_status("t", plan_store.PLAN_STATUS_PLANNING, plan_mode=True)
 
     assert saved == {"markdown": "", "status": "planning"}
-    assert merged == {
-        "plan_status": "planning",
-        "plan_mode": True,
-        "plan_approved_by": None,
-        "plan_approved_at": None,
-    }
+    assert merged == {"plan_status": "planning", "plan_mode": True}
 
 
 async def test_save_plan_content_clear_comments_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -606,11 +601,7 @@ async def test_save_plan_content_can_skip_plan_mode_metadata(
 
     await plan_store.save_plan_content("t", markdown="x", plan_mode=None)
 
-    assert merged == {
-        "plan_status": "ready",
-        "plan_approved_by": None,
-        "plan_approved_at": None,
-    }
+    assert merged == {"plan_status": "ready"}
 
 
 async def test_get_plan_returns_approval_attribution(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -475,6 +475,50 @@ async def test_set_plan_status_preserves_plan_file_path(monkeypatch: pytest.Monk
     assert saved["status"] == plan_store.PLAN_STATUS_REVISING
 
 
+async def test_set_plan_status_records_approver_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent.dashboard import plan_store
+
+    saved: dict[str, Any] = {}
+    merged: dict[str, Any] = {}
+
+    class _Store:
+        async def get_item(self, *a: Any, **k: Any) -> Any:
+            return {
+                "value": {
+                    "markdown": "# Plan",
+                    "status": "ready",
+                    "plan_file_path": "/workspace/plans/foo.md",
+                }
+            }
+
+        async def put_item(self, namespace: Any, key: str, value: Any, *a: Any, **k: Any) -> None:
+            saved.update(value)
+
+    async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
+        merged.update(metadata)
+
+    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
+
+    await plan_store.set_plan_status(
+        "t",
+        plan_store.PLAN_STATUS_APPROVED,
+        plan_mode=False,
+        approved_by={"id": "octo", "name": "Octo", "source": "dashboard"},
+    )
+
+    assert saved["markdown"] == "# Plan"
+    assert saved["plan_file_path"] == "/workspace/plans/foo.md"
+    assert saved["approved_by"] == {"id": "octo", "name": "Octo", "source": "dashboard"}
+    assert isinstance(saved["approved_at"], str)
+    assert merged == {
+        "plan_status": "approved",
+        "plan_mode": False,
+        "plan_approved_by": saved["approved_by"],
+        "plan_approved_at": saved["approved_at"],
+    }
+
+
 async def test_set_plan_status_clears_shared_content_when_entering_plan_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -504,7 +548,12 @@ async def test_set_plan_status_clears_shared_content_when_entering_plan_mode(
     await plan_store.set_plan_status("t", plan_store.PLAN_STATUS_PLANNING, plan_mode=True)
 
     assert saved == {"markdown": "", "status": "planning"}
-    assert merged == {"plan_status": "planning", "plan_mode": True}
+    assert merged == {
+        "plan_status": "planning",
+        "plan_mode": True,
+        "plan_approved_by": None,
+        "plan_approved_at": None,
+    }
 
 
 async def test_save_plan_content_clear_comments_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -556,7 +605,42 @@ async def test_save_plan_content_can_skip_plan_mode_metadata(
 
     await plan_store.save_plan_content("t", markdown="x", plan_mode=None)
 
-    assert merged == {"plan_status": "ready"}
+    assert merged == {
+        "plan_status": "ready",
+        "plan_approved_by": None,
+        "plan_approved_at": None,
+    }
+
+
+async def test_get_plan_returns_approval_attribution(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent.dashboard import plan_api
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return {"source": "slack", "github_login": "owner"}
+
+    async def fake_content(thread_id: str) -> dict[str, Any]:
+        return {
+            "markdown": "# Plan",
+            "status": "approved",
+            "approved_by": {"id": "reviewer", "name": "Reviewer", "source": "dashboard"},
+            "approved_at": "2026-08-16T12:00:00+00:00",
+        }
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+    monkeypatch.setattr(plan_api, "get_plan_content", fake_content)
+
+    result = await plan_api.get_plan(
+        "t1",
+        session={"sub": "reviewer", "email": None, "name": "Reviewer"},
+    )
+
+    assert result["isOwner"] is False
+    assert result["approvedBy"] == {
+        "id": "reviewer",
+        "name": "Reviewer",
+        "source": "dashboard",
+    }
+    assert result["approvedAt"] == "2026-08-16T12:00:00+00:00"
 
 
 def _patch_update_plan_deps(
@@ -680,7 +764,23 @@ async def test_update_plan_blocked_once_approved(monkeypatch: pytest.MonkeyPatch
     assert exc.value.status_code == 409
 
 
-async def test_approve_plan_dispatches_published_markdown(
+async def test_approve_plan_hides_unreadable_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    from agent.dashboard import plan_api
+
+    async def fake_meta(thread_id: str) -> dict[str, Any]:
+        return {"source": "unknown", "github_login": "owner"}
+
+    monkeypatch.setattr(plan_api, "_thread_metadata", fake_meta)
+
+    with pytest.raises(HTTPException) as exc:
+        await plan_api.approve_plan("t1", session={"sub": "reviewer", "email": None})
+
+    assert exc.value.status_code == 404
+
+
+async def test_non_owner_can_approve_and_dispatch_published_markdown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from agent.dashboard import plan_api
@@ -688,7 +788,7 @@ async def test_approve_plan_dispatches_published_markdown(
     dispatched: dict[str, Any] = {}
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
-        return {"plan_status": "ready"}
+        return {"source": "slack", "plan_status": "ready"}
 
     async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         return {"markdown": "# Edited plan\n\nstep one", "status": "ready"}
@@ -696,8 +796,14 @@ async def test_approve_plan_dispatches_published_markdown(
     async def fake_list(thread_id: str, *, raise_on_error: bool = False) -> list[dict[str, Any]]:
         return [{"author": "bob", "body": "use snake_case"}]
 
-    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
-        return None
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
+        dispatched.update(status=status, approved_by=approved_by)
 
     async def fake_dispatch(
         thread_id: str, metadata: dict[str, Any], text: str, *, plan_mode: bool
@@ -719,6 +825,7 @@ async def test_approve_plan_dispatches_published_markdown(
     assert "reasonable engineering judgment" in dispatched["text"]
     assert "exactly as written" not in dispatched["text"]
     assert dispatched["plan_mode"] is False
+    assert dispatched["approved_by"] == {"id": "a", "name": "a", "source": "dashboard"}
 
 
 async def test_approve_plan_posts_slack_approval_notice(
@@ -731,6 +838,7 @@ async def test_approve_plan_posts_slack_approval_notice(
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
         return {
+            "source": "slack",
             "plan_status": "ready",
             "source_context": {"slack_thread": {"channel_id": "C1", "thread_ts": "123.45"}},
         }
@@ -744,7 +852,13 @@ async def test_approve_plan_posts_slack_approval_notice(
             {"author": "bob", "body": "add a test"},
         ]
 
-    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
         return None
 
     async def fake_post(
@@ -811,14 +925,20 @@ async def test_approve_plan_aborts_when_plan_read_fails(
     dispatched: list[Any] = []
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
-        return {"plan_status": "ready"}
+        return {"source": "slack", "plan_status": "ready"}
 
     async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         # A transient store failure must abort approval, not silently drop the
         # owner's edited plan and dispatch the generic fallback text.
         raise RuntimeError("store down")
 
-    async def fake_set_status(thread_id: str, status: str, *, plan_mode: Any = None) -> None:
+    async def fake_set_status(
+        thread_id: str,
+        status: str,
+        *,
+        plan_mode: Any = None,
+        approved_by: Any = None,
+    ) -> None:
         return None
 
     async def fake_dispatch(*a: Any, **k: Any) -> None:
@@ -845,7 +965,7 @@ async def test_approve_plan_rejects_shared_content(
     dispatched: list[Any] = []
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
-        return {"plan_status": "shared"}
+        return {"source": "slack", "plan_status": "shared"}
 
     async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         return {"markdown": "# Report", "status": "shared"}
@@ -874,7 +994,7 @@ async def test_reject_plan_rejects_shared_content(
     dispatched: list[Any] = []
 
     async def fake_meta(thread_id: str) -> dict[str, Any]:
-        return {"plan_status": "shared"}
+        return {"source": "slack", "plan_status": "shared"}
 
     async def fake_get_content(thread_id: str, *, raise_on_error: bool = False) -> dict[str, Any]:
         return {"markdown": "# Report", "status": "shared"}

--- a/tests/dashboard/test_dashboard_web_handoff.py
+++ b/tests/dashboard/test_dashboard_web_handoff.py
@@ -172,13 +172,7 @@ async def test_dashboard_followup_on_busy_thread_queues_dashboard_handoff(
     )
 
     assert client.threads.updates[0]["source"] == "dashboard"
-    assert queued_messages == [
-        {
-            "text": "continue in web",
-            "source": "dashboard",
-            "approver": {"id": "octocat", "name": "octocat", "source": "dashboard"},
-        }
-    ]
+    assert queued_messages == [{"text": "continue in web", "source": "dashboard"}]
 
 
 @pytest.mark.asyncio
@@ -225,13 +219,7 @@ async def test_dashboard_followup_on_busy_slack_thread_updates_trace_reply(
         email="octocat@example.com",
     )
 
-    assert queued_messages == [
-        {
-            "text": "continue in web",
-            "source": "dashboard",
-            "approver": {"id": "octocat", "name": "octocat", "source": "dashboard"},
-        }
-    ]
+    assert queued_messages == [{"text": "continue in web", "source": "dashboard"}]
     assert handoff_updates == [
         {"channel_id": "C1", "message_ts": "123.46", "thread_id": "thread-1"}
     ]
@@ -323,7 +311,6 @@ async def test_dashboard_followup_on_busy_thread_queues_images(
         {
             "text": "continue in web",
             "source": "dashboard",
-            "approver": {"id": "octocat", "name": "octocat", "source": "dashboard"},
             "images": [{"type": "image", "data": "aW1hZ2U=", "mime_type": "image/png"}],
         }
     ]

--- a/tests/dashboard/test_dashboard_web_handoff.py
+++ b/tests/dashboard/test_dashboard_web_handoff.py
@@ -173,7 +173,11 @@ async def test_dashboard_followup_on_busy_thread_queues_dashboard_handoff(
 
     assert client.threads.updates[0]["source"] == "dashboard"
     assert queued_messages == [
-        {"text": "continue in web", "source": "dashboard", "from_owner": True}
+        {
+            "text": "continue in web",
+            "source": "dashboard",
+            "approver": {"id": "octocat", "name": "octocat", "source": "dashboard"},
+        }
     ]
 
 
@@ -222,7 +226,11 @@ async def test_dashboard_followup_on_busy_slack_thread_updates_trace_reply(
     )
 
     assert queued_messages == [
-        {"text": "continue in web", "source": "dashboard", "from_owner": True}
+        {
+            "text": "continue in web",
+            "source": "dashboard",
+            "approver": {"id": "octocat", "name": "octocat", "source": "dashboard"},
+        }
     ]
     assert handoff_updates == [
         {"channel_id": "C1", "message_ts": "123.46", "thread_id": "thread-1"}
@@ -315,7 +323,7 @@ async def test_dashboard_followup_on_busy_thread_queues_images(
         {
             "text": "continue in web",
             "source": "dashboard",
-            "from_owner": True,
+            "approver": {"id": "octocat", "name": "octocat", "source": "dashboard"},
             "images": [{"type": "image", "data": "aW1hZ2U=", "mime_type": "image/png"}],
         }
     ]

--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -91,7 +91,7 @@ test.describe("Plan review (HTTP comments)", () => {
     );
   });
 
-  test("Slack plan request → comments → owner approves → PR", async ({
+  test("Slack plan request → comments → collaborator approves → PR", async ({
     browser,
     request,
   }, testInfo) => {
@@ -234,8 +234,7 @@ test.describe("Plan review (HTTP comments)", () => {
     await expect(owner.getByTestId("plan-comment")).toHaveCount(1);
     await expect(owner.getByTestId("reject-plan")).toBeEnabled();
 
-    // 5. A COLLABORATOR opens the same plan: sees it AND the owner's comment
-    //    (fetched over HTTP), but has NO approve button.
+    // 5. A COLLABORATOR opens the same plan and sees the owner's comment.
     const collabCtx = await browser.newContext();
     await collabCtx.request.post("/control/login", { data: COLLABORATOR });
     const collab = await collabCtx.newPage();
@@ -252,7 +251,7 @@ test.describe("Plan review (HTTP comments)", () => {
     await expect(collab.getByTestId("plan-comment")).toContainText(
       "looks solid",
     );
-    await expect(collab.getByTestId("approve-plan")).toHaveCount(0);
+    await expect(collab.getByTestId("approve-plan")).toBeVisible();
     await expect(collab.getByTestId("reject-plan")).toBeVisible();
 
     // Collaborator leaves feedback with Ctrl+Enter.
@@ -263,13 +262,10 @@ test.describe("Plan review (HTTP comments)", () => {
     );
     await expect(collab.getByTestId("plan-comment")).toHaveCount(2);
 
-    // 6. The owner sees the collaborator's comment (polled), then approves and
-    //    returns to the main conversation while implementation starts.
-    await expect(owner.getByTestId("plan-comment")).toHaveCount(2, {
-      timeout: 30_000,
-    });
-    await owner.getByTestId("approve-plan").click();
-    await expect(owner).toHaveURL(new RegExp(`/agents/${threadId}$`));
+    // 6. The collaborator approves and returns to the main conversation while
+    //    implementation starts.
+    await collab.getByTestId("approve-plan").click();
+    await expect(collab).toHaveURL(new RegExp(`/agents/${threadId}$`));
 
     // 7. The agent implements, opens a PR, and links it back in the Slack thread,
     //    echoing the reviewers' feedback — which proves the comments were stored

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -36,7 +36,17 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         {
             (("queue", "thread-1"), "pending_messages"): {
                 "messages": [
-                    {"content": {"text": "continue in web", "source": "dashboard"}},
+                    {
+                        "content": {
+                            "text": "continue in web",
+                            "source": "dashboard",
+                            "approver": {
+                                "id": "teammate",
+                                "name": "teammate",
+                                "source": "dashboard",
+                            },
+                        }
+                    },
                 ]
             }
         }
@@ -65,19 +75,33 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
     assert message["role"] == "user"
     assert DASHBOARD_HANDOFF_MARKER in message["content"][0]["text"]
     assert message["content"][1] == {"type": "text", "text": "continue in web"}
-    assert result["plan_approval_blocked"] is True
+    assert result["plan_approver"] == {
+        "id": "teammate",
+        "name": "teammate",
+        "source": "dashboard",
+    }
     assert "dashboard/Web UI" in result["rendered_system_prompt"]
     assert "Make `slack_thread_reply` your first tool call" not in result["rendered_system_prompt"]
     assert store.deleted == [(("queue", "thread-1"), "pending_messages")]
 
 
 @pytest.mark.asyncio
-async def test_check_message_queue_allows_owner_dashboard_approval() -> None:
+async def test_check_message_queue_tracks_dashboard_approver() -> None:
     store = _FakeStore(
         {
             (("queue", "thread-1"), "pending_messages"): {
                 "messages": [
-                    {"content": {"text": "go ahead", "source": "dashboard", "from_owner": True}},
+                    {
+                        "content": {
+                            "text": "go ahead",
+                            "source": "dashboard",
+                            "approver": {
+                                "id": "octo",
+                                "name": "octo",
+                                "source": "dashboard",
+                            },
+                        }
+                    },
                 ]
             }
         }
@@ -95,7 +119,11 @@ async def test_check_message_queue_allows_owner_dashboard_approval() -> None:
         )
 
     assert result is not None
-    assert result["plan_approval_blocked"] is False
+    assert result["plan_approver"] == {
+        "id": "octo",
+        "name": "octo",
+        "source": "dashboard",
+    }
     assert result["messages"][0]["content"][1] == {"type": "text", "text": "go ahead"}
 
 

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -36,17 +36,7 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         {
             (("queue", "thread-1"), "pending_messages"): {
                 "messages": [
-                    {
-                        "content": {
-                            "text": "continue in web",
-                            "source": "dashboard",
-                            "approver": {
-                                "id": "teammate",
-                                "name": "teammate",
-                                "source": "dashboard",
-                            },
-                        }
-                    },
+                    {"content": {"text": "continue in web", "source": "dashboard"}},
                 ]
             }
         }
@@ -75,33 +65,19 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
     assert message["role"] == "user"
     assert DASHBOARD_HANDOFF_MARKER in message["content"][0]["text"]
     assert message["content"][1] == {"type": "text", "text": "continue in web"}
-    assert result["plan_approver"] == {
-        "id": "teammate",
-        "name": "teammate",
-        "source": "dashboard",
-    }
+    assert "plan_approver" not in result
     assert "dashboard/Web UI" in result["rendered_system_prompt"]
     assert "Make `slack_thread_reply` your first tool call" not in result["rendered_system_prompt"]
     assert store.deleted == [(("queue", "thread-1"), "pending_messages")]
 
 
 @pytest.mark.asyncio
-async def test_check_message_queue_tracks_dashboard_approver() -> None:
+async def test_check_message_queue_does_not_persist_dashboard_approver() -> None:
     store = _FakeStore(
         {
             (("queue", "thread-1"), "pending_messages"): {
                 "messages": [
-                    {
-                        "content": {
-                            "text": "go ahead",
-                            "source": "dashboard",
-                            "approver": {
-                                "id": "octo",
-                                "name": "octo",
-                                "source": "dashboard",
-                            },
-                        }
-                    },
+                    {"content": {"text": "go ahead", "source": "dashboard"}},
                 ]
             }
         }
@@ -119,11 +95,7 @@ async def test_check_message_queue_tracks_dashboard_approver() -> None:
         )
 
     assert result is not None
-    assert result["plan_approver"] == {
-        "id": "octo",
-        "name": "octo",
-        "source": "dashboard",
-    }
+    assert "plan_approver" not in result
     assert result["messages"][0]["content"][1] == {"type": "text", "text": "go ahead"}
 
 

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -72,15 +72,13 @@ async def test_slack_processing_error_posts_dashboard_link(
     assert "<https://ui/t1|Open SWE Web>" in await_args.args[2]
 
 
-async def test_natural_language_plan_approval_uses_shared_approval_flow(
+async def test_non_owner_natural_language_plan_approval_uses_shared_flow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    is_owner = AsyncMock(return_value=True)
     metadata = {"plan_mode": True, "plan_status": "ready"}
     load_metadata = AsyncMock(return_value=metadata)
     approve = AsyncMock(return_value={"status": "approved"})
 
-    monkeypatch.setattr(slack_webhook.common, "_slack_user_is_thread_owner", is_owner)
     monkeypatch.setattr(plan_api, "_thread_metadata", load_metadata)
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve)
 
@@ -89,18 +87,35 @@ async def test_natural_language_plan_approval_uses_shared_approval_flow(
     )
 
     assert handled is True
-    is_owner.assert_awaited_once_with("t1", "U1")
     load_metadata.assert_awaited_once_with("t1")
-    approve.assert_awaited_once_with("t1", metadata=metadata, actor="Alice")
+    approve.assert_awaited_once_with(
+        "t1",
+        metadata=metadata,
+        approver={"id": "U1", "name": "Alice", "source": "slack"},
+    )
+
+
+async def test_non_owner_can_send_untagged_ready_plan_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        plan_api,
+        "_thread_metadata",
+        AsyncMock(return_value={"plan_mode": True, "plan_status": "ready"}),
+    )
+    owner_check = AsyncMock(return_value=False)
+    monkeypatch.setattr(slack_webhook.common, "_slack_user_is_thread_owner", owner_check)
+
+    allowed = await slack_webhook._slack_user_can_reply_to_ready_plan("C1", "123.45", "U2")
+
+    assert allowed is True
+    owner_check.assert_not_awaited()
 
 
 @pytest.mark.parametrize("reply", ["LGTM, thanks", "Looks good — please implement this"])
 async def test_plan_approval_allows_polite_surrounding_words(
     monkeypatch: pytest.MonkeyPatch, reply: str
 ) -> None:
-    monkeypatch.setattr(
-        slack_webhook.common, "_slack_user_is_thread_owner", AsyncMock(return_value=True)
-    )
     monkeypatch.setattr(
         plan_api,
         "_thread_metadata",
@@ -125,9 +140,6 @@ async def test_duplicate_plan_approval_dispatches_once(monkeypatch: pytest.Monke
         metadata.update(plan_mode=False, plan_status="approved")
         return {"status": "approved"}
 
-    monkeypatch.setattr(
-        slack_webhook.common, "_slack_user_is_thread_owner", AsyncMock(return_value=True)
-    )
     monkeypatch.setattr(plan_api, "_thread_metadata", AsyncMock(return_value=metadata))
     approve_mock = AsyncMock(side_effect=approve)
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve_mock)

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -77,7 +77,7 @@ async def test_non_owner_natural_language_plan_approval_uses_shared_flow(
 ) -> None:
     metadata = {"plan_mode": True, "plan_status": "ready"}
     load_metadata = AsyncMock(return_value=metadata)
-    approve = AsyncMock(return_value={"status": "approved"})
+    approve = AsyncMock(return_value={"status": "approved", "run_id": "run-1"})
 
     monkeypatch.setattr(plan_api, "_thread_metadata", load_metadata)
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve)
@@ -90,9 +90,22 @@ async def test_non_owner_natural_language_plan_approval_uses_shared_flow(
     load_metadata.assert_awaited_once_with("t1")
     approve.assert_awaited_once_with(
         "t1",
-        metadata=metadata,
         approver={"id": "U1", "name": "Alice", "source": "slack"},
     )
+
+
+async def test_approval_phrase_on_missing_thread_continues_as_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        plan_api, "_thread_metadata", AsyncMock(side_effect=RuntimeError("missing"))
+    )
+
+    handled = await slack_webhook._maybe_approve_ready_plan_reply(
+        "new-thread", "C1", "123.45", "U1", "Alice", "please implement issue 123"
+    )
+
+    assert handled is False
 
 
 async def test_non_owner_can_send_untagged_ready_plan_reply(
@@ -121,7 +134,7 @@ async def test_plan_approval_allows_polite_surrounding_words(
         "_thread_metadata",
         AsyncMock(return_value={"plan_mode": True, "plan_status": "ready"}),
     )
-    approve = AsyncMock(return_value={"status": "approved"})
+    approve = AsyncMock(return_value={"status": "approved", "run_id": "run-1"})
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve)
 
     assert (
@@ -133,15 +146,17 @@ async def test_plan_approval_allows_polite_surrounding_words(
     approve.assert_awaited_once()
 
 
-async def test_duplicate_plan_approval_dispatches_once(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_duplicate_plan_approval_returns_shared_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     metadata = {"plan_mode": True, "plan_status": "ready"}
-
-    async def approve(*_args: object, **_kwargs: object) -> dict[str, str]:
-        metadata.update(plan_mode=False, plan_status="approved")
-        return {"status": "approved"}
-
     monkeypatch.setattr(plan_api, "_thread_metadata", AsyncMock(return_value=metadata))
-    approve_mock = AsyncMock(side_effect=approve)
+    approve_mock = AsyncMock(
+        side_effect=[
+            {"status": "approved", "run_id": "run-1"},
+            {"status": "approved", "already_approved": True},
+        ]
+    )
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve_mock)
 
     results = await asyncio.gather(
@@ -154,7 +169,28 @@ async def test_duplicate_plan_approval_dispatches_once(monkeypatch: pytest.Monke
     )
 
     assert results == [True, False]
-    approve_mock.assert_awaited_once()
+    assert approve_mock.await_count == 2
+
+
+async def test_slack_plan_button_failure_notifies_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    approve = AsyncMock(side_effect=RuntimeError("store down"))
+    notify = AsyncMock()
+    monkeypatch.setattr(slack_webhook, "_maybe_approve_ready_plan_reply", approve)
+    monkeypatch.setattr(slack_webhook, "_notify_slack_processing_error", notify)
+    event_data = {
+        "thread_id": "t1",
+        "channel_id": "C1",
+        "thread_ts": "123.45",
+        "user_id": "U1",
+        "user_name": "Alice",
+    }
+    repo_config = {"owner": "langchain-ai", "name": "open-swe"}
+
+    await slack_webhook.process_slack_plan_approval(event_data, repo_config)
+
+    notify.assert_awaited_once_with(event_data, repo_config)
 
 
 async def test_plan_revision_reply_does_not_trigger_approval(

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -116,13 +116,13 @@ async def test_non_owner_can_send_untagged_ready_plan_reply(
         "_thread_metadata",
         AsyncMock(return_value={"plan_mode": True, "plan_status": "ready"}),
     )
-    owner_check = AsyncMock(return_value=False)
-    monkeypatch.setattr(slack_webhook.common, "_slack_user_is_thread_owner", owner_check)
+    lookup_thread = AsyncMock(return_value="t1")
+    monkeypatch.setattr(slack_webhook.common, "lookup_slack_thread_id", lookup_thread)
 
     allowed = await slack_webhook._slack_user_can_reply_to_ready_plan("C1", "123.45", "U2")
 
     assert allowed is True
-    owner_check.assert_not_awaited()
+    lookup_thread.assert_awaited_once()
 
 
 @pytest.mark.parametrize("reply", ["LGTM, thanks", "Looks good — please implement this"])

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -81,11 +81,9 @@ export function PlanReview({
   }, [plan.markdown, editing])
 
   const isShared = plan.status === "shared"
-  const canEdit =
-    plan.isOwner &&
-    !isShared &&
-    plan.status !== "approved" &&
-    plan.status !== "cancelled"
+  const isTerminal = plan.status === "approved" || plan.status === "cancelled"
+  const canEdit = plan.isOwner && !isShared && !isTerminal
+  const canApprove = !isShared && !isTerminal
 
   const startEditing = useCallback(() => {
     setEditDraft(markdown)
@@ -237,6 +235,7 @@ export function PlanReview({
             {isShared ? "Viewing" : "Reviewing"} as {plan.user.name}
             {plan.isOwner ? " (owner)" : ""} · status:{" "}
             <span data-testid="plan-status">{plan.status}</span>
+            {plan.approvedBy ? ` · approved by ${plan.approvedBy.name}` : ""}
           </p>
         </div>
         <div
@@ -289,7 +288,7 @@ export function PlanReview({
               >
                 {copied ? "Copied!" : "Copy markdown"}
               </Button>
-              {!isShared && plan.isOwner && (
+              {canApprove && (
                 <Button
                   data-testid="approve-plan"
                   disabled={busy !== null || decision !== null}

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -83,7 +83,7 @@ export function PlanReview({
   const isShared = plan.status === "shared"
   const isTerminal = plan.status === "approved" || plan.status === "cancelled"
   const canEdit = plan.isOwner && !isShared && !isTerminal
-  const canApprove = !isShared && !isTerminal
+  const canApprove = plan.status === "ready"
 
   const startEditing = useCallback(() => {
     setEditDraft(markdown)

--- a/ui/src/lib/plan.ts
+++ b/ui/src/lib/plan.ts
@@ -30,11 +30,19 @@ export interface PlanUser {
 export type PlanStatus =
   "planning" | "ready" | "shared" | "revising" | "approved" | "cancelled"
 
+export interface PlanApprover {
+  id: string
+  name: string
+  source: string
+}
+
 export interface PlanData {
   threadId: string
   status: PlanStatus
   markdown: string
   isOwner: boolean
+  approvedBy: PlanApprover | null
+  approvedAt: string | null
   user: PlanUser
 }
 


### PR DESCRIPTION
## Description
Allow authenticated collaborators to approve surfaced plans across dashboard, Slack, and agent-mediated flows while recording the verified approver identity and timestamp.

## Release Note
Plan approvals can now be completed by collaborators other than the plan creator, with approver attribution shown in the dashboard.

## Test Plan
- [x] Verify non-owner dashboard, Slack, and tool approvals persist attribution and dispatch once.

Made by [Open SWE](https://openswe.vercel.app/agents/544cda70-cb94-fafd-a707-cf1af2463ab3)

## References
- Plan: https://openswe.vercel.app/agents/544cda70-cb94-fafd-a707-cf1af2463ab3/plan