### PR TITLE
fix: warn before discarding automation changes

### DIFF
--- a/ui/src/features/automations/components/AutomationEditor.tsx
+++ b/ui/src/features/automations/components/AutomationEditor.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/features/agents/lib/queries"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import { ModelPicker } from "@/features/agents/components/ModelPicker"
+import { useUnsavedChangesWarning } from "@/features/automations/lib/useUnsavedChangesWarning"
 import { useRepos } from "@/lib/profile"
 
 interface AutomationEditorProps {
@@ -86,10 +87,21 @@ export function AutomationEditor({
     ModelSelection | null | undefined
   >(undefined)
 
+  const initialSelection =
+    scheduleToSelection(models, schedule) ?? defaultSelection
   const activeSelection =
-    selectionOverride !== undefined
-      ? selectionOverride
-      : (scheduleToSelection(models, schedule) ?? defaultSelection)
+    selectionOverride !== undefined ? selectionOverride : initialSelection
+  const isDirty =
+    name !== (schedule?.name ?? template?.name ?? "") ||
+    prompt !== (schedule?.prompt ?? template?.prompt ?? "") ||
+    cron !== initialCron ||
+    repo !== (schedule?.repo ?? null) ||
+    slackChannelId !== (schedule?.slackChannelId ?? "") ||
+    slackNotificationMode !== (schedule?.slackNotificationMode ?? "always") ||
+    enabled !== (schedule?.enabled ?? true) ||
+    activeSelection?.modelId !== initialSelection?.modelId ||
+    activeSelection?.effort !== initialSelection?.effort
+  const allowNavigation = useUnsavedChangesWarning(isDirty)
 
   const error =
     createSchedule.error || updateSchedule.error || deleteSchedule.error
@@ -126,7 +138,12 @@ export function AutomationEditor({
           model_id: modelId,
           effort,
         },
-        { onSuccess: () => navigate({ to: "/agents/automations" }) }
+        {
+          onSuccess: () => {
+            allowNavigation()
+            navigate({ to: "/agents/automations" })
+          },
+        }
       )
       return
     }
@@ -146,7 +163,12 @@ export function AutomationEditor({
           enabled,
         },
       },
-      { onSuccess: () => navigate({ to: "/agents/automations" }) }
+      {
+        onSuccess: () => {
+          allowNavigation()
+          navigate({ to: "/agents/automations" })
+        },
+      }
     )
   }
 
@@ -154,7 +176,10 @@ export function AutomationEditor({
     if (!schedule) return
     if (!window.confirm(`Delete "${schedule.name}"?`)) return
     deleteSchedule.mutate(schedule.id, {
-      onSuccess: () => navigate({ to: "/agents/automations" }),
+      onSuccess: () => {
+        allowNavigation()
+        navigate({ to: "/agents/automations" })
+      },
     })
   }
 

--- a/ui/src/features/automations/lib/useUnsavedChangesWarning.test.tsx
+++ b/ui/src/features/automations/lib/useUnsavedChangesWarning.test.tsx
@@ -1,0 +1,68 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useUnsavedChangesWarning } from "./useUnsavedChangesWarning"
+
+const { useBlockerMock } = vi.hoisted(() => ({
+  useBlockerMock: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useBlocker: useBlockerMock,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+describe("useUnsavedChangesWarning", () => {
+  it("only blocks navigation and unloads while changes are dirty", () => {
+    const { rerender } = renderHook(
+      ({ isDirty }) => useUnsavedChangesWarning(isDirty),
+      { initialProps: { isDirty: false } }
+    )
+
+    expect(useBlockerMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ disabled: true, enableBeforeUnload: false })
+    )
+
+    rerender({ isDirty: true })
+
+    expect(useBlockerMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ disabled: false, enableBeforeUnload: true })
+    )
+  })
+
+  it("blocks client navigation when the user keeps editing", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false)
+    renderHook(() => useUnsavedChangesWarning(true))
+    const options = useBlockerMock.mock.lastCall?.[0] as {
+      shouldBlockFn: () => boolean
+    }
+
+    expect(options.shouldBlockFn()).toBe(true)
+    expect(window.confirm).toHaveBeenCalledWith(
+      "You have unsaved changes. Leave without saving?"
+    )
+  })
+
+  it("allows confirmed and successful navigation", () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
+    const { result } = renderHook(() => useUnsavedChangesWarning(true))
+    const options = useBlockerMock.mock.lastCall?.[0] as {
+      shouldBlockFn: () => boolean
+    }
+
+    expect(options.shouldBlockFn()).toBe(false)
+
+    confirm.mockClear()
+    act(() => result.current())
+
+    expect(options.shouldBlockFn()).toBe(false)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/features/automations/lib/useUnsavedChangesWarning.ts
+++ b/ui/src/features/automations/lib/useUnsavedChangesWarning.ts
@@ -1,0 +1,23 @@
+import { useCallback, useRef } from "react"
+import { useBlocker } from "@tanstack/react-router"
+
+const UNSAVED_CHANGES_MESSAGE =
+  "You have unsaved changes. Leave without saving?"
+
+export function useUnsavedChangesWarning(isDirty: boolean) {
+  const allowNavigationRef = useRef(false)
+  const shouldBlockFn = useCallback(() => {
+    if (allowNavigationRef.current) return false
+    return !window.confirm(UNSAVED_CHANGES_MESSAGE)
+  }, [])
+
+  useBlocker({
+    shouldBlockFn,
+    enableBeforeUnload: isDirty,
+    disabled: !isDirty,
+  })
+
+  return useCallback(() => {
+    allowNavigationRef.current = true
+  }, [])
+}


### PR DESCRIPTION
## Description
Warn before leaving an automation with unsaved edits, including browser refreshes and tab closes. Successful saves and deletes bypass the guard before returning to the automation list.

## Release Note
Automation editing now warns users before unsaved changes are discarded.

## Test Plan
- [x] Added focused tests for clean, blocked, confirmed, and successful navigation states
- [x] Built the production dashboard bundle

Made by [Open SWE](https://openswe.vercel.app/agents/c9efc618-8f32-6dfe-6473-541bcef0d5f5)