### PR TITLE
feat: stop Slack runs on x reactions

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -83,6 +83,7 @@ from .integrations.stagehand_browser import load_browser_tools
 from .middleware import (
     BasePrepareRunMiddleware,
     DynamicToolMiddleware,
+    ExcludeToolsMiddleware,
     ModelCallTimeoutMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
@@ -199,6 +200,7 @@ DEEP_AGENT_TOOL_NAMES = {
     "task",
     "write_file",
 }
+STOP_SUMMARY_EXCLUDED_TOOLS = frozenset({"delete", "edit_file", "execute", "task", "write_file"})
 
 
 def _tool_loader_timeout_seconds() -> float:
@@ -1223,31 +1225,36 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if admin_environments:
         logger.info("Admin thread %s: adding environment management tools", thread_id)
 
-    observability_authorized = await _observability_authorized(config, profile_login)
-    if observability_authorized:
-        observability_tools = await _load_observability_tools(True, profile_login)
-    elif await _allowed_org_member(config, profile_login):
-        observability_tools = await load_langsmith_tools(profile_login)
-    else:
-        observability_tools = await load_langsmith_tools(profile_login, allow_team=False)
-    corridor_tools = await _load_corridor_mcp_tools()
-    browser_tools = load_browser_tools()
-
+    stop_summary_mode = configurable.get("stop_summary") is True
+    observability_tools: list[Any] = []
+    corridor_tools: list[Any] = []
+    browser_tools: list[Any] = []
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
-    if profile_login:
-        currents_tools, notion_tools = await asyncio.gather(
-            _cached_tool_loader(
-                f"tools:currents:{profile_login}",
-                300,
-                lambda: load_currents_tools(profile_login),
-            ),
-            _cached_tool_loader(
-                f"tools:notion:{profile_login}",
-                300,
-                lambda: load_notion_tools(profile_login),
-            ),
-        )
+    if not stop_summary_mode:
+        observability_authorized = await _observability_authorized(config, profile_login)
+        if observability_authorized:
+            observability_tools = await _load_observability_tools(True, profile_login)
+        elif await _allowed_org_member(config, profile_login):
+            observability_tools = await load_langsmith_tools(profile_login)
+        else:
+            observability_tools = await load_langsmith_tools(profile_login, allow_team=False)
+        corridor_tools = await _load_corridor_mcp_tools()
+        browser_tools = load_browser_tools()
+
+        if profile_login:
+            currents_tools, notion_tools = await asyncio.gather(
+                _cached_tool_loader(
+                    f"tools:currents:{profile_login}",
+                    300,
+                    lambda: load_currents_tools(profile_login),
+                ),
+                _cached_tool_loader(
+                    f"tools:notion:{profile_login}",
+                    300,
+                    lambda: load_notion_tools(profile_login),
+                ),
+            )
 
     slack_tools = [
         slack_add_reaction,
@@ -1286,6 +1293,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         slack_thread_reply,
         *(ENVIRONMENT_TOOLS if admin_environments else ()),
     ]
+    if stop_summary_mode:
+        static_tools = [slack_read_thread_messages, slack_thread_reply]
     reserved_tool_names = {tool.__name__ for tool in static_tools}
     if not _slack_tools_enabled(configurable):
         static_tools = [tool for tool in static_tools if tool not in slack_tools]
@@ -1366,6 +1375,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 SanitizeToolInputsMiddleware(),
                 ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
                 ToolErrorMiddleware(),
+                *(
+                    [ExcludeToolsMiddleware(excluded=STOP_SUMMARY_EXCLUDED_TOOLS)]
+                    if stop_summary_mode
+                    else []
+                ),
                 WorkingRepoMiddleware(thread_id=thread_id, backend=backend, thread_client=client),
                 SubdirAgentsReadMiddleware(),
                 ToolRetryMiddleware(
@@ -1378,7 +1392,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 ),
                 PullRequestCreationGuardMiddleware(),
                 refresh_github_proxy_before_model,
-                check_message_queue_before_model,
+                *([] if stop_summary_mode else [check_message_queue_before_model]),
                 TimeoutWrapupMiddleware(),
                 notify_step_limit_reached,
                 *fallback_middleware,

--- a/agent/utils/slack_stop.py
+++ b/agent/utils/slack_stop.py
@@ -1,0 +1,229 @@
+"""Slack emergency-stop reaction handling."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from langgraph_sdk import get_client
+from langgraph_sdk.client import LangGraphClient
+
+from agent.dispatch import dispatch_agent_run
+
+from .slack import lookup_slack_run_mapping, store_slack_run_mapping
+from .slack_events import claim_slack_event
+from .thread_ids import generate_thread_id_from_slack_thread
+
+logger = logging.getLogger(__name__)
+
+LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
+    "LANGGRAPH_URL_PROD", "http://localhost:2024"
+)
+_QUEUE_RECORDS = (
+    (("queue",), "pending_messages"),
+    (("autofix",), "pending_event"),
+)
+
+
+def _mapping_value(value: object, key: str) -> object:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _thread_metadata(thread: object) -> dict[str, Any]:
+    metadata = _mapping_value(thread, "metadata")
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _matching_slack_context(
+    metadata: Mapping[str, Any], channel_id: str, thread_ts: str
+) -> dict[str, Any] | None:
+    source_context = metadata.get("source_context")
+    if not isinstance(source_context, Mapping):
+        return None
+    slack_thread = source_context.get("slack_thread")
+    if not isinstance(slack_thread, Mapping):
+        return None
+    if slack_thread.get("channel_id") != channel_id or slack_thread.get("thread_ts") != thread_ts:
+        return None
+    return dict(slack_thread)
+
+
+async def _resolve_stop_target(
+    client: LangGraphClient, channel_id: str, message_ts: str
+) -> tuple[str, str, dict[str, Any], dict[str, Any]] | None:
+    mapping = await lookup_slack_run_mapping(client, channel_id, message_ts)
+    if mapping is None:
+        thread_ts = message_ts
+    else:
+        mapped_thread_ts = mapping.get("thread_ts")
+        if not isinstance(mapped_thread_ts, str) or not mapped_thread_ts:
+            return None
+        thread_ts = mapped_thread_ts
+
+    thread_id = generate_thread_id_from_slack_thread(channel_id, thread_ts)
+    try:
+        thread = await client.threads.get(thread_id)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "Ignoring Slack stop reaction without a matching thread: channel=%s message=%s",
+            channel_id,
+            message_ts,
+        )
+        return None
+
+    metadata = _thread_metadata(thread)
+    slack_thread = _matching_slack_context(metadata, channel_id, thread_ts)
+    if slack_thread is None:
+        logger.warning(
+            "Ignoring Slack stop reaction with mismatched thread metadata: thread=%s",
+            thread_id,
+        )
+        return None
+    return thread_id, thread_ts, metadata, slack_thread
+
+
+async def _active_run_ids(client: LangGraphClient, thread_id: str) -> list[str]:
+    run_ids: set[str] = set()
+    for status in ("pending", "running"):
+        offset = 0
+        while True:
+            runs = await client.runs.list(thread_id, status=status, limit=100, offset=offset)
+            for run in runs:
+                run_id = _mapping_value(run, "run_id") or _mapping_value(run, "id")
+                if isinstance(run_id, str) and run_id:
+                    run_ids.add(run_id)
+            if len(runs) < 100:
+                break
+            offset += len(runs)
+    return sorted(run_ids)
+
+
+async def _clear_deferred_work(client: LangGraphClient, thread_id: str) -> None:
+    for namespace_prefix, key in _QUEUE_RECORDS:
+        await client.store.delete_item((*namespace_prefix, thread_id), key)
+
+
+def _summary_configurable(
+    metadata: Mapping[str, Any], slack_thread: Mapping[str, Any]
+) -> dict[str, Any]:
+    source = metadata.get("source")
+    configurable: dict[str, Any] = {
+        "source": source if source in {"slack", "schedule"} else "slack",
+        "slack_thread": dict(slack_thread),
+        "plan_mode": False,
+        "stop_summary": True,
+    }
+
+    repo = metadata.get("repo")
+    if isinstance(repo, Mapping) and repo.get("owner") and repo.get("name"):
+        configurable["repo"] = dict(repo)
+    else:
+        owner = metadata.get("repo_owner")
+        name = metadata.get("repo_name")
+        if isinstance(owner, str) and owner and isinstance(name, str) and name:
+            configurable["repo"] = {"owner": owner, "name": name}
+
+    for metadata_key, config_key in (
+        ("github_login", "github_login"),
+        ("triggering_user_email", "user_email"),
+        ("environment", "environment"),
+    ):
+        value = metadata.get(metadata_key)
+        if isinstance(value, str) and value:
+            configurable[config_key] = value
+    return configurable
+
+
+def _stop_summary_prompt(had_active_runs: bool) -> str:
+    observed_state = (
+        "One or more active runs were interrupted before this turn started."
+        if had_active_runs
+        else "No active run was present when the stop reaction was processed."
+    )
+    return f"""This is an internal stop-summary turn triggered by a Slack :x: reaction, not a new task request. {observed_state}
+
+Do not resume or continue the prior task. Do not modify files, run mutating commands, commit, push, open or update a pull request, or take any other implementation action. Inspect only the existing conversation and current sandbox state with read-only tools as needed.
+
+Your first and only user-facing action must be one concise `slack_thread_reply` that factually summarizes what was completed, what was in progress when interrupted, and what remains. If no active run existed, say so. Do not post an acknowledgement before the summary. End immediately after posting it."""
+
+
+def _agent_version_metadata() -> dict[str, str]:
+    revision = os.environ.get("LANGCHAIN_REVISION_ID")
+    return {"LANGSMITH_AGENT_VERSION": revision} if revision else {}
+
+
+async def _process_slack_stop_reaction(event: dict[str, Any], event_id: str) -> None:
+    if event.get("reaction") != "x":
+        return
+    item = event.get("item")
+    if not isinstance(item, dict) or item.get("type") != "message":
+        return
+    channel_id = item.get("channel")
+    message_ts = item.get("ts")
+    if not (
+        isinstance(channel_id, str) and channel_id and isinstance(message_ts, str) and message_ts
+    ):
+        return
+    if not event_id:
+        logger.warning("Ignoring Slack stop reaction without an event id")
+        return
+
+    client = get_client(url=LANGGRAPH_URL)
+    target = await _resolve_stop_target(client, channel_id, message_ts)
+    if target is None:
+        return
+    if not await claim_slack_event(event_id):
+        return
+
+    thread_id, thread_ts, metadata, slack_thread = target
+    run_ids = await _active_run_ids(client, thread_id)
+    if run_ids:
+        await client.runs.cancel_many(
+            thread_id=thread_id,
+            run_ids=run_ids,
+            action="interrupt",
+        )
+    await _clear_deferred_work(client, thread_id)
+    await client.threads.update(
+        thread_id=thread_id,
+        metadata={
+            "latest_run_status": "interrupted",
+            "stop_requested_at_ms": int(datetime.now(UTC).timestamp() * 1000),
+        },
+    )
+
+    configurable = _summary_configurable(metadata, slack_thread)
+    summary_run = await dispatch_agent_run(
+        thread_id,
+        _stop_summary_prompt(bool(run_ids)),
+        configurable,
+        source=str(configurable["source"]),
+        metadata=_agent_version_metadata(),
+        client=client,
+    )
+    summary_run_id = _mapping_value(summary_run, "run_id") or _mapping_value(summary_run, "id")
+    if isinstance(summary_run_id, str) and summary_run_id:
+        triggering_user_id = slack_thread.get("triggering_user_id")
+        await store_slack_run_mapping(
+            client,
+            channel_id,
+            thread_ts,
+            summary_run_id,
+            triggering_user_id=(
+                triggering_user_id
+                if isinstance(triggering_user_id, str) and triggering_user_id
+                else None
+            ),
+        )
+
+
+async def process_slack_stop_reaction(event: dict[str, Any], event_id: str = "") -> None:
+    try:
+        await _process_slack_stop_reaction(event, event_id)
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to stop Open SWE from Slack reaction")

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -128,6 +128,7 @@ from ..utils.slack_feedback import (
     process_slack_reaction_added,
     process_slack_reaction_removed,
 )
+from ..utils.slack_stop import process_slack_stop_reaction
 from ..utils.thread_ids import generate_thread_id_from_slack_thread
 from ..utils.thread_ops import queue_message_for_thread  # noqa: F401
 from ..utils.thread_participants import PARTICIPANT_LOGINS_KEY, merge_participant_logins
@@ -248,6 +249,7 @@ __all__ = [
     "post_slack_trace_reply",
     "process_slack_reaction_added",
     "process_slack_reaction_removed",
+    "process_slack_stop_reaction",
     "queue_message_for_thread",
     "react_to_github_comment",
     "react_to_linear_comment",

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -43,6 +43,11 @@ async def slack_webhook(
 
     if event.get("type") == "reaction_added":
         reaction = event.get("reaction")
+        if reaction == "x":
+            background_tasks.add_task(
+                common.process_slack_stop_reaction, event, payload.get("event_id", "")
+            )
+            return {"status": "accepted", "message": "Stop reaction queued"}
         if reaction in common.FEEDBACK_REACTIONS:
             background_tasks.add_task(
                 common.process_slack_reaction_added, event, payload.get("event_id", "")

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -264,6 +264,32 @@ async def test_slack_source_context_includes_slack_tools(source: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_summary_agent_is_read_only_and_slack_only() -> None:
+    config = _base_config()
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    configurable.update(
+        {
+            "source": "slack",
+            "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"},
+            "stop_summary": True,
+        }
+    )
+
+    captured = await _capture_create_deep_agent_kwargs(config)
+    tools = captured["tools"]
+    middleware = captured["middleware"]
+    assert isinstance(tools, list)
+    assert isinstance(middleware, list)
+
+    tool_names = {getattr(tool, "name", None) or getattr(tool, "__name__", None) for tool in tools}
+    assert tool_names == {"slack_read_thread_messages", "slack_thread_reply"}
+    middleware_names = {type(item).__name__ for item in middleware}
+    assert "ExcludeToolsMiddleware" in middleware_names
+    assert "check_message_queue_before_model" not in middleware_names
+
+
+@pytest.mark.asyncio
 async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
     captured = await _capture_create_deep_agent_kwargs()
     middleware = captured["middleware"]

--- a/tests/slack/test_slack_feedback.py
+++ b/tests/slack/test_slack_feedback.py
@@ -236,6 +236,25 @@ async def test_slack_webhook_queues_reaction_added(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_slack_webhook_queues_stop_reaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = _reaction_event("x")
+    payload = {"type": "event_callback", "event_id": "EvStop", "event": event}
+    background_tasks = _FakeBackgroundTasks()
+
+    monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
+
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload)),
+        cast(BackgroundTasks, background_tasks),
+    )
+
+    assert response == {"status": "accepted", "message": "Stop reaction queued"}
+    assert background_tasks.tasks == [
+        (webhook_common.process_slack_stop_reaction, (event, "EvStop"))
+    ]
+
+
+@pytest.mark.asyncio
 async def test_slack_webhook_queues_reaction_removed(monkeypatch: pytest.MonkeyPatch) -> None:
     event = {**_reaction_event("-1"), "type": "reaction_removed"}
     payload = {"type": "event_callback", "event_id": "Ev2", "event": event}

--- a/tests/slack/test_slack_stop.py
+++ b/tests/slack/test_slack_stop.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent.utils import slack_stop
+from agent.utils.slack_stop import process_slack_stop_reaction
+from agent.utils.thread_ids import generate_thread_id_from_slack_thread
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.items: dict[tuple[tuple[str, ...], str], dict[str, Any]] = {}
+        self.deleted: list[tuple[tuple[str, ...], str]] = []
+        self.fail_delete = False
+
+    async def get_item(self, namespace: tuple[str, ...], key: str) -> dict[str, Any] | None:
+        return self.items.get((namespace, key))
+
+    async def put_item(self, namespace: tuple[str, ...], key: str, value: dict[str, Any]) -> None:
+        self.items[(namespace, key)] = {"value": value}
+
+    async def delete_item(self, namespace: tuple[str, ...], key: str) -> None:
+        if self.fail_delete:
+            raise RuntimeError("store unavailable")
+        self.deleted.append((namespace, key))
+        self.items.pop((namespace, key), None)
+
+
+class FakeThreads:
+    def __init__(self) -> None:
+        self.values: dict[str, dict[str, Any]] = {}
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+
+    async def get(self, thread_id: str) -> dict[str, Any]:
+        if thread_id not in self.values:
+            raise RuntimeError("not found")
+        return self.values[thread_id]
+
+    async def update(self, *, thread_id: str, metadata: dict[str, Any]) -> None:
+        self.updates.append((thread_id, metadata))
+        current = self.values[thread_id].setdefault("metadata", {})
+        current.update(metadata)
+
+
+class FakeRuns:
+    def __init__(self) -> None:
+        self.by_status: dict[str, list[dict[str, str]]] = {"pending": [], "running": []}
+        self.cancelled: list[dict[str, Any]] = []
+        self.fail_cancel = False
+
+    async def list(
+        self, thread_id: str, *, status: str, limit: int, offset: int
+    ) -> list[dict[str, str]]:
+        del thread_id
+        return self.by_status[status][offset : offset + limit]
+
+    async def cancel_many(self, *, thread_id: str, run_ids: list[str], action: str) -> None:
+        if self.fail_cancel:
+            raise RuntimeError("cancel failed")
+        self.cancelled.append({"thread_id": thread_id, "run_ids": run_ids, "action": action})
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.store = FakeStore()
+        self.threads = FakeThreads()
+        self.runs = FakeRuns()
+
+
+def _event(message_ts: str, *, user_id: str = "UOTHER") -> dict[str, Any]:
+    return {
+        "type": "reaction_added",
+        "reaction": "x",
+        "user": user_id,
+        "item": {"type": "message", "channel": "C123", "ts": message_ts},
+    }
+
+
+def _add_thread(client: FakeClient, thread_ts: str = "1.000") -> str:
+    thread_id = generate_thread_id_from_slack_thread("C123", thread_ts)
+    client.threads.values[thread_id] = {
+        "thread_id": thread_id,
+        "metadata": {
+            "source": "slack",
+            "github_login": "owner",
+            "triggering_user_email": "owner@example.com",
+            "repo": {"owner": "langchain-ai", "name": "open-swe"},
+            "environment": "default",
+            "source_context": {
+                "slack_thread": {
+                    "channel_id": "C123",
+                    "thread_ts": thread_ts,
+                    "triggering_user_id": "UOWNER",
+                    "triggering_user_email": "owner@example.com",
+                }
+            },
+        },
+    }
+    return thread_id
+
+
+def _map_reply(client: FakeClient, message_ts: str, thread_ts: str = "1.000") -> None:
+    client.store.items[(("slack_run_map", "C123"), f"message:{message_ts}")] = {
+        "value": {"run_id": "run-old", "thread_ts": thread_ts}
+    }
+
+
+def _patch_handler(
+    monkeypatch: pytest.MonkeyPatch, client: FakeClient
+) -> tuple[list[dict[str, Any]], list[str]]:
+    dispatched: list[dict[str, Any]] = []
+    claimed: list[str] = []
+
+    async def fake_claim(event_id: str) -> bool:
+        claimed.append(event_id)
+        return True
+
+    async def fake_dispatch(
+        thread_id: str,
+        content: str,
+        configurable: dict[str, Any],
+        *,
+        source: str,
+        metadata: dict[str, Any],
+        client: FakeClient,
+    ) -> dict[str, str]:
+        dispatched.append(
+            {
+                "thread_id": thread_id,
+                "content": content,
+                "configurable": configurable,
+                "source": source,
+                "metadata": metadata,
+                "client": client,
+            }
+        )
+        return {"run_id": "run-summary"}
+
+    monkeypatch.setattr(slack_stop, "get_client", lambda url: client)
+    monkeypatch.setattr(slack_stop, "claim_slack_event", fake_claim)
+    monkeypatch.setattr(slack_stop, "dispatch_agent_run", fake_dispatch)
+    return dispatched, claimed
+
+
+async def test_stop_reaction_on_mapped_reply_interrupts_all_runs_and_dispatches_agent_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    thread_id = _add_thread(client)
+    _map_reply(client, "2.000")
+    client.runs.by_status["pending"] = [{"run_id": "run-pending"}]
+    client.runs.by_status["running"] = [{"run_id": "run-running"}]
+    client.store.items[(("queue", thread_id), "pending_messages")] = {
+        "value": {"messages": [{"content": "later"}]}
+    }
+    client.store.items[(("autofix", thread_id), "pending_event")] = {"value": {"reason": "ci"}}
+    dispatched, claimed = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("2.000"), event_id="EvStop")
+
+    assert claimed == ["EvStop"]
+    assert client.runs.cancelled == [
+        {
+            "thread_id": thread_id,
+            "run_ids": ["run-pending", "run-running"],
+            "action": "interrupt",
+        }
+    ]
+    assert (("queue", thread_id), "pending_messages") in client.store.deleted
+    assert (("autofix", thread_id), "pending_event") in client.store.deleted
+    assert client.threads.updates[0][1]["latest_run_status"] == "interrupted"
+    assert len(dispatched) == 1
+    assert dispatched[0]["thread_id"] == thread_id
+    assert dispatched[0]["source"] == "slack"
+    assert dispatched[0]["configurable"]["github_login"] == "owner"
+    assert dispatched[0]["configurable"]["stop_summary"] is True
+    assert dispatched[0]["configurable"]["slack_thread"]["triggering_user_id"] == "UOWNER"
+    assert "first and only user-facing action" in dispatched[0]["content"]
+    assert "active runs were interrupted" in dispatched[0]["content"]
+    thread_mapping = client.store.items[(("slack_run_map", "C123"), "thread:1.000")]
+    assert thread_mapping["value"]["run_id"] == "run-summary"
+
+
+async def test_stop_reaction_on_root_dispatches_no_active_run_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    thread_id = _add_thread(client)
+    dispatched, claimed = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("1.000"), event_id="EvRoot")
+
+    assert claimed == ["EvRoot"]
+    assert client.runs.cancelled == []
+    assert dispatched[0]["thread_id"] == thread_id
+    assert "No active run was present" in dispatched[0]["content"]
+
+
+async def test_stop_reaction_from_non_owner_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+    _add_thread(client)
+    _map_reply(client, "2.000")
+    client.runs.by_status["running"] = [{"run_id": "run-running"}]
+    dispatched, _ = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("2.000", user_id="UNRELATED"), event_id="EvOtherUser")
+
+    assert len(dispatched) == 1
+    assert client.runs.cancelled[0]["run_ids"] == ["run-running"]
+
+
+async def test_stop_reaction_ignores_unmapped_non_root_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    _add_thread(client)
+    dispatched, claimed = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("9.000"), event_id="EvUnmapped")
+
+    assert dispatched == []
+    assert claimed == []
+    assert client.runs.cancelled == []
+
+
+async def test_stop_reaction_ignores_mismatched_thread_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    thread_id = _add_thread(client)
+    client.threads.values[thread_id]["metadata"]["source_context"]["slack_thread"]["channel_id"] = (
+        "COTHER"
+    )
+    _map_reply(client, "2.000")
+    dispatched, claimed = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("2.000"), event_id="EvMismatch")
+
+    assert dispatched == []
+    assert claimed == []
+
+
+async def test_stop_reaction_without_event_id_has_no_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    _add_thread(client)
+    _map_reply(client, "2.000")
+    dispatched, claimed = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("2.000"))
+
+    assert dispatched == []
+    assert claimed == []
+    assert client.runs.cancelled == []
+
+
+async def test_duplicate_stop_reaction_has_no_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    _add_thread(client)
+    _map_reply(client, "2.000")
+    dispatched, _ = _patch_handler(monkeypatch, client)
+
+    async def duplicate_claim(event_id: str) -> bool:
+        assert event_id == "EvDuplicate"
+        return False
+
+    monkeypatch.setattr(slack_stop, "claim_slack_event", duplicate_claim)
+
+    await process_slack_stop_reaction(_event("2.000"), event_id="EvDuplicate")
+
+    assert dispatched == []
+    assert client.runs.cancelled == []
+    assert client.store.deleted == []
+
+
+async def test_failed_cancellation_does_not_dispatch_success_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    _add_thread(client)
+    _map_reply(client, "2.000")
+    client.runs.by_status["running"] = [{"run_id": "run-running"}]
+    client.runs.fail_cancel = True
+    dispatched, _ = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("2.000"), event_id="EvFailure")
+
+    assert dispatched == []
+    assert client.store.deleted == []
+    assert client.threads.updates == []
+
+
+async def test_failed_queue_cleanup_does_not_dispatch_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    _add_thread(client)
+    _map_reply(client, "2.000")
+    client.store.fail_delete = True
+    dispatched, _ = _patch_handler(monkeypatch, client)
+
+    await process_slack_stop_reaction(_event("2.000"), event_id="EvStoreFailure")
+
+    assert dispatched == []
+    assert client.threads.updates == []


### PR DESCRIPTION
## Description
Treat Slack `:x:` reactions as an emergency stop after validating the mapped Open SWE message or thread root. Active runs and queued work are interrupted, then a restricted read-only agent turn writes the factual stopped summary.

## Release Note
Slack users can stop an active Open SWE thread by reacting with `:x:`.

## Test Plan
- [x] Verify mapped replies, roots, non-owner reactions, dedupe, failure handling, restricted summary tools, and existing feedback behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/71cb3dd7-b20a-2b68-8b66-25cc22960703)

## References
- Plan: https://openswe.vercel.app/agents/71cb3dd7-b20a-2b68-8b66-25cc22960703/plan