### PR TITLE
fix: ban white check mark Slack reactions

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -117,7 +117,7 @@ SLACK_SOURCE_GUIDANCE = """This run was triggered from Slack.
 - `slack_thread_reply` is the canonical user-facing output. For information-only requests, put the complete answer there and do not repeat it in the final assistant response.
 - Keep every `slack_thread_reply` as concise as possible: default to one sentence with only the outcome/status and link, or one blocking question. Omit greetings, preambles, headings, recaps, implementation details, and redundant context; use bullets only when multiple items are essential.
 - Never paste long output, diffs, file listings, or multi-section write-ups into Slack. Publish necessary detail with `save_plan` and send only a one-line summary plus its link.
-- For follow-ups, use `slack_add_reaction` instead of a perfunctory status reply. Never react to a root post containing a pull request link with `white_check_mark`.
+- For follow-ups, use `slack_add_reaction` instead of a perfunctory status reply. Never use `white_check_mark`, because teams use it to indicate that a pull request is approved.
 - When asked to break out work, use `slack_start_new_thread` with a headline-only title and self-contained instructions.
 - When a plan is ready, send its review link with `slack_thread_reply`, pass `options=["Approve & implement", "Request changes"]`, and invite manual feedback too; use these options rather than constructing custom Block Kit."""
 

--- a/agent/tools/slack_add_reaction.py
+++ b/agent/tools/slack_add_reaction.py
@@ -12,11 +12,10 @@ async def slack_add_reaction(
     """Add a context-appropriate reaction to a Slack message in the current thread.
 
     Prefer `saluting_face` for taking ownership, `eyes` for active review,
-    `thinking_face` for investigation, `white_check_mark` for handled work, and
-    `tada` for genuine wins. Never use `white_check_mark` on a root-level Slack post
-    containing a pull request link; use a neutral reaction instead. If `message_ts`
-    is omitted, this reacts to the latest message that triggered the run. Pass
-    emoji names without surrounding colons.
+    `thinking_face` for investigation, and `tada` for genuine wins. Never use
+    `white_check_mark`, because teams use it to indicate that a pull request is approved.
+    If `message_ts` is omitted, this reacts to the latest message that triggered the run.
+    Pass emoji names without surrounding colons.
     """
     config = get_config()
     configurable = config.get("configurable", {})
@@ -36,6 +35,11 @@ async def slack_add_reaction(
     reaction = emoji.strip().strip(":")
     if not reaction:
         return {"success": False, "error": "emoji is required"}
+    if reaction == "white_check_mark":
+        return {
+            "success": False,
+            "error": "white_check_mark is not allowed because it can imply PR approval",
+        }
     if any(char.isspace() for char in reaction):
         return {
             "success": False,

--- a/tests/slack/test_slack_add_reaction_tool.py
+++ b/tests/slack/test_slack_add_reaction_tool.py
@@ -50,12 +50,29 @@ async def test_slack_add_reaction_accepts_explicit_message_and_normalizes_emoji(
     monkeypatch.setattr(slack_reaction_tool, "get_config", _config)
     monkeypatch.setattr(slack_reaction_tool, "add_slack_reaction", fake_add_slack_reaction)
 
-    result = await slack_reaction_tool.slack_add_reaction(
-        emoji=":white_check_mark:", message_ts="1.2"
-    )
+    result = await slack_reaction_tool.slack_add_reaction(emoji=":eyes:", message_ts="1.2")
 
     assert result == {"success": True}
-    assert captured == {"channel_id": "C1", "message_ts": "1.2", "emoji": "white_check_mark"}
+    assert captured == {"channel_id": "C1", "message_ts": "1.2", "emoji": "eyes"}
+
+
+@pytest.mark.parametrize("emoji", ["white_check_mark", ":white_check_mark:"])
+async def test_slack_add_reaction_rejects_white_check_mark(
+    monkeypatch: pytest.MonkeyPatch,
+    emoji: str,
+) -> None:
+    async def fail_if_called(channel_id: str, message_ts: str, reaction: str) -> bool:
+        pytest.fail(f"unexpected Slack reaction: {channel_id} {message_ts} {reaction}")
+
+    monkeypatch.setattr(slack_reaction_tool, "get_config", _config)
+    monkeypatch.setattr(slack_reaction_tool, "add_slack_reaction", fail_if_called)
+
+    result = await slack_reaction_tool.slack_add_reaction(emoji=emoji)
+
+    assert result == {
+        "success": False,
+        "error": "white_check_mark is not allowed because it can imply PR approval",
+    }
 
 
 async def test_slack_add_reaction_requires_slack_channel(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
Prevent Open SWE from using `white_check_mark` reactions because teams interpret them as PR approval. The prompt and tool description now ban the reaction, and the tool enforces the ban before dispatching to Slack.

## Test Plan
- [x] Verify plain and colon-wrapped `white_check_mark` names are rejected before Slack API dispatch.

Made by [Open SWE](https://openswe.vercel.app/agents/9da3b31f-f908-04ac-86fc-899f13a5f44c)