### PR TITLE
feat: add sandbox file download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Stripe's key insight: *tool curation matters more than tool quantity.* Open SWE 
 | Tool | Purpose |
 |---|---|
 | `execute` | Shell commands in the sandbox |
+| `create_sandbox_file_download` | Create an authenticated download URL for a sandbox file |
 | `fetch_url` | Fetch web pages as markdown |
 | `http_request` | API calls (GET, POST, etc.) |
 | `linear_comment` | Post updates to Linear tickets |

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from ..dashboard import router as dashboard_router
 from ..dashboard.plan_api import plan_router
+from ..dashboard.sandbox_download_api import sandbox_download_router
 from ..dashboard.workflow_approval_api import workflow_approval_router
 from ..webhooks.github_routes import router as github_webhook_router
 from ..webhooks.linear_routes import router as linear_webhook_router
@@ -50,6 +51,7 @@ def create_app() -> FastAPI:
         )
     app.include_router(dashboard_router)
     app.include_router(plan_router)
+    app.include_router(sandbox_download_router)
     app.include_router(workflow_approval_router)
     app.include_router(linear_webhook_router)
     app.include_router(slack_webhook_router)

--- a/agent/dashboard/sandbox_download_api.py
+++ b/agent/dashboard/sandbox_download_api.py
@@ -49,6 +49,8 @@ async def download_sandbox_file_route(
         session["sub"],
         email=session.get("email"),
     )
+    if sandbox_id != claims.sandbox_id:
+        raise HTTPException(404, "sandbox download is no longer available")
     try:
         backend = await create_sandbox(sandbox_id)
         info, content = await download_sandbox_file(backend, claims.file_path)
@@ -61,6 +63,14 @@ async def download_sandbox_file_route(
     except Exception as exc:
         logger.exception("Sandbox file download failed for thread %s", claims.thread_id)
         raise HTTPException(502, "sandbox file could not be downloaded") from exc
+
+    current_sandbox_id, _ = await get_dashboard_terminal_sandbox(
+        claims.thread_id,
+        session["sub"],
+        email=session.get("email"),
+    )
+    if current_sandbox_id != claims.sandbox_id:
+        raise HTTPException(404, "sandbox download is no longer available")
 
     media_type = mimetypes.guess_type(info.filename)[0] or "application/octet-stream"
     return Response(

--- a/agent/dashboard/sandbox_download_api.py
+++ b/agent/dashboard/sandbox_download_api.py
@@ -4,20 +4,21 @@ from __future__ import annotations
 
 import logging
 import mimetypes
+from collections.abc import AsyncIterator
 from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import Response
+from fastapi.responses import StreamingResponse
 
 from ..utils.sandbox import create_sandbox
 from ..utils.sandbox_downloads import (
     InvalidSandboxDownloadToken,
     SandboxDownloadError,
     SandboxDownloadFileNotFound,
-    SandboxDownloadFileTooLarge,
     decode_sandbox_download_token,
-    download_sandbox_file,
+    inspect_sandbox_file,
+    stream_sandbox_file_chunks,
 )
 from .oauth import require_session
 from .thread_api import get_dashboard_terminal_sandbox
@@ -35,7 +36,7 @@ _SESSION_DEP = Depends(require_session)
 async def download_sandbox_file_route(
     token: str,
     session: dict[str, Any] = _SESSION_DEP,
-) -> Response:
+) -> StreamingResponse:
     try:
         claims = decode_sandbox_download_token(token)
     except InvalidSandboxDownloadToken as exc:
@@ -53,11 +54,9 @@ async def download_sandbox_file_route(
         raise HTTPException(404, "sandbox download is no longer available")
     try:
         backend = await create_sandbox(sandbox_id)
-        info, content = await download_sandbox_file(backend, claims.file_path)
+        info = await inspect_sandbox_file(backend, claims.file_path)
     except SandboxDownloadFileNotFound as exc:
         raise HTTPException(404, str(exc)) from exc
-    except SandboxDownloadFileTooLarge as exc:
-        raise HTTPException(413, str(exc)) from exc
     except SandboxDownloadError as exc:
         raise HTTPException(502, str(exc)) from exc
     except Exception as exc:
@@ -72,12 +71,34 @@ async def download_sandbox_file_route(
     if current_sandbox_id != claims.sandbox_id:
         raise HTTPException(404, "sandbox download is no longer available")
 
+    async def guarded_stream() -> AsyncIterator[bytes]:
+        yielded = False
+        async for chunk in stream_sandbox_file_chunks(backend, info):
+            current_sandbox_id, _ = await get_dashboard_terminal_sandbox(
+                claims.thread_id,
+                session["sub"],
+                email=session.get("email"),
+            )
+            if current_sandbox_id != claims.sandbox_id:
+                raise SandboxDownloadError("sandbox download is no longer available")
+            yielded = True
+            yield chunk
+        if not yielded:
+            current_sandbox_id, _ = await get_dashboard_terminal_sandbox(
+                claims.thread_id,
+                session["sub"],
+                email=session.get("email"),
+            )
+            if current_sandbox_id != claims.sandbox_id:
+                raise SandboxDownloadError("sandbox download is no longer available")
+
     media_type = mimetypes.guess_type(info.filename)[0] or "application/octet-stream"
-    return Response(
-        content=content,
+    return StreamingResponse(
+        content=guarded_stream(),
         media_type=media_type,
         headers={
             "Content-Disposition": _content_disposition(info.filename),
+            "Content-Length": str(info.size),
             "Cache-Control": "private, no-store",
             "X-Content-Type-Options": "nosniff",
         },

--- a/agent/dashboard/sandbox_download_api.py
+++ b/agent/dashboard/sandbox_download_api.py
@@ -1,0 +1,84 @@
+"""Authenticated endpoint for signed sandbox file downloads."""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+from typing import Any
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+
+from ..utils.sandbox import create_sandbox
+from ..utils.sandbox_downloads import (
+    InvalidSandboxDownloadToken,
+    SandboxDownloadError,
+    SandboxDownloadFileNotFound,
+    SandboxDownloadFileTooLarge,
+    decode_sandbox_download_token,
+    download_sandbox_file,
+)
+from .oauth import require_session
+from .thread_api import get_dashboard_terminal_sandbox
+
+logger = logging.getLogger(__name__)
+
+sandbox_download_router = APIRouter(
+    prefix="/dashboard/api/sandbox-files",
+    tags=["dashboard"],
+)
+_SESSION_DEP = Depends(require_session)
+
+
+@sandbox_download_router.get("/{token}")
+async def download_sandbox_file_route(
+    token: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> Response:
+    try:
+        claims = decode_sandbox_download_token(token)
+    except InvalidSandboxDownloadToken as exc:
+        raise HTTPException(401, str(exc)) from exc
+    except RuntimeError as exc:
+        logger.exception("Sandbox download token configuration failed")
+        raise HTTPException(500, "sandbox downloads are not configured") from exc
+
+    sandbox_id, _ = await get_dashboard_terminal_sandbox(
+        claims.thread_id,
+        session["sub"],
+        email=session.get("email"),
+    )
+    try:
+        backend = await create_sandbox(sandbox_id)
+        info, content = await download_sandbox_file(backend, claims.file_path)
+    except SandboxDownloadFileNotFound as exc:
+        raise HTTPException(404, str(exc)) from exc
+    except SandboxDownloadFileTooLarge as exc:
+        raise HTTPException(413, str(exc)) from exc
+    except SandboxDownloadError as exc:
+        raise HTTPException(502, str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Sandbox file download failed for thread %s", claims.thread_id)
+        raise HTTPException(502, "sandbox file could not be downloaded") from exc
+
+    media_type = mimetypes.guess_type(info.filename)[0] or "application/octet-stream"
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={
+            "Content-Disposition": _content_disposition(info.filename),
+            "Cache-Control": "private, no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+def _content_disposition(filename: str) -> str:
+    fallback = "".join(
+        character if 32 <= ord(character) < 127 and character not in {'"', "\\"} else "_"
+        for character in filename
+    )
+    fallback = fallback or "download"
+    encoded = quote(filename, safe="")
+    return f"attachment; filename=\"{fallback}\"; filename*=UTF-8''{encoded}"

--- a/agent/server.py
+++ b/agent/server.py
@@ -117,6 +117,7 @@ from .thread_title import TITLE_GENERATION_MAX_TOKENS, schedule_thread_title_gen
 from .tools import (
     approve_plan,
     capture_environment_snapshot,
+    create_sandbox_file_download,
     delete_environment,
     delete_user_skill,
     enter_plan_mode,
@@ -1260,6 +1261,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         fetch_url,
         web_search,
         approve_plan,
+        create_sandbox_file_download,
         enter_plan_mode,
         save_plan,
         save_user_instructions,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -6,6 +6,7 @@ _TOOL_MODULES = {
     "add_finding": ".add_finding",
     "approve_plan": ".approve_plan",
     "capture_environment_snapshot": ".environments",
+    "create_sandbox_file_download": ".create_sandbox_file_download",
     "delete_environment": ".environments",
     "enter_plan_mode": ".enter_plan_mode",
     "fetch_review_diff": ".fetch_review_diff",
@@ -51,6 +52,7 @@ __all__ = [
     "add_finding",
     "approve_plan",
     "capture_environment_snapshot",
+    "create_sandbox_file_download",
     "delete_environment",
     "enter_plan_mode",
     "fetch_review_diff",
@@ -95,6 +97,7 @@ __all__ = [
 if TYPE_CHECKING:
     from .add_finding import add_finding
     from .approve_plan import approve_plan
+    from .create_sandbox_file_download import create_sandbox_file_download
     from .enter_plan_mode import enter_plan_mode
     from .environments import (
         capture_environment_snapshot,

--- a/agent/tools/create_sandbox_file_download.py
+++ b/agent/tools/create_sandbox_file_download.py
@@ -8,13 +8,13 @@ from typing import Any
 from langgraph.config import get_config
 
 from ..utils.sandbox_downloads import create_sandbox_download_link, inspect_sandbox_file
-from ..utils.sandbox_state import get_sandbox_backend
+from ..utils.sandbox_state import get_sandbox_backend, unwrap_sandbox_backend
 
 logger = logging.getLogger(__name__)
 
 
 async def create_sandbox_file_download(file_path: str) -> dict[str, Any]:
-    """Create a 24-hour download URL for an absolute file path in this sandbox."""
+    """Create a download URL for an absolute file path in this sandbox."""
     try:
         config = get_config()
     except Exception:
@@ -25,9 +25,13 @@ async def create_sandbox_file_download(file_path: str) -> dict[str, Any]:
         return {"success": False, "error": "no thread_id in run config"}
 
     try:
-        backend = await get_sandbox_backend(thread_id)
+        backend_proxy = await get_sandbox_backend(thread_id)
+        backend = unwrap_sandbox_backend(backend_proxy)
+        sandbox_id = backend.id
         info = await inspect_sandbox_file(backend, file_path)
-        link = create_sandbox_download_link(thread_id, info.path)
+        if backend_proxy.id != sandbox_id:
+            raise RuntimeError("sandbox changed while creating the download URL; retry")
+        link = create_sandbox_download_link(thread_id, sandbox_id, info.path)
     except Exception as exc:
         logger.info("Could not create sandbox download for thread %s: %s", thread_id, exc)
         return {"success": False, "error": str(exc)}
@@ -38,5 +42,4 @@ async def create_sandbox_file_download(file_path: str) -> dict[str, Any]:
         "file_path": info.path,
         "filename": info.filename,
         "size_bytes": info.size,
-        "expires_at": link.expires_at.isoformat(),
     }

--- a/agent/tools/create_sandbox_file_download.py
+++ b/agent/tools/create_sandbox_file_download.py
@@ -1,0 +1,42 @@
+"""Tool for creating an authenticated sandbox file download URL."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..utils.sandbox_downloads import create_sandbox_download_link, inspect_sandbox_file
+from ..utils.sandbox_state import get_sandbox_backend
+
+logger = logging.getLogger(__name__)
+
+
+async def create_sandbox_file_download(file_path: str) -> dict[str, Any]:
+    """Create a 24-hour download URL for an absolute file path in this sandbox."""
+    try:
+        config = get_config()
+    except Exception:
+        config = {}
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
+    if not isinstance(thread_id, str) or not thread_id:
+        return {"success": False, "error": "no thread_id in run config"}
+
+    try:
+        backend = await get_sandbox_backend(thread_id)
+        info = await inspect_sandbox_file(backend, file_path)
+        link = create_sandbox_download_link(thread_id, info.path)
+    except Exception as exc:
+        logger.info("Could not create sandbox download for thread %s: %s", thread_id, exc)
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "url": link.url,
+        "file_path": info.path,
+        "filename": info.filename,
+        "size_bytes": info.size,
+        "expires_at": link.expires_at.isoformat(),
+    }

--- a/agent/utils/sandbox_downloads.py
+++ b/agent/utils/sandbox_downloads.py
@@ -7,11 +7,9 @@ import base64
 import json
 import os
 import posixpath
-import time
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -19,7 +17,6 @@ import jwt
 
 from .dashboard_links import dashboard_base_url
 
-SANDBOX_DOWNLOAD_TTL_SECONDS = 24 * 60 * 60
 SANDBOX_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024
 _SANDBOX_DOWNLOAD_TIMEOUT_SECONDS = 120
 _SANDBOX_CLEANUP_TIMEOUT_SECONDS = 10
@@ -54,12 +51,12 @@ class SandboxFileInfo:
 @dataclass(frozen=True)
 class SandboxDownloadLink:
     url: str
-    expires_at: datetime
 
 
 @dataclass(frozen=True)
 class SandboxDownloadClaims:
     thread_id: str
+    sandbox_id: str
     file_path: str
 
 
@@ -259,29 +256,27 @@ def _command_payload(result: Any) -> dict[str, Any]:
 
 def create_sandbox_download_link(
     thread_id: str,
+    sandbox_id: str,
     file_path: str,
-    *,
-    now: int | None = None,
 ) -> SandboxDownloadLink:
     path = normalize_sandbox_file_path(file_path)
     if not isinstance(thread_id, str) or not thread_id:
         raise SandboxDownloadError("thread_id is required")
-    issued_at = int(time.time()) if now is None else now
-    expires_at = issued_at + SANDBOX_DOWNLOAD_TTL_SECONDS
+    if not isinstance(sandbox_id, str) or not sandbox_id:
+        raise SandboxDownloadError("sandbox_id is required")
     token = jwt.encode(
         {
             "aud": _SANDBOX_DOWNLOAD_AUDIENCE,
             "typ": _SANDBOX_DOWNLOAD_TOKEN_TYPE,
             "tid": thread_id,
+            "sid": sandbox_id,
             "path": path,
-            "iat": issued_at,
-            "exp": expires_at,
         },
         _jwt_secret(),
         algorithm=_JWT_ALGORITHM,
     )
     url = f"{dashboard_base_url()}/dashboard/api/sandbox-files/{quote(token, safe='')}"
-    return SandboxDownloadLink(url=url, expires_at=datetime.fromtimestamp(expires_at, tz=UTC))
+    return SandboxDownloadLink(url=url)
 
 
 def decode_sandbox_download_token(token: str) -> SandboxDownloadClaims:
@@ -291,21 +286,32 @@ def decode_sandbox_download_token(token: str) -> SandboxDownloadClaims:
             _jwt_secret(),
             algorithms=[_JWT_ALGORITHM],
             audience=_SANDBOX_DOWNLOAD_AUDIENCE,
-            options={"require": ["aud", "typ", "tid", "path", "iat", "exp"]},
+            options={"require": ["aud", "typ", "tid", "sid", "path"]},
         )
     except jwt.PyJWTError as exc:
-        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL") from exc
+        raise InvalidSandboxDownloadToken("invalid sandbox download URL") from exc
     if payload.get("typ") != _SANDBOX_DOWNLOAD_TOKEN_TYPE:
-        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL")
+        raise InvalidSandboxDownloadToken("invalid sandbox download URL")
     thread_id = payload.get("tid")
+    sandbox_id = payload.get("sid")
     file_path = payload.get("path")
-    if not isinstance(thread_id, str) or not thread_id or not isinstance(file_path, str):
-        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL")
+    if (
+        not isinstance(thread_id, str)
+        or not thread_id
+        or not isinstance(sandbox_id, str)
+        or not sandbox_id
+        or not isinstance(file_path, str)
+    ):
+        raise InvalidSandboxDownloadToken("invalid sandbox download URL")
     try:
         normalized_path = normalize_sandbox_file_path(file_path)
     except SandboxDownloadError as exc:
-        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL") from exc
-    return SandboxDownloadClaims(thread_id=thread_id, file_path=normalized_path)
+        raise InvalidSandboxDownloadToken("invalid sandbox download URL") from exc
+    return SandboxDownloadClaims(
+        thread_id=thread_id,
+        sandbox_id=sandbox_id,
+        file_path=normalized_path,
+    )
 
 
 def _jwt_secret() -> str:

--- a/agent/utils/sandbox_downloads.py
+++ b/agent/utils/sandbox_downloads.py
@@ -1,0 +1,343 @@
+"""Signed links and bounded reads for sandbox file downloads."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import posixpath
+import time
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import quote
+
+import jwt
+
+from .dashboard_links import dashboard_base_url
+
+SANDBOX_DOWNLOAD_TTL_SECONDS = 24 * 60 * 60
+SANDBOX_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024
+_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS = 120
+_SANDBOX_CLEANUP_TIMEOUT_SECONDS = 10
+_SANDBOX_DOWNLOAD_AUDIENCE = "open-swe-sandbox-file"
+_SANDBOX_DOWNLOAD_TOKEN_TYPE = "sandbox-file-download"
+_JWT_ALGORITHM = "HS256"
+
+
+class SandboxDownloadError(ValueError):
+    pass
+
+
+class SandboxDownloadFileNotFound(SandboxDownloadError):
+    pass
+
+
+class SandboxDownloadFileTooLarge(SandboxDownloadError):
+    pass
+
+
+class InvalidSandboxDownloadToken(SandboxDownloadError):
+    pass
+
+
+@dataclass(frozen=True)
+class SandboxFileInfo:
+    path: str
+    filename: str
+    size: int
+
+
+@dataclass(frozen=True)
+class SandboxDownloadLink:
+    url: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class SandboxDownloadClaims:
+    thread_id: str
+    file_path: str
+
+
+def normalize_sandbox_file_path(file_path: str) -> str:
+    if not isinstance(file_path, str) or not file_path or "\x00" in file_path:
+        raise SandboxDownloadError("file_path must be a non-empty absolute path")
+    if len(file_path) > 4096 or not posixpath.isabs(file_path):
+        raise SandboxDownloadError("file_path must be a non-empty absolute path")
+    normalized = posixpath.normpath(file_path)
+    if (
+        normalized != file_path
+        or normalized == "/"
+        or posixpath.basename(normalized) in {"", ".", ".."}
+    ):
+        raise SandboxDownloadError("file_path must be a normalized absolute file path")
+    return normalized
+
+
+async def inspect_sandbox_file(backend: Any, file_path: str) -> SandboxFileInfo:
+    path = normalize_sandbox_file_path(file_path)
+    command_path = _backend_command_path(backend, path)
+    result = await backend.aexecute(
+        _inspect_command(command_path), timeout=_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS
+    )
+    payload = _command_payload(result)
+    if payload.get("ok") is not True:
+        if payload.get("error") == "not_found":
+            raise SandboxDownloadFileNotFound("sandbox file not found")
+        raise SandboxDownloadError("sandbox file could not be inspected")
+    size = payload.get("size")
+    if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+        raise SandboxDownloadError("sandbox file size is unavailable")
+    if size > SANDBOX_DOWNLOAD_MAX_BYTES:
+        raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
+    return SandboxFileInfo(path=path, filename=posixpath.basename(path), size=size)
+
+
+async def download_sandbox_file(backend: Any, file_path: str) -> tuple[SandboxFileInfo, bytes]:
+    info = await inspect_sandbox_file(backend, file_path)
+    staged_path, staged_size = await _stage_sandbox_file(backend, info.path)
+    try:
+        async with asyncio.timeout(_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS):
+            downloads = await backend.adownload_files([staged_path])
+        if not downloads:
+            raise SandboxDownloadFileNotFound("sandbox file could not be downloaded")
+        error = _value(downloads[0], "error")
+        if error:
+            if "not_found" in str(error).lower() or "path_not_found" in str(error).lower():
+                raise SandboxDownloadFileNotFound("sandbox file could not be downloaded")
+            raise SandboxDownloadError("sandbox file could not be downloaded")
+        content = _download_content(downloads[0])
+        if content is None:
+            raise SandboxDownloadError("sandbox file content is unavailable")
+        if len(content) > SANDBOX_DOWNLOAD_MAX_BYTES:
+            raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
+        current_info = SandboxFileInfo(path=info.path, filename=info.filename, size=staged_size)
+        return current_info, content
+    finally:
+        await _delete_staged_file(backend, staged_path)
+
+
+async def _stage_sandbox_file(backend: Any, file_path: str) -> tuple[str, int]:
+    staged_path = f"/tmp/open-swe-download-{uuid.uuid4().hex}"
+    command_file_path = _backend_command_path(backend, file_path)
+    command_staged_path = _backend_command_path(backend, staged_path)
+    try:
+        result = await backend.aexecute(
+            _stage_command(command_file_path, command_staged_path, staged_path),
+            timeout=_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+        payload = _command_payload(result)
+        if payload.get("ok") is not True:
+            error = payload.get("error")
+            if error == "too_large":
+                raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
+            if error == "not_found":
+                raise SandboxDownloadFileNotFound("sandbox file could not be staged")
+            raise SandboxDownloadError("sandbox file could not be staged")
+        returned_path = payload.get("path")
+        size = payload.get("size")
+        if (
+            returned_path != staged_path
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+        ):
+            raise SandboxDownloadError("sandbox file staging returned an invalid response")
+        if size > SANDBOX_DOWNLOAD_MAX_BYTES:
+            raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
+        return staged_path, size
+    except Exception:
+        await _delete_staged_file(backend, staged_path)
+        raise
+
+
+async def _delete_staged_file(backend: Any, staged_path: str) -> None:
+    try:
+        async with asyncio.timeout(_SANDBOX_CLEANUP_TIMEOUT_SECONDS):
+            await backend.adelete(staged_path)
+    except Exception:
+        pass
+
+
+def _backend_command_path(backend: Any, file_path: str) -> str:
+    try:
+        current = getattr(backend, "current", None)
+    except Exception:
+        current = None
+    command_backend = current if current is not None else backend
+    if getattr(command_backend, "virtual_mode", False) is True:
+        return file_path.removeprefix("/")
+    return file_path
+
+
+def _inspect_command(file_path: str) -> str:
+    encoded = _encoded_payload({"path": file_path})
+    script = r"""python - <<'PY'
+import base64
+import json
+from pathlib import Path
+
+payload = json.loads(base64.b64decode('__PAYLOAD__').decode())
+path = Path(payload['path'])
+try:
+    if not path.is_file():
+        raise FileNotFoundError
+    print(json.dumps({'ok': True, 'size': path.stat().st_size}))
+except FileNotFoundError:
+    print(json.dumps({'ok': False, 'error': 'not_found'}))
+except OSError:
+    print(json.dumps({'ok': False, 'error': 'io_error'}))
+PY"""
+    return script.replace("__PAYLOAD__", encoded)
+
+
+def _stage_command(file_path: str, staged_path: str, returned_path: str) -> str:
+    encoded = _encoded_payload(
+        {
+            "path": file_path,
+            "staged_path": staged_path,
+            "returned_path": returned_path,
+            "max_bytes": SANDBOX_DOWNLOAD_MAX_BYTES,
+        }
+    )
+    script = r"""python - <<'PY'
+import base64
+import json
+from pathlib import Path
+
+payload = json.loads(base64.b64decode('__PAYLOAD__').decode())
+source = Path(payload['path'])
+destination = Path(payload['staged_path'])
+returned_path = payload['returned_path']
+limit = payload['max_bytes']
+total = 0
+try:
+    if not source.is_file():
+        raise FileNotFoundError
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with source.open('rb') as input_file, destination.open('xb') as output_file:
+        while chunk := input_file.read(1024 * 1024):
+            total += len(chunk)
+            if total > limit:
+                raise OverflowError
+            output_file.write(chunk)
+    print(json.dumps({'ok': True, 'path': returned_path, 'size': total}))
+except OverflowError:
+    destination.unlink(missing_ok=True)
+    print(json.dumps({'ok': False, 'error': 'too_large'}))
+except FileNotFoundError:
+    destination.unlink(missing_ok=True)
+    print(json.dumps({'ok': False, 'error': 'not_found'}))
+except OSError:
+    destination.unlink(missing_ok=True)
+    print(json.dumps({'ok': False, 'error': 'io_error'}))
+PY"""
+    return script.replace("__PAYLOAD__", encoded)
+
+
+def _encoded_payload(payload: dict[str, Any]) -> str:
+    return base64.b64encode(json.dumps(payload).encode()).decode()
+
+
+def _command_payload(result: Any) -> dict[str, Any]:
+    output = _value(result, "output")
+    exit_code = _value(result, "exit_code")
+    if not isinstance(output, str) or exit_code not in {0, None}:
+        raise SandboxDownloadError("sandbox file command failed")
+    try:
+        payload = json.loads(output.strip().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise SandboxDownloadError("sandbox file command returned an invalid response") from exc
+    if not isinstance(payload, dict):
+        raise SandboxDownloadError("sandbox file command returned an invalid response")
+    return payload
+
+
+def create_sandbox_download_link(
+    thread_id: str,
+    file_path: str,
+    *,
+    now: int | None = None,
+) -> SandboxDownloadLink:
+    path = normalize_sandbox_file_path(file_path)
+    if not isinstance(thread_id, str) or not thread_id:
+        raise SandboxDownloadError("thread_id is required")
+    issued_at = int(time.time()) if now is None else now
+    expires_at = issued_at + SANDBOX_DOWNLOAD_TTL_SECONDS
+    token = jwt.encode(
+        {
+            "aud": _SANDBOX_DOWNLOAD_AUDIENCE,
+            "typ": _SANDBOX_DOWNLOAD_TOKEN_TYPE,
+            "tid": thread_id,
+            "path": path,
+            "iat": issued_at,
+            "exp": expires_at,
+        },
+        _jwt_secret(),
+        algorithm=_JWT_ALGORITHM,
+    )
+    url = f"{dashboard_base_url()}/dashboard/api/sandbox-files/{quote(token, safe='')}"
+    return SandboxDownloadLink(url=url, expires_at=datetime.fromtimestamp(expires_at, tz=UTC))
+
+
+def decode_sandbox_download_token(token: str) -> SandboxDownloadClaims:
+    try:
+        payload = jwt.decode(
+            token,
+            _jwt_secret(),
+            algorithms=[_JWT_ALGORITHM],
+            audience=_SANDBOX_DOWNLOAD_AUDIENCE,
+            options={"require": ["aud", "typ", "tid", "path", "iat", "exp"]},
+        )
+    except jwt.PyJWTError as exc:
+        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL") from exc
+    if payload.get("typ") != _SANDBOX_DOWNLOAD_TOKEN_TYPE:
+        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL")
+    thread_id = payload.get("tid")
+    file_path = payload.get("path")
+    if not isinstance(thread_id, str) or not thread_id or not isinstance(file_path, str):
+        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL")
+    try:
+        normalized_path = normalize_sandbox_file_path(file_path)
+    except SandboxDownloadError as exc:
+        raise InvalidSandboxDownloadToken("invalid or expired sandbox download URL") from exc
+    return SandboxDownloadClaims(thread_id=thread_id, file_path=normalized_path)
+
+
+def _jwt_secret() -> str:
+    secret = os.environ.get("DASHBOARD_JWT_SECRET", "")
+    if not secret:
+        raise RuntimeError("DASHBOARD_JWT_SECRET not configured")
+    return secret
+
+
+def _download_content(result: Any) -> bytes | None:
+    for key in ("content", "data", "bytes"):
+        value = _value(result, key)
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, str):
+            return value.encode()
+    file_data = _value(result, "file_data")
+    if isinstance(file_data, bytes):
+        return file_data
+    if isinstance(file_data, str):
+        return file_data.encode()
+    if isinstance(file_data, Mapping):
+        for key in ("content", "data", "bytes"):
+            value = file_data.get(key)
+            if isinstance(value, bytes):
+                return value
+            if isinstance(value, str):
+                return value.encode()
+    return None
+
+
+def _value(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)

--- a/agent/utils/sandbox_downloads.py
+++ b/agent/utils/sandbox_downloads.py
@@ -8,7 +8,7 @@ import json
 import os
 import posixpath
 import uuid
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
@@ -17,12 +17,13 @@ import jwt
 
 from .dashboard_links import dashboard_base_url
 
-SANDBOX_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024
+SANDBOX_DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 _SANDBOX_DOWNLOAD_TIMEOUT_SECONDS = 120
 _SANDBOX_CLEANUP_TIMEOUT_SECONDS = 10
 _SANDBOX_DOWNLOAD_AUDIENCE = "open-swe-sandbox-file"
 _SANDBOX_DOWNLOAD_TOKEN_TYPE = "sandbox-file-download"
 _JWT_ALGORITHM = "HS256"
+_BACKGROUND_CLEANUPS: set[asyncio.Task[None]] = set()
 
 
 class SandboxDownloadError(ValueError):
@@ -30,10 +31,6 @@ class SandboxDownloadError(ValueError):
 
 
 class SandboxDownloadFileNotFound(SandboxDownloadError):
-    pass
-
-
-class SandboxDownloadFileTooLarge(SandboxDownloadError):
     pass
 
 
@@ -46,6 +43,7 @@ class SandboxFileInfo:
     path: str
     filename: str
     size: int
+    signature: str = ""
 
 
 @dataclass(frozen=True)
@@ -87,69 +85,86 @@ async def inspect_sandbox_file(backend: Any, file_path: str) -> SandboxFileInfo:
             raise SandboxDownloadFileNotFound("sandbox file not found")
         raise SandboxDownloadError("sandbox file could not be inspected")
     size = payload.get("size")
+    signature = payload.get("signature")
     if not isinstance(size, int) or isinstance(size, bool) or size < 0:
         raise SandboxDownloadError("sandbox file size is unavailable")
-    if size > SANDBOX_DOWNLOAD_MAX_BYTES:
-        raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
-    return SandboxFileInfo(path=path, filename=posixpath.basename(path), size=size)
+    if not isinstance(signature, str) or not signature:
+        raise SandboxDownloadError("sandbox file signature is unavailable")
+    return SandboxFileInfo(
+        path=path,
+        filename=posixpath.basename(path),
+        size=size,
+        signature=signature,
+    )
 
 
-async def download_sandbox_file(backend: Any, file_path: str) -> tuple[SandboxFileInfo, bytes]:
-    info = await inspect_sandbox_file(backend, file_path)
-    staged_path, staged_size = await _stage_sandbox_file(backend, info.path)
-    try:
-        async with asyncio.timeout(_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS):
-            downloads = await backend.adownload_files([staged_path])
-        if not downloads:
-            raise SandboxDownloadFileNotFound("sandbox file could not be downloaded")
-        error = _value(downloads[0], "error")
-        if error:
-            if "not_found" in str(error).lower() or "path_not_found" in str(error).lower():
-                raise SandboxDownloadFileNotFound("sandbox file could not be downloaded")
-            raise SandboxDownloadError("sandbox file could not be downloaded")
-        content = _download_content(downloads[0])
-        if content is None:
-            raise SandboxDownloadError("sandbox file content is unavailable")
-        if len(content) > SANDBOX_DOWNLOAD_MAX_BYTES:
-            raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
-        current_info = SandboxFileInfo(path=info.path, filename=info.filename, size=staged_size)
-        return current_info, content
-    finally:
-        await _delete_staged_file(backend, staged_path)
+async def stream_sandbox_file_chunks(
+    backend: Any,
+    info: SandboxFileInfo,
+) -> AsyncIterator[bytes]:
+    if info.size == 0:
+        await _download_sandbox_file_chunk(backend, info, 0, 0)
+        return
+    for offset in range(0, info.size, SANDBOX_DOWNLOAD_CHUNK_BYTES):
+        length = min(SANDBOX_DOWNLOAD_CHUNK_BYTES, info.size - offset)
+        yield await _download_sandbox_file_chunk(backend, info, offset, length)
 
 
-async def _stage_sandbox_file(backend: Any, file_path: str) -> tuple[str, int]:
+async def _download_sandbox_file_chunk(
+    backend: Any,
+    info: SandboxFileInfo,
+    offset: int,
+    length: int,
+) -> bytes:
     staged_path = f"/tmp/open-swe-download-{uuid.uuid4().hex}"
-    command_file_path = _backend_command_path(backend, file_path)
+    command_file_path = _backend_command_path(backend, info.path)
     command_staged_path = _backend_command_path(backend, staged_path)
-    try:
-        result = await backend.aexecute(
-            _stage_command(command_file_path, command_staged_path, staged_path),
+    command_task = asyncio.create_task(
+        backend.aexecute(
+            _chunk_command(
+                command_file_path,
+                command_staged_path,
+                staged_path,
+                info.signature,
+                offset,
+                length,
+            ),
             timeout=_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS,
         )
+    )
+    cleanup_deferred = False
+    try:
+        result = await asyncio.shield(command_task)
         payload = _command_payload(result)
         if payload.get("ok") is not True:
             error = payload.get("error")
-            if error == "too_large":
-                raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
             if error == "not_found":
-                raise SandboxDownloadFileNotFound("sandbox file could not be staged")
-            raise SandboxDownloadError("sandbox file could not be staged")
-        returned_path = payload.get("path")
-        size = payload.get("size")
-        if (
-            returned_path != staged_path
-            or not isinstance(size, int)
-            or isinstance(size, bool)
-            or size < 0
-        ):
-            raise SandboxDownloadError("sandbox file staging returned an invalid response")
-        if size > SANDBOX_DOWNLOAD_MAX_BYTES:
-            raise SandboxDownloadFileTooLarge("sandbox file exceeds the 100 MiB download limit")
-        return staged_path, size
-    except Exception:
-        await _delete_staged_file(backend, staged_path)
+                raise SandboxDownloadFileNotFound("sandbox file could not be streamed")
+            if error == "changed":
+                raise SandboxDownloadError("sandbox file changed during download")
+            raise SandboxDownloadError("sandbox file chunk could not be staged")
+        if payload.get("path") != staged_path or payload.get("size") != length:
+            raise SandboxDownloadError("sandbox file chunk returned an invalid response")
+        async with asyncio.timeout(_SANDBOX_DOWNLOAD_TIMEOUT_SECONDS):
+            downloads = await backend.adownload_files([staged_path])
+        if not downloads:
+            raise SandboxDownloadFileNotFound("sandbox file chunk could not be downloaded")
+        error = _value(downloads[0], "error")
+        if error:
+            if "not_found" in str(error).lower():
+                raise SandboxDownloadFileNotFound("sandbox file chunk could not be downloaded")
+            raise SandboxDownloadError("sandbox file chunk could not be downloaded")
+        content = _download_content(downloads[0])
+        if content is None or len(content) != length:
+            raise SandboxDownloadError("sandbox file chunk content is invalid")
+        return content
+    except asyncio.CancelledError:
+        cleanup_deferred = True
+        _defer_staged_file_cleanup(command_task, backend, staged_path)
         raise
+    finally:
+        if not cleanup_deferred:
+            await _run_staged_file_cleanup(backend, staged_path)
 
 
 async def _delete_staged_file(backend: Any, staged_path: str) -> None:
@@ -158,6 +173,35 @@ async def _delete_staged_file(backend: Any, staged_path: str) -> None:
             await backend.adelete(staged_path)
     except Exception:
         pass
+
+
+async def _run_staged_file_cleanup(backend: Any, staged_path: str) -> None:
+    cleanup_task = asyncio.create_task(_delete_staged_file(backend, staged_path))
+    try:
+        await asyncio.shield(cleanup_task)
+    except asyncio.CancelledError:
+        _track_background_cleanup(cleanup_task)
+        raise
+
+
+def _defer_staged_file_cleanup(
+    command_task: asyncio.Task[Any],
+    backend: Any,
+    staged_path: str,
+) -> None:
+    async def cleanup() -> None:
+        try:
+            await command_task
+        except BaseException:
+            pass
+        await _delete_staged_file(backend, staged_path)
+
+    _track_background_cleanup(asyncio.create_task(cleanup()))
+
+
+def _track_background_cleanup(cleanup_task: asyncio.Task[None]) -> None:
+    _BACKGROUND_CLEANUPS.add(cleanup_task)
+    cleanup_task.add_done_callback(_BACKGROUND_CLEANUPS.discard)
 
 
 def _backend_command_path(backend: Any, file_path: str) -> str:
@@ -183,7 +227,9 @@ path = Path(payload['path'])
 try:
     if not path.is_file():
         raise FileNotFoundError
-    print(json.dumps({'ok': True, 'size': path.stat().st_size}))
+    stat = path.stat()
+    signature = f'{stat.st_dev}:{stat.st_ino}:{stat.st_size}:{stat.st_mtime_ns}:{stat.st_ctime_ns}'
+    print(json.dumps({'ok': True, 'size': stat.st_size, 'signature': signature}))
 except FileNotFoundError:
     print(json.dumps({'ok': False, 'error': 'not_found'}))
 except OSError:
@@ -192,40 +238,59 @@ PY"""
     return script.replace("__PAYLOAD__", encoded)
 
 
-def _stage_command(file_path: str, staged_path: str, returned_path: str) -> str:
+def _chunk_command(
+    file_path: str,
+    staged_path: str,
+    returned_path: str,
+    signature: str,
+    offset: int,
+    length: int,
+) -> str:
     encoded = _encoded_payload(
         {
             "path": file_path,
             "staged_path": staged_path,
             "returned_path": returned_path,
-            "max_bytes": SANDBOX_DOWNLOAD_MAX_BYTES,
+            "signature": signature,
+            "offset": offset,
+            "length": length,
         }
     )
     script = r"""python - <<'PY'
 import base64
 import json
+import os
 from pathlib import Path
 
 payload = json.loads(base64.b64decode('__PAYLOAD__').decode())
 source = Path(payload['path'])
 destination = Path(payload['staged_path'])
 returned_path = payload['returned_path']
-limit = payload['max_bytes']
-total = 0
+expected_signature = payload['signature']
+offset = payload['offset']
+length = payload['length']
+
+def signature(stat):
+    return f'{stat.st_dev}:{stat.st_ino}:{stat.st_size}:{stat.st_mtime_ns}:{stat.st_ctime_ns}'
+
 try:
     if not source.is_file():
         raise FileNotFoundError
+    with source.open('rb') as input_file:
+        if signature(os.fstat(input_file.fileno())) != expected_signature:
+            raise RuntimeError
+        input_file.seek(offset)
+        content = input_file.read(length)
+        if signature(os.fstat(input_file.fileno())) != expected_signature:
+            raise RuntimeError
+    if len(content) != length:
+        raise RuntimeError
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with source.open('rb') as input_file, destination.open('xb') as output_file:
-        while chunk := input_file.read(1024 * 1024):
-            total += len(chunk)
-            if total > limit:
-                raise OverflowError
-            output_file.write(chunk)
-    print(json.dumps({'ok': True, 'path': returned_path, 'size': total}))
-except OverflowError:
+    destination.write_bytes(content)
+    print(json.dumps({'ok': True, 'path': returned_path, 'size': len(content)}))
+except RuntimeError:
     destination.unlink(missing_ok=True)
-    print(json.dumps({'ok': False, 'error': 'too_large'}))
+    print(json.dumps({'ok': False, 'error': 'changed'}))
 except FileNotFoundError:
     destination.unlink(missing_ok=True)
     print(json.dumps({'ok': False, 'error': 'not_found'}))

--- a/tests/dashboard/test_sandbox_download_api.py
+++ b/tests/dashboard/test_sandbox_download_api.py
@@ -4,13 +4,34 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 
 from agent.api.app import create_app
 from agent.dashboard import sandbox_download_api
-from agent.utils.sandbox_downloads import SandboxFileInfo, create_sandbox_download_link
+from agent.utils.sandbox_downloads import (
+    SandboxDownloadError,
+    SandboxFileInfo,
+    create_sandbox_download_link,
+)
 
 
-async def test_download_route_requires_owner_and_returns_attachment(monkeypatch) -> None:
+async def report_chunks(_backend, _info):
+    yield b"a,b\n1"
+
+
+async def empty_chunks(_backend, _info):
+    if False:
+        yield b""
+
+
+async def response_body(response: StreamingResponse) -> bytes:
+    chunks: list[bytes] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.encode() if isinstance(chunk, str) else bytes(chunk))
+    return b"".join(chunks)
+
+
+async def test_download_route_requires_owner_and_streams_attachment(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
     token = create_sandbox_download_link(
         "thread-1", "sandbox-1", "/workspace/report.csv"
@@ -25,32 +46,33 @@ async def test_download_route_requires_owner_and_returns_attachment(monkeypatch)
     )
     monkeypatch.setattr(
         sandbox_download_api,
-        "download_sandbox_file",
+        "inspect_sandbox_file",
         AsyncMock(
-            return_value=(
-                SandboxFileInfo(
-                    path="/workspace/report.csv",
-                    filename="report.csv",
-                    size=5,
-                ),
-                b"a,b\n1",
+            return_value=SandboxFileInfo(
+                path="/workspace/report.csv",
+                filename="report.csv",
+                size=5,
+                signature="signature",
             )
         ),
     )
+    monkeypatch.setattr(sandbox_download_api, "stream_sandbox_file_chunks", report_chunks)
 
     response = await sandbox_download_api.download_sandbox_file_route(
         token,
         {"sub": "octocat", "email": "octocat@example.com"},
     )
+    body = await response_body(response)
 
-    assert authorize.await_count == 2
+    assert authorize.await_count == 3
     authorize.assert_awaited_with(
         "thread-1",
         "octocat",
         email="octocat@example.com",
     )
-    assert response.body == b"a,b\n1"
+    assert body == b"a,b\n1"
     assert response.media_type == "text/csv"
+    assert response.headers["content-length"] == "5"
     assert response.headers["content-disposition"].startswith('attachment; filename="report.csv"')
     assert response.headers["cache-control"] == "private, no-store"
     assert response.headers["x-content-type-options"] == "nosniff"
@@ -77,7 +99,7 @@ async def test_download_route_rejects_replaced_sandbox(monkeypatch) -> None:
     assert "no longer available" in exc_info.value.detail
 
 
-async def test_download_route_rejects_recreation_during_download(monkeypatch) -> None:
+async def test_download_route_rejects_recreation_during_inspection(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
     token = create_sandbox_download_link(
         "thread-1", "sandbox-old", "/workspace/report.csv"
@@ -94,15 +116,13 @@ async def test_download_route_rejects_recreation_during_download(monkeypatch) ->
     )
     monkeypatch.setattr(
         sandbox_download_api,
-        "download_sandbox_file",
+        "inspect_sandbox_file",
         AsyncMock(
-            return_value=(
-                SandboxFileInfo(
-                    path="/workspace/report.csv",
-                    filename="report.csv",
-                    size=5,
-                ),
-                b"a,b\n1",
+            return_value=SandboxFileInfo(
+                path="/workspace/report.csv",
+                filename="report.csv",
+                size=5,
+                signature="signature",
             )
         ),
     )
@@ -115,6 +135,94 @@ async def test_download_route_rejects_recreation_during_download(monkeypatch) ->
 
     assert exc_info.value.status_code == 404
     assert "no longer available" in exc_info.value.detail
+
+
+async def test_download_route_stops_after_recreation_during_stream(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link(
+        "thread-1", "sandbox-old", "/workspace/report.csv"
+    ).url.rsplit("/", 1)[-1]
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "get_dashboard_terminal_sandbox",
+        AsyncMock(
+            side_effect=[
+                ("sandbox-old", "repo"),
+                ("sandbox-old", "repo"),
+                ("sandbox-new", "repo"),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "create_sandbox",
+        AsyncMock(return_value=object()),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "inspect_sandbox_file",
+        AsyncMock(
+            return_value=SandboxFileInfo(
+                path="/workspace/report.csv",
+                filename="report.csv",
+                size=5,
+                signature="signature",
+            )
+        ),
+    )
+    monkeypatch.setattr(sandbox_download_api, "stream_sandbox_file_chunks", report_chunks)
+
+    response = await sandbox_download_api.download_sandbox_file_route(
+        token,
+        {"sub": "octocat"},
+    )
+
+    with pytest.raises(SandboxDownloadError, match="no longer available"):
+        await response_body(response)
+
+
+async def test_empty_download_stops_after_recreation(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link(
+        "thread-1", "sandbox-old", "/workspace/empty.bin"
+    ).url.rsplit("/", 1)[-1]
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "get_dashboard_terminal_sandbox",
+        AsyncMock(
+            side_effect=[
+                ("sandbox-old", "repo"),
+                ("sandbox-old", "repo"),
+                ("sandbox-new", "repo"),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "create_sandbox",
+        AsyncMock(return_value=object()),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "inspect_sandbox_file",
+        AsyncMock(
+            return_value=SandboxFileInfo(
+                path="/workspace/empty.bin",
+                filename="empty.bin",
+                size=0,
+                signature="signature",
+            )
+        ),
+    )
+    monkeypatch.setattr(sandbox_download_api, "stream_sandbox_file_chunks", empty_chunks)
+
+    response = await sandbox_download_api.download_sandbox_file_route(
+        token,
+        {"sub": "octocat"},
+    )
+
+    with pytest.raises(SandboxDownloadError, match="no longer available"):
+        await response_body(response)
 
 
 async def test_download_route_rejects_invalid_token(monkeypatch) -> None:

--- a/tests/dashboard/test_sandbox_download_api.py
+++ b/tests/dashboard/test_sandbox_download_api.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from agent.api.app import create_app
+from agent.dashboard import sandbox_download_api
+from agent.utils.sandbox_downloads import SandboxFileInfo, create_sandbox_download_link
+
+
+async def test_download_route_requires_owner_and_returns_attachment(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link("thread-1", "/workspace/report.csv").url.rsplit("/", 1)[-1]
+    authorize = AsyncMock(return_value=("sandbox-1", "repo"))
+    backend = object()
+    monkeypatch.setattr(sandbox_download_api, "get_dashboard_terminal_sandbox", authorize)
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "create_sandbox",
+        AsyncMock(return_value=backend),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "download_sandbox_file",
+        AsyncMock(
+            return_value=(
+                SandboxFileInfo(
+                    path="/workspace/report.csv",
+                    filename="report.csv",
+                    size=5,
+                ),
+                b"a,b\n1",
+            )
+        ),
+    )
+
+    response = await sandbox_download_api.download_sandbox_file_route(
+        token,
+        {"sub": "octocat", "email": "octocat@example.com"},
+    )
+
+    authorize.assert_awaited_once_with(
+        "thread-1",
+        "octocat",
+        email="octocat@example.com",
+    )
+    assert response.body == b"a,b\n1"
+    assert response.media_type == "text/csv"
+    assert response.headers["content-disposition"].startswith('attachment; filename="report.csv"')
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+
+async def test_download_route_rejects_invalid_token(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sandbox_download_api.download_sandbox_file_route(
+            "invalid",
+            {"sub": "octocat"},
+        )
+
+    assert exc_info.value.status_code == 401
+
+
+def test_sandbox_download_router_is_mounted() -> None:
+    paths = create_app().openapi()["paths"]
+
+    assert "/dashboard/api/sandbox-files/{token}" in paths

--- a/tests/dashboard/test_sandbox_download_api.py
+++ b/tests/dashboard/test_sandbox_download_api.py
@@ -12,7 +12,9 @@ from agent.utils.sandbox_downloads import SandboxFileInfo, create_sandbox_downlo
 
 async def test_download_route_requires_owner_and_returns_attachment(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
-    token = create_sandbox_download_link("thread-1", "/workspace/report.csv").url.rsplit("/", 1)[-1]
+    token = create_sandbox_download_link(
+        "thread-1", "sandbox-1", "/workspace/report.csv"
+    ).url.rsplit("/", 1)[-1]
     authorize = AsyncMock(return_value=("sandbox-1", "repo"))
     backend = object()
     monkeypatch.setattr(sandbox_download_api, "get_dashboard_terminal_sandbox", authorize)
@@ -41,7 +43,8 @@ async def test_download_route_requires_owner_and_returns_attachment(monkeypatch)
         {"sub": "octocat", "email": "octocat@example.com"},
     )
 
-    authorize.assert_awaited_once_with(
+    assert authorize.await_count == 2
+    authorize.assert_awaited_with(
         "thread-1",
         "octocat",
         email="octocat@example.com",
@@ -51,6 +54,67 @@ async def test_download_route_requires_owner_and_returns_attachment(monkeypatch)
     assert response.headers["content-disposition"].startswith('attachment; filename="report.csv"')
     assert response.headers["cache-control"] == "private, no-store"
     assert response.headers["x-content-type-options"] == "nosniff"
+
+
+async def test_download_route_rejects_replaced_sandbox(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link(
+        "thread-1", "sandbox-old", "/workspace/report.csv"
+    ).url.rsplit("/", 1)[-1]
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "get_dashboard_terminal_sandbox",
+        AsyncMock(return_value=("sandbox-new", "repo")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sandbox_download_api.download_sandbox_file_route(
+            token,
+            {"sub": "octocat"},
+        )
+
+    assert exc_info.value.status_code == 404
+    assert "no longer available" in exc_info.value.detail
+
+
+async def test_download_route_rejects_recreation_during_download(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link(
+        "thread-1", "sandbox-old", "/workspace/report.csv"
+    ).url.rsplit("/", 1)[-1]
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "get_dashboard_terminal_sandbox",
+        AsyncMock(side_effect=[("sandbox-old", "repo"), ("sandbox-new", "repo")]),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "create_sandbox",
+        AsyncMock(return_value=object()),
+    )
+    monkeypatch.setattr(
+        sandbox_download_api,
+        "download_sandbox_file",
+        AsyncMock(
+            return_value=(
+                SandboxFileInfo(
+                    path="/workspace/report.csv",
+                    filename="report.csv",
+                    size=5,
+                ),
+                b"a,b\n1",
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sandbox_download_api.download_sandbox_file_route(
+            token,
+            {"sub": "octocat"},
+        )
+
+    assert exc_info.value.status_code == 404
+    assert "no longer available" in exc_info.value.detail
 
 
 async def test_download_route_rejects_invalid_token(monkeypatch) -> None:

--- a/tests/tools/test_sandbox_file_download.py
+++ b/tests/tools/test_sandbox_file_download.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from agent.tools.create_sandbox_file_download import create_sandbox_file_download
+from agent.utils.sandbox_downloads import SandboxDownloadLink, SandboxFileInfo
+
+
+async def test_create_sandbox_file_download_returns_link() -> None:
+    config = {"configurable": {"thread_id": "thread-1"}}
+    info = SandboxFileInfo(
+        path="/workspace/artifact.zip",
+        filename="artifact.zip",
+        size=42,
+    )
+
+    with (
+        patch("agent.tools.create_sandbox_file_download.get_config", return_value=config),
+        patch(
+            "agent.tools.create_sandbox_file_download.get_sandbox_backend",
+            new_callable=AsyncMock,
+            return_value=object(),
+        ),
+        patch(
+            "agent.tools.create_sandbox_file_download.inspect_sandbox_file",
+            new_callable=AsyncMock,
+            return_value=info,
+        ),
+        patch(
+            "agent.tools.create_sandbox_file_download.create_sandbox_download_link",
+            return_value=SandboxDownloadLink(
+                url="https://example.test/download",
+                expires_at=datetime.fromisoformat("2026-08-18T12:00:00+00:00"),
+            ),
+        ),
+    ):
+        result = await create_sandbox_file_download("/workspace/artifact.zip")
+
+    assert result == {
+        "success": True,
+        "url": "https://example.test/download",
+        "file_path": "/workspace/artifact.zip",
+        "filename": "artifact.zip",
+        "size_bytes": 42,
+        "expires_at": "2026-08-18T12:00:00+00:00",
+    }
+
+
+async def test_create_sandbox_file_download_requires_thread() -> None:
+    with patch(
+        "agent.tools.create_sandbox_file_download.get_config",
+        return_value={"configurable": {}},
+    ):
+        result = await create_sandbox_file_download("/workspace/artifact.zip")
+
+    assert result == {"success": False, "error": "no thread_id in run config"}
+
+
+def test_create_sandbox_file_download_exported() -> None:
+    from agent.tools import create_sandbox_file_download as exported
+
+    assert exported is create_sandbox_file_download

--- a/tests/tools/test_sandbox_file_download.py
+++ b/tests/tools/test_sandbox_file_download.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from agent.tools.create_sandbox_file_download import create_sandbox_file_download
@@ -20,7 +20,7 @@ async def test_create_sandbox_file_download_returns_link() -> None:
         patch(
             "agent.tools.create_sandbox_file_download.get_sandbox_backend",
             new_callable=AsyncMock,
-            return_value=object(),
+            return_value=SimpleNamespace(id="sandbox-1"),
         ),
         patch(
             "agent.tools.create_sandbox_file_download.inspect_sandbox_file",
@@ -29,21 +29,55 @@ async def test_create_sandbox_file_download_returns_link() -> None:
         ),
         patch(
             "agent.tools.create_sandbox_file_download.create_sandbox_download_link",
-            return_value=SandboxDownloadLink(
-                url="https://example.test/download",
-                expires_at=datetime.fromisoformat("2026-08-18T12:00:00+00:00"),
-            ),
-        ),
+            return_value=SandboxDownloadLink(url="https://example.test/download"),
+        ) as create_link,
     ):
         result = await create_sandbox_file_download("/workspace/artifact.zip")
 
+    create_link.assert_called_once_with(
+        "thread-1",
+        "sandbox-1",
+        "/workspace/artifact.zip",
+    )
     assert result == {
         "success": True,
         "url": "https://example.test/download",
         "file_path": "/workspace/artifact.zip",
         "filename": "artifact.zip",
         "size_bytes": 42,
-        "expires_at": "2026-08-18T12:00:00+00:00",
+    }
+
+
+async def test_create_sandbox_file_download_rejects_concurrent_recreation() -> None:
+    config = {"configurable": {"thread_id": "thread-1"}}
+    backend = SimpleNamespace(id="sandbox-old")
+    backend_proxy = SimpleNamespace(id="sandbox-old")
+
+    async def inspect(_backend, file_path: str):
+        backend_proxy.id = "sandbox-new"
+        return SandboxFileInfo(path=file_path, filename="artifact.zip", size=42)
+
+    with (
+        patch("agent.tools.create_sandbox_file_download.get_config", return_value=config),
+        patch(
+            "agent.tools.create_sandbox_file_download.get_sandbox_backend",
+            new_callable=AsyncMock,
+            return_value=backend_proxy,
+        ),
+        patch(
+            "agent.tools.create_sandbox_file_download.unwrap_sandbox_backend",
+            return_value=backend,
+        ),
+        patch(
+            "agent.tools.create_sandbox_file_download.inspect_sandbox_file",
+            side_effect=inspect,
+        ),
+    ):
+        result = await create_sandbox_file_download("/workspace/artifact.zip")
+
+    assert result == {
+        "success": False,
+        "error": "sandbox changed while creating the download URL; retry",
     }
 
 

--- a/tests/utils/test_sandbox_downloads.py
+++ b/tests/utils/test_sandbox_downloads.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from deepagents.backends import LocalShellBackend
+
+from agent.utils.sandbox_downloads import (
+    SANDBOX_DOWNLOAD_MAX_BYTES,
+    InvalidSandboxDownloadToken,
+    SandboxDownloadError,
+    SandboxDownloadFileTooLarge,
+    create_sandbox_download_link,
+    decode_sandbox_download_token,
+    download_sandbox_file,
+    inspect_sandbox_file,
+)
+
+
+class FakeBackend:
+    def __init__(
+        self,
+        *,
+        size: int = 3,
+        content: object = b"abc",
+        stage_error: str | None = None,
+    ) -> None:
+        self.size = size
+        self.content = content
+        self.stage_error = stage_error
+        self.deleted_paths: list[str] = []
+        self.staged_path: str | None = None
+
+    async def aexecute(self, command: str, *, timeout: int | None = None):
+        assert timeout == 120
+        encoded = command.split("base64.b64decode('", 1)[1].split("')", 1)[0]
+        payload = json.loads(base64.b64decode(encoded).decode())
+        if "staged_path" not in payload:
+            return SimpleNamespace(
+                output=json.dumps({"ok": True, "size": self.size}),
+                exit_code=0,
+            )
+        self.staged_path = payload["returned_path"]
+        if self.stage_error:
+            return SimpleNamespace(
+                output=json.dumps({"ok": False, "error": self.stage_error}),
+                exit_code=0,
+            )
+        return SimpleNamespace(
+            output=json.dumps({"ok": True, "path": self.staged_path, "size": self.size}),
+            exit_code=0,
+        )
+
+    async def adownload_files(self, paths: list[str]):
+        assert paths == [self.staged_path]
+        return [self.content]
+
+    async def adelete(self, path: str):
+        self.deleted_paths.append(path)
+        return SimpleNamespace(error=None)
+
+
+def test_sandbox_download_link_round_trip(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example/")
+    now = int(time.time())
+
+    link = create_sandbox_download_link("thread-1", "/workspace/artifact.bin", now=now)
+    token = link.url.rsplit("/", 1)[-1]
+
+    assert link.url.startswith("https://dashboard.example/dashboard/api/sandbox-files/")
+    assert decode_sandbox_download_token(token).thread_id == "thread-1"
+    assert decode_sandbox_download_token(token).file_path == "/workspace/artifact.bin"
+    assert int(link.expires_at.timestamp()) > now
+
+
+def test_sandbox_download_token_rejects_tampering(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link("thread-1", "/workspace/artifact.bin").url.rsplit("/", 1)[
+        -1
+    ]
+    tampered = ("a" if token[0] != "a" else "b") + token[1:]
+
+    with pytest.raises(InvalidSandboxDownloadToken):
+        decode_sandbox_download_token(tampered)
+
+
+def test_sandbox_download_token_rejects_expiration(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    token = create_sandbox_download_link("thread-1", "/workspace/artifact.bin", now=1).url.rsplit(
+        "/", 1
+    )[-1]
+
+    with pytest.raises(InvalidSandboxDownloadToken):
+        decode_sandbox_download_token(token)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["artifact.bin", "/workspace/../secret", "/workspace//artifact.bin", "/"],
+)
+def test_inspect_sandbox_file_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(SandboxDownloadError):
+        create_sandbox_download_link("thread-1", path)
+
+
+async def test_inspect_sandbox_file_enforces_size_limit() -> None:
+    backend = FakeBackend(size=SANDBOX_DOWNLOAD_MAX_BYTES + 1)
+
+    with pytest.raises(SandboxDownloadFileTooLarge):
+        await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+
+
+async def test_download_sandbox_file_with_local_backend(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.bin"
+    artifact.write_bytes(b"binary\x00content")
+    backend = LocalShellBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    info, content = await download_sandbox_file(backend, "/artifact.bin")
+
+    assert info.size == len(content)
+    assert content == b"binary\x00content"
+
+
+async def test_download_sandbox_file_reads_nested_provider_content() -> None:
+    backend = FakeBackend(content={"file_data": {"content": "abc"}})
+
+    info, content = await download_sandbox_file(backend, "/workspace/artifact.bin")
+
+    assert info.filename == "artifact.bin"
+    assert info.size == 3
+    assert content == b"abc"
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_download_sandbox_file_rejects_growth_during_staging() -> None:
+    backend = FakeBackend(stage_error="too_large")
+
+    with pytest.raises(SandboxDownloadFileTooLarge):
+        await download_sandbox_file(backend, "/workspace/artifact.bin")
+
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_download_sandbox_file_handles_staging_io_error() -> None:
+    backend = FakeBackend(stage_error="io_error")
+
+    with pytest.raises(SandboxDownloadError, match="could not be staged"):
+        await download_sandbox_file(backend, "/workspace/artifact.bin")
+
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_download_sandbox_file_handles_provider_error() -> None:
+    backend = FakeBackend(content=SimpleNamespace(error="permission_denied", content=None))
+
+    with pytest.raises(SandboxDownloadError, match="could not be downloaded"):
+        await download_sandbox_file(backend, "/workspace/artifact.bin")
+
+    assert backend.deleted_paths == [backend.staged_path]

--- a/tests/utils/test_sandbox_downloads.py
+++ b/tests/utils/test_sandbox_downloads.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,15 +11,14 @@ import jwt
 import pytest
 from deepagents.backends import LocalShellBackend
 
+from agent.utils import sandbox_downloads
 from agent.utils.sandbox_downloads import (
-    SANDBOX_DOWNLOAD_MAX_BYTES,
     InvalidSandboxDownloadToken,
     SandboxDownloadError,
-    SandboxDownloadFileTooLarge,
     create_sandbox_download_link,
     decode_sandbox_download_token,
-    download_sandbox_file,
     inspect_sandbox_file,
+    stream_sandbox_file_chunks,
 )
 
 
@@ -26,14 +27,28 @@ class FakeBackend:
         self,
         *,
         size: int = 3,
-        content: object = b"abc",
-        stage_error: str | None = None,
+        content: object | None = None,
+        chunk_error: str | None = None,
+        delay_chunk: bool = False,
+        delay_download: bool = False,
+        delay_delete: bool = False,
     ) -> None:
         self.size = size
         self.content = content
-        self.stage_error = stage_error
+        self.chunk_error = chunk_error
+        self.delay_chunk = delay_chunk
+        self.delay_download = delay_download
+        self.delay_delete = delay_delete
+        self.command_started = asyncio.Event()
+        self.command_release = asyncio.Event()
+        self.download_started = asyncio.Event()
+        self.download_release = asyncio.Event()
+        self.delete_started = asyncio.Event()
+        self.delete_release = asyncio.Event()
         self.deleted_paths: list[str] = []
         self.staged_path: str | None = None
+        self.chunk_length = 0
+        self.download_count = 0
 
     async def aexecute(self, command: str, *, timeout: int | None = None):
         assert timeout == 120
@@ -41,27 +56,44 @@ class FakeBackend:
         payload = json.loads(base64.b64decode(encoded).decode())
         if "staged_path" not in payload:
             return SimpleNamespace(
-                output=json.dumps({"ok": True, "size": self.size}),
+                output=json.dumps({"ok": True, "size": self.size, "signature": "file-signature"}),
                 exit_code=0,
             )
         self.staged_path = payload["returned_path"]
-        if self.stage_error:
+        self.chunk_length = payload["length"]
+        if self.delay_chunk:
+            self.command_started.set()
+            await self.command_release.wait()
+        if self.chunk_error:
             return SimpleNamespace(
-                output=json.dumps({"ok": False, "error": self.stage_error}),
+                output=json.dumps({"ok": False, "error": self.chunk_error}),
                 exit_code=0,
             )
         return SimpleNamespace(
-            output=json.dumps({"ok": True, "path": self.staged_path, "size": self.size}),
+            output=json.dumps({"ok": True, "path": self.staged_path, "size": self.chunk_length}),
             exit_code=0,
         )
 
     async def adownload_files(self, paths: list[str]):
         assert paths == [self.staged_path]
-        return [self.content]
+        self.download_count += 1
+        if self.delay_download:
+            self.download_started.set()
+            await self.download_release.wait()
+        if self.content is not None:
+            return [self.content]
+        return [SimpleNamespace(content=b"x" * self.chunk_length, error=None)]
 
     async def adelete(self, path: str):
+        if self.delay_delete:
+            self.delete_started.set()
+            await self.delete_release.wait()
         self.deleted_paths.append(path)
         return SimpleNamespace(error=None)
+
+
+async def collect_chunks(backend, info) -> bytes:
+    return b"".join([chunk async for chunk in stream_sandbox_file_chunks(backend, info)])
 
 
 def test_sandbox_download_link_round_trip(monkeypatch) -> None:
@@ -111,57 +143,167 @@ def test_inspect_sandbox_file_rejects_unsafe_paths(path: str) -> None:
         create_sandbox_download_link("thread-1", "sandbox-1", path)
 
 
-async def test_inspect_sandbox_file_enforces_size_limit() -> None:
-    backend = FakeBackend(size=SANDBOX_DOWNLOAD_MAX_BYTES + 1)
+async def test_inspect_sandbox_file_accepts_files_over_previous_limit() -> None:
+    backend = FakeBackend(size=101 * 1024 * 1024)
 
-    with pytest.raises(SandboxDownloadFileTooLarge):
-        await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+
+    assert info.size == 101 * 1024 * 1024
 
 
-async def test_download_sandbox_file_with_local_backend(tmp_path: Path) -> None:
+async def test_stream_sandbox_file_with_local_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sandbox_downloads, "SANDBOX_DOWNLOAD_CHUNK_BYTES", 4)
     artifact = tmp_path / "artifact.bin"
     artifact.write_bytes(b"binary\x00content")
     backend = LocalShellBackend(root_dir=str(tmp_path), virtual_mode=True)
+    info = await inspect_sandbox_file(backend, "/artifact.bin")
 
-    info, content = await download_sandbox_file(backend, "/artifact.bin")
+    content = await collect_chunks(backend, info)
 
     assert info.size == len(content)
     assert content == b"binary\x00content"
 
 
-async def test_download_sandbox_file_reads_nested_provider_content() -> None:
+async def test_stream_sandbox_file_detects_same_size_rewrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sandbox_downloads, "SANDBOX_DOWNLOAD_CHUNK_BYTES", 4)
+    artifact = tmp_path / "artifact.bin"
+    artifact.write_bytes(b"abcdefgh")
+    backend = LocalShellBackend(root_dir=str(tmp_path), virtual_mode=True)
+    info = await inspect_sandbox_file(backend, "/artifact.bin")
+    chunks = stream_sandbox_file_chunks(backend, info)
+
+    assert await anext(chunks) == b"abcd"
+    original = artifact.stat()
+    artifact.write_bytes(b"ABCDEFGH")
+    os.utime(artifact, ns=(original.st_atime_ns, original.st_mtime_ns))
+
+    with pytest.raises(SandboxDownloadError, match="changed during download"):
+        await anext(chunks)
+
+
+async def test_stream_sandbox_file_validates_empty_file(tmp_path: Path) -> None:
+    artifact = tmp_path / "empty.bin"
+    artifact.write_bytes(b"")
+    backend = LocalShellBackend(root_dir=str(tmp_path), virtual_mode=True)
+    info = await inspect_sandbox_file(backend, "/empty.bin")
+    artifact.write_bytes(b"changed")
+
+    with pytest.raises(SandboxDownloadError, match="changed during download"):
+        await collect_chunks(backend, info)
+
+
+async def test_stream_sandbox_file_defers_cleanup_after_cancellation() -> None:
+    backend = FakeBackend(delay_chunk=True)
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+    chunks = stream_sandbox_file_chunks(backend, info)
+    next_chunk = asyncio.ensure_future(anext(chunks))
+    await backend.command_started.wait()
+
+    next_chunk.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await next_chunk
+    assert backend.deleted_paths == []
+
+    backend.command_release.set()
+    for _ in range(10):
+        if backend.deleted_paths:
+            break
+        await asyncio.sleep(0)
+
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_stream_sandbox_file_defers_cleanup_after_download_cancellation() -> None:
+    backend = FakeBackend(delay_download=True)
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+    chunks = stream_sandbox_file_chunks(backend, info)
+    next_chunk = asyncio.ensure_future(anext(chunks))
+    await backend.download_started.wait()
+
+    next_chunk.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await next_chunk
+    for _ in range(10):
+        if backend.deleted_paths:
+            break
+        await asyncio.sleep(0)
+
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_stream_sandbox_file_continues_cleanup_after_delete_cancellation() -> None:
+    backend = FakeBackend(delay_delete=True)
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+    chunks = stream_sandbox_file_chunks(backend, info)
+    next_chunk = asyncio.ensure_future(anext(chunks))
+    await backend.delete_started.wait()
+
+    next_chunk.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await next_chunk
+    assert backend.deleted_paths == []
+
+    backend.delete_release.set()
+    for _ in range(10):
+        if backend.deleted_paths:
+            break
+        await asyncio.sleep(0)
+
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_stream_sandbox_file_uses_bounded_chunks(monkeypatch) -> None:
+    monkeypatch.setattr(sandbox_downloads, "SANDBOX_DOWNLOAD_CHUNK_BYTES", 2)
+    backend = FakeBackend(size=5)
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+
+    content = await collect_chunks(backend, info)
+
+    assert content == b"xxxxx"
+    assert backend.download_count == 3
+    assert len(backend.deleted_paths) == 3
+    assert len(set(backend.deleted_paths)) == 3
+
+
+async def test_stream_sandbox_file_reads_nested_provider_content() -> None:
     backend = FakeBackend(content={"file_data": {"content": "abc"}})
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
 
-    info, content = await download_sandbox_file(backend, "/workspace/artifact.bin")
+    content = await collect_chunks(backend, info)
 
-    assert info.filename == "artifact.bin"
-    assert info.size == 3
     assert content == b"abc"
     assert backend.deleted_paths == [backend.staged_path]
 
 
-async def test_download_sandbox_file_rejects_growth_during_staging() -> None:
-    backend = FakeBackend(stage_error="too_large")
+async def test_stream_sandbox_file_rejects_source_changes() -> None:
+    backend = FakeBackend(chunk_error="changed")
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
 
-    with pytest.raises(SandboxDownloadFileTooLarge):
-        await download_sandbox_file(backend, "/workspace/artifact.bin")
-
-    assert backend.deleted_paths == [backend.staged_path]
-
-
-async def test_download_sandbox_file_handles_staging_io_error() -> None:
-    backend = FakeBackend(stage_error="io_error")
-
-    with pytest.raises(SandboxDownloadError, match="could not be staged"):
-        await download_sandbox_file(backend, "/workspace/artifact.bin")
+    with pytest.raises(SandboxDownloadError, match="changed during download"):
+        await collect_chunks(backend, info)
 
     assert backend.deleted_paths == [backend.staged_path]
 
 
-async def test_download_sandbox_file_handles_provider_error() -> None:
+async def test_stream_sandbox_file_handles_chunk_io_error() -> None:
+    backend = FakeBackend(chunk_error="io_error")
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
+
+    with pytest.raises(SandboxDownloadError, match="chunk could not be staged"):
+        await collect_chunks(backend, info)
+
+    assert backend.deleted_paths == [backend.staged_path]
+
+
+async def test_stream_sandbox_file_handles_provider_error() -> None:
     backend = FakeBackend(content=SimpleNamespace(error="permission_denied", content=None))
+    info = await inspect_sandbox_file(backend, "/workspace/artifact.bin")
 
-    with pytest.raises(SandboxDownloadError, match="could not be downloaded"):
-        await download_sandbox_file(backend, "/workspace/artifact.bin")
+    with pytest.raises(SandboxDownloadError, match="chunk could not be downloaded"):
+        await collect_chunks(backend, info)
 
     assert backend.deleted_paths == [backend.staged_path]

--- a/tests/utils/test_sandbox_downloads.py
+++ b/tests/utils/test_sandbox_downloads.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import base64
 import json
-import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import jwt
 import pytest
 from deepagents.backends import LocalShellBackend
 
@@ -65,38 +65,41 @@ class FakeBackend:
 
 
 def test_sandbox_download_link_round_trip(monkeypatch) -> None:
-    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    secret = "test-secret-that-is-at-least-32-bytes"
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", secret)
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example/")
-    now = int(time.time())
 
-    link = create_sandbox_download_link("thread-1", "/workspace/artifact.bin", now=now)
+    link = create_sandbox_download_link(
+        "thread-1",
+        "sandbox-1",
+        "/workspace/artifact.bin",
+    )
     token = link.url.rsplit("/", 1)[-1]
+    claims = decode_sandbox_download_token(token)
+    payload = jwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],
+        audience="open-swe-sandbox-file",
+    )
 
     assert link.url.startswith("https://dashboard.example/dashboard/api/sandbox-files/")
-    assert decode_sandbox_download_token(token).thread_id == "thread-1"
-    assert decode_sandbox_download_token(token).file_path == "/workspace/artifact.bin"
-    assert int(link.expires_at.timestamp()) > now
+    assert claims.thread_id == "thread-1"
+    assert claims.sandbox_id == "sandbox-1"
+    assert claims.file_path == "/workspace/artifact.bin"
+    assert "exp" not in payload
+    assert "iat" not in payload
 
 
 def test_sandbox_download_token_rejects_tampering(monkeypatch) -> None:
     monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
-    token = create_sandbox_download_link("thread-1", "/workspace/artifact.bin").url.rsplit("/", 1)[
-        -1
-    ]
+    token = create_sandbox_download_link(
+        "thread-1", "sandbox-1", "/workspace/artifact.bin"
+    ).url.rsplit("/", 1)[-1]
     tampered = ("a" if token[0] != "a" else "b") + token[1:]
 
     with pytest.raises(InvalidSandboxDownloadToken):
         decode_sandbox_download_token(tampered)
-
-
-def test_sandbox_download_token_rejects_expiration(monkeypatch) -> None:
-    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
-    token = create_sandbox_download_link("thread-1", "/workspace/artifact.bin", now=1).url.rsplit(
-        "/", 1
-    )[-1]
-
-    with pytest.raises(InvalidSandboxDownloadToken):
-        decode_sandbox_download_token(token)
 
 
 @pytest.mark.parametrize(
@@ -105,7 +108,7 @@ def test_sandbox_download_token_rejects_expiration(monkeypatch) -> None:
 )
 def test_inspect_sandbox_file_rejects_unsafe_paths(path: str) -> None:
     with pytest.raises(SandboxDownloadError):
-        create_sandbox_download_link("thread-1", path)
+        create_sandbox_download_link("thread-1", "sandbox-1", path)
 
 
 async def test_inspect_sandbox_file_enforces_size_limit() -> None:


### PR DESCRIPTION
## Description
Add an authenticated agent tool that creates signed download URLs bound to the originating sandbox lifetime and streams files in bounded chunks across sandbox providers.
## Release Note
Agents can now share authenticated, streaming download URLs for files generated in their sandbox.
## Test Plan
- [x] Verify multi-chunk and empty binary streams, auth, permanent claims, sandbox replacement, mutation detection, cancellation cleanup, and local virtual sandbox behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/a3af4000-f91d-2b9f-7698-4451ff115be0)