### PR TITLE
fix: Make dashboard plan mode opt-in

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -178,9 +178,13 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 ### Plan Mode
 
-If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment. Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link according to the Source Context section. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
+{plan_mode_entry_guidance} Once in plan mode, stay read-only for the target repo, research the code, create/edit your plan as a dated Markdown file under `/workspace/plans/` (for example, `/workspace/plans/YYYY-MM-DD-short-task-slug.md`), publish it with `save_plan`, and share the plan-review link according to the Source Context section. When the user approves the plan or asks you to proceed, call `approve_plan` to exit plan mode and continue.
 
 Plan-review link for this conversation: {plan_review_url}"""
+
+DEFAULT_PLAN_MODE_ENTRY_GUIDANCE = """If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment."""
+
+DASHBOARD_PLAN_MODE_ENTRY_GUIDANCE = """In the dashboard/Web UI, call `enter_plan_mode` only when the user explicitly asks in their prompt to enter or use plan mode. Do not infer plan mode from task complexity, size, or ambiguity; the dashboard's dedicated plan control enables it separately when selected."""
 
 PLAN_MODE_SECTION = """---
 
@@ -504,6 +508,11 @@ def construct_system_prompt(
         linear_project_id=linear_project_id or "<PROJECT_ID>",
         linear_issue_number=linear_issue_number or "<ISSUE_NUMBER>",
         plan_review_url=plan_url or "(the dashboard plan-review page)",
+        plan_mode_entry_guidance=(
+            DASHBOARD_PLAN_MODE_ENTRY_GUIDANCE
+            if source == "dashboard"
+            else DEFAULT_PLAN_MODE_ENTRY_GUIDANCE
+        ),
         plan_mode_section=(
             PLAN_MODE_SECTION.format(plan_url=plan_url or "(plan-review link unavailable)")
             if plan_mode

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -18,6 +18,14 @@ def test_construct_system_prompt_gates_active_plan_mode(enabled: bool) -> None:
     assert ("### Plan Mode (ACTIVE)" in prompt) is enabled
 
 
+def test_dashboard_only_enters_plan_mode_on_explicit_request() -> None:
+    dashboard_prompt = construct_system_prompt(working_dir="/work", source="dashboard")
+    slack_prompt = construct_system_prompt(working_dir="/work", source="slack", slack_context=True)
+
+    assert "call `enter_plan_mode` only when the user explicitly asks" in dashboard_prompt
+    assert "If a task would genuinely benefit from a structured plan" in slack_prompt
+
+
 def test_plan_mode_prompt_requests_slack_approval_options() -> None:
     prompt = construct_system_prompt(
         working_dir="/work", plan_mode=True, source="slack", slack_context=True


### PR DESCRIPTION
Dashboard runs now enter plan mode only when the user explicitly requests it or selects the dedicated UI control. Slack and other integrations retain complexity-based plan-mode activation.

Tests: `uv run pytest -q tests/agent/test_plan_mode.py`