### PR TITLE
feat: separate automation threads from active work

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -1936,6 +1936,7 @@ async def api_list_threads_sidebar(
     active_limit: int = 50,
     resolved_limit: int = 20,
     active_thread_id: str | None = None,
+    include_automations: bool = False,
     all: bool = False,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
@@ -1947,6 +1948,7 @@ async def api_list_threads_sidebar(
         active_limit=active_limit,
         resolved_limit=resolved_limit,
         active_thread_id=active_thread_id,
+        include_automations=include_automations,
         include_all=all,
     )
 

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -493,6 +493,9 @@ def _agent_run_metadata(
     title_prefix = "Test" if test_run else "Scheduled"
     metadata: dict[str, Any] = {
         "source": "schedule",
+        "origin": "schedule",
+        "thread_category": "automation",
+        "trigger_kind": "schedule_test" if test_run else "schedule",
         "schedule_id": record["id"],
         "schedule_name": record.get("name"),
         "schedule_test": test_run,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -399,6 +399,39 @@ def _thread_source_url(metadata: Mapping[str, Any]) -> str | None:
     return permalink.strip() if isinstance(permalink, str) and permalink.strip() else None
 
 
+def _metadata_string(metadata: Mapping[str, Any], key: str) -> str | None:
+    value = metadata.get(key)
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _thread_classification(metadata: Mapping[str, Any]) -> tuple[str, str, str]:
+    source = _thread_source(metadata)
+    origin = _metadata_string(metadata, "origin") or source
+    trigger_kind = _metadata_string(metadata, "trigger_kind") or (
+        "schedule_test"
+        if metadata.get("schedule_test") is True
+        else "schedule"
+        if source == "schedule" or _metadata_string(metadata, "schedule_id")
+        else "user"
+    )
+    category = _metadata_string(metadata, "thread_category")
+    if not category:
+        source_context = metadata.get("source_context")
+        if source == "schedule" or _metadata_string(metadata, "schedule_id"):
+            category = "automation"
+        elif isinstance(metadata.get("pr_number"), int) or (
+            isinstance(source_context, dict) and source_context.get("pr_number")
+        ):
+            category = "pull_request"
+        elif isinstance(source_context, dict) and (
+            source_context.get("github_issue") or source_context.get("linear_issue")
+        ):
+            category = "issue"
+        else:
+            category = "interactive"
+    return category, origin, trigger_kind
+
+
 async def _thread_summary(
     thread: ThreadLike,
     *,
@@ -428,6 +461,7 @@ async def _thread_summary(
     pr_url = metadata.get("pr_url")
     pr_title = metadata.get("pr_title")
     pr_state = metadata.get("pr_state")
+    thread_category, origin, trigger_kind = _thread_classification(metadata)
 
     thread_id = thread.get("thread_id") or thread.get("id")
     trace_url = await get_langsmith_trace_url(thread_id) if isinstance(thread_id, str) else None
@@ -455,6 +489,11 @@ async def _thread_summary(
         "environment": metadata.get("environment"),
         "planStatus": metadata.get("plan_status"),
         "source": _thread_source(metadata),
+        "origin": origin,
+        "threadCategory": thread_category,
+        "triggerKind": trigger_kind,
+        "automationId": _metadata_string(metadata, "schedule_id"),
+        "automationName": _metadata_string(metadata, "schedule_name"),
         "status": status,
         "viewed": _is_thread_viewed(metadata, latest_run_id),
         "viewedAt": (
@@ -1150,6 +1189,9 @@ async def _create_dashboard_thread_record(
     initial_title = title or prompt[:80] or "New agent"
     metadata: dict[str, Any] = {
         "source": _DASHBOARD_SOURCE,
+        "origin": _DASHBOARD_SOURCE,
+        "thread_category": "interactive",
+        "trigger_kind": "user",
         "github_login": login,
         PARTICIPANT_LOGINS_KEY: [login],
         "title": initial_title,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -404,6 +404,14 @@ def _metadata_string(metadata: Mapping[str, Any], key: str) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 
 
+def _is_automation_thread(metadata: Mapping[str, Any]) -> bool:
+    return (
+        _metadata_string(metadata, "thread_category") == "automation"
+        or _thread_source(metadata) == "schedule"
+        or _metadata_string(metadata, "schedule_id") is not None
+    )
+
+
 def _thread_classification(metadata: Mapping[str, Any]) -> tuple[str, str, str]:
     source = _thread_source(metadata)
     origin = _metadata_string(metadata, "origin") or source
@@ -417,7 +425,7 @@ def _thread_classification(metadata: Mapping[str, Any]) -> tuple[str, str, str]:
     category = _metadata_string(metadata, "thread_category")
     if not category:
         source_context = metadata.get("source_context")
-        if source == "schedule" or _metadata_string(metadata, "schedule_id"):
+        if _is_automation_thread(metadata):
             category = "automation"
         elif isinstance(metadata.get("pr_number"), int) or (
             isinstance(source_context, dict) and source_context.get("pr_number")
@@ -866,6 +874,7 @@ async def list_dashboard_threads_sidebar(
     active_limit: int = 50,
     resolved_limit: int = 20,
     active_thread_id: str | None = None,
+    include_automations: bool = False,
     include_all: bool = False,
 ) -> dict[str, Any]:
     client = langgraph_client()
@@ -895,6 +904,8 @@ async def list_dashboard_threads_sidebar(
             for thread in batch:
                 metadata = _thread_metadata(thread)
                 if not include_all and not _user_owns_thread(metadata, login, email):
+                    continue
+                if not include_automations and _is_automation_thread(metadata):
                     continue
                 thread_id = _thread_id(thread)
                 if not thread_id or thread_id in active or thread_id in resolved_threads:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -746,7 +746,19 @@ async def upsert_agent_thread_owner_metadata(
     mirror the owner-identifying fields onto the thread here.
     """
     now_ms = int(datetime.now(UTC).timestamp() * 1000)
-    metadata: dict[str, Any] = {"source": source, "updated_at_ms": now_ms}
+    category = "interactive"
+    if isinstance(source_context, dict):
+        if source_context.get("github_issue") or source_context.get("linear_issue"):
+            category = "issue"
+        elif source_context.get("pr_number"):
+            category = "pull_request"
+    metadata: dict[str, Any] = {
+        "source": source,
+        "origin": source,
+        "thread_category": category,
+        "trigger_kind": "user",
+        "updated_at_ms": now_ms,
+    }
     if isinstance(repo_config, dict) and repo_config.get("owner") and repo_config.get("name"):
         metadata["repo"] = repo_config
         metadata["repo_owner"] = repo_config["owner"]

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -567,6 +567,9 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(fake_client,
     assert fake_client.threads.created[0]["thread_id"] == thread_id
     metadata = fake_client.threads.created[0]["metadata"]
     assert metadata["source"] == "schedule"
+    assert metadata["origin"] == "schedule"
+    assert metadata["thread_category"] == "automation"
+    assert metadata["trigger_kind"] == "schedule"
     assert metadata["repo_owner"] == "langchain-ai"
     assert metadata["repo_name"] == "open-swe"
     run = fake_client.runs.created[0]

--- a/tests/dashboard/test_dashboard_repo_optional.py
+++ b/tests/dashboard/test_dashboard_repo_optional.py
@@ -46,6 +46,39 @@ async def test_thread_summary_keeps_repo_when_present() -> None:
     assert summary["repoFullName"] == "octo/repo"
 
 
+async def test_thread_summary_classifies_legacy_schedule_metadata() -> None:
+    summary = await thread_api._thread_summary(
+        {
+            "thread_id": "scheduled",
+            "metadata": {
+                "source": "schedule",
+                "schedule_id": "schedule-1",
+                "schedule_name": "Daily triage",
+            },
+        }
+    )
+    assert summary["origin"] == "schedule"
+    assert summary["threadCategory"] == "automation"
+    assert summary["triggerKind"] == "schedule"
+    assert summary["automationId"] == "schedule-1"
+    assert summary["automationName"] == "Daily triage"
+
+
+async def test_thread_summary_derives_issue_category_from_source_context() -> None:
+    summary = await thread_api._thread_summary(
+        {
+            "thread_id": "linear",
+            "metadata": {
+                "source": "linear",
+                "source_context": {"linear_issue": {"id": "issue-1"}},
+            },
+        }
+    )
+    assert summary["origin"] == "linear"
+    assert summary["threadCategory"] == "issue"
+    assert summary["triggerKind"] == "user"
+
+
 async def test_thread_summary_includes_trace_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         thread_api,

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1509,6 +1509,45 @@ async def test_list_dashboard_threads_sidebar_fills_buckets_with_one_endpoint(mo
     assert {call["offset"] for call in searches} == {0, page_size}
 
 
+async def test_list_dashboard_threads_sidebar_excludes_automations_before_limiting(
+    monkeypatch,
+) -> None:
+    page_size = thread_api._THREADS_SEARCH_PAGE
+    threads = _make_threads(page_size + 5, resolved_before=0)
+    for thread in threads[:page_size]:
+        metadata = cast(dict[str, object], thread["metadata"])
+        metadata["source"] = "schedule"
+        metadata["schedule_id"] = f"schedule-{thread['thread_id']}"
+    offsets: list[int] = []
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            offsets.append(offset)
+            return threads[offset : offset + limit]
+
+        async def update(self, *, thread_id, metadata):
+            return None
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            return []
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    result = await thread_api.list_dashboard_threads_sidebar(
+        "octocat", email=None, active_limit=5, resolved_limit=5
+    )
+
+    assert [item["id"] for item in result["active"]["items"]] == [
+        f"t{index}" for index in range(page_size, page_size + 5)
+    ]
+    assert set(offsets) == {0, page_size}
+
+
 async def test_list_dashboard_threads_sidebar_includes_readable_active_thread(
     monkeypatch,
 ) -> None:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -221,6 +221,9 @@ async def test_enrich_run_start_command_creates_and_stamps_new_thread(monkeypatc
     stamped = created["metadata"]
     assert isinstance(stamped, dict)
     assert stamped["source"] == "dashboard"
+    assert stamped["origin"] == "dashboard"
+    assert stamped["thread_category"] == "interactive"
+    assert stamped["trigger_kind"] == "user"
     assert stamped["github_login"] == "octocat"
     assert stamped["title"] == "Fix the flaky test"
     assert stamped["repo_owner"] == "octo"

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -126,7 +126,12 @@ export function AgentsSidebar({
     setFilters,
     resetFilters,
   } = useSidebarPrefs()
-  const sidebar = useSidebarThreads(RESOLVED_SIDEBAR_LIMIT, activeThreadId)
+  const sidebar = useSidebarThreads(
+    RESOLVED_SIDEBAR_LIMIT,
+    activeThreadId,
+    prefs.filters.includeAutomations ||
+      prefs.filters.sources.includes("schedule")
+  )
   const { sessions: localSessions, deleteSession: deleteLocalSession } =
     useDesktopAcpSessions()
   const {

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -775,6 +775,8 @@ function ThreadRow({
   const SourceIcon = source?.icon
   const prMeta = thread.pr ? PR_STATE_META[thread.pr.state] : null
   const PrIcon = prMeta?.icon
+  const isAutomation =
+    thread.threadCategory === "automation" || thread.source === "schedule"
   const showFinishedIndicator = thread.status === "finished" && !thread.viewed
 
   const openTrace = () => {
@@ -838,6 +840,11 @@ function ThreadRow({
           <span className="min-w-0 flex-1 truncate text-[13px]">
             {thread.title}
           </span>
+          {!compact && isAutomation && (
+            <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] text-muted-foreground group-hover:hidden">
+              Automation
+            </span>
+          )}
           {!compact && prMeta && PrIcon && (
             <PrIcon
               className={cn(

--- a/ui/src/features/agents/components/SidebarFilterMenu.tsx
+++ b/ui/src/features/agents/components/SidebarFilterMenu.tsx
@@ -266,6 +266,23 @@ export function SidebarFilterMenu({
                     <Menu.Separator className={SEPARATOR_CLASS} />
 
                     <Menu.CheckboxItem
+                      checked={filters.includeAutomations}
+                      onCheckedChange={(checked) =>
+                        patch({ includeAutomations: checked })
+                      }
+                      closeOnClick={false}
+                      className={ITEM_CLASS}
+                    >
+                      <span className="truncate">Include automations</span>
+                      <Menu.CheckboxItemIndicator className="ml-auto flex">
+                        <CheckIcon
+                          className="size-3.5 shrink-0"
+                          weight="bold"
+                        />
+                      </Menu.CheckboxItemIndicator>
+                    </Menu.CheckboxItem>
+
+                    <Menu.CheckboxItem
                       checked={filters.includeResolved}
                       onCheckedChange={(checked) =>
                         patch({ includeResolved: checked })

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -216,6 +216,7 @@ function buildSidebarThreadsQuery(params: {
   activeLimit?: number
   resolvedLimit?: number
   activeThreadId?: string
+  includeAutomations?: boolean
 }): string {
   const search = new URLSearchParams()
   if (params.activeLimit != null) {
@@ -227,6 +228,9 @@ function buildSidebarThreadsQuery(params: {
   if (params.activeThreadId) {
     search.set("active_thread_id", params.activeThreadId)
   }
+  if (params.includeAutomations != null) {
+    search.set("include_automations", String(params.includeAutomations))
+  }
   const query = search.toString()
   return query ? `?${query}` : ""
 }
@@ -237,6 +241,7 @@ export const agentsApi = {
     activeLimit?: number
     resolvedLimit?: number
     activeThreadId?: string
+    includeAutomations?: boolean
   }) =>
     agentsRequest<SidebarThreads>(
       `/threads/sidebar${buildSidebarThreadsQuery(params)}`

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -19,6 +19,7 @@ export const agentThreadKeys = {
     activeLimit: number
     resolvedLimit: number
     activeThreadId?: string
+    includeAutomations: boolean
   }) => ["agent-threads", "lists", "sidebar", params] as const,
   detail: (threadId: string) => ["agent-threads", threadId] as const,
   prDiff: (threadId: string) => ["agent-threads", threadId, "pr-diff"] as const,
@@ -219,12 +220,14 @@ function sidebarRefetchInterval(query: { state: { data?: SidebarThreads } }) {
 
 export function useSidebarThreads(
   resolvedLimit: number,
-  activeThreadId?: string
+  activeThreadId?: string,
+  includeAutomations = false
 ) {
   const params = {
     activeLimit: SIDEBAR_ACTIVE_LIMIT,
     resolvedLimit,
     activeThreadId,
+    includeAutomations,
   }
   return useQuery({
     queryKey: agentThreadKeys.sidebar(params),

--- a/ui/src/features/agents/lib/sidebarFilter.test.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.test.ts
@@ -37,9 +37,37 @@ function filters(overrides: Partial<SidebarFilters> = {}): SidebarFilters {
 }
 
 describe("filterThreads", () => {
-  it("returns all threads with default filters", () => {
-    const threads = [makeThread(), makeThread()]
-    expect(filterThreads(threads, DEFAULT_SIDEBAR_FILTERS)).toHaveLength(2)
+  it("returns ordinary threads with default filters", () => {
+    const threads = [
+      makeThread(),
+      makeThread({ source: "schedule", threadCategory: "automation" }),
+    ]
+    expect(filterThreads(threads, DEFAULT_SIDEBAR_FILTERS)).toHaveLength(1)
+  })
+
+  it("includes automations when requested", () => {
+    const ordinary = makeThread()
+    const automation = makeThread({
+      source: "schedule",
+      threadCategory: "automation",
+    })
+    expect(
+      filterThreads(
+        [ordinary, automation],
+        filters({ includeAutomations: true })
+      )
+    ).toEqual([ordinary, automation])
+  })
+
+  it("includes automations when Schedule is the selected source", () => {
+    const ordinary = makeThread()
+    const automation = makeThread({
+      source: "schedule",
+      threadCategory: "automation",
+    })
+    expect(
+      filterThreads([ordinary, automation], filters({ sources: ["schedule"] }))
+    ).toEqual([automation])
   })
 
   it("filters by ownership", () => {
@@ -192,7 +220,8 @@ describe("hasActiveFilters", () => {
   it("is true when any dimension changes", () => {
     expect(hasActiveFilters(filters({ ownership: "mine" }))).toBe(true)
     expect(hasActiveFilters(filters({ statuses: ["running"] }))).toBe(true)
-    expect(hasActiveFilters(filters({ includeResolved: false }))).toBe(true)
+    expect(hasActiveFilters(filters({ includeAutomations: true }))).toBe(true)
+    expect(hasActiveFilters(filters({ includeResolved: true }))).toBe(true)
   })
 })
 

--- a/ui/src/features/agents/lib/sidebarFilter.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.ts
@@ -14,6 +14,7 @@ export interface SidebarFilters {
   pr: Array<PrFilter>
   models: Array<string>
   repos: Array<string>
+  includeAutomations: boolean
   includeResolved: boolean
 }
 
@@ -24,7 +25,8 @@ export const DEFAULT_SIDEBAR_FILTERS: SidebarFilters = {
   pr: [],
   models: [],
   repos: [],
-  includeResolved: true,
+  includeAutomations: false,
+  includeResolved: false,
 }
 
 export const GROUP_MODE_OPTIONS: Array<{
@@ -84,12 +86,26 @@ function threadPr(thread: AgentThread): PrFilter {
   return thread.pr ? thread.pr.state : "none"
 }
 
+function isAutomationThread(thread: AgentThread): boolean {
+  return (
+    thread.threadCategory === "automation" ||
+    threadSource(thread) === "schedule"
+  )
+}
+
 /** Apply the active filter dimensions to a list of threads. */
 export function filterThreads(
   threads: Array<AgentThread>,
   filters: SidebarFilters
 ): Array<AgentThread> {
   return threads.filter((thread) => {
+    if (
+      !filters.includeAutomations &&
+      isAutomationThread(thread) &&
+      !filters.sources.includes("schedule")
+    ) {
+      return false
+    }
     if (filters.ownership === "mine" && thread.isOwner === false) return false
     if (filters.ownership === "shared" && thread.isOwner !== false) return false
     if (
@@ -266,6 +282,7 @@ export function hasActiveFilters(filters: SidebarFilters): boolean {
     filters.pr.length > 0 ||
     filters.models.length > 0 ||
     filters.repos.length > 0 ||
+    filters.includeAutomations !== DEFAULT_SIDEBAR_FILTERS.includeAutomations ||
     filters.includeResolved !== DEFAULT_SIDEBAR_FILTERS.includeResolved
   )
 }

--- a/ui/src/features/agents/lib/sidebarPrefs.ts
+++ b/ui/src/features/agents/lib/sidebarPrefs.ts
@@ -22,7 +22,7 @@ export interface SidebarPrefs {
 }
 
 export const DEFAULT_SIDEBAR_PREFS: SidebarPrefs = {
-  group: "date",
+  group: "repo",
   compact: false,
   collapsed: { local: false, cloud: false },
   filters: DEFAULT_SIDEBAR_FILTERS,
@@ -48,6 +48,10 @@ function sanitizeFilters(value: unknown): SidebarFilters {
     pr: asStringArray(raw.pr) as SidebarFilters["pr"],
     models: asStringArray(raw.models),
     repos: asStringArray(raw.repos),
+    includeAutomations:
+      typeof raw.includeAutomations === "boolean"
+        ? raw.includeAutomations
+        : DEFAULT_SIDEBAR_FILTERS.includeAutomations,
     includeResolved:
       typeof raw.includeResolved === "boolean"
         ? raw.includeResolved

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -18,6 +18,18 @@ export type AgentStatus =
 export type AgentSource =
   "dashboard" | "github" | "slack" | "linear" | "schedule"
 
+export type AgentThreadCategory =
+  "interactive" | "issue" | "pull_request" | "automation" | "review" | "system"
+
+export type AgentTriggerKind =
+  | "user"
+  | "schedule"
+  | "schedule_test"
+  | "wakeup"
+  | "reviewer"
+  | "analyzer"
+  | "ci_autofix"
+
 export interface TodoItem {
   content: string
   status: TodoStatus
@@ -228,6 +240,11 @@ export interface AgentThread {
   planStatus?: string | null
   adminThread?: boolean
   source?: AgentSource
+  origin?: AgentSource | string
+  threadCategory?: AgentThreadCategory | string
+  triggerKind?: AgentTriggerKind | string
+  automationId?: string | null
+  automationName?: string | null
   status: AgentStatus
   viewed: boolean
   viewedAt?: number | null

--- a/ui/src/features/automations/components/AutomationsList.tsx
+++ b/ui/src/features/automations/components/AutomationsList.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
+  ArrowSquareOutIcon,
   ClockIcon,
   LightningIcon,
   PauseIcon,
@@ -221,6 +222,16 @@ function AutomationRow({ schedule }: { schedule: AgentSchedule }) {
           )}
         </div>
       </Link>
+      {schedule.lastThreadId && (
+        <Link
+          to="/agents/$threadId"
+          params={{ threadId: schedule.lastThreadId }}
+          aria-label="Open latest automation run"
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <ArrowSquareOutIcon className="size-4" />
+        </Link>
+      )}
       <button
         type="button"
         onClick={onTest}


### PR DESCRIPTION
## Description
Keep normal agent work focused by hiding automation and resolved threads by default, grouping new sidebars by project, and projecting deterministic category/origin/trigger metadata. Automation definitions now link directly to their latest run.

## Release Note
Automation runs no longer clutter the default Agents sidebar and remain accessible from Automations or filters.

## Test Plan
- [x] Verify legacy scheduled threads are classified and can be explicitly included

Made by [Open SWE](https://openswe.vercel.app/agents/5838c0a1-b480-8433-ff09-2be4b1a9ce9e)

## References
- Plan: https://openswe.vercel.app/agents/5838c0a1-b480-8433-ff09-2be4b1a9ce9e/plan