### PR TITLE
chore: ban future annotations imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,8 @@ Webhooks compute deterministic thread ids so the same Linear issue / Slack threa
 - New dashboard endpoints: add to `agent/dashboard/routes.py`. The router is auto-mounted on the FastAPI app.
 - New graphs: register the entrypoint in `langgraph.json` under `graphs`.
 - Minimal-to-no code comments — only when the *why* isn't obvious from the code.
+- Never use `from __future__ import annotations` in repository code.
+- Tests must verify behavior, not implementation text; never add tests that only assert a literal string appears in a prompt.
 
 <!-- OPENWIKI:START -->
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -10,8 +10,6 @@ on public repos even when the GitHub App is not installed on them.
 """
 # ruff: noqa: E402
 
-from __future__ import annotations
-
 import logging
 import os
 import warnings

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -14,8 +14,6 @@ GitHub-backed tools never receive a user credential.
 """
 # ruff: noqa: E402
 
-from __future__ import annotations
-
 import logging
 import warnings
 from typing import Any, cast

--- a/agent/completion.py
+++ b/agent/completion.py
@@ -12,8 +12,6 @@ manual payloads without a run id fall back to legacy thread-level idempotence so
 missing ids degrade dedupe instead of silencing failure replies.
 """
 
-from __future__ import annotations
-
 import hmac
 import logging
 import os

--- a/agent/dashboard/admin.py
+++ b/agent/dashboard/admin.py
@@ -1,7 +1,5 @@
 """Admin gate driven by the CONFIGURED_ADMINS env var."""
 
-from __future__ import annotations
-
 import os
 
 

--- a/agent/dashboard/agent_instructions.py
+++ b/agent/dashboard/agent_instructions.py
@@ -4,8 +4,6 @@ Each record holds a user-authored instruction prompt (edited in the dashboard)
 that is appended to the main agent's system prompt for runs targeting that repo.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 from typing import Any

--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -1,7 +1,5 @@
 """Profile lookup + override helpers consumed by ``agent.server.get_agent``."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -1,7 +1,5 @@
 """Forward-looking Open SWE Agent usage telemetry."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from collections import Counter

--- a/agent/dashboard/analyzer_cron.py
+++ b/agent/dashboard/analyzer_cron.py
@@ -6,8 +6,6 @@ thread + sandbox each night) and authenticate via the GitHub App installation
 token resolved inside ``get_analyzer`` (the cron carries no fresh user token).
 """
 
-from __future__ import annotations
-
 import hashlib
 import logging
 

--- a/agent/dashboard/autofix_state.py
+++ b/agent/dashboard/autofix_state.py
@@ -7,8 +7,6 @@ re-enabled with ``@open-swe autofix on``), mirroring Cursor's
 agent thread so a disable command is honored even before any fix run exists.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 

--- a/agent/dashboard/enabled_repos.py
+++ b/agent/dashboard/enabled_repos.py
@@ -6,8 +6,6 @@ operator who installs the GitHub App into a new org doesn't get surprise
 review comments on every PR.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -20,8 +20,6 @@ whose snapshot is not ready, runs fall back to the per-repo snapshot and then to
 the configured base snapshot.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import re

--- a/agent/dashboard/eval_jobs.py
+++ b/agent/dashboard/eval_jobs.py
@@ -8,8 +8,6 @@ dashboard and reconciles a run whose heartbeat has gone stale (e.g. the Action
 was killed) to ``failed``.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from datetime import UTC, datetime

--- a/agent/dashboard/notion_oauth.py
+++ b/agent/dashboard/notion_oauth.py
@@ -1,7 +1,5 @@
 """Notion MCP OAuth helpers."""
 
-from __future__ import annotations
-
 import base64
 import hashlib
 import os

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -1,7 +1,5 @@
 """GitHub App OAuth code-exchange and signed-JWT session cookie."""
 
-from __future__ import annotations
-
 import base64
 import hashlib
 import hmac

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -1,7 +1,5 @@
 """Supported models and reasoning efforts surfaced in the profile editor."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Mapping, Sequence
 from functools import cache, lru_cache
 from importlib import import_module

--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -12,8 +12,6 @@ request changes (reject); only the thread owner can approve. A comment can be
 deleted by its author or the thread owner.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -9,8 +9,6 @@ Reviewers leave whole-document comments, stored one item per comment under
 store operations (no CRDT/WebSocket).
 """
 
-from __future__ import annotations
-
 import logging
 import re
 import uuid

--- a/agent/dashboard/pr_diff.py
+++ b/agent/dashboard/pr_diff.py
@@ -6,8 +6,6 @@ both the thread PR diff endpoint (user token) and the review diff endpoint
 (App installation token).
 """
 
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 from urllib.parse import quote

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -10,8 +10,6 @@ Each upsert only touches its own namespace, so the two flows can't clobber
 each other's fields even when they interleave.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
@@ -49,7 +47,7 @@ class ProfileUpdate(BaseModel):
     review_draft_prs: bool | None = None
 
     @model_validator(mode="after")
-    def _normalize_stale_model_pairs(self) -> ProfileUpdate:
+    def _normalize_stale_model_pairs(self) -> "ProfileUpdate":
         model, effort = _normalize_stale_model_pair(
             self.default_model,
             self.reasoning_effort,

--- a/agent/dashboard/repo_access.py
+++ b/agent/dashboard/repo_access.py
@@ -1,7 +1,5 @@
 """GitHub repository access checks for dashboard actions."""
 
-from __future__ import annotations
-
 import httpx
 from fastapi import HTTPException
 

--- a/agent/dashboard/repo_cache.py
+++ b/agent/dashboard/repo_cache.py
@@ -12,8 +12,6 @@ this cache — ``accessible_repo_full_names`` (an authorization boundary) stays
 fresh on every call.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable

--- a/agent/dashboard/repo_snapshots.py
+++ b/agent/dashboard/repo_snapshots.py
@@ -11,8 +11,6 @@ which uploads the Dockerfile context to a throwaway LangSmith builder sandbox,
 runs BuildKit there, and captures the result. Nothing is executed on the host.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import tempfile

--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -6,8 +6,6 @@ endpoints surface that state plus live PR details/diff fetched from GitHub
 with the App installation token.
 """
 
-from __future__ import annotations
-
 import ipaddress
 import logging
 import re

--- a/agent/dashboard/review_chat_api.py
+++ b/agent/dashboard/review_chat_api.py
@@ -8,8 +8,6 @@ the chat counterpart of ``thread_api``'s agent proxy, pinned to assistant
 ``chat`` and scoped to the review's PR.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from collections.abc import AsyncIterator

--- a/agent/dashboard/review_style_jobs.py
+++ b/agent/dashboard/review_style_jobs.py
@@ -1,7 +1,5 @@
 """Kick off and sync per-repo review style analysis runs."""
 
-from __future__ import annotations
-
 import logging
 import os
 import uuid

--- a/agent/dashboard/review_styles.py
+++ b/agent/dashboard/review_styles.py
@@ -4,8 +4,6 @@ Each record holds a synthesized custom prompt (editable in the dashboard),
 analysis metadata, and the status of the background style-analysis run.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 from typing import Any, Literal

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -1,7 +1,5 @@
 """FastAPI router for the dashboard backend."""
 
-from __future__ import annotations
-
 import asyncio
 import hmac
 import json

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -1,7 +1,5 @@
 """Dashboard-managed recurring agent schedules."""
 
-from __future__ import annotations
-
 import logging
 import re
 import uuid

--- a/agent/dashboard/skills.py
+++ b/agent/dashboard/skills.py
@@ -1,7 +1,5 @@
 """Per-user Agent Skills stored as virtual ``SKILL.md`` files."""
 
-from __future__ import annotations
-
 import base64
 import binascii
 import json

--- a/agent/dashboard/slack_oauth.py
+++ b/agent/dashboard/slack_oauth.py
@@ -7,8 +7,6 @@ claims give us a Slack-*verified* member id and email, so a logged-in GitHub
 user can only ever link their own Slack identity (no self-asserted spoofing).
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from dataclasses import dataclass

--- a/agent/dashboard/team_credentials.py
+++ b/agent/dashboard/team_credentials.py
@@ -6,8 +6,6 @@ record so a settings read never surfaces a secret. They feed the server-side
 Datadog MCP tools and LangSmith read tools — the sandbox never sees these keys.
 """
 
-from __future__ import annotations
-
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -5,8 +5,6 @@ configuration in one place. Per-repo style prompts live in
 :mod:`agent.dashboard.review_styles`.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import re
@@ -115,7 +113,7 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
         return text
 
     @model_validator(mode="after")
-    def _validate_model_pairs(self) -> TeamSettingsUpdate:
+    def _validate_model_pairs(self) -> "TeamSettingsUpdate":
         self.default_agent_model, self.default_agent_reasoning_effort = _normalize_stale_model_pair(
             self.default_agent_model,
             self.default_agent_reasoning_effort,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1,7 +1,5 @@
 """Dashboard thread list/detail/run/stream endpoints backed by LangGraph."""
 
-from __future__ import annotations
-
 import asyncio
 import base64
 import binascii

--- a/agent/dashboard/user_credentials.py
+++ b/agent/dashboard/user_credentials.py
@@ -1,7 +1,5 @@
 """Per-user third-party service credentials."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from dataclasses import dataclass

--- a/agent/dashboard/user_instructions.py
+++ b/agent/dashboard/user_instructions.py
@@ -8,8 +8,6 @@ Stored in its own namespace rather than on the ``["profiles"]`` record so
 agent-written updates and dashboard profile saves can't clobber each other.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 from typing import Any

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -21,8 +21,6 @@ call sites degrade to "unmapped" (the same conservative behavior as a missing
 dict entry).
 """
 
-from __future__ import annotations
-
 import logging
 import threading
 from datetime import UTC, datetime

--- a/agent/dashboard/voice.py
+++ b/agent/dashboard/voice.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 
 import httpx

--- a/agent/dashboard/workflow_approval.py
+++ b/agent/dashboard/workflow_approval.py
@@ -1,7 +1,5 @@
 """Workflow-file push approval state."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any

--- a/agent/dashboard/workflow_approval_api.py
+++ b/agent/dashboard/workflow_approval_api.py
@@ -1,7 +1,5 @@
 """REST API for approving workflow-file pushes."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -19,8 +19,6 @@ busy-check and the custom store-queue) with one function that always uses:
   until it happened to emit its next event.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import uuid

--- a/agent/integrations/corridor_mcp.py
+++ b/agent/integrations/corridor_mcp.py
@@ -5,8 +5,6 @@ Credentials are read from environment variables and attached as an
 LangGraph server process. The sandbox never holds Corridor credentials.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from dataclasses import dataclass

--- a/agent/integrations/currents_tools.py
+++ b/agent/integrations/currents_tools.py
@@ -9,8 +9,6 @@ and list projects so the agent can dig into e2e test failures including
 screenshots and DOM snapshots.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/integrations/datadog_mcp.py
+++ b/agent/integrations/datadog_mcp.py
@@ -9,8 +9,6 @@ dashboards, monitors, incidents, hosts, services, events). Override via
 ``DATADOG_MCP_TOOLSETS``.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from datetime import timedelta

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -1,7 +1,5 @@
 """LangSmith sandbox backend integration."""
 
-from __future__ import annotations
-
 import asyncio
 import base64
 import json

--- a/agent/integrations/langsmith_tools.py
+++ b/agent/integrations/langsmith_tools.py
@@ -6,8 +6,6 @@ The surface is intentionally read-only: fetch a single run/trace and list recent
 runs in a project.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from typing import Any

--- a/agent/integrations/notion_mcp.py
+++ b/agent/integrations/notion_mcp.py
@@ -1,7 +1,5 @@
 """Server-side Notion tools backed by Notion's hosted MCP server."""
 
-from __future__ import annotations
-
 import logging
 from datetime import timedelta
 from typing import Any

--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -28,8 +28,6 @@ run config) and reused across tool calls, so ``navigate`` → ``act`` → ``extr
 operate on the same live page. Always finish with ``browser_close``.
 """
 
-from __future__ import annotations
-
 import asyncio
 import contextlib
 import inspect

--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -5,8 +5,6 @@ comments that arrived while the agent was busy) and injects them as new
 human messages before the next model call.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any, NotRequired, cast
 

--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -1,7 +1,5 @@
 """Load optional integration tool schemas only when requested."""
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
 from typing import Annotated, Any, NotRequired
 

--- a/agent/middleware/exclude_tools.py
+++ b/agent/middleware/exclude_tools.py
@@ -5,8 +5,6 @@ tools. It mirrors Deep Agents' private `_ToolExclusionMiddleware` without
 depending on a private import path.
 """
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/agent/middleware/model_call_timeout.py
+++ b/agent/middleware/model_call_timeout.py
@@ -8,8 +8,6 @@ This middleware turns that hang into a timeout error, so the fallback model — 
 the run-completion webhook — reports it instead of the run going silent.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/agent/middleware/model_fallback.py
+++ b/agent/middleware/model_fallback.py
@@ -25,8 +25,6 @@ ends with a visible message in Slack/GitHub instead of an abrupt crash. The
 turn's progress is checkpointed, so the user can retrigger to continue.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import random

--- a/agent/middleware/notify_step_limit.py
+++ b/agent/middleware/notify_step_limit.py
@@ -1,7 +1,5 @@
 """After-agent middleware that notifies users when the step limit is reached."""
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Mapping
 from typing import Any

--- a/agent/middleware/plan_mode.py
+++ b/agent/middleware/plan_mode.py
@@ -9,8 +9,6 @@ tool list is recomputed on every model call), rather than only affecting a futur
 run.
 """
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any, NotRequired
 

--- a/agent/middleware/pr_creation_guard.py
+++ b/agent/middleware/pr_creation_guard.py
@@ -1,7 +1,5 @@
 """Block shell fallbacks that create pull requests outside open_pull_request."""
 
-from __future__ import annotations
-
 import json
 import os
 import re

--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import hashlib
 import json
 from collections.abc import Awaitable, Callable, Mapping

--- a/agent/middleware/refresh_github_proxy.py
+++ b/agent/middleware/refresh_github_proxy.py
@@ -7,8 +7,6 @@ the proxy with a fresh token before each model call when the recorded token is
 near expiry.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/middleware/repair_orphaned_tool_calls.py
+++ b/agent/middleware/repair_orphaned_tool_calls.py
@@ -13,8 +13,6 @@ This middleware scans the outgoing message list and inserts a synthetic error
 and can retry instead of dying.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from collections.abc import Awaitable, Callable

--- a/agent/middleware/sandbox_circuit_breaker.py
+++ b/agent/middleware/sandbox_circuit_breaker.py
@@ -1,7 +1,5 @@
 """Circuit breaker for runs stuck retrying an unreachable sandbox."""
 
-from __future__ import annotations
-
 import logging
 import re
 from collections.abc import Mapping, Sequence

--- a/agent/middleware/sanitize_fireworks_messages.py
+++ b/agent/middleware/sanitize_fireworks_messages.py
@@ -13,8 +13,6 @@ This middleware drops the redundant legacy field from assistant messages before
 they reach the Fireworks serializer, mirroring the thinking-block sanitizer.
 """
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/agent/middleware/sanitize_openai_responses.py
+++ b/agent/middleware/sanitize_openai_responses.py
@@ -1,7 +1,5 @@
 """Remove non-replayable reasoning items from stateless OpenAI history."""
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/agent/middleware/sanitize_thinking_blocks.py
+++ b/agent/middleware/sanitize_thinking_blocks.py
@@ -1,7 +1,5 @@
 """Middleware that removes malformed Anthropic thinking blocks before model calls."""
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/agent/middleware/sanitize_tool_inputs.py
+++ b/agent/middleware/sanitize_tool_inputs.py
@@ -6,8 +6,6 @@ validation.  The LLM occasionally generates strings like ``'1, 80'`` or
 sequence so the call succeeds instead of burning an LLM turn on a retry.
 """
 
-from __future__ import annotations
-
 import logging
 import re
 from collections.abc import Awaitable, Callable

--- a/agent/middleware/settle_review_check.py
+++ b/agent/middleware/settle_review_check.py
@@ -7,8 +7,6 @@ would hang "in progress" on the PR forever. This hook closes it as neutral —
 the review not completing is reviewer infrastructure failing, not the PR.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/middleware/subdir_agents.py
+++ b/agent/middleware/subdir_agents.py
@@ -1,7 +1,5 @@
 """Auto-load applicable ``AGENTS.md`` files after file reads."""
 
-from __future__ import annotations
-
 import logging
 import posixpath
 from collections import defaultdict

--- a/agent/middleware/task_retry.py
+++ b/agent/middleware/task_retry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 
 _RETURN_TO_MODEL_CODES = frozenset({"invalid_prompt", "context_length_exceeded"})

--- a/agent/middleware/timeout_wrapup.py
+++ b/agent/middleware/timeout_wrapup.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import time
 from collections.abc import Awaitable, Callable

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -4,8 +4,6 @@ Wraps all tool calls in try/except so that unhandled exceptions are
 returned as error ToolMessages instead of crashing the agent run.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping

--- a/agent/middleware/workflow_push_guard.py
+++ b/agent/middleware/workflow_push_guard.py
@@ -1,7 +1,5 @@
 """Gate workflow-file pushes on human approval."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 import logging

--- a/agent/middleware/working_repo.py
+++ b/agent/middleware/working_repo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import re
 import shlex

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -74,6 +74,7 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 ### Working with Code
 
 - Read files before modifying them. Fix root causes, not symptoms. Match existing code style. Ignore unrelated bugs or broken tests.
+- Never use `from __future__ import annotations`. Use annotation syntax compatible with the repository's supported Python versions instead.
 - Never add inline comments; keep any docstrings you add to ~1 line. Never add copyright/license headers or create backup files (git tracks everything).
 - Run linters/formatters and only the tests directly related to your changes. **Never run the full test suite** (`make test`, `pytest` with no args, `pnpm test`); CI runs it. Pass flags that disable color (`NO_COLOR=1`, `--no-colors`). If a command fails and you change code to fix it, re-run it to confirm.
 - Never modify `.github/workflows/` permissions unless explicitly asked.

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -74,7 +74,6 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 ### Working with Code
 
 - Read files before modifying them. Fix root causes, not symptoms. Match existing code style. Ignore unrelated bugs or broken tests.
-- Never use `from __future__ import annotations`. Use annotation syntax compatible with the repository's supported Python versions instead.
 - Never add inline comments; keep any docstrings you add to ~1 line. Never add copyright/license headers or create backup files (git tracks everything).
 - Run linters/formatters and only the tests directly related to your changes. **Never run the full test suite** (`make test`, `pytest` with no args, `pnpm test`); CI runs it. Pass flags that disable color (`NO_COLOR=1`, `--no-colors`). If a command fails and you change code to fix it, re-run it to confirm.
 - Never modify `.github/workflows/` permissions unless explicitly asked.

--- a/agent/reconcile.py
+++ b/agent/reconcile.py
@@ -7,8 +7,6 @@ safety net: find busy threads, look for stale ``pending`` runs on them, and
 cancel the ones older than ``max_age_seconds`` so the thread frees up.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 from typing import Any

--- a/agent/review/diff.py
+++ b/agent/review/diff.py
@@ -12,8 +12,6 @@ The reviewer needs three things from a PR diff:
    (``last_reviewed_sha..new_head_sha``).
 """
 
-from __future__ import annotations
-
 import hashlib
 import logging
 import re
@@ -305,7 +303,7 @@ def review_diff_path(work_dir: str, base_ref: str, head_ref: str, merge_base: bo
 
 
 async def materialize_review_diff(
-    sandbox_backend: SandboxBackendProtocol,
+    sandbox_backend: "SandboxBackendProtocol",
     *,
     work_dir: str,
     base_ref: str,
@@ -380,7 +378,7 @@ def _download_content(response: object) -> str | None:
 
 
 async def compute_diff_in_sandbox(
-    sandbox_backend: SandboxBackendProtocol,
+    sandbox_backend: "SandboxBackendProtocol",
     work_dir: str,
     base_ref: str,
     head_ref: str,

--- a/agent/review/eval_store.py
+++ b/agent/review/eval_store.py
@@ -6,8 +6,6 @@ dashboard. Both ``agent.dashboard.eval_jobs`` (reader) and
 ``evals.reviewer.store_reporter`` (writer) import from here.
 """
 
-from __future__ import annotations
-
 import re
 
 EVALS_NAMESPACE: list[str] = ["evals"]

--- a/agent/review/findings.py
+++ b/agent/review/findings.py
@@ -10,8 +10,6 @@ via the langgraph SDK (a future UI lists all reviewer threads by filtering on
 already uses for durable non-secret run state like ``sandbox_id``.
 """
 
-from __future__ import annotations
-
 import asyncio
 import hashlib
 import json
@@ -137,9 +135,9 @@ class Finding(TypedDict):
     resolution_note: str | None
     diff_hunk: str | None
     fingerprint: str
-    anchor: FindingAnchor | None
-    surface: FindingSurface | None
-    interactions: list[FindingInteraction]
+    anchor: "FindingAnchor | None"
+    surface: "FindingSurface | None"
+    interactions: "list[FindingInteraction]"
 
 
 class AppendFindingResult(TypedDict):

--- a/agent/review/groups.py
+++ b/agent/review/groups.py
@@ -12,8 +12,6 @@ and the UI falls back to the folder/flat view. The grouping never blocks or
 breaks the review itself.
 """
 
-from __future__ import annotations
-
 import hashlib
 import logging
 from datetime import UTC, datetime

--- a/agent/review/reconcile.py
+++ b/agent/review/reconcile.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from .findings import (

--- a/agent/review/style_collector.py
+++ b/agent/review/style_collector.py
@@ -1,7 +1,5 @@
 """Collect historical PR review samples from GitHub for style analysis."""
 
-from __future__ import annotations
-
 import logging
 import uuid
 from collections import Counter

--- a/agent/review/trace_context.py
+++ b/agent/review/trace_context.py
@@ -1,7 +1,5 @@
 """Best-effort author trace resolution for the reviewer graph."""
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -1,7 +1,5 @@
 """LangGraph entrypoint that fans cron ticks into fresh agent threads."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any, TypedDict
 

--- a/agent/thread_title.py
+++ b/agent/thread_title.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import contextvars
 import logging

--- a/agent/tools/_sandbox_output.py
+++ b/agent/tools/_sandbox_output.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import posixpath
 import uuid

--- a/agent/tools/add_finding.py
+++ b/agent/tools/add_finding.py
@@ -1,7 +1,5 @@
 """Tool: ``add_finding``. Records one review finding on the reviewer thread."""
 
-from __future__ import annotations
-
 from typing import Annotated, Any
 
 from langgraph.config import get_config

--- a/agent/tools/approve_plan.py
+++ b/agent/tools/approve_plan.py
@@ -1,7 +1,5 @@
 """Tool: ``approve_plan``. Approve a reviewed plan and exit plan mode."""
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Mapping
 from typing import Annotated, Any

--- a/agent/tools/enter_plan_mode.py
+++ b/agent/tools/enter_plan_mode.py
@@ -1,7 +1,5 @@
 """Tool: ``enter_plan_mode``. Switch the run into read-only planning."""
 
-from __future__ import annotations
-
 import logging
 from typing import Annotated, Any
 

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -5,8 +5,6 @@ re-checks the triggering user against ``CONFIGURED_ADMINS`` so a thread whose
 metadata says "admin" cannot act on behalf of someone who is not one.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/tools/fetch_review_diff.py
+++ b/agent/tools/fetch_review_diff.py
@@ -1,7 +1,5 @@
 """Tool: materialize the current reviewer diff in the sandbox."""
 
-from __future__ import annotations
-
 import re
 from typing import Any
 

--- a/agent/tools/list_findings.py
+++ b/agent/tools/list_findings.py
@@ -1,7 +1,5 @@
 """Tool: ``list_findings``. Return findings persisted on the reviewer thread."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from ..review.findings import (

--- a/agent/tools/list_review_findings.py
+++ b/agent/tools/list_review_findings.py
@@ -5,8 +5,6 @@ reviewer thread for the PR. The reviewer thread id is seeded into the run config
 by the dashboard chat proxy.
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from langgraph.config import get_config

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import logging
 from collections.abc import Mapping

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -1,7 +1,5 @@
 """Open a GitHub pull request attributed to the triggering user."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 from urllib.parse import quote

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -1,7 +1,5 @@
 """Tool: ``publish_review``. Post the findings list to GitHub as a PR Review."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from typing import Annotated, Any
 

--- a/agent/tools/read_finding_outcomes.py
+++ b/agent/tools/read_finding_outcomes.py
@@ -5,8 +5,6 @@ dismissed (false positive / 👎), so the analyzer can promote the bug patterns
 this team actually fixes and add the noisy ones to a skip-list.
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from langgraph.config import get_config

--- a/agent/tools/read_repo_file.py
+++ b/agent/tools/read_repo_file.py
@@ -5,8 +5,6 @@ the GitHub contents API. Repo coordinates and a read-only token come from the
 run config (seeded by the dashboard chat proxy).
 """
 
-from __future__ import annotations
-
 import base64
 from typing import Any
 

--- a/agent/tools/read_user_settings.py
+++ b/agent/tools/read_user_settings.py
@@ -1,7 +1,5 @@
 """Read safe settings for verified participants in the active thread."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Mapping
 from typing import Any

--- a/agent/tools/recreate_sandbox.py
+++ b/agent/tools/recreate_sandbox.py
@@ -1,7 +1,5 @@
 """Tool for explicitly rebinding the current thread to a fresh sandbox."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/tools/reply_to_finding_thread.py
+++ b/agent/tools/reply_to_finding_thread.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from langgraph.config import get_config

--- a/agent/tools/resolve_finding_thread.py
+++ b/agent/tools/resolve_finding_thread.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from langgraph.config import get_config

--- a/agent/tools/save_plan.py
+++ b/agent/tools/save_plan.py
@@ -5,8 +5,6 @@ plan-review page. In plan mode it is an approvable implementation plan; outside
 plan mode it is read-only shared content.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Mapping
 from typing import Annotated, Any

--- a/agent/tools/save_review_style.py
+++ b/agent/tools/save_review_style.py
@@ -1,7 +1,5 @@
 """Tool: persist synthesized per-repo review style prompt."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/tools/save_user_instructions.py
+++ b/agent/tools/save_user_instructions.py
@@ -1,7 +1,5 @@
 """Tool: persist the triggering user's user-level custom instructions."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/tools/schedule_thread_wakeup.py
+++ b/agent/tools/schedule_thread_wakeup.py
@@ -1,7 +1,5 @@
 """Tool that schedules a one-shot re-trigger of the current agent thread."""
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any

--- a/agent/tools/search_repo_code.py
+++ b/agent/tools/search_repo_code.py
@@ -1,7 +1,5 @@
 """Tool: ``search_repo_code``. Search the PR's repository via the GitHub code-search API."""
 
-from __future__ import annotations
-
 from typing import Any
 
 import httpx

--- a/agent/tools/update_finding.py
+++ b/agent/tools/update_finding.py
@@ -1,7 +1,5 @@
 """Tool: ``update_finding``. Mutate an existing finding by id."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from langgraph.config import get_config

--- a/agent/tools/user_skills.py
+++ b/agent/tools/user_skills.py
@@ -1,7 +1,5 @@
 """Tools for managing the triggering user's skills."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from langgraph.config import get_config

--- a/agent/utils/agents_md.py
+++ b/agent/utils/agents_md.py
@@ -4,8 +4,6 @@ Used by the reviewer to deterministically load repo conventions into context
 without the model having to clone the repo and read the file itself.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import posixpath

--- a/agent/utils/analyzer_skills.py
+++ b/agent/utils/analyzer_skills.py
@@ -12,8 +12,6 @@ The ``files`` channel is seeded at invoke time (see the launchers). Because
 address them under ``/skills/...``.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any
 

--- a/agent/utils/api_standards_skill.py
+++ b/agent/utils/api_standards_skill.py
@@ -9,8 +9,6 @@ Best-effort: any failure (missing handle, no API key, SDK error) returns
 ``None`` and the reviewer runs without the supplement.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -1,7 +1,5 @@
 """GitHub OAuth and LangSmith authentication utilities."""
 
-from __future__ import annotations
-
 import logging
 import os
 from collections.abc import Mapping

--- a/agent/utils/authorship.py
+++ b/agent/utils/authorship.py
@@ -1,7 +1,5 @@
 """Helpers for collaborative commit and PR attribution."""
 
-from __future__ import annotations
-
 import logging
 from dataclasses import dataclass
 from typing import Any

--- a/agent/utils/comments.py
+++ b/agent/utils/comments.py
@@ -1,7 +1,5 @@
 """Helpers for Linear comment processing."""
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 from typing import Any
 

--- a/agent/utils/deferred_model.py
+++ b/agent/utils/deferred_model.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from langchain_core.language_models import BaseChatModel
@@ -24,7 +22,7 @@ class DeferredErrorModel(BaseChatModel):
                 params["ls_provider"] = self.model_id.split(":", 1)[0]
         return params
 
-    def bind_tools(self, tools: Any, **kwargs: Any) -> DeferredErrorModel:
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "DeferredErrorModel":
         return self
 
     def _generate(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any):

--- a/agent/utils/file_diff.py
+++ b/agent/utils/file_diff.py
@@ -6,8 +6,6 @@ yet — git can only describe edits that already landed (see
 ``utils/turn_checkpoint.py`` for the post-hoc side).
 """
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from typing import Any
 

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -9,8 +9,6 @@ opt-in via ``LANGSMITH_GATEWAY_ENABLED`` (deployment default) or the
 :func:`agent.utils.model.make_model`.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 

--- a/agent/utils/github_app.py
+++ b/agent/utils/github_app.py
@@ -1,7 +1,5 @@
 """GitHub App installation token generation."""
 
-from __future__ import annotations
-
 import logging
 import os
 import time

--- a/agent/utils/github_checks.py
+++ b/agent/utils/github_checks.py
@@ -9,8 +9,6 @@ All calls are best-effort: check runs require the GitHub App's
 break review dispatch or publish.
 """
 
-from __future__ import annotations
-
 import logging
 from datetime import UTC, datetime
 from typing import Literal

--- a/agent/utils/github_ci.py
+++ b/agent/utils/github_ci.py
@@ -9,8 +9,6 @@ permission, and a missing permission or transient error must never break
 webhook handling.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/agent/utils/github_comments.py
+++ b/agent/utils/github_comments.py
@@ -1,7 +1,5 @@
 """GitHub webhook comment utilities."""
 
-from __future__ import annotations
-
 import asyncio
 import hashlib
 import hmac

--- a/agent/utils/github_feedback.py
+++ b/agent/utils/github_feedback.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 import re

--- a/agent/utils/github_http.py
+++ b/agent/utils/github_http.py
@@ -14,8 +14,6 @@ This centralises:
   "secondary rate limit" body message), backing off before retrying.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import random

--- a/agent/utils/github_org_membership.py
+++ b/agent/utils/github_org_membership.py
@@ -1,7 +1,5 @@
 """GitHub organization membership checks for webhook gating."""
 
-from __future__ import annotations
-
 import logging
 import os
 from urllib.parse import quote

--- a/agent/utils/github_proxy.py
+++ b/agent/utils/github_proxy.py
@@ -7,8 +7,6 @@ sandbox. This module records when each thread's proxy token expires and lets a
 before-model middleware re-configure the proxy before it goes stale.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from collections.abc import Sequence

--- a/agent/utils/github_token.py
+++ b/agent/utils/github_token.py
@@ -1,7 +1,5 @@
 """GitHub token lookup utilities."""
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta

--- a/agent/utils/json_types.py
+++ b/agent/utils/json_types.py
@@ -1,7 +1,5 @@
 """Helpers for LangGraph SDK / store JSON values that type as ``dict | None``."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from typing import Any, TypeAlias, cast
 

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -1,7 +1,5 @@
 """LangSmith trace URL utilities."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/agent/utils/linear.py
+++ b/agent/utils/linear.py
@@ -1,7 +1,5 @@
 """Linear API utilities."""
 
-from __future__ import annotations
-
 import logging
 import os
 from typing import Any

--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -1,7 +1,5 @@
 """Utilities for building multimodal content blocks."""
 
-from __future__ import annotations
-
 import base64
 import logging
 import mimetypes

--- a/agent/utils/read_only_backend.py
+++ b/agent/utils/read_only_backend.py
@@ -1,7 +1,5 @@
 """Read-only adapter for virtual backend routes."""
 
-from __future__ import annotations
-
 from deepagents.backends.protocol import (
     BackendProtocol,
     FileDownloadResponse,

--- a/agent/utils/repo.py
+++ b/agent/utils/repo.py
@@ -1,7 +1,5 @@
 """Utilities for extracting repository configuration from text."""
 
-from __future__ import annotations
-
 import os
 import re
 

--- a/agent/utils/repo_prep.py
+++ b/agent/utils/repo_prep.py
@@ -10,8 +10,6 @@ Best-effort: any failure leaves the sandbox usable (the review still works off
 the fetched diff) and returns ``False`` so callers can skip skill wiring.
 """
 
-from __future__ import annotations
-
 import logging
 import posixpath
 import shlex

--- a/agent/utils/reviewer_outcomes.py
+++ b/agent/utils/reviewer_outcomes.py
@@ -11,8 +11,6 @@ Writes are best-effort and deterministic (one example id per
 updates in place instead of duplicating.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/agent/utils/run_usage.py
+++ b/agent/utils/run_usage.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 

--- a/agent/utils/sandbox_paths.py
+++ b/agent/utils/sandbox_paths.py
@@ -1,7 +1,5 @@
 """Helpers for resolving portable writable paths inside sandboxes."""
 
-from __future__ import annotations
-
 import logging
 import posixpath
 import shlex

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -1,7 +1,5 @@
 """Shared sandbox state used by server and middleware."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -1,7 +1,5 @@
 """Slack API utilities."""
 
-from __future__ import annotations
-
 import asyncio
 import copy
 import hashlib

--- a/agent/utils/slack_events.py
+++ b/agent/utils/slack_events.py
@@ -1,7 +1,5 @@
 """Deduplication of Slack Event API deliveries."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/agent/utils/slack_feedback.py
+++ b/agent/utils/slack_feedback.py
@@ -1,7 +1,5 @@
 """Slack reaction feedback handling."""
 
-from __future__ import annotations
-
 import logging
 import os
 from collections.abc import Mapping

--- a/agent/utils/thread_ops.py
+++ b/agent/utils/thread_ops.py
@@ -7,8 +7,6 @@ below is retained for the dashboard's deliberate "inject a follow-up into a
 run that's already in flight" path (``thread_api.send_dashboard_message``).
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from typing import Any

--- a/agent/utils/thread_participants.py
+++ b/agent/utils/thread_participants.py
@@ -1,7 +1,5 @@
 """Resolve verified participants for the active agent thread."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Mapping
 from typing import Any

--- a/agent/utils/ttl_cache.py
+++ b/agent/utils/ttl_cache.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable

--- a/agent/utils/turn_checkpoint.py
+++ b/agent/utils/turn_checkpoint.py
@@ -10,8 +10,6 @@ Both the snapshot and the read-back are best effort: on any failure the caller
 gets ``None`` / ``status="error"`` and the UI degrades to "diff unavailable".
 """
 
-from __future__ import annotations
-
 import base64
 import binascii
 import json

--- a/agent/utils/url_safety.py
+++ b/agent/utils/url_safety.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import ipaddress
 import socket
 from collections.abc import Callable, Mapping

--- a/evals/reviewer/build_dataset.py
+++ b/evals/reviewer/build_dataset.py
@@ -9,8 +9,6 @@ Usage:
         --dataset-name openswe-reviewer-v1
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import re

--- a/evals/reviewer/judge.py
+++ b/evals/reviewer/judge.py
@@ -10,8 +10,6 @@ withmartian/code-review-benchmark `step3_judge_comments.py` so scores are
 directly comparable to martian's published numbers.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import threading

--- a/evals/reviewer/run_eval.py
+++ b/evals/reviewer/run_eval.py
@@ -4,8 +4,6 @@ Usage:
     uv run python -m evals.reviewer.run_eval
 """
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import contextlib

--- a/evals/reviewer/store_reporter.py
+++ b/evals/reviewer/store_reporter.py
@@ -7,8 +7,6 @@ heartbeat goes stale to ``failed`` (see ``agent.dashboard.eval_jobs``), so the
 reporter must keep heartbeating while the eval runs.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/evals/reviewer/target.py
+++ b/evals/reviewer/target.py
@@ -7,8 +7,6 @@ structured output for the eval. Findings are normalized into the legacy
 verbatim form martian published.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import threading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,14 @@ select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
+    "TID251",
 ]
 ignore = [
     "E501",  # line too long (handled by formatter)
 ]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"__future__.annotations".msg = "Do not use postponed annotation evaluation."
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/check_pr_merge_status.py
+++ b/scripts/check_pr_merge_status.py
@@ -1,7 +1,5 @@
 """Check merge status counts for PR URLs exported from LangGraph threads."""
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import json

--- a/scripts/purge_wakeup_crons.py
+++ b/scripts/purge_wakeup_crons.py
@@ -12,8 +12,6 @@ Resolves the deployment URL from ``--url`` or ``LANGGRAPH_URL`` / ``LANGGRAPH_UR
 and the API key from ``LANGGRAPH_API_KEY`` / ``LANGSMITH_API_KEY`` / ``LANGSMITH_API_KEY_PROD``.
 """
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import logging

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import cast
 from unittest.mock import AsyncMock, patch
 

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -273,6 +273,12 @@ async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
     assert names.index("ToolErrorMiddleware") < names.index("ToolRetryMiddleware")
 
 
+def test_shared_base_bans_future_annotations() -> None:
+    from agent.prompt import OPEN_SWE_SHARED_BASE
+
+    assert "Never use `from __future__ import annotations`" in OPEN_SWE_SHARED_BASE
+
+
 @pytest.mark.asyncio
 async def test_general_purpose_subagent_carries_open_swe_shared_base() -> None:
     from agent.prompt import OPEN_SWE_SHARED_BASE

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -7,8 +7,6 @@ is what makes deepagents auto-wire `FilesystemMiddleware` tool-result eviction a
 `PatchToolCallsMiddleware` that `create_deep_agent` adds covers it.
 """
 
-from __future__ import annotations
-
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,7 +20,7 @@ from agent.utils.sandbox_state import SandboxBackendProxy, clear_sandbox_backend
 
 
 class _DummyAgent:
-    def with_config(self, config: RunnableConfig) -> _DummyAgent:
+    def with_config(self, config: RunnableConfig) -> "_DummyAgent":
         self.config = config
         return self
 

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -273,12 +273,6 @@ async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
     assert names.index("ToolErrorMiddleware") < names.index("ToolRetryMiddleware")
 
 
-def test_shared_base_bans_future_annotations() -> None:
-    from agent.prompt import OPEN_SWE_SHARED_BASE
-
-    assert "Never use `from __future__ import annotations`" in OPEN_SWE_SHARED_BASE
-
-
 @pytest.mark.asyncio
 async def test_general_purpose_subagent_carries_open_swe_shared_base() -> None:
     from agent.prompt import OPEN_SWE_SHARED_BASE

--- a/tests/agent/test_agent_instructions.py
+++ b/tests/agent/test_agent_instructions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from unittest.mock import AsyncMock, patch
 

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/agent/test_agent_thread_pr_state.py
+++ b/tests/agent/test_agent_thread_pr_state.py
@@ -1,7 +1,5 @@
 """Unit tests for agent-thread PR-state tracking from PR webhook events."""
 
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/agent/test_agent_usage.py
+++ b/tests/agent/test_agent_usage.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 from agent.dashboard import agent_usage

--- a/tests/agent/test_agents_md.py
+++ b/tests/agent/test_agents_md.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/agent/test_api_standards_skill.py
+++ b/tests/agent/test_api_standards_skill.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import patch
 
 import pytest

--- a/tests/agent/test_dispatch.py
+++ b/tests/agent/test_dispatch.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from typing import Any
 

--- a/tests/agent/test_multimodal.py
+++ b/tests/agent/test_multimodal.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import socket
 from typing import Any, cast
 from urllib.parse import urlparse

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 from unittest.mock import AsyncMock

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, cast
 
 import pytest
@@ -410,7 +408,7 @@ class _FakeReq:
         self.tools = tools
         self.state = state
 
-    def override(self, **kw: Any) -> _FakeReq:
+    def override(self, **kw: Any) -> "_FakeReq":
         return _FakeReq(kw.get("tools", self.tools), self.state)
 
 

--- a/tests/agent/test_prompt_default_repo.py
+++ b/tests/agent/test_prompt_default_repo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 
 import pytest

--- a/tests/agent/test_read_user_settings.py
+++ b/tests/agent/test_read_user_settings.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 from unittest.mock import AsyncMock, patch
 

--- a/tests/agent/test_repo_prep.py
+++ b/tests/agent/test_repo_prep.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import cast
 
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol

--- a/tests/agent/test_skills.py
+++ b/tests/agent/test_skills.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import ANY, AsyncMock, patch
 
 import pytest

--- a/tests/agent/test_task_retry.py
+++ b/tests/agent/test_task_retry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 
 import httpx

--- a/tests/agent/test_timeout_wrapup.py
+++ b/tests/agent/test_timeout_wrapup.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import cast
 
 import pytest

--- a/tests/agent/test_turn_checkpoint.py
+++ b/tests/agent/test_turn_checkpoint.py
@@ -1,7 +1,5 @@
 """Turn checkpoints: git plumbing output parsing and checkpoint bookkeeping."""
 
-from __future__ import annotations
-
 import base64
 import subprocess
 from types import SimpleNamespace

--- a/tests/agent/test_user_instructions.py
+++ b/tests/agent/test_user_instructions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/agent/test_workflow_push_guard.py
+++ b/tests/agent/test_workflow_push_guard.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any, cast
 
@@ -73,7 +71,7 @@ class _Request:
             "id": "call-1",
         }
 
-    def override(self, **kwargs: Any) -> _Request:
+    def override(self, **kwargs: Any) -> "_Request":
         next_request = _Request()
         next_request.tool_call = kwargs.get("tool_call", self.tool_call)
         return next_request

--- a/tests/analyzer/test_analyzer_cron.py
+++ b/tests/analyzer/test_analyzer_cron.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/analyzer/test_analyzer_skills.py
+++ b/tests/analyzer/test_analyzer_skills.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pathlib
 
 from deepagents.middleware.skills import _parse_skill_metadata

--- a/tests/analyzer/test_eval_jobs.py
+++ b/tests/analyzer/test_eval_jobs.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 

--- a/tests/analyzer/test_eval_store_reporter.py
+++ b/tests/analyzer/test_eval_store_reporter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/auth/test_auth_sources.py
+++ b/tests/auth/test_auth_sources.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 
 import pytest

--- a/tests/auth/test_authorship.py
+++ b/tests/auth/test_authorship.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from agent.utils.authorship import (
     OPEN_SWE_BOT_EMAIL,
     OPEN_SWE_BOT_NAME,

--- a/tests/auth/test_encryption.py
+++ b/tests/auth/test_encryption.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 from cryptography.fernet import Fernet
 

--- a/tests/auth/test_github_oauth_refresh.py
+++ b/tests/auth/test_github_oauth_refresh.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 

--- a/tests/auth/test_github_token_ttl.py
+++ b/tests/auth/test_github_token_ttl.py
@@ -8,8 +8,6 @@ Covers:
   failure when GitHub responds 401
 """
 
-from __future__ import annotations
-
 import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -166,7 +164,7 @@ class _MockHttpxClient:
         self.posts: list[dict[str, Any]] = []
         self.gets: list[dict[str, Any]] = []
 
-    async def __aenter__(self) -> _MockHttpxClient:
+    async def __aenter__(self) -> "_MockHttpxClient":
         return self
 
     async def __aexit__(self, *args: Any) -> None:

--- a/tests/auth/test_notion_oauth.py
+++ b/tests/auth/test_notion_oauth.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse

--- a/tests/auth/test_slack_oauth.py
+++ b/tests/auth/test_slack_oauth.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from urllib.parse import parse_qs, urlparse
 
 import pytest

--- a/tests/auth/test_user_credentials.py
+++ b/tests/auth/test_user_credentials.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Shared pytest fixtures."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 
 import pytest

--- a/tests/dashboard/test_account_link.py
+++ b/tests/dashboard/test_account_link.py
@@ -1,7 +1,5 @@
 """Tests for the Slack account-link prompt."""
 
-from __future__ import annotations
-
 from typing import TypedDict
 
 import pytest

--- a/tests/dashboard/test_autofix_state.py
+++ b/tests/dashboard/test_autofix_state.py
@@ -1,7 +1,5 @@
 """Unit tests for per-PR auto-fix opt-out state."""
 
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/dashboard/test_dashboard_admin.py
+++ b/tests/dashboard/test_dashboard_admin.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 from agent.dashboard.admin import is_admin, is_observability_authorized

--- a/tests/dashboard/test_dashboard_csrf.py
+++ b/tests/dashboard/test_dashboard_csrf.py
@@ -1,7 +1,5 @@
 """CSRF defenses for cookie-authenticated dashboard mutations."""
 
-from __future__ import annotations
-
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient

--- a/tests/dashboard/test_dashboard_oauth_redirect.py
+++ b/tests/dashboard/test_dashboard_oauth_redirect.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import hashlib
 from typing import Any

--- a/tests/dashboard/test_dashboard_org_login_gate.py
+++ b/tests/dashboard/test_dashboard_org_login_gate.py
@@ -1,7 +1,5 @@
 """Tests for the dashboard GitHub-org login gate (ALLOWED_GITHUB_ORGS)."""
 
-from __future__ import annotations
-
 import pytest
 from fastapi import HTTPException
 

--- a/tests/dashboard/test_dashboard_repo_optional.py
+++ b/tests/dashboard/test_dashboard_repo_optional.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 

--- a/tests/dashboard/test_dashboard_repos.py
+++ b/tests/dashboard/test_dashboard_repos.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/dashboard/test_dashboard_reviews.py
+++ b/tests/dashboard/test_dashboard_reviews.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock

--- a/tests/dashboard/test_dashboard_run_email.py
+++ b/tests/dashboard/test_dashboard_run_email.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/dashboard/test_dashboard_web_handoff.py
+++ b/tests/dashboard/test_dashboard_web_handoff.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/dashboard/test_public_repo_org_gate.py
+++ b/tests/dashboard/test_public_repo_org_gate.py
@@ -1,7 +1,5 @@
 """Tests for the public-repo org-membership gate on GitHub webhooks."""
 
-from __future__ import annotations
-
 import hashlib
 import hmac
 import json
@@ -362,7 +360,7 @@ class _FakeAsyncClient:
     def __init__(self, response) -> None:
         self._response = response
 
-    async def __aenter__(self) -> _FakeAsyncClient:
+    async def __aenter__(self) -> "_FakeAsyncClient":
         return self
 
     async def __aexit__(self, *_args) -> None:

--- a/tests/dashboard/test_team_credentials.py
+++ b/tests/dashboard/test_team_credentials.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/dashboard/test_team_settings_fable.py
+++ b/tests/dashboard/test_team_settings_fable.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/dashboard/test_team_settings_grouping.py
+++ b/tests/dashboard/test_team_settings_grouping.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/dashboard/test_team_settings_org_guidelines.py
+++ b/tests/dashboard/test_team_settings_org_guidelines.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/dashboard/test_team_settings_thread_title.py
+++ b/tests/dashboard/test_team_settings_thread_title.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/dashboard/test_team_settings_transcription.py
+++ b/tests/dashboard/test_team_settings_transcription.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/dashboard/test_user_mappings.py
+++ b/tests/dashboard/test_user_mappings.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/dashboard/test_voice.py
+++ b/tests/dashboard/test_voice.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import httpx
 import pytest
 from fastapi import FastAPI, HTTPException

--- a/tests/dashboard/test_workflow_approval_api.py
+++ b/tests/dashboard/test_workflow_approval_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from agent.dashboard import workflow_approval_api
 
 

--- a/tests/e2e/agent_entrypoint.py
+++ b/tests/e2e/agent_entrypoint.py
@@ -5,8 +5,6 @@ REAL traced agent factory. The langgraph dev config points the ``agent`` graph
 here instead of ``agent.server`` so the patches are in effect in the worker.
 """
 
-from __future__ import annotations
-
 import os
 import sys
 

--- a/tests/e2e/e2e_env.py
+++ b/tests/e2e/e2e_env.py
@@ -8,8 +8,6 @@ Everything here only configures *boundaries* (which sandbox, which fake API
 URLs, where git writes its global config). The agent code itself is unchanged.
 """
 
-from __future__ import annotations
-
 import os
 from pathlib import Path
 

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -7,8 +7,6 @@ the real ``open_pull_request`` tool, and post the result back with the real
 the preceding tool result, exactly as a real model would.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import re
@@ -525,7 +523,7 @@ class FakeScriptedChatModel(BaseChatModel):
     def _llm_type(self) -> str:
         return "fake-scripted"
 
-    def bind_tools(self, tools: Any, **kwargs: Any) -> FakeScriptedChatModel:  # noqa: ARG002
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "FakeScriptedChatModel":  # noqa: ARG002
         return self
 
     def _generate(

--- a/tests/e2e/fakes.py
+++ b/tests/e2e/fakes.py
@@ -5,8 +5,6 @@ These stores are the single source of truth that both the real agent code
 sees in the UI is exactly what the agent produced.
 """
 
-from __future__ import annotations
-
 import shutil
 import subprocess
 import time

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -10,8 +10,6 @@ Nothing here touches agent logic — it only stands in for the SaaS boundaries
 and renders their state back as a user-facing UI.
 """
 
-from __future__ import annotations
-
 import hashlib
 import hmac
 import json

--- a/tests/e2e/local_desktop_login.py
+++ b/tests/e2e/local_desktop_login.py
@@ -10,8 +10,6 @@ and sign in. Endpoints other than /auth/* and /me need a real backend and will
 error; login is what this harness covers.
 """
 
-from __future__ import annotations
-
 import os
 from html import escape
 from typing import Any

--- a/tests/e2e/patches.py
+++ b/tests/e2e/patches.py
@@ -10,8 +10,6 @@ Applied at import of both the graph entrypoint and the HTTP harness (same dev
 process), so it runs before the first run regardless of import order. Idempotent.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 
@@ -107,7 +105,7 @@ class _FakeSnapshot:
 class _FakeSandboxClient:
     """Stands in for ``AsyncSandboxClient`` for snapshot calls only."""
 
-    async def __aenter__(self) -> _FakeSandboxClient:
+    async def __aenter__(self) -> "_FakeSandboxClient":
         return self
 
     async def __aexit__(self, *_exc: object) -> bool:

--- a/tests/github/test_github_app.py
+++ b/tests/github/test_github_app.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -29,7 +27,7 @@ class _FakeAsyncClient:
     def __init__(self, **kwargs: Any) -> None:
         pass
 
-    async def __aenter__(self) -> _FakeAsyncClient:
+    async def __aenter__(self) -> "_FakeAsyncClient":
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
@@ -87,7 +85,7 @@ class _CountingClient:
     def __init__(self, **kwargs: Any) -> None:
         pass
 
-    async def __aenter__(self) -> _CountingClient:
+    async def __aenter__(self) -> "_CountingClient":
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:

--- a/tests/github/test_github_checks.py
+++ b/tests/github/test_github_checks.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import httpx
@@ -38,7 +36,7 @@ class _FakeAsyncClient:
     def __init__(self, **kwargs: Any) -> None:
         pass
 
-    async def __aenter__(self) -> _FakeAsyncClient:
+    async def __aenter__(self) -> "_FakeAsyncClient":
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:

--- a/tests/github/test_github_ci.py
+++ b/tests/github/test_github_ci.py
@@ -1,7 +1,5 @@
 """Unit tests for GitHub CI read helpers used by the auto-fix flow."""
 
-from __future__ import annotations
-
 from typing import Any
 
 import httpx
@@ -31,7 +29,7 @@ class _FakeClient:
     def __init__(self, **kwargs: Any) -> None:
         pass
 
-    async def __aenter__(self) -> _FakeClient:
+    async def __aenter__(self) -> "_FakeClient":
         return self
 
     async def __aexit__(self, *_: object) -> None:

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
@@ -34,7 +32,7 @@ class _CaptureRequestModel(BaseChatModel):
     def _get_ls_params(self, stop: list[str] | None = None, **kwargs: Any) -> LangSmithParams:
         return LangSmithParams(ls_provider="openai")
 
-    def bind_tools(self, tools: Any, **kwargs: Any) -> _CaptureRequestModel:
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "_CaptureRequestModel":
         self.captured_tools = tools
         return self
 

--- a/tests/github/test_github_feedback.py
+++ b/tests/github/test_github_feedback.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any, cast
 

--- a/tests/github/test_github_http.py
+++ b/tests/github/test_github_http.py
@@ -1,7 +1,5 @@
 """Unit tests for the shared GitHub HTTP helper."""
 
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import httpx

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import hashlib
 import hmac

--- a/tests/github/test_github_proxy_refresh.py
+++ b/tests/github/test_github_proxy_refresh.py
@@ -1,7 +1,5 @@
 """Tests for mid-run GitHub proxy token refresh."""
 
-from __future__ import annotations
-
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from typing import cast

--- a/tests/github/test_normalize_repo.py
+++ b/tests/github/test_normalize_repo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 from agent.dashboard.review_styles import normalize_repo_full_name

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import sys
 from typing import Any
@@ -28,7 +26,7 @@ class _FakeClient:
         self.post_calls: list[dict[str, Any]] = []
         self.get_calls: list[dict[str, Any]] = []
 
-    async def __aenter__(self) -> _FakeClient:
+    async def __aenter__(self) -> "_FakeClient":
         return self
 
     async def __aexit__(self, *_exc: object) -> None:
@@ -58,7 +56,7 @@ class _RoutingClient:
         self.post_calls: list[dict[str, Any]] = []
         self.get_calls: list[dict[str, Any]] = []
 
-    async def __aenter__(self) -> _RoutingClient:
+    async def __aenter__(self) -> "_RoutingClient":
         return self
 
     async def __aexit__(self, *_exc: object) -> None:

--- a/tests/github/test_pr_creation_guard.py
+++ b/tests/github/test_pr_creation_guard.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any, cast
 

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, replace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -27,7 +25,7 @@ class _Request:
     tool_call: dict[str, Any] | None = None
     tool: BaseTool | None = None
 
-    def override(self, **kwargs: Any) -> _Request:
+    def override(self, **kwargs: Any) -> "_Request":
         return replace(self, **kwargs)
 
 

--- a/tests/middleware/test_model_call_timeout.py
+++ b/tests/middleware/test_model_call_timeout.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any, cast
 from unittest.mock import MagicMock

--- a/tests/middleware/test_model_fallback_middleware.py
+++ b/tests/middleware/test_model_fallback_middleware.py
@@ -1,7 +1,5 @@
 """Tests for ModelFallbackMiddleware."""
 
-from __future__ import annotations
-
 from typing import Any, cast
 from unittest.mock import MagicMock
 

--- a/tests/middleware/test_prepare_run_middleware.py
+++ b/tests/middleware/test_prepare_run_middleware.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any, cast
 from unittest.mock import MagicMock

--- a/tests/middleware/test_repair_orphaned_tool_calls.py
+++ b/tests/middleware/test_repair_orphaned_tool_calls.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any, cast
 from unittest.mock import MagicMock

--- a/tests/middleware/test_sanitize_fireworks_messages.py
+++ b/tests/middleware/test_sanitize_fireworks_messages.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, cast
 from unittest.mock import MagicMock
 

--- a/tests/middleware/test_sanitize_thinking_blocks.py
+++ b/tests/middleware/test_sanitize_thinking_blocks.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, cast
 from unittest.mock import MagicMock
 

--- a/tests/middleware/test_sanitize_tool_inputs.py
+++ b/tests/middleware/test_sanitize_tool_inputs.py
@@ -5,8 +5,6 @@ integer field in read_file (e.g. offset='1, 80'), causing a Pydantic
 ValidationError and an unnecessary retry.
 """
 
-from __future__ import annotations
-
 from agent.middleware.sanitize_tool_inputs import _coerce_int, _sanitize_read_file_args
 
 

--- a/tests/middleware/test_subdir_agents_middleware.py
+++ b/tests/middleware/test_subdir_agents_middleware.py
@@ -1,7 +1,5 @@
 """Tests for subdirectory AGENTS.md auto-loading on read_file."""
 
-from __future__ import annotations
-
 from types import SimpleNamespace
 from typing import Any
 

--- a/tests/middleware/test_working_repo_middleware.py
+++ b/tests/middleware/test_working_repo_middleware.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from types import SimpleNamespace
 from typing import Any
 

--- a/tests/models/test_anthropic_effort.py
+++ b/tests/models/test_anthropic_effort.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from agent.utils.model import anthropic_effort_for, anthropic_thinking_for
 
 

--- a/tests/models/test_deferred_model.py
+++ b/tests/models/test_deferred_model.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 from langchain_core.messages import HumanMessage
 

--- a/tests/models/test_model_request_timeout.py
+++ b/tests/models/test_model_request_timeout.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import patch
 

--- a/tests/reviewer/test_factory_config_isolation.py
+++ b/tests/reviewer/test_factory_config_isolation.py
@@ -1,7 +1,5 @@
 """Tests that get_reviewer_agent and get_chat_agent do not mutate the caller's config."""
 
-from __future__ import annotations
-
 from typing import cast
 from unittest.mock import MagicMock, patch
 

--- a/tests/reviewer/test_fetch_review_diff_tool.py
+++ b/tests/reviewer/test_fetch_review_diff_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/reviewer/test_pr_ready_auto_review.py
+++ b/tests/reviewer/test_pr_ready_auto_review.py
@@ -1,7 +1,5 @@
 """Tests for the opened / ready_for_review auto-review webhook handlers."""
 
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/reviewer/test_reconcile_sweep.py
+++ b/tests/reviewer/test_reconcile_sweep.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock

--- a/tests/reviewer/test_review_chat.py
+++ b/tests/reviewer/test_review_chat.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import importlib
 import sys

--- a/tests/reviewer/test_review_style_sync.py
+++ b/tests/reviewer/test_review_style_sync.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/reviewer/test_review_styles_store.py
+++ b/tests/reviewer/test_review_styles_store.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -44,7 +42,7 @@ def test_finding_reply_context_wraps_reply_as_untrusted_data() -> None:
 
 
 class _DummyAgent:
-    def with_config(self, config: dict[str, object]) -> _DummyAgent:
+    def with_config(self, config: dict[str, object]) -> "_DummyAgent":
         self.config = config
         return self
 

--- a/tests/reviewer/test_reviewer_diff.py
+++ b/tests/reviewer/test_reviewer_diff.py
@@ -1,7 +1,5 @@
 """Unit tests for the unified-diff parsing helpers."""
 
-from __future__ import annotations
-
 import pytest
 
 from agent.review.diff import (

--- a/tests/reviewer/test_reviewer_eval_judge.py
+++ b/tests/reviewer/test_reviewer_eval_judge.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from types import SimpleNamespace
 from typing import cast

--- a/tests/reviewer/test_reviewer_eval_run.py
+++ b/tests/reviewer/test_reviewer_eval_run.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from unittest.mock import patch
 

--- a/tests/reviewer/test_reviewer_eval_target.py
+++ b/tests/reviewer/test_reviewer_eval_target.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/reviewer/test_reviewer_findings.py
+++ b/tests/reviewer/test_reviewer_findings.py
@@ -1,7 +1,5 @@
 """Unit tests for the Finding schema + thread-metadata helpers."""
 
-from __future__ import annotations
-
 import asyncio
 import copy
 from typing import Any

--- a/tests/reviewer/test_reviewer_groups.py
+++ b/tests/reviewer/test_reviewer_groups.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/reviewer/test_reviewer_outcomes.py
+++ b/tests/reviewer/test_reviewer_outcomes.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, cast
 
 from agent.review.findings import Finding
@@ -66,7 +64,7 @@ class _FakeClient:
         self.updated: list[dict[str, Any]] = []
         self.conflict_once = False
 
-    async def __aenter__(self) -> _FakeClient:
+    async def __aenter__(self) -> "_FakeClient":
         return self
 
     async def __aexit__(self, *exc: Any) -> None:

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -1,7 +1,5 @@
 """Unit tests for the publish_review rendering and orchestration helpers."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/reviewer/test_reviewer_reconcile.py
+++ b/tests/reviewer/test_reviewer_reconcile.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/reviewer/test_reviewer_tools.py
+++ b/tests/reviewer/test_reviewer_tools.py
@@ -1,7 +1,5 @@
 """Unit tests for the add_finding / update_finding / list_findings tools."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, patch

--- a/tests/reviewer/test_reviewer_trace_context.py
+++ b/tests/reviewer/test_reviewer_trace_context.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import re
 from typing import Any

--- a/tests/reviewer/test_reviewer_watch.py
+++ b/tests/reviewer/test_reviewer_watch.py
@@ -1,7 +1,5 @@
 """Unit tests for the watch-mode webhook handlers."""
 
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -1,7 +1,5 @@
 """Unit tests for LangSmith LLM Gateway routing (agent/utils/gateway.py + make_model)."""
 
-from __future__ import annotations
-
 from typing import Any, cast
 from unittest.mock import patch
 

--- a/tests/sandbox/test_langsmith_sandbox_timeout.py
+++ b/tests/sandbox/test_langsmith_sandbox_timeout.py
@@ -1,7 +1,5 @@
 """Client-side execution deadline for the LangSmith sandbox backend."""
 
-from __future__ import annotations
-
 import asyncio
 import time
 from types import SimpleNamespace

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -1,7 +1,5 @@
 """Tests for GitHub proxy auth configuration."""
 
-from __future__ import annotations
-
 import base64
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/sandbox/test_repo_snapshots.py
+++ b/tests/sandbox/test_repo_snapshots.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/sandbox/test_sandbox_paths.py
+++ b/tests/sandbox/test_sandbox_paths.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import shlex
 from typing import cast
 

--- a/tests/sandbox/test_sandbox_recreation.py
+++ b/tests/sandbox/test_sandbox_recreation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Awaitable, Callable
 from types import SimpleNamespace

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from typing import Any
 

--- a/tests/slack/test_slack_add_reaction_tool.py
+++ b/tests/slack/test_slack_add_reaction_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from typing import Any
 

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -1,7 +1,5 @@
 """Tests for Slack message API utilities."""
 
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/slack/test_slack_start_new_thread_tool.py
+++ b/tests/slack/test_slack_start_new_thread_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from typing import Any
 

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from typing import Any
 

--- a/tests/slack/test_slack_warning_logging.py
+++ b/tests/slack/test_slack_warning_logging.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import contextvars
 from typing import Any, cast

--- a/tests/test_tool_output_offloading.py
+++ b/tests/test_tool_output_offloading.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 import json
 import sys

--- a/tests/tools/test_corridor_mcp.py
+++ b/tests/tools/test_corridor_mcp.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/tools/test_currents_tools.py
+++ b/tests/tools/test_currents_tools.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/tools/test_http_security.py
+++ b/tests/tools/test_http_security.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 import json
 import socket as real_socket
@@ -72,14 +70,14 @@ class FakeAsyncClient:
     installed in place of ``httpx.AsyncClient`` on the tool module under test.
     """
 
-    last_instance: FakeAsyncClient | None = None
+    last_instance: "FakeAsyncClient | None" = None
 
     def __init__(self, responder, *args: Any, **kwargs: Any) -> None:
         self._responder = responder
         self.calls: list[dict[str, Any]] = []
         FakeAsyncClient.last_instance = self
 
-    async def __aenter__(self) -> FakeAsyncClient:
+    async def __aenter__(self) -> "FakeAsyncClient":
         return self
 
     async def __aexit__(self, *exc: Any) -> bool:

--- a/tests/tools/test_linear_search_issues.py
+++ b/tests/tools/test_linear_search_issues.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from typing import Any
 

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal, cast
 from unittest.mock import AsyncMock, call, patch
 

--- a/tests/tools/test_recreate_sandbox_tool.py
+++ b/tests/tools/test_recreate_sandbox_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/tools/test_report_platform_issue_tool.py
+++ b/tests/tools/test_report_platform_issue_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import uuid
 from typing import get_type_hints

--- a/tests/tools/test_schedule_thread_wakeup.py
+++ b/tests/tools/test_schedule_thread_wakeup.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from datetime import UTC, datetime, timedelta
 from typing import Any

--- a/tests/utils/test_thread_participants.py
+++ b/tests/utils/test_thread_participants.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock
 

--- a/tests/webhooks/test_linear_trace_comment.py
+++ b/tests/webhooks/test_linear_trace_comment.py
@@ -1,7 +1,5 @@
 """Tests for the Linear trace-URL comment."""
 
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, patch
 
 from agent.utils import linear as linear_utils

--- a/tests/webhooks/test_linear_webhook_author.py
+++ b/tests/webhooks/test_linear_webhook_author.py
@@ -1,7 +1,5 @@
 """Tests for Linear webhook PR author linking (reuse of the Slack user mapping)."""
 
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
## Description
Enforce the repository ban on `from __future__ import annotations` with Ruff TID251, remove all existing imports, and keep the matching `AGENTS.md` convention plus the prompt-string-test ban. Forward references are quoted where Python 3.12 requires deferred evaluation.

## Release Note
none

## Test Plan
- [x] Ruff lint/ban probe, basedpyright, 1,835-test collection, and 100 focused tests.

Made by [Open SWE](https://openswe.vercel.app/agents/4236d0b3-61cc-9360-d09e-26c25ac17dde)