### PR TITLE
fix: align plan header in narrow panels

### DIFF
--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -215,6 +215,17 @@ test.describe("Plan review (HTTP comments)", () => {
     await expect(owner.getByTestId("plan-document")).toContainText("greet", {
       timeout: 30_000,
     });
+    const embeddedSummaryBox = await owner
+      .getByTestId("plan-summary")
+      .boundingBox();
+    const embeddedActionsBox = await owner
+      .getByTestId("plan-actions")
+      .boundingBox();
+    expect(embeddedSummaryBox).not.toBeNull();
+    expect(embeddedActionsBox).not.toBeNull();
+    expect(embeddedActionsBox!.y).toBeGreaterThanOrEqual(
+      embeddedSummaryBox!.y + embeddedSummaryBox!.height,
+    );
     await expect(owner.getByTestId("approve-plan")).toBeVisible();
     // "Request changes" is meaningless with no feedback → disabled until a
     // comment exists.

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -221,11 +221,11 @@ export function PlanReview({
   return (
     <div
       data-testid="plan-review"
-      className="flex min-h-0 flex-1 flex-col bg-background text-foreground"
+      className="@container flex min-h-0 flex-1 flex-col bg-background text-foreground"
     >
       <div
         className={cn(
-          "flex flex-col gap-3 border-b border-border px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-4",
+          "flex flex-col gap-3 border-b border-border px-4 py-3 @3xl:flex-row @3xl:items-center @3xl:justify-between @3xl:gap-4",
           !compact && "md:px-6"
         )}
       >
@@ -241,12 +241,12 @@ export function PlanReview({
         </div>
         <div
           data-testid="plan-actions"
-          className="flex min-w-0 flex-wrap items-center gap-2 lg:shrink-0 lg:justify-end"
+          className="flex min-w-0 flex-wrap items-center gap-2 @3xl:shrink-0 @3xl:justify-end"
         >
           {decision && (
             <span
               data-testid="plan-decision"
-              className="w-full text-xs text-muted-foreground/70 lg:w-auto"
+              className="w-full text-xs text-muted-foreground/70 @3xl:w-auto"
             >
               {decision}
             </span>


### PR DESCRIPTION
## Description
Make the plan header respond to its resizable panel width instead of the browser viewport, preventing metadata and actions from overlapping. Extend the Playwright plan-review flow with a geometry assertion for the embedded narrow panel.

## Release Note
Fixed plan review header alignment in narrow dashboard panels.

## Test Plan
- [x] `npm --prefix tests/e2e run test -- plan_review.spec.ts --grep "Slack plan request"`
- [x] `pnpm -C ui run build`

Made by [Open SWE](https://openswe.vercel.app/agents/cd74d49b-e01e-a643-33bf-bdc1e5a014a1)