### PR TITLE
chore: use sentence case for automatic thread titles

### DIFF
--- a/agent/thread_title.py
+++ b/agent/thread_title.py
@@ -27,6 +27,7 @@ Return only the structured title field.
 
 Rules:
 - Use 3-8 words and no more than 80 characters.
+- Use sentence case: capitalize only the first word, except for proper nouns and acronyms.
 - Name the durable subject and desired outcome, not the current workflow step.
 - Prefer a compact noun phrase or clear action phrase.
 - For reviews, name what is being reviewed and the relevant concern.

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -148,7 +148,6 @@ async def test_title_generation_disables_inherited_callbacks() -> None:
     )
 
     assert recorder["config"]["callbacks"] == []
-    assert "capitalize only the first word" in recorder["messages"][0].content
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -148,6 +148,7 @@ async def test_title_generation_disables_inherited_callbacks() -> None:
     )
 
     assert recorder["config"]["callbacks"] == []
+    assert "capitalize only the first word" in recorder["messages"][0].content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Automatic thread titles could use title case. Require sentence case while preserving proper nouns and acronyms.
## Release Note
Automatic thread titles now use sentence case.
## Test Plan
- [ ] Generate a thread title and confirm sentence casing while preserving acronyms.

Made by [Open SWE](https://openswe.vercel.app/agents/6e5f1696-47be-3bde-5a8d-77402a83b747)