### PR TITLE
fix: rename agent button to thread

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -262,7 +262,7 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     expect(threadId).not.toBe("");
     await waitForThreadIdle(page, threadId);
 
-    await page.getByRole("link", { name: "New Agent" }).click();
+    await page.getByRole("link", { name: "New Thread" }).click();
     await expect(page).toHaveURL(/\/agents\/?$/);
     await page.goBack();
     await expect(page).toHaveURL(new RegExp(`/agents/${threadId}$`));

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -190,7 +190,7 @@ export function AgentsSidebar({
           className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
         >
           <PlusIcon className="size-4" />
-          New Agent
+          New Thread
         </Link>
       </div>
 


### PR DESCRIPTION
## Description
Renames the sidebar creation action from “New Agent” to “New Thread” so the label matches the thread-based workflow without changing its behavior.

## Release Note
Dashboard sidebar now labels new agent sessions as threads.

## Test Plan
- [x] Focused Playwright scenario verifies “New Thread” navigates to `/agents`.

Made by [Open SWE](https://openswe.vercel.app/agents/75dba182-2fc8-5d6c-b572-6cb2fbf8dae7)