### PR TITLE
fix: exclude cached input from Slack token count

### DIFF
--- a/agent/utils/run_usage.py
+++ b/agent/utils/run_usage.py
@@ -18,13 +18,17 @@ def _tokens(usage: Any) -> int | None:
     if not isinstance(usage, dict):
         return None
     total = _number(usage.get("total_tokens"))
-    if total is not None:
-        return total
-    input_tokens = _number(usage.get("input_tokens"))
-    output_tokens = _number(usage.get("output_tokens"))
-    if input_tokens is None or output_tokens is None:
-        return None
-    return input_tokens + output_tokens
+    if total is None:
+        input_tokens = _number(usage.get("input_tokens"))
+        output_tokens = _number(usage.get("output_tokens"))
+        if input_tokens is None or output_tokens is None:
+            return None
+        total = input_tokens + output_tokens
+    input_details = usage.get("input_token_details")
+    cache_read = (
+        _number(input_details.get("cache_read")) if isinstance(input_details, dict) else None
+    )
+    return max(total - (cache_read or 0), 0)
 
 
 def _message_model(message: AIMessage) -> str | None:

--- a/tests/agent/test_run_usage.py
+++ b/tests/agent/test_run_usage.py
@@ -3,7 +3,9 @@ from langchain_core.messages import AIMessage, HumanMessage
 from agent.utils.run_usage import summarize_run_usage
 
 
-def _message(*, model: str, input_tokens: int, output_tokens: int) -> AIMessage:
+def _message(
+    *, model: str, input_tokens: int, output_tokens: int, cache_read_tokens: int = 0
+) -> AIMessage:
     return AIMessage(
         content="",
         response_metadata={"model_name": model},
@@ -11,6 +13,7 @@ def _message(*, model: str, input_tokens: int, output_tokens: int) -> AIMessage:
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "total_tokens": input_tokens + output_tokens,
+            "input_token_details": {"cache_read": cache_read_tokens},
         },
     )
 
@@ -31,6 +34,25 @@ def test_summarize_run_usage_uses_only_latest_human_turn() -> None:
     assert summary is not None
     assert summary.models == ("model-a", "model-b")
     assert summary.main_agent_tokens == 3_300
+
+
+def test_summarize_run_usage_excludes_cached_input_tokens() -> None:
+    summary = summarize_run_usage(
+        {
+            "messages": [
+                HumanMessage(content="current"),
+                _message(
+                    model="model-a",
+                    input_tokens=1_000,
+                    output_tokens=100,
+                    cache_read_tokens=600,
+                ),
+            ]
+        }
+    )
+
+    assert summary is not None
+    assert summary.main_agent_tokens == 500
 
 
 def test_summarize_run_usage_ignores_messages_without_usage() -> None:


### PR DESCRIPTION
## Description
Exclude cached-read input tokens from the main-agent token usage shown in Slack footers so the displayed count reflects non-cached usage.

## Release Note
Slack token counts now exclude cached-read input tokens.

## Test Plan
- [x] Verify cached input is subtracted while uncached usage remains unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/624f9bb4-0cf6-5386-81ff-8e3bfe900d75)