### PR TITLE
fix: open threads from completion notifications

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -24,7 +24,7 @@ import {
 } from "@phosphor-icons/react"
 import { IoLogoGithub, IoLogoSlack } from "react-icons/io5"
 import { SiLinear } from "react-icons/si"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import type { ComponentType, ReactNode, SVGProps } from "react"
 
 import type { SessionUser } from "@/lib/api"
@@ -118,6 +118,13 @@ export function AgentsSidebar({
   activeLocalSessionId,
   layout,
 }: AgentsSidebarProps) {
+  const navigate = useNavigate()
+  const openThread = useCallback(
+    (threadId: string) => {
+      void navigate({ to: "/agents/$threadId", params: { threadId } })
+    },
+    [navigate]
+  )
   const {
     prefs,
     setGroup,
@@ -147,7 +154,7 @@ export function AgentsSidebar({
   const resolvedHasMore = sidebar.data?.resolved.hasMore ?? false
   const visibleThreads = [...activeThreads, ...resolvedThreads]
   useSeedAgentThreadDetails(visibleThreads, activeThreadId)
-  useRunCompletionNotifier(visibleThreads, activeThreadId)
+  useRunCompletionNotifier(visibleThreads, activeThreadId, openThread)
 
   const facets = availableFacets(visibleThreads)
   const filteredActive = filterThreads(activeThreads, prefs.filters)

--- a/ui/src/features/agents/lib/useRunCompletionNotifier.ts
+++ b/ui/src/features/agents/lib/useRunCompletionNotifier.ts
@@ -13,7 +13,8 @@ const TERMINAL_STATUSES = new Set(["finished", "error", "interrupted"])
  */
 export function useRunCompletionNotifier(
   threads: Array<AgentThread> | undefined,
-  activeThreadId?: string
+  activeThreadId: string | undefined,
+  openThread: (threadId: string) => void
 ) {
   const prevStatusRef = useRef<Map<string, string>>(new Map())
 
@@ -33,9 +34,9 @@ export function useRunCompletionNotifier(
         TERMINAL_STATUSES.has(thread.status) &&
         !(isViewingThread && thread.id === activeThreadId)
       ) {
-        showRunNotification(thread)
+        showRunNotification(thread, openThread)
       }
       prev.set(thread.id, thread.status)
     }
-  }, [threads, activeThreadId])
+  }, [threads, activeThreadId, openThread])
 }

--- a/ui/src/lib/notifications.test.ts
+++ b/ui/src/lib/notifications.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { AgentThread } from "@/features/agents/lib/types"
+import {
+  NOTIFICATIONS_PREF_KEY,
+  showRunNotification,
+} from "@/lib/notifications"
+
+class FakeNotification {
+  static permission: NotificationPermission = "granted"
+  static instances: Array<FakeNotification> = []
+
+  onclick: (() => void) | null = null
+  close = vi.fn()
+
+  constructor(
+    readonly title: string,
+    readonly options?: NotificationOptions
+  ) {
+    FakeNotification.instances.push(this)
+  }
+}
+
+const thread: AgentThread = {
+  id: "thread-123",
+  title: "Fix notifications",
+  repo: "open-swe",
+  repoFullName: "langchain-ai/open-swe",
+  branch: "main",
+  model: "test-model",
+  status: "finished",
+  viewed: false,
+  createdAt: 1,
+  updatedAt: 2,
+  messages: [],
+}
+
+afterEach(() => {
+  FakeNotification.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("showRunNotification", () => {
+  it("opens the completed thread when the notification is clicked", () => {
+    vi.stubGlobal("Notification", FakeNotification)
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) =>
+        key === NOTIFICATIONS_PREF_KEY ? "true" : null
+      ),
+    })
+    const focus = vi.spyOn(window, "focus").mockImplementation(() => {})
+    const openThread = vi.fn()
+
+    showRunNotification(thread, openThread)
+
+    expect(FakeNotification.instances).toHaveLength(1)
+    const notification = FakeNotification.instances[0]
+    if (!notification) throw new Error("Notification was not created")
+    notification.onclick?.()
+
+    expect(focus).toHaveBeenCalledOnce()
+    expect(openThread).toHaveBeenCalledOnce()
+    expect(openThread).toHaveBeenCalledWith("thread-123")
+    expect(notification.close).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/lib/notifications.ts
+++ b/ui/src/lib/notifications.ts
@@ -36,7 +36,10 @@ export function setNotificationsPref(enabled: boolean) {
   }
 }
 
-export function showRunNotification(thread: AgentThread) {
+export function showRunNotification(
+  thread: AgentThread,
+  onClick: (threadId: string) => void
+) {
   if (!notificationsEnabled()) return
   const statusLabel =
     thread.status === "error"
@@ -54,6 +57,7 @@ export function showRunNotification(thread: AgentThread) {
     })
     n.onclick = () => {
       window.focus()
+      onClick(thread.id)
       n.close()
     }
   } catch {


### PR DESCRIPTION
## Summary
- navigate completion-notification clicks to the exact completed thread using the typed TanStack route
- preserve window focus and notification close behavior
- cover the clicked thread ID with a focused notification test

## Testing
- `pnpm --dir ui exec vitest run src/lib/notifications.test.ts`
- `pnpm --dir ui build`
- `pnpm --dir ui exec prettier --check src/lib/notifications.ts src/lib/notifications.test.ts src/features/agents/lib/useRunCompletionNotifier.ts src/features/agents/components/AgentsSidebar.tsx`
- `pnpm --dir ui typecheck` *(blocked by the pre-existing `ui/src/routes/admin.tsx:797` nullability error)*