### PR TITLE
fix: tint active admin composer control

### DIFF
--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatComposer, buildCommandItems } from "./ChatComposer"
 import { replaceTextRange } from "./composerTrigger"
+import type { ChatComposerProps } from "./ChatComposer"
 import { AgentThreadStreamBoundary } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
 
 const stream = {
@@ -44,14 +45,20 @@ beforeEach(() => {
   cancelThread.mockClear()
 })
 
-function renderComposer(running: boolean) {
+function renderComposer(
+  running: boolean,
+  props: Partial<ChatComposerProps> = {}
+) {
   const client = new QueryClient({
     defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
   })
   render(
     <QueryClientProvider client={client}>
       <AgentThreadStreamBoundary>
-        <ChatComposer activeRun={{ threadId: "thread-1", running }} />
+        <ChatComposer
+          activeRun={{ threadId: "thread-1", running }}
+          {...props}
+        />
       </AgentThreadStreamBoundary>
     </QueryClientProvider>
   )
@@ -121,6 +128,20 @@ describe("ChatComposer stop button", () => {
 
     expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy()
     expect(screen.queryByRole("button", { name: "Stop run" })).toBeNull()
+  })
+})
+
+describe("ChatComposer admin mode", () => {
+  it("tints the composer options control when enabled", () => {
+    renderComposer(false, {
+      adminThread: true,
+      onAdminThreadChange: vi.fn(),
+    })
+
+    const options = screen.getByRole("button", {
+      name: "More composer options",
+    })
+    expect(options.className.split(" ")).toContain("bg-destructive/10")
   })
 })
 

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -752,7 +752,11 @@ export const ChatComposer = memo(function ChatComposer({
               render={
                 <ComposerControl
                   aria-label="More composer options"
-                  className="size-7 px-0"
+                  className={cn(
+                    "size-7 px-0",
+                    adminThread &&
+                      "bg-destructive/10 text-foreground hover:bg-destructive/10 hover:text-foreground"
+                  )}
                   type="button"
                 />
               }


### PR DESCRIPTION
## Description
Tints the new-thread composer’s `+` control with the existing admin-thread shade while admin mode is enabled.

## Release Note
Active admin mode is now visually indicated on the initial composer.

## Test Plan
- [x] Verify focused ChatComposer tests and formatting

Made by [Open SWE](https://openswe.vercel.app/agents/8bd87b5d-488a-5015-8193-1f24b9a733a4)