### PR TITLE
fix: handle cleared transcription model selection

### DIFF
--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -790,6 +790,7 @@ function DictationSection() {
           <Select
             value={preset && customModel === null ? selectedModel : "custom"}
             onValueChange={(model) => {
+              if (model === null) return
               if (model === "custom")
                 setCustomModel(preset ? "" : selectedModel)
               else {


### PR DESCRIPTION
## Description
Guard the nullable Base UI Select callback before saving a transcription model, preserving the API's string-only contract and restoring dashboard typechecking.

## Release Note
Fix dashboard typechecking for transcription model settings.

## Test Plan
- [x] Run dashboard typecheck, Prettier check, and focused ESLint on the admin route.

Made by [Open SWE](https://openswe.vercel.app/agents/0194d4d9-7d75-43dc-ae06-ee3c1a4c0bdd)