### PR TITLE
fix: persist Slack button selections

### DIFF
--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -120,6 +120,7 @@ from ..utils.slack import (
     select_slack_context_messages,  # noqa: F401
     store_slack_run_mapping,  # noqa: F401
     strip_bot_mention,  # noqa: F401
+    update_slack_message,
     verify_slack_signature,
 )
 from ..utils.slack_events import (
@@ -269,6 +270,7 @@ __all__ = [
     "store_slack_run_mapping",
     "strip_bot_mention",
     "update_agent_thread_pr_state",
+    "update_slack_message",
     "upsert_agent_thread_owner_metadata",
     "verify_github_signature",
     "verify_linear_signature",

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -466,12 +466,16 @@ async def _update_selected_option_message(
     action: dict[str, common.Any],
     fallback_label: str,
 ) -> None:
-    channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
-    message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
-    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
+    channel_value = payload.get("channel")
+    channel = channel_value if isinstance(channel_value, dict) else {}
+    message_value = payload.get("message")
+    message = message_value if isinstance(message_value, dict) else {}
+    container_value = payload.get("container")
+    container = container_value if isinstance(container_value, dict) else {}
     channel_id = str(channel.get("id") or container.get("channel_id") or "")
     message_ts = str(message.get("ts") or container.get("message_ts") or "")
-    action_text = action.get("text") if isinstance(action.get("text"), dict) else {}
+    action_text_value = action.get("text")
+    action_text = action_text_value if isinstance(action_text_value, dict) else {}
     label = str(action_text.get("text") or fallback_label).strip()[:150]
     blocks = _selected_option_blocks(message, label)
     if not channel_id or not message_ts or not label or not blocks:

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -286,6 +286,12 @@ async def slack_interactivity(
                 agent_thread_id=thread_id,
             )
             return {"status": "ignored", "reason": "workflow approval not found"}
+        background_tasks.add_task(
+            _update_selected_option_message,
+            payload,
+            action,
+            "Approve workflow push" if approved else "Reject workflow push",
+        )
         if not approved:
             await common.post_slack_thread_reply(
                 channel_id=channel_id,
@@ -349,6 +355,9 @@ async def slack_interactivity(
             return {"status": "ignored", "reason": "Slack thread is not associated"}
 
         if plan_action == "cancel":
+            background_tasks.add_task(
+                _update_selected_option_message, payload, action, "Cancel plan"
+            )
             await common.post_slack_thread_reply(
                 channel_id=channel_id,
                 thread_ts=thread_ts,
@@ -367,6 +376,9 @@ async def slack_interactivity(
                 )
                 return {"status": "ignored", "reason": "approver is not the thread owner"}
             await common._set_thread_plan_mode(thread_id, False)
+            background_tasks.add_task(
+                _update_selected_option_message, payload, action, "Approve plan"
+            )
             channel_context = await common._get_slack_channel_context(channel_id)
             repo_config = await common.get_slack_repo_config(
                 channel_id,
@@ -391,6 +403,9 @@ async def slack_interactivity(
             )
             return {"status": "accepted", "message": "Plan approved, starting implementation"}
 
+        background_tasks.add_task(
+            _update_selected_option_message, payload, action, "Request plan changes"
+        )
         return {"status": "accepted", "message": "Reply to revise the plan"}
 
     if action_value.get("type") != "open_swe_option":
@@ -428,6 +443,7 @@ async def slack_interactivity(
         channel_context=channel_context,
         thread_id=thread_id,
     )
+    background_tasks.add_task(_update_selected_option_message, payload, action, response)
     background_tasks.add_task(
         service.process_slack_mention,
         {
@@ -443,6 +459,79 @@ async def slack_interactivity(
         repo_config,
     )
     return {"status": "accepted", "message": "Slack option queued"}
+
+
+async def _update_selected_option_message(
+    payload: dict[str, common.Any],
+    action: dict[str, common.Any],
+    fallback_label: str,
+) -> None:
+    channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
+    message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
+    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
+    channel_id = str(channel.get("id") or container.get("channel_id") or "")
+    message_ts = str(message.get("ts") or container.get("message_ts") or "")
+    action_text = action.get("text") if isinstance(action.get("text"), dict) else {}
+    label = str(action_text.get("text") or fallback_label).strip()[:150]
+    blocks = _selected_option_blocks(message, label)
+    if not channel_id or not message_ts or not label or not blocks:
+        return
+
+    try:
+        ok, error = await common.update_slack_message(
+            channel_id,
+            message_ts,
+            str(message.get("text") or label),
+            blocks=blocks,
+        )
+    except Exception:
+        common.logger.warning(
+            "Could not persist Slack option selection: channel=%s ts=%s",
+            channel_id,
+            message_ts,
+            exc_info=True,
+        )
+        return
+    if not ok:
+        common.logger.warning(
+            "Could not persist Slack option selection: channel=%s ts=%s error=%s",
+            channel_id,
+            message_ts,
+            error,
+        )
+
+
+def _selected_option_blocks(
+    message: dict[str, common.Any], label: str
+) -> list[dict[str, common.Any]]:
+    raw_blocks = message.get("blocks")
+    if not isinstance(raw_blocks, list):
+        return []
+
+    selected_block: dict[str, common.Any] = {
+        "type": "context",
+        "elements": [{"type": "plain_text", "text": f"Selected: {label}"}],
+    }
+    updated_blocks: list[dict[str, common.Any]] = []
+    replaced = False
+    for block in raw_blocks:
+        if not isinstance(block, dict):
+            continue
+        elements = block.get("elements")
+        if block.get("type") != "actions" or _first_open_swe_option_action(elements) is None:
+            updated_blocks.append(block)
+            continue
+        if not replaced:
+            updated_blocks.append(selected_block)
+            replaced = True
+        if isinstance(elements, list):
+            remaining = [
+                element for element in elements if _first_open_swe_option_action([element]) is None
+            ]
+            if remaining:
+                updated_blocks.append({**block, "elements": remaining})
+
+    return updated_blocks if replaced else []
 
 
 def _first_open_swe_option_action(actions: common.Any) -> dict[str, common.Any] | None:

--- a/tests/e2e/fakes.py
+++ b/tests/e2e/fakes.py
@@ -65,6 +65,29 @@ def slack_messages(channel: str) -> list[dict[str, Any]]:
     return sorted(messages, key=lambda message: message["ts"])
 
 
+def slack_message(channel: str, thread_ts: str, message_ts: str) -> dict[str, Any] | None:
+    return next(
+        (message for message in slack_thread(channel, thread_ts) if message["ts"] == message_ts),
+        None,
+    )
+
+
+def update_slack_message(
+    channel: str, message_ts: str, *, text: str, blocks: Any = None
+) -> dict[str, Any] | None:
+    for (message_channel, _thread_ts), thread_messages in SLACK_MESSAGES.items():
+        if message_channel != channel:
+            continue
+        for message in thread_messages:
+            if message["ts"] != message_ts:
+                continue
+            message["text"] = text
+            if blocks is not None:
+                message["blocks"] = blocks
+            return message
+    return None
+
+
 # --- GitHub ----------------------------------------------------------------
 PULLS: list[dict[str, Any]] = []
 REPO_PRIVATE = [False]

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -273,6 +273,9 @@ async def slack_action(request: Request) -> JSONResponse:
     user_id = str(body.get("user") or TEST_USERS[0]["slack_id"])
     if not isinstance(action, dict) or not channel_id or not thread_ts or not message_ts:
         raise HTTPException(status_code=400, detail="Missing Slack action context")
+    source_message = fakes.slack_message(channel_id, thread_ts, message_ts)
+    if source_message is None:
+        raise HTTPException(status_code=404, detail="Slack message not found")
 
     payload = {
         "type": "block_actions",
@@ -283,7 +286,12 @@ async def slack_action(request: Request) -> JSONResponse:
             "message_ts": message_ts,
             "thread_ts": thread_ts,
         },
-        "message": {"ts": message_ts, "thread_ts": thread_ts},
+        "message": {
+            "ts": message_ts,
+            "thread_ts": thread_ts,
+            "text": source_message["text"],
+            "blocks": source_message["blocks"],
+        },
         "actions": [{**action, "action_ts": fakes.next_slack_ts()}],
     }
     response = await _deliver_slack_interaction(payload)
@@ -684,6 +692,20 @@ async def slack_post_message(request: Request) -> JSONResponse:
         is_bot=True,
     )
     return _ok({"ts": ts, "message": {"ts": ts}})
+
+
+@app.post("/fake-slack/chat.update")
+async def slack_update_message(request: Request) -> JSONResponse:
+    body = await request.json()
+    message = fakes.update_slack_message(
+        str(body.get("channel") or ""),
+        str(body.get("ts") or ""),
+        text=str(body.get("text") or ""),
+        blocks=body.get("blocks"),
+    )
+    if message is None:
+        return JSONResponse({"ok": False, "error": "message_not_found"})
+    return _ok({"ts": message["ts"], "message": message})
 
 
 @app.post("/fake-slack/chat.postEphemeral")

--- a/tests/e2e/static/slack.html
+++ b/tests/e2e/static/slack.html
@@ -11,6 +11,7 @@
       .msg.bot { background: #f0f7ff; }
       .who { font-weight: 700; font-size: 0.8rem; color: #444; }
       .text { white-space: pre-wrap; }
+      .context { color: #4b5563; font-size: 0.8rem; margin-top: 0.35rem; }
       .compose { display: flex; gap: 0.5rem; margin-top: 1rem; }
       .compose input { flex: 1; padding: 0.5rem; font: inherit; }
       button { padding: 0.5rem 0.9rem; font: inherit; cursor: pointer; }
@@ -63,11 +64,22 @@
           .map((m, index) => {
             const who = m.is_bot ? "open-swe (bot)" : userNames[m.user] || m.user;
             const linked = m.text.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '<a href="$1">$2</a>');
-            return `<div class="msg ${m.is_bot ? "bot" : ""}" data-bot="${m.is_bot}" data-thread-ts="${m.thread_ts || ""}" data-message-index="${index}"><div class="who">${who}</div><div class="text">${linked}</div><div class="actions"></div></div>`;
+            return `<div class="msg ${m.is_bot ? "bot" : ""}" data-bot="${m.is_bot}" data-thread-ts="${m.thread_ts || ""}" data-message-index="${index}"><div class="who">${who}</div><div class="text">${linked}</div><div class="contexts"></div><div class="actions"></div></div>`;
           })
           .join("");
         $("thread").innerHTML = html || "<p style='color:#888'>No messages yet.</p>";
         messages.forEach((message, index) => {
+          const contextContainer = document.querySelector(`[data-message-index="${index}"] .contexts`);
+          const contexts = (message.blocks || [])
+            .filter((block) => block.type === "context")
+            .flatMap((block) => block.elements || [])
+            .filter((element) => element.type === "plain_text" && element.text);
+          for (const context of contexts) {
+            const element = document.createElement("div");
+            element.className = "context";
+            element.textContent = context.text;
+            contextContainer.appendChild(element);
+          }
           const actions = (message.blocks || [])
             .filter((block) => block.type === "actions")
             .flatMap((block) => block.elements || []);

--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -78,6 +78,8 @@ test.describe("Plan review (HTTP comments)", () => {
     ).toBeVisible();
 
     await approve.click();
+    await expect(ready).toContainText("Selected: Approve & implement");
+    await expect(ready.getByRole("button")).toHaveCount(0);
 
     const reply = page
       .locator(".msg.bot")

--- a/tests/slack/test_slack_interactivity.py
+++ b/tests/slack/test_slack_interactivity.py
@@ -1,0 +1,114 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+from urllib.parse import urlencode
+
+import pytest
+from fastapi import BackgroundTasks, Request
+
+from agent.webhooks import slack_routes
+
+
+def _request(payload: dict[str, Any]) -> Request:
+    body = urlencode({"payload": json.dumps(payload)}).encode()
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/webhooks/slack/interactivity",
+            "headers": [],
+        },
+        receive,
+    )
+
+
+def _option_payload() -> dict[str, Any]:
+    action = {
+        "action_id": "open_swe_option_select_1",
+        "action_ts": "3.0",
+        "text": {"type": "plain_text", "text": "Option B"},
+        "value": json.dumps({"type": "open_swe_option", "response": "Option B"}),
+    }
+    return {
+        "actions": [action],
+        "channel": {"id": "C1"},
+        "message": {
+            "ts": "2.0",
+            "thread_ts": "1.0",
+            "text": "Pick one",
+            "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": "Pick one"}},
+                {"type": "actions", "elements": [action]},
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": "Open in Web"}],
+                },
+            ],
+        },
+        "user": {"id": "U1"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_selected_option_updates_original_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _option_payload()
+    update = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr(slack_routes.common, "update_slack_message", update)
+
+    await slack_routes._update_selected_option_message(payload, payload["actions"][0], "Option B")
+
+    update.assert_awaited_once_with(
+        "C1",
+        "2.0",
+        "Pick one",
+        blocks=[
+            {"type": "section", "text": {"type": "mrkdwn", "text": "Pick one"}},
+            {
+                "type": "context",
+                "elements": [{"type": "plain_text", "text": "Selected: Option B"}],
+            },
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": "Open in Web"}],
+            },
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_option_interaction_schedules_update_before_agent_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _option_payload()
+    update = AsyncMock()
+    process = AsyncMock()
+    monkeypatch.setattr(slack_routes.common, "verify_slack_signature", lambda **_kwargs: True)
+    monkeypatch.setattr(slack_routes.common, "get_client", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        slack_routes.common, "lookup_slack_thread_id", AsyncMock(return_value="thread-1")
+    )
+    monkeypatch.setattr(
+        slack_routes.common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"name": "proj-open-swe"}),
+    )
+    monkeypatch.setattr(
+        slack_routes.common,
+        "get_slack_repo_config",
+        AsyncMock(return_value={"owner": "langchain-ai", "name": "open-swe"}),
+    )
+    monkeypatch.setattr(slack_routes, "_update_selected_option_message", update)
+    monkeypatch.setattr(slack_routes.service, "process_slack_mention", process)
+    background_tasks = BackgroundTasks()
+
+    result = await slack_routes.slack_interactivity(_request(payload), background_tasks)
+
+    assert result == {"status": "accepted", "message": "Slack option queued"}
+    assert [task.func for task in background_tasks.tasks] == [update, process]
+    await background_tasks()
+    update.assert_awaited_once_with(payload, payload["actions"][0], "Option B")
+    process.assert_awaited_once()


### PR DESCRIPTION
## Description
Slack buttons reset after clicks because the interaction callback never updates the original Block Kit message. Accepted option and approval actions now use `chat.update` to replace controls with a persistent selected state while preserving other blocks.
## Release Note
Slack option buttons now show persistent selection state after accepted clicks.
## Test Plan
- [x] Playwright: click a Slack plan option and verify the buttons are replaced with the selected value.

Made by [Open SWE](https://openswe.vercel.app/agents/666df63b-840f-5b99-96d5-e37a5e65af27)