### PR TITLE
fix: standardize user-facing Open SWE branding

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -1348,7 +1348,7 @@ async def list_repos(
     refresh: bool = False,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
-    """List repos where open-swe is installed and the user has access.
+    """List repos where Open SWE is installed and the user has access.
 
     Served from the per-login cache (stale-while-revalidate) unless
     ``refresh=true``, because the fan-out over every installation takes 10s+

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -214,7 +214,7 @@ The admin panel (**Admin → LLM Gateway**) exposes a per-workspace toggle store
 
 Routing is applied centrally in `make_model` (`agent/utils/model.py`), which resolves the effective on/off and delegates URL/key wiring to `agent/utils/gateway.py`. **OpenAI, Anthropic, Fireworks, and Google Gemini** are routed (their LangChain integrations accept `base_url` + `api_key`); Google Vertex (service-account auth) and any other provider call the provider directly with a logged warning.
 
-**Caveat — OpenAI endpoint:** open-swe uses the OpenAI Responses API by default because OpenAI reasoning models with function tools reject `reasoning_effort` on Chat Completions. Direct OpenAI calls use a `wss://` base URL; gateway-routed OpenAI uses the HTTPS gateway base URL with Responses enabled. Set `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=false` only if you need to force Chat Completions. Anthropic and Fireworks are unaffected.
+**Caveat — OpenAI endpoint:** Open SWE uses the OpenAI Responses API by default because OpenAI reasoning models with function tools reject `reasoning_effort` on Chat Completions. Direct OpenAI calls use a `wss://` base URL; gateway-routed OpenAI uses the HTTPS gateway base URL with Responses enabled. Set `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES=false` only if you need to force Chat Completions. Anthropic and Fireworks are unaffected.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -60,7 +60,7 @@ Write this down. You'll use it in the callback URL below and again in step 4 whe
 
 1. Go to **GitHub Settings → Developer settings → [GitHub Apps](https://github.com/settings/apps) → [New GitHub App](https://github.com/settings/apps/new)**
 2. Fill in:
-   - **App name**: `open-swe` (or your preferred name)
+   - **App name**: `Open SWE` (or your preferred name)
    - **Homepage URL**: This can be any valid URL — it's only shown on the GitHub Marketplace page (which you won't be using). Use something like `https://github.com/langchain-ai/open-swe`
    - **Callback URL**: GitHub Apps allow multiple callback URLs (one per line). Add **both**:
      1. `https://smith.langchain.com/host-oauth-callback/<your-provider-id>` — replace `<your-provider-id>` with the ID you chose in step 3a (e.g. `https://smith.langchain.com/host-oauth-callback/your-org-github-oauth`). This is the **agent-runtime** OAuth callback, brokered by LangSmith (step 4b).
@@ -306,7 +306,7 @@ Open SWE listens for Linear comments that mention `@openswe`.
 
 1. In Linear, go to **Settings → API → Webhooks → New webhook**
 2. Fill in:
-   - **Label**: `open-swe`
+   - **Label**: `Open SWE`
    - **URL**: `https://<your-ngrok-url>/webhooks/linear` — use the ngrok URL from step 2
    - **Secret**: generate with `openssl rand -hex 32` — save this as `LINEAR_WEBHOOK_SECRET`
 3. Under **Data change events**, enable **Comments → Create** only
@@ -315,7 +315,7 @@ Open SWE listens for Linear comments that mention `@openswe`.
 **Get your API key:**
 
 1. Go to **Settings → API → Personal API keys → New API key**
-2. Name it `open-swe`, select **All access**, and copy the key
+2. Name it `Open SWE`, select **All access**, and copy the key
 3. Save it as `LINEAR_API_KEY`
 
 **Configure team-to-repo mapping:**

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -360,17 +360,17 @@ async def fake_github_authorize(redirect_to: str = "", login: str = "") -> Respo
             for u in TEST_USERS
         )
         return HTMLResponse(
-            f"""<!doctype html><meta charset=utf-8><title>GitHub · Authorize open-swe</title>
+            f"""<!doctype html><meta charset=utf-8><title>GitHub · Authorize Open SWE</title>
             <body style="font-family:system-ui;max-width:420px;margin:3rem auto;padding:0 1rem">
             <main data-testid="fake-github-login">
-              <h1 style="font-size:1.1rem">Authorize open-swe</h1>
+              <h1 style="font-size:1.1rem">Authorize Open SWE</h1>
               <p style="color:#888;font-size:0.9rem">Pick a fake GitHub account to continue.</p>
               <form method=get action=/fake-gh/login/oauth/authorize>
                 <input type=hidden name=redirect_to value="{escape(dest, quote=True)}">
                 <label>GitHub user
                   <select name=login style="font:inherit;padding:0.4rem">{options}</select>
                 </label>
-                <button style="font:inherit;padding:0.45rem 0.9rem;cursor:pointer">Authorize open-swe</button>
+                <button style="font:inherit;padding:0.45rem 0.9rem;cursor:pointer">Authorize Open SWE</button>
               </form>
             </main>
             </body>"""

--- a/tests/e2e/static/slack.html
+++ b/tests/e2e/static/slack.html
@@ -61,7 +61,7 @@
       function render(messages) {
         const html = messages
           .map((m, index) => {
-            const who = m.is_bot ? "open-swe (bot)" : userNames[m.user] || m.user;
+            const who = m.is_bot ? "Open SWE (bot)" : userNames[m.user] || m.user;
             const linked = m.text.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '<a href="$1">$2</a>');
             return `<div class="msg ${m.is_bot ? "bot" : ""}" data-bot="${m.is_bot}" data-thread-ts="${m.thread_ts || ""}" data-message-index="${index}"><div class="who">${who}</div><div class="text">${linked}</div><div class="actions"></div></div>`;
           })

--- a/tests/e2e/tests/plan_review.spec.ts
+++ b/tests/e2e/tests/plan_review.spec.ts
@@ -154,14 +154,14 @@ test.describe("Plan review (HTTP comments)", () => {
     await expect(loggedOut).toHaveURL(
       new RegExp(`/login\\?redirect=.*${threadId}.*plan`),
     );
-    await expect(loggedOut.getByText("Sign in to open-swe")).toBeVisible({
+    await expect(loggedOut.getByText("Sign in to Open SWE")).toBeVisible({
       timeout: 30_000,
     });
     await loggedOut.getByRole("link", { name: "Continue with GitHub" }).click();
     await expect(loggedOut).toHaveURL(/\/fake-gh\/login\/oauth\/authorize/);
     await expect(loggedOut.getByTestId("fake-github-login")).toBeVisible();
     await loggedOut.getByLabel("GitHub user").selectOption(OWNER.login);
-    await loggedOut.getByRole("button", { name: "Authorize open-swe" }).click();
+    await loggedOut.getByRole("button", { name: "Authorize Open SWE" }).click();
     await expect(loggedOut).toHaveURL(new RegExp(`/agents/${threadId}/plan$`));
     await expect(loggedOut.getByTestId("plan-review")).toBeVisible({
       timeout: 30_000,

--- a/tests/e2e/tests/ssr.spec.ts
+++ b/tests/e2e/tests/ssr.spec.ts
@@ -14,7 +14,7 @@ test.describe("server rendering", () => {
 
   test("the login page arrives server-rendered", async ({ request }) => {
     const html = await (await request.get("/login")).text();
-    expect(html).toContain("Sign in to open-swe");
+    expect(html).toContain("Sign in to Open SWE");
   });
 
   test("an authenticated route is rendered with the session already resolved", async ({

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -29,7 +29,7 @@ export const Route = createRootRouteWithContext<{
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
       { name: "theme-color", content: "#1c1c1c" },
-      { title: "open-swe" },
+      { title: "Open SWE" },
     ],
     links: [
       { rel: "stylesheet", href: appCss },

--- a/ui/src/routes/login.tsx
+++ b/ui/src/routes/login.tsx
@@ -61,7 +61,7 @@ function Login() {
     <main className="flex min-h-svh items-center justify-center p-6">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle>Sign in to open-swe</CardTitle>
+          <CardTitle>Sign in to Open SWE</CardTitle>
           <CardDescription>
             Use your GitHub account. We'll configure your default model,
             reasoning effort, and default repo for Slack/Linear/GitHub triggered

--- a/ui/src/routes/review.tsx
+++ b/ui/src/routes/review.tsx
@@ -280,7 +280,7 @@ function RepositoriesSection({ canEdit: _canEdit }: { canEdit: boolean }) {
         )}
         {!loading && grouped.length === 0 && (
           <p className="px-4 py-3 text-xs text-muted-foreground">
-            No GitHub App installations found. Install the open-swe GitHub App
+            No GitHub App installations found. Install the Open SWE GitHub App
             on an account or org to manage repos here.
           </p>
         )}


### PR DESCRIPTION
## Description
Standardizes product-name copy to `Open SWE` across browser titles, dashboard text, maintained docs, OpenAPI prose, and E2E fixtures while preserving technical identifiers.

## Release Note
Fixed user-facing Open SWE capitalization across dashboard titles and copy.

## Test Plan
- [x] Verify SSR login and plan OAuth E2E flows render the updated branding.

Made by [Open SWE](https://openswe.vercel.app/agents/d6a48ef7-420a-57df-a43a-0644c1701052)