### PR TITLE
fix(ui): proxy /webhooks through the hosted dashboard

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -141,9 +141,14 @@ if (process.env.VERCEL && !process.env.DASHBOARD_API_URL) {
 const DASHBOARD_API_URL =
   process.env.DASHBOARD_API_URL ?? "http://localhost:2024"
 
-// A deployed dashboard only fronts the API; dev fronts every backend path so a
-// local mock backend's login redirects resolve on this origin.
-const PROXIED_PREFIXES = IS_PRODUCTION ? ["/dashboard/api"] : BACKEND_PREFIXES
+// A deployed dashboard fronts the API and the webhook endpoints — a webhook
+// sender only ever gets one URL per instance, and unproxied paths fall through
+// to the app router, which answers a signed POST with a login redirect. Dev
+// fronts every backend path so a local mock backend's login redirects resolve on
+// this origin.
+const PROXIED_PREFIXES = IS_PRODUCTION
+  ? ["/dashboard/api", "/webhooks"]
+  : BACKEND_PREFIXES
 
 // Nitro's proxy follows redirects itself, which swallows the OAuth 3xx hops: the
 // browser's address bar never moves and login dies at the first hop. Vercel's


### PR DESCRIPTION
A hosted dashboard proxies only `/dashboard/api/**` to its backend. Every other
path falls through to the app router, so a webhook POST to
`https://dev.open-swe.langchain.dev/webhooks/slack` answers `307 → /login`
instead of the endpoint. Slack's URL verification fails on that redirect, and
GitHub/Linear deliveries to the same host would be silently swallowed.

`/webhooks` is already in `BACKEND_PREFIXES`; production just dropped it. Adding
it to the deployed prefix list gives each instance a single public hostname for
both its dashboard and its webhook senders, instead of requiring senders to know
the LangGraph deployment URL.

Nitro streams the request body through the proxy unchanged, so the Slack
signature — computed over the raw bytes — still verifies at
`agent/webhooks/slack_routes.py`.

## Test Plan

- [x] Reproduced the failure: `POST https://dev.open-swe.langchain.dev/webhooks/slack` with a `url_verification` payload returns `307` to `/login?redirect=%2Fwebhooks%2Fslack`
- [x] Confirmed the same payload against the backend host directly verifies (Slack Request URL shows Verified for `…us.langgraph.app/webhooks/slack`)
- [x] Confirmed `/webhooks` is already present in `BACKEND_PREFIXES`, so dev behaviour is unchanged
