### PR TITLE
ci: publish the preview dashboard image on every preview build

### DIFF
--- a/.github/workflows/publish_preview_dashboard.yml
+++ b/.github/workflows/publish_preview_dashboard.yml
@@ -1,0 +1,73 @@
+name: Publish preview dashboard image
+
+# `preview` is force-pushed on every push to main and on every label event, and
+# the GKE deployment pulls `:preview` on restart. Publishing here is what makes a
+# merge to main reach dev.open-swe.langchain.dev.
+on:
+  push:
+    branches: [preview]
+  workflow_dispatch:
+
+# A force-push mid-build would otherwise race an older commit onto the tag.
+concurrency:
+  group: publish-preview-dashboard
+  cancel-in-progress: true
+
+env:
+  IMAGE: us-docker.pkg.dev/langchain-artifacts/langchain/open-swe-dashboard
+
+jobs:
+  publish:
+    name: Build and push :preview
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Check configuration
+        run: |
+          test -n "${{ vars.GCP_WIF_PROVIDER }}" || {
+            echo "GCP_WIF_PROVIDER is unset. Set it and GCP_CI_SERVICE_ACCOUNT from" >&2
+            echo "the open_swe_ci outputs in langchain-ai/deployments." >&2
+            exit 1
+          }
+          test -n "${{ vars.PREVIEW_DASHBOARD_API_URL }}" || {
+            echo "PREVIEW_DASHBOARD_API_URL is unset. It is the preview backend this" >&2
+            echo "image belongs to, and ui/Dockerfile has no default on purpose." >&2
+            exit 1
+          }
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v3.0.1
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+
+      - uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Build and push
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ui/Dockerfile
+          build-args: DASHBOARD_API_URL=${{ vars.PREVIEW_DASHBOARD_API_URL }}
+          # The commit tag is what makes a rollback a tag swap rather than a rebuild.
+          tags: |
+            ${{ env.IMAGE }}:preview
+            ${{ env.IMAGE }}:${{ github.sha }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "Pushed \`${IMAGE}:preview\` (${GITHUB_SHA})." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo 'Roll it: `kubectl rollout restart deployment/open-swe-dashboard -n open-swe-dev`' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`us-docker.pkg.dev/langchain-artifacts/langchain/open-swe-dashboard:preview` is
built by hand today, so a merge to `main` only reaches
`dev.open-swe.langchain.dev` when someone remembers to run a local
`docker build && docker push`. This publishes it on every `preview` build
instead.

`preview` is force-pushed on every push to `main` and on every label event, so
`concurrency` with `cancel-in-progress` keeps an older commit from racing a newer
one onto the moving tag. Each build also gets an immutable `:<sha>` tag, which
turns a rollback into a tag swap rather than a rebuild.

Auth is keyless via the existing `github-actions` workload identity pool, not a
service-account key.

**Blocked on `langchain-ai/deployments`** granting the service account push
access. Until that lands and these Actions *variables* are set, the job fails
fast in its first step with a message naming the missing one:

| Variable | Source |
|---|---|
| `GCP_WIF_PROVIDER` | `open_swe_ci_wif_provider` output |
| `GCP_CI_SERVICE_ACCOUNT` | `open_swe_ci_service_account` output |
| `PREVIEW_DASHBOARD_API_URL` | the preview backend this image is built for |

`DASHBOARD_API_URL` comes from a variable rather than being committed here: it is
a property of the deployment, not of the app, and `ui/Dockerfile` has no default
on purpose — a fallback would be production's backend, silently inherited.

The rollout stays manual — `kubectl rollout restart deployment/open-swe-dashboard
-n open-swe-dev` — and the run summary prints that command. Automating it needs a
cluster role this grant deliberately excludes.

## Test Plan

- [x] YAML parses; single `publish` job, triggers are `push: [preview]` + `workflow_dispatch`
- [x] Confirmed `open-swe` has no `GOOGLE_CREDENTIALS` secret, so keyless auth is the only option that works here
- [x] Confirmed no backend URL is committed in the workflow
