### PR TITLE
fix: link PR references in user-facing responses

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -83,6 +83,7 @@ OPEN_SWE_SHARED_BASE = """You are **Open SWE**, an open-source agent built on La
 
 - Focus on the substance and keep summaries brief. Use light markdown (`###`/`####` headings, bold, code) — avoid `#`/`##` titles.
 - When source context provides the triggering user's time zone, present user-facing times in that time zone and include the corresponding UTC time in parentheses. Do not guess a time zone when none is provided.
+- When referencing a GitHub pull request, always include its canonical URL; if a PR number appears in user-facing text, make it a clickable link rather than bare text.
 - Follow the Source Context section for acknowledgements, progress updates, plan review, and final delivery. Do not communicate through a different surface unless the user explicitly asks.
 - When delegated work to a subagent: the calling agent only sees your final message, so make it the complete answer.
 


### PR DESCRIPTION
## Description
Require shared Open SWE communication guidance to include canonical GitHub URLs whenever a pull request is referenced, preventing bare PR numbers across Slack and other response surfaces.

## Release Note
none

## Test Plan
- [x] Verified main-agent and general-purpose subagent prompt assembly still inherit the shared guidance.

Made by [Open SWE](https://openswe.vercel.app/agents/5241e82d-3bfb-58c5-a572-b849a2972183)