### PR TITLE
refactor(ui): read the backend URL at runtime, not build time

### DIFF
--- a/.github/workflows/publish_preview_dashboard.yml
+++ b/.github/workflows/publish_preview_dashboard.yml
@@ -33,11 +33,6 @@ jobs:
             echo "the open_swe_ci outputs in langchain-ai/deployments." >&2
             exit 1
           }
-          test -n "${{ vars.PREVIEW_DASHBOARD_API_URL }}" || {
-            echo "PREVIEW_DASHBOARD_API_URL is unset. It is the preview backend this" >&2
-            echo "image belongs to, and ui/Dockerfile has no default on purpose." >&2
-            exit 1
-          }
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3.0.0
@@ -57,7 +52,6 @@ jobs:
         with:
           context: .
           file: ui/Dockerfile
-          build-args: DASHBOARD_API_URL=${{ vars.PREVIEW_DASHBOARD_API_URL }}
           # The commit tag is what makes a rollback a tag swap rather than a rebuild.
           tags: |
             ${{ env.IMAGE }}:preview

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -648,7 +648,7 @@ pnpm install          # from the repo root: ui/ and desktop/ are one pnpm worksp
 pnpm run dev          # turbo -> vite dev --port 3000 -> http://localhost:3000
 ```
 
-No `ui/.env` is needed: the dev server proxies `/dashboard/api/*` to `DASHBOARD_API_URL`, which defaults to `http://localhost:2024`. Point it elsewhere by exporting that variable before `pnpm run dev`. It is read at build time, so a production build bakes in the backend it proxies to.
+No `ui/.env` is needed: the dev server proxies `/dashboard/api/*` to `DASHBOARD_API_URL`, which defaults to `http://localhost:2024`. Point it elsewhere by exporting that variable before `pnpm run dev`. It is read at request time, so the same build can front any backend.
 
 Because the browser only ever talks to `http://localhost:3000`, no **CORS** preflight is involved. `DASHBOARD_ALLOWED_ORIGINS="http://localhost:3000"` is still required, though: the same allowlist is the backend's CSRF gate for every non-GET request, and it compares the browser's `Origin` — the dashboard's — against the origins it knows. Without it, the dashboard reads fine and every save returns `403 CSRF check failed`.
 
@@ -756,11 +756,11 @@ The `langgraph.json` at the project root defines the graphs and HTTP app baked i
 
 **Backend — LangGraph Cloud / Platform:** alternatively, push your code to a GitHub repository, connect the repo to LangGraph Cloud, set the same environment variables in the deployment config, and use the hosted deployment URL for `LANGGRAPH_URL` and webhook callbacks.
 
-**Dashboard** — the `ui/` app deploys to [Vercel](https://vercel.com/). The build detects Vercel and emits a Nitro server that renders routes on request, so set `DASHBOARD_API_URL` in the Vercel project to your hosted backend URL. Browser requests to `/dashboard/api/*` are rewritten to it at the platform edge (no function in the path, so streaming responses are unaffected), and server renders call it directly with the request's `osw_session` cookie forwarded.
+**Dashboard** — the `ui/` app builds to a Nitro server that renders routes on request. Set `DASHBOARD_API_URL` in its environment to your hosted backend URL; it is read per request, so one image serves any backend. Browser requests to `/dashboard/api/*` and webhook deliveries to `/webhooks/*` are proxied to it, and server renders call it directly with the request's `osw_session` cookie forwarded.
 
 Requests are therefore **same-origin**: set both `DASHBOARD_API_BASE_URL` and the GitHub App dashboard callback URL to the Vercel/dashboard origin (for example, `https://your-dashboard.vercel.app/dashboard/api/auth/callback`). The OAuth callback response then sets the `osw_session` cookie on the dashboard host, and later `/dashboard/api/*` requests include it.
 
-Alternatively, you can have the browser call the backend cross-origin: set `VITE_DASHBOARD_API_BASE_URL` to the hosted backend origin, set `DASHBOARD_API_BASE_URL` to that same backend origin, and include the dashboard origin in `DASHBOARD_ALLOWED_ORIGINS`. Keep `DASHBOARD_API_URL` pointed at the same backend so server renders reach it too. In this mode `osw_session` belongs to the backend's origin, so the dashboard's own requests never carry it and the session is resolved on the client instead — pages render unauthenticated and fill in after hydration.
+Alternatively, you can have the browser call the backend cross-origin: set `VITE_DASHBOARD_API_BASE_URL` to the hosted backend origin, set `DASHBOARD_API_BASE_URL` to that same backend origin, and include the dashboard origin in `DASHBOARD_ALLOWED_ORIGINS`. Keep `DASHBOARD_API_URL` pointed at the same backend so server renders and the webhook proxy reach it too. In this mode `osw_session` belongs to the backend's origin, so the dashboard's own requests never carry it and the session is resolved on the client instead — pages render unauthenticated and fill in after hydration.
 
 ## Troubleshooting
 

--- a/docs/PREVIEW_ENV.md
+++ b/docs/PREVIEW_ENV.md
@@ -54,27 +54,22 @@ copy across by mistake:
 Scope preview with its own `ALLOWED_GITHUB_ORGS` / `ALLOWED_GITHUB_REPOS` and install its
 GitHub App only on the repositories it should touch.
 
-## Vercel
+## Dashboard
 
-Root directory `ui/`, production branch `preview`, and `DASHBOARD_API_URL` set to the
-preview LangGraph deployment URL. Requests stay same-origin — the build turns that
-variable into the platform rewrite for `/dashboard/api/*` — so `DASHBOARD_API_BASE_URL`,
-the GitHub App callback URL, and the `DASHBOARD_ALLOWED_ORIGINS` entry must all point at
-the preview Vercel domain. That allowlist is the backend's CSRF gate as well as its CORS
-config, so a missing entry leaves the preview dashboard readable but unable to save.
+The dashboard reads `DASHBOARD_API_URL` — the backend it fronts — from its own
+environment at request time, so one built image serves any deployment. Set it wherever
+the dashboard runs (the pod environment on Kubernetes, the project settings on Vercel).
+It has no default: a fallback would be production's backend, and preview would inherit it
+and drive production's agents, threads, and sandboxes.
 
-`ui/vercel.json` limits git deployments to `main` and `preview`, the two projects'
-production branches, so feature branches no longer build. Both projects read that one file
-(same root directory), so each still preview-deploys the other's production branch — to
-stop the preview project building anything but `preview`, set its Ignored Build Step to
-`[ "$VERCEL_ENV" != "production" ]` in the Vercel dashboard.
+Requests stay same-origin — the server proxies `/dashboard/api/*` and `/webhooks/*` to
+that backend — so `DASHBOARD_API_BASE_URL`, the GitHub App callback URL, and the
+`DASHBOARD_ALLOWED_ORIGINS` entry must all point at the dashboard's own domain, not the
+backend's. That allowlist is the backend's CSRF gate as well as its CORS config, so a
+missing entry leaves the dashboard readable but unable to save.
 
-> The build **fails** if `DASHBOARD_API_URL` is unset on Vercel, rather than falling back
-> to a default — a default would be production's backend, and preview would inherit it
-> and drive production's agents, threads, and sandboxes from the preview dashboard.
->
-> `DASHBOARD_API_URL` is read at build time. A change to it only takes effect on the next
-> deployment, not on redeploy of an existing build.
+Webhook senders get the dashboard's domain too: `/webhooks/*` is proxied for exactly this
+reason, so each instance publishes one hostname rather than leaking its LangGraph URL.
 
 ## Verifying isolation
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      h3:
+        specifier: 2.0.1-rc.22
+        version: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
       lexical:
         specifier: ^0.41.0
         version: 0.41.0
@@ -2181,6 +2184,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -9258,7 +9262,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -10380,13 +10384,13 @@ snapshots:
 
   node-abi@4.33.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-addon-api@7.1.1: {}
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-gyp@12.4.0:
     dependencies:
@@ -10395,7 +10399,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 7.29.0

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -37,10 +37,17 @@ export default async function globalSetup() {
     });
   }
 
+  // DASHBOARD_API_URL is read per request, so the running server needs it too —
+  // not just the build.
   const child = spawn("node", [server], {
     cwd: ui,
     stdio: "inherit",
-    env: { ...process.env, HOST: "127.0.0.1", PORT: uiPort },
+    env: {
+      ...process.env,
+      HOST: "127.0.0.1",
+      PORT: uiPort,
+      DASHBOARD_API_URL: harness,
+    },
   });
   child.on("exit", (code) => {
     if (code) throw new Error(`ui server exited with code ${code}`);

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,7 @@
-# Build from the repo root: docker build -f ui/Dockerfile --build-arg DASHBOARD_API_URL=... .
+# Build from the repo root: docker build -f ui/Dockerfile .
+#
+# The backend this dashboard fronts is read from DASHBOARD_API_URL at runtime, so
+# one image serves any deployment. Set it in the deployment's environment.
 FROM node:24-alpine AS build
 
 RUN corepack enable
@@ -10,13 +13,6 @@ RUN pnpm install --frozen-lockfile --filter open-swe-dashboard...
 
 COPY ui ui
 
-# Baked into the bundle as the `/dashboard/api/*` proxy target and the backend
-# server renders call, so one image belongs to exactly one backend. No default:
-# a fallback would be production's backend, silently inherited by every other
-# deployment. See docs/PREVIEW_ENV.md.
-ARG DASHBOARD_API_URL
-RUN test -n "$DASHBOARD_API_URL" || (echo "DASHBOARD_API_URL build-arg is required" >&2; exit 1)
-ENV DASHBOARD_API_URL=$DASHBOARD_API_URL
 RUN pnpm --filter open-swe-dashboard run build
 
 FROM node:24-alpine

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "@tanstack/router-plugin": "^1.166.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "h3": "2.0.1-rc.22",
     "lexical": "^0.41.0",
     "lucide-react": "^1.16.0",
     "monaco-editor": "^0.52.2",

--- a/ui/server/backend-proxy.ts
+++ b/ui/server/backend-proxy.ts
@@ -1,3 +1,5 @@
+import { proxyRequest } from "h3"
+
 // Read per request, not at build time: which backend an instance fronts is a
 // property of the deployment, so it lives in the pod's environment.
 function backendOrigin(): string {
@@ -11,36 +13,14 @@ function backendOrigin(): string {
   return configured
 }
 
-export default async function backendProxy(event: {
-  req: Request
-}): Promise<Response> {
+export default async function backendProxy(
+  event: Parameters<typeof proxyRequest>[0]
+) {
   const url = new URL(event.req.url)
 
   // `redirect: "manual"` keeps the OAuth 3xx hops intact — following them here
-  // would leave the browser's address bar where it started. The body is passed
-  // through as a stream, which is what keeps webhook signatures verifiable.
-  const upstream = await fetch(
-    `${backendOrigin()}${url.pathname}${url.search}`,
-    {
-      method: event.req.method,
-      headers: event.req.headers,
-      body: event.req.body,
-      redirect: "manual",
-      // @ts-expect-error -- required by undici to stream a request body
-      duplex: "half",
-    }
-  )
-
-  // undici decompresses the body but leaves the upstream framing headers on it,
-  // so forwarding them makes the browser decode an already-decoded body.
-  const headers = new Headers(upstream.headers)
-  headers.delete("content-encoding")
-  headers.delete("content-length")
-  headers.delete("transfer-encoding")
-
-  return new Response(upstream.body, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers,
+  // would leave the browser's address bar where it started.
+  return proxyRequest(event, `${backendOrigin()}${url.pathname}${url.search}`, {
+    fetchOptions: { redirect: "manual" },
   })
 }

--- a/ui/server/backend-proxy.ts
+++ b/ui/server/backend-proxy.ts
@@ -19,12 +19,28 @@ export default async function backendProxy(event: {
   // `redirect: "manual"` keeps the OAuth 3xx hops intact — following them here
   // would leave the browser's address bar where it started. The body is passed
   // through as a stream, which is what keeps webhook signatures verifiable.
-  return fetch(`${backendOrigin()}${url.pathname}${url.search}`, {
-    method: event.req.method,
-    headers: event.req.headers,
-    body: event.req.body,
-    redirect: "manual",
-    // @ts-expect-error -- required by undici to stream a request body
-    duplex: "half",
+  const upstream = await fetch(
+    `${backendOrigin()}${url.pathname}${url.search}`,
+    {
+      method: event.req.method,
+      headers: event.req.headers,
+      body: event.req.body,
+      redirect: "manual",
+      // @ts-expect-error -- required by undici to stream a request body
+      duplex: "half",
+    }
+  )
+
+  // undici decompresses the body but leaves the upstream framing headers on it,
+  // so forwarding them makes the browser decode an already-decoded body.
+  const headers = new Headers(upstream.headers)
+  headers.delete("content-encoding")
+  headers.delete("content-length")
+  headers.delete("transfer-encoding")
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
   })
 }

--- a/ui/server/backend-proxy.ts
+++ b/ui/server/backend-proxy.ts
@@ -1,0 +1,30 @@
+// Read per request, not at build time: which backend an instance fronts is a
+// property of the deployment, so it lives in the pod's environment.
+function backendOrigin(): string {
+  const configured = (process.env.DASHBOARD_API_URL ?? "").replace(/\/$/, "")
+  if (!configured) {
+    throw new Error(
+      "DASHBOARD_API_URL is not set. It is the backend this dashboard fronts; " +
+        "there is no default because a fallback would be production's backend."
+    )
+  }
+  return configured
+}
+
+export default async function backendProxy(event: {
+  req: Request
+}): Promise<Response> {
+  const url = new URL(event.req.url)
+
+  // `redirect: "manual"` keeps the OAuth 3xx hops intact — following them here
+  // would leave the browser's address bar where it started. The body is passed
+  // through as a stream, which is what keeps webhook signatures verifiable.
+  return fetch(`${backendOrigin()}${url.pathname}${url.search}`, {
+    method: event.req.method,
+    headers: event.req.headers,
+    body: event.req.body,
+    redirect: "manual",
+    // @ts-expect-error -- required by undici to stream a request body
+    duplex: "half",
+  })
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -122,48 +122,24 @@ const SHIKI_LANGS = [
 
 // Browser `/dashboard/api/*` calls are proxied to the Python backend by the
 // server rather than sent cross-origin, so the session cookie stays same-origin.
-// On Vercel this route rule compiles to a platform rewrite, keeping streaming
-// responses out of the serverless function.
 const IS_PRODUCTION = process.env.NODE_ENV === "production"
 
-// No default on a hosted build. A fallback here would be a production backend
-// URL, which the preview deployment would silently inherit — pointing preview's
-// dashboard at production's agents, threads, and sandboxes. Failing the build is
-// the recoverable outcome.
-if (process.env.VERCEL && !process.env.DASHBOARD_API_URL) {
-  throw new Error(
-    "DASHBOARD_API_URL is required for a hosted build: it becomes the platform " +
-      "rewrite for /dashboard/api/* and the backend that server renders call. " +
-      "Set it in the Vercel project to this deployment's own backend URL."
-  )
-}
-
-const DASHBOARD_API_URL =
-  process.env.DASHBOARD_API_URL ?? "http://localhost:2024"
-
-// A deployed dashboard fronts the API and the webhook endpoints — a webhook
-// sender only ever gets one URL per instance, and unproxied paths fall through
-// to the app router, which answers a signed POST with a login redirect. Dev
-// fronts every backend path so a local mock backend's login redirects resolve on
-// this origin.
-const PROXIED_PREFIXES = IS_PRODUCTION
-  ? ["/dashboard/api", "/webhooks"]
-  : BACKEND_PREFIXES
-
-// Nitro's proxy follows redirects itself, which swallows the OAuth 3xx hops: the
-// browser's address bar never moves and login dies at the first hop. Vercel's
-// rewrite passes 3xx through on its own, and any fetchOptions here would push
-// these requests through the serverless function instead of that rewrite.
-const PROXY_OPTIONS = process.env.VERCEL
+// Dev proxies every backend path in-process so a local mock backend's login
+// redirects resolve on this origin. A deployed build proxies at runtime instead,
+// in server/middleware/backend-proxy.ts, so one image can front any backend.
+const devRouteRules = IS_PRODUCTION
   ? {}
-  : { fetchOptions: { redirect: "manual" as const } }
-
-const backendRouteRules = Object.fromEntries(
-  PROXIED_PREFIXES.map((prefix) => [
-    `${prefix}/**`,
-    { proxy: { to: `${DASHBOARD_API_URL}${prefix}/**`, ...PROXY_OPTIONS } },
-  ])
-)
+  : Object.fromEntries(
+      BACKEND_PREFIXES.map((prefix) => [
+        `${prefix}/**`,
+        {
+          proxy: {
+            to: `${process.env.DASHBOARD_API_URL ?? "http://localhost:2024"}${prefix}/**`,
+            fetchOptions: { redirect: "manual" as const },
+          },
+        },
+      ])
+    )
 
 // The Electron app and the service worker's offline navigation both load a
 // client-only `_shell.html`. SSR alone doesn't emit one, so prerender `/` with
@@ -182,11 +158,6 @@ const SHELL_PAGE = {
 
 const config = defineConfig({
   base: "/",
-  // Server renders read the same resolved target as the proxy route rule, so the
-  // two can't disagree about which backend the app is talking to.
-  define: {
-    "process.env.DASHBOARD_API_URL": JSON.stringify(DASHBOARD_API_URL),
-  },
   optimizeDeps: {
     include: [
       "streamdown",
@@ -205,7 +176,18 @@ const config = defineConfig({
     mockHarnessProxy(),
     devtools(),
     nitro({
-      routeRules: backendRouteRules,
+      routeRules: devRouteRules,
+      // Registered explicitly: nitro's convention scan does not reach this
+      // directory under the vite plugin. Deployed builds only — dev proxies the
+      // same prefixes through devRouteRules, which has a localhost default the
+      // handler deliberately refuses to have. Only the two prefixes a deployed
+      // dashboard fronts, since proxying `/static` would shadow nitro's assets.
+      handlers: IS_PRODUCTION
+        ? ["/dashboard/api", "/webhooks"].map((prefix) => ({
+            route: `${prefix}/**`,
+            handler: "./server/backend-proxy.ts",
+          }))
+        : [],
       // Nitro gives every node_modules package its own server chunk. The
       // LangGraph SDK reaches CJS-only `eventemitter3` through `p-queue`, and
       // splitting that cycle puts the CommonJS interop helper in the SDK's chunk


### PR DESCRIPTION
Which backend a dashboard fronts is a property of the deployment, but it was an
input to `docker build`: `vite.config.ts` inlined it into the bundle with `define`
and compiled it into nitro's proxy `routeRules`. One image could therefore serve
exactly one backend, `ui/Dockerfile` required a `--build-arg`, and standing up a
second environment meant a second image build rather than a second env var.

Now the server reads `DASHBOARD_API_URL` per request, in
`ui/server/backend-proxy.ts`, and proxies `/dashboard/api/*` and `/webhooks/*` to
it. One image serves any backend; the value belongs to the Kubernetes deployment
(or the Vercel project) that runs it.

`ui/src/lib/dashboard-fetch.ts` already read `process.env.DASHBOARD_API_URL` at
request time — the `define` was overwriting it at compile time, so that intent was
already there and just wasn't reachable.

What went away: the `--build-arg`, the `ARG`/`ENV`/`test -n` block in the
Dockerfile, the Vercel build-time guard, and the `define`.

The handler is registered only for production builds. Dev keeps its existing
in-process route rules, which have a `localhost:2024` default that the deployed
path deliberately refuses to have — unset in production is a loud 500 naming the
variable, not a silent fallback to production's backend.

Follow-up in `langchain-ai/deployments`: set `DASHBOARD_API_URL` under
`dashboard.env` for the open-swe release. Until then the pod 500s on those two
prefixes with that message. This also drops the `PREVIEW_DASHBOARD_API_URL`
variable that #2039 introduces.

## Test Plan

- [x] `NODE_ENV=production pnpm run build` clean; handler present in `.output/server/index.mjs`
- [x] `NODE_ENV=development pnpm run build` clean; handler absent, so dev still uses route rules
- [x] Ran one production build against two backends by env var alone — `DASHBOARD_API_URL=http://127.0.0.1:9101` and `:9102` — and each `/webhooks/slack` POST reached the matching backend
- [x] Request body arrives byte-identical through the proxy (echoed `raw` matches the POSTed JSON), which is what keeps Slack signature verification valid
- [x] With `DASHBOARD_API_URL` unset, the request 500s with `DASHBOARD_API_URL is not set…` rather than defaulting
- [x] `pnpm run typecheck` and `pnpm run format:check` clean
