### PR TITLE
ci: publish the dashboard image to langchain-nonprod

### DIFF
--- a/.github/workflows/publish_preview_dashboard.yml
+++ b/.github/workflows/publish_preview_dashboard.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: us-docker.pkg.dev/langchain-artifacts/langchain/open-swe-dashboard
+  IMAGE: us-docker.pkg.dev/langchain-artifacts/langchain-nonprod/open-swe-dashboard
 
 jobs:
   publish:


### PR DESCRIPTION
The publisher workflow pushes to `langchain-artifacts/langchain`, the shared
production repository holding `langsmith-backend`, `ci-runner`, `smithdb` and
friends. Corridor and Open SWE both flagged granting CI write access there on
`langchain-ai/deployments#35866`: Artifact Registry Writer permits retagging, so a
compromised workflow in this repo could overwrite a production tag and get code
execution on the next pod restart in prod, eu-prod, apac-prod, or internal.

That grant is therefore scoped to `langchain-nonprod`, and this points the
workflow at the repository it will actually have rights to. Without this the first
publish fails with a 403.

The chart still pulls `open-swe-dashboard` from `langchain`, deliberately — moving
it before a `preview` tag exists in `langchain-nonprod` would put the running
dashboard into ImagePullBackOff. Once this workflow has published once, the chart
default moves in a follow-up on the deployments side. Reads need no new grant: the
internal cluster has project-level Artifact Registry reader on `langchain-artifacts`
via `grant_registry_access` / `registry_project_ids`, which covers every repository
in the project.

## Test Plan

- [x] Confirmed `langchain-nonprod` exists as `google_artifact_registry_repository.langchain_nonprod_us` in `langchain-ai/deployments`, and that the pending IAM grant targets exactly it
- [x] Confirmed no prod, eu-prod, or apac-prod workload pulls from `langchain-nonprod` — its only readers today are `sandbox_artifact_reader` and `blacksmith_ci_artifact_reader`
- [x] YAML still parses; the only change is the `IMAGE` env value
