### PR TITLE
feat(code): add `$` skill picker

### DIFF
--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -162,6 +162,46 @@ describe("ChatComposer skill autocomplete", () => {
     expect(items).toEqual([])
   })
 
+  it("shows only skills for the dollar picker while slash keeps both", () => {
+    const skills = [
+      {
+        name: "baby-sit",
+        description: "Monitor a pull request",
+        instructions: "",
+      },
+    ]
+    const dollarItems = buildCommandItems(
+      {
+        kind: "skill-command",
+        query: "baby",
+        rangeStart: 0,
+        rangeEnd: 5,
+      },
+      [],
+      skills
+    )
+    const slashItems = buildCommandItems(
+      {
+        kind: "slash-command",
+        query: "",
+        rangeStart: 0,
+        rangeEnd: 1,
+      },
+      [],
+      skills
+    )
+
+    expect(dollarItems).toEqual([
+      expect.objectContaining({
+        type: "skill",
+        name: "baby-sit",
+        label: "/baby-sit",
+      }),
+    ])
+    expect(slashItems.some((item) => item.type === "slash-command")).toBe(true)
+    expect(slashItems.some((item) => item.type === "skill")).toBe(true)
+  })
+
   it("prefers a colliding skill and preserves surrounding prompt text", () => {
     const trigger = {
       kind: "slash-command" as const,

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -156,7 +156,18 @@ export function buildCommandItems(
 ): Array<ComposerCommandItem> {
   const query = trigger.query.toLowerCase()
 
-  if (trigger.kind === "slash-command") {
+  if (trigger.kind === "slash-command" || trigger.kind === "skill-command") {
+    const skillItems = skills
+      .filter((skill) => skill.name.startsWith(query))
+      .map((skill) => ({
+        id: `skill:${skill.name}`,
+        type: "skill" as const,
+        name: skill.name,
+        label: `/${skill.name}`,
+        description: skill.description,
+      }))
+    if (trigger.kind === "skill-command") return skillItems
+
     const skillNames = new Set(skills.map((skill) => skill.name))
     return [
       ...SLASH_COMMANDS.filter(
@@ -171,15 +182,7 @@ export function buildCommandItems(
         label: spec.label,
         description: spec.description,
       })),
-      ...skills
-        .filter((skill) => skill.name.startsWith(query))
-        .map((skill) => ({
-          id: `skill:${skill.name}`,
-          type: "skill" as const,
-          name: skill.name,
-          label: `/${skill.name}`,
-          description: skill.description,
-        })),
+      ...skillItems,
     ]
   }
 
@@ -196,8 +199,9 @@ export function buildCommandItems(
 }
 
 /**
- * The prompt composer: a Lexical editor with `@file` chips and `/command`
- * autocomplete, plus the control row (model, plan mode, attachments, context)
+ * The prompt composer: a Lexical editor with `@file` chips, `/command`
+ * autocomplete, and `$skill` autocomplete, plus the control row (model, plan
+ * mode, attachments, context)
  * and the send/stop button.
  */
 export const ChatComposer = memo(function ChatComposer({

--- a/ui/src/features/agents/components/composer/ComposerCommandMenu.tsx
+++ b/ui/src/features/agents/components/composer/ComposerCommandMenu.tsx
@@ -37,9 +37,9 @@ interface ComposerCommandMenuProps {
 }
 
 /**
- * The autocomplete popup for `@path` and `/command`. Keyboard navigation lives
- * in the composer (the editor keeps focus while this is open), so this only
- * reflects the active item and reports pointer intent back up.
+ * The autocomplete popup for `@path`, `/command`, and `$skill`. Keyboard
+ * navigation lives in the composer (the editor keeps focus while this is open),
+ * so this only reflects the active item and reports pointer intent back up.
  */
 export const ComposerCommandMenu = memo(function ComposerCommandMenu({
   items,
@@ -64,7 +64,13 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu({
     <div
       className="dropdown-glass absolute bottom-full left-0 z-50 mb-2 w-full max-w-md overflow-hidden rounded-xl"
       role="listbox"
-      aria-label={triggerKind === "path" ? "Files" : "Commands"}
+      aria-label={
+        triggerKind === "path"
+          ? "Files"
+          : triggerKind === "skill-command"
+            ? "Skills"
+            : "Commands"
+      }
     >
       {items.length > 0 ? (
         <div ref={listRef} className="max-h-64 overflow-y-auto py-1">

--- a/ui/src/features/agents/components/composer/composerTrigger.test.ts
+++ b/ui/src/features/agents/components/composer/composerTrigger.test.ts
@@ -44,6 +44,15 @@ describe("detectComposerTrigger", () => {
     expect(detectComposerTrigger("see src/a/b", 11)).toBeNull()
   })
 
+  it("treats a whitespace-delimited dollar token as a skill picker", () => {
+    expect(detectComposerTrigger("use $baby-sit", 13)).toEqual({
+      kind: "skill-command",
+      query: "baby-sit",
+      rangeStart: 4,
+      rangeEnd: 13,
+    })
+  })
+
   it("closes the trigger once the cursor moves off the token", () => {
     expect(detectComposerTrigger("@src/app.tsx done", 17)).toBeNull()
   })

--- a/ui/src/features/agents/components/composer/composerTrigger.ts
+++ b/ui/src/features/agents/components/composer/composerTrigger.ts
@@ -1,11 +1,12 @@
 /**
- * Trigger parsing for the composer's autocomplete: `@path` file mentions and
- * `/command` slash commands. The prompt stays a plain string end to end — the
- * Lexical editor only renders chips over it — so everything here operates on
+ * Trigger parsing for the composer's autocomplete: `@path` file mentions,
+ * `/command` slash commands, and `$skill` skill commands. The prompt stays a
+ * plain string end to end — the Lexical editor only renders chips over it — so
+ * everything here operates on
  * text plus a cursor offset rather than on editor nodes.
  */
 
-export type ComposerTriggerKind = "path" | "slash-command"
+export type ComposerTriggerKind = "path" | "slash-command" | "skill-command"
 
 /** Slash commands open-swe understands. `model` opens the picker rather than editing the prompt. */
 export type ComposerSlashCommand = "plan" | "default" | "model"
@@ -77,10 +78,19 @@ export function detectComposerTrigger(
   while (tokenIdx >= 0 && !isWhitespace(text[tokenIdx] ?? "")) tokenIdx -= 1
   const tokenStart = tokenIdx + 1
   const token = text.slice(tokenStart, cursor)
-  if (!token.startsWith("@") && !token.startsWith("/")) return null
+  if (
+    !token.startsWith("@") &&
+    !token.startsWith("/") &&
+    !token.startsWith("$")
+  )
+    return null
 
   return {
-    kind: token.startsWith("/") ? "slash-command" : "path",
+    kind: token.startsWith("@")
+      ? "path"
+      : token.startsWith("$")
+        ? "skill-command"
+        : "slash-command",
     query: token.slice(1),
     rangeStart: tokenStart,
     rangeEnd: cursor,


### PR DESCRIPTION
The dashboard composer now supports `$` to browse skills without showing slash commands.

---

Add `$` as a skills-only composer picker while preserving `/` for both skills and built-in commands. Selected skills continue to insert canonical `/skill-name` syntax.

Made by [Open SWE](https://openswe.vercel.app/agents/380b30bb-10f2-536f-880c-be4e04121637)