### PR TITLE
feat(ui): add an operations restart endpoint

### DIFF
--- a/.github/workflows/publish_preview_dashboard.yml
+++ b/.github/workflows/publish_preview_dashboard.yml
@@ -60,8 +60,38 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The dashboard runs behind a private API server this runner cannot reach, so
+      # it restarts itself: `imagePullPolicy: Always` re-resolves the tag when the
+      # kubelet launches the replacement container. The token this mints can do
+      # nothing but restart that one service.
+      - name: Restart the preview dashboard
+        if: vars.PREVIEW_DASHBOARD_URL != ''
+        env:
+          SECRET: ${{ secrets.OPERATIONS_API_JWT_SECRET }}
+          URL: ${{ vars.PREVIEW_DASHBOARD_URL }}
+        run: |
+          set -euo pipefail
+          test -n "$SECRET" || { echo "OPERATIONS_API_JWT_SECRET is unset" >&2; exit 1; }
+
+          token=$(python3 - <<'PY'
+          import base64, hashlib, hmac, json, os, time
+
+          def b64(raw: bytes) -> str:
+              return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+          header = b64(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+          claims = b64(json.dumps({"act": "restart", "exp": int(time.time()) + 120}, separators=(",", ":")).encode())
+          signed = f"{header}.{claims}"
+          signature = b64(hmac.new(os.environ["SECRET"].encode(), signed.encode(), hashlib.sha256).digest())
+          print(f"{signed}.{signature}")
+          PY
+          )
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $token" "$URL/operations/restart")
+          test "$code" = "202" || { echo "restart returned $code" >&2; exit 1; }
+          echo "restart accepted"
+
       - name: Summary
         run: |
           echo "Pushed \`${IMAGE}:preview\` (${GITHUB_SHA})." >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo 'Roll it: `kubectl rollout restart deployment/open-swe-dashboard -n open-swe-dev`' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/PREVIEW_ENV.md
+++ b/docs/PREVIEW_ENV.md
@@ -62,6 +62,15 @@ the dashboard runs (the pod environment on Kubernetes, the project settings on V
 It has no default: a fallback would be production's backend, and preview would inherit it
 and drive production's agents, threads, and sandboxes.
 
+The preview image workflow also needs these repository settings:
+
+- Variable `PREVIEW_DASHBOARD_URL` — the preview dashboard's public URL.
+- Actions secret `OPERATIONS_API_JWT_SECRET` — the restart signing secret.
+
+Set `OPERATIONS_API_JWT_SECRET` to the same value in the preview dashboard deployment. The
+workflow signs a short-lived restart token with it after publishing an image, and the dashboard
+uses its deployment secret to verify that token.
+
 Requests stay same-origin — the server proxies `/dashboard/api/*` and `/webhooks/*` to
 that backend — so `DASHBOARD_API_BASE_URL`, the GitHub App callback URL, and the
 `DASHBOARD_ALLOWED_ORIGINS` entry must all point at the dashboard's own domain, not the

--- a/ui/server/operations-restart.ts
+++ b/ui/server/operations-restart.ts
@@ -1,0 +1,80 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+
+/**
+ * Restarts this container. `imagePullPolicy: Always` makes the runtime re-resolve
+ * the image tag when the kubelet launches the replacement, so exiting is what
+ * picks up a newly published image — no cluster credentials anywhere, and a
+ * caller holding this secret can do nothing but restart this one service.
+ */
+const RESTART_ACTION = "restart"
+
+// A minted token is used within seconds of a publish; a long window would leave a
+// replayable restart lying around in CI logs.
+const MAX_LIFETIME_SECONDS = 300
+
+function decodeSegment(segment: string): unknown {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"))
+}
+
+function signatureMatches(signed: string, signature: string, key: string) {
+  const expected = createHmac("sha256", key).update(signed).digest()
+  const received = Buffer.from(signature, "base64url")
+  return (
+    expected.length === received.length && timingSafeEqual(expected, received)
+  )
+}
+
+function tokenIsValid(token: string, key: string): boolean {
+  const [encodedHeader, encodedClaims, signature, ...rest] = token.split(".")
+  if (!encodedHeader || !encodedClaims || !signature || rest.length)
+    return false
+
+  if (!signatureMatches(`${encodedHeader}.${encodedClaims}`, signature, key)) {
+    return false
+  }
+
+  try {
+    // Pinned rather than read from the token: honouring the header's `alg` is what
+    // lets a caller downgrade to `none` and sign nothing.
+    const header = decodeSegment(encodedHeader) as { alg?: unknown }
+    if (header.alg !== "HS256") return false
+
+    const claims = decodeSegment(encodedClaims) as {
+      act?: unknown
+      exp?: unknown
+    }
+    if (claims.act !== RESTART_ACTION) return false
+    if (typeof claims.exp !== "number") return false
+
+    const now = Math.floor(Date.now() / 1000)
+    return claims.exp > now && claims.exp - now <= MAX_LIFETIME_SECONDS
+  } catch {
+    return false
+  }
+}
+
+export default async function operationsRestart(event: {
+  req: Request
+}): Promise<Response> {
+  if (event.req.method !== "POST") {
+    return new Response("method not allowed\n", { status: 405 })
+  }
+
+  const key = process.env.OPERATIONS_API_JWT_SECRET ?? ""
+  if (!key) {
+    // Absent secret closes the endpoint rather than opening it.
+    return new Response("not found\n", { status: 404 })
+  }
+
+  const header = event.req.headers.get("authorization") ?? ""
+  const token = header.startsWith("Bearer ") ? header.slice(7) : ""
+  if (!token || !tokenIsValid(token, key)) {
+    return new Response("unauthorized\n", { status: 401 })
+  }
+
+  // Exit after the response is on the wire, so the caller sees 202 rather than a
+  // dropped connection it cannot distinguish from a network fault.
+  setTimeout(() => process.exit(0), 250)
+
+  return new Response("restarting\n", { status: 202 })
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -182,12 +182,20 @@ const config = defineConfig({
       // same prefixes through devRouteRules, which has a localhost default the
       // handler deliberately refuses to have. Only the two prefixes a deployed
       // dashboard fronts, since proxying `/static` would shadow nitro's assets.
-      handlers: IS_PRODUCTION
-        ? ["/dashboard/api", "/webhooks"].map((prefix) => ({
-            route: `${prefix}/**`,
-            handler: "./server/backend-proxy.ts",
-          }))
-        : [],
+      handlers: [
+        ...(IS_PRODUCTION
+          ? ["/dashboard/api", "/webhooks"].map((prefix) => ({
+              route: `${prefix}/**`,
+              handler: "./server/backend-proxy.ts",
+            }))
+          : []),
+        // Deliberately outside the proxied prefixes: this one is answered by this
+        // server, not forwarded to the backend.
+        {
+          route: "/operations/restart",
+          handler: "./server/operations-restart.ts",
+        },
+      ],
       // Nitro gives every node_modules package its own server chunk. The
       // LangGraph SDK reaches CJS-only `eventemitter3` through `p-queue`, and
       // splitting that cycle puts the CommonJS interop helper in the SDK's chunk


### PR DESCRIPTION
The dashboard runs on a GKE cluster whose API server has
`enable_private_endpoint = true` and authorises only Tailscale CGNAT, so a GitHub
runner cannot reach it — a `kubectl rollout restart` step is not available, and
putting Tailscale credentials in this repo to get one is a bigger grant than the
job needs.

So the dashboard restarts itself. `POST /operations/restart` exits the process;
`imagePullPolicy: Always` means the runtime re-resolves the image tag when the
kubelet launches the replacement container, which is what picks up the image the
preceding step just pushed. Nothing outside the cluster needs cluster credentials,
and the secret this endpoint holds can do exactly one thing: restart this one
service.

Auth is an HS256 JWT signed with `OPERATIONS_API_JWT_SECRET`:

- `alg` is pinned to HS256 rather than read from the token, so a caller cannot
  downgrade to `none` and sign nothing
- `act` must be `restart`, so the claim names what it authorises
- `exp` must be present, in the future, and no more than 5 minutes out — a token is
  used seconds after a publish, and a long window leaves a replayable restart in CI
  logs
- signature comparison is `timingSafeEqual`
- with the secret unset the endpoint is 404, so a deployment that has not opted in
  cannot be restarted at all

The route is registered outside the `/dashboard/api` and `/webhooks` proxy
prefixes, so it is answered by this server rather than forwarded to the backend.

Two settings are needed on this repo before the step does anything: the
`OPERATIONS_API_JWT_SECRET` secret, and a `PREVIEW_DASHBOARD_URL` variable. The
step is skipped when the variable is absent, so this merges inert.
`OPERATIONS_API_JWT_SECRET` must also be set on the dashboard deployment.

## Test Plan

- [x] Verified the auth matrix against a production build: no header 401, `GET` 405, wrong secret 401, `act` other than `restart` 401, expired 401, `exp` beyond 5 minutes 401, valid token 202
- [x] Verified the process actually exits after a 202, and that the 202 reaches the caller first
- [x] Verified that with `OPERATIONS_API_JWT_SECRET` unset a validly-shaped token gets 404 and the process stays up
- [x] Confirmed against the Kubernetes docs that `imagePullPolicy: Always` makes the runtime "resolve the image tag or name to a digest" each time the kubelet launches a container, so a restart is sufficient to pick up a moved tag
- [x] `pnpm run typecheck`, `pnpm run format:check`, and a production build are clean
