### PR TITLE
feat: toggle desktop thread sources

### DIFF
--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -147,7 +147,36 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
       await maybeLater.click();
     }
 
+    const cloudSource = page.getByRole("button", {
+      name: /Cloud threads, \d+/,
+    });
+    const localSource = page.getByRole("button", {
+      name: /This Mac threads, \d+/,
+    });
+    await expect(localSource).toHaveAttribute("aria-pressed", "true");
+
+    await cloudSource.click();
+    await expect(cloudSource).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByRole("button", { name: "Cloud", exact: true }),
+    ).toBeVisible();
+    const cloudScreenshot = testInfo.outputPath("desktop-cloud-threads.png");
+    await page.screenshot({ path: cloudScreenshot, fullPage: true });
+    await testInfo.attach("desktop-cloud-threads", {
+      path: cloudScreenshot,
+      contentType: "image/png",
+    });
+
+    await localSource.click();
+    await expect(localSource).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByText(/This Mac · demo/)).toBeVisible();
+    const localScreenshot = testInfo.outputPath("desktop-local-threads.png");
+    await page.screenshot({ path: localScreenshot, fullPage: true });
+    await testInfo.attach("desktop-local-threads", {
+      path: localScreenshot,
+      contentType: "image/png",
+    });
+
     await typeIntoComposer(
       page,
       "E2E_DESKTOP_LOCAL please add a greet() helper and open a PR",

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/features/agents/lib/provider/useModelOptions"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
 import { localThreadKeys } from "@/features/agents/lib/desktopLocal"
+import { useDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
 import { useProfile, useRepos } from "@/lib/profile"
 import { useSession } from "@/lib/session"
 import {
@@ -78,9 +79,8 @@ export function AgentsHome() {
   const [submitting, setSubmitting] = useState(false)
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
-  const [runTarget, setRunTarget] = useState<RunTarget>(() =>
-    isDesktop ? "local" : "cloud"
-  )
+  const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
+  const runTarget: RunTarget = isDesktop ? desktopThreadSource : "cloud"
   const [localProjectPath, setLocalProjectPath] = useState<string | null>(null)
   const localProjectPathRef = useRef(localProjectPath)
   localProjectPathRef.current = localProjectPath
@@ -129,7 +129,6 @@ export function AgentsHome() {
       (project) => project.cwd === localProjectPath || project.cwd === stored
     )
     setLocalProjectPath(selected?.cwd ?? localProjects[0]?.cwd ?? null)
-    if (!localProjectPath) setRunTarget("local")
   }, [isDesktop, localProjectPath, localProjects])
 
   const refreshLocalProjectBranch = useCallback(async () => {
@@ -150,14 +149,14 @@ export function AgentsHome() {
   }, [refreshLocalProjectBranch])
 
   const handleRunTargetChange = (next: RunTarget) => {
-    setRunTarget(next)
+    setDesktopThreadSource(next)
     setLocalError(null)
   }
 
   const handleSelectLocalProject = (cwd: string) => {
     setLocalProjectPath(cwd)
     window.localStorage.setItem(LAST_LOCAL_PROJECT_KEY, cwd)
-    setRunTarget("local")
+    setDesktopThreadSource("local")
     setLocalError(null)
   }
 

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -25,14 +25,15 @@ import {
 } from "@phosphor-icons/react"
 import { IoLogoGithub, IoLogoSlack } from "react-icons/io5"
 import { SiLinear } from "react-icons/si"
-import { useCallback, useState } from "react"
-import type { ComponentType, ReactNode, SVGProps } from "react"
+import { useCallback, useEffect, useState } from "react"
+import type { ComponentType, SVGProps } from "react"
 
 import type { SessionUser } from "@/lib/api"
 import type { DesktopLocalThreadSummary, DesktopProject } from "@/desktop"
 import type { AgentSource, AgentThread } from "@/features/agents/lib/types"
 import type { SidebarLayout } from "@/components/sidebar-layout"
 import { SidebarUserMenu } from "@/components/SidebarUserMenu"
+import { DesktopThreadSourceToggle } from "@/features/agents/components/DesktopThreadSourceToggle"
 import { SidebarFilterMenu } from "@/features/agents/components/SidebarFilterMenu"
 import { Button } from "@/components/ui/button"
 import {
@@ -60,6 +61,7 @@ import {
   useRefreshLocalThreads,
 } from "@/features/agents/lib/desktopLocal"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
+import { useDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
 import { cn } from "@/lib/utils"
 
 const RESOLVED_SIDEBAR_LIMIT = 20
@@ -130,14 +132,8 @@ export function AgentsSidebar({
     },
     [navigate]
   )
-  const {
-    prefs,
-    setGroup,
-    setCompact,
-    toggleSection,
-    setFilters,
-    resetFilters,
-  } = useSidebarPrefs()
+  const { prefs, setGroup, setCompact, setFilters, resetFilters } =
+    useSidebarPrefs()
   const sidebar = useSidebarThreads(
     RESOLVED_SIDEBAR_LIMIT,
     activeThreadId,
@@ -160,6 +156,12 @@ export function AgentsSidebar({
   const localGroups = groupLocalProjects(localProjects, localSessions)
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
+  const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
+  useEffect(() => {
+    if (!isDesktop) return
+    if (activeLocalSessionId) setDesktopThreadSource("local")
+    else if (activeThreadId) setDesktopThreadSource("cloud")
+  }, [activeLocalSessionId, activeThreadId, isDesktop, setDesktopThreadSource])
   const activeThreads = sidebar.data?.active.items ?? []
   const resolvedThreads = sidebar.data?.resolved.items ?? []
   const resolvedHasMore = sidebar.data?.resolved.hasMore ?? false
@@ -176,8 +178,7 @@ export function AgentsSidebar({
       ? [...filteredActive, ...filteredResolved]
       : filteredActive
   const sections = groupThreadsByMode(groupedThreads, prefs.group)
-  const isEmpty =
-    localGroups.length === 0 &&
+  const isCloudEmpty =
     sections.length === 0 &&
     (!showResolved || filteredResolved.length === 0) &&
     hasActiveFilters(prefs.filters)
@@ -185,7 +186,10 @@ export function AgentsSidebar({
     (total, group) => total + group.sessions.length,
     0
   )
-  const cloudCollapsed = isDesktop && prefs.collapsed.cloud
+  const cloudThreadCount =
+    filteredActive.length + (showResolved ? filteredResolved.length : 0)
+  const showLocalThreads = isDesktop && desktopThreadSource === "local"
+  const showCloudThreads = !isDesktop || desktopThreadSource === "cloud"
 
   return (
     <SidebarFrame {...layout} className="border-r border-border bg-sidebar">
@@ -238,67 +242,51 @@ export function AgentsSidebar({
 
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
         {isDesktop && (
-          <div
-            className={cn(
-              "mb-3 flex min-h-0 flex-col",
-              prefs.collapsed.local
-                ? "shrink-0"
-                : cloudCollapsed
-                  ? "flex-1"
-                  : "max-h-1/2 shrink-0"
-            )}
-          >
-            <SectionHeader
-              label="Local"
-              count={localSessionCount}
-              collapsed={prefs.collapsed.local}
-              onToggle={() => toggleSection("local")}
-            >
+          <DesktopThreadSourceToggle
+            source={desktopThreadSource}
+            localCount={localSessionCount}
+            cloudCount={cloudThreadCount}
+            onSourceChange={setDesktopThreadSource}
+          />
+        )}
+        {showLocalThreads && (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="mb-1 flex items-center px-2 py-1">
+              <span className="min-w-0 flex-1 truncate font-heading text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                Projects and threads
+              </span>
               <button
                 aria-label="Add project"
-                className="mr-1 flex size-5 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+                className="flex size-5 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
                 onClick={() => void addLocalProject()}
                 title="Add project"
                 type="button"
               >
                 <FolderPlusIcon className="size-3.5" />
               </button>
-            </SectionHeader>
-            {!prefs.collapsed.local && (
-              <div className="min-h-0 overflow-y-auto">
-                {localGroups.map((group) => (
-                  <LocalThreadGroup
-                    key={group.project.cwd}
-                    project={group.project}
-                    sessions={group.sessions}
-                    activeSessionId={activeLocalSessionId}
-                    onNavigate={layout.closeOnMobile}
-                    onDelete={deleteLocalSession}
-                    onRemove={() => void removeLocalProject(group.project.cwd)}
-                    compact={prefs.compact}
-                  />
-                ))}
-                {localGroups.length === 0 && (
-                  <p className="px-2.5 py-3 text-center text-xs text-muted-foreground/70">
-                    No projects yet
-                  </p>
-                )}
-              </div>
-            )}
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {localGroups.map((group) => (
+                <LocalThreadGroup
+                  key={group.project.cwd}
+                  project={group.project}
+                  sessions={group.sessions}
+                  activeSessionId={activeLocalSessionId}
+                  onNavigate={layout.closeOnMobile}
+                  onDelete={deleteLocalSession}
+                  onRemove={() => void removeLocalProject(group.project.cwd)}
+                  compact={prefs.compact}
+                />
+              ))}
+              {localGroups.length === 0 && (
+                <p className="px-2.5 py-3 text-center text-xs text-muted-foreground/70">
+                  No projects yet
+                </p>
+              )}
+            </div>
           </div>
         )}
-        {isDesktop && (
-          <SectionHeader
-            label="Cloud"
-            count={
-              filteredActive.length +
-              (showResolved ? filteredResolved.length : 0)
-            }
-            collapsed={prefs.collapsed.cloud}
-            onToggle={() => toggleSection("cloud")}
-          />
-        )}
-        {!cloudCollapsed && (
+        {showCloudThreads && (
           <div className="min-h-0 flex-1 overflow-y-auto">
             {prefs.group === "none"
               ? sections[0]?.threads.map((thread) => (
@@ -340,7 +328,7 @@ export function AgentsSidebar({
                 compact={prefs.compact}
               />
             )}
-            {isEmpty && (
+            {isCloudEmpty && (
               <p className="px-2.5 py-6 text-center text-xs text-muted-foreground/70">
                 No threads match these filters.
               </p>
@@ -353,47 +341,18 @@ export function AgentsSidebar({
         <div className="min-w-0 flex-1">
           <SidebarUserMenu user={user} showSettingsLink />
         </div>
-        <SidebarFilterMenu
-          prefs={prefs}
-          facets={facets}
-          onGroupChange={setGroup}
-          onFiltersChange={setFilters}
-          onCompactChange={setCompact}
-          onResetFilters={resetFilters}
-        />
+        {showCloudThreads && (
+          <SidebarFilterMenu
+            prefs={prefs}
+            facets={facets}
+            onGroupChange={setGroup}
+            onFiltersChange={setFilters}
+            onCompactChange={setCompact}
+            onResetFilters={resetFilters}
+          />
+        )}
       </div>
     </SidebarFrame>
-  )
-}
-
-function SectionHeader({
-  label,
-  count,
-  collapsed,
-  onToggle,
-  children,
-}: {
-  label: string
-  count: number
-  collapsed: boolean
-  onToggle: () => void
-  children?: ReactNode
-}) {
-  return (
-    <div className="flex items-center">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1.5 text-left font-heading text-xs font-semibold tracking-wide text-foreground uppercase transition-colors hover:text-foreground/80"
-        aria-expanded={!collapsed}
-      >
-        <span className="min-w-0 flex-1 truncate">{label}</span>
-        <span className="text-[10px] font-medium text-muted-foreground/70">
-          {count}
-        </span>
-      </button>
-      {children}
-    </div>
   )
 }
 

--- a/ui/src/features/agents/components/DesktopThreadSourceToggle.test.tsx
+++ b/ui/src/features/agents/components/DesktopThreadSourceToggle.test.tsx
@@ -1,0 +1,31 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { DesktopThreadSourceToggle } from "./DesktopThreadSourceToggle"
+
+afterEach(() => cleanup())
+
+describe("DesktopThreadSourceToggle", () => {
+  it("exposes the selected source and switches sources", () => {
+    const onSourceChange = vi.fn()
+    render(
+      <DesktopThreadSourceToggle
+        source="local"
+        localCount={4}
+        cloudCount={7}
+        onSourceChange={onSourceChange}
+      />
+    )
+
+    const cloud = screen.getByRole("button", { name: "Cloud threads, 7" })
+    const local = screen.getByRole("button", { name: "This Mac threads, 4" })
+    expect(cloud.getAttribute("aria-pressed")).toBe("false")
+    expect(local.getAttribute("aria-pressed")).toBe("true")
+
+    fireEvent.click(cloud)
+
+    expect(onSourceChange).toHaveBeenCalledWith("cloud")
+  })
+})

--- a/ui/src/features/agents/components/DesktopThreadSourceToggle.tsx
+++ b/ui/src/features/agents/components/DesktopThreadSourceToggle.tsx
@@ -1,0 +1,79 @@
+import { CloudIcon, LaptopIcon } from "@phosphor-icons/react"
+
+import type { DesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
+import { cn } from "@/lib/utils"
+
+export function DesktopThreadSourceToggle({
+  source,
+  localCount,
+  cloudCount,
+  onSourceChange,
+}: {
+  source: DesktopThreadSource
+  localCount: number
+  cloudCount: number
+  onSourceChange: (source: DesktopThreadSource) => void
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Thread location"
+      className="mb-3 grid grid-cols-2 gap-0.5 rounded-lg bg-sidebar-control-surface p-0.5"
+    >
+      <SourceButton
+        label="Cloud"
+        count={cloudCount}
+        active={source === "cloud"}
+        icon={CloudIcon}
+        onClick={() => onSourceChange("cloud")}
+      />
+      <SourceButton
+        label="This Mac"
+        count={localCount}
+        active={source === "local"}
+        icon={LaptopIcon}
+        onClick={() => onSourceChange("local")}
+      />
+    </div>
+  )
+}
+
+function SourceButton({
+  label,
+  count,
+  active,
+  icon: Icon,
+  onClick,
+}: {
+  label: string
+  count: number
+  active: boolean
+  icon: typeof CloudIcon
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`${label} threads, ${count}`}
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "flex min-w-0 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors",
+        active
+          ? "bg-sidebar text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground"
+      )}
+    >
+      <Icon className="size-3.5 shrink-0" />
+      <span className="truncate">{label}</span>
+      <span
+        className={cn(
+          "text-[9px] tabular-nums",
+          active ? "text-muted-foreground" : "text-muted-foreground/70"
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  )
+}

--- a/ui/src/features/agents/lib/desktopThreadSource.test.tsx
+++ b/ui/src/features/agents/lib/desktopThreadSource.test.tsx
@@ -1,0 +1,37 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { useDesktopThreadSource } from "./desktopThreadSource"
+
+beforeEach(() => window.localStorage.clear())
+afterEach(() => cleanup())
+
+function SourceControl({ label }: { label: string }) {
+  const [source, setSource] = useDesktopThreadSource()
+  return (
+    <button type="button" onClick={() => setSource("cloud")}>
+      {label}: {source}
+    </button>
+  )
+}
+
+describe("useDesktopThreadSource", () => {
+  it("defaults to local and synchronizes mounted consumers", () => {
+    render(
+      <>
+        <SourceControl label="First" />
+        <SourceControl label="Second" />
+      </>
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "First: local" }))
+
+    expect(screen.getByRole("button", { name: "First: cloud" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Second: cloud" })).toBeTruthy()
+    expect(
+      window.localStorage.getItem("open-swe.agents.desktop-thread-source")
+    ).toBe("cloud")
+  })
+})

--- a/ui/src/features/agents/lib/desktopThreadSource.ts
+++ b/ui/src/features/agents/lib/desktopThreadSource.ts
@@ -1,0 +1,59 @@
+import { useSyncExternalStore } from "react"
+
+export type DesktopThreadSource = "local" | "cloud"
+
+const STORAGE_KEY = "open-swe.agents.desktop-thread-source"
+const listeners = new Set<() => void>()
+let storageListenerAttached = false
+
+export function readStoredDesktopThreadSource(): DesktopThreadSource {
+  if (typeof window === "undefined") return "local"
+  return window.localStorage.getItem(STORAGE_KEY) === "cloud"
+    ? "cloud"
+    : "local"
+}
+
+function handleStorage(event: StorageEvent): void {
+  if (event.key !== STORAGE_KEY) return
+  listeners.forEach((listener) => listener())
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  if (typeof window !== "undefined" && !storageListenerAttached) {
+    window.addEventListener("storage", handleStorage)
+    storageListenerAttached = true
+  }
+  return () => {
+    listeners.delete(listener)
+    if (
+      typeof window !== "undefined" &&
+      storageListenerAttached &&
+      listeners.size === 0
+    ) {
+      window.removeEventListener("storage", handleStorage)
+      storageListenerAttached = false
+    }
+  }
+}
+
+export function writeStoredDesktopThreadSource(
+  source: DesktopThreadSource
+): void {
+  if (typeof window === "undefined") return
+  if (readStoredDesktopThreadSource() === source) return
+  window.localStorage.setItem(STORAGE_KEY, source)
+  listeners.forEach((listener) => listener())
+}
+
+export function useDesktopThreadSource(): [
+  DesktopThreadSource,
+  (source: DesktopThreadSource) => void,
+] {
+  const source = useSyncExternalStore(
+    subscribe,
+    readStoredDesktopThreadSource,
+    (): DesktopThreadSource => "local"
+  )
+  return [source, writeStoredDesktopThreadSource]
+}


### PR DESCRIPTION
## Description
Replace the competing Local and Cloud sidebar sections with one persisted source toggle and a full-height source-specific list. The toggle is shared with the composer so New Thread inherits the selected execution location; desktop E2E now records both working states.

## Release Note
Desktop users can toggle between local and cloud thread lists from one sidebar control.

## Test Plan
- [x] Real Electron E2E switches Cloud → This Mac, validates the composer target, and records both screenshots.

Made by [Open SWE](https://openswe.vercel.app/agents/1736d0a1-f321-5130-8669-b96387679e2b)