### PR TITLE
fix: simplify Slack session cost status

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -417,26 +417,30 @@ def format_slack_run_usage(usage: RunUsageSummary | None) -> str:
     if len(labels) > 3:
         model_text = f"{model_text} +{len(labels) - 3}"
     parts = [model_text] if model_text else []
-    if usage.main_agent_tokens is not None:
-        parts.append(f"{_format_token_count(usage.main_agent_tokens)} main-agent tokens")
     if usage.session_cost_usd is not None:
         parts.append(format_slack_session_cost(usage.session_cost_usd))
+    elif usage.main_agent_tokens is not None:
+        parts.append(f"{_format_token_count(usage.main_agent_tokens)} main-agent tokens")
     return " • ".join(parts)
 
 
-_SESSION_COST_LABEL_RE = re.compile(r"(?: • )?(?:<\$0\.01|\$[0-9]+(?:\.[0-9]+)?) session cost$")
+_SESSION_COST_LABEL_RE = re.compile(
+    r"(?: • )?(?:<\$0\.01|\$[0-9]+(?:\.[0-9]+)?)(?: session cost)?$"
+)
+_MAIN_AGENT_TOKEN_LABEL_RE = re.compile(r"(?: • )?[0-9]+(?:\.[0-9]+)?[KM]? main-agent tokens$")
 
 
 def format_slack_session_cost(cost: float) -> str:
     if 0 < cost < 0.01:
-        return "<$0.01 session cost"
-    return f"${cost:.2f} session cost"
+        return "<$0.01"
+    return f"${cost:.2f}"
 
 
 def _replace_slack_session_cost(text: str, cost: float, *, require_web_link: bool) -> str:
     if require_web_link and SLACK_WEB_LINK_FOOTER_LABEL not in text:
         return text
     cleaned = _SESSION_COST_LABEL_RE.sub("", text).rstrip()
+    cleaned = _MAIN_AGENT_TOKEN_LABEL_RE.sub("", cleaned).rstrip()
     return f"{cleaned} • {format_slack_session_cost(cost)}"
 
 

--- a/tests/agent/test_session_cost.py
+++ b/tests/agent/test_session_cost.py
@@ -131,7 +131,8 @@ async def test_refresh_updates_exact_mapped_slack_message_in_place(
     args = update.await_args
     assert args is not None
     assert args.args[:2] == ("C1", "1.1")
-    assert args.args[2].endswith("10 main-agent tokens • $0.42 session cost")
+    assert args.args[2].endswith("model-a • $0.42")
+    assert "main-agent tokens" not in args.args[2]
     assert args.kwargs["blocks"][1] == blocks[1]
 
 

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -585,6 +585,14 @@ def test_format_slack_web_link_footer_includes_run_usage() -> None:
     )
 
 
+def test_format_slack_web_link_footer_prefers_session_cost() -> None:
+    usage = RunUsageSummary(models=("model-a",), main_agent_tokens=12_345, session_cost_usd=0.42)
+
+    footer = slack_utils.format_slack_web_link_footer("https://app.example/agents/t1", usage)
+
+    assert footer == "<https://app.example/agents/t1|Open in Web> • model-a • $0.42"
+
+
 def test_with_slack_session_cost_preserves_blocks_and_is_idempotent() -> None:
     text = "Done <https://app.example/agents/t1|Open in Web> • model-a • 110 main-agent tokens"
     blocks = [
@@ -608,12 +616,12 @@ def test_with_slack_session_cost_preserves_blocks_and_is_idempotent() -> None:
     repeated = slack_utils.with_slack_session_cost(updated_text, updated_blocks, 0.42)
 
     assert repeated == (updated_text, updated_blocks)
-    assert updated_text.endswith("110 main-agent tokens • $0.42 session cost")
+    assert updated_text.endswith("model-a • $0.42")
+    assert "main-agent tokens" not in updated_text
     assert updated_blocks is not None
     assert updated_blocks[1] == blocks[1]
-    assert updated_blocks[2]["elements"][0]["text"].endswith(
-        "110 main-agent tokens • $0.42 session cost"
-    )
+    assert updated_blocks[2]["elements"][0]["text"].endswith("model-a • $0.42")
+    assert "main-agent tokens" not in updated_blocks[2]["elements"][0]["text"]
 
 
 def test_post_slack_trace_reply_has_no_tip(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description
When session cost is available, show it instead of the less useful token count and remove the redundant “session cost” label. Deferred Slack footer refreshes also clean up existing token-count and legacy cost labels.

## Release Note
Slack completion status lines now show only the dollar amount when session cost is available.

## Test Plan
- [x] Verify initial and deferred Slack usage footers prefer cost and remain idempotent.

Made by [Open SWE](https://openswe.vercel.app/agents/4d5524a2-a8f7-5d54-b3dd-d2927de478cd)