### PR TITLE
fix: ignore generated desktop backend runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # production
 /build
 /desktop/build
+/desktop/resources/local-backend/
 /dist
 **/dist
 .turbo/


### PR DESCRIPTION
## Summary

- ignore the generated desktop local-backend bundle
- keep the checked-in desktop icons tracked
- allow `make install-desktop` to pass its clean-worktree check after a previous install

## Why

Desktop packaging assembles a standalone Python runtime and locked Open SWE dependencies under `desktop/resources/local-backend/` before Electron copies them into the app. This creates roughly 22,000 files (about 494 MB locally), but the generated directory was not ignored.

## Verification

- `git check-ignore -v desktop/resources/local-backend`
- confirmed `desktop/resources/icon.png` and `desktop/resources/icon.icns` remain tracked and unignored
- confirmed the installer clean-worktree check passes after committing the ignore rule