### PR TITLE
fix: sync local thread running status

### DIFF
--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
+import { useQueryClient } from "@tanstack/react-query"
 import {
   CircleAlert,
   FolderOpen,
@@ -9,6 +10,7 @@ import {
 } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
+import type { DesktopLocalThreadSummary } from "@/desktop"
 import type { ImageChunk } from "@/features/agents/lib/types"
 import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
@@ -29,9 +31,9 @@ import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
 import { usePanelTabs } from "@/features/agents/lib/panelTabs"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import {
+  localThreadKeys,
   useDesktopLocalThread,
   useLocalThreadDiff,
-  useRefreshLocalThreads,
 } from "@/features/agents/lib/desktopLocal"
 import {
   readStoredPanelCollapsed,
@@ -68,7 +70,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const stream = useAgentThreadStream()
   const threadQuery = useDesktopLocalThread(sessionId)
   const thread = threadQuery.data
-  const refreshThreads = useRefreshLocalThreads()
+  const queryClient = useQueryClient()
   const initialPromptRef = useRef<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const isMobile = useIsMobile()
@@ -188,13 +190,19 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
 
   const updateStatus = useCallback(
     async (status: "idle" | "running" | "error") => {
-      await window.openSweDesktop?.updateLocalThread({
+      const updated = await window.openSweDesktop?.updateLocalThread({
         threadId: sessionId,
         status,
       })
-      refreshThreads(sessionId)
+      if (!updated) return
+      queryClient.setQueryData(localThreadKeys.detail(sessionId), updated)
+      queryClient.setQueryData<Array<DesktopLocalThreadSummary>>(
+        localThreadKeys.all,
+        (threads = []) =>
+          threads.map((thread) => (thread.id === sessionId ? updated : thread))
+      )
     },
-    [refreshThreads, sessionId]
+    [queryClient, sessionId]
   )
 
   const submit = useCallback(


### PR DESCRIPTION
## Description
Keep desktop local-thread detail and sidebar caches synchronized when run status changes so the running spinner updates immediately.

## Release Note
Fixed the desktop local-thread running indicator.

## Test Plan
- [x] Typecheck and formatting pass

Made by [Open SWE](https://openswe.vercel.app/agents/01a01b11-6f62-733a-ba8b-3e38b0f3074b)