### PR TITLE
fix: allow narrower desktop windows

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1003,7 +1003,7 @@ function createWindow() {
     title: appRuntime.name,
     width: 1440,
     height: 900,
-    minWidth: 900,
+    minWidth: 480,
     minHeight: 600,
     backgroundColor: "#ffffff",
     icon: iconPath(),


### PR DESCRIPTION
## Description
Lower the desktop window minimum width to 480px so macOS half-screen tiling works on narrower displays.

## Release Note
Desktop windows can now be resized to 480px wide.

## Test Plan
- [x] Desktop typecheck and unit tests

Made by [Open SWE](https://openswe.vercel.app/agents/01a01b1e-6237-7768-833a-da8dfed5c81a)