### PR TITLE
feat(desktop): add local branch controls

### DIFF
--- a/desktop/src/git-diff.cts
+++ b/desktop/src/git-diff.cts
@@ -36,6 +36,30 @@ function git(
   })
 }
 
+async function localBranches(cwd) {
+  try {
+    const output = text(
+      await git(
+        cwd,
+        ["for-each-ref", "--format=%(refname:short)", "--sort=-committerdate", "refs/heads"],
+        null,
+        5_000
+      )
+    )
+    return output ? output.split("\n") : []
+  } catch {
+    return []
+  }
+}
+
+async function checkoutBranch(cwd, branch, create = false) {
+  if (typeof branch !== "string" || !branch.trim()) throw new Error("Branch name is required")
+  const name = branch.trim()
+  await git(cwd, ["check-ref-format", "--branch", name], null, 5_000)
+  await git(cwd, create ? ["switch", "-c", name] : ["switch", name], null, 30_000)
+  return name
+}
+
 async function currentBranch(cwd) {
   try {
     return text(await git(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"], null, 5_000)) || null
@@ -329,7 +353,9 @@ async function readDiff(repo, base) {
 module.exports = {
   captureCheckpoint,
   checkpointRef,
+  checkoutBranch,
   currentBranch,
+  localBranches,
   deleteRefs,
   parsePullRequest,
   readDiff,

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -17,7 +17,9 @@ const { LocalThreadStore } = require("./local-thread-store.cjs");
 const {
   captureCheckpoint,
   checkpointRef,
+  checkoutBranch,
   currentBranch,
+  localBranches,
   deleteRefs,
   readDiff,
   repoRoot,
@@ -165,10 +167,25 @@ function configureDesktopIpc() {
     return listProjects();
   });
 
-  ipcMain.handle("desktop:project-branch", async (event, cwd) => {
+  ipcMain.handle("desktop:project-branches", async (event, cwd) => {
     requireTrustedDesktopIpc(event);
     const project = typeof cwd === "string" ? registeredProject(cwd) : null;
-    return project ? currentBranch(project) : null;
+    if (!project) return { current: null, branches: [] };
+    const [current, branches] = await Promise.all([
+      currentBranch(project),
+      localBranches(project),
+    ]);
+    return { current, branches };
+  });
+
+  ipcMain.handle("desktop:checkout-project-branch", async (event, input) => {
+    requireTrustedDesktopIpc(event);
+    const project =
+      input && typeof input.cwd === "string"
+        ? registeredProject(input.cwd)
+        : null;
+    if (!project) throw new Error("Project is not registered");
+    return checkoutBranch(project, input.branch, input.create === true);
   });
 
   ipcMain.handle("desktop:add-project", async (event) => {

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -3,7 +3,9 @@ const { contextBridge, ipcRenderer } = require("electron")
 contextBridge.exposeInMainWorld("openSweDesktop", {
   isDesktop: true,
   listProjects: () => ipcRenderer.invoke("desktop:projects"),
-  getProjectBranch: (cwd) => ipcRenderer.invoke("desktop:project-branch", cwd),
+  getProjectBranches: (cwd) => ipcRenderer.invoke("desktop:project-branches", cwd),
+  checkoutProjectBranch: (input) =>
+    ipcRenderer.invoke("desktop:checkout-project-branch", { ...input }),
   addProject: () => ipcRenderer.invoke("desktop:add-project"),
   removeProject: (cwd) => ipcRenderer.invoke("desktop:remove-project", cwd),
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -8,7 +8,9 @@ const path = require("node:path")
 const {
   captureCheckpoint,
   checkpointRef,
+  checkoutBranch,
   currentBranch,
+  localBranches,
   parsePullRequest,
   readDiff,
   repoRoot,
@@ -67,6 +69,11 @@ test("diffs the worktree against a session checkpoint", async (t) => {
   git(dir, ["commit", "-qm", "init"])
 
   const repo = await repoRoot(dir)
+  assert.equal(await currentBranch(dir), "main")
+  await checkoutBranch(dir, "feature", true)
+  assert.equal(await currentBranch(dir), "feature")
+  assert.deepEqual(await localBranches(dir), ["feature", "main"])
+  await checkoutBranch(dir, "main")
   assert.equal(await currentBranch(dir), "main")
   const ref = checkpointRef("session-id")
   await captureCheckpoint(repo, ref)

--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -169,7 +169,12 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
 
     await localSource.click();
     await expect(localSource).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByText(/This Mac · demo/)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "demo", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "main", exact: true }),
+    ).toBeVisible();
     const localScreenshot = testInfo.outputPath("desktop-local-threads.png");
     await page.screenshot({ path: localScreenshot, fullPage: true });
     await testInfo.attach("desktop-local-threads", {

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -126,7 +126,15 @@ declare global {
     openSweDesktop?: {
       isDesktop: true
       listProjects: () => Promise<Array<DesktopProject>>
-      getProjectBranch: (cwd: string) => Promise<string | null>
+      getProjectBranches: (cwd: string) => Promise<{
+        current: string | null
+        branches: Array<string>
+      }>
+      checkoutProjectBranch: (input: {
+        cwd: string
+        branch: string
+        create?: boolean
+      }) => Promise<string>
       addProject: () => Promise<DesktopProject | null>
       removeProject: (cwd: string) => Promise<boolean>
       onProjectsChanged: (

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -87,6 +87,9 @@ export function AgentsHome() {
   const [localProjectBranch, setLocalProjectBranch] = useState<string | null>(
     null
   )
+  const [localProjectBranches, setLocalProjectBranches] = useState<
+    Array<string>
+  >([])
   const [localError, setLocalError] = useState<string | null>(null)
   const {
     projects: localProjects,
@@ -133,10 +136,13 @@ export function AgentsHome() {
 
   const refreshLocalProjectBranch = useCallback(async () => {
     const cwd = localProjectPathRef.current
-    const branch = cwd
-      ? ((await window.openSweDesktop?.getProjectBranch(cwd)) ?? null)
-      : null
-    if (localProjectPathRef.current === cwd) setLocalProjectBranch(branch)
+    const result = cwd
+      ? await window.openSweDesktop?.getProjectBranches(cwd)
+      : undefined
+    if (localProjectPathRef.current === cwd) {
+      setLocalProjectBranch(result?.current ?? null)
+      setLocalProjectBranches(result?.branches ?? [])
+    }
   }, [])
 
   useEffect(() => {
@@ -158,6 +164,23 @@ export function AgentsHome() {
     window.localStorage.setItem(LAST_LOCAL_PROJECT_KEY, cwd)
     setDesktopThreadSource("local")
     setLocalError(null)
+  }
+
+  const checkoutLocalProjectBranch = async (branch: string, create = false) => {
+    if (!localProjectPath) return
+    setLocalError(null)
+    try {
+      await window.openSweDesktop?.checkoutProjectBranch({
+        cwd: localProjectPath,
+        branch,
+        create,
+      })
+      await refreshLocalProjectBranch()
+    } catch (error) {
+      setLocalError(
+        error instanceof Error ? error.message : "Could not checkout branch"
+      )
+    }
   }
 
   const handleAddLocalProject = async () => {
@@ -291,10 +314,17 @@ export function AgentsHome() {
             localProjects={localProjects}
             selectedLocalProjectPath={localProjectPath}
             selectedLocalProjectBranch={localProjectBranch}
+            localProjectBranches={localProjectBranches}
             onSelectLocalProject={handleSelectLocalProject}
             onAddLocalProject={() => void handleAddLocalProject()}
             onRemoveLocalProject={(cwd) => void handleRemoveLocalProject(cwd)}
             onRefreshLocalProjectBranch={() => void refreshLocalProjectBranch()}
+            onSelectLocalProjectBranch={(branch) =>
+              void checkoutLocalProjectBranch(branch)
+            }
+            onCreateLocalProjectBranch={(branch) =>
+              void checkoutLocalProjectBranch(branch, true)
+            }
             planMode={planMode}
             onPlanModeChange={runTarget === "cloud" ? setPlanMode : undefined}
             environments={environments}

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -19,7 +19,11 @@ import {
 } from "./ComposerPromptEditor"
 import { ContextWindowMeter } from "./ContextWindowMeter"
 import { EnvironmentSelector } from "./EnvironmentSelector"
-import { RunTargetSelector } from "./RunTargetSelector"
+import {
+  LocalBranchSelector,
+  LocalProjectSelector,
+  RunTargetSelector,
+} from "./RunTargetSelector"
 import {
   COMPOSER_PATH_DRAG_MIME,
   detectComposerTrigger,
@@ -104,10 +108,13 @@ export interface ChatComposerProps {
   localProjects?: Array<DesktopProject>
   selectedLocalProjectPath?: string | null
   selectedLocalProjectBranch?: string | null
+  localProjectBranches?: Array<string>
   onSelectLocalProject?: (cwd: string) => void
   onAddLocalProject?: () => void
   onRemoveLocalProject?: (cwd: string) => void
   onRefreshLocalProjectBranch?: () => void
+  onSelectLocalProjectBranch?: (branch: string) => void
+  onCreateLocalProjectBranch?: (branch: string) => void
   /** When provided, a Plan mode toggle is shown. Plan mode researches read-only and proposes a plan before editing. */
   planMode?: boolean
   onPlanModeChange?: (next: boolean) => void
@@ -224,10 +231,13 @@ export const ChatComposer = memo(function ChatComposer({
   localProjects = [],
   selectedLocalProjectPath = null,
   selectedLocalProjectBranch = null,
+  localProjectBranches = [],
   onSelectLocalProject,
   onAddLocalProject,
   onRemoveLocalProject,
   onRefreshLocalProjectBranch,
+  onSelectLocalProjectBranch,
+  onCreateLocalProjectBranch,
   planMode = false,
   onPlanModeChange,
   adminThread = false,
@@ -634,23 +644,32 @@ export const ChatComposer = memo(function ChatComposer({
               onChange={onEnvironmentChange}
             />
           )}
-          {runTarget &&
-            onRunTargetChange &&
+          {runTarget && onRunTargetChange && (
+            <RunTargetSelector onChange={onRunTargetChange} value={runTarget} />
+          )}
+          {runTarget === "local" &&
             onSelectLocalProject &&
             onAddLocalProject &&
-            onRemoveLocalProject &&
-            onRefreshLocalProjectBranch && (
-              <RunTargetSelector
-                localEnabled={Boolean(window.openSweDesktop)}
-                onChange={onRunTargetChange}
+            onRemoveLocalProject && (
+              <LocalProjectSelector
                 onAddProject={onAddLocalProject}
                 onRemoveProject={onRemoveLocalProject}
-                onRefreshBranch={onRefreshLocalProjectBranch}
                 onSelectProject={onSelectLocalProject}
                 projects={localProjects}
                 selectedProjectPath={selectedLocalProjectPath}
-                selectedProjectBranch={selectedLocalProjectBranch}
-                value={runTarget}
+              />
+            )}
+          {runTarget === "local" &&
+            onRefreshLocalProjectBranch &&
+            onSelectLocalProjectBranch &&
+            onCreateLocalProjectBranch && (
+              <LocalBranchSelector
+                branches={localProjectBranches}
+                disabled={!selectedLocalProjectPath}
+                onCreateBranch={onCreateLocalProjectBranch}
+                onRefresh={onRefreshLocalProjectBranch}
+                onSelectBranch={onSelectLocalProjectBranch}
+                selectedBranch={selectedLocalProjectBranch}
               />
             )}
         </div>

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -630,6 +630,9 @@ export const ChatComposer = memo(function ChatComposer({
     >
       {(onRepoChange || onRunTargetChange || onEnvironmentChange) && (
         <div className="mb-2 flex min-w-0 flex-wrap items-center gap-2 px-1 text-xs">
+          {runTarget && onRunTargetChange && (
+            <RunTargetSelector onChange={onRunTargetChange} value={runTarget} />
+          )}
           {runTarget !== "local" && onRepoChange && (
             <RepoSelector
               repos={repos}
@@ -643,9 +646,6 @@ export const ChatComposer = memo(function ChatComposer({
               selectedSlug={selectedEnvironment}
               onChange={onEnvironmentChange}
             />
-          )}
-          {runTarget && onRunTargetChange && (
-            <RunTargetSelector onChange={onRunTargetChange} value={runTarget} />
           )}
           {runTarget === "local" &&
             onSelectLocalProject &&

--- a/ui/src/features/agents/components/composer/RunTargetSelector.tsx
+++ b/ui/src/features/agents/components/composer/RunTargetSelector.tsx
@@ -3,8 +3,9 @@ import {
   Cloud,
   FolderOpen,
   FolderPlus,
+  GitBranch,
   Laptop,
-  LockKeyhole,
+  Plus,
   Trash2,
 } from "lucide-react"
 
@@ -25,130 +26,169 @@ import {
 
 export type RunTarget = "cloud" | "local"
 
-interface RunTargetSelectorProps {
-  value: RunTarget
-  onChange: (value: RunTarget) => void
-  localEnabled?: boolean
-  projects: Array<DesktopProject>
-  selectedProjectPath: string | null
-  selectedProjectBranch: string | null
-  onSelectProject: (cwd: string) => void
-  onAddProject: () => void
-  onRemoveProject: (cwd: string) => void
-  onRefreshBranch: () => void
-}
-
 export function RunTargetSelector({
   value,
   onChange,
-  localEnabled = false,
+}: {
+  value: RunTarget
+  onChange: (value: RunTarget) => void
+}) {
+  const Icon = value === "local" ? Laptop : Cloud
+  return (
+    <Menu>
+      <MenuTrigger className="flex items-center gap-1 text-muted-foreground transition-opacity hover:opacity-80">
+        <Icon className="size-3.5 shrink-0" />
+        <span>{value === "local" ? "This Mac" : "Cloud"}</span>
+        <ComposerControlChevron />
+      </MenuTrigger>
+      <MenuPopup align="start" className="w-44" sideOffset={7}>
+        <MenuGroup>
+          <MenuGroupLabel>Work in</MenuGroupLabel>
+          <MenuItem onClick={() => onChange("local")}>
+            <Laptop />
+            This Mac{value === "local" && <Check className="ml-auto" />}
+          </MenuItem>
+          <MenuItem onClick={() => onChange("cloud")}>
+            <Cloud />
+            Cloud{value === "cloud" && <Check className="ml-auto" />}
+          </MenuItem>
+        </MenuGroup>
+      </MenuPopup>
+    </Menu>
+  )
+}
+
+export function LocalProjectSelector({
   projects,
   selectedProjectPath,
-  selectedProjectBranch,
   onSelectProject,
   onAddProject,
   onRemoveProject,
-  onRefreshBranch,
-}: RunTargetSelectorProps) {
+}: {
+  projects: Array<DesktopProject>
+  selectedProjectPath: string | null
+  onSelectProject: (cwd: string) => void
+  onAddProject: () => void
+  onRemoveProject: (cwd: string) => void
+}) {
   const selectedProject = projects.find(
     (project) => project.cwd === selectedProjectPath
   )
-  const Icon = value === "local" ? Laptop : Cloud
-  const label =
-    value === "local"
-      ? selectedProject
-        ? `This Mac · ${selectedProject.name}${selectedProjectBranch ? ` · ${selectedProjectBranch}` : ""}`
-        : "This Mac"
-      : "Cloud"
-
   return (
-    <Menu onOpenChange={(open) => open && onRefreshBranch()}>
+    <Menu>
       <MenuTrigger
         className="flex max-w-[260px] items-center gap-1 text-muted-foreground transition-opacity hover:opacity-80"
         title={selectedProject?.cwd}
       >
-        <Icon className="size-3.5 shrink-0" />
-        <span className="truncate">{label}</span>
+        <FolderOpen className="size-3.5 shrink-0" />
+        <span className="truncate">
+          {selectedProject?.name ?? "Select project"}
+        </span>
         <ComposerControlChevron />
       </MenuTrigger>
-      <MenuPopup align="start" className="w-56" sideOffset={7}>
+      <MenuPopup align="start" className="w-64" sideOffset={7}>
         <MenuGroup>
-          <MenuGroupLabel>Run on</MenuGroupLabel>
-          <MenuItem onClick={() => onChange("cloud")}>
-            <Cloud />
-            Cloud
-            {value === "cloud" && <Check className="ml-auto" />}
-          </MenuItem>
-          <MenuSub>
-            <MenuSubTrigger disabled={!localEnabled}>
-              <Laptop />
-              This Mac
-              {!localEnabled && <LockKeyhole className="ml-auto" />}
-              {localEnabled && value === "local" && (
+          <MenuGroupLabel>Projects</MenuGroupLabel>
+          {projects.length === 0 && (
+            <MenuItem disabled>No projects added</MenuItem>
+          )}
+          {projects.map((project) => (
+            <MenuItem
+              key={project.cwd}
+              onClick={() => onSelectProject(project.cwd)}
+              title={project.cwd}
+            >
+              <FolderOpen />
+              <span className="min-w-0 flex-1 truncate">{project.name}</span>
+              {selectedProjectPath === project.cwd && (
                 <Check className="ml-auto" />
               )}
-            </MenuSubTrigger>
-            <MenuSubPopup className="w-64">
-              <MenuGroup>
-                <MenuGroupLabel>Projects</MenuGroupLabel>
-                {projects.length === 0 && (
-                  <MenuItem disabled>No projects added</MenuItem>
-                )}
-                {projects.map((project) => (
-                  <MenuItem
-                    key={project.cwd}
-                    onClick={() => onSelectProject(project.cwd)}
-                    title={project.cwd}
-                  >
-                    <FolderOpen />
-                    <span className="min-w-0 flex-1 truncate">
-                      {project.name}
-                      {project.cwd === selectedProjectPath &&
-                        selectedProjectBranch && (
-                          <span className="text-muted-foreground/60">
-                            {` · ${selectedProjectBranch}`}
-                          </span>
-                        )}
-                    </span>
-                    {selectedProjectPath === project.cwd && (
-                      <Check className="ml-auto" />
-                    )}
-                  </MenuItem>
-                ))}
-              </MenuGroup>
-              <MenuSeparator />
-              <MenuGroup>
-                <MenuItem onClick={onAddProject}>
-                  <FolderPlus />
-                  Add project…
-                </MenuItem>
-                {projects.length > 0 && (
-                  <MenuSub>
-                    <MenuSubTrigger>
-                      <Trash2 />
-                      Remove project…
-                    </MenuSubTrigger>
-                    <MenuSubPopup className="w-64">
-                      <MenuGroup>
-                        {projects.map((project) => (
-                          <MenuItem
-                            key={project.cwd}
-                            onClick={() => onRemoveProject(project.cwd)}
-                            title={project.cwd}
-                            variant="destructive"
-                          >
-                            <FolderOpen />
-                            <span className="truncate">{project.name}</span>
-                          </MenuItem>
-                        ))}
-                      </MenuGroup>
-                    </MenuSubPopup>
-                  </MenuSub>
-                )}
-              </MenuGroup>
-            </MenuSubPopup>
-          </MenuSub>
+            </MenuItem>
+          ))}
         </MenuGroup>
+        <MenuSeparator />
+        <MenuGroup>
+          <MenuItem onClick={onAddProject}>
+            <FolderPlus />
+            Add project…
+          </MenuItem>
+          {projects.length > 0 && (
+            <MenuSub>
+              <MenuSubTrigger>
+                <Trash2 />
+                Remove project…
+              </MenuSubTrigger>
+              <MenuSubPopup className="w-64">
+                <MenuGroup>
+                  {projects.map((project) => (
+                    <MenuItem
+                      key={project.cwd}
+                      onClick={() => onRemoveProject(project.cwd)}
+                      title={project.cwd}
+                      variant="destructive"
+                    >
+                      <FolderOpen />
+                      <span className="truncate">{project.name}</span>
+                    </MenuItem>
+                  ))}
+                </MenuGroup>
+              </MenuSubPopup>
+            </MenuSub>
+          )}
+        </MenuGroup>
+      </MenuPopup>
+    </Menu>
+  )
+}
+
+export function LocalBranchSelector({
+  branches,
+  selectedBranch,
+  disabled = false,
+  onRefresh,
+  onSelectBranch,
+  onCreateBranch,
+}: {
+  branches: Array<string>
+  selectedBranch: string | null
+  disabled?: boolean
+  onRefresh: () => void
+  onSelectBranch: (branch: string) => void
+  onCreateBranch: (branch: string) => void
+}) {
+  const createBranch = () => {
+    const branch = window.prompt("New branch name")?.trim()
+    if (branch) onCreateBranch(branch)
+  }
+  return (
+    <Menu onOpenChange={(open) => open && onRefresh()}>
+      <MenuTrigger
+        className="flex max-w-[260px] items-center gap-1 text-muted-foreground transition-opacity hover:opacity-80 disabled:opacity-50"
+        disabled={disabled}
+      >
+        <GitBranch className="size-3.5 shrink-0" />
+        <span className="truncate">{selectedBranch ?? "No branch"}</span>
+        <ComposerControlChevron />
+      </MenuTrigger>
+      <MenuPopup align="start" className="w-64" sideOffset={7}>
+        <MenuGroup>
+          <MenuGroupLabel>Branches</MenuGroupLabel>
+          {branches.length === 0 && (
+            <MenuItem disabled>No local branches</MenuItem>
+          )}
+          {branches.map((branch) => (
+            <MenuItem key={branch} onClick={() => onSelectBranch(branch)}>
+              <GitBranch />
+              <span className="min-w-0 flex-1 truncate">{branch}</span>
+              {selectedBranch === branch && <Check className="ml-auto" />}
+            </MenuItem>
+          ))}
+        </MenuGroup>
+        <MenuSeparator />
+        <MenuItem onClick={createBranch}>
+          <Plus />
+          Create and checkout new branch…
+        </MenuItem>
       </MenuPopup>
     </Menu>
   )


### PR DESCRIPTION
## Summary
- add desktop IPC support for listing, switching, and creating local branches
- split local project and branch controls in the composer
- refresh branch state after checkout and surface checkout errors

## Testing
- `pnpm --dir desktop run test`
- `pnpm --dir desktop run typecheck`
- `pnpm --dir ui run typecheck`

Made by [Open SWE](https://openswe.vercel.app/agents/01a01b34-bdf0-77a3-8971-a4c155c09d6d)
