### PR TITLE
feat: add keyboard command system

### DIFF
--- a/desktop/src/commands.cts
+++ b/desktop/src/commands.cts
@@ -1,0 +1,15 @@
+const DESKTOP_COMMAND_IDS = [
+  "new-thread",
+  "show-command-palette",
+  "open-settings",
+  "show-keyboard-shortcuts",
+  "toggle-sidebar",
+] as const;
+
+const desktopCommandIds = new Set<string>(DESKTOP_COMMAND_IDS);
+
+function isDesktopCommandId(value: unknown) {
+  return typeof value === "string" && desktopCommandIds.has(value);
+}
+
+module.exports = { DESKTOP_COMMAND_IDS, isDesktopCommandId };

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -35,6 +35,7 @@ const {
   removeProject,
 } = require("./project-store.cjs");
 const { beginLogin } = require("./login-server.cjs");
+const { isDesktopCommandId } = require("./commands.cjs");
 const {
   APP_ORIGIN,
   APP_URL,
@@ -88,6 +89,12 @@ let loginFlow = null;
 let quitting = false;
 let localThreadStore = null;
 let backendSupervisor = null;
+
+function sendDesktopCommand(commandId) {
+  if (!isDesktopCommandId(commandId) || !mainWindow || mainWindow.isDestroyed())
+    return;
+  mainWindow.webContents.send("desktop:command", commandId);
+}
 
 function requireTrustedDesktopIpc(event) {
   const senderUrl = event.senderFrame?.url || event.sender.getURL();
@@ -535,6 +542,12 @@ function createMenu() {
     label: "Backend URL…",
     click: () => createSetupWindow(),
   };
+  const settingsItem = {
+    id: "open-settings",
+    label: "Settings…",
+    accelerator: "CmdOrCtrl+,",
+    click: () => sendDesktopCommand("open-settings"),
+  };
   const template = [
     ...(process.platform === "darwin"
       ? [
@@ -542,6 +555,7 @@ function createMenu() {
             label: app.name,
             submenu: [
               { role: "about" },
+              settingsItem,
               backendSettingsItem,
               { type: "separator" },
               { role: "services" },
@@ -555,18 +569,28 @@ function createMenu() {
           },
         ]
       : []),
-    ...(process.platform === "darwin"
-      ? []
-      : [
-          {
-            label: "File",
-            submenu: [
-              backendSettingsItem,
-              { type: "separator" },
-              { role: "quit" },
-            ],
-          },
-        ]),
+    {
+      label: "File",
+      submenu: [
+        {
+          id: "new-thread",
+          label: "New Thread",
+          accelerator: "CmdOrCtrl+N",
+          click: () => sendDesktopCommand("new-thread"),
+        },
+        {
+          id: "show-command-palette",
+          label: "Search Commands and Threads…",
+          accelerator: "CmdOrCtrl+K",
+          click: () => sendDesktopCommand("show-command-palette"),
+        },
+        ...(process.platform === "darwin"
+          ? []
+          : [{ type: "separator" }, settingsItem, backendSettingsItem]),
+        { type: "separator" },
+        { role: process.platform === "darwin" ? "close" : "quit" },
+      ],
+    },
     {
       label: "Edit",
       submenu: [
@@ -582,6 +606,13 @@ function createMenu() {
     {
       label: "View",
       submenu: [
+        {
+          id: "toggle-sidebar",
+          label: "Toggle Sidebar",
+          accelerator: "CmdOrCtrl+B",
+          click: () => sendDesktopCommand("toggle-sidebar"),
+        },
+        { type: "separator" },
         {
           label: "Reload",
           accelerator: "CmdOrCtrl+R",
@@ -605,6 +636,13 @@ function createMenu() {
     {
       role: "help",
       submenu: [
+        {
+          id: "show-keyboard-shortcuts",
+          label: "Keyboard Shortcuts",
+          accelerator: "CmdOrCtrl+/",
+          click: () => sendDesktopCommand("show-keyboard-shortcuts"),
+        },
+        { type: "separator" },
         {
           label: "Open SWE on GitHub",
           click: () =>

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -1,5 +1,15 @@
 const { contextBridge, ipcRenderer } = require("electron")
-const { isDesktopCommandId } = require("./commands.cjs")
+const desktopCommandIds = new Set([
+  "new-thread",
+  "show-command-palette",
+  "open-settings",
+  "show-keyboard-shortcuts",
+  "toggle-sidebar",
+])
+
+function isDesktopCommandId(value) {
+  return typeof value === "string" && desktopCommandIds.has(value)
+}
 
 contextBridge.exposeInMainWorld("openSweDesktop", {
   isDesktop: true,

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -1,7 +1,15 @@
 const { contextBridge, ipcRenderer } = require("electron")
+const { isDesktopCommandId } = require("./commands.cjs")
 
 contextBridge.exposeInMainWorld("openSweDesktop", {
   isDesktop: true,
+  onCommand: (callback) => {
+    const listener = (_event, commandId) => {
+      if (isDesktopCommandId(commandId)) callback(commandId)
+    }
+    ipcRenderer.on("desktop:command", listener)
+    return () => ipcRenderer.removeListener("desktop:command", listener)
+  },
   listProjects: () => ipcRenderer.invoke("desktop:projects"),
   getProjectBranch: (cwd) => ipcRenderer.invoke("desktop:project-branch", cwd),
   addProject: () => ipcRenderer.invoke("desktop:add-project"),

--- a/desktop/test/commands.test.cjs
+++ b/desktop/test/commands.test.cjs
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  DESKTOP_COMMAND_IDS,
+  isDesktopCommandId,
+} = require("../build/commands.cjs");
+
+test("desktop commands use a fixed allowlist", () => {
+  assert.deepEqual(DESKTOP_COMMAND_IDS, [
+    "new-thread",
+    "show-command-palette",
+    "open-settings",
+    "show-keyboard-shortcuts",
+    "toggle-sidebar",
+  ]);
+  for (const commandId of DESKTOP_COMMAND_IDS) {
+    assert.equal(isDesktopCommandId(commandId), true);
+  }
+  assert.equal(isDesktopCommandId("open-url"), false);
+  assert.equal(isDesktopCommandId({ id: "new-thread" }), false);
+});

--- a/desktop/test/preload-command.test.cjs
+++ b/desktop/test/preload-command.test.cjs
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+test("preload command subscriptions validate IDs and unsubscribe", () => {
+  let exposed;
+  const listeners = new Map();
+  const electron = {
+    contextBridge: {
+      exposeInMainWorld: (_name, bridge) => {
+        exposed = bridge;
+      },
+    },
+    ipcRenderer: {
+      invoke: () => undefined,
+      on: (channel, listener) => listeners.set(channel, listener),
+      removeListener: (channel, listener) => {
+        if (listeners.get(channel) === listener) listeners.delete(channel);
+      },
+    },
+  };
+  const originalLoad = Module._load;
+  const originalWindow = global.window;
+  Module._load = function (request, parent, isMain) {
+    if (request === "electron") return electron;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  global.window = { addEventListener: () => undefined };
+
+  try {
+    const preloadPath = require.resolve("../build/preload.cjs");
+    delete require.cache[preloadPath];
+    require(preloadPath);
+
+    const received = [];
+    const unsubscribe = exposed.onCommand((commandId) =>
+      received.push(commandId),
+    );
+    const listener = listeners.get("desktop:command");
+    listener(undefined, "new-thread");
+    listener(undefined, "open-url");
+
+    assert.deepEqual(received, ["new-thread"]);
+    unsubscribe();
+    assert.equal(listeners.has("desktop:command"), false);
+  } finally {
+    Module._load = originalLoad;
+    global.window = originalWindow;
+  }
+});

--- a/ui/src/components/AppCommandPalette.test.tsx
+++ b/ui/src/components/AppCommandPalette.test.tsx
@@ -1,0 +1,96 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { DesktopLocalThreadSummary } from "@/desktop"
+import type { AgentThread } from "@/features/agents/lib/types"
+import type { AppCommand } from "@/lib/appCommands"
+import { AppCommandPalette } from "./AppCommandPalette"
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  cloudThread: { id: "cloud-1", title: "Cloud result" } as AgentThread,
+  localThread: {
+    id: "local-1",
+    title: "Local result",
+    cwd: "/tmp/repo",
+    status: "idle",
+    createdAt: 1,
+    updatedAt: 2,
+    modelId: null,
+    effort: null,
+  } as DesktopLocalThreadSummary,
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+}))
+vi.mock("@/features/agents/lib/queries", () => ({
+  useThreadsPage: () => ({
+    data: { items: [mocks.cloudThread] },
+    isFetching: false,
+    isError: false,
+  }),
+}))
+vi.mock("@/features/agents/lib/desktopLocal", () => ({
+  useDesktopLocalThreads: () => ({ data: [mocks.localThread] }),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const commands: Array<AppCommand> = [
+  {
+    id: "settings",
+    label: "Open settings",
+    shortcuts: ["mod+,"],
+    group: "Navigation",
+    run: vi.fn(),
+  },
+]
+
+describe("AppCommandPalette", () => {
+  it("moves through results with the keyboard and opens a cloud thread", () => {
+    render(
+      <AppCommandPalette commands={commands} open onOpenChange={vi.fn()} />
+    )
+
+    const input = screen.getByRole("combobox")
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: "/agents/$threadId",
+      params: { threadId: "cloud-1" },
+    })
+  })
+
+  it("filters thread titles as text and routes local results", () => {
+    render(
+      <AppCommandPalette commands={commands} open onOpenChange={vi.fn()} />
+    )
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "LOCAL RESULT" },
+    })
+    fireEvent.click(screen.getByRole("option", { name: /Local result/ }))
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: "/agents/local/$sessionId",
+      params: { sessionId: "local-1" },
+    })
+  })
+
+  it("closes on Escape", () => {
+    const onOpenChange = vi.fn()
+    render(
+      <AppCommandPalette commands={commands} open onOpenChange={onOpenChange} />
+    )
+
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" })
+    expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything())
+  })
+})

--- a/ui/src/components/AppCommandPalette.test.tsx
+++ b/ui/src/components/AppCommandPalette.test.tsx
@@ -10,6 +10,7 @@ import { AppCommandPalette } from "./AppCommandPalette"
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
+  fetchNextPage: vi.fn(),
   cloudThread: { id: "cloud-1", title: "Cloud result" } as AgentThread,
   localThread: {
     id: "local-1",
@@ -27,10 +28,13 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mocks.navigate,
 }))
 vi.mock("@/features/agents/lib/queries", () => ({
-  useThreadsPage: () => ({
-    data: { items: [mocks.cloudThread] },
+  useInfiniteThreadsPages: () => ({
+    data: { pages: [{ items: [mocks.cloudThread] }] },
     isFetching: false,
     isError: false,
+    hasNextPage: true,
+    isFetchingNextPage: false,
+    fetchNextPage: mocks.fetchNextPage,
   }),
 }))
 vi.mock("@/features/agents/lib/desktopLocal", () => ({
@@ -82,6 +86,16 @@ describe("AppCommandPalette", () => {
       to: "/agents/local/$sessionId",
       params: { sessionId: "local-1" },
     })
+  })
+
+  it("loads additional cloud thread pages", () => {
+    render(
+      <AppCommandPalette commands={commands} open onOpenChange={vi.fn()} />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more threads" }))
+
+    expect(mocks.fetchNextPage).toHaveBeenCalledOnce()
   })
 
   it("closes on Escape", () => {

--- a/ui/src/components/AppCommandPalette.tsx
+++ b/ui/src/components/AppCommandPalette.tsx
@@ -13,7 +13,7 @@ import type { AppCommand } from "@/lib/appCommands"
 import type { AgentThread } from "@/features/agents/lib/types"
 import type { DesktopLocalThreadSummary } from "@/desktop"
 import { Kbd } from "@/components/ui/kbd"
-import { useThreadsPage } from "@/features/agents/lib/queries"
+import { useInfiniteThreadsPages } from "@/features/agents/lib/queries"
 import { useDesktopLocalThreads } from "@/features/agents/lib/desktopLocal"
 import { useShortcutLabel } from "@/lib/hotkeys"
 import { cn } from "@/lib/utils"
@@ -124,10 +124,9 @@ export function AppCommandPalette({
     return () => window.clearTimeout(timer)
   }, [open, query])
 
-  const cloudThreads = useThreadsPage(
+  const cloudThreads = useInfiniteThreadsPages(
     {
       limit: 20,
-      offset: 0,
       q: debouncedQuery || undefined,
       scope: "interactive",
     },
@@ -138,11 +137,11 @@ export function AppCommandPalette({
     () =>
       buildPaletteResults(
         commands,
-        cloudThreads.data?.items ?? [],
+        cloudThreads.data?.pages.flatMap((page) => page.items) ?? [],
         localThreads.data ?? [],
         query
       ),
-    [cloudThreads.data?.items, commands, localThreads.data, query]
+    [cloudThreads.data?.pages, commands, localThreads.data, query]
   )
   const resultGroups = useMemo(() => {
     const grouped = new Map<string, Array<PaletteResult>>()
@@ -256,49 +255,64 @@ export function AppCommandPalette({
                 No commands or threads found.
               </p>
             ) : (
-              resultGroups.map(([group, groupResults]) => (
-                <div aria-label={group} key={group} role="group">
-                  <div className="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
-                    {group}
+              <>
+                {resultGroups.map(([group, groupResults]) => (
+                  <div aria-label={group} key={group} role="group">
+                    <div className="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                      {group}
+                    </div>
+                    {groupResults.map((result) => {
+                      const index = results.indexOf(result)
+                      const command =
+                        result.kind === "command" ? result.command : null
+                      const Icon =
+                        result.kind === "command"
+                          ? CommandIcon
+                          : result.kind === "local-thread"
+                            ? Laptop
+                            : MessageSquare
+                      return (
+                        <button
+                          aria-selected={index === activeIndex}
+                          className={cn(
+                            "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm",
+                            index === activeIndex
+                              ? "bg-accent text-accent-foreground"
+                              : "text-foreground"
+                          )}
+                          id={result.id}
+                          key={result.id}
+                          onClick={() => runResult(result)}
+                          onMouseEnter={() => setActiveIndex(index)}
+                          role="option"
+                          type="button"
+                        >
+                          <Icon className="size-4 shrink-0 text-muted-foreground" />
+                          <span className="min-w-0 flex-1 truncate">
+                            {result.label}
+                          </span>
+                          {command?.shortcuts?.[0] && (
+                            <ShortcutHint shortcut={command.shortcuts[0]} />
+                          )}
+                        </button>
+                      )
+                    })}
                   </div>
-                  {groupResults.map((result) => {
-                    const index = results.indexOf(result)
-                    const command =
-                      result.kind === "command" ? result.command : null
-                    const Icon =
-                      result.kind === "command"
-                        ? CommandIcon
-                        : result.kind === "local-thread"
-                          ? Laptop
-                          : MessageSquare
-                    return (
-                      <button
-                        aria-selected={index === activeIndex}
-                        className={cn(
-                          "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm",
-                          index === activeIndex
-                            ? "bg-accent text-accent-foreground"
-                            : "text-foreground"
-                        )}
-                        id={result.id}
-                        key={result.id}
-                        onClick={() => runResult(result)}
-                        onMouseEnter={() => setActiveIndex(index)}
-                        role="option"
-                        type="button"
-                      >
-                        <Icon className="size-4 shrink-0 text-muted-foreground" />
-                        <span className="min-w-0 flex-1 truncate">
-                          {result.label}
-                        </span>
-                        {command?.shortcuts?.[0] && (
-                          <ShortcutHint shortcut={command.shortcuts[0]} />
-                        )}
-                      </button>
-                    )
-                  })}
-                </div>
-              ))
+                ))}
+                {cloudThreads.hasNextPage && (
+                  <button
+                    className="flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                    disabled={cloudThreads.isFetchingNextPage}
+                    onClick={() => void cloudThreads.fetchNextPage()}
+                    type="button"
+                  >
+                    {cloudThreads.isFetchingNextPage && (
+                      <LoaderCircle className="size-3.5 animate-spin" />
+                    )}
+                    Load more threads
+                  </button>
+                )}
+              </>
             )}
           </div>
         </Dialog.Popup>

--- a/ui/src/components/AppCommandPalette.tsx
+++ b/ui/src/components/AppCommandPalette.tsx
@@ -1,0 +1,308 @@
+import { Dialog } from "@base-ui/react/dialog"
+import { useNavigate } from "@tanstack/react-router"
+import {
+  Command as CommandIcon,
+  Laptop,
+  LoaderCircle,
+  MessageSquare,
+  Search,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+
+import type { AppCommand } from "@/lib/appCommands"
+import type { AgentThread } from "@/features/agents/lib/types"
+import type { DesktopLocalThreadSummary } from "@/desktop"
+import { Kbd } from "@/components/ui/kbd"
+import { useThreadsPage } from "@/features/agents/lib/queries"
+import { useDesktopLocalThreads } from "@/features/agents/lib/desktopLocal"
+import { useShortcutLabel } from "@/lib/hotkeys"
+import { cn } from "@/lib/utils"
+
+interface CommandResult {
+  id: string
+  kind: "command"
+  label: string
+  command: AppCommand
+}
+
+interface CloudThreadResult {
+  id: string
+  kind: "cloud-thread"
+  label: string
+  thread: AgentThread
+}
+
+interface LocalThreadResult {
+  id: string
+  kind: "local-thread"
+  label: string
+  thread: DesktopLocalThreadSummary
+}
+
+type PaletteResult = CommandResult | CloudThreadResult | LocalThreadResult
+
+function ShortcutHint({ shortcut }: { shortcut: string }) {
+  const label = useShortcutLabel(shortcut)
+  return <Kbd className="ml-auto bg-background/70">{label}</Kbd>
+}
+
+function commandMatches(command: AppCommand, query: string): boolean {
+  const haystack = [command.label, ...(command.aliases ?? [])]
+    .join(" ")
+    .toLowerCase()
+  return haystack.includes(query.toLowerCase())
+}
+
+export function buildPaletteResults(
+  commands: ReadonlyArray<AppCommand>,
+  cloudThreads: ReadonlyArray<AgentThread>,
+  localThreads: ReadonlyArray<DesktopLocalThreadSummary>,
+  query: string
+): Array<PaletteResult> {
+  const normalizedQuery = query.trim().toLowerCase()
+  const commandResults: Array<CommandResult> = commands
+    .filter(
+      (command) =>
+        command.run &&
+        command.showInPalette !== false &&
+        (!normalizedQuery || commandMatches(command, normalizedQuery))
+    )
+    .map((command) => ({
+      id: `command:${command.id}`,
+      kind: "command",
+      label: command.label,
+      command,
+    }))
+  const cloudResults: Array<CloudThreadResult> = cloudThreads
+    .filter(
+      (thread) =>
+        !normalizedQuery || thread.title.toLowerCase().includes(normalizedQuery)
+    )
+    .map((thread) => ({
+      id: `cloud:${thread.id}`,
+      kind: "cloud-thread",
+      label: thread.title,
+      thread,
+    }))
+  const localResults: Array<LocalThreadResult> = localThreads
+    .filter(
+      (thread) =>
+        !normalizedQuery || thread.title.toLowerCase().includes(normalizedQuery)
+    )
+    .map((thread) => ({
+      id: `local:${thread.id}`,
+      kind: "local-thread",
+      label: thread.title,
+      thread,
+    }))
+  return [...commandResults, ...cloudResults, ...localResults]
+}
+
+export function AppCommandPalette({
+  commands,
+  open,
+  onOpenChange,
+}: {
+  commands: ReadonlyArray<AppCommand>
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState("")
+  const [debouncedQuery, setDebouncedQuery] = useState("")
+  const [activeIndex, setActiveIndex] = useState(0)
+  const isDesktop =
+    typeof window !== "undefined" && Boolean(window.openSweDesktop)
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setDebouncedQuery("")
+      return
+    }
+    const timer = window.setTimeout(() => setDebouncedQuery(query.trim()), 180)
+    return () => window.clearTimeout(timer)
+  }, [open, query])
+
+  const cloudThreads = useThreadsPage(
+    {
+      limit: 20,
+      offset: 0,
+      q: debouncedQuery || undefined,
+      scope: "interactive",
+    },
+    { enabled: open, staleWhileRevalidate: true }
+  )
+  const localThreads = useDesktopLocalThreads({ enabled: open && isDesktop })
+  const results = useMemo(
+    () =>
+      buildPaletteResults(
+        commands,
+        cloudThreads.data?.items ?? [],
+        localThreads.data ?? [],
+        query
+      ),
+    [cloudThreads.data?.items, commands, localThreads.data, query]
+  )
+  const resultGroups = useMemo(() => {
+    const grouped = new Map<string, Array<PaletteResult>>()
+    for (const result of results) {
+      const group =
+        result.kind === "command"
+          ? result.command.group
+          : result.kind === "cloud-thread"
+            ? "Cloud threads"
+            : "This Mac"
+      grouped.set(group, [...(grouped.get(group) ?? []), result])
+    }
+    return [...grouped]
+  }, [results])
+  const resultKey = results.map((result) => result.id).join("|")
+
+  useEffect(() => setActiveIndex(0), [resultKey])
+
+  const runResult = (result: PaletteResult | undefined) => {
+    if (!result) return
+    onOpenChange(false)
+    if (result.kind === "command") {
+      void result.command.run?.()
+    } else if (result.kind === "cloud-thread") {
+      void navigate({
+        to: "/agents/$threadId",
+        params: { threadId: result.thread.id },
+      })
+    } else {
+      void navigate({
+        to: "/agents/local/$sessionId",
+        params: { sessionId: result.thread.id },
+      })
+    }
+  }
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setActiveIndex((current) =>
+        results.length === 0 ? 0 : (current + 1) % results.length
+      )
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setActiveIndex((current) =>
+        results.length === 0
+          ? 0
+          : (current - 1 + results.length) % results.length
+      )
+    } else if (event.key === "Home") {
+      event.preventDefault()
+      setActiveIndex(0)
+    } else if (event.key === "End") {
+      event.preventDefault()
+      setActiveIndex(Math.max(0, results.length - 1))
+    } else if (event.key === "Enter") {
+      event.preventDefault()
+      runResult(results[activeIndex])
+    }
+  }
+
+  const showLoading = cloudThreads.isFetching && results.length === 0
+  const showError = cloudThreads.isError && results.length === 0
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/45 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <Dialog.Popup
+          className="fixed top-[18%] left-1/2 z-50 flex max-h-[min(34rem,70vh)] w-[min(40rem,calc(100vw-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-2xl outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95"
+          data-hotkeys="ignore"
+        >
+          <Dialog.Title className="sr-only">
+            Search commands and threads
+          </Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Search commands, cloud threads, and local desktop threads.
+          </Dialog.Description>
+          <div className="flex items-center gap-2 border-b border-border px-4">
+            <Search className="size-4 shrink-0 text-muted-foreground" />
+            <input
+              autoFocus
+              aria-activedescendant={results[activeIndex]?.id}
+              aria-autocomplete="list"
+              aria-controls="app-command-results"
+              className="h-12 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={onInputKeyDown}
+              placeholder="Search commands and threads"
+              role="combobox"
+              value={query}
+            />
+            <Kbd>Esc</Kbd>
+          </div>
+          <div
+            className="min-h-20 overflow-y-auto p-2"
+            id="app-command-results"
+            role="listbox"
+          >
+            {showLoading ? (
+              <div className="flex items-center justify-center gap-2 py-10 text-xs text-muted-foreground">
+                <LoaderCircle className="size-4 animate-spin" />
+                Searching threads…
+              </div>
+            ) : showError ? (
+              <p className="py-10 text-center text-xs text-destructive">
+                Thread search is unavailable.
+              </p>
+            ) : results.length === 0 ? (
+              <p className="py-10 text-center text-xs text-muted-foreground">
+                No commands or threads found.
+              </p>
+            ) : (
+              resultGroups.map(([group, groupResults]) => (
+                <div aria-label={group} key={group} role="group">
+                  <div className="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    {group}
+                  </div>
+                  {groupResults.map((result) => {
+                    const index = results.indexOf(result)
+                    const command =
+                      result.kind === "command" ? result.command : null
+                    const Icon =
+                      result.kind === "command"
+                        ? CommandIcon
+                        : result.kind === "local-thread"
+                          ? Laptop
+                          : MessageSquare
+                    return (
+                      <button
+                        aria-selected={index === activeIndex}
+                        className={cn(
+                          "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm",
+                          index === activeIndex
+                            ? "bg-accent text-accent-foreground"
+                            : "text-foreground"
+                        )}
+                        id={result.id}
+                        key={result.id}
+                        onClick={() => runResult(result)}
+                        onMouseEnter={() => setActiveIndex(index)}
+                        role="option"
+                        type="button"
+                      >
+                        <Icon className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 flex-1 truncate">
+                          {result.label}
+                        </span>
+                        {command?.shortcuts?.[0] && (
+                          <ShortcutHint shortcut={command.shortcuts[0]} />
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/ui/src/components/AppShortcutReference.tsx
+++ b/ui/src/components/AppShortcutReference.tsx
@@ -1,0 +1,85 @@
+import { Dialog } from "@base-ui/react/dialog"
+import { X } from "lucide-react"
+
+import type { AppCommand } from "@/lib/appCommands"
+import { Kbd } from "@/components/ui/kbd"
+import { useShortcutLabel } from "@/lib/hotkeys"
+
+function ShortcutKey({ shortcut }: { shortcut: string }) {
+  const label = useShortcutLabel(shortcut)
+  return <Kbd>{label}</Kbd>
+}
+
+export function AppShortcutReference({
+  commands,
+  open,
+  onOpenChange,
+}: {
+  commands: ReadonlyArray<AppCommand>
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const groups = new Map<string, Array<AppCommand>>()
+  for (const command of commands) {
+    if (!command.shortcuts?.length) continue
+    const group = groups.get(command.group) ?? []
+    group.push(command)
+    groups.set(command.group, group)
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/45 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <Dialog.Popup
+          className="fixed top-1/2 left-1/2 z-50 flex max-h-[min(40rem,80vh)] w-[min(38rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-2xl outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95"
+          data-hotkeys="ignore"
+        >
+          <div className="flex items-center justify-between border-b border-border px-5 py-4">
+            <Dialog.Title className="font-heading text-sm font-medium">
+              Keyboard shortcuts
+            </Dialog.Title>
+            <Dialog.Close
+              aria-label="Close keyboard shortcuts"
+              className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <X className="size-4" />
+            </Dialog.Close>
+          </div>
+          <Dialog.Description className="sr-only">
+            Keyboard shortcuts available in the current view.
+          </Dialog.Description>
+          <div className="overflow-y-auto p-5">
+            {[...groups].map(([group, groupCommands]) => (
+              <section className="mb-6 last:mb-0" key={group}>
+                <h3 className="mb-2 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                  {group}
+                </h3>
+                <div className="divide-y divide-border/60 rounded-lg border border-border">
+                  {groupCommands.map((command) => (
+                    <div
+                      className="flex min-h-10 items-center gap-3 px-3 py-2"
+                      key={command.id}
+                    >
+                      <span className="min-w-0 flex-1 text-sm">
+                        {command.label}
+                      </span>
+                      <div className="flex shrink-0 items-center gap-1">
+                        {command.shortcuts?.map((shortcut) => (
+                          <ShortcutKey
+                            key={`${command.id}:${shortcut}`}
+                            shortcut={shortcut}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -8,7 +8,6 @@ import {
 } from "react"
 import { SidebarSimpleIcon } from "@phosphor-icons/react"
 
-import { useHotkey } from "@/lib/hotkeys"
 import { cn } from "@/lib/utils"
 
 const STORAGE_WIDTH = "open-swe.sidebar.width"
@@ -58,8 +57,6 @@ export function useSidebarLayout() {
     () => setCollapsed(!collapsed),
     [collapsed, setCollapsed]
   )
-
-  useHotkey("mod+b", toggle, { enableInFormFields: true, ignoreRepeat: true })
 
   const closeOnMobile = useCallback(() => {
     if (typeof window === "undefined") return

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -1,6 +1,13 @@
 import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
 import type { AgentThread, ImageChunk } from "@/features/agents/lib/types"
 
+export type DesktopCommandId =
+  | "new-thread"
+  | "show-command-palette"
+  | "open-settings"
+  | "show-keyboard-shortcuts"
+  | "toggle-sidebar"
+
 export interface DesktopProject {
   cwd: string
   name: string
@@ -125,6 +132,7 @@ declare global {
   interface Window {
     openSweDesktop?: {
       isDesktop: true
+      onCommand: (callback: (commandId: DesktopCommandId) => void) => () => void
       listProjects: () => Promise<Array<DesktopProject>>
       getProjectBranch: (cwd: string) => Promise<string | null>
       addProject: () => Promise<DesktopProject | null>

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -39,6 +39,7 @@ import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
 import { usePanelTabs } from "@/features/agents/lib/panelTabs"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import { terminalTabTitle } from "@/features/agents/lib/terminalTabTitle"
+import { useRegisterAppCommands } from "@/lib/appCommands"
 import { cn } from "@/lib/utils"
 
 export type AgentPanelTab = "git" | "plan"
@@ -115,6 +116,55 @@ export function AgentGitPanel({
     },
     [onCollapsedChange, panel, terminals]
   )
+  const terminalAvailable =
+    thread.isOwner !== false && Boolean(thread.sandboxId)
+  const toggleTerminal = useCallback(() => {
+    if (!collapsed && panel.activeTab?.kind === "terminal") {
+      onCollapsedChange(true)
+      return
+    }
+    onCollapsedChange(false)
+    onTabChange("git")
+    const existing = panel.tabs.find(
+      (candidate) => candidate.kind === "terminal"
+    )
+    if (existing) handleSelectTab(existing.id)
+    else handleOpenKind("terminal")
+  }, [
+    collapsed,
+    handleOpenKind,
+    handleSelectTab,
+    onCollapsedChange,
+    onTabChange,
+    panel.activeTab?.kind,
+    panel.tabs,
+  ])
+  const panelCommands = useMemo(
+    () => [
+      {
+        id: "toggle-work-panel",
+        label: "Toggle work panel",
+        aliases: ["show panel", "hide panel", "review panel"],
+        shortcuts: ["mod+alt+b"],
+        group: "Workspace",
+        run: () => onCollapsedChange(!collapsed),
+      },
+      ...(terminalAvailable
+        ? [
+            {
+              id: "toggle-terminal",
+              label: "Toggle terminal",
+              aliases: ["open terminal", "hide terminal"],
+              shortcuts: ["ctrl+`"],
+              group: "Workspace",
+              run: toggleTerminal,
+            },
+          ]
+        : []),
+    ],
+    [collapsed, onCollapsedChange, terminalAvailable, toggleTerminal]
+  )
+  useRegisterAppCommands(panelCommands)
   const terminalGroupIds = terminals.state.terminalGroups
     .map((group) => group.id)
     .join(",")

--- a/ui/src/features/agents/components/AgentPanelShell.tsx
+++ b/ui/src/features/agents/components/AgentPanelShell.tsx
@@ -28,8 +28,8 @@ const PANEL_TAB_META: Record<
 > = {
   review: { label: "Review", hint: "⌃⇧G", Icon: FileDiff },
   terminal: { label: "Terminal", Icon: SquareTerminal },
-  browser: { label: "Browser", hint: "⌘T", Icon: Globe },
-  files: { label: "Files", hint: "⌘P", Icon: Folder },
+  browser: { label: "Browser", Icon: Globe },
+  files: { label: "Files", Icon: Folder },
   plan: { label: "Plan", Icon: ListChecks },
 }
 

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -18,6 +18,7 @@ import {
   GitPullRequestIcon,
   KanbanIcon,
   LightningIcon,
+  MagnifyingGlassIcon,
   PlusIcon,
   SparkleIcon,
   TrashIcon,
@@ -25,7 +26,7 @@ import {
 } from "@phosphor-icons/react"
 import { IoLogoGithub, IoLogoSlack } from "react-icons/io5"
 import { SiLinear } from "react-icons/si"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import type { ComponentType, SVGProps } from "react"
 
 import type { SessionUser } from "@/lib/api"
@@ -62,9 +63,27 @@ import {
 } from "@/features/agents/lib/desktopLocal"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
 import { useDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
+import { Kbd } from "@/components/ui/kbd"
+import {
+  useAppCommand,
+  useAppCommandControls,
+  useRegisterAppCommands,
+} from "@/lib/appCommands"
+import { useShortcutLabel } from "@/lib/hotkeys"
 import { cn } from "@/lib/utils"
 
 const RESOLVED_SIDEBAR_LIMIT = 20
+
+function SidebarShortcut({ commandId }: { commandId: string }) {
+  const shortcut = useAppCommand(commandId)?.shortcuts?.[0] ?? ""
+  const label = useShortcutLabel(shortcut)
+  if (!shortcut) return null
+  return (
+    <Kbd className="ml-auto h-4 min-w-4 bg-transparent px-0 text-[10px]">
+      {label}
+    </Kbd>
+  )
+}
 
 type SourceIcon = ComponentType<SVGProps<SVGSVGElement>>
 
@@ -126,6 +145,7 @@ export function AgentsSidebar({
   layout,
 }: AgentsSidebarProps) {
   const navigate = useNavigate()
+  const { openPalette } = useAppCommandControls()
   const openThread = useCallback(
     (threadId: string) => {
       void navigate({ to: "/agents/$threadId", params: { threadId } })
@@ -209,7 +229,7 @@ export function AgentsSidebar({
         <SidebarCollapseButton onToggle={layout.toggle} />
       </div>
 
-      <div className="px-2 pb-1">
+      <div className="flex flex-col gap-0.5 px-2 pb-1">
         <Link
           to="/agents"
           onClick={layout.closeOnMobile}
@@ -217,7 +237,20 @@ export function AgentsSidebar({
         >
           <PlusIcon className="size-4" />
           New Thread
+          <SidebarShortcut commandId="new-thread" />
         </Link>
+        <button
+          type="button"
+          onClick={() => {
+            layout.closeOnMobile()
+            openPalette()
+          }}
+          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+        >
+          <MagnifyingGlassIcon className="size-4" />
+          Search
+          <SidebarShortcut commandId="search-commands" />
+        </button>
       </div>
 
       <nav className="flex flex-col gap-0.5 px-2 pb-4">
@@ -978,6 +1011,23 @@ export function AgentsShell({
   children: React.ReactNode
 }) {
   const layout = useSidebarLayout()
+  const sidebarCommands = useMemo(
+    () => [
+      {
+        id: "toggle-sidebar",
+        label: "Toggle sidebar",
+        aliases: ["show sidebar", "hide sidebar"],
+        shortcuts: ["mod+b"],
+        group: "Workspace",
+        run: layout.toggle,
+        desktopId: "toggle-sidebar" as const,
+        desktopShortcuts: ["mod+b"],
+      },
+    ],
+    [layout.toggle]
+  )
+  useRegisterAppCommands(sidebarCommands)
+
   return (
     <SidebarLayoutProvider value={layout}>
       <div className="agents-ui flex h-svh overflow-hidden bg-background">

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/features/agents/lib/gitPanelPreferences"
 import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
+import { useRegisterAppCommands } from "@/lib/appCommands"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 
@@ -133,6 +134,50 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     },
     [panel, terminals]
   )
+  const toggleTerminal = useCallback(() => {
+    if (!panelCollapsed && panel.activeTab?.kind === "terminal") {
+      handlePanelCollapsedChange(true)
+      return
+    }
+    handlePanelCollapsedChange(false)
+    const existing = panel.tabs.find(
+      (candidate) => candidate.kind === "terminal"
+    )
+    if (existing) handleSelectTab(existing.id)
+    else handleOpenKind("terminal")
+  }, [
+    handleOpenKind,
+    handlePanelCollapsedChange,
+    handleSelectTab,
+    panel.activeTab?.kind,
+    panel.tabs,
+    panelCollapsed,
+  ])
+  const threadCommands = useMemo(
+    () =>
+      thread
+        ? [
+            {
+              id: "toggle-terminal",
+              label: "Toggle terminal",
+              aliases: ["open terminal", "hide terminal"],
+              shortcuts: ["ctrl+`"],
+              group: "Workspace",
+              run: toggleTerminal,
+            },
+            {
+              id: "toggle-work-panel",
+              label: "Toggle work panel",
+              aliases: ["show panel", "hide panel", "review panel"],
+              shortcuts: ["mod+alt+b"],
+              group: "Workspace",
+              run: () => handlePanelCollapsedChange(!panelCollapsed),
+            },
+          ]
+        : [],
+    [handlePanelCollapsedChange, panelCollapsed, thread, toggleTerminal]
+  )
+  useRegisterAppCommands(threadCommands)
 
   const terminalGroupIds = terminals.state.terminalGroups
     .map((group) => group.id)

--- a/ui/src/features/agents/components/PlanReview.tsx
+++ b/ui/src/features/agents/components/PlanReview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import type { KeyboardEvent } from "react"
 
@@ -13,6 +13,7 @@ import {
 } from "@/lib/plan"
 import { Button } from "@/components/ui/button"
 import { Markdown } from "@/features/agents/components/chat/Markdown"
+import { useRegisterAppCommands } from "@/lib/appCommands"
 import { useResolvedTheme } from "@/lib/theme"
 import { cn } from "@/lib/utils"
 
@@ -74,6 +75,19 @@ export function PlanReview({
   const [editing, setEditing] = useState(false)
   const [editDraft, setEditDraft] = useState(plan.markdown)
   const [saving, setSaving] = useState(false)
+  const planShortcuts = useMemo(
+    () => [
+      {
+        id: "plan-submit-comment",
+        label: "Submit plan comment",
+        shortcuts: ["mod+enter"],
+        group: "Plan review",
+        showInPalette: false,
+      },
+    ],
+    []
+  )
+  useRegisterAppCommands(planShortcuts)
 
   // Reflect external plan updates (e.g. an agent revision) while not editing.
   useEffect(() => {

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -281,7 +281,10 @@ export function TerminalPanel({
   const atSplitLimit = terminalIds.length >= MAX_TERMINALS_PER_GROUP
 
   return (
-    <div className="group/terminal relative flex h-full min-h-0 flex-col">
+    <div
+      className="group/terminal relative flex h-full min-h-0 flex-col"
+      data-hotkeys="ignore"
+    >
       <div className="absolute top-1 right-2 z-10 flex items-center rounded-md border border-border bg-background/95 opacity-0 shadow-sm transition-opacity group-hover/terminal:opacity-100 focus-within:opacity-100">
         <ActionButton
           label={`Split horizontally${atSplitLimit ? " (maximum 4)" : ""}`}

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -41,6 +41,7 @@ import { ModelPicker } from "@/features/agents/components/ModelPicker"
 import { RepoSelector } from "@/features/settings/components/RepoSelector"
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@/components/ui/menu"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+import { useRegisterAppCommands } from "@/lib/appCommands"
 import { transcribeAudio } from "@/lib/api"
 import { cn } from "@/lib/utils"
 
@@ -254,6 +255,37 @@ export const ChatComposer = memo(function ChatComposer({
     "idle" | "recording" | "transcribing"
   >("idle")
   const [dictationError, setDictationError] = useState<string | null>(null)
+  const composerShortcuts = useMemo(
+    () => [
+      {
+        id: "composer-send",
+        label: "Send message",
+        shortcuts: ["enter"],
+        group: "Composer",
+        showInPalette: false,
+      },
+      {
+        id: "composer-new-line",
+        label: "New line",
+        shortcuts: ["shift+enter"],
+        group: "Composer",
+        showInPalette: false,
+      },
+      ...(activeRun?.running
+        ? [
+            {
+              id: "composer-stop-run",
+              label: "Stop active run",
+              shortcuts: ["escape"],
+              group: "Composer",
+              showInPalette: false,
+            },
+          ]
+        : []),
+    ],
+    [activeRun?.running]
+  )
+  useRegisterAppCommands(composerShortcuts)
 
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)

--- a/ui/src/features/agents/lib/desktopLocal.ts
+++ b/ui/src/features/agents/lib/desktopLocal.ts
@@ -45,11 +45,12 @@ export function useDesktopLocalThread(threadId: string) {
   })
 }
 
-export function useDesktopLocalThreads() {
+export function useDesktopLocalThreads(options: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: localThreadKeys.all,
     queryFn: () => window.openSweDesktop?.listLocalThreads() ?? [],
-    refetchInterval: 1000,
+    enabled: options.enabled,
+    refetchInterval: options.enabled === false ? false : 1000,
   })
 }
 

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect } from "react"
 
@@ -33,6 +38,8 @@ export const agentThreadKeys = {
     ["agent-threads", threadId, "workflow-approvals"] as const,
   page: (params: ThreadsPageParams) =>
     ["agent-threads", "lists", "page", params] as const,
+  infinitePages: (params: Omit<ThreadsPageParams, "offset">) =>
+    ["agent-threads", "lists", "infinite-pages", params] as const,
 }
 
 export function invalidateAgentThreadLists(queryClient: QueryClient): void {
@@ -509,6 +516,28 @@ export function useResolveAgentThread() {
       queryClient.setQueryData(agentThreadKeys.detail(vars.threadId), thread)
       invalidateAgentThreadLists(queryClient)
     },
+  })
+}
+
+export function useInfiniteThreadsPages(
+  params: Omit<ThreadsPageParams, "offset">,
+  options: { enabled?: boolean; staleWhileRevalidate?: boolean } = {}
+) {
+  return useInfiniteQuery({
+    queryKey: agentThreadKeys.infinitePages(params),
+    queryFn: ({ pageParam }) =>
+      agentsApi.listThreadsPage({ ...params, offset: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (page) =>
+      page.hasMore ? page.offset + page.items.length : undefined,
+    enabled: options.enabled,
+    ...(options.staleWhileRevalidate
+      ? {
+          staleTime: 30_000,
+          gcTime: Infinity,
+          refetchOnWindowFocus: true,
+        }
+      : {}),
   })
 }
 

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -501,11 +501,12 @@ export function useResolveAgentThread() {
 
 export function useThreadsPage(
   params: ThreadsPageParams,
-  options: { staleWhileRevalidate?: boolean } = {}
+  options: { enabled?: boolean; staleWhileRevalidate?: boolean } = {}
 ) {
   return useQuery({
     queryKey: agentThreadKeys.page(params),
     queryFn: () => agentsApi.listThreadsPage(params),
+    enabled: options.enabled,
     placeholderData: (prev) => prev,
     ...(options.staleWhileRevalidate
       ? {

--- a/ui/src/lib/appCommands.test.ts
+++ b/ui/src/lib/appCommands.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { DesktopLocalThreadSummary } from "@/desktop"
+import type { AgentThread } from "@/features/agents/lib/types"
+import type { AppCommand } from "./appCommands"
+import { buildPaletteResults } from "@/components/AppCommandPalette"
+import { resolveAppCommands } from "./appCommands"
+
+function command(id: string, label = id): AppCommand {
+  return { id, label, group: "General", run: vi.fn() }
+}
+
+describe("app commands", () => {
+  it("lets the latest contextual registration replace a command", () => {
+    const global = [command("new-thread")]
+    const contextual = command("toggle-sidebar", "First sidebar")
+    const replacement = command("toggle-sidebar", "Current sidebar")
+
+    const resolved = resolveAppCommands(global, [
+      { key: 1, commands: [contextual] },
+      { key: 2, commands: [replacement] },
+    ])
+
+    expect(resolved.map((item) => item.id)).toEqual([
+      "new-thread",
+      "toggle-sidebar",
+    ])
+    expect(resolved[1]?.label).toBe("Current sidebar")
+  })
+
+  it("drops unavailable contextual commands", () => {
+    const unavailable = { ...command("terminal"), available: false }
+    expect(
+      resolveAppCommands([], [{ key: 1, commands: [unavailable] }])
+    ).toEqual([])
+  })
+
+  it("filters commands and merges cloud and local thread results", () => {
+    const cloud = {
+      id: "cloud-1",
+      title: "Fix cloud search",
+    } as AgentThread
+    const local: DesktopLocalThreadSummary = {
+      id: "local-1",
+      title: "Fix local search",
+      cwd: "/tmp/repo",
+      status: "idle",
+      createdAt: 1,
+      updatedAt: 2,
+      modelId: null,
+      effort: null,
+    }
+    const commands = [
+      { ...command("settings", "Open settings"), aliases: ["preferences"] },
+      { ...command("hidden", "Hidden"), showInPalette: false },
+    ]
+
+    const results = buildPaletteResults(commands, [cloud], [local], "fix")
+
+    expect(results.map((item) => item.id)).toEqual([
+      "cloud:cloud-1",
+      "local:local-1",
+    ])
+    expect(buildPaletteResults(commands, [], [], "preferences")[0]?.id).toBe(
+      "command:settings"
+    )
+  })
+})

--- a/ui/src/lib/appCommands.tsx
+++ b/ui/src/lib/appCommands.tsx
@@ -13,12 +13,7 @@ import type { DesktopCommandId } from "@/desktop"
 import { AppCommandPalette } from "@/components/AppCommandPalette"
 import { AppShortcutReference } from "@/components/AppShortcutReference"
 import { useSession } from "@/lib/session"
-import {
-  eventMatchesShortcut,
-  isHotkeySuppressed,
-  isTypingContext,
-  shouldIgnoreHotkey,
-} from "@/lib/hotkeys"
+import { eventMatchesShortcut, shouldIgnoreHotkey } from "@/lib/hotkeys"
 
 export interface AppCommand {
   id: string
@@ -173,12 +168,7 @@ export function AppCommandProvider({
     const desktop = window.openSweDesktop
     if (!desktop) return
     return desktop.onCommand((commandId) => {
-      if (
-        !enabledRef.current ||
-        isTypingContext(document.activeElement) ||
-        isHotkeySuppressed(document.activeElement)
-      )
-        return
+      if (!enabledRef.current) return
       const command = commandsRef.current.find(
         (candidate) =>
           candidate.desktopId === commandId && candidate.run !== undefined

--- a/ui/src/lib/appCommands.tsx
+++ b/ui/src/lib/appCommands.tsx
@@ -1,0 +1,236 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { useNavigate } from "@tanstack/react-router"
+import type { DesktopCommandId } from "@/desktop"
+
+import { AppCommandPalette } from "@/components/AppCommandPalette"
+import { AppShortcutReference } from "@/components/AppShortcutReference"
+import { useSession } from "@/lib/session"
+import {
+  eventMatchesShortcut,
+  isHotkeySuppressed,
+  isTypingContext,
+  shouldIgnoreHotkey,
+} from "@/lib/hotkeys"
+
+export interface AppCommand {
+  id: string
+  label: string
+  aliases?: ReadonlyArray<string>
+  shortcuts?: ReadonlyArray<string>
+  group: string
+  run?: () => void | Promise<void>
+  available?: boolean
+  showInPalette?: boolean
+  desktopId?: DesktopCommandId
+  desktopShortcuts?: ReadonlyArray<string>
+}
+
+interface CommandRegistration {
+  key: number
+  commands: ReadonlyArray<AppCommand>
+}
+
+interface AppCommandsContextValue {
+  commands: ReadonlyArray<AppCommand>
+  openPalette: () => void
+  openShortcutReference: () => void
+  register: (commands: ReadonlyArray<AppCommand>) => () => void
+}
+
+const AppCommandsContext = createContext<AppCommandsContextValue | null>(null)
+
+export function resolveAppCommands(
+  globalCommands: ReadonlyArray<AppCommand>,
+  registrations: ReadonlyArray<CommandRegistration>
+): Array<AppCommand> {
+  const resolved = new Map<string, AppCommand>()
+  for (const command of globalCommands) resolved.set(command.id, command)
+  for (const registration of registrations) {
+    for (const command of registration.commands)
+      resolved.set(command.id, command)
+  }
+  return [...resolved.values()].filter((command) => command.available !== false)
+}
+
+export function AppCommandProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const navigate = useNavigate()
+  const session = useSession()
+  const enabled = Boolean(session.data)
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const [shortcutReferenceOpen, setShortcutReferenceOpen] = useState(false)
+  const [registrations, setRegistrations] = useState<
+    Array<CommandRegistration>
+  >([])
+  const nextRegistrationKey = useRef(0)
+
+  const openPalette = useCallback(() => setPaletteOpen(true), [])
+  const openShortcutReference = useCallback(
+    () => setShortcutReferenceOpen(true),
+    []
+  )
+
+  const globalCommands = useMemo<ReadonlyArray<AppCommand>>(
+    () => [
+      {
+        id: "search-commands",
+        label: "Search commands and threads",
+        aliases: ["command palette", "quick switcher"],
+        shortcuts: ["mod+k"],
+        group: "General",
+        run: openPalette,
+        showInPalette: false,
+        desktopId: "show-command-palette",
+        desktopShortcuts: ["mod+k"],
+      },
+      {
+        id: "new-thread",
+        label: "New thread",
+        aliases: ["new chat", "start thread"],
+        shortcuts: ["mod+n"],
+        group: "General",
+        run: () => void navigate({ to: "/agents" }),
+        desktopId: "new-thread",
+        desktopShortcuts: ["mod+n"],
+      },
+      {
+        id: "open-settings",
+        label: "Open settings",
+        aliases: ["preferences", "dashboard"],
+        shortcuts: ["mod+,"],
+        group: "Navigation",
+        run: () => void navigate({ to: "/my-settings" }),
+        desktopId: "open-settings",
+        desktopShortcuts: ["mod+,"],
+      },
+      {
+        id: "show-keyboard-shortcuts",
+        label: "Keyboard shortcuts",
+        aliases: ["shortcut reference", "help"],
+        shortcuts: ["mod+/", "?"],
+        group: "General",
+        run: openShortcutReference,
+        desktopId: "show-keyboard-shortcuts",
+        desktopShortcuts: ["mod+/"],
+      },
+    ],
+    [navigate, openPalette, openShortcutReference]
+  )
+
+  const register = useCallback((commands: ReadonlyArray<AppCommand>) => {
+    const key = nextRegistrationKey.current++
+    setRegistrations((current) => [...current, { key, commands }])
+    return () => {
+      setRegistrations((current) =>
+        current.filter((registration) => registration.key !== key)
+      )
+    }
+  }, [])
+
+  const commands = useMemo(
+    () => resolveAppCommands(globalCommands, registrations),
+    [globalCommands, registrations]
+  )
+  const commandsRef = useRef(commands)
+  commandsRef.current = commands
+  const enabledRef = useRef(enabled)
+  enabledRef.current = enabled
+
+  useEffect(() => {
+    if (!enabled || paletteOpen || shortcutReferenceOpen) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (shouldIgnoreHotkey(event)) return
+      const desktop = Boolean(window.openSweDesktop)
+      const command = commandsRef.current.find(
+        (candidate) =>
+          candidate.run &&
+          candidate.shortcuts?.some(
+            (shortcut) =>
+              !(desktop && candidate.desktopShortcuts?.includes(shortcut)) &&
+              eventMatchesShortcut(event, shortcut)
+          )
+      )
+      if (!command?.run) return
+      event.preventDefault()
+      void command.run()
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [enabled, paletteOpen, shortcutReferenceOpen])
+
+  useEffect(() => {
+    const desktop = window.openSweDesktop
+    if (!desktop) return
+    return desktop.onCommand((commandId) => {
+      if (
+        !enabledRef.current ||
+        isTypingContext(document.activeElement) ||
+        isHotkeySuppressed(document.activeElement)
+      )
+        return
+      const command = commandsRef.current.find(
+        (candidate) =>
+          candidate.desktopId === commandId && candidate.run !== undefined
+      )
+      if (command?.run) void command.run()
+    })
+  }, [])
+
+  const context = useMemo<AppCommandsContextValue>(
+    () => ({ commands, openPalette, openShortcutReference, register }),
+    [commands, openPalette, openShortcutReference, register]
+  )
+
+  return (
+    <AppCommandsContext.Provider value={context}>
+      {children}
+      {enabled && (
+        <>
+          <AppCommandPalette
+            commands={commands}
+            open={paletteOpen}
+            onOpenChange={setPaletteOpen}
+          />
+          <AppShortcutReference
+            commands={commands}
+            open={shortcutReferenceOpen}
+            onOpenChange={setShortcutReferenceOpen}
+          />
+        </>
+      )}
+    </AppCommandsContext.Provider>
+  )
+}
+
+export function useAppCommandControls() {
+  const context = useContext(AppCommandsContext)
+  if (!context) throw new Error("AppCommandProvider is missing")
+  return {
+    openPalette: context.openPalette,
+    openShortcutReference: context.openShortcutReference,
+  }
+}
+
+export function useAppCommand(commandId: string) {
+  const context = useContext(AppCommandsContext)
+  if (!context) throw new Error("AppCommandProvider is missing")
+  return context.commands.find((command) => command.id === commandId)
+}
+
+export function useRegisterAppCommands(commands: ReadonlyArray<AppCommand>) {
+  const context = useContext(AppCommandsContext)
+  if (!context) throw new Error("AppCommandProvider is missing")
+  const { register } = context
+  useEffect(() => register(commands), [commands, register])
+}

--- a/ui/src/lib/hotkeys.test.ts
+++ b/ui/src/lib/hotkeys.test.ts
@@ -1,0 +1,109 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  eventMatchesShortcut,
+  formatShortcut,
+  isHotkeySuppressed,
+  isTypingContext,
+  shouldIgnoreHotkey,
+} from "./hotkeys"
+
+function eventWithTarget(
+  target: Element,
+  init: KeyboardEventInit = {}
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "k",
+    ...init,
+  })
+  Object.defineProperty(event, "target", { value: target })
+  return event
+}
+
+describe("keyboard shortcut utilities", () => {
+  it("resolves mod to the platform modifier", () => {
+    expect(
+      eventMatchesShortcut(
+        new KeyboardEvent("keydown", { key: "k", metaKey: true }),
+        "mod+k",
+        "mac"
+      )
+    ).toBe(true)
+    expect(
+      eventMatchesShortcut(
+        new KeyboardEvent("keydown", { key: "k", ctrlKey: true }),
+        "mod+k",
+        "other"
+      )
+    ).toBe(true)
+    expect(
+      eventMatchesShortcut(
+        new KeyboardEvent("keydown", { key: "k", ctrlKey: true }),
+        "mod+k",
+        "mac"
+      )
+    ).toBe(false)
+    expect(
+      eventMatchesShortcut(
+        new KeyboardEvent("keydown", { key: "?", shiftKey: true }),
+        "?",
+        "other"
+      )
+    ).toBe(true)
+  })
+
+  it("formats platform-specific shortcut labels", () => {
+    expect(formatShortcut("mod+k", "mac")).toBe("⌘K")
+    expect(formatShortcut("mod+alt+b", "other")).toBe("Ctrl Alt B")
+    expect(formatShortcut("ctrl+`", "mac")).toBe("⌃`")
+    expect(formatShortcut("shift+?", "other")).toBe("?")
+  })
+
+  it("detects every supported typing context including descendants", () => {
+    const input = document.createElement("input")
+    const textarea = document.createElement("textarea")
+    const select = document.createElement("select")
+    const textbox = document.createElement("div")
+    textbox.setAttribute("role", "textbox")
+    const editable = document.createElement("div")
+    editable.setAttribute("contenteditable", "true")
+    const child = document.createElement("span")
+    editable.append(child)
+
+    expect(isTypingContext(input)).toBe(true)
+    expect(isTypingContext(textarea)).toBe(true)
+    expect(isTypingContext(select)).toBe(true)
+    expect(isTypingContext(document.createElement("iframe"))).toBe(true)
+    expect(isTypingContext(textbox)).toBe(true)
+    expect(isTypingContext(child)).toBe(true)
+    expect(isTypingContext(document.createElement("button"))).toBe(false)
+  })
+
+  it("suppresses app shortcuts while typing or inside an ignored region", () => {
+    const input = document.createElement("input")
+    const ignored = document.createElement("div")
+    ignored.dataset.hotkeys = "ignore"
+    const child = document.createElement("button")
+    ignored.append(child)
+
+    expect(shouldIgnoreHotkey(eventWithTarget(input))).toBe(true)
+    expect(isHotkeySuppressed(child)).toBe(true)
+    expect(shouldIgnoreHotkey(eventWithTarget(child))).toBe(true)
+  })
+
+  it("ignores composition, repeats, and previously handled events", () => {
+    const target = document.createElement("button")
+    const composing = eventWithTarget(target, { isComposing: true })
+    const repeated = eventWithTarget(target, { repeat: true })
+    const prevented = eventWithTarget(target)
+    prevented.preventDefault()
+
+    expect(shouldIgnoreHotkey(composing)).toBe(true)
+    expect(shouldIgnoreHotkey(repeated)).toBe(true)
+    expect(shouldIgnoreHotkey(prevented)).toBe(true)
+  })
+})

--- a/ui/src/lib/hotkeys.ts
+++ b/ui/src/lib/hotkeys.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
 export interface HotkeyOptions {
   enabled?: boolean
@@ -16,12 +16,15 @@ interface ParsedCombo {
   shift: boolean
 }
 
-function isMac(): boolean {
-  if (typeof navigator === "undefined") return false
+export type ShortcutPlatform = "mac" | "other"
+
+export function shortcutPlatform(): ShortcutPlatform {
+  if (typeof navigator === "undefined") return "other"
   return /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent)
+    ? "mac"
+    : "other"
 }
 
-/** Parse a combo string like "mod+b" or "shift+escape" into its parts. */
 function parseCombo(combo: string): ParsedCombo {
   const parsed: ParsedCombo = {
     key: "",
@@ -34,7 +37,7 @@ function parseCombo(combo: string): ParsedCombo {
   for (const part of combo
     .toLowerCase()
     .split("+")
-    .map((p) => p.trim())) {
+    .map((value) => value.trim())) {
     switch (part) {
       case "":
         break
@@ -64,26 +67,101 @@ function parseCombo(combo: string): ParsedCombo {
   return parsed
 }
 
-function eventMatchesCombo(event: KeyboardEvent, combo: ParsedCombo): boolean {
+export function eventMatchesShortcut(
+  event: KeyboardEvent,
+  shortcut: string,
+  platform = shortcutPlatform()
+): boolean {
+  const combo = parseCombo(shortcut)
   if (event.key.toLowerCase() !== combo.key) return false
-  const mac = isMac()
-  const expectMeta = combo.meta || (combo.mod && mac)
-  const expectCtrl = combo.ctrl || (combo.mod && !mac)
+  const expectMeta = combo.meta || (combo.mod && platform === "mac")
+  const expectCtrl = combo.ctrl || (combo.mod && platform !== "mac")
+  const bareQuestionMark =
+    combo.key === "?" &&
+    !combo.mod &&
+    !combo.meta &&
+    !combo.ctrl &&
+    !combo.alt &&
+    !combo.shift
   return (
     event.metaKey === expectMeta &&
     event.ctrlKey === expectCtrl &&
     event.altKey === combo.alt &&
-    event.shiftKey === combo.shift
+    (event.shiftKey === combo.shift || bareQuestionMark)
   )
 }
 
-function isFormField(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false
+function shortcutKeyLabel(key: string): string {
+  const labels: Record<string, string> = {
+    escape: "Esc",
+    enter: "Enter",
+    space: "Space",
+    tab: "Tab",
+  }
+  return labels[key] ?? (key.length === 1 ? key.toUpperCase() : key)
+}
+
+export function formatShortcut(
+  shortcut: string,
+  platform = shortcutPlatform()
+): string {
+  const combo = parseCombo(shortcut)
+  if (combo.key === "?" && combo.shift) return "?"
+
+  if (platform === "mac") {
+    const modifiers = [
+      combo.mod || combo.meta ? "⌘" : "",
+      combo.ctrl ? "⌃" : "",
+      combo.alt ? "⌥" : "",
+      combo.shift ? "⇧" : "",
+    ].join("")
+    return `${modifiers}${shortcutKeyLabel(combo.key)}`
+  }
+
+  const modifiers = [
+    combo.mod || combo.ctrl ? "Ctrl" : "",
+    combo.meta ? "Meta" : "",
+    combo.alt ? "Alt" : "",
+    combo.shift ? "Shift" : "",
+  ].filter(Boolean)
+  return [...modifiers, shortcutKeyLabel(combo.key)].join(" ")
+}
+
+export function useShortcutLabel(shortcut: string): string {
+  const [label, setLabel] = useState(() => formatShortcut(shortcut, "other"))
+  useEffect(() => setLabel(formatShortcut(shortcut)), [shortcut])
+  return label
+}
+
+function closestElement(target: EventTarget | null): Element | null {
+  if (typeof Element === "undefined" || !(target instanceof Element))
+    return null
+  return target
+}
+
+export function isTypingContext(target: EventTarget | null): boolean {
+  return Boolean(
+    closestElement(target)?.closest(
+      'input, textarea, select, iframe, [role="textbox"], [role="searchbox"], [contenteditable]:not([contenteditable="false"])'
+    )
+  )
+}
+
+export function isHotkeySuppressed(target: EventTarget | null): boolean {
+  return Boolean(closestElement(target)?.closest('[data-hotkeys="ignore"]'))
+}
+
+export function shouldIgnoreHotkey(
+  event: KeyboardEvent,
+  enableInFormFields = false,
+  ignoreRepeat = true
+): boolean {
   return (
-    target.tagName === "INPUT" ||
-    target.tagName === "TEXTAREA" ||
-    target.tagName === "SELECT" ||
-    target.isContentEditable
+    event.defaultPrevented ||
+    event.isComposing ||
+    (ignoreRepeat && event.repeat) ||
+    isHotkeySuppressed(event.target) ||
+    (!enableInFormFields && isTypingContext(event.target))
   )
 }
 
@@ -100,20 +178,19 @@ export function useHotkey(
     enabled = true,
     preventDefault = true,
     enableInFormFields = false,
-    ignoreRepeat = false,
+    ignoreRepeat = true,
   } = options
   const handlerRef = useRef(handler)
   handlerRef.current = handler
 
-  const comboKey = Array.isArray(combo) ? combo.join(",") : combo
+  const comboKey = Array.isArray(combo) ? combo.join("\u0000") : combo
 
   useEffect(() => {
     if (!enabled || typeof window === "undefined") return
-    const combos = comboKey.split(",").map(parseCombo)
+    const combos = comboKey.split("\u0000")
     const onKeyDown = (event: KeyboardEvent) => {
-      if (ignoreRepeat && event.repeat) return
-      if (!enableInFormFields && isFormField(event.target)) return
-      if (!combos.some((c) => eventMatchesCombo(event, c))) return
+      if (shouldIgnoreHotkey(event, enableInFormFields, ignoreRepeat)) return
+      if (!combos.some((value) => eventMatchesShortcut(event, value))) return
       if (preventDefault) event.preventDefault()
       handlerRef.current(event)
     }

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import type { QueryClient } from "@tanstack/react-query"
 
 import appCss from "../styles.css?url"
+import { AppCommandProvider } from "@/lib/appCommands"
 import { resolveSessionOnServer } from "@/lib/session-ssr"
 
 const themeInitScript = `(function(){try{var t=localStorage.getItem("open-swe-theme");var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
@@ -59,7 +60,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         <QueryClientProvider client={queryClient}>
-          {children ?? <Outlet />}
+          <AppCommandProvider>{children ?? <Outlet />}</AppCommandProvider>
           {import.meta.env.VITE_DEVTOOLS !== "false" && (
             <>
               <TanStackDevtools


### PR DESCRIPTION
## Description
Adds one authenticated command registry for keyboard shortcuts, command/thread search, contextual panel actions, and safe Electron menu delivery while suppressing shortcuts in typing surfaces.

## Release Note
Added a command palette, thread search, shortcut reference, and keyboard navigation for web and desktop.
## Test Plan
- [x] Exercise command routing, typing suppression, desktop allowlists, typechecks, and production builds.

Made by [Open SWE](https://openswe.vercel.app/agents/8c2cdc24-4fa2-5f21-b32f-ab6dff459539)

## References
- Plan: https://openswe.vercel.app/agents/8c2cdc24-4fa2-5f21-b32f-ab6dff459539/plan