### PR TITLE
chore: ignore stray playwright output at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ __pycache__/
 
 #
 logs/
+
+# Playwright output written when run from the repo root
+test-results/
+playwright-report/
+blob-report/


### PR DESCRIPTION
`tests/e2e/.gitignore` only ignores `test-results/` and `playwright-report/` relative to `tests/e2e/`. Running `npx playwright test` with the repo root as cwd writes `test-results/` at the repo root, where it shows up as untracked and can be committed by accident (this happened and needed an amend).

Adds both entries to the root `.gitignore` so the stray directory can never be committed regardless of cwd.

## Test Plan

- [x] none — gitignore-only change