### PR TITLE
fix: restore model switching for local threads

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -289,7 +289,11 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:update-local-thread", (event, input) => {
     requireTrustedDesktopIpc(event);
-    return localThreadStore.update(input?.threadId, { status: input?.status });
+    return localThreadStore.update(input?.threadId, {
+      status: input?.status,
+      ...(typeof input?.modelId === "string" ? { modelId: input.modelId } : {}),
+      ...(typeof input?.effort === "string" ? { effort: input.effort } : {}),
+    });
   });
   ipcMain.handle("desktop:delete-local-thread", async (event, threadId) => {
     requireTrustedDesktopIpc(event);

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -168,6 +168,8 @@ declare global {
       updateLocalThread: (input: {
         threadId: string
         status: DesktopLocalThreadSummary["status"]
+        modelId?: string
+        effort?: string
       }) => Promise<DesktopLocalThreadSummary | null>
       deleteLocalThread: (threadId: string) => Promise<boolean>
       getLocalDiff: (threadId: string) => Promise<DesktopLocalDiff>

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -13,6 +13,7 @@ import { Link } from "@tanstack/react-router"
 import type { DesktopLocalThreadSummary } from "@/desktop"
 import type { ImageChunk } from "@/features/agents/lib/types"
 import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
+import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useSidebarCollapsed } from "@/components/sidebar-layout"
@@ -30,6 +31,7 @@ import { Messages } from "@/features/agents/components/messages"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
 import { usePanelTabs } from "@/features/agents/lib/panelTabs"
 import { useAgentSkills } from "@/features/agents/lib/queries"
+import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import {
   localThreadKeys,
@@ -73,6 +75,20 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const thread = threadQuery.data
   const queryClient = useQueryClient()
   const skills = useAgentSkills()
+  const { models, defaultSelection } = useModelOptions()
+  const [selection, setSelection] = useState<ModelSelection | null>(null)
+  useEffect(() => setSelection(null), [sessionId])
+  const threadSelection = useMemo<ModelSelection | null>(() => {
+    if (!thread?.modelId || !thread.effort) return null
+    return models.some(
+      (model) =>
+        model.id === thread.modelId &&
+        model.efforts.includes(thread.effort ?? "")
+    )
+      ? { modelId: thread.modelId, effort: thread.effort }
+      : null
+  }, [models, thread?.effort, thread?.modelId])
+  const activeSelection = selection ?? threadSelection ?? defaultSelection
   const initialPromptRef = useRef<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const isMobile = useIsMobile()
@@ -191,10 +207,14 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   )
 
   const updateStatus = useCallback(
-    async (status: "idle" | "running" | "error") => {
+    async (
+      status: "idle" | "running" | "error",
+      model?: ModelSelection | null
+    ) => {
       const updated = await window.openSweDesktop?.updateLocalThread({
         threadId: sessionId,
         status,
+        ...(model && { modelId: model.modelId, effort: model.effort }),
       })
       if (!updated) return
       queryClient.setQueryData(localThreadKeys.detail(sessionId), updated)
@@ -211,8 +231,18 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     async (prompt: string, images: Array<ImageChunk>) => {
       if (!thread) return false
       setError(null)
-      await updateStatus("running")
+      const credential =
+        await window.openSweDesktop?.localModelCredentialStatus(
+          activeSelection?.modelId
+        )
+      if (credential && !credential.available) {
+        setError(
+          `Set ${credential.variable} in the environment before starting Open SWE.`
+        )
+        return false
+      }
       try {
+        await updateStatus("running", activeSelection)
         await stream.submit(
           {
             messages: [
@@ -224,8 +254,10 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
               configurable: {
                 source: "desktop",
                 local_project_path: thread.cwd,
-                ...(thread.modelId ? { agent_model_id: thread.modelId } : {}),
-                ...(thread.effort ? { agent_effort: thread.effort } : {}),
+                ...(activeSelection && {
+                  agent_model_id: activeSelection.modelId,
+                  agent_effort: activeSelection.effort,
+                }),
               },
             },
           }
@@ -238,7 +270,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         return false
       }
     },
-    [stream, thread, updateStatus]
+    [activeSelection, stream, thread, updateStatus]
   )
 
   useEffect(() => {
@@ -365,6 +397,9 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
                 activeRun={{ threadId: thread.id, running: isRunning }}
                 busy={isRunning}
                 compact
+                models={models}
+                selection={activeSelection}
+                onSelectionChange={setSelection}
                 onStop={async () => {
                   try {
                     await stream.stop()

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -75,7 +75,11 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const thread = threadQuery.data
   const queryClient = useQueryClient()
   const skills = useAgentSkills()
-  const { models, defaultSelection } = useModelOptions()
+  const {
+    models,
+    defaultSelection,
+    isLoading: modelsLoading,
+  } = useModelOptions()
   const [selection, setSelection] = useState<ModelSelection | null>(null)
   useEffect(() => setSelection(null), [sessionId])
   const threadSelection = useMemo<ModelSelection | null>(() => {
@@ -274,7 +278,8 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   )
 
   useEffect(() => {
-    if (!thread || initialPromptRef.current === sessionId) return
+    if (modelsLoading || !thread || initialPromptRef.current === sessionId)
+      return
     initialPromptRef.current = sessionId
     void stream.hydrationPromise
       .then(() => window.openSweDesktop?.getLocalPrompt(sessionId))
@@ -291,7 +296,14 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         setError(errorMessage(cause))
         void updateStatus("error")
       })
-  }, [sessionId, stream.hydrationPromise, submit, thread, updateStatus])
+  }, [
+    modelsLoading,
+    sessionId,
+    stream.hydrationPromise,
+    submit,
+    thread,
+    updateStatus,
+  ])
 
   useEffect(() => {
     if (!stream.error) return


### PR DESCRIPTION
## Description
Restore the model picker on existing local threads and persist the selected model and effort before each run, matching cloud thread behavior.

## Release Note
Fixed model switching in desktop local threads.

## Test Plan
- [x] Switch models on a local follow-up and verify the selected model is used

Made by [Open SWE](https://openswe.vercel.app/agents/01a01b5b-6cb8-76da-8165-ed3e89930126)