### PR TITLE
fix: toggle composer stop and send actions

### DIFF
--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -123,11 +123,11 @@ describe("ChatComposer stop button", () => {
     expect(cancelThread).not.toHaveBeenCalled()
   })
 
-  it("shows steer and stop actions while a run is live", () => {
+  it("shows only the stop action while a live run has no queued message", () => {
     renderComposer(true)
 
-    expect(screen.getByRole("button", { name: "Steer agent" })).toBeTruthy()
     expect(screen.getByRole("button", { name: "Stop run" })).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Steer agent" })).toBeNull()
   })
 
   it("shows the send button when no run is live", () => {

--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ChatComposer, buildCommandItems } from "./ChatComposer"
+import { ComposerPrimaryActions } from "./ComposerPrimaryActions"
 import { replaceTextRange } from "./composerTrigger"
 import type { ChatComposerProps } from "./ChatComposer"
 import { AgentThreadStreamBoundary } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
@@ -136,6 +137,24 @@ describe("ChatComposer stop button", () => {
     expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy()
     expect(screen.queryByRole("button", { name: "Steer agent" })).toBeNull()
     expect(screen.queryByRole("button", { name: "Stop run" })).toBeNull()
+  })
+
+  it("stops a direct run on Escape while steer is shown", () => {
+    const onStop = vi.fn()
+    render(
+      <ComposerPrimaryActions
+        activeRun={{ threadId: "thread-1", running: true }}
+        canSubmit
+        onStop={onStop}
+        onSubmit={vi.fn()}
+        submitting={false}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Steer agent" })).toBeTruthy()
+    fireEvent.keyDown(document.body, { key: "Escape" })
+
+    expect(onStop).toHaveBeenCalledOnce()
   })
 })
 

--- a/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
@@ -182,25 +182,25 @@ function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
     }
   }
 
+  const running = stream.isLoading || props.activeRun?.running
+  useEscapeToStop(
+    Boolean(running && props.canSubmit && props.stopOnEscape),
+    () => void handleStop()
+  )
+
   // Server truth (`activeRun.running`) matters as much as the client stream:
   // this browser only sees `isLoading` once it observes a lifecycle event, so a
   // run it never joined would otherwise render an unusable send button.
-  if (!stream.isLoading && !props.activeRun?.running)
-    return <SendButton {...props} />
+  if (!running) return <SendButton {...props} />
 
-  return (
-    <div className="flex gap-1">
-      <SendButton
-        {...props}
-        canSubmit={props.canSubmit && !stopping}
-        label="Steer agent"
-      />
-      <StopButton
-        disabled={stopping}
-        onStop={() => void handleStop()}
-        stopOnEscape={props.stopOnEscape}
-      />
-    </div>
+  return props.canSubmit ? (
+    <SendButton {...props} canSubmit={!stopping} label="Steer agent" />
+  ) : (
+    <StopButton
+      disabled={stopping}
+      onStop={() => void handleStop()}
+      stopOnEscape={props.stopOnEscape}
+    />
   )
 }
 
@@ -216,7 +216,9 @@ function DirectPrimaryActions(props: ComposerPrimaryActionsProps) {
       setStopping(false)
     }
   }
-  return (
+  return props.canSubmit ? (
+    <SendButton {...props} canSubmit={!stopping} label="Steer agent" />
+  ) : (
     <StopButton
       disabled={stopping}
       onStop={() => void stop()}

--- a/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
@@ -184,7 +184,7 @@ function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
 
   const running = stream.isLoading || props.activeRun?.running
   useEscapeToStop(
-    Boolean(running && props.canSubmit && props.stopOnEscape),
+    Boolean(running && props.canSubmit && props.stopOnEscape !== false),
     () => void handleStop()
   )
 
@@ -206,9 +206,9 @@ function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
 
 function DirectPrimaryActions(props: ComposerPrimaryActionsProps) {
   const [stopping, setStopping] = useState(false)
-  if (!props.activeRun?.running || !props.onStop)
-    return <SendButton {...props} />
+  const running = Boolean(props.activeRun?.running && props.onStop)
   const stop = async () => {
+    if (stopping) return
     setStopping(true)
     try {
       await props.onStop?.()
@@ -216,6 +216,11 @@ function DirectPrimaryActions(props: ComposerPrimaryActionsProps) {
       setStopping(false)
     }
   }
+  useEscapeToStop(
+    Boolean(running && props.canSubmit && props.stopOnEscape !== false),
+    () => void stop()
+  )
+  if (!running) return <SendButton {...props} />
   return props.canSubmit ? (
     <SendButton {...props} canSubmit={!stopping} label="Steer agent" />
   ) : (


### PR DESCRIPTION
## Description
Show one primary composer action during a run: stop when empty, send when content is ready.

## Release Note
The running agent composer now swaps between stop and send instead of showing both.

## Test Plan
- [x] Verify the focused composer tests and UI typecheck

Made by [Open SWE](https://openswe.vercel.app/agents/01a01b87-0986-73cf-8cd5-233afb99a605)