### PR TITLE
fix: sync managed skills to local sessions

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -36,6 +36,7 @@ from deepagents import create_deep_agent
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import BackendProtocol, SandboxBackendProtocol
+from deepagents.backends.state import StateBackend
 from deepagents.backends.store import StoreBackend
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolRetryMiddleware
@@ -1490,19 +1491,25 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     logger.info("Returning agent with sandbox for thread %s", thread_id)
     agent_backend: BackendProtocol = backend
     skill_routes: dict[str, BackendProtocol] = {
-        ORGANIZATION_SKILLS_ROUTE: ReadOnlyBackend(
-            StoreBackend(namespace=lambda _runtime: (ORGANIZATION_SKILLS_NAMESPACE,))
-        ),
         BUNDLED_SKILLS_ROUTE: ReadOnlyBackend(
             FilesystemBackend(root_dir=BUNDLED_SKILLS_DIR, virtual_mode=True)
         ),
     }
-    skill_sources = [ORGANIZATION_SKILLS_ROUTE, BUNDLED_SKILLS_ROUTE]
-    if profile_login:
-        skill_routes[USER_SKILLS_ROUTE] = ReadOnlyBackend(
-            StoreBackend(namespace=lambda _runtime, login=profile_login: (SKILLS_NAMESPACE, login))
+    if is_desktop_run(configurable):
+        skill_routes[USER_SKILLS_ROUTE] = ReadOnlyBackend(StateBackend())
+        skill_sources = [USER_SKILLS_ROUTE, BUNDLED_SKILLS_ROUTE]
+    else:
+        skill_routes[ORGANIZATION_SKILLS_ROUTE] = ReadOnlyBackend(
+            StoreBackend(namespace=lambda _runtime: (ORGANIZATION_SKILLS_NAMESPACE,))
         )
-        skill_sources.insert(0, USER_SKILLS_ROUTE)
+        skill_sources = [ORGANIZATION_SKILLS_ROUTE, BUNDLED_SKILLS_ROUTE]
+        if profile_login:
+            skill_routes[USER_SKILLS_ROUTE] = ReadOnlyBackend(
+                StoreBackend(
+                    namespace=lambda _runtime, login=profile_login: (SKILLS_NAMESPACE, login)
+                )
+            )
+            skill_sources.insert(0, USER_SKILLS_ROUTE)
     agent_backend = CompositeBackend(default=backend, routes=skill_routes)
     main_model = _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
     subagent_model = _make_model_or_defer(

--- a/desktop/src/local-thread-store.cjs
+++ b/desktop/src/local-thread-store.cjs
@@ -4,6 +4,7 @@ const { randomUUID } = require("node:crypto")
 
 const STATUSES = new Set(["starting", "idle", "running", "error"])
 const MUTABLE_FIELDS = new Set(["title", "modelId", "effort", "status"])
+const SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -32,6 +33,28 @@ function cleanImages(value) {
     }))
 }
 
+function cleanSkills(value) {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter(
+      (skill) =>
+        isRecord(skill) &&
+        typeof skill.name === "string" &&
+        skill.name.length <= 64 &&
+        SKILL_NAME.test(skill.name) &&
+        typeof skill.description === "string" &&
+        skill.description.trim() &&
+        skill.description.length <= 1_024 &&
+        typeof skill.instructions === "string" &&
+        skill.instructions.length <= 20_000
+    )
+    .map(({ name, description, instructions }) => ({
+      name,
+      description: description.trim(),
+      instructions,
+    }))
+}
+
 function normalizeThread(value) {
   if (
     !isRecord(value) ||
@@ -55,6 +78,7 @@ function normalizeThread(value) {
     ? {
         prompt: stringOrNull(value.pending.prompt, 2_000_000) || "",
         images: cleanImages(value.pending.images),
+        skills: cleanSkills(value.pending.skills),
       }
     : null
   return {
@@ -147,7 +171,7 @@ class LocalThreadStore {
       createdAt: now,
       updatedAt: now,
       checkpoint: { repo: null, ref: null },
-      pending: { prompt, images: cleanImages(input.images) },
+      pending: { prompt, images: cleanImages(input.images), skills: cleanSkills(input.skills) },
     }
     this.threads.set(thread.id, thread)
     this.persist()

--- a/desktop/test/local-thread-store.test.cjs
+++ b/desktop/test/local-thread-store.test.cjs
@@ -28,12 +28,17 @@ test("persists a prompt until it is acknowledged", (t) => {
     images: [{ base64: "aW1n", mimeType: "image/png", fileName: "bug.png" }],
     modelId: "anthropic:test",
     effort: "high",
+    skills: [
+      { name: "review", description: "Review changes", instructions: "Be concise." },
+      { name: "../bad", description: "Invalid", instructions: "Ignore." },
+    ],
   })
   assert.equal(thread.title, "fix the tests")
   assert.equal(fs.statSync(fixture.path).mode & 0o777, 0o600)
   assert.deepEqual(store.pendingPrompt(thread.id), {
     prompt: "  fix the tests  ",
     images: [{ kind: "image", base64: "aW1n", mimeType: "image/png", fileName: "bug.png" }],
+    skills: [{ name: "review", description: "Review changes", instructions: "Be concise." }],
   })
   assert.deepEqual(store.pendingPrompt(thread.id), store.pendingPrompt(thread.id))
   store.clearPrompt(thread.id)

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -157,7 +157,9 @@ async def test_agent_wires_user_organization_and_bundled_skills_into_agents() ->
 @pytest.mark.asyncio
 async def test_desktop_agent_loads_snapshotted_and_bundled_skills() -> None:
     config = _base_config()
-    config["configurable"].update({"source": "desktop", "local_project_path": "/tmp"})
+    config.setdefault("configurable", {}).update(
+        {"source": "desktop", "local_project_path": "/tmp"}
+    )
     with patch("agent.server.create_desktop_backend", return_value=MagicMock()):
         captured = await _capture_create_deep_agent_kwargs(config)
 

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.state import StateBackend
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import _registered_tool_name, get_agent
@@ -151,6 +152,20 @@ async def test_agent_wires_user_organization_and_bundled_skills_into_agents() ->
     assert isinstance(subagents, list)
     gp = next(s for s in subagents if s["name"] == "general-purpose")
     assert gp["skills"] == sources
+
+
+@pytest.mark.asyncio
+async def test_desktop_agent_loads_snapshotted_and_bundled_skills() -> None:
+    config = _base_config()
+    config["configurable"].update({"source": "desktop", "local_project_path": "/tmp"})
+    with patch("agent.server.create_desktop_backend", return_value=MagicMock()):
+        captured = await _capture_create_deep_agent_kwargs(config)
+
+    assert captured["skills"] == ["/skills/", "/bundled-skills/"]
+    backend = captured["backend"]
+    assert isinstance(backend, CompositeBackend)
+    assert isinstance(backend.routes["/skills/"], ReadOnlyBackend)
+    assert isinstance(backend.routes["/skills/"]._backend, StateBackend)
 
 
 @pytest.mark.asyncio

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -1,5 +1,6 @@
 import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
 import type { AgentThread, ImageChunk } from "@/features/agents/lib/types"
+import type { Skill } from "@/lib/api"
 
 export interface DesktopProject {
   cwd: string
@@ -28,6 +29,7 @@ export interface DesktopLocalDiff {
 export interface DesktopLocalPromptInput {
   prompt: string
   images: Array<ImageChunk>
+  skills: Array<Skill>
 }
 
 export type DesktopTerminalStatus = "starting" | "running" | "exited" | "error"

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -225,10 +225,9 @@ export function AgentsHome() {
           images,
           skills: [
             ...new Map(
-              [
-                ...managedSkills.personal,
-                ...managedSkills.organization,
-              ].map((skill) => [skill.name, skill])
+              [...managedSkills.personal, ...managedSkills.organization].map(
+                (skill) => [skill.name, skill]
+              )
             ).values(),
           ],
           modelId: activeSelection?.modelId,

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -222,6 +222,14 @@ export function AgentsHome() {
           cwd: localProjectPath,
           prompt,
           images,
+          skills: [
+            ...new Map(
+              [...skills.personal, ...skills.organization].map((skill) => [
+                skill.name,
+                skill,
+              ])
+            ).values(),
+          ],
           modelId: activeSelection?.modelId,
           effort: activeSelection?.effort,
         })

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -218,16 +218,17 @@ export function AgentsHome() {
           )
           return
         }
+        const managedSkills = await skills.refetch()
         const localSession = await desktop.startLocalThread({
           cwd: localProjectPath,
           prompt,
           images,
           skills: [
             ...new Map(
-              [...skills.personal, ...skills.organization].map((skill) => [
-                skill.name,
-                skill,
-              ])
+              [
+                ...managedSkills.personal,
+                ...managedSkills.organization,
+              ].map((skill) => [skill.name, skill])
             ).values(),
           ],
           modelId: activeSelection?.modelId,

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -10,7 +10,10 @@ import {
 } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
-import type { DesktopLocalThreadSummary } from "@/desktop"
+import type {
+  DesktopLocalPromptInput,
+  DesktopLocalThreadSummary,
+} from "@/desktop"
 import type { ImageChunk } from "@/features/agents/lib/types"
 import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
@@ -61,6 +64,18 @@ function promptContent(text: string, images: Array<ImageChunk>) {
     ...(image.fileName ? { file_name: image.fileName } : {}),
   }))
   return [...imageBlocks, ...(trimmed ? [{ type: "text", text: trimmed }] : [])]
+}
+
+function skillFiles(skills: DesktopLocalPromptInput["skills"]) {
+  return Object.fromEntries(
+    skills.map(({ name, description, instructions }) => [
+      `/${name}/SKILL.md`,
+      {
+        content: `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n\n${instructions.trim()}\n`,
+        encoding: "utf-8",
+      },
+    ])
+  )
 }
 
 function errorMessage(error: unknown): string {
@@ -208,7 +223,11 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   )
 
   const submit = useCallback(
-    async (prompt: string, images: Array<ImageChunk>) => {
+    async (
+      prompt: string,
+      images: Array<ImageChunk>,
+      skills: DesktopLocalPromptInput["skills"] = []
+    ) => {
       if (!thread) return false
       setError(null)
       await updateStatus("running")
@@ -218,6 +237,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             messages: [
               { type: "human", content: promptContent(prompt, images) },
             ],
+            ...(skills.length ? { files: skillFiles(skills) } : {}),
           },
           {
             config: {
@@ -248,7 +268,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
       .then(() => window.openSweDesktop?.getLocalPrompt(sessionId))
       .then(async (pending) => {
         if (!pending) return
-        if (await submit(pending.prompt, pending.images)) {
+        if (await submit(pending.prompt, pending.images, pending.skills)) {
           await window.openSweDesktop?.clearLocalPrompt(sessionId)
         } else {
           initialPromptRef.current = null

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -137,6 +137,18 @@ export function useAgentSkills() {
     ...personal,
     personal: personal.data ?? [],
     organization: organization.data ?? [],
+    refetch: async () => {
+      const [personalResult, organizationResult] = await Promise.all([
+        personal.refetch(),
+        organization.refetch(),
+      ])
+      if (personalResult.error) throw personalResult.error
+      if (organizationResult.error) throw organizationResult.error
+      return {
+        personal: personalResult.data ?? [],
+        organization: organizationResult.data ?? [],
+      }
+    },
     data: [
       ...new Map(
         [

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -135,6 +135,8 @@ export function useAgentSkills() {
   const organization = useOrganizationAgentSkills()
   return {
     ...personal,
+    personal: personal.data ?? [],
+    organization: organization.data ?? [],
     data: [
       ...new Map(
         [


### PR DESCRIPTION
## Description
Snapshot managed personal and organization skills into new desktop-local threads and mount them from LangGraph state. This gives local sessions cloud skill parity without sharing cloud storage credentials.

## Release Note
Desktop local sessions now have access to managed skills.

## Test Plan
- [x] Create a desktop thread with managed skills and verify only valid skill snapshots persist.

Made by [Open SWE](https://openswe.vercel.app/agents/01a01b8a-7f02-73bd-b4ba-19803ac87cbe)