### PR TITLE
fix: reconcile timed-out sandbox creation

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -37,8 +37,6 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS = 30 * 24 * 60 * 60  # 30 days
 SANDBOX_CREATE_MAX_ATTEMPTS = 3
 SANDBOX_CREATE_RETRY_DELAYS_SECONDS = (1.0, 3.0)
 SANDBOX_CREATE_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
-SANDBOX_CREATE_RECONCILE_MAX_ATTEMPTS = 30
-SANDBOX_CREATE_RECONCILE_DELAY_SECONDS = 2.0
 PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
@@ -273,23 +271,6 @@ async def _reuse_existing_sandbox(client: AsyncSandboxClient, sandbox_id: str) -
         raise RuntimeError(msg) from e
 
 
-async def _reconcile_timed_out_sandbox(client: AsyncSandboxClient, name: str) -> Any | None:
-    """Wait for an ambiguously timed-out create request to finish server-side."""
-    for attempt in range(SANDBOX_CREATE_RECONCILE_MAX_ATTEMPTS):
-        try:
-            sandbox = await client.get_sandbox(name=name)
-        except ResourceNotFoundError:
-            sandbox = None
-        if sandbox is not None:
-            if sandbox.status == "ready":
-                return sandbox
-            if sandbox.status == "failed":
-                return None
-        if attempt < SANDBOX_CREATE_RECONCILE_MAX_ATTEMPTS - 1:
-            await asyncio.sleep(SANDBOX_CREATE_RECONCILE_DELAY_SECONDS)
-    return None
-
-
 async def _create_sandbox_with_retry(
     client: AsyncSandboxClient,
     *,
@@ -316,12 +297,18 @@ async def _create_sandbox_with_retry(
             )
         except Exception as exc:
             if name and isinstance(exc, httpx.ReadTimeout):
-                sandbox = await _reconcile_timed_out_sandbox(client, name)
-                if sandbox is not None:
-                    logger.warning(
-                        "Sandbox create response timed out; adopted ready sandbox %s", name
-                    )
-                    return sandbox
+                for reconcile_attempt in range(30):
+                    try:
+                        sandbox = await client.get_sandbox(name=name)
+                    except ResourceNotFoundError:
+                        pass
+                    else:
+                        if sandbox.status == "ready":
+                            return sandbox
+                        if sandbox.status == "failed":
+                            break
+                    if reconcile_attempt < 29:
+                        await asyncio.sleep(2)
             if attempt == SANDBOX_CREATE_MAX_ATTEMPTS - 1 or not _is_retryable_sandbox_create_error(
                 exc
             ):

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -15,6 +15,7 @@ from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from langsmith.sandbox import (
     AsyncSandboxClient,
     CommandTimeoutError,
+    ResourceNotFoundError,
     SandboxConnectionError,
     SandboxServerReloadError,
 )
@@ -36,6 +37,8 @@ DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS = 30 * 24 * 60 * 60  # 30 days
 SANDBOX_CREATE_MAX_ATTEMPTS = 3
 SANDBOX_CREATE_RETRY_DELAYS_SECONDS = (1.0, 3.0)
 SANDBOX_CREATE_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+SANDBOX_CREATE_RECONCILE_MAX_ATTEMPTS = 30
+SANDBOX_CREATE_RECONCILE_DELAY_SECONDS = 2.0
 PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
@@ -270,6 +273,23 @@ async def _reuse_existing_sandbox(client: AsyncSandboxClient, sandbox_id: str) -
         raise RuntimeError(msg) from e
 
 
+async def _reconcile_timed_out_sandbox(client: AsyncSandboxClient, name: str) -> Any | None:
+    """Wait for an ambiguously timed-out create request to finish server-side."""
+    for attempt in range(SANDBOX_CREATE_RECONCILE_MAX_ATTEMPTS):
+        try:
+            sandbox = await client.get_sandbox(name=name)
+        except ResourceNotFoundError:
+            sandbox = None
+        if sandbox is not None:
+            if sandbox.status == "ready":
+                return sandbox
+            if sandbox.status == "failed":
+                return None
+        if attempt < SANDBOX_CREATE_RECONCILE_MAX_ATTEMPTS - 1:
+            await asyncio.sleep(SANDBOX_CREATE_RECONCILE_DELAY_SECONDS)
+    return None
+
+
 async def _create_sandbox_with_retry(
     client: AsyncSandboxClient,
     *,
@@ -295,6 +315,13 @@ async def _create_sandbox_with_retry(
                 timeout=timeout,
             )
         except Exception as exc:
+            if name and isinstance(exc, httpx.ReadTimeout):
+                sandbox = await _reconcile_timed_out_sandbox(client, name)
+                if sandbox is not None:
+                    logger.warning(
+                        "Sandbox create response timed out; adopted ready sandbox %s", name
+                    )
+                    return sandbox
             if attempt == SANDBOX_CREATE_MAX_ATTEMPTS - 1 or not _is_retryable_sandbox_create_error(
                 exc
             ):

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from langsmith.sandbox import AsyncSandboxClient, ResourceNotFoundError
+from langsmith.sandbox import AsyncSandboxClient
 
 from agent.integrations.langsmith import (
     DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS,
@@ -185,30 +185,19 @@ class _FakeStatusSandbox:
         self.status = status
 
 
-class _TimedOutCreateClient:
-    def __init__(self, lookups: list[BaseException | _FakeStatusSandbox]) -> None:
-        self.lookups = lookups
-        self.create_calls = 0
-        self.get_calls = 0
+async def test_create_read_timeout_adopts_sandbox_when_it_becomes_ready(monkeypatch) -> None:  # noqa: ANN001
+    client = AsyncMock(spec=AsyncSandboxClient)
+    client.create_sandbox.side_effect = httpx.ReadTimeout("timed out")
+    client.get_sandbox.side_effect = [
+        _FakeStatusSandbox("provisioning"),
+        _FakeStatusSandbox("ready"),
+    ]
+    monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", AsyncMock())
 
-    async def create_sandbox(self, **kwargs):  # noqa: ANN003, ANN202
-        self.create_calls += 1
-        request = httpx.Request("POST", "https://api.smith.langchain.com/v2/sandboxes/boxes")
-        raise httpx.ReadTimeout("timed out", request=request)
-
-    async def get_sandbox(self, *, name: str) -> _FakeStatusSandbox:
-        self.get_calls += 1
-        result = self.lookups.pop(0)
-        if isinstance(result, BaseException):
-            raise result
-        return result
-
-
-async def _create_with_client(client: _TimedOutCreateClient, *, name: str | None = "openswe-abc"):
-    return await _create_sandbox_with_retry(
+    result = await _create_sandbox_with_retry(
         cast(AsyncSandboxClient, client),
         snapshot_id="snap-1",
-        name=name,
+        name="openswe-abc",
         fs_capacity_bytes=None,
         vcpus=None,
         mem_bytes=None,
@@ -217,47 +206,9 @@ async def _create_with_client(client: _TimedOutCreateClient, *, name: str | None
         timeout=180,
     )
 
-
-@pytest.mark.asyncio
-async def test_create_read_timeout_adopts_sandbox_when_it_becomes_ready(monkeypatch) -> None:  # noqa: ANN001
-    client = _TimedOutCreateClient(
-        [
-            ResourceNotFoundError("not found", resource_type="sandbox"),
-            _FakeStatusSandbox("provisioning"),
-            _FakeStatusSandbox("ready"),
-        ]
-    )
-    sleep = AsyncMock()
-    monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", sleep)
-
-    result = await _create_with_client(client)
-
     assert result.status == "ready"
-    assert client.create_calls == 1
-    assert client.get_calls == 3
-    assert sleep.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_create_read_timeout_does_not_adopt_failed_sandbox() -> None:
-    client = _TimedOutCreateClient([_FakeStatusSandbox("failed")])
-
-    with pytest.raises(httpx.ReadTimeout):
-        await _create_with_client(client)
-
-    assert client.create_calls == 1
-    assert client.get_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_create_read_timeout_without_deterministic_name_is_not_reconciled() -> None:
-    client = _TimedOutCreateClient([])
-
-    with pytest.raises(httpx.ReadTimeout):
-        await _create_with_client(client, name=None)
-
-    assert client.create_calls == 1
-    assert client.get_calls == 0
+    assert client.create_sandbox.await_count == 1
+    assert client.get_sandbox.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
-from langsmith.sandbox import AsyncSandboxClient
+from langsmith.sandbox import AsyncSandboxClient, ResourceNotFoundError
 
 from agent.integrations.langsmith import (
     DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS,
@@ -182,6 +183,81 @@ class _FakeSandboxClient:
 class _FakeStatusSandbox:
     def __init__(self, status: str) -> None:
         self.status = status
+
+
+class _TimedOutCreateClient:
+    def __init__(self, lookups: list[BaseException | _FakeStatusSandbox]) -> None:
+        self.lookups = lookups
+        self.create_calls = 0
+        self.get_calls = 0
+
+    async def create_sandbox(self, **kwargs):  # noqa: ANN003, ANN202
+        self.create_calls += 1
+        request = httpx.Request("POST", "https://api.smith.langchain.com/v2/sandboxes/boxes")
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    async def get_sandbox(self, *, name: str) -> _FakeStatusSandbox:
+        self.get_calls += 1
+        result = self.lookups.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+async def _create_with_client(client: _TimedOutCreateClient, *, name: str | None = "openswe-abc"):
+    return await _create_sandbox_with_retry(
+        cast(AsyncSandboxClient, client),
+        snapshot_id="snap-1",
+        name=name,
+        fs_capacity_bytes=None,
+        vcpus=None,
+        mem_bytes=None,
+        idle_ttl_seconds=None,
+        delete_after_stop_seconds=None,
+        timeout=180,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_read_timeout_adopts_sandbox_when_it_becomes_ready(monkeypatch) -> None:  # noqa: ANN001
+    client = _TimedOutCreateClient(
+        [
+            ResourceNotFoundError("not found", resource_type="sandbox"),
+            _FakeStatusSandbox("provisioning"),
+            _FakeStatusSandbox("ready"),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("agent.integrations.langsmith.asyncio.sleep", sleep)
+
+    result = await _create_with_client(client)
+
+    assert result.status == "ready"
+    assert client.create_calls == 1
+    assert client.get_calls == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_read_timeout_does_not_adopt_failed_sandbox() -> None:
+    client = _TimedOutCreateClient([_FakeStatusSandbox("failed")])
+
+    with pytest.raises(httpx.ReadTimeout):
+        await _create_with_client(client)
+
+    assert client.create_calls == 1
+    assert client.get_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_create_read_timeout_without_deterministic_name_is_not_reconciled() -> None:
+    client = _TimedOutCreateClient([])
+
+    with pytest.raises(httpx.ReadTimeout):
+        await _create_with_client(client, name=None)
+
+    assert client.create_calls == 1
+    assert client.get_calls == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reconcile ambiguous LangSmith sandbox create read timeouts by polling the deterministic per-thread sandbox name
- adopt only once the server-side sandbox is ready, without issuing a duplicate create
- preserve the original timeout when the sandbox never appears or provisioning fails

## Validation

- `uv run pytest -q tests/sandbox/test_langsmith_sandbox_config.py` — 23 passed
- scoped Ruff check/format — passed
- scoped basedpyright — passed

Production evidence: the timed-out sandbox became ready about 25 seconds after the client HTTP deadline, so GET-by-name reconciliation avoids reporting a failed run for a successful create.