### PR TITLE
fix: recover sandbox startup after interrupted runs

### DIFF
--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -112,10 +112,14 @@ class SandboxBackendProxy(BaseSandbox):
 
     def _startup_completed(self, task: asyncio.Task[SandboxBackendProtocol]) -> None:
         if task.cancelled():
+            if self._startup_task is task:
+                self._startup_task = None
             logger.warning("Sandbox startup was cancelled for thread %s", self._thread_id)
             return
         exception = task.exception()
         if exception is not None:
+            if self._startup_task is task:
+                self._startup_task = None
             logger.warning(
                 "Sandbox startup failed for thread %s: %s",
                 self._thread_id,

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -268,6 +268,36 @@ async def test_sandbox_proxy_startup_survives_waiter_cancellation() -> None:
     assert calls == 1
 
 
+def test_sandbox_proxy_retries_startup_after_interrupted_loop() -> None:
+    calls = 0
+
+    async def reconnect():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await asyncio.Future()
+        return _FakeSandboxBackend()
+
+    proxy = SandboxBackendProxy(
+        thread_id="thread-1",
+        reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
+    )
+
+    async def interrupt() -> None:
+        proxy.start()
+        waiter = asyncio.create_task(proxy.ready())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    asyncio.run(interrupt())
+    backend = asyncio.run(proxy.ready())
+
+    assert backend.id == "sandbox-1"
+    assert calls == 2
+
+
 @pytest.mark.asyncio
 async def test_sandbox_proxy_retries_failed_startup() -> None:
     calls = 0


### PR DESCRIPTION
## Description
Clear cancelled or failed startup tasks from the stable sandbox proxy so the next run reconnects instead of awaiting a task owned by the interrupted loop.

## Release Note
Fixed threads becoming unusable after an interrupted run during sandbox startup.

## Test Plan
- [x] Reproduce failure across separate event loops, then verify reconnect succeeds

Made by [Open SWE](https://openswe.vercel.app/agents/e90c456a-9ca8-5d4b-90f8-f0dade1df93b)