### PR TITLE
fix: guard review chat repo reads

### DIFF
--- a/agent/chat.py
+++ b/agent/chat.py
@@ -125,6 +125,7 @@ with severity, confidence, and resolution notes.
 Guidance:
 - Be concrete and cite specific files and line numbers from the diff.
 - Ground claims about the review in the actual findings; don't invent issues.
+- If repository access fails, disclose it and qualify claims that require unread source.
 - When you propose a change, describe it precisely — you cannot apply it yourself.
 - Keep answers focused and skimmable. Match the depth of the question.
 """

--- a/agent/tools/read_repo_file.py
+++ b/agent/tools/read_repo_file.py
@@ -55,12 +55,17 @@ async def read_repo_file(path: str, ref: str | None = None) -> dict[str, Any]:
     owner, repo, token, head_sha = _chat_repo_context()
     if not owner or not repo:
         return {"success": False, "error": "repository context unavailable"}
+    if not token:
+        return {
+            "success": False,
+            "error": "GitHub credentials unavailable; repository source was not read",
+        }
 
     clean_path = path.strip().lstrip("/")
     resolved_ref = (ref or head_sha or "").strip()
     params = {"ref": resolved_ref} if resolved_ref else None
     url = f"{_GITHUB_API}/repos/{owner}/{repo}/contents/{clean_path}"
-    headers = github_headers(token or "")
+    headers = github_headers(token)
     try:
         async with httpx.AsyncClient(timeout=30) as client:
             response = await client.get(url, headers=headers, params=params)

--- a/agent/tools/search_repo_code.py
+++ b/agent/tools/search_repo_code.py
@@ -44,9 +44,14 @@ async def search_repo_code(query: str, max_results: int = 20) -> dict[str, Any]:
     owner, repo, token = _chat_repo_context()
     if not owner or not repo:
         return {"success": False, "error": "repository context unavailable"}
+    if not token:
+        return {
+            "success": False,
+            "error": "GitHub credentials unavailable; repository source was not read",
+        }
 
     capped = max(1, min(max_results, 50))
-    headers = github_headers(token or "")
+    headers = github_headers(token)
     headers["Accept"] = "application/vnd.github.text-match+json"
     params = {"q": f"{query} repo:{owner}/{repo}", "per_page": capped}
     try:

--- a/tests/reviewer/test_review_chat.py
+++ b/tests/reviewer/test_review_chat.py
@@ -313,10 +313,19 @@ async def test_read_repo_file_lists_directory(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_repo_file_missing_context(monkeypatch) -> None:
+async def test_repo_tools_require_context_and_token(monkeypatch) -> None:
     monkeypatch.setattr(read_repo_file, "get_config", lambda: {"configurable": {}})
     result = await read_repo_file.read_repo_file("src/app.py")
     assert result["success"] is False
+
+    config = {"configurable": {"chat_repo_owner": "acme", "chat_repo_name": "repo"}}
+    for module, tool, args in (
+        (read_repo_file, read_repo_file.read_repo_file, ("src/app.py",)),
+        (search_repo_code, search_repo_code.search_repo_code, ("foo",)),
+    ):
+        monkeypatch.setattr(module, "get_config", lambda: config)
+        result = await tool(*args)
+        assert result["error"] == "GitHub credentials unavailable; repository source was not read"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Guard repository read/search tools before building auth headers and instruct review chat to disclose unavailable source access.

## Release Note
PR review chat now reports missing GitHub credentials instead of issuing unqualified source claims.

## Test Plan
- [x] Simulate missing-token reads and searches; verify explicit failures

Made by [Open SWE](https://openswe.vercel.app/agents/8d3134f2-cd25-54f0-ace9-1f09d9eb9855)