### PR TITLE
fix: stop a failed or interrupted run from bricking its thread

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -5,7 +5,6 @@ import base64
 import json
 import logging
 import os
-import uuid
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -15,9 +14,12 @@ from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from langsmith.sandbox import (
     AsyncSandboxClient,
     CommandTimeoutError,
+    ResourceNotFoundError,
     SandboxConnectionError,
     SandboxServerReloadError,
 )
+
+from agent.utils.sandbox import SandboxGoneError
 
 logger = logging.getLogger(__name__)
 
@@ -86,33 +88,6 @@ def _get_sandbox_api_endpoint() -> str:
     root = _get_sandbox_endpoint().rstrip("/")
     suffix = "/v2/sandboxes"
     return root if root.endswith(suffix) else f"{root}{suffix}"
-
-
-def _current_thread_id() -> str | None:
-    """The LangGraph thread id for the active run, if any."""
-    try:
-        from langgraph.config import get_config
-
-        return get_config().get("configurable", {}).get("thread_id")
-    except Exception:
-        return None
-
-
-def _sandbox_name_for_thread(thread_id: str | None) -> str | None:
-    """Deterministic, thread-traceable sandbox name: ``openswe-<b32(thread uuid)>``.
-
-    The thread id (a UUID) is base32-encoded lowercase without padding so the
-    name is a compact, hyphen-free token that maps back to the thread. Returns
-    None when the thread id is missing or not a UUID, leaving the name unset.
-    """
-    if not thread_id:
-        return None
-    try:
-        raw = uuid.UUID(thread_id).bytes
-    except ValueError:
-        return None
-    encoded = base64.b32encode(raw).decode("ascii").rstrip("=").lower()
-    return f"openswe-{encoded}"
 
 
 def _parse_optional_int(name: str, default: int) -> int:
@@ -258,13 +233,12 @@ def _is_retryable_sandbox_create_error(exc: BaseException) -> bool:
     }
 
 
-def _is_sandbox_name_taken_error(exc: BaseException) -> bool:
-    return "already exists" in str(exc).lower()
-
-
 async def _reuse_existing_sandbox(client: AsyncSandboxClient, sandbox_id: str) -> Any:
     try:
         return await client.get_sandbox(name=sandbox_id)
+    except ResourceNotFoundError as e:
+        msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
+        raise SandboxGoneError(msg) from e
     except Exception as e:
         msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
         raise RuntimeError(msg) from e
@@ -274,7 +248,6 @@ async def _create_sandbox_with_retry(
     client: AsyncSandboxClient,
     *,
     snapshot_id: str,
-    name: str | None,
     fs_capacity_bytes: int | None,
     vcpus: int | None,
     mem_bytes: int | None,
@@ -286,7 +259,6 @@ async def _create_sandbox_with_retry(
         try:
             return await client.create_sandbox(
                 snapshot_id=snapshot_id,
-                name=name,
                 fs_capacity_bytes=fs_capacity_bytes,
                 vcpus=vcpus,
                 mem_bytes=mem_bytes,
@@ -420,36 +392,17 @@ async def create_langsmith_sandbox(
     backend = await provider.get_or_create(
         sandbox_id=sandbox_id,
         snapshot_id=effective_snapshot_id,
-        name=_sandbox_name_for_thread(_current_thread_id()),
         fs_capacity_bytes=fs_capacity_bytes,
         vcpus=vcpus,
         mem_bytes=mem_bytes,
         idle_ttl_seconds=idle_ttl_seconds,
         delete_after_stop_seconds=delete_after_stop_seconds,
     )
-    await _update_thread_sandbox_metadata(backend.id)
 
     if sandbox_id is None and github_token:
         await _configure_github_proxy(backend.id, github_token)
 
     return backend
-
-
-async def _update_thread_sandbox_metadata(sandbox_id: str) -> None:
-    """Update thread metadata with sandbox_id."""
-    try:
-        from langgraph_sdk import get_client
-
-        thread_id = _current_thread_id()
-        if not thread_id:
-            return
-        client = get_client()
-        await client.threads.update(
-            thread_id=thread_id,
-            metadata={"sandbox_id": sandbox_id},
-        )
-    except Exception:
-        pass
 
 
 class TimeoutLangSmithSandbox(LangSmithSandbox):
@@ -543,10 +496,9 @@ class SandboxProvider(ABC):
     """Interface for creating sandbox backends.
 
     Intentionally has no delete. A sandbox holds the agent's only copy of its
-    working tree, and callers cannot reliably tell a free name from one held by
-    a live box — thread metadata reads and writes both fail open to "no sandbox".
-    Reclamation is the platform's job, via the idle TTL and delete-after-stop
-    set at create time.
+    working tree, and the thread metadata read fails open to "no sandbox", so a
+    delete keyed off it can destroy a live box. Reclamation is the platform's
+    job, via the idle TTL and delete-after-stop set at create time.
     """
 
     @abstractmethod
@@ -613,7 +565,6 @@ class LangSmithProvider(SandboxProvider):
         sandbox_id: str | None = None,
         timeout: int = 180,
         snapshot_id: str | None = None,
-        name: str | None = None,
         fs_capacity_bytes: int | None = None,
         vcpus: int | None = None,
         mem_bytes: int | None = None,
@@ -651,7 +602,6 @@ class LangSmithProvider(SandboxProvider):
                 sandbox = await _create_sandbox_with_retry(
                     client,
                     snapshot_id=snapshot_id,
-                    name=name,
                     fs_capacity_bytes=fs_capacity_bytes,
                     vcpus=vcpus,
                     mem_bytes=mem_bytes,
@@ -660,13 +610,7 @@ class LangSmithProvider(SandboxProvider):
                     timeout=timeout,
                 )
             except Exception as e:
-                if not (name and _is_sandbox_name_taken_error(e)):
-                    msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
-                    raise RuntimeError(msg) from e
-                # Sandbox names are deterministic per thread, so the holder is this
-                # thread's own sandbox from a run that died before persisting its id.
-                # Creating is impossible and failing strands the thread forever.
-                logger.warning("Sandbox %s already exists; adopting it instead of creating", name)
-                sandbox = await _reuse_existing_sandbox(client, name)
+                msg = f"Failed to create sandbox from snapshot '{snapshot_id}': {e}"
+                raise RuntimeError(msg) from e
 
             return TimeoutLangSmithSandbox(sandbox.to_sync())

--- a/agent/server.py
+++ b/agent/server.py
@@ -180,7 +180,7 @@ from .utils.model import (
     provider_model_kwargs,
 )
 from .utils.read_only_backend import ReadOnlyBackend
-from .utils.sandbox import create_sandbox
+from .utils.sandbox import SandboxGoneError, create_sandbox
 from .utils.sandbox_paths import aresolve_sandbox_work_dir
 from .utils.sandbox_state import (
     SANDBOX_BACKENDS,
@@ -456,7 +456,10 @@ async def _connect_existing_sandbox(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
 ) -> SandboxBackendProtocol:
-    """Reuse the sandbox already bound to ``thread_id``, or fail unreachable."""
+    """Reuse the sandbox already bound to ``thread_id``, or fail unreachable.
+
+    A ``SandboxGoneError`` propagates untouched so the caller recreates.
+    """
     if cached is not None:
         logger.info("Using cached sandbox backend for thread %s", thread_id)
         sandbox_backend = await check_sandbox_reachable(cached, thread_id)
@@ -464,6 +467,8 @@ async def _connect_existing_sandbox(
         logger.info("Connecting to existing sandbox %s", sandbox_id)
         try:
             sandbox_backend = await create_sandbox(str(sandbox_id))
+        except SandboxGoneError:
+            raise
         except Exception as exc:
             logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
             raise SandboxUnreachableError(thread_id, sandbox_id, str(exc)) from exc
@@ -492,17 +497,16 @@ async def ensure_sandbox_for_thread(
     2. Metadata has an id -> reconnect, then refresh proxy.
     3. No sandbox at all -> create one and persist the id.
 
-    By default only case 3 creates: a sandbox that exists but can't be reached
-    raises ``SandboxUnreachableError`` instead of being replaced, because a
-    replacement is empty and swapping one in silently destroys whatever the agent
-    had not yet committed.
+    A sandbox that exists but can't be reached raises ``SandboxUnreachableError``
+    instead of being replaced, because a replacement is empty and swapping one in
+    silently destroys whatever the agent had not yet committed. A *deleted* one
+    (``SandboxGoneError``) is always replaced: it holds nothing, and the stale id
+    in thread metadata is what every later run keeps reconnecting to, so refusing
+    would brick the thread permanently.
 
-    ``allow_replacement`` opts out of that protection for callers whose sandbox
-    holds nothing but a re-derivable checkout — the read-only reviewer, which
-    re-preps the repo every run. There, refusing to replace bricks the thread
-    permanently: sandboxes are deleted once their retention window elapses, and
-    the stale id in thread metadata is what every later run keeps reconnecting
-    to. Replacing it clears that id in the metadata update below.
+    ``allow_replacement`` extends replacement to merely unreachable sandboxes,
+    for callers whose sandbox holds nothing but a re-derivable checkout — the
+    read-only reviewer, which re-preps the repo every run.
 
     For LangSmith sandboxes, also refreshes the GitHub App proxy auth. When
     ``repo`` has a ``ready`` repo-scoped snapshot, newly created sandboxes boot
@@ -539,12 +543,14 @@ async def ensure_sandbox_for_thread(
                 github_proxy_token=github_proxy_token,
                 github_proxy_repositories=github_proxy_repositories,
             )
-        except SandboxUnreachableError as exc:
-            if not allow_replacement:
+        except (SandboxGoneError, SandboxUnreachableError) as exc:
+            gone = isinstance(exc, SandboxGoneError)
+            if not (gone or allow_replacement):
                 raise
             logger.warning(
-                "Replacing unreachable sandbox %s for thread %s",
-                exc.sandbox_id,
+                "Replacing %s sandbox %s for thread %s",
+                "deleted" if gone else "unreachable",
+                sandbox_id,
                 thread_id,
             )
             try:
@@ -558,24 +564,27 @@ async def ensure_sandbox_for_thread(
                 # Keep the failure typed so callers still recognize "this run has no
                 # sandbox" and can notify the user.
                 logger.warning(
-                    "Failed to replace unreachable sandbox %s for thread %s",
-                    exc.sandbox_id,
+                    "Failed to replace sandbox %s for thread %s",
+                    sandbox_id,
                     thread_id,
                     exc_info=True,
                 )
                 raise SandboxUnreachableError(
-                    thread_id, exc.sandbox_id, str(create_exc)
+                    thread_id, sandbox_id, str(create_exc)
                 ) from create_exc
             logger.info("Replacement sandbox created: %s", sandbox_backend.id)
 
     sandbox_backend = set_sandbox_backend(thread_id, sandbox_backend)
 
+    await _configure_git_identity(sandbox_backend)
+
+    # Bind the thread only once the sandbox is created and initialized: a run
+    # that dies earlier leaves no id to reconnect to, so the next run creates
+    # rather than adopting a half-built box.
     if sandbox_id != sandbox_backend.id:
         await client.threads.update(
             thread_id=thread_id, metadata={"sandbox_id": sandbox_backend.id}
         )
-
-    await _configure_git_identity(sandbox_backend)
 
     return sandbox_backend
 

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -10,6 +10,15 @@ if TYPE_CHECKING:
 
 SandboxFactory = Callable[..., Any]
 
+
+class SandboxGoneError(RuntimeError):
+    """The sandbox a thread is bound to no longer exists.
+
+    Distinct from a sandbox that is merely unreachable: a deleted one holds no
+    working tree, so callers recreate instead of failing the run.
+    """
+
+
 SANDBOX_FACTORIES: dict[str, tuple[str, str]] = {
     "langsmith": ("agent.integrations.langsmith", "create_langsmith_sandbox"),
     "daytona": ("agent.integrations.daytona", "create_daytona_sandbox"),

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -3,6 +3,8 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from weakref import WeakKeyDictionary
 
 from deepagents.backends.protocol import (
     DeleteResult,
@@ -49,6 +51,21 @@ class SandboxUnreachableError(RuntimeError):
 _SYNC_UNSUPPORTED = "SandboxBackendProxy is async-only; use the a-prefixed method instead."
 
 
+@dataclass
+class _LoopState:
+    """Startup state owned by one event loop.
+
+    A proxy is cached per thread and outlives every run, but a task and a lock
+    belong to the loop that made them: awaiting either from another loop raises
+    "attached to a different loop". Keeping them here, keyed by loop, means a
+    run only ever sees its own — an interrupted run's leftovers are unreachable
+    rather than poisonous, and go away with the loop that owns them.
+    """
+
+    lock: asyncio.Lock
+    startup_task: asyncio.Task[SandboxBackendProtocol] | None = None
+
+
 class SandboxBackendProxy(BaseSandbox):
     """Stable per-thread backend handle whose target can be replaced.
 
@@ -69,8 +86,9 @@ class SandboxBackendProxy(BaseSandbox):
         self._backend = backend
         self._thread_id = thread_id
         self._reconnect = reconnect
-        self._startup_task: asyncio.Task[SandboxBackendProtocol] | None = None
-        self._lock: asyncio.Lock | None = None
+        self._loop_state: WeakKeyDictionary[asyncio.AbstractEventLoop, _LoopState] = (
+            WeakKeyDictionary()
+        )
 
     @property
     def current(self) -> SandboxBackendProtocol:
@@ -82,15 +100,23 @@ class SandboxBackendProxy(BaseSandbox):
 
     def replace_backend(self, backend: SandboxBackendProtocol) -> None:
         self._backend = backend
-        self._startup_task = None
+        for state in self._loop_state.values():
+            state.startup_task = None
 
     @property
     def has_backend(self) -> bool:
         return self._backend is not None
 
     def cancel_startup(self) -> None:
-        if self._startup_task is not None:
-            self._startup_task.cancel()
+        # Only this loop's task: each loop runs on its own thread, so cancelling
+        # a task owned by another one is not thread-safe.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        state = self._loop_state.get(loop)
+        if state is not None and state.startup_task is not None:
+            state.startup_task.cancel()
 
     def set_reconnect(
         self,
@@ -99,16 +125,17 @@ class SandboxBackendProxy(BaseSandbox):
         self._reconnect = reconnect
 
     def start(self) -> None:
-        if self._startup_task is not None:
-            if not self._startup_task.cancelled():
+        state = self._state()
+        if state.startup_task is not None:
+            if not state.startup_task.cancelled():
                 return
-            self._startup_task = None
+            state.startup_task = None
         if self._reconnect is None:
             if self._backend is not None:
                 return
             raise RuntimeError("Cannot start sandbox without a reconnect callback")
-        self._startup_task = asyncio.ensure_future(self._reconnect())
-        self._startup_task.add_done_callback(self._startup_completed)
+        state.startup_task = asyncio.ensure_future(self._reconnect())
+        state.startup_task.add_done_callback(self._startup_completed)
 
     def _startup_completed(self, task: asyncio.Task[SandboxBackendProtocol]) -> None:
         if task.cancelled():
@@ -131,21 +158,25 @@ class SandboxBackendProxy(BaseSandbox):
             raise RuntimeError(f"No sandbox backend cached{suffix}")
         return self._backend
 
-    def _get_lock(self) -> asyncio.Lock:
-        if self._lock is None:
-            self._lock = asyncio.Lock()
-        return self._lock
+    def _state(self) -> _LoopState:
+        loop = asyncio.get_running_loop()
+        state = self._loop_state.get(loop)
+        if state is None:
+            state = _LoopState(lock=asyncio.Lock())
+            self._loop_state[loop] = state
+        return state
 
     async def _aget_backend(self) -> SandboxBackendProtocol:
-        if self._backend is not None and self._startup_task is None:
+        state = self._state()
+        if self._backend is not None and state.startup_task is None:
             return self._backend
         if not self._thread_id:
             raise RuntimeError("No sandbox backend cached")
 
-        async with self._get_lock():
-            if self._backend is not None and self._startup_task is None:
+        async with state.lock:
+            if self._backend is not None and state.startup_task is None:
                 return self._backend
-            if self._startup_task is None:
+            if state.startup_task is None:
                 if self._reconnect is not None:
                     logger.info("Reconnecting sandbox backend for thread %s", self._thread_id)
                     self.start()
@@ -159,9 +190,9 @@ class SandboxBackendProxy(BaseSandbox):
                     logger.info(
                         "Reconnecting sandbox backend for thread %s from metadata", self._thread_id
                     )
-                    self._startup_task = asyncio.create_task(create_sandbox(sandbox_id))
-                    self._startup_task.add_done_callback(self._startup_completed)
-            startup_task = self._startup_task
+                    state.startup_task = asyncio.create_task(create_sandbox(sandbox_id))
+                    state.startup_task.add_done_callback(self._startup_completed)
+            startup_task = state.startup_task
             if startup_task is None:
                 raise RuntimeError(f"Sandbox startup task missing for thread {self._thread_id}")
 
@@ -169,15 +200,15 @@ class SandboxBackendProxy(BaseSandbox):
             sandbox_backend = await asyncio.shield(startup_task)
         except BaseException:
             if startup_task.done():
-                async with self._get_lock():
-                    if self._startup_task is startup_task:
-                        self._startup_task = None
+                async with state.lock:
+                    if state.startup_task is startup_task:
+                        state.startup_task = None
             raise
 
-        async with self._get_lock():
-            if self._startup_task is startup_task:
+        async with state.lock:
+            if state.startup_task is startup_task:
                 self._backend = unwrap_sandbox_backend(sandbox_backend)
-                self._startup_task = None
+                state.startup_task = None
                 SANDBOX_BACKENDS[self._thread_id] = self
             backend = self._backend
             if backend is None:

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -1,13 +1,11 @@
 """Tests for LangSmith sandbox env-var configuration parsing."""
 
-import base64
-import uuid
 from pathlib import Path
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from langsmith.sandbox import AsyncSandboxClient
+from langsmith.sandbox import AsyncSandboxClient, ResourceNotFoundError
 
 from agent.integrations.langsmith import (
     DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS,
@@ -21,9 +19,9 @@ from agent.integrations.langsmith import (
     _get_sandbox_create_extra_fields,
     _get_sandbox_snapshot_config,
     _install_create_extra_fields,
-    _is_sandbox_name_taken_error,
-    _sandbox_name_for_thread,
+    _reuse_existing_sandbox,
 )
+from agent.utils.sandbox import SandboxGoneError
 
 
 def test_sandbox_api_endpoint_appends_v2_sandboxes() -> None:
@@ -39,33 +37,13 @@ def test_sandbox_api_endpoint_no_double_suffix() -> None:
         assert _get_sandbox_api_endpoint() == "https://x.smith.langchain.com/v2/sandboxes"
 
 
-def test_sandbox_name_for_thread_encodes_uuid() -> None:
-    thread_id = "12345678-1234-5678-1234-567812345678"
-    name = _sandbox_name_for_thread(thread_id)
-    assert name is not None
-    prefix, _, encoded = name.partition("-")
-    assert prefix == "openswe"
-    assert encoded == encoded.lower()
-    assert "=" not in encoded and "-" not in encoded
-    # Round-trips back to the original UUID.
-    padded = encoded.upper() + "=" * (-len(encoded) % 8)
-    assert uuid.UUID(bytes=base64.b32decode(padded)) == uuid.UUID(thread_id)
-
-
-def test_sandbox_name_for_thread_none_or_invalid() -> None:
-    assert _sandbox_name_for_thread(None) is None
-    assert _sandbox_name_for_thread("not-a-uuid") is None
-
-
 def test_nothing_deletes_sandboxes() -> None:
     """No code path may delete a sandbox.
 
-    A sandbox holds the agent's only copy of its working tree, and callers can't
-    tell a free name from one held by a live box: both the metadata read
-    (``get_sandbox_id_from_metadata``) and write (``_update_thread_sandbox_metadata``)
-    fail open to "this thread has no sandbox". A delete keyed off that guess
-    destroys a running box. Reclamation belongs to the platform's idle TTL and
-    delete-after-stop.
+    A sandbox holds the agent's only copy of its working tree, and the metadata
+    read (``get_sandbox_id_from_metadata``) fails open to "this thread has no
+    sandbox". A delete keyed off that guess destroys a running box. Reclamation
+    belongs to the platform's idle TTL and delete-after-stop.
     """
     agent_root = Path(__file__).resolve().parents[2] / "agent"
     offenders = [
@@ -179,11 +157,6 @@ class _FakeSandboxClient:
         return {"sandbox": kwargs["snapshot_id"]}
 
 
-class _FakeStatusSandbox:
-    def __init__(self, status: str) -> None:
-        self.status = status
-
-
 @pytest.mark.asyncio
 async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -> None:  # noqa: ANN001
     client = _FakeSandboxClient(failures=2)
@@ -192,7 +165,6 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
     result = await _create_sandbox_with_retry(
         cast(AsyncSandboxClient, client),
         snapshot_id="snap-1",
-        name="openswe-abc",
         fs_capacity_bytes=None,
         vcpus=None,
         mem_bytes=None,
@@ -203,7 +175,7 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
 
     assert result == {"sandbox": "snap-1"}
     assert client.calls == 3
-    assert client.last_kwargs["name"] == "openswe-abc"
+    assert "name" not in client.last_kwargs
 
 
 def test_extra_fields_unset_is_empty() -> None:
@@ -274,40 +246,26 @@ async def test_install_create_extra_fields_noop_when_empty() -> None:
     assert client._http.post == "sentinel"
 
 
-class _NameTakenClient:
-    """create_sandbox always collides; get_sandbox returns the orphan by that name."""
+class _MissingSandboxClient:
+    """get_sandbox raises instead of returning a sandbox."""
 
-    def __init__(self, status: str = "running") -> None:
-        self.create_calls = 0
-        self.status = status
-        self.requested: list[str] = []
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
 
-    async def create_sandbox(self, **kwargs):  # noqa: ANN003, ANN202
-        self.create_calls += 1
-        raise RuntimeError(f"Sandbox '{kwargs['name']}' already exists")
-
-    async def get_sandbox(self, *, name: str) -> _FakeStatusSandbox:
-        self.requested.append(name)
-        return _FakeStatusSandbox(self.status)
+    async def get_sandbox(self, *, name: str) -> None:
+        raise self.exc
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", ["running", "creating", "stopped"])
-async def test_name_collision_adopts_the_orphaned_sandbox(status: str) -> None:
-    from agent.integrations.langsmith import _reuse_existing_sandbox
-
-    client = _NameTakenClient(status=status)
-    try:
-        await client.create_sandbox(name="openswe-abc", snapshot_id="snap-1")
-    except RuntimeError as exc:
-        assert _is_sandbox_name_taken_error(exc)
-        adopted = await _reuse_existing_sandbox(cast(AsyncSandboxClient, client), "openswe-abc")
-        assert adopted.status == status
-        assert client.requested == ["openswe-abc"]
-    else:  # pragma: no cover
-        pytest.fail("expected a name collision")
+async def test_reuse_reports_a_deleted_sandbox_as_gone() -> None:
+    client = _MissingSandboxClient(ResourceNotFoundError("Sandbox 'openswe-abc' not found"))
+    with pytest.raises(SandboxGoneError):
+        await _reuse_existing_sandbox(cast(AsyncSandboxClient, client), "openswe-abc")
 
 
-def test_unrelated_create_errors_are_not_treated_as_collisions() -> None:
-    assert not _is_sandbox_name_taken_error(RuntimeError("snapshot not found"))
-    assert _is_sandbox_name_taken_error(RuntimeError("Sandbox 'x' already exists"))
+@pytest.mark.asyncio
+async def test_reuse_keeps_other_failures_untyped() -> None:
+    client = _MissingSandboxClient(RuntimeError("boom"))
+    with pytest.raises(RuntimeError) as excinfo:
+        await _reuse_existing_sandbox(cast(AsyncSandboxClient, client), "openswe-abc")
+    assert not isinstance(excinfo.value, SandboxGoneError)

--- a/tests/sandbox/test_repo_snapshots.py
+++ b/tests/sandbox/test_repo_snapshots.py
@@ -286,7 +286,6 @@ async def test_create_langsmith_sandbox_uses_repo_snapshot_override() -> None:
     with (
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-default"}, clear=True),
         patch.object(langsmith, "LangSmithProvider", return_value=provider),
-        patch.object(langsmith, "_update_thread_sandbox_metadata", new_callable=AsyncMock),
     ):
         await langsmith.create_langsmith_sandbox(snapshot_id="repo-snap")
 
@@ -304,7 +303,6 @@ async def test_create_langsmith_sandbox_falls_back_to_default() -> None:
     with (
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-default"}, clear=True),
         patch.object(langsmith, "LangSmithProvider", return_value=provider),
-        patch.object(langsmith, "_update_thread_sandbox_metadata", new_callable=AsyncMock),
     ):
         await langsmith.create_langsmith_sandbox()
 

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -13,6 +13,7 @@ from langsmith.sandbox import SandboxClientError
 
 from agent.reviewer import PrepareReviewerRunMiddleware, _ensure_reviewer_sandbox_for_thread
 from agent.server import SANDBOX_BACKENDS, ensure_sandbox_for_thread
+from agent.utils.sandbox import SandboxGoneError
 from agent.utils.sandbox_state import SandboxUnreachableError, set_sandbox_backend
 
 
@@ -200,3 +201,51 @@ async def test_reviewer_notifies_when_replacement_also_fails() -> None:
         "sandbox_id": "sandbox-deleted",
         "replacement_attempted": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_deleted_sandbox_is_replaced_without_opting_in() -> None:
+    thread_id = "thread-agent-gone-sandbox"
+    SANDBOX_BACKENDS.clear()
+    replacement = MagicMock()
+    replacement.id = "sandbox-replacement"
+    order: list[str] = []
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-deleted",
+        ),
+        patch(
+            "agent.server.create_sandbox",
+            new_callable=AsyncMock,
+            side_effect=SandboxGoneError("Sandbox 'sandbox-deleted' not found"),
+        ),
+        patch(
+            "agent.server._create_sandbox_with_proxy",
+            new_callable=AsyncMock,
+            return_value=replacement,
+        ) as create_replacement,
+        patch(
+            "agent.server._configure_git_identity",
+            new_callable=AsyncMock,
+            side_effect=lambda *_: order.append("init"),
+        ),
+        patch(
+            "agent.server.client.threads.update",
+            new_callable=AsyncMock,
+            side_effect=lambda **_: order.append("bind"),
+        ) as update_thread,
+    ):
+        result = await ensure_sandbox_for_thread(thread_id)
+
+    assert result.id == "sandbox-replacement"
+    create_replacement.assert_awaited_once()
+    assert update_thread.await_args_list[-1].kwargs == {
+        "thread_id": thread_id,
+        "metadata": {"sandbox_id": "sandbox-replacement"},
+    }
+    # The thread binds to the sandbox only once it is initialized.
+    assert order == ["init", "bind"]
+    SANDBOX_BACKENDS.clear()

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -351,3 +351,50 @@ async def test_sandbox_id_metadata_falls_back_to_live_thread(
 
     assert await get_sandbox_id_from_metadata("thread-1") == "sandbox-live"
     threads.get.assert_awaited_once_with("thread-1")
+
+
+def test_sandbox_proxy_recovers_when_the_next_run_runs_on_another_loop() -> None:
+    """The queue hands consecutive runs to different loops; the cache spans both.
+
+    An interrupted run leaves a shielded startup task behind. Awaiting that task
+    from the next run's loop raises "attached to a different loop" and locks the
+    thread out of every later run, so the next loop must start its own.
+    """
+    calls = 0
+
+    async def reconnect():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await asyncio.Event().wait()
+        return _FakeSandboxBackend()
+
+    proxy = SandboxBackendProxy(
+        thread_id="thread-1",
+        reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
+    )
+
+    async def interrupted_run() -> None:
+        proxy.start()
+        waiter = asyncio.create_task(proxy.ready())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    async def next_run() -> SandboxBackendProtocol:
+        proxy.start()
+        return await proxy.ready()
+
+    # Both runners stay open: a queue runner's loop outlives the job it ran, so
+    # the abandoned startup task is still pending on a live, idle loop.
+    first_loop, second_loop = asyncio.Runner(), asyncio.Runner()
+    try:
+        first_loop.run(interrupted_run())
+        backend = second_loop.run(next_run())
+    finally:
+        first_loop.close()
+        second_loop.close()
+
+    assert backend.id == "sandbox-1"
+    assert calls == 2


### PR DESCRIPTION
Three separate faults could leave an Open SWE thread unable to ever start another run. All three showed up on the same thread today.

**Sandbox names were derived from the thread id.** A run that died while its sandbox was still provisioning left a box holding the only name that thread could use. The next run collided (409), adopted the half-built box, and its proxy-config PATCH came back `400 sandbox "..." is in "provisioning" state, must be "ready"`. Sandboxes are now created unnamed, and the thread binds to one only after it is created *and* initialized — a run that dies earlier leaves nothing to adopt.

**A deleted sandbox was treated like an unreachable one.** Reconnecting raised `SandboxUnreachableError`, which is deliberately never replaced: an unreachable box may still hold uncommitted work. A deleted box holds nothing, so it now raises `SandboxGoneError` and is always replaced, regardless of `allow_replacement`. Merely-unreachable still fails loudly.

**An interrupted run poisoned the sandbox cache.** It left its shielded startup task on the proxy in the process-global `SANDBOX_BACKENDS`. Queue runners each own an event loop that outlives the job it ran, so the next run awaited a task belonging to another live loop and died with `attached to a different loop` inside `PrepareAgentRunMiddleware.before_agent`. The startup task and its lock now live in per-loop state keyed weakly by the loop, so a run only ever sees its own. The startup/assembly overlap is unchanged.

## Test Plan

- [x] `test_sandbox_proxy_recovers_when_the_next_run_runs_on_another_loop` reproduces the loop bug against two open `asyncio.Runner`s — verified it fails without the fix with the production error, passes with it
- [x] `test_deleted_sandbox_is_replaced_without_opting_in` covers recreate-on-404 and asserts the thread binds only after initialization
- [x] `_reuse_existing_sandbox` tests cover both not-found shapes and that other failures stay untyped
- [x] Full unit suite: 1740 passed; the 10 failures in `tests/github` and `tests/tools` are pre-existing and fail identically on a clean tree