### PR TITLE
fix: require one event loop per process, and say so when it is not

### DIFF
--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -10,10 +10,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from ..dashboard import router as dashboard_router
 from ..dashboard.plan_api import plan_router
 from ..dashboard.workflow_approval_api import workflow_approval_router
+from ..utils.event_loop import pin_single_event_loop
 from ..webhooks.github_routes import router as github_webhook_router
 from ..webhooks.linear_routes import router as linear_webhook_router
 from ..webhooks.slack_routes import router as slack_webhook_router
 from .health import router as health_router
+
+# Before the queue starts: it reads this when it builds its workers, and Open SWE
+# cannot survive them landing on different loops.
+pin_single_event_loop()
 
 
 @asynccontextmanager
@@ -21,6 +26,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     from ..utils.model import close_cached_models, validate_local_dev_llm_config
     from ..utils.sandbox import validate_sandbox_startup_config
 
+    pin_single_event_loop()
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
     try:

--- a/agent/server.py
+++ b/agent/server.py
@@ -1263,7 +1263,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         )
 
     backend = _get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
-    backend.start()
+    backend.mark_stale()
 
     # `profile_login` is whoever sent the message that started this run; it drives
     # authorization and credentialed integrations, which stay personal to them.

--- a/agent/utils/event_loop.py
+++ b/agent/utils/event_loop.py
@@ -1,0 +1,50 @@
+"""Open SWE runs on exactly one event loop per process.
+
+Sandbox state is cached per thread in a process-global registry and reused by
+later runs. Isolated queue loops hand each worker its own loop, so anything
+loop-affine a run leaves in that registry is unusable from the next run's loop
+and strands the thread permanently.
+"""
+
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+ISOLATED_LOOPS_ENV = "BG_JOB_ISOLATED_LOOPS"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def pin_single_event_loop() -> None:
+    """Force the queue to run every job on the server's loop.
+
+    Raises if the setting cannot be forced: running with isolated loops is worse
+    than not booting, because it fails later as a permanently unusable thread.
+    """
+    requested = os.environ.get(ISOLATED_LOOPS_ENV, "").strip().lower() in _TRUTHY
+    # Covers the server reading its config after us; importing it here instead
+    # would drag in a module that demands DATABASE_URI just to be loaded.
+    os.environ[ISOLATED_LOOPS_ENV] = "false"
+
+    langgraph_config = sys.modules.get("langgraph_api.config")
+    if langgraph_config is None:
+        return
+
+    if not hasattr(langgraph_config, ISOLATED_LOOPS_ENV):
+        msg = (
+            f"langgraph_api.config has no {ISOLATED_LOOPS_ENV}. The queue's loop model "
+            "changed, so Open SWE can no longer guarantee one event loop per process."
+        )
+        raise RuntimeError(msg)
+
+    setattr(langgraph_config, ISOLATED_LOOPS_ENV, False)
+    if getattr(langgraph_config, ISOLATED_LOOPS_ENV):
+        msg = f"Could not force {ISOLATED_LOOPS_ENV} off"
+        raise RuntimeError(msg)
+
+    if requested:
+        logger.warning(
+            "%s was set; forcing it off. Open SWE requires one event loop per process.",
+            ISOLATED_LOOPS_ENV,
+        )

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -23,6 +23,7 @@ from deepagents.backends.sandbox import BaseSandbox
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
+from .event_loop import ISOLATED_LOOPS_ENV
 from .sandbox import create_sandbox
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class SandboxBackendProxy(BaseSandbox):
         self._thread_id = thread_id
         self._reconnect = reconnect
         self._lock: asyncio.Lock | None = None
-        self._lock_loop: asyncio.AbstractEventLoop | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
         self._stale = False
 
     @property
@@ -114,12 +115,22 @@ class SandboxBackendProxy(BaseSandbox):
         return self._backend
 
     def _get_lock(self) -> asyncio.Lock:
-        # A lock binds to the loop that first awaits it, and this proxy is cached
-        # across runs that do not share one, so it belongs to a single loop only.
         loop = asyncio.get_running_loop()
-        if self._lock is None or self._lock_loop is not loop:
+        if self._loop is None:
+            self._loop = loop
+        elif self._loop is not loop:
+            # Everything cached here is loop-affine. Recovering silently is how a
+            # thread ends up permanently unusable, so refuse loudly instead: the
+            # process was supposed to have one loop (see pin_single_event_loop).
+            msg = (
+                f"Sandbox proxy for thread {self._thread_id} was created on event loop "
+                f"{self._loop!r} and is now being used from {loop!r}. Open SWE requires "
+                f"one event loop per process; check {ISOLATED_LOOPS_ENV}."
+            )
+            logger.error(msg)
+            raise RuntimeError(msg)
+        if self._lock is None:
             self._lock = asyncio.Lock()
-            self._lock_loop = loop
         return self._lock
 
     async def _aget_backend(self) -> SandboxBackendProtocol:

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -3,8 +3,6 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from weakref import WeakKeyDictionary
 
 from deepagents.backends.protocol import (
     DeleteResult,
@@ -51,21 +49,6 @@ class SandboxUnreachableError(RuntimeError):
 _SYNC_UNSUPPORTED = "SandboxBackendProxy is async-only; use the a-prefixed method instead."
 
 
-@dataclass
-class _LoopState:
-    """Startup state owned by one event loop.
-
-    A proxy is cached per thread and outlives every run, but a task and a lock
-    belong to the loop that made them: awaiting either from another loop raises
-    "attached to a different loop". Keeping them here, keyed by loop, means a
-    run only ever sees its own — an interrupted run's leftovers are unreachable
-    rather than poisonous, and go away with the loop that owns them.
-    """
-
-    lock: asyncio.Lock
-    startup_task: asyncio.Task[SandboxBackendProtocol] | None = None
-
-
 class SandboxBackendProxy(BaseSandbox):
     """Stable per-thread backend handle whose target can be replaced.
 
@@ -86,9 +69,9 @@ class SandboxBackendProxy(BaseSandbox):
         self._backend = backend
         self._thread_id = thread_id
         self._reconnect = reconnect
-        self._loop_state: WeakKeyDictionary[asyncio.AbstractEventLoop, _LoopState] = (
-            WeakKeyDictionary()
-        )
+        self._lock: asyncio.Lock | None = None
+        self._lock_loop: asyncio.AbstractEventLoop | None = None
+        self._stale = False
 
     @property
     def current(self) -> SandboxBackendProtocol:
@@ -100,54 +83,26 @@ class SandboxBackendProxy(BaseSandbox):
 
     def replace_backend(self, backend: SandboxBackendProtocol) -> None:
         self._backend = backend
-        for state in self._loop_state.values():
-            state.startup_task = None
+        self._stale = False
+
+    def mark_stale(self) -> None:
+        """Force one reconnect on next access, even though a backend is cached.
+
+        Every run re-resolves its sandbox once: the reconnect pings the box and
+        refreshes the GitHub proxy token, which expires well inside a thread's
+        lifetime. Tool calls after that hit the cached backend.
+        """
+        self._stale = True
 
     @property
     def has_backend(self) -> bool:
         return self._backend is not None
-
-    def cancel_startup(self) -> None:
-        # Only this loop's task: each loop runs on its own thread, so cancelling
-        # a task owned by another one is not thread-safe.
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return
-        state = self._loop_state.get(loop)
-        if state is not None and state.startup_task is not None:
-            state.startup_task.cancel()
 
     def set_reconnect(
         self,
         reconnect: Callable[[], Awaitable[SandboxBackendProtocol]] | None,
     ) -> None:
         self._reconnect = reconnect
-
-    def start(self) -> None:
-        state = self._state()
-        if state.startup_task is not None:
-            if not state.startup_task.cancelled():
-                return
-            state.startup_task = None
-        if self._reconnect is None:
-            if self._backend is not None:
-                return
-            raise RuntimeError("Cannot start sandbox without a reconnect callback")
-        state.startup_task = asyncio.ensure_future(self._reconnect())
-        state.startup_task.add_done_callback(self._startup_completed)
-
-    def _startup_completed(self, task: asyncio.Task[SandboxBackendProtocol]) -> None:
-        if task.cancelled():
-            logger.warning("Sandbox startup was cancelled for thread %s", self._thread_id)
-            return
-        exception = task.exception()
-        if exception is not None:
-            logger.warning(
-                "Sandbox startup failed for thread %s: %s",
-                self._thread_id,
-                exception,
-            )
 
     async def ready(self) -> SandboxBackendProtocol:
         return await self._aget_backend()
@@ -158,62 +113,41 @@ class SandboxBackendProxy(BaseSandbox):
             raise RuntimeError(f"No sandbox backend cached{suffix}")
         return self._backend
 
-    def _state(self) -> _LoopState:
+    def _get_lock(self) -> asyncio.Lock:
+        # A lock binds to the loop that first awaits it, and this proxy is cached
+        # across runs that do not share one, so it belongs to a single loop only.
         loop = asyncio.get_running_loop()
-        state = self._loop_state.get(loop)
-        if state is None:
-            state = _LoopState(lock=asyncio.Lock())
-            self._loop_state[loop] = state
-        return state
+        if self._lock is None or self._lock_loop is not loop:
+            self._lock = asyncio.Lock()
+            self._lock_loop = loop
+        return self._lock
 
     async def _aget_backend(self) -> SandboxBackendProtocol:
-        state = self._state()
-        if self._backend is not None and state.startup_task is None:
+        if self._backend is not None and not self._stale:
             return self._backend
         if not self._thread_id:
             raise RuntimeError("No sandbox backend cached")
 
-        async with state.lock:
-            if self._backend is not None and state.startup_task is None:
+        async with self._get_lock():
+            if self._backend is not None and not self._stale:
                 return self._backend
-            if state.startup_task is None:
-                if self._reconnect is not None:
-                    logger.info("Reconnecting sandbox backend for thread %s", self._thread_id)
-                    self.start()
-                else:
-                    sandbox_id = await get_sandbox_id_from_metadata(self._thread_id)
-                    if not sandbox_id:
-                        raise ValueError(
-                            f"Missing sandbox_id in thread metadata for {self._thread_id}"
-                        )
 
-                    logger.info(
-                        "Reconnecting sandbox backend for thread %s from metadata", self._thread_id
-                    )
-                    state.startup_task = asyncio.create_task(create_sandbox(sandbox_id))
-                    state.startup_task.add_done_callback(self._startup_completed)
-            startup_task = state.startup_task
-            if startup_task is None:
-                raise RuntimeError(f"Sandbox startup task missing for thread {self._thread_id}")
+            if self._reconnect is not None:
+                logger.info("Reconnecting sandbox backend for thread %s", self._thread_id)
+                backend = await self._reconnect()
+            else:
+                sandbox_id = await get_sandbox_id_from_metadata(self._thread_id)
+                if not sandbox_id:
+                    raise ValueError(f"Missing sandbox_id in thread metadata for {self._thread_id}")
+                logger.info(
+                    "Reconnecting sandbox backend for thread %s from metadata", self._thread_id
+                )
+                backend = await create_sandbox(sandbox_id)
 
-        try:
-            sandbox_backend = await asyncio.shield(startup_task)
-        except BaseException:
-            if startup_task.done():
-                async with state.lock:
-                    if state.startup_task is startup_task:
-                        state.startup_task = None
-            raise
-
-        async with state.lock:
-            if state.startup_task is startup_task:
-                self._backend = unwrap_sandbox_backend(sandbox_backend)
-                state.startup_task = None
-                SANDBOX_BACKENDS[self._thread_id] = self
-            backend = self._backend
-            if backend is None:
-                raise RuntimeError(f"No sandbox backend cached for thread {self._thread_id}")
-            return backend
+            self._backend = unwrap_sandbox_backend(backend)
+            self._stale = False
+            SANDBOX_BACKENDS[self._thread_id] = self
+            return self._backend
 
     def ls(self, path: str) -> LsResult:
         raise NotImplementedError(_SYNC_UNSUPPORTED)
@@ -381,7 +315,10 @@ def get_or_create_sandbox_backend_proxy(
 ) -> SandboxBackendProxy:
     sandbox_backend = SANDBOX_BACKENDS.get(thread_id)
     if sandbox_backend:
-        sandbox_backend.set_reconnect(reconnect)
+        # Callers that only want the handle pass no callback; keep the one the
+        # run registered rather than dropping it to the metadata fallback.
+        if reconnect is not None:
+            sandbox_backend.set_reconnect(reconnect)
         return sandbox_backend
 
     sandbox_backend = SandboxBackendProxy(thread_id=thread_id, reconnect=reconnect)
@@ -390,9 +327,7 @@ def get_or_create_sandbox_backend_proxy(
 
 
 def clear_sandbox_backend(thread_id: str) -> None:
-    sandbox_backend = SANDBOX_BACKENDS.pop(thread_id, None)
-    if sandbox_backend is not None:
-        sandbox_backend.cancel_startup()
+    SANDBOX_BACKENDS.pop(thread_id, None)
 
 
 async def get_sandbox_id_from_metadata(thread_id: str) -> str | None:

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -7,7 +7,6 @@ is what makes deepagents auto-wire `FilesystemMiddleware` tool-result eviction a
 `PatchToolCallsMiddleware` that `create_deep_agent` adds covers it.
 """
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -83,25 +82,16 @@ async def _capture_create_deep_agent_kwargs(
 
 
 @pytest.mark.asyncio
-async def test_agent_starts_sandbox_while_loading_settings() -> None:
-    started = asyncio.Event()
-    release = asyncio.Event()
+async def test_agent_assembly_does_not_touch_the_sandbox() -> None:
+    """Assembly only registers how to reconnect; the run resolves the sandbox."""
 
     async def ensure_sandbox(*args: object, **kwargs: object) -> MagicMock:
         del args, kwargs
-        started.set()
-        await release.wait()
-        return MagicMock()
-
-    async def load_defaults(*args: object) -> tuple[tuple[str, str], tuple[str, str]]:
-        del args
-        await started.wait()
-        return (("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low"))
+        raise AssertionError("sandbox resolved during agent assembly")
 
     clear_sandbox_backend("thread-ctx")
     with (
         patch("agent.server.ensure_sandbox_for_thread", side_effect=ensure_sandbox),
-        patch("agent.server._cached_team_default_model_pair", side_effect=load_defaults),
         patch("agent.server._cached_gateway_enabled", new_callable=AsyncMock, return_value=False),
         patch("agent.server._cached_profile", new_callable=AsyncMock, return_value=None),
         patch("agent.server._cached_fable_enabled", new_callable=AsyncMock, return_value=True),
@@ -113,11 +103,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
         patch("agent.server.fallback_model_id_for", return_value=None),
         patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
     ):
-        agent_task = asyncio.create_task(get_agent(_base_config()))
-        await asyncio.wait_for(started.wait(), timeout=1)
-        assert not agent_task.done()
-        release.set()
-        await agent_task
+        await get_agent(_base_config())
 
     clear_sandbox_backend("thread-ctx")
 

--- a/tests/sandbox/test_event_loop_pin.py
+++ b/tests/sandbox/test_event_loop_pin.py
@@ -1,0 +1,39 @@
+"""Open SWE forces the queue onto one event loop per process."""
+
+import os
+import sys
+import types
+
+import pytest
+
+from agent.utils.event_loop import ISOLATED_LOOPS_ENV, pin_single_event_loop
+
+
+def test_pin_clears_the_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ISOLATED_LOOPS_ENV, "true")
+    monkeypatch.delitem(sys.modules, "langgraph_api.config", raising=False)
+
+    pin_single_event_loop()
+
+    # The server reads its config from the environment at import time.
+    assert os.environ[ISOLATED_LOOPS_ENV] == "false"
+
+
+def test_pin_overrides_config_the_server_already_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = types.ModuleType("langgraph_api.config")
+    module.BG_JOB_ISOLATED_LOOPS = True
+    monkeypatch.setitem(sys.modules, "langgraph_api.config", module)
+    monkeypatch.setenv(ISOLATED_LOOPS_ENV, "true")
+
+    pin_single_event_loop()
+
+    assert module.BG_JOB_ISOLATED_LOOPS is False
+
+
+def test_pin_fails_when_the_setting_is_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A renamed setting means the loop model changed and must be re-verified."""
+    module = types.ModuleType("langgraph_api.config")
+    monkeypatch.setitem(sys.modules, "langgraph_api.config", module)
+
+    with pytest.raises(RuntimeError, match="one event loop per process"):
+        pin_single_event_loop()

--- a/tests/sandbox/test_event_loop_pin.py
+++ b/tests/sandbox/test_event_loop_pin.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import types
+from typing import cast
 
 import pytest
 
@@ -20,8 +21,7 @@ def test_pin_clears_the_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_pin_overrides_config_the_server_already_read(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = types.ModuleType("langgraph_api.config")
-    module.BG_JOB_ISOLATED_LOOPS = True
+    module = cast(types.ModuleType, types.SimpleNamespace(BG_JOB_ISOLATED_LOOPS=True))
     monkeypatch.setitem(sys.modules, "langgraph_api.config", module)
     monkeypatch.setenv(ISOLATED_LOOPS_ENV, "true")
 

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -314,7 +314,7 @@ def test_sandbox_proxy_refuses_a_second_event_loop() -> None:
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )
 
-    async def run() -> object:
+    async def run() -> SandboxBackendProtocol:
         proxy.mark_stale()
         return await proxy.ready()
 

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -192,7 +192,7 @@ async def test_sandbox_proxy_uses_registered_reconnect_once(
 
 
 @pytest.mark.asyncio
-async def test_sandbox_proxy_refreshes_initialized_backend_when_started() -> None:
+async def test_sandbox_proxy_refreshes_a_stale_backend() -> None:
     refreshed = _FakeSandboxBackend()
     calls = 0
 
@@ -206,70 +206,16 @@ async def test_sandbox_proxy_refreshes_initialized_backend_when_started() -> Non
         thread_id="thread-1",
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )
-    proxy.start()
+    proxy.mark_stale()
 
+    assert await proxy.ready() is refreshed
+    # The refresh happens once per run, not once per access.
     assert await proxy.ready() is refreshed
     assert calls == 1
 
 
 @pytest.mark.asyncio
-async def test_sandbox_proxy_starts_reconnect_before_first_operation() -> None:
-    started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def reconnect():
-        started.set()
-        await release.wait()
-        return _FakeSandboxBackend()
-
-    proxy = SandboxBackendProxy(
-        thread_id="thread-1",
-        reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
-    )
-    proxy.start()
-
-    await started.wait()
-    assert not proxy.has_backend
-    release.set()
-    backend = await proxy.ready()
-
-    assert backend.id == "sandbox-1"
-    assert proxy.has_backend
-
-
-@pytest.mark.asyncio
-async def test_sandbox_proxy_startup_survives_waiter_cancellation() -> None:
-    started = asyncio.Event()
-    release = asyncio.Event()
-    calls = 0
-
-    async def reconnect():
-        nonlocal calls
-        calls += 1
-        started.set()
-        await release.wait()
-        return _FakeSandboxBackend()
-
-    proxy = SandboxBackendProxy(
-        thread_id="thread-1",
-        reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
-    )
-    proxy.start()
-    waiter = asyncio.create_task(proxy.ready())
-    await started.wait()
-    waiter.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await waiter
-
-    release.set()
-    backend = await proxy.ready()
-
-    assert backend.id == "sandbox-1"
-    assert calls == 1
-
-
-@pytest.mark.asyncio
-async def test_sandbox_proxy_retries_failed_startup() -> None:
+async def test_sandbox_proxy_retries_a_failed_reconnect() -> None:
     calls = 0
 
     async def reconnect():
@@ -283,7 +229,6 @@ async def test_sandbox_proxy_retries_failed_startup() -> None:
         thread_id="thread-1",
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )
-    proxy.start()
 
     with pytest.raises(RuntimeError, match="startup failed"):
         await proxy.ready()
@@ -309,7 +254,7 @@ async def test_sandbox_proxy_delegates_delete_after_lazy_startup() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_sandbox_backend_awaits_registered_startup() -> None:
+async def test_get_sandbox_backend_awaits_the_reconnect() -> None:
     thread_id = "thread-1"
     clear_sandbox_backend(thread_id)
     release = asyncio.Event()
@@ -322,7 +267,6 @@ async def test_get_sandbox_backend_awaits_registered_startup() -> None:
         thread_id,
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )
-    proxy.start()
     waiter = asyncio.create_task(get_sandbox_backend(thread_id))
     await asyncio.sleep(0)
     assert not waiter.done()
@@ -356,17 +300,16 @@ async def test_sandbox_id_metadata_falls_back_to_live_thread(
 def test_sandbox_proxy_recovers_when_the_next_run_runs_on_another_loop() -> None:
     """The queue hands consecutive runs to different loops; the cache spans both.
 
-    An interrupted run leaves a shielded startup task behind. Awaiting that task
-    from the next run's loop raises "attached to a different loop" and locks the
-    thread out of every later run, so the next loop must start its own.
+    Concurrent callers queue on the proxy's lock, which binds it to the loop
+    that ran them. Reusing that lock from the next run's loop raises "attached
+    to a different loop" and locks the thread out of every later run.
     """
     calls = 0
 
     async def reconnect():
         nonlocal calls
         calls += 1
-        if calls == 1:
-            await asyncio.Event().wait()
+        await asyncio.sleep(0)
         return _FakeSandboxBackend()
 
     proxy = SandboxBackendProxy(
@@ -374,27 +317,20 @@ def test_sandbox_proxy_recovers_when_the_next_run_runs_on_another_loop() -> None
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )
 
-    async def interrupted_run() -> None:
-        proxy.start()
-        waiter = asyncio.create_task(proxy.ready())
-        await asyncio.sleep(0)
-        waiter.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await waiter
+    async def contended_run() -> list[object]:
+        # Two callers so one waits on the lock: an uncontended lock never binds.
+        proxy.mark_stale()
+        return await asyncio.gather(proxy.ready(), proxy.ready(), return_exceptions=True)
 
-    async def next_run() -> SandboxBackendProtocol:
-        proxy.start()
-        return await proxy.ready()
-
-    # Both runners stay open: a queue runner's loop outlives the job it ran, so
-    # the abandoned startup task is still pending on a live, idle loop.
+    # Both runners stay open: a queue runner's loop outlives the job it ran.
     first_loop, second_loop = asyncio.Runner(), asyncio.Runner()
     try:
-        first_loop.run(interrupted_run())
-        backend = second_loop.run(next_run())
+        first = first_loop.run(contended_run())
+        second = second_loop.run(contended_run())
     finally:
         first_loop.close()
         second_loop.close()
 
-    assert backend.id == "sandbox-1"
+    assert all(getattr(result, "id", None) == "sandbox-1" for result in first + second)
+    # One resolve per run, not one per caller.
     assert calls == 2

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -297,18 +297,15 @@ async def test_sandbox_id_metadata_falls_back_to_live_thread(
     threads.get.assert_awaited_once_with("thread-1")
 
 
-def test_sandbox_proxy_recovers_when_the_next_run_runs_on_another_loop() -> None:
-    """The queue hands consecutive runs to different loops; the cache spans both.
+def test_sandbox_proxy_refuses_a_second_event_loop() -> None:
+    """One loop per process is an invariant, so a second one is a hard failure.
 
-    Concurrent callers queue on the proxy's lock, which binds it to the loop
-    that ran them. Reusing that lock from the next run's loop raises "attached
-    to a different loop" and locks the thread out of every later run.
+    Everything the proxy caches is loop-affine. Papering over a second loop is
+    what left threads permanently unusable, so it raises instead — loudly, where
+    the cause is still visible.
     """
-    calls = 0
 
     async def reconnect():
-        nonlocal calls
-        calls += 1
         await asyncio.sleep(0)
         return _FakeSandboxBackend()
 
@@ -317,20 +314,15 @@ def test_sandbox_proxy_recovers_when_the_next_run_runs_on_another_loop() -> None
         reconnect=cast(Callable[[], Awaitable[SandboxBackendProtocol]], reconnect),
     )
 
-    async def contended_run() -> list[object]:
-        # Two callers so one waits on the lock: an uncontended lock never binds.
+    async def run() -> object:
         proxy.mark_stale()
-        return await asyncio.gather(proxy.ready(), proxy.ready(), return_exceptions=True)
+        return await proxy.ready()
 
-    # Both runners stay open: a queue runner's loop outlives the job it ran.
     first_loop, second_loop = asyncio.Runner(), asyncio.Runner()
     try:
-        first = first_loop.run(contended_run())
-        second = second_loop.run(contended_run())
+        assert first_loop.run(run()).id == "sandbox-1"
+        with pytest.raises(RuntimeError, match="one event loop per process"):
+            second_loop.run(run())
     finally:
         first_loop.close()
         second_loop.close()
-
-    assert all(getattr(result, "id", None) == "sandbox-1" for result in first + second)
-    # One resolve per run, not one per caller.
-    assert calls == 2


### PR DESCRIPTION
Follow-up to #2084, which made the prefetched sandbox startup survive being shared across event loops. This removes the reason it was shared at all.

**Force one loop per process.** The queue only splits loops when `BG_JOB_ISOLATED_LOOPS` is set ([queue.py:226](https://github.com/langchain-ai/open-swe/blob/main/.venv) — non-isolated dispatch is a plain `asyncio.create_task` on the server's loop). `pin_single_event_loop()` clears that env var before the server reads it, and corrects `langgraph_api.config` in place if the server read it first. It never imports that config module — merely importing it demands `DATABASE_URI`, and `agent.webapp`'s import closure is pinned by a test. If the setting can't be forced off, startup aborts: failing at boot beats failing hours later as a thread that can no longer run.

**Fail loud if a second loop ever shows up.** A proxy used from a loop other than the one that created it raises, naming both loops and the env var, instead of quietly rebuilding its state. Silent recovery is what let this go unnoticed since July.

**Drop the startup prefetch** (#1939). Overlapping sandbox startup with agent assembly is what put a live `asyncio.Task` into the process-global cache. The run now resolves its sandbox inline: assembly marks the cached proxy stale, first access reconnects — which is also what pings the box and refreshes the GitHub proxy token — and later tool calls hit the cached backend. Cost: reconnect latency moves onto the run's critical path.

Two things this surfaced that weren't obvious:

- `start()` was load-bearing beyond performance — it forced the per-run proxy-token refresh on a cached backend (#1178, #1496). `mark_stale()` preserves that.
- The middleware looks the proxy up with no `reconnect` argument, which **cleared** the callback. Harmless before, because the prefetch task had already captured the closure; without it, every reconnect fell through to the thread-metadata fallback.

Behind the enforced invariant the proxy keeps a plain lazily created `asyncio.Lock`, which still dedupes concurrent callers into one resolve.

## Test Plan

- [x] `test_sandbox_proxy_refuses_a_second_event_loop` drives two `asyncio.Runner`s and asserts the raise, so silent recovery can't come back
- [x] `test_event_loop_pin.py` covers clearing the env var, correcting an already-read config, and aborting when the setting is gone
- [x] `test_sandbox_proxy_refreshes_a_stale_backend` covers refresh once per run, not once per access
- [x] `test_agent_assembly_does_not_touch_the_sandbox` asserts assembly only registers the reconnect
- [x] `agent.webapp` still imports without `DATABASE_URI`; `test_import_hygiene` passes
- [x] Full unit suite: 1748 passed; the 3 `test_background_execute.py` failures are pre-existing and fail identically on a clean tree