### PR TITLE
feat: highlight user messages

### DIFF
--- a/ui/src/features/agents/components/messages/UserMessage.tsx
+++ b/ui/src/features/agents/components/messages/UserMessage.tsx
@@ -50,7 +50,9 @@ export function UserMessage({ message }: { message: Message }) {
         {(text || images.length > 0) && (
           <div
             className={`relative overflow-hidden rounded-2xl p-3 ${
-              isSystem ? "border border-border bg-muted/50" : "bg-accent"
+              isSystem
+                ? "border border-border bg-muted/50"
+                : "bg-primary text-primary-foreground shadow-sm shadow-primary/25"
             }`}
           >
             {images.length > 0 && (
@@ -73,7 +75,11 @@ export function UserMessage({ message }: { message: Message }) {
               <div
                 ref={textRef}
                 onScroll={updateScrollIndicators}
-                className="max-h-[250px] overflow-auto text-[14px] leading-[1.6] break-words whitespace-pre-wrap text-accent-foreground"
+                className={`max-h-[250px] overflow-auto text-[14px] leading-[1.6] break-words whitespace-pre-wrap ${
+                  isSystem
+                    ? "text-accent-foreground"
+                    : "text-primary-foreground"
+                }`}
                 style={{
                   maskImage: textEdgeMask,
                   WebkitMaskImage: textEdgeMask,


### PR DESCRIPTION
## Description
User messages now use the high-contrast primary surface so they are easy to find while scanning long dcode threads. System messages retain their existing neutral treatment.

## Release Note
User messages are now visually distinct in dcode threads.

## Test Plan
- [x] Prettier check, TypeScript typecheck, and dashboard production build
- [ ] ESLint (the existing UI script cannot find an ESLint binary)

Made by [Open SWE](https://openswe.vercel.app/agents/98b8aece-9d1a-5b67-be13-4369e8d901ca)