### PR TITLE
fix(deps): patch nanoid and brace-expansion advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@hono/node-server': 2.0.10
-  brace-expansion@2.1.1: 2.1.2
+  brace-expansion@2.1.1: 2.1.4
   brace-expansion@>=5.0.0: 5.0.9
   dompurify: 3.4.13
   fast-uri: 3.1.5
@@ -14,7 +14,7 @@ overrides:
   ip-address: 10.3.1
   js-yaml: 4.3.1
   mermaid: 11.16.1
-  nanoid@>=3.0.0 <4.0.0: 3.3.17
+  nanoid@>=3.0.0 <4.0.0: 3.3.18
   postcss: 8.5.23
   undici: 7.29.0
 
@@ -2338,8 +2338,8 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -4317,8 +4317,8 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8118,7 +8118,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -10295,11 +10295,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -10319,7 +10319,7 @@ snapshots:
 
   mustache@4.2.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10645,7 +10645,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ allowBuilds:
 
 overrides:
   '@hono/node-server': 2.0.10
-  brace-expansion@2.1.1: 2.1.2
+  brace-expansion@2.1.1: 2.1.4
   'brace-expansion@>=5.0.0': 5.0.9
   dompurify: 3.4.13
   fast-uri: 3.1.5
@@ -19,6 +19,6 @@ overrides:
   ip-address: 10.3.1
   js-yaml: 4.3.1
   mermaid: 11.16.1
-  'nanoid@>=3.0.0 <4.0.0': 3.3.17
+  'nanoid@>=3.0.0 <4.0.0': 3.3.18
   postcss: 8.5.23
   undici: 7.29.0


### PR DESCRIPTION
## Summary

- bump the `nanoid` override from 3.3.17 to 3.3.18
- bump the `brace-expansion` 2.x override from 2.1.2 to 2.1.4
- resolve Dependabot alerts #232, #233, and #234

Advisories: GHSA-2v37-7h3g-55p8, GHSA-rgw5-rvv9-x895, GHSA-mh99-v99m-4gvg.

## Validation

- [x] `corepack pnpm install --lockfile-only`
- [x] `corepack pnpm install --frozen-lockfile`
- [x] `corepack pnpm audit --prod` — no known vulnerabilities
- [x] `git diff --check`
- [ ] `corepack pnpm check` — desktop typecheck and 42 tests passed; UI Vite build was killed with exit 137 after transforming 8,802 modules (sandbox memory limit)

Scoped to the affected overrides and lockfile entries only.