### PR TITLE
fix(sandbox): start a stopped sandbox before failing the proxy refresh

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -42,6 +42,9 @@ PROXY_CONFIG_MAX_ATTEMPTS = 3
 PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
 PROXY_CONFIG_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+PROXY_CONFIG_NOT_READY_STATUS = 400
+PROXY_CONFIG_ERROR_BODY_CHARS = 500
+SANDBOX_START_TIMEOUT_SECONDS = 120
 PROXY_GH_TOKEN_PLACEHOLDER = "proxy-injected"
 
 
@@ -283,6 +286,86 @@ async def _create_sandbox_with_retry(
     raise RuntimeError("unreachable sandbox retry state")
 
 
+def _with_response_body(exc: BaseException) -> httpx.HTTPStatusError | None:
+    """Re-raisable copy of ``exc`` carrying the response body, or ``None`` to re-raise as-is.
+
+    ``raise_for_status`` builds its message from the status line and an MDN link
+    only, so the API's own explanation of a rejection never reaches the logs.
+    """
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return None
+    body = exc.response.text.strip()[:PROXY_CONFIG_ERROR_BODY_CHARS]
+    if not body:
+        return None
+    return httpx.HTTPStatusError(
+        f"{exc}\nResponse body: {body}",
+        request=exc.request,
+        response=exc.response,
+    )
+
+
+async def _patch_proxy_config(
+    client: httpx.AsyncClient,
+    url: str,
+    payload: dict[str, Any],
+    api_key: str,
+    sandbox_name: str,
+) -> None:
+    for attempt in range(PROXY_CONFIG_MAX_ATTEMPTS):
+        try:
+            response = await client.patch(
+                url,
+                json=payload,
+                headers={"X-API-Key": api_key},
+            )
+            response.raise_for_status()
+            return
+        except Exception as exc:
+            if attempt == PROXY_CONFIG_MAX_ATTEMPTS - 1 or not _is_retryable_proxy_config_error(
+                exc
+            ):
+                enriched = _with_response_body(exc)
+                if enriched is not None:
+                    raise enriched from exc
+                raise
+            retry_after = (
+                _retry_after_seconds(exc.response)
+                if isinstance(exc, httpx.HTTPStatusError)
+                else None
+            )
+            delay = (
+                retry_after
+                or PROXY_CONFIG_RETRY_DELAYS_SECONDS[
+                    min(attempt, len(PROXY_CONFIG_RETRY_DELAYS_SECONDS) - 1)
+                ]
+            )
+            logger.warning(
+                "Failed to configure GitHub proxy for sandbox %s (%s); retrying in %.1fs",
+                sandbox_name,
+                type(exc).__name__,
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+
+async def _start_sandbox_best_effort(sandbox_name: str) -> None:
+    """Start ``sandbox_name`` so a proxy-config update can land on it.
+
+    The API rejects a proxy-config update on any sandbox that is not ``ready``,
+    and an idle sandbox is stopped rather than deleted — its filesystem, and the
+    agent's uncommitted work with it, comes back when the box starts again.
+    Failures are logged and swallowed: the retried update reports the real state.
+    """
+    client = get_async_sandbox_client()
+    try:
+        await client.start_sandbox(sandbox_name, timeout=SANDBOX_START_TIMEOUT_SECONDS)
+        logger.info("Started sandbox %s before retrying GitHub proxy config", sandbox_name)
+    except Exception:
+        logger.warning("Failed to start sandbox %s", sandbox_name, exc_info=True)
+    finally:
+        await client.aclose()
+
+
 async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
     """Configure sandbox proxy to inject GitHub auth for GitHub traffic.
 
@@ -302,38 +385,18 @@ async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
     url = f"{langsmith_endpoint}/v2/sandboxes/boxes/{sandbox_name}"
     payload = {"proxy_config": {"rules": _github_proxy_rules(github_token)}}
     async with httpx.AsyncClient(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:
-        for attempt in range(PROXY_CONFIG_MAX_ATTEMPTS):
-            try:
-                response = await client.patch(
-                    url,
-                    json=payload,
-                    headers={"X-API-Key": api_key},
-                )
-                response.raise_for_status()
-                break
-            except Exception as exc:
-                if attempt == PROXY_CONFIG_MAX_ATTEMPTS - 1 or not _is_retryable_proxy_config_error(
-                    exc
-                ):
-                    raise
-                retry_after = (
-                    _retry_after_seconds(exc.response)
-                    if isinstance(exc, httpx.HTTPStatusError)
-                    else None
-                )
-                delay = (
-                    retry_after
-                    or PROXY_CONFIG_RETRY_DELAYS_SECONDS[
-                        min(attempt, len(PROXY_CONFIG_RETRY_DELAYS_SECONDS) - 1)
-                    ]
-                )
-                logger.warning(
-                    "Failed to configure GitHub proxy for sandbox %s (%s); retrying in %.1fs",
-                    sandbox_name,
-                    type(exc).__name__,
-                    delay,
-                )
-                await asyncio.sleep(delay)
+        try:
+            await _patch_proxy_config(client, url, payload, api_key, sandbox_name)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != PROXY_CONFIG_NOT_READY_STATUS:
+                raise
+            logger.warning(
+                "Proxy config rejected for sandbox %s; starting it and retrying: %s",
+                sandbox_name,
+                exc,
+            )
+            await _start_sandbox_best_effort(sandbox_name)
+            await _patch_proxy_config(client, url, payload, api_key, sandbox_name)
     logger.info("Configured GitHub proxy for sandbox %s", sandbox_name)
 
 

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -195,8 +195,8 @@ class TestConfigureGithubProxy:
         request = httpx.Request(
             "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
         )
-        response = httpx.Response(400, request=request)
-        error = httpx.HTTPStatusError("Bad request", request=request, response=response)
+        response = httpx.Response(403, request=request)
+        error = httpx.HTTPStatusError("Forbidden", request=request, response=response)
         with (
             patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
             patch(
@@ -215,6 +215,122 @@ class TestConfigureGithubProxy:
 
             mock_client.patch.assert_called_once()
             mock_sleep.assert_not_called()
+
+    async def test_error_message_carries_response_body(self) -> None:
+        """The API's explanation must survive into the raised error."""
+        request = httpx.Request(
+            "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
+        )
+        response = httpx.Response(403, request=request, text="sandbox belongs to another tenant")
+        error = httpx.HTTPStatusError("Forbidden", request=request, response=response)
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            failed_response = MagicMock()
+            failed_response.raise_for_status.side_effect = error
+            mock_client.patch = AsyncMock(return_value=failed_response)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            with pytest.raises(httpx.HTTPStatusError, match="another tenant"):
+                await _configure_github_proxy("sandbox-abc", "token")
+
+
+class TestConfigureGithubProxyStartsStoppedSandbox:
+    """A 400 means the sandbox is not ready; start it and retry the update."""
+
+    @staticmethod
+    def _not_ready_error() -> httpx.HTTPStatusError:
+        request = httpx.Request(
+            "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
+        )
+        response = httpx.Response(
+            400,
+            request=request,
+            text='sandbox "sandbox-abc" is in "stopped" state, must be "ready"',
+        )
+        return httpx.HTTPStatusError("Bad request", request=request, response=response)
+
+    async def test_starts_sandbox_then_retries(self) -> None:
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.get_async_sandbox_client"
+            ) as mock_sandbox_client_factory,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            failed_response = MagicMock()
+            failed_response.raise_for_status.side_effect = self._not_ready_error()
+            successful_response = MagicMock()
+            successful_response.raise_for_status = MagicMock()
+            mock_client.patch = AsyncMock(side_effect=[failed_response, successful_response])
+            _mock_async_client(mock_client_cls, mock_client)
+
+            sandbox_client = MagicMock()
+            sandbox_client.start_sandbox = AsyncMock()
+            sandbox_client.aclose = AsyncMock()
+            mock_sandbox_client_factory.return_value = sandbox_client
+
+            await _configure_github_proxy("sandbox-abc", "token")
+
+            sandbox_client.start_sandbox.assert_awaited_once()
+            assert sandbox_client.start_sandbox.await_args.args[0] == "sandbox-abc"
+            sandbox_client.aclose.assert_awaited_once()
+            assert mock_client.patch.call_count == 2
+
+    async def test_retries_even_when_start_fails(self) -> None:
+        """A failed start is logged, not fatal: the retry reports the real state."""
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.get_async_sandbox_client"
+            ) as mock_sandbox_client_factory,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            failed_response = MagicMock()
+            failed_response.raise_for_status.side_effect = self._not_ready_error()
+            mock_client.patch = AsyncMock(return_value=failed_response)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            sandbox_client = MagicMock()
+            sandbox_client.start_sandbox = AsyncMock(side_effect=RuntimeError("start rejected"))
+            sandbox_client.aclose = AsyncMock()
+            mock_sandbox_client_factory.return_value = sandbox_client
+
+            with pytest.raises(httpx.HTTPStatusError, match="stopped"):
+                await _configure_github_proxy("sandbox-abc", "token")
+
+            sandbox_client.start_sandbox.assert_awaited_once()
+            sandbox_client.aclose.assert_awaited_once()
+            assert mock_client.patch.call_count == 2
+
+    async def test_does_not_start_twice(self) -> None:
+        """Only one start attempt per configure call, even if the retry also 400s."""
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.get_async_sandbox_client"
+            ) as mock_sandbox_client_factory,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            failed_response = MagicMock()
+            failed_response.raise_for_status.side_effect = self._not_ready_error()
+            mock_client.patch = AsyncMock(return_value=failed_response)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            sandbox_client = MagicMock()
+            sandbox_client.start_sandbox = AsyncMock()
+            sandbox_client.aclose = AsyncMock()
+            mock_sandbox_client_factory.return_value = sandbox_client
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await _configure_github_proxy("sandbox-abc", "token")
+
+            sandbox_client.start_sandbox.assert_awaited_once()
 
 
 class TestCreateSandboxWithProxy:


### PR DESCRIPTION
A thread whose sandbox had been stopped could never run again.

`PATCH /v2/sandboxes/boxes/{name}` with a `proxy_config` is rejected with a 400 unless the box is `ready` — smith-go's `UpdateSandbox` checks the status explicitly, and every other rejection in that path returns 422. So a 400 there means exactly one thing: the box is not ready.

Two ways it gets there:

- `DEFAULT_SANDBOX_IDLE_TTL_SECONDS` is 2h, so a sandbox idle across a lunch break is stopped.
- The box is `ready` in the DB but has no live host placement (node drained, host restart). `ensureReadySandboxLive` flips it to `stopped` and the same request then trips its own status check.

Either way `_refresh_github_proxy_or_fail` turned that into `SandboxUnreachableError`, which by design is never replaced — and nothing in this repo ever started a stopped sandbox. Every subsequent run on the thread failed identically, forever.

The box is only stopped, not deleted: `delete_after_stop` is 30 days, so the filesystem and the agent's uncommitted work are still there. Starting it is the actual recovery, and it preserves the working tree that `SandboxUnreachableError` exists to protect.

On a 400, `_configure_github_proxy` now starts the sandbox and retries the PATCH once. A failed start is logged and swallowed rather than raising — the retry reports the real state. One start attempt per call, so a box that is genuinely wedged raises instead of looping. Every other status propagates unchanged.

Reactive rather than starting pre-emptively on every refresh: `POST /start` is not idempotent (`LockedStartSandbox` 400s on anything that is not `stopped` or `failed`), and the happy path is already ready+live, so an unconditional start would add three API calls and a wait to every run for nothing.

Separately, the raised error now carries the response body. `raise_for_status` builds its message from the status line and an MDN link only, so the API's own `sandbox "..." is in "stopped" state, must be "ready" to update proxy config` was being thrown away — the reason this took a dig through smith-go to diagnose.

Known gap, left out deliberately: a deleted sandbox 404s on this PATCH, and 404 is not 400, so it still surfaces as unreachable instead of `SandboxGoneError`. Worth a follow-up.

## Test Plan

- [x] `make test` — `tests/sandbox/` passes (150), full suite green
- [x] New coverage in `tests/sandbox/test_proxy_auth.py`: start-then-retry succeeds; retry still runs when the start raises; no double-start when the retry also 400s; response body reaches the error message
- [x] `make lint` and `make typecheck` clean
