### PR TITLE
perf(dashboard): warm the thread state fetch and time it server-side

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import shlex
+from time import perf_counter
 from typing import Any, Literal
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 
@@ -21,10 +22,11 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from fastapi.responses import RedirectResponse, Response, StreamingResponse
+from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
 from ..utils.thread_ops import langgraph_url
+from ..utils.timing import server_timing_header
 from .admin import is_admin
 from .agent_instructions import (
     AgentInstructionsCreate,
@@ -2263,8 +2265,16 @@ async def api_delete_thread(
 async def api_get_thread_state(
     thread_id: str,
     session: dict[str, Any] = _SESSION_DEP,
-) -> dict[str, Any]:
-    return await get_dashboard_thread_state(thread_id, session["sub"], email=session.get("email"))
+) -> Response:
+    timings: dict[str, float] = {}
+    started = perf_counter()
+    payload = await get_dashboard_thread_state(
+        thread_id, session["sub"], email=session.get("email"), timings=timings
+    )
+    timings["total"] = (perf_counter() - started) * 1000
+    header = server_timing_header(timings)
+    logger.info("thread state timings thread_id=%s %s", thread_id, header)
+    return JSONResponse(payload, headers={"Server-Timing": header})
 
 
 @router.post("/threads/{thread_id}/stream/events")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -43,6 +43,7 @@ from ..utils.thread_ops import (
     queue_message_for_thread,
 )
 from ..utils.thread_participants import PARTICIPANT_LOGINS_KEY, merge_participant_logins
+from ..utils.timing import phase
 from .admin import is_admin
 from .agent_overrides import normalize_profile_overrides
 from .environments import get_environment, slugify
@@ -571,12 +572,14 @@ async def _latest_run_status(thread_id: str) -> str | None:
 
 
 async def _refresh_latest_run_metadata(
-    client: Any, thread: ThreadLike
+    client: Any, thread: ThreadLike, *, timings: dict[str, float] | None = None
 ) -> tuple[ThreadLike, str | None, str | None]:
+    record = timings if timings is not None else {}
     thread_id = thread.get("thread_id") or thread.get("id")
     if not isinstance(thread_id, str) or not thread_id:
         return thread, None, None
-    latest_run_status, latest_run_id = await _latest_run_info(client, thread_id)
+    with phase(record, "runs_list"):
+        latest_run_status, latest_run_id = await _latest_run_info(client, thread_id)
     metadata = thread_metadata(thread)
     metadata_update: dict[str, Any] = {}
     if latest_run_status and latest_run_status != metadata.get("latest_run_status"):
@@ -584,12 +587,15 @@ async def _refresh_latest_run_metadata(
     if latest_run_id and latest_run_id != metadata.get("latest_run_id"):
         metadata_update["latest_run_id"] = latest_run_id
     if metadata_update:
-        try:
-            await client.threads.update(thread_id=thread_id, metadata=metadata_update)
-        except Exception:  # noqa: BLE001
-            logger.debug("Could not persist latest run metadata for %s", thread_id, exc_info=True)
-        else:
-            thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
+        with phase(record, "thread_update"):
+            try:
+                await client.threads.update(thread_id=thread_id, metadata=metadata_update)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Could not persist latest run metadata for %s", thread_id, exc_info=True
+                )
+            else:
+                thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
     return thread, latest_run_status, latest_run_id
 
 
@@ -1873,18 +1879,27 @@ async def _readable_thread_metadata(
 
 
 async def get_dashboard_thread_state(
-    thread_id: str, login: str, *, email: str | None = None
+    thread_id: str,
+    login: str,
+    *,
+    email: str | None = None,
+    timings: dict[str, float] | None = None,
 ) -> dict[str, Any]:
+    record = timings if timings is not None else {}
     client = langgraph_client()
-    try:
-        thread = await client.threads.get(thread_id)
-    except Exception as exc:  # noqa: BLE001
-        raise HTTPException(404, "thread not found") from exc
+    with phase(record, "thread_get"):
+        try:
+            thread = await client.threads.get(thread_id)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(404, "thread not found") from exc
     metadata = thread_metadata(thread)
     _assert_thread_readable(metadata)
-    thread, latest_run_status, _ = await _refresh_latest_run_metadata(client, thread)
+    thread, latest_run_status, _ = await _refresh_latest_run_metadata(
+        client, thread, timings=record
+    )
     metadata = thread_metadata(thread)
-    state = await client.threads.get_state(thread_id)
+    with phase(record, "get_state"):
+        state = await client.threads.get_state(thread_id)
     result = as_json_object(state)
     # The SDK's `useStream` opens its live event subscription only when the
     # hydrated `getState()` looks active (`next` non-empty / absent). When a

--- a/agent/utils/timing.py
+++ b/agent/utils/timing.py
@@ -1,0 +1,19 @@
+"""Phase timings for endpoints whose latency needs a breakdown."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from time import perf_counter
+
+
+@contextmanager
+def phase(timings: dict[str, float], name: str) -> Iterator[None]:
+    """Record how long the block took, in milliseconds, under ``name``."""
+    start = perf_counter()
+    try:
+        yield
+    finally:
+        timings[name] = (perf_counter() - start) * 1000
+
+
+def server_timing_header(timings: dict[str, float]) -> str:
+    return ", ".join(f"{name};dur={value:.1f}" for name, value in timings.items())

--- a/ui/src/features/agents/lib/threadStateWarmup.test.ts
+++ b/ui/src/features/agents/lib/threadStateWarmup.test.ts
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { threadStateWarmupScript } from "./threadStateWarmup"
+
+const THREAD_ID = "1dd69115-f4b9-507f-b4d5-9f355f9f5ba0"
+const STATE_PATH = `/dashboard/api/threads/${THREAD_ID}/state`
+
+function setReadyState(value: DocumentReadyState) {
+  Object.defineProperty(document, "readyState", {
+    value,
+    configurable: true,
+  })
+}
+
+function run(script: string) {
+  new Function(script)()
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  setReadyState("complete")
+})
+
+describe("threadStateWarmupScript", () => {
+  it("only matches a cloud thread route", () => {
+    expect(threadStateWarmupScript("/agents")).toBeNull()
+    expect(threadStateWarmupScript("/agents/threads")).toBeNull()
+    expect(threadStateWarmupScript("/agents/skills")).toBeNull()
+    expect(threadStateWarmupScript(`/agents/local/${THREAD_ID}`)).toBeNull()
+    expect(threadStateWarmupScript(`/agents/${THREAD_ID}/plan`)).toBeNull()
+    expect(threadStateWarmupScript(`/agents/${THREAD_ID}`)).toContain(
+      STATE_PATH
+    )
+  })
+
+  it("issues the state request during parse and hands it to the first matching fetch", async () => {
+    setReadyState("loading")
+    const response = new Response("{}")
+    const original = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(response)
+    )
+    vi.stubGlobal("fetch", original)
+
+    run(threadStateWarmupScript(`/agents/${THREAD_ID}`)!)
+
+    expect(original).toHaveBeenCalledTimes(1)
+    expect(String(original.mock.calls[0]?.[0])).toContain(STATE_PATH)
+
+    const handed = await window.fetch(new URL(STATE_PATH, location.href).href, {
+      credentials: "include",
+    })
+    expect(handed).toBe(response)
+    expect(original).toHaveBeenCalledTimes(1)
+
+    await window.fetch(new URL(STATE_PATH, location.href).href)
+    expect(original).toHaveBeenCalledTimes(2)
+    expect(window.fetch).toBe(original)
+  })
+
+  it("passes unrelated requests through and restores fetch", async () => {
+    setReadyState("loading")
+    const original = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("{}"))
+    )
+    vi.stubGlobal("fetch", original)
+
+    run(threadStateWarmupScript(`/agents/${THREAD_ID}`)!)
+    await window.fetch("/dashboard/api/options")
+
+    expect(original).toHaveBeenCalledTimes(2)
+    expect(String(original.mock.calls[1]?.[0])).toBe("/dashboard/api/options")
+  })
+
+  it("is inert once the document has parsed", () => {
+    setReadyState("complete")
+    const original = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("{}"))
+    )
+    vi.stubGlobal("fetch", original)
+
+    run(threadStateWarmupScript(`/agents/${THREAD_ID}`)!)
+
+    expect(original).not.toHaveBeenCalled()
+    expect(window.fetch).toBe(original)
+  })
+})

--- a/ui/src/features/agents/lib/threadStateWarmup.ts
+++ b/ui/src/features/agents/lib/threadStateWarmup.ts
@@ -1,0 +1,35 @@
+import { agentsLangGraphApiUrl } from "./api"
+
+const THREAD_PATH_RE =
+  /^\/agents\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i
+
+/**
+ * Inline head script that starts the thread's `getState` request while the HTML
+ * is still parsing and hands the in-flight response to the SDK. The SDK's own
+ * call cannot be issued until the bundle has booted, which is most of the delay
+ * before a transcript can paint.
+ */
+export function threadStateWarmupScript(pathname: string): string | null {
+  const threadId = THREAD_PATH_RE.exec(pathname)?.[1]
+  if (!threadId) return null
+  const url = JSON.stringify(
+    `${agentsLangGraphApiUrl}/threads/${threadId}/state`
+  )
+  return `(function(){
+if(document.readyState!=="loading")return;
+var url=new URL(${url},location.href).href;
+var pending=fetch(url,{credentials:"include"});
+pending.catch(function(){});
+var original=window.fetch;
+var timer=setTimeout(release,15000);
+function release(){clearTimeout(timer);pending=null;if(window.fetch===patched)window.fetch=original}
+function patched(input,init){
+var method=String((init&&init.method)||(input&&input.method)||"GET").toUpperCase();
+if(pending&&method==="GET"){
+var href=typeof input==="string"?input:(input&&input.url)||String(input);
+try{if(new URL(href,location.href).href===url){var warmed=pending;release();return warmed}}catch(e){}
+}
+return original.apply(window,arguments)}
+window.fetch=patched;
+})();`
+}

--- a/ui/src/features/agents/lib/threadStateWarmup.ts
+++ b/ui/src/features/agents/lib/threadStateWarmup.ts
@@ -4,6 +4,56 @@ const THREAD_PATH_RE =
   /^\/agents\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i
 
 /**
+ * Serialized into the document with `toString()`, so it may not reference
+ * imports, module scope, or any syntax the build lowers with a helper.
+ */
+function warmThreadState(stateUrl: string) {
+  if (document.readyState !== "loading") return
+
+  const target = new URL(stateUrl, location.href).href
+  let pending: Promise<Response> | null = fetch(target, {
+    credentials: "include",
+  })
+  pending.catch(() => {})
+
+  const original = window.fetch
+  const timer = setTimeout(release, 15000)
+
+  function release() {
+    clearTimeout(timer)
+    pending = null
+    if (window.fetch === patched) window.fetch = original
+  }
+
+  function patched(
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> {
+    const method = String(
+      init?.method ?? (input as Request).method ?? "GET"
+    ).toUpperCase()
+    if (pending && method === "GET") {
+      const href =
+        typeof input === "string"
+          ? input
+          : ((input as Request).url ?? String(input))
+      try {
+        if (new URL(href, location.href).href === target) {
+          const warmed = pending
+          release()
+          return warmed
+        }
+      } catch {
+        // A URL the constructor rejects is not the one we warmed.
+      }
+    }
+    return original.call(window, input, init)
+  }
+
+  window.fetch = patched
+}
+
+/**
  * Inline head script that starts the thread's `getState` request while the HTML
  * is still parsing and hands the in-flight response to the SDK. The SDK's own
  * call cannot be issued until the bundle has booted, which is most of the delay
@@ -12,24 +62,6 @@ const THREAD_PATH_RE =
 export function threadStateWarmupScript(pathname: string): string | null {
   const threadId = THREAD_PATH_RE.exec(pathname)?.[1]
   if (!threadId) return null
-  const url = JSON.stringify(
-    `${agentsLangGraphApiUrl}/threads/${threadId}/state`
-  )
-  return `(function(){
-if(document.readyState!=="loading")return;
-var url=new URL(${url},location.href).href;
-var pending=fetch(url,{credentials:"include"});
-pending.catch(function(){});
-var original=window.fetch;
-var timer=setTimeout(release,15000);
-function release(){clearTimeout(timer);pending=null;if(window.fetch===patched)window.fetch=original}
-function patched(input,init){
-var method=String((init&&init.method)||(input&&input.method)||"GET").toUpperCase();
-if(pending&&method==="GET"){
-var href=typeof input==="string"?input:(input&&input.url)||String(input);
-try{if(new URL(href,location.href).href===url){var warmed=pending;release();return warmed}}catch(e){}
-}
-return original.apply(window,arguments)}
-window.fetch=patched;
-})();`
+  const url = `${agentsLangGraphApiUrl}/threads/${threadId}/state`
+  return `(${warmThreadState.toString()})(${JSON.stringify(url)});`
 }

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import {
   Scripts,
   createRootRouteWithContext,
   useRouter,
+  useRouterState,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools"
 import { TanStackDevtools } from "@tanstack/react-devtools"
@@ -14,6 +15,7 @@ import type { QueryClient } from "@tanstack/react-query"
 import appCss from "../styles.css?url"
 import { AppCommandProvider } from "@/lib/appCommands"
 import { resolveSessionOnServer } from "@/lib/session-ssr"
+import { threadStateWarmupScript } from "@/features/agents/lib/threadStateWarmup"
 
 const themeInitScript = `(function(){try{var t=localStorage.getItem("open-swe-theme");var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
 
@@ -52,10 +54,15 @@ export const Route = createRootRouteWithContext<{
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   const { queryClient } = useRouter().options.context
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const warmupScript = threadStateWarmupScript(pathname)
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {warmupScript && (
+          <script dangerouslySetInnerHTML={{ __html: warmupScript }} />
+        )}
         <HeadContent />
       </head>
       <body>


### PR DESCRIPTION
Opening a thread felt like it took a perceptible second to render. It isn't rendering. Measured on `1dd69115-…` with a cold, cache-disabled load:

| | |
|---|---|
| Total blocking time | 26 ms |
| Long tasks | 2 (60 ms, 66 ms), both during boot |
| `GET /threads/{id}/state` | starts 807 ms, TTFB 640 ms, download 498 ms (132 KB) |
| Transcript first paints | 1989 ms |

React commits the whole transcript inside one frame. The delay is ~800 ms of bundle boot before the request can be issued, then ~1.1 s waiting on it.

## Warm the state fetch

An inline script in `<head>` starts `GET /threads/{id}/state` while the HTML is still parsing, then hands the in-flight response to the SDK's own `getState` by swapping `window.fetch` for one call. This takes the boot wait off the critical path without a second request.

It only emits on `/agents/<uuid>`, it is inert unless `document.readyState === "loading"` (so client-side navigation is unaffected), and it restores `window.fetch` on first match or after 15 s.

## Time the server side

The 640 ms TTFB is still unexplained. `get_dashboard_thread_state` makes three sequential LangGraph calls — `threads.get` for the auth check, `runs.list` (plus a conditional `threads.update` write) to reconcile run status, and the `get_state` that produces the payload. Each phase is now timed and reported as a `Server-Timing` header and a log line, so the breakdown is readable from browser resource timing and from Datadog.

Nothing is optimised on the basis of a guess here — the timings decide whether the fix is `asyncio.gather` over the three calls, a slimmer payload, or something in LangGraph itself.

## Test Plan

- [x] `pnpm test` in `ui/` — 4 new tests cover route matching, the fetch handoff, pass-through of unrelated requests, and inertness after parse. The 31 pre-existing failures are unchanged from `main`.
- [x] `uv run pytest tests/dashboard` — 271 passed.
- [x] `make lint` (ruff check + format) and `pnpm typecheck` clean.
- [x] Verified against a local SSR render: the warmup script appears in the HTML for `/agents/<uuid>` and is absent for `/agents`, `/agents/instructions`.
