### PR TITLE
fix(e2e): write the plan fixture as HTML so save_plan accepts it

### DIFF
--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -291,22 +291,76 @@ def _desktop_reply_step(messages: list[BaseMessage]) -> AIMessage:
     )
 
 
-PLAN_FILE_PATH = "/workspace/plans/2026-06-29-greet-helper.md"
+PLAN_FILE_PATH = "/workspace/plans/2026-06-29-greet-helper.html"
 
-PLAN_MARKDOWN = """## Plan: Add greet() helper
+PLAN_HTML = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Greeting Blueprint</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #1c1c1c;
+        --muted: #5c5c5c;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root:not([data-theme="light"]) {
+          --bg: #1c1c1c;
+          --fg: #f4f4f4;
+          --muted: #a8a8a8;
+        }
+      }
+      :root[data-theme="dark"] {
+        --bg: #1c1c1c;
+        --fg: #f4f4f4;
+        --muted: #a8a8a8;
+      }
+      body {
+        margin: 0;
+        padding: 2rem 1.5rem;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+        line-height: 1.6;
+      }
+      main { margin: 0 auto; max-width: 44rem; }
+      h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+      h2 { font-size: 1.05rem; margin: 1.75rem 0 0.5rem; }
+      p.lede { color: var(--muted); margin: 0; }
+      code {
+        background: rgba(127, 127, 127, 0.18);
+        border-radius: 0.25rem;
+        padding: 0.1em 0.35em;
+      }
+      a:focus-visible, :focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Add greet() helper</h1>
+      <p class="lede">Add a tiny greeting helper to the demo repo.</p>
 
-### Overview
-Add a tiny greeting helper to the demo repo.
+      <h2>Files to change</h2>
+      <ul>
+        <li><code>greet.py</code> — new module exposing a <code>greet(name)</code> function.</li>
+      </ul>
 
-### Files to change
-- `greet.py` — new module exposing a `greet(name)` function.
+      <h2>Steps</h2>
+      <ol>
+        <li>Create <code>greet.py</code> with a <code>greet(name)</code> function.</li>
+        <li>Open a draft PR with the change.</li>
+      </ol>
 
-### Steps
-1. Create `greet.py` with a `greet(name)` function.
-2. Open a draft PR with the change.
-
-### Verification
-- Import `greet` and confirm it returns the expected string.
+      <h2>Verification</h2>
+      <ul>
+        <li>Import <code>greet</code> and confirm it returns the expected string.</li>
+      </ul>
+    </main>
+  </body>
+</html>
 """
 
 
@@ -341,7 +395,7 @@ def _write_plan_step(_messages: list[BaseMessage]) -> AIMessage:
         tool_calls=[
             {
                 "name": "write_file",
-                "args": {"file_path": PLAN_FILE_PATH, "content": PLAN_MARKDOWN},
+                "args": {"file_path": PLAN_FILE_PATH, "content": PLAN_HTML},
                 "id": "call-write-plan",
             }
         ],


### PR DESCRIPTION
`Browser E2E (2/3)` has been red on `main` since `f964ef83d`, failing three specs in `tests/e2e/tests/plan_review.spec.ts`:

- `:57` Slack plan approval button starts implementation — no `/pull/` link
- `:96` Slack plan request → comments → collaborator approves → PR — no `plan-review`
- `:315` plan decisions return to a connected conversation — no `plan-review`

## Cause

50c75492d ("render plans as sandboxed HTML artifacts") narrowed `save_plan` to accept only a complete HTML document: `_is_html_path` requires a `.html` file under `/workspace/plans`, and `_validate_html` requires `<html>`, `<head>`, `<body>`, and `<title>`. It updated `plan_review.spec.ts` to match but left the scripted model writing Markdown to `2026-06-29-greet-helper.md`.

Every plan run therefore got `plan_file_path must point to an HTML file in /workspace/plans` back from `save_plan`. Nothing reached the plan store, so `PlanView` stayed on "The agent is still writing the content…" and `plan-review` never rendered. The third failure is the same cause one step downstream: no stored plan means no approval, so no PR link ever lands in Slack.

The spec was already asserting on HTML that existed nowhere in the tree — it checks the clipboard for `<title>Greeting Blueprint</title>` and `<h2>Verification</h2>`. This adds the fixture those assertions were written against.

## Test Plan

- [x] `npx playwright test tests/plan_review.spec.ts` — 3 passed (55.4s).
- [x] Confirmed the fix is load-bearing: with the fixture stashed, `:315` fails in 32.8s, matching CI.
- [x] Fixture checked against the real validators — `_is_html_path` true, `_validate_html` returns `None` — and contains the `<title>Greeting Blueprint</title>` / `<h2>Verification</h2>` markers the spec asserts.
- [x] `make lint` clean.
