### PR TITLE
feat(dashboard): show a loading placeholder in the threads sidebar

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -668,4 +668,31 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       page.getByText(new RegExp(`@${OTHER_USER.login}`)).first(),
     ).toBeVisible();
   });
+
+  // A slow sidebar used to render as a blank column, indistinguishable from an
+  // account with no threads.
+  test("shows a loading placeholder while the sidebar list is in flight", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/dashboard/api/threads/sidebar*", async (route) => {
+      await held;
+      await route.continue();
+    });
+
+    // The held request would block `load`, so stop waiting at the first byte.
+    await page.goto("/agents", { waitUntil: "commit" });
+
+    const skeleton = page.getByTestId("sidebar-threads-skeleton");
+    await expect(skeleton).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole("status")).toContainText("Loading threads");
+
+    release();
+    await expect(skeleton).toBeHidden({ timeout: 30_000 });
+  });
 });

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -695,4 +695,52 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     release();
     await expect(skeleton).toBeHidden({ timeout: 30_000 });
   });
+
+  // A persisted filter makes the "no matches" branch true before any data has
+  // arrived, so the two states could otherwise render together.
+  test("does not claim an empty result while the sidebar is still loading", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "open-swe.agents.sidebar-prefs",
+        JSON.stringify({ filters: { statuses: ["running"] } }),
+      );
+    });
+
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/dashboard/api/threads/sidebar*", async (route) => {
+      await held;
+      await route.continue();
+    });
+
+    await page.goto("/agents", { waitUntil: "commit" });
+
+    const skeleton = page.getByTestId("sidebar-threads-skeleton");
+    await expect(skeleton).toBeVisible({ timeout: 30_000 });
+
+    // The skeleton is in the server-rendered HTML, so its presence says nothing
+    // about hydration — and the persisted filter is only read on the client.
+    // `useSidebarPrefs` writes the full sanitized object back on mount, so the
+    // stored value gaining a key the seed never had is the hydration signal.
+    await page.waitForFunction(
+      () =>
+        (
+          localStorage.getItem("open-swe.agents.sidebar-prefs") ?? ""
+        ).includes("collapsed"),
+      undefined,
+      { timeout: 30_000 },
+    );
+
+    await expect(skeleton).toBeVisible();
+    await expect(page.getByText("No threads match these filters.")).toHaveCount(
+      0,
+    );
+
+    release();
+  });
 });

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -65,6 +65,7 @@ import {
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
 import { useDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
 import { Kbd } from "@/components/ui/kbd"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   useAppCommand,
   useAppCommandControls,
@@ -320,37 +321,41 @@ export function AgentsSidebar({
         )}
         {showCloudThreads && (
           <div className="min-h-0 flex-1 overflow-y-auto">
-            {prefs.group === "none"
-              ? sections[0]?.threads.map((thread) => (
-                  <ThreadRow
-                    key={thread.id}
-                    thread={thread}
-                    isActive={thread.id === activeThreadId}
-                    onNavigate={layout.closeOnMobile}
-                    compact={prefs.compact}
-                  />
-                ))
-              : sections.map((section) => (
-                  <ThreadGroup
-                    key={`${prefs.group}:${section.key}`}
-                    label={section.label}
-                    threads={section.threads}
-                    activeThreadId={activeThreadId}
-                    onNavigate={layout.closeOnMobile}
-                    defaultCollapsed={section.defaultCollapsed}
-                    compact={prefs.compact}
-                    hasMore={
-                      prefs.group === "focus" && section.key === "done"
-                        ? resolvedHasMore
-                        : false
-                    }
-                    count={
-                      prefs.group === "focus" && section.key === "done"
-                        ? filteredResolved.length
-                        : section.threads.length
-                    }
-                  />
-                ))}
+            {sidebar.isPending && (
+              <ThreadListSkeleton compact={prefs.compact} />
+            )}
+            {!sidebar.isPending &&
+              (prefs.group === "none"
+                ? sections[0]?.threads.map((thread) => (
+                    <ThreadRow
+                      key={thread.id}
+                      thread={thread}
+                      isActive={thread.id === activeThreadId}
+                      onNavigate={layout.closeOnMobile}
+                      compact={prefs.compact}
+                    />
+                  ))
+                : sections.map((section) => (
+                    <ThreadGroup
+                      key={`${prefs.group}:${section.key}`}
+                      label={section.label}
+                      threads={section.threads}
+                      activeThreadId={activeThreadId}
+                      onNavigate={layout.closeOnMobile}
+                      defaultCollapsed={section.defaultCollapsed}
+                      compact={prefs.compact}
+                      hasMore={
+                        prefs.group === "focus" && section.key === "done"
+                          ? resolvedHasMore
+                          : false
+                      }
+                      count={
+                        prefs.group === "focus" && section.key === "done"
+                          ? filteredResolved.length
+                          : section.threads.length
+                      }
+                    />
+                  )))}
             {showResolved && prefs.group !== "focus" && (
               <ResolvedThreadGroup
                 threads={filteredResolved}
@@ -642,6 +647,44 @@ function LocalThreadRow({
         error={deleteError}
       />
     </>
+  )
+}
+
+/**
+ * Mirrors the grouped thread list's shape so the sidebar reads as loading
+ * rather than as an account with no threads. Widths vary per row because a
+ * column of identical bars reads as a UI element, not as pending content.
+ */
+function ThreadListSkeleton({ compact = false }: { compact?: boolean }) {
+  const groups = [
+    [90, 64, 76],
+    [72, 84],
+  ]
+  return (
+    <div data-testid="sidebar-threads-skeleton">
+      <span className="sr-only" role="status">
+        Loading threads
+      </span>
+      {groups.map((widths, groupIndex) => (
+        <div key={groupIndex} className={compact ? "mb-2" : "mb-3"} aria-hidden>
+          <div className="flex items-center gap-1 px-2 py-1">
+            <Skeleton className="h-2 w-16 rounded-sm" />
+          </div>
+          {widths.map((width, rowIndex) => (
+            <div
+              key={rowIndex}
+              className={cn(
+                "mb-0.5 flex items-center gap-2 px-2.5",
+                compact ? "h-7 gap-1.5" : "h-8"
+              )}
+            >
+              <Skeleton className="size-3 shrink-0 rounded-full" />
+              <Skeleton className="h-2.5" style={{ width: `${width}%` }} />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
   )
 }
 

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -198,7 +198,11 @@ export function AgentsSidebar({
       ? [...filteredActive, ...filteredResolved]
       : filteredActive
   const sections = groupThreadsByMode(groupedThreads, prefs.group)
+  // Never alongside the loading placeholder: a first load with a persisted
+  // filter has no sections yet, and "no matches" would be a definitive answer
+  // to a request still in flight.
   const isCloudEmpty =
+    !sidebar.isPending &&
     sections.length === 0 &&
     (!showResolved || filteredResolved.length === 0) &&
     hasActiveFilters(prefs.filters)


### PR DESCRIPTION
The sidebar renders `sidebar.data?.active.items ?? []`, so before the first response lands there are no rows — and `isCloudEmpty` only speaks up when a filter is active. The result is a blank column, indistinguishable from an account with no threads. It lasts about a second: the request cannot start until the bundle boots.

This renders placeholder rows while the query is pending. They mirror the grouped list's shape (group label + rows with a status dot and a title bar), with per-row widths so the column reads as pending content rather than as a UI element.

`placeholderData: (prev) => prev` on the query means the placeholder only appears on a genuine first load — navigating between threads changes the query key but keeps the previous data, and a 2 s poll never clears it, so there is no flash in either case.

The live region sits outside the `aria-hidden` wrapper: `aria-hidden` hides its whole subtree, so a nested `aria-hidden={false}` would not have announced anything.

Not changed here: a sidebar that finishes loading with genuinely zero threads and no active filters still renders nothing at all. That is a separate gap — say the word and I will add an empty state too.

## Test Plan

- [x] New Playwright test holds `/threads/sidebar` open, asserts the placeholder and the "Loading threads" status, releases, and asserts the placeholder goes away. Passes in 639 ms.
- [x] Confirmed non-vacuous: with the component change stashed, that test fails (30.9 s timeout).
- [x] Verified visually against the mock harness with the request held open — placeholder in place of the blank column, and the real grouped list unchanged once it resolves.
- [x] `pnpm typecheck` clean; `pnpm test` 169 passed (the 31 failures are pre-existing on `main`).
