### PR TITLE
perf: keep recent thread views mounted

### DIFF
--- a/ui/src/features/agents/components/AgentThreadPage.tsx
+++ b/ui/src/features/agents/components/AgentThreadPage.tsx
@@ -1,0 +1,34 @@
+import { Navigate } from "@tanstack/react-router"
+
+import { AgentThreadView } from "@/features/agents/components/AgentThreadView"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AgentThreadStreamBoundary } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
+import { useAgentThread } from "@/features/agents/lib/queries"
+
+export function AgentThreadPage({
+  threadId,
+  active = true,
+}: {
+  threadId: string
+  active?: boolean
+}) {
+  const threadQuery = useAgentThread(threadId)
+
+  if (threadQuery.isLoading) {
+    return (
+      <main className="flex min-w-0 flex-1 items-center justify-center p-6">
+        <Skeleton className="h-40 w-full max-w-md" />
+      </main>
+    )
+  }
+
+  if (threadQuery.isError || !threadQuery.data) {
+    return active ? <Navigate to="/agents" /> : null
+  }
+
+  return (
+    <AgentThreadStreamBoundary>
+      <AgentThreadView thread={threadQuery.data} />
+    </AgentThreadStreamBoundary>
+  )
+}

--- a/ui/src/features/agents/components/AgentThreadPage.tsx
+++ b/ui/src/features/agents/components/AgentThreadPage.tsx
@@ -27,7 +27,7 @@ export function AgentThreadPage({
   }
 
   return (
-    <AgentThreadStreamBoundary>
+    <AgentThreadStreamBoundary active={active}>
       <AgentThreadView thread={threadQuery.data} />
     </AgentThreadStreamBoundary>
   )

--- a/ui/src/features/agents/components/RecentAgentThreads.test.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.test.tsx
@@ -17,9 +17,13 @@ vi.mock("@/features/agents/lib/AgentThreadStreamProvider", () => ({
 }))
 
 vi.mock("@/features/agents/components/AgentThreadPage", () => ({
-  AgentThreadPage: ({ threadId }: { threadId: string }) => (
-    <div>thread {threadId}</div>
-  ),
+  AgentThreadPage: ({
+    threadId,
+    active,
+  }: {
+    threadId: string
+    active: boolean
+  }) => <div data-active={active}>thread {threadId}</div>,
 }))
 
 afterEach(cleanup)
@@ -29,12 +33,8 @@ describe("RecentAgentThreads", () => {
     const view = render(<RecentAgentThreads activeThreadId="one" />)
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="two" />))
-    expect(
-      screen
-        .getByText("thread one")
-        .closest("[aria-hidden]")
-        ?.getAttribute("aria-hidden")
-    ).toBe("true")
+    expect(screen.getByText("thread one").dataset.active).toBe("false")
+    expect(screen.getByText("thread two").dataset.active).toBe("true")
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
     act(() => view.rerender(<RecentAgentThreads activeThreadId="four" />))

--- a/ui/src/features/agents/components/RecentAgentThreads.test.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RecentAgentThreads } from "./RecentAgentThreads"
+import type { ReactNode } from "react"
+
+vi.mock("@/features/agents/lib/AgentThreadStreamProvider", () => ({
+  AgentThreadStreamProvider: ({
+    threadId,
+    children,
+  }: {
+    threadId: string
+    children: ReactNode
+  }) => <section data-provider={threadId}>{children}</section>,
+}))
+
+vi.mock("@/features/agents/components/AgentThreadPage", () => ({
+  AgentThreadPage: ({ threadId }: { threadId: string }) => (
+    <div>thread {threadId}</div>
+  ),
+}))
+
+afterEach(cleanup)
+
+describe("RecentAgentThreads", () => {
+  it("keeps the three most recently viewed threads mounted", () => {
+    const view = render(<RecentAgentThreads activeThreadId="one" />)
+
+    act(() => view.rerender(<RecentAgentThreads activeThreadId="two" />))
+    expect(
+      screen
+        .getByText("thread one")
+        .closest("[aria-hidden]")
+        ?.getAttribute("aria-hidden")
+    ).toBe("true")
+
+    act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
+    act(() => view.rerender(<RecentAgentThreads activeThreadId="four" />))
+
+    expect(screen.queryByText("thread one")).toBeNull()
+    expect(screen.getByText("thread two")).toBeTruthy()
+    expect(screen.getByText("thread three")).toBeTruthy()
+    expect(screen.getByText("thread four")).toBeTruthy()
+  })
+})

--- a/ui/src/features/agents/components/RecentAgentThreads.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react"
+
+import { AgentThreadPage } from "@/features/agents/components/AgentThreadPage"
+import { AgentThreadStreamProvider } from "@/features/agents/lib/AgentThreadStreamProvider"
+import { cn } from "@/lib/utils"
+
+const MAX_MOUNTED_THREADS = 3
+
+function addRecentThread(recentThreadIds: Array<string>, threadId: string) {
+  return [threadId, ...recentThreadIds.filter((id) => id !== threadId)].slice(
+    0,
+    MAX_MOUNTED_THREADS
+  )
+}
+
+export function RecentAgentThreads({
+  activeThreadId,
+}: {
+  activeThreadId: string
+}) {
+  const [recentThreadIds, setRecentThreadIds] = useState(() => [activeThreadId])
+  const visibleThreadIds = addRecentThread(recentThreadIds, activeThreadId)
+
+  useEffect(() => {
+    setRecentThreadIds((current) => addRecentThread(current, activeThreadId))
+  }, [activeThreadId])
+
+  return visibleThreadIds.map((threadId) => {
+    const active = threadId === activeThreadId
+    return (
+      <div
+        key={threadId}
+        className={cn(active ? "contents" : "hidden")}
+        aria-hidden={!active}
+      >
+        <AgentThreadStreamProvider threadId={threadId}>
+          <AgentThreadPage threadId={threadId} active={active} />
+        </AgentThreadStreamProvider>
+      </div>
+    )
+  })
+}

--- a/ui/src/features/agents/lib/provider/useIsInAgentThreadStream.tsx
+++ b/ui/src/features/agents/lib/provider/useIsInAgentThreadStream.tsx
@@ -20,12 +20,14 @@ export function useIsInAgentThreadStream(): boolean {
 }
 
 export function AgentThreadStreamBoundary({
+  active = true,
   children,
 }: {
+  active?: boolean
   children: ReactNode
 }) {
   return (
-    <AgentThreadStreamBoundaryContext.Provider value={true}>
+    <AgentThreadStreamBoundaryContext.Provider value={active}>
       {children}
     </AgentThreadStreamBoundaryContext.Provider>
   )

--- a/ui/src/routes/agents/$threadId.tsx
+++ b/ui/src/routes/agents/$threadId.tsx
@@ -1,33 +1,12 @@
-import { Navigate, createFileRoute } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 
-import { AgentThreadView } from "@/features/agents/components/AgentThreadView"
-import { Skeleton } from "@/components/ui/skeleton"
-import { AgentThreadStreamBoundary } from "@/features/agents/lib/provider/useIsInAgentThreadStream"
-import { useAgentThread } from "@/features/agents/lib/queries"
+import { RecentAgentThreads } from "@/features/agents/components/RecentAgentThreads"
 
 export const Route = createFileRoute("/agents/$threadId")({
-  component: AgentThreadPage,
+  component: AgentThreadRoute,
 })
 
-function AgentThreadPage() {
+function AgentThreadRoute() {
   const { threadId } = Route.useParams()
-  const threadQuery = useAgentThread(threadId)
-
-  if (threadQuery.isLoading) {
-    return (
-      <main className="flex min-w-0 flex-1 items-center justify-center p-6">
-        <Skeleton className="h-40 w-full max-w-md" />
-      </main>
-    )
-  }
-
-  if (threadQuery.isError || !threadQuery.data) {
-    return <Navigate to="/agents" />
-  }
-
-  return (
-    <AgentThreadStreamBoundary>
-      <AgentThreadView key={threadId} thread={threadQuery.data} />
-    </AgentThreadStreamBoundary>
-  )
+  return <RecentAgentThreads activeThreadId={threadId} />
 }


### PR DESCRIPTION
## Description
Keep the three most recently viewed agent threads mounted and hide inactive views, preserving rendered transcripts and stream state for faster switching.

## Release Note
Thread switching in the dashboard is faster for recently viewed threads.

## Test Plan
- [x] Switch across four threads and verify only the three most recent remain mounted.