### PR TITLE
fix: close the LangSmith client in trace_context

### DIFF
--- a/agent/review/trace_context.py
+++ b/agent/review/trace_context.py
@@ -204,15 +204,18 @@ async def _resolve_session(
     if pr_context is None:
         return None, "Missing repo owner/name or PR number.", project
 
-    client = _client(creds)
-    thread_id, evidence = await _resolve_thread(client, project, pr_context)
-    if thread_id is None:
-        detail = f"No coding-agent thread matched (tried {_attempted_keys(pr_context)})."
-        return None, detail, project
+    # ``async with`` so the client's connection pool is released here rather than
+    # whenever the cycle collector happens to run: httpcore's pool graph is
+    # cyclic, so dropping the client leaves its socket open until then.
+    async with _client(creds) as client:
+        thread_id, evidence = await _resolve_thread(client, project, pr_context)
+        if thread_id is None:
+            detail = f"No coding-agent thread matched (tried {_attempted_keys(pr_context)})."
+            return None, detail, project
 
-    runs = await _list_thread_runs(client, project, thread_id, limit=_MAX_SESSION_RUNS)
-    if not runs:
-        return None, f"Matched thread {thread_id} but it returned no runs.", project
+        runs = await _list_thread_runs(client, project, thread_id, limit=_MAX_SESSION_RUNS)
+        if not runs:
+            return None, f"Matched thread {thread_id} but it returned no runs.", project
 
     runs.sort(key=lambda r: _run_time(r, "start_time") or datetime.min.replace(tzinfo=UTC))
     confidence = 0.9 if evidence.startswith("branch:") else 0.85

--- a/tests/reviewer/test_reviewer_trace_context.py
+++ b/tests/reviewer/test_reviewer_trace_context.py
@@ -47,6 +47,7 @@ def _thread_id_from_filter(filter_expr: str) -> str | None:
 class _FakeLangSmithClient:
     def __init__(self, search_results: dict[str, list[dict[str, Any]]] | None = None) -> None:
         self.filters: list[str] = []
+        self.closed = False
         self.search_results = (
             search_results
             if search_results is not None
@@ -55,6 +56,12 @@ class _FakeLangSmithClient:
                 'search("abc1234567890abcdef")': [_run("sha", "thread-1")],
             }
         )
+
+    async def __aenter__(self) -> "_FakeLangSmithClient":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.closed = True
 
     async def list_runs(self, **kwargs: Any):
         filter_expr = kwargs["filter"]
@@ -130,6 +137,9 @@ async def test_prepare_pr_trace_context_resolves_on_branch_alone() -> None:
         )
 
     assert result is not None
+    # The client is an async context manager: its connection pool must be released
+    # on the way out, not left to the cycle collector.
+    assert fake_client.closed is True
     assert result.file_path == "/workspace/.open-swe/review-author-trace.json"
     assert sandbox.uploaded_path == "/workspace/.open-swe/review-author-trace.json"
     assert result.thread_id == "thread-1"
@@ -208,6 +218,8 @@ async def test_prepare_pr_trace_context_returns_none_without_match() -> None:
 
     assert result is None
     assert sandbox.payload is None
+    # This path returns from inside the `async with`; the client must still close.
+    assert fake_client.closed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`_resolve_session` in `agent/review/trace_context.py` built a LangSmith `AsyncClient` and let it fall out of scope without `aclose()`:

```python
client = _client(creds)
thread_id, evidence = await _resolve_thread(client, project, pr_context)
runs = await _list_thread_runs(client, project, thread_id, limit=_MAX_SESSION_RUNS)
return session, "Resolved.", project   # client just goes out of scope
```

Every other caller of that same private helper already wraps it in `async with` (`agent/integrations/langsmith_tools.py`) — this was the only call site that did not.

## Why dropping the client is not enough

The `AsyncClient` object itself *is* reclaimed promptly by refcounting. The connection is not. `langsmith.AsyncClient` owns an `httpx.AsyncClient`, which owns an httpcore connection pool, and that pool's object graph is cyclic (`pool._connections` list ↔ `AsyncPoolRequest` ↔ connection). Refcounting cannot collect a cycle, so the pooled socket stays open until the generational collector runs — at an unpredictable time, and rarely once the objects are promoted to gen2.

Nothing in the stack cleans up on GC either: neither `langsmith.AsyncClient` (the *sync* `Client` does have `weakref.finalize`, the async one does not), nor `httpx.AsyncClient`, nor httpcore define `__del__`. The socket is closed only as a side effect of asyncio's transport finalizer, which also emits `ResourceWarning: unclosed socket`.

Probing a live client right after the owning function returns:

```
connection alive after client dropped (no gc): True
  referrer: builtins.list  held by: [httpcore.AsyncConnectionPool]   # pool._connections
  referrer: httpcore._async.connection_pool.AsyncPoolRequest
```

## Reproduction

Self-contained, no network and no repo dependencies — save as `repro.py` and run with `uv run python repro.py`:

```python
"""Minimal repro: an unclosed httpx.AsyncClient holds its socket until GC runs."""

import asyncio
import gc
import os
import threading
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer

import httpx


class _Handler(BaseHTTPRequestHandler):
    protocol_version = "HTTP/1.1"  # keep-alive, like api.smith.langchain.com

    def do_GET(self) -> None:
        body = b"{}"
        self.send_response(200)
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)

    def log_message(self, *args: object) -> None:
        pass


server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
threading.Thread(target=server.serve_forever, daemon=True).start()
URL = f"http://127.0.0.1:{server.server_port}"

# macOS; on Linux use /proc/self/fd
open_fds = lambda: len(os.listdir("/dev/fd"))


async def unclosed() -> None:
    client = httpx.AsyncClient(base_url=URL)
    await client.get("/ok")
    # no aclose() — the client is dropped here


async def closed() -> None:
    async with httpx.AsyncClient(base_url=URL) as client:
        await client.get("/ok")


async def main() -> None:
    await closed()
    gc.collect()
    await asyncio.sleep(0.1)
    base = open_fds()
    print(f"baseline open fds: {base}\n")

    print("--- unclosed (no manual gc.collect() anywhere) ---")
    for n in (1, 5, 20, 50):
        for _ in range(n):
            await unclosed()
        await asyncio.sleep(0.05)
        print(f"  after {n:>2} requests: {open_fds() - base:+d} fds")
    gc.collect()
    await asyncio.sleep(0.1)
    print(f"  after gc.collect(): {open_fds() - base:+d} fds\n")

    print("--- closed via `async with` ---")
    for n in (1, 5, 20, 50):
        for _ in range(n):
            await closed()
        await asyncio.sleep(0.05)
        print(f"  after {n:>2} requests: {open_fds() - base:+d} fds")


asyncio.run(main())
```

Output — note the sawtooth as automatic collections fire, and that the closed variant never grows at all:

```
baseline open fds: 9

--- unclosed (no manual gc.collect() anywhere) ---
  after  1 requests: +2 fds
  after  5 requests: +12 fds
  after 20 requests: +24 fds
  after 50 requests: +12 fds     <- an automatic GC pass fired here
  after gc.collect(): +0 fds

--- closed via `async with` ---
  after  1 requests: +0 fds
  after  5 requests: +0 fds
  after 20 requests: +0 fds
  after 50 requests: +0 fds
```

(+2 rather than +1 per request because the test server shares the process, so both ends of each connection are counted. In production it is one fd per client.)

## Impact

Not a permanent leak — nothing retains the client forever. But it is also not released at function return, which is the intuition the old code relied on. In practice: one live TCP+TLS connection per reviewer run that resolves an author trace, held for a GC-determined window, against a shared process fd limit, with concurrent reviewer runs overlapping. Plus `ResourceWarning` noise.

## Fix

Wrap the client in `async with`, matching the existing convention. The `runs.sort(...)` and `_ResolvedSession` construction move below the block since they need no client.

## Tests

Extended the existing `_FakeLangSmithClient` with the async-context-manager protocol and a `closed` flag, and asserted it on two paths:

- the happy path, and
- the no-match path, which `return`s from *inside* the `async with` — the case a naive `await client.aclose()` at the end of the function would miss.

Both assertions fail against the pre-fix code and pass after:

```
$ uv run pytest -q tests/reviewer/test_reviewer_trace_context.py   # pre-fix
FAILED test_prepare_pr_trace_context_resolves_on_branch_alone
FAILED test_prepare_pr_trace_context_returns_none_without_match
2 failed, 4 passed

$ uv run pytest -q tests/reviewer/test_reviewer_trace_context.py   # post-fix
6 passed
```

`uv run pytest tests/reviewer tests/sandbox` → 450 passed. `make lint` and `make typecheck` clean.
