### PR TITLE
fix: restrict admin thread messages

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -82,6 +82,9 @@ _MAX_DASHBOARD_IMAGE_BYTES = 10 * 1024 * 1024
 _PROXY_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
 _DISCOVERY_HISTORY_LIMIT = 5
 _PROXY_STREAM_TIMEOUT = httpx.Timeout(None)
+_THREAD_POST_COMMAND_METHODS = frozenset(
+    {"run.start", "input.respond", "input.inject", "state.fork"}
+)
 # Sources whose threads should surface in the Agents UI (besides "dashboard").
 _SURFACED_SOURCES: tuple[str, ...] = ("dashboard", "github", "slack", "linear", "schedule")
 # PR lifecycle states surfaced to the UI for a thread's associated pull request.
@@ -339,6 +342,14 @@ def _thread_is_readable(metadata: Mapping[str, Any]) -> bool:
 def _assert_thread_readable(metadata: Mapping[str, Any]) -> None:
     if not _thread_is_readable(metadata):
         raise HTTPException(404, "thread not found")
+
+
+def _assert_thread_postable(
+    metadata: Mapping[str, Any], login: str, email: str | None = None
+) -> None:
+    _assert_thread_readable(metadata)
+    if metadata.get("admin_thread") is True and not is_admin(email, login=login):
+        raise HTTPException(403, "only admins can send messages in admin threads")
 
 
 def _metadata_repo(metadata: Mapping[str, Any]) -> tuple[str, str, str]:
@@ -1672,7 +1683,7 @@ async def send_dashboard_message(
         raise HTTPException(404, "thread not found") from exc
 
     metadata = thread_metadata(thread)
-    _assert_thread_readable(metadata)
+    _assert_thread_postable(metadata, login, email)
 
     prompt = body.content.strip()
     now_ms = _now_ms()
@@ -2403,9 +2414,9 @@ async def proxy_dashboard_thread_commands(
     # yet. That command lazily creates + stamps + owns the thread (in
     # ``_enrich_run_start_command``); any other command against a missing thread
     # is a 404. On an existing thread, ``run.start`` (the posting path) is open
-    # to any org member and attributed in ``_enrich_run_start_command``; every
-    # other write command carries unattributed input (e.g. ``input.respond``),
-    # so it stays owner-only.
+    # to any org member and attributed in ``_enrich_run_start_command``. Input
+    # commands on admin threads require an admin; other threads keep unattributed
+    # commands such as ``input.respond`` owner-only.
     method = parsed.get("method")
     try:
         thread = await langgraph_client().threads.get(thread_id)
@@ -2421,9 +2432,12 @@ async def proxy_dashboard_thread_commands(
         thread_busy = False
     else:
         metadata = thread_metadata(thread)
-        if method == "run.start":
-            _assert_thread_readable(metadata)
+        post_command = method in _THREAD_POST_COMMAND_METHODS
+        if post_command:
+            _assert_thread_postable(metadata, login, email)
         else:
+            _assert_thread_readable(metadata)
+        if method != "run.start" and not (post_command and metadata.get("admin_thread") is True):
             _assert_thread_owner(metadata, login, email)
         metadata_run_status = metadata.get("latest_run_status")
         thread_busy = _thread_is_busy(thread) or metadata_run_status in {"pending", "running"}

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1070,6 +1070,91 @@ async def test_proxy_commands_non_run_start_by_non_owner_is_rejected(monkeypatch
     assert exc_info.value.status_code == 404
 
 
+async def test_proxy_commands_rejects_non_admin_on_admin_thread(monkeypatch) -> None:
+    class AdminThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {
+                    "source": "dashboard",
+                    "github_login": "workspace-admin",
+                    "admin_thread": True,
+                },
+            }
+
+    class AdminClient:
+        threads = AdminThreads()
+
+    monkeypatch.setenv("CONFIGURED_ADMINS", "workspace-admin")
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: AdminClient())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.proxy_dashboard_thread_commands(
+            "tid", "teammate", b'{"method": "run.start"}'
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "only admins can send messages in admin threads"
+
+
+async def test_proxy_commands_preserves_admin_writes_and_owner_reads(monkeypatch) -> None:
+    class AdminThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {
+                    "source": "dashboard",
+                    "github_login": "workspace-admin",
+                    "admin_thread": True,
+                },
+            }
+
+    class AdminClient:
+        threads = AdminThreads()
+
+    class FakeResponse:
+        status_code = 200
+        content = b"{}"
+        headers: dict[str, str] = {}
+
+    posted: list[bytes] = []
+
+    class FakeAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+        async def post(self, url: str, *, content: bytes, headers: dict[str, str]) -> FakeResponse:
+            posted.append(content)
+            return FakeResponse()
+
+    monkeypatch.setenv("CONFIGURED_ADMINS", "workspace-admin,another-admin")
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: AdminClient())
+    monkeypatch.setattr(thread_api.httpx, "AsyncClient", FakeAsyncClient)
+
+    status_code, _, _ = await thread_api.proxy_dashboard_thread_commands(
+        "tid", "another-admin", b'{"method": "input.respond"}'
+    )
+
+    assert status_code == 200
+
+    monkeypatch.setenv("CONFIGURED_ADMINS", "another-admin")
+    status_code, _, _ = await thread_api.proxy_dashboard_thread_commands(
+        "tid", "workspace-admin", b'{"method": "agent.getTree"}'
+    )
+
+    assert status_code == 200
+    assert posted == [
+        b'{"method": "input.respond"}',
+        b'{"method": "agent.getTree"}',
+    ]
+
+
 async def test_run_cancel_enforces_thread_ownership(monkeypatch) -> None:
     """Cancelling a run still requires thread ownership (it is not "posting")."""
 
@@ -1240,6 +1325,47 @@ async def test_send_dashboard_message_returns_502_when_activity_unknown(monkeypa
         )
 
     assert exc_info.value.status_code == 502
+
+
+async def test_send_dashboard_message_rejects_non_admin_on_admin_thread(monkeypatch) -> None:
+    class AdminThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {
+                    "source": "dashboard",
+                    "github_login": "workspace-admin",
+                    "admin_thread": True,
+                },
+            }
+
+        async def update(self, **kwargs: object) -> None:
+            raise AssertionError("must not update")
+
+    class AdminClient:
+        threads = AdminThreads()
+
+    monkeypatch.setenv("CONFIGURED_ADMINS", "workspace-admin")
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: AdminClient())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.send_dashboard_message(
+            "tid",
+            "teammate",
+            thread_api.ThreadMessageBody(content="ship it"),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "only admins can send messages in admin threads"
+
+
+def test_assert_thread_postable_allows_configured_admin(monkeypatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "workspace-admin")
+
+    thread_api._assert_thread_postable(
+        {"source": "dashboard", "admin_thread": True},
+        "workspace-admin",
+    )
 
 
 async def test_send_dashboard_message_attributes_non_owner(monkeypatch) -> None:

--- a/tests/e2e/tests/environments.spec.ts
+++ b/tests/e2e/tests/environments.spec.ts
@@ -182,7 +182,9 @@ test.describe("Environments", () => {
     // No Admin toggle in the composer, so they cannot start an admin thread.
     await openNewAgentHome(page);
     await expect(page.getByTestId("composer-editor")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Admin" })).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Admin mode", exact: true }),
+    ).toHaveCount(0);
   });
 
   test("the composer picker appears only with several environments, and the pick reaches the run", async ({
@@ -272,20 +274,14 @@ test.describe("Environments", () => {
     await page.request.post("/control/reset");
 
     await openNewAgentHome(page);
-    const extras = page.getByRole("button", { name: "More composer options" });
-    const enableAdmin = page.getByRole("menuitem", {
-      name: "Enable admin mode",
+    const adminToggle = page.getByRole("button", {
+      name: "Admin mode",
+      exact: true,
     });
-    await expect(async () => {
-      await extras.click();
-      await expect(enableAdmin).toBeVisible({ timeout: 2000 });
-    }).toPass({ timeout: 20_000 });
-    await enableAdmin.click();
-    await extras.click();
-    await expect(
-      page.getByRole("menuitem", { name: "Disable admin mode" }),
-    ).toBeVisible();
-    await page.keyboard.press("Escape");
+    await expect(adminToggle).toBeVisible({ timeout: 20_000 });
+    await expect(adminToggle).toHaveAttribute("aria-pressed", "false");
+    await adminToggle.click();
+    await expect(adminToggle).toHaveAttribute("aria-pressed", "true");
 
     await typeIntoComposer(
       page,

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -26,6 +26,7 @@ import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps
 import { useSubmitAgentMessage } from "@/features/agents/lib/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import { useAgentSkills } from "@/features/agents/lib/queries"
+import { useSession } from "@/lib/session"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 
@@ -94,6 +95,8 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
   const sidebarCollapsed = useSidebarCollapsed()
   const skills = useAgentSkills()
+  const session = useSession()
+  const canPost = !thread.adminThread || session.data?.is_admin === true
 
   const { models, defaultSelection } = useModelOptions()
   const threadSelection = useMemo<ModelSelection | null>(() => {
@@ -266,8 +269,13 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
             <div className="shrink-0 px-4 pb-4">
               <div className="mx-auto w-full max-w-3xl min-w-0">
                 <AgentPromptBar
-                  placeholder="Add a follow up"
+                  placeholder={
+                    canPost
+                      ? "Add a follow up"
+                      : "Only workspace admins can send messages in this thread"
+                  }
                   compact
+                  disabled={!canPost}
                   busy={isStreaming}
                   activeRun={activeRun}
                   onSubmit={(content, images) =>
@@ -321,8 +329,13 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
             )}
             <div className="w-full max-w-3xl">
               <AgentPromptBar
-                placeholder="Send the first message"
+                placeholder={
+                  canPost
+                    ? "Send the first message"
+                    : "Only workspace admins can send messages in this thread"
+                }
                 compact
+                disabled={!canPost}
                 busy={isStreaming}
                 activeRun={activeRun}
                 onSubmit={(content, images) =>

--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -37,6 +37,10 @@ vi.mock("@/features/agents/lib/api", () => ({
   AgentsApiError: class AgentsApiError extends Error {},
 }))
 
+vi.mock("@/lib/appCommands", () => ({
+  useRegisterAppCommands: vi.fn(),
+}))
+
 afterEach(() => cleanup())
 
 beforeEach(() => {
@@ -159,16 +163,50 @@ describe("ChatComposer stop button", () => {
 })
 
 describe("ChatComposer admin mode", () => {
-  it("tints the composer options control when enabled", () => {
+  it("hides the toggle when admin mode is unavailable", () => {
+    renderComposer(false)
+
+    expect(screen.queryByRole("button", { name: "Admin mode" })).toBeNull()
+  })
+
+  it("shows a direct toggle for eligible admins", () => {
+    const onAdminThreadChange = vi.fn()
+    renderComposer(false, { onAdminThreadChange })
+
+    const toggle = screen.getByRole("button", { name: "Admin mode" })
+    expect(toggle.getAttribute("aria-pressed")).toBe("false")
+
+    fireEvent.click(toggle)
+
+    expect(onAdminThreadChange).toHaveBeenCalledWith(true)
+  })
+
+  it("shows the active state and can disable admin mode", () => {
+    const onAdminThreadChange = vi.fn()
     renderComposer(false, {
       adminThread: true,
-      onAdminThreadChange: vi.fn(),
+      onAdminThreadChange,
     })
 
-    const options = screen.getByRole("button", {
-      name: "More composer options",
-    })
-    expect(options.className.split(" ")).toContain("bg-destructive/10")
+    const toggle = screen.getByRole("button", { name: "Admin mode" })
+    expect(toggle.getAttribute("aria-pressed")).toBe("true")
+    expect(toggle.className.split(" ")).toContain("bg-destructive/10")
+
+    fireEvent.click(toggle)
+
+    expect(onAdminThreadChange).toHaveBeenCalledWith(false)
+  })
+
+  it("cannot change modes while the composer is disabled", () => {
+    const onAdminThreadChange = vi.fn()
+    renderComposer(false, { disabled: true, onAdminThreadChange })
+
+    const toggle = screen.getByRole("button", { name: "Admin mode" })
+    expect(toggle.hasAttribute("disabled")).toBe(true)
+
+    fireEvent.click(toggle)
+
+    expect(onAdminThreadChange).not.toHaveBeenCalled()
   })
 })
 

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -812,11 +812,7 @@ export const ChatComposer = memo(function ChatComposer({
               render={
                 <ComposerControl
                   aria-label="More composer options"
-                  className={cn(
-                    "size-7 px-0",
-                    adminThread &&
-                      "bg-destructive/10 text-foreground hover:bg-destructive/10 hover:text-foreground"
-                  )}
+                  className="size-7 px-0"
                   type="button"
                 />
               }
@@ -837,12 +833,6 @@ export const ChatComposer = memo(function ChatComposer({
                   {planMode ? "Disable plan mode" : "Enable plan mode"}
                 </MenuItem>
               )}
-              {onAdminThreadChange && (
-                <MenuItem onClick={() => onAdminThreadChange(!adminThread)}>
-                  <ServerCogIcon />
-                  {adminThread ? "Disable admin mode" : "Enable admin mode"}
-                </MenuItem>
-              )}
             </MenuPopup>
           </Menu>
 
@@ -857,6 +847,32 @@ export const ChatComposer = memo(function ChatComposer({
                 selection={selection}
                 triggerClassName="h-7 max-w-full rounded-md px-2 text-xs/relaxed text-muted-foreground/70 hover:bg-muted hover:text-foreground/80"
               />
+            )}
+
+            {onAdminThreadChange && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <ComposerControl
+                      aria-label="Admin mode"
+                      aria-pressed={adminThread}
+                      className={cn(
+                        adminThread &&
+                          "bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive"
+                      )}
+                      disabled={disabled}
+                      onClick={() => onAdminThreadChange(!adminThread)}
+                      type="button"
+                    />
+                  }
+                >
+                  <ComposerControlIcon icon={ServerCogIcon} />
+                  <span>Admin</span>
+                </TooltipTrigger>
+                <TooltipPopup side="top">
+                  {adminThread ? "Disable admin mode" : "Enable admin mode"}
+                </TooltipPopup>
+              </Tooltip>
             )}
 
             {planMode && onPlanModeChange && (


### PR DESCRIPTION
## Description
Admin threads remain readable by org members, but only currently configured admins can send messages or execution input. Eligible admins now get a visible Admin mode toggle in the new cloud-thread composer, with a red active state.

## Release Note
Admin threads now accept input only from workspace admins and expose a clearer creation toggle.

## Test Plan
- [x] Verify non-admin rejection, admin interaction, toggle states, disabled submission behavior, and dashboard type safety

Made by [Open SWE](https://openswe.vercel.app/agents/4d318c54-2e7b-5b03-b187-9d95bcb28a23)