### PR TITLE
fix: correct GitHub OAuth storage documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Supported model IDs and per-model effort/reasoning rules live in `agent/dashboar
 
 ### Auth
 
-- **GitHub**: dual-mode. User OAuth tokens are encrypted-at-rest in thread metadata (`agent/encryption.py`, `utils/auth.py:resolve_github_token`). When no user token is available, falls back to a GitHub App installation token (`utils/github_app.py`). The installation token is also what configures the LangSmith sandbox's GitHub proxy.
+- **GitHub**: dual-mode. User OAuth tokens are encrypted at rest in the dashboard OAuth store and cached only in process during a run (`utils/auth.py:resolve_github_token`, `utils/github_token.py`). When no user token is available, falls back to a GitHub App installation token (`utils/github_app.py`). The installation token is also what configures the LangSmith sandbox's GitHub proxy.
 - **Webhooks**: GitHub signatures verified in `utils/github_comments.py:verify_github_signature`; Slack/Linear handled in their respective utils.
 - **Dashboard / UI**: GitHub OAuth login lives in `agent/dashboard/oauth.py` and `routes.py` (`/auth/login`, `/auth/callback`, `/auth/logout`, `/me`).
 


### PR DESCRIPTION
## Description
Align `CLAUDE.md` with the source and mirrored `AGENTS.md`: user OAuth tokens are encrypted in the dashboard OAuth store and cached only in process during runs.

## Release Note
none

## Test Plan
- [x] Confirm the Auth lines in `CLAUDE.md` and `AGENTS.md` match

Made by [Open SWE](https://openswe.vercel.app/agents/c6b44395-57c7-5013-85df-4fbe9fba033b)