### PR TITLE
fix: render Slack messages correctly in dashboard

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -60,7 +60,7 @@ async function openRunningThreadViaSlackLink(page: Page) {
 // "Open in Web" link, landing on the actual dashboard app.
 async function openThreadViaSlackLink(
   page: Page,
-  options: { repoPrivate?: boolean } = {},
+  options: { repoPrivate?: boolean; message?: string } = {},
 ) {
   await page.goto("/mock/slack");
   await page.locator("#reset").click();
@@ -70,7 +70,9 @@ async function openThreadViaSlackLink(
   await expect(page.locator("#thread")).toContainText("No messages yet");
   await page
     .locator("#text")
-    .fill("<@U0BOT> please add a greet() helper and open a PR");
+    .fill(
+      options.message ?? "<@U0BOT> please add a greet() helper and open a PR",
+    );
   await page.locator("#send").click();
   await expect(
     page.locator(".msg.bot").filter({ hasText: "Add greet() helper" }),
@@ -189,6 +191,34 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect(
       page.getByText("This thread has no messages yet."),
     ).toHaveCount(0);
+  });
+
+  test("renders Slack mrkdwn and identifies the Slack sender", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page, {
+      message:
+        "<@U0BOT> please add a greet() helper and open a PR; review *important* R&amp;D `<https://example.com/code|code docs>` <https://example.com/slack-docs|Slack docs>",
+    });
+    await expectTranscriptVisible(page);
+
+    const slackMessage = page
+      .locator('[data-message-surface="slack"]')
+      .filter({ hasText: "Slack docs" })
+      .first();
+    await expect(
+      slackMessage.getByRole("img", { name: "Slack" }),
+    ).toBeVisible();
+    await expect(slackMessage.locator("strong")).toHaveText("important");
+    await expect(slackMessage).toContainText("R&D");
+    await expect(slackMessage.locator("code")).toContainText("code docs");
+    await expect(
+      slackMessage.getByRole("link", { name: "code docs" }),
+    ).toHaveCount(0);
+    await expect(
+      slackMessage.getByRole("link", { name: "Slack docs" }),
+    ).toHaveAttribute("href", "https://example.com/slack-docs");
   });
 
   test("keeps sent Slack messages visible while work is folded", async ({

--- a/ui/src/features/agents/components/chat/ReplyCard.tsx
+++ b/ui/src/features/agents/components/chat/ReplyCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react"
 import { MessageCircle } from "lucide-react"
+import { SlackMrkdwn } from "../messages/SlackMrkdwn"
 import { Markdown } from "./Markdown"
 import type { ReactNode } from "react"
 import type { ToolExecutionChunk } from "@/features/agents/lib/types"
@@ -16,10 +17,6 @@ function headerLabel(
   if (isLinear) return pending ? "Commenting on Linear…" : "Commented on Linear"
   return pending ? "Replying in Slack…" : "Replied in Slack"
 }
-
-const SLACK_TOKEN = /<([^>]+)>/g
-const LINK_CLASS =
-  "text-foreground/90 underline decoration-foreground/40 break-words [overflow-wrap:anywhere]"
 
 type SlackTextObject = { type?: string; text?: string }
 type SlackBlock = {
@@ -41,56 +38,6 @@ function isSlackBlockArray(value: unknown): value is Array<SlackBlock> {
     Array.isArray(value) &&
     value.every((block) => !!block && typeof block === "object")
   )
-}
-
-// Slack mrkdwn isn't standard Markdown — rewrite its link/mention syntax for display
-// rather than feeding it to the Markdown renderer (which mis-renders *bold* etc.).
-function renderSlackBody(text: string): Array<ReactNode> {
-  const nodes: Array<ReactNode> = []
-  let lastIndex = 0
-  let key = 0
-  SLACK_TOKEN.lastIndex = 0
-  for (
-    let match = SLACK_TOKEN.exec(text);
-    match;
-    match = SLACK_TOKEN.exec(text)
-  ) {
-    if (match.index > lastIndex) nodes.push(text.slice(lastIndex, match.index))
-    const token = match[1] ?? ""
-    const sep = token.indexOf("|")
-    const target = sep === -1 ? token : token.slice(0, sep)
-    const label = sep === -1 ? "" : token.slice(sep + 1)
-    if (target.startsWith("@") || target.startsWith("#")) {
-      const sigil = target[0]
-      nodes.push(
-        <span key={key++} className="text-foreground/90">
-          {sigil}
-          {label || target.slice(1)}
-        </span>
-      )
-    } else if (target.startsWith("!")) {
-      nodes.push(
-        <span key={key++} className="text-foreground/90">
-          @{label || target.slice(1)}
-        </span>
-      )
-    } else {
-      nodes.push(
-        <a
-          key={key++}
-          href={target}
-          target="_blank"
-          rel="noreferrer"
-          className={LINK_CLASS}
-        >
-          {label || target}
-        </a>
-      )
-    }
-    lastIndex = match.index + match[0].length
-  }
-  if (lastIndex < text.length) nodes.push(text.slice(lastIndex))
-  return nodes
 }
 
 function blocksFromOptions(
@@ -128,7 +75,11 @@ function renderSlackBlocks(blocks: Array<SlackBlock>): ReactNode {
               key={index}
               className="[overflow-wrap:anywhere] break-words whitespace-pre-wrap"
             >
-              {renderSlackBody(block.text.text ?? "")}
+              {block.text.type === "mrkdwn" ? (
+                <SlackMrkdwn text={block.text.text ?? ""} />
+              ) : (
+                block.text.text
+              )}
             </div>
           )
         }
@@ -186,7 +137,7 @@ export const ReplyCard = memo(function ReplyCard({ chunk }: ReplyCardProps) {
               renderSlackBlocks(blocks)
             ) : (
               <div className="[overflow-wrap:anywhere] break-words whitespace-pre-wrap">
-                {renderSlackBody(body)}
+                <SlackMrkdwn text={body} />
               </div>
             )}
           </div>

--- a/ui/src/features/agents/components/messages/SlackMrkdwn.test.tsx
+++ b/ui/src/features/agents/components/messages/SlackMrkdwn.test.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { SlackMrkdwn } from "./SlackMrkdwn"
+
+describe("SlackMrkdwn", () => {
+  it("renders Slack links, mentions, and inline formatting", () => {
+    const html = renderToStaticMarkup(
+      <SlackMrkdwn text="Read *important* <https://example.com/docs|docs> with <@U123|Alice>" />
+    )
+
+    expect(html).toContain("<strong>important</strong>")
+    expect(html).toContain('href="https://example.com/docs"')
+    expect(html).toContain(">docs</a>")
+    expect(html).toContain("@Alice")
+  })
+
+  it("keeps formatting active across Slack tokens", () => {
+    const html = renderToStaticMarkup(
+      <SlackMrkdwn
+        text={
+          "*See <https://example.com/docs|docs>* and <https://example.com/encoded|R&amp;amp;D>"
+        }
+      />
+    )
+
+    expect(html).toContain("<strong>See <a")
+    expect(html).toContain(">docs</a></strong>")
+    expect(html).toContain(">R&amp;amp;D</a>")
+
+    const underscoredUrl = renderToStaticMarkup(
+      <SlackMrkdwn text="_See <https://example.com/foo_bar|docs>_" />
+    )
+    expect(underscoredUrl).toContain("<em>See <a")
+    expect(underscoredUrl).toContain(">docs</a></em>")
+  })
+
+  it("keeps code spans inert and decodes Slack entities", () => {
+    const html = renderToStaticMarkup(
+      <SlackMrkdwn
+        text={
+          "R&amp;D `<https://example.com/code|code docs>` <!date^1700000000^{date_short}|Posted Nov 14>"
+        }
+      />
+    )
+
+    expect(html).toContain("R&amp;D")
+    expect(html).toContain("&lt;https://example.com/code|code docs&gt;")
+    expect(html).not.toContain('href="https://example.com/code"')
+    expect(html).toContain("Posted Nov 14")
+    expect(html).not.toContain("@Posted Nov 14")
+  })
+
+  it("does not create links for unsupported URL schemes", () => {
+    const html = renderToStaticMarkup(
+      <SlackMrkdwn text="<javascript:alert(1)|unsafe>" />
+    )
+
+    expect(html).not.toContain("href=")
+    expect(html).toContain("unsafe")
+  })
+})

--- a/ui/src/features/agents/components/messages/SlackMrkdwn.tsx
+++ b/ui/src/features/agents/components/messages/SlackMrkdwn.tsx
@@ -1,0 +1,205 @@
+import { Fragment } from "react"
+import type { ReactNode } from "react"
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"])
+const LINK_CLASS =
+  "text-foreground/90 underline decoration-foreground/40 break-words [overflow-wrap:anywhere]"
+
+function decodeSlackText(text: string): string {
+  return text.replace(/&(?:amp|lt|gt);/g, (entity) => {
+    if (entity === "&amp;") return "&"
+    if (entity === "&lt;") return "<"
+    return ">"
+  })
+}
+
+function safeHref(target: string): string | null {
+  try {
+    const url = new URL(target)
+    return ALLOWED_PROTOCOLS.has(url.protocol) ? target : null
+  } catch {
+    return null
+  }
+}
+
+function closingDelimiter(
+  text: string,
+  delimiter: string,
+  start: number,
+  end: number
+): number {
+  if (delimiter === "`") {
+    const closing = text.indexOf(delimiter, start)
+    if (closing === -1 || closing >= end) return -1
+    return text.slice(start, closing).includes("\n") ? -1 : closing
+  }
+
+  let cursor = start
+  while (cursor < end) {
+    const character = text[cursor]
+    if (character === "\n") return -1
+    if (character === "`") {
+      const codeEnd = text.indexOf("`", cursor + 1)
+      if (codeEnd !== -1 && codeEnd < end) {
+        cursor = codeEnd + 1
+        continue
+      }
+    }
+    if (character === "<") {
+      const tokenEnd = text.indexOf(">", cursor + 1)
+      if (
+        tokenEnd !== -1 &&
+        tokenEnd < end &&
+        !text.slice(cursor + 1, tokenEnd).includes("\n")
+      ) {
+        cursor = tokenEnd + 1
+        continue
+      }
+    }
+    if (character === delimiter) return cursor > start ? cursor : -1
+    cursor += 1
+  }
+  return -1
+}
+
+function slackTokenNode(token: string, key: string): ReactNode {
+  const separator = token.indexOf("|")
+  const rawTarget = separator === -1 ? token : token.slice(0, separator)
+  const rawLabel = separator === -1 ? "" : token.slice(separator + 1)
+  const target = decodeSlackText(rawTarget)
+  const label = decodeSlackText(rawLabel)
+
+  if (target.startsWith("@") || target.startsWith("#")) {
+    const sigil = target[0]
+    const displayLabel = (label || target.slice(1)).replace(/^[@#]/, "")
+    return (
+      <span key={key} className="text-foreground/90">
+        {sigil}
+        {displayLabel}
+      </span>
+    )
+  }
+
+  if (target.startsWith("!date^")) {
+    return <Fragment key={key}>{label || target}</Fragment>
+  }
+
+  if (target.startsWith("!subteam^")) {
+    return (
+      <span key={key} className="text-foreground/90">
+        {label || "@subteam"}
+      </span>
+    )
+  }
+
+  if (target.startsWith("!")) {
+    const displayLabel = label || target.slice(1)
+    return (
+      <span key={key} className="text-foreground/90">
+        {displayLabel.startsWith("@") ? displayLabel : `@${displayLabel}`}
+      </span>
+    )
+  }
+
+  const href = safeHref(target)
+  if (!href) {
+    const fallback = rawLabel || `&lt;${rawTarget}&gt;`
+    return (
+      <Fragment key={key}>
+        {renderRange(fallback, 0, fallback.length, `${key}-fallback`)}
+      </Fragment>
+    )
+  }
+
+  const linkText = rawLabel || rawTarget
+  return (
+    <a
+      key={key}
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className={LINK_CLASS}
+    >
+      {renderRange(linkText, 0, linkText.length, `${key}-label`)}
+    </a>
+  )
+}
+
+function renderRange(
+  text: string,
+  start: number,
+  end: number,
+  keyPrefix: string
+): Array<ReactNode> {
+  const nodes: Array<ReactNode> = []
+  let cursor = start
+  let literalStart = start
+
+  const flushLiteral = (until: number) => {
+    if (until > literalStart) {
+      nodes.push(decodeSlackText(text.slice(literalStart, until)))
+    }
+  }
+
+  while (cursor < end) {
+    const character = text[cursor]
+    const key = `${keyPrefix}-${cursor}`
+
+    if (character === "`") {
+      const closing = closingDelimiter(text, "`", cursor + 1, end)
+      if (closing !== -1) {
+        flushLiteral(cursor)
+        nodes.push(
+          <code key={key} className="rounded bg-background/60 px-1 font-mono">
+            {decodeSlackText(text.slice(cursor + 1, closing))}
+          </code>
+        )
+        cursor = closing + 1
+        literalStart = cursor
+        continue
+      }
+    }
+
+    if (character === "*" || character === "_" || character === "~") {
+      const closing = closingDelimiter(text, character, cursor + 1, end)
+      if (closing !== -1) {
+        flushLiteral(cursor)
+        const children = renderRange(text, cursor + 1, closing, `${key}-format`)
+        if (character === "*") nodes.push(<strong key={key}>{children}</strong>)
+        else if (character === "_") nodes.push(<em key={key}>{children}</em>)
+        else nodes.push(<s key={key}>{children}</s>)
+        cursor = closing + 1
+        literalStart = cursor
+        continue
+      }
+    }
+
+    if (character === "<") {
+      const closing = text.indexOf(">", cursor + 1)
+      if (
+        closing !== -1 &&
+        closing < end &&
+        !text.slice(cursor + 1, closing).includes("\n")
+      ) {
+        flushLiteral(cursor)
+        nodes.push(slackTokenNode(text.slice(cursor + 1, closing), key))
+        cursor = closing + 1
+        literalStart = cursor
+        continue
+      }
+    }
+
+    cursor += 1
+  }
+
+  flushLiteral(end)
+  return nodes
+}
+
+export function renderSlackMrkdwn(text: string): Array<ReactNode> {
+  return renderRange(text, 0, text.length, "slack")
+}
+
+export function SlackMrkdwn({ text }: { text: string }) {
+  return <>{renderSlackMrkdwn(text)}</>
+}

--- a/ui/src/features/agents/components/messages/UserMessage.tsx
+++ b/ui/src/features/agents/components/messages/UserMessage.tsx
@@ -1,12 +1,15 @@
 import { ChevronDown, ChevronRight } from "lucide-react"
+import { IoLogoSlack } from "react-icons/io5"
 import { useCallback, useLayoutEffect, useRef, useState } from "react"
 
 import { SkillPromptText } from "../SkillBadge"
 import { MessageTimestamp } from "./MessageTimestamp"
+import { SlackMrkdwn } from "./SlackMrkdwn"
 import type { Message } from "@/features/agents/lib/types"
 
 export function UserMessage({ message }: { message: Message }) {
   const isSystem = message.structuredSenderKind === "system"
+  const isSlack = message.structuredSurface === "slack"
   const text = message.chunks
     .filter((c) => c.kind === "text")
     .map((c) => c.text)
@@ -42,6 +45,7 @@ export function UserMessage({ message }: { message: Message }) {
     <div
       className={`group/turn my-4 flex flex-col gap-1 ${isSystem ? "items-start" : "items-end"}`}
       data-message-sender-kind={message.structuredSenderKind}
+      data-message-surface={message.structuredSurface}
     >
       <div className="max-w-[80%]">
         {isSystem ? (
@@ -60,9 +64,14 @@ export function UserMessage({ message }: { message: Message }) {
             <span>{message.structuredSenderName || "Context"}</span>
           </button>
         ) : (
-          message.structuredSenderName && (
-            <div className="mb-1 px-1 text-[11px] font-medium text-muted-foreground">
-              {message.structuredSenderName}
+          (message.structuredSenderName || isSlack) && (
+            <div className="mb-1 flex items-center gap-1 px-1 text-[11px] font-medium text-muted-foreground">
+              {isSlack && (
+                <IoLogoSlack className="size-3" role="img" aria-label="Slack" />
+              )}
+              {message.structuredSenderName && (
+                <span>{message.structuredSenderName}</span>
+              )}
             </div>
           )
         )}
@@ -98,7 +107,11 @@ export function UserMessage({ message }: { message: Message }) {
                   WebkitMaskImage: textEdgeMask,
                 }}
               >
-                <SkillPromptText text={text} />
+                {isSlack ? (
+                  <SlackMrkdwn text={text} />
+                ) : (
+                  <SkillPromptText text={text} />
+                )}
               </div>
             )}
           </div>

--- a/ui/src/features/agents/lib/streamMessagesToUi.test.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.test.ts
@@ -35,12 +35,14 @@ describe("streamMessagesToUi", () => {
       structuredSenderId: "github:alice",
       structuredSenderKind: "person",
       structuredSenderName: "Alice",
+      structuredSurface: "web",
       chunks: [{ kind: "text", text: "Hello <b>world</b>" }],
     })
     expect(messages[1]).toMatchObject({
       author: "system",
       structuredSenderKind: "system",
       structuredSenderName: "Scheduler",
+      structuredSurface: "automation",
       chunks: [{ kind: "text", text: "Check CI" }],
     })
     expect(messages[2]).toMatchObject({

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -378,6 +378,7 @@ export function streamMessagesToUi(
           ? {
               structuredSenderId: parsed.sender,
               structuredSenderKind: parsed.senderKind,
+              structuredSurface: parsed.surface,
               structuredSenderName:
                 entity?.displayName ??
                 (entity?.handle ? `@${entity.handle}` : undefined),

--- a/ui/src/features/agents/lib/structuredInputMessages.test.ts
+++ b/ui/src/features/agents/lib/structuredInputMessages.test.ts
@@ -54,6 +54,7 @@ describe("structured input messages", () => {
       content: "please add a greet() helper",
       sender: "slack:U_ALICE",
       senderKind: "person",
+      surface: "slack",
     })
   })
 
@@ -67,6 +68,7 @@ describe("structured input messages", () => {
       content: "ship it",
       sender: "slack:U_ALICE",
       senderKind: "person",
+      surface: "slack",
     })
   })
 
@@ -80,6 +82,7 @@ describe("structured input messages", () => {
       content: "Fix it",
       sender: "linear:dev@example.com",
       senderKind: "person",
+      surface: "linear",
     })
   })
 
@@ -102,6 +105,7 @@ describe("structured input messages", () => {
       content: "Hello & welcome",
       sender: "github:alice",
       senderKind: "person",
+      surface: "web",
     })
     expect(
       parseStructuredInput(
@@ -113,6 +117,7 @@ describe("structured input messages", () => {
       content: "Check CI",
       sender: "system:scheduler",
       senderKind: "system",
+      surface: "automation",
     })
   })
 

--- a/ui/src/features/agents/lib/structuredInputMessages.ts
+++ b/ui/src/features/agents/lib/structuredInputMessages.ts
@@ -13,6 +13,7 @@ export type ParsedStructuredInput =
       content: string
       sender: string
       senderKind: StructuredSenderKind
+      surface?: string
     }
   | { type: "legacy"; content: string }
 
@@ -175,6 +176,7 @@ export function parseStructuredInput(
         content: decodeXmlText(split.content),
         sender: attributes.sender,
         senderKind: senderKind(attributes, entities),
+        surface: attributes.surface,
       }
     }
   }

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -155,6 +155,7 @@ export interface Message {
   structuredSenderId?: string
   structuredSenderKind?: "person" | "system"
   structuredSenderName?: string
+  structuredSurface?: string
   /** Id of the user message that opened this agent run and keys its diff artifact. */
   turnKey?: string
   /** Timestamp of the first message in an agent turn; used to derive work duration. */


### PR DESCRIPTION
## Description
Slack-origin messages displayed literal Slack syntax and lacked attribution; retain surface metadata, safely render mrkdwn, and show the sidebar Slack icon beside senders.
## Release Note
Slack-origin dashboard messages now render links and formatting correctly and show Slack attribution.
## Test Plan
- [x] Verify the real Slack-to-dashboard Playwright flow renders formatting, safe links, inert code, entity decoding, and the Slack icon.

Made by [Open SWE](https://openswe.vercel.app/agents/7501f2d9-6e8a-5148-aec4-e2811305fa98)