### PR TITLE
feat: show thread activity by run location

### DIFF
--- a/desktop/src/local-thread-store.cjs
+++ b/desktop/src/local-thread-store.cjs
@@ -3,7 +3,7 @@ const path = require("node:path")
 const { randomUUID } = require("node:crypto")
 
 const STATUSES = new Set(["starting", "idle", "running", "error"])
-const MUTABLE_FIELDS = new Set(["title", "modelId", "effort", "status"])
+const MUTABLE_FIELDS = new Set(["title", "modelId", "effort", "status", "viewed"])
 const SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 function isRecord(value) {
@@ -88,6 +88,7 @@ function normalizeThread(value) {
     modelId: stringOrNull(value.modelId),
     effort: stringOrNull(value.effort),
     status: STATUSES.has(value.status) ? value.status : "error",
+    viewed: value.viewed !== false,
     createdAt: value.createdAt,
     updatedAt: value.updatedAt,
     checkpoint,
@@ -168,6 +169,7 @@ class LocalThreadStore {
       modelId: stringOrNull(input.modelId),
       effort: stringOrNull(input.effort),
       status: "idle",
+      viewed: true,
       createdAt: now,
       updatedAt: now,
       checkpoint: { repo: null, ref: null },
@@ -196,7 +198,11 @@ class LocalThreadStore {
       if (!STATUSES.has(patch.status)) throw new Error("Invalid local thread status")
       next.status = patch.status
     }
-    next.updatedAt = this.now()
+    if ("viewed" in patch) {
+      if (typeof patch.viewed !== "boolean") throw new Error("Invalid viewed state")
+      next.viewed = patch.viewed
+    }
+    if (Object.keys(patch).some((key) => key !== "viewed")) next.updatedAt = this.now()
     this.threads.set(id, next)
     this.persist()
     return this.get(id)

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -298,6 +298,7 @@ function configureDesktopIpc() {
     requireTrustedDesktopIpc(event);
     return localThreadStore.update(input?.threadId, {
       status: input?.status,
+      ...(typeof input?.viewed === "boolean" ? { viewed: input.viewed } : {}),
       ...(typeof input?.modelId === "string" ? { modelId: input.modelId } : {}),
       ...(typeof input?.effort === "string" ? { effort: input.effort } : {}),
     });

--- a/desktop/test/local-thread-store.test.cjs
+++ b/desktop/test/local-thread-store.test.cjs
@@ -53,10 +53,11 @@ test("reconciles interrupted threads and retains checkpoint refs until deletion"
   const store = fixture.create()
   const thread = store.create({ cwd: path.resolve("/tmp/project"), prompt: "work" })
   store.setCheckpoint(thread.id, { repo: path.resolve("/tmp/project"), ref: "refs/open-swe/local/thread-1" })
-  store.update(thread.id, { status: "running" })
+  store.update(thread.id, { status: "running", viewed: false })
 
   const restored = fixture.create()
   assert.equal(restored.get(thread.id).status, "error")
+  assert.equal(restored.get(thread.id).viewed, false)
   assert.equal(restored.get(thread.id).checkpoint.ref, "refs/open-swe/local/thread-1")
   assert.equal(restored.delete(thread.id).checkpoint.ref, "refs/open-swe/local/thread-1")
   assert.equal(restored.get(thread.id), null)

--- a/ui/src/components/AppCommandPalette.test.tsx
+++ b/ui/src/components/AppCommandPalette.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     title: "Local result",
     cwd: "/tmp/repo",
     status: "idle",
+    viewed: true,
     createdAt: 1,
     updatedAt: 2,
     modelId: null,

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -20,6 +20,7 @@ export interface DesktopLocalThreadSummary {
   cwd: string
   title: string
   status: "starting" | "idle" | "running" | "error"
+  viewed: boolean
   createdAt: number
   updatedAt: number
   modelId: string | null
@@ -178,6 +179,7 @@ declare global {
       updateLocalThread: (input: {
         threadId: string
         status: DesktopLocalThreadSummary["status"]
+        viewed?: boolean
         modelId?: string
         effort?: string
       }) => Promise<DesktopLocalThreadSummary | null>

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -212,6 +212,24 @@ export function AgentsSidebar({
   )
   const cloudThreadCount =
     filteredActive.length + (showResolved ? filteredResolved.length : 0)
+  const cloudActivity = {
+    running: activeThreads.filter((thread) => thread.status === "running")
+      .length,
+    completed: activeThreads.filter(
+      (thread) => thread.status === "finished" && !thread.viewed
+    ).length,
+  }
+  const localActivity = {
+    running: localSessions.filter(
+      (thread) => thread.status === "running" || thread.status === "starting"
+    ).length,
+    completed: localSessions.filter(
+      (thread) =>
+        !thread.viewed &&
+        thread.status !== "running" &&
+        thread.status !== "starting"
+    ).length,
+  }
   const showLocalThreads = isDesktop && desktopThreadSource === "local"
   const showCloudThreads = !isDesktop || desktopThreadSource === "cloud"
 
@@ -283,6 +301,8 @@ export function AgentsSidebar({
             source={desktopThreadSource}
             localCount={localSessionCount}
             cloudCount={cloudThreadCount}
+            localActivity={localActivity}
+            cloudActivity={cloudActivity}
             onSourceChange={setDesktopThreadSource}
           />
         )}

--- a/ui/src/features/agents/components/DesktopThreadSourceToggle.test.tsx
+++ b/ui/src/features/agents/components/DesktopThreadSourceToggle.test.tsx
@@ -15,12 +15,18 @@ describe("DesktopThreadSourceToggle", () => {
         source="local"
         localCount={4}
         cloudCount={7}
+        localActivity={{ running: 1, completed: 2 }}
+        cloudActivity={{ running: 3, completed: 1 }}
         onSourceChange={onSourceChange}
       />
     )
 
-    const cloud = screen.getByRole("button", { name: "Cloud threads, 7" })
-    const local = screen.getByRole("button", { name: "This Mac threads, 4" })
+    const cloud = screen.getByRole("button", {
+      name: "Cloud threads, 7, 3 running, 1 completed",
+    })
+    const local = screen.getByRole("button", {
+      name: "This Mac threads, 4, 1 running, 2 completed",
+    })
     expect(cloud.getAttribute("aria-pressed")).toBe("false")
     expect(local.getAttribute("aria-pressed")).toBe("true")
 

--- a/ui/src/features/agents/components/DesktopThreadSourceToggle.tsx
+++ b/ui/src/features/agents/components/DesktopThreadSourceToggle.tsx
@@ -3,15 +3,24 @@ import { CloudIcon, LaptopIcon } from "@phosphor-icons/react"
 import type { DesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
 import { cn } from "@/lib/utils"
 
+export interface ThreadActivity {
+  running: number
+  completed: number
+}
+
 export function DesktopThreadSourceToggle({
   source,
   localCount,
   cloudCount,
+  localActivity,
+  cloudActivity,
   onSourceChange,
 }: {
   source: DesktopThreadSource
   localCount: number
   cloudCount: number
+  localActivity: ThreadActivity
+  cloudActivity: ThreadActivity
   onSourceChange: (source: DesktopThreadSource) => void
 }) {
   return (
@@ -23,6 +32,7 @@ export function DesktopThreadSourceToggle({
       <SourceButton
         label="Cloud"
         count={cloudCount}
+        activity={cloudActivity}
         active={source === "cloud"}
         icon={CloudIcon}
         onClick={() => onSourceChange("cloud")}
@@ -30,6 +40,7 @@ export function DesktopThreadSourceToggle({
       <SourceButton
         label="This Mac"
         count={localCount}
+        activity={localActivity}
         active={source === "local"}
         icon={LaptopIcon}
         onClick={() => onSourceChange("local")}
@@ -41,12 +52,14 @@ export function DesktopThreadSourceToggle({
 function SourceButton({
   label,
   count,
+  activity,
   active,
   icon: Icon,
   onClick,
 }: {
   label: string
   count: number
+  activity: ThreadActivity
   active: boolean
   icon: typeof CloudIcon
   onClick: () => void
@@ -54,7 +67,7 @@ function SourceButton({
   return (
     <button
       type="button"
-      aria-label={`${label} threads, ${count}`}
+      aria-label={`${label} threads, ${count}, ${activity.running} running, ${activity.completed} completed`}
       aria-pressed={active}
       onClick={onClick}
       className={cn(
@@ -74,6 +87,40 @@ function SourceButton({
       >
         {count}
       </span>
+      {activity.running > 0 && (
+        <ActivityCount
+          label={`${activity.running} running`}
+          count={activity.running}
+          className="bg-primary"
+        />
+      )}
+      {activity.completed > 0 && (
+        <ActivityCount
+          label={`${activity.completed} completed`}
+          count={activity.completed}
+          className="bg-success-foreground"
+        />
+      )}
     </button>
+  )
+}
+
+function ActivityCount({
+  label,
+  count,
+  className,
+}: {
+  label: string
+  count: number
+  className: string
+}) {
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 text-[9px] tabular-nums"
+      title={label}
+    >
+      <span className={cn("size-1.5 rounded-full", className)} />
+      {count}
+    </span>
   )
 }

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -278,6 +278,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
       const updated = await window.openSweDesktop?.updateLocalThread({
         threadId: sessionId,
         status,
+        viewed: status === "running",
         ...(model && { modelId: model.modelId, effort: model.effort }),
       })
       if (!updated) return
@@ -290,6 +291,25 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     },
     [queryClient, sessionId]
   )
+
+  useEffect(() => {
+    if (!thread || thread.viewed || isRunning) return
+    void window.openSweDesktop
+      ?.updateLocalThread({
+        threadId: sessionId,
+        status: thread.status,
+        viewed: true,
+      })
+      .then((updated) => {
+        if (!updated) return
+        queryClient.setQueryData(localThreadKeys.detail(sessionId), updated)
+        queryClient.setQueryData<Array<DesktopLocalThreadSummary>>(
+          localThreadKeys.all,
+          (threads = []) =>
+            threads.map((item) => (item.id === sessionId ? updated : item))
+        )
+      })
+  }, [isRunning, queryClient, sessionId, thread])
 
   const submit = useCallback(
     async (

--- a/ui/src/lib/appCommands.test.ts
+++ b/ui/src/lib/appCommands.test.ts
@@ -53,6 +53,7 @@ describe("app commands", () => {
       title: "Fix local search",
       cwd: "/tmp/repo",
       status: "idle",
+      viewed: true,
       createdAt: 1,
       updatedAt: 2,
       modelId: null,


### PR DESCRIPTION
## Description
Show running and unseen-completed counts on the Cloud and This Mac tabs. Persist local viewed state so both surfaces derive activity consistently.

## Release Note
Desktop source tabs now show running and completed thread activity.

## Test Plan
- [x] Verify Cloud and This Mac expose running/completed counts
- [x] Verify local completion state survives reload

Made by [Open SWE](https://openswe.vercel.app/agents/01a02023-d8c5-774e-a54e-c2adc0555ba6)