### PR TITLE
fix: synchronize thread status caches

### DIFF
--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { useSubmitAgentMessage } from "./useSubmitAgentMessage"
 import type { AgentThread } from "@/features/agents/lib/types"
 import { AgentsApiError } from "@/features/agents/lib/api"
+import type { SidebarThreads } from "@/features/agents/lib/api"
 import { agentThreadKeys } from "@/features/agents/lib/queries"
 
 const stream = { isLoading: false, submit: vi.fn(async () => undefined) }
@@ -35,11 +36,23 @@ function setup() {
   const client = new QueryClient({
     defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
   })
-  client.setQueryData(agentThreadKeys.detail(THREAD_ID), {
+  const thread = {
     id: THREAD_ID,
     status: "idle",
     messages: [],
-  } as unknown as AgentThread)
+  } as unknown as AgentThread
+  client.setQueryData(agentThreadKeys.detail(THREAD_ID), thread)
+  client.setQueryData<SidebarThreads>(
+    agentThreadKeys.sidebar({
+      activeLimit: 50,
+      resolvedLimit: 20,
+      includeAutomations: false,
+    }),
+    {
+      active: { items: [thread], limit: 50, hasMore: false },
+      resolved: { items: [], limit: 20, hasMore: false },
+    }
+  )
   const queuedCounts: Array<number> = []
   client.getQueryCache().subscribe(() => {
     const thread = client.getQueryData<AgentThread>(
@@ -60,6 +73,12 @@ function queuedMessages(client: QueryClient) {
     ?.queuedMessages
 }
 
+function sidebarStatus(client: QueryClient) {
+  return client.getQueriesData<SidebarThreads>({
+    queryKey: ["agent-threads", "lists", "sidebar"],
+  })[0]?.[1]?.active.items[0]?.status
+}
+
 beforeEach(() => {
   stream.isLoading = false
   stream.submit.mockClear()
@@ -70,11 +89,12 @@ beforeEach(() => {
 describe("useSubmitAgentMessage", () => {
   it("never flashes a queued bubble when the send starts a new run", async () => {
     queueMessage.mockRejectedValueOnce(new AgentsApiError(409, "no active run"))
-    const { queuedCounts, result } = setup()
+    const { client, queuedCounts, result } = setup()
 
     await result.current.mutateAsync({ content: "hi", images: [] })
 
     await waitFor(() => expect(stream.submit).toHaveBeenCalled())
+    expect(sidebarStatus(client)).toBe("running")
     expect(queuedCounts.every((count) => count === 0)).toBe(true)
   })
 

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
@@ -6,7 +6,7 @@ import type { AgentThread } from "@/features/agents/lib/types"
 import { AgentsApiError, agentsApi } from "@/features/agents/lib/api"
 import {
   agentThreadKeys,
-  invalidateAgentThreadLists,
+  setAgentThreadStatus,
 } from "@/features/agents/lib/queries"
 
 /**
@@ -149,17 +149,11 @@ export function useSubmitAgentMessage(threadId: string) {
           // 409 active-run race), but `onSuccess` already optimistically set
           // `status: "running"`. Surface the failure and clear the busy state
           // instead of leaving the thread falsely running.
-          queryClient.setQueryData(agentThreadKeys.detail(threadId), (prev) =>
-            prev ? { ...prev, status: "error" as const } : prev
-          )
-          invalidateAgentThreadLists(queryClient)
+          setAgentThreadStatus(queryClient, threadId, "error")
         })
     },
     onSuccess: () => {
-      queryClient.setQueryData(agentThreadKeys.detail(threadId), (prev) =>
-        prev ? { ...prev, status: "running" as const } : prev
-      )
-      invalidateAgentThreadLists(queryClient)
+      setAgentThreadStatus(queryClient, threadId, "running")
     },
   })
 }

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -15,7 +15,13 @@ import type {
   ThreadTurnDiffOptions,
   ThreadsPageParams,
 } from "./api"
-import type { AgentThread, Chunk, ImageChunk, Message } from "./types"
+import type {
+  AgentStatus,
+  AgentThread,
+  Chunk,
+  ImageChunk,
+  Message,
+} from "./types"
 import type { Skill, SkillInput } from "@/lib/api"
 import { api } from "@/lib/api"
 
@@ -44,6 +50,28 @@ export const agentThreadKeys = {
 
 export function invalidateAgentThreadLists(queryClient: QueryClient): void {
   void queryClient.invalidateQueries({ queryKey: agentThreadKeys.lists })
+}
+
+export function setAgentThreadStatus(
+  queryClient: QueryClient,
+  threadId: string,
+  status: AgentStatus
+): void {
+  const update = (thread: AgentThread) =>
+    thread.id === threadId ? { ...thread, status } : thread
+  queryClient.setQueryData<AgentThread>(
+    agentThreadKeys.detail(threadId),
+    (prev) => (prev ? update(prev) : prev)
+  )
+  queryClient.setQueriesData<SidebarThreads>(
+    { queryKey: ["agent-threads", "lists", "sidebar"] },
+    (prev) =>
+      prev && {
+        ...prev,
+        active: { ...prev.active, items: prev.active.items.map(update) },
+        resolved: { ...prev.resolved, items: prev.resolved.items.map(update) },
+      }
+  )
 }
 
 export function seedAgentThreadLists(


### PR DESCRIPTION
## Description
Keep detail and sidebar thread status projections synchronized when a run starts or fails to start.

## Release Note
Fixed stale thread activity indicators in the dashboard sidebar.

## Test Plan
- [x] Verify a new run immediately marks its cached sidebar row running

Made by [Open SWE](https://openswe.vercel.app/agents/01a02021-5c4e-7419-b0d0-824d94aa4cb2)