### PR TITLE
fix: reserve Slack reactions for active work

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -158,7 +158,7 @@ SLACK_SOURCE_GUIDANCE = """This run was triggered from Slack.
 - `slack_thread_reply` is the canonical user-facing output. For information-only requests, put the complete answer there and do not repeat it in the final assistant response.
 - Keep every `slack_thread_reply` as concise as possible: default to one sentence with only the outcome/status and link, or one blocking question. Omit greetings, preambles, headings, recaps, implementation details, and redundant context; use bullets only when multiple items are essential.
 - Never paste long output, diffs, file listings, or multi-section write-ups into Slack. Publish necessary detail with `save_plan` and send only a one-line summary plus its link.
-- For follow-ups, use `slack_add_reaction` instead of a perfunctory status reply. Never use `white_check_mark`, because teams use it to indicate that a pull request is approved.
+- For follow-ups that require action, use `slack_add_reaction` instead of a perfunctory status reply, then follow up with the outcome. A reaction commits you to taking action: never react to a message you will handle with `no_op`. Never use `white_check_mark`, because teams use it to indicate that a pull request is approved.
 - When asked to move or continue the current thread in another Slack thread, use `slack_move_thread` with a concise, non-sensitive message to preserve history and detach the original thread.
 - When asked to break out work, use `slack_start_new_thread` with a headline-only title and self-contained instructions.
 - When a plan is ready, send its review link with `slack_thread_reply`, pass `options=["Approve & implement", "Request changes"]`, and invite manual feedback too; use these options rather than constructing custom Block Kit."""

--- a/agent/tools/slack_add_reaction.py
+++ b/agent/tools/slack_add_reaction.py
@@ -10,9 +10,10 @@ async def slack_add_reaction(
     emoji: str,
     message_ts: str | None = None,
 ) -> dict[str, Any]:
-    """Add a context-appropriate reaction to a Slack message in the current thread.
+    """Commit to acting on a Slack message by adding a context-appropriate reaction.
 
-    Prefer `saluting_face` for taking ownership, `eyes` for active review,
+    Use this only when work will continue and always follow up with the outcome; never react before
+    `no_op`. Prefer `saluting_face` for taking ownership, `eyes` for active review,
     `thinking_face` for investigation, and `tada` for genuine wins. Never use
     `white_check_mark`, because teams use it to indicate that a pull request is approved.
     To target a specific message, pass its `message_ts` identifier shown in Slack context.

--- a/agent/tools/slack_add_reaction.py
+++ b/agent/tools/slack_add_reaction.py
@@ -12,8 +12,8 @@ async def slack_add_reaction(
 ) -> dict[str, Any]:
     """Commit to acting on a Slack message by adding a context-appropriate reaction.
 
-    Use this only when work will continue and always follow up with the outcome; never react before
-    `no_op`. Prefer `saluting_face` for taking ownership, `eyes` for active review,
+    Use this only when work will continue and always follow up with the outcome; never react to
+    a message you will handle with `no_op`. Prefer `saluting_face` for taking ownership,
     `thinking_face` for investigation, and `tada` for genuine wins. Never use
     `white_check_mark`, because teams use it to indicate that a pull request is approved.
     To target a specific message, pass its `message_ts` identifier shown in Slack context.

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -101,8 +101,9 @@ _UNTAGGED_REPLY_PREAMBLE = (
     "conversation, answers to your questions, and follow-up instructions are addressed to you. "
     "Someone thinking out loud, talking to another person, or commenting on the thread without "
     "expecting you to act is not.\n\n"
-    "If it is not addressed to you, call `no_op` and post nothing. Staying silent is the right "
-    "outcome; an unwanted reply from an untagged message is worse than no reply. If it is "
+    "If it is not addressed to you, call `no_op` and post nothing, including no reaction. Staying "
+    "silent is the right outcome; an unwanted reply or reaction from an untagged message is worse "
+    "than no reply. If it is "
     "addressed to you, handle it exactly as you would a direct mention.\n\n"
 )
 


### PR DESCRIPTION
## Description
Passive untagged thread events could receive a reaction before the agent chose `no_op`. Make reactions an explicit commitment to continued work and require a follow-up outcome.

## Release Note
Slack reactions now indicate that Open SWE is actively handling a request.

## Test Plan
- [x] Verify untagged-message and reaction-tool guidance with focused Slack tests

Made by [Open SWE](https://openswe.vercel.app/agents/f1095097-5c0e-5647-9a42-2052c69df5b2)