### PR TITLE
fix: render local task calls as subagents

### DIFF
--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -761,7 +761,7 @@ def _is_move_followup(text: str) -> bool:
 
 def _is_approval(text: str) -> bool:
     t = text.lower()
-    return "approved" in t and "implement" in t
+    return "the plan has been approved" in t or ("approved" in t and "implement" in t)
 
 
 def _is_revision(text: str) -> bool:

--- a/ui/src/features/agents/lib/streamMessagesToUi.test.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.test.ts
@@ -101,6 +101,28 @@ describe("streamMessagesToUi", () => {
     ).toEqual(["user-1", "user-2"])
   })
 
+  it("identifies local task calls as subagents", () => {
+    const messages = streamMessagesToUi([
+      new AIMessage({
+        id: "ai-1",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            name: "task",
+            args: { description: "Investigate the issue" },
+            type: "tool_call",
+          },
+        ],
+      }),
+    ])
+
+    expect(messages[0]?.chunks[0]).toMatchObject({
+      kind: "tool-execution",
+      toolKind: "task",
+    })
+  })
+
   it("attaches validated output iframe artifacts to their tool call", () => {
     const messages = streamMessagesToUi([
       new HumanMessage({ id: "user-1", content: "draw a chart" }),

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -41,6 +41,7 @@ type ToolKind = ToolExecutionChunk["toolKind"]
 
 function toolKind(name: string): ToolKind {
   const lowered = name.toLowerCase()
+  if (lowered === "task") return "task"
   if (lowered === "slack_thread_reply") return "slack"
   if (lowered === "linear_comment") return "linear"
   if (lowered === "write_todos") return "other"


### PR DESCRIPTION
## Description
Local transcripts classified `task` calls as generic tools, leaving the collapsed display stuck on “Task...”. Map them to the existing subagent UI and fix the stale plan-approval E2E matcher exposed by CI.

## Release Note
Fixed local subagent activity rendering.

## Test Plan
- [x] Local `task` calls render through the subagent path

Made by [Open SWE](https://openswe.vercel.app/agents/01a02088-36ce-7629-87c0-8e05bab91afc)