### PR TITLE
fix: unify cloud and local changes panel

### DIFF
--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -1,113 +1,81 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  DownloadIcon,
-  EllipsisIcon,
-  GitPullRequestIcon,
-  RefreshCwIcon,
-  TextAlignStartIcon,
-} from "lucide-react"
+import { DownloadIcon } from "lucide-react"
 
 import type { AgentThread } from "@/features/agents/lib/types"
 import type { PanelTabKind } from "@/features/agents/lib/panelTabs"
 import { agentsApi } from "@/features/agents/lib/api"
 import { useAgentThreadTurnDiff } from "@/features/agents/lib/queries"
-import { ReviewTab } from "@/features/reviews/components/ReviewTab"
 import { AgentPanelShell } from "@/features/agents/components/AgentPanelShell"
-import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuSeparator,
-  MenuTrigger,
-} from "@/components/ui/menu"
-import { useDiffWrap } from "@/features/agents/utils/diffUtils"
-import {
-  DiffFilesView,
-  toPanelFiles,
-} from "@/features/agents/components/DiffFilesView"
+import { ChangesPanel } from "@/features/agents/components/ChangesPanel"
+import { toPanelFiles } from "@/features/agents/components/DiffFilesView"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
-import { usePanelTabs } from "@/features/agents/lib/panelTabs"
+import {
+  AGENT_COMMON_TABS,
+  AGENT_PANEL_KINDS,
+  usePanelTabs,
+} from "@/features/agents/lib/panelTabs"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import { terminalTabTitle } from "@/features/agents/lib/terminalTabTitle"
 import { useRegisterAppCommands } from "@/lib/appCommands"
 import { cn } from "@/lib/utils"
 
-export type AgentPanelTab = "git"
-
 interface AgentGitPanelProps {
   thread: AgentThread
-  /** Path to select and scroll to, set when a transcript row is clicked. */
   revealFilePath?: string | null
+  revealChangesKey?: number
   collapsed: boolean
-  requestedTab: AgentPanelTab
   onCollapsedChange: (next: boolean) => void
-  onTabChange: (tab: AgentPanelTab) => void
 }
 
 export function AgentGitPanel({
   thread,
   revealFilePath,
+  revealChangesKey = 0,
   collapsed,
-  requestedTab,
   onCollapsedChange,
-  onTabChange,
 }: AgentGitPanelProps) {
-  const [tab, setTab] = useState<"diff" | "review" | "commits">("diff")
-  const [wrap, setWrap] = useDiffWrap()
-  const panel = usePanelTabs(`cloud:${thread.id}`)
+  const panel = usePanelTabs(`cloud:${thread.id}`, AGENT_COMMON_TABS)
   const terminals = useTerminalGroups(
     { kind: "cloud", threadId: thread.id },
     ""
   )
-  const topTab =
-    panel.activeTab?.kind === "terminal" ? panel.activeTab.id : requestedTab
+  const activeTabId = panel.activeTabId
+  useEffect(() => {
+    if (revealChangesKey > 0) panel.openChanges()
+  }, [panel.openChanges, revealChangesKey])
+  const terminalAvailable =
+    thread.isOwner !== false && Boolean(thread.sandboxId)
+
   const handleOpenKind = useCallback(
     (kind: PanelTabKind) => {
       if (kind !== "terminal") return
-      onTabChange("git")
       panel.open({ id: terminals.addGroup(), kind })
     },
-    [onTabChange, panel, terminals]
+    [panel, terminals]
   )
   const handleSelectTab = useCallback(
     (id: string) => {
-      if (id === "git") {
-        onTabChange(id)
-        panel.select("")
-        return
-      }
       panel.select(id)
       const terminalId = terminals.state.terminalGroups.find(
         (group) => group.id === id
       )?.terminalIds[0]
       if (terminalId) terminals.focus(terminalId)
     },
-    [onTabChange, panel, terminals]
+    [panel, terminals]
   )
   const handleCloseTab = useCallback(
     async (id: string) => {
-      if (id === "git") {
-        onCollapsedChange(true)
-        return
-      }
-      if (await terminals.closeGroup(id)) panel.close(id)
+      if (id !== "changes" && (await terminals.closeGroup(id))) panel.close(id)
     },
-    [onCollapsedChange, panel, terminals]
+    [panel, terminals]
   )
-  const terminalAvailable =
-    thread.isOwner !== false && Boolean(thread.sandboxId)
   const toggleTerminal = useCallback(() => {
     if (!collapsed && panel.activeTab?.kind === "terminal") {
       onCollapsedChange(true)
       return
     }
     onCollapsedChange(false)
-    onTabChange("git")
-    const existing = panel.tabs.find(
-      (candidate) => candidate.kind === "terminal"
-    )
+    const existing = panel.tabs.find((tab) => tab.kind === "terminal")
     if (existing) handleSelectTab(existing.id)
     else handleOpenKind("terminal")
   }, [
@@ -115,36 +83,38 @@ export function AgentGitPanel({
     handleOpenKind,
     handleSelectTab,
     onCollapsedChange,
-    onTabChange,
     panel.activeTab?.kind,
     panel.tabs,
   ])
-  const panelCommands = useMemo(
-    () => [
-      {
-        id: "toggle-work-panel",
-        label: "Toggle work panel",
-        aliases: ["show panel", "hide panel", "review panel"],
-        shortcuts: ["mod+alt+b"],
-        group: "Workspace",
-        run: () => onCollapsedChange(!collapsed),
-      },
-      ...(terminalAvailable
-        ? [
-            {
-              id: "toggle-terminal",
-              label: "Toggle terminal",
-              aliases: ["open terminal", "hide terminal"],
-              shortcuts: ["ctrl+`"],
-              group: "Workspace",
-              run: toggleTerminal,
-            },
-          ]
-        : []),
-    ],
-    [collapsed, onCollapsedChange, terminalAvailable, toggleTerminal]
+
+  useRegisterAppCommands(
+    useMemo(
+      () => [
+        {
+          id: "toggle-work-panel",
+          label: "Toggle work panel",
+          aliases: ["show panel", "hide panel", "changes panel"],
+          shortcuts: ["mod+alt+b"],
+          group: "Workspace",
+          run: () => onCollapsedChange(!collapsed),
+        },
+        ...(terminalAvailable
+          ? [
+              {
+                id: "toggle-terminal",
+                label: "Toggle terminal",
+                aliases: ["open terminal", "hide terminal"],
+                shortcuts: ["ctrl+`"],
+                group: "Workspace",
+                run: toggleTerminal,
+              },
+            ]
+          : []),
+      ],
+      [collapsed, onCollapsedChange, terminalAvailable, toggleTerminal]
+    )
   )
-  useRegisterAppCommands(panelCommands)
+
   const terminalGroupIds = terminals.state.terminalGroups
     .map((group) => group.id)
     .join(",")
@@ -152,29 +122,22 @@ export function AgentGitPanel({
   useEffect(() => {
     syncTerminals(terminalGroupIds ? terminalGroupIds.split(",") : [])
   }, [syncTerminals, terminalGroupIds])
-  // Collapsed state is owned and persisted by the parent.
-  const setCollapsed = onCollapsedChange
 
-  const pr = thread.pr
-
-  // The open/closed state is persisted to localStorage, so it carries across
-  // threads and reloads. Still uncollapse when a PR lands mid-session.
-  const [prSeen, setPrSeen] = useState<{ threadId: string; hadPr: boolean }>(
-    () => ({ threadId: thread.id, hadPr: Boolean(pr) })
+  const turnDiff = useAgentThreadTurnDiff(
+    thread.id,
+    null,
+    !collapsed && activeTabId === "changes",
+    {},
+    thread.status === "running"
   )
-  if (prSeen.threadId !== thread.id) {
-    setPrSeen({ threadId: thread.id, hadPr: Boolean(pr) })
-  } else if (pr && !prSeen.hadPr) {
-    setPrSeen({ threadId: thread.id, hadPr: true })
-    setCollapsed(false)
-  }
-
-  const turnDiff = useAgentThreadTurnDiff(thread.id, null, !collapsed)
+  const files = useMemo(
+    () => toPanelFiles(turnDiff.data?.files ?? []),
+    [turnDiff.data?.files]
+  )
   const [recoveringPatch, setRecoveringPatch] = useState(false)
   const [recoveryError, setRecoveryError] = useState<string | null>(null)
   const canDownloadRecovery =
     thread.status !== "running" && thread.isOwner !== false
-
   const downloadRecoveryPatch = useCallback(async () => {
     setRecoveringPatch(true)
     setRecoveryError(null)
@@ -199,189 +162,70 @@ export function AgentGitPanel({
     }
   }, [thread.id])
 
-  const files = useMemo(
-    () => toPanelFiles(turnDiff.data?.files ?? []),
-    [turnDiff.data]
-  )
-
-  const totals = useMemo(
-    () =>
-      files.reduce(
-        (sum, file) => ({
-          additions: sum.additions + file.additions,
-          deletions: sum.deletions + file.deletions,
-        }),
-        { additions: 0, deletions: 0 }
-      ),
-    [files]
-  )
-  const truncated = turnDiff.data?.truncated
-  const tabLabels = { diff: "Thread", review: "Review", commits: "Committed" }
-  const refreshDiff = () => void turnDiff.refetch()
-
-  const reviewHeader = (
-    <div className="shrink-0 px-3 pb-2">
-      <div className="@container flex min-h-9 items-center gap-2">
-        <Menu>
-          <MenuTrigger className="flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent">
-            {tabLabels[tab]}
-            <ChevronDownIcon className="size-3.5 text-muted-foreground" />
-          </MenuTrigger>
-          <MenuPopup align="start" className="w-44">
-            {(
-              [
-                ["diff", "Branch"],
-                ["review", "Review"],
-                ["commits", "Committed"],
-              ] as const
-            ).map(([id, label]) => (
-              <MenuItem key={id} onClick={() => setTab(id)}>
-                <span className="flex-1">{label}</span>
-                {tab === id && <CheckIcon />}
-              </MenuItem>
-            ))}
-          </MenuPopup>
-        </Menu>
-        {files.length > 0 && (
-          <span className="flex items-center gap-2 text-sm">
-            <span
-              title={truncated ? "Only the first files are shown" : undefined}
-              className="text-xs text-muted-foreground"
-            >
-              {truncated ? "first " : ""}
-              {files.length} file{files.length === 1 ? "" : "s"}
-            </span>
-            <span className="text-success-foreground">+{totals.additions}</span>
-            <span className="text-destructive">-{totals.deletions}</span>
-          </span>
-        )}
-        <div className="ml-auto flex items-center gap-2">
-          {recoveryError && (
-            <span
-              title={recoveryError}
-              className="max-w-32 truncate text-[11px] text-destructive"
-            >
-              {recoveryError}
-            </span>
-          )}
-          {pr && (
-            <a
-              href={pr.url}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="View PR"
-              className="flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-            >
-              <GitPullRequestIcon className="size-3.5" />
-              <span className="hidden @[700px]:inline">View PR</span>
-            </a>
-          )}
-          <Menu>
-            <MenuTrigger
-              aria-label="Review options"
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            >
-              <EllipsisIcon className="size-4" />
-            </MenuTrigger>
-            <MenuPopup align="end" className="w-48">
-              <MenuItem onClick={refreshDiff}>
-                <RefreshCwIcon />
-                Refresh
-              </MenuItem>
-              <MenuItem onClick={() => setWrap(!wrap)}>
-                <TextAlignStartIcon />
-                {wrap ? "Disable" : "Enable"} word wrap
-              </MenuItem>
-              {canDownloadRecovery && (
-                <>
-                  <MenuSeparator />
-                  <MenuItem
-                    disabled={recoveringPatch}
-                    onClick={downloadRecoveryPatch}
-                  >
-                    <DownloadIcon />
-                    {recoveringPatch ? "Preparing…" : "Download patch"}
-                  </MenuItem>
-                </>
-              )}
-            </MenuPopup>
-          </Menu>
-        </div>
-      </div>
-    </div>
-  )
-
   return (
     <AgentPanelShell
-      tabs={[
-        { id: "git", kind: "review" as const, closable: false },
-        ...panel.tabs.map((panelTab) => ({
-          ...panelTab,
-          title: terminalTabTitle(terminals, panelTab.id),
-        })),
-      ]}
-      activeTabId={topTab}
+      tabs={panel.tabs.map((tab) =>
+        tab.kind === "terminal"
+          ? { ...tab, title: terminalTabTitle(terminals, tab.id) }
+          : tab
+      )}
+      activeTabId={activeTabId}
       onSelectTab={handleSelectTab}
       onCloseTab={handleCloseTab}
-      onOpenKind={
-        thread.isOwner !== false && thread.sandboxId
-          ? handleOpenKind
-          : undefined
-      }
-      menuKinds={
-        thread.isOwner !== false && thread.sandboxId ? ["terminal"] : []
-      }
+      onOpenKind={terminalAvailable ? handleOpenKind : undefined}
+      menuKinds={AGENT_PANEL_KINDS}
       collapsed={collapsed}
-      onCollapsedChange={setCollapsed}
-      seamlessHeader={topTab === "git"}
+      onCollapsedChange={onCollapsedChange}
     >
       {({ fullScreen }) => (
         <>
-          {topTab === "git" ? (
-            <>
-              {reviewHeader}
-              {tab === "diff" ? (
-                <DiffFilesView
-                  files={files}
-                  revealFilePath={revealFilePath}
-                  fullScreen={fullScreen}
-                  hideHeader
-                  emptyLabel={
-                    turnDiff.isLoading
-                      ? "Loading thread diff…"
-                      : "No diff available."
-                  }
-                  truncated={truncated}
+          {activeTabId === "changes" && (
+            <ChangesPanel
+              files={files}
+              status={turnDiff.data?.status}
+              isLoading={turnDiff.isPending}
+              isFetching={turnDiff.isFetching}
+              error={turnDiff.error}
+              truncated={turnDiff.data?.truncated}
+              branch={thread.branch}
+              pr={thread.pr}
+              revealFilePath={revealFilePath}
+              fullScreen={fullScreen}
+              onRefresh={() => void turnDiff.refetch()}
+              extraActions={
+                canDownloadRecovery ? (
+                  <button
+                    type="button"
+                    aria-label="Download recovery patch"
+                    title={recoveryError ?? "Download recovery patch"}
+                    disabled={recoveringPatch}
+                    onClick={() => void downloadRecoveryPatch()}
+                    className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                  >
+                    <DownloadIcon className="size-3.5" />
+                  </button>
+                ) : undefined
+              }
+            />
+          )}
+          {panel.tabs
+            .filter((tab) => tab.kind === "terminal")
+            .map((tab) => (
+              <div
+                key={tab.id}
+                className={cn(
+                  "min-h-0 flex-1",
+                  tab.id !== activeTabId && "hidden"
+                )}
+              >
+                <TerminalPanel
+                  target={{ kind: "cloud", threadId: thread.id }}
+                  cwd=""
+                  groupId={tab.id}
+                  terminals={terminals}
                 />
-              ) : (
-                <div className="flex min-h-0 flex-1">
-                  {tab === "review" ? (
-                    <ReviewTab thread={thread} />
-                  ) : (
-                    <div className="min-h-0 flex-1 overflow-y-auto p-6 text-center text-xs text-muted-foreground/70">
-                      Coming Soon
-                    </div>
-                  )}
-                </div>
-              )}
-            </>
-          ) : null}
-          {panel.tabs.map((terminalTab) => (
-            <div
-              key={terminalTab.id}
-              className={cn(
-                "min-h-0 flex-1",
-                terminalTab.id !== topTab && "hidden"
-              )}
-            >
-              <TerminalPanel
-                target={{ kind: "cloud", threadId: thread.id }}
-                cwd=""
-                groupId={terminalTab.id}
-                terminals={terminals}
-              />
-            </div>
-          ))}
+              </div>
+            ))}
         </>
       )}
     </AgentPanelShell>

--- a/ui/src/features/agents/components/AgentPanelShell.tsx
+++ b/ui/src/features/agents/components/AgentPanelShell.tsx
@@ -4,7 +4,7 @@ import {
   ArrowsOutIcon,
   SidebarSimpleIcon,
 } from "@phosphor-icons/react"
-import { FileDiff, Folder, Globe, Plus, SquareTerminal, X } from "lucide-react"
+import { FileDiff, Plus, SquareTerminal, X } from "lucide-react"
 
 import type { PanelTab, PanelTabKind } from "@/features/agents/lib/panelTabs"
 import { isMultiInstanceKind } from "@/features/agents/lib/panelTabs"
@@ -18,10 +18,8 @@ const PANEL_TAB_META: Record<
   PanelTabKind,
   { label: string; hint?: string; Icon: typeof FileDiff }
 > = {
-  review: { label: "Review", hint: "⌃⇧G", Icon: FileDiff },
+  changes: { label: "Changes", hint: "⌃⇧G", Icon: FileDiff },
   terminal: { label: "Terminal", Icon: SquareTerminal },
-  browser: { label: "Browser", Icon: Globe },
-  files: { label: "Files", Icon: Folder },
 }
 
 const PANEL_STORAGE_WIDTH = "open-swe.gitpanel.width"
@@ -204,26 +202,16 @@ function PanelLauncher({
   )
 }
 
-export function PanelComingSoon() {
-  return (
-    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-xs text-muted-foreground/70">
-      Coming Soon
-    </div>
-  )
-}
-
 interface AgentPanelShellProps {
   tabs: ReadonlyArray<PanelTab>
   activeTabId: string | null
   onSelectTab: (id: string) => void
-  /** Omit to make tabs non-closable (cloud threads). */
   onCloseTab?: (id: string) => void
   onOpenKind?: (kind: PanelTabKind) => void
   /** Kinds offered by the launcher and the "+" menu. */
   menuKinds: ReadonlyArray<PanelTabKind>
   collapsed: boolean
   onCollapsedChange: (next: boolean) => void
-  seamlessHeader?: boolean
   /** Rendered as the panel body; `fullScreen` drives layout-only extras. */
   children: (state: { fullScreen: boolean }) => React.ReactNode
 }
@@ -242,7 +230,6 @@ export function AgentPanelShell({
   menuKinds,
   collapsed,
   onCollapsedChange,
-  seamlessHeader = false,
   children,
 }: AgentPanelShellProps) {
   const [width, setWidthState] = useState(() => readStoredPanelWidth())
@@ -316,12 +303,7 @@ export function AgentPanelShell({
       )}
       style={overlay ? { zIndex: Z.MODAL } : { width }}
     >
-      <div
-        className={cn(
-          "flex h-11 shrink-0 items-center px-2",
-          !seamlessHeader && "border-b border-border"
-        )}
-      >
+      <div className="flex h-11 shrink-0 items-center border-b border-border px-2">
         <div className="flex min-w-0 flex-1 items-center overflow-x-auto">
           {tabs.map((tab, index) => {
             const { label, Icon } = PANEL_TAB_META[tab.kind]

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -8,7 +8,6 @@ import type {
   QueuedThreadMessage,
 } from "@/features/agents/lib/types"
 import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
-import type { AgentPanelTab } from "@/features/agents/components/AgentGitPanel"
 import { Alert, AlertAction, AlertDescription } from "@/components/ui/alert"
 import { useSidebarCollapsed } from "@/components/sidebar-layout"
 import { AgentGitPanel } from "@/features/agents/components/AgentGitPanel"
@@ -124,7 +123,6 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed(thread.id)
   )
-  const [panelTab, setPanelTab] = useState<AgentPanelTab>("git")
   const handlePanelCollapsedChange = useCallback(
     (next: boolean) => {
       setPanelCollapsed(next)
@@ -133,10 +131,11 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
     [thread.id]
   )
   const [revealFilePath, setRevealFilePath] = useState<string | null>(null)
+  const [revealChangesKey, setRevealChangesKey] = useState(0)
   const handleOpenFile = useCallback(
     (filePath: string) => {
       setRevealFilePath(filePath)
-      setPanelTab("git")
+      setRevealChangesKey((key) => key + 1)
       handlePanelCollapsedChange(false)
     },
     [handlePanelCollapsedChange]
@@ -365,10 +364,9 @@ export function AgentThreadView({ thread }: AgentThreadViewProps) {
       <AgentGitPanel
         thread={thread}
         revealFilePath={revealFilePath}
+        revealChangesKey={revealChangesKey}
         collapsed={panelCollapsed}
-        requestedTab={panelTab}
         onCollapsedChange={handlePanelCollapsedChange}
-        onTabChange={setPanelTab}
       />
     </div>
   )

--- a/ui/src/features/agents/components/ChangesPanel.test.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.test.tsx
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest"
+
+import { changesEmptyLabel } from "./ChangesPanel"
+
+describe("changesEmptyLabel", () => {
+  it("distinguishes loading, missing, error, and empty changes", () => {
+    expect(changesEmptyLabel({ isLoading: true })).toBe("Reading changes…")
+    expect(changesEmptyLabel({ isLoading: false, status: "missing" })).toBe(
+      "Changes are not available for this workspace."
+    )
+    expect(changesEmptyLabel({ isLoading: false, status: "error" })).toBe(
+      "Could not read changes. Try refreshing."
+    )
+    expect(changesEmptyLabel({ isLoading: false, status: "ready" })).toBe(
+      "No changes yet."
+    )
+  })
+
+  it("surfaces request errors", () => {
+    expect(
+      changesEmptyLabel({
+        isLoading: false,
+        error: new Error("Sandbox unavailable"),
+      })
+    ).toBe("Sandbox unavailable")
+  })
+})

--- a/ui/src/features/agents/components/ChangesPanel.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from "react"
+import { GitPullRequestIcon, RefreshCwIcon } from "lucide-react"
+
+import type { AgentThread } from "@/features/agents/lib/types"
+import type { PanelFile } from "@/features/agents/components/DiffFilesView"
+import { DiffFilesView } from "@/features/agents/components/DiffFilesView"
+
+export type ChangesStatus = "ready" | "missing" | "error"
+
+interface ChangesPanelProps {
+  files: Array<PanelFile>
+  status?: ChangesStatus
+  isLoading: boolean
+  isFetching: boolean
+  error?: unknown
+  truncated?: boolean
+  branch?: string | null
+  pr?: AgentThread["pr"] | null
+  revealFilePath?: string | null
+  fullScreen: boolean
+  onRefresh: () => void
+  extraActions?: React.ReactNode
+}
+
+function errorMessage(error: unknown): string | null {
+  if (!error) return null
+  return error instanceof Error ? error.message : "Could not load changes."
+}
+
+export function changesEmptyLabel({
+  status,
+  isLoading,
+  error,
+}: Pick<ChangesPanelProps, "status" | "isLoading" | "error">): string {
+  if (isLoading) return "Reading changes…"
+  if (error) return errorMessage(error) ?? "Could not load changes."
+  if (status === "missing")
+    return "Changes are not available for this workspace."
+  if (status === "error") return "Could not read changes. Try refreshing."
+  return "No changes yet."
+}
+
+export function ChangesPanel({
+  files,
+  status,
+  isLoading,
+  isFetching,
+  error,
+  truncated,
+  branch,
+  pr,
+  revealFilePath,
+  fullScreen,
+  onRefresh,
+  extraActions,
+}: ChangesPanelProps) {
+  const emptyLabel = changesEmptyLabel({ status, isLoading, error })
+  const actions = useMemo(
+    () => (
+      <>
+        <button
+          type="button"
+          aria-label="Refresh changes"
+          title="Refresh changes"
+          onClick={onRefresh}
+          disabled={isFetching}
+          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+        >
+          <RefreshCwIcon
+            className={isFetching ? "size-3.5 animate-spin" : "size-3.5"}
+          />
+        </button>
+        {extraActions}
+        {pr && (
+          <a
+            href={pr.url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            <GitPullRequestIcon className="size-3.5" />
+            View PR
+          </a>
+        )}
+      </>
+    ),
+    [extraActions, isFetching, onRefresh, pr]
+  )
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {truncated && (
+        <div className="shrink-0 border-b border-border bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+          Only the first {files.length} changed file
+          {files.length === 1 ? " is" : "s are"} shown.
+        </div>
+      )}
+      <DiffFilesView
+        files={files}
+        revealFilePath={revealFilePath}
+        fullScreen={fullScreen}
+        emptyLabel={emptyLabel}
+        truncated={truncated}
+        leading={
+          <span className="min-w-0 truncate text-sm font-medium text-foreground">
+            Changes{branch ? ` · ${branch}` : ""}
+          </span>
+        }
+        actions={actions}
+      />
+    </div>
+  )
+}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { useQueryClient } from "@tanstack/react-query"
-import {
-  CircleAlert,
-  FolderOpen,
-  GitPullRequestIcon,
-  RefreshCwIcon,
-  X,
-} from "lucide-react"
+import { CircleAlert, FolderOpen, X } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 
 import type {
@@ -23,16 +17,18 @@ import { useSidebarCollapsed } from "@/components/sidebar-layout"
 import {
   AgentPanelShell,
   PANEL_MIN_CHAT_WIDTH,
-  PanelComingSoon,
 } from "@/features/agents/components/AgentPanelShell"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
-import {
-  DiffFilesView,
-  toPanelFiles,
-} from "@/features/agents/components/DiffFilesView"
+import { ChangesPanel } from "@/features/agents/components/ChangesPanel"
+import { toPanelFiles } from "@/features/agents/components/DiffFilesView"
 import { Messages } from "@/features/agents/components/messages"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
-import { usePanelTabs } from "@/features/agents/lib/panelTabs"
+import {
+  AGENT_COMMON_TABS,
+  AGENT_PANEL_KINDS,
+  CHANGES_TAB,
+  usePanelTabs,
+} from "@/features/agents/lib/panelTabs"
 import { useAgentSkills } from "@/features/agents/lib/queries"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
@@ -50,13 +46,6 @@ import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps
 import { useRegisterAppCommands } from "@/lib/appCommands"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
-
-const LOCAL_PANEL_KINDS: ReadonlyArray<PanelTabKind> = [
-  "review",
-  "terminal",
-  "browser",
-  "files",
-]
 
 function promptContent(text: string, images: Array<ImageChunk>) {
   const trimmed = text.trim()
@@ -116,7 +105,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed(sessionId)
   )
-  const panel = usePanelTabs(sessionId)
+  const panel = usePanelTabs(sessionId, AGENT_COMMON_TABS)
   const terminals = useTerminalGroups(
     { kind: "local", sessionId },
     thread?.cwd ?? ""
@@ -133,7 +122,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const handleOpenFile = useCallback(
     (filePath: string) => {
       setRevealFilePath(filePath)
-      panel.open({ id: "review", kind: "review" })
+      panel.open(CHANGES_TAB)
       handlePanelCollapsedChange(false)
     },
     [handlePanelCollapsedChange, panel]
@@ -141,13 +130,14 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const handleOpenKind = useCallback(
     (kind: PanelTabKind) => {
       if (kind !== "terminal") {
-        panel.open({ id: kind, kind })
+        panel.open(CHANGES_TAB)
         return
       }
       panel.open({ id: terminals.addGroup(), kind })
     },
     [panel, terminals]
   )
+  const activePanelTabId = panel.activeTabId
   const handleSelectTab = useCallback(
     (id: string) => {
       panel.select(id)
@@ -161,6 +151,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   )
   const handleCloseTab = useCallback(
     async (id: string) => {
+      if (id === "changes") return
       if (
         panel.tabs.find((tab) => tab.id === id)?.kind === "terminal" &&
         !(await terminals.closeGroup(id))
@@ -205,7 +196,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             {
               id: "toggle-work-panel",
               label: "Toggle work panel",
-              aliases: ["show panel", "hide panel", "review panel"],
+              aliases: ["show panel", "hide panel", "changes panel"],
               shortcuts: ["mod+alt+b"],
               group: "Workspace",
               run: () => handlePanelCollapsedChange(!panelCollapsed),
@@ -227,7 +218,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const isRunning = stream.isLoading || thread?.status === "running"
   const diff = useLocalThreadDiff(
     sessionId,
-    !panelCollapsed && panel.activeTab?.kind === "review" && Boolean(thread),
+    !panelCollapsed && activePanelTabId === "changes" && Boolean(thread),
     isRunning
   )
   const files = useMemo(
@@ -236,30 +227,6 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   )
   const repository = diff.data?.repository
   const pr = repository?.pr
-  const diffActions = (
-    <>
-      <button
-        type="button"
-        aria-label="Refresh changes"
-        title="Refresh changes"
-        onClick={() => void diff.refetch()}
-        className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-      >
-        <RefreshCwIcon className="size-3.5" />
-      </button>
-      {pr && (
-        <a
-          href={pr.url}
-          target="_blank"
-          rel="noreferrer"
-          className="flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-        >
-          <GitPullRequestIcon className="size-3.5" />
-          View PR
-        </a>
-      )}
-    </>
-  )
   const messages = useMemo(
     () =>
       streamMessagesToUi(
@@ -529,36 +496,31 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             ? { ...tab, title: terminalTabTitle(terminals, tab.id) }
             : tab
         )}
-        activeTabId={panel.activeTabId}
+        activeTabId={activePanelTabId}
         onSelectTab={handleSelectTab}
         onCloseTab={handleCloseTab}
         onOpenKind={handleOpenKind}
-        menuKinds={LOCAL_PANEL_KINDS}
+        menuKinds={AGENT_PANEL_KINDS}
         collapsed={panelCollapsed}
         onCollapsedChange={handlePanelCollapsedChange}
       >
         {({ fullScreen }) => (
           <>
-            {panel.activeTab?.kind === "review" && (
-              <DiffFilesView
+            {activePanelTabId === "changes" && (
+              <ChangesPanel
                 files={files}
+                status={diff.data?.status}
+                isLoading={diff.isPending}
+                isFetching={diff.isFetching}
+                error={diff.error}
+                truncated={diff.data?.truncated}
+                branch={repository?.branch}
+                pr={pr}
                 revealFilePath={revealFilePath}
                 fullScreen={fullScreen}
-                emptyLabel={localDiffEmptyLabel(
-                  diff.data?.status,
-                  diff.isPending
-                )}
-                truncated={diff.data?.truncated}
-                leading={
-                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
-                    Branch{repository?.branch ? ` · ${repository.branch}` : ""}
-                  </span>
-                }
-                actions={diffActions}
+                onRefresh={() => void diff.refetch()}
               />
             )}
-            {(panel.activeTab?.kind === "browser" ||
-              panel.activeTab?.kind === "files") && <PanelComingSoon />}
             {/* Kept mounted across tabs: unmounting kills the user's shell. */}
             {panel.tabs
               .filter((tab) => tab.kind === "terminal")
@@ -567,7 +529,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
                   key={tab.id}
                   className={cn(
                     "min-h-0 flex-1",
-                    tab.id !== panel.activeTabId && "hidden"
+                    tab.id !== activePanelTabId && "hidden"
                   )}
                 >
                   <TerminalPanel
@@ -605,14 +567,4 @@ function terminalTabTitle(
     (terminalId ? terminals.metadataById.get(terminalId)?.label : null) ||
     "Terminal"
   )
-}
-
-function localDiffEmptyLabel(
-  status: string | undefined,
-  isPending: boolean
-): string {
-  if (isPending) return "Reading changes…"
-  if (status === "missing") return "This project is not a git repository."
-  if (status === "error") return "Could not read this project's git changes."
-  return "No changes yet."
 }

--- a/ui/src/features/agents/lib/panelTabs.test.ts
+++ b/ui/src/features/agents/lib/panelTabs.test.ts
@@ -1,32 +1,67 @@
-import { describe, expect, it } from "vitest"
+/** @vitest-environment jsdom */
 
-import { closePanelTab, openPanelTab, syncTerminalTabs } from "./panelTabs"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  CHANGES_TAB,
+  closePanelTab,
+  openPanelTab,
+  readPanelTabs,
+  syncTerminalTabs,
+  writePanelTabs,
+} from "./panelTabs"
+
+beforeEach(() => window.localStorage.clear())
 
 describe("panel tabs", () => {
   it("focuses an existing single-instance tab instead of duplicating it", () => {
     const opened = openPanelTab(
-      openPanelTab(
-        { tabs: [], activeTabId: null },
-        { id: "review", kind: "review" }
-      ),
+      openPanelTab({ tabs: [], activeTabId: null }, CHANGES_TAB),
       { id: "term-a", kind: "terminal" }
     )
-    const reopened = openPanelTab(opened, { id: "review", kind: "review" })
+    const reopened = openPanelTab(opened, CHANGES_TAB)
 
     expect(reopened.tabs).toHaveLength(2)
-    expect(reopened.activeTabId).toBe("review")
+    expect(reopened.activeTabId).toBe("changes")
   })
 
   it("activates a neighbour when the active tab closes", () => {
     const state = {
-      tabs: [
-        { id: "review", kind: "review" as const },
-        { id: "group-term-1", kind: "terminal" as const },
-      ],
+      tabs: [CHANGES_TAB, { id: "group-term-1", kind: "terminal" as const }],
       activeTabId: "group-term-1",
     }
 
-    expect(closePanelTab(state, "group-term-1").activeTabId).toBe("review")
-    expect(syncTerminalTabs(state, []).tabs).toEqual([state.tabs[0]])
+    expect(closePanelTab(state, "group-term-1").activeTabId).toBe("changes")
+    expect(syncTerminalTabs(state, []).tabs).toEqual([CHANGES_TAB])
+  })
+
+  it("migrates the legacy review tab and active id", () => {
+    window.localStorage.setItem(
+      "open-swe.panel-tabs.v1:thread-1",
+      JSON.stringify({
+        tabs: [{ id: "review", kind: "review" }],
+        activeTabId: "review",
+      })
+    )
+
+    expect(readPanelTabs("thread-1", [CHANGES_TAB])).toEqual({
+      tabs: [CHANGES_TAB],
+      activeTabId: "changes",
+    })
+  })
+
+  it("persists Changes selection and rejects an invalid empty active id", () => {
+    writePanelTabs("thread-1", {
+      tabs: [CHANGES_TAB, { id: "term-a", kind: "terminal" }],
+      activeTabId: "",
+    })
+
+    expect(readPanelTabs("thread-1", [CHANGES_TAB]).activeTabId).toBe("changes")
+
+    writePanelTabs("thread-1", {
+      tabs: [CHANGES_TAB, { id: "term-a", kind: "terminal" }],
+      activeTabId: "changes",
+    })
+    expect(readPanelTabs("thread-1", [CHANGES_TAB]).activeTabId).toBe("changes")
   })
 })

--- a/ui/src/features/agents/lib/panelTabs.ts
+++ b/ui/src/features/agents/lib/panelTabs.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
-export type PanelTabKind = "review" | "terminal" | "browser" | "files"
+export type PanelTabKind = "changes" | "terminal"
 
 export interface PanelTab {
   id: string
   kind: PanelTabKind
-  /** Overrides the kind's default label (terminal tabs use the shell label). */
   title?: string
   closable?: boolean
 }
@@ -17,14 +16,17 @@ export interface PanelTabsState {
 
 const STORAGE_PREFIX = "open-swe.panel-tabs.v1:"
 const EMPTY: PanelTabsState = { tabs: [], activeTabId: null }
-const KINDS: ReadonlyArray<PanelTabKind> = [
-  "review",
-  "terminal",
-  "browser",
-  "files",
-]
+const KINDS: ReadonlyArray<PanelTabKind> = ["changes", "terminal"]
 
-/** Only terminals can be opened more than once. */
+export const CHANGES_TAB: PanelTab = {
+  id: "changes",
+  kind: "changes",
+  title: "Changes",
+  closable: false,
+}
+export const AGENT_COMMON_TABS: ReadonlyArray<PanelTab> = [CHANGES_TAB]
+export const AGENT_PANEL_KINDS: ReadonlyArray<PanelTabKind> = ["terminal"]
+
 export function isMultiInstanceKind(kind: PanelTabKind): boolean {
   return kind === "terminal"
 }
@@ -47,7 +49,7 @@ export function closePanelTab(
   id: string
 ): PanelTabsState {
   const index = state.tabs.findIndex((tab) => tab.id === id)
-  if (index < 0) return state
+  if (index < 0 || state.tabs[index]?.closable === false) return state
   const tabs = state.tabs.filter((tab) => tab.id !== id)
   return {
     tabs,
@@ -58,7 +60,6 @@ export function closePanelTab(
   }
 }
 
-/** Terminal tabs mirror the live terminal groups owned by `terminalState`. */
 export function syncTerminalTabs(
   state: PanelTabsState,
   groupIds: ReadonlyArray<string>
@@ -81,31 +82,58 @@ export function syncTerminalTabs(
   }
 }
 
-function isPanelTab(value: unknown): value is PanelTab {
+function migratePanelTab(value: unknown): PanelTab | null {
   const tab = value as PanelTab | null
-  return (
-    typeof tab?.id === "string" && tab.id.length > 0 && KINDS.includes(tab.kind)
-  )
+  if (typeof tab?.id !== "string" || tab.id.length === 0) return null
+  const kind = (tab.kind as string) === "review" ? "changes" : tab.kind
+  const id = tab.id === "review" ? "changes" : tab.id
+  if (!KINDS.includes(kind)) return null
+  return { ...tab, id, kind }
 }
 
-export function readPanelTabs(sessionId: string): PanelTabsState {
-  if (typeof window === "undefined") return EMPTY
+function normalizePanelTabs(
+  state: PanelTabsState,
+  commonTabs: ReadonlyArray<PanelTab>
+): PanelTabsState {
+  const tabs = [...commonTabs]
+  for (const tab of state.tabs) {
+    if (!tabs.some((candidate) => candidate.id === tab.id)) tabs.push(tab)
+  }
+  const activeTabId =
+    state.activeTabId === "review" ? "changes" : state.activeTabId
+  return {
+    tabs,
+    activeTabId: tabs.some((tab) => tab.id === activeTabId)
+      ? activeTabId
+      : (tabs[0]?.id ?? null),
+  }
+}
+
+export function readPanelTabs(
+  sessionId: string,
+  commonTabs: ReadonlyArray<PanelTab> = []
+): PanelTabsState {
+  if (typeof window === "undefined")
+    return normalizePanelTabs(EMPTY, commonTabs)
   const raw = window.localStorage.getItem(`${STORAGE_PREFIX}${sessionId}`)
-  if (!raw) return EMPTY
+  if (!raw) return normalizePanelTabs(EMPTY, commonTabs)
   try {
     const parsed = JSON.parse(raw) as Partial<PanelTabsState>
-    const tabs = (Array.isArray(parsed.tabs) ? parsed.tabs : []).filter(
-      isPanelTab
+    const tabs = (Array.isArray(parsed.tabs) ? parsed.tabs : [])
+      .map(migratePanelTab)
+      .filter((tab): tab is PanelTab => tab !== null)
+    const state = normalizePanelTabs(
+      {
+        tabs,
+        activeTabId:
+          typeof parsed.activeTabId === "string" ? parsed.activeTabId : null,
+      },
+      commonTabs
     )
-    return {
-      tabs,
-      activeTabId:
-        tabs.find((tab) => tab.id === parsed.activeTabId)?.id ??
-        tabs[0]?.id ??
-        null,
-    }
+    writePanelTabs(sessionId, state)
+    return state
   } catch {
-    return EMPTY
+    return normalizePanelTabs(EMPTY, commonTabs)
   }
 }
 
@@ -117,22 +145,52 @@ export function writePanelTabs(sessionId: string, state: PanelTabsState): void {
   )
 }
 
-export function usePanelTabs(sessionId: string) {
+export function usePanelTabs(
+  sessionId: string,
+  commonTabs: ReadonlyArray<PanelTab> = []
+) {
   const [state, setState] = useState<PanelTabsState>(() =>
-    readPanelTabs(sessionId)
+    readPanelTabs(sessionId, commonTabs)
   )
 
-  useEffect(() => setState(readPanelTabs(sessionId)), [sessionId])
+  useEffect(
+    () => setState(readPanelTabs(sessionId, commonTabs)),
+    [commonTabs, sessionId]
+  )
 
   const update = useCallback(
     (change: (current: PanelTabsState) => PanelTabsState) => {
       setState((current) => {
-        const next = change(current)
-        if (next !== current) writePanelTabs(sessionId, next)
+        const next = normalizePanelTabs(change(current), commonTabs)
+        writePanelTabs(sessionId, next)
         return next
       })
     },
-    [sessionId]
+    [commonTabs, sessionId]
+  )
+
+  const open = useCallback(
+    (tab: PanelTab) => update((current) => openPanelTab(current, tab)),
+    [update]
+  )
+  const select = useCallback(
+    (id: string) =>
+      update((current) =>
+        current.tabs.some((tab) => tab.id === id)
+          ? { ...current, activeTabId: id }
+          : current
+      ),
+    [update]
+  )
+  const openChanges = useCallback(() => open(CHANGES_TAB), [open])
+  const close = useCallback(
+    (id: string) => update((current) => closePanelTab(current, id)),
+    [update]
+  )
+  const syncTerminals = useCallback(
+    (groupIds: ReadonlyArray<string>) =>
+      update((current) => syncTerminalTabs(current, groupIds)),
+    [update]
   )
 
   return useMemo(
@@ -140,13 +198,12 @@ export function usePanelTabs(sessionId: string) {
       tabs: state.tabs,
       activeTabId: state.activeTabId,
       activeTab: state.tabs.find((tab) => tab.id === state.activeTabId) ?? null,
-      open: (tab: PanelTab) => update((current) => openPanelTab(current, tab)),
-      select: (id: string) =>
-        update((current) => ({ ...current, activeTabId: id })),
-      close: (id: string) => update((current) => closePanelTab(current, id)),
-      syncTerminals: (groupIds: ReadonlyArray<string>) =>
-        update((current) => syncTerminalTabs(current, groupIds)),
+      open,
+      select,
+      openChanges,
+      close,
+      syncTerminals,
     }),
-    [state, update]
+    [close, open, openChanges, select, state, syncTerminals]
   )
 }

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -5,8 +5,12 @@ import { render, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { agentsApi } from "./api"
-import { agentThreadKeys, useThreadsPage } from "./queries"
-import type { ThreadsPage, ThreadsPageParams } from "./api"
+import {
+  agentThreadKeys,
+  useAgentThreadTurnDiff,
+  useThreadsPage,
+} from "./queries"
+import type { ThreadTurnDiff, ThreadsPage, ThreadsPageParams } from "./api"
 
 const params: ThreadsPageParams = {
   limit: 100,
@@ -28,6 +32,122 @@ afterEach(() => {
   for (const client of clients) client.clear()
   clients.length = 0
   vi.restoreAllMocks()
+})
+
+describe("useAgentThreadTurnDiff", () => {
+  const diff: ThreadTurnDiff = {
+    status: "ready",
+    truncated: false,
+    summary: { files: 0, additions: 0, deletions: 0 },
+    files: [],
+  }
+
+  function Probe({
+    running,
+    enabled = true,
+  }: {
+    running: boolean
+    enabled?: boolean
+  }) {
+    useAgentThreadTurnDiff("thread-1", null, enabled, {}, running)
+    return null
+  }
+
+  function renderProbe(running: boolean, enabled = true) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    clients.push(client)
+    return render(
+      <QueryClientProvider client={client}>
+        <Probe running={running} enabled={enabled} />
+      </QueryClientProvider>
+    )
+  }
+
+  it("keeps polling ready cloud diffs while the run is active", async () => {
+    vi.useFakeTimers()
+    const getDiff = vi
+      .spyOn(agentsApi, "getThreadTurnDiff")
+      .mockResolvedValue(diff)
+
+    renderProbe(true)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
+    await vi.advanceTimersByTimeAsync(3000)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(2))
+  })
+
+  it("refreshes immediately and twice after a running cloud diff finishes", async () => {
+    vi.useFakeTimers()
+    const getDiff = vi
+      .spyOn(agentsApi, "getThreadTurnDiff")
+      .mockResolvedValue(diff)
+    const view = renderProbe(true)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
+
+    view.rerender(
+      <QueryClientProvider client={clients.at(-1)!}>
+        <Probe running={false} />
+      </QueryClientProvider>
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(2))
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(3))
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(4))
+  })
+
+  it("refetches a fresh cached diff when enabled after the run finished", async () => {
+    vi.useFakeTimers()
+    const getDiff = vi
+      .spyOn(agentsApi, "getThreadTurnDiff")
+      .mockResolvedValue(diff)
+    const view = renderProbe(true)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
+
+    view.rerender(
+      <QueryClientProvider client={clients.at(-1)!}>
+        <Probe running enabled={false} />
+      </QueryClientProvider>
+    )
+    view.rerender(
+      <QueryClientProvider client={clients.at(-1)!}>
+        <Probe running={false} enabled={false} />
+      </QueryClientProvider>
+    )
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(getDiff).toHaveBeenCalledTimes(1)
+
+    view.rerender(
+      <QueryClientProvider client={clients.at(-1)!}>
+        <Probe running={false} enabled />
+      </QueryClientProvider>
+    )
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(2))
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(getDiff).toHaveBeenCalledTimes(2)
+  })
+
+  it("cleans delayed final refreshes on unmount", async () => {
+    vi.useFakeTimers()
+    const getDiff = vi
+      .spyOn(agentsApi, "getThreadTurnDiff")
+      .mockResolvedValue(diff)
+    const view = renderProbe(true)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
+
+    view.rerender(
+      <QueryClientProvider client={clients.at(-1)!}>
+        <Probe running={false} />
+      </QueryClientProvider>
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(2))
+    view.unmount()
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(getDiff).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe("useThreadsPage", () => {

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -129,6 +129,25 @@ describe("useAgentThreadTurnDiff", () => {
     expect(getDiff).toHaveBeenCalledTimes(2)
   })
 
+  it("refetches a fresh cached diff when remounted after the run finished", async () => {
+    const getDiff = vi
+      .spyOn(agentsApi, "getThreadTurnDiff")
+      .mockResolvedValue(diff)
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    client.setQueryData(agentThreadKeys.turnDiff("thread-1", null, {}), diff)
+    clients.push(client)
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe running={false} />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
+  })
+
   it("cleans delayed final refreshes on unmount", async () => {
     vi.useFakeTimers()
     const getDiff = vi

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -5,7 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 import { agentsApi } from "./api"
 import type { QueryClient } from "@tanstack/react-query"
@@ -340,17 +340,38 @@ export function useAgentThreadTurnDiff(
   threadId: string,
   turnKey: string | null,
   enabled: boolean,
-  options: ThreadTurnDiffOptions = {}
+  options: ThreadTurnDiffOptions = {},
+  pollWhileRunning = false
 ) {
-  return useQuery({
-    queryKey: agentThreadKeys.turnDiff(threadId, turnKey, options),
+  const queryKey = agentThreadKeys.turnDiff(threadId, turnKey, options)
+  const query = useQuery({
+    queryKey,
     queryFn: () => agentsApi.getThreadTurnDiff(threadId, turnKey, options),
     enabled: enabled && Boolean(threadId),
     staleTime: 30_000,
-    refetchInterval: (query) =>
-      query.state.data?.status === "ready" ? false : 3000,
+    refetchInterval: pollWhileRunning
+      ? 3000
+      : (query) => (query.state.data?.status === "ready" ? false : 3000),
     retry: false,
   })
+
+  const { refetch } = query
+  const previous = useRef({ enabled, pollWhileRunning })
+  useEffect(() => {
+    const was = previous.current
+    previous.current = { enabled, pollWhileRunning }
+    const finishedWhileVisible =
+      was.enabled && was.pollWhileRunning && enabled && !pollWhileRunning
+    if (finishedWhileVisible) {
+      const timers = [0, 1000, 3000].map((delay) =>
+        window.setTimeout(() => void refetch(), delay)
+      )
+      return () => timers.forEach(window.clearTimeout)
+    }
+    if (!was.enabled && enabled && !pollWhileRunning) void refetch()
+  }, [enabled, pollWhileRunning, refetch])
+
+  return query
 }
 
 export function useWorkflowApprovals(

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -356,7 +356,7 @@ export function useAgentThreadTurnDiff(
   })
 
   const { refetch } = query
-  const previous = useRef({ enabled, pollWhileRunning })
+  const previous = useRef({ enabled: false, pollWhileRunning })
   useEffect(() => {
     const was = previous.current
     previous.current = { enabled, pollWhileRunning }


### PR DESCRIPTION
## Description
Unify the cloud and desktop right panel behind the same Changes and terminal UI, removing the embedded review/committed views and local-only placeholders. Persist and migrate panel state consistently, and keep cloud diffs fresh through active runs and completion.

## Release Note
Cloud and local agent threads now share the same right-panel and changed-files experience.

## Test Plan
- [x] Verify legacy Review tab state migrates to Changes and remains selected after reload.
- [x] Verify cloud diffs poll while running and refresh after completion or reopening.