### PR TITLE
feat: make live work status expandable

### DIFF
--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -295,6 +295,7 @@ export const Messages = memo(function MessagesComponent({
                   projectPath={projectPath}
                   threadId={threadId}
                   isLatestTurn={index === lastAgentIndex}
+                  activityLabel={messageIsStreaming ? activityLabel : undefined}
                   onApprove={onApprove}
                   onReject={onReject}
                   onAutoApprove={onAutoApprove}
@@ -307,7 +308,10 @@ export const Messages = memo(function MessagesComponent({
             )}
             <QueuedMessages queuedMessages={queuedMessages} />
             <ThinkingSpinner
-              isActive={!!(isThinking || streamIsLoading || isStreaming)}
+              isActive={
+                !!(isThinking || streamIsLoading || isStreaming) &&
+                !(isStreaming && lastAgentIndex === visibleMessages.length - 1)
+              }
               settingUpSandbox={settingUpSandbox}
               label={activityLabel}
             />

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -102,6 +102,7 @@ export function AgentTurn({
   projectPath,
   threadId,
   isLatestTurn,
+  activityLabel,
   ...callbacks
 }: {
   message: Message
@@ -111,6 +112,7 @@ export function AgentTurn({
   /** Cloud threads only; enables the git-sourced changed-files card. */
   threadId?: string
   isLatestTurn?: boolean
+  activityLabel?: string
 } & ApprovalCallbacks) {
   const renderItems = useMemo(
     () => buildRenderItems(message.chunks, message.id),
@@ -179,7 +181,7 @@ export function AgentTurn({
         .trim(),
     [replyItems]
   )
-  const canFoldWork = !isStreaming && workItems.length > 0
+  const canFoldWork = !!isStreaming || workItems.length > 0
   const [workFoldExpanded, setWorkFoldExpanded] = useState(false)
   const toggleWorkFold = useCallback(
     () => setWorkFoldExpanded((value) => !value),
@@ -276,10 +278,11 @@ export function AgentTurn({
     workDurationMs && workDurationMs >= 1000
       ? `Worked for ${formatElapsed(workDurationMs)}`
       : "Worked"
-  const foldLabel =
+  const foldLabel = isStreaming ? (activityLabel ?? "Working…") : workLabel
+  const foldLabelWithCount =
     actionCount > 0
-      ? `${workLabel} · ${actionCount} action${actionCount === 1 ? "" : "s"}`
-      : workLabel
+      ? `${foldLabel} · ${actionCount} action${actionCount === 1 ? "" : "s"}`
+      : foldLabel
   const visibleItems =
     canFoldWork && workFoldExpanded
       ? renderItems
@@ -291,7 +294,7 @@ export function AgentTurn({
     <div className="group/turn my-2 min-w-0 space-y-1.5">
       {canFoldWork && (
         <TurnFoldRow
-          label={foldLabel}
+          label={foldLabelWithCount}
           expanded={workFoldExpanded}
           onToggle={toggleWorkFold}
         />


### PR DESCRIPTION
## Description
Use the expandable work row during a run, updating its label with the current activity before finalizing it to “Worked”.

## Release Note
Live work status is now expandable while an agent is running.

## Test Plan
- [x] Verify focused UI lint, typecheck, and tests

Made by [Open SWE](https://openswe.vercel.app/agents/01a02091-8d43-75e4-b8c5-64065dbd26eb)