### PR TITLE
feat: simplify sidebar navigation

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -6,7 +6,6 @@ import {
   CalendarBlankIcon,
   CaretDownIcon,
   CaretRightIcon,
-  ChartLineUpIcon,
   ChatCircleIcon,
   CheckCircleIcon,
   CircleNotchIcon,
@@ -16,7 +15,6 @@ import {
   FolderPlusIcon,
   GitMergeIcon,
   GitPullRequestIcon,
-  KanbanIcon,
   LightningIcon,
   MagnifyingGlassIcon,
   PlusIcon,
@@ -24,6 +22,7 @@ import {
   TrashIcon,
   TreeStructureIcon,
 } from "@phosphor-icons/react"
+import { Kanban } from "lucide-react"
 import { IoLogoGithub, IoLogoSlack } from "react-icons/io5"
 import { SiLinear } from "react-icons/si"
 import { useCallback, useEffect, useMemo, useState } from "react"
@@ -131,10 +130,9 @@ interface AgentsSidebarProps {
 }
 
 const NAV = [
-  { to: "/agents/threads", label: "Threads", icon: KanbanIcon },
+  { to: "/agents/threads", label: "Kanban", icon: Kanban },
   { to: "/agents/skills", label: "Skills", icon: SparkleIcon },
   { to: "/agents/automations", label: "Automations", icon: LightningIcon },
-  { to: "/my-settings", label: "Dashboard", icon: ChartLineUpIcon },
   { to: "/agents/reviews", label: "Reviews", icon: GitPullRequestIcon },
 ] as const
 


### PR DESCRIPTION
## Description
Remove the redundant Dashboard sidebar link and rename Threads to Kanban with a Lucide icon.

## Release Note
Sidebar navigation now labels the thread board as Kanban and removes the redundant Dashboard link.

## Test Plan
- [x] TypeScript typecheck
- [x] Prettier check

Made by [Open SWE](https://openswe.vercel.app/agents/01a020a3-fe70-724d-84de-81876687b0c8)