### PR TITLE
fix: show local run activity before messages

### DIFF
--- a/ui/src/features/agents/components/messages/Messages.test.tsx
+++ b/ui/src/features/agents/components/messages/Messages.test.tsx
@@ -1,0 +1,16 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { Messages } from "./Messages"
+
+afterEach(() => cleanup())
+
+describe("Messages", () => {
+  it("shows run activity while a stream is starting with no messages", () => {
+    render(<Messages messages={[]} isStreaming />)
+
+    expect(screen.getByRole("status").textContent).toBe("Working…")
+  })
+})

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -310,7 +310,11 @@ export const Messages = memo(function MessagesComponent({
             <ThinkingSpinner
               isActive={
                 !!(isThinking || streamIsLoading || isStreaming) &&
-                !(isStreaming && lastAgentIndex === visibleMessages.length - 1)
+                !(
+                  isStreaming &&
+                  lastAgentIndex >= 0 &&
+                  lastAgentIndex === visibleMessages.length - 1
+                )
               }
               settingUpSandbox={settingUpSandbox}
               label={activityLabel}


### PR DESCRIPTION
## Summary

- keep the live activity indicator visible while a desktop-local run is starting with an empty transcript
- avoid treating the empty-list `-1` index as an existing live agent turn
- add regression coverage for the blank local-run state

## Verification

- `pnpm exec vitest run src/features/agents/components/messages/Messages.test.tsx src/features/agents/components/messages/ThinkingSpinner.test.tsx`
- `pnpm run typecheck`
- `pnpm exec prettier --check src/features/agents/components/messages/Messages.tsx src/features/agents/components/messages/Messages.test.tsx`
- `pnpm run build`