### PR TITLE
feat: show automation action outcomes

### DIFF
--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -501,6 +501,8 @@ def _agent_run_metadata(
         "schedule_id": record["id"],
         "schedule_name": record.get("name"),
         "schedule_test": test_run,
+        "automation_notification_mode": _slack_notification_mode(record),
+        "automation_action_taken": False,
         "github_login": record.get("created_by"),
         PARTICIPANT_LOGINS_KEY: [record["created_by"]] if record.get("created_by") else [],
         "triggering_user_email": record.get("user_email"),

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -558,6 +558,12 @@ async def _thread_summary(
         "triggerKind": trigger_kind,
         "automationId": _metadata_string(metadata, "schedule_id"),
         "automationName": _metadata_string(metadata, "schedule_name"),
+        "automationNotificationMode": (
+            metadata.get("automation_notification_mode")
+            if metadata.get("automation_notification_mode") in {"always", "on_action"}
+            else None
+        ),
+        "automationActionTaken": metadata.get("automation_action_taken") is True,
         "status": status,
         "viewed": _is_thread_viewed(metadata, latest_run_id),
         "viewedAt": (

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -41,6 +41,16 @@ async def _release_reservation(client: Any, thread_id: str) -> None:
         logger.exception("Failed to release automation notification for %s", thread_id)
 
 
+async def _record_action_taken(client: Any, thread_id: str) -> None:
+    try:
+        await client.threads.update(
+            thread_id=thread_id,
+            metadata={"automation_action_taken": True},
+        )
+    except Exception:
+        logger.exception("Failed to record automation action for %s", thread_id)
+
+
 async def notify_automation_channel(message: str) -> dict[str, Any]:
     """Notify the configured automation channel once after a concrete requested action."""
     config = get_config()
@@ -77,6 +87,7 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
         }
 
     client = get_client()
+    await _record_action_taken(client, thread_id)
     async with _notification_lock(thread_id):
         try:
             item = await client.store.get_item(_NOTIFICATION_NAMESPACE, thread_id)

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -691,6 +691,8 @@ async def test_launch_conditional_slack_schedule_starts_silently(
     assert "read-only checks" in (prompt.findtext("content") or "")
     metadata = fake_client.threads.created[0]["metadata"]
     assert "source_context" not in metadata
+    assert metadata["automation_notification_mode"] == "on_action"
+    assert metadata["automation_action_taken"] is False
 
 
 async def test_launch_scheduled_agent_run_stops_when_slack_post_fails(

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -413,6 +413,20 @@ async def test_thread_summary_omits_pr_when_no_pr_metadata() -> None:
     assert "diffStats" not in summary
 
 
+async def test_thread_summary_exposes_automation_action_result() -> None:
+    summary = await thread_api._thread_summary(
+        _thread_with_metadata(
+            {
+                "automation_notification_mode": "on_action",
+                "automation_action_taken": True,
+            }
+        )
+    )
+
+    assert summary["automationNotificationMode"] == "on_action"
+    assert summary["automationActionTaken"] is True
+
+
 async def test_thread_summary_exposes_sandbox_id() -> None:
     summary = await thread_api._thread_summary(_thread_with_metadata({"sandbox_id": "sb-abc123"}))
 

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -21,9 +21,18 @@ class _FakeStore:
         self.items.pop((tuple(namespace), key), None)
 
 
+class _FakeThreads:
+    def __init__(self) -> None:
+        self.updated: list[dict[str, Any]] = []
+
+    async def update(self, **kwargs: Any) -> None:
+        self.updated.append(kwargs)
+
+
 class _FakeClient:
     def __init__(self) -> None:
         self.store = _FakeStore()
+        self.threads = _FakeThreads()
 
 
 def _config(thread_id: str = "thread_1") -> dict[str, Any]:
@@ -108,6 +117,7 @@ async def test_notify_automation_channel_validates_message(
         "error": "Message must be at most 3000 characters",
     }
     assert fake_client.store.items == {}
+    assert fake_client.threads.updated == []
 
 
 async def test_notify_automation_channel_posts_to_trusted_destination(
@@ -134,6 +144,12 @@ async def test_notify_automation_channel_posts_to_trusted_destination(
     stored = fake_client.store.items[(("automation_notifications",), "thread_1")]
     assert stored["status"] == "delivered"
     assert stored["message_ts"] == "1786504009.596419"
+    assert fake_client.threads.updated == [
+        {
+            "thread_id": "thread_1",
+            "metadata": {"automation_action_taken": True},
+        }
+    ]
 
 
 async def test_notify_automation_channel_suppresses_duplicate_posts(

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -282,6 +282,8 @@ export interface AgentThread {
   triggerKind?: AgentTriggerKind | string
   automationId?: string | null
   automationName?: string | null
+  automationNotificationMode?: SlackNotificationMode | null
+  automationActionTaken?: boolean
   status: AgentStatus
   viewed: boolean
   viewedAt?: number | null

--- a/ui/src/features/automations/components/AutomationRuns.test.tsx
+++ b/ui/src/features/automations/components/AutomationRuns.test.tsx
@@ -38,4 +38,56 @@ describe("AutomationRuns", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
     expect(refetch).toHaveBeenCalledOnce()
   })
+
+  it("shows whether action-only runs performed an action", () => {
+    vi.mocked(useThreadsPage).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "action",
+            title: "Action run",
+            automationId: "schedule-1",
+            automationName: "Dependency check",
+            automationNotificationMode: "on_action",
+            automationActionTaken: true,
+            triggerKind: "schedule",
+            status: "finished",
+            updatedAt: 3,
+          },
+          {
+            id: "no-action",
+            title: "No action run",
+            automationId: "schedule-1",
+            automationName: "Dependency check",
+            automationNotificationMode: "on_action",
+            automationActionTaken: false,
+            triggerKind: "schedule",
+            status: "finished",
+            updatedAt: 2,
+          },
+          {
+            id: "pending",
+            title: "Pending run",
+            automationId: "schedule-1",
+            automationName: "Dependency check",
+            automationNotificationMode: "on_action",
+            automationActionTaken: false,
+            triggerKind: "schedule",
+            status: "running",
+            updatedAt: 1,
+          },
+        ],
+        hasMore: false,
+      },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    } as unknown as ReturnType<typeof useThreadsPage>)
+
+    render(<AutomationRuns automationId="schedule-1" />)
+
+    expect(screen.getByText("Action taken")).toBeTruthy()
+    expect(screen.getByText("No action")).toBeTruthy()
+    expect(screen.getByText("Awaiting action")).toBeTruthy()
+  })
 })

--- a/ui/src/features/automations/components/AutomationRuns.tsx
+++ b/ui/src/features/automations/components/AutomationRuns.tsx
@@ -117,6 +117,14 @@ function groupAutomationRuns(runs: Array<AgentThread>) {
 
 function AutomationRunRow({ run }: { run: AgentThread }) {
   const isTest = run.triggerKind === "schedule_test"
+  const actionLabel =
+    run.automationNotificationMode !== "on_action"
+      ? null
+      : run.automationActionTaken
+        ? "Action taken"
+        : run.status === "running"
+          ? "Awaiting action"
+          : "No action"
   return (
     <Link
       to="/agents/$threadId"
@@ -144,6 +152,13 @@ function AutomationRunRow({ run }: { run: AgentThread }) {
         <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground/70">
           <span>{STATUS_LABELS[run.status]}</span>
           <span>{isTest ? "Test run" : "Scheduled run"}</span>
+          {actionLabel && (
+            <span
+              className={cn(actionLabel === "Action taken" && "text-success")}
+            >
+              {actionLabel}
+            </span>
+          )}
           {run.repoFullName && <span>{run.repoFullName}</span>}
           <span>{formatRelativeTime(run.updatedAt)}</span>
         </div>


### PR DESCRIPTION
## Description
Action-only automation runs now record whether the agent performed a concrete action and surface that result in the automation log. Running jobs show “Awaiting action” until they finish or act.

## Release Note
Automation run history now indicates action taken, no action, or awaiting action for action-only Slack notifications.

## Test Plan
- [x] Verify backend metadata and notification-tool tracking with focused pytest coverage
- [x] Verify automation run labels with Vitest, TypeScript, ESLint, Ruff, and basedpyright

Made by [Open SWE](https://openswe.vercel.app/agents/f67eefdb-90cc-5035-af01-e814fbb0a5ab)