### PR TITLE
feat: shimmer active task names

### DIFF
--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -295,6 +295,7 @@ export function AgentTurn({
       {canFoldWork && (
         <TurnFoldRow
           label={foldLabelWithCount}
+          active={!!isStreaming}
           expanded={workFoldExpanded}
           onToggle={toggleWorkFold}
         />

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -179,7 +179,12 @@ export function WorkEntryRow({
               <span
                 className={cn(
                   "min-w-0 shrink truncate font-medium",
-                  isError ? "text-destructive" : "text-foreground/82"
+                  isError
+                    ? "text-destructive"
+                    : entry.status === "pending" ||
+                        entry.status === "in_progress"
+                      ? "shimmer-text"
+                      : "text-foreground/82"
                 )}
               >
                 {entry.heading}

--- a/ui/src/features/agents/components/messages/timeline/foldRows.tsx
+++ b/ui/src/features/agents/components/messages/timeline/foldRows.tsx
@@ -8,10 +8,12 @@ import { cn } from "@/lib/utils"
  */
 export function TurnFoldRow({
   label,
+  active,
   expanded,
   onToggle,
 }: {
   label: string
+  active: boolean
   expanded: boolean
   onToggle: () => void
 }) {
@@ -25,7 +27,7 @@ export function TurnFoldRow({
         onClick={onToggle}
         className="flex cursor-pointer items-center gap-1 rounded-md px-1 text-[13px] text-muted-foreground tabular-nums transition-colors select-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:outline-none focus-visible:ring-inset"
       >
-        <span>{label}</span>
+        <span className={active ? "shimmer-text" : undefined}>{label}</span>
         <Icon className="size-3.5" />
       </button>
     </div>


### PR DESCRIPTION
## Description
Shimmer active collapsed task labels and in-progress tool names so ongoing runs remain visually apparent.

## Release Note
Active agent task names now shimmer while a run is ongoing.

## Test Plan
- [ ] Confirm shimmer stops when a run settles.

Made by [Open SWE](https://openswe.vercel.app/agents/01a020f5-f753-7118-91e1-dfee572d647d)