### PR TITLE
feat: highlight JSON tool results

### DIFF
--- a/ui/src/features/agents/components/messages/timeline/ToolResultBody.test.tsx
+++ b/ui/src/features/agents/components/messages/timeline/ToolResultBody.test.tsx
@@ -1,0 +1,28 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ToolResultBody } from "./ToolResultBody"
+
+vi.mock("@/features/agents/components/chat/CodeBlock", () => ({
+  CodeBlock: ({ text, language }: { text: string; language?: string }) => (
+    <code data-language={language}>{text}</code>
+  ),
+}))
+
+afterEach(() => cleanup())
+
+describe("ToolResultBody", () => {
+  it("renders JSON through the syntax-highlighted code path", () => {
+    render(<ToolResultBody value='{"answer":42}' />)
+
+    expect(screen.getByText(/"answer": 42/).dataset.language).toBe("json")
+  })
+
+  it("keeps invalid JSON as plain text", () => {
+    const { container } = render(<ToolResultBody value="{not json}" />)
+
+    expect(container.querySelector("pre")?.textContent).toBe("{not json}")
+  })
+})

--- a/ui/src/features/agents/components/messages/timeline/ToolResultBody.tsx
+++ b/ui/src/features/agents/components/messages/timeline/ToolResultBody.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from "react"
+
+import { CodeBlock } from "@/features/agents/components/chat/CodeBlock"
+import { formatJsonToolResult } from "./toolResultJson"
+
+export function ToolResultBody({ value }: { value: string }) {
+  const json = useMemo(() => formatJsonToolResult(value), [value])
+
+  if (json !== null) return <CodeBlock text={json} language="json" />
+
+  return (
+    <pre className="max-h-64 cursor-text overflow-auto font-mono text-[12px] leading-relaxed break-words whitespace-pre-wrap text-muted-foreground select-text">
+      {value}
+    </pre>
+  )
+}

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -20,6 +20,7 @@ import type { WorkEntryIconName, WorkEntryView } from "./workEntry"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
 import { formatHoverTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { cn } from "@/lib/utils"
+import { ToolResultBody } from "./ToolResultBody"
 
 const ICONS: Record<WorkEntryIconName, typeof Bot> = {
   bot: Bot,
@@ -256,11 +257,10 @@ export function WorkEntryRow({
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          {body ?? (
-            <pre className="max-h-64 cursor-text overflow-auto font-mono text-[12px] leading-relaxed break-words whitespace-pre-wrap text-muted-foreground select-text">
-              {entry.expandedText}
-            </pre>
-          )}
+          {body ??
+            (entry.expandedText != null && (
+              <ToolResultBody value={entry.expandedText} />
+            ))}
         </div>
       )}
     </div>

--- a/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
+++ b/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react"
 
 import type { ToolExecutionChunk } from "@/features/agents/lib/types"
+import { ToolResultBody } from "./ToolResultBody"
 
 export const ShellEntryBody = memo(function ShellEntryBody({
   chunk,
@@ -19,11 +20,7 @@ export const ShellEntryBody = memo(function ShellEntryBody({
           {command}
         </pre>
       )}
-      {output && (
-        <pre className="max-h-64 cursor-text overflow-auto font-mono text-[12px] leading-relaxed whitespace-pre text-muted-foreground select-text">
-          {output}
-        </pre>
-      )}
+      {output && <ToolResultBody value={output} />}
       {!output && chunk.status === "in_progress" && (
         <p className="font-mono text-[12px] text-muted-foreground">Running…</p>
       )}

--- a/ui/src/features/agents/components/messages/timeline/toolResultJson.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/toolResultJson.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { formatJsonToolResult } from "./toolResultJson"
+
+describe("formatJsonToolResult", () => {
+  it("pretty-prints JSON objects and arrays", () => {
+    expect(formatJsonToolResult('{"answer":42}')).toBe('{\n  "answer": 42\n}')
+    expect(formatJsonToolResult('["one",2]')).toBe('[\n  "one",\n  2\n]')
+  })
+
+  it("ignores non-JSON and values that do not begin with an object or array", () => {
+    expect(formatJsonToolResult("{not json}")).toBeNull()
+    expect(formatJsonToolResult('  {"answer":42}')).toBeNull()
+    expect(formatJsonToolResult('"value"')).toBeNull()
+  })
+
+  it("ignores values at or above one MiB", () => {
+    const value = `{"value":"${"x".repeat(1024 * 1024)}"}`
+
+    expect(formatJsonToolResult(value)).toBeNull()
+  })
+
+  it("measures the UTF-8 byte size", () => {
+    const value = `{"value":"${"é".repeat(600_000)}"}`
+
+    expect(value.length).toBeLessThan(1024 * 1024)
+    expect(formatJsonToolResult(value)).toBeNull()
+  })
+})

--- a/ui/src/features/agents/components/messages/timeline/toolResultJson.ts
+++ b/ui/src/features/agents/components/messages/timeline/toolResultJson.ts
@@ -1,0 +1,16 @@
+const MAX_JSON_TOOL_RESULT_BYTES = 1024 * 1024
+
+export function formatJsonToolResult(value: string): string | null {
+  if (value[0] !== "{" && value[0] !== "[") return null
+  if (
+    new TextEncoder().encode(value).byteLength >= MAX_JSON_TOOL_RESULT_BYTES
+  ) {
+    return null
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2) ?? null
+  } catch {
+    return null
+  }
+}

--- a/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
@@ -140,6 +140,14 @@ describe("describeWorkEntry", () => {
 
     expect(entry.expandedText).toBe("ls\n\na.ts\nb.ts")
   })
+
+  it("keeps complete JSON tool output available for highlighted rendering", () => {
+    const output = JSON.stringify({ value: "x".repeat(5000) })
+    const entry = describeWorkEntry(chunk({ output }), projectPath)
+
+    expect(entry.expandedText).toBe(JSON.stringify(JSON.parse(output), null, 2))
+    expect(entry.expandedText).not.toContain("…")
+  })
 })
 
 describe("liveActivityLabel", () => {

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -8,6 +8,7 @@ import {
   formatToolDisplayParts,
 } from "@/features/agents/components/chat/toolExecutionDisplay"
 import { countLineChanges } from "@/features/agents/utils/diffStats"
+import { formatJsonToolResult } from "./toolResultJson"
 
 export type WorkEntryIconName =
   | "bot"
@@ -109,8 +110,10 @@ function expandedTextForChunk(
     typeof chunk.input?.command === "string" ? chunk.input.command.trim() : ""
   if (command) blocks.push(command)
 
-  const output = chunk.output?.trim()
-  if (output) blocks.push(output)
+  const rawOutput = chunk.output ?? ""
+  const output = rawOutput.trim()
+  const jsonOutput = formatJsonToolResult(rawOutput)
+  if (output) blocks.push(jsonOutput ?? output)
 
   const locations = chunk.locations ?? []
   if (!output && locations.length > 0) {
@@ -121,6 +124,7 @@ function expandedTextForChunk(
 
   if (blocks.length === 0) return null
   const joined = blocks.join("\n\n")
+  if (jsonOutput !== null && !command) return joined
   return joined.length > MAX_EXPANDED_TEXT_LENGTH
     ? `${joined.slice(0, MAX_EXPANDED_TEXT_LENGTH)}\n…`
     : joined


### PR DESCRIPTION
## Description
Detect object and array tool results under 1 MiB, pretty-print them, and render them through the existing Shiki JSON highlighter. Invalid, prefixed, and oversized values retain plain-text rendering.

## Test Plan
- [x] Verify object/array JSON, invalid values, and UTF-8 size limits
- [x] Build the dashboard production bundle

Made by [Open SWE](https://openswe.vercel.app/agents/01a02125-5f47-740d-9958-33fc38e2aba4)