### PR TITLE
fix: align sidebar toggle in macOS fullscreen

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -805,6 +805,12 @@ function createWindow() {
   window.webContents.on("will-attach-webview", (event) =>
     event.preventDefault(),
   );
+  window.on("enter-full-screen", () =>
+    window.webContents.send("desktop:fullscreen-change", true),
+  );
+  window.on("leave-full-screen", () =>
+    window.webContents.send("desktop:fullscreen-change", false),
+  );
   mainWindow = window;
   void loadApp(window);
   return window;

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -805,6 +805,9 @@ function createWindow() {
   window.webContents.on("will-attach-webview", (event) =>
     event.preventDefault(),
   );
+  window.webContents.on("did-finish-load", () =>
+    window.webContents.send("desktop:fullscreen-change", window.isFullScreen()),
+  );
   window.on("enter-full-screen", () =>
     window.webContents.send("desktop:fullscreen-change", true),
   );

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -73,6 +73,10 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
 
 const DRAG_REGION_ID = "open-swe-desktop-drag-region"
 
+ipcRenderer.on("desktop:fullscreen-change", (_event, fullscreen) => {
+  document.documentElement.classList.toggle("desktop-fullscreen", fullscreen)
+})
+
 window.addEventListener("DOMContentLoaded", () => {
   if (process.platform !== "darwin") return
 
@@ -100,6 +104,10 @@ window.addEventListener("DOMContentLoaded", () => {
     [data-sidebar-expand] {
       -webkit-app-region: no-drag;
       left: 90px !important;
+    }
+
+    .desktop-fullscreen :is([data-sidebar-collapse], [data-sidebar-expand]) {
+      left: 12px !important;
     }
   `
   document.head.append(style)

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -227,6 +227,7 @@ export function SidebarCollapseButton({
     <button
       type="button"
       aria-label="Collapse sidebar"
+      data-sidebar-collapse=""
       onClick={onToggle}
       className={cn(
         "flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground",


### PR DESCRIPTION
## Description
Move the desktop sidebar toggle to the window edge when macOS enters fullscreen, while preserving traffic-light clearance in windowed mode.

## Release Note
Fixed sidebar toggle alignment in macOS fullscreen.

## Test Plan
- [x] Verify desktop build, tests, and typecheck

Made by [Open SWE](https://openswe.vercel.app/agents/01a02131-f5c0-7119-a629-2df5a4956892)