### PR TITLE
fix: read the Changes surface from a selectable diff scope

### DIFF
--- a/agent/desktop.py
+++ b/agent/desktop.py
@@ -1,9 +1,12 @@
 import json
 import os
+import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
 from deepagents.backends import LocalShellBackend
+from deepagents.backends.filesystem import FilesystemBackend
 
 SHELL_ENV_KEYS = ("HOME", "LANG", "LC_ALL", "PATH", "SHELL", "TMPDIR")
 
@@ -38,3 +41,29 @@ def create_desktop_backend(configurable: dict[str, Any]) -> LocalShellBackend:
         virtual_mode=True,
         env={key: value for key in SHELL_ENV_KEYS if (value := os.environ.get(key))},
     )
+
+
+def _artifacts_root() -> Path:
+    configured = os.environ.get("OPEN_SWE_LOCAL_ARTIFACTS_DIR")
+    if configured:
+        return Path(configured)
+    return Path(tempfile.gettempdir()) / f"open-swe-artifacts-{os.getuid()}"
+
+
+def desktop_artifact_routes(thread_id: str) -> dict[str, FilesystemBackend]:
+    """Backends for the agent's own scratch files on a desktop run.
+
+    Offloaded tool results and evicted history default to the artifacts root,
+    which for a desktop run is the user's project: the dumps would show up as
+    changes and be swept into the next `git add -A`. Route them out of the
+    repository while leaving the virtual paths the model sees unchanged.
+    """
+    # The thread id becomes a path segment, so it may only be a plain name.
+    safe_id = re.sub(r"[^A-Za-z0-9._-]", "-", thread_id or "thread").lstrip(".") or "thread"
+    root = _artifacts_root() / safe_id
+    routes = {}
+    for name in ("large_tool_results", "conversation_history"):
+        directory = root / name
+        directory.mkdir(parents=True, exist_ok=True)
+        routes[f"/{name}/"] = FilesystemBackend(root_dir=directory, virtual_mode=True)
+    return routes

--- a/agent/server.py
+++ b/agent/server.py
@@ -75,7 +75,7 @@ from .dashboard.team_settings import (
     get_team_fable_enabled,
 )
 from .dashboard.user_mappings import email_for_login
-from .desktop import create_desktop_backend, is_desktop_run
+from .desktop import create_desktop_backend, desktop_artifact_routes, is_desktop_run
 from .input_messages import append_message_data
 from .integrations.corridor_mcp import load_corridor_tools
 from .integrations.currents_tools import load_currents_tools
@@ -1528,6 +1528,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if is_desktop_run(configurable):
         skill_routes[USER_SKILLS_ROUTE] = ReadOnlyBackend(StateBackend())
         skill_sources = [USER_SKILLS_ROUTE, BUNDLED_SKILLS_ROUTE]
+        # The default backend is the user's project, so offloads would land in
+        # their repository. Keep the agent's scratch files out of it.
+        skill_routes.update(desktop_artifact_routes(thread_id))
     else:
         skill_routes[ORGANIZATION_SKILLS_ROUTE] = ReadOnlyBackend(
             StoreBackend(namespace=lambda _runtime: (ORGANIZATION_SKILLS_NAMESPACE,))

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -137,6 +137,9 @@ class BackendSupervisor {
         ...this.options.env,
         OPEN_SWE_LOCAL_AUTH_TOKEN: this.token,
         OPEN_SWE_LOCAL_PROJECTS_FILE: this.options.projectsFile,
+        ...(this.options.stateDir
+          ? { OPEN_SWE_LOCAL_ARTIFACTS_DIR: path.join(this.options.stateDir, "artifacts") }
+          : {}),
         PYTHONUNBUFFERED: "1",
       },
       stdio: ["ignore", "pipe", "pipe"],

--- a/desktop/src/git-diff.cts
+++ b/desktop/src/git-diff.cts
@@ -122,7 +122,7 @@ function parsePullRequest(raw) {
   }
 }
 
-async function pullRequest(repo, env) {
+async function pullRequest(repo, env, branch = null) {
   try {
     const output = await new Promise<string>((resolve, reject) => {
       execFile(
@@ -130,6 +130,7 @@ async function pullRequest(repo, env) {
         [
           "pr",
           "view",
+          ...(branch ? [branch] : []),
           "--json",
           "number,title,state,isDraft,headRefName,baseRefName,url,author,createdAt,additions,deletions,changedFiles",
         ],
@@ -149,9 +150,15 @@ async function pullRequest(repo, env) {
   }
 }
 
-async function repositoryMetadata(repo, env) {
-  const branch = await currentBranch(repo)
-  return { branch, pr: branch ? await pullRequest(repo, env) : null }
+/**
+ * `threadBranch` is the branch the thread last worked on. Every session in the
+ * project shares one worktree, so the branch that happens to be checked out
+ * right now is not necessarily the one this thread's pull request belongs to.
+ */
+async function repositoryMetadata(repo, env, threadBranch = null) {
+  const named = await validBranchName(repo, threadBranch)
+  const branch = named ?? (await currentBranch(repo))
+  return { branch, pr: branch ? await pullRequest(repo, env, named) : null }
 }
 
 function gitStdin(cwd, args, input) {
@@ -376,14 +383,22 @@ async function readDiff(repo, base, headish = null) {
 }
 
 /** First ref spec that resolves to a commit, preferring the pushed remote. */
-async function resolveBaseRef(repo, baseRef) {
-  if (typeof baseRef !== "string" || !baseRef.trim()) return null
-  const name = baseRef.trim()
+/** A branch name safe to pass as a positional argument, or null. */
+async function validBranchName(repo, branch) {
+  if (typeof branch !== "string" || !branch.trim()) return null
+  const name = branch.trim()
+  if (name.startsWith("-")) return null
   try {
     await git(repo, ["check-ref-format", "--branch", name], null, 5_000)
   } catch {
     return null
   }
+  return name
+}
+
+async function resolveBaseRef(repo, baseRef) {
+  const name = await validBranchName(repo, baseRef)
+  if (!name) return null
   for (const spec of [`origin/${name}`, name]) {
     try {
       return text(await git(repo, ["rev-parse", "--verify", "-q", `${spec}^{commit}`], null, 5_000))
@@ -393,17 +408,31 @@ async function resolveBaseRef(repo, baseRef) {
 }
 
 /**
- * What the current branch has *committed* on top of `baseRef` — the pull
- * request's own content. Committed refs only: the worktree is shared with
- * every other session in the project, so its uncommitted state says nothing
- * about which thread made a change.
+ * What `headRef` has *committed* on top of `baseRef` — the pull request's own
+ * content. Committed refs only: the worktree is shared with every other
+ * session in the project, so its uncommitted state says nothing about which
+ * thread made a change. `headRef` defaults to the checkout only when the
+ * thread's own branch is unknown.
  */
-async function readBranchDiff(repo, baseRef) {
+async function readBranchDiff(repo, baseRef, headRef = null) {
+  const missing = { status: "missing", files: [], truncated: false }
   const base = await resolveBaseRef(repo, baseRef)
-  if (!base) return { status: "missing", files: [], truncated: false }
-  const mergeBase = text(await git(repo, ["merge-base", base, "HEAD"], null, 10_000))
-  if (!mergeBase) return { status: "missing", files: [], truncated: false }
-  return readDiff(repo, mergeBase, "HEAD")
+  if (!base) return missing
+  const named = await validBranchName(repo, headRef)
+  let head = "HEAD"
+  if (named) {
+    try {
+      head = text(await git(repo, ["rev-parse", "--verify", "-q", `${named}^{commit}`], null, 5_000))
+    } catch {
+      return missing
+    }
+    if (!head) return missing
+  } else if (headRef) {
+    return missing
+  }
+  const mergeBase = text(await git(repo, ["merge-base", base, head], null, 10_000))
+  if (!mergeBase) return missing
+  return readDiff(repo, mergeBase, head)
 }
 
 module.exports = {

--- a/desktop/src/git-diff.cts
+++ b/desktop/src/git-diff.cts
@@ -68,10 +68,21 @@ async function currentBranch(cwd) {
   }
 }
 
+function count(value) {
+  return Number.isInteger(value) && value >= 0 ? value : 0
+}
+
+/** `owner/repo` from an already-validated pull request URL. */
+function repoFullNameFromUrl(url: URL) {
+  const [owner, repo] = url.pathname.split("/").filter(Boolean)
+  return owner && repo ? `${owner}/${repo}` : null
+}
+
 function parsePullRequest(raw) {
   try {
     const value = JSON.parse(raw)
     const url = new URL(value.url)
+    const repoFullName = repoFullNameFromUrl(url)
     if (
       !Number.isInteger(value.number) ||
       value.number < 1 ||
@@ -80,10 +91,12 @@ function parsePullRequest(raw) {
       typeof value.isDraft !== "boolean" ||
       typeof value.headRefName !== "string" ||
       typeof value.baseRefName !== "string" ||
-      !["http:", "https:"].includes(url.protocol)
+      !["http:", "https:"].includes(url.protocol) ||
+      !repoFullName
     ) {
       return null
     }
+    const login = value.author?.login
     return {
       number: value.number,
       title: value.title,
@@ -94,6 +107,15 @@ function parsePullRequest(raw) {
       headRef: value.headRefName,
       baseRef: value.baseRefName,
       url: url.href,
+      repoFullName,
+      author: typeof login === "string" && login ? login : null,
+      authorAvatarUrl: null,
+      createdAt: typeof value.createdAt === "string" ? value.createdAt : null,
+      diffStats: {
+        files: count(value.changedFiles),
+        additions: count(value.additions),
+        deletions: count(value.deletions),
+      },
     }
   } catch {
     return null
@@ -109,7 +131,7 @@ async function pullRequest(repo, env) {
           "pr",
           "view",
           "--json",
-          "number,title,state,isDraft,headRefName,baseRefName,url",
+          "number,title,state,isDraft,headRefName,baseRefName,url,author,createdAt,additions,deletions,changedFiles",
         ],
         {
           cwd: repo,
@@ -316,9 +338,12 @@ function decode(blob: Buffer | false | null) {
   return content.includes("\u0000") ? [null, true] : [content, false]
 }
 
-/** Files changed between `base` and the live worktree, shaped like the cloud turn diff. */
-async function readDiff(repo, base) {
-  const head = await writeWorktreeTree(repo)
+/**
+ * Files changed between `base` and `head`, shaped like the cloud turn diff.
+ * `head` defaults to the live worktree.
+ */
+async function readDiff(repo, base, headish = null) {
+  const head = headish ?? (await writeWorktreeTree(repo))
   const range = ["--no-renames", "--no-ext-diff", "--no-textconv", base, head]
   const numstat = (await git(repo, ["diff", "--numstat", "-z", ...range])).toString("utf8")
   const nameStatus = (await git(repo, ["diff", "--name-status", "-z", ...range])).toString("utf8")
@@ -350,8 +375,40 @@ async function readDiff(repo, base) {
   }
 }
 
+/** First ref spec that resolves to a commit, preferring the pushed remote. */
+async function resolveBaseRef(repo, baseRef) {
+  if (typeof baseRef !== "string" || !baseRef.trim()) return null
+  const name = baseRef.trim()
+  try {
+    await git(repo, ["check-ref-format", "--branch", name], null, 5_000)
+  } catch {
+    return null
+  }
+  for (const spec of [`origin/${name}`, name]) {
+    try {
+      return text(await git(repo, ["rev-parse", "--verify", "-q", `${spec}^{commit}`], null, 5_000))
+    } catch {}
+  }
+  return null
+}
+
+/**
+ * What the current branch has *committed* on top of `baseRef` — the pull
+ * request's own content. Committed refs only: the worktree is shared with
+ * every other session in the project, so its uncommitted state says nothing
+ * about which thread made a change.
+ */
+async function readBranchDiff(repo, baseRef) {
+  const base = await resolveBaseRef(repo, baseRef)
+  if (!base) return { status: "missing", files: [], truncated: false }
+  const mergeBase = text(await git(repo, ["merge-base", base, "HEAD"], null, 10_000))
+  if (!mergeBase) return { status: "missing", files: [], truncated: false }
+  return readDiff(repo, mergeBase, "HEAD")
+}
+
 module.exports = {
   captureCheckpoint,
+  readBranchDiff,
   checkpointRef,
   checkoutBranch,
   currentBranch,

--- a/desktop/src/local-thread-store.cjs
+++ b/desktop/src/local-thread-store.cjs
@@ -72,8 +72,9 @@ function normalizeThread(value) {
     ? {
         repo: stringOrNull(value.checkpoint.repo, 8_192),
         ref: stringOrNull(value.checkpoint.ref, 1_024),
+        branch: stringOrNull(value.checkpoint.branch, 1_024),
       }
-    : { repo: null, ref: null }
+    : { repo: null, ref: null, branch: null }
   const pending = isRecord(value.pending)
     ? {
         prompt: stringOrNull(value.pending.prompt, 2_000_000) || "",
@@ -172,7 +173,7 @@ class LocalThreadStore {
       viewed: true,
       createdAt: now,
       updatedAt: now,
-      checkpoint: { repo: null, ref: null },
+      checkpoint: { repo: null, ref: null, branch: null },
       pending: { prompt, images: cleanImages(input.images), skills: cleanSkills(input.skills) },
     }
     this.threads.set(thread.id, thread)
@@ -213,7 +214,11 @@ class LocalThreadStore {
     if (!current) return null
     const next = {
       ...current,
-      checkpoint: { repo: checkpoint.repo, ref: checkpoint.ref },
+      checkpoint: {
+        repo: checkpoint.repo,
+        ref: checkpoint.ref,
+        branch: stringOrNull(checkpoint.branch, 1_024),
+      },
       updatedAt: this.now(),
     }
     this.threads.set(id, next)

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -166,7 +166,31 @@ async function recordLocalCheckpoint(thread) {
   if (!repo) return thread;
   const ref = checkpointRef(thread.id);
   await captureCheckpoint(repo, ref);
-  return localThreadStore.setCheckpoint(thread.id, { repo, ref });
+  const branch = await currentBranch(repo);
+  return localThreadStore.setCheckpoint(thread.id, { repo, ref, branch });
+}
+
+/**
+ * Remember which branch this thread is working on. Sessions share one worktree,
+ * so the checked-out branch only belongs to a thread while that thread has it:
+ * record it then, and read the recorded value afterwards.
+ */
+async function syncThreadBranch(thread) {
+  if (!thread?.checkpoint.repo) return thread;
+  const branch = await currentBranch(thread.checkpoint.repo);
+  if (!branch || branch === thread.checkpoint.branch) return thread;
+  return (
+    localThreadStore.setCheckpoint(thread.id, {
+      ...thread.checkpoint,
+      branch,
+    }) ?? thread
+  );
+}
+
+/** A running thread owns the checkout, so its branch can still be changing. */
+async function diffThread(threadId) {
+  const thread = localThreadStore.get(threadId);
+  return thread?.status === "running" ? syncThreadBranch(thread) : thread;
 }
 
 function configureDesktopIpc() {
@@ -295,14 +319,15 @@ function configureDesktopIpc() {
     requireTrustedDesktopIpc(event);
     return localThreadStore.list();
   });
-  ipcMain.handle("desktop:update-local-thread", (event, input) => {
+  ipcMain.handle("desktop:update-local-thread", async (event, input) => {
     requireTrustedDesktopIpc(event);
-    return localThreadStore.update(input?.threadId, {
+    const updated = localThreadStore.update(input?.threadId, {
       status: input?.status,
       ...(typeof input?.viewed === "boolean" ? { viewed: input.viewed } : {}),
       ...(typeof input?.modelId === "string" ? { modelId: input.modelId } : {}),
       ...(typeof input?.effort === "string" ? { effort: input.effort } : {}),
     });
+    return syncThreadBranch(updated);
   });
   ipcMain.handle("desktop:delete-local-thread", async (event, threadId) => {
     requireTrustedDesktopIpc(event);
@@ -323,7 +348,7 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:get-local-diff", async (event, threadId) => {
     requireTrustedDesktopIpc(event);
-    const thread = localThreadStore.get(threadId);
+    const thread = await diffThread(threadId);
     if (
       !thread ||
       !registeredProject(thread.cwd) ||
@@ -334,7 +359,11 @@ function configureDesktopIpc() {
     try {
       const [diff, repository] = await Promise.all([
         readDiff(thread.checkpoint.repo, thread.checkpoint.ref),
-        repositoryMetadata(thread.checkpoint.repo),
+        repositoryMetadata(
+          thread.checkpoint.repo,
+          undefined,
+          thread.checkpoint.branch,
+        ),
       ]);
       return { ...diff, repository };
     } catch {
@@ -343,16 +372,21 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:get-local-pr-diff", async (event, threadId) => {
     requireTrustedDesktopIpc(event);
-    const thread = localThreadStore.get(threadId);
+    const thread = await diffThread(threadId);
     if (!thread || !registeredProject(thread.cwd) || !thread.checkpoint.repo)
       return { status: "missing", files: [], truncated: false };
     try {
-      const repository = await repositoryMetadata(thread.checkpoint.repo);
+      const repository = await repositoryMetadata(
+        thread.checkpoint.repo,
+        undefined,
+        thread.checkpoint.branch,
+      );
       if (!repository.pr)
         return { status: "missing", files: [], truncated: false, repository };
       const diff = await readBranchDiff(
         thread.checkpoint.repo,
         repository.pr.baseRef,
+        thread.checkpoint.branch,
       );
       return { ...diff, repository };
     } catch {

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -21,6 +21,7 @@ const {
   currentBranch,
   localBranches,
   deleteRefs,
+  readBranchDiff,
   readDiff,
   repoRoot,
   repositoryMetadata,
@@ -335,6 +336,24 @@ function configureDesktopIpc() {
         readDiff(thread.checkpoint.repo, thread.checkpoint.ref),
         repositoryMetadata(thread.checkpoint.repo),
       ]);
+      return { ...diff, repository };
+    } catch {
+      return { status: "error", files: [], truncated: false };
+    }
+  });
+  ipcMain.handle("desktop:get-local-pr-diff", async (event, threadId) => {
+    requireTrustedDesktopIpc(event);
+    const thread = localThreadStore.get(threadId);
+    if (!thread || !registeredProject(thread.cwd) || !thread.checkpoint.repo)
+      return { status: "missing", files: [], truncated: false };
+    try {
+      const repository = await repositoryMetadata(thread.checkpoint.repo);
+      if (!repository.pr)
+        return { status: "missing", files: [], truncated: false, repository };
+      const diff = await readBranchDiff(
+        thread.checkpoint.repo,
+        repository.pr.baseRef,
+      );
       return { ...diff, repository };
     } catch {
       return { status: "error", files: [], truncated: false };

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -39,6 +39,7 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   updateLocalThread: (input) => ipcRenderer.invoke("desktop:update-local-thread", input),
   deleteLocalThread: (threadId) => ipcRenderer.invoke("desktop:delete-local-thread", threadId),
   getLocalDiff: (threadId) => ipcRenderer.invoke("desktop:get-local-diff", threadId),
+  getLocalPrDiff: (threadId) => ipcRenderer.invoke("desktop:get-local-pr-diff", threadId),
   onProjectsChanged: (callback) => {
     const listener = (_event, projects) => callback(projects)
     ipcRenderer.on("desktop:projects-changed", listener)

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -151,4 +151,18 @@ test("branch diff reports only what the branch committed", async (t) => {
 
   assert.equal((await readBranchDiff(repo, "no-such-branch")).status, "missing")
   assert.equal((await readBranchDiff(repo, "--upload-pack=touch")).status, "missing")
+
+  // The thread's branch is reported even while another one holds the checkout.
+  await checkoutBranch(dir, "main")
+  fs.writeFileSync(path.join(dir, "search.ts"), "search\nmain work\n")
+  git(dir, ["add", "-A"])
+  git(dir, ["commit", "-qm", "main work"])
+
+  const fromElsewhere = await readBranchDiff(repo, "main", "feature")
+  assert.deepEqual(
+    fromElsewhere.files.map((file) => file.path),
+    ["models.ts"]
+  )
+  assert.equal((await readBranchDiff(repo, "main", "no-such-branch")).status, "missing")
+  assert.equal((await readBranchDiff(repo, "main", "--upload-pack=touch")).status, "missing")
 })

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -12,6 +12,7 @@ const {
   currentBranch,
   localBranches,
   parsePullRequest,
+  readBranchDiff,
   readDiff,
   repoRoot,
 } = require("../build/git-diff.cjs")
@@ -30,6 +31,11 @@ test("normalizes validated pull request metadata", () => {
       headRefName: "feature",
       baseRefName: "main",
       url: "https://github.com/example/repo/pull/12",
+      author: { login: "octocat" },
+      createdAt: "2026-08-20T00:00:00Z",
+      changedFiles: 3,
+      additions: 10,
+      deletions: 2,
     })
   )
   assert.deepEqual(pr, {
@@ -39,6 +45,11 @@ test("normalizes validated pull request metadata", () => {
     headRef: "feature",
     baseRef: "main",
     url: "https://github.com/example/repo/pull/12",
+    repoFullName: "example/repo",
+    author: "octocat",
+    authorAvatarUrl: null,
+    createdAt: "2026-08-20T00:00:00Z",
+    diffStats: { files: 3, additions: 10, deletions: 2 },
   })
   assert.equal(
     parsePullRequest(
@@ -108,4 +119,36 @@ test("diffs the worktree against a session checkpoint", async (t) => {
   const huge = diff.files.find((file) => file.path === "huge.txt")
   assert.equal(huge.unrenderable, true)
   assert.equal(huge.modifiedContent, null)
+})
+
+test("branch diff reports only what the branch committed", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "open-swe-git-"))
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }))
+  git(dir, ["init", "-q", "-b", "main"])
+  git(dir, ["config", "user.email", "test@example.com"])
+  git(dir, ["config", "user.name", "Test"])
+  fs.writeFileSync(path.join(dir, "models.ts"), "one\n")
+  fs.writeFileSync(path.join(dir, "search.ts"), "search\n")
+  git(dir, ["add", "-A"])
+  git(dir, ["commit", "-qm", "init"])
+
+  const repo = await repoRoot(dir)
+  await checkoutBranch(dir, "feature", true)
+  fs.writeFileSync(path.join(dir, "models.ts"), "one\ntwo\n")
+  git(dir, ["add", "-A"])
+  git(dir, ["commit", "-qm", "feature work"])
+
+  // Another session dirties the shared worktree; none of it is this branch's.
+  fs.writeFileSync(path.join(dir, "search.ts"), "search\nelsewhere\n")
+  fs.writeFileSync(path.join(dir, "stray.txt"), "stray\n")
+
+  const diff = await readBranchDiff(repo, "main")
+  assert.equal(diff.status, "ready")
+  assert.deepEqual(
+    diff.files.map((file) => [file.path, file.status, file.additions]),
+    [["models.ts", "modified", 1]]
+  )
+
+  assert.equal((await readBranchDiff(repo, "no-such-branch")).status, "missing")
+  assert.equal((await readBranchDiff(repo, "--upload-pack=touch")).status, "missing")
 })

--- a/desktop/test/local-thread-store.test.cjs
+++ b/desktop/test/local-thread-store.test.cjs
@@ -52,7 +52,12 @@ test("reconciles interrupted threads and retains checkpoint refs until deletion"
   const fixture = temporaryStore(t)
   const store = fixture.create()
   const thread = store.create({ cwd: path.resolve("/tmp/project"), prompt: "work" })
-  store.setCheckpoint(thread.id, { repo: path.resolve("/tmp/project"), ref: "refs/open-swe/local/thread-1" })
+  store.setCheckpoint(thread.id, {
+    repo: path.resolve("/tmp/project"),
+    ref: "refs/open-swe/local/thread-1",
+    branch: "feature",
+  })
+  assert.equal(store.get(thread.id).checkpoint.branch, "feature")
   store.update(thread.id, { status: "running", viewed: false })
 
   const restored = fixture.create()

--- a/tests/agent/test_desktop.py
+++ b/tests/agent/test_desktop.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from agent.desktop import create_desktop_backend, resolve_desktop_project
+from agent.desktop import (
+    create_desktop_backend,
+    desktop_artifact_routes,
+    resolve_desktop_project,
+)
 
 
 def test_desktop_backend_allows_registered_project_without_provider_secrets(
@@ -34,3 +38,29 @@ def test_desktop_backend_rejects_unregistered_project(
 
     with pytest.raises(ValueError, match="not an allowed project"):
         resolve_desktop_project({"local_project_path": str(project)})
+
+
+def test_artifact_routes_stay_out_of_the_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifacts = tmp_path / "artifacts"
+    monkeypatch.setenv("OPEN_SWE_LOCAL_ARTIFACTS_DIR", str(artifacts))
+
+    routes = desktop_artifact_routes("thread-1")
+    assert set(routes) == {"/large_tool_results/", "/conversation_history/"}
+    for prefix, backend in routes.items():
+        root = Path(str(backend.cwd)).resolve()
+        assert root.is_dir()
+        assert root == (artifacts / "thread-1" / prefix.strip("/")).resolve()
+
+
+def test_artifact_routes_reject_a_traversing_thread_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifacts = tmp_path / "artifacts"
+    monkeypatch.setenv("OPEN_SWE_LOCAL_ARTIFACTS_DIR", str(artifacts))
+
+    routes = desktop_artifact_routes("../../etc")
+    for backend in routes.values():
+        root = Path(str(backend.cwd)).resolve()
+        assert artifacts.resolve() in root.parents

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -1,5 +1,5 @@
 import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
-import type { AgentThread, ImageChunk } from "@/features/agents/lib/types"
+import type { AgentPullRequest, ImageChunk } from "@/features/agents/lib/types"
 import type { Skill } from "@/lib/api"
 
 export type DesktopCommandId =
@@ -31,7 +31,7 @@ export interface DesktopLocalDiff {
   status: "ready" | "missing" | "error"
   truncated: boolean
   files: Array<ThreadPrDiffFile>
-  repository?: { branch: string | null; pr: AgentThread["pr"] | null }
+  repository?: { branch: string | null; pr: AgentPullRequest | null }
 }
 
 export interface DesktopLocalPromptInput {
@@ -185,6 +185,7 @@ declare global {
       }) => Promise<DesktopLocalThreadSummary | null>
       deleteLocalThread: (threadId: string) => Promise<boolean>
       getLocalDiff: (threadId: string) => Promise<DesktopLocalDiff>
+      getLocalPrDiff: (threadId: string) => Promise<DesktopLocalDiff>
       terminal: DesktopTerminalBridge
     }
   }

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -3,10 +3,17 @@ import { DownloadIcon } from "lucide-react"
 
 import type { AgentThread } from "@/features/agents/lib/types"
 import { agentsApi } from "@/features/agents/lib/api"
-import { useAgentThreadTurnDiff } from "@/features/agents/lib/queries"
+import {
+  useAgentThreadPrDiff,
+  useAgentThreadTurnDiff,
+} from "@/features/agents/lib/queries"
 import { ChangesPanel } from "@/features/agents/components/ChangesPanel"
 import { toPanelFiles } from "@/features/agents/components/DiffFilesView"
 import { AgentRightPanel } from "@/features/agents/components/panel/AgentRightPanel"
+import {
+  selectThreadDiffScope,
+  useDiffPanelStore,
+} from "@/features/agents/lib/diffPanelStore"
 import {
   selectThreadRightPanelState,
   useRightPanelStore,
@@ -48,17 +55,58 @@ export function AgentGitPanel({
   const terminalAvailable =
     thread.isOwner !== false && Boolean(thread.sandboxId)
 
+  const hasPullRequest = Boolean(thread.pr)
+  const selectScope = useDiffPanelStore((state) => state.selectScope)
+  const scope = useDiffPanelStore((state) =>
+    selectThreadDiffScope(state.byThreadKey, threadRef, hasPullRequest)
+  )
+  const diffVisible = !collapsed && activeSurfaceId === "diff"
+
   const turnDiff = useAgentThreadTurnDiff(
     thread.id,
     null,
-    !collapsed && activeSurfaceId === "diff",
+    diffVisible && scope === "thread",
     {},
     thread.status === "running"
   )
-  const files = useMemo(
-    () => toPanelFiles(turnDiff.data?.files ?? []),
-    [turnDiff.data?.files]
+  const prDiff = useAgentThreadPrDiff(
+    thread.id,
+    diffVisible && scope === "pull-request"
   )
+  const diff =
+    scope === "pull-request"
+      ? {
+          files: prDiff.data?.files ?? [],
+          // The PR endpoint answers from GitHub: a successful response is
+          // always a real diff, and a failure surfaces through `error`.
+          status: prDiff.data ? ("ready" as const) : undefined,
+          truncated: prDiff.data?.truncated,
+          isPending: prDiff.isPending,
+          isFetching: prDiff.isFetching,
+          error: prDiff.error,
+          refetch: prDiff.refetch,
+        }
+      : {
+          files: turnDiff.data?.files ?? [],
+          status: turnDiff.data?.status,
+          truncated: turnDiff.data?.truncated,
+          isPending: turnDiff.isPending,
+          isFetching: turnDiff.isFetching,
+          error: turnDiff.error,
+          refetch: turnDiff.refetch,
+        }
+  const files = useMemo(() => toPanelFiles(diff.files), [diff.files])
+
+  // Refresh whenever the window regains focus: the diff is read live, so a
+  // push or a review landing elsewhere should be visible on return.
+  const refetchDiff = diff.refetch
+  useEffect(() => {
+    if (!diffVisible) return
+    const onFocus = () => void refetchDiff()
+    window.addEventListener("focus", onFocus)
+    return () => window.removeEventListener("focus", onFocus)
+  }, [diffVisible, refetchDiff])
+
   const [recoveringPatch, setRecoveringPatch] = useState(false)
   const [recoveryError, setRecoveryError] = useState<string | null>(null)
   const canDownloadRecovery =
@@ -101,16 +149,20 @@ export function AgentGitPanel({
       renderDiff={({ fullScreen }) => (
         <ChangesPanel
           files={files}
-          status={turnDiff.data?.status}
-          isLoading={turnDiff.isPending}
-          isFetching={turnDiff.isFetching}
-          error={turnDiff.error}
-          truncated={turnDiff.data?.truncated}
+          status={diff.status}
+          isLoading={diff.isPending}
+          isFetching={diff.isFetching}
+          error={diff.error}
+          truncated={diff.truncated}
           branch={thread.branch}
           pr={thread.pr}
           revealFilePath={revealFilePath}
           fullScreen={fullScreen}
-          onRefresh={() => void turnDiff.refetch()}
+          onRefresh={() => void diff.refetch()}
+          scope={hasPullRequest ? scope : undefined}
+          onScopeChange={
+            hasPullRequest ? (next) => selectScope(threadRef, next) : undefined
+          }
           extraActions={
             canDownloadRecovery ? (
               <button

--- a/ui/src/features/agents/components/ChangesPanel.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.tsx
@@ -1,9 +1,15 @@
-import { useMemo } from "react"
-import { GitPullRequestIcon, RefreshCwIcon } from "lucide-react"
+import { useMemo, useState } from "react"
+import {
+  ChevronDownIcon,
+  GitPullRequestIcon,
+  RefreshCwIcon,
+} from "lucide-react"
 
 import type { AgentThread } from "@/features/agents/lib/types"
+import type { DiffScopeKind } from "@/features/agents/lib/diffPanelStore"
 import type { PanelFile } from "@/features/agents/components/DiffFilesView"
 import { DiffFilesView } from "@/features/agents/components/DiffFilesView"
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@/components/ui/menu"
 
 export type ChangesStatus = "ready" | "missing" | "error"
 
@@ -20,6 +26,9 @@ interface ChangesPanelProps {
   fullScreen: boolean
   onRefresh: () => void
   extraActions?: React.ReactNode
+  /** Omitted when the surface has only one diff source to read. */
+  scope?: DiffScopeKind
+  onScopeChange?: (scope: DiffScopeKind) => void
 }
 
 function errorMessage(error: unknown): string | null {
@@ -31,13 +40,58 @@ export function changesEmptyLabel({
   status,
   isLoading,
   error,
-}: Pick<ChangesPanelProps, "status" | "isLoading" | "error">): string {
+  scope,
+}: Pick<
+  ChangesPanelProps,
+  "status" | "isLoading" | "error" | "scope"
+>): string {
   if (isLoading) return "Reading changes…"
   if (error) return errorMessage(error) ?? "Could not load changes."
   if (status === "missing")
     return "Changes are not available for this workspace."
   if (status === "error") return "Could not read changes. Try refreshing."
+  if (scope === "pull-request") return "This pull request has no changes."
   return "No changes yet."
+}
+
+function ScopeSwitcher(props: {
+  scope: DiffScopeKind
+  prNumber: number | null
+  branch?: string | null
+  onScopeChange: (scope: DiffScopeKind) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const threadLabel = props.branch ? `Changes · ${props.branch}` : "Changes"
+  const prLabel =
+    props.prNumber === null ? "Pull request" : `Pull request #${props.prNumber}`
+  const label = props.scope === "pull-request" ? prLabel : threadLabel
+
+  return (
+    <Menu open={open} onOpenChange={setOpen}>
+      <MenuTrigger
+        className="flex h-6 min-w-0 cursor-pointer items-center gap-1 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        aria-label={`Diff scope: ${label}`}
+      >
+        <span className="min-w-0 truncate">{label}</span>
+        <ChevronDownIcon className="size-3.5 shrink-0 opacity-70" />
+      </MenuTrigger>
+      <MenuPopup
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="min-w-52"
+      >
+        <MenuItem onClick={() => props.onScopeChange("thread")}>
+          {threadLabel}
+        </MenuItem>
+        {props.prNumber === null ? null : (
+          <MenuItem onClick={() => props.onScopeChange("pull-request")}>
+            {prLabel}
+          </MenuItem>
+        )}
+      </MenuPopup>
+    </Menu>
+  )
 }
 
 export function ChangesPanel({
@@ -53,8 +107,10 @@ export function ChangesPanel({
   fullScreen,
   onRefresh,
   extraActions,
+  scope,
+  onScopeChange,
 }: ChangesPanelProps) {
-  const emptyLabel = changesEmptyLabel({ status, isLoading, error })
+  const emptyLabel = changesEmptyLabel({ status, isLoading, error, scope })
   const actions = useMemo(
     () => (
       <>
@@ -102,9 +158,18 @@ export function ChangesPanel({
         emptyLabel={emptyLabel}
         truncated={truncated}
         leading={
-          <span className="min-w-0 truncate text-sm font-medium text-foreground">
-            Changes{branch ? ` · ${branch}` : ""}
-          </span>
+          scope && onScopeChange ? (
+            <ScopeSwitcher
+              scope={scope}
+              prNumber={pr?.number ?? null}
+              branch={branch}
+              onScopeChange={onScopeChange}
+            />
+          ) : (
+            <span className="min-w-0 truncate text-sm font-medium text-foreground">
+              Changes{branch ? ` · ${branch}` : ""}
+            </span>
+          )
         }
         actions={actions}
       />

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -19,6 +19,10 @@ import { Messages } from "@/features/agents/components/messages"
 import { AgentRightPanel } from "@/features/agents/components/panel/AgentRightPanel"
 import { SIBLING_COLUMN_MIN_WIDTH } from "@/features/agents/components/panel/RightPanelShell"
 import {
+  selectThreadDiffScope,
+  useDiffPanelStore,
+} from "@/features/agents/lib/diffPanelStore"
+import {
   selectThreadRightPanelState,
   useRightPanelStore,
 } from "@/features/agents/lib/rightPanelStore"
@@ -29,6 +33,7 @@ import {
   localThreadKeys,
   useDesktopLocalThread,
   useLocalThreadDiff,
+  useLocalThreadPrDiff,
 } from "@/features/agents/lib/desktopLocal"
 import {
   readStoredPanelCollapsed,
@@ -129,17 +134,29 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   )
 
   const isRunning = stream.isLoading || thread?.status === "running"
-  const diff = useLocalThreadDiff(
+  const diffVisible =
+    !panelCollapsed && activeSurfaceId === "diff" && Boolean(thread)
+  const selectScope = useDiffPanelStore((state) => state.selectScope)
+  // Also the source of the branch/PR metadata, so it stays enabled in either
+  // scope: it is what tells us the branch has a pull request at all.
+  const checkpointDiff = useLocalThreadDiff(sessionId, diffVisible, isRunning)
+  const hasPullRequest = Boolean(checkpointDiff.data?.repository?.pr)
+  const scope = useDiffPanelStore((state) =>
+    selectThreadDiffScope(state.byThreadKey, threadRef, hasPullRequest)
+  )
+  const prDiff = useLocalThreadPrDiff(
     sessionId,
-    !panelCollapsed && activeSurfaceId === "diff" && Boolean(thread),
+    diffVisible && scope === "pull-request",
     isRunning
   )
+  const repository = prDiff.data?.repository ?? checkpointDiff.data?.repository
+  const pr = repository?.pr ?? null
+  const diff = scope === "pull-request" ? prDiff : checkpointDiff
+  const pullRequests = useMemo(() => (pr ? [pr] : []), [pr])
   const files = useMemo(
     () => toPanelFiles(diff.data?.files ?? []),
     [diff.data?.files]
   )
-  const repository = diff.data?.repository
-  const pr = repository?.pr
   const messages = useMemo(
     () =>
       streamMessagesToUi(
@@ -410,7 +427,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         cwd={thread.cwd}
         terminalAvailable
         diffAvailable
-        pullRequests={[]}
+        pullRequests={pullRequests}
         collapsed={panelCollapsed}
         onCollapsedChange={handlePanelCollapsedChange}
         onTerminalOpenFile={handleOpenFile}
@@ -430,6 +447,12 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             revealFilePath={revealFilePath}
             fullScreen={fullScreen}
             onRefresh={() => void diff.refetch()}
+            scope={hasPullRequest ? scope : undefined}
+            onScopeChange={
+              hasPullRequest
+                ? (next) => selectScope(threadRef, next)
+                : undefined
+            }
           />
         )}
       />

--- a/ui/src/features/agents/lib/desktopLocal.ts
+++ b/ui/src/features/agents/lib/desktopLocal.ts
@@ -14,6 +14,7 @@ export const localThreadKeys = {
   detail: (threadId: string) => ["local-threads", threadId] as const,
   ready: (threadId: string) => ["local-thread-ready", threadId] as const,
   diff: (threadId: string) => ["local-thread-diff", threadId] as const,
+  prDiff: (threadId: string) => ["local-thread-pr-diff", threadId] as const,
 }
 
 export function useReadyDesktopLocalThread(threadId: string) {
@@ -62,6 +63,31 @@ export function useLocalThreadDiff(
   const query = useQuery({
     queryKey: localThreadKeys.diff(threadId),
     queryFn: () => window.openSweDesktop?.getLocalDiff(threadId) ?? NO_DIFF,
+    enabled,
+    refetchInterval: isRunning ? 5000 : false,
+  })
+
+  const { refetch } = query
+  useEffect(() => {
+    if (enabled && !isRunning) void refetch()
+  }, [enabled, isRunning, refetch])
+
+  return query
+}
+
+/**
+ * What the thread's branch has committed on top of its pull request's base.
+ * Unlike the checkpoint diff this ignores the worktree, which every session in
+ * the project shares.
+ */
+export function useLocalThreadPrDiff(
+  threadId: string,
+  enabled: boolean,
+  isRunning: boolean
+) {
+  const query = useQuery({
+    queryKey: localThreadKeys.prDiff(threadId),
+    queryFn: () => window.openSweDesktop?.getLocalPrDiff(threadId) ?? NO_DIFF,
     enabled,
     refetchInterval: isRunning ? 5000 : false,
   })

--- a/ui/src/features/agents/lib/diffPanelStore.test.ts
+++ b/ui/src/features/agents/lib/diffPanelStore.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  migratePersistedDiffPanelState,
+  selectThreadDiffScope,
+  useDiffPanelStore,
+} from "@/features/agents/lib/diffPanelStore"
+
+const ref = { scope: "cloud" as const, threadId: "thread-1" }
+const other = { scope: "local" as const, threadId: "thread-1" }
+
+describe("diffPanelStore", () => {
+  beforeEach(() => {
+    useDiffPanelStore.setState({ byThreadKey: {} })
+  })
+
+  it("defaults to the pull request scope only when the thread has one", () => {
+    const { byThreadKey } = useDiffPanelStore.getState()
+    expect(selectThreadDiffScope(byThreadKey, ref, true)).toBe("pull-request")
+    expect(selectThreadDiffScope(byThreadKey, ref, false)).toBe("thread")
+    expect(selectThreadDiffScope(byThreadKey, null, true)).toBe("pull-request")
+  })
+
+  it("remembers an explicit scope per thread", () => {
+    useDiffPanelStore.getState().selectScope(ref, "thread")
+    const { byThreadKey } = useDiffPanelStore.getState()
+    expect(selectThreadDiffScope(byThreadKey, ref, true)).toBe("thread")
+    // Same thread id under a different scope is a different panel.
+    expect(selectThreadDiffScope(byThreadKey, other, true)).toBe("pull-request")
+  })
+
+  it("falls back to thread changes when the stored PR scope is unavailable", () => {
+    useDiffPanelStore.getState().selectScope(ref, "pull-request")
+    const { byThreadKey } = useDiffPanelStore.getState()
+    expect(selectThreadDiffScope(byThreadKey, ref, false)).toBe("thread")
+  })
+
+  it("drops a thread's selection", () => {
+    useDiffPanelStore.getState().selectScope(ref, "thread")
+    useDiffPanelStore.getState().removeThread(ref)
+    expect(useDiffPanelStore.getState().byThreadKey).toEqual({})
+  })
+
+  it("ignores malformed persisted state", () => {
+    expect(migratePersistedDiffPanelState(null)).toEqual({ byThreadKey: {} })
+    expect(migratePersistedDiffPanelState("nope")).toEqual({ byThreadKey: {} })
+    expect(migratePersistedDiffPanelState({ byThreadKey: 7 })).toEqual({
+      byThreadKey: {},
+    })
+  })
+
+  it("drops persisted entries whose kind is unknown", () => {
+    expect(
+      migratePersistedDiffPanelState({
+        byThreadKey: {
+          "cloud:a": { kind: "pull-request" },
+          "cloud:b": { kind: "unstaged" },
+          "cloud:c": null,
+          "cloud:d": { kind: "thread", extra: "ignored" },
+        },
+      })
+    ).toEqual({
+      byThreadKey: {
+        "cloud:a": { kind: "pull-request" },
+        "cloud:d": { kind: "thread" },
+      },
+    })
+  })
+})

--- a/ui/src/features/agents/lib/diffPanelStore.ts
+++ b/ui/src/features/agents/lib/diffPanelStore.ts
@@ -1,0 +1,126 @@
+/**
+ * Thread-scoped diff selection.
+ *
+ * The panel never stores diff data — only which source the Changes surface is
+ * pointed at. Diffs are fetched live per scope, so a thread whose sandbox is
+ * gone can still show its pull request's diff instead of an empty result.
+ */
+import { create } from "zustand"
+import { createJSONStorage, persist } from "zustand/middleware"
+
+import {
+  scopedThreadKey,
+  type PanelThreadRef,
+} from "@/features/agents/lib/rightPanelStore"
+
+export const DIFF_SCOPE_KINDS = ["thread", "pull-request"] as const
+export type DiffScopeKind = (typeof DIFF_SCOPE_KINDS)[number]
+
+export type DiffPanelSelection = { kind: DiffScopeKind }
+
+const THREAD_SELECTION: DiffPanelSelection = { kind: "thread" }
+const PULL_REQUEST_SELECTION: DiffPanelSelection = { kind: "pull-request" }
+
+const DIFF_PANEL_STORAGE_KEY = "open-swe:diff-panel-state"
+const DIFF_PANEL_STORAGE_VERSION = 1
+
+interface DiffPanelStoreState {
+  byThreadKey: Record<string, DiffPanelSelection>
+  selectScope: (ref: PanelThreadRef, kind: DiffScopeKind) => void
+  removeThread: (ref: PanelThreadRef) => void
+}
+
+/**
+ * Persisted selections are untrusted input: every entry is re-validated and
+ * anything unrecognized is dropped rather than trusted.
+ */
+export function migratePersistedDiffPanelState(persistedState: unknown): {
+  byThreadKey: Record<string, DiffPanelSelection>
+} {
+  if (!persistedState || typeof persistedState !== "object")
+    return { byThreadKey: {} }
+  if (!("byThreadKey" in persistedState)) return { byThreadKey: {} }
+  const raw = (persistedState as { byThreadKey: unknown }).byThreadKey
+  if (!raw || typeof raw !== "object") return { byThreadKey: {} }
+
+  const byThreadKey: Record<string, DiffPanelSelection> = {}
+  for (const [threadKey, value] of Object.entries(
+    raw as Record<string, unknown>
+  )) {
+    if (!threadKey || !value || typeof value !== "object") continue
+    const kind = (value as { kind?: unknown }).kind
+    if (kind === "thread") byThreadKey[threadKey] = THREAD_SELECTION
+    else if (kind === "pull-request")
+      byThreadKey[threadKey] = PULL_REQUEST_SELECTION
+  }
+  return { byThreadKey }
+}
+
+const memoryStorage = (): Storage => {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (key) => map.get(key) ?? null,
+    key: (index) => [...map.keys()][index] ?? null,
+    removeItem: (key) => void map.delete(key),
+    setItem: (key, value) => void map.set(key, value),
+  }
+}
+
+export const useDiffPanelStore = create<DiffPanelStoreState>()(
+  persist(
+    (set) => ({
+      byThreadKey: {},
+      selectScope: (ref, kind) =>
+        set((state) => {
+          const threadKey = scopedThreadKey(ref)
+          if (state.byThreadKey[threadKey]?.kind === kind) return state
+          return {
+            byThreadKey: {
+              ...state.byThreadKey,
+              [threadKey]:
+                kind === "pull-request"
+                  ? PULL_REQUEST_SELECTION
+                  : THREAD_SELECTION,
+            },
+          }
+        }),
+      removeThread: (ref) =>
+        set((state) => {
+          const threadKey = scopedThreadKey(ref)
+          if (!(threadKey in state.byThreadKey)) return state
+          const { [threadKey]: _removed, ...byThreadKey } = state.byThreadKey
+          return { byThreadKey }
+        }),
+    }),
+    {
+      name: DIFF_PANEL_STORAGE_KEY,
+      version: DIFF_PANEL_STORAGE_VERSION,
+      storage: createJSONStorage(() =>
+        typeof window === "undefined" ? memoryStorage() : window.localStorage
+      ),
+      partialize: (state) => ({ byThreadKey: state.byThreadKey }),
+      migrate: migratePersistedDiffPanelState,
+    }
+  )
+)
+
+/**
+ * The scope the Changes surface should read. Absent an explicit choice a
+ * thread with a pull request defaults to it: the PR diff is served from
+ * GitHub, so it survives the sandbox the thread's own diff depends on.
+ */
+export function selectThreadDiffScope(
+  byThreadKey: Record<string, DiffPanelSelection>,
+  ref: PanelThreadRef | null | undefined,
+  hasPullRequest = false
+): DiffScopeKind {
+  const stored = ref ? byThreadKey[scopedThreadKey(ref)] : undefined
+  if (stored?.kind === "pull-request")
+    return hasPullRequest ? stored.kind : "thread"
+  if (stored?.kind === "thread") return stored.kind
+  return hasPullRequest ? "pull-request" : "thread"
+}


### PR DESCRIPTION
## Problem

The right panel's Changes surface showed diffs that did not match the thread's actual work.

**Cloud threads** — "No changes yet." on a finished thread. `ChangesPanel` only ever read `GET /threads/{id}/turn-diff`, which needs a live sandbox and a checkpoint that still differs from HEAD. For a merged thread the endpoint answers `{status: "ready", files: []}`, indistinguishable from a thread that changed nothing.

**Local (desktop) threads** — unrelated files listed, and a permanently dead Pull request tab. `desktop:get-local-diff` diffs a checkpoint captured *once* at thread creation against the **live worktree**, so anything that landed in the repo afterwards — commits from earlier threads, another session's uncommitted edits, the user's own editor — gets attributed to this thread. A thread whose PR contains a single line showed 3 files / +10 -2. Separately, `LocalAgentThreadView` hardcoded `pullRequests={[]}` while the same query already carried the PR that the "View PR" button uses, so the PR tab always read "no pull request yet".

**Offloaded tool dumps** — oversized tool results and evicted conversation history showed up in the Changes list on local threads. deepagents' `FilesystemMiddleware` writes them to `{artifacts_root}/large_tool_results/…` and `{artifacts_root}/conversation_history/…`, and `CompositeBackend.artifacts_root` defaults to `/` — which on a desktop run is the user's project, so the dumps landed in the git worktree (and would be swept into the next `git add -A`). Cloud is unaffected: there the sandbox root sits above the checkout.

## Change

Store a per-thread **diff scope selection** rather than diff data, and fetch live per scope.

- `ui/src/features/agents/lib/diffPanelStore.ts` — zustand + `persist`, `byThreadKey` keyed `scope:threadId`, with a field-validating migration that drops anything unrecognized out of `localStorage`.
- **Cloud**: the second scope is `GET /threads/{id}/pr-diff`. That endpoint, its API client and its query hook already existed with no UI consumer, and its file shape already matched `toPanelFiles`.
- **Local**: new `readBranchDiff` in `desktop/src/git-diff.cts` computes the PR's content from **committed refs only** — resolve the PR base (preferring `origin/<base>`, validated with `git check-ref-format`), take its merge base with HEAD, diff that to HEAD. Nothing uncommitted can leak in. It reuses `readDiff`, now able to take an explicit head, so the existing file/blob/byte caps are untouched. Exposed as `desktop:get-local-pr-diff` behind the same `requireTrustedDesktopIpc` + `registeredProject` guards as the existing handler.
- The thread's branch is persisted on its checkpoint (at creation, on status changes, and while running) and passed explicitly to `gh pr view <branch>` and to the branch diff's head, so a thread's Changes view no longer follows whatever branch the shared worktree currently has checked out. Branch names are validated with `git check-ref-format --branch` (and a leading `-` rejected) before being passed as positional argv.
- Threads with a pull request default to the PR scope, since it is the durable source; threads without one keep the previous behaviour exactly, switcher hidden. `ChangesPanel`'s header label becomes the scope menu when both exist.
- `gh pr view` now also returns `author`, `createdAt` and diff stats, and the repo name is derived from the already-validated PR URL, so the local PR can be passed to the panel in full and the Pull request tab works.
- The cloud diff refetches when the window regains focus.
- `agent/desktop.py:desktop_artifact_routes` routes `/large_tool_results/` and `/conversation_history/` to `FilesystemBackend`s under an artifacts directory outside the repository (`OPEN_SWE_LOCAL_ARTIFACTS_DIR`, set by the desktop supervisor to the app's state dir). The virtual paths the model sees are unchanged. Desktop runs only.

## Testing

- `ui/src/features/agents/lib/diffPanelStore.test.ts` — 6 tests: default scope with/without a PR, per-thread and per-scope isolation, fallback when a stored PR scope is no longer available, removal, and migration of malformed input and unknown kinds.
- `desktop/test/git-diff.test.cjs` — a new branch-diff test that dirties the worktree from a simulated second session and asserts only the branch's own committed file is reported, plus rejection of an unresolvable base and of an argument-injection-shaped ref. Extended PR-metadata assertions for the new fields. All 43 desktop tests pass.
- `tests/agent/test_desktop.py` — two tests that the artifact routes resolve under the artifacts root and that a traversing thread id (`../../etc`) cannot escape it. `make test` / `make lint` / `make typecheck` clean apart from 11 pre-existing failures also present on a clean tree (`setsid` is absent on macOS, plus unrelated webhook/voice tests).
- `pnpm typecheck` and `pnpm build` clean. UI: 258 passing; the one failure (`apiWarmup.test.ts`) is pre-existing on `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)