### PR TITLE
chore: move the langgraph runtime off end-of-life 0.10.x

### DIFF
--- a/langgraph.desktop.json
+++ b/langgraph.desktop.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://langgra.ph/schema.json",
   "python_version": "3.12",
-  "api_version": "0.10.0rc3",
+  "api_version": "0.12.6",
   "graphs": {
     "agent": "agent.graphs.agent:traced_agent"
   },

--- a/langgraph.json
+++ b/langgraph.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://langgra.ph/schema.json",
   "python_version": "3.12",
-  "api_version": "0.10.0rc3",
+  "api_version": "0.12.6",
   "graphs": {
     "agent": "agent.graphs.agent:traced_agent",
     "reviewer": "agent.graphs.reviewer:traced_reviewer_agent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,10 @@ dev = [
 # override both transitive bounds until langchain-e2b publishes compatible metadata.
 override-dependencies = ["deepagents==0.7.6", "wcmatch>=11.0"]
 # Each langgraph-api release pins its langgraph-runtime-inmem peer to a single
-# minor window expressed in `.dev0` bounds (`>=0.32.0.dev0,<0.33.0.dev0`). Under
-# uv's default pre-release policy that makes every recent pair unattractive, so a
-# plain resolve lands on langgraph-api 0.10.3 — end of life, and its `run.start`
-# handler drops the run input, which leaves the local dev server unable to run a
-# web follow-up at all. Hold the dev/CI runtime at the current stable pair.
+# minor window expressed in `.dev0` bounds (`>=0.32.0.dev0,<0.33.0.dev0`), which
+# uv's default pre-release policy shies away from, so a plain resolve lands on the
+# end-of-life 0.10.3. Hold the local dev server at the version `langgraph.json`
+# declares for the deployment, so tests run against the runtime that serves prod.
 constraint-dependencies = ["langgraph-api>=0.12.6,<0.13"]
 
 [build-system]

--- a/tests/e2e/langgraph.desktop.json
+++ b/tests/e2e/langgraph.desktop.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://langgra.ph/schema.json",
   "python_version": "3.12",
-  "api_version": "0.10.0rc3",
+  "api_version": "0.12.6",
   "graphs": {
     "agent": "./tests/e2e/agent_entrypoint.py:traced_agent"
   },


### PR DESCRIPTION
`langgraph.json` has pinned `api_version: 0.10.0rc3` since #1475, when that release candidate was the first to support the v2 stream protocol. 0.12.6 is the current stable and 0.10.x is end of life, so this moves the deployment (and both desktop configs) onto it. #2130 already holds the local dev server at the same version, so dev, CI, and the deployment now declare one runtime instead of three.

It also corrects a claim I wrote into that constraint's comment in #2130: **0.10.x does not drop `run.start` input.** Re-tested with the runtime forced back to 0.10.3 and the id fix removed, the duplicate reproduces exactly as before (`Expected: 1, Received: 2`) — the original diagnostic just ended before the follow-up run finished. The constraint buys parity with the deployed runtime, not the ability to reproduce the bug.

Merging changes the runtime image the next deploy builds.

## Test Plan

- [x] `make lint`, `make typecheck` clean
- [x] E2E browser suite 49/51; both failures are order-dependent flakes that reproduce on unmodified `main` (running the pair together fails whichever of the two goes first), and `api_version` only affects built images, not `langgraph dev`
