### PR TITLE
perf(ui): incremental rendering for large agent threads

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -10,6 +10,7 @@ export default [
       ".tanstack/**",
       "dev-dist/**",
       "dist/**",
+      "public/**",
       "src/routeTree.gen.ts",
       "src/components/ui/**",
       "src/features/agents/experiments/**",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "build": "node --max-old-space-size=4096 ./node_modules/vite/bin/vite.js build",
     "preview": "vite preview",
     "test": "vitest run",
+    "bench": "vitest bench --run",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx}\"",

--- a/ui/server/operations-restart.ts
+++ b/ui/server/operations-restart.ts
@@ -53,9 +53,7 @@ function tokenIsValid(token: string, key: string): boolean {
   }
 }
 
-export default async function operationsRestart(event: {
-  req: Request
-}): Promise<Response> {
+export default function operationsRestart(event: { req: Request }): Response {
   if (event.req.method !== "POST") {
     return new Response("method not allowed\n", { status: 405 })
   }

--- a/ui/src/components/AppCommandPalette.test.tsx
+++ b/ui/src/components/AppCommandPalette.test.tsx
@@ -3,10 +3,9 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { DesktopLocalThreadSummary } from "@/desktop"
+import { AppCommandPalette } from "./AppCommandPalette"
 import type { AgentThread } from "@/features/agents/lib/types"
 import type { AppCommand } from "@/lib/appCommands"
-import { AppCommandPalette } from "./AppCommandPalette"
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -22,7 +21,7 @@ const mocks = vi.hoisted(() => ({
     updatedAt: 2,
     modelId: null,
     effort: null,
-  } as DesktopLocalThreadSummary,
+  },
 }))
 
 vi.mock("@tanstack/react-router", () => ({

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -22,7 +22,7 @@ import {
 import { Messages } from "@/features/agents/components/messages"
 import { OptimisticThreadHydrationRecovery } from "@/features/agents/components/OptimisticThreadHydrationRecovery"
 import { latestContextTokens } from "@/features/agents/lib/contextUsage"
-import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
+import { createUiMessageProjector } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { useSubmitAgentMessage } from "@/features/agents/lib/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
@@ -147,14 +147,18 @@ export function AgentThreadView({
     [handlePanelCollapsedChange]
   )
 
+  // Incremental: unchanged turns keep their Message identity across stream
+  // flushes, so the memoized message components below re-render only the turn
+  // that is actually streaming.
+  const [projectMessages] = useState(() => createUiMessageProjector())
   const baseMessages = useMemo<Array<Message>>(() => {
     if (thread.messages.length > 0) return thread.messages
-    return streamMessagesToUi(
+    return projectMessages(
       stream.messages,
       stream.toolCalls,
       messageArrivalTimestamp
     )
-  }, [stream.messages, stream.toolCalls, thread.messages])
+  }, [projectMessages, stream.messages, stream.toolCalls, thread.messages])
 
   const isStreaming =
     thread.status === "running" ||

--- a/ui/src/features/agents/components/DesktopThreadSourceToggle.tsx
+++ b/ui/src/features/agents/components/DesktopThreadSourceToggle.tsx
@@ -1,5 +1,5 @@
-import type { IconType } from "react-icons"
 import { IoCloudOutline, IoLaptopOutline } from "react-icons/io5"
+import type { IconType } from "react-icons"
 
 import type { DesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
 import { cn } from "@/lib/utils"

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -264,7 +264,7 @@ export function DiffFilesView({
 }
 
 const FileDiffSection = memo(
-  function FileDiffSection({
+  function FileDiffSectionComponent({
     file,
     sectionRef,
   }: {

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -41,7 +41,7 @@ import {
   readStoredPanelCollapsed,
   writeStoredPanelCollapsed,
 } from "@/features/agents/lib/gitPanelPreferences"
-import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
+import { createUiMessageProjector } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
@@ -167,8 +167,11 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     () => toPanelFiles(diff.data?.files ?? []),
     [diff.data?.files]
   )
+  // Incremental: unchanged turns keep their Message identity across stream
+  // flushes, so the memoized message components re-render only the streaming turn.
+  const [projectMessages] = useState(() => createUiMessageProjector())
   const messages = useMemo(() => {
-    const live = streamMessagesToUi(
+    const live = projectMessages(
       stream.messages,
       stream.toolCalls,
       messageArrivalTimestamp
@@ -186,7 +189,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         ],
       } satisfies Message,
     ]
-  }, [sessionId, stream.messages, stream.toolCalls, thread])
+  }, [projectMessages, sessionId, stream.messages, stream.toolCalls, thread])
 
   const rememberSelection = useCallback(
     async (model?: ModelSelection | null) => {
@@ -202,7 +205,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
       queryClient.setQueryData<Array<DesktopLocalThreadSummary>>(
         localThreadKeys.all,
         (threads = []) =>
-          threads.map((thread) => (thread.id === sessionId ? updated : thread))
+          threads.map((item) => (item.id === sessionId ? updated : item))
       )
     },
     [queryClient, sessionId]
@@ -232,7 +235,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     async (
       prompt: string,
       images: Array<ImageChunk>,
-      skills: DesktopLocalPromptInput["skills"] = []
+      promptSkills: DesktopLocalPromptInput["skills"] = []
     ) => {
       if (!thread) return false
       setError(null)
@@ -250,7 +253,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             messages: [
               { type: "human", content: promptContent(prompt, images) },
             ],
-            ...(skills.length ? { files: skillFiles(skills) } : {}),
+            ...(promptSkills.length ? { files: skillFiles(promptSkills) } : {}),
           },
           {
             config: {

--- a/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
+++ b/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
@@ -32,7 +32,6 @@ export function NewAgentTerminalPanel({
     openTerminal(threadRef, terminals.addGroup())
     // Only on the first mount for this session; adding `terminals` here would
     // spawn a second pty whenever the controller identity changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/ui/src/features/agents/components/SandboxedHtmlFrame.tsx
+++ b/ui/src/features/agents/components/SandboxedHtmlFrame.tsx
@@ -17,7 +17,7 @@ type SandboxedHtmlFrameProps = (
 export const SandboxedHtmlFrame = forwardRef<
   HTMLIFrameElement,
   SandboxedHtmlFrameProps
->(function SandboxedHtmlFrame(
+>(function SandboxedHtmlFrameComponent(
   { html, src, title, sandbox = "", allow, className, style, testId },
   ref
 ) {

--- a/ui/src/features/agents/components/chat/CodeBlock.tsx
+++ b/ui/src/features/agents/components/chat/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { memo, useEffect, useMemo, useState } from "react"
 import { getSingletonHighlighter } from "shiki"
 import type { ThemedToken } from "shiki"
 import { useResolvedTheme } from "@/lib/theme"
@@ -45,7 +45,10 @@ function languageLabel(language: string): string {
   return language
 }
 
-export function CodeBlock({ text, language }: CodeBlockProps) {
+export const CodeBlock = memo(function CodeBlockComponent({
+  text,
+  language,
+}: CodeBlockProps) {
   const [tokens, setTokens] = useState<Array<Array<ThemedToken>> | null>(null)
   const [copied, setCopied] = useState(false)
   const resolvedTheme = useResolvedTheme()
@@ -147,4 +150,4 @@ export function CodeBlock({ text, language }: CodeBlockProps) {
       </pre>
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/chat/DiffView.tsx
+++ b/ui/src/features/agents/components/chat/DiffView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { memo, useMemo } from "react"
 import { MultiFileDiff } from "@pierre/diffs/react"
 import type { DiffData } from "@/features/agents/lib/types"
 import { useDiffOptions } from "@/features/agents/utils/diffUtils"
@@ -9,7 +9,10 @@ interface DiffViewProps {
   snippet?: boolean
 }
 
-export function DiffView({ diffData, snippet = false }: DiffViewProps) {
+export const DiffView = memo(function DiffViewComponent({
+  diffData,
+  snippet = false,
+}: DiffViewProps) {
   const diffOptions = useDiffOptions()
   const options = useMemo(
     () =>
@@ -54,4 +57,4 @@ export function DiffView({ diffData, snippet = false }: DiffViewProps) {
       </div>
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/chat/Markdown.tsx
+++ b/ui/src/features/agents/components/chat/Markdown.tsx
@@ -140,7 +140,7 @@ class MarkdownErrorBoundary extends Component<BoundaryProps, BoundaryState> {
   }
 }
 
-export const Markdown = memo(function Markdown({
+export const Markdown = memo(function MarkdownComponent({
   content,
   isLive = false,
   transformImageUrl,

--- a/ui/src/features/agents/components/chat/OutputIframe.tsx
+++ b/ui/src/features/agents/components/chat/OutputIframe.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react"
 import { ChevronDown, Download } from "lucide-react"
 
-import { SandboxedHtmlFrame } from "@/features/agents/components/SandboxedHtmlFrame"
 import type { OutputIframeDisplay } from "@/features/agents/lib/types"
+import { SandboxedHtmlFrame } from "@/features/agents/components/SandboxedHtmlFrame"
 import { IconButton } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 

--- a/ui/src/features/agents/components/chat/ReplyCard.tsx
+++ b/ui/src/features/agents/components/chat/ReplyCard.tsx
@@ -111,7 +111,9 @@ function renderSlackBlocks(blocks: Array<SlackBlock>): ReactNode {
   )
 }
 
-export const ReplyCard = memo(function ReplyCard({ chunk }: ReplyCardProps) {
+export const ReplyCard = memo(function ReplyCardComponent({
+  chunk,
+}: ReplyCardProps) {
   const isLinear = chunk.toolKind === "linear"
   const body =
     ((isLinear ? chunk.input?.comment_body : chunk.input?.message) as string) ||

--- a/ui/src/features/agents/components/chat/ToolExecution.tsx
+++ b/ui/src/features/agents/components/chat/ToolExecution.tsx
@@ -33,7 +33,7 @@ function getFileName(path: string): string {
   return parts[parts.length - 1] || path
 }
 
-const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
+const InlineDiffCollapsible = memo(function InlineDiffCollapsibleComponent({
   filePath,
   fileName,
   originalContent,
@@ -143,7 +143,7 @@ const InlineDiffCollapsible = memo(function InlineDiffCollapsible({
   )
 })
 
-export const ToolExecution = memo(function ToolExecution({
+export const ToolExecution = memo(function ToolExecutionComponent({
   chunk,
   projectPath,
 }: ToolExecutionProps) {
@@ -166,13 +166,17 @@ export const ToolExecution = memo(function ToolExecution({
     ? stripProjectPath(diffData.filePath, projectPath)
     : ""
   const editedFileName = editedFilePath ? getFileName(editedFilePath) : ""
-  const diffStats = diffData
-    ? countLineChanges(
-        diffData.originalContent,
-        diffData.newContent,
-        diffData.filePath
-      )
-    : null
+  const diffStats = useMemo(
+    () =>
+      diffData
+        ? countLineChanges(
+            diffData.originalContent,
+            diffData.newContent,
+            diffData.filePath
+          )
+        : null,
+    [diffData]
+  )
 
   if (isCompletedEditOp && diffStats) {
     return (

--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -27,10 +27,12 @@ vi.mock("@langchain/react", () => ({
   useStreamContext: () => stream,
 }))
 
-const cancelThread = vi.fn(async (threadId: string) => ({
-  id: threadId,
-  status: "interrupted",
-}))
+const cancelThread = vi.fn((threadId: string) =>
+  Promise.resolve({
+    id: threadId,
+    status: "interrupted",
+  })
+)
 
 vi.mock("@/features/agents/lib/api", () => ({
   agentsApi: { cancelThread: (threadId: string) => cancelThread(threadId) },

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -212,7 +212,7 @@ export function buildCommandItems(
  * mode, attachments, context)
  * and the send/stop button.
  */
-export const ChatComposer = memo(function ChatComposer({
+export const ChatComposer = memo(function ChatComposerComponent({
   placeholder = "Ask Open SWE to build, fix bugs, explore",
   autoFocus = false,
   compact = false,

--- a/ui/src/features/agents/components/composer/ComposerCommandMenu.tsx
+++ b/ui/src/features/agents/components/composer/ComposerCommandMenu.tsx
@@ -41,7 +41,7 @@ interface ComposerCommandMenuProps {
  * navigation lives in the composer (the editor keeps focus while this is open),
  * so this only reflects the active item and reports pointer intent back up.
  */
-export const ComposerCommandMenu = memo(function ComposerCommandMenu({
+export const ComposerCommandMenu = memo(function ComposerCommandMenuComponent({
   items,
   triggerKind,
   activeItemId,

--- a/ui/src/features/agents/components/composer/ComposerPromptEditor.test.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPromptEditor.test.tsx
@@ -62,7 +62,7 @@ describe("ComposerPromptEditor", () => {
     const { rerender } = render(<Harness initialValue="/autopilot fix this" />)
     expect(screen.queryByText("/autopilot")).toBeNull()
 
-    await act(async () => {
+    await act(() => {
       rerender(
         <Harness
           initialValue="/autopilot fix this"
@@ -109,7 +109,7 @@ describe("ComposerPromptEditor", () => {
     }
 
     const { rerender } = render(<Controlled value="" />)
-    await act(async () => {
+    await act(() => {
       rerender(<Controlled value="look at [a.ts](src/a.ts) " />)
     })
 

--- a/ui/src/features/agents/components/composer/ComposerPromptEditor.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPromptEditor.tsx
@@ -586,12 +586,12 @@ function ComposerPromptEditorInner({
   }, [editor, skillNamesKey])
 
   const focusAt = useCallback(
-    (cursor: number) => {
+    (offset: number) => {
       const rootElement = editor.getRootElement()
       if (!rootElement) return
       rootElement.focus({ preventScroll: true })
       editor.update(() => {
-        $setSelectionAtOffset(cursor)
+        $setSelectionAtOffset(offset)
       })
     },
     [editor]

--- a/ui/src/features/agents/components/messages/MessageTimestamp.tsx
+++ b/ui/src/features/agents/components/messages/MessageTimestamp.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react"
+
 type MessageTimestampProps = {
   timestamp: string
   startedAt?: string
@@ -44,7 +46,7 @@ function shortTimestamp(date: Date): string {
     : datedTimeFormatter.format(date)
 }
 
-export function MessageTimestamp({
+export const MessageTimestamp = memo(function MessageTimestampComponent({
   timestamp,
   startedAt,
   align = "left",
@@ -72,4 +74,4 @@ export function MessageTimestamp({
       </time>
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/messages/Messages.bench.tsx
+++ b/ui/src/features/agents/components/messages/Messages.bench.tsx
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react"
+import { flushSync } from "react-dom"
+import { createRoot } from "react-dom/client"
+import { bench, describe } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+import { Messages } from "./Messages"
+import type { Root } from "react-dom/client"
+
+import type { ThreadStreamFixture } from "@/features/agents/lib/threadStreamFixture"
+
+import {
+  buildThreadFixture,
+  streamTicks,
+} from "@/features/agents/lib/threadStreamFixture"
+import {
+  createUiMessageProjector,
+  streamMessagesToUi,
+} from "@/features/agents/lib/streamMessagesToUi"
+
+const actEnvironment = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+const OPTIONS = { warmupIterations: 1, iterations: 5, time: 0, warmupTime: 0 }
+
+function convert(fixture: ThreadStreamFixture) {
+  return streamMessagesToUi(fixture.messages, fixture.toolCalls)
+}
+
+describe("streamMessagesToUi", () => {
+  const fixture = buildThreadFixture(120)
+
+  bench(
+    "full rebuild, 120 turns",
+    () => {
+      convert(fixture)
+    },
+    OPTIONS
+  )
+})
+
+for (const turns of [30, 120]) {
+  describe(`Messages, ${turns}-turn thread`, () => {
+    const fixture = buildThreadFixture(turns)
+    const ticks = streamTicks(fixture, 20)
+
+    bench(
+      "mount",
+      () => {
+        render(
+          <Messages
+            messages={convert(fixture)}
+            isStreaming={false}
+            streamIsLoading={false}
+          />
+        )
+        cleanup()
+      },
+      OPTIONS
+    )
+
+    // The synchronous first render only — the tail window a reader sees
+    // before the rest of the thread mounts in the follow-up transition.
+    bench(
+      "mount: first paint",
+      () => {
+        const actEnv = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        actEnv.IS_REACT_ACT_ENVIRONMENT = false
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        const paintRoot = createRoot(container)
+        flushSync(() => {
+          paintRoot.render(
+            <Messages
+              messages={convert(fixture)}
+              isStreaming={false}
+              streamIsLoading={false}
+            />
+          )
+        })
+        paintRoot.unmount()
+        container.remove()
+        actEnv.IS_REACT_ACT_ENVIRONMENT = true
+      },
+      OPTIONS
+    )
+
+    // One persistent root (outside RTL's cleanup registry): each iteration
+    // replays 20 stream flushes against the mounted thread, the shape of the
+    // work the UI does continuously while an agent streams. Conversion goes
+    // through the same incremental projector the thread views use.
+    const project = createUiMessageProjector()
+    let root: Root | null = null
+    const renderInto = (fx: ThreadStreamFixture) => {
+      if (!root) {
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        root = createRoot(container)
+      }
+      const mounted = root
+      act(() => {
+        mounted.render(
+          <Messages
+            messages={project(fx.messages, fx.toolCalls)}
+            isStreaming
+            streamIsLoading
+          />
+        )
+      })
+    }
+
+    bench(
+      "20 stream flushes: convert + rerender",
+      () => {
+        renderInto(fixture)
+        for (const tick of ticks) renderInto(tick)
+      },
+      OPTIONS
+    )
+  })
+}

--- a/ui/src/features/agents/components/messages/Messages.streamRender.test.tsx
+++ b/ui/src/features/agents/components/messages/Messages.streamRender.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { Messages } from "./Messages"
+import type * as renderItemsModule from "./renderItems"
+import { createUiMessageProjector } from "@/features/agents/lib/streamMessagesToUi"
+import {
+  buildThreadFixture,
+  streamTicks,
+} from "@/features/agents/lib/threadStreamFixture"
+
+const counters = vi.hoisted(() => ({ buildRenderItems: 0 }))
+
+// `buildRenderItems` runs when a turn's chunks change identity, so its call
+// count is the number of turns that actually re-derived their timeline.
+vi.mock(
+  "@/features/agents/components/messages/renderItems",
+  async (importOriginal) => {
+    const actual = await importOriginal<typeof renderItemsModule>()
+    return {
+      ...actual,
+      buildRenderItems: (
+        ...args: Parameters<typeof actual.buildRenderItems>
+      ) => {
+        counters.buildRenderItems += 1
+        return actual.buildRenderItems(...args)
+      },
+    }
+  }
+)
+
+afterEach(() => {
+  cleanup()
+  counters.buildRenderItems = 0
+})
+
+describe("Messages under stream flushes", () => {
+  it("re-derives only the streaming turn's timeline per flush", () => {
+    const fixture = buildThreadFixture(20)
+    const project = createUiMessageProjector()
+    const view = render(
+      <Messages
+        messages={project(fixture.messages, fixture.toolCalls)}
+        isStreaming
+        streamIsLoading
+      />
+    )
+    expect(counters.buildRenderItems).toBe(20)
+
+    counters.buildRenderItems = 0
+    for (const tick of streamTicks(fixture, 3)) {
+      view.rerender(
+        <Messages
+          messages={project(tick.messages, tick.toolCalls)}
+          isStreaming
+          streamIsLoading
+        />
+      )
+    }
+    expect(counters.buildRenderItems).toBe(3)
+  })
+})

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -1,5 +1,6 @@
 import {
   memo,
+  startTransition,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -20,6 +21,14 @@ import { InlinePlanArtifact } from "@/features/agents/components/InlinePlanArtif
 import { useLiveMarkdownMessageId } from "@/features/agents/lib/provider/useLiveMarkdownMessageId"
 
 const BOTTOM_LOCK_THRESHOLD_PX = 24
+
+/**
+ * How many trailing messages the first render mounts. The rest of a large
+ * thread mounts in a transition immediately after, above a viewport that is
+ * already pinned to the bottom — so first paint stays fast at any thread size
+ * and the reader never sees the older turns stream in.
+ */
+const INITIAL_MOUNT_MESSAGES = 16
 
 function QueuedMessages({
   queuedMessages,
@@ -225,6 +234,15 @@ export const Messages = memo(function MessagesComponent({
     () => messages.filter((message) => !message.hidden),
     [messages]
   )
+  const [tailOnly, setTailOnly] = useState(
+    () => visibleMessages.length > INITIAL_MOUNT_MESSAGES
+  )
+  useEffect(() => {
+    if (tailOnly) startTransition(() => setTailOnly(false))
+  }, [tailOnly])
+  const renderedMessages = tailOnly
+    ? visibleMessages.slice(-INITIAL_MOUNT_MESSAGES)
+    : visibleMessages
   const liveMarkdownMessageId = useLiveMarkdownMessageId(
     visibleMessages,
     streamIsLoading,
@@ -250,7 +268,7 @@ export const Messages = memo(function MessagesComponent({
   }, [onShowScrollToBottomChange, showScrollToBottom])
 
   const projectPath = project?.path
-  const lastAgentIndex = visibleMessages.findLastIndex(
+  const lastAgentIndex = renderedMessages.findLastIndex(
     (message) => message.author === "agent"
   )
   const activityLabel = useMemo(() => {
@@ -274,8 +292,8 @@ export const Messages = memo(function MessagesComponent({
             className={`w-full ${contentWidthClass} mx-auto min-w-0 ${contentPaddingClass}`}
             style={bottomInset > 0 ? { paddingBottom: bottomInset } : undefined}
           >
-            {visibleMessages.map((message, index) => {
-              const isLastMessage = index === visibleMessages.length - 1
+            {renderedMessages.map((message, index) => {
+              const isLastMessage = index === renderedMessages.length - 1
               const messageIsStreaming = isStreaming && isLastMessage
               const messageIsMarkdownLive = message.id === liveMarkdownMessageId
 
@@ -313,7 +331,7 @@ export const Messages = memo(function MessagesComponent({
                 !(
                   isStreaming &&
                   lastAgentIndex >= 0 &&
-                  lastAgentIndex === visibleMessages.length - 1
+                  lastAgentIndex === renderedMessages.length - 1
                 )
               }
               settingUpSandbox={settingUpSandbox}

--- a/ui/src/features/agents/components/messages/ReasoningBlock.tsx
+++ b/ui/src/features/agents/components/messages/ReasoningBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { memo, useEffect, useRef, useState } from "react"
 import { ChevronRight } from "lucide-react"
 
 import { formatElapsed } from "@/lib/utils"
@@ -15,7 +15,7 @@ function reasoningLabel(elapsedMs: number | null): string {
  * reasoning ends it auto-collapses into a "Thought for …" toggle the user can
  * expand on demand.
  */
-export function ReasoningBlock({
+export const ReasoningBlock = memo(function ReasoningBlockComponent({
   text,
   isLive,
 }: {
@@ -76,4 +76,4 @@ export function ReasoningBlock({
       )}
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/messages/SlackMrkdwn.tsx
+++ b/ui/src/features/agents/components/messages/SlackMrkdwn.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react"
+import { Fragment, memo } from "react"
 import type { ReactNode } from "react"
 
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"])
@@ -200,6 +200,10 @@ export function renderSlackMrkdwn(text: string): Array<ReactNode> {
   return renderRange(text, 0, text.length, "slack")
 }
 
-export function SlackMrkdwn({ text }: { text: string }) {
+export const SlackMrkdwn = memo(function SlackMrkdwnComponent({
+  text,
+}: {
+  text: string
+}) {
   return <>{renderSlackMrkdwn(text)}</>
-}
+})

--- a/ui/src/features/agents/components/messages/TurnChangedFilesCard.tsx
+++ b/ui/src/features/agents/components/messages/TurnChangedFilesCard.tsx
@@ -8,89 +8,92 @@ import { useAgentThreadRunDiff } from "@/features/agents/lib/queries"
 const INLINE_CHANGED_FILES_LIMIT = 10
 
 /** What a completed agent run changed, loaded from its persisted diff artifact. */
-export const TurnChangedFilesCard = memo(function TurnChangedFilesCard({
-  threadId,
-  turnKey,
-  isLatestTurn,
-  onOpenFile,
-}: {
-  threadId: string
-  turnKey: string
-  isLatestTurn: boolean
-  onOpenFile?: (filePath: string) => void
-}) {
-  const [open, setOpen] = useState(isLatestTurn)
-  const turnDiff = useAgentThreadRunDiff(threadId, turnKey, open, {
-    maxFiles: INLINE_CHANGED_FILES_LIMIT,
-    includeContent: false,
-  })
-  const files = turnDiff.data?.files ?? []
-  const summary = turnDiff.data?.summary
+export const TurnChangedFilesCard = memo(
+  function TurnChangedFilesCardComponent({
+    threadId,
+    turnKey,
+    isLatestTurn,
+    onOpenFile,
+  }: {
+    threadId: string
+    turnKey: string
+    isLatestTurn: boolean
+    onOpenFile?: (filePath: string) => void
+  }) {
+    const [open, setOpen] = useState(isLatestTurn)
+    const turnDiff = useAgentThreadRunDiff(threadId, turnKey, open, {
+      maxFiles: INLINE_CHANGED_FILES_LIMIT,
+      includeContent: false,
+    })
+    const files = turnDiff.data?.files ?? []
+    const summary = turnDiff.data?.summary
 
-  if (
-    turnDiff.data?.status === "missing" ||
-    (turnDiff.isFetched && files.length === 0)
-  ) {
-    return null
-  }
+    if (
+      turnDiff.data?.status === "missing" ||
+      (turnDiff.isFetched && files.length === 0)
+    ) {
+      return null
+    }
 
-  const totalFiles = summary?.files ?? files.length
-  const additions = summary?.additions ?? 0
-  const deletions = summary?.deletions ?? 0
-  const omittedFiles = Math.max(0, totalFiles - files.length)
+    const totalFiles = summary?.files ?? files.length
+    const additions = summary?.additions ?? 0
+    const deletions = summary?.deletions ?? 0
+    const omittedFiles = Math.max(0, totalFiles - files.length)
 
-  return (
-    <div
-      data-testid="turn-changed-files-card"
-      className="mt-3 overflow-hidden rounded-xl bg-muted/40"
-    >
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent/30"
+    return (
+      <div
+        data-testid="turn-changed-files-card"
+        className="mt-3 overflow-hidden rounded-xl bg-muted/40"
       >
-        {open ? (
-          <ChevronDown className="size-3.5" />
-        ) : (
-          <ChevronRight className="size-3.5" />
-        )}
-        {turnDiff.isPending && open ? (
-          <span>Reading changed files…</span>
-        ) : totalFiles > 0 ? (
-          <>
-            <span>
-              {totalFiles} file{totalFiles === 1 ? "" : "s"} changed
-            </span>
-            <span className="text-success-foreground">+{additions}</span>
-            <span className="text-destructive">-{deletions}</span>
-          </>
-        ) : (
-          <span>Changed files</span>
-        )}
-      </button>
-      {open && files.length > 0 && (
-        <div className="border-t border-border">
-          {files.map((file) => (
-            <ChangedFileRow
-              key={file.path}
-              file={file}
-              onOpenFile={onOpenFile}
-            />
-          ))}
-          {omittedFiles > 0 && (
-            <div
-              data-testid="turn-changed-files-omitted"
-              className="px-3 py-1.5 text-xs text-muted-foreground"
-            >
-              {omittedFiles} more file{omittedFiles === 1 ? "" : "s"} not shown
-            </div>
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent/30"
+        >
+          {open ? (
+            <ChevronDown className="size-3.5" />
+          ) : (
+            <ChevronRight className="size-3.5" />
           )}
-        </div>
-      )}
-    </div>
-  )
-})
+          {turnDiff.isPending && open ? (
+            <span>Reading changed files…</span>
+          ) : totalFiles > 0 ? (
+            <>
+              <span>
+                {totalFiles} file{totalFiles === 1 ? "" : "s"} changed
+              </span>
+              <span className="text-success-foreground">+{additions}</span>
+              <span className="text-destructive">-{deletions}</span>
+            </>
+          ) : (
+            <span>Changed files</span>
+          )}
+        </button>
+        {open && files.length > 0 && (
+          <div className="border-t border-border">
+            {files.map((file) => (
+              <ChangedFileRow
+                key={file.path}
+                file={file}
+                onOpenFile={onOpenFile}
+              />
+            ))}
+            {omittedFiles > 0 && (
+              <div
+                data-testid="turn-changed-files-omitted"
+                className="px-3 py-1.5 text-xs text-muted-foreground"
+              >
+                {omittedFiles} more file{omittedFiles === 1 ? "" : "s"} not
+                shown
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+)
 
 function ChangedFileRow({
   file,

--- a/ui/src/features/agents/components/messages/UserMessage.tsx
+++ b/ui/src/features/agents/components/messages/UserMessage.tsx
@@ -1,13 +1,17 @@
 import { ChevronDown, ChevronRight } from "lucide-react"
 import { IoLogoSlack } from "react-icons/io5"
-import { useCallback, useLayoutEffect, useRef, useState } from "react"
+import { memo, useCallback, useLayoutEffect, useRef, useState } from "react"
 
 import { SkillPromptText } from "../SkillBadge"
 import { MessageTimestamp } from "./MessageTimestamp"
 import { SlackMrkdwn } from "./SlackMrkdwn"
 import type { Message } from "@/features/agents/lib/types"
 
-export function UserMessage({ message }: { message: Message }) {
+export const UserMessage = memo(function UserMessageComponent({
+  message,
+}: {
+  message: Message
+}) {
   const isSystem = message.structuredSenderKind === "system"
   const isSlack = message.structuredSurface === "slack"
   const text = message.chunks
@@ -43,7 +47,7 @@ export function UserMessage({ message }: { message: Message }) {
 
   return (
     <div
-      className={`group/turn my-4 flex flex-col gap-1 ${isSystem ? "items-start" : "items-end"}`}
+      className={`group/turn my-4 flex flex-col gap-1 [contain-intrinsic-size:auto_100px] [content-visibility:auto] ${isSystem ? "items-start" : "items-end"}`}
       data-testid="user-message"
       data-message-sender-kind={message.structuredSenderKind}
       data-message-surface={message.structuredSurface}
@@ -138,4 +142,4 @@ export function UserMessage({ message }: { message: Message }) {
       </div>
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { DiffView } from "../../chat/DiffView"
 import { ChunkRenderer } from "../ChunkRenderer"
@@ -37,7 +37,7 @@ const MAX_VISIBLE_WORK_LOG_ENTRIES = 1
  * the turn's changed-files card and the side panel, both of which read git —
  * rendering a per-call diff here made repeated edits of one file look duplicated.
  */
-function EditWorkEntry({
+const EditWorkEntry = memo(function EditWorkEntryComponent({
   chunk,
   projectPath,
 }: {
@@ -53,27 +53,30 @@ function EditWorkEntry({
       defaultExpanded={chunk.status === "pending"}
     />
   )
-}
+})
 
 /**
  * A run of related tool calls (exploration, mostly). Collapsed, it shows only
  * the most recent entries plus a toggle for the rest.
  */
-function WorkGroup({
+const WorkGroup = memo(function WorkGroupComponent({
+  id,
   chunks,
   projectPath,
   expanded,
   onToggle,
 }: {
+  id: string
   chunks: Array<ToolExecutionChunk>
   projectPath?: string
   expanded: boolean
-  onToggle: () => void
+  onToggle: (id: string) => void
 }) {
   const hiddenCount = Math.max(0, chunks.length - MAX_VISIBLE_WORK_LOG_ENTRIES)
   const visible = expanded
     ? chunks
     : chunks.slice(chunks.length - MAX_VISIBLE_WORK_LOG_ENTRIES)
+  const toggle = useCallback(() => onToggle(id), [id, onToggle])
 
   return (
     <div>
@@ -81,7 +84,7 @@ function WorkGroup({
         <WorkGroupToggleRow
           hiddenCount={hiddenCount}
           expanded={expanded}
-          onToggle={onToggle}
+          onToggle={toggle}
         />
       )}
       {visible.map((chunk, index) => (
@@ -93,9 +96,9 @@ function WorkGroup({
       ))}
     </div>
   )
-}
+})
 
-export function AgentTurn({
+export const AgentTurn = memo(function AgentTurnComponent({
   message,
   isStreaming,
   isMarkdownLive,
@@ -211,10 +214,11 @@ export function AgentTurn({
         return (
           <WorkGroup
             key={item.key}
+            id={item.id}
             chunks={item.chunks}
             projectPath={projectPath}
             expanded={expandedGroups[item.id] ?? false}
-            onToggle={() => toggleGroup(item.id)}
+            onToggle={toggleGroup}
           />
         )
 
@@ -291,7 +295,7 @@ export function AgentTurn({
         : renderItems
 
   return (
-    <div className="group/turn my-2 min-w-0 space-y-1.5">
+    <div className="group/turn my-2 min-w-0 space-y-1.5 [contain-intrinsic-size:auto_150px] [content-visibility:auto]">
       {canFoldWork && (
         <TurnFoldRow
           label={foldLabelWithCount}
@@ -329,4 +333,4 @@ export function AgentTurn({
       </div>
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/messages/timeline/MessageCopyButton.tsx
+++ b/ui/src/features/agents/components/messages/timeline/MessageCopyButton.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 
 const COPIED_RESET_MS = 1500
 
-export const MessageCopyButton = memo(function MessageCopyButton({
+export const MessageCopyButton = memo(function MessageCopyButtonComponent({
   text,
   className,
 }: {

--- a/ui/src/features/agents/components/messages/timeline/ToolResultBody.tsx
+++ b/ui/src/features/agents/components/messages/timeline/ToolResultBody.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react"
 
-import { CodeBlock } from "@/features/agents/components/chat/CodeBlock"
 import { formatJsonToolResult } from "./toolResultJson"
+import { CodeBlock } from "@/features/agents/components/chat/CodeBlock"
 
 export function ToolResultBody({ value }: { value: string }) {
   const json = useMemo(() => formatJsonToolResult(value), [value])

--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { memo, useCallback, useState } from "react"
 import {
   Bot,
   Check,
@@ -14,13 +14,13 @@ import {
   X,
   Zap,
 } from "lucide-react"
+import { ToolResultBody } from "./ToolResultBody"
 import type { KeyboardEvent, ReactNode } from "react"
 
 import type { WorkEntryIconName, WorkEntryView } from "./workEntry"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
 import { formatHoverTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { cn } from "@/lib/utils"
-import { ToolResultBody } from "./ToolResultBody"
 
 const ICONS: Record<WorkEntryIconName, typeof Bot> = {
   bot: Bot,
@@ -101,7 +101,7 @@ function StatusIndicator({ status }: { status: WorkEntryView["status"] }) {
  * Expanding reveals `body` when a tool has a richer renderer (a diff, terminal
  * output) and falls back to the entry's plain text otherwise.
  */
-export function WorkEntryRow({
+export const WorkEntryRow = memo(function WorkEntryRowComponent({
   entry,
   timestamp,
   body,
@@ -265,4 +265,4 @@ export function WorkEntryRow({
       )}
     </div>
   )
-}
+})

--- a/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
+++ b/ui/src/features/agents/components/messages/timeline/entryBodies.tsx
@@ -1,9 +1,9 @@
 import { memo } from "react"
 
-import type { ToolExecutionChunk } from "@/features/agents/lib/types"
 import { ToolResultBody } from "./ToolResultBody"
+import type { ToolExecutionChunk } from "@/features/agents/lib/types"
 
-export const ShellEntryBody = memo(function ShellEntryBody({
+export const ShellEntryBody = memo(function ShellEntryBodyComponent({
   chunk,
 }: {
   chunk: ToolExecutionChunk

--- a/ui/src/features/agents/components/messages/timeline/foldRows.tsx
+++ b/ui/src/features/agents/components/messages/timeline/foldRows.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { ChevronDown, ChevronRight } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -6,7 +7,7 @@ import { cn } from "@/lib/utils"
  * Collapses a settled turn's work log behind a single "Worked for …" line, so
  * the transcript reads as replies until the reader asks for the details.
  */
-export function TurnFoldRow({
+export const TurnFoldRow = memo(function TurnFoldRowComponent({
   label,
   active,
   expanded,
@@ -32,13 +33,13 @@ export function TurnFoldRow({
       </button>
     </div>
   )
-}
+})
 
 /**
  * Reveals the earlier entries of a work group; only the most recent stay
  * visible while a group is collapsed.
  */
-export function WorkGroupToggleRow({
+export const WorkGroupToggleRow = memo(function WorkGroupToggleRowComponent({
   hiddenCount,
   expanded,
   onToggle,
@@ -70,4 +71,4 @@ export function WorkGroupToggleRow({
       </span>
     </button>
   )
-}
+})

--- a/ui/src/features/agents/components/messages/timeline/toolResultJson.ts
+++ b/ui/src/features/agents/components/messages/timeline/toolResultJson.ts
@@ -9,7 +9,7 @@ export function formatJsonToolResult(value: string): string | null {
   }
 
   try {
-    return JSON.stringify(JSON.parse(value), null, 2) ?? null
+    return JSON.stringify(JSON.parse(value), null, 2)
   } catch {
     return null
   }

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -1,3 +1,4 @@
+import { formatJsonToolResult } from "./toolResultJson"
 import type {
   AcpToolStatus,
   Chunk,
@@ -8,7 +9,6 @@ import {
   formatToolDisplayParts,
 } from "@/features/agents/components/chat/toolExecutionDisplay"
 import { countLineChanges } from "@/features/agents/utils/diffStats"
-import { formatJsonToolResult } from "./toolResultJson"
 
 export type WorkEntryIconName =
   | "bot"
@@ -137,7 +137,28 @@ export function latestDiff(chunk: ToolExecutionChunk) {
     : chunk.diffData
 }
 
+/**
+ * Chunk identities are stable across stream flushes (the projector reuses
+ * untouched chunks), so the description — including the line-diff behind
+ * `diffStats` — is computed once per chunk instead of on every render.
+ */
+const workEntryCache = new WeakMap<
+  ToolExecutionChunk,
+  { projectPath?: string; view: WorkEntryView }
+>()
+
 export function describeWorkEntry(
+  chunk: ToolExecutionChunk,
+  projectPath?: string
+): WorkEntryView {
+  const cached = workEntryCache.get(chunk)
+  if (cached && cached.projectPath === projectPath) return cached.view
+  const view = buildWorkEntry(chunk, projectPath)
+  workEntryCache.set(chunk, { projectPath, view })
+  return view
+}
+
+function buildWorkEntry(
   chunk: ToolExecutionChunk,
   projectPath?: string
 ): WorkEntryView {

--- a/ui/src/features/agents/components/panel/AgentRightPanel.tsx
+++ b/ui/src/features/agents/components/panel/AgentRightPanel.tsx
@@ -1,15 +1,10 @@
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   ArrowsInIcon,
   ArrowsOutIcon,
   SidebarSimpleIcon,
 } from "@phosphor-icons/react"
+import type { ReactNode } from "react"
 
 import type {
   PanelThreadRef,
@@ -288,9 +283,7 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
             <TerminalPanel
               target={terminalTarget}
               cwd={cwd}
-              groupId={
-                surface.kind === "terminal" ? surface.resourceId : surface.id
-              }
+              groupId={surface.resourceId}
               terminals={terminals}
               {...(props.onTerminalOpenFile
                 ? { onOpenFile: props.onTerminalOpenFile }
@@ -322,7 +315,7 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
       }
       onCloseAllSurfaces={() => closeAllSurfaces(threadRef)}
       onCopyFilePath={(relativePath) => {
-        void navigator.clipboard?.writeText(relativePath)
+        void navigator.clipboard.writeText(relativePath)
       }}
       onAddTerminal={handleAddTerminal}
       onAddDiff={handleAddDiff}

--- a/ui/src/features/agents/components/panel/RightPanelSheet.tsx
+++ b/ui/src/features/agents/components/panel/RightPanelSheet.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react"
+import type { ReactNode } from "react"
 
 import { Sheet, SheetPopup } from "@/components/ui/sheet"
 import { RIGHT_PANEL_SHEET_CLASS_NAME } from "@/features/agents/components/panel/rightPanelLayout"

--- a/ui/src/features/agents/components/panel/RightPanelShell.tsx
+++ b/ui/src/features/agents/components/panel/RightPanelShell.tsx
@@ -1,11 +1,5 @@
-import {
-  type ReactNode,
-  type RefObject,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import type { ReactNode, RefObject } from "react"
 
 import { useResizableWidth } from "@/lib/useResizableWidth"
 import { cn } from "@/lib/utils"

--- a/ui/src/features/agents/components/panel/RightPanelTabs.tsx
+++ b/ui/src/features/agents/components/panel/RightPanelTabs.tsx
@@ -1,13 +1,4 @@
-import {
-  type KeyboardEvent as ReactKeyboardEvent,
-  type MouseEvent as ReactMouseEvent,
-  type ReactElement,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import {
   Bot,
   FileDiff,
@@ -18,8 +9,15 @@ import {
   TerminalSquare,
   X,
 } from "lucide-react"
+import type {
+  ReactElement,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from "react"
 
 import type { RightPanelSurface } from "@/features/agents/lib/rightPanelStore"
+import type { RightPanelMode } from "@/features/agents/components/panel/RightPanelShell"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import {
@@ -31,10 +29,7 @@ import {
 } from "@/components/ui/menu"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
-import {
-  RightPanelShell,
-  type RightPanelMode,
-} from "@/features/agents/components/panel/RightPanelShell"
+import { RightPanelShell } from "@/features/agents/components/panel/RightPanelShell"
 import { cn } from "@/lib/utils"
 
 interface RightPanelTabsProps {
@@ -89,8 +84,11 @@ type SurfaceShortcutEvent = Pick<
 >
 
 export function surfaceShortcutActionForKey<
-  const Action extends { available: boolean; shortcut: string },
->(actions: ReadonlyArray<Action>, event: SurfaceShortcutEvent): Action | null {
+  const TAction extends { available: boolean; shortcut: string },
+>(
+  actions: ReadonlyArray<TAction>,
+  event: SurfaceShortcutEvent
+): TAction | null {
   if (event.defaultPrevented || event.isComposing) return null
   if (event.metaKey || event.ctrlKey || event.altKey) return null
   return (

--- a/ui/src/features/agents/components/subagents/SubagentCard.tsx
+++ b/ui/src/features/agents/components/subagents/SubagentCard.tsx
@@ -14,7 +14,7 @@ function asString(value: unknown): string {
  * A single subagent spawned via the `task` tool. Shows the subagent type and
  * the task input (its `description`) as a compact rectangle.
  */
-export const SubagentCard = memo(function SubagentCard({
+export const SubagentCard = memo(function SubagentCardComponent({
   chunk,
 }: {
   chunk: ToolExecutionChunk

--- a/ui/src/features/agents/components/subagents/SubagentGroup.tsx
+++ b/ui/src/features/agents/components/subagents/SubagentGroup.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react"
+
 import { SubagentCard } from "./SubagentCard"
 import type { ToolExecutionChunk } from "@/features/agents/lib/types"
 
@@ -10,7 +12,7 @@ const MAX_SUBAGENT_COLUMNS = 4
  * {@link MAX_SUBAGENT_COLUMNS}, so 1–4 subagents fill the row evenly and 5+
  * wrap onto additional rows.
  */
-export function SubagentGroup({
+export const SubagentGroup = memo(function SubagentGroupComponent({
   chunks,
 }: {
   chunks: Array<ToolExecutionChunk>
@@ -26,4 +28,4 @@ export function SubagentGroup({
       ))}
     </div>
   )
-}
+})

--- a/ui/src/features/agents/lib/diffPanelStore.ts
+++ b/ui/src/features/agents/lib/diffPanelStore.ts
@@ -9,10 +9,8 @@
 import { create } from "zustand"
 import { createJSONStorage, persist } from "zustand/middleware"
 
-import {
-  scopedThreadKey,
-  type PanelThreadRef,
-} from "@/features/agents/lib/rightPanelStore"
+import type { PanelThreadRef } from "@/features/agents/lib/rightPanelStore"
+import { scopedThreadKey } from "@/features/agents/lib/rightPanelStore"
 
 export const DIFF_SCOPE_KINDS = ["working-tree", "branch"] as const
 export type DiffScopeKind = (typeof DIFF_SCOPE_KINDS)[number]
@@ -41,7 +39,7 @@ export function migratePersistedDiffPanelState(persistedState: unknown): {
   if (!persistedState || typeof persistedState !== "object")
     return { byThreadKey: {} }
   if (!("byThreadKey" in persistedState)) return { byThreadKey: {} }
-  const raw = (persistedState as { byThreadKey: unknown }).byThreadKey
+  const raw = persistedState.byThreadKey
   if (!raw || typeof raw !== "object") return { byThreadKey: {} }
 
   const byThreadKey: Record<string, DiffPanelSelection> = {}

--- a/ui/src/features/agents/lib/messageTimestamps.ts
+++ b/ui/src/features/agents/lib/messageTimestamps.ts
@@ -27,16 +27,23 @@ function load(): Map<string, string> {
   return cache
 }
 
-function persist(map: Map<string, string>): void {
-  if (typeof window === "undefined") return
-  try {
-    const entries = [...map.entries()]
-    const trimmed =
-      entries.length > MAX_ENTRIES ? entries.slice(-MAX_ENTRIES) : entries
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed))
-  } catch {
-    // Quota/serialization failure — timestamps stay in memory only.
-  }
+let persistTimer: ReturnType<typeof setTimeout> | null = null
+
+// Coalesced: hydrating a large thread stamps hundreds of ids in one pass, and
+// serializing the full map synchronously per id would stall the render path.
+function schedulePersist(map: Map<string, string>): void {
+  if (typeof window === "undefined" || persistTimer !== null) return
+  persistTimer = setTimeout(() => {
+    persistTimer = null
+    try {
+      const entries = [...map.entries()]
+      const trimmed =
+        entries.length > MAX_ENTRIES ? entries.slice(-MAX_ENTRIES) : entries
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed))
+    } catch {
+      // Quota/serialization failure — timestamps stay in memory only.
+    }
+  }, 1000)
 }
 
 /**
@@ -52,7 +59,7 @@ export function messageArrivalTimestamp(messageId: string): string {
   if (existing) return existing
   const iso = new Date().toISOString()
   map.set(messageId, iso)
-  persist(map)
+  schedulePersist(map)
   return iso
 }
 

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
@@ -6,11 +6,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSubmitAgentMessage } from "./useSubmitAgentMessage"
 import type { AgentThread } from "@/features/agents/lib/types"
-import { AgentsApiError } from "@/features/agents/lib/api"
 import type { SidebarThreads } from "@/features/agents/lib/api"
+import { AgentsApiError } from "@/features/agents/lib/api"
 import { agentThreadKeys } from "@/features/agents/lib/queries"
 
-const stream = { isLoading: false, submit: vi.fn(async () => undefined) }
+const stream = {
+  isLoading: false,
+  submit: vi.fn(() => Promise.resolve(undefined)),
+}
 
 vi.mock("@langchain/react", () => ({
   useStreamContext: () => stream,
@@ -55,10 +58,10 @@ function setup() {
   )
   const queuedCounts: Array<number> = []
   client.getQueryCache().subscribe(() => {
-    const thread = client.getQueryData<AgentThread>(
+    const current = client.getQueryData<AgentThread>(
       agentThreadKeys.detail(THREAD_ID)
     )
-    queuedCounts.push(thread?.queuedMessages?.length ?? 0)
+    queuedCounts.push(current?.queuedMessages?.length ?? 0)
   })
   const { result } = renderHook(() => useSubmitAgentMessage(THREAD_ID), {
     wrapper: ({ children }: { children: React.ReactNode }) => (

--- a/ui/src/features/agents/lib/queuedMessages.test.ts
+++ b/ui/src/features/agents/lib/queuedMessages.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
 import type { Message, QueuedThreadMessage } from "@/features/agents/lib/types"
+import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
 
 describe("visibleQueuedMessages", () => {
   it("reconciles a queued follow-up with its streamed fallback timestamp", () => {

--- a/ui/src/features/agents/lib/rightPanelStore.ts
+++ b/ui/src/features/agents/lib/rightPanelStore.ts
@@ -180,7 +180,7 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
   if (!persistedState || typeof persistedState !== "object")
     return { byThreadKey: {} }
   if (!("byThreadKey" in persistedState)) return { byThreadKey: {} }
-  const raw = (persistedState as { byThreadKey: unknown }).byThreadKey
+  const raw = persistedState.byThreadKey
   if (!raw || typeof raw !== "object") return { byThreadKey: {} }
 
   const byThreadKey = Object.fromEntries(
@@ -354,7 +354,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
                 (
                   surface
                 ): surface is Extract<RightPanelSurface, { kind: "file" }> =>
-                  surface.id === surfaceId && surface.kind === "file"
+                  surface.id === surfaceId
               )
               const surface = fileSurface(
                 relativePath,

--- a/ui/src/features/agents/lib/streamMessagesToUi.test.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.test.ts
@@ -1,7 +1,12 @@
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
 import { describe, expect, it } from "vitest"
 
-import { streamMessagesToUi } from "./streamMessagesToUi"
+import {
+  createUiMessageProjector,
+  streamMessagesToUi,
+} from "./streamMessagesToUi"
+import { buildThreadFixture, streamTicks } from "./threadStreamFixture"
+import type { BaseMessage } from "@langchain/core/messages"
 
 describe("streamMessagesToUi", () => {
   it("hides entity introductions and renders structured senders distinctly", () => {
@@ -230,5 +235,124 @@ describe("streamMessagesToUi", () => {
     expect(
       tool?.kind === "tool-execution" ? tool.display : undefined
     ).toBeUndefined()
+  })
+})
+
+describe("createUiMessageProjector", () => {
+  it("keeps identities for untouched units across a stream flush", () => {
+    const fixture = buildThreadFixture(6)
+    const project = createUiMessageProjector()
+    const base = project(fixture.messages, fixture.toolCalls)
+    const [tick] = streamTicks(fixture, 1)
+
+    const next = project(tick!.messages, tick!.toolCalls)
+
+    expect(next).toHaveLength(base.length)
+    for (let i = 0; i < next.length - 1; i += 1) {
+      expect(next[i]).toBe(base[i])
+    }
+    const baseLast = base[base.length - 1]!
+    const nextLast = next[next.length - 1]!
+    expect(nextLast).not.toBe(baseLast)
+    expect(nextLast.chunks[0]).toBe(baseLast.chunks[0])
+  })
+
+  it("returns the identical array when no input reference changed", () => {
+    const fixture = buildThreadFixture(3)
+    const project = createUiMessageProjector()
+    const base = project(fixture.messages, fixture.toolCalls)
+
+    expect(project(fixture.messages.slice(), fixture.toolCalls)).toBe(base)
+  })
+
+  it("matches the one-shot conversion across a mutation sequence", () => {
+    const fixture = buildThreadFixture(4)
+    const project = createUiMessageProjector()
+    expect(project(fixture.messages, fixture.toolCalls)).toEqual(
+      streamMessagesToUi(fixture.messages, fixture.toolCalls)
+    )
+
+    for (const tick of streamTicks(fixture, 3)) {
+      expect(project(tick.messages, tick.toolCalls)).toEqual(
+        streamMessagesToUi(tick.messages, tick.toolCalls)
+      )
+    }
+  })
+
+  it("rebuilds a turn when its tool result lands", () => {
+    const stampAt = (message: BaseMessage, iso: string) =>
+      Object.assign(message, { created_at: iso }) as BaseMessage
+    const call = {
+      id: "call-1",
+      name: "execute",
+      args: { command: "pnpm test" },
+      type: "tool_call" as const,
+    }
+    const before: Array<BaseMessage> = [
+      stampAt(
+        new HumanMessage({ id: "user-1", content: "run the tests" }),
+        "2026-01-01T00:00:00.000Z"
+      ),
+      stampAt(
+        new AIMessage({ id: "ai-1", content: "", tool_calls: [call] }),
+        "2026-01-01T00:00:01.000Z"
+      ),
+    ]
+    const project = createUiMessageProjector()
+    const initial = project(before)
+    expect(initial[1]?.chunks[0]).toMatchObject({ status: "in_progress" })
+
+    const after = [
+      ...before,
+      stampAt(
+        new ToolMessage({
+          id: "tool-1",
+          tool_call_id: "call-1",
+          content: "1 passed",
+          status: "success",
+        }),
+        "2026-01-01T00:00:02.000Z"
+      ),
+    ]
+    const next = project(after)
+    expect(next[0]).toBe(initial[0])
+    expect(next[1]).not.toBe(initial[1])
+    expect(next[1]?.chunks[0]).toMatchObject({
+      status: "completed",
+      output: "1 passed",
+    })
+    expect(next).toEqual(streamMessagesToUi(after))
+  })
+
+  it("rebuilds a user message when its sender entity arrives later", () => {
+    const stampAt = (message: BaseMessage, iso: string) =>
+      Object.assign(message, { created_at: iso }) as BaseMessage
+    const structured = stampAt(
+      new HumanMessage({
+        id: "structured-1",
+        content:
+          '<input-message sender="github:alice" surface="slack"><content>hello</content></input-message>',
+      }),
+      "2026-01-01T00:00:00.000Z"
+    )
+    const project = createUiMessageProjector()
+    const initial = project([structured])
+    expect(initial[0]?.structuredSenderName).toBeUndefined()
+
+    const withEntity = [
+      structured,
+      stampAt(
+        new HumanMessage({
+          id: "entity-1",
+          content:
+            '<dynamic-context kind="person" id="github:alice"><display_name>Alice</display_name></dynamic-context>',
+        }),
+        "2026-01-01T00:00:01.000Z"
+      ),
+    ]
+    const next = project(withEntity)
+    expect(next[0]).not.toBe(initial[0])
+    expect(next[0]?.structuredSenderName).toBe("Alice")
+    expect(next).toEqual(streamMessagesToUi(withEntity))
   })
 })

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -1,14 +1,14 @@
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
 import { messageArrivalTimestamp } from "./messageTimestamps"
-import {
-  collectStructuredEntities,
-  parseStructuredInput,
-} from "./structuredInputMessages"
+import { parseStructuredInput } from "./structuredInputMessages"
 import { humanizeToolName } from "./toolNames"
 import type { BaseMessage, ContentBlock } from "@langchain/core/messages"
 import type { AssembledToolCall } from "@langchain/react"
 
-import type { StructuredEntity } from "./structuredInputMessages"
+import type {
+  ParsedStructuredInput,
+  StructuredEntity,
+} from "./structuredInputMessages"
 import type {
   Chunk,
   DiffData,
@@ -304,6 +304,116 @@ function outputIframeDisplay(
   return undefined
 }
 
+function aiMessageChunks(
+  raw: AIMessage,
+  index: number,
+  toolCallsById: ReadonlyMap<string, AssembledToolCall>,
+  toolMessagesById: ReadonlyMap<string, ToolMessage>
+): Array<Chunk> {
+  const chunks: Array<Chunk> = []
+  const reasoning = reasoningText(raw)
+  if (reasoning) chunks.push({ kind: "reasoning", text: reasoning })
+  const text = raw.text.trim()
+  if (text) chunks.push({ kind: "text", text })
+
+  for (const toolCall of raw.tool_calls ?? []) {
+    const name = toolCall.name || "tool"
+    if (INTERNAL_TOOLS.has(name)) continue
+    const toolCallId = toolCall.id || `tool-${index}-${chunks.length}`
+    const args = parseToolArgs(toolCall.args)
+    const assembled = toolCallsById.get(toolCallId)
+    const toolMessage = toolMessagesById.get(toolCallId)
+    const chunk: ToolExecutionChunk = {
+      kind: "tool-execution",
+      toolCallId,
+      timestamp: messageArrivalTimestamp(toolCallId),
+      title: toolTitle(name, args),
+      toolKind: toolKind(name),
+      input: args,
+      status: toolStatus(assembled, toolMessage),
+    }
+    const output = toolOutputText(assembled, toolMessage)
+    if (output) chunk.output = output
+    const display = outputIframeDisplay(toolMessage)
+    if (display) chunk.display = display
+    const diffData = maybeDiffFromArgs(args)
+    if (diffData) chunk.diffData = diffData
+    chunks.push(chunk)
+  }
+
+  return chunks
+}
+
+function humanUiMessage(
+  raw: HumanMessage,
+  msgId: string,
+  parsed: ParsedStructuredInput,
+  entity: StructuredEntity | undefined,
+  resolveCreatedAt?: (messageId: string) => string | undefined
+): Message | null {
+  if (parsed.type === "entity") return null
+  // Our own replies reach the transcript twice: once forwarded as thread
+  // context, once as the `slack_thread_reply` call that sent them.
+  if (entity?.senderType === "self") return null
+
+  const content = (raw as unknown as { content?: unknown }).content
+  const chunks = imageChunks(content)
+  const text = parsed.content
+  if (text.trim()) chunks.push({ kind: "text", text })
+  if (!chunks.length) return null
+
+  const { value: timestamp, isFallback: timestampIsFallback } =
+    messageTimestamp(raw, msgId, resolveCreatedAt)
+  return {
+    id: msgId,
+    author:
+      parsed.type === "message" && parsed.senderKind === "system"
+        ? "system"
+        : "user",
+    timestamp,
+    timestampIsFallback,
+    chunks,
+    ...(parsed.type === "message"
+      ? {
+          structuredSenderId: parsed.sender,
+          structuredSenderKind: parsed.senderKind,
+          structuredSurface: parsed.surface,
+          structuredSenderName:
+            entity?.displayName ??
+            (entity?.handle ? `@${entity.handle}` : undefined),
+          structuredSenderNote: senderNote(entity),
+        }
+      : {}),
+  }
+}
+
+interface HumanParseCacheEntry {
+  base: ParsedStructuredInput
+  entity: StructuredEntity | null
+  withEntity?: {
+    entity: StructuredEntity | undefined
+    parsed: ParsedStructuredInput
+  }
+}
+
+interface AiChunkCacheEntry {
+  deps: Array<unknown>
+  chunks: Array<Chunk>
+}
+
+interface UnitCacheEntry {
+  deps: Array<unknown>
+  message: Message | null
+}
+
+function depsEqual(a: Array<unknown>, b: Array<unknown>): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i += 1) {
+    if (!Object.is(a[i], b[i])) return false
+  }
+  return true
+}
+
 /**
  * Convert the SDK's live projections into the dashboard chunk model so the
  * transcript streams (and hydrates) directly from the SDK instead of a
@@ -317,151 +427,221 @@ function outputIframeDisplay(
  * - `diffData` is derived from the call's own args, which is all that is
  *   available before an edit is applied (what a pending approval renders). What
  *   a turn actually changed comes from its persisted run diff.
+ *
+ * The returned projector is incremental: the SDK keeps object identity stable
+ * for messages a stream flush did not touch, so each output unit (one user
+ * message, or one agent turn spanning consecutive AI messages) is cached
+ * against the references it was derived from and reused verbatim when none of
+ * them changed. Stable `Message`/`Chunk` identities are what let the memoized
+ * message components skip everything but the turn that is actually streaming.
  */
+export function createUiMessageProjector(): (
+  messages: Array<BaseMessage>,
+  toolCalls?: ReadonlyArray<AssembledToolCall>,
+  resolveCreatedAt?: (messageId: string) => string | undefined
+) => Array<Message> {
+  let prevUnits = new Map<string, UnitCacheEntry>()
+  let prevResult: Array<Message> = []
+  const humanParses = new WeakMap<BaseMessage, HumanParseCacheEntry>()
+  const aiChunks = new WeakMap<BaseMessage, AiChunkCacheEntry>()
+
+  return function project(messages, toolCalls = [], resolveCreatedAt?) {
+    const toolCallsById = new Map<string, AssembledToolCall>()
+    for (const toolCall of toolCalls) {
+      const id = toolCall.id || toolCall.callId
+      if (id) toolCallsById.set(id, toolCall)
+    }
+
+    const toolMessagesById = new Map<string, ToolMessage>()
+    for (const raw of messages) {
+      if (ToolMessage.isInstance(raw) && typeof raw.tool_call_id === "string") {
+        toolMessagesById.set(raw.tool_call_id, raw)
+      }
+    }
+
+    const baseParse = (raw: HumanMessage): HumanParseCacheEntry => {
+      const cached = humanParses.get(raw)
+      if (cached) return cached
+      const base = parseStructuredInput(raw.text)
+      const entry: HumanParseCacheEntry = {
+        base,
+        entity:
+          base.type === "entity"
+            ? {
+                kind: base.kind,
+                displayName: base.displayName,
+                handle: base.handle,
+                senderType: base.senderType,
+                openSweAccount: base.openSweAccount,
+              }
+            : null,
+      }
+      humanParses.set(raw, entry)
+      return entry
+    }
+
+    const structuredEntities = new Map<string, StructuredEntity>()
+    for (const raw of messages) {
+      if (!HumanMessage.isInstance(raw)) continue
+      const { base, entity } = baseParse(raw)
+      if (base.type === "entity" && entity)
+        structuredEntities.set(base.id, entity)
+    }
+
+    // Sender kind falls back to the sender's entity, so the parse is keyed on
+    // that entity's identity and only re-runs when the entity itself changed.
+    const parseWithEntities = (raw: HumanMessage): ParsedStructuredInput => {
+      const entry = baseParse(raw)
+      if (entry.base.type !== "message") return entry.base
+      const entity = structuredEntities.get(entry.base.sender)
+      if (entry.withEntity && entry.withEntity.entity === entity) {
+        return entry.withEntity.parsed
+      }
+      const parsed = parseStructuredInput(raw.text, structuredEntities)
+      entry.withEntity = { entity, parsed }
+      return parsed
+    }
+
+    const nextUnits = new Map<string, UnitCacheEntry>()
+    const result: Array<Message> = []
+    let turnKey: string | undefined
+
+    const finishUnit = (
+      key: string,
+      deps: Array<unknown>,
+      build: () => Message | null
+    ) => {
+      const cached = prevUnits.get(key)
+      const entry =
+        cached && depsEqual(cached.deps, deps)
+          ? cached
+          : { deps, message: build() }
+      nextUnits.set(key, entry)
+      if (entry.message) result.push(entry.message)
+    }
+
+    let turnRaws: Array<{
+      raw: AIMessage
+      index: number
+      rawDeps: Array<unknown>
+    }> = []
+    let turnDeps: Array<unknown> = []
+
+    const flushAgentTurn = () => {
+      if (turnRaws.length === 0) return
+      const raws = turnRaws
+      const deps = turnDeps
+      turnRaws = []
+      turnDeps = []
+      const first = raws[0]
+      if (!first) return
+      const firstId =
+        typeof first.raw.id === "string" && first.raw.id
+          ? first.raw.id
+          : `msg-${first.index}`
+      finishUnit(`a:${firstId}`, deps, () => {
+        let turn: AgentTurn | null = null
+        for (const { raw, index, rawDeps } of raws) {
+          const cached = aiChunks.get(raw)
+          let chunks: Array<Chunk>
+          if (cached && depsEqual(cached.deps, rawDeps)) {
+            chunks = cached.chunks
+          } else {
+            chunks = aiMessageChunks(
+              raw,
+              index,
+              toolCallsById,
+              toolMessagesById
+            )
+            aiChunks.set(raw, { deps: rawDeps, chunks })
+          }
+          if (!chunks.length) continue
+          const msgId =
+            typeof raw.id === "string" && raw.id ? raw.id : `msg-${index}`
+          const { value: timestamp, isFallback: timestampIsFallback } =
+            messageTimestamp(raw, msgId, resolveCreatedAt)
+          if (!turn) {
+            turn = {
+              id: msgId,
+              author: "agent",
+              timestamp,
+              turnKey: deps[0] as string | undefined,
+              startedAt: timestamp,
+              timestampIsFallback,
+              chunks: [...chunks],
+            }
+          } else {
+            turn.timestamp = timestamp
+            turn.timestampIsFallback =
+              turn.timestampIsFallback || timestampIsFallback
+            turn.chunks.push(...chunks)
+          }
+        }
+        if (!turn) return null
+        return { ...turn, chunks: mergeTextChunks(turn.chunks) }
+      })
+    }
+
+    messages.forEach((raw, index) => {
+      if (HumanMessage.isInstance(raw)) {
+        flushAgentTurn()
+        turnKey = typeof raw.id === "string" ? raw.id : undefined
+        const msgId =
+          typeof raw.id === "string" && raw.id ? raw.id : `msg-${index}`
+        const parsed = parseWithEntities(raw)
+        const entity =
+          parsed.type === "message"
+            ? structuredEntities.get(parsed.sender)
+            : undefined
+        finishUnit(
+          `h:${msgId}`,
+          [raw, index, entity ?? null, resolveCreatedAt ?? null],
+          () => humanUiMessage(raw, msgId, parsed, entity, resolveCreatedAt)
+        )
+        return
+      }
+
+      if (AIMessage.isInstance(raw)) {
+        if (turnRaws.length === 0) {
+          turnDeps = [turnKey, resolveCreatedAt ?? null]
+        }
+        const rawDeps: Array<unknown> = [index]
+        for (const toolCall of raw.tool_calls ?? []) {
+          const id = toolCall.id
+          rawDeps.push(
+            id ? (toolCallsById.get(id) ?? null) : null,
+            id ? (toolMessagesById.get(id) ?? null) : null
+          )
+        }
+        turnRaws.push({ raw, index, rawDeps })
+        turnDeps.push(raw, ...rawDeps)
+      }
+
+      // `ToolMessage`s no longer produce their own chunk — their status/output
+      // is attached to the originating tool-call chunk above via
+      // `stream.toolCalls`, and their identity participates in each turn's
+      // dependency list.
+    })
+
+    flushAgentTurn()
+    prevUnits = nextUnits
+
+    if (
+      result.length === prevResult.length &&
+      result.every((message, i) => message === prevResult[i])
+    ) {
+      return prevResult
+    }
+    prevResult = result
+    return result
+  }
+}
+
+/** One-shot projection; equivalent to a fresh projector applied once. */
 export function streamMessagesToUi(
   messages: Array<BaseMessage>,
   toolCalls: ReadonlyArray<AssembledToolCall> = [],
   resolveCreatedAt?: (messageId: string) => string | undefined
 ): Array<Message> {
-  const toolCallsById = new Map<string, AssembledToolCall>()
-  for (const toolCall of toolCalls) {
-    const id = toolCall.id || toolCall.callId
-    if (id) toolCallsById.set(id, toolCall)
-  }
-
-  const toolMessagesById = new Map<string, ToolMessage>()
-  for (const raw of messages) {
-    if (ToolMessage.isInstance(raw) && typeof raw.tool_call_id === "string") {
-      toolMessagesById.set(raw.tool_call_id, raw)
-    }
-  }
-
-  const structuredEntities = collectStructuredEntities(
-    messages
-      .filter((message) => HumanMessage.isInstance(message))
-      .map((message) => message.text)
-  )
-  const uiMessages: Array<Message> = []
-  let agentTurn: AgentTurn | null = null
-  let turnKey: string | undefined
-
-  const flushAgentTurn = () => {
-    if (!agentTurn) return
-    uiMessages.push({ ...agentTurn, chunks: mergeTextChunks(agentTurn.chunks) })
-    agentTurn = null
-  }
-
-  const appendAgentChunks = (
-    msgId: string,
-    timestamp: string,
-    timestampIsFallback: boolean,
-    chunks: Array<Chunk>
-  ) => {
-    if (!agentTurn) {
-      agentTurn = {
-        id: msgId,
-        author: "agent",
-        timestamp,
-        turnKey,
-        startedAt: timestamp,
-        timestampIsFallback,
-        chunks: [...chunks],
-      }
-    } else {
-      agentTurn.timestamp = timestamp
-      agentTurn.timestampIsFallback =
-        agentTurn.timestampIsFallback || timestampIsFallback
-      agentTurn.chunks.push(...chunks)
-    }
-  }
-
-  messages.forEach((raw, index) => {
-    const msgId = typeof raw.id === "string" && raw.id ? raw.id : `msg-${index}`
-    const { value: timestamp, isFallback: timestampIsFallback } =
-      messageTimestamp(raw, msgId, resolveCreatedAt)
-
-    if (HumanMessage.isInstance(raw)) {
-      flushAgentTurn()
-      turnKey = typeof raw.id === "string" ? raw.id : undefined
-      const content = (raw as unknown as { content?: unknown }).content
-      const chunks = imageChunks(content)
-      const parsed = parseStructuredInput(raw.text, structuredEntities)
-      if (parsed.type === "entity") return
-      const entity =
-        parsed.type === "message"
-          ? structuredEntities.get(parsed.sender)
-          : undefined
-      // Our own replies reach the transcript twice: once forwarded as thread
-      // context, once as the `slack_thread_reply` call that sent them.
-      if (entity?.senderType === "self") return
-      const text = parsed.content
-      if (text.trim()) chunks.push({ kind: "text", text })
-      if (!chunks.length) return
-      uiMessages.push({
-        id: msgId,
-        author:
-          parsed.type === "message" && parsed.senderKind === "system"
-            ? "system"
-            : "user",
-        timestamp,
-        timestampIsFallback,
-        chunks,
-        ...(parsed.type === "message"
-          ? {
-              structuredSenderId: parsed.sender,
-              structuredSenderKind: parsed.senderKind,
-              structuredSurface: parsed.surface,
-              structuredSenderName:
-                entity?.displayName ??
-                (entity?.handle ? `@${entity.handle}` : undefined),
-              structuredSenderNote: senderNote(entity),
-            }
-          : {}),
-      })
-      return
-    }
-
-    if (AIMessage.isInstance(raw)) {
-      const chunks: Array<Chunk> = []
-      const reasoning = reasoningText(raw)
-      if (reasoning) chunks.push({ kind: "reasoning", text: reasoning })
-      const text = raw.text.trim()
-      if (text) chunks.push({ kind: "text", text })
-
-      for (const toolCall of raw.tool_calls ?? []) {
-        const name = toolCall.name || "tool"
-        if (INTERNAL_TOOLS.has(name)) continue
-        const toolCallId = toolCall.id || `tool-${index}-${chunks.length}`
-        const args = parseToolArgs(toolCall.args)
-        const assembled = toolCallsById.get(toolCallId)
-        const toolMessage = toolMessagesById.get(toolCallId)
-        const chunk: ToolExecutionChunk = {
-          kind: "tool-execution",
-          toolCallId,
-          timestamp: messageArrivalTimestamp(toolCallId),
-          title: toolTitle(name, args),
-          toolKind: toolKind(name),
-          input: args,
-          status: toolStatus(assembled, toolMessage),
-        }
-        const output = toolOutputText(assembled, toolMessage)
-        if (output) chunk.output = output
-        const display = outputIframeDisplay(toolMessage)
-        if (display) chunk.display = display
-        const diffData = maybeDiffFromArgs(args)
-        if (diffData) chunk.diffData = diffData
-        chunks.push(chunk)
-      }
-
-      if (chunks.length) {
-        appendAgentChunks(msgId, timestamp, timestampIsFallback, chunks)
-      }
-    }
-
-    // `ToolMessage`s no longer produce their own chunk — their status/output is
-    // attached to the originating tool-call chunk above via `stream.toolCalls`.
-  })
-
-  flushAgentTurn()
-  return uiMessages
+  return createUiMessageProjector()(messages, toolCalls, resolveCreatedAt)
 }

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -5,8 +5,8 @@ import type {
   DesktopTerminalSessionSnapshot,
   DesktopTerminalSummary,
 } from "@/desktop"
-import { agentsApi } from "@/features/agents/lib/api"
 import type { CloudTerminalConnection } from "@/features/agents/lib/api"
+import { agentsApi } from "@/features/agents/lib/api"
 
 export type TerminalTarget =
   { kind: "local"; sessionId: string } | { kind: "cloud"; threadId: string }
@@ -228,7 +228,7 @@ export interface AttachedTerminal extends TerminalSessionState {
 
 export function cloudTerminalProtocols(
   connection: CloudTerminalConnection
-): string[] {
+): Array<string> {
   return [connection.protocol, connection.ticket]
 }
 

--- a/ui/src/features/agents/lib/threadStreamFixture.ts
+++ b/ui/src/features/agents/lib/threadStreamFixture.ts
@@ -1,0 +1,213 @@
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
+import type { BaseMessage } from "@langchain/core/messages"
+import type { AssembledToolCall } from "@langchain/react"
+
+/**
+ * Synthetic `stream.messages` / `stream.toolCalls` state for benchmarks and
+ * render tests. Mirrors the SDK's identity semantics: a streaming flush
+ * replaces only the streaming message's slot with a fresh object while every
+ * other element keeps its reference, and `toolCalls` changes only on tool
+ * lifecycle events — never on token deltas.
+ */
+export interface ThreadStreamFixture {
+  messages: Array<BaseMessage>
+  toolCalls: Array<AssembledToolCall>
+}
+
+const BASE_TIME = Date.parse("2026-01-01T00:00:00.000Z")
+
+function isoAt(offsetSeconds: number): string {
+  return new Date(BASE_TIME + offsetSeconds * 1000).toISOString()
+}
+
+/** The SDK surfaces server `created_at` on the raw message object. */
+function stamp<T extends BaseMessage>(message: T, iso: string): T {
+  Object.assign(message, { created_at: iso })
+  return message
+}
+
+function fileBody(turn: number, lines: number, edited: boolean): string {
+  const rows: Array<string> = []
+  for (let i = 0; i < lines; i += 1) {
+    rows.push(
+      edited && i % 7 === 3
+        ? `  const value${i} = resolve(${turn}, ${i})`
+        : `  const value${i} = compute(${turn}, ${i})`
+    )
+  }
+  return `export function turn${turn}(): void {\n${rows.join("\n")}\n}`
+}
+
+function replyMarkdown(turn: number, extraSentences = 0): string {
+  const extra = Array.from(
+    { length: extraSentences },
+    (_, i) => `Streamed sentence ${i + 1} lands here with a bit more detail.`
+  ).join(" ")
+  return [
+    `### Turn ${turn} summary`,
+    ``,
+    `Updated the \`parser\` so nested blocks resolve before the fallback path runs. The cursor now stays stable across retries, which removes the duplicated-token symptom.`,
+    ``,
+    `- rewrote \`resolveBlock\` to return early on balanced input`,
+    `- added a regression test for unterminated fences`,
+    `- kept the public API unchanged`,
+    ``,
+    "```ts",
+    `export function resolveBlock(input: string, depth = ${turn % 5}): string {`,
+    `  if (!input.includes("\\n")) return input`,
+    `  return input.split("\\n").map((line) => line.trimEnd()).join("\\n")`,
+    `}`,
+    "```",
+    ``,
+    `See [the change](https://example.com/diff/${turn}) for details.${extra ? ` ${extra}` : ""}`,
+  ].join("\n")
+}
+
+interface FixtureToolCall {
+  id: string
+  name: string
+  args: Record<string, unknown>
+  output: string
+}
+
+function turnToolCalls(turn: number): Array<FixtureToolCall> {
+  const calls: Array<FixtureToolCall> = []
+  for (let i = 0; i < 3; i += 1) {
+    calls.push({
+      id: `t${turn}-read-${i}`,
+      name: "read_file",
+      args: { file_path: `src/features/module${turn % 9}/file${i}.ts` },
+      output: fileBody(turn, 40, false),
+    })
+  }
+  calls.push({
+    id: `t${turn}-grep`,
+    name: "grep",
+    args: { pattern: `resolveBlock${turn}`, path: "src" },
+    output: `src/features/module${turn % 9}/file0.ts:12: resolveBlock${turn}(input)`,
+  })
+  calls.push({
+    id: `t${turn}-edit`,
+    name: "edit_file",
+    args: {
+      file_path: `src/features/module${turn % 9}/file0.ts`,
+      old_string: fileBody(turn, 30, false),
+      new_string: fileBody(turn, 30, true),
+    },
+    output: "ok",
+  })
+  for (let i = 0; i < 2; i += 1) {
+    calls.push({
+      id: `t${turn}-run-${i}`,
+      name: "execute",
+      args: { command: `pnpm vitest run src/features/module${turn % 9}` },
+      output: `Test Files  ${i + 1} passed (${i + 1})\n     Tests  ${12 + i} passed (${12 + i})`,
+    })
+  }
+  calls.push({
+    id: `t${turn}-fetch`,
+    name: "fetch_url",
+    args: { url: `https://example.com/docs/${turn}` },
+    output: `# Docs page ${turn}\n\nReference content for turn ${turn}.`,
+  })
+  return calls
+}
+
+export function buildThreadFixture(turnCount: number): ThreadStreamFixture {
+  const messages: Array<BaseMessage> = []
+  const toolCalls: Array<AssembledToolCall> = []
+
+  for (let turn = 0; turn < turnCount; turn += 1) {
+    const t0 = turn * 100
+    messages.push(
+      stamp(
+        new HumanMessage({
+          id: `user-${turn}`,
+          content: `Please fix the parser regression in module${turn % 9} and add a test for turn ${turn}.`,
+        }),
+        isoAt(t0)
+      )
+    )
+
+    const calls = turnToolCalls(turn)
+    messages.push(
+      stamp(
+        new AIMessage({
+          id: `ai-${turn}-work`,
+          content: "",
+          tool_calls: calls.map((call) => ({
+            id: call.id,
+            name: call.name,
+            args: call.args,
+            type: "tool_call" as const,
+          })),
+        }),
+        isoAt(t0 + 5)
+      )
+    )
+    calls.forEach((call, index) => {
+      messages.push(
+        stamp(
+          new ToolMessage({
+            id: `${call.id}-result`,
+            tool_call_id: call.id,
+            content: call.output,
+            status: "success",
+          }),
+          isoAt(t0 + 10 + index)
+        )
+      )
+      toolCalls.push({
+        name: call.name,
+        callId: call.id,
+        id: call.id,
+        namespace: [],
+        input: call.args,
+        args: call.args,
+        output: call.output,
+        status: "finished",
+        error: undefined,
+      })
+    })
+
+    messages.push(
+      stamp(
+        new AIMessage({ id: `ai-${turn}-reply`, content: replyMarkdown(turn) }),
+        isoAt(t0 + 60)
+      )
+    )
+  }
+
+  return { messages, toolCalls }
+}
+
+/**
+ * Successive stream flushes growing the final reply. Snapshot N shares every
+ * message reference with the base fixture except the last reply, which is a
+ * fresh `AIMessage` per flush — exactly what the SDK's delta path produces.
+ */
+export function streamTicks(
+  fixture: ThreadStreamFixture,
+  tickCount: number
+): Array<ThreadStreamFixture> {
+  const last = fixture.messages[fixture.messages.length - 1]
+  if (!(last instanceof AIMessage)) {
+    throw new Error("fixture must end with a streaming AI reply")
+  }
+  const lastTurn = Math.round(
+    (fixture.messages.filter((m) => m instanceof HumanMessage).length || 1) - 1
+  )
+  const createdAt = (last as unknown as { created_at?: string }).created_at
+
+  const snapshots: Array<ThreadStreamFixture> = []
+  for (let tick = 1; tick <= tickCount; tick += 1) {
+    const messages = fixture.messages.slice()
+    const grown = new AIMessage({
+      id: last.id,
+      content: replyMarkdown(lastTurn, tick),
+    })
+    messages[messages.length - 1] = createdAt ? stamp(grown, createdAt) : grown
+    snapshots.push({ messages, toolCalls: fixture.toolCalls })
+  }
+  return snapshots
+}

--- a/ui/src/features/reviews/components/ReviewMainBody.tsx
+++ b/ui/src/features/reviews/components/ReviewMainBody.tsx
@@ -1466,7 +1466,7 @@ function GroupHeader({ group }: { group: ResolvedGroup }) {
   )
 }
 
-const FileDiffCard = memo(function FileDiffCard({
+const FileDiffCard = memo(function FileDiffCardComponent({
   file,
   findings,
   selectedLines,

--- a/ui/src/features/reviews/components/ReviewSidebar.tsx
+++ b/ui/src/features/reviews/components/ReviewSidebar.tsx
@@ -187,7 +187,7 @@ export function renderInlineCode(text: string): Array<ReactNode> {
 // outline. Clicking (or Enter/Space) scrolls the diff to that block. The active
 // block (scroll-spy) gets an accent rule + emphasis. memo'd so scroll-spy
 // re-renders only repaint the rows whose active state actually changed.
-const ReviewGroupRow = memo(function ReviewGroupRow({
+const ReviewGroupRow = memo(function ReviewGroupRowComponent({
   group,
   active,
   onSelectGroup,

--- a/ui/src/features/settings/components/PreferencesSection.tsx
+++ b/ui/src/features/settings/components/PreferencesSection.tsx
@@ -53,10 +53,7 @@ export function PreferencesSection() {
         label="Appearance"
         description="Theme used across the dashboard."
         control={
-          <Select
-            value={theme}
-            onValueChange={(v) => v && setTheme(v as Theme)}
-          >
+          <Select value={theme} onValueChange={(v) => v && setTheme(v)}>
             <SelectTrigger className="w-40">
               <SelectValue />
             </SelectTrigger>

--- a/ui/src/lib/appCommands.test.ts
+++ b/ui/src/lib/appCommands.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { createNewThreadCommand, resolveAppCommands } from "./appCommands"
 import type { DesktopLocalThreadSummary } from "@/desktop"
 import type { AgentThread } from "@/features/agents/lib/types"
 import type { AppCommand } from "./appCommands"
 import { buildPaletteResults } from "@/components/AppCommandPalette"
-import { createNewThreadCommand, resolveAppCommands } from "./appCommands"
 
 function command(id: string, label = id): AppCommand {
   return { id, label, group: "General", run: vi.fn() }

--- a/ui/src/lib/session-ssr.ts
+++ b/ui/src/lib/session-ssr.ts
@@ -1,11 +1,11 @@
 import { redirect } from "@tanstack/react-router"
 import { createIsomorphicFn } from "@tanstack/react-start"
 import { getRequestUrl } from "@tanstack/react-start/server"
-import type { QueryClient } from "@tanstack/react-query"
 
 import { isCrossOriginApiBase } from "./api-base"
 import { sanitizeAuthRedirect } from "./auth-redirect-core"
 import { sessionQueryOptions } from "./session"
+import type { QueryClient } from "@tanstack/react-query"
 
 const PUBLIC_PATH_RE = /^\/(?:login|dashboard\/api|_serverFn)(?:[/?#]|$)/
 

--- a/ui/src/lib/useRepos.test.tsx
+++ b/ui/src/lib/useRepos.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { useRepos } from "./profile"
 import { writeCachedRepos } from "./repoCache"
+import type * as apiModule from "./api"
 import type { ReposPayload } from "./api"
 
 const sessionLogin = vi.hoisted(() => ({ current: "octocat" }))
@@ -17,7 +18,7 @@ vi.mock("./session", () => ({
 const reposMock = vi.hoisted(() => vi.fn())
 
 vi.mock("./api", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./api")>()),
+  ...(await importOriginal<typeof apiModule>()),
   api: { repos: reposMock },
 }))
 

--- a/ui/src/lib/useResizableWidth.ts
+++ b/ui/src/lib/useResizableWidth.ts
@@ -1,9 +1,5 @@
-import {
-  type PointerEvent as ReactPointerEvent,
-  useCallback,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useRef, useState } from "react"
+import type { PointerEvent as ReactPointerEvent } from "react"
 
 function readStoredWidth(storageKey: string): number | null {
   if (typeof window === "undefined") return null

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import http from "node:http"
 import { defineConfig } from "vite"
 import { devtools } from "@tanstack/devtools-vite"
@@ -158,6 +159,9 @@ const SHELL_PAGE = {
 
 const config = defineConfig({
   base: "/",
+  test: {
+    setupFiles: ["./vitest.setup.ts"],
+  },
   optimizeDeps: {
     include: [
       "streamdown",

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -1,0 +1,45 @@
+// Node ≥ 22 defines its own `localStorage`/`sessionStorage` globals, which are
+// `undefined` unless the process runs with `--localstorage-file`. Vitest's
+// jsdom environment leaves those Node getters in place, shadowing jsdom's
+// storage — so DOM tests see `window.localStorage === undefined`. Replace any
+// missing storage with an in-memory implementation (fresh per test file).
+class MemoryStorage implements Storage {
+  #entries = new Map<string, string>()
+
+  get length(): number {
+    return this.#entries.size
+  }
+
+  key(index: number): string | null {
+    return [...this.#entries.keys()][index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    return this.#entries.get(String(key)) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.#entries.set(String(key), String(value))
+  }
+
+  removeItem(key: string): void {
+    this.#entries.delete(String(key))
+  }
+
+  clear(): void {
+    this.#entries.clear()
+  }
+}
+
+if (typeof document !== "undefined") {
+  const globals = globalThis as Record<string, unknown>
+  for (const name of ["localStorage", "sessionStorage"]) {
+    if (!globals[name]) {
+      Object.defineProperty(globalThis, name, {
+        value: new MemoryStorage(),
+        configurable: true,
+        writable: true,
+      })
+    }
+  }
+}


### PR DESCRIPTION
## Problem

On long threads, every stream flush rebuilt the entire transcript: `streamMessagesToUi` recreated every `Message`/`Chunk` identity per event (defeating all downstream memoization), and the message components were unmemoized — so each streamed token re-rendered every turn, including per-row full-file line diffs. Per-flush cost was linear in thread length (~28ms/flush at 120 turns, at roughly one flush per macrotask), and opening a large thread blocked on a full mount.

## Changes

- **Incremental projection** — `createUiMessageProjector()` caches each output unit (user message / agent turn) against the exact input references it derives from (raw messages, tool results, assembled tool calls, sender entity). The SDK keeps identities stable for untouched messages, so a flush rebuilds only the streaming turn; everything else keeps identity, and the array itself keeps identity when nothing changed. `streamMessagesToUi` remains as the equivalent one-shot (proven by deep-equality tests across mutation sequences). Both thread views project through a per-view instance.
- **Memoization** — `memo()` on `AgentTurn`, `UserMessage`, `WorkEntryRow`, `MessageTimestamp`, `ReasoningBlock`, `SlackMrkdwn`, `CodeBlock`, `DiffView`, `SubagentGroup`, fold rows; `describeWorkEntry` cached per chunk (the line diff behind its stats now runs once per chunk, not per render); `ToolExecution` diff stats memoized; stable toggle callbacks.
- **Two-phase mount** — first paint renders the newest 16 messages; the rest mounts in a transition above the already-bottom-pinned viewport.
- **`content-visibility: auto`** on message rows so off-screen turns skip browser layout/paint.
- **Coalesced** the arrival-timestamp localStorage persist (was a full 5000-entry serialize per new message id, on the render path).

Also repairs the package's dev tooling, which was broken independently of this change:
- Node ≥ 22 ships a global `localStorage` that is `undefined` without `--localstorage-file`; vitest's jsdom environment leaves that getter shadowing jsdom's storage, failing 26 tests. `vitest.setup.ts` installs an in-memory Storage per test file.
- `eslint` was only a peer dependency and never installed (`pnpm lint` → "eslint: command not found"). Added it and cleared every error/warning it surfaced.

## Numbers

Committed benchmark (`pnpm bench`, jsdom; synthetic fixture mirrors the SDK's identity semantics):

| Benchmark | Before | After |
|---|---|---|
| 20 stream flushes, 120-turn thread | 554ms (28ms/flush, O(thread size)) | 130–200ms (~7–10ms/flush, flat across sizes) |
| 20 stream flushes, 30-turn thread | 228ms | ~110–150ms |
| First paint, 120-turn thread | 421ms (blocking full mount) | ~34ms |

## Verification

- New regression test: a stream flush re-derives exactly **1** turn's timeline (was N).
- Projector deep-equals the one-shot conversion across mutation sequences (append, tool-result arrival, late entity introduction, streaming growth); identity-stability tests for untouched units.
- End-to-end in a real browser against the e2e mock harness: seeded a 120-turn/977-message thread; verified hydration pinned to bottom, scrolling top/middle/bottom under `content-visibility` with no blank regions, fold expansion with diff stats, scroll-to-bottom, and a live streaming follow-up run (2 main-thread long tasks across the entire run).
- `pnpm test` 243/243 (was 26 env failures), `pnpm lint` 0 errors, `pnpm typecheck` and `pnpm format:check` clean.

Two `no-shadow` warnings remain in `TurnChangedFilesCard.tsx`/`queries.ts`, deliberately untouched because a separate change to that polling code is in flight.