### PR TITLE
feat: add desktop checkout install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev desktop install-desktop
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev desktop install-desktop install-checkout
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -17,6 +17,12 @@ desktop:
 	cd desktop && pnpm run dev
 
 install-desktop:
+	@test -z "$$(git status --porcelain)" || { echo 'Commit or stash repository changes first.' >&2; exit 1; }
+	@git switch main
+	@git pull --ff-only origin main
+	@./scripts/install_desktop.sh
+
+install-checkout:
 	@./scripts/install_desktop.sh
 
 install:
@@ -71,7 +77,8 @@ help:
 	@echo 'dev                          - run LangGraph dev server'
 	@echo 'run                          - run webhook server'
 	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
-	@echo 'install-desktop              - install the current checkout of Open SWE Desktop on macOS'
+	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
+	@echo 'install-checkout             - install the current checkout of Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,6 @@ desktop:
 	cd desktop && pnpm run dev
 
 install-desktop:
-	@test -z "$$(git status --porcelain)" || { echo 'Commit or stash repository changes first.' >&2; exit 1; }
-	@git switch main
-	@git pull --ff-only origin main
 	@./scripts/install_desktop.sh
 
 install:
@@ -74,7 +71,7 @@ help:
 	@echo 'dev                          - run LangGraph dev server'
 	@echo 'run                          - run webhook server'
 	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
-	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
+	@echo 'install-desktop              - install the current checkout of Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'


### PR DESCRIPTION
## Description
Add `make install-checkout` for installing the desktop app from the current checkout while preserving `make install-desktop` behavior.

## Release Note
Add `make install-checkout` for experimental desktop builds.

## Test Plan
- [x] Dry-ran both install targets

Made by [Open SWE](https://openswe.vercel.app/agents/01a0216a-5ef4-71b7-b74d-3982750934a7)