### PR TITLE
feat: fold the PR surface into the diff scope selector

### DIFF
--- a/agent/dashboard/pr_diff.py
+++ b/agent/dashboard/pr_diff.py
@@ -1,9 +1,11 @@
-"""Shared builder for full-content PR diffs.
+"""Shared builders for full-content GitHub diffs.
 
-Fetches a PR's changed files and their full original/modified contents so the
-UI can render syntax-highlighted diffs with pierre's ``MultiFileDiff``. Used by
-both the thread PR diff endpoint (user token) and the review diff endpoint
-(App installation token).
+Fetches the changed files of a pull request — or of an arbitrary
+``base...head`` comparison, for a branch that has no pull request — together
+with their full original/modified contents, so the UI can render
+syntax-highlighted diffs with pierre's ``MultiFileDiff``. Used by the thread
+branch diff endpoint (user token) and the review diff endpoint (App
+installation token).
 """
 
 import asyncio
@@ -77,12 +79,66 @@ async def build_pr_diff_files(
     if not isinstance(raw_files, list):
         raise HTTPException(502, "github API returned an unexpected files payload")
 
+    return await _build_diff_files(client, full_name, raw_files, base_sha, head_sha)
+
+
+async def build_compare_diff_files(
+    client: httpx.AsyncClient,
+    full_name: str,
+    base_ref: str,
+    head_ref: str,
+) -> dict[str, Any]:
+    """Return ``{base_sha, head_sha, truncated, files}`` for ``base...head``.
+
+    Three-dot compare semantics: the base is the merge base of the two refs, so
+    commits landed on the base branch since the head branch forked are not
+    attributed to it. Same payload shape as :func:`build_pr_diff_files`; refs
+    are fully escaped, so a ref can never widen the request path.
+
+    ``head_sha`` is the ref itself, not a commit: the compare payload's commit
+    list is paginated, so its last entry is not reliably the branch tip. Blobs
+    are read at the ref, which always resolves to the tip.
+    """
+    base = quote(base_ref, safe="")
+    head = quote(head_ref, safe="")
+    response = await client.get(f"{_GITHUB_API}/repos/{full_name}/compare/{base}...{head}")
+    if response.status_code == 404:
+        raise HTTPException(404, "branch not found on GitHub")
+    if response.status_code != 200:
+        raise HTTPException(502, f"github API error ({response.status_code})")
+    comparison = response.json()
+    if not isinstance(comparison, dict):
+        raise HTTPException(502, "github API returned an unexpected compare payload")
+    merge_base = comparison.get("merge_base_commit")
+    base_sha = merge_base.get("sha") if isinstance(merge_base, dict) else None
+    if not isinstance(base_sha, str):
+        raise HTTPException(502, "github API returned an unexpected compare payload")
+
+    raw_files = comparison.get("files")
+    if raw_files is None:
+        raw_files = []
+    if not isinstance(raw_files, list):
+        raise HTTPException(502, "github API returned an unexpected files payload")
+
+    return await _build_diff_files(client, full_name, raw_files, base_sha, head_ref)
+
+
+async def _build_diff_files(
+    client: httpx.AsyncClient,
+    full_name: str,
+    raw_files: list[Any],
+    base_ref: str,
+    head_ref: str,
+) -> dict[str, Any]:
+    """Build file entries by reading each blob at ``base_ref`` and ``head_ref``."""
     truncated = len(raw_files) > PR_DIFF_MAX_FILES
     raw_files = raw_files[:PR_DIFF_MAX_FILES]
 
     semaphore = asyncio.Semaphore(PR_DIFF_FETCH_CONCURRENCY)
 
-    async def build_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
+    async def build_entry(raw: Any) -> dict[str, Any] | None:
+        if not isinstance(raw, dict):
+            return None
         path = raw.get("filename")
         if not isinstance(path, str):
             return None
@@ -94,10 +150,10 @@ async def build_pr_diff_files(
         modified: str | None = ""
         if status != "added":
             original = await _fetch_file_at_ref(
-                client, semaphore, full_name, original_path, base_sha
+                client, semaphore, full_name, original_path, base_ref
             )
         if status != "removed":
-            modified = await _fetch_file_at_ref(client, semaphore, full_name, path, head_sha)
+            modified = await _fetch_file_at_ref(client, semaphore, full_name, path, head_ref)
 
         return {
             "path": path,
@@ -115,8 +171,8 @@ async def build_pr_diff_files(
     entries = await asyncio.gather(*(build_entry(raw) for raw in raw_files))
 
     return {
-        "base_sha": base_sha,
-        "head_sha": head_sha,
+        "base_sha": base_ref,
+        "head_sha": head_ref,
         "truncated": truncated,
         "files": [entry for entry in entries if entry is not None],
     }

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -227,7 +227,7 @@ from .thread_api import (
     delete_dashboard_thread,
     get_dashboard_terminal_sandbox,
     get_dashboard_thread,
-    get_dashboard_thread_pr_diff,
+    get_dashboard_thread_branch_diff,
     get_dashboard_thread_recovery_patch,
     get_dashboard_thread_state,
     get_dashboard_thread_turn_diff,
@@ -2184,12 +2184,25 @@ async def api_get_thread_turn_diff(
     )
 
 
+@router.get("/threads/{thread_id}/branch-diff")
+async def api_get_thread_branch_diff(
+    thread_id: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await get_dashboard_thread_branch_diff(
+        thread_id,
+        session["sub"],
+        email=session.get("email"),
+    )
+
+
+# The pre-branch-diff name, kept for desktop bundles already in the wild.
 @router.get("/threads/{thread_id}/pr-diff")
 async def api_get_thread_pr_diff(
     thread_id: str,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
-    return await get_dashboard_thread_pr_diff(
+    return await get_dashboard_thread_branch_diff(
         thread_id,
         session["sub"],
         email=session.get("email"),

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -56,7 +56,7 @@ from .options import (
     model_supports_effort,
     model_supports_images,
 )
-from .pr_diff import build_pr_diff_files
+from .pr_diff import build_compare_diff_files, build_pr_diff_files
 from .profiles import get_profile, get_valid_access_token
 from .team_settings import get_team_default_model, get_team_fable_enabled
 from .ttft import AssistantTextEventDetector, record_dashboard_thread_ttft
@@ -2395,17 +2395,46 @@ async def get_dashboard_thread_turn_diff(
     )
 
 
-async def get_dashboard_thread_pr_diff(
+_UNSAFE_REF_CHARACTERS = set(" ~^:?*[\\\x7f") | {chr(code) for code in range(32)}
+
+
+def _safe_git_ref(value: Any) -> str | None:
+    """A branch name safe to place in a GitHub API path, or ``None``."""
+    if not isinstance(value, str) or not value or len(value) > 200:
+        return None
+    if value.startswith("-") or value.startswith("/") or value.endswith("/"):
+        return None
+    if ".." in value or "@{" in value or value.endswith(".lock"):
+        return None
+    if any(character in _UNSAFE_REF_CHARACTERS for character in value):
+        return None
+    return value
+
+
+async def get_dashboard_thread_branch_diff(
     thread_id: str, login: str, *, email: str | None = None
 ) -> dict[str, Any]:
+    """Everything the thread's branch changes against its base.
+
+    Served from GitHub rather than the sandbox, so it outlives the workspace.
+    A thread with a pull request reads that PR; one without compares its branch
+    to the base it was cut from, which is the same three-dot range the PR would
+    eventually show.
+    """
     metadata = await _readable_thread_metadata(thread_id, login=login, email=email)
     pr_number = metadata.get("pr_number")
     pr_ref = parse_github_pr_url(str(metadata.get("pr_url") or ""))
     _, _, full_name = _metadata_repo(metadata)
     if pr_ref and pr_ref.number == pr_number:
         full_name = f"{pr_ref.owner}/{pr_ref.repo}"
-    if not isinstance(pr_number, int) or not full_name:
-        raise HTTPException(404, "thread has no pull request")
+    if not full_name:
+        raise HTTPException(404, "thread has no repository")
+    pull_request: int | None = pr_number if isinstance(pr_number, int) else None
+
+    base_ref = _safe_git_ref(metadata.get("base_branch")) or "main"
+    head_ref = _safe_git_ref(metadata.get("branch_name"))
+    if pull_request is None and head_ref == base_ref:
+        raise HTTPException(404, "thread never branched off its base")
 
     token = await _github_token_for_login(login)
     headers = {
@@ -2414,10 +2443,17 @@ async def get_dashboard_thread_pr_diff(
         "X-GitHub-Api-Version": "2022-11-28",
     }
     async with httpx.AsyncClient(headers=headers, timeout=_PROXY_REQUEST_TIMEOUT) as client:
-        diff = await build_pr_diff_files(client, full_name, pr_number)
+        if pull_request is not None:
+            diff = await build_pr_diff_files(client, full_name, pull_request)
+        elif head_ref is not None:
+            diff = await build_compare_diff_files(client, full_name, base_ref, head_ref)
+        else:
+            raise HTTPException(404, "thread has no branch")
 
     return {
-        "prNumber": pr_number,
+        "prNumber": pull_request,
+        "baseRef": base_ref,
+        "headRef": head_ref,
         "baseSha": diff["base_sha"],
         "headSha": diff["head_sha"],
         "truncated": diff["truncated"],

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2490,7 +2490,7 @@ async def test_turn_diff_rejects_checkpoints_from_different_repositories(monkeyp
     create_sandbox.assert_not_awaited()
 
 
-async def test_pr_diff_uses_repository_from_pr_url(monkeypatch) -> None:
+async def test_branch_diff_uses_repository_from_pr_url(monkeypatch) -> None:
     metadata = {
         "repo_owner": "langchain-ai",
         "repo_name": "deepagents",
@@ -2504,10 +2504,55 @@ async def test_pr_diff_uses_repository_from_pr_url(monkeypatch) -> None:
     )
     monkeypatch.setattr(thread_api, "build_pr_diff_files", build_diff)
 
-    await thread_api.get_dashboard_thread_pr_diff("thread-1", "owner")
+    await thread_api.get_dashboard_thread_branch_diff("thread-1", "owner")
 
     assert build_diff.await_args is not None
     assert build_diff.await_args.args[1:] == ("langchain-ai/open-swe", 1925)
+
+
+async def test_branch_diff_without_a_pull_request_compares_against_the_base(monkeypatch) -> None:
+    metadata = {
+        "repo_owner": "langchain-ai",
+        "repo_name": "open-swe",
+        "base_branch": "main",
+        "branch_name": "open-swe/feature",
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    monkeypatch.setattr(thread_api, "_github_token_for_login", AsyncMock(return_value="token"))
+    build_compare = AsyncMock(
+        return_value={"base_sha": "merge-base", "head_sha": "head", "truncated": False, "files": []}
+    )
+    monkeypatch.setattr(thread_api, "build_compare_diff_files", build_compare)
+
+    result = await thread_api.get_dashboard_thread_branch_diff("thread-1", "owner")
+
+    assert build_compare.await_args is not None
+    assert build_compare.await_args.args[1:] == (
+        "langchain-ai/open-swe",
+        "main",
+        "open-swe/feature",
+    )
+    assert result["prNumber"] is None
+    assert result["baseSha"] == "merge-base"
+
+
+async def test_branch_diff_rejects_an_unsafe_branch_name(monkeypatch) -> None:
+    metadata = {
+        "repo_owner": "langchain-ai",
+        "repo_name": "open-swe",
+        "base_branch": "main",
+        "branch_name": "../../etc/passwd",
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    monkeypatch.setattr(thread_api, "_github_token_for_login", AsyncMock(return_value="token"))
+    build_compare = AsyncMock()
+    monkeypatch.setattr(thread_api, "build_compare_diff_files", build_compare)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await thread_api.get_dashboard_thread_branch_diff("thread-1", "owner")
+
+    assert excinfo.value.status_code == 404
+    build_compare.assert_not_awaited()
 
 
 async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypatch) -> None:

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -4,7 +4,7 @@ import { DownloadIcon } from "lucide-react"
 import type { AgentThread } from "@/features/agents/lib/types"
 import { agentsApi } from "@/features/agents/lib/api"
 import {
-  useAgentThreadPrDiff,
+  useAgentThreadBranchDiff,
   useAgentThreadTurnDiff,
 } from "@/features/agents/lib/queries"
 import { ChangesPanel } from "@/features/agents/components/ChangesPanel"
@@ -55,36 +55,43 @@ export function AgentGitPanel({
   const terminalAvailable =
     thread.isOwner !== false && Boolean(thread.sandboxId)
 
-  const hasPullRequest = Boolean(thread.pr)
+  // Served from GitHub, so it needs a repository — with or without a PR.
+  const branchScopeAvailable =
+    Boolean(thread.repoFullName) && Boolean(thread.branch)
   const selectScope = useDiffPanelStore((state) => state.selectScope)
   const scope = useDiffPanelStore((state) =>
-    selectThreadDiffScope(state.byThreadKey, threadRef, hasPullRequest)
+    selectThreadDiffScope(
+      state.byThreadKey,
+      threadRef,
+      branchScopeAvailable,
+      Boolean(thread.pr)
+    )
   )
   const diffVisible = !collapsed && activeSurfaceId === "diff"
 
   const turnDiff = useAgentThreadTurnDiff(
     thread.id,
     null,
-    diffVisible && scope === "thread",
+    diffVisible && scope === "working-tree",
     {},
     thread.status === "running"
   )
-  const prDiff = useAgentThreadPrDiff(
+  const branchDiff = useAgentThreadBranchDiff(
     thread.id,
-    diffVisible && scope === "pull-request"
+    diffVisible && scope === "branch"
   )
   const diff =
-    scope === "pull-request"
+    scope === "branch"
       ? {
-          files: prDiff.data?.files ?? [],
-          // The PR endpoint answers from GitHub: a successful response is
+          files: branchDiff.data?.files ?? [],
+          // The branch endpoint answers from GitHub: a successful response is
           // always a real diff, and a failure surfaces through `error`.
-          status: prDiff.data ? ("ready" as const) : undefined,
-          truncated: prDiff.data?.truncated,
-          isPending: prDiff.isPending,
-          isFetching: prDiff.isFetching,
-          error: prDiff.error,
-          refetch: prDiff.refetch,
+          status: branchDiff.data ? ("ready" as const) : undefined,
+          truncated: branchDiff.data?.truncated,
+          isPending: branchDiff.isPending,
+          isFetching: branchDiff.isFetching,
+          error: branchDiff.error,
+          refetch: branchDiff.refetch,
         }
       : {
           files: turnDiff.data?.files ?? [],
@@ -143,7 +150,6 @@ export function AgentGitPanel({
       cwd=""
       terminalAvailable={terminalAvailable}
       diffAvailable
-      pullRequests={thread.pullRequests ?? []}
       collapsed={collapsed}
       onCollapsedChange={onCollapsedChange}
       renderDiff={({ fullScreen }) => (
@@ -159,10 +165,9 @@ export function AgentGitPanel({
           revealFilePath={revealFilePath}
           fullScreen={fullScreen}
           onRefresh={() => void diff.refetch()}
-          scope={hasPullRequest ? scope : undefined}
-          onScopeChange={
-            hasPullRequest ? (next) => selectScope(threadRef, next) : undefined
-          }
+          scope={scope}
+          branchScopeAvailable={branchScopeAvailable}
+          onScopeChange={(next) => selectScope(threadRef, next)}
           extraActions={
             canDownloadRecovery ? (
               <button

--- a/ui/src/features/agents/components/ChangesPanel.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.tsx
@@ -10,6 +10,7 @@ import type { DiffScopeKind } from "@/features/agents/lib/diffPanelStore"
 import type { PanelFile } from "@/features/agents/components/DiffFilesView"
 import { DiffFilesView } from "@/features/agents/components/DiffFilesView"
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@/components/ui/menu"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
 
 export type ChangesStatus = "ready" | "missing" | "error"
 
@@ -26,9 +27,10 @@ interface ChangesPanelProps {
   fullScreen: boolean
   onRefresh: () => void
   extraActions?: React.ReactNode
-  /** Omitted when the surface has only one diff source to read. */
-  scope?: DiffScopeKind
-  onScopeChange?: (scope: DiffScopeKind) => void
+  scope: DiffScopeKind
+  onScopeChange: (scope: DiffScopeKind) => void
+  /** False when nothing tells us what this branch is based on. */
+  branchScopeAvailable: boolean
 }
 
 function errorMessage(error: unknown): string | null {
@@ -41,30 +43,44 @@ export function changesEmptyLabel({
   isLoading,
   error,
   scope,
-}: Pick<
-  ChangesPanelProps,
-  "status" | "isLoading" | "error" | "scope"
->): string {
+}: Pick<ChangesPanelProps, "status" | "isLoading" | "error"> & {
+  scope?: DiffScopeKind
+}): string {
   if (isLoading) return "Reading changes…"
   if (error) return errorMessage(error) ?? "Could not load changes."
   if (status === "missing")
     return "Changes are not available for this workspace."
   if (status === "error") return "Could not read changes. Try refreshing."
-  if (scope === "pull-request") return "This pull request has no changes."
+  if (scope === "branch") return "This branch changes nothing yet."
   return "No changes yet."
+}
+
+const SCOPE_LABELS: Record<DiffScopeKind, string> = {
+  "working-tree": "Working tree",
+  branch: "Branch changes",
 }
 
 function ScopeSwitcher(props: {
   scope: DiffScopeKind
-  prNumber: number | null
-  branch?: string | null
+  branchScopeAvailable: boolean
   onScopeChange: (scope: DiffScopeKind) => void
 }) {
   const [open, setOpen] = useState(false)
-  const threadLabel = props.branch ? `Changes · ${props.branch}` : "Changes"
-  const prLabel =
-    props.prNumber === null ? "Pull request" : `Pull request #${props.prNumber}`
-  const label = props.scope === "pull-request" ? prLabel : threadLabel
+  const label = SCOPE_LABELS[props.scope]
+
+  const branchItem = (
+    <MenuItem
+      className={
+        props.branchScopeAvailable
+          ? undefined
+          : "data-disabled:pointer-events-auto"
+      }
+      disabled={!props.branchScopeAvailable}
+      onClick={() => props.onScopeChange("branch")}
+    >
+      {SCOPE_LABELS.branch}
+    </MenuItem>
+  )
 
   return (
     <Menu open={open} onOpenChange={setOpen}>
@@ -81,13 +97,18 @@ function ScopeSwitcher(props: {
         sideOffset={6}
         className="min-w-52"
       >
-        <MenuItem onClick={() => props.onScopeChange("thread")}>
-          {threadLabel}
+        <MenuItem onClick={() => props.onScopeChange("working-tree")}>
+          {SCOPE_LABELS["working-tree"]}
         </MenuItem>
-        {props.prNumber === null ? null : (
-          <MenuItem onClick={() => props.onScopeChange("pull-request")}>
-            {prLabel}
-          </MenuItem>
+        {props.branchScopeAvailable ? (
+          branchItem
+        ) : (
+          <Tooltip>
+            <TooltipTrigger render={branchItem} />
+            <TooltipPopup side="right">
+              This thread has no branch to compare against its base yet.
+            </TooltipPopup>
+          </Tooltip>
         )}
       </MenuPopup>
     </Menu>
@@ -109,6 +130,7 @@ export function ChangesPanel({
   extraActions,
   scope,
   onScopeChange,
+  branchScopeAvailable,
 }: ChangesPanelProps) {
   const emptyLabel = changesEmptyLabel({ status, isLoading, error, scope })
   const actions = useMemo(
@@ -158,18 +180,18 @@ export function ChangesPanel({
         emptyLabel={emptyLabel}
         truncated={truncated}
         leading={
-          scope && onScopeChange ? (
+          <div className="flex min-w-0 items-center gap-1.5">
             <ScopeSwitcher
               scope={scope}
-              prNumber={pr?.number ?? null}
-              branch={branch}
+              branchScopeAvailable={branchScopeAvailable}
               onScopeChange={onScopeChange}
             />
-          ) : (
-            <span className="min-w-0 truncate text-sm font-medium text-foreground">
-              Changes{branch ? ` · ${branch}` : ""}
-            </span>
-          )
+            {branch && (
+              <span className="min-w-0 truncate text-xs text-muted-foreground">
+                {branch}
+              </span>
+            )}
+          </div>
         }
         actions={actions}
       />

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -140,19 +140,20 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   // Also the source of the branch/PR metadata, so it stays enabled in either
   // scope: it is what tells us the branch has a pull request at all.
   const checkpointDiff = useLocalThreadDiff(sessionId, diffVisible, isRunning)
-  const hasPullRequest = Boolean(checkpointDiff.data?.repository?.pr)
+  // The pull request is what tells us the base to diff the branch against.
+  const branchScopeAvailable = Boolean(checkpointDiff.data?.repository?.pr)
   const scope = useDiffPanelStore((state) =>
-    selectThreadDiffScope(state.byThreadKey, threadRef, hasPullRequest)
+    selectThreadDiffScope(state.byThreadKey, threadRef, branchScopeAvailable)
   )
-  const prDiff = useLocalThreadPrDiff(
+  const branchDiff = useLocalThreadPrDiff(
     sessionId,
-    diffVisible && scope === "pull-request",
+    diffVisible && scope === "branch",
     isRunning
   )
-  const repository = prDiff.data?.repository ?? checkpointDiff.data?.repository
+  const repository =
+    branchDiff.data?.repository ?? checkpointDiff.data?.repository
   const pr = repository?.pr ?? null
-  const diff = scope === "pull-request" ? prDiff : checkpointDiff
-  const pullRequests = useMemo(() => (pr ? [pr] : []), [pr])
+  const diff = scope === "branch" ? branchDiff : checkpointDiff
   const files = useMemo(
     () => toPanelFiles(diff.data?.files ?? []),
     [diff.data?.files]
@@ -427,7 +428,6 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         cwd={thread.cwd}
         terminalAvailable
         diffAvailable
-        pullRequests={pullRequests}
         collapsed={panelCollapsed}
         onCollapsedChange={handlePanelCollapsedChange}
         onTerminalOpenFile={handleOpenFile}
@@ -447,12 +447,9 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             revealFilePath={revealFilePath}
             fullScreen={fullScreen}
             onRefresh={() => void diff.refetch()}
-            scope={hasPullRequest ? scope : undefined}
-            onScopeChange={
-              hasPullRequest
-                ? (next) => selectScope(threadRef, next)
-                : undefined
-            }
+            scope={scope}
+            branchScopeAvailable={branchScopeAvailable}
+            onScopeChange={(next) => selectScope(threadRef, next)}
           />
         )}
       />

--- a/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
+++ b/ui/src/features/agents/components/NewAgentTerminalPanel.tsx
@@ -43,7 +43,6 @@ export function NewAgentTerminalPanel({
       cwd={cwd}
       terminalAvailable
       diffAvailable={false}
-      pullRequests={[]}
       collapsed={collapsed}
       onCollapsedChange={onCollapsedChange}
       renderDiff={() => null}

--- a/ui/src/features/agents/components/panel/AgentRightPanel.tsx
+++ b/ui/src/features/agents/components/panel/AgentRightPanel.tsx
@@ -11,25 +11,18 @@ import {
   SidebarSimpleIcon,
 } from "@phosphor-icons/react"
 
-import type { AgentPullRequest } from "@/features/agents/lib/types"
 import type {
   PanelThreadRef,
   RightPanelSurface,
 } from "@/features/agents/lib/rightPanelStore"
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import type { TerminalTarget } from "@/features/agents/lib/terminalSession"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
 import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
-import { ThreadPullRequests } from "@/features/agents/components/ThreadPullRequests"
-import {
-  RightPanelTabs,
-  type PullRequestTabStatus,
-} from "@/features/agents/components/panel/RightPanelTabs"
+import { RightPanelTabs } from "@/features/agents/components/panel/RightPanelTabs"
 import { RightPanelSheet } from "@/features/agents/components/panel/RightPanelSheet"
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "@/features/agents/components/panel/rightPanelLayout"
 import {
-  pullRequestSurfaceId,
   selectThreadRightPanelState,
   useRightPanelStore,
 } from "@/features/agents/lib/rightPanelStore"
@@ -46,7 +39,6 @@ export interface AgentRightPanelProps {
   diffAvailable: boolean
   /** Rendered for the Changes surface; `fullScreen` drives layout-only extras. */
   renderDiff: (state: { fullScreen: boolean }) => ReactNode
-  pullRequests: ReadonlyArray<AgentPullRequest>
   collapsed: boolean
   onCollapsedChange: (next: boolean) => void
   onTerminalOpenFile?: (path: string) => void
@@ -91,7 +83,7 @@ function PanelControl(props: {
 
 /**
  * The right-hand column shared by cloud threads and local desktop sessions.
- * Surfaces (changes, terminals, pull requests) live in the right-panel store so
+ * Surfaces (changes, terminals) live in the right-panel store so
  * a thread's tabs survive navigation; this component owns only the layout
  * controls and the mapping from a surface to the component that renders it.
  */
@@ -103,7 +95,6 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
     cwd,
     terminalAvailable,
     diffAvailable,
-    pullRequests,
     collapsed,
     onCollapsedChange,
   } = props
@@ -111,9 +102,6 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
   const byThreadKey = useRightPanelStore((state) => state.byThreadKey)
   const openSurface = useRightPanelStore((state) => state.open)
   const openTerminalSurface = useRightPanelStore((state) => state.openTerminal)
-  const openPullRequestSurface = useRightPanelStore(
-    (state) => state.openPullRequest
-  )
   const activateSurface = useRightPanelStore((state) => state.activateSurface)
   const closeSurfaceById = useRightPanelStore((state) => state.closeSurface)
   const closeOtherSurfaces = useRightPanelStore(
@@ -159,22 +147,6 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
     return labels
   }, [terminals])
 
-  const pullRequestStatuses = useMemo(() => {
-    const statuses: Record<string, PullRequestTabStatus> = {}
-    for (const pullRequest of pullRequests) {
-      const id = pullRequestSurfaceId({
-        repository: pullRequest.repoFullName,
-        number: pullRequest.number,
-      })
-      statuses[id] = {
-        repository: pullRequest.repoFullName,
-        number: pullRequest.number,
-        state: pullRequest.state,
-      }
-    }
-    return statuses
-  }, [pullRequests])
-
   const handleAddTerminal = useCallback(() => {
     openTerminalSurface(threadRef, terminals.addGroup())
   }, [openTerminalSurface, terminals, threadRef])
@@ -182,15 +154,6 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
   const handleAddDiff = useCallback(() => {
     openSurface(threadRef, "diff")
   }, [openSurface, threadRef])
-
-  const handleAddPullRequest = useCallback(() => {
-    const pullRequest = pullRequests[0]
-    if (!pullRequest) return
-    openPullRequestSurface(threadRef, {
-      repository: pullRequest.repoFullName,
-      number: pullRequest.number,
-    })
-  }, [openPullRequestSurface, pullRequests, threadRef])
 
   const handleActivate = useCallback(
     (surface: RightPanelSurface) => {
@@ -310,24 +273,6 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
       {activeSurface?.kind === "diff"
         ? props.renderDiff({ fullScreen: maximized })
         : null}
-      {activeSurface?.kind === "pull-request"
-        ? (() => {
-            const pullRequest = pullRequests.find(
-              (candidate) =>
-                candidate.repoFullName === activeSurface.repository &&
-                candidate.number === activeSurface.number
-            )
-            return (
-              <ScrollArea className="min-h-0 flex-1">
-                <div className="p-3">
-                  <ThreadPullRequests
-                    pullRequests={pullRequest ? [pullRequest] : []}
-                  />
-                </div>
-              </ScrollArea>
-            )
-          })()
-        : null}
       {/* Terminals stay mounted while hidden so their scrollback survives tab
           switches; every other surface unmounts. */}
       {surfaces
@@ -381,11 +326,8 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
       }}
       onAddTerminal={handleAddTerminal}
       onAddDiff={handleAddDiff}
-      onAddPullRequest={handleAddPullRequest}
       terminalAvailable={terminalAvailable}
       diffAvailable={diffAvailable}
-      pullRequestAvailable={pullRequests.length > 0}
-      pullRequestStatuses={pullRequestStatuses}
       layoutControls={layoutControls}
     >
       {body}

--- a/ui/src/features/agents/components/panel/RightPanelTabs.tsx
+++ b/ui/src/features/agents/components/panel/RightPanelTabs.tsx
@@ -13,7 +13,6 @@ import {
   FileDiff,
   FileIcon,
   Files,
-  GitPullRequest,
   Globe2,
   Plus,
   TerminalSquare,
@@ -21,7 +20,6 @@ import {
 } from "lucide-react"
 
 import type { RightPanelSurface } from "@/features/agents/lib/rightPanelStore"
-import type { AgentPullRequest } from "@/features/agents/lib/types"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import {
@@ -59,24 +57,14 @@ interface RightPanelTabsProps {
   onCopyFilePath: (relativePath: string) => void
   onAddTerminal: () => void
   onAddDiff: () => void
-  onAddPullRequest: () => void
   terminalAvailable: boolean
   diffAvailable: boolean
-  pullRequestAvailable: boolean
-  pullRequestStatuses?: Readonly<Record<string, PullRequestTabStatus>>
   children: ReactNode
-}
-
-export interface PullRequestTabStatus {
-  repository: string
-  number: number
-  state: AgentPullRequest["state"]
 }
 
 const SURFACE_DISABLED_REASONS = {
   terminal: "Terminals are only available from a running workspace.",
   diff: "Changes are only available for threads with a repository.",
-  pullRequest: "This thread's branch has no pull request yet.",
 } as const
 
 /** Overlays that must win over the launcher's letter shortcuts. */
@@ -93,7 +81,6 @@ const LAUNCHER_SHORTCUT_BLOCKING_LAYERS = [
 const SURFACE_UNAVAILABLE_HINTS = {
   terminal: "Available once the workspace is running.",
   diff: "Available for Git repositories.",
-  pullRequest: "No pull request on this branch yet.",
 } as const
 
 type SurfaceShortcutEvent = Pick<
@@ -161,10 +148,8 @@ function SurfaceMenuItem(props: {
 function RightPanelEmptyState(props: {
   onAddTerminal: () => void
   onAddDiff: () => void
-  onAddPullRequest: () => void
   terminalAvailable: boolean
   diffAvailable: boolean
-  pullRequestAvailable: boolean
 }) {
   // -1 means no highlight: it only appears on hover or arrow use.
   const [highlight, setHighlight] = useState(-1)
@@ -187,15 +172,6 @@ function RightPanelEmptyState(props: {
       available: props.diffAvailable,
       disabledReason: SURFACE_UNAVAILABLE_HINTS.diff,
       onClick: props.onAddDiff,
-    },
-    {
-      label: "Pull request",
-      description: "Open this branch's pull request.",
-      icon: GitPullRequest,
-      shortcut: "P",
-      available: props.pullRequestAvailable,
-      disabledReason: SURFACE_UNAVAILABLE_HINTS.pullRequest,
-      onClick: props.onAddPullRequest,
     },
   ] as const
 
@@ -389,8 +365,6 @@ export function surfaceTitle(
       )
     case "terminal":
       return terminalLabelsById.get(surface.resourceId) ?? "Terminal"
-    case "pull-request":
-      return `#${surface.number}`
     case "agents":
       return "Agents"
     case "preview":
@@ -398,14 +372,7 @@ export function surfaceTitle(
   }
 }
 
-function SurfaceIcon({
-  surface,
-  pullRequestStatuses,
-}: {
-  surface: RightPanelSurface
-  pullRequestStatuses:
-    Readonly<Record<string, PullRequestTabStatus>> | undefined
-}) {
+function SurfaceIcon({ surface }: { surface: RightPanelSurface }) {
   switch (surface.kind) {
     case "preview":
       return <Globe2 className="size-3 shrink-0" />
@@ -419,20 +386,6 @@ function SurfaceIcon({
       return <TerminalSquare className="size-3 shrink-0" />
     case "agents":
       return <Bot className="size-3 shrink-0" />
-    case "pull-request": {
-      const status = pullRequestStatuses?.[surface.id] ?? null
-      const toneClassName =
-        status?.state === "merged"
-          ? "text-violet-600 dark:text-violet-300/90"
-          : status?.state === "closed"
-            ? "text-red-600 dark:text-red-300/90"
-            : status?.state === "draft"
-              ? "text-zinc-500 dark:text-zinc-400/80"
-              : status?.state === "open"
-                ? "text-emerald-600 dark:text-emerald-300/90"
-                : "text-muted-foreground"
-      return <GitPullRequest className={cn("size-3 shrink-0", toneClassName)} />
-    }
   }
 }
 
@@ -463,14 +416,6 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
       available: props.diffAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.diff,
       onClick: props.onAddDiff,
-    },
-    {
-      label: "Pull request",
-      icon: GitPullRequest,
-      shortcut: "P",
-      available: props.pullRequestAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.pullRequest,
-      onClick: props.onAddPullRequest,
     },
   ] as const
 
@@ -574,10 +519,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                     onClick={() => props.onCloseSurface(surface)}
                   >
                     <span className="relative flex size-3 items-center justify-center group-hover/tab:hidden group-focus-visible/close:hidden">
-                      <SurfaceIcon
-                        surface={surface}
-                        pullRequestStatuses={props.pullRequestStatuses}
-                      />
+                      <SurfaceIcon surface={surface} />
                       {pending ? (
                         <span
                           className="absolute -right-0.5 -bottom-0.5 size-1.5 rounded-full bg-current"
@@ -710,10 +652,8 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           <RightPanelEmptyState
             onAddTerminal={props.onAddTerminal}
             onAddDiff={props.onAddDiff}
-            onAddPullRequest={props.onAddPullRequest}
             terminalAvailable={props.terminalAvailable}
             diffAvailable={props.diffAvailable}
-            pullRequestAvailable={props.pullRequestAvailable}
           />
         ) : (
           props.children

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -73,8 +73,10 @@ export interface ThreadPrDiffFile {
   unrenderable: boolean
 }
 
-export interface ThreadPrDiff {
-  prNumber: number
+export interface ThreadBranchDiff {
+  prNumber: number | null
+  baseRef: string
+  headRef: string | null
   baseSha: string
   headSha: string
   truncated: boolean
@@ -341,9 +343,9 @@ export const agentsApi = {
     agentsRequest<void>(`/threads/${encodeURIComponent(threadId)}`, {
       method: "DELETE",
     }),
-  getThreadPrDiff: (threadId: string) =>
-    agentsRequest<ThreadPrDiff>(
-      `/threads/${encodeURIComponent(threadId)}/pr-diff`
+  getThreadBranchDiff: (threadId: string) =>
+    agentsRequest<ThreadBranchDiff>(
+      `/threads/${encodeURIComponent(threadId)}/branch-diff`
     ),
   getThreadTurnDiff: (
     threadId: string,

--- a/ui/src/features/agents/lib/diffPanelStore.test.ts
+++ b/ui/src/features/agents/lib/diffPanelStore.test.ts
@@ -14,29 +14,45 @@ describe("diffPanelStore", () => {
     useDiffPanelStore.setState({ byThreadKey: {} })
   })
 
-  it("defaults to the pull request scope only when the thread has one", () => {
+  it("defaults to branch changes only when they are available", () => {
     const { byThreadKey } = useDiffPanelStore.getState()
-    expect(selectThreadDiffScope(byThreadKey, ref, true)).toBe("pull-request")
-    expect(selectThreadDiffScope(byThreadKey, ref, false)).toBe("thread")
-    expect(selectThreadDiffScope(byThreadKey, null, true)).toBe("pull-request")
+    expect(selectThreadDiffScope(byThreadKey, ref, true)).toBe("branch")
+    expect(selectThreadDiffScope(byThreadKey, ref, false)).toBe("working-tree")
+    expect(selectThreadDiffScope(byThreadKey, null, true)).toBe("branch")
+  })
+
+  it("keeps a selectable branch scope off the default when asked", () => {
+    const { byThreadKey } = useDiffPanelStore.getState()
+    expect(selectThreadDiffScope(byThreadKey, ref, true, false)).toBe(
+      "working-tree"
+    )
+    useDiffPanelStore.getState().selectScope(ref, "branch")
+    expect(
+      selectThreadDiffScope(
+        useDiffPanelStore.getState().byThreadKey,
+        ref,
+        true,
+        false
+      )
+    ).toBe("branch")
   })
 
   it("remembers an explicit scope per thread", () => {
-    useDiffPanelStore.getState().selectScope(ref, "thread")
+    useDiffPanelStore.getState().selectScope(ref, "working-tree")
     const { byThreadKey } = useDiffPanelStore.getState()
-    expect(selectThreadDiffScope(byThreadKey, ref, true)).toBe("thread")
+    expect(selectThreadDiffScope(byThreadKey, ref, true)).toBe("working-tree")
     // Same thread id under a different scope is a different panel.
-    expect(selectThreadDiffScope(byThreadKey, other, true)).toBe("pull-request")
+    expect(selectThreadDiffScope(byThreadKey, other, true)).toBe("branch")
   })
 
-  it("falls back to thread changes when the stored PR scope is unavailable", () => {
-    useDiffPanelStore.getState().selectScope(ref, "pull-request")
+  it("falls back to the working tree when branch changes are unavailable", () => {
+    useDiffPanelStore.getState().selectScope(ref, "branch")
     const { byThreadKey } = useDiffPanelStore.getState()
-    expect(selectThreadDiffScope(byThreadKey, ref, false)).toBe("thread")
+    expect(selectThreadDiffScope(byThreadKey, ref, false)).toBe("working-tree")
   })
 
   it("drops a thread's selection", () => {
-    useDiffPanelStore.getState().selectScope(ref, "thread")
+    useDiffPanelStore.getState().selectScope(ref, "working-tree")
     useDiffPanelStore.getState().removeThread(ref)
     expect(useDiffPanelStore.getState().byThreadKey).toEqual({})
   })
@@ -49,7 +65,7 @@ describe("diffPanelStore", () => {
     })
   })
 
-  it("drops persisted entries whose kind is unknown", () => {
+  it("drops persisted entries whose kind is unknown, and maps the v1 names", () => {
     expect(
       migratePersistedDiffPanelState({
         byThreadKey: {
@@ -57,12 +73,16 @@ describe("diffPanelStore", () => {
           "cloud:b": { kind: "unstaged" },
           "cloud:c": null,
           "cloud:d": { kind: "thread", extra: "ignored" },
+          "cloud:e": { kind: "branch" },
+          "cloud:f": { kind: "working-tree" },
         },
       })
     ).toEqual({
       byThreadKey: {
-        "cloud:a": { kind: "pull-request" },
-        "cloud:d": { kind: "thread" },
+        "cloud:a": { kind: "branch" },
+        "cloud:d": { kind: "working-tree" },
+        "cloud:e": { kind: "branch" },
+        "cloud:f": { kind: "working-tree" },
       },
     })
   })

--- a/ui/src/features/agents/lib/diffPanelStore.ts
+++ b/ui/src/features/agents/lib/diffPanelStore.ts
@@ -2,8 +2,9 @@
  * Thread-scoped diff selection.
  *
  * The panel never stores diff data — only which source the Changes surface is
- * pointed at. Diffs are fetched live per scope, so a thread whose sandbox is
- * gone can still show its pull request's diff instead of an empty result.
+ * pointed at: the workspace's working tree, or everything the branch changes
+ * against its base. Diffs are fetched live per scope, so a thread whose sandbox
+ * is gone can still show its branch changes instead of an empty result.
  */
 import { create } from "zustand"
 import { createJSONStorage, persist } from "zustand/middleware"
@@ -13,16 +14,16 @@ import {
   type PanelThreadRef,
 } from "@/features/agents/lib/rightPanelStore"
 
-export const DIFF_SCOPE_KINDS = ["thread", "pull-request"] as const
+export const DIFF_SCOPE_KINDS = ["working-tree", "branch"] as const
 export type DiffScopeKind = (typeof DIFF_SCOPE_KINDS)[number]
 
 export type DiffPanelSelection = { kind: DiffScopeKind }
 
-const THREAD_SELECTION: DiffPanelSelection = { kind: "thread" }
-const PULL_REQUEST_SELECTION: DiffPanelSelection = { kind: "pull-request" }
+const WORKING_TREE_SELECTION: DiffPanelSelection = { kind: "working-tree" }
+const BRANCH_SELECTION: DiffPanelSelection = { kind: "branch" }
 
 const DIFF_PANEL_STORAGE_KEY = "open-swe:diff-panel-state"
-const DIFF_PANEL_STORAGE_VERSION = 1
+const DIFF_PANEL_STORAGE_VERSION = 2
 
 interface DiffPanelStoreState {
   byThreadKey: Record<string, DiffPanelSelection>
@@ -49,9 +50,11 @@ export function migratePersistedDiffPanelState(persistedState: unknown): {
   )) {
     if (!threadKey || !value || typeof value !== "object") continue
     const kind = (value as { kind?: unknown }).kind
-    if (kind === "thread") byThreadKey[threadKey] = THREAD_SELECTION
-    else if (kind === "pull-request")
-      byThreadKey[threadKey] = PULL_REQUEST_SELECTION
+    // "thread"/"pull-request" are the v1 names for the same two sources.
+    if (kind === "working-tree" || kind === "thread")
+      byThreadKey[threadKey] = WORKING_TREE_SELECTION
+    else if (kind === "branch" || kind === "pull-request")
+      byThreadKey[threadKey] = BRANCH_SELECTION
   }
   return { byThreadKey }
 }
@@ -82,9 +85,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
             byThreadKey: {
               ...state.byThreadKey,
               [threadKey]:
-                kind === "pull-request"
-                  ? PULL_REQUEST_SELECTION
-                  : THREAD_SELECTION,
+                kind === "branch" ? BRANCH_SELECTION : WORKING_TREE_SELECTION,
             },
           }
         }),
@@ -110,17 +111,20 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
 
 /**
  * The scope the Changes surface should read. Absent an explicit choice a
- * thread with a pull request defaults to it: the PR diff is served from
- * GitHub, so it survives the sandbox the thread's own diff depends on.
+ * thread that already has a pull request defaults to its branch changes: that
+ * diff is served from GitHub, so it survives the sandbox the working tree
+ * depends on. A branch that was never pushed is selectable but not the
+ * default, since GitHub has nothing to compare yet.
  */
 export function selectThreadDiffScope(
   byThreadKey: Record<string, DiffPanelSelection>,
   ref: PanelThreadRef | null | undefined,
-  hasPullRequest = false
+  branchAvailable = false,
+  branchIsDefault = branchAvailable
 ): DiffScopeKind {
   const stored = ref ? byThreadKey[scopedThreadKey(ref)] : undefined
-  if (stored?.kind === "pull-request")
-    return hasPullRequest ? stored.kind : "thread"
-  if (stored?.kind === "thread") return stored.kind
-  return hasPullRequest ? "pull-request" : "thread"
+  if (stored?.kind === "branch")
+    return branchAvailable ? stored.kind : "working-tree"
+  if (stored?.kind === "working-tree") return stored.kind
+  return branchAvailable && branchIsDefault ? "branch" : "working-tree"
 }

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -37,7 +37,8 @@ export const agentThreadKeys = {
   sidebarActive: (threadId: string) =>
     ["agent-threads", "lists", "sidebar-active", threadId] as const,
   detail: (threadId: string) => ["agent-threads", threadId] as const,
-  prDiff: (threadId: string) => ["agent-threads", threadId, "pr-diff"] as const,
+  branchDiff: (threadId: string) =>
+    ["agent-threads", threadId, "branch-diff"] as const,
   turnDiff: (
     threadId: string,
     turnKey: string | null,
@@ -390,10 +391,10 @@ export function useAgentThread(threadId: string) {
   })
 }
 
-export function useAgentThreadPrDiff(threadId: string, enabled: boolean) {
+export function useAgentThreadBranchDiff(threadId: string, enabled: boolean) {
   return useQuery({
-    queryKey: agentThreadKeys.prDiff(threadId),
-    queryFn: () => agentsApi.getThreadPrDiff(threadId),
+    queryKey: agentThreadKeys.branchDiff(threadId),
+    queryFn: () => agentsApi.getThreadBranchDiff(threadId),
     enabled,
     staleTime: 30_000,
     retry: false,

--- a/ui/src/features/agents/lib/rightPanelStore.test.ts
+++ b/ui/src/features/agents/lib/rightPanelStore.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it } from "vitest"
 
 import {
   migratePersistedRightPanelState,
-  pullRequestSurfaceId,
   selectActiveRightPanelSurface,
   selectThreadRightPanelState,
   useRightPanelStore,
@@ -53,16 +52,6 @@ describe("right panel store", () => {
     expect(
       state().surfaces.some((surface) => surface.id === state().activeSurfaceId)
     ).toBe(true)
-  })
-
-  it("keeps several pull requests open as peers", () => {
-    const { openPullRequest } = useRightPanelStore.getState()
-    openPullRequest(ref, { repository: "acme/app", number: 1 })
-    openPullRequest(ref, { repository: "acme/app", number: 2 })
-    expect(state().surfaces.map((surface) => surface.id)).toEqual([
-      pullRequestSurfaceId({ repository: "acme/app", number: 1 }),
-      pullRequestSurfaceId({ repository: "acme/app", number: 2 }),
-    ])
   })
 
   it("closes others and to the right relative to a surface", () => {
@@ -128,10 +117,12 @@ describe("migratePersistedRightPanelState", () => {
             { id: "diff", kind: "diff" },
             { id: "evil", kind: "script" },
             { id: "file:", kind: "file" },
+            // The retired pull-request surface, well formed as it was persisted.
             {
               id: "pull-request:acme%2Fapp:1",
               kind: "pull-request",
               repository: "acme/app",
+              number: 1,
             },
           ],
         },

--- a/ui/src/features/agents/lib/rightPanelStore.ts
+++ b/ui/src/features/agents/lib/rightPanelStore.ts
@@ -53,7 +53,7 @@ export type RightPanelSurface =
   | { id: "agents"; kind: "agents" }
 
 const RIGHT_PANEL_STORAGE_KEY = "open-swe:right-panel-state"
-const RIGHT_PANEL_STORAGE_VERSION = 1
+const RIGHT_PANEL_STORAGE_VERSION = 2
 
 export interface ThreadRightPanelState {
   isOpen: boolean

--- a/ui/src/features/agents/lib/rightPanelStore.ts
+++ b/ui/src/features/agents/lib/rightPanelStore.ts
@@ -26,7 +26,6 @@ export const RIGHT_PANEL_KINDS = [
   "file",
   "preview",
   "terminal",
-  "pull-request",
   "agents",
 ] as const
 export type RightPanelKind = (typeof RIGHT_PANEL_KINDS)[number]
@@ -51,16 +50,6 @@ export type RightPanelSurface =
       revealLine: number | null
       revealRequestId: number
     }
-  | {
-      /**
-       * A pull request opened beside a thread. The reference lives in the id so
-       * several pull requests can remain open as peer tabs.
-       */
-      id: `pull-request:${string}`
-      kind: "pull-request"
-      repository: string
-      number: number
-    }
   | { id: "agents"; kind: "agents" }
 
 const RIGHT_PANEL_STORAGE_KEY = "open-swe:right-panel-state"
@@ -72,23 +61,16 @@ export interface ThreadRightPanelState {
   surfaces: Array<RightPanelSurface>
 }
 
-type SingletonKind = Exclude<
-  RightPanelKind,
-  "file" | "preview" | "terminal" | "pull-request"
->
+type SingletonKind = Exclude<RightPanelKind, "file" | "preview" | "terminal">
 
 interface RightPanelStoreState {
   byThreadKey: Record<string, ThreadRightPanelState>
   open: (
     ref: PanelThreadRef,
-    kind: Exclude<RightPanelKind, "file" | "terminal" | "pull-request">
+    kind: Exclude<RightPanelKind, "file" | "terminal">
   ) => void
   openBrowser: (ref: PanelThreadRef, tabId: string | null) => void
   openFile: (ref: PanelThreadRef, relativePath: string, line?: number) => void
-  openPullRequest: (
-    ref: PanelThreadRef,
-    target: { repository: string; number: number }
-  ) => void
   openTerminal: (ref: PanelThreadRef, terminalId: string) => void
   activateSurface: (ref: PanelThreadRef, surfaceId: string) => void
   closeSurface: (ref: PanelThreadRef, surfaceId: string) => void
@@ -104,7 +86,7 @@ interface RightPanelStoreState {
   toggleVisibility: (ref: PanelThreadRef) => void
   toggle: (
     ref: PanelThreadRef,
-    kind: Exclude<RightPanelKind, "file" | "terminal" | "pull-request">
+    kind: Exclude<RightPanelKind, "file" | "terminal">
   ) => void
   removeThread: (ref: PanelThreadRef) => void
 }
@@ -150,30 +132,6 @@ const terminalSurface = (terminalId: string): RightPanelSurface => ({
   terminalIds: [terminalId],
   activeTerminalId: terminalId,
 })
-
-export type PullRequestSurface = Extract<
-  RightPanelSurface,
-  { kind: "pull-request" }
->
-
-export function pullRequestSurfaceId(target: {
-  repository: string
-  number: number
-}): PullRequestSurface["id"] {
-  return `pull-request:${encodeURIComponent(target.repository)}:${target.number}`
-}
-
-export function pullRequestSurface(target: {
-  repository: string
-  number: number
-}): PullRequestSurface {
-  return {
-    id: pullRequestSurfaceId(target),
-    kind: "pull-request",
-    repository: target.repository,
-    number: target.number,
-  }
-}
 
 const upsertSurface = (
   current: ThreadRightPanelState,
@@ -262,22 +220,6 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                   : 0
               return [
                 fileSurface(surface.relativePath, revealLine, revealRequestId),
-              ]
-            }
-            if (kind === "pull-request") {
-              if (
-                typeof surface.repository !== "string" ||
-                typeof surface.number !== "number" ||
-                !Number.isSafeInteger(surface.number) ||
-                surface.number < 1
-              ) {
-                return []
-              }
-              return [
-                pullRequestSurface({
-                  repository: surface.repository,
-                  number: surface.number,
-                }),
               ]
             }
             if (kind === "preview") {
@@ -396,14 +338,6 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
                 surface
               )
             }
-          ),
-        })),
-      openPullRequest: (ref, target) =>
-        set((state) => ({
-          byThreadKey: updateThread(
-            state.byThreadKey,
-            scopedThreadKey(ref),
-            (current) => upsertSurface(current, pullRequestSurface(target))
           ),
         })),
       openFile: (ref, relativePath, line) =>


### PR DESCRIPTION
The right panel's **pull-request** surface only ever rendered a link card to the PR — the PR's actual changes were already reachable from the Changes surface's scope switcher. This drops that surface and makes the switcher the single way to pick what the diff shows, following the reference implementation: everything under one Diff tab, with a scope dropdown.

Scopes are **Working tree** and **Branch changes** (the reference's per-turn scopes have no native equivalent here).

## Branch changes without a pull request

Branch changes are served from GitHub rather than the sandbox, so they outlive the workspace. They previously required a PR, since the PR was what named the base. Now a PR-less thread is compared against the base branch it was cut from — GitHub's three-dot `base...head` compare, the same range the PR would eventually show.

- New `GET /threads/{id}/branch-diff`; `/pr-diff` stays as an alias so desktop bundles already in the wild keep working.
- `build_compare_diff_files` shares the per-file blob-reading logic with `build_pr_diff_files` via `_build_diff_files`. The base SHA comes from `merge_base_commit.sha`, and blobs are read at the head *ref*: the compare payload's commit list is paginated, so its last entry is not reliably the branch tip.
- Refs pass a `_safe_git_ref` allowlist (no control characters, spaces, `..`, `@{`, leading `-`, `.lock`, over 200 chars) and are fully URL-encoded before they reach the API path. Ownership still goes through `_readable_thread_metadata`.

## Defaults

The branch scope is *selectable* whenever a thread has a repo and a branch, but only *defaults on* once a PR exists — otherwise a brand-new thread whose branch has not been pushed yet would open on an endpoint that 404s. `selectThreadDiffScope` grew an optional `branchIsDefault` parameter for that.

Persisted state migrates forward: the v1 diff-scope names (`thread`, `pull-request`) map to `working-tree` / `branch`, and retired `pull-request` panel surfaces are dropped by the existing allowlist migration.

## Checks

`make lint`, `make typecheck` (0 errors) and `npx tsc --noEmit` are clean. The Python and vitest failures on this branch (Slack webhook tests, voice, `setsid`-dependent background-execute tests, `apiWarmup`) reproduce identically on a clean `main` and are unrelated.

Made by [Open SWE](https://openswe.vercel.app/agents/01a02183-1e9b-723d-a611-c82e1e549294)
