### PR TITLE
fix: hide active run divider

### DIFF
--- a/ui/src/features/agents/components/messages/timeline/foldRows.tsx
+++ b/ui/src/features/agents/components/messages/timeline/foldRows.tsx
@@ -20,7 +20,7 @@ export function TurnFoldRow({
   const Icon = expanded ? ChevronDown : ChevronRight
 
   return (
-    <div className="border-b border-border/60 pt-1 pb-2">
+    <div className={cn("pt-1 pb-2", !active && "border-b border-border/60")}>
       <button
         type="button"
         aria-expanded={expanded}


### PR DESCRIPTION
## Description
Hide the tool status underline while a run is active and restore it when complete.

## Release Note
Fixed active run status styling.

## Test Plan
- [x] Confirmed UI typecheck and formatting pass.

Made by [Open SWE](https://openswe.vercel.app/agents/01a0216d-43a8-727c-9979-e74fd8073a87)