### PR TITLE
fix: clarify active tool call shimmer

### DIFF
--- a/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
+++ b/ui/src/features/agents/components/messages/timeline/WorkEntryRow.tsx
@@ -179,7 +179,7 @@ export function WorkEntryRow({
             <p className="flex w-full min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
               <span
                 className={cn(
-                  "min-w-0 shrink truncate font-medium",
+                  "shrink-0 truncate font-medium",
                   isError
                     ? "text-destructive"
                     : entry.status === "pending" ||

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -139,15 +139,15 @@ html[data-agents-theme] * {
 html[data-agents-theme] .shimmer-text {
   background: linear-gradient(
     90deg,
-    var(--muted-foreground) 40%,
+    var(--muted-foreground) 35%,
     var(--foreground) 50%,
-    var(--muted-foreground) 60%
+    var(--muted-foreground) 65%
   );
-  background-size: 200% auto;
+  background-size: 150% auto;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  animation: agents-shimmer 4s linear infinite;
+  animation: agents-shimmer 2s linear infinite;
 }
 
 @keyframes agents-shimmer {


### PR DESCRIPTION
## Description
Make in-progress tool calls easier to spot while limiting the shimmer to the action label, not its path or argument.

## Release Note
Improved in-progress tool call shimmer visibility.

## Test Plan
- [x] Confirm active tool labels retain a fixed width separate from previews

Made by [Open SWE](https://openswe.vercel.app/agents/01a021a1-d971-772c-9666-b3995d7b404c)