### PR TITLE
fix: read working tree changes from live sandbox

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -2332,14 +2332,13 @@ async def get_dashboard_thread_turn_diff(
         }
 
     checkpoint = checkpoints[index]
+    stored = None
     if turn_key is not None:
         stored = await get_run_diff(thread_id, turn_key)
         if stored is not None:
             return project_run_diff(stored, max_files=max_files, include_content=include_content)
     else:
         stored = await get_run_diff(thread_id, THREAD_DIFF_KEY)
-        if stored is not None:
-            return project_run_diff(stored, max_files=max_files, include_content=include_content)
 
     plan_ref = checkpoint.get("plan_ref")
     if (
@@ -2376,6 +2375,8 @@ async def get_dashboard_thread_turn_diff(
         sandbox = await create_sandbox(sandbox_id)
     except Exception:  # noqa: BLE001
         logger.debug("Could not connect to sandbox %s for turn diff", sandbox_id, exc_info=True)
+        if stored is not None:
+            return project_run_diff(stored, max_files=max_files, include_content=include_content)
         return {
             "status": "missing",
             "files": [],
@@ -2384,7 +2385,7 @@ async def get_dashboard_thread_turn_diff(
         }
 
     repo_path = checkpoint.get("repo_path")
-    return await read_turn_diff(
+    live = await read_turn_diff(
         sandbox,
         None,
         str(checkpoint["ref"]),
@@ -2393,6 +2394,9 @@ async def get_dashboard_thread_turn_diff(
         include_content=include_content,
         repo_path=repo_path if isinstance(repo_path, str) else None,
     )
+    if live.get("status") != "ready" and stored is not None:
+        return project_run_diff(stored, max_files=max_files, include_content=include_content)
+    return live
 
 
 _UNSAFE_REF_CHARACTERS = set(" ~^:?*[\\\x7f") | {chr(code) for code in range(32)}

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2358,6 +2358,84 @@ async def test_turn_diff_prefers_persisted_run_artifact(monkeypatch) -> None:
     create_sandbox.assert_not_awaited()
 
 
+async def test_working_tree_diff_prefers_live_sandbox_over_persisted_artifact(monkeypatch) -> None:
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [
+            {
+                "key": "msg-1",
+                "ref": "refs/open-swe/turns/msg-1",
+                "started_at": "t0",
+                "repo_path": "/workspace/repo",
+            }
+        ],
+    }
+    stored = {
+        "status": "ready",
+        "files": [],
+        "truncated": False,
+        "summary": {"files": 0, "additions": 0, "deletions": 0},
+    }
+    live = {
+        "status": "ready",
+        "files": [{"path": "new.py", "additions": 1, "deletions": 0}],
+        "truncated": False,
+        "summary": {"files": 1, "additions": 1, "deletions": 0},
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", AsyncMock(return_value=stored))
+    sandbox = object()
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=sandbox))
+    read_diff = AsyncMock(return_value=live)
+    monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
+
+    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner")
+
+    assert result == live
+    read_diff.assert_awaited_once_with(
+        sandbox,
+        None,
+        "refs/open-swe/turns/msg-1",
+        None,
+        max_files=200,
+        include_content=True,
+        repo_path="/workspace/repo",
+    )
+
+
+async def test_working_tree_diff_falls_back_to_persisted_artifact(monkeypatch) -> None:
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [
+            {"key": "msg-1", "ref": "refs/open-swe/turns/msg-1", "started_at": "t0"}
+        ],
+    }
+    stored = {
+        "status": "ready",
+        "files": [
+            {
+                "path": "persisted.py",
+                "originalContent": "before",
+                "modifiedContent": "after",
+            }
+        ],
+        "truncated": False,
+        "summary": {"files": 1, "additions": 1, "deletions": 1},
+    }
+    monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
+    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", AsyncMock(return_value=stored))
+    monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(side_effect=RuntimeError))
+
+    result = await thread_api.get_dashboard_thread_turn_diff(
+        "thread-1", "owner", include_content=False
+    )
+
+    assert result == {
+        **stored,
+        "files": [{**stored["files"][0], "originalContent": None, "modifiedContent": None}],
+    }
+
+
 async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:
     metadata = {
         "sandbox_id": "sandbox-1",


### PR DESCRIPTION
## Summary

- read the Changes panel working-tree scope from the live sandbox before persisted artifacts
- retain persisted completed-run diffs as a fallback when the sandbox is unavailable
- cover live precedence and persisted fallback with regression tests

## Testing

- `uv run pytest -q tests/dashboard/test_dashboard_thread_api.py`
- `uv run ruff check agent/dashboard/thread_api.py tests/dashboard/test_dashboard_thread_api.py`
- `uv run ruff format --check agent/dashboard/thread_api.py tests/dashboard/test_dashboard_thread_api.py`