### PR TITLE
ci: run E2E tests only for relevant changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
             exit 0
           fi
 
-          paths=(agent ui tests/e2e package.json pnpm-lock.yaml pyproject.toml uv.lock langgraph.json langgraph.desktop.json Makefile .github/workflows/ci.yml)
+          paths=(agent ui tests/e2e package.json pnpm-lock.yaml pnpm-workspace.yaml pyproject.toml uv.lock langgraph.json langgraph.desktop.json Makefile .github/workflows/ci.yml)
           if git diff --quiet "$BASE_SHA" HEAD -- "${paths[@]}"; then
             echo "browser=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,42 @@ jobs:
       - name: Run desktop checks
         run: pnpm run check
 
+  e2e-changes:
+    name: Detect E2E changes
+    runs-on: ubuntu-latest
+    outputs:
+      browser: ${{ steps.changes.outputs.browser }}
+      desktop: ${{ steps.changes.outputs.desktop }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            echo "browser=true" >> "$GITHUB_OUTPUT"
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          paths=(agent ui tests/e2e package.json pnpm-lock.yaml pyproject.toml uv.lock langgraph.json langgraph.desktop.json Makefile .github/workflows/ci.yml)
+          if git diff --quiet "$BASE_SHA" HEAD -- "${paths[@]}"; then
+            echo "browser=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "browser=true" >> "$GITHUB_OUTPUT"
+          fi
+          if git diff --quiet "$BASE_SHA" HEAD -- "${paths[@]}" desktop; then
+            echo "desktop=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+          fi
+
   browser-e2e:
     name: Browser E2E (${{ matrix.shard }}/3)
+    needs: e2e-changes
+    if: ${{ needs.e2e-changes.outputs.browser == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -139,6 +173,8 @@ jobs:
 
   desktop-e2e:
     name: Desktop E2E
+    needs: e2e-changes
+    if: ${{ needs.e2e-changes.outputs.desktop == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -169,10 +205,14 @@ jobs:
   e2e:
     name: Playwright E2E
     if: ${{ always() }}
-    needs: [browser-e2e, desktop-e2e]
+    needs: [e2e-changes, browser-e2e, desktop-e2e]
     runs-on: ubuntu-latest
     env:
+      CHANGES_RESULT: ${{ needs.e2e-changes.result }}
       BROWSER_RESULT: ${{ needs.browser-e2e.result }}
       DESKTOP_RESULT: ${{ needs.desktop-e2e.result }}
     steps:
-      - run: test "$BROWSER_RESULT" = success && test "$DESKTOP_RESULT" = success
+      - run: |
+          test "$CHANGES_RESULT" = success
+          test "$BROWSER_RESULT" = success || test "$BROWSER_RESULT" = skipped
+          test "$DESKTOP_RESULT" = success || test "$DESKTOP_RESULT" = skipped


### PR DESCRIPTION
## Description
Skip browser and desktop E2E suites when a PR does not change their runtime, UI, test, or dependency paths. Keep the aggregate check successful for intentionally skipped suites.

## Release Note
none

## Test Plan
- [ ] Confirm a docs-only PR skips both E2E suites while Playwright E2E passes

Made by [Open SWE](https://openswe.vercel.app/agents/01a021aa-7c04-7778-ba6b-178e0ff2e313)