### PR TITLE
fix: read working tree changes against head

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -2306,9 +2306,9 @@ async def get_dashboard_thread_turn_diff(
     include_content: bool = True,
     email: str | None = None,
 ) -> dict[str, Any]:
-    """Return a persisted run diff, with sandbox checkpoints as a legacy fallback."""
+    """Return the live working tree or a persisted diff for one completed turn."""
     from ..utils.turn_checkpoint import read_turn_diff
-    from .run_diffs import THREAD_DIFF_KEY, get_run_diff, project_run_diff
+    from .run_diffs import get_run_diff, project_run_diff
 
     metadata = await _readable_thread_metadata(thread_id, login=login, email=email)
     checkpoints = metadata.get("turn_checkpoints")
@@ -2337,8 +2337,6 @@ async def get_dashboard_thread_turn_diff(
         stored = await get_run_diff(thread_id, turn_key)
         if stored is not None:
             return project_run_diff(stored, max_files=max_files, include_content=include_content)
-    else:
-        stored = await get_run_diff(thread_id, THREAD_DIFF_KEY)
 
     plan_ref = checkpoint.get("plan_ref")
     if (
@@ -2388,7 +2386,7 @@ async def get_dashboard_thread_turn_diff(
     live = await read_turn_diff(
         sandbox,
         None,
-        str(checkpoint["ref"]),
+        "HEAD" if turn_key is None else str(checkpoint["ref"]),
         head,
         max_files=max_files,
         include_content=include_content,

--- a/agent/utils/turn_checkpoint.py
+++ b/agent/utils/turn_checkpoint.py
@@ -83,6 +83,13 @@ def _diff_command(
     repo_path: str | None = None,
 ) -> str:
     resolve_head = f"H={shlex.quote(head)}" if head else f"{_WRITE_WORKTREE_TREE}; H=$T"
+    resolve_trees = (
+        f"B_INPUT={shlex.quote(base)}; "
+        'if B=$(git rev-parse --verify "${B_INPUT}^{tree}" 2>/dev/null); then :; '
+        'elif [ "$B_INPUT" = HEAD ]; then B=$(git hash-object -t tree /dev/null); '
+        "else exit 4; fi; "
+        'H=$(git rev-parse --verify "${H}^{tree}" 2>/dev/null) || exit 4'
+    )
     script = r"""python3 - "$B" "$H" __MAX_FILES__ <<'PY'
 import json, subprocess, sys
 
@@ -109,6 +116,7 @@ for record in records:
     if parts[1].isdigit():
         deletions += int(parts[1])
 print(json.dumps({
+    'base': base,
     'head': head,
     'numstat': (b'\0'.join(records[:limit]) + (b'\0' if records else b'')).decode(errors='replace'),
     'nameStatus': (b'\0'.join(fields[:limit * 2]) + (b'\0' if fields else b'')).decode(errors='replace'),
@@ -116,7 +124,7 @@ print(json.dumps({
 }))
 PY"""
     script = script.replace("__MAX_FILES__", str(max_files))
-    return f"{_cd_repo(work_dir, repo_path)}; {resolve_head}; B={shlex.quote(base)}; {script}"
+    return f"{_cd_repo(work_dir, repo_path)}; {resolve_head}; {resolve_trees}; {script}"
 
 
 def _contents_command(
@@ -403,8 +411,11 @@ async def read_turn_diff(
         }
         numstat_raw = payload["numstat"]
         name_status_raw = payload["nameStatus"]
+        base_tree = payload["base"]
         head_tree = payload["head"]
-        if not all(isinstance(value, str) for value in (numstat_raw, name_status_raw, head_tree)):
+        if not all(
+            isinstance(value, str) for value in (numstat_raw, name_status_raw, base_tree, head_tree)
+        ):
             raise TypeError
     except (IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError):
         return {
@@ -421,7 +432,7 @@ async def read_turn_diff(
         try:
             blobs = await _execute(
                 sandbox,
-                _contents_command(work_dir, base, head_tree, paths, repo_path),
+                _contents_command(work_dir, base_tree, head_tree, paths, repo_path),
                 DIFF_TIMEOUT_SECONDS,
             )
             decoded = json.loads(_output(blobs).strip().splitlines()[-1])

--- a/tests/agent/test_turn_checkpoint.py
+++ b/tests/agent/test_turn_checkpoint.py
@@ -71,6 +71,16 @@ def test_diff_command_bounds_file_metadata_and_keeps_full_summary(tmp_path: Path
     stats = parse_numstat(payload["numstat"])
 
     assert len(stats) == 10
+    assert (
+        payload["base"]
+        == subprocess.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
     assert any(additions is None and deletions is None for _, additions, deletions in stats)
     assert payload["summary"] == {"files": 13, "additions": 12, "deletions": 0}
     assert "change-09.txt" not in payload["numstat"]
@@ -95,6 +105,7 @@ async def test_read_turn_diff_metadata_only_skips_file_contents() -> None:
     statuses.extend(("A", "binary.bin"))
     sandbox = _FakeSandbox(
         {
+            "base": "base-tree",
             "head": "head-tree",
             "numstat": "\0".join([*records, ""]),
             "nameStatus": "\0".join([*statuses, ""]),
@@ -123,6 +134,7 @@ async def test_read_turn_diff_metadata_only_skips_file_contents() -> None:
 async def test_read_turn_diff_includes_contents_by_default() -> None:
     sandbox = _FakeSandbox(
         {
+            "base": "base-tree",
             "head": "head-tree",
             "numstat": "1\t1\tchange.txt\0",
             "nameStatus": "M\0change.txt\0",
@@ -143,6 +155,41 @@ async def test_read_turn_diff_includes_contents_by_default() -> None:
     assert result["files"][0]["originalContent"] == "before\n"
     assert result["files"][0]["modifiedContent"] == "after\n"
     assert result["summary"] == {"files": 1, "additions": 1, "deletions": 1}
+
+
+async def test_read_working_tree_diff_supports_an_unborn_branch(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "new.txt").write_text("new\n")
+
+    class Sandbox:
+        async def aexecute(self, command: str, *, timeout: int):
+            result = subprocess.run(
+                ["bash", "-lc", command],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return SimpleNamespace(
+                exit_code=result.returncode, output=result.stdout + result.stderr
+            )
+
+    result = await read_turn_diff(Sandbox(), str(tmp_path), "HEAD", None)
+
+    assert result["status"] == "ready"
+    assert result["summary"] == {"files": 1, "additions": 1, "deletions": 0}
+    assert result["files"] == [
+        {
+            "path": "new.txt",
+            "previousPath": None,
+            "status": "added",
+            "additions": 1,
+            "deletions": 0,
+            "originalContent": None,
+            "modifiedContent": "new\n",
+            "unrenderable": False,
+        }
+    ]
 
 
 def test_merge_checkpoint_keeps_the_first_snapshot_for_a_turn() -> None:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2358,7 +2358,7 @@ async def test_turn_diff_prefers_persisted_run_artifact(monkeypatch) -> None:
     create_sandbox.assert_not_awaited()
 
 
-async def test_working_tree_diff_prefers_live_sandbox_over_persisted_artifact(monkeypatch) -> None:
+async def test_working_tree_diff_reads_live_sandbox_against_head(monkeypatch) -> None:
     metadata = {
         "sandbox_id": "sandbox-1",
         "turn_checkpoints": [
@@ -2370,12 +2370,6 @@ async def test_working_tree_diff_prefers_live_sandbox_over_persisted_artifact(mo
             }
         ],
     }
-    stored = {
-        "status": "ready",
-        "files": [],
-        "truncated": False,
-        "summary": {"files": 0, "additions": 0, "deletions": 0},
-    }
     live = {
         "status": "ready",
         "files": [{"path": "new.py", "additions": 1, "deletions": 0}],
@@ -2383,7 +2377,8 @@ async def test_working_tree_diff_prefers_live_sandbox_over_persisted_artifact(mo
         "summary": {"files": 1, "additions": 1, "deletions": 0},
     }
     monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
-    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", AsyncMock(return_value=stored))
+    get_run_diff = AsyncMock()
+    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", get_run_diff)
     sandbox = object()
     monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=sandbox))
     read_diff = AsyncMock(return_value=live)
@@ -2392,10 +2387,11 @@ async def test_working_tree_diff_prefers_live_sandbox_over_persisted_artifact(mo
     result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner")
 
     assert result == live
+    get_run_diff.assert_not_awaited()
     read_diff.assert_awaited_once_with(
         sandbox,
         None,
-        "refs/open-swe/turns/msg-1",
+        "HEAD",
         None,
         max_files=200,
         include_content=True,
@@ -2403,37 +2399,27 @@ async def test_working_tree_diff_prefers_live_sandbox_over_persisted_artifact(mo
     )
 
 
-async def test_working_tree_diff_falls_back_to_persisted_artifact(monkeypatch) -> None:
+async def test_working_tree_diff_does_not_fall_back_to_persisted_artifact(monkeypatch) -> None:
     metadata = {
         "sandbox_id": "sandbox-1",
         "turn_checkpoints": [
             {"key": "msg-1", "ref": "refs/open-swe/turns/msg-1", "started_at": "t0"}
         ],
     }
-    stored = {
-        "status": "ready",
-        "files": [
-            {
-                "path": "persisted.py",
-                "originalContent": "before",
-                "modifiedContent": "after",
-            }
-        ],
-        "truncated": False,
-        "summary": {"files": 1, "additions": 1, "deletions": 1},
-    }
     monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
-    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", AsyncMock(return_value=stored))
+    get_run_diff = AsyncMock()
+    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", get_run_diff)
     monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(side_effect=RuntimeError))
 
-    result = await thread_api.get_dashboard_thread_turn_diff(
-        "thread-1", "owner", include_content=False
-    )
+    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner")
 
     assert result == {
-        **stored,
-        "files": [{**stored["files"][0], "originalContent": None, "modifiedContent": None}],
+        "status": "missing",
+        "files": [],
+        "truncated": False,
+        "summary": {"files": 0, "additions": 0, "deletions": 0},
     }
+    get_run_diff.assert_not_awaited()
 
 
 async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- make the Working tree panel compare the live sandbox worktree against HEAD, matching git status semantics
- stop falling back to a stale cumulative run artifact that can falsely show an empty tree
- preserve persisted checkpoint behavior for per-turn changed-file cards

## Testing

- uv run pytest -q tests/agent/test_turn_checkpoint.py tests/dashboard/test_dashboard_thread_api.py
- uv run ruff check agent/dashboard/thread_api.py tests/dashboard/test_dashboard_thread_api.py
- uv run ruff format --check agent/dashboard/thread_api.py tests/dashboard/test_dashboard_thread_api.py
- git diff --check