### PR TITLE
fix: rebuild usage telemetry from source events

### DIFF
--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -1,34 +1,32 @@
-"""Forward-looking Open SWE Agent usage telemetry."""
+"""Open SWE Agent and Review usage telemetry."""
 
 import asyncio
-import logging
+import hashlib
+import json
+import weakref
 from collections import Counter
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 import httpx
 from langgraph_sdk import get_client
 
-from ..review.findings import REVIEWER_THREAD_KIND
-from ..utils.github_app import get_github_app_installation_token
-from ..utils.json_types import ThreadLike, as_json_object, thread_metadata
+from ..utils.json_types import as_json_object
 
-USAGE_THREAD_NAMESPACE: list[str] = ["agent_usage", "threads"]
-USAGE_PR_NAMESPACE: list[str] = ["agent_usage", "prs"]
-USAGE_LEADERBOARD_CACHE_NAMESPACE: list[str] = ["agent_usage", "leaderboard_cache"]
-REVIEWER_STATS_CACHE_NAMESPACE: list[str] = ["agent_usage", "reviewer_stats_cache"]
+AGENT_RUN_NAMESPACE = ["usage", "v2", "agent_runs"]
+AGENT_PR_NAMESPACE = ["usage", "v2", "agent_prs"]
+REVIEW_NAMESPACE = ["usage", "v2", "reviews"]
+REVIEW_FINDING_NAMESPACE = ["usage", "v2", "review_findings"]
 
 Period = Literal["7d", "30d", "all"]
-_AGENT_SOURCES = frozenset({"dashboard", "github", "slack", "linear"})
-_PR_REFRESH_INTERVAL_MS = 10 * 60 * 1000
-_MAX_PR_REFRESH_PER_REQUEST = 25
-_PR_REFRESH_CONCURRENCY = 5
-_CACHE_TTL_MS = 10 * 60 * 1000
-_CACHE_SEARCH_LIMIT = 1000
-_GITHUB_API = "https://api.github.com"
-
-logger = logging.getLogger(__name__)
+_PAGE_SIZE = 1000
+_AGENT_SOURCES = frozenset({"dashboard", "github", "slack", "linear", "schedule"})
+_WRITE_LOCKS: weakref.WeakValueDictionary[tuple[tuple[str, ...], str, int], asyncio.Lock] = (
+    weakref.WeakValueDictionary()
+)
+_USAGE_CACHE: dict[tuple[str, str], tuple[int, dict[str, Any]]] = {}
+_USAGE_CACHE_TTL_MS = 60_000
 
 
 def _client():
@@ -37,73 +35,6 @@ def _client():
 
 def _now_ms() -> int:
     return int(datetime.now(UTC).timestamp() * 1000)
-
-
-def _period_cutoff_ms(period: str) -> int | None:
-    now = datetime.now(UTC)
-    if period == "7d":
-        return int((now - timedelta(days=7)).timestamp() * 1000)
-    if period == "30d":
-        return int((now - timedelta(days=30)).timestamp() * 1000)
-    return None
-
-
-def _normalize_period(period: str | None) -> Period:
-    if period == "7d":
-        return "7d"
-    if period == "all":
-        return "all"
-    return "30d"
-
-
-def _record_from_item(item: Any) -> dict[str, Any] | None:
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-async def _get_value(namespace: list[str], key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(namespace, key)
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return None
-        raise
-    return _record_from_item(item)
-
-
-async def _search_values(
-    namespace: list[str], *, limit: int = _CACHE_SEARCH_LIMIT
-) -> list[dict[str, Any]]:
-    result = await _client().store.search_items(namespace, limit=limit)
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    values: list[dict[str, Any]] = []
-    for item in items or []:
-        record = _record_from_item(item)
-        if record:
-            values.append(record)
-    return values
-
-
-def _user_key(github_login: str | None, email: str | None) -> str:
-    login = github_login.strip().lower() if isinstance(github_login, str) else ""
-    if login:
-        return f"github:{login}"
-    norm_email = email.strip().lower() if isinstance(email, str) else ""
-    if norm_email:
-        return f"email:{norm_email}"
-    return "unknown"
-
-
-def _coerce_int(value: object) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    return 0
 
 
 def _timestamp_ms(value: object) -> int:
@@ -126,56 +57,80 @@ def _timestamp_ms(value: object) -> int:
     return 0
 
 
-def _in_period(record: dict[str, Any], cutoff_ms: int | None) -> bool:
-    if cutoff_ms is None:
-        return True
-    created_at = _coerce_int(record.get("created_at_ms"))
-    return created_at >= cutoff_ms
+def _normalize_period(period: str | None) -> Period:
+    if period == "7d" or period == "all":
+        return period
+    return "30d"
 
 
-def _display_name(github_login: str, email: str) -> str:
-    if github_login:
-        return github_login
-    if email:
-        return email.split("@", 1)[0]
-    return "Unknown user"
+def _period_cutoff_ms(period: Period) -> int:
+    days = 7 if period == "7d" else 30 if period == "30d" else 0
+    return int((datetime.now(UTC) - timedelta(days=days)).timestamp() * 1000) if days else 0
 
 
-def _ensure_user(
-    users: dict[str, dict[str, Any]],
+def _store_key(*parts: object) -> str:
+    encoded = json.dumps(parts, separators=(",", ":"), ensure_ascii=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _record(item: Any) -> dict[str, Any] | None:
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+def _write_lock(namespace: list[str], key: str) -> asyncio.Lock:
+    lock_key = (tuple(namespace), key, id(asyncio.get_running_loop()))
+    lock = _WRITE_LOCKS.get(lock_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _WRITE_LOCKS[lock_key] = lock
+    return lock
+
+
+async def _get(namespace: list[str], key: str) -> dict[str, Any] | None:
+    try:
+        return _record(await _client().store.get_item(namespace, key))
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return None
+        raise
+
+
+async def _mutate(
+    namespace: list[str], key: str, update: Callable[[dict[str, Any] | None], dict[str, Any]]
+) -> None:
+    async with _write_lock(namespace, key):
+        await _client().store.put_item(namespace, key, update(await _get(namespace, key)))
+
+
+async def _all(namespace: list[str]) -> list[dict[str, Any]]:
+    values: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        result = await _client().store.search_items(namespace, limit=_PAGE_SIZE, offset=offset)
+        items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+        page = list(items or [])
+        values.extend(value for item in page if (value := _record(item)) is not None)
+        if len(page) < _PAGE_SIZE:
+            return values
+        offset += len(page)
+
+
+def _login(value: object) -> str:
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+def _email(value: object) -> str:
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+def _int(value: object, fallback: object = 0) -> int:
+    return value if isinstance(value, int) else fallback if isinstance(fallback, int) else 0
+
+
+async def record_agent_run_usage(
     *,
-    github_login: str | None,
-    email: str | None,
-) -> dict[str, Any]:
-    login = github_login.strip() if isinstance(github_login, str) else ""
-    norm_email = email.strip().lower() if isinstance(email, str) else ""
-    key = _user_key(login, norm_email)
-    user = users.get(key)
-    if user is None:
-        user = {
-            "key": key,
-            "github_login": login,
-            "email": norm_email,
-            "name": _display_name(login, norm_email),
-            "agent_runs": 0,
-            "prs_opened": 0,
-            "merged_prs": 0,
-            "agent_loc": 0,
-            "additions": 0,
-            "deletions": 0,
-            "model_counts": Counter(),
-        }
-        users[key] = user
-    elif login and not user.get("github_login"):
-        user["github_login"] = login
-        user["name"] = _display_name(login, norm_email)
-    if norm_email and not user.get("email"):
-        user["email"] = norm_email
-    return user
-
-
-async def record_agent_thread_usage(
-    *,
+    run_id: str,
     thread_id: str,
     github_login: str | None,
     user_email: str | None,
@@ -183,28 +138,25 @@ async def record_agent_thread_usage(
     effort: str | None,
     source: str | None,
 ) -> None:
-    """Record one Open SWE Agent thread for leaderboard aggregation."""
-    if not thread_id:
+    """Record one actual Agent run, idempotently."""
+    if not run_id or not thread_id:
         return
-    source_value = source if isinstance(source, str) and source in _AGENT_SOURCES else "dashboard"
+    key = _store_key("run", run_id)
     now_ms = _now_ms()
-    existing = await _get_value(USAGE_THREAD_NAMESPACE, thread_id)
-    value = {
-        **(existing or {}),
-        "thread_id": thread_id,
-        "github_login": github_login.strip() if isinstance(github_login, str) else "",
-        "user_email": user_email.strip().lower() if isinstance(user_email, str) else "",
-        "model_id": model_id,
-        "effort": effort or "",
-        "source": source_value,
-        "agent_kind": "agent",
-        "updated_at_ms": now_ms,
-    }
-    if not existing:
-        value["created_at_ms"] = now_ms
-    elif not value.get("created_at_ms"):
-        value["created_at_ms"] = existing.get("created_at_ms") or now_ms
-    await _client().store.put_item(USAGE_THREAD_NAMESPACE, thread_id, value)
+
+    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
+        return existing or {
+            "run_id": run_id,
+            "thread_id": thread_id,
+            "github_login": _login(github_login),
+            "user_email": _email(user_email),
+            "model_id": model_id,
+            "effort": effort or "",
+            "source": source if source in _AGENT_SOURCES else "dashboard",
+            "created_at_ms": now_ms,
+        }
+
+    await _mutate(AGENT_RUN_NAMESPACE, key, update)
 
 
 async def record_agent_pr_usage(
@@ -223,465 +175,240 @@ async def record_agent_pr_usage(
     changed_files: int = 0,
     state: str | None = None,
     merged: bool = False,
+    created_at: object = None,
+    merged_at: object = None,
 ) -> None:
-    """Record one Open SWE Agent pull request for leaderboard aggregation."""
+    """Record an Agent-authored PR while preserving its original attribution."""
     if not owner or not repo or not pr_number:
         return
-    key = f"{owner}/{repo}#{pr_number}"
+    key = _store_key("pr", owner.lower(), repo.lower(), pr_number)
     now_ms = _now_ms()
-    existing = await _get_value(USAGE_PR_NAMESPACE, key)
-    value = {
-        **(existing or {}),
-        "key": key,
-        "thread_id": thread_id or "",
-        "github_login": github_login.strip() if isinstance(github_login, str) else "",
-        "user_email": user_email.strip().lower() if isinstance(user_email, str) else "",
-        "owner": owner,
-        "repo": repo,
-        "pr_number": pr_number,
-        "pr_url": pr_url or "",
-        "head": head,
-        "base": base,
-        "additions": max(0, additions),
-        "deletions": max(0, deletions),
-        "changed_files": max(0, changed_files),
-        "state": state or "open",
-        "merged": bool(merged),
-        "agent_kind": "agent",
-        "updated_at_ms": now_ms,
-    }
+
+    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
+        was_merged = bool((existing or {}).get("merged"))
+        value = {
+            **(existing or {}),
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "pr_url": pr_url or (existing or {}).get("pr_url", ""),
+            "head": head,
+            "base": base,
+            "additions": max(0, additions),
+            "deletions": max(0, deletions),
+            "changed_files": max(0, changed_files),
+            "state": "closed" if was_merged else state or "open",
+            "merged": was_merged or bool(merged),
+            "merged_at_ms": _timestamp_ms(merged_at) or (existing or {}).get("merged_at_ms", 0),
+            "updated_at_ms": now_ms,
+        }
+        if not existing:
+            value.update(
+                thread_id=thread_id or "",
+                github_login=_login(github_login),
+                user_email=_email(user_email),
+                created_at_ms=_timestamp_ms(created_at) or now_ms,
+            )
+        return value
+
+    await _mutate(AGENT_PR_NAMESPACE, key, update)
+
+
+async def update_agent_pr_usage_from_webhook(payload: dict[str, Any]) -> None:
+    """Update a known Agent PR from a verified GitHub webhook payload."""
+    pr = payload.get("pull_request")
+    repo_payload = payload.get("repository")
+    if not isinstance(pr, dict) or not isinstance(repo_payload, dict):
+        return
+    owner_payload = repo_payload.get("owner")
+    owner = owner_payload.get("login") if isinstance(owner_payload, dict) else None
+    repo = repo_payload.get("name")
+    number = pr.get("number")
+    if not isinstance(owner, str) or not isinstance(repo, str) or not isinstance(number, int):
+        return
+    key = _store_key("pr", owner.lower(), repo.lower(), number)
+    existing = await _get(AGENT_PR_NAMESPACE, key)
     if not existing:
-        value["created_at_ms"] = now_ms
-    elif not value.get("created_at_ms"):
-        value["created_at_ms"] = existing.get("created_at_ms") or now_ms
-    await _client().store.put_item(USAGE_PR_NAMESPACE, key, value)
-
-
-def _github_headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-
-
-async def _refresh_pr_record(
-    client: httpx.AsyncClient, token: str, record: dict[str, Any]
-) -> dict[str, Any]:
-    owner = record.get("owner")
-    repo = record.get("repo")
-    pr_number = record.get("pr_number")
-    if not isinstance(owner, str) or not isinstance(repo, str) or not isinstance(pr_number, int):
-        return record
-    resp = await client.get(
-        f"{_GITHUB_API}/repos/{owner}/{repo}/pulls/{pr_number}",
-        headers=_github_headers(token),
+        return
+    await record_agent_pr_usage(
+        thread_id=existing.get("thread_id") if isinstance(existing.get("thread_id"), str) else None,
+        github_login=existing.get("github_login"),
+        user_email=existing.get("user_email"),
+        owner=owner,
+        repo=repo,
+        pr_number=number,
+        pr_url=pr.get("html_url"),
+        head=as_json_object(pr.get("head")).get("ref") or existing.get("head", ""),
+        base=as_json_object(pr.get("base")).get("ref") or existing.get("base", ""),
+        additions=_int(pr.get("additions"), existing.get("additions")),
+        deletions=_int(pr.get("deletions"), existing.get("deletions")),
+        changed_files=_int(pr.get("changed_files"), existing.get("changed_files")),
+        state=pr.get("state") if isinstance(pr.get("state"), str) else existing.get("state"),
+        merged=bool(pr.get("merged")),
+        created_at=pr.get("created_at"),
+        merged_at=pr.get("merged_at"),
     )
-    if resp.status_code != 200:
-        logger.debug(
-            "GitHub returned %s refreshing usage PR %s/%s#%s",
-            resp.status_code,
-            owner,
-            repo,
-            pr_number,
-        )
-        return record
-    data = resp.json()
-    if not isinstance(data, dict):
-        return record
-    updated = {
-        **record,
-        "pr_url": data.get("html_url") or record.get("pr_url") or "",
-        "state": data.get("state") if isinstance(data.get("state"), str) else record.get("state"),
-        "merged": bool(data.get("merged")),
-        "additions": data.get("additions") if isinstance(data.get("additions"), int) else 0,
-        "deletions": data.get("deletions") if isinstance(data.get("deletions"), int) else 0,
-        "changed_files": data.get("changed_files")
-        if isinstance(data.get("changed_files"), int)
-        else 0,
-        "updated_at_ms": _now_ms(),
-    }
-    key = updated.get("key")
-    if isinstance(key, str) and key:
-        await _client().store.put_item(USAGE_PR_NAMESPACE, key, updated)
-    return updated
 
 
-async def _refresh_pr_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    now_ms = _now_ms()
-    stale_indexes = [
-        index
-        for index, record in enumerate(records)
-        if not (updated_at := _coerce_int(record.get("updated_at_ms")))
-        or now_ms - updated_at >= _PR_REFRESH_INTERVAL_MS
-    ][:_MAX_PR_REFRESH_PER_REQUEST]
-    if not stale_indexes:
-        return records
-    token = await get_github_app_installation_token()
-    if not token:
-        return records
-
-    refreshed = list(records)
-    semaphore = asyncio.Semaphore(_PR_REFRESH_CONCURRENCY)
-
-    async def refresh_one(index: int, client: httpx.AsyncClient) -> tuple[int, dict[str, Any]]:
-        async with semaphore:
-            try:
-                return index, await _refresh_pr_record(client, token, records[index])
-            except Exception:
-                logger.debug("Failed to refresh usage PR record", exc_info=True)
-                return index, records[index]
-
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        for index, record in await asyncio.gather(
-            *(refresh_one(index, client) for index in stale_indexes)
-        ):
-            refreshed[index] = record
-    return refreshed
-
-
-def _serialize_usage_user(index: int, user: dict[str, Any]) -> dict[str, Any]:
-    model_counts: Counter[str] = user.get("model_counts", Counter())
-    favorite_model = model_counts.most_common(1)[0][0] if model_counts else "default"
-    return {
-        "rank": index,
-        "key": user["key"],
-        "name": user.get("name") or "Unknown user",
-        "github_login": user.get("github_login") or None,
-        "email": user.get("email") or None,
-        "favorite_model": favorite_model,
-        "agent_runs": user["agent_runs"],
-        "prs_opened": user["prs_opened"],
-        "merged_prs": user["merged_prs"],
-        "agent_loc": user["agent_loc"],
-        "additions": user["additions"],
-        "deletions": user["deletions"],
-    }
-
-
-async def _build_usage_leaderboard_snapshot(period: Period) -> dict[str, Any]:
-    cutoff_ms = _period_cutoff_ms(period)
-    users: dict[str, dict[str, Any]] = {}
-
-    for thread in await _search_values(USAGE_THREAD_NAMESPACE):
-        if thread.get("agent_kind") != "agent" or thread.get("source") not in _AGENT_SOURCES:
-            continue
-        if not _in_period(thread, cutoff_ms):
-            continue
-        user = _ensure_user(
-            users,
-            github_login=thread.get("github_login"),
-            email=thread.get("user_email"),
-        )
-        user["agent_runs"] += 1
-        model_id = thread.get("model_id")
-        if isinstance(model_id, str) and model_id:
-            user["model_counts"][model_id] += 1
-
-    pr_records = [
-        pr
-        for pr in await _search_values(USAGE_PR_NAMESPACE)
-        if pr.get("agent_kind") == "agent" and _in_period(pr, cutoff_ms)
-    ]
-    for pr in await _refresh_pr_records(pr_records):
-        user = _ensure_user(
-            users,
-            github_login=pr.get("github_login"),
-            email=pr.get("user_email"),
-        )
-        additions = _coerce_int(pr.get("additions"))
-        deletions = _coerce_int(pr.get("deletions"))
-        user["prs_opened"] += 1
-        if pr.get("merged"):
-            user["merged_prs"] += 1
-        user["additions"] += additions
-        user["deletions"] += deletions
-        user["agent_loc"] += additions + deletions
-
-    sorted_users = sorted(
-        users.values(),
-        key=lambda item: (
-            -item["merged_prs"],
-            -item["agent_loc"],
-            -item["prs_opened"],
-            -item["agent_runs"],
-            item.get("name") or "",
-        ),
-    )
-    return {
-        "period": period,
-        "users": [_serialize_usage_user(index, user) for index, user in enumerate(sorted_users, 1)],
-        "total_members": len(sorted_users),
-    }
-
-
-async def refresh_usage_leaderboard_cache(period: str | None = "30d") -> dict[str, Any]:
-    normalized_period = _normalize_period(period)
-    snapshot = await _build_usage_leaderboard_snapshot(normalized_period)
-    await _client().store.put_item(
-        USAGE_LEADERBOARD_CACHE_NAMESPACE,
-        normalized_period,
-        {"generated_at_ms": _now_ms(), "snapshot": snapshot},
-    )
-    return snapshot
-
-
-def _is_finding_surfaced(finding: dict[str, Any]) -> bool:
-    surface = as_json_object(finding.get("surface"))
-    state = surface.get("state")
-    if state in {"surfaced", "resolve_pending", "resolved"}:
-        return True
-    if isinstance(finding.get("github_review_id"), int):
-        return True
-    if isinstance(finding.get("github_review_comment_id"), int):
-        return True
-    comment_ids = finding.get("github_review_comment_ids")
-    thread_ids = finding.get("github_review_thread_ids")
-    return bool(comment_ids or thread_ids)
-
-
-def _is_finding_resolved_by_us(finding: dict[str, Any]) -> bool:
-    if finding.get("status") != "resolved" or not _is_finding_surfaced(finding):
-        return False
+def _finding_surfaced(finding: Mapping[str, Any]) -> bool:
     surface = as_json_object(finding.get("surface"))
     return bool(
-        surface.get("state") == "resolved"
-        or finding.get("github_thread_resolved")
-        or finding.get("github_resolved_thread_ids")
-        or finding.get("resolution_note")
+        surface.get("state") in {"surfaced", "resolve_pending", "resolved"}
+        or isinstance(finding.get("github_review_id"), int)
+        or isinstance(finding.get("github_review_comment_id"), int)
+        or finding.get("github_review_comment_ids")
     )
 
 
-def _thread_created_at_ms(thread: ThreadLike, metadata: dict[str, Any]) -> int:
-    timestamp = _thread_explicit_created_at_ms(thread, metadata)
-    if timestamp:
-        return timestamp
-    for source in (
-        metadata.get("updated_at_ms"),
-        metadata.get("updated_at"),
-        thread.get("updated_at"),
-        thread.get("updatedAt"),
-    ):
-        timestamp = _timestamp_ms(source)
-        if timestamp:
-            return timestamp
-    return _now_ms()
-
-
-def _thread_explicit_created_at_ms(thread: ThreadLike, metadata: dict[str, Any]) -> int:
-    for source in (
-        metadata.get("created_at_ms"),
-        metadata.get("created_at"),
-        thread.get("created_at"),
-        thread.get("createdAt"),
-    ):
-        timestamp = _timestamp_ms(source)
-        if timestamp:
-            return timestamp
-    return 0
-
-
-def _counter_rows(counter: Counter[str], *, limit: int = 5) -> list[dict[str, Any]]:
-    return [{"name": name, "count": count} for name, count in counter.most_common(limit)]
-
-
-async def _iter_reviewer_thread_pages(cutoff_ms: int | None):
-    client = _client()
-    offset = 0
-    while True:
-        page = await client.threads.search(
-            metadata={"kind": REVIEWER_THREAD_KIND},
-            limit=_CACHE_SEARCH_LIMIT,
-            offset=offset,
-            sort_by="created_at",
-            sort_order="desc",
-        )
-        if not page:
-            return
-        yield page
-        if len(page) < _CACHE_SEARCH_LIMIT:
-            return
-        if cutoff_ms is not None:
-            last_thread = next(
-                (thread for thread in reversed(page) if isinstance(thread, dict)), None
-            )
-            if last_thread is not None:
-                metadata = thread_metadata(last_thread)
-                last_created_at_ms = _thread_explicit_created_at_ms(last_thread, metadata)
-                if last_created_at_ms and last_created_at_ms < cutoff_ms:
-                    return
-        offset += len(page)
-
-
-async def _build_reviewer_stats_snapshot(period: Period) -> dict[str, Any]:
-    cutoff_ms = _period_cutoff_ms(period)
-
-    reviewed_prs = 0
-    prs_with_findings = 0
-    findings_recorded = 0
-    surfaced_findings = 0
-    addressed_findings = 0
-    dismissed_findings = 0
-    human_replies = 0
-    resolved_after_update = 0
-    severity_counts: Counter[str] = Counter()
-    category_counts: Counter[str] = Counter()
-
-    async for page in _iter_reviewer_thread_pages(cutoff_ms):
-        for thread in page:
-            if not isinstance(thread, dict):
-                continue
-            metadata = thread_metadata(thread)
-            if cutoff_ms is not None and _thread_created_at_ms(thread, metadata) < cutoff_ms:
-                continue
-
-            reviewed_prs += 1
-            findings = metadata.get("findings")
-            if not isinstance(findings, list):
-                continue
-            valid_findings = [finding for finding in findings if isinstance(finding, dict)]
-            if valid_findings:
-                prs_with_findings += 1
-            for finding in valid_findings:
-                findings_recorded += 1
-                severity = finding.get("severity")
-                if isinstance(severity, str) and severity:
-                    severity_counts[severity] += 1
-                category = finding.get("category")
-                if isinstance(category, str) and category:
-                    category_counts[category] += 1
-                interactions = finding.get("interactions")
-                if isinstance(interactions, list):
-                    human_replies += sum(
-                        1
-                        for interaction in interactions
-                        if isinstance(interaction, dict)
-                        and interaction.get("kind") == "human_reply"
-                    )
-                elif finding.get("last_human_reply_at"):
-                    human_replies += 1
-
-                surfaced = _is_finding_surfaced(finding)
-                if surfaced:
-                    surfaced_findings += 1
-                if _is_finding_resolved_by_us(finding):
-                    addressed_findings += 1
-                    first_seen_sha = finding.get("first_seen_sha")
-                    head_sha = metadata.get("head_sha") or finding.get("last_confirmed_sha")
-                    if (
-                        isinstance(first_seen_sha, str)
-                        and isinstance(head_sha, str)
-                        and first_seen_sha != head_sha
-                    ):
-                        resolved_after_update += 1
-                if finding.get("status") == "dismissed":
-                    dismissed_findings += 1
-
-    unresolved_surfaced_findings = max(
-        0, surfaced_findings - addressed_findings - dismissed_findings
-    )
-    resolution_rate = addressed_findings / surfaced_findings if surfaced_findings else 0.0
-    return {
-        "period": period,
-        "reviewed_prs": reviewed_prs,
-        "prs_with_findings": prs_with_findings,
-        "findings_recorded": findings_recorded,
-        "surfaced_findings": surfaced_findings,
-        "addressed_findings": addressed_findings,
-        "resolved_after_update": resolved_after_update,
-        "dismissed_findings": dismissed_findings,
-        "unresolved_surfaced_findings": unresolved_surfaced_findings,
-        "resolution_rate": resolution_rate,
-        "human_replies": human_replies,
-        "severity_counts": dict(severity_counts),
-        "top_categories": _counter_rows(category_counts),
-    }
-
-
-async def refresh_reviewer_stats_cache(period: str | None = "30d") -> dict[str, Any]:
-    normalized_period = _normalize_period(period)
-    snapshot = await _build_reviewer_stats_snapshot(normalized_period)
+async def record_reviewer_publication(
+    *,
+    thread_id: str,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    findings: Sequence[Mapping[str, Any]],
+) -> None:
+    """Record a completed review and its finding cohort."""
+    now_ms = _now_ms()
     await _client().store.put_item(
-        REVIEWER_STATS_CACHE_NAMESPACE,
-        normalized_period,
-        {"generated_at_ms": _now_ms(), "snapshot": snapshot},
+        REVIEW_NAMESPACE,
+        _store_key("review", thread_id, head_sha),
+        {
+            "thread_id": thread_id,
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+            "findings_recorded": sum(
+                1 for finding in findings if finding.get("first_seen_sha") == head_sha
+            ),
+            "published_at_ms": now_ms,
+        },
     )
-    return snapshot
-
-
-async def _cached_snapshot(
-    namespace: list[str],
-    period: Period,
-    refresh: Callable[[str | None], Awaitable[dict[str, Any]]],
-    *,
-    schedule_refresh: Callable[[Period], None] | None = None,
-) -> tuple[dict[str, Any], int | None]:
-    cached = await _get_value(namespace, period)
-    if cached:
-        snapshot = cached.get("snapshot")
-        generated_at_ms = _coerce_int(cached.get("generated_at_ms"))
-        if isinstance(snapshot, dict):
-            if not generated_at_ms or _now_ms() - generated_at_ms <= _CACHE_TTL_MS:
-                return snapshot, generated_at_ms or None
-            if schedule_refresh is not None:
-                schedule_refresh(period)
-                return snapshot, generated_at_ms
-    return await refresh(period), _now_ms()
-
-
-def _usage_payload_from_snapshot(
-    snapshot: dict[str, Any],
-    *,
-    limit: int,
-    current_login: str | None,
-    current_email: str | None,
-    generated_at_ms: int | None,
-) -> dict[str, Any]:
-    safe_limit = min(max(limit, 1), 100)
-    current_keys = {
-        _user_key(current_login, current_email),
-        _user_key(current_login, None),
-        _user_key(None, current_email),
-    }
-    rows: list[dict[str, Any]] = []
-    current_user_row: dict[str, Any] | None = None
-    for user in snapshot.get("users", []):
-        if not isinstance(user, dict):
+    for finding in findings:
+        finding_id = finding.get("id")
+        if not isinstance(finding_id, str) or not finding_id:
             continue
-        github_login = (
-            user.get("github_login") if isinstance(user.get("github_login"), str) else None
+        key = _store_key("finding", thread_id, finding_id)
+        surfaced = _finding_surfaced(finding)
+
+        def update(
+            existing: dict[str, Any] | None,
+            finding: Mapping[str, Any] = finding,
+            finding_id: str = finding_id,
+            surfaced: bool = surfaced,
+        ) -> dict[str, Any]:
+            value = {
+                **(existing or {}),
+                "thread_id": thread_id,
+                "finding_id": finding_id,
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "severity": finding.get("severity") or "",
+                "category": finding.get("category") or "",
+                "status": finding.get("status") or "open",
+                "first_seen_sha": finding.get("first_seen_sha") or "",
+                "last_confirmed_sha": finding.get("last_confirmed_sha") or "",
+                "surfaced_at_ms": (existing or {}).get("surfaced_at_ms")
+                or (now_ms if surfaced else 0),
+                "human_replies": _human_reply_count(finding),
+                "updated_at_ms": now_ms,
+            }
+            if not existing:
+                value["recorded_at_ms"] = now_ms
+            if value["status"] == "resolved" and not value.get("resolved_at_ms"):
+                value["resolved_at_ms"] = now_ms
+                value["resolved_sha"] = value["last_confirmed_sha"]
+            return value
+
+        await _mutate(REVIEW_FINDING_NAMESPACE, key, update)
+
+
+def _human_reply_count(finding: Mapping[str, Any]) -> int:
+    interactions = finding.get("interactions")
+    if isinstance(interactions, list):
+        return sum(
+            1
+            for interaction in interactions
+            if isinstance(interaction, dict) and interaction.get("kind") == "human_reply"
         )
-        is_current_user = user.get("key") in current_keys
-        row = {
-            "rank": _coerce_int(user.get("rank")),
-            "user": {
-                "name": user.get("name") if is_current_user or github_login else "Open SWE user",
-                "github_login": github_login,
-                "email": (user.get("email") or None) if is_current_user else None,
-            },
-            "favorite_model": user.get("favorite_model") or "default",
-            "agent_runs": _coerce_int(user.get("agent_runs")),
-            "prs_opened": _coerce_int(user.get("prs_opened")),
-            "merged_prs": _coerce_int(user.get("merged_prs")),
-            "agent_loc": _coerce_int(user.get("agent_loc")),
-            "additions": _coerce_int(user.get("additions")),
-            "deletions": _coerce_int(user.get("deletions")),
+    return int(bool(finding.get("last_human_reply_at")))
+
+
+async def record_reviewer_finding_state(thread_id: str, finding: Mapping[str, Any]) -> None:
+    """Update an already-published finding's outcome state."""
+    finding_id = finding.get("id")
+    if not isinstance(finding_id, str) or not finding_id:
+        return
+    key = _store_key("finding", thread_id, finding_id)
+    now_ms = _now_ms()
+
+    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
+        if not existing:
+            return {}
+        status = finding.get("status") or "open"
+        value = {
+            **existing,
+            "status": status,
+            "severity": finding.get("severity") or existing.get("severity", ""),
+            "category": finding.get("category") or existing.get("category", ""),
+            "last_confirmed_sha": finding.get("last_confirmed_sha") or "",
+            "human_replies": _human_reply_count(finding),
+            "updated_at_ms": now_ms,
         }
-        if is_current_user:
-            current_user_row = row
-        if len(rows) < safe_limit:
-            rows.append(row)
+        if _finding_surfaced(finding) and not value.get("surfaced_at_ms"):
+            value["surfaced_at_ms"] = now_ms
+        if status == "resolved" and not value.get("resolved_at_ms"):
+            value["resolved_at_ms"] = now_ms
+            value["resolved_sha"] = value["last_confirmed_sha"]
+        return value
 
-    if current_user_row and all(row["rank"] != current_user_row["rank"] for row in rows):
-        rows.append(current_user_row)
+    async with _write_lock(REVIEW_FINDING_NAMESPACE, key):
+        existing = await _get(REVIEW_FINDING_NAMESPACE, key)
+        if existing:
+            await _client().store.put_item(REVIEW_FINDING_NAMESPACE, key, update(existing))
 
+
+def _aliases(records: list[dict[str, Any]]) -> dict[str, str]:
     return {
-        "period": snapshot.get("period") or "30d",
-        "rows": rows,
-        "total_members": _coerce_int(snapshot.get("total_members")),
-        "current_user_rank": current_user_row["rank"] if current_user_row else None,
-        "generated_at_ms": generated_at_ms,
+        email: login
+        for record in records
+        if (email := _email(record.get("user_email")))
+        and (login := _login(record.get("github_login")))
     }
+
+
+def _user_key(record: dict[str, Any], aliases: dict[str, str]) -> str | None:
+    login = _login(record.get("github_login")) or aliases.get(_email(record.get("user_email")), "")
+    if login:
+        return f"github:{login}"
+    email = _email(record.get("user_email"))
+    return f"email:{email}" if email else None
+
+
+def _new_user(key: str, record: dict[str, Any], aliases: dict[str, str]) -> dict[str, Any]:
+    login = _login(record.get("github_login")) or aliases.get(_email(record.get("user_email")), "")
+    email = _email(record.get("user_email"))
+    return {
+        "key": key,
+        "github_login": login,
+        "email": email,
+        "name": login or email.split("@", 1)[0],
+        "agent_runs": 0,
+        "prs_opened": 0,
+        "merged_prs": 0,
+        "agent_loc": 0,
+        "additions": 0,
+        "deletions": 0,
+        "models": Counter(),
+    }
+
+
+def _in_period(record: dict[str, Any], field: str, cutoff_ms: int) -> bool:
+    timestamp = _timestamp_ms(record.get(field))
+    return timestamp > 0 and timestamp >= cutoff_ms
 
 
 async def list_agent_usage_leaderboard(
@@ -690,29 +417,153 @@ async def list_agent_usage_leaderboard(
     limit: int,
     current_login: str | None,
     current_email: str | None,
-    schedule_usage_refresh: Callable[[Period], None] | None = None,
-    schedule_reviewer_refresh: Callable[[Period], None] | None = None,
 ) -> dict[str, Any]:
-    """Return cached Open SWE Agent and reviewer usage stats."""
-    normalized_period = _normalize_period(period)
-    usage_snapshot, generated_at_ms = await _cached_snapshot(
-        USAGE_LEADERBOARD_CACHE_NAMESPACE,
-        normalized_period,
-        refresh_usage_leaderboard_cache,
-        schedule_refresh=schedule_usage_refresh,
+    """Aggregate current usage from complete, paginated telemetry."""
+    normalized = _normalize_period(period)
+    cache_key = (normalized, _login(current_login) or _email(current_email))
+    cached = _USAGE_CACHE.get(cache_key)
+    if cached and _now_ms() - cached[0] < _USAGE_CACHE_TTL_MS:
+        payload = dict(cached[1])
+        payload["rows"] = payload["rows"][: min(max(limit, 1), 100)]
+        return payload
+    cutoff_ms = _period_cutoff_ms(normalized)
+    runs, prs, review_records, finding_records = await asyncio.gather(
+        _all(AGENT_RUN_NAMESPACE),
+        _all(AGENT_PR_NAMESPACE),
+        _all(REVIEW_NAMESPACE),
+        _all(REVIEW_FINDING_NAMESPACE),
     )
-    reviewer_stats, reviewer_generated_at_ms = await _cached_snapshot(
-        REVIEWER_STATS_CACHE_NAMESPACE,
-        normalized_period,
-        refresh_reviewer_stats_cache,
-        schedule_refresh=schedule_reviewer_refresh,
+    aliases = _aliases(runs + prs)
+    users: dict[str, dict[str, Any]] = {}
+
+    for record in runs:
+        if not _in_period(record, "created_at_ms", cutoff_ms):
+            continue
+        key = _user_key(record, aliases)
+        if not key:
+            continue
+        user = users.setdefault(key, _new_user(key, record, aliases))
+        user["agent_runs"] += 1
+        model = record.get("model_id")
+        if isinstance(model, str) and model:
+            user["models"][model] += 1
+
+    for record in prs:
+        if not _in_period(record, "created_at_ms", cutoff_ms):
+            continue
+        key = _user_key(record, aliases)
+        if not key:
+            continue
+        user = users.setdefault(key, _new_user(key, record, aliases))
+        additions = int(record.get("additions") or 0)
+        deletions = int(record.get("deletions") or 0)
+        user["prs_opened"] += 1
+        user["merged_prs"] += int(bool(record.get("merged")))
+        user["additions"] += additions
+        user["deletions"] += deletions
+        user["agent_loc"] += additions + deletions
+
+    ordered = sorted(
+        users.values(),
+        key=lambda user: (
+            -user["merged_prs"],
+            -user["agent_loc"],
+            -user["prs_opened"],
+            -user["agent_runs"],
+            user["name"],
+        ),
     )
-    payload = _usage_payload_from_snapshot(
-        usage_snapshot,
-        limit=limit,
-        current_login=current_login,
-        current_email=current_email,
-        generated_at_ms=generated_at_ms,
+    current_keys = {
+        f"github:{_login(current_login)}" if _login(current_login) else "",
+        f"email:{_email(current_email)}" if _email(current_email) else "",
+    }
+    rows: list[dict[str, Any]] = []
+    current_row: dict[str, Any] | None = None
+    for rank, user in enumerate(ordered, 1):
+        models: Counter[str] = user["models"]
+        is_current = user["key"] in current_keys
+        row = {
+            "rank": rank,
+            "user": {
+                "name": user["name"] if is_current or user["github_login"] else "Open SWE user",
+                "github_login": user["github_login"] or None,
+                "email": (user["email"] or None) if is_current else None,
+            },
+            "favorite_model": models.most_common(1)[0][0] if models else "default",
+            **{
+                key: user[key]
+                for key in (
+                    "agent_runs",
+                    "prs_opened",
+                    "merged_prs",
+                    "agent_loc",
+                    "additions",
+                    "deletions",
+                )
+            },
+        }
+        if is_current:
+            current_row = row
+        if len(rows) < 100:
+            rows.append(row)
+    if current_row and current_row not in rows:
+        rows.append(current_row)
+
+    reviews = [
+        record for record in review_records if _in_period(record, "published_at_ms", cutoff_ms)
+    ]
+    findings = [
+        record for record in finding_records if _in_period(record, "recorded_at_ms", cutoff_ms)
+    ]
+    surfaced = [
+        record for record in finding_records if _in_period(record, "surfaced_at_ms", cutoff_ms)
+    ]
+    reviewed_prs = {(r.get("owner"), r.get("repo"), r.get("pr_number")) for r in reviews}
+    prs_with_findings = {
+        (r.get("owner"), r.get("repo"), r.get("pr_number"))
+        for r in reviews
+        if int(r.get("findings_recorded") or 0) > 0
+    }
+    addressed = [record for record in surfaced if record.get("status") == "resolved"]
+    dismissed = [record for record in surfaced if record.get("status") == "dismissed"]
+    unresolved = [record for record in surfaced if record.get("status") == "open"]
+    severity = Counter(str(record.get("severity")) for record in findings if record.get("severity"))
+    categories = Counter(
+        str(record.get("category")) for record in findings if record.get("category")
     )
-    payload["reviewer_stats"] = {**reviewer_stats, "generated_at_ms": reviewer_generated_at_ms}
-    return payload
+    now_ms = _now_ms()
+    reviewer_stats = {
+        "period": normalized,
+        "reviewed_prs": len(reviewed_prs),
+        "prs_with_findings": len(prs_with_findings),
+        "findings_recorded": len(findings),
+        "surfaced_findings": len(surfaced),
+        "addressed_findings": len(addressed),
+        "resolved_after_update": sum(
+            1
+            for record in addressed
+            if record.get("resolved_sha")
+            and record.get("resolved_sha") != record.get("first_seen_sha")
+        ),
+        "dismissed_findings": len(dismissed),
+        "unresolved_surfaced_findings": len(unresolved),
+        "resolution_rate": len(addressed) / len(surfaced) if surfaced else 0.0,
+        "human_replies": sum(int(record.get("human_replies") or 0) for record in surfaced),
+        "severity_counts": dict(severity),
+        "top_categories": [
+            {"name": name, "count": count} for name, count in categories.most_common(5)
+        ],
+        "generated_at_ms": now_ms,
+    }
+    payload = {
+        "period": normalized,
+        "rows": rows,
+        "total_members": len(ordered),
+        "current_user_rank": current_row["rank"] if current_row else None,
+        "generated_at_ms": now_ms,
+        "reviewer_stats": reviewer_stats,
+    }
+    _USAGE_CACHE[cache_key] = (now_ms, payload)
+    result = dict(payload)
+    result["rows"] = rows[: min(max(limit, 1), 100)]
+    return result

--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import logging
 import weakref
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
@@ -12,7 +13,7 @@ from typing import Any, Literal
 import httpx
 from langgraph_sdk import get_client
 
-from ..utils.json_types import as_json_object
+from ..utils.json_types import as_json_object, thread_metadata
 
 AGENT_RUN_NAMESPACE = ["usage", "v2", "agent_runs"]
 AGENT_PR_NAMESPACE = ["usage", "v2", "agent_prs"]
@@ -25,8 +26,15 @@ _AGENT_SOURCES = frozenset({"dashboard", "github", "slack", "linear", "schedule"
 _WRITE_LOCKS: weakref.WeakValueDictionary[tuple[tuple[str, ...], str, int], asyncio.Lock] = (
     weakref.WeakValueDictionary()
 )
-_USAGE_CACHE: dict[tuple[str, str], tuple[int, dict[str, Any]]] = {}
+_USAGE_CACHE: dict[tuple[str, str], tuple[int, dict[str, Any], dict[str, Any] | None]] = {}
 _USAGE_CACHE_TTL_MS = 60_000
+
+LEGACY_THREAD_NAMESPACE = ["agent_usage", "threads"]
+LEGACY_PR_NAMESPACE = ["agent_usage", "prs"]
+BACKFILL_NAMESPACE = ["usage", "v2", "backfill"]
+_BACKFILL_KEY = "legacy_v1"
+
+logger = logging.getLogger(__name__)
 
 
 def _client():
@@ -126,6 +134,171 @@ def _email(value: object) -> str:
 
 def _int(value: object, fallback: object = 0) -> int:
     return value if isinstance(value, int) else fallback if isinstance(fallback, int) else 0
+
+
+async def _backfill_legacy_agent_records() -> None:
+    legacy_threads, legacy_prs = await asyncio.gather(
+        _all(LEGACY_THREAD_NAMESPACE), _all(LEGACY_PR_NAMESPACE)
+    )
+    for record in legacy_threads:
+        thread_id = record.get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id:
+            continue
+        if record.get("source") not in _AGENT_SOURCES:
+            continue
+        key = _store_key("run", f"legacy:{thread_id}")
+        if await _get(AGENT_RUN_NAMESPACE, key):
+            continue
+        await _client().store.put_item(
+            AGENT_RUN_NAMESPACE,
+            key,
+            {
+                "run_id": f"legacy:{thread_id}",
+                "thread_id": thread_id,
+                "github_login": _login(record.get("github_login")),
+                "user_email": _email(record.get("user_email")),
+                "model_id": record.get("model_id") or "",
+                "effort": record.get("effort") or "",
+                "source": record.get("source"),
+                "created_at_ms": _timestamp_ms(record.get("created_at_ms"))
+                or _timestamp_ms(record.get("updated_at_ms")),
+            },
+        )
+    for record in legacy_prs:
+        owner = record.get("owner")
+        repo = record.get("repo")
+        number = record.get("pr_number")
+        if not isinstance(owner, str) or not isinstance(repo, str) or not isinstance(number, int):
+            continue
+        key = _store_key("pr", owner.lower(), repo.lower(), number)
+        if await _get(AGENT_PR_NAMESPACE, key):
+            continue
+        await _client().store.put_item(
+            AGENT_PR_NAMESPACE,
+            key,
+            {
+                **record,
+                "github_login": _login(record.get("github_login")),
+                "user_email": _email(record.get("user_email")),
+                "created_at_ms": _timestamp_ms(record.get("created_at_ms"))
+                or _timestamp_ms(record.get("updated_at_ms")),
+                "merged_at_ms": 0,
+            },
+        )
+
+
+async def _backfill_legacy_reviews() -> None:
+    from ..review.findings import REVIEWER_THREAD_KIND
+
+    offset = 0
+    while True:
+        page = await _client().threads.search(
+            metadata={"kind": REVIEWER_THREAD_KIND}, limit=_PAGE_SIZE, offset=offset
+        )
+        threads = list(page or [])
+        for thread in threads:
+            metadata = thread_metadata(thread)
+            thread_id = thread.get("thread_id") if isinstance(thread, Mapping) else None
+            if not isinstance(thread_id, str) or not thread_id:
+                continue
+            findings = [item for item in metadata.get("findings") or [] if isinstance(item, dict)]
+            head_sha = metadata.get("last_reviewed_sha") or metadata.get("head_sha") or ""
+            reviewed_at_ms = _timestamp_ms(
+                metadata.get("created_at")
+                or (thread.get("created_at") if isinstance(thread, Mapping) else None)
+            )
+            await _backfill_legacy_review(
+                thread_id=thread_id,
+                metadata=metadata,
+                findings=findings,
+                head_sha=str(head_sha),
+                reviewed_at_ms=reviewed_at_ms,
+            )
+        if len(threads) < _PAGE_SIZE:
+            return
+        offset += len(threads)
+
+
+async def _backfill_legacy_review(
+    *,
+    thread_id: str,
+    metadata: dict[str, Any],
+    findings: list[dict[str, Any]],
+    head_sha: str,
+    reviewed_at_ms: int,
+) -> None:
+    pr_meta = as_json_object(metadata.get("pr"))
+    owner = str(pr_meta.get("owner") or "")
+    repo = str(pr_meta.get("name") or "")
+    pr_number = pr_meta.get("number")
+    if not owner or not repo or not isinstance(pr_number, int):
+        return
+    review_key = _store_key("review", thread_id, head_sha)
+    if not await _get(REVIEW_NAMESPACE, review_key):
+        await _client().store.put_item(
+            REVIEW_NAMESPACE,
+            review_key,
+            {
+                "thread_id": thread_id,
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "findings_recorded": len(findings),
+                "published_at_ms": reviewed_at_ms,
+            },
+        )
+    for finding in findings:
+        finding_id = finding.get("id")
+        if not isinstance(finding_id, str) or not finding_id:
+            continue
+        key = _store_key("finding", thread_id, finding_id)
+        if await _get(REVIEW_FINDING_NAMESPACE, key):
+            continue
+        status = finding.get("status") or "open"
+        surfaced = _finding_surfaced(finding)
+        await _client().store.put_item(
+            REVIEW_FINDING_NAMESPACE,
+            key,
+            {
+                "thread_id": thread_id,
+                "finding_id": finding_id,
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "severity": finding.get("severity") or "",
+                "category": finding.get("category") or "",
+                "status": status,
+                "first_seen_sha": finding.get("first_seen_sha") or "",
+                "last_confirmed_sha": finding.get("last_confirmed_sha") or "",
+                "surfaced_at_ms": reviewed_at_ms if surfaced else 0,
+                "human_replies": _human_reply_count(finding),
+                "recorded_at_ms": reviewed_at_ms,
+                "updated_at_ms": reviewed_at_ms,
+                "resolved_at_ms": reviewed_at_ms if status == "resolved" else 0,
+                "resolved_sha": finding.get("last_confirmed_sha") or ""
+                if status == "resolved"
+                else "",
+            },
+        )
+
+
+async def _backfill_legacy_usage() -> None:
+    """Migrate pre-v2 usage records into the event namespaces exactly once."""
+    if await _get(BACKFILL_NAMESPACE, _BACKFILL_KEY):
+        return
+    async with _write_lock(BACKFILL_NAMESPACE, _BACKFILL_KEY):
+        if await _get(BACKFILL_NAMESPACE, _BACKFILL_KEY):
+            return
+        try:
+            await _backfill_legacy_agent_records()
+            await _backfill_legacy_reviews()
+        except Exception:  # noqa: BLE001
+            logger.warning("Legacy usage backfill failed; retrying next read", exc_info=True)
+            return
+        await _client().store.put_item(
+            BACKFILL_NAMESPACE, _BACKFILL_KEY, {"completed_at_ms": _now_ms()}
+        )
 
 
 async def record_agent_run_usage(
@@ -271,10 +444,10 @@ async def record_reviewer_publication(
 ) -> None:
     """Record a completed review and its finding cohort."""
     now_ms = _now_ms()
-    await _client().store.put_item(
-        REVIEW_NAMESPACE,
-        _store_key("review", thread_id, head_sha),
-        {
+
+    def update_review(existing: dict[str, Any] | None) -> dict[str, Any]:
+        return {
+            **(existing or {}),
             "thread_id": thread_id,
             "owner": owner,
             "repo": repo,
@@ -283,9 +456,10 @@ async def record_reviewer_publication(
             "findings_recorded": sum(
                 1 for finding in findings if finding.get("first_seen_sha") == head_sha
             ),
-            "published_at_ms": now_ms,
-        },
-    )
+            "published_at_ms": (existing or {}).get("published_at_ms") or now_ms,
+        }
+
+    await _mutate(REVIEW_NAMESPACE, _store_key("review", thread_id, head_sha), update_review)
     for finding in findings:
         finding_id = finding.get("id")
         if not isinstance(finding_id, str) or not finding_id:
@@ -406,6 +580,15 @@ def _new_user(key: str, record: dict[str, Any], aliases: dict[str, str]) -> dict
     }
 
 
+def _limited_rows(
+    rows: list[dict[str, Any]], current_row: dict[str, Any] | None, limit: int
+) -> list[dict[str, Any]]:
+    limited = rows[: min(max(limit, 1), 100)]
+    if current_row and all(row["rank"] != current_row["rank"] for row in limited):
+        return [*limited, current_row]
+    return limited
+
+
 def _in_period(record: dict[str, Any], field: str, cutoff_ms: int) -> bool:
     timestamp = _timestamp_ms(record.get(field))
     return timestamp > 0 and timestamp >= cutoff_ms
@@ -424,8 +607,9 @@ async def list_agent_usage_leaderboard(
     cached = _USAGE_CACHE.get(cache_key)
     if cached and _now_ms() - cached[0] < _USAGE_CACHE_TTL_MS:
         payload = dict(cached[1])
-        payload["rows"] = payload["rows"][: min(max(limit, 1), 100)]
+        payload["rows"] = _limited_rows(payload["rows"], cached[2], limit)
         return payload
+    await _backfill_legacy_usage()
     cutoff_ms = _period_cutoff_ms(normalized)
     runs, prs, review_records, finding_records = await asyncio.gather(
         _all(AGENT_RUN_NAMESPACE),
@@ -506,8 +690,6 @@ async def list_agent_usage_leaderboard(
             current_row = row
         if len(rows) < 100:
             rows.append(row)
-    if current_row and current_row not in rows:
-        rows.append(current_row)
 
     reviews = [
         record for record in review_records if _in_period(record, "published_at_ms", cutoff_ms)
@@ -563,7 +745,7 @@ async def list_agent_usage_leaderboard(
         "generated_at_ms": now_ms,
         "reviewer_stats": reviewer_stats,
     }
-    _USAGE_CACHE[cache_key] = (now_ms, payload)
+    _USAGE_CACHE[cache_key] = (now_ms, payload, current_row)
     result = dict(payload)
-    result["rows"] = rows[: min(max(limit, 1), 100)]
+    result["rows"] = _limited_rows(rows, current_row, limit)
     return result

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -37,11 +37,7 @@ from .agent_instructions import (
     list_agent_instructions,
     set_agent_instructions,
 )
-from .agent_usage import (
-    list_agent_usage_leaderboard,
-    refresh_reviewer_stats_cache,
-    refresh_usage_leaderboard_cache,
-)
+from .agent_usage import list_agent_usage_leaderboard
 from .analyzer_cron import remove_continual_cron
 from .enabled_repos import (
     list_enabled_review_repos,
@@ -1852,7 +1848,6 @@ async def api_delete_organization_skill(
 
 @router.get("/agent-usage-leaderboard")
 async def api_agent_usage_leaderboard(
-    background_tasks: BackgroundTasks,
     period: str | None = "30d",
     limit: int = 10,
     session: dict[str, Any] = _SESSION_DEP,
@@ -1862,12 +1857,6 @@ async def api_agent_usage_leaderboard(
         limit=limit,
         current_login=session["sub"],
         current_email=session.get("email"),
-        schedule_usage_refresh=lambda cache_period: background_tasks.add_task(
-            refresh_usage_leaderboard_cache, cache_period
-        ),
-        schedule_reviewer_refresh=lambda cache_period: background_tasks.add_task(
-            refresh_reviewer_stats_cache, cache_period
-        ),
     )
 
 

--- a/agent/review/findings.py
+++ b/agent/review/findings.py
@@ -406,6 +406,15 @@ async def _replace_findings_unlocked(thread_id: str, findings: list[Finding]) ->
         await client.threads.update(thread_id=thread_id, metadata={"findings": findings})
     except LangGraphSDKNotFoundError as exc:
         raise ReviewerThreadMissingError(thread_id, exc) from exc
+    from ..dashboard.agent_usage import record_reviewer_finding_state
+
+    results = await asyncio.gather(
+        *(record_reviewer_finding_state(thread_id, finding) for finding in findings),
+        return_exceptions=True,
+    )
+    failures = [result for result in results if isinstance(result, Exception)]
+    if failures:
+        logger.debug("Failed to update reviewer usage telemetry: %s", failures[0])
 
 
 def thread_missing_tool_result(exc: ReviewerThreadMissingError) -> dict[str, Any]:

--- a/agent/server.py
+++ b/agent/server.py
@@ -51,7 +51,7 @@ from .dashboard.agent_overrides import (
     profile_draft_prs,
     resolve_github_login,
 )
-from .dashboard.agent_usage import record_agent_thread_usage
+from .dashboard.agent_usage import record_agent_run_usage
 from .dashboard.environments import (
     environment_prompt,
     environment_snapshot_id,
@@ -1171,14 +1171,17 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                     **({"turn_checkpoints": turn_checkpoints} if turn_checkpoints else {}),
                 },
             )
-            await record_agent_thread_usage(
-                thread_id=self._thread_id,
-                github_login=self._profile_login,
-                user_email=self._user_email,
-                model_id=self._model_id,
-                effort=self._effort,
-                source=self._source,
-            )
+            prepare_run_id = configurable.get("prepare_run_id")
+            if isinstance(prepare_run_id, str):
+                await record_agent_run_usage(
+                    run_id=prepare_run_id,
+                    thread_id=self._thread_id,
+                    github_login=self._profile_login,
+                    user_email=self._user_email,
+                    model_id=self._model_id,
+                    effort=self._effort,
+                    source=self._source,
+                )
         except Exception:
             logger.debug(
                 "Failed to record agent usage for thread %s", self._thread_id, exc_info=True

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -563,6 +563,8 @@ async def _record_pr_telemetry(
             changed_files=changed_files,
             state=state,
             merged=merged,
+            created_at=details.get("created_at") or pr.get("created_at"),
+            merged_at=details.get("merged_at") or pr.get("merged_at"),
         )
         if isinstance(thread_id, str) and thread_id:
             repo_private = None

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -1,11 +1,13 @@
 """Tool: ``publish_review``. Post the findings list to GitHub as a PR Review."""
 
+import logging
 from collections.abc import Mapping
 from typing import Annotated, Any
 
 from langgraph.config import get_config
 from langgraph.prebuilt import InjectedState
 
+from ..dashboard.agent_usage import record_reviewer_publication
 from ..dashboard.team_settings import get_team_review_trace_links_enabled
 from ..review.diff import compute_diff_line_set, fetch_pr_diff, is_range_in_diff
 from ..review.findings import (
@@ -55,6 +57,15 @@ from ..utils.github_token import (
 from ..utils.langsmith import get_langsmith_trace_url
 from ..utils.slack import post_slack_thread_reply
 from ..utils.tracing import REVIEW_TRACING_PROJECT
+
+logger = logging.getLogger(__name__)
+
+
+async def _record_reviewer_usage(**kwargs: Any) -> None:
+    try:
+        await record_reviewer_publication(**kwargs)
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record reviewer usage", exc_info=True)
 
 
 async def publish_review(
@@ -337,6 +348,14 @@ async def _publish_review_async(
             findings=findings,
         )
         await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
+        await _record_reviewer_usage(
+            thread_id=thread_id,
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            findings=await list_findings_async(thread_id),
+        )
         await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
         conclusion, check_title, check_summary = review_check_conclusion(0)
         await settle_review_check_run(
@@ -523,6 +542,14 @@ async def _publish_review_async(
         )
 
     await set_reviewer_thread_metadata(thread_id, last_reviewed_sha=head_sha)
+    await _record_reviewer_usage(
+        thread_id=thread_id,
+        owner=owner,
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        findings=await list_findings_async(thread_id),
+    )
     await clear_review_started_comment(thread_id=thread_id, owner=owner, repo=repo, token=token)
     conclusion, check_title, check_summary = review_check_conclusion(len(inline_comments))
     await settle_review_check_run(

--- a/agent/tools/update_finding.py
+++ b/agent/tools/update_finding.py
@@ -128,13 +128,6 @@ async def update_finding(
 
     config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
-    if status is not None:
-        try:
-            head_sha = await resolve_review_head_sha(get_thread_id_from_runtime(), configurable)
-        except ReviewerThreadMissingError as exc:
-            return thread_missing_tool_result(exc)
-        if head_sha:
-            updates["last_confirmed_sha"] = head_sha
 
     if not updates:
         if suggestion_dropped:
@@ -202,6 +195,14 @@ async def update_finding(
                     "Only include `suggestion` for small, obvious fixes."
                 )
             return result
+
+    if status is not None and not delegated_resolution:
+        try:
+            head_sha = await resolve_review_head_sha(thread_id, configurable)
+        except ReviewerThreadMissingError as exc:
+            return thread_missing_tool_result(exc)
+        if head_sha:
+            updates["last_confirmed_sha"] = head_sha
 
     try:
         updated = await update_finding_fields(thread_id, finding_id, updates)

--- a/agent/tools/update_finding.py
+++ b/agent/tools/update_finding.py
@@ -128,7 +128,7 @@ async def update_finding(
 
     config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
-    if status == "open":
+    if status is not None:
         try:
             head_sha = await resolve_review_head_sha(get_thread_id_from_runtime(), configurable)
         except ReviewerThreadMissingError as exc:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -20,6 +20,7 @@ from ..dashboard.agent_overrides import (
     resolve_agent_model_id,  # noqa: F401
     resolve_login_from_email_async,
 )
+from ..dashboard.agent_usage import update_agent_pr_usage_from_webhook
 from ..dashboard.enabled_repos import is_review_repo_enabled
 from ..dashboard.oauth import build_settings_url
 from ..dashboard.options import default_vision_model_pair, model_supports_images  # noqa: F401
@@ -270,6 +271,7 @@ __all__ = [
     "slack_event_already_seen",
     "store_slack_run_mapping",
     "strip_bot_mention",
+    "update_agent_pr_usage_from_webhook",
     "update_agent_thread_pr_state",
     "update_slack_message",
     "upsert_agent_thread_owner_metadata",
@@ -1117,13 +1119,14 @@ _SUPPORTED_GH_PULL_REQUEST_ACTIONS = frozenset(
         "converted_to_draft",
         "closed",
         "reopened",
+        "synchronize",
     ]
 )
 _GH_PR_WATCH_TOGGLE_ACTIONS = frozenset(["closed", "reopened", "converted_to_draft"])
 _GH_PR_FIRST_REVIEW_ACTIONS = frozenset(["opened", "ready_for_review"])
 # PR lifecycle actions that should refresh the agent thread's tracked pr_state.
 _GH_PR_AGENT_STATE_ACTIONS = frozenset(
-    ["closed", "reopened", "converted_to_draft", "ready_for_review"]
+    ["closed", "reopened", "converted_to_draft", "ready_for_review", "synchronize"]
 )
 _SUPPORTED_GH_COMMENT_ACTIONS = {
     "issue_comment": frozenset(["created", "edited"]),

--- a/agent/webhooks/github_routes.py
+++ b/agent/webhooks/github_routes.py
@@ -53,6 +53,10 @@ async def github_webhook(
             }
         if action in common._GH_PR_AGENT_STATE_ACTIONS:
             background_tasks.add_task(common.update_agent_thread_pr_state, payload)
+            try:
+                await common.update_agent_pr_usage_from_webhook(payload)
+            except Exception:  # noqa: BLE001
+                common.logger.debug("Failed to update Agent PR usage", exc_info=True)
         if action in common._GH_PR_WATCH_TOGGLE_ACTIONS:
             common.logger.info(
                 "Accepted GitHub PR %s webhook, scheduling reviewer watch update", action
@@ -68,6 +72,8 @@ async def github_webhook(
             common.logger.info("Accepted GitHub PR %s webhook, scheduling auto-review task", action)
             background_tasks.add_task(service.process_github_pr_ready, payload)
             return {"status": "accepted", "message": f"Processing PR {action} for auto-review"}
+        if action in common._GH_PR_AGENT_STATE_ACTIONS:
+            return {"status": "accepted", "message": f"Processing PR {action} state"}
         common.logger.info("Ignoring unsupported GitHub pull_request action: %s", action)
         return {
             "status": "ignored",

--- a/tests/agent/test_agent_usage.py
+++ b/tests/agent/test_agent_usage.py
@@ -4,213 +4,101 @@ from agent.dashboard import agent_usage
 
 
 class FakeStore:
-    def __init__(self, values: dict[tuple[tuple[str, ...], str], dict] | None = None):
-        self.values = values or {}
-        self.puts: list[tuple[list[str], str, dict]] = []
+    def __init__(self):
+        self.values: dict[tuple[tuple[str, ...], str], dict] = {}
+        self.search_calls: list[tuple[tuple[str, ...], int]] = []
 
     async def get_item(self, namespace: list[str], key: str) -> dict | None:
         value = self.values.get((tuple(namespace), key))
         return {"value": value} if value is not None else None
 
     async def put_item(self, namespace: list[str], key: str, value: dict) -> None:
-        self.puts.append((namespace, key, value))
         self.values[(tuple(namespace), key)] = value
 
-
-class FakeThreads:
-    def __init__(self, threads: list[dict]):
-        self.threads = threads
-        self.calls: list[dict] = []
-
-    async def search(self, **kwargs) -> list[dict]:
-        self.calls.append(kwargs)
-        offset = kwargs.get("offset") or 0
-        limit = kwargs.get("limit") or len(self.threads)
-        return self.threads[offset : offset + limit]
+    async def search_items(self, namespace: list[str], *, limit: int, offset: int) -> dict:
+        self.search_calls.append((tuple(namespace), offset))
+        values = [
+            {"value": value}
+            for (item_namespace, _), value in self.values.items()
+            if item_namespace == tuple(namespace)
+        ]
+        return {"items": values[offset : offset + limit]}
 
 
 class FakeClient:
-    def __init__(self, *, store: FakeStore | None = None, threads: FakeThreads | None = None):
-        self.store = store or FakeStore()
-        self.threads = threads or FakeThreads([])
+    def __init__(self, store: FakeStore):
+        self.store = store
 
 
 @pytest.mark.asyncio
-async def test_cached_usage_payload_returns_stale_snapshot_and_schedules_refresh(monkeypatch):
-    usage_snapshot = {
-        "period": "30d",
-        "total_members": 2,
-        "users": [
-            {
-                "rank": 1,
-                "key": "github:octo",
-                "name": "octo",
-                "github_login": "octo",
-                "email": "octo@example.com",
-                "favorite_model": "claude",
-                "agent_runs": 3,
-                "prs_opened": 2,
-                "merged_prs": 1,
-                "agent_loc": 10,
-                "additions": 8,
-                "deletions": 2,
-            },
-            {
-                "rank": 2,
-                "key": "email:private@example.com",
-                "name": "private",
-                "github_login": None,
-                "email": "private@example.com",
-                "favorite_model": "default",
-                "agent_runs": 1,
-                "prs_opened": 0,
-                "merged_prs": 0,
-                "agent_loc": 0,
-                "additions": 0,
-                "deletions": 0,
-            },
-        ],
-    }
-    reviewer_snapshot = {
-        "period": "30d",
-        "reviewed_prs": 1,
-        "prs_with_findings": 1,
-        "findings_recorded": 1,
-        "surfaced_findings": 1,
-        "addressed_findings": 0,
-        "resolved_after_update": 0,
-        "dismissed_findings": 0,
-        "unresolved_surfaced_findings": 1,
-        "resolution_rate": 0.0,
-        "human_replies": 0,
-        "severity_counts": {"medium": 1},
-        "top_categories": [{"name": "correctness", "count": 1}],
-    }
-    store = FakeStore(
-        {
-            (tuple(agent_usage.USAGE_LEADERBOARD_CACHE_NAMESPACE), "30d"): {
-                "generated_at_ms": 1,
-                "snapshot": usage_snapshot,
-            },
-            (tuple(agent_usage.REVIEWER_STATS_CACHE_NAMESPACE), "30d"): {
-                "generated_at_ms": 1,
-                "snapshot": reviewer_snapshot,
-            },
-        }
-    )
-    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store=store))
-    monkeypatch.setattr(agent_usage, "_now_ms", lambda: agent_usage._CACHE_TTL_MS + 2)
+async def test_usage_records_runs_and_reads_every_page(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store))
+    monkeypatch.setattr(agent_usage, "_PAGE_SIZE", 1)
+    monkeypatch.setattr(agent_usage, "_now_ms", lambda: 1_800_000_000_000)
+    agent_usage._USAGE_CACHE.clear()
 
-    usage_refreshes: list[str] = []
-    reviewer_refreshes: list[str] = []
+    for run_id in ("run-1", "run-2"):
+        await agent_usage.record_agent_run_usage(
+            run_id=run_id,
+            thread_id="shared-thread",
+            github_login="octo",
+            user_email="octo@example.com",
+            model_id="claude",
+            effort=None,
+            source="dashboard",
+        )
+    await agent_usage.record_agent_run_usage(
+        run_id="run-1",
+        thread_id="shared-thread",
+        github_login="octo",
+        user_email="octo@example.com",
+        model_id="claude",
+        effort=None,
+        source="dashboard",
+    )
+
     payload = await agent_usage.list_agent_usage_leaderboard(
-        period="30d",
-        limit=1,
-        current_login="octo",
-        current_email="octo@example.com",
-        schedule_usage_refresh=usage_refreshes.append,
-        schedule_reviewer_refresh=reviewer_refreshes.append,
+        period="all", limit=10, current_login="octo", current_email="octo@example.com"
     )
 
-    assert usage_refreshes == ["30d"]
-    assert reviewer_refreshes == ["30d"]
-    assert payload["rows"][0]["user"]["email"] == "octo@example.com"
-    assert payload["total_members"] == 2
-    assert payload["reviewer_stats"]["surfaced_findings"] == 1
-    assert store.puts == []
+    assert payload["rows"][0]["agent_runs"] == 2
+    assert (tuple(agent_usage.AGENT_RUN_NAMESPACE), 1) in store.search_calls
 
 
 @pytest.mark.asyncio
-async def test_reviewer_stats_snapshot_counts_surfaced_and_resolved_findings(monkeypatch):
-    threads = [
-        {
-            "created_at": "2025-01-01T00:00:00Z",
-            "metadata": {
-                "kind": "reviewer",
-                "head_sha": "fixed-sha",
-                "pr": {"owner": "langchain-ai", "name": "open-swe", "number": 1},
-                "findings": [
-                    {
-                        "id": "f_1",
-                        "status": "resolved",
-                        "severity": "high",
-                        "category": "correctness",
-                        "first_seen_sha": "buggy-sha",
-                        "github_thread_resolved": True,
-                        "github_review_comment_id": 10,
-                        "resolution_note": "Fixed in a follow-up commit.",
-                        "interactions": [{"kind": "human_reply"}],
-                    },
-                    {
-                        "id": "f_2",
-                        "status": "open",
-                        "severity": "medium",
-                        "category": "performance",
-                        "github_review_comment_id": 11,
-                    },
-                    {
-                        "id": "f_3",
-                        "status": "dismissed",
-                        "severity": "low",
-                        "category": "style",
-                        "github_review_id": 12,
-                    },
-                ],
-            },
-        }
-    ]
-    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(threads=FakeThreads(threads)))
+async def test_reviewer_stats_use_publication_and_resolution_events(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store))
+    monkeypatch.setattr(agent_usage, "_now_ms", lambda: 1_800_000_000_000)
+    agent_usage._USAGE_CACHE.clear()
+    finding = {
+        "id": "finding-1",
+        "status": "open",
+        "severity": "high",
+        "category": "correctness",
+        "first_seen_sha": "bad",
+        "last_confirmed_sha": "bad",
+        "github_review_comment_id": 1,
+        "interactions": [],
+    }
 
-    snapshot = await agent_usage._build_reviewer_stats_snapshot("all")
+    await agent_usage.record_reviewer_publication(
+        thread_id="review-thread",
+        owner="langchain-ai",
+        repo="open-swe",
+        pr_number=1,
+        head_sha="bad",
+        findings=[finding],
+    )
+    finding.update(status="resolved", last_confirmed_sha="fixed")
+    await agent_usage.record_reviewer_finding_state("review-thread", finding)
+    payload = await agent_usage.list_agent_usage_leaderboard(
+        period="all", limit=10, current_login=None, current_email=None
+    )
 
-    assert snapshot["reviewed_prs"] == 1
-    assert snapshot["prs_with_findings"] == 1
-    assert snapshot["findings_recorded"] == 3
-    assert snapshot["surfaced_findings"] == 3
-    assert snapshot["addressed_findings"] == 1
-    assert snapshot["resolved_after_update"] == 1
-    assert snapshot["dismissed_findings"] == 1
-    assert snapshot["unresolved_surfaced_findings"] == 1
-    assert snapshot["human_replies"] == 1
-    assert snapshot["severity_counts"] == {"high": 1, "medium": 1, "low": 1}
-    assert snapshot["top_categories"] == [
-        {"name": "correctness", "count": 1},
-        {"name": "performance", "count": 1},
-        {"name": "style", "count": 1},
-    ]
-
-
-@pytest.mark.asyncio
-async def test_reviewer_stats_paginates_reviewer_threads(monkeypatch):
-    threads = [
-        {"created_at": "2025-01-03T00:00:00Z", "metadata": {"kind": "reviewer", "findings": []}},
-        {"created_at": "2025-01-02T00:00:00Z", "metadata": {"kind": "reviewer", "findings": []}},
-        {"created_at": "2025-01-01T00:00:00Z", "metadata": {"kind": "reviewer", "findings": []}},
-    ]
-    fake_threads = FakeThreads(threads)
-    monkeypatch.setattr(agent_usage, "_CACHE_SEARCH_LIMIT", 2)
-    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(threads=fake_threads))
-
-    snapshot = await agent_usage._build_reviewer_stats_snapshot("all")
-
-    assert snapshot["reviewed_prs"] == 3
-    assert [call["offset"] for call in fake_threads.calls] == [0, 2]
-    assert all(call["sort_by"] == "created_at" for call in fake_threads.calls)
-
-
-@pytest.mark.asyncio
-async def test_reviewer_stats_stops_after_page_older_than_cutoff(monkeypatch):
-    threads = [
-        {"created_at": "2025-01-03T00:00:00Z", "metadata": {"kind": "reviewer", "findings": []}},
-        {"created_at": "2025-01-01T00:00:00Z", "metadata": {"kind": "reviewer", "findings": []}},
-        {"created_at": "2024-12-31T00:00:00Z", "metadata": {"kind": "reviewer", "findings": []}},
-    ]
-    fake_threads = FakeThreads(threads)
-    monkeypatch.setattr(agent_usage, "_CACHE_SEARCH_LIMIT", 2)
-    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(threads=fake_threads))
-    cutoff_ms = agent_usage._timestamp_ms("2025-01-02T00:00:00Z")
-
-    pages = [page async for page in agent_usage._iter_reviewer_thread_pages(cutoff_ms)]
-
-    assert len(pages) == 1
-    assert [call["offset"] for call in fake_threads.calls] == [0]
+    stats = payload["reviewer_stats"]
+    assert stats["reviewed_prs"] == 1
+    assert stats["surfaced_findings"] == 1
+    assert stats["addressed_findings"] == 1
+    assert stats["resolved_after_update"] == 1

--- a/tests/agent/test_agent_usage.py
+++ b/tests/agent/test_agent_usage.py
@@ -25,9 +25,18 @@ class FakeStore:
         return {"items": values[offset : offset + limit]}
 
 
+class FakeThreads:
+    def __init__(self, threads: list[dict] | None = None):
+        self.threads = threads or []
+
+    async def search(self, *, metadata: dict, limit: int, offset: int) -> list[dict]:
+        return self.threads[offset : offset + limit]
+
+
 class FakeClient:
-    def __init__(self, store: FakeStore):
+    def __init__(self, store: FakeStore, threads: list[dict] | None = None):
         self.store = store
+        self.threads = FakeThreads(threads)
 
 
 @pytest.mark.asyncio
@@ -102,3 +111,96 @@ async def test_reviewer_stats_use_publication_and_resolution_events(monkeypatch)
     assert stats["surfaced_findings"] == 1
     assert stats["addressed_findings"] == 1
     assert stats["resolved_after_update"] == 1
+
+
+@pytest.mark.asyncio
+async def test_republishing_keeps_the_original_publication_time(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store))
+    monkeypatch.setattr(agent_usage, "_now_ms", lambda: 1_000)
+    await agent_usage.record_reviewer_publication(
+        thread_id="review-thread", owner="o", repo="r", pr_number=1, head_sha="sha", findings=[]
+    )
+    monkeypatch.setattr(agent_usage, "_now_ms", lambda: 1_800_000_000_000)
+    await agent_usage.record_reviewer_publication(
+        thread_id="review-thread", owner="o", repo="r", pr_number=1, head_sha="sha", findings=[]
+    )
+
+    reviews = await agent_usage._all(agent_usage.REVIEW_NAMESPACE)
+    assert [review["published_at_ms"] for review in reviews] == [1_000]
+
+
+@pytest.mark.asyncio
+async def test_current_user_row_survives_the_limit(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store))
+    monkeypatch.setattr(agent_usage, "_now_ms", lambda: 1_800_000_000_000)
+    agent_usage._USAGE_CACHE.clear()
+    for index in range(4):
+        await agent_usage.record_agent_run_usage(
+            run_id=f"run-{index}",
+            thread_id=f"thread-{index}",
+            github_login=f"user-{index}",
+            user_email=None,
+            model_id="claude",
+            effort=None,
+            source="dashboard",
+        )
+
+    kwargs = {"period": "all", "limit": 1, "current_login": "user-3", "current_email": None}
+    payload = await agent_usage.list_agent_usage_leaderboard(**kwargs)
+    cached = await agent_usage.list_agent_usage_leaderboard(**kwargs)
+
+    for result in (payload, cached):
+        assert len(result["rows"]) == 2
+        assert result["rows"][-1]["user"]["github_login"] == "user-3"
+        assert result["current_user_rank"] == 4
+
+
+@pytest.mark.asyncio
+async def test_legacy_records_are_backfilled_once(monkeypatch):
+    store = FakeStore()
+    thread = {
+        "thread_id": "legacy-review",
+        "created_at": "2026-08-01T00:00:00Z",
+        "metadata": {
+            "kind": "reviewer",
+            "pr": {"owner": "o", "name": "r", "number": 3},
+            "last_reviewed_sha": "sha",
+            "findings": [{"id": "f_1", "status": "open", "github_review_comment_id": 1}],
+        },
+    }
+    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store, [thread]))
+    monkeypatch.setattr(agent_usage, "_now_ms", lambda: 1_800_000_000_000)
+    agent_usage._USAGE_CACHE.clear()
+    store.values[(tuple(agent_usage.LEGACY_THREAD_NAMESPACE), "t-1")] = {
+        "thread_id": "t-1",
+        "github_login": "octo",
+        "model_id": "claude",
+        "source": "dashboard",
+        "created_at_ms": 1_700_000_000_000,
+    }
+    store.values[(tuple(agent_usage.LEGACY_PR_NAMESPACE), "o/r#1")] = {
+        "owner": "o",
+        "repo": "r",
+        "pr_number": 1,
+        "github_login": "octo",
+        "merged": True,
+        "additions": 5,
+        "deletions": 2,
+        "created_at_ms": 1_700_000_000_000,
+    }
+
+    payload = await agent_usage.list_agent_usage_leaderboard(
+        period="all", limit=10, current_login="octo", current_email=None
+    )
+    assert payload["rows"][0]["agent_runs"] == 1
+    assert payload["rows"][0]["merged_prs"] == 1
+    assert payload["reviewer_stats"]["reviewed_prs"] == 1
+    assert payload["reviewer_stats"]["surfaced_findings"] == 1
+
+    agent_usage._USAGE_CACHE.clear()
+    await agent_usage.list_agent_usage_leaderboard(
+        period="all", limit=10, current_login="octo", current_email=None
+    )
+    assert len(await agent_usage._all(agent_usage.AGENT_RUN_NAMESPACE)) == 1

--- a/ui/src/routes/usage.tsx
+++ b/ui/src/routes/usage.tsx
@@ -48,7 +48,8 @@ function UsagePage() {
     queryKey: ["usageLeaderboard", activePeriod],
     queryFn: () => api.usageLeaderboard(activePeriod, 10),
     enabled: !!session.data,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
   })
 
   if (session.isLoading) {
@@ -135,6 +136,11 @@ function UsagePage() {
           </div>
         )}
       </SettingsSection>
+      {leaderboard.data?.generated_at_ms ? (
+        <p className="text-right text-xs text-muted-foreground">
+          Updated {formatTime(leaderboard.data.generated_at_ms)}
+        </p>
+      ) : null}
     </AppShell>
   )
 }
@@ -324,6 +330,13 @@ function initialsFor(name: string): string {
   const second = parts[1]
   if (!second) return first.slice(0, 2).toUpperCase()
   return `${first[0] ?? ""}${second[0] ?? ""}`.toUpperCase()
+}
+
+function formatTime(value: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(value)
 }
 
 function formatNumber(value: number): string {


### PR DESCRIPTION
## Description
Replaces stale snapshot-based usage stats with paginated, source-event telemetry for Agent runs, PR lifecycle, review publications, and finding outcomes. Adds a short live-response cache plus dashboard polling and visible freshness.

## Release Note
Usage dashboards now report current Agent and Review activity from durable source events.

## Test Plan
- [x] Verify repeated run IDs remain idempotent across paginated Store reads.
- [x] Verify review publications and post-update resolutions aggregate correctly.

Made by [Open SWE](https://openswe.vercel.app/agents/01a02185-9914-7277-9355-230207fcbd2f)