### PR TITLE
fix: reconnect cloud terminals after disconnects

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -2077,7 +2077,7 @@ async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[st
             "exec ${SHELL:-/bin/bash} -l",
             cwd=cwd,
             timeout=0,
-            idle_timeout=0,
+            idle_timeout=-1,
             kill_on_disconnect=True,
             pty=True,
             wait=False,

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -2075,7 +2075,7 @@ async def _cloud_terminal(websocket: WebSocket, thread_id: str, session: dict[st
             "exec ${SHELL:-/bin/bash} -l",
             cwd=cwd,
             timeout=0,
-            idle_timeout=300,
+            idle_timeout=0,
             kill_on_disconnect=True,
             pty=True,
             wait=False,

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import {
   Copy,
+  LoaderCircle,
   Plus,
   RefreshCw,
   SquareSplitHorizontal,
@@ -224,6 +225,12 @@ function TerminalViewport({
           >
             <Copy className="size-3" />
           </button>
+        </div>
+      )}
+      {target.kind === "cloud" && state.status === "starting" && (
+        <div className="absolute top-2 left-2 flex items-center gap-1.5 rounded-md border border-border bg-background/95 px-2 py-1 text-xs text-muted-foreground shadow-sm">
+          <LoaderCircle className="size-3 animate-spin" />
+          {state.buffer ? "Reconnecting…" : "Connecting…"}
         </div>
       )}
       {(error || state.error) && (

--- a/ui/src/features/agents/lib/terminalSession.test.ts
+++ b/ui/src/features/agents/lib/terminalSession.test.ts
@@ -6,6 +6,7 @@ import {
   applyTerminalSnapshot,
   cloudTerminalCloseError,
   cloudTerminalProtocols,
+  shouldReconnectCloudTerminal,
 } from "./terminalSession"
 
 const snapshot = {
@@ -108,5 +109,13 @@ describe("cloud terminal connection", () => {
     expect(cloudTerminalCloseError("", null)).toBe(
       "Cloud terminal disconnected"
     )
+  })
+
+  it("retries transient closes but not policy failures or attempt exhaustion", () => {
+    expect(shouldReconnectCloudTerminal(1013, 0)).toBe(true)
+    expect(shouldReconnectCloudTerminal(1006, 4)).toBe(true)
+    expect(shouldReconnectCloudTerminal(1008, 0)).toBe(false)
+    expect(shouldReconnectCloudTerminal(1000, 0)).toBe(false)
+    expect(shouldReconnectCloudTerminal(1006, 5)).toBe(false)
   })
 })

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -259,22 +259,43 @@ export function useAttachedTerminal(
       let disposed = false
       let sequence = 0
       let socket: WebSocket | null = null
+      let retryTimer: ReturnType<typeof setTimeout> | null = null
+      let retryCount = 0
+      let exited = false
       pendingRef.current = []
       cloudConnectingRef.current = true
       setState({ ...EMPTY_TERMINAL_SESSION, status: "starting" })
 
-      void agentsApi
-        .connectCloudTerminal(target.threadId)
-        .then((connection) => {
-          if (disposed) return
-          const createdSocket = new WebSocket(
-            connection.url,
-            cloudTerminalProtocols(connection)
-          )
-          socket = createdSocket
-          socketRef.current = createdSocket
-          createdSocket.onopen = () => {
-            if (socketRef.current === createdSocket && !disposed) {
+      const reconnect = () => {
+        if (disposed || exited) return
+        cloudConnectingRef.current = true
+        setState((current) => ({
+          ...current,
+          status: "starting",
+          error: null,
+          version: current.version + 1,
+        }))
+        retryTimer = setTimeout(
+          connect,
+          Math.min(500 * 2 ** retryCount++, 10_000)
+        )
+      }
+
+      const connect = () => {
+        if (disposed || exited) return
+        void agentsApi
+          .connectCloudTerminal(target.threadId)
+          .then((connection) => {
+            if (disposed || exited) return
+            const createdSocket = new WebSocket(
+              connection.url,
+              cloudTerminalProtocols(connection)
+            )
+            socket = createdSocket
+            socketRef.current = createdSocket
+            createdSocket.onopen = () => {
+              if (socketRef.current !== createdSocket || disposed) return
+              retryCount = 0
               cloudConnectingRef.current = false
               setState((current) => ({
                 ...current,
@@ -285,108 +306,68 @@ export function useAttachedTerminal(
                 createdSocket.send(JSON.stringify(message))
               }
             }
-          }
-          createdSocket.onmessage = (event) => {
-            if (
-              disposed ||
-              socketRef.current !== createdSocket ||
-              typeof event.data !== "string"
-            )
-              return
-            let message: {
-              type: string
-              data?: string
-              exitCode?: number
-              message?: string
-            }
-            try {
-              message = JSON.parse(event.data)
-            } catch {
-              return
-            }
-            if (message.type === "output" && typeof message.data === "string") {
-              setState((current) => ({
-                ...current,
-                buffer: trimBuffer(`${current.buffer}${message.data}`),
-                status: "running",
-                error: null,
-                version: current.version + 1,
-                sequence: ++sequence,
-              }))
-            } else if (message.type === "exit") {
-              setState((current) => ({
-                ...current,
-                status: "exited",
-                version: current.version + 1,
-                sequence: ++sequence,
-              }))
-            } else if (message.type === "error") {
-              setState((current) => ({
-                ...current,
-                status: "error",
-                error: message.message ?? "Cloud terminal disconnected",
-                version: current.version + 1,
-              }))
-            }
-          }
-          createdSocket.onerror = () => {
-            if (socketRef.current !== createdSocket || disposed) return
-            cloudConnectingRef.current = false
-            setState((current) => ({
-              ...current,
-              status: "error",
-              error: "Unable to connect to cloud terminal",
-              version: current.version + 1,
-            }))
-          }
-          createdSocket.onclose = (event) => {
-            const active = socketRef.current === createdSocket
-            if (active) {
-              socketRef.current = null
-              cloudConnectingRef.current = false
-            }
-            if (active && !disposed) {
-              pendingRef.current = []
-              setState((current) =>
-                event.code !== 1000
-                  ? {
-                      ...current,
-                      status: "error",
-                      error: cloudTerminalCloseError(
-                        event.reason,
-                        current.error
-                      ),
-                      version: current.version + 1,
-                    }
-                  : current.status === "error"
-                    ? current
-                    : {
-                        ...current,
-                        status: "closed",
-                        version: current.version + 1,
-                      }
+            createdSocket.onmessage = (event) => {
+              if (
+                disposed ||
+                socketRef.current !== createdSocket ||
+                typeof event.data !== "string"
               )
+                return
+              let message: {
+                type: string
+                data?: string
+                exitCode?: number
+                message?: string
+              }
+              try {
+                message = JSON.parse(event.data)
+              } catch {
+                return
+              }
+              if (
+                message.type === "output" &&
+                typeof message.data === "string"
+              ) {
+                setState((current) => ({
+                  ...current,
+                  buffer: trimBuffer(`${current.buffer}${message.data}`),
+                  status: "running",
+                  error: null,
+                  version: current.version + 1,
+                  sequence: ++sequence,
+                }))
+              } else if (message.type === "exit") {
+                exited = true
+                cloudConnectingRef.current = false
+                setState((current) => ({
+                  ...current,
+                  status: "exited",
+                  version: current.version + 1,
+                  sequence: ++sequence,
+                }))
+              } else if (message.type === "error") {
+                setState((current) => ({
+                  ...current,
+                  error: message.message ?? "Cloud terminal disconnected",
+                  version: current.version + 1,
+                }))
+              }
             }
-          }
-        })
-        .catch((error: unknown) => {
-          if (disposed) return
-          cloudConnectingRef.current = false
-          pendingRef.current = []
-          setState({
-            ...EMPTY_TERMINAL_SESSION,
-            status: "error",
-            error:
-              error instanceof Error
-                ? error.message
-                : "Unable to connect to cloud terminal",
+            createdSocket.onclose = () => {
+              if (socketRef.current !== createdSocket) return
+              socketRef.current = null
+              reconnect()
+            }
           })
-        })
+          .catch(reconnect)
+      }
 
+      connect()
       return () => {
         disposed = true
         cloudConnectingRef.current = false
         pendingRef.current = []
+        if (retryTimer) clearTimeout(retryTimer)
         socket?.close()
         if (socketRef.current === socket) socketRef.current = null
       }

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -326,7 +326,6 @@ export function useAttachedTerminal(
             socketRef.current = createdSocket
             createdSocket.onopen = () => {
               if (socketRef.current !== createdSocket || disposed) return
-              retryCount = 0
               cloudConnectingRef.current = false
               setState((current) => ({
                 ...current,
@@ -359,6 +358,7 @@ export function useAttachedTerminal(
                 message.type === "output" &&
                 typeof message.data === "string"
               ) {
+                retryCount = 0
                 setState((current) => ({
                   ...current,
                   buffer: trimBuffer(`${current.buffer}${message.data}`),

--- a/ui/src/features/agents/lib/terminalSession.ts
+++ b/ui/src/features/agents/lib/terminalSession.ts
@@ -239,6 +239,20 @@ export function cloudTerminalCloseError(
   return reason || currentError || "Cloud terminal disconnected"
 }
 
+const MAX_CLOUD_RECONNECT_ATTEMPTS = 5
+
+export function cloudTerminalReconnectDelay(attempt: number): number {
+  return Math.min(500 * 2 ** attempt, 10_000)
+}
+
+export function shouldReconnectCloudTerminal(
+  code: number,
+  attempt: number
+): boolean {
+  if (code === 1000 || code === 1008) return false
+  return attempt < MAX_CLOUD_RECONNECT_ATTEMPTS
+}
+
 export function useAttachedTerminal(
   target: TerminalTarget,
   terminalId: string,
@@ -277,7 +291,24 @@ export function useAttachedTerminal(
         }))
         retryTimer = setTimeout(
           connect,
-          Math.min(500 * 2 ** retryCount++, 10_000)
+          cloudTerminalReconnectDelay(retryCount++)
+        )
+      }
+
+      const stop = (reason: string | null) => {
+        cloudConnectingRef.current = false
+        pendingRef.current = []
+        setState((current) =>
+          reason === null
+            ? current.status === "error"
+              ? current
+              : { ...current, status: "closed", version: current.version + 1 }
+            : {
+                ...current,
+                status: "error",
+                error: cloudTerminalCloseError(reason, current.error),
+                version: current.version + 1,
+              }
         )
       }
 
@@ -353,13 +384,29 @@ export function useAttachedTerminal(
                 }))
               }
             }
-            createdSocket.onclose = () => {
+            createdSocket.onclose = (event) => {
               if (socketRef.current !== createdSocket) return
               socketRef.current = null
-              reconnect()
+              if (disposed || exited) return
+              if (shouldReconnectCloudTerminal(event.code, retryCount)) {
+                reconnect()
+                return
+              }
+              stop(event.code === 1000 ? null : event.reason)
             }
           })
-          .catch(reconnect)
+          .catch((error: unknown) => {
+            if (disposed || exited) return
+            if (retryCount < MAX_CLOUD_RECONNECT_ATTEMPTS) {
+              reconnect()
+              return
+            }
+            stop(
+              error instanceof Error
+                ? error.message
+                : "Unable to connect to cloud terminal"
+            )
+          })
       }
 
       connect()


### PR DESCRIPTION
## Description
Keep quiet cloud terminals alive and automatically reconnect transiently dropped WebSockets with fresh tickets and capped backoff.

## Release Note
Cloud terminals now recover automatically from transient disconnects.

## Test Plan
- [x] Verify terminal session tests and UI typecheck

Made by [Open SWE](https://openswe.vercel.app/agents/01a02214-03cd-76d8-ac06-8e3aae89d037)