### PR TITLE
feat: Add desktop local account sign-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run:
 	uv run uvicorn agent.webapp:app --reload --port 8000
 
 desktop:
-	cd desktop && pnpm run dev
+	pnpm run dev:desktop
 
 install-desktop:
 	@test -z "$$(git status --porcelain)" || { echo 'Commit or stash repository changes first.' >&2; exit 1; }
@@ -76,7 +76,7 @@ help:
 	@echo '----'
 	@echo 'dev                          - run LangGraph dev server'
 	@echo 'run                          - run webhook server'
-	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
+	@echo 'desktop                      - run the backend and Electron desktop app'
 	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
 	@echo 'install-checkout             - install the current checkout of Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'

--- a/agent/desktop.py
+++ b/agent/desktop.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import re
@@ -50,7 +51,7 @@ def _artifacts_root() -> Path:
     return Path(tempfile.gettempdir()) / f"open-swe-artifacts-{os.getuid()}"
 
 
-def desktop_artifact_routes(thread_id: str) -> dict[str, FilesystemBackend]:
+async def desktop_artifact_routes(thread_id: str) -> dict[str, FilesystemBackend]:
     """Backends for the agent's own scratch files on a desktop run.
 
     Offloaded tool results and evicted history default to the artifacts root,
@@ -64,6 +65,6 @@ def desktop_artifact_routes(thread_id: str) -> dict[str, FilesystemBackend]:
     routes = {}
     for name in ("large_tool_results", "conversation_history"):
         directory = root / name
-        directory.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(directory.mkdir, parents=True, exist_ok=True)
         routes[f"/{name}/"] = FilesystemBackend(root_dir=directory, virtual_mode=True)
     return routes

--- a/agent/integrations/local.py
+++ b/agent/integrations/local.py
@@ -4,6 +4,18 @@ from pathlib import Path
 from deepagents.backends import LocalShellBackend
 
 SANDBOX_GITCONFIG = ".gitconfig-sandbox"
+LOCAL_SHELL_ENV_EXCLUDE = {
+    "ANTHROPIC_API_KEY",
+    "FIREWORKS_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "LANGSMITH_API_KEY",
+    "OPEN_SWE_OPENAI_OAUTH_ACCOUNT_FILE",
+    "OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN",
+    "OPEN_SWE_OPENAI_OAUTH_BROKER_URL",
+    "OPENAI_API_KEY",
+}
 
 
 def _scoped_git_config_env(root_dir: str) -> dict[str, str]:
@@ -39,11 +51,13 @@ def create_local_sandbox(sandbox_id: str | None = None):
     root_dir = os.getenv("LOCAL_SANDBOX_ROOT_DIR", os.getcwd())
     os.makedirs(root_dir, exist_ok=True)
 
-    env = {} if os.getenv("GIT_CONFIG_GLOBAL") else _scoped_git_config_env(root_dir)
+    env = {key: value for key, value in os.environ.items() if key not in LOCAL_SHELL_ENV_EXCLUDE}
+    if not os.getenv("GIT_CONFIG_GLOBAL"):
+        env.update(_scoped_git_config_env(root_dir))
 
     return LocalShellBackend(
         root_dir=root_dir,
         virtual_mode=True,
-        inherit_env=True,
+        inherit_env=False,
         env=env,
     )

--- a/agent/server.py
+++ b/agent/server.py
@@ -1530,7 +1530,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         skill_sources = [USER_SKILLS_ROUTE, BUNDLED_SKILLS_ROUTE]
         # The default backend is the user's project, so offloads would land in
         # their repository. Keep the agent's scratch files out of it.
-        skill_routes.update(desktop_artifact_routes(thread_id))
+        skill_routes.update(await desktop_artifact_routes(thread_id))
     else:
         skill_routes[ORGANIZATION_SKILLS_ROUTE] = ReadOnlyBackend(
             StoreBackend(namespace=lambda _runtime: (ORGANIZATION_SKILLS_NAMESPACE,))

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -6,6 +6,7 @@ from langchain.chat_models import init_chat_model
 
 from ..dashboard.options import DEFAULT_MODEL_ID, model_profile_with_context_override
 from .gateway import gateway_env_default, gateway_overrides
+from .openai_oauth import build_desktop_openai_oauth_model, desktop_openai_oauth_available
 
 OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 
@@ -142,12 +143,26 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
         model_kwargs["use_responses_api"] = True
 
     enabled = gateway_env_default() if use_gateway is None else use_gateway
+    gateway_applied = False
+    oauth_applied = False
     if enabled:
         overrides = gateway_overrides(model_id)
         if overrides is not None:
             model_kwargs.update(overrides)
+            gateway_applied = True
+
+    if (
+        model_id.startswith("openai:")
+        and not gateway_applied
+        and not os.environ.get("OPENAI_API_KEY")
+        and desktop_openai_oauth_available()
+    ):
+        model_kwargs.pop("base_url", None)
+        oauth_applied = True
 
     if model_id.startswith("openai:"):
+        if oauth_applied:
+            model_kwargs.pop("max_tokens", None)
         _configure_openai_responses_kwargs(model_kwargs)
         _coerce_openai_chat_completions_kwargs(model_kwargs)
 
@@ -167,7 +182,12 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
     cached = _MODEL_CACHE.get(key)
     if cached is not None:
         return cached
-    model = init_chat_model(model=model_id, **cast(dict[str, Any], model_kwargs))
+    if oauth_applied:
+        model = build_desktop_openai_oauth_model(
+            model_id.split(":", 1)[1], **cast(dict[str, Any], model_kwargs)
+        )
+    else:
+        model = init_chat_model(model=model_id, **cast(dict[str, Any], model_kwargs))
     _MODEL_CACHE[key] = model
     return model
 
@@ -317,7 +337,11 @@ def validate_local_dev_llm_config() -> None:
 
     model_id = os.environ.get("LLM_MODEL_ID", DEFAULT_MODEL_ID)
 
-    if model_id.startswith("openai:") and not os.environ.get("OPENAI_API_KEY"):
+    if (
+        model_id.startswith("openai:")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not desktop_openai_oauth_available()
+    ):
         raise ValueError(f"OPENAI_API_KEY is required for configured model {model_id}")
     elif model_id.startswith("anthropic:") and not os.environ.get("ANTHROPIC_API_KEY"):
         raise ValueError(f"ANTHROPIC_API_KEY is required for configured model {model_id}")

--- a/agent/utils/openai_oauth.py
+++ b/agent/utils/openai_oauth.py
@@ -1,0 +1,91 @@
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from langchain_core.language_models import BaseChatModel
+from langchain_openai.chat_models.codex import _ChatOpenAICodex  # noqa: PLC2701
+from langchain_openai.chatgpt_oauth import (  # noqa: PLC2701
+    _ChatGPTOAuthTokenProvider,
+    _ChatGPTToken,
+)
+
+_BROKER_URL_ENV = "OPEN_SWE_OPENAI_OAUTH_BROKER_URL"
+_BROKER_TOKEN_ENV = "OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN"
+_BROKER_MANAGED_REFRESH_TOKEN = "managed-by-desktop-broker"
+
+
+def _broker_config() -> tuple[str, str] | None:
+    url = os.environ.get(_BROKER_URL_ENV, "")
+    token = os.environ.get(_BROKER_TOKEN_ENV, "")
+    if not url or not token:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme != "http" or parsed.hostname != "127.0.0.1" or parsed.path != "/token":
+        return None
+    return url, token
+
+
+def desktop_openai_oauth_available() -> bool:
+    return _broker_config() is not None
+
+
+class _DesktopOpenAIOAuthTokenProvider(_ChatGPTOAuthTokenProvider):
+    def __init__(self, broker_url: str, broker_token: str) -> None:
+        self._broker_url = broker_url
+        self._broker_token = broker_token
+        self._current_token: _ChatGPTToken | None = None
+
+    def get_token(self) -> _ChatGPTToken:
+        if self._current_token is None:
+            raise RuntimeError("Local OpenAI credentials have not been fetched asynchronously")
+        return self._current_token
+
+    async def aget_token(self) -> _ChatGPTToken:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                self._broker_url,
+                headers={"Authorization": f"Bearer {self._broker_token}"},
+            )
+        response.raise_for_status()
+        payload = response.json()
+        access_token = payload.get("access_token") if isinstance(payload, dict) else None
+        account_id = payload.get("account_id") if isinstance(payload, dict) else None
+        if not isinstance(access_token, str) or not access_token:
+            raise ValueError("Local OpenAI credential broker returned no access token")
+        if (
+            not isinstance(account_id, str)
+            or not account_id
+            or len(account_id) > 512
+            or "\r" in account_id
+            or "\n" in account_id
+        ):
+            raise ValueError("Local OpenAI credential broker returned no account ID")
+        token = _ChatGPTToken(
+            access_token=access_token,
+            refresh_token=_BROKER_MANAGED_REFRESH_TOKEN,
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            account_id=account_id,
+        )
+        self._current_token = token
+        return token
+
+    def get_access_token(self) -> str:
+        return self.get_token().access_token
+
+    async def aget_access_token(self) -> str:
+        return (await self.aget_token()).access_token
+
+
+def build_desktop_openai_oauth_model(model_name: str, **kwargs: Any) -> BaseChatModel:
+    config = _broker_config()
+    if config is None:
+        raise ValueError("Local OpenAI credentials are unavailable")
+    provider = _DesktopOpenAIOAuthTokenProvider(*config)
+    return _ChatOpenAICodex(
+        model=model_name,
+        token_provider=provider,
+        originator="open_swe_desktop",
+        **kwargs,
+    )

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -10,6 +10,12 @@ Desktop users can choose **This Mac** in the new-task composer to run the same O
 
 The packaged app bundles its Python runtime and locked Open SWE dependencies. Source development uses `uv run langgraph dev`. Provider credentials stay in the local LangGraph process and are not inherited by agent shell commands. Added projects and local thread history are persisted in the desktop app's local data.
 
+For local OpenAI models, the app can use either `OPENAI_API_KEY` or Sign in with ChatGPT. When no
+API key is configured, sending the first local task opens the system browser for sign-in. OAuth
+credentials are encrypted with the operating system's secure storage, refreshed by Electron, and
+made available to the local model client through an authenticated loopback broker. Refresh tokens
+are never placed in the local backend environment or inherited by agent shell commands.
+
 The side panel's **Changes** tab diffs the project against a git snapshot taken when the session
 started, so it shows what the agent changed and not the working tree's prior state. It also shows
 the current branch and discovers its pull request when the GitHub CLI is installed and authenticated.
@@ -29,6 +35,11 @@ The backend's GitHub App must allow `<backend-url>/dashboard/api/auth/callback` 
 Set `ALLOWED_GITHUB_ORGS` on the backend to prevent GitHub users outside the organization from
 creating dashboard sessions.
 
+The desktop sign-in screen also offers **Continue in local mode**. This skips GitHub sign-in and
+limits the Agents workspace to projects and threads on **This Mac**; cloud threads, settings, and
+other account-backed features remain behind sign-in. The choice is remembered on that computer,
+and **Sign in for cloud mode** remains available from the local sidebar.
+
 ## Install on macOS
 
 Install Git, Node.js 22, and `uv`, clone this repository, then run this from its root:
@@ -43,12 +54,15 @@ backend settings, login sessions, and projects are preserved.
 
 ## Local development
 
-Install the workspace dependencies, run the backend at `http://localhost:2024`, then start Electron:
+Install the workspace dependencies, then start the backend and Electron together:
 
 ```bash
 pnpm install                  # from the repo root
-pnpm run dev:desktop
+make desktop
 ```
+
+`pnpm run dev:desktop` is the equivalent workspace command. Both commands stop the backend when
+the desktop app exits, and stop the desktop app if the backend fails.
 
 Source launches use an isolated `Open SWE Development` Electron profile, so the dev app can run
 beside an installed `Open SWE` app without sharing its login session, backend configuration,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "node scripts/build-main.cjs",
     "build:ui": "pnpm --filter open-swe-dashboard run build",
     "dev": "pnpm run build:ui && pnpm run build && electron . --dev",
+    "dev:full": "concurrently --kill-others --success first --names backend,desktop --prefix-colors blue,magenta \"uv --directory .. run langgraph dev --no-browser\" \"pnpm run dev\"",
     "start": "pnpm run build:ui && pnpm run build && electron .",
     "test:run": "node --test test/*.test.cjs",
     "test": "pnpm run build && pnpm run test:run",
@@ -100,6 +101,7 @@
   "devDependencies": {
     "@electron/notarize": "3.1.1",
     "@types/node": "22.20.1",
+    "concurrently": "10.0.5",
     "electron": "41.10.3",
     "electron-builder": "26.15.3",
     "typescript": "5.9.3"

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -86,12 +86,17 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
 
-function modelCredentialStatus(modelId, env) {
+function modelCredentialStatus(modelId, env, options = {}) {
   const provider = typeof modelId === "string" ? modelId.split(":", 1)[0] : ""
   const variables = PROVIDER_KEYS[provider]
   if (!variables) return { available: true, variable: null }
   const variable = variables.find((key) => env[key])
-  return { available: Boolean(variable), variable: variable || variables[0] }
+  const oauthAvailable = provider === "openai" && options.openAiOAuth === true
+  return {
+    available: Boolean(variable) || oauthAvailable,
+    variable: variable || (oauthAvailable ? null : variables[0]),
+    ...(provider === "openai" && !variable ? { canSignIn: true } : {}),
+  }
 }
 
 class BackendSupervisor {
@@ -135,6 +140,7 @@ class BackendSupervisor {
       env: {
         ...process.env,
         ...this.options.env,
+        ...(this.options.providerEnv?.() || {}),
         OPEN_SWE_LOCAL_AUTH_TOKEN: this.token,
         OPEN_SWE_LOCAL_PROJECTS_FILE: this.options.projectsFile,
         ...(this.options.stateDir
@@ -192,7 +198,11 @@ class BackendSupervisor {
   }
 
   credentialStatus(modelId) {
-    return modelCredentialStatus(modelId, { ...process.env, ...this.options.env })
+    return modelCredentialStatus(
+      modelId,
+      { ...process.env, ...this.options.env },
+      { openAiOAuth: this.options.openAiOAuthAvailable?.() === true }
+    )
   }
 
   publicConfig() {

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -9,6 +9,7 @@ const {
   dialog,
   net,
   protocol,
+  safeStorage,
   session,
   shell,
 } = require("electron");
@@ -38,6 +39,7 @@ const {
   removeProject,
 } = require("./project-store.cjs");
 const { beginLogin } = require("./login-server.cjs");
+const { OpenAiOAuthManager } = require("./openai-oauth.cjs");
 const { isDesktopCommandId } = require("./commands.cjs");
 const {
   APP_ORIGIN,
@@ -92,6 +94,7 @@ let loginFlow = null;
 let quitting = false;
 let localThreadStore = null;
 let backendSupervisor = null;
+let openAiOAuth = null;
 
 function sendDesktopCommand(commandId) {
   if (!isDesktopCommandId(commandId) || !mainWindow || mainWindow.isDestroyed())
@@ -278,6 +281,11 @@ function configureDesktopIpc() {
   ipcMain.handle("desktop:local-model-credential-status", (event, modelId) => {
     requireTrustedDesktopIpc(event);
     return backendSupervisor.credentialStatus(modelId);
+  });
+  ipcMain.handle("desktop:local-openai-sign-in", async (event) => {
+    requireTrustedDesktopIpc(event);
+    if (!openAiOAuth) throw new Error("OpenAI sign-in is unavailable");
+    return openAiOAuth.login((url) => shell.openExternal(url));
   });
   ipcMain.handle("desktop:start-local-thread", async (event, input) => {
     requireTrustedDesktopIpc(event);
@@ -962,7 +970,7 @@ if (!hasSingleInstanceLock) {
     window.focus();
   });
 
-  app.whenReady().then(() => {
+  app.whenReady().then(async () => {
     try {
       backendUrl = resolveBackendUrl({
         argv: process.argv.slice(1),
@@ -983,12 +991,29 @@ if (!hasSingleInstanceLock) {
     localThreadStore = new LocalThreadStore(
       path.join(app.getPath("userData"), "desktop-local-threads.json"),
     );
+    openAiOAuth = new OpenAiOAuthManager({
+      storagePath: path.join(app.getPath("userData"), "openai-auth.bin"),
+      encryptString: (value) => {
+        if (!safeStorage.isEncryptionAvailable()) {
+          throw new Error("Secure credential storage is unavailable");
+        }
+        return safeStorage.encryptString(value);
+      },
+      decryptString: (value) => safeStorage.decryptString(value),
+    });
+    await openAiOAuth.startBroker().catch((error) => {
+      console.warn("Could not start the local OpenAI credential broker", error);
+    });
     backendSupervisor = new BackendSupervisor({
       isPackaged: app.isPackaged,
       repoRoot: path.resolve(__dirname, "../.."),
       resourcesPath: process.resourcesPath,
       stateDir: path.join(app.getPath("userData"), "local-backend"),
       projectsFile: projectsPath(),
+      providerEnv: () => openAiOAuth?.backendEnv() || {},
+      openAiOAuthAvailable: () =>
+        openAiOAuth?.status().signedIn === true &&
+        Boolean(openAiOAuth?.backendEnv().OPEN_SWE_OPENAI_OAUTH_BROKER_URL),
     });
     protocol.handle("open-swe", serveBundledUi);
     configurePermissions();
@@ -1017,10 +1042,12 @@ if (!hasSingleInstanceLock) {
     if (quitting) return;
     event.preventDefault();
     quitting = true;
-    void Promise.all([closeAllTerminals(), backendSupervisor?.close()]).finally(
-      () => {
-        app.quit();
-      },
-    );
+    void Promise.all([
+      closeAllTerminals(),
+      backendSupervisor?.close(),
+      openAiOAuth?.close(),
+    ]).finally(() => {
+      app.quit();
+    });
   });
 }

--- a/desktop/src/openai-oauth.cts
+++ b/desktop/src/openai-oauth.cts
@@ -1,0 +1,421 @@
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const { createHash, randomBytes, timingSafeEqual } = require("node:crypto");
+
+const AUTH_ISSUER = "https://auth.openai.com";
+const TOKEN_URL = `${AUTH_ISSUER}/oauth/token`;
+const API_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CALLBACK_PORTS = [1455, 1457];
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+const REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const FALLBACK_REFRESH_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const SIGNED_IN_PAGE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Open SWE</title>
+<style>:root{color-scheme:light dark}body{font:16px/1.5 system-ui,-apple-system,sans-serif;margin:0;min-height:100vh;display:grid;place-items:center;text-align:center;padding:2rem}h1{font-size:1.25rem;margin:0 0 .5rem}p{margin:0;opacity:.7}</style>
+</head><body><main><h1>You're signed in</h1><p>You can close this tab and return to Open SWE.</p></main></body></html>`;
+
+const FAILED_PAGE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Open SWE</title>
+<style>:root{color-scheme:light dark}body{font:16px/1.5 system-ui,-apple-system,sans-serif;margin:0;min-height:100vh;display:grid;place-items:center;text-align:center;padding:2rem}h1{font-size:1.25rem;margin:0 0 .5rem}p{margin:0;opacity:.7}</style>
+</head><body><main><h1>Sign-in failed</h1><p>Return to Open SWE and try again.</p></main></body></html>`;
+
+function decodeJwtPayload(token) {
+  if (typeof token !== "string") return null;
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function accountIdFromTokens(tokens) {
+  if (typeof tokens?.accountId === "string" && tokens.accountId)
+    return tokens.accountId;
+  for (const token of [tokens?.idToken, tokens?.accessToken]) {
+    const claims = decodeJwtPayload(token);
+    const auth = claims?.["https://api.openai.com/auth"];
+    const accountId = auth?.chatgpt_account_id ?? claims?.chatgpt_account_id;
+    if (typeof accountId === "string" && accountId) return accountId;
+  }
+  return null;
+}
+
+function tokenExpiresAt(token) {
+  const expiration = decodeJwtPayload(token)?.exp;
+  return typeof expiration === "number" ? expiration * 1000 : null;
+}
+
+function validCredentials(value) {
+  if (!value || typeof value !== "object") return null;
+  const credentials = {
+    accessToken: value.accessToken,
+    refreshToken: value.refreshToken,
+    idToken: value.idToken,
+    accountId: accountIdFromTokens(value),
+    refreshedAt: value.refreshedAt,
+  };
+  if (
+    typeof credentials.accessToken !== "string" ||
+    !credentials.accessToken ||
+    typeof credentials.refreshToken !== "string" ||
+    !credentials.refreshToken ||
+    typeof credentials.idToken !== "string" ||
+    !credentials.idToken ||
+    typeof credentials.accountId !== "string" ||
+    !credentials.accountId
+  ) {
+    return null;
+  }
+  if (typeof credentials.refreshedAt !== "number") credentials.refreshedAt = 0;
+  return credentials;
+}
+
+function buildAuthorizeUrl({ redirectUri, challenge, state }) {
+  const url = new URL("/oauth/authorize", AUTH_ISSUER);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", CLIENT_ID);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set(
+    "scope",
+    "openid profile email offline_access api.connectors.read api.connectors.invoke",
+  );
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("id_token_add_organizations", "true");
+  url.searchParams.set("codex_cli_simplified_flow", "true");
+  url.searchParams.set("state", state);
+  url.searchParams.set("originator", "open_swe_desktop");
+  return url.toString();
+}
+
+async function listen(server, ports = CALLBACK_PORTS) {
+  let lastError;
+  for (const port of ports) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error) => {
+          server.removeListener("listening", onListening);
+          reject(error);
+        };
+        const onListening = () => {
+          server.removeListener("error", onError);
+          resolve();
+        };
+        server.once("error", onError);
+        server.once("listening", onListening);
+        server.listen(port, "127.0.0.1");
+      });
+      return server.address().port;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError || new Error("Could not open a local sign-in listener");
+}
+
+async function beginOpenAiLogin(options: any = {}) {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const state = randomBytes(32).toString("base64url");
+  let resolveResult;
+  let rejectResult;
+  let finished = false;
+  const result = new Promise((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+
+  let timer = null;
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, "http://localhost");
+    if (url.pathname !== "/auth/callback") {
+      response.writeHead(404).end();
+      return;
+    }
+    const code = url.searchParams.get("code");
+    const returnedState = url.searchParams.get("state");
+    const providerError =
+      url.searchParams.get("error_description") ||
+      url.searchParams.get("error");
+    const valid = Boolean(code && returnedState === state && !providerError);
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    });
+    response.end(valid ? SIGNED_IN_PAGE : FAILED_PAGE);
+    if (providerError) finish(new Error(`Sign-in failed: ${providerError}`));
+    else if (returnedState !== state)
+      finish(new Error("Sign-in state did not match"));
+    else if (!code) finish(new Error("Sign-in returned no authorization code"));
+    else finish(null, { code, verifier, redirectUri });
+  });
+
+  function finish(error, value?) {
+    if (finished) return;
+    finished = true;
+    if (timer) clearTimeout(timer);
+    timer = null;
+    server.closeAllConnections();
+    server.close();
+    if (error) rejectResult(error);
+    else resolveResult(value);
+  }
+
+  const port = await listen(server, options.ports);
+  const redirectUri = `http://localhost:${port}/auth/callback`;
+  timer = setTimeout(
+    () => finish(new Error("Sign-in timed out")),
+    LOGIN_TIMEOUT_MS,
+  );
+  timer.unref();
+
+  return {
+    url: buildAuthorizeUrl({ redirectUri, challenge, state }),
+    port,
+    state,
+    verifier,
+    result,
+    cancel: () => finish(new Error("Sign-in was canceled")),
+  };
+}
+
+function bearerMatches(request, secret) {
+  const value = request.headers.authorization;
+  const expected = `Bearer ${secret}`;
+  if (typeof value !== "string" || value.length !== expected.length)
+    return false;
+  return timingSafeEqual(Buffer.from(value), Buffer.from(expected));
+}
+
+class OpenAiOAuthManager {
+  options: any;
+  fetch: any;
+  now: () => number;
+  credentials: any;
+  loginFlow: any;
+  refreshing: Promise<any> | null;
+  broker: any;
+  brokerUrl: string | null;
+  brokerSecret: string;
+
+  constructor(options) {
+    this.options = options;
+    this.fetch = options.fetchImpl || fetch;
+    this.now = options.now || Date.now;
+    this.credentials = this.readCredentials();
+    this.loginFlow = null;
+    this.refreshing = null;
+    this.broker = null;
+    this.brokerUrl = null;
+    this.brokerSecret = randomBytes(32).toString("base64url");
+  }
+
+  readCredentials() {
+    try {
+      const encrypted = fs.readFileSync(this.options.storagePath);
+      const serialized = this.options.decryptString(encrypted);
+      return validCredentials(JSON.parse(serialized));
+    } catch {
+      return null;
+    }
+  }
+
+  saveCredentials(value) {
+    const credentials = validCredentials(value);
+    if (!credentials)
+      throw new Error(
+        "The sign-in response did not include usable credentials",
+      );
+    const encrypted = this.options.encryptString(JSON.stringify(credentials));
+    fs.mkdirSync(path.dirname(this.options.storagePath), { recursive: true });
+    const temporary = `${this.options.storagePath}.${process.pid}.tmp`;
+    fs.writeFileSync(temporary, encrypted, { mode: 0o600 });
+    fs.renameSync(temporary, this.options.storagePath);
+    this.credentials = credentials;
+    return credentials;
+  }
+
+  clearCredentials() {
+    this.credentials = null;
+    try {
+      fs.unlinkSync(this.options.storagePath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+
+  status() {
+    return { signedIn: Boolean(this.credentials) };
+  }
+
+  backendEnv() {
+    if (!this.brokerUrl) return {};
+    return {
+      OPEN_SWE_OPENAI_OAUTH_BROKER_URL: this.brokerUrl,
+      OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN: this.brokerSecret,
+    };
+  }
+
+  async exchangeCode({ code, verifier, redirectUri }) {
+    const body = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: CLIENT_ID,
+      code_verifier: verifier,
+    });
+    const response = await this.fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (!response.ok)
+      throw new Error(`The sign-in token exchange failed (${response.status})`);
+    const payload = await response.json();
+    return this.saveCredentials({
+      accessToken: payload.access_token,
+      refreshToken: payload.refresh_token,
+      idToken: payload.id_token,
+      refreshedAt: this.now(),
+    });
+  }
+
+  async login(openExternal, options: any = {}) {
+    this.loginFlow?.cancel();
+    const flow = await beginOpenAiLogin(options);
+    this.loginFlow = flow;
+    try {
+      await openExternal(flow.url);
+      const callback: any = await flow.result;
+      await this.exchangeCode(callback);
+      await this.startBroker();
+      return this.status();
+    } finally {
+      if (this.loginFlow === flow) this.loginFlow = null;
+    }
+  }
+
+  needsRefresh(credentials) {
+    const expiresAt = tokenExpiresAt(credentials.accessToken);
+    if (expiresAt !== null) return expiresAt <= this.now() + REFRESH_WINDOW_MS;
+    return credentials.refreshedAt <= this.now() - FALLBACK_REFRESH_AGE_MS;
+  }
+
+  async refresh() {
+    const current = this.credentials;
+    if (!current) throw new Error("Sign in to use OpenAI models");
+    const response = await this.fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_id: CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token: current.refreshToken,
+      }),
+    });
+    if (!response.ok) {
+      if (response.status === 400 || response.status === 401)
+        this.clearCredentials();
+      throw new Error(
+        `The OpenAI session could not be refreshed (${response.status})`,
+      );
+    }
+    const payload = await response.json();
+    const accessToken = payload.access_token;
+    if (typeof accessToken !== "string" || !accessToken) {
+      throw new Error("The OpenAI refresh response included no access token");
+    }
+    const idToken = payload.id_token || current.idToken;
+    const refreshedAccountId = accountIdFromTokens({ idToken, accessToken });
+    if (refreshedAccountId && refreshedAccountId !== current.accountId) {
+      this.clearCredentials();
+      throw new Error(
+        "The OpenAI account changed during token refresh; sign in again",
+      );
+    }
+    return this.saveCredentials({
+      accessToken,
+      refreshToken: payload.refresh_token || current.refreshToken,
+      idToken,
+      accountId: current.accountId,
+      refreshedAt: this.now(),
+    });
+  }
+
+  async accessToken() {
+    if (!this.credentials) throw new Error("Sign in to use OpenAI models");
+    if (this.needsRefresh(this.credentials)) {
+      if (!this.refreshing) {
+        this.refreshing = this.refresh().finally(() => {
+          this.refreshing = null;
+        });
+      }
+      await this.refreshing;
+    }
+    return this.credentials.accessToken;
+  }
+
+  async startBroker() {
+    if (this.broker) return this.backendEnv();
+    const server = http.createServer(async (request, response) => {
+      if (request.method !== "GET" || request.url !== "/token") {
+        response.writeHead(404).end();
+        return;
+      }
+      if (!bearerMatches(request, this.brokerSecret)) {
+        response.writeHead(401, { "cache-control": "no-store" }).end();
+        return;
+      }
+      try {
+        const accessToken = await this.accessToken();
+        const accountId = this.credentials?.accountId;
+        if (!accountId)
+          throw new Error("The OpenAI session included no account ID");
+        response.writeHead(200, {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+        });
+        response.end(
+          JSON.stringify({ access_token: accessToken, account_id: accountId }),
+        );
+      } catch (error) {
+        response.writeHead(401, {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+        });
+        response.end(JSON.stringify({ error: error.message }));
+      }
+    });
+    const port = await listen(server, [0]);
+    this.broker = server;
+    this.brokerUrl = `http://127.0.0.1:${port}/token`;
+    return this.backendEnv();
+  }
+
+  async close() {
+    this.loginFlow?.cancel();
+    this.loginFlow = null;
+    const server = this.broker;
+    this.broker = null;
+    this.brokerUrl = null;
+    if (!server) return;
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+module.exports = {
+  API_BASE_URL,
+  AUTH_ISSUER,
+  CLIENT_ID,
+  OpenAiOAuthManager,
+  accountIdFromTokens,
+  beginOpenAiLogin,
+  buildAuthorizeUrl,
+  decodeJwtPayload,
+};

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -31,6 +31,7 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
     ipcRenderer.invoke("desktop:resolve-local-project-path", { ...input }),
   localModelCredentialStatus: (modelId) =>
     ipcRenderer.invoke("desktop:local-model-credential-status", modelId),
+  signInLocalOpenAI: () => ipcRenderer.invoke("desktop:local-openai-sign-in"),
   startLocalThread: (input) => ipcRenderer.invoke("desktop:start-local-thread", input),
   getLocalPrompt: (threadId) => ipcRenderer.invoke("desktop:get-local-prompt", threadId),
   clearLocalPrompt: (threadId) => ipcRenderer.invoke("desktop:clear-local-prompt", threadId),

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -47,10 +47,16 @@ test("reports whether the selected provider is configured", () => {
   assert.deepEqual(modelCredentialStatus("openai:gpt-test", {}), {
     available: false,
     variable: "OPENAI_API_KEY",
+    canSignIn: true,
   })
   assert.deepEqual(modelCredentialStatus("openai:gpt-test", { OPENAI_API_KEY: "secret" }), {
     available: true,
     variable: "OPENAI_API_KEY",
+  })
+  assert.deepEqual(modelCredentialStatus("openai:gpt-test", {}, { openAiOAuth: true }), {
+    available: true,
+    variable: null,
+    canSignIn: true,
   })
   assert.deepEqual(modelCredentialStatus("google_genai:test", { GEMINI_API_KEY: "secret" }), {
     available: true,

--- a/desktop/test/openai-oauth.test.cjs
+++ b/desktop/test/openai-oauth.test.cjs
@@ -1,0 +1,165 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  AUTH_ISSUER,
+  CLIENT_ID,
+  OpenAiOAuthManager,
+  beginOpenAiLogin,
+  buildAuthorizeUrl,
+} = require("../build/openai-oauth.cjs");
+
+function jwt(payload) {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
+test("builds the native OAuth authorization request with PKCE", () => {
+  const url = new URL(
+    buildAuthorizeUrl({
+      redirectUri: "http://localhost:1455/auth/callback",
+      challenge: "challenge",
+      state: "state",
+    }),
+  );
+  assert.equal(url.origin, AUTH_ISSUER);
+  assert.equal(url.pathname, "/oauth/authorize");
+  assert.equal(url.searchParams.get("client_id"), CLIENT_ID);
+  assert.equal(url.searchParams.get("code_challenge"), "challenge");
+  assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+  assert.equal(url.searchParams.get("state"), "state");
+  assert.match(url.searchParams.get("scope"), /offline_access/);
+});
+
+test("accepts only the matching state on the loopback callback", async () => {
+  const flow = await beginOpenAiLogin({ ports: [0] });
+  const response = await fetch(
+    `http://127.0.0.1:${flow.port}/auth/callback?code=authorization-code&state=${flow.state}`,
+  );
+  assert.equal(response.status, 200);
+  assert.match(await response.text(), /You're signed in/);
+  assert.deepEqual(await flow.result, {
+    code: "authorization-code",
+    verifier: flow.verifier,
+    redirectUri: `http://localhost:${flow.port}/auth/callback`,
+  });
+});
+
+test("stores encrypted credentials and refreshes them through the loopback broker", async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "open-swe-openai-auth-"),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const now = 2_000_000_000_000;
+  const accountId = "account-123";
+  const idToken = jwt({
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+  });
+  const expiredAccessToken = jwt({ exp: now / 1000 - 10 });
+  const freshAccessToken = jwt({ exp: now / 1000 + 3600 });
+  const requests = [];
+  const manager = new OpenAiOAuthManager({
+    storagePath: path.join(directory, "auth.bin"),
+    now: () => now,
+    encryptString: (value) => Buffer.from(value).reverse(),
+    decryptString: (value) => Buffer.from(value).reverse().toString("utf8"),
+    fetchImpl: async (url, init) => {
+      requests.push({ url, init });
+      if (
+        init.headers["content-type"] === "application/x-www-form-urlencoded"
+      ) {
+        return new Response(
+          JSON.stringify({
+            access_token: expiredAccessToken,
+            refresh_token: "refresh-1",
+            id_token: idToken,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: freshAccessToken,
+          refresh_token: "refresh-2",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  t.after(() => manager.close());
+
+  await manager.exchangeCode({
+    code: "authorization-code",
+    verifier: "verifier",
+    redirectUri: "http://localhost:1455/auth/callback",
+  });
+  assert.equal(manager.status().signedIn, true);
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(directory, "auth.bin"), "utf8"),
+    /refresh-1/,
+  );
+
+  const env = await manager.startBroker();
+  const response = await fetch(env.OPEN_SWE_OPENAI_OAUTH_BROKER_URL, {
+    headers: {
+      Authorization: `Bearer ${env.OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN}`,
+    },
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    access_token: freshAccessToken,
+    account_id: accountId,
+  });
+  assert.equal(requests.length, 2);
+  assert.deepEqual(JSON.parse(requests[1].init.body), {
+    client_id: CLIENT_ID,
+    grant_type: "refresh_token",
+    refresh_token: "refresh-1",
+  });
+});
+
+test("rejects unauthenticated broker requests", async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "open-swe-openai-auth-"),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const manager = new OpenAiOAuthManager({
+    storagePath: path.join(directory, "auth.bin"),
+    encryptString: (value) => Buffer.from(value),
+    decryptString: (value) => value.toString("utf8"),
+  });
+  t.after(() => manager.close());
+  const env = await manager.startBroker();
+  const response = await fetch(env.OPEN_SWE_OPENAI_OAUTH_BROKER_URL);
+  assert.equal(response.status, 401);
+});
+
+test("clears credentials when refresh authorization is permanently rejected", async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "open-swe-openai-auth-"),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const now = 2_000_000_000_000;
+  const manager = new OpenAiOAuthManager({
+    storagePath: path.join(directory, "auth.bin"),
+    now: () => now,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: (value) => value.toString("utf8"),
+    fetchImpl: async () => new Response(null, { status: 401 }),
+  });
+  t.after(() => manager.close());
+  manager.saveCredentials({
+    accessToken: jwt({ exp: now / 1000 - 10 }),
+    refreshToken: "refresh-token",
+    idToken: jwt({
+      "https://api.openai.com/auth": { chatgpt_account_id: "account-123" },
+    }),
+    refreshedAt: now,
+  });
+
+  await assert.rejects(manager.accessToken(), /could not be refreshed \(401\)/);
+  assert.equal(manager.status().signedIn, false);
+  assert.equal(fs.existsSync(path.join(directory, "auth.bin")), false);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@11.18.0",
   "scripts": {
     "dev": "turbo run dev --filter=open-swe-dashboard",
-    "dev:desktop": "turbo run dev --filter=open-swe-desktop",
+    "dev:desktop": "pnpm --dir desktop run dev:full",
     "dev:mock": "bash tests/e2e/dev-mock.sh",
     "build": "turbo run build",
     "check": "turbo run check",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,16 +34,19 @@ importers:
     devDependencies:
       '@electron/notarize':
         specifier: 3.1.1
-        version: 3.1.1(supports-color@7.2.0)
+        version: 3.1.1(supports-color@10.2.2)
       '@types/node':
         specifier: 22.20.1
         version: 22.20.1
+      concurrently:
+        specifier: 10.0.5
+        version: 10.0.5
       electron:
         specifier: 41.10.3
-        version: 41.10.3(supports-color@7.2.0)
+        version: 41.10.3(supports-color@10.2.2)
       electron-builder:
         specifier: 26.15.3
-        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
+        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -106,10 +109,10 @@ importers:
         version: 1.167.1(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.166.15
-        version: 1.168.42(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+        version: 1.168.42(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       '@tanstack/router-plugin':
         specifier: ^1.166.13
-        version: 1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+        version: 1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -142,13 +145,13 @@ importers:
         version: 5.7.0(react@19.2.8)
       shadcn:
         specifier: ^4.7.0
-        version: 4.16.2(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(typescript@5.9.3)
+        version: 4.16.2(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(typescript@5.9.3)
       shiki:
         specifier: ^4.1.0
         version: 4.4.3
       streamdown:
         specifier: ^2.5.0
-        version: 2.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@7.2.0)
+        version: 2.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -160,17 +163,17 @@ importers:
         version: 1.4.0
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(supports-color@7.2.0)(typescript@5.9.3)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+        version: 5.1.4(supports-color@10.2.2)(typescript@5.9.3)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       zustand:
         specifier: ^5.0.9
         version: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       '@tanstack/devtools-vite':
         specifier: ^0.6.0
-        version: 0.6.1(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+        version: 0.6.1(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       '@tanstack/eslint-config':
         specifier: ^0.4.0
-        version: 0.4.0(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 0.4.0(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -188,13 +191,13 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+        version: 5.2.0(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       httpxy:
         specifier: 0.5.3
         version: 0.5.3
       jsdom:
         specifier: ^27.4.0
-        version: 27.4.0(@noble/hashes@2.3.0)(supports-color@7.2.0)
+        version: 27.4.0(@noble/hashes@2.3.0)(supports-color@10.2.2)
       prettier:
         specifier: ^3.8.1
         version: 3.9.6
@@ -209,7 +212,7 @@ importers:
         version: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@types/node@22.20.1)(jsdom@27.4.0(@noble/hashes@2.3.0)(supports-color@7.2.0))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+        version: 4.1.10(@types/node@22.20.1)(jsdom@27.4.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       web-vitals:
         specifier: ^5.1.0
         version: 5.3.0
@@ -2253,6 +2256,10 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -2464,6 +2471,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
@@ -2525,6 +2536,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@10.0.5:
+    resolution: {integrity: sha512-JaP/CoftUrCcAFW/g//RbgEGwlelnEae6cfBLgH6ZdO6s8jPkn6p9SB9u6pdVxYXoiSnFqseOlHfrEfF82TVOg==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   conf@10.2.0:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
@@ -4943,6 +4959,9 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -5034,6 +5053,10 @@ packages:
 
   shell-quote@1.10.0:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   shiki@4.4.3:
@@ -5184,6 +5207,10 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5276,6 +5303,10 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5725,6 +5756,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5777,9 +5812,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yjs@13.6.32:
     resolution: {integrity: sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==}
@@ -5870,20 +5913,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@7.2.0)':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5910,41 +5953,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5954,18 +5997,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
@@ -5985,53 +6028,53 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6043,7 +6086,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
 
-  '@babel/traverse@7.29.8(supports-color@7.2.0)':
+  '@babel/traverse@7.29.8(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
@@ -6051,7 +6094,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6148,52 +6191,52 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@3.1.0(supports-color@7.2.0)':
+  '@electron/get@3.1.0(supports-color@10.2.2)':
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1(supports-color@7.2.0)
+      sumchecker: 3.0.1(supports-color@10.2.2)
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@5.1.0(supports-color@7.2.0)':
+  '@electron/get@5.1.0(supports-color@10.2.2)':
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
       semver: 7.8.5
-      sumchecker: 3.0.1(supports-color@7.2.0)
+      sumchecker: 3.0.1(supports-color@10.2.2)
     optionalDependencies:
       undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/notarize@2.5.0(supports-color@7.2.0)':
+  '@electron/notarize@2.5.0(supports-color@10.2.2)':
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/notarize@3.1.1(supports-color@7.2.0)':
+  '@electron/notarize@3.1.1(supports-color@10.2.2)':
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/osx-sign@1.3.3(supports-color@7.2.0)':
+  '@electron/osx-sign@1.3.3(supports-color@10.2.2)':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -6201,22 +6244,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@4.2.0(supports-color@7.2.0)':
+  '@electron/rebuild@4.2.0(supports-color@10.2.2)':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       node-abi: 4.33.0
       node-api-version: 0.2.1
       node-gyp: 12.4.0
-      read-binary-file-arch: 1.0.6(supports-color@7.2.0)
+      read-binary-file-arch: 1.0.6(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/universal@2.0.3(supports-color@7.2.0)':
+  '@electron/universal@2.0.3(supports-color@10.2.2)':
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       dir-compare: 4.2.0
       fs-extra: 11.4.0
       minimatch: 9.0.9
@@ -6224,10 +6267,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/windows-sign@1.2.2(supports-color@7.2.0)':
+  '@electron/windows-sign@1.2.2(supports-color@10.2.2)':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 11.4.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -6329,17 +6372,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
+  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
@@ -6352,9 +6395,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))':
+  '@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))':
     optionalDependencies:
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -6655,9 +6698,9 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@malept/flatpak-bundler@0.4.0(supports-color@7.2.0)':
+  '@malept/flatpak-bundler@0.4.0(supports-color@10.2.2)':
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
@@ -6668,7 +6711,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
@@ -6678,8 +6721,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.1
-      express: 5.2.1(supports-color@7.2.0)
-      express-rate-limit: 8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
       hono: 4.12.34
       jose: 6.2.8
       json-schema-typed: 8.0.2
@@ -7023,11 +7066,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@typescript-eslint/types': 8.67.0
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -7140,12 +7183,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.6.1(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
+  '@tanstack/devtools-vite@0.6.1(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
       '@tanstack/devtools-client': 0.0.6
       '@tanstack/devtools-event-bus': 0.4.1
@@ -7176,16 +7219,16 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/eslint-config@0.4.0(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@tanstack/eslint-config@0.4.0(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
-      '@eslint/js': 10.0.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
-      eslint-plugin-n: 17.24.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(typescript@5.9.3)
+      '@eslint/js': 10.0.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-plugin-n: 17.24.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(typescript@5.9.3)
       globals: 17.9.0
-      typescript-eslint: 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      vue-eslint-parser: 10.4.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+      typescript-eslint: 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      vue-eslint-parser: 10.4.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint-import-resolver-node
@@ -7262,14 +7305,14 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-start-rsc@0.1.41(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
+  '@tanstack/react-start-rsc@0.1.41(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
     dependencies:
       '@tanstack/react-router': 1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-core': 1.171.21
-      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       '@tanstack/start-client-core': 1.170.21
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.33(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+      '@tanstack/start-plugin-core': 1.171.33(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       '@tanstack/start-storage-context': 1.167.23
       pathe: 2.0.3
       react: 19.2.8
@@ -7298,15 +7341,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.42(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
+  '@tanstack/react-start@1.168.42(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
     dependencies:
       '@tanstack/react-router': 1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start-client': 1.168.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-start-rsc': 0.1.41(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+      '@tanstack/react-start-rsc': 0.1.41(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       '@tanstack/react-start-server': 1.167.30(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       '@tanstack/start-client-core': 1.170.21
-      '@tanstack/start-plugin-core': 1.171.33(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+      '@tanstack/start-plugin-core': 1.171.33(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       '@tanstack/start-server-core': 1.169.25(crossws@0.4.10(srvx@0.11.22))
       pathe: 2.0.3
       react: 19.2.8
@@ -7349,11 +7392,11 @@ snapshots:
     optionalDependencies:
       csstype: 3.2.3
 
-  '@tanstack/router-generator@1.167.27(supports-color@7.2.0)':
+  '@tanstack/router-generator@1.167.27(supports-color@10.2.2)':
     dependencies:
       '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.21
-      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
@@ -7362,14 +7405,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
+  '@tanstack/router-plugin@1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.21
-      '@tanstack/router-generator': 1.167.27(supports-color@7.2.0)
-      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
+      '@tanstack/router-generator': 1.167.27(supports-color@10.2.2)
+      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
       zod: 4.4.3
@@ -7391,13 +7434,13 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       '@tanstack/router-core': 1.171.21
 
-  '@tanstack/router-utils@1.162.2(supports-color@7.2.0)':
+  '@tanstack/router-utils@1.162.2(supports-color@10.2.2)':
     dependencies:
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       ansis: 4.3.1
-      babel-dead-code-elimination: 1.0.12(supports-color@7.2.0)
+      babel-dead-code-elimination: 1.0.12(supports-color@10.2.2)
       diff: 8.0.4
       pathe: 2.0.3
       tinyglobby: 0.2.17
@@ -7413,15 +7456,15 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.33(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
+  '@tanstack/start-plugin-core@1.171.33(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.21
-      '@tanstack/router-generator': 1.167.27(supports-color@7.2.0)
-      '@tanstack/router-plugin': 1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
-      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
+      '@tanstack/router-generator': 1.167.27(supports-color@10.2.2)
+      '@tanstack/router-plugin': 1.168.29(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
+      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       '@tanstack/start-server-core': 1.169.25(crossws@0.4.10(srvx@0.11.22))
       exsolve: 1.1.1
       lightningcss: 1.33.0
@@ -7740,15 +7783,15 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.67.0
-      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.67.0
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -7756,23 +7799,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.67.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.67.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.67.0(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.67.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7786,13 +7829,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7800,13 +7843,13 @@ snapshots:
 
   '@typescript-eslint/types@8.67.0': {}
 
-  '@typescript-eslint/typescript-estree@8.67.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.67.0(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.67.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.67.0(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -7815,13 +7858,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@10.2.2)(typescript@5.9.3)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7908,11 +7951,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.2.0(supports-color@7.2.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
+  '@vitejs/plugin-react@5.2.0(supports-color@10.2.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -8012,35 +8055,37 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  ansi-styles@6.2.3: {}
+
   ansis@4.3.1: {}
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0):
+  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
-      '@electron/get': 3.1.0(supports-color@7.2.0)
-      '@electron/notarize': 2.5.0(supports-color@7.2.0)
-      '@electron/osx-sign': 1.3.3(supports-color@7.2.0)
-      '@electron/rebuild': 4.2.0(supports-color@7.2.0)
-      '@electron/universal': 2.0.3(supports-color@7.2.0)
-      '@malept/flatpak-bundler': 0.4.0(supports-color@7.2.0)
+      '@electron/get': 3.1.0(supports-color@10.2.2)
+      '@electron/notarize': 2.5.0(supports-color@10.2.2)
+      '@electron/osx-sign': 1.3.3(supports-color@10.2.2)
+      '@electron/rebuild': 4.2.0(supports-color@10.2.2)
+      '@electron/universal': 2.0.3(supports-color@10.2.2)
+      '@malept/flatpak-bundler': 0.4.0(supports-color@10.2.2)
       '@noble/hashes': 2.3.0
       '@peculiar/webcrypto': 1.7.1
       '@types/fs-extra': 9.0.13
       ajv: 8.20.0
       asn1js: 3.0.10
       async-exit-hook: 2.0.1
-      builder-util: 26.15.3(supports-color@7.2.0)
-      builder-util-runtime: 9.7.0(supports-color@7.2.0)
+      builder-util: 26.15.3(supports-color@10.2.2)
+      builder-util-runtime: 9.7.0(supports-color@10.2.2)
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
-      debug: 4.4.3(supports-color@7.2.0)
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)(supports-color@7.2.0)
-      electron-publish: 26.15.3(supports-color@7.2.0)
+      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)(supports-color@10.2.2)
+      electron-publish: 26.15.3(supports-color@10.2.2)
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
@@ -8092,11 +8137,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  babel-dead-code-elimination@1.0.12(supports-color@7.2.0):
+  babel-dead-code-elimination@1.0.12(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.8
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
@@ -8117,11 +8162,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.3.0(supports-color@7.2.0):
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -8161,23 +8206,23 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  builder-util-runtime@9.7.0(supports-color@7.2.0):
+  builder-util-runtime@9.7.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       sax: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
-  builder-util@26.15.3(supports-color@7.2.0):
+  builder-util@26.15.3(supports-color@10.2.2):
     dependencies:
       '@types/debug': 4.1.13
-      builder-util-runtime: 9.7.0(supports-color@7.2.0)
+      builder-util-runtime: 9.7.0(supports-color@10.2.2)
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 10.1.0
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
@@ -8268,6 +8313,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
@@ -8309,6 +8360,15 @@ snapshots:
   compare-version@0.1.2: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@10.0.5:
+    dependencies:
+      chalk: 5.6.2
+      rxjs: 7.8.2
+      shell-quote: 1.9.0
+      supports-color: 10.2.2
+      tree-kill: 1.2.2
+      yargs: 18.0.0
 
   conf@10.2.0:
     dependencies:
@@ -8589,11 +8649,11 @@ snapshots:
     dependencies:
       mimic-fn: 3.1.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
-      supports-color: 7.2.0
+      supports-color: 10.2.2
 
   decimal.js@10.6.0: {}
 
@@ -8666,10 +8726,10 @@ snapshots:
       minimatch: 3.1.5
       p-limit: 3.1.0
 
-  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0):
+  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
-      builder-util: 26.15.3(supports-color@7.2.0)
+      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      builder-util: 26.15.3(supports-color@10.2.2)
       fs-extra: 10.1.0
       js-yaml: 4.3.1
     transitivePeerDependencies:
@@ -8710,23 +8770,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3)(supports-color@7.2.0):
+  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3)(supports-color@10.2.2):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
-      builder-util: 26.15.3(supports-color@7.2.0)
-      electron-winstaller: 5.4.0(supports-color@7.2.0)
+      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      builder-util: 26.15.3(supports-color@10.2.2)
+      electron-winstaller: 5.4.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0):
+  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
-      builder-util: 26.15.3(supports-color@7.2.0)
-      builder-util-runtime: 9.7.0(supports-color@7.2.0)
+      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      builder-util: 26.15.3(supports-color@10.2.2)
+      builder-util-runtime: 9.7.0(supports-color@10.2.2)
       chalk: 4.1.2
       ci-info: 4.4.0
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
+      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -8735,12 +8795,12 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-publish@26.15.3(supports-color@7.2.0):
+  electron-publish@26.15.3(supports-color@10.2.2):
     dependencies:
       '@types/fs-extra': 9.0.13
       aws4: 1.13.2
-      builder-util: 26.15.3(supports-color@7.2.0)
-      builder-util-runtime: 9.7.0(supports-color@7.2.0)
+      builder-util: 26.15.3(supports-color@10.2.2)
+      builder-util-runtime: 9.7.0(supports-color@10.2.2)
       chalk: 4.1.2
       form-data: 4.0.6
       fs-extra: 10.1.0
@@ -8751,22 +8811,22 @@ snapshots:
 
   electron-to-chromium@1.5.404: {}
 
-  electron-winstaller@5.4.0(supports-color@7.2.0):
+  electron-winstaller@5.4.0(supports-color@10.2.2):
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 7.0.1
       lodash: 4.18.1
       temp: 0.9.4
     optionalDependencies:
-      '@electron/windows-sign': 1.2.2(supports-color@7.2.0)
+      '@electron/windows-sign': 1.2.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.10.3(supports-color@7.2.0):
+  electron@41.10.3(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
-      '@electron/get': 5.1.0(supports-color@7.2.0)
+      '@electron/get': 5.1.0(supports-color@10.2.2)
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
@@ -8871,9 +8931,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-compat-utils@0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       semver: 7.8.5
 
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
@@ -8883,19 +8943,19 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.12.2
 
-  eslint-plugin-es-x@7.8.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-plugin-es-x@7.8.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
-      eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@typescript-eslint/types': 8.67.0
       comment-parser: 1.4.8
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
       minimatch: 10.2.6
@@ -8903,16 +8963,16 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.12.2
     optionalDependencies:
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-n@17.24.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(typescript@5.9.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       enhanced-resolve: 5.24.5
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
-      eslint-plugin-es-x: 7.8.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-plugin-es-x: 7.8.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       get-tsconfig: 4.14.1
       globals: 15.15.0
       globrex: 0.1.2
@@ -8935,11 +8995,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0):
+  eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
+      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -8949,7 +9009,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -9047,28 +9107,28 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0):
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      express: 5.2.1(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.3.1
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@7.2.0):
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@7.2.0)
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@7.2.0)
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -9079,9 +9139,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0(supports-color@7.2.0)
-      send: 1.2.1(supports-color@7.2.0)
-      serve-static: 2.2.1(supports-color@7.2.0)
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -9134,9 +9194,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@7.2.0):
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -9405,7 +9465,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
+  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
@@ -9414,9 +9474,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -9475,10 +9535,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
+  http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9487,10 +9547,10 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9641,7 +9701,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.4.0(@noble/hashes@2.3.0)(supports-color@7.2.0):
+  jsdom@27.4.0(@noble/hashes@2.3.0)(supports-color@10.2.2):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
@@ -9650,8 +9710,8 @@ snapshots:
       data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@2.3.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.1
       saxes: 6.0.0
@@ -9906,14 +9966,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.3(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2(supports-color@10.2.2)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -9931,67 +9991,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
+  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@7.2.0):
+  mdast-util-gfm@3.1.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
+  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
+  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -9999,7 +10059,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -10008,13 +10068,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
+  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10255,10 +10315,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@7.2.0):
+  micromark@4.0.2(supports-color@10.2.2):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -10782,9 +10842,9 @@ snapshots:
 
   react@19.2.8: {}
 
-  read-binary-file-arch@1.0.6(supports-color@7.2.0):
+  read-binary-file-arch@1.0.6(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10833,21 +10893,21 @@ snapshots:
       '@types/hast': 3.0.5
       hast-util-sanitize: 5.0.2
 
-  remark-gfm@4.0.1(supports-color@7.2.0):
+  remark-gfm@4.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@7.2.0):
+  remark-parse@11.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -10975,9 +11035,9 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0(supports-color@7.2.0):
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -10992,6 +11052,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   rw@1.3.3: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-buffer@5.1.2: {}
 
@@ -11020,9 +11084,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@7.2.0):
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -11053,25 +11117,25 @@ snapshots:
 
   seroval@1.6.2: {}
 
-  serve-static@2.2.1(supports-color@7.2.0):
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@7.2.0)
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.16.2(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(typescript@5.9.3):
+  shadcn@4.16.2(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(typescript@5.9.3):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.8
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@dotenvx/dotenvx': 1.75.1
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.8
       commander: 14.0.3
@@ -11111,6 +11175,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.10.0: {}
+
+  shell-quote@1.9.0: {}
 
   shiki@4.4.3:
     dependencies:
@@ -11201,10 +11267,10 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  streamdown@2.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@7.2.0):
+  streamdown@2.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2):
     dependencies:
       clsx: 2.1.1
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
       html-url-attributes: 3.0.1
       marked: 17.0.6
       mermaid: 11.16.1
@@ -11213,8 +11279,8 @@ snapshots:
       rehype-harden: 1.1.8
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0
-      remark-gfm: 4.0.1(supports-color@7.2.0)
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-rehype: 11.1.2
       remend: 1.3.0
       tailwind-merge: 3.6.0
@@ -11275,11 +11341,13 @@ snapshots:
 
   stylis@4.4.0: {}
 
-  sumchecker@3.0.1(supports-color@7.2.0):
+  sumchecker@3.0.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -11366,6 +11434,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -11426,13 +11496,13 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
-  typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -11584,9 +11654,9 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-tsconfig-paths@5.1.4(supports-color@7.2.0)(typescript@5.9.3)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)):
+  vite-tsconfig-paths@5.1.4(supports-color@10.2.2)(typescript@5.9.3)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
@@ -11614,7 +11684,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)
 
-  vitest@4.1.10(@types/node@22.20.1)(jsdom@27.4.0(@noble/hashes@2.3.0)(supports-color@7.2.0))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)):
+  vitest@4.1.10(@types/node@22.20.1)(jsdom@27.4.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2))
@@ -11638,14 +11708,14 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
-      jsdom: 27.4.0(@noble/hashes@2.3.0)(supports-color@7.2.0)
+      jsdom: 27.4.0(@noble/hashes@2.3.0)(supports-color@10.2.2)
     transitivePeerDependencies:
       - msw
 
-  vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
+  vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
@@ -11712,6 +11782,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.21.3: {}
@@ -11744,6 +11820,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
@@ -11753,6 +11831,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yjs@13.6.32:
     dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "langchain-anthropic>=1.5.4",
     "langgraph-cli[inmem]>=0.4.31",
     "langsmith>=0.11.1",
-    "langchain-openai>=1.4.1",
+    "langchain-openai>=1.4.1,<2.0.0",
     "langchain-fireworks>=1.5.2",
     # langchain-fireworks 1.4.2 pins a pre-release fireworks-ai; opt in explicitly so uv resolves it.
     "fireworks-ai>=1.2.5",

--- a/tests/agent/test_desktop.py
+++ b/tests/agent/test_desktop.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+from blockbuster import blockbuster_ctx
 
 from agent.desktop import (
     create_desktop_backend,
@@ -40,13 +41,14 @@ def test_desktop_backend_rejects_unregistered_project(
         resolve_desktop_project({"local_project_path": str(project)})
 
 
-def test_artifact_routes_stay_out_of_the_project(
+async def test_artifact_routes_stay_out_of_the_project(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     artifacts = tmp_path / "artifacts"
     monkeypatch.setenv("OPEN_SWE_LOCAL_ARTIFACTS_DIR", str(artifacts))
 
-    routes = desktop_artifact_routes("thread-1")
+    with blockbuster_ctx():
+        routes = await desktop_artifact_routes("thread-1")
     assert set(routes) == {"/large_tool_results/", "/conversation_history/"}
     for prefix, backend in routes.items():
         root = Path(str(backend.cwd)).resolve()
@@ -54,13 +56,13 @@ def test_artifact_routes_stay_out_of_the_project(
         assert root == (artifacts / "thread-1" / prefix.strip("/")).resolve()
 
 
-def test_artifact_routes_reject_a_traversing_thread_id(
+async def test_artifact_routes_reject_a_traversing_thread_id(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     artifacts = tmp_path / "artifacts"
     monkeypatch.setenv("OPEN_SWE_LOCAL_ARTIFACTS_DIR", str(artifacts))
 
-    routes = desktop_artifact_routes("../../etc")
+    routes = await desktop_artifact_routes("../../etc")
     for backend in routes.values():
         root = Path(str(backend.cwd)).resolve()
         assert artifacts.resolve() in root.parents

--- a/tests/models/test_openai_oauth.py
+++ b/tests/models/test_openai_oauth.py
@@ -1,0 +1,134 @@
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from blockbuster import blockbuster_ctx
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_openai.chat_models.codex import (  # noqa: PLC2701
+    CHATGPT_CODEX_BASE_URL,
+    _ChatOpenAICodex,
+)
+
+from agent.utils import model, openai_oauth
+
+
+@pytest.fixture(autouse=True)
+def _clean_oauth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "OPEN_SWE_OPENAI_OAUTH_BROKER_URL",
+        "OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    model._MODEL_CACHE.clear()
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPEN_SWE_OPENAI_OAUTH_BROKER_URL", "http://127.0.0.1:3210/token")
+    monkeypatch.setenv("OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN", "broker-secret")
+
+
+def test_oauth_model_uses_dedicated_account_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def fake_model(model_name: str, **kwargs: Any) -> str:
+        captured["model_name"] = model_name
+        captured.update(kwargs)
+        return "MODEL"
+
+    with (
+        patch.object(model, "build_desktop_openai_oauth_model", fake_model),
+        blockbuster_ctx(),
+    ):
+        result = model.make_model("openai:gpt-5.6-sol", use_gateway=False, max_tokens=123)
+
+    assert result == "MODEL"
+    assert captured["model_name"] == "gpt-5.6-sol"
+    assert "base_url" not in captured
+    assert "max_tokens" not in captured
+
+
+@pytest.mark.filterwarnings("ignore:.*experimental and unofficial.*:UserWarning")
+def test_oauth_model_enforces_account_backend_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure(monkeypatch)
+
+    result = openai_oauth.build_desktop_openai_oauth_model("gpt-5.6-sol")
+
+    assert isinstance(result, _ChatOpenAICodex)
+    assert str(result.openai_api_base).rstrip("/") == CHATGPT_CODEX_BASE_URL
+    assert result.use_responses_api is True
+    assert result.store is False
+    assert result.streaming is True
+    assert result.originator == "open_swe_desktop"
+
+
+def test_oauth_rejects_non_loopback_broker(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch)
+    monkeypatch.setenv("OPEN_SWE_OPENAI_OAUTH_BROKER_URL", "https://example.com/token")
+    assert openai_oauth.desktop_openai_oauth_available() is False
+
+
+@pytest.mark.filterwarnings("ignore:.*experimental and unofficial.*:UserWarning")
+async def test_token_provider_authenticates_to_broker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure(monkeypatch)
+    requests: list[tuple[str, dict[str, str]]] = []
+    payloads = iter(
+        [
+            {"access_token": "access-token-a", "account_id": "account-a"},
+            {"access_token": "access-token-b", "account_id": "account-b"},
+        ]
+    )
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return next(payloads)
+
+    class Client:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def get(self, url: str, *, headers: dict[str, str]):
+            requests.append((url, headers))
+            return Response()
+
+    oauth_model = openai_oauth.build_desktop_openai_oauth_model("gpt-5.6-sol")
+    monkeypatch.setattr(openai_oauth.httpx, "AsyncClient", Client)
+    provider = oauth_model.token_provider  # type: ignore[attr-defined]
+    first_token = await provider.aget_token()
+    second_token = await provider.aget_token()
+
+    assert first_token.access_token == "access-token-a"
+    assert first_token.account_id == "account-a"
+    assert second_token.access_token == "access-token-b"
+    assert second_token.account_id == "account-b"
+    assert provider.get_access_token() == "access-token-b"
+    assert requests == [
+        (
+            "http://127.0.0.1:3210/token",
+            {"Authorization": "Bearer broker-secret"},
+        ),
+        (
+            "http://127.0.0.1:3210/token",
+            {"Authorization": "Bearer broker-secret"},
+        ),
+    ]
+
+    payload = oauth_model._get_request_payload(  # type: ignore[attr-defined]
+        [SystemMessage("agent instructions"), HumanMessage("hello")]
+    )
+    assert payload["instructions"] == "agent instructions"
+    assert all(item.get("role") != "system" for item in payload["input"])

--- a/tests/sandbox/test_local_integration.py
+++ b/tests/sandbox/test_local_integration.py
@@ -22,7 +22,7 @@ def test_create_local_sandbox_creates_missing_root_dir(monkeypatch, tmp_path):
     stub = cast(_StubLocalShellBackend, backend)
     assert stub.root_dir == str(root)
     assert stub.virtual_mode is True
-    assert stub.inherit_env is True
+    assert stub.inherit_env is False
 
 
 def test_create_local_sandbox_defaults_to_cwd(monkeypatch, tmp_path):
@@ -64,5 +64,26 @@ def test_create_local_sandbox_keeps_explicit_global_git_config(monkeypatch, tmp_
     backend = local_mod.create_local_sandbox()
 
     stub = cast(_StubLocalShellBackend, backend)
-    assert "GIT_CONFIG_GLOBAL" not in stub.env
+    assert stub.env["GIT_CONFIG_GLOBAL"] == str(tmp_path / "chosen-gitconfig")
     assert not (tmp_path / "work" / local_mod.SANDBOX_GITCONFIG).exists()
+
+
+def test_create_local_sandbox_excludes_credential_broker_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOCAL_SANDBOX_ROOT_DIR", str(tmp_path / "work"))
+    monkeypatch.setenv("OPEN_SWE_OPENAI_OAUTH_BROKER_URL", "http://127.0.0.1:3210/token")
+    monkeypatch.setenv("OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN", "broker-secret")
+    monkeypatch.setenv("OPEN_SWE_OPENAI_OAUTH_ACCOUNT_FILE", "/tmp/legacy-account.json")
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-secret")
+    monkeypatch.setenv("VISIBLE_TO_AGENT", "visible")
+    monkeypatch.setattr(local_mod, "LocalShellBackend", _StubLocalShellBackend)
+
+    backend = local_mod.create_local_sandbox()
+
+    stub = cast(_StubLocalShellBackend, backend)
+    assert stub.env["VISIBLE_TO_AGENT"] == "visible"
+    assert "OPEN_SWE_OPENAI_OAUTH_BROKER_URL" not in stub.env
+    assert "OPEN_SWE_OPENAI_OAUTH_BROKER_TOKEN" not in stub.env
+    assert "OPEN_SWE_OPENAI_OAUTH_ACCOUNT_FILE" not in stub.env
+    assert "OPENAI_API_KEY" not in stub.env
+    assert "ANTHROPIC_API_KEY" not in stub.env

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -157,9 +157,12 @@ declare global {
         localSessionId: string
         path: string
       }) => Promise<string | null>
-      localModelCredentialStatus: (
-        modelId?: string
-      ) => Promise<{ available: boolean; variable: string | null }>
+      localModelCredentialStatus: (modelId?: string) => Promise<{
+        available: boolean
+        variable: string | null
+        canSignIn?: boolean
+      }>
+      signInLocalOpenAI: () => Promise<{ signedIn: boolean }>
       startLocalThread: (
         input: DesktopLocalPromptInput & {
           cwd: string

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -24,7 +24,10 @@ import {
   useModelOptions,
 } from "@/features/agents/lib/provider/useModelOptions"
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
-import { localThreadKeys } from "@/features/agents/lib/desktopLocal"
+import {
+  ensureDesktopModelCredential,
+  localThreadKeys,
+} from "@/features/agents/lib/desktopLocal"
 import { useDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
 import { useProfile, useRepos } from "@/lib/profile"
 import { useSession } from "@/lib/session"
@@ -64,7 +67,8 @@ export function AgentsHome() {
   }
   const [planMode, setPlanMode] = useState(false)
   const [adminThread, setAdminThread] = useState(false)
-  const environmentOptions = useEnvironmentOptions()
+  const cloudEnabled = Boolean(session.data)
+  const environmentOptions = useEnvironmentOptions(cloudEnabled)
   const environments = environmentOptions.data?.environments ?? []
   // undefined = untouched, so the run falls back to the default environment.
   const [environmentOverride, setEnvironmentOverride] = useState<string | null>(
@@ -80,7 +84,11 @@ export function AgentsHome() {
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
   const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
-  const runTarget: RunTarget = isDesktop ? desktopThreadSource : "cloud"
+  const runTarget: RunTarget = isDesktop
+    ? cloudEnabled
+      ? desktopThreadSource
+      : "local"
+    : "cloud"
   const [localProjectPath, setLocalProjectPath] = useState<string | null>(null)
   const localProjectPathRef = useRef(localProjectPath)
   localProjectPathRef.current = localProjectPath
@@ -99,7 +107,7 @@ export function AgentsHome() {
 
   const reposQuery = useRepos()
   const profileQuery = useProfile()
-  const skills = useAgentSkills()
+  const skills = useAgentSkills({ enabled: cloudEnabled })
   // undefined = untouched (fall back to the profile default); null = explicitly "no repo".
   const [repoOverride, setRepoOverride] = useState<string | null | undefined>(
     undefined
@@ -208,17 +216,17 @@ export function AgentsHome() {
       window.localStorage.setItem(LAST_LOCAL_PROJECT_KEY, localProjectPath)
       await refreshLocalProjectBranch()
       try {
-        const credential = await desktop.localModelCredentialStatus(
+        const credentialError = await ensureDesktopModelCredential(
           activeSelection?.modelId
         )
-        if (!credential.available) {
+        if (credentialError) {
           setSubmitting(false)
-          setLocalError(
-            `Set ${credential.variable} in the environment before starting Open SWE.`
-          )
+          setLocalError(credentialError)
           return
         }
-        const managedSkills = await skills.refetch()
+        const managedSkills = cloudEnabled
+          ? await skills.refetch()
+          : { personal: [], organization: [] }
         const localSession = await desktop.startLocalThread({
           cwd: localProjectPath,
           prompt,
@@ -298,7 +306,7 @@ export function AgentsHome() {
 
   return (
     <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-3 py-6 sm:px-6 sm:py-8">
-      <OnboardingDialog />
+      {session.data && <OnboardingDialog />}
       <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center">
         <div className="flex w-full flex-col items-center gap-6">
           <Logo />
@@ -318,7 +326,9 @@ export function AgentsHome() {
             selectedRepo={repo}
             onRepoChange={setRepoOverride}
             runTarget={isDesktop ? runTarget : undefined}
-            onRunTargetChange={isDesktop ? handleRunTargetChange : undefined}
+            onRunTargetChange={
+              isDesktop && cloudEnabled ? handleRunTargetChange : undefined
+            }
             localProjects={localProjects}
             selectedLocalProjectPath={localProjectPath}
             selectedLocalProjectBranch={localProjectBranch}

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -122,7 +122,8 @@ const PR_STATE_META: Record<
 }
 
 interface AgentsSidebarProps {
-  user: SessionUser
+  user: SessionUser | null
+  localOnly?: boolean
   activeThreadId?: string
   activeLocalSessionId?: string
   layout: SidebarLayout
@@ -137,6 +138,7 @@ const NAV = [
 
 export function AgentsSidebar({
   user,
+  localOnly = false,
   activeThreadId,
   activeLocalSessionId,
   layout,
@@ -157,6 +159,7 @@ export function AgentsSidebar({
       prefs.filters.includeAutomations ||
       prefs.filters.sources.includes("schedule"),
     includeResolved: prefs.filters.includeResolved,
+    enabled: !localOnly,
   })
   const localSessions = useDesktopLocalThreads().data ?? []
   const refreshLocalThreads = useRefreshLocalThreads()
@@ -231,8 +234,10 @@ export function AgentsSidebar({
         thread.status !== "starting"
     ).length,
   }
-  const showLocalThreads = isDesktop && desktopThreadSource === "local"
-  const showCloudThreads = !isDesktop || desktopThreadSource === "cloud"
+  const showLocalThreads =
+    isDesktop && (localOnly || desktopThreadSource === "local")
+  const showCloudThreads =
+    !localOnly && (!isDesktop || desktopThreadSource === "cloud")
 
   return (
     <SidebarFrame {...layout} className="border-r border-border bg-sidebar">
@@ -243,7 +248,7 @@ export function AgentsSidebar({
         )}
       >
         <Link
-          to="/my-settings"
+          to={localOnly ? "/agents" : "/my-settings"}
           className="flex items-center gap-2 font-heading text-sm font-medium tracking-tight text-foreground"
         >
           <img src="/logo-mark.png" alt="" className="size-5" />
@@ -278,28 +283,31 @@ export function AgentsSidebar({
         </Link>
       </div>
 
-      <nav className="flex flex-col gap-0.5 px-2 pb-4">
-        {NAV.map((item) => {
-          const Icon = item.icon
-          return (
-            <Link
-              key={item.to}
-              to={item.to}
-              onClick={layout.closeOnMobile}
-              className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
-              activeProps={{
-                className: "bg-sidebar-row-hover !text-foreground font-medium",
-              }}
-            >
-              <Icon className="size-4" />
-              {item.label}
-            </Link>
-          )
-        })}
-      </nav>
+      {!localOnly && (
+        <nav className="flex flex-col gap-0.5 px-2 pb-4">
+          {NAV.map((item) => {
+            const Icon = item.icon
+            return (
+              <Link
+                key={item.to}
+                to={item.to}
+                onClick={layout.closeOnMobile}
+                className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+                activeProps={{
+                  className:
+                    "bg-sidebar-row-hover !text-foreground font-medium",
+                }}
+              >
+                <Icon className="size-4" />
+                {item.label}
+              </Link>
+            )
+          })}
+        </nav>
+      )}
 
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
-        {isDesktop && (
+        {isDesktop && !localOnly && (
           <DesktopThreadSourceToggle
             source={desktopThreadSource}
             localActivity={localActivity}
@@ -426,7 +434,16 @@ export function AgentsSidebar({
 
       <div className="flex items-center gap-1 p-2">
         <div className="min-w-0 flex-1">
-          <SidebarUserMenu user={user} showSettingsLink />
+          {user ? (
+            <SidebarUserMenu user={user} showSettingsLink />
+          ) : (
+            <Link
+              to="/login"
+              className="flex w-full items-center justify-center rounded-md border border-border px-2 py-1.5 text-xs font-medium hover:bg-sidebar-accent"
+            >
+              Sign in for cloud mode
+            </Link>
+          )}
         </div>
         {showCloudThreads && (
           <SidebarFilterMenu
@@ -1102,11 +1119,13 @@ function ThreadRow({
 
 export function AgentsShell({
   user,
+  localOnly = false,
   activeThreadId,
   activeLocalSessionId,
   children,
 }: {
-  user: SessionUser
+  user: SessionUser | null
+  localOnly?: boolean
   activeThreadId?: string
   activeLocalSessionId?: string
   children: React.ReactNode
@@ -1134,6 +1153,7 @@ export function AgentsShell({
       <div className="agents-ui flex h-svh overflow-hidden bg-background">
         <AgentsSidebar
           user={user}
+          localOnly={localOnly}
           activeThreadId={activeThreadId}
           activeLocalSessionId={activeLocalSessionId}
           layout={layout}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -30,6 +30,7 @@ import { useAgentSkills } from "@/features/agents/lib/queries"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import { useTerminalGroups } from "@/features/agents/lib/terminalGroups"
 import {
+  ensureDesktopModelCredential,
   localThreadKeys,
   useDesktopLocalThread,
   useLocalThreadDiff,
@@ -43,6 +44,7 @@ import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
+import { useSession } from "@/lib/session"
 
 function promptContent(text: string, images: Array<ImageChunk>) {
   const trimmed = text.trim()
@@ -72,11 +74,12 @@ function errorMessage(error: unknown): string {
 }
 
 export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
+  const session = useSession()
   const stream = useAgentThreadStream()
   const threadQuery = useDesktopLocalThread(sessionId)
   const thread = threadQuery.data
   const queryClient = useQueryClient()
-  const skills = useAgentSkills()
+  const skills = useAgentSkills({ enabled: Boolean(session.data) })
   const {
     models,
     defaultSelection,
@@ -231,14 +234,11 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     ) => {
       if (!thread) return false
       setError(null)
-      const credential =
-        await window.openSweDesktop?.localModelCredentialStatus(
-          activeSelection?.modelId
-        )
-      if (credential && !credential.available) {
-        setError(
-          `Set ${credential.variable} in the environment before starting Open SWE.`
-        )
+      const credentialError = await ensureDesktopModelCredential(
+        activeSelection?.modelId
+      )
+      if (credentialError) {
+        setError(credentialError)
         return false
       }
       try {

--- a/ui/src/features/agents/lib/desktopLocal.test.ts
+++ b/ui/src/features/agents/lib/desktopLocal.test.ts
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ensureDesktopModelCredential } from "./desktopLocal"
+
+describe("ensureDesktopModelCredential", () => {
+  const originalDesktop = window.openSweDesktop
+
+  afterEach(() => {
+    Object.defineProperty(window, "openSweDesktop", {
+      configurable: true,
+      value: originalDesktop,
+    })
+  })
+
+  const setDesktop = (
+    value: Partial<NonNullable<typeof window.openSweDesktop>>
+  ) => {
+    Object.defineProperty(window, "openSweDesktop", {
+      configurable: true,
+      value,
+    })
+  }
+
+  it("opens sign-in when an OpenAI model has no API key", async () => {
+    const signInLocalOpenAI = vi.fn().mockResolvedValue({ signedIn: true })
+    setDesktop({
+      localModelCredentialStatus: vi.fn().mockResolvedValue({
+        available: false,
+        variable: "OPENAI_API_KEY",
+        canSignIn: true,
+      }),
+      signInLocalOpenAI,
+    })
+
+    await expect(
+      ensureDesktopModelCredential("openai:gpt-test")
+    ).resolves.toBeNull()
+    expect(signInLocalOpenAI).toHaveBeenCalledOnce()
+  })
+
+  it("keeps the environment-variable guidance for other providers", async () => {
+    setDesktop({
+      localModelCredentialStatus: vi.fn().mockResolvedValue({
+        available: false,
+        variable: "ANTHROPIC_API_KEY",
+      }),
+    })
+
+    await expect(ensureDesktopModelCredential("anthropic:test")).resolves.toBe(
+      "Set ANTHROPIC_API_KEY in the environment before starting Open SWE."
+    )
+  })
+})

--- a/ui/src/features/agents/lib/desktopLocal.ts
+++ b/ui/src/features/agents/lib/desktopLocal.ts
@@ -17,6 +17,26 @@ export const localThreadKeys = {
   prDiff: (threadId: string) => ["local-thread-pr-diff", threadId] as const,
 }
 
+export async function ensureDesktopModelCredential(
+  modelId?: string
+): Promise<string | null> {
+  const desktop = window.openSweDesktop
+  if (!desktop) return null
+  const credential = await desktop.localModelCredentialStatus(modelId)
+  if (credential.available) return null
+  if (credential.canSignIn) {
+    try {
+      const result = await desktop.signInLocalOpenAI()
+      if (result.signedIn) return null
+    } catch (cause) {
+      return cause instanceof Error ? cause.message : "OpenAI sign-in failed"
+    }
+  }
+  return credential.variable
+    ? `Set ${credential.variable} in the environment before starting Open SWE.`
+    : "Sign in to use the selected model."
+}
+
 export function useReadyDesktopLocalThread(threadId: string) {
   const queryClient = useQueryClient()
   return useQuery({

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -141,11 +141,12 @@ export const environmentOptionKeys = {
 }
 
 /** Environments a new thread can boot from. Empty when none are configured. */
-export function useEnvironmentOptions() {
+export function useEnvironmentOptions(enabled = true) {
   return useQuery({
     queryKey: environmentOptionKeys.all,
     queryFn: api.listEnvironmentOptions,
     staleTime: 60_000,
+    enabled,
   })
 }
 
@@ -171,23 +172,26 @@ async function listOrganizationSkills() {
   return items
 }
 
-export function usePersonalAgentSkills() {
+export function usePersonalAgentSkills(enabled = true) {
   return useQuery({
     queryKey: agentSkillKeys.personal,
     queryFn: listPersonalSkills,
+    enabled,
   })
 }
 
-export function useOrganizationAgentSkills() {
+export function useOrganizationAgentSkills(enabled = true) {
   return useQuery({
     queryKey: agentSkillKeys.organization,
     queryFn: listOrganizationSkills,
+    enabled,
   })
 }
 
-export function useAgentSkills() {
-  const personal = usePersonalAgentSkills()
-  const organization = useOrganizationAgentSkills()
+export function useAgentSkills(options: { enabled?: boolean } = {}) {
+  const enabled = options.enabled ?? true
+  const personal = usePersonalAgentSkills(enabled)
+  const organization = useOrganizationAgentSkills(enabled)
   return {
     ...personal,
     personal: personal.data ?? [],
@@ -298,19 +302,21 @@ export function useSidebarThreads({
   activeThreadId,
   includeAutomations = false,
   includeResolved = false,
+  enabled = true,
 }: {
   activeThreadId?: string
   includeAutomations?: boolean
   includeResolved?: boolean
+  enabled?: boolean
 }) {
   const scope = includeAutomations ? "all" : "interactive"
   const activeQuery = useInfiniteThreadsPages(
     { limit: SIDEBAR_PAGE_SIZE, resolved: false, scope },
-    { pollWhileRunning: true }
+    { enabled, pollWhileRunning: true }
   )
   const resolvedQuery = useInfiniteThreadsPages(
     { limit: SIDEBAR_PAGE_SIZE, resolved: true, scope },
-    { enabled: includeResolved, pollWhileRunning: true }
+    { enabled: enabled && includeResolved, pollWhileRunning: true }
   )
   const loadedActive = infinitePageThreads(activeQuery.data)
   const loadedResolved = infinitePageThreads(resolvedQuery.data)
@@ -323,7 +329,10 @@ export function useSidebarThreads({
     queryFn: () =>
       agentsApi.getThread(activeThreadId as string, { markViewed: false }),
     enabled:
-      Boolean(activeThreadId) && activeQuery.isSuccess && !activeThreadLoaded,
+      enabled &&
+      Boolean(activeThreadId) &&
+      activeQuery.isSuccess &&
+      !activeThreadLoaded,
     staleTime: 30_000,
     refetchInterval: (query) =>
       query.state.data?.status === "running" ? 2000 : false,

--- a/ui/src/lib/ThemeSync.test.tsx
+++ b/ui/src/lib/ThemeSync.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ThemeSync } from "./ThemeSync"
+import { useTheme } from "./theme"
+
+function ThemeControl() {
+  const { setTheme } = useTheme()
+  return <button onClick={() => setTheme("light")}>Use light theme</button>
+}
+
+describe("ThemeSync", () => {
+  const values = new Map<string, string>()
+  const storage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size
+    },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  } as Storage
+
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    })
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    document.documentElement.classList.remove("dark")
+    document.documentElement.style.colorScheme = ""
+    vi.restoreAllMocks()
+  })
+
+  it("applies the system theme when no preference control is mounted", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: () => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    })
+
+    render(<ThemeSync />)
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("dark")).toBe(true)
+      expect(document.documentElement.style.colorScheme).toBe("dark")
+    })
+  })
+
+  it("does not overwrite an explicit preference when the system theme changes", async () => {
+    let prefersDark = false
+    const listeners = new Set<() => void>()
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: () => ({
+        get matches() {
+          return prefersDark
+        },
+        addEventListener: (_event: string, listener: () => void) =>
+          listeners.add(listener),
+        removeEventListener: (_event: string, listener: () => void) =>
+          listeners.delete(listener),
+      }),
+    })
+
+    render(
+      <>
+        <ThemeSync />
+        <ThemeControl />
+      </>
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Use light theme" }))
+    prefersDark = true
+    listeners.forEach((listener) => listener())
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("dark")).toBe(false)
+      expect(document.documentElement.style.colorScheme).toBe("light")
+    })
+  })
+})

--- a/ui/src/lib/ThemeSync.tsx
+++ b/ui/src/lib/ThemeSync.tsx
@@ -1,0 +1,6 @@
+import { useTheme } from "./theme"
+
+export function ThemeSync() {
+  useTheme()
+  return null
+}

--- a/ui/src/lib/desktop-local-mode.test.ts
+++ b/ui/src/lib/desktop-local-mode.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  DESKTOP_LOCAL_MODE_STORAGE_KEY,
+  enableDesktopLocalMode,
+  isDesktopLocalModeEnabled,
+} from "./desktop-local-mode"
+import { readStoredDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
+
+beforeEach(() => {
+  const values = new Map<string, string>()
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    },
+  })
+  window.openSweDesktop = undefined
+})
+
+describe("desktop local mode", () => {
+  it("is unavailable outside the desktop app", () => {
+    window.localStorage.setItem(DESKTOP_LOCAL_MODE_STORAGE_KEY, "true")
+    expect(isDesktopLocalModeEnabled()).toBe(false)
+  })
+
+  it("persists local-only mode and selects This Mac", () => {
+    window.openSweDesktop = { isDesktop: true } as Window["openSweDesktop"]
+
+    enableDesktopLocalMode()
+
+    expect(isDesktopLocalModeEnabled()).toBe(true)
+    expect(window.localStorage.getItem(DESKTOP_LOCAL_MODE_STORAGE_KEY)).toBe(
+      "true"
+    )
+    expect(readStoredDesktopThreadSource()).toBe("local")
+  })
+})

--- a/ui/src/lib/desktop-local-mode.ts
+++ b/ui/src/lib/desktop-local-mode.ts
@@ -1,0 +1,18 @@
+import { writeStoredDesktopThreadSource } from "@/features/agents/lib/desktopThreadSource"
+
+export const DESKTOP_LOCAL_MODE_STORAGE_KEY =
+  "open-swe.desktop.local-mode-without-sign-in"
+
+export function isDesktopLocalModeEnabled(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    Boolean(window.openSweDesktop) &&
+    window.localStorage.getItem(DESKTOP_LOCAL_MODE_STORAGE_KEY) === "true"
+  )
+}
+
+export function enableDesktopLocalMode(): void {
+  if (typeof window === "undefined" || !window.openSweDesktop) return
+  window.localStorage.setItem(DESKTOP_LOCAL_MODE_STORAGE_KEY, "true")
+  writeStoredDesktopThreadSource("local")
+}

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -20,11 +20,9 @@ export function useProfile() {
 }
 
 export function useOptions() {
-  const session = useSession()
   return useQuery({
     queryKey: ["options"],
     queryFn: api.options,
-    enabled: !!session.data,
   })
 }
 

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -4,6 +4,7 @@ export type Theme = "light" | "dark" | "system"
 export type ResolvedTheme = "light" | "dark"
 
 export const THEME_STORAGE_KEY = "open-swe-theme"
+const THEME_CHANGE_EVENT = "open-swe-theme-change"
 
 function isTheme(value: string | null): value is Theme {
   return value === "light" || value === "dark" || value === "system"
@@ -39,11 +40,15 @@ export function useTheme() {
   const themeRef = useRef<Theme>("system")
 
   useEffect(() => {
-    const stored = readStoredTheme()
-    themeRef.current = stored
-    setThemeState(stored)
-    setResolvedTheme(resolveTheme(stored))
-    applyTheme(resolveTheme(stored))
+    const syncPreference = () => {
+      const stored = readStoredTheme()
+      const resolved = resolveTheme(stored)
+      themeRef.current = stored
+      setThemeState(stored)
+      setResolvedTheme(resolved)
+      applyTheme(resolved)
+    }
+    syncPreference()
 
     const media = window.matchMedia("(prefers-color-scheme: dark)")
     const onChange = () => {
@@ -53,12 +58,17 @@ export function useTheme() {
       applyTheme(next)
     }
     media.addEventListener("change", onChange)
-    return () => media.removeEventListener("change", onChange)
+    window.addEventListener(THEME_CHANGE_EVENT, syncPreference)
+    return () => {
+      media.removeEventListener("change", onChange)
+      window.removeEventListener(THEME_CHANGE_EVENT, syncPreference)
+    }
   }, [])
 
   const setTheme = useCallback((next: Theme) => {
     if (typeof window !== "undefined") {
       window.localStorage.setItem(THEME_STORAGE_KEY, next)
+      window.dispatchEvent(new Event(THEME_CHANGE_EVENT))
     }
     themeRef.current = next
     const resolved = resolveTheme(next)

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import type { QueryClient } from "@tanstack/react-query"
 import appCss from "../styles.css?url"
 import { AppCommandProvider } from "@/lib/appCommands"
 import { resolveSessionOnServer } from "@/lib/session-ssr"
+import { ThemeSync } from "@/lib/ThemeSync"
 import { apiWarmupScript } from "@/features/agents/lib/apiWarmup"
 
 const themeInitScript = `(function(){try{var t=localStorage.getItem("open-swe-theme");var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
@@ -66,6 +67,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
+        <ThemeSync />
         <QueryClientProvider client={queryClient}>
           <AppCommandProvider>{children ?? <Outlet />}</AppCommandProvider>
           {import.meta.env.VITE_DEVTOOLS !== "false" && (

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { AgentThreadStreamProvider } from "@/features/agents/lib/AgentThreadStreamProvider"
 import { RequireLogin } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
+import { isDesktopLocalModeEnabled } from "@/lib/desktop-local-mode"
 
 export const Route = createFileRoute("/agents")({
   component: AgentsLayout,
@@ -45,6 +46,11 @@ function AgentsLayout() {
       : undefined
   const activeLocalSessionId =
     section === "agents" && threadId === "local" ? nestedRoute : undefined
+  const localOnly = !session.data && isDesktopLocalModeEnabled()
+  const isLocalRoute =
+    pathname === "/agents" ||
+    pathname === "/agents/" ||
+    pathname.startsWith("/agents/local/")
 
   if (session.isLoading) {
     return (
@@ -54,11 +60,12 @@ function AgentsLayout() {
     )
   }
 
-  if (!session.data) return <RequireLogin />
+  if (!session.data && (!localOnly || !isLocalRoute)) return <RequireLogin />
 
   return (
     <AgentsShell
-      user={session.data}
+      user={session.data ?? null}
+      localOnly={localOnly}
       activeThreadId={activeThreadId}
       activeLocalSessionId={activeLocalSessionId}
     >

--- a/ui/src/routes/login.tsx
+++ b/ui/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { Link, createFileRoute } from "@tanstack/react-router"
 import { useEffect, useMemo } from "react"
 
 import { buttonVariants } from "@/components/ui/button"
@@ -19,6 +19,7 @@ import {
 } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
 import { cn } from "@/lib/utils"
+import { enableDesktopLocalMode } from "@/lib/desktop-local-mode"
 
 type LoginSearch = { redirect?: string }
 
@@ -44,6 +45,8 @@ function Login() {
     () => (session.data ? consumeAuthRedirect(redirectParam) : null),
     [redirectParam, session.data]
   )
+  const isDesktop =
+    typeof window !== "undefined" && Boolean(window.openSweDesktop)
 
   if (session.isLoading) {
     return (
@@ -68,13 +71,25 @@ function Login() {
             runs.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="flex flex-col gap-3">
           <a
             href={loginUrl(intendedPath)}
             className={cn(buttonVariants({ size: "lg" }), "w-full")}
           >
             Continue with GitHub
           </a>
+          {isDesktop && (
+            <Link
+              to="/agents"
+              onClick={enableDesktopLocalMode}
+              className={cn(
+                buttonVariants({ size: "lg", variant: "outline" }),
+                "w-full"
+              )}
+            >
+              Continue in local mode
+            </Link>
+          )}
         </CardContent>
       </Card>
     </main>

--- a/uv.lock
+++ b/uv.lock
@@ -2124,7 +2124,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.2" },
     { name = "langchain-mcp-adapters", specifier = ">=0.3.1" },
     { name = "langchain-modal", specifier = ">=0.0.6" },
-    { name = "langchain-openai", specifier = ">=1.4.1" },
+    { name = "langchain-openai", specifier = ">=1.4.1,<2.0.0" },
     { name = "langchain-runloop", specifier = ">=0.0.7" },
     { name = "langgraph", specifier = ">=1.2.10" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.31" },


### PR DESCRIPTION
## Summary

- add account-based desktop sign-in and a skip-login local mode
- add a single-command desktop development target without opening a browser
- follow the system theme while preserving explicit appearance choices
- keep provider credentials out of task shell environments

## Testing

- `pnpm --dir desktop test`
- `pnpm --dir desktop typecheck`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui exec vitest run src/lib/ThemeSync.test.tsx`
- `uv run pytest -q tests/models/test_openai_oauth.py tests/sandbox/test_local_integration.py tests/agent/test_desktop.py`
