### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -87,6 +87,16 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "default_effort": "high",
         "supports_images": False,
     },
+    {
+        "id": "orcarouter:auto",
+        "label": "OrcaRouter Auto",
+        # OrcaRouter routes the selected effort to a reasoning upstream model
+        # when available; ``none`` disables reasoning. ``supports_images`` is
+        # False because the smart-routed gateway may land on a text-only model.
+        "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+        "default_effort": "high",
+        "supports_images": False,
+    },
 ]
 
 SUPPORTED_MODEL_IDS: frozenset[str] = frozenset(m["id"] for m in SUPPORTED_MODELS)

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -9,6 +9,16 @@ from .gateway import gateway_env_default, gateway_overrides
 
 OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 
+# OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible model gateway
+# that routes a single API key across many upstream models. Like OpenRouter it
+# accepts Chat Completions at ``/v1``, so the ``openai:`` ChatOpenAI transport
+# is reused with ``model_provider="openai"`` and a bare ``orcarouter/...`` model
+# id. ``orcarouter:`` keeps the repo's ``provider:model`` id convention; the
+# prefix is stripped in ``make_model`` because ``init_chat_model`` would
+# otherwise reject the ``orcarouter`` provider.
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+ORCAROUTER_MODEL_PREFIX = "orcarouter:"
+
 # Anthropic SDK default is 2; a 529 burst can outlive that. Bump to give the
 # primary provider a fair chance before the fallback middleware kicks in.
 DEFAULT_MAX_RETRIES = 6
@@ -19,7 +29,7 @@ DEFAULT_MAX_RETRIES = 6
 # max-effort reasoning on a long context, and let ``max_retries`` above turn a
 # stall into a retry instead of a dead run.
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 600.0
-_TIMEOUT_PROVIDER_PREFIXES = ("openai:", "anthropic:", "google_genai:", "fireworks:")
+_TIMEOUT_PROVIDER_PREFIXES = ("openai:", "anthropic:", "google_genai:", "fireworks:", "orcarouter:")
 
 _MODEL_CACHE: dict[
     tuple[str, bool | None, int | None, tuple[tuple[str, str], ...], int | None], Any
@@ -140,6 +150,24 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
             or OPENAI_RESPONSES_WS_BASE_URL
         )
         model_kwargs["use_responses_api"] = True
+
+    # OrcaRouter talks Chat Completions over ``/v1`` — the ChatOpenAI transport
+    # with an explicit ``model_provider`` and a bare ``orcarouter/...`` model id.
+    # The api key comes from ORCAROUTER_API_KEY (required); the base URL is
+    # overridable via ORCAROUTER_BASE_URL for self-hosted/regional gateways.
+    if model_id.startswith(ORCAROUTER_MODEL_PREFIX):
+        orcarouter_model = model_id[len(ORCAROUTER_MODEL_PREFIX) :]
+        if "/" not in orcarouter_model:
+            orcarouter_model = f"orcarouter/{orcarouter_model}"
+        model_kwargs["model_provider"] = "openai"
+        model_kwargs["base_url"] = os.environ.get("ORCAROUTER_BASE_URL") or ORCAROUTER_BASE_URL
+        model_kwargs["api_key"] = os.environ.get("ORCAROUTER_API_KEY")
+        if model_kwargs["api_key"] is None:
+            raise ValueError(
+                "ORCAROUTER_API_KEY is required for configured model "
+                f"{model_id} (get one at https://www.orcarouter.ai)"
+            )
+        model_id = orcarouter_model
 
     enabled = gateway_env_default() if use_gateway is None else use_gateway
     if enabled:
@@ -300,6 +328,13 @@ def provider_model_kwargs(
         effort = fireworks_reasoning_effort_for(profile_effort)
         if effort is not None:
             kwargs["model_kwargs"] = {"reasoning_effort": effort}
+    elif model_id.startswith(ORCAROUTER_MODEL_PREFIX):
+        # OrcaRouter proxies upstream Chat Completions and honors a
+        # ``reasoning_effort`` request field on reasoning models. Pass the
+        # selected effort straight through; ``none`` disables reasoning.
+        effort = fireworks_reasoning_effort_for(profile_effort)
+        if effort is not None:
+            kwargs["reasoning_effort"] = effort
     return kwargs
 
 
@@ -327,3 +362,5 @@ def validate_local_dev_llm_config() -> None:
         raise ValueError(f"GROQ_API_KEY is required for configured model {model_id}")
     elif model_id.startswith("fireworks:") and not os.environ.get("FIREWORKS_API_KEY"):
         raise ValueError(f"FIREWORKS_API_KEY is required for configured model {model_id}")
+    elif model_id.startswith(ORCAROUTER_MODEL_PREFIX) and not os.environ.get("ORCAROUTER_API_KEY"):
+        raise ValueError(f"ORCAROUTER_API_KEY is required for configured model {model_id}")

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -12,6 +12,7 @@ const PROVIDER_KEYS = {
   fireworks: ["FIREWORKS_API_KEY"],
   google_genai: ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
   openai: ["OPENAI_API_KEY"],
+  orcarouter: ["ORCAROUTER_API_KEY"],
 }
 
 function devBackendTarget({ repoRoot, port, env = process.env }) {

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -56,6 +56,14 @@ test("reports whether the selected provider is configured", () => {
     available: true,
     variable: "GEMINI_API_KEY",
   })
+  assert.deepEqual(modelCredentialStatus("orcarouter:auto", {}), {
+    available: false,
+    variable: "ORCAROUTER_API_KEY",
+  })
+  assert.deepEqual(modelCredentialStatus("orcarouter:auto", { ORCAROUTER_API_KEY: "secret" }), {
+    available: true,
+    variable: "ORCAROUTER_API_KEY",
+  })
   assert.deepEqual(modelCredentialStatus("custom:test", {}), {
     available: true,
     variable: null,

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -164,6 +164,9 @@ model = make_model("openai:gpt-5.6-sol", max_tokens=128_000, reasoning={"effort"
 
 # Google
 model = make_model("google_genai:gemini-2.5-pro", temperature=0, max_tokens=16_000)
+
+# OrcaRouter (OpenAI-compatible model gateway; set ORCAROUTER_API_KEY)
+model = make_model("orcarouter:auto", max_tokens=16_000, reasoning_effort="high")
 ```
 
 The `make_model()` helper in `agent/utils/model.py` wraps `langchain.chat_models.init_chat_model`. For OpenAI models, it automatically enables the Responses API. For full control, pass a pre-configured model instance directly:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -467,6 +467,8 @@ OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dicta
 # OPENAI_BASE_URL="https://api.openai.com/v1"  # Optional OpenAI-compatible API base URL
 GOOGLE_API_KEY=""                      # Google AI API key (when using google_genai: models)
 FIREWORKS_API_KEY=""                   # Fireworks API key (when using fireworks: models)
+ORCAROUTER_API_KEY=""                  # OrcaRouter API key (when using orcarouter: models)
+# ORCAROUTER_BASE_URL="https://api.orcarouter.ai/v1"  # Optional OrcaRouter base URL override
 # Voice dictation uses this OpenAI configuration.
 # Admins choose its transcription model in the dashboard Admin page.
 

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -13,6 +13,7 @@ from agent.dashboard.options import (
     fable_disabled_fallback,
     gate_fable_model,
     model_profile_context_window,
+    model_supports_effort,
     models_with_profile_context_windows,
     provider_fallback_pair,
 )
@@ -307,3 +308,10 @@ def test_fable_disabled_fallback_is_non_fable_anthropic() -> None:
     assert model == SUPPORTED_ANTHROPIC
     assert model not in FABLE_MODEL_IDS
     assert effort == "high"
+
+
+def test_orcarouter_auto_is_supported_selectable_model() -> None:
+    assert "orcarouter:auto" in SUPPORTED_MODEL_IDS
+    assert any(m["id"] == "orcarouter:auto" for m in SUPPORTED_MODELS)
+    assert model_supports_effort("orcarouter:auto", "high")
+    assert model_supports_effort("orcarouter:auto", "none")

--- a/tests/models/test_orcarouter_provider.py
+++ b/tests/models/test_orcarouter_provider.py
@@ -1,0 +1,96 @@
+"""Tests for the OrcaRouter named provider in agent.utils.model."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent.utils import model
+
+ORCAROUTER = "orcarouter:auto"
+
+
+def _capture() -> tuple[dict[str, Any], Any]:
+    captured: dict[str, Any] = {}
+
+    def _fake(model: str, **kwargs: Any) -> str:
+        captured["model"] = model
+        captured.update(kwargs)
+        return "MODEL"
+
+    return captured, _fake
+
+
+def _make_model(model_id: str, **kwargs: Any) -> dict[str, Any]:
+    model._MODEL_CACHE.clear()
+    captured, fake = _capture()
+    with patch.object(model, "init_chat_model", fake):
+        model.make_model(model_id, use_gateway=False, **kwargs)
+    return captured
+
+
+def test_orcarouter_routes_through_openai_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    captured = _make_model(ORCAROUTER)
+    assert captured["model"] == "orcarouter/auto"
+    assert captured["model_provider"] == "openai"
+    assert captured["base_url"] == model.ORCAROUTER_BASE_URL
+    assert captured["api_key"] == "sk-orca-test"
+
+
+def test_orcarouter_bare_model_gets_namespace_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    captured = _make_model("orcarouter:auto")
+    assert captured["model"] == "orcarouter/auto"
+
+
+def test_orcarouter_explicit_provider_model_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    # A provider/model id with a slash is routed directly by OrcaRouter, so the
+    # ``orcarouter/`` namespace prefix is not added.
+    captured = _make_model("orcarouter:deepseek/deepseek-v4-pro")
+    assert captured["model"] == "deepseek/deepseek-v4-pro"
+
+
+def test_orcarouter_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="ORCAROUTER_API_KEY is required"):
+        _make_model(ORCAROUTER)
+
+
+def test_orcarouter_base_url_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.setenv("ORCAROUTER_BASE_URL", "https://orcarouter.example/v1")
+    captured = _make_model(ORCAROUTER)
+    assert captured["base_url"] == "https://orcarouter.example/v1"
+
+
+def test_orcarouter_gets_default_request_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    captured = _make_model(ORCAROUTER)
+    assert captured["timeout"] == model.DEFAULT_REQUEST_TIMEOUT_SECONDS
+    assert captured["max_retries"] == model.DEFAULT_MAX_RETRIES
+
+
+def test_orcarouter_provider_kwargs_maps_effort() -> None:
+    kwargs = model.provider_model_kwargs(ORCAROUTER, "high", max_tokens=1000)
+    assert kwargs["reasoning_effort"] == "high"
+
+
+def test_orcarouter_provider_kwargs_none_disables_reasoning() -> None:
+    kwargs = model.provider_model_kwargs(ORCAROUTER, "none", max_tokens=1000)
+    assert kwargs["reasoning_effort"] == "none"
+
+
+def test_orcarouter_provider_kwargs_no_effort_is_empty() -> None:
+    kwargs = model.provider_model_kwargs(ORCAROUTER, None, max_tokens=1000)
+    assert kwargs == {"max_tokens": 1000}
+
+
+def test_validate_local_dev_llm_config_requires_orca_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://localhost:8000")
+    monkeypatch.setenv("LLM_MODEL_ID", ORCAROUTER)
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ORCAROUTER_API_KEY is required"):
+        model.validate_local_dev_llm_config()


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a named OpenAI-compatible provider.

[OrcaRouter](https://www.orcarouter.ai) is a model gateway that routes a single API key across many upstream models (Anthropic, OpenAI, DeepSeek, Google, and more) through a Chat Completions-compatible endpoint at `https://api.orcarouter.ai/v1`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why

Open SWE's model layer already supports OpenAI, Anthropic, Google, and Fireworks through `init_chat_model`. OrcaRouter slots into the same `provider:model` convention (`orcarouter:auto`) and reuses the existing ChatOpenAI transport, so users can select it from the dashboard and point a single key at the whole upstream catalog.

## What changed

- **`agent/utils/model.py`** — new `orcarouter:` branch in `make_model`: routes through the ChatOpenAI transport with `model_provider="openai"`, `base_url=https://api.orcarouter.ai/v1` (overridable via `ORCAROUTER_BASE_URL`), and `api_key` from `ORCAROUTER_API_KEY`. A bare `orcarouter:auto` gets the `orcarouter/` namespace prefix; a `provider/model` id like `orcarouter:deepseek/deepseek-v4-pro` is passed through unchanged. `provider_model_kwargs` maps the selected effort to `reasoning_effort`; `validate_local_dev_llm_config` enforces the key.
- **`agent/dashboard/options.py`** — `SUPPORTED_MODELS` entry `orcarouter:auto` ("OrcaRouter Auto"), so it's selectable in the dashboard model picker and accepted by profile/team-settings validation.
- **`desktop/src/backend-supervisor.cjs`** — `PROVIDER_KEYS` entry so the desktop app reports `ORCAROUTER_API_KEY` as the required credential for `orcarouter:` models.
- **Docs** — `docs/INSTALLATION.md` env block and `docs/CUSTOMIZATION.md` switching-models example.
- **Tests** — new `tests/models/test_orcarouter_provider.py` (10 unit tests covering transport routing, base URL override, missing key, timeout, and effort mapping) plus an `orcarouter:auto` registry assertion and a desktop credential-status case.

## Verification

- `ruff check .` and `ruff format . --check` — clean.
- Affected tests pass: `tests/models/test_orcarouter_provider.py`, `tests/models/test_model_fallback_resolution.py`, `tests/models/test_model_request_timeout.py`, `tests/dashboard/test_dashboard_thread_api.py` (148 passed). `tests/sandbox/test_gateway.py` and `tests/models/test_agent_subagent_models.py` have pre-existing collection errors on a clean base (`fireworks` / `markdownify` not installed locally) — unrelated to this change.
- Desktop: `node --test test/backend-supervisor.test.cjs` — 6/6 passed.
- **L3 live test** — with a real OrcaRouter key, `make_model("orcarouter:auto")` (reasoning_effort=high) and `make_model("orcarouter:deepseek/deepseek-v4-pro")` both returned HTTP 200 from `https://api.orcarouter.ai/v1/chat/completions`.

Disclosure: I'm an engineer on the OrcaRouter team.
