### PR TITLE
feat: configure environment sandbox creation

### DIFF
--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -24,7 +24,7 @@ import logging
 import os
 import re
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from langgraph_sdk import get_client
 from pydantic import BaseModel, Field, field_validator
@@ -37,6 +37,13 @@ ENVIRONMENTS_NAMESPACE: list[str] = ["environments"]
 DEFAULT_ENVIRONMENT_SLUG = "default"
 
 SnapshotStatus = Literal["none", "capturing", "ready", "failed"]
+
+
+class SandboxResources(TypedDict, total=False):
+    mem_bytes: int
+    vcpus: int
+    fs_capacity_bytes: int
+
 
 NAME_MAX_CHARS = 80
 PROMPT_MAX_CHARS = 20_000
@@ -118,6 +125,9 @@ class EnvironmentCreate(BaseModel):
     name: str
     prompt: str = ""
     repos: list[str] = Field(default_factory=list)
+    mem_bytes: int | None = Field(default=None, gt=0)
+    vcpus: int | None = Field(default=None, gt=0)
+    fs_capacity_bytes: int | None = Field(default=None, gt=0)
 
     @field_validator("name")
     @classmethod
@@ -141,6 +151,9 @@ class EnvironmentUpdate(BaseModel):
     name: str | None = None
     prompt: str | None = None
     repos: list[str] | None = None
+    mem_bytes: int | None = Field(default=None, gt=0)
+    vcpus: int | None = Field(default=None, gt=0)
+    fs_capacity_bytes: int | None = Field(default=None, gt=0)
 
     @field_validator("name")
     @classmethod
@@ -204,6 +217,9 @@ async def create_environment(create: EnvironmentCreate, created_by: str) -> dict
         "name": create.name.strip(),
         "prompt": create.prompt,
         "repos": create.repos,
+        "mem_bytes": create.mem_bytes,
+        "vcpus": create.vcpus,
+        "fs_capacity_bytes": create.fs_capacity_bytes,
         "snapshot_id": None,
         "snapshot_name": None,
         "snapshot_status": "none",
@@ -231,6 +247,9 @@ async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, 
         record["prompt"] = update.prompt
     if update.repos is not None:
         record["repos"] = update.repos
+    for field in ("mem_bytes", "vcpus", "fs_capacity_bytes"):
+        if field in update.model_fields_set:
+            record[field] = getattr(update, field)
     await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
     return record
 
@@ -328,6 +347,17 @@ def environment_prompt(record: dict[str, Any] | None) -> str | None:
         return None
     prompt = record.get("prompt")
     return prompt.strip() or None if isinstance(prompt, str) else None
+
+
+def environment_sandbox_resources(record: dict[str, Any] | None) -> SandboxResources:
+    if not record:
+        return {}
+    resources: SandboxResources = {}
+    for field in ("mem_bytes", "vcpus", "fs_capacity_bytes"):
+        value = record.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            resources[field] = value
+    return resources
 
 
 async def _set_snapshot_state(

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -20,6 +20,7 @@ whose snapshot is not ready, runs fall back to the per-repo snapshot and then to
 the configured base snapshot.
 """
 
+import json
 import logging
 import os
 import re
@@ -27,7 +28,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal, TypedDict
 
 from langgraph_sdk import get_client
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, JsonValue, field_validator
 
 from .review_styles import normalize_repo_full_name
 
@@ -48,9 +49,26 @@ class SandboxResources(TypedDict, total=False):
 NAME_MAX_CHARS = 80
 PROMPT_MAX_CHARS = 20_000
 MAX_REPOS = 50
+CREATE_PARAMS_MAX_CHARS = 20_000
 CAPTURE_NAME_ATTEMPTS = 5
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+_SENSITIVE_CREATE_PARAM_KEYS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "authorization",
+        "cookie",
+        "credential",
+        "credentials",
+        "password",
+        "pat",
+        "private_key",
+        "secret",
+        "token",
+    }
+)
+_SENSITIVE_HEADER_NAMES = frozenset({"authorization", "cookie", "proxy-authorization", "x-api-key"})
 # `env:my-box` anywhere in a message, as a whole word.
 _ENV_TAG_RE = re.compile(r"(?:(?<=\s)|^)env:([A-Za-z0-9][A-Za-z0-9._-]*)(?=\s|$)")
 
@@ -121,6 +139,43 @@ def _validate_repos(value: list[str] | None) -> list[str]:
     return list(dict.fromkeys(normalize_repo_full_name(entry) for entry in value))
 
 
+def _has_sensitive_create_param(value: JsonValue) -> bool:
+    if isinstance(value, dict):
+        header_name = value.get("name")
+        if isinstance(header_name, str) and header_name.strip().lower() in _SENSITIVE_HEADER_NAMES:
+            return True
+        for key, nested in value.items():
+            snake_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key.strip())
+            normalized = re.sub(r"[^a-z0-9]+", "_", snake_key.lower()).strip("_")
+            parts = set(normalized.split("_"))
+            if normalized in _SENSITIVE_CREATE_PARAM_KEYS or parts & _SENSITIVE_CREATE_PARAM_KEYS:
+                return True
+            if _has_sensitive_create_param(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_has_sensitive_create_param(item) for item in value)
+    return False
+
+
+def _validate_create_params(value: dict[str, JsonValue] | None) -> dict[str, JsonValue]:
+    params = value or {}
+    proxy_config = params.get("proxy_config")
+    if proxy_config is not None:
+        if not isinstance(proxy_config, dict):
+            raise ValueError("create_params.proxy_config must be a JSON object")
+        if "rules" in proxy_config and not isinstance(proxy_config["rules"], list):
+            raise ValueError("create_params.proxy_config.rules must be a JSON array")
+    try:
+        serialized = json.dumps(params, allow_nan=False, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("create_params must contain only valid JSON values") from exc
+    if len(serialized) > CREATE_PARAMS_MAX_CHARS:
+        raise ValueError(f"create_params must be at most {CREATE_PARAMS_MAX_CHARS} JSON characters")
+    if _has_sensitive_create_param(params):
+        raise ValueError("create_params must not contain secrets or authentication credentials")
+    return params
+
+
 class EnvironmentCreate(BaseModel):
     name: str
     prompt: str = ""
@@ -128,6 +183,7 @@ class EnvironmentCreate(BaseModel):
     mem_bytes: int | None = Field(default=None, gt=0)
     vcpus: int | None = Field(default=None, gt=0)
     fs_capacity_bytes: int | None = Field(default=None, gt=0)
+    create_params: dict[str, JsonValue] = Field(default_factory=dict)
 
     @field_validator("name")
     @classmethod
@@ -144,6 +200,11 @@ class EnvironmentCreate(BaseModel):
     def _check_repos(cls, v: list[str]) -> list[str]:
         return _validate_repos(v)
 
+    @field_validator("create_params")
+    @classmethod
+    def _check_create_params(cls, v: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        return _validate_create_params(v)
+
 
 class EnvironmentUpdate(BaseModel):
     """Partial update: only the fields present are written."""
@@ -154,6 +215,7 @@ class EnvironmentUpdate(BaseModel):
     mem_bytes: int | None = Field(default=None, gt=0)
     vcpus: int | None = Field(default=None, gt=0)
     fs_capacity_bytes: int | None = Field(default=None, gt=0)
+    create_params: dict[str, JsonValue] | None = None
 
     @field_validator("name")
     @classmethod
@@ -169,6 +231,11 @@ class EnvironmentUpdate(BaseModel):
     @classmethod
     def _check_repos(cls, v: list[str] | None) -> list[str] | None:
         return None if v is None else _validate_repos(v)
+
+    @field_validator("create_params")
+    @classmethod
+    def _check_create_params(cls, v: dict[str, JsonValue] | None) -> dict[str, JsonValue] | None:
+        return None if v is None else _validate_create_params(v)
 
 
 def _client():
@@ -220,6 +287,7 @@ async def create_environment(create: EnvironmentCreate, created_by: str) -> dict
         "mem_bytes": create.mem_bytes,
         "vcpus": create.vcpus,
         "fs_capacity_bytes": create.fs_capacity_bytes,
+        "create_params": create.create_params,
         "snapshot_id": None,
         "snapshot_name": None,
         "snapshot_status": "none",
@@ -247,7 +315,7 @@ async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, 
         record["prompt"] = update.prompt
     if update.repos is not None:
         record["repos"] = update.repos
-    for field in ("mem_bytes", "vcpus", "fs_capacity_bytes"):
+    for field in ("mem_bytes", "vcpus", "fs_capacity_bytes", "create_params"):
         if field in update.model_fields_set:
             record[field] = getattr(update, field)
     await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
@@ -358,6 +426,23 @@ def environment_sandbox_resources(record: dict[str, Any] | None) -> SandboxResou
         if isinstance(value, int) and not isinstance(value, bool) and value > 0:
             resources[field] = value
     return resources
+
+
+def environment_sandbox_create_params(
+    record: dict[str, Any] | None,
+) -> dict[str, JsonValue]:
+    if not record:
+        return {}
+    value = record.get("create_params")
+    if not isinstance(value, dict):
+        return {}
+    try:
+        return _validate_create_params(value)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid sandbox create params for environment %s", record.get("slug")
+        )
+        return {}
 
 
 async def _set_snapshot_state(

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -68,7 +68,30 @@ _SENSITIVE_CREATE_PARAM_KEYS = frozenset(
         "token",
     }
 )
-_SENSITIVE_HEADER_NAMES = frozenset({"authorization", "cookie", "proxy-authorization", "x-api-key"})
+_SENSITIVE_CREATE_PARAM_SUFFIXES = (
+    "_api_key",
+    "_apikey",
+    "_authorization",
+    "_cookie",
+    "_credential",
+    "_credentials",
+    "_password",
+    "_pat",
+    "_private_key",
+    "_secret",
+    "_token",
+)
+_SENSITIVE_CREATE_PARAM_PREFIXES = (
+    "api_key_",
+    "authorization_",
+    "credential_",
+    "credentials_",
+    "password_",
+    "private_key_",
+    "secret_",
+    "token_",
+)
+_SENSITIVE_HEADER_NAMES = frozenset({"authorization", "cookie", "proxy_authorization", "x_api_key"})
 # `env:my-box` anywhere in a message, as a whole word.
 _ENV_TAG_RE = re.compile(r"(?:(?<=\s)|^)env:([A-Za-z0-9][A-Za-z0-9._-]*)(?=\s|$)")
 
@@ -139,16 +162,31 @@ def _validate_repos(value: list[str] | None) -> list[str]:
     return list(dict.fromkeys(normalize_repo_full_name(entry) for entry in value))
 
 
+def _normalize_create_param_name(value: str) -> str:
+    snake_value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value.strip())
+    return re.sub(r"[^a-z0-9]+", "_", snake_value.lower()).strip("_")
+
+
+def _is_sensitive_create_param_name(value: str) -> bool:
+    normalized = _normalize_create_param_name(value)
+    return (
+        normalized in _SENSITIVE_CREATE_PARAM_KEYS
+        or normalized.endswith(_SENSITIVE_CREATE_PARAM_SUFFIXES)
+        or normalized.startswith(_SENSITIVE_CREATE_PARAM_PREFIXES)
+    )
+
+
 def _has_sensitive_create_param(value: JsonValue) -> bool:
     if isinstance(value, dict):
         header_name = value.get("name")
-        if isinstance(header_name, str) and header_name.strip().lower() in _SENSITIVE_HEADER_NAMES:
-            return True
+        if isinstance(header_name, str):
+            normalized_header = _normalize_create_param_name(header_name)
+            if normalized_header in _SENSITIVE_HEADER_NAMES or _is_sensitive_create_param_name(
+                normalized_header
+            ):
+                return True
         for key, nested in value.items():
-            snake_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key.strip())
-            normalized = re.sub(r"[^a-z0-9]+", "_", snake_key.lower()).strip("_")
-            parts = set(normalized.split("_"))
-            if normalized in _SENSITIVE_CREATE_PARAM_KEYS or parts & _SENSITIVE_CREATE_PARAM_KEYS:
+            if _is_sensitive_create_param_name(key):
                 return True
             if _has_sensitive_create_param(nested):
                 return True

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -421,6 +421,9 @@ async def create_langsmith_sandbox(
     github_token: str | None = None,
     *,
     snapshot_id: str | None = None,
+    mem_bytes: int | None = None,
+    vcpus: int | None = None,
+    fs_capacity_bytes: int | None = None,
 ) -> SandboxBackendProtocol:
     """Create or connect to a LangSmith sandbox without automatic cleanup.
 
@@ -434,7 +437,10 @@ async def create_langsmith_sandbox(
         github_token: Optional GitHub token. Used to configure proxy auth on
                       new sandboxes. Ignored when connecting to an existing sandbox.
         snapshot_id: Optional repo-scoped snapshot to boot from. When omitted,
-                      falls back to DEFAULT_SANDBOX_SNAPSHOT_ID.
+            falls back to DEFAULT_SANDBOX_SNAPSHOT_ID.
+        mem_bytes: Optional memory capacity override for a newly-created sandbox.
+        vcpus: Optional virtual CPU count override for a newly-created sandbox.
+        fs_capacity_bytes: Optional filesystem capacity override for a newly-created sandbox.
 
     Returns:
         SandboxBackendProtocol instance
@@ -442,22 +448,30 @@ async def create_langsmith_sandbox(
     api_key = _get_sandbox_api_key()
     (
         default_snapshot_id,
-        fs_capacity_bytes,
-        vcpus,
-        mem_bytes,
+        default_fs_capacity_bytes,
+        default_vcpus,
+        default_mem_bytes,
         idle_ttl_seconds,
         delete_after_stop_seconds,
     ) = _get_sandbox_snapshot_config()
 
     effective_snapshot_id = snapshot_id or default_snapshot_id
+    if mem_bytes is None and vcpus is None:
+        effective_mem_bytes = default_mem_bytes
+        effective_vcpus = default_vcpus
+    else:
+        effective_mem_bytes = mem_bytes
+        effective_vcpus = vcpus
 
     provider = LangSmithProvider(api_key=api_key)
     backend = await provider.get_or_create(
         sandbox_id=sandbox_id,
         snapshot_id=effective_snapshot_id,
-        fs_capacity_bytes=fs_capacity_bytes,
-        vcpus=vcpus,
-        mem_bytes=mem_bytes,
+        fs_capacity_bytes=(
+            fs_capacity_bytes if fs_capacity_bytes is not None else default_fs_capacity_bytes
+        ),
+        vcpus=effective_vcpus,
+        mem_bytes=effective_mem_bytes,
         idle_ttl_seconds=idle_ttl_seconds,
         delete_after_stop_seconds=delete_after_stop_seconds,
     )

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -159,6 +159,13 @@ def _merge_sandbox_create_extra_fields(
     return {**_get_sandbox_create_extra_fields(), **(create_params or {})}
 
 
+def _get_sandbox_proxy_config(
+    create_params: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    proxy_config = _merge_sandbox_create_extra_fields(create_params).get("proxy_config")
+    return dict(proxy_config) if isinstance(proxy_config, dict) else None
+
+
 def _install_create_extra_fields(client: AsyncSandboxClient, extra: dict[str, Any]) -> None:
     """Merge ``extra`` into the JSON body of the sandbox-create request.
 
@@ -395,11 +402,7 @@ async def _configure_github_proxy(
         return
     langsmith_endpoint = _get_sandbox_endpoint()
     url = f"{langsmith_endpoint}/v2/sandboxes/boxes/{sandbox_name}"
-    if base_proxy_config is None:
-        global_proxy_config = _get_sandbox_create_extra_fields().get("proxy_config")
-        proxy_config = dict(global_proxy_config) if isinstance(global_proxy_config, dict) else {}
-    else:
-        proxy_config = dict(base_proxy_config)
+    proxy_config = dict(base_proxy_config or {})
     custom_rules = proxy_config.get("rules")
     proxy_config["rules"] = [
         *(custom_rules if isinstance(custom_rules, list) else []),
@@ -502,8 +505,8 @@ async def create_langsmith_sandbox(
     )
 
     if sandbox_id is None and github_token:
-        proxy_config = (create_params or {}).get("proxy_config")
-        if isinstance(proxy_config, dict):
+        proxy_config = _get_sandbox_proxy_config(create_params)
+        if proxy_config is not None:
             await _configure_github_proxy(
                 backend.id,
                 github_token,

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -153,6 +153,12 @@ def _get_sandbox_create_extra_fields() -> dict[str, Any]:
     return parsed
 
 
+def _merge_sandbox_create_extra_fields(
+    create_params: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {**_get_sandbox_create_extra_fields(), **(create_params or {})}
+
+
 def _install_create_extra_fields(client: AsyncSandboxClient, extra: dict[str, Any]) -> None:
     """Merge ``extra`` into the JSON body of the sandbox-create request.
 
@@ -366,7 +372,12 @@ async def _start_sandbox_best_effort(sandbox_name: str) -> None:
         await client.aclose()
 
 
-async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
+async def _configure_github_proxy(
+    sandbox_name: str,
+    github_token: str,
+    *,
+    base_proxy_config: dict[str, Any] | None = None,
+) -> None:
     """Configure sandbox proxy to inject GitHub auth for GitHub traffic.
 
     Uses the LangSmith proxy-config API to set up header injection so that
@@ -376,6 +387,7 @@ async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
     Args:
         sandbox_name: The sandbox name/ID returned by the LangSmith API.
         github_token: GitHub token to inject as Authorization header.
+        base_proxy_config: Additional persisted proxy settings to preserve.
     """
     api_key = _get_sandbox_api_key()
     if not api_key:
@@ -383,7 +395,17 @@ async def _configure_github_proxy(sandbox_name: str, github_token: str) -> None:
         return
     langsmith_endpoint = _get_sandbox_endpoint()
     url = f"{langsmith_endpoint}/v2/sandboxes/boxes/{sandbox_name}"
-    payload = {"proxy_config": {"rules": _github_proxy_rules(github_token)}}
+    if base_proxy_config is None:
+        global_proxy_config = _get_sandbox_create_extra_fields().get("proxy_config")
+        proxy_config = dict(global_proxy_config) if isinstance(global_proxy_config, dict) else {}
+    else:
+        proxy_config = dict(base_proxy_config)
+    custom_rules = proxy_config.get("rules")
+    proxy_config["rules"] = [
+        *(custom_rules if isinstance(custom_rules, list) else []),
+        *_github_proxy_rules(github_token),
+    ]
+    payload = {"proxy_config": proxy_config}
     async with httpx.AsyncClient(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:
         try:
             await _patch_proxy_config(client, url, payload, api_key, sandbox_name)
@@ -424,6 +446,7 @@ async def create_langsmith_sandbox(
     mem_bytes: int | None = None,
     vcpus: int | None = None,
     fs_capacity_bytes: int | None = None,
+    create_params: dict[str, Any] | None = None,
 ) -> SandboxBackendProtocol:
     """Create or connect to a LangSmith sandbox without automatic cleanup.
 
@@ -441,6 +464,7 @@ async def create_langsmith_sandbox(
         mem_bytes: Optional memory capacity override for a newly-created sandbox.
         vcpus: Optional virtual CPU count override for a newly-created sandbox.
         fs_capacity_bytes: Optional filesystem capacity override for a newly-created sandbox.
+        create_params: Optional additional fields merged into the sandbox create body.
 
     Returns:
         SandboxBackendProtocol instance
@@ -474,10 +498,19 @@ async def create_langsmith_sandbox(
         mem_bytes=effective_mem_bytes,
         idle_ttl_seconds=idle_ttl_seconds,
         delete_after_stop_seconds=delete_after_stop_seconds,
+        create_params=create_params,
     )
 
     if sandbox_id is None and github_token:
-        await _configure_github_proxy(backend.id, github_token)
+        proxy_config = (create_params or {}).get("proxy_config")
+        if isinstance(proxy_config, dict):
+            await _configure_github_proxy(
+                backend.id,
+                github_token,
+                base_proxy_config=proxy_config,
+            )
+        else:
+            await _configure_github_proxy(backend.id, github_token)
 
     return backend
 
@@ -647,6 +680,7 @@ class LangSmithProvider(SandboxProvider):
         mem_bytes: int | None = None,
         idle_ttl_seconds: int | None = None,
         delete_after_stop_seconds: int | None = None,
+        create_params: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> SandboxBackendProtocol:
         """Get existing or create new LangSmith sandbox.
@@ -673,7 +707,10 @@ class LangSmithProvider(SandboxProvider):
                 )
                 raise ValueError(msg)
 
-            _install_create_extra_fields(client, _get_sandbox_create_extra_fields())
+            _install_create_extra_fields(
+                client,
+                _merge_sandbox_create_extra_fields(create_params),
+            )
 
             try:
                 sandbox = await _create_sandbox_with_retry(

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -458,7 +458,7 @@ This is an admin thread. You have tools to manage environments — a named promp
 
 Build one by provisioning this sandbox and capturing it:
 
-1. `save_environment` to create or update the record (name, prompt, repos).
+1. `save_environment` to create or update the record (name, prompt, repos, and optional VM sizing). Memory and filesystem capacity are bytes; vCPUs are a count. Sizing applies when new sandboxes are created for that environment, not to this already-running admin sandbox. Use `clear_sizing` to restore provider defaults.
 2. Provision this sandbox with ordinary commands: clone the repos the environment covers, install toolchains and dependencies, warm caches. Everything on disk lands in the snapshot, so leave the sandbox in the state a run should start from.
 3. `capture_environment_snapshot` to snapshot this sandbox. Capture is slow; run it once the sandbox is fully provisioned rather than after each step.
 

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -458,7 +458,7 @@ This is an admin thread. You have tools to manage environments — a named promp
 
 Build one by provisioning this sandbox and capturing it:
 
-1. `save_environment` to create or update the record (name, prompt, repos, and optional VM sizing). Memory and filesystem capacity are bytes; vCPUs are a count. Sizing applies when new sandboxes are created for that environment, not to this already-running admin sandbox. Use `clear_sizing` to restore provider defaults.
+1. `save_environment` to create or update the record (name, prompt, repos, optional VM sizing, and optional additional create parameters). Memory and filesystem capacity are bytes; vCPUs are a count. Sizing and `create_params` apply when new sandboxes are created for that environment, not to this already-running admin sandbox. Use `clear_sizing` and `clear_create_params` to restore defaults. Create parameters are persisted: use them for non-sensitive settings such as `_internal_runtime` or proxy routing, never for tokens, credentials, or other secrets.
 2. Provision this sandbox with ordinary commands: clone the repos the environment covers, install toolchains and dependencies, warm caches. Everything on disk lands in the snapshot, so leave the sandbox in the state a run should start from.
 3. `capture_environment_snapshot` to snapshot this sandbox. Capture is slow; run it once the sandbox is fully provisioned rather than after each step.
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -55,6 +55,7 @@ from .dashboard.agent_usage import record_agent_thread_usage
 from .dashboard.environments import (
     SandboxResources,
     environment_prompt,
+    environment_sandbox_create_params,
     environment_sandbox_resources,
     environment_snapshot_id,
     resolve_environment,
@@ -308,13 +309,14 @@ async def _resolve_proxy_token(
 async def _resolve_sandbox_create_config(
     repo: dict[str, str] | None,
     environment_slug: str | None = None,
-) -> tuple[str | None, SandboxResources]:
-    """Resolve the snapshot and VM sizing a new sandbox uses."""
+) -> tuple[str | None, SandboxResources, dict[str, Any]]:
+    """Resolve the snapshot, VM sizing, and create parameters for a new sandbox."""
     environment = await resolve_environment(environment_slug)
     environment_snapshot = environment_snapshot_id(environment)
     resources = environment_sandbox_resources(environment)
+    create_params = environment_sandbox_create_params(environment)
     if environment_snapshot:
-        return environment_snapshot, resources
+        return environment_snapshot, resources, create_params
     if repo:
         try:
             repo_snapshot_id = await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
@@ -322,8 +324,8 @@ async def _resolve_sandbox_create_config(
             logger.debug("Failed to resolve repo-scoped snapshot", exc_info=True)
             repo_snapshot_id = None
         if repo_snapshot_id:
-            return repo_snapshot_id, resources
-    return await get_admin_base_snapshot_id(), resources
+            return repo_snapshot_id, resources, create_params
+    return await get_admin_base_snapshot_id(), resources, create_params
 
 
 async def _resolve_snapshot_id(
@@ -331,7 +333,7 @@ async def _resolve_snapshot_id(
     environment_slug: str | None = None,
 ) -> str | None:
     """Resolve the snapshot a new sandbox boots from."""
-    snapshot_id, _ = await _resolve_sandbox_create_config(repo, environment_slug)
+    snapshot_id, _, _ = await _resolve_sandbox_create_config(repo, environment_slug)
     return snapshot_id
 
 
@@ -344,8 +346,17 @@ async def _create_sandbox_with_proxy(
     environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
-    snapshot_id, resources = await _resolve_sandbox_create_config(repo, environment_slug)
-    sandbox_backend = await create_sandbox(snapshot_id=snapshot_id, **resources)
+    snapshot_id, resources, create_params = await _resolve_sandbox_create_config(
+        repo, environment_slug
+    )
+    if create_params:
+        sandbox_backend = await create_sandbox(
+            snapshot_id=snapshot_id,
+            create_params=create_params,
+            **resources,
+        )
+    else:
+        sandbox_backend = await create_sandbox(snapshot_id=snapshot_id, **resources)
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     if sandbox_type == "langsmith":
@@ -354,12 +365,21 @@ async def _create_sandbox_with_proxy(
             msg = "Cannot configure proxy: GitHub App installation token is unavailable"
             logger.error(msg)
             raise ValueError(msg)
-        await _configure_github_proxy(sandbox_backend.id, token)
+        proxy_config = create_params.get("proxy_config")
+        if isinstance(proxy_config, dict):
+            await _configure_github_proxy(
+                sandbox_backend.id,
+                token,
+                base_proxy_config=proxy_config,
+            )
+        else:
+            await _configure_github_proxy(sandbox_backend.id, token)
         record_proxy_token_expiry(
             thread_id,
             expires_at,
             repositories=github_proxy_repositories,
             permissions=permissions,
+            base_proxy_config=proxy_config if isinstance(proxy_config, dict) else None,
         )
 
     return sandbox_backend
@@ -371,6 +391,7 @@ async def _refresh_github_proxy(
     *,
     thread_id: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
+    environment_slug: str | None = None,
 ) -> None:
     """Refresh GitHub proxy credentials for reused LangSmith sandboxes."""
     if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
@@ -385,12 +406,23 @@ async def _refresh_github_proxy(
         return
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
-    await _configure_github_proxy(current_backend.id, token)
+    environment = await resolve_environment(environment_slug)
+    create_params = environment_sandbox_create_params(environment)
+    proxy_config = create_params.get("proxy_config")
+    if isinstance(proxy_config, dict):
+        await _configure_github_proxy(
+            current_backend.id,
+            token,
+            base_proxy_config=proxy_config,
+        )
+    else:
+        await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
         thread_id,
         expires_at,
         repositories=github_proxy_repositories,
         permissions=permissions,
+        base_proxy_config=proxy_config if isinstance(proxy_config, dict) else None,
     )
 
 
@@ -399,6 +431,7 @@ async def _refresh_github_proxy_or_fail(
     thread_id: str,
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
+    environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Refresh proxy credentials; a sandbox we can't reconfigure is unreachable."""
     try:
@@ -407,6 +440,7 @@ async def _refresh_github_proxy_or_fail(
             github_proxy_token,
             thread_id=thread_id,
             github_proxy_repositories=github_proxy_repositories,
+            environment_slug=environment_slug,
         )
     except Exception as exc:
         logger.warning(
@@ -433,6 +467,7 @@ async def _connect_existing_sandbox(
     sandbox_id: str | None,
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
+    environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Reuse the sandbox already bound to ``thread_id``, or fail unreachable.
 
@@ -453,7 +488,11 @@ async def _connect_existing_sandbox(
             logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
             raise SandboxUnreachableError(thread_id, sandbox_id, str(exc)) from exc
     return await _refresh_github_proxy_or_fail(
-        sandbox_backend, thread_id, github_proxy_token, github_proxy_repositories
+        sandbox_backend,
+        thread_id,
+        github_proxy_token,
+        github_proxy_repositories,
+        environment_slug,
     )
 
 
@@ -521,6 +560,7 @@ async def ensure_sandbox_for_thread(
                 sandbox_id=sandbox_id,
                 github_proxy_token=github_proxy_token,
                 github_proxy_repositories=github_proxy_repositories,
+                environment_slug=environment_slug,
             )
         except (SandboxGoneError, SandboxUnreachableError) as exc:
             gone = isinstance(exc, SandboxGoneError)

--- a/agent/server.py
+++ b/agent/server.py
@@ -83,7 +83,7 @@ from .input_messages import append_message_data
 from .integrations.corridor_mcp import load_corridor_tools
 from .integrations.currents_tools import load_currents_tools
 from .integrations.datadog_mcp import load_datadog_tools
-from .integrations.langsmith import _configure_github_proxy
+from .integrations.langsmith import _configure_github_proxy, _get_sandbox_proxy_config
 from .integrations.langsmith_tools import load_langsmith_tools
 from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
@@ -177,7 +177,7 @@ from .utils.dashboard_links import dashboard_base_url, dashboard_plan_url, dashb
 from .utils.deferred_model import make_deferred_error_model
 from .utils.github_app import get_github_app_installation_token_with_expiry
 from .utils.github_org_membership import is_user_active_org_member
-from .utils.github_proxy import record_proxy_token_expiry
+from .utils.github_proxy import get_recorded_proxy_base_config, record_proxy_token_expiry
 from .utils.json_types import as_json_object
 from .utils.model import (
     DEFAULT_LLM_REASONING,
@@ -195,6 +195,7 @@ from .utils.sandbox_state import (
     SandboxUnreachableError,
     get_or_create_sandbox_backend_proxy,
     get_sandbox_id_from_metadata,
+    get_sandbox_metadata,
     set_sandbox_backend,
     unwrap_sandbox_backend,
 )
@@ -209,6 +210,7 @@ from .utils.turn_checkpoint import merge_checkpoint, read_turn_diff, record_turn
 
 client = get_client()
 
+_SANDBOX_PROXY_CONFIG_METADATA_KEY = "sandbox_base_proxy_config"
 DEFAULT_TOOL_LOADER_TIMEOUT_SECONDS = 5.0
 USER_SKILLS_ROUTE = "/skills/"
 ORGANIZATION_SKILLS_ROUTE = "/organization-skills/"
@@ -365,8 +367,8 @@ async def _create_sandbox_with_proxy(
             msg = "Cannot configure proxy: GitHub App installation token is unavailable"
             logger.error(msg)
             raise ValueError(msg)
-        proxy_config = create_params.get("proxy_config")
-        if isinstance(proxy_config, dict):
+        proxy_config = _get_sandbox_proxy_config(create_params)
+        if proxy_config is not None:
             await _configure_github_proxy(
                 sandbox_backend.id,
                 token,
@@ -379,7 +381,7 @@ async def _create_sandbox_with_proxy(
             expires_at,
             repositories=github_proxy_repositories,
             permissions=permissions,
-            base_proxy_config=proxy_config if isinstance(proxy_config, dict) else None,
+            base_proxy_config=proxy_config,
         )
 
     return sandbox_backend
@@ -391,7 +393,7 @@ async def _refresh_github_proxy(
     *,
     thread_id: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
-    environment_slug: str | None = None,
+    base_proxy_config: dict[str, Any] | None = None,
 ) -> None:
     """Refresh GitHub proxy credentials for reused LangSmith sandboxes."""
     if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
@@ -406,14 +408,11 @@ async def _refresh_github_proxy(
         return
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
-    environment = await resolve_environment(environment_slug)
-    create_params = environment_sandbox_create_params(environment)
-    proxy_config = create_params.get("proxy_config")
-    if isinstance(proxy_config, dict):
+    if base_proxy_config is not None:
         await _configure_github_proxy(
             current_backend.id,
             token,
-            base_proxy_config=proxy_config,
+            base_proxy_config=base_proxy_config,
         )
     else:
         await _configure_github_proxy(current_backend.id, token)
@@ -422,7 +421,7 @@ async def _refresh_github_proxy(
         expires_at,
         repositories=github_proxy_repositories,
         permissions=permissions,
-        base_proxy_config=proxy_config if isinstance(proxy_config, dict) else None,
+        base_proxy_config=base_proxy_config,
     )
 
 
@@ -431,7 +430,7 @@ async def _refresh_github_proxy_or_fail(
     thread_id: str,
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
-    environment_slug: str | None = None,
+    base_proxy_config: dict[str, Any] | None = None,
 ) -> SandboxBackendProtocol:
     """Refresh proxy credentials; a sandbox we can't reconfigure is unreachable."""
     try:
@@ -440,7 +439,7 @@ async def _refresh_github_proxy_or_fail(
             github_proxy_token,
             thread_id=thread_id,
             github_proxy_repositories=github_proxy_repositories,
-            environment_slug=environment_slug,
+            base_proxy_config=base_proxy_config,
         )
     except Exception as exc:
         logger.warning(
@@ -467,7 +466,7 @@ async def _connect_existing_sandbox(
     sandbox_id: str | None,
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
-    environment_slug: str | None = None,
+    base_proxy_config: dict[str, Any] | None = None,
 ) -> SandboxBackendProtocol:
     """Reuse the sandbox already bound to ``thread_id``, or fail unreachable.
 
@@ -492,7 +491,7 @@ async def _connect_existing_sandbox(
         thread_id,
         github_proxy_token,
         github_proxy_repositories,
-        environment_slug,
+        base_proxy_config,
     )
 
 
@@ -541,6 +540,14 @@ async def ensure_sandbox_for_thread(
         else None
     )
     sandbox_id = await get_sandbox_id_from_metadata(thread_id)
+    sandbox_metadata = await get_sandbox_metadata(thread_id) if sandbox_id is not None else {}
+    metadata_proxy_config = sandbox_metadata.get(_SANDBOX_PROXY_CONFIG_METADATA_KEY)
+    base_proxy_config = (
+        metadata_proxy_config
+        if isinstance(metadata_proxy_config, dict)
+        else get_recorded_proxy_base_config(thread_id)
+    )
+    created_proxy_config: dict[str, Any] | None = None
 
     if sandbox_backend is None and sandbox_id is None:
         logger.info("Creating new sandbox for thread %s", thread_id)
@@ -551,6 +558,7 @@ async def ensure_sandbox_for_thread(
             repo=repo,
             environment_slug=environment_slug,
         )
+        created_proxy_config = get_recorded_proxy_base_config(thread_id)
         logger.info("Sandbox created: %s", sandbox_backend.id)
     else:
         try:
@@ -560,7 +568,7 @@ async def ensure_sandbox_for_thread(
                 sandbox_id=sandbox_id,
                 github_proxy_token=github_proxy_token,
                 github_proxy_repositories=github_proxy_repositories,
-                environment_slug=environment_slug,
+                base_proxy_config=base_proxy_config,
             )
         except (SandboxGoneError, SandboxUnreachableError) as exc:
             gone = isinstance(exc, SandboxGoneError)
@@ -580,6 +588,7 @@ async def ensure_sandbox_for_thread(
                     repo=repo,
                     environment_slug=environment_slug,
                 )
+                created_proxy_config = get_recorded_proxy_base_config(thread_id)
             except Exception as create_exc:
                 # Keep the failure typed so callers still recognize "this run has no
                 # sandbox" and can notify the user.
@@ -600,9 +609,10 @@ async def ensure_sandbox_for_thread(
     # that dies earlier leaves no id to reconnect to, so the next run creates
     # rather than adopting a half-built box.
     if sandbox_id != sandbox_backend.id:
-        await client.threads.update(
-            thread_id=thread_id, metadata={"sandbox_id": sandbox_backend.id}
-        )
+        sandbox_metadata: dict[str, Any] = {"sandbox_id": sandbox_backend.id}
+        if created_proxy_config is not None:
+            sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = created_proxy_config
+        await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
 
     # Publishing last is what makes a failure above visible. Callers reach the
     # proxy's cached backend without awaiting the startup task that produced it,
@@ -633,9 +643,13 @@ async def recreate_sandbox_for_thread(
         raise RuntimeError("Sandbox provider did not create a distinct sandbox")
 
     await _configure_git_identity(new_sandbox)
+    sandbox_metadata: dict[str, Any] = {"sandbox_id": new_sandbox.id}
+    base_proxy_config = get_recorded_proxy_base_config(thread_id)
+    if base_proxy_config is not None:
+        sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = base_proxy_config
     await client.threads.update(
         thread_id=thread_id,
-        metadata={"sandbox_id": new_sandbox.id},
+        metadata=sandbox_metadata,
     )
     set_sandbox_backend(thread_id, new_sandbox)
     logger.info(

--- a/agent/server.py
+++ b/agent/server.py
@@ -53,7 +53,9 @@ from .dashboard.agent_overrides import (
 )
 from .dashboard.agent_usage import record_agent_thread_usage
 from .dashboard.environments import (
+    SandboxResources,
     environment_prompt,
+    environment_sandbox_resources,
     environment_snapshot_id,
     resolve_environment,
 )
@@ -303,20 +305,16 @@ async def _resolve_proxy_token(
     return token, expires_at, None
 
 
-async def _resolve_snapshot_id(
+async def _resolve_sandbox_create_config(
     repo: dict[str, str] | None,
     environment_slug: str | None = None,
-) -> str | None:
-    """Resolve the snapshot a new sandbox boots from.
-
-    The run's environment (its selection, else ``default``) wins, then the repo's
-    built snapshot, then the admin-configured base snapshot. Never raises: any
-    failure resolves to ``None`` so sandbox creation falls back to the configured
-    ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
-    """
-    environment_snapshot = environment_snapshot_id(await resolve_environment(environment_slug))
+) -> tuple[str | None, SandboxResources]:
+    """Resolve the snapshot and VM sizing a new sandbox uses."""
+    environment = await resolve_environment(environment_slug)
+    environment_snapshot = environment_snapshot_id(environment)
+    resources = environment_sandbox_resources(environment)
     if environment_snapshot:
-        return environment_snapshot
+        return environment_snapshot, resources
     if repo:
         try:
             repo_snapshot_id = await resolve_repo_snapshot_id(repo.get("owner"), repo.get("name"))
@@ -324,8 +322,17 @@ async def _resolve_snapshot_id(
             logger.debug("Failed to resolve repo-scoped snapshot", exc_info=True)
             repo_snapshot_id = None
         if repo_snapshot_id:
-            return repo_snapshot_id
-    return await get_admin_base_snapshot_id()
+            return repo_snapshot_id, resources
+    return await get_admin_base_snapshot_id(), resources
+
+
+async def _resolve_snapshot_id(
+    repo: dict[str, str] | None,
+    environment_slug: str | None = None,
+) -> str | None:
+    """Resolve the snapshot a new sandbox boots from."""
+    snapshot_id, _ = await _resolve_sandbox_create_config(repo, environment_slug)
+    return snapshot_id
 
 
 async def _create_sandbox_with_proxy(
@@ -337,8 +344,8 @@ async def _create_sandbox_with_proxy(
     environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
-    snapshot_id = await _resolve_snapshot_id(repo, environment_slug)
-    sandbox_backend = await create_sandbox(snapshot_id=snapshot_id)
+    snapshot_id, resources = await _resolve_sandbox_create_config(repo, environment_slug)
+    sandbox_backend = await create_sandbox(snapshot_id=snapshot_id, **resources)
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     if sandbox_type == "langsmith":
@@ -531,6 +538,7 @@ async def ensure_sandbox_for_thread(
                     thread_id=thread_id,
                     github_proxy_repositories=github_proxy_repositories,
                     repo=repo,
+                    environment_slug=environment_slug,
                 )
             except Exception as create_exc:
                 # Keep the failure typed so callers still recognize "this run has no

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -46,6 +46,9 @@ def _summary(record: dict[str, Any]) -> dict[str, Any]:
         "slug": record.get("slug"),
         "prompt": record.get("prompt"),
         "repos": record.get("repos") or [],
+        "mem_bytes": record.get("mem_bytes"),
+        "vcpus": record.get("vcpus"),
+        "fs_capacity_bytes": record.get("fs_capacity_bytes"),
         "snapshot_status": record.get("snapshot_status"),
         "snapshot_id": record.get("snapshot_id"),
         "snapshot_name": record.get("snapshot_name"),
@@ -78,8 +81,12 @@ async def save_environment(
     name: str,
     prompt: str,
     repos: list[str] | None = None,
+    mem_bytes: int | None = None,
+    vcpus: int | None = None,
+    fs_capacity_bytes: int | None = None,
+    clear_sizing: bool = False,
 ) -> dict[str, Any]:
-    """Create an environment, or replace the prompt and repo list of an existing one.
+    """Create an environment, or update an existing one's configuration.
 
     Does not touch the environment's snapshot: capture that separately with
     ``capture_environment_snapshot`` once this sandbox is provisioned.
@@ -95,12 +102,26 @@ async def save_environment(
             whole text, not a delta. Empty string clears it.
         repos: Optional ``owner/repo`` list this environment covers, for the
             dashboard. Does not clone anything by itself.
+        mem_bytes: Optional memory capacity for newly-created sandbox VMs.
+        vcpus: Optional virtual CPU count for newly-created sandbox VMs.
+        fs_capacity_bytes: Optional filesystem capacity for newly-created sandbox VMs.
+            Omitted sizing fields keep provider defaults when creating an environment,
+            or preserve the existing values when updating one.
+        clear_sizing: Restore provider defaults by clearing all three sizing overrides.
+            Cannot be combined with a sizing value.
 
     Returns:
         ``{"ok": True, "environment": {...}, "created": bool}``.
     """
     if error := _require_admin():
         return {"ok": False, "error": error}
+    sizing = {
+        "mem_bytes": mem_bytes,
+        "vcpus": vcpus,
+        "fs_capacity_bytes": fs_capacity_bytes,
+    }
+    if clear_sizing and any(value is not None for value in sizing.values()):
+        return {"ok": False, "error": "clear_sizing cannot be combined with sizing values"}
     try:
         slug = store.slugify(name)
     except ValueError as exc:
@@ -111,13 +132,26 @@ async def save_environment(
         if existing is None:
             login = _configurable().get("github_login")
             record = await store.create_environment(
-                store.EnvironmentCreate(name=name, prompt=prompt, repos=repos or []),
+                store.EnvironmentCreate(
+                    name=name,
+                    prompt=prompt,
+                    repos=repos or [],
+                    mem_bytes=mem_bytes,
+                    vcpus=vcpus,
+                    fs_capacity_bytes=fs_capacity_bytes,
+                ),
                 login if isinstance(login, str) else "open-swe",
             )
         else:
+            update_values: dict[str, Any] = {"name": name, "prompt": prompt, "repos": repos}
+            update_values.update(
+                dict.fromkeys(sizing)
+                if clear_sizing
+                else {field: value for field, value in sizing.items() if value is not None}
+            )
             record = await store.update_environment(
                 slug,
-                store.EnvironmentUpdate(name=name, prompt=prompt, repos=repos),
+                store.EnvironmentUpdate(**update_values),
             )
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -49,6 +49,7 @@ def _summary(record: dict[str, Any]) -> dict[str, Any]:
         "mem_bytes": record.get("mem_bytes"),
         "vcpus": record.get("vcpus"),
         "fs_capacity_bytes": record.get("fs_capacity_bytes"),
+        "create_params": record.get("create_params") or {},
         "snapshot_status": record.get("snapshot_status"),
         "snapshot_id": record.get("snapshot_id"),
         "snapshot_name": record.get("snapshot_name"),
@@ -85,6 +86,8 @@ async def save_environment(
     vcpus: int | None = None,
     fs_capacity_bytes: int | None = None,
     clear_sizing: bool = False,
+    create_params: dict[str, Any] | None = None,
+    clear_create_params: bool = False,
 ) -> dict[str, Any]:
     """Create an environment, or update an existing one's configuration.
 
@@ -109,6 +112,12 @@ async def save_environment(
             or preserve the existing values when updating one.
         clear_sizing: Restore provider defaults by clearing all three sizing overrides.
             Cannot be combined with a sizing value.
+        create_params: Additional LangSmith sandbox create-body fields, such as
+            ``_internal_runtime`` or ``proxy_config``. This object is persisted and
+            must never contain secrets or authentication credentials. Omit it when
+            updating to preserve the existing object.
+        clear_create_params: Clear all additional create parameters. Cannot be combined
+            with ``create_params``.
 
     Returns:
         ``{"ok": True, "environment": {...}, "created": bool}``.
@@ -122,6 +131,8 @@ async def save_environment(
     }
     if clear_sizing and any(value is not None for value in sizing.values()):
         return {"ok": False, "error": "clear_sizing cannot be combined with sizing values"}
+    if clear_create_params and create_params is not None:
+        return {"ok": False, "error": "clear_create_params cannot be combined with create_params"}
     try:
         slug = store.slugify(name)
     except ValueError as exc:
@@ -139,6 +150,7 @@ async def save_environment(
                     mem_bytes=mem_bytes,
                     vcpus=vcpus,
                     fs_capacity_bytes=fs_capacity_bytes,
+                    create_params=create_params or {},
                 ),
                 login if isinstance(login, str) else "open-swe",
             )
@@ -149,6 +161,10 @@ async def save_environment(
                 if clear_sizing
                 else {field: value for field, value in sizing.items() if value is not None}
             )
+            if create_params is not None:
+                update_values["create_params"] = create_params
+            elif clear_create_params:
+                update_values["create_params"] = {}
             record = await store.update_environment(
                 slug,
                 store.EnvironmentUpdate(**update_values),

--- a/agent/utils/github_proxy.py
+++ b/agent/utils/github_proxy.py
@@ -32,6 +32,7 @@ PROXY_TOKEN_FALLBACK_TTL = timedelta(minutes=50)
 _PROXY_TOKEN_EXPIRY: dict[
     str, tuple[datetime | None, datetime, tuple[str, ...] | None, PermissionKey]
 ] = {}
+_PROXY_BASE_CONFIGS: dict[str, dict[str, Any]] = {}
 ProxyTokenRecord = tuple[datetime | None, datetime, tuple[str, ...] | None, PermissionKey]
 
 
@@ -66,6 +67,7 @@ def record_proxy_token_expiry(
     *,
     repositories: Sequence[str] | None = None,
     permissions: PermissionMap | None = None,
+    base_proxy_config: dict[str, Any] | None = None,
 ) -> None:
     """Record when ``thread_id``'s proxy token expires and the repo scope it was minted with.
 
@@ -81,11 +83,16 @@ def record_proxy_token_expiry(
         scope,
         normalize_permissions(permissions),
     )
+    if base_proxy_config is not None:
+        _PROXY_BASE_CONFIGS[thread_id] = dict(base_proxy_config)
+    else:
+        _PROXY_BASE_CONFIGS.pop(thread_id, None)
 
 
 def clear_proxy_token_expiry(thread_id: str | None) -> None:
     if thread_id:
         _PROXY_TOKEN_EXPIRY.pop(thread_id, None)
+        _PROXY_BASE_CONFIGS.pop(thread_id, None)
 
 
 def _unpack_proxy_token_record(record: tuple[Any, ...]) -> ProxyTokenRecord:
@@ -141,12 +148,21 @@ async def refresh_proxy_token(
     from ..integrations.langsmith import _configure_github_proxy
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
-    await _configure_github_proxy(current_backend.id, token)
+    base_proxy_config = _PROXY_BASE_CONFIGS.get(thread_id)
+    if base_proxy_config is not None:
+        await _configure_github_proxy(
+            current_backend.id,
+            token,
+            base_proxy_config=base_proxy_config,
+        )
+    else:
+        await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
         thread_id,
         expires_at,
         repositories=effective_repositories,
         permissions=dict(permission_key) if permission_key else None,
+        base_proxy_config=base_proxy_config,
     )
     logger.info("Refreshed GitHub proxy token for thread %s", thread_id)
     return True

--- a/agent/utils/github_proxy.py
+++ b/agent/utils/github_proxy.py
@@ -89,6 +89,13 @@ def record_proxy_token_expiry(
         _PROXY_BASE_CONFIGS.pop(thread_id, None)
 
 
+def get_recorded_proxy_base_config(thread_id: str | None) -> dict[str, Any] | None:
+    if not thread_id:
+        return None
+    config = _PROXY_BASE_CONFIGS.get(thread_id)
+    return dict(config) if config is not None else None
+
+
 def clear_proxy_token_expiry(thread_id: str | None) -> None:
     if thread_id:
         _PROXY_TOKEN_EXPIRY.pop(thread_id, None)

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -45,6 +45,9 @@ async def create_sandbox(
     sandbox_id: str | None = None,
     *,
     snapshot_id: str | None = None,
+    mem_bytes: int | None = None,
+    vcpus: int | None = None,
+    fs_capacity_bytes: int | None = None,
 ) -> "SandboxBackendProtocol":
     """Create or reconnect to a sandbox using the configured provider.
 
@@ -61,14 +64,27 @@ async def create_sandbox(
         snapshot_id: Optional snapshot to boot a new sandbox from. Only the
             langsmith provider honors this; others ignore it. When omitted the
             langsmith provider falls back to DEFAULT_SANDBOX_SNAPSHOT_ID.
+        mem_bytes: Optional memory capacity override for a new LangSmith sandbox.
+        vcpus: Optional virtual CPU count override for a new LangSmith sandbox.
+        fs_capacity_bytes: Optional filesystem capacity override for a new LangSmith sandbox.
 
     Returns:
         A sandbox backend implementing SandboxBackendProtocol.
     """
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     factory = _load_sandbox_factory(sandbox_type)
-    if sandbox_type == "langsmith" and snapshot_id is not None:
-        return await factory(sandbox_id, snapshot_id=snapshot_id)
+    if sandbox_type == "langsmith":
+        options = {
+            key: value
+            for key, value in {
+                "snapshot_id": snapshot_id,
+                "mem_bytes": mem_bytes,
+                "vcpus": vcpus,
+                "fs_capacity_bytes": fs_capacity_bytes,
+            }.items()
+            if value is not None
+        }
+        return await factory(sandbox_id, **options)
     if inspect.iscoroutinefunction(factory):
         return await factory(sandbox_id)
     return await asyncio.to_thread(factory, sandbox_id)

--- a/agent/utils/sandbox.py
+++ b/agent/utils/sandbox.py
@@ -48,6 +48,7 @@ async def create_sandbox(
     mem_bytes: int | None = None,
     vcpus: int | None = None,
     fs_capacity_bytes: int | None = None,
+    create_params: dict[str, Any] | None = None,
 ) -> "SandboxBackendProtocol":
     """Create or reconnect to a sandbox using the configured provider.
 
@@ -67,6 +68,7 @@ async def create_sandbox(
         mem_bytes: Optional memory capacity override for a new LangSmith sandbox.
         vcpus: Optional virtual CPU count override for a new LangSmith sandbox.
         fs_capacity_bytes: Optional filesystem capacity override for a new LangSmith sandbox.
+        create_params: Optional additional LangSmith sandbox create-body fields.
 
     Returns:
         A sandbox backend implementing SandboxBackendProtocol.
@@ -81,6 +83,7 @@ async def create_sandbox(
                 "mem_bytes": mem_bytes,
                 "vcpus": vcpus,
                 "fs_capacity_bytes": fs_capacity_bytes,
+                "create_params": create_params,
             }.items()
             if value is not None
         }

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from deepagents.backends.protocol import (
     DeleteResult,
@@ -367,15 +368,13 @@ def clear_sandbox_backend(thread_id: str) -> None:
         sandbox_backend.cancel_startup()
 
 
-async def get_sandbox_id_from_metadata(thread_id: str) -> str | None:
-    """Fetch sandbox_id from thread metadata."""
+async def get_sandbox_metadata(thread_id: str) -> dict[str, Any]:
+    """Fetch sandbox metadata from the run config or live thread."""
     try:
         config = get_config()
         metadata = config.get("metadata", {})
-        if isinstance(metadata, dict):
-            sandbox_id = metadata.get("sandbox_id")
-            if isinstance(sandbox_id, str):
-                return sandbox_id
+        if isinstance(metadata, dict) and isinstance(metadata.get("sandbox_id"), str):
+            return metadata
     except Exception:
         logger.debug(
             "Failed to read inline thread metadata for sandbox; falling back to live lookup",
@@ -387,10 +386,16 @@ async def get_sandbox_id_from_metadata(thread_id: str) -> str | None:
         thread = await client.threads.get(thread_id)
     except Exception:
         logger.exception("Failed to fetch live thread metadata for sandbox")
-        return None
+        return {}
 
     metadata = thread.get("metadata", {}) if isinstance(thread, dict) else {}
-    sandbox_id = metadata.get("sandbox_id") if isinstance(metadata, dict) else None
+    return metadata if isinstance(metadata, dict) else {}
+
+
+async def get_sandbox_id_from_metadata(thread_id: str) -> str | None:
+    """Fetch sandbox_id from thread metadata."""
+    metadata = await get_sandbox_metadata(thread_id)
+    sandbox_id = metadata.get("sandbox_id")
     return sandbox_id if isinstance(sandbox_id, str) else None
 
 

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -72,11 +72,14 @@ async def test_environment_sandbox_sizing_is_resolved_with_snapshot() -> None:
         "mem_bytes": 32 * 1024**3,
         "vcpus": 16,
         "fs_capacity_bytes": 512 * 1024**3,
+        "create_params": {"_internal_runtime": "v2"},
     }
     with patch.object(
         server, "resolve_environment", new_callable=AsyncMock, return_value=environment
     ):
-        snapshot_id, resources = await server._resolve_sandbox_create_config(None, "base")
+        snapshot_id, resources, create_params = await server._resolve_sandbox_create_config(
+            None, "base"
+        )
 
     assert snapshot_id == "env-snap"
     assert resources == {
@@ -84,6 +87,7 @@ async def test_environment_sandbox_sizing_is_resolved_with_snapshot() -> None:
         "vcpus": 16,
         "fs_capacity_bytes": 512 * 1024**3,
     }
+    assert create_params == {"_internal_runtime": "v2"}
 
 
 def test_environment_slug_reads_the_run_config() -> None:
@@ -158,6 +162,7 @@ async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.Monk
             "mem_bytes": 16 * 1024**3,
             "vcpus": 8,
             "fs_capacity_bytes": 256 * 1024**3,
+            "create_params": {"_internal_runtime": "v2"},
         }
     )
     with (
@@ -171,6 +176,7 @@ async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.Monk
             mem_bytes=16 * 1024**3,
             vcpus=8,
             fs_capacity_bytes=256 * 1024**3,
+            create_params={"_internal_runtime": "v2"},
         )
 
     assert create.await_args is not None
@@ -178,7 +184,9 @@ async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.Monk
     assert saved.mem_bytes == 16 * 1024**3
     assert saved.vcpus == 8
     assert saved.fs_capacity_bytes == 256 * 1024**3
+    assert saved.create_params == {"_internal_runtime": "v2"}
     assert result["environment"]["vcpus"] == 8
+    assert result["environment"]["create_params"] == {"_internal_runtime": "v2"}
 
 
 @pytest.mark.asyncio
@@ -193,6 +201,7 @@ async def test_save_environment_can_clear_sandbox_sizing(monkeypatch: pytest.Mon
             "mem_bytes": None,
             "vcpus": None,
             "fs_capacity_bytes": None,
+            "create_params": {},
         }
     )
     with (
@@ -205,7 +214,12 @@ async def test_save_environment_can_clear_sandbox_sizing(monkeypatch: pytest.Mon
         ),
         patch.object(env_tools.store, "update_environment", update),
     ):
-        result = await env_tools.save_environment("base", "prompt", clear_sizing=True)
+        result = await env_tools.save_environment(
+            "base",
+            "prompt",
+            clear_sizing=True,
+            clear_create_params=True,
+        )
 
     assert update.await_args is not None
     saved = update.await_args.args[1]
@@ -213,6 +227,8 @@ async def test_save_environment_can_clear_sandbox_sizing(monkeypatch: pytest.Mon
     assert saved.mem_bytes is None
     assert saved.vcpus is None
     assert saved.fs_capacity_bytes is None
+    assert saved.create_params == {}
+    assert "create_params" in saved.model_fields_set
     assert result["ok"] is True
 
 

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -65,6 +65,27 @@ async def test_snapshot_resolution_passes_the_threads_environment() -> None:
     resolve.assert_awaited_once_with("staging")
 
 
+@pytest.mark.asyncio
+async def test_environment_sandbox_sizing_is_resolved_with_snapshot() -> None:
+    environment = {
+        **_READY,
+        "mem_bytes": 32 * 1024**3,
+        "vcpus": 16,
+        "fs_capacity_bytes": 512 * 1024**3,
+    }
+    with patch.object(
+        server, "resolve_environment", new_callable=AsyncMock, return_value=environment
+    ):
+        snapshot_id, resources = await server._resolve_sandbox_create_config(None, "base")
+
+    assert snapshot_id == "env-snap"
+    assert resources == {
+        "mem_bytes": 32 * 1024**3,
+        "vcpus": 16,
+        "fs_capacity_bytes": 512 * 1024**3,
+    }
+
+
 def test_environment_slug_reads_the_run_config() -> None:
     assert server._environment_slug({"environment": "staging"}) == "staging"
     assert server._environment_slug({"environment": "  "}) is None
@@ -126,6 +147,90 @@ async def test_tools_refuse_non_admins(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    create = AsyncMock(
+        return_value={
+            "name": "base",
+            "slug": "base",
+            "prompt": "prompt",
+            "repos": [],
+            "mem_bytes": 16 * 1024**3,
+            "vcpus": 8,
+            "fs_capacity_bytes": 256 * 1024**3,
+        }
+    )
+    with (
+        patch.object(env_tools, "get_config", return_value=_config(github_login="ramonn")),
+        patch.object(env_tools.store, "get_environment", new_callable=AsyncMock, return_value=None),
+        patch.object(env_tools.store, "create_environment", create),
+    ):
+        result = await env_tools.save_environment(
+            "base",
+            "prompt",
+            mem_bytes=16 * 1024**3,
+            vcpus=8,
+            fs_capacity_bytes=256 * 1024**3,
+        )
+
+    assert create.await_args is not None
+    saved = create.await_args.args[0]
+    assert saved.mem_bytes == 16 * 1024**3
+    assert saved.vcpus == 8
+    assert saved.fs_capacity_bytes == 256 * 1024**3
+    assert result["environment"]["vcpus"] == 8
+
+
+@pytest.mark.asyncio
+async def test_save_environment_can_clear_sandbox_sizing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    update = AsyncMock(
+        return_value={
+            "name": "base",
+            "slug": "base",
+            "prompt": "prompt",
+            "repos": [],
+            "mem_bytes": None,
+            "vcpus": None,
+            "fs_capacity_bytes": None,
+        }
+    )
+    with (
+        patch.object(env_tools, "get_config", return_value=_config(github_login="ramonn")),
+        patch.object(
+            env_tools.store,
+            "get_environment",
+            new_callable=AsyncMock,
+            return_value={"slug": "base"},
+        ),
+        patch.object(env_tools.store, "update_environment", update),
+    ):
+        result = await env_tools.save_environment("base", "prompt", clear_sizing=True)
+
+    assert update.await_args is not None
+    saved = update.await_args.args[1]
+    assert {"mem_bytes", "vcpus", "fs_capacity_bytes"} <= saved.model_fields_set
+    assert saved.mem_bytes is None
+    assert saved.vcpus is None
+    assert saved.fs_capacity_bytes is None
+    assert result["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_save_environment_rejects_clear_sizing_with_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    with patch.object(env_tools, "get_config", return_value=_config(github_login="ramonn")):
+        result = await env_tools.save_environment("base", "prompt", vcpus=8, clear_sizing=True)
+
+    assert result == {
+        "ok": False,
+        "error": "clear_sizing cannot be combined with sizing values",
+    }
+
+
+@pytest.mark.asyncio
 async def test_capture_tool_requires_a_saved_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
     with (
@@ -164,6 +269,7 @@ def test_environment_instructions_render_in_system_prompt() -> None:
 def test_admin_section_only_for_admin_threads() -> None:
     prompt = construct_system_prompt(working_dir="/workspace", admin_environments=True)
     assert "### Admin Thread: Environment Setup" in prompt
+    assert "optional VM sizing" in prompt
     assert "direct them to an admin thread" not in prompt
 
 

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -8,6 +8,7 @@ from agent.dashboard.environments import (
     EnvironmentCreate,
     EnvironmentUpdate,
     environment_prompt,
+    environment_sandbox_resources,
     environment_snapshot_id,
     slugify,
     snapshot_name_for,
@@ -79,6 +80,29 @@ def test_create_validates_repo_full_names() -> None:
     assert create.repos == ["owner/repo"]
 
 
+def test_sandbox_resources_require_positive_integers() -> None:
+    with pytest.raises(ValueError, match="greater than 0"):
+        EnvironmentCreate(name="env", mem_bytes=0)
+    with pytest.raises(ValueError, match="greater than 0"):
+        EnvironmentUpdate(vcpus=-1)
+
+
+def test_environment_sandbox_resources_omits_invalid_stored_values() -> None:
+    assert environment_sandbox_resources(
+        {
+            "mem_bytes": 16 * 1024**3,
+            "vcpus": 8,
+            "fs_capacity_bytes": 256 * 1024**3,
+            "unexpected": 1,
+        }
+    ) == {
+        "mem_bytes": 16 * 1024**3,
+        "vcpus": 8,
+        "fs_capacity_bytes": 256 * 1024**3,
+    }
+    assert environment_sandbox_resources({"mem_bytes": -1, "vcpus": True}) == {}
+
+
 def test_snapshot_id_only_resolves_when_ready() -> None:
     assert environment_snapshot_id({"snapshot_status": "capturing", "snapshot_id": "s-1"}) is None
     assert environment_snapshot_id({"snapshot_status": "ready", "snapshot_id": "s-1"}) == "s-1"
@@ -121,11 +145,29 @@ async def test_update_writes_only_provided_fields() -> None:
     client, _ = _fake_client()
     with patch.object(env_store, "get_client", return_value=client):
         await env_store.create_environment(
-            EnvironmentCreate(name="base", prompt="original", repos=["o/r"]), "ramon"
+            EnvironmentCreate(
+                name="base",
+                prompt="original",
+                repos=["o/r"],
+                mem_bytes=8 * 1024**3,
+                vcpus=4,
+                fs_capacity_bytes=128 * 1024**3,
+            ),
+            "ramon",
         )
-        updated = await env_store.update_environment("base", EnvironmentUpdate(prompt="replaced"))
+        updated = await env_store.update_environment(
+            "base", EnvironmentUpdate(prompt="replaced", vcpus=8)
+        )
         assert updated["prompt"] == "replaced"
         assert updated["repos"] == ["o/r"]
+        assert updated["mem_bytes"] == 8 * 1024**3
+        assert updated["vcpus"] == 8
+        assert updated["fs_capacity_bytes"] == 128 * 1024**3
+
+        cleared = await env_store.update_environment("base", EnvironmentUpdate(mem_bytes=None))
+        assert cleared["mem_bytes"] is None
+        assert cleared["vcpus"] == 8
+        assert cleared["fs_capacity_bytes"] == 128 * 1024**3
 
 
 @pytest.mark.asyncio

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -121,12 +121,18 @@ def test_create_params_accept_non_sensitive_runtime_and_proxy_settings() -> None
     "create_params",
     [
         {"env_vars": {"API_TOKEN": "sensitive"}},
+        {"env_vars": {"OPENAI_API_KEY": "sensitive"}},
         {"clientSecret": "sensitive"},
         {
             "proxy_config": {
                 "rules": [
                     {"headers": [{"name": "Authorization", "type": "opaque", "value": "sensitive"}]}
                 ]
+            }
+        },
+        {
+            "proxy_config": {
+                "rules": [{"headers": [{"name": "X-OpenAI-Api-Key", "value": "sensitive"}]}]
             }
         },
     ],

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -8,6 +8,7 @@ from agent.dashboard.environments import (
     EnvironmentCreate,
     EnvironmentUpdate,
     environment_prompt,
+    environment_sandbox_create_params,
     environment_sandbox_resources,
     environment_snapshot_id,
     slugify,
@@ -103,6 +104,58 @@ def test_environment_sandbox_resources_omits_invalid_stored_values() -> None:
     assert environment_sandbox_resources({"mem_bytes": -1, "vcpus": True}) == {}
 
 
+def test_create_params_accept_non_sensitive_runtime_and_proxy_settings() -> None:
+    params = {
+        "_internal_runtime": "v2",
+        "proxy_config": {
+            "rules": [{"name": "public-api", "match_hosts": ["example.com"]}],
+        },
+    }
+    create = EnvironmentCreate(name="env", create_params=params)
+
+    assert create.create_params == params
+    assert environment_sandbox_create_params({"create_params": params}) == params
+
+
+@pytest.mark.parametrize(
+    "create_params",
+    [
+        {"env_vars": {"API_TOKEN": "sensitive"}},
+        {"clientSecret": "sensitive"},
+        {
+            "proxy_config": {
+                "rules": [
+                    {"headers": [{"name": "Authorization", "type": "opaque", "value": "sensitive"}]}
+                ]
+            }
+        },
+    ],
+)
+def test_create_params_reject_persisted_secrets(create_params: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="must not contain secrets"):
+        EnvironmentCreate(name="env", create_params=create_params)
+
+
+@pytest.mark.parametrize(
+    "create_params",
+    [
+        {"proxy_config": "enabled"},
+        {"proxy_config": {"rules": {"name": "invalid"}}},
+    ],
+)
+def test_create_params_validate_proxy_config_shape(create_params: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="proxy_config"):
+        EnvironmentCreate(name="env", create_params=create_params)
+
+
+def test_create_params_enforce_serialized_size_limit() -> None:
+    with pytest.raises(ValueError, match="at most"):
+        EnvironmentCreate(
+            name="env",
+            create_params={"metadata": "x" * env_store.CREATE_PARAMS_MAX_CHARS},
+        )
+
+
 def test_snapshot_id_only_resolves_when_ready() -> None:
     assert environment_snapshot_id({"snapshot_status": "capturing", "snapshot_id": "s-1"}) is None
     assert environment_snapshot_id({"snapshot_status": "ready", "snapshot_id": "s-1"}) == "s-1"
@@ -152,6 +205,7 @@ async def test_update_writes_only_provided_fields() -> None:
                 mem_bytes=8 * 1024**3,
                 vcpus=4,
                 fs_capacity_bytes=128 * 1024**3,
+                create_params={"_internal_runtime": "v2"},
             ),
             "ramon",
         )
@@ -163,11 +217,16 @@ async def test_update_writes_only_provided_fields() -> None:
         assert updated["mem_bytes"] == 8 * 1024**3
         assert updated["vcpus"] == 8
         assert updated["fs_capacity_bytes"] == 128 * 1024**3
+        assert updated["create_params"] == {"_internal_runtime": "v2"}
 
-        cleared = await env_store.update_environment("base", EnvironmentUpdate(mem_bytes=None))
+        cleared = await env_store.update_environment(
+            "base",
+            EnvironmentUpdate(mem_bytes=None, create_params={}),
+        )
         assert cleared["mem_bytes"] is None
         assert cleared["vcpus"] == 8
         assert cleared["fs_capacity_bytes"] == 128 * 1024**3
+        assert cleared["create_params"] == {}
 
 
 @pytest.mark.asyncio
@@ -390,11 +449,16 @@ async def test_resolve_environment_prefers_the_selection() -> None:
 
 
 @pytest.mark.asyncio
-async def test_environment_options_omit_prompts() -> None:
+async def test_environment_options_omit_admin_only_settings() -> None:
     client, _ = _fake_client()
     with patch.object(env_store, "get_client", return_value=client):
         await env_store.create_environment(
-            EnvironmentCreate(name="default", prompt="secret-ish prompt"), "ramon"
+            EnvironmentCreate(
+                name="default",
+                prompt="secret-ish prompt",
+                create_params={"_internal_runtime": "v2"},
+            ),
+            "ramon",
         )
         await env_store._set_snapshot_state("default", "ready", extra={"snapshot_id": "snap-1"})
         options = await env_store.list_environment_options()

--- a/tests/github/test_github_proxy_refresh.py
+++ b/tests/github/test_github_proxy_refresh.py
@@ -21,8 +21,10 @@ from agent.utils.github_proxy import (
 @pytest.fixture(autouse=True)
 def _clear_state() -> Generator[None, None, None]:
     github_proxy._PROXY_TOKEN_EXPIRY.clear()
+    github_proxy._PROXY_BASE_CONFIGS.clear()
     yield
     github_proxy._PROXY_TOKEN_EXPIRY.clear()
+    github_proxy._PROXY_BASE_CONFIGS.clear()
 
 
 class TestProxyTokenNeedsRefresh:
@@ -112,6 +114,39 @@ class TestMaybeRefreshProxyToken:
         expires_at, _recorded, _scope, permissions = github_proxy._PROXY_TOKEN_EXPIRY["thread-1"]
         assert expires_at == datetime(2025, 1, 1, 13, 0, 0, tzinfo=UTC)
         assert permissions == ()
+
+    @pytest.mark.asyncio
+    async def test_preserves_base_proxy_config_on_refresh(self) -> None:
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        base_proxy_config = {"rules": [{"name": "public-api", "match_hosts": ["example.com"]}]}
+        record_proxy_token_expiry(
+            "thread-1",
+            now + timedelta(minutes=1),
+            base_proxy_config=base_proxy_config,
+        )
+        backend = MagicMock(id="sb-1")
+
+        with (
+            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
+            patch.dict(github_proxy.SANDBOX_BACKENDS, {"thread-1": backend}, clear=True),
+            patch(
+                "agent.utils.github_proxy.get_github_app_installation_token_with_expiry",
+                new=AsyncMock(return_value=("ghs_new", "2025-01-01T13:00:00Z")),
+            ),
+            patch(
+                "agent.integrations.langsmith._configure_github_proxy",
+                new_callable=AsyncMock,
+            ) as mock_configure,
+        ):
+            result = await maybe_refresh_proxy_token("thread-1", now=now)
+
+        assert result is True
+        mock_configure.assert_awaited_once_with(
+            "sb-1",
+            "ghs_new",
+            base_proxy_config=base_proxy_config,
+        )
+        assert github_proxy._PROXY_BASE_CONFIGS["thread-1"] == base_proxy_config
 
     @pytest.mark.asyncio
     async def test_preserves_repo_scope_on_refresh(self) -> None:

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -19,6 +19,7 @@ from agent.integrations.langsmith import (
     _get_sandbox_create_extra_fields,
     _get_sandbox_snapshot_config,
     _install_create_extra_fields,
+    _merge_sandbox_create_extra_fields,
     _reuse_existing_sandbox,
     create_langsmith_sandbox,
 )
@@ -103,6 +104,7 @@ async def test_create_langsmith_sandbox_prefers_resource_overrides() -> None:
             mem_bytes=2_000,
             vcpus=8,
             fs_capacity_bytes=1_000,
+            create_params={"_internal_runtime": "v2"},
         )
 
     provider.get_or_create.assert_awaited_once_with(
@@ -113,6 +115,7 @@ async def test_create_langsmith_sandbox_prefers_resource_overrides() -> None:
         mem_bytes=2_000,
         idle_ttl_seconds=300,
         delete_after_stop_seconds=400,
+        create_params={"_internal_runtime": "v2"},
     )
 
 
@@ -254,6 +257,21 @@ def test_extra_fields_parsed() -> None:
         clear=True,
     ):
         assert _get_sandbox_create_extra_fields() == {"_internal_runtime": "v2"}
+
+
+def test_environment_create_params_override_deployment_defaults() -> None:
+    with patch.dict(
+        "os.environ",
+        {"SANDBOX_CREATE_EXTRA_JSON": '{"_internal_runtime": "v1", "shared": true}'},
+        clear=True,
+    ):
+        assert _merge_sandbox_create_extra_fields(
+            {"_internal_runtime": "v2", "proxy_config": {"rules": []}}
+        ) == {
+            "_internal_runtime": "v2",
+            "shared": True,
+            "proxy_config": {"rules": []},
+        }
 
 
 def test_extra_fields_rejects_invalid_json() -> None:

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from typing import cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langsmith.sandbox import AsyncSandboxClient, ResourceNotFoundError
@@ -20,6 +20,7 @@ from agent.integrations.langsmith import (
     _get_sandbox_snapshot_config,
     _install_create_extra_fields,
     _reuse_existing_sandbox,
+    create_langsmith_sandbox,
 )
 from agent.utils.sandbox import SandboxGoneError
 
@@ -84,6 +85,67 @@ def test_overrides_from_env() -> None:
         _, _, _, _, idle, delete_after = _get_sandbox_snapshot_config()
     assert idle == 120
     assert delete_after == 3600
+
+
+@pytest.mark.asyncio
+async def test_create_langsmith_sandbox_prefers_resource_overrides() -> None:
+    provider = MagicMock()
+    provider.get_or_create = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            "agent.integrations.langsmith._get_sandbox_snapshot_config",
+            return_value=("default-snap", 100, 2, 200, 300, 400),
+        ),
+        patch("agent.integrations.langsmith.LangSmithProvider", return_value=provider),
+    ):
+        await create_langsmith_sandbox(
+            snapshot_id="env-snap",
+            mem_bytes=2_000,
+            vcpus=8,
+            fs_capacity_bytes=1_000,
+        )
+
+    provider.get_or_create.assert_awaited_once_with(
+        sandbox_id=None,
+        snapshot_id="env-snap",
+        fs_capacity_bytes=1_000,
+        vcpus=8,
+        mem_bytes=2_000,
+        idle_ttl_seconds=300,
+        delete_after_stop_seconds=400,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "expected_vcpus", "expected_mem_bytes"),
+    [
+        ({"vcpus": 8}, 8, None),
+        ({"mem_bytes": 8_000}, None, 8_000),
+    ],
+)
+async def test_create_langsmith_sandbox_derives_partial_cpu_memory_overrides(
+    overrides: dict[str, int],
+    expected_vcpus: int | None,
+    expected_mem_bytes: int | None,
+) -> None:
+    provider = MagicMock()
+    provider.get_or_create = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            "agent.integrations.langsmith._get_sandbox_snapshot_config",
+            return_value=("default-snap", 100, 2, 200, 300, 400),
+        ),
+        patch("agent.integrations.langsmith.LangSmithProvider", return_value=provider),
+    ):
+        await create_langsmith_sandbox(
+            mem_bytes=overrides.get("mem_bytes"),
+            vcpus=overrides.get("vcpus"),
+        )
+
+    assert provider.get_or_create.await_args is not None
+    assert provider.get_or_create.await_args.kwargs["vcpus"] == expected_vcpus
+    assert provider.get_or_create.await_args.kwargs["mem_bytes"] == expected_mem_bytes
 
 
 def test_zero_disables_ttls() -> None:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -560,12 +560,20 @@ class TestRefreshProxyOnSandboxReuse:
             patch(
                 "agent.server.resolve_environment",
                 new_callable=AsyncMock,
-                return_value={"create_params": {"proxy_config": base_proxy_config}},
+                return_value={"create_params": {"proxy_config": {}}},
             ),
             patch(
                 "agent.server.get_sandbox_id_from_metadata",
                 new_callable=AsyncMock,
                 return_value="sandbox-cached",
+            ),
+            patch(
+                "agent.server.get_sandbox_metadata",
+                new_callable=AsyncMock,
+                return_value={
+                    "sandbox_id": "sandbox-cached",
+                    "sandbox_base_proxy_config": base_proxy_config,
+                },
             ),
             patch(
                 "agent.server.get_github_app_installation_token_with_expiry",
@@ -627,6 +635,11 @@ class TestRefreshProxyOnSandboxReuse:
                 return_value="sandbox-existing",
             ),
             patch(
+                "agent.server.get_sandbox_metadata",
+                new_callable=AsyncMock,
+                return_value={"sandbox_id": "sandbox-existing"},
+            ),
+            patch(
                 "agent.server.create_sandbox",
                 new_callable=AsyncMock,
                 return_value=mock_sandbox,
@@ -646,6 +659,7 @@ class TestRefreshProxyOnSandboxReuse:
             patch("agent.server.construct_system_prompt", return_value="prompt"),
             patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
             patch.dict("agent.server.SANDBOX_BACKENDS", {}, clear=True),
+            patch.dict("agent.utils.github_proxy._PROXY_BASE_CONFIGS", {}, clear=True),
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
             from agent.server import get_agent

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -1,7 +1,7 @@
 """Tests for GitHub proxy auth configuration."""
 
 import base64
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -55,6 +55,7 @@ class TestSandboxFactoryLoading:
                 mem_bytes=16,
                 vcpus=8,
                 fs_capacity_bytes=128,
+                create_params={"_internal_runtime": "v2"},
             )
 
         module.create_langsmith_sandbox.assert_awaited_once_with(
@@ -63,6 +64,7 @@ class TestSandboxFactoryLoading:
             mem_bytes=16,
             vcpus=8,
             fs_capacity_bytes=128,
+            create_params={"_internal_runtime": "v2"},
         )
 
 
@@ -116,6 +118,29 @@ class TestConfigureGithubProxy:
             assert headers[0]["name"] == "Authorization"
             assert headers[0]["type"] == "opaque"
             assert headers[0]["value"] == f"Basic {expected_basic}"
+
+    async def test_preserves_custom_proxy_config_when_adding_github_auth(self) -> None:
+        custom_rule = {"name": "public-api", "match_hosts": ["example.com"]}
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "ls-api-key"}),
+        ):
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            await _configure_github_proxy(
+                "sandbox-abc123",
+                "token",
+                base_proxy_config={"rules": [custom_rule], "enabled": True},
+            )
+
+        proxy_config = mock_client.patch.call_args.kwargs["json"]["proxy_config"]
+        assert proxy_config["enabled"] is True
+        assert proxy_config["rules"][0] == custom_rule
+        assert [rule["name"] for rule in proxy_config["rules"][1:]] == ["github-api", "github"]
 
     async def test_sends_to_correct_url(self) -> None:
         """Verify the PATCH hits the right endpoint."""
@@ -387,12 +412,16 @@ class TestCreateSandboxWithProxy:
 
     @pytest.mark.asyncio
     async def test_passes_environment_resources_to_sandbox_creation(self) -> None:
-        environment = {
+        environment: dict[str, Any] = {
             "snapshot_status": "ready",
             "snapshot_id": "env-snap",
             "mem_bytes": 16,
             "vcpus": 8,
             "fs_capacity_bytes": 128,
+            "create_params": {
+                "_internal_runtime": "v2",
+                "proxy_config": {"rules": [{"name": "public-api", "match_hosts": ["example.com"]}]},
+            },
         }
         with (
             patch(
@@ -404,7 +433,9 @@ class TestCreateSandboxWithProxy:
                 new_callable=AsyncMock,
                 return_value=("ghs_install", None),
             ),
-            patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
+            patch(
+                "agent.server._configure_github_proxy", new_callable=AsyncMock
+            ) as mock_configure_proxy,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
             mock_create.return_value = MagicMock(id="sandbox-123")
@@ -418,6 +449,12 @@ class TestCreateSandboxWithProxy:
             mem_bytes=16,
             vcpus=8,
             fs_capacity_bytes=128,
+            create_params=environment["create_params"],
+        )
+        mock_configure_proxy.assert_awaited_once_with(
+            "sandbox-123",
+            "ghs_install",
+            base_proxy_config=environment["create_params"]["proxy_config"],
         )
 
     @pytest.mark.asyncio
@@ -507,6 +544,7 @@ class TestRefreshProxyOnSandboxReuse:
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-cached")
         mock_sandbox.aexecute = AsyncMock()
+        base_proxy_config = {"rules": [{"name": "public-api", "match_hosts": ["example.com"]}]}
         captured: dict[str, object] = {}
 
         def fake_create_deep_agent(**kwargs):
@@ -518,6 +556,11 @@ class TestRefreshProxyOnSandboxReuse:
                 "agent.server.resolve_github_token",
                 new_callable=AsyncMock,
                 return_value=("ghp", None),
+            ),
+            patch(
+                "agent.server.resolve_environment",
+                new_callable=AsyncMock,
+                return_value={"create_params": {"proxy_config": base_proxy_config}},
             ),
             patch(
                 "agent.server.get_sandbox_id_from_metadata",
@@ -554,7 +597,11 @@ class TestRefreshProxyOnSandboxReuse:
                 cast(Runtime[None], MagicMock()),
             )
 
-            mock_proxy.assert_called_once_with("sandbox-cached", "ghs_fresh")
+            mock_proxy.assert_called_once_with(
+                "sandbox-cached",
+                "ghs_fresh",
+                base_proxy_config=base_proxy_config,
+            )
 
     @pytest.mark.asyncio
     async def test_refreshes_proxy_when_reconnecting_to_existing_langsmith_sandbox(self) -> None:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -39,6 +39,32 @@ class TestSandboxFactoryLoading:
         mock_import_module.assert_called_once_with("agent.integrations.local")
         module.create_local_sandbox.assert_called_once_with("existing")
 
+    async def test_create_sandbox_passes_langsmith_resource_overrides(self) -> None:
+        with (
+            patch("agent.utils.sandbox.import_module") as mock_import_module,
+            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
+        ):
+            module = MagicMock()
+            module.create_langsmith_sandbox = AsyncMock(return_value=MagicMock(id="langsmith"))
+            mock_import_module.return_value = module
+
+            from agent.utils.sandbox import create_sandbox
+
+            await create_sandbox(
+                snapshot_id="env-snap",
+                mem_bytes=16,
+                vcpus=8,
+                fs_capacity_bytes=128,
+            )
+
+        module.create_langsmith_sandbox.assert_awaited_once_with(
+            None,
+            snapshot_id="env-snap",
+            mem_bytes=16,
+            vcpus=8,
+            fs_capacity_bytes=128,
+        )
+
 
 class TestConfigureGithubProxy:
     """Tests for _configure_github_proxy payload shape and error handling."""
@@ -358,6 +384,41 @@ class TestCreateSandboxWithProxy:
             mock_create.assert_called_once_with(snapshot_id=None)
             mock_proxy.assert_called_once_with("sandbox-123", "ghs_install")
             mock_get_token.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_passes_environment_resources_to_sandbox_creation(self) -> None:
+        environment = {
+            "snapshot_status": "ready",
+            "snapshot_id": "env-snap",
+            "mem_bytes": 16,
+            "vcpus": 8,
+            "fs_capacity_bytes": 128,
+        }
+        with (
+            patch(
+                "agent.server.resolve_environment", new_callable=AsyncMock, return_value=environment
+            ),
+            patch("agent.server.create_sandbox", new_callable=AsyncMock) as mock_create,
+            patch(
+                "agent.server.get_github_app_installation_token_with_expiry",
+                new_callable=AsyncMock,
+                return_value=("ghs_install", None),
+            ),
+            patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
+            patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
+        ):
+            mock_create.return_value = MagicMock(id="sandbox-123")
+
+            from agent.server import _create_sandbox_with_proxy
+
+            await _create_sandbox_with_proxy(environment_slug="large")
+
+        mock_create.assert_awaited_once_with(
+            snapshot_id="env-snap",
+            mem_bytes=16,
+            vcpus=8,
+            fs_capacity_bytes=128,
+        )
 
     @pytest.mark.asyncio
     async def test_raises_when_installation_token_mint_fails(self) -> None:

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -43,10 +43,20 @@ async def test_replaces_unreachable_sandbox_when_replacement_allowed() -> None:
         patch("agent.server._configure_git_identity", new_callable=AsyncMock),
         patch("agent.server.client.threads.update", new_callable=AsyncMock) as update_thread,
     ):
-        result = await ensure_sandbox_for_thread(thread_id, allow_replacement=True)
+        result = await ensure_sandbox_for_thread(
+            thread_id,
+            environment_slug="large",
+            allow_replacement=True,
+        )
 
     assert result.id == "sandbox-replacement"
-    create_replacement.assert_awaited_once()
+    create_replacement.assert_awaited_once_with(
+        None,
+        thread_id=thread_id,
+        github_proxy_repositories=None,
+        repo=None,
+        environment_slug="large",
+    )
     # The stale id is cleared by persisting the replacement, so later runs stop
     # reconnecting to a sandbox that no longer exists.
     assert update_thread.await_args_list[-1].kwargs == {

--- a/tests/sandbox/test_sandbox_publish_ordering.py
+++ b/tests/sandbox/test_sandbox_publish_ordering.py
@@ -51,3 +51,41 @@ async def test_initialization_failure_publishes_nothing(failing_step: str) -> No
     assert not proxy.has_backend
     assert not SANDBOX_BACKENDS[thread_id].has_backend
     SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_new_sandbox_persists_its_base_proxy_config() -> None:
+    thread_id = "thread-proxy-config"
+    SANDBOX_BACKENDS.clear()
+    created = MagicMock(id="sandbox-new")
+    base_proxy_config = {"rules": [{"name": "public-api", "match_hosts": ["example.com"]}]}
+    update = AsyncMock()
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agent.server._create_sandbox_with_proxy",
+            new_callable=AsyncMock,
+            return_value=created,
+        ),
+        patch(
+            "agent.server.get_recorded_proxy_base_config",
+            return_value=base_proxy_config,
+        ),
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", update),
+    ):
+        await ensure_sandbox_for_thread(thread_id)
+
+    update.assert_awaited_once_with(
+        thread_id=thread_id,
+        metadata={
+            "sandbox_id": "sandbox-new",
+            "sandbox_base_proxy_config": base_proxy_config,
+        },
+    )
+    SANDBOX_BACKENDS.clear()


### PR DESCRIPTION
## Description
Allow admin-thread environment definitions to persist VM sizing and validated non-sensitive LangSmith sandbox create parameters. Environment values override deployment defaults, survive replacement/reuse, and preserve custom proxy settings while runtime GitHub auth is refreshed.
## Release Note
Admin-defined environments can configure sandbox sizing and additional non-sensitive LangSmith create settings.
## Test Plan
- [x] Verify sized, partial, cleared, and replacement environment provisioning paths.
- [x] Verify create-param validation, override propagation, body injection, and proxy refresh preservation.

Made by [Open SWE](https://openswe.vercel.app/agents/4222fefe-64f1-5f17-a73e-a68e198965c7)