### PR TITLE
fix: require explicit plan mode requests

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -224,9 +224,7 @@ PLAN_MODE_GUIDANCE_SECTION = """---
 
 Plan-review link for this conversation: {plan_review_url}"""
 
-DEFAULT_PLAN_MODE_ENTRY_GUIDANCE = """If a task would genuinely benefit from a structured plan before any code — complex, many files, or multiple valid approaches — call the `enter_plan_mode` tool. This is NOT triggered by the word "plan" in the request; use judgment."""
-
-DASHBOARD_PLAN_MODE_ENTRY_GUIDANCE = """In the dashboard/Web UI, call `enter_plan_mode` only when the user explicitly asks in their prompt to enter or use plan mode. Do not infer plan mode from task complexity, size, or ambiguity; the dashboard's dedicated plan control enables it separately when selected."""
+PLAN_MODE_ENTRY_GUIDANCE = """Call `enter_plan_mode` only when the user explicitly asks to enter or use plan mode. Do not infer plan mode from task complexity, size, or ambiguity."""
 
 PLAN_MODE_SECTION = """---
 
@@ -566,11 +564,7 @@ def construct_system_prompt(
         linear_project_id=linear_project_id or "<PROJECT_ID>",
         linear_issue_number=linear_issue_number or "<ISSUE_NUMBER>",
         plan_review_url=plan_url or "(the dashboard plan-review page)",
-        plan_mode_entry_guidance=(
-            DASHBOARD_PLAN_MODE_ENTRY_GUIDANCE
-            if source == "dashboard"
-            else DEFAULT_PLAN_MODE_ENTRY_GUIDANCE
-        ),
+        plan_mode_entry_guidance=PLAN_MODE_ENTRY_GUIDANCE,
         plan_mode_section=(
             PLAN_MODE_SECTION.format(plan_url=plan_url or "(plan-review link unavailable)")
             if plan_mode

--- a/tests/agent/test_plan_mode.py
+++ b/tests/agent/test_plan_mode.py
@@ -16,12 +16,17 @@ def test_construct_system_prompt_gates_active_plan_mode(enabled: bool) -> None:
     assert ("### Plan Mode (ACTIVE)" in prompt) is enabled
 
 
-def test_dashboard_only_enters_plan_mode_on_explicit_request() -> None:
-    dashboard_prompt = construct_system_prompt(working_dir="/work", source="dashboard")
-    slack_prompt = construct_system_prompt(working_dir="/work", source="slack", slack_context=True)
+@pytest.mark.parametrize(
+    "source", ["dashboard", "slack", "linear", "github", "schedule", "desktop", "generic"]
+)
+def test_plan_mode_requires_an_explicit_request_for_every_source(source: str) -> None:
+    prompt = construct_system_prompt(
+        working_dir="/work", source=source, slack_context=source == "slack"
+    )
 
-    assert "call `enter_plan_mode` only when the user explicitly asks" in dashboard_prompt
-    assert "If a task would genuinely benefit from a structured plan" in slack_prompt
+    assert "Call `enter_plan_mode` only when the user explicitly asks" in prompt
+    assert "Do not infer plan mode from task complexity, size, or ambiguity" in prompt
+    assert "If a task would genuinely benefit from a structured plan" not in prompt
 
 
 def test_plan_mode_prompt_requests_slack_approval_options() -> None:


### PR DESCRIPTION
## Description
Prevents Open SWE from inferring plan mode based on task complexity and applies one explicit-request rule to every source.
## Release Note
Plan mode is now entered only when explicitly requested.
## Test Plan
- [x] Verify generated prompts for dashboard, Slack, Linear, GitHub, schedule, desktop, and generic sources.

Made by [Open SWE](https://openswe.vercel.app/agents/48ad15f7-f8fa-50a7-9411-f2358bfcb577)