### PR TITLE
fix: offload FilesystemBackend construction and stop blockbuster_ctx leaks

### DIFF
--- a/agent/desktop.py
+++ b/agent/desktop.py
@@ -66,5 +66,7 @@ async def desktop_artifact_routes(thread_id: str) -> dict[str, FilesystemBackend
     for name in ("large_tool_results", "conversation_history"):
         directory = root / name
         await asyncio.to_thread(directory.mkdir, parents=True, exist_ok=True)
-        routes[f"/{name}/"] = FilesystemBackend(root_dir=directory, virtual_mode=True)
+        routes[f"/{name}/"] = await asyncio.to_thread(
+            FilesystemBackend, root_dir=directory, virtual_mode=True
+        )
     return routes

--- a/tests/agent/test_desktop.py
+++ b/tests/agent/test_desktop.py
@@ -1,14 +1,27 @@
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from blockbuster import blockbuster_ctx
+from blockbuster import BlockBuster
 
 from agent.desktop import (
     create_desktop_backend,
     desktop_artifact_routes,
     resolve_desktop_project,
 )
+
+
+@contextmanager
+def detect_blocking_calls() -> Iterator[None]:
+    """Leak-proof ``blockbuster_ctx``: deactivates even when the body raises."""
+    blockbuster = BlockBuster()
+    blockbuster.activate()
+    try:
+        yield
+    finally:
+        blockbuster.deactivate()
 
 
 def test_desktop_backend_allows_registered_project_without_provider_secrets(
@@ -47,7 +60,7 @@ async def test_artifact_routes_stay_out_of_the_project(
     artifacts = tmp_path / "artifacts"
     monkeypatch.setenv("OPEN_SWE_LOCAL_ARTIFACTS_DIR", str(artifacts))
 
-    with blockbuster_ctx():
+    with detect_blocking_calls():
         routes = await desktop_artifact_routes("thread-1")
     assert set(routes) == {"/large_tool_results/", "/conversation_history/"}
     for prefix, backend in routes.items():

--- a/tests/models/test_openai_oauth.py
+++ b/tests/models/test_openai_oauth.py
@@ -1,8 +1,10 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import patch
 
 import pytest
-from blockbuster import blockbuster_ctx
+from blockbuster import BlockBuster
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai.chat_models.codex import (  # noqa: PLC2701
     CHATGPT_CODEX_BASE_URL,
@@ -10,6 +12,17 @@ from langchain_openai.chat_models.codex import (  # noqa: PLC2701
 )
 
 from agent.utils import model, openai_oauth
+
+
+@contextmanager
+def detect_blocking_calls() -> Iterator[None]:
+    """Leak-proof ``blockbuster_ctx``: deactivates even when the body raises."""
+    blockbuster = BlockBuster()
+    blockbuster.activate()
+    try:
+        yield
+    finally:
+        blockbuster.deactivate()
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +52,7 @@ def test_oauth_model_uses_dedicated_account_transport(monkeypatch: pytest.Monkey
 
     with (
         patch.object(model, "build_desktop_openai_oauth_model", fake_model),
-        blockbuster_ctx(),
+        detect_blocking_calls(),
     ):
         result = model.make_model("openai:gpt-5.6-sol", use_gateway=False, max_tokens=123)
 


### PR DESCRIPTION
## Summary
- `desktop_artifact_routes` constructed `FilesystemBackend` directly on the event loop; its `__init__` does blocking path resolution (`Path.resolve()` → `os.readlink`/`os.path.abspath`). Now offloaded via `asyncio.to_thread`.
- Replaced `blockbuster_ctx()` in the desktop/openai-oauth tests with a leak-proof wrapper: upstream's context manager skips `deactivate()` when an exception crosses the `with` block, leaving blocking-call detection active process-wide and failing every later async test that touches the filesystem.

## Test plan
- All 32 CI failures reproduced locally and resolved; full set of previously failing files passes (172 tests).
- `make lint` / `make typecheck` clean.