### PR TITLE
feat(ui): replace desktop sidebar heading with project selector

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -12,7 +12,6 @@ import {
   CopyIcon,
   DotsThreeVerticalIcon,
   FolderOpenIcon,
-  FolderPlusIcon,
   GitMergeIcon,
   GitPullRequestIcon,
   LightningIcon,
@@ -35,6 +34,7 @@ import type { SidebarLayout } from "@/components/sidebar-layout"
 import { SidebarUserMenu } from "@/components/SidebarUserMenu"
 import { DesktopThreadSourceToggle } from "@/features/agents/components/DesktopThreadSourceToggle"
 import { SidebarFilterMenu } from "@/features/agents/components/SidebarFilterMenu"
+import { SidebarProjectSelector } from "@/features/agents/components/SidebarProjectSelector"
 import { Button } from "@/components/ui/button"
 import {
   SidebarCollapseButton,
@@ -175,6 +175,17 @@ export function AgentsSidebar({
     removeProject: removeLocalProject,
   } = useDesktopProjects()
   const localGroups = groupLocalProjects(localProjects, localSessions)
+  const [selectedProjectPath, setSelectedProjectPath] = useState<string | null>(
+    null
+  )
+  const activeProjectPath = localProjects.some(
+    (project) => project.cwd === selectedProjectPath
+  )
+    ? selectedProjectPath
+    : null
+  const visibleLocalGroups = activeProjectPath
+    ? localGroups.filter((group) => group.project.cwd === activeProjectPath)
+    : localGroups
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
   const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
@@ -317,22 +328,15 @@ export function AgentsSidebar({
         )}
         {showLocalThreads && (
           <div className="flex min-h-0 flex-1 flex-col">
-            <div className="mb-1 flex items-center px-2 py-1">
-              <span className="min-w-0 flex-1 truncate font-heading text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
-                Projects and threads
-              </span>
-              <button
-                aria-label="Add project"
-                className="flex size-5 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
-                onClick={() => void addLocalProject()}
-                title="Add project"
-                type="button"
-              >
-                <FolderPlusIcon className="size-3.5" />
-              </button>
-            </div>
+            <SidebarProjectSelector
+              projects={localProjects}
+              selectedProjectPath={activeProjectPath}
+              onSelectProject={setSelectedProjectPath}
+              onAddProject={() => void addLocalProject()}
+              onRemoveProject={(cwd) => void removeLocalProject(cwd)}
+            />
             <div className="min-h-0 flex-1 overflow-y-auto">
-              {localGroups.map((group) => (
+              {visibleLocalGroups.map((group) => (
                 <LocalThreadGroup
                   key={group.project.cwd}
                   project={group.project}

--- a/ui/src/features/agents/components/SidebarProjectSelector.tsx
+++ b/ui/src/features/agents/components/SidebarProjectSelector.tsx
@@ -1,0 +1,95 @@
+import {
+  CaretDownIcon,
+  CheckIcon,
+  FolderIcon,
+  FolderPlusIcon,
+  TrashIcon,
+} from "@phosphor-icons/react"
+
+import type { DesktopProject } from "@/desktop"
+import {
+  Menu,
+  MenuGroup,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@/components/ui/menu"
+
+export function SidebarProjectSelector({
+  projects,
+  selectedProjectPath,
+  onSelectProject,
+  onAddProject,
+  onRemoveProject,
+}: {
+  projects: Array<DesktopProject>
+  selectedProjectPath: string | null
+  onSelectProject: (cwd: string | null) => void
+  onAddProject: () => void
+  onRemoveProject: (cwd: string) => void
+}) {
+  const selectedProject = projects.find(
+    (project) => project.cwd === selectedProjectPath
+  )
+
+  return (
+    <div className="mb-1 flex items-center gap-1 px-1 py-1">
+      <Menu>
+        <MenuTrigger
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-1 text-[13px] font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
+          title={selectedProject?.cwd}
+        >
+          <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-left">
+            {selectedProject?.name ?? "All projects"}
+          </span>
+          <CaretDownIcon className="size-3 shrink-0 text-muted-foreground" />
+        </MenuTrigger>
+        <MenuPopup align="start" className="w-60" sideOffset={4}>
+          <MenuGroup>
+            <MenuItem onClick={() => onSelectProject(null)}>
+              <FolderIcon />
+              <span className="min-w-0 flex-1 truncate">All projects</span>
+              {!selectedProject && <CheckIcon className="ml-auto" />}
+            </MenuItem>
+            {projects.map((project) => (
+              <MenuItem
+                key={project.cwd}
+                className="pe-1"
+                onClick={() => onSelectProject(project.cwd)}
+                title={project.cwd}
+              >
+                <FolderIcon />
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                {selectedProject?.cwd === project.cwd && <CheckIcon />}
+                <button
+                  aria-label={`Remove ${project.name}`}
+                  className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-sidebar-row-hover hover:text-destructive"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    if (selectedProject?.cwd === project.cwd)
+                      onSelectProject(null)
+                    onRemoveProject(project.cwd)
+                  }}
+                  title="Remove project"
+                  type="button"
+                >
+                  <TrashIcon className="size-3.5" />
+                </button>
+              </MenuItem>
+            ))}
+          </MenuGroup>
+        </MenuPopup>
+      </Menu>
+      <button
+        aria-label="Add project"
+        className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+        onClick={onAddProject}
+        title="Add project"
+        type="button"
+      >
+        <FolderPlusIcon className="size-4" />
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description
The desktop sidebar's static "Projects and threads" label is replaced with a project selector menu (All projects or a single project) that filters the local thread list, with the add-project button on the same line.

## Release Note
Desktop sidebar now lets you scope the thread list to a single local project.

## Test Plan
- [ ] In the desktop app, open the sidebar's This Mac view, pick a project from the selector and confirm only that project's threads show; switch back to All projects.
- [ ] Remove a project from the selector menu while it is selected and confirm the list falls back to All projects.