### PR TITLE
fix: read working tree directly from sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ For `SANDBOX_TYPE=langsmith` (default), every sandbox creation/refresh also call
 
 Every run re-applies `git config --global user.name/email` for the bot identity, because reused/reconnected sandboxes can lose `--global` config and Vercel preview deploys reject commits whose author email doesn't resolve to a GitHub account.
 
-`PrepareAgentRunMiddleware` also snapshots the worktree into `refs/open-swe/turns/<user-message-id>` at run start (`utils/turn_checkpoint.py`), recording the refs in thread metadata. `GET /threads/{id}/turn-diff` reads them back so the dashboard's changed-files views come from git rather than from replaying edit tool calls — which is the only way to catch edits made through `execute` and to drop files that were later reverted.
+`PrepareAgentRunMiddleware` also snapshots the worktree into `refs/open-swe/turns/<user-message-id>` at run start (`utils/turn_checkpoint.py`), recording the refs in thread metadata. `GET /threads/{id}/run-diff` reads them back so the dashboard's changed-files views come from git rather than from replaying edit tool calls — which is the only way to catch edits made through `execute` and to drop files that were later reverted.
 
 ### Middleware stack (order matters)
 

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -229,8 +229,9 @@ from .thread_api import (
     get_dashboard_thread,
     get_dashboard_thread_branch_diff,
     get_dashboard_thread_recovery_patch,
+    get_dashboard_thread_run_diff,
     get_dashboard_thread_state,
-    get_dashboard_thread_turn_diff,
+    get_dashboard_thread_working_tree_diff,
     list_dashboard_threads,
     list_dashboard_threads_page,
     list_dashboard_threads_sidebar,
@@ -2178,15 +2179,25 @@ async def api_get_thread_recovery_patch(
     )
 
 
-@router.get("/threads/{thread_id}/turn-diff")
-async def api_get_thread_turn_diff(
+@router.get("/threads/{thread_id}/working-tree-diff")
+async def api_get_thread_working_tree_diff(
     thread_id: str,
-    turn_key: str | None = None,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await get_dashboard_thread_working_tree_diff(
+        thread_id, session["sub"], email=session.get("email")
+    )
+
+
+@router.get("/threads/{thread_id}/run-diff")
+async def api_get_thread_run_diff(
+    thread_id: str,
+    turn_key: str,
     max_files: int = Query(200, ge=1, le=200),
     include_content: bool = True,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
-    return await get_dashboard_thread_turn_diff(
+    return await get_dashboard_thread_run_diff(
         thread_id,
         session["sub"],
         turn_key=turn_key,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -2297,62 +2297,77 @@ async def _github_token_for_login(login: str) -> str:
     return token
 
 
-async def get_dashboard_thread_turn_diff(
+def _missing_diff() -> dict[str, Any]:
+    return {
+        "status": "missing",
+        "files": [],
+        "truncated": False,
+        "summary": {"files": 0, "additions": 0, "deletions": 0},
+    }
+
+
+def _ready_empty_diff() -> dict[str, Any]:
+    return {**_missing_diff(), "status": "ready"}
+
+
+async def get_dashboard_thread_working_tree_diff(
+    thread_id: str, login: str, *, email: str | None = None
+) -> dict[str, Any]:
+    """Return the sandbox's live working tree against HEAD."""
+    from ..utils.turn_checkpoint import read_turn_diff
+
+    metadata = await _readable_thread_metadata(thread_id, login=login, email=email)
+    sandbox_id = metadata.get("sandbox_id")
+    if not isinstance(sandbox_id, str) or not sandbox_id:
+        return _missing_diff()
+    try:
+        sandbox = await create_sandbox(sandbox_id)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "Could not connect to sandbox %s for working tree diff", sandbox_id, exc_info=True
+        )
+        return _missing_diff()
+    return await read_turn_diff(sandbox, None, "HEAD", None)
+
+
+async def get_dashboard_thread_run_diff(
     thread_id: str,
     login: str,
     *,
-    turn_key: str | None = None,
+    turn_key: str,
     max_files: int = 200,
     include_content: bool = True,
     email: str | None = None,
 ) -> dict[str, Any]:
-    """Return the live working tree or a persisted diff for one completed turn."""
+    """Return a persisted diff for one completed run, with checkpoint fallback."""
     from ..utils.turn_checkpoint import read_turn_diff
     from .run_diffs import get_run_diff, project_run_diff
 
     metadata = await _readable_thread_metadata(thread_id, login=login, email=email)
-    checkpoints = metadata.get("turn_checkpoints")
+    stored = await get_run_diff(thread_id, turn_key)
+    if stored is not None:
+        return project_run_diff(stored, max_files=max_files, include_content=include_content)
+
+    raw_checkpoints = metadata.get("turn_checkpoints")
     checkpoints = [
         entry
-        for entry in (checkpoints if isinstance(checkpoints, list) else [])
+        for entry in (raw_checkpoints if isinstance(raw_checkpoints, list) else [])
         if isinstance(entry, Mapping) and isinstance(entry.get("ref"), str)
     ]
-    index = (
-        next((i for i, entry in enumerate(checkpoints) if entry.get("key") == turn_key), -1)
-        if turn_key is not None
-        else 0
-    )
+    index = next((i for i, entry in enumerate(checkpoints) if entry.get("key") == turn_key), -1)
     sandbox_id = metadata.get("sandbox_id")
-    if index < 0 or not checkpoints or not isinstance(sandbox_id, str) or not sandbox_id:
-        return {
-            "status": "missing",
-            "files": [],
-            "truncated": False,
-            "summary": {"files": 0, "additions": 0, "deletions": 0},
-        }
+    if index < 0 or not isinstance(sandbox_id, str) or not sandbox_id:
+        return _missing_diff()
 
     checkpoint = checkpoints[index]
-    stored = None
-    if turn_key is not None:
-        stored = await get_run_diff(thread_id, turn_key)
-        if stored is not None:
-            return project_run_diff(stored, max_files=max_files, include_content=include_content)
-
     plan_ref = checkpoint.get("plan_ref")
-    if (
-        turn_key is not None
-        and checkpoint.get("plan_mode") is True
-        and (not isinstance(plan_ref, str) or plan_ref == checkpoint.get("ref"))
+    if checkpoint.get("plan_mode") is True and (
+        not isinstance(plan_ref, str) or plan_ref == checkpoint.get("ref")
     ):
-        return {
-            "status": "ready",
-            "files": [],
-            "truncated": False,
-            "summary": {"files": 0, "additions": 0, "deletions": 0},
-        }
+        return _ready_empty_diff()
 
-    head = plan_ref if turn_key is not None and isinstance(plan_ref, str) else None
-    if head is None and turn_key and index + 1 < len(checkpoints):
+    head = plan_ref if isinstance(plan_ref, str) else None
+    if head is None and index + 1 < len(checkpoints):
         next_checkpoint = checkpoints[index + 1]
         repo_path = checkpoint.get("repo_path")
         next_repo_path = next_checkpoint.get("repo_path")
@@ -2361,40 +2376,25 @@ async def get_dashboard_thread_turn_diff(
             and isinstance(next_repo_path, str)
             and repo_path != next_repo_path
         ):
-            return {
-                "status": "missing",
-                "files": [],
-                "truncated": False,
-                "summary": {"files": 0, "additions": 0, "deletions": 0},
-            }
+            return _missing_diff()
         head = next_checkpoint["ref"]
 
     try:
         sandbox = await create_sandbox(sandbox_id)
     except Exception:  # noqa: BLE001
-        logger.debug("Could not connect to sandbox %s for turn diff", sandbox_id, exc_info=True)
-        if stored is not None:
-            return project_run_diff(stored, max_files=max_files, include_content=include_content)
-        return {
-            "status": "missing",
-            "files": [],
-            "truncated": False,
-            "summary": {"files": 0, "additions": 0, "deletions": 0},
-        }
+        logger.debug("Could not connect to sandbox %s for run diff", sandbox_id, exc_info=True)
+        return _missing_diff()
 
     repo_path = checkpoint.get("repo_path")
-    live = await read_turn_diff(
+    return await read_turn_diff(
         sandbox,
         None,
-        "HEAD" if turn_key is None else str(checkpoint["ref"]),
+        str(checkpoint["ref"]),
         head,
         max_files=max_files,
         include_content=include_content,
         repo_path=repo_path if isinstance(repo_path, str) else None,
     )
-    if live.get("status") != "ready" and stored is not None:
-        return project_run_diff(stored, max_files=max_files, include_content=include_content)
-    return live
 
 
 _UNSAFE_REF_CHARACTERS = set(" ~^:?*[\\\x7f") | {chr(code) for code in range(32)}

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -2314,6 +2314,7 @@ async def get_dashboard_thread_working_tree_diff(
     thread_id: str, login: str, *, email: str | None = None
 ) -> dict[str, Any]:
     """Return the sandbox's live working tree against HEAD."""
+    from ..utils.sandbox_paths import aresolve_sandbox_work_dir
     from ..utils.turn_checkpoint import read_turn_diff
 
     metadata = await _readable_thread_metadata(thread_id, login=login, email=email)
@@ -2327,7 +2328,20 @@ async def get_dashboard_thread_working_tree_diff(
             "Could not connect to sandbox %s for working tree diff", sandbox_id, exc_info=True
         )
         return _missing_diff()
-    return await read_turn_diff(sandbox, None, "HEAD", None)
+    work_dir = await aresolve_sandbox_work_dir(sandbox)
+    checkpoints = metadata.get("turn_checkpoints")
+    repo_path = next(
+        (
+            entry["repo_path"]
+            for entry in reversed(checkpoints if isinstance(checkpoints, list) else [])
+            if isinstance(entry, Mapping) and isinstance(entry.get("repo_path"), str)
+        ),
+        None,
+    )
+    if repo_path is None:
+        _, repo_name, _ = _metadata_repo(metadata)
+        repo_path = posixpath.join(work_dir, repo_name) if repo_name else None
+    return await read_turn_diff(sandbox, work_dir, "HEAD", None, repo_path=repo_path)
 
 
 async def get_dashboard_thread_run_diff(

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2343,7 +2343,7 @@ async def test_turn_diff_prefers_persisted_run_artifact(monkeypatch) -> None:
     create_sandbox = AsyncMock()
     monkeypatch.setattr(thread_api, "create_sandbox", create_sandbox)
 
-    result = await thread_api.get_dashboard_thread_turn_diff(
+    result = await thread_api.get_dashboard_thread_run_diff(
         "thread-1", "owner", turn_key="msg-1", max_files=2, include_content=False
     )
 
@@ -2359,17 +2359,7 @@ async def test_turn_diff_prefers_persisted_run_artifact(monkeypatch) -> None:
 
 
 async def test_working_tree_diff_reads_live_sandbox_against_head(monkeypatch) -> None:
-    metadata = {
-        "sandbox_id": "sandbox-1",
-        "turn_checkpoints": [
-            {
-                "key": "msg-1",
-                "ref": "refs/open-swe/turns/msg-1",
-                "started_at": "t0",
-                "repo_path": "/workspace/repo",
-            }
-        ],
-    }
+    metadata = {"sandbox_id": "sandbox-1"}
     live = {
         "status": "ready",
         "files": [{"path": "new.py", "additions": 1, "deletions": 0}],
@@ -2377,41 +2367,23 @@ async def test_working_tree_diff_reads_live_sandbox_against_head(monkeypatch) ->
         "summary": {"files": 1, "additions": 1, "deletions": 0},
     }
     monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
-    get_run_diff = AsyncMock()
-    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", get_run_diff)
     sandbox = object()
     monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=sandbox))
     read_diff = AsyncMock(return_value=live)
     monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
 
-    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner")
+    result = await thread_api.get_dashboard_thread_working_tree_diff("thread-1", "owner")
 
     assert result == live
-    get_run_diff.assert_not_awaited()
-    read_diff.assert_awaited_once_with(
-        sandbox,
-        None,
-        "HEAD",
-        None,
-        max_files=200,
-        include_content=True,
-        repo_path="/workspace/repo",
-    )
+    read_diff.assert_awaited_once_with(sandbox, None, "HEAD", None)
 
 
 async def test_working_tree_diff_does_not_fall_back_to_persisted_artifact(monkeypatch) -> None:
-    metadata = {
-        "sandbox_id": "sandbox-1",
-        "turn_checkpoints": [
-            {"key": "msg-1", "ref": "refs/open-swe/turns/msg-1", "started_at": "t0"}
-        ],
-    }
+    metadata = {"sandbox_id": "sandbox-1"}
     monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
-    get_run_diff = AsyncMock()
-    monkeypatch.setattr("agent.dashboard.run_diffs.get_run_diff", get_run_diff)
     monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(side_effect=RuntimeError))
 
-    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner")
+    result = await thread_api.get_dashboard_thread_working_tree_diff("thread-1", "owner")
 
     assert result == {
         "status": "missing",
@@ -2419,7 +2391,6 @@ async def test_working_tree_diff_does_not_fall_back_to_persisted_artifact(monkey
         "truncated": False,
         "summary": {"files": 0, "additions": 0, "deletions": 0},
     }
-    get_run_diff.assert_not_awaited()
 
 
 async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:
@@ -2440,7 +2411,7 @@ async def test_turn_diff_hides_plan_mode_checkpoint(monkeypatch) -> None:
     create_sandbox = AsyncMock()
     monkeypatch.setattr(thread_api, "create_sandbox", create_sandbox)
 
-    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+    result = await thread_api.get_dashboard_thread_run_diff("thread-1", "owner", turn_key="msg-1")
 
     assert result == {
         "status": "ready",
@@ -2471,7 +2442,7 @@ async def test_turn_diff_preserves_changes_before_mid_run_plan_mode(monkeypatch)
     read_diff = AsyncMock(return_value={"status": "ready", "files": [], "truncated": False})
     monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
 
-    await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+    await thread_api.get_dashboard_thread_run_diff("thread-1", "owner", turn_key="msg-1")
 
     read_diff.assert_awaited_once_with(
         sandbox,
@@ -2508,7 +2479,7 @@ async def test_turn_diff_reads_the_checkpoint_repository(monkeypatch) -> None:
     read_diff = AsyncMock(return_value={"status": "ready", "files": [], "truncated": False})
     monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
 
-    await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+    await thread_api.get_dashboard_thread_run_diff("thread-1", "owner", turn_key="msg-1")
 
     read_diff.assert_awaited_once_with(
         sandbox,
@@ -2543,7 +2514,7 @@ async def test_turn_diff_rejects_checkpoints_from_different_repositories(monkeyp
     create_sandbox = AsyncMock()
     monkeypatch.setattr(thread_api, "create_sandbox", create_sandbox)
 
-    result = await thread_api.get_dashboard_thread_turn_diff("thread-1", "owner", turn_key="msg-1")
+    result = await thread_api.get_dashboard_thread_run_diff("thread-1", "owner", turn_key="msg-1")
 
     assert result == {
         "status": "missing",

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2359,7 +2359,10 @@ async def test_turn_diff_prefers_persisted_run_artifact(monkeypatch) -> None:
 
 
 async def test_working_tree_diff_reads_live_sandbox_against_head(monkeypatch) -> None:
-    metadata = {"sandbox_id": "sandbox-1"}
+    metadata = {
+        "sandbox_id": "sandbox-1",
+        "turn_checkpoints": [{"repo_path": "/work/repo"}],
+    }
     live = {
         "status": "ready",
         "files": [{"path": "new.py", "additions": 1, "deletions": 0}],
@@ -2369,13 +2372,17 @@ async def test_working_tree_diff_reads_live_sandbox_against_head(monkeypatch) ->
     monkeypatch.setattr(thread_api, "_readable_thread_metadata", AsyncMock(return_value=metadata))
     sandbox = object()
     monkeypatch.setattr(thread_api, "create_sandbox", AsyncMock(return_value=sandbox))
+    monkeypatch.setattr(
+        "agent.utils.sandbox_paths.aresolve_sandbox_work_dir",
+        AsyncMock(return_value="/work"),
+    )
     read_diff = AsyncMock(return_value=live)
     monkeypatch.setattr("agent.utils.turn_checkpoint.read_turn_diff", read_diff)
 
     result = await thread_api.get_dashboard_thread_working_tree_diff("thread-1", "owner")
 
     assert result == live
-    read_diff.assert_awaited_once_with(sandbox, None, "HEAD", None)
+    read_diff.assert_awaited_once_with(sandbox, "/work", "HEAD", None, repo_path="/work/repo")
 
 
 async def test_working_tree_diff_does_not_fall_back_to_persisted_artifact(monkeypatch) -> None:

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -394,7 +394,7 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       const url = new URL(response.url());
       return (
         response.request().method() === "GET" &&
-        url.pathname === `/dashboard/api/threads/${threadId}/turn-diff` &&
+        url.pathname === `/dashboard/api/threads/${threadId}/run-diff` &&
         url.searchParams.get("max_files") === "10" &&
         url.searchParams.get("include_content") === "false"
       );

--- a/ui/src/features/agents/components/AgentGitPanel.tsx
+++ b/ui/src/features/agents/components/AgentGitPanel.tsx
@@ -5,7 +5,7 @@ import type { AgentThread } from "@/features/agents/lib/types"
 import { agentsApi } from "@/features/agents/lib/api"
 import {
   useAgentThreadBranchDiff,
-  useAgentThreadTurnDiff,
+  useAgentThreadWorkingTreeDiff,
 } from "@/features/agents/lib/queries"
 import { ChangesPanel } from "@/features/agents/components/ChangesPanel"
 import { toPanelFiles } from "@/features/agents/components/DiffFilesView"
@@ -69,11 +69,9 @@ export function AgentGitPanel({
   )
   const diffVisible = !collapsed && activeSurfaceId === "diff"
 
-  const turnDiff = useAgentThreadTurnDiff(
+  const turnDiff = useAgentThreadWorkingTreeDiff(
     thread.id,
-    null,
     diffVisible && scope === "working-tree",
-    {},
     thread.status === "running"
   )
   const branchDiff = useAgentThreadBranchDiff(

--- a/ui/src/features/agents/components/messages/TurnChangedFilesCard.tsx
+++ b/ui/src/features/agents/components/messages/TurnChangedFilesCard.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, ChevronRight } from "lucide-react"
 
 import type { ThreadPrDiffFile } from "@/features/agents/lib/api"
 import { COMPOSER_PATH_DRAG_MIME } from "@/features/agents/components/composer/composerTrigger"
-import { useAgentThreadTurnDiff } from "@/features/agents/lib/queries"
+import { useAgentThreadRunDiff } from "@/features/agents/lib/queries"
 
 const INLINE_CHANGED_FILES_LIMIT = 10
 
@@ -20,7 +20,7 @@ export const TurnChangedFilesCard = memo(function TurnChangedFilesCard({
   onOpenFile?: (filePath: string) => void
 }) {
   const [open, setOpen] = useState(isLatestTurn)
-  const turnDiff = useAgentThreadTurnDiff(threadId, turnKey, open, {
+  const turnDiff = useAgentThreadRunDiff(threadId, turnKey, open, {
     maxFiles: INLINE_CHANGED_FILES_LIMIT,
     includeContent: false,
   })

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -349,22 +349,24 @@ export const agentsApi = {
     agentsRequest<ThreadBranchDiff>(
       `/threads/${encodeURIComponent(threadId)}/branch-diff`
     ),
-  getThreadTurnDiff: (
+  getThreadWorkingTreeDiff: (threadId: string) =>
+    agentsRequest<ThreadTurnDiff>(
+      `/threads/${encodeURIComponent(threadId)}/working-tree-diff`
+    ),
+  getThreadRunDiff: (
     threadId: string,
-    turnKey?: string | null,
+    turnKey: string,
     options: ThreadTurnDiffOptions = {}
   ) => {
-    const params = new URLSearchParams()
-    if (turnKey) params.set("turn_key", turnKey)
+    const params = new URLSearchParams({ turn_key: turnKey })
     if (options.maxFiles != null) {
       params.set("max_files", String(options.maxFiles))
     }
     if (options.includeContent != null) {
       params.set("include_content", String(options.includeContent))
     }
-    const query = params.size > 0 ? `?${params.toString()}` : ""
     return agentsRequest<ThreadTurnDiff>(
-      `/threads/${encodeURIComponent(threadId)}/turn-diff${query}`
+      `/threads/${encodeURIComponent(threadId)}/run-diff?${params.toString()}`
     )
   },
   downloadThreadRecoveryPatch: (threadId: string) =>

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -9,7 +9,7 @@ import {
   SIDEBAR_PAGE_SIZE,
   agentThreadKeys,
   setAgentThreadStatus,
-  useAgentThreadTurnDiff,
+  useAgentThreadWorkingTreeDiff,
   useSidebarThreads,
   useThreadsPage,
 } from "./queries"
@@ -47,7 +47,7 @@ function testClient() {
   return client
 }
 
-describe("useAgentThreadTurnDiff", () => {
+describe("useAgentThreadWorkingTreeDiff", () => {
   const diff: ThreadTurnDiff = {
     status: "ready",
     truncated: false,
@@ -62,7 +62,7 @@ describe("useAgentThreadTurnDiff", () => {
     running: boolean
     enabled?: boolean
   }) {
-    useAgentThreadTurnDiff("thread-1", null, enabled, {}, running)
+    useAgentThreadWorkingTreeDiff("thread-1", enabled, running)
     return null
   }
 
@@ -81,7 +81,7 @@ describe("useAgentThreadTurnDiff", () => {
   it("keeps polling ready cloud diffs while the run is active", async () => {
     vi.useFakeTimers()
     const getDiff = vi
-      .spyOn(agentsApi, "getThreadTurnDiff")
+      .spyOn(agentsApi, "getThreadWorkingTreeDiff")
       .mockResolvedValue(diff)
 
     renderProbe(true)
@@ -93,7 +93,7 @@ describe("useAgentThreadTurnDiff", () => {
   it("refreshes immediately and twice after a running cloud diff finishes", async () => {
     vi.useFakeTimers()
     const getDiff = vi
-      .spyOn(agentsApi, "getThreadTurnDiff")
+      .spyOn(agentsApi, "getThreadWorkingTreeDiff")
       .mockResolvedValue(diff)
     const view = renderProbe(true)
     await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
@@ -114,7 +114,7 @@ describe("useAgentThreadTurnDiff", () => {
   it("refetches a fresh cached diff when enabled after the run finished", async () => {
     vi.useFakeTimers()
     const getDiff = vi
-      .spyOn(agentsApi, "getThreadTurnDiff")
+      .spyOn(agentsApi, "getThreadWorkingTreeDiff")
       .mockResolvedValue(diff)
     const view = renderProbe(true)
     await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))
@@ -144,12 +144,12 @@ describe("useAgentThreadTurnDiff", () => {
 
   it("refetches a fresh cached diff when remounted after the run finished", async () => {
     const getDiff = vi
-      .spyOn(agentsApi, "getThreadTurnDiff")
+      .spyOn(agentsApi, "getThreadWorkingTreeDiff")
       .mockResolvedValue(diff)
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     })
-    client.setQueryData(agentThreadKeys.turnDiff("thread-1", null, {}), diff)
+    client.setQueryData(agentThreadKeys.workingTreeDiff("thread-1"), diff)
     clients.push(client)
 
     render(
@@ -164,7 +164,7 @@ describe("useAgentThreadTurnDiff", () => {
   it("cleans delayed final refreshes on unmount", async () => {
     vi.useFakeTimers()
     const getDiff = vi
-      .spyOn(agentsApi, "getThreadTurnDiff")
+      .spyOn(agentsApi, "getThreadWorkingTreeDiff")
       .mockResolvedValue(diff)
     const view = renderProbe(true)
     await vi.waitFor(() => expect(getDiff).toHaveBeenCalledTimes(1))

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -39,11 +39,13 @@ export const agentThreadKeys = {
   detail: (threadId: string) => ["agent-threads", threadId] as const,
   branchDiff: (threadId: string) =>
     ["agent-threads", threadId, "branch-diff"] as const,
-  turnDiff: (
+  workingTreeDiff: (threadId: string) =>
+    ["agent-threads", threadId, "working-tree-diff"] as const,
+  runDiff: (
     threadId: string,
-    turnKey: string | null,
+    turnKey: string,
     options: ThreadTurnDiffOptions = {}
-  ) => ["agent-threads", threadId, "turn-diff", turnKey, options] as const,
+  ) => ["agent-threads", threadId, "run-diff", turnKey, options] as const,
   workflowApprovals: (threadId: string) =>
     ["agent-threads", threadId, "workflow-approvals"] as const,
   page: (params: ThreadsPageParams) =>
@@ -410,17 +412,14 @@ export function useAgentThreadBranchDiff(threadId: string, enabled: boolean) {
   })
 }
 
-export function useAgentThreadTurnDiff(
+export function useAgentThreadWorkingTreeDiff(
   threadId: string,
-  turnKey: string | null,
   enabled: boolean,
-  options: ThreadTurnDiffOptions = {},
   pollWhileRunning = false
 ) {
-  const queryKey = agentThreadKeys.turnDiff(threadId, turnKey, options)
   const query = useQuery({
-    queryKey,
-    queryFn: () => agentsApi.getThreadTurnDiff(threadId, turnKey, options),
+    queryKey: agentThreadKeys.workingTreeDiff(threadId),
+    queryFn: () => agentsApi.getThreadWorkingTreeDiff(threadId),
     enabled: enabled && Boolean(threadId),
     staleTime: 30_000,
     refetchInterval: pollWhileRunning
@@ -434,9 +433,7 @@ export function useAgentThreadTurnDiff(
   useEffect(() => {
     const was = previous.current
     previous.current = { enabled, pollWhileRunning }
-    const finishedWhileVisible =
-      was.enabled && was.pollWhileRunning && enabled && !pollWhileRunning
-    if (finishedWhileVisible) {
+    if (was.enabled && was.pollWhileRunning && enabled && !pollWhileRunning) {
       const timers = [0, 1000, 3000].map((delay) =>
         window.setTimeout(() => void refetch(), delay)
       )
@@ -446,6 +443,21 @@ export function useAgentThreadTurnDiff(
   }, [enabled, pollWhileRunning, refetch])
 
   return query
+}
+
+export function useAgentThreadRunDiff(
+  threadId: string,
+  turnKey: string,
+  enabled: boolean,
+  options: ThreadTurnDiffOptions = {}
+) {
+  return useQuery({
+    queryKey: agentThreadKeys.runDiff(threadId, turnKey, options),
+    queryFn: () => agentsApi.getThreadRunDiff(threadId, turnKey, options),
+    enabled: enabled && Boolean(threadId),
+    staleTime: 30_000,
+    retry: false,
+  })
 }
 
 export function useWorkflowApprovals(

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -316,7 +316,7 @@ function outputIframeDisplay(
  *   already persisted) so the in-progress card renders instantly.
  * - `diffData` is derived from the call's own args, which is all that is
  *   available before an edit is applied (what a pending approval renders). What
- *   a turn actually changed comes from git, via the turn-diff endpoint.
+ *   a turn actually changed comes from its persisted run diff.
  */
 export function streamMessagesToUi(
   messages: Array<BaseMessage>,


### PR DESCRIPTION
## Description
Replace the overloaded turn-diff API. Working tree changes now reconnect to the sandbox and discover the repo directly; completed-run diffs use a separate persisted endpoint.

## Release Note
Fix the dashboard working tree selector for threads without checkpoint metadata.

## Test Plan
- [x] Verify working tree reads do not require turn checkpoints

Made by [Open SWE](https://openswe.vercel.app/agents/01a02581-612e-7488-a473-a56ffb1951bc)