### PR TITLE
fix(ui): clear dictation error on message send

### DIFF
--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -450,6 +450,7 @@ export const ChatComposer = memo(function ChatComposer({
     setIsSubmitting(true)
     applyPrompt("", 0)
     setPendingImages([])
+    setDictationError(null)
     try {
       await onSubmit?.(trimmed, images)
     } catch {


### PR DESCRIPTION
## Description
The composer's dictation error (e.g. "No speech was detected") persisted indefinitely. Clear it when a message is submitted.

## Release Note
Voice dictation errors in the composer now clear after the next message is sent.

## Test Plan
- [ ] Trigger a dictation error (record silence), send a message, confirm the banner disappears.

Made by [Open SWE](https://openswe.vercel.app/agents/01a025a5-2480-7549-ae65-cb22cb748821)