### PR TITLE
feat: show Slack action indicator for automation runs

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -559,6 +559,10 @@ async def _thread_summary(
         "triggerKind": trigger_kind,
         "automationId": _metadata_string(metadata, "schedule_id"),
         "automationName": _metadata_string(metadata, "schedule_name"),
+        "automationActionPosted": (
+            thread_category == "automation"
+            and _metadata_string(metadata, "automation_action_posted_at") is not None
+        ),
         "status": status,
         "viewed": _is_thread_viewed(metadata, latest_run_id),
         "viewedAt": (

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -41,6 +41,16 @@ async def _release_reservation(client: Any, thread_id: str) -> None:
         logger.exception("Failed to release automation notification for %s", thread_id)
 
 
+async def _mark_action_posted(client: Any, thread_id: str, notified_at: str) -> None:
+    try:
+        await client.threads.update(
+            thread_id=thread_id,
+            metadata={"automation_action_posted_at": notified_at},
+        )
+    except Exception:
+        logger.exception("Failed to mark automation action posted for %s", thread_id)
+
+
 async def notify_automation_channel(message: str) -> dict[str, Any]:
     """Notify the configured automation channel once after a concrete requested action."""
     config = get_config()
@@ -85,6 +95,9 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             return {"success": False, "error": "Could not check the Slack notification state"}
         existing = _stored_value(item)
         if existing is not None:
+            notified_at = existing.get("notified_at")
+            if existing.get("status") == "delivered" and isinstance(notified_at, str):
+                await _mark_action_posted(client, thread_id, notified_at)
             return {
                 "success": True,
                 "already_notified": True,
@@ -135,4 +148,5 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             await client.store.put_item(_NOTIFICATION_NAMESPACE, thread_id, delivered)
         except Exception:
             logger.exception("Failed to finalize automation notification for %s", thread_id)
+        await _mark_action_posted(client, thread_id, delivered["notified_at"])
         return {"success": True, "message_ts": message_ts}

--- a/tests/dashboard/test_dashboard_repo_optional.py
+++ b/tests/dashboard/test_dashboard_repo_optional.py
@@ -60,6 +60,22 @@ async def test_thread_summary_classifies_legacy_schedule_metadata() -> None:
     assert summary["triggerKind"] == "schedule"
     assert summary["automationId"] == "schedule-1"
     assert summary["automationName"] == "Daily triage"
+    assert summary["automationActionPosted"] is False
+
+
+async def test_thread_summary_marks_automation_actions_posted_to_slack() -> None:
+    summary = await thread_api._thread_summary(
+        {
+            "thread_id": "scheduled-action",
+            "metadata": {
+                "source": "schedule",
+                "schedule_id": "schedule-1",
+                "automation_action_posted_at": "2026-08-21T12:00:00+00:00",
+            },
+        }
+    )
+
+    assert summary["automationActionPosted"] is True
 
 
 async def test_thread_summary_derives_issue_category_from_source_context() -> None:

--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -205,6 +205,7 @@ function automationThreads(): Array<ThreadSeed> {
         trigger_kind: "schedule",
         schedule_id: SCHEDULE_IDS.daily,
         schedule_name: "E2E Daily Health",
+        automation_action_posted_at: "2026-08-21T12:00:00+00:00",
         latest_run_id: "e2e-run-daily-scheduled",
         latest_run_status: "success",
       }),
@@ -1008,8 +1009,10 @@ test.describe("automation run history", () => {
     });
     await expect(scheduledRun).toContainText("Finished");
     await expect(scheduledRun).toContainText("Scheduled run");
+    await expect(scheduledRun).toContainText("Posted to Slack");
     await expect(scheduledRun).toContainText("acme/alpha");
     await expect(testRun).toContainText("Error");
+    await expect(testRun).not.toContainText("Posted to Slack");
     await expect(testRun).toContainText("Test run");
     await expect(weekly).toContainText("Running");
     await expect(automations).not.toContainText(TITLES.attention);

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -21,9 +21,18 @@ class _FakeStore:
         self.items.pop((tuple(namespace), key), None)
 
 
+class _FakeThreads:
+    def __init__(self) -> None:
+        self.updates: list[dict[str, Any]] = []
+
+    async def update(self, *, thread_id: str, metadata: dict[str, Any]) -> None:
+        self.updates.append({"thread_id": thread_id, "metadata": metadata})
+
+
 class _FakeClient:
     def __init__(self) -> None:
         self.store = _FakeStore()
+        self.threads = _FakeThreads()
 
 
 def _config(thread_id: str = "thread_1") -> dict[str, Any]:
@@ -134,6 +143,12 @@ async def test_notify_automation_channel_posts_to_trusted_destination(
     stored = fake_client.store.items[(("automation_notifications",), "thread_1")]
     assert stored["status"] == "delivered"
     assert stored["message_ts"] == "1786504009.596419"
+    assert fake_client.threads.updates == [
+        {
+            "thread_id": "thread_1",
+            "metadata": {"automation_action_posted_at": stored["notified_at"]},
+        }
+    ]
 
 
 async def test_notify_automation_channel_suppresses_duplicate_posts(

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -1000,6 +1000,14 @@ function ThreadRow({
           <span className="min-w-0 flex-1 truncate text-[13px]">
             {thread.title}
           </span>
+          {thread.automationActionPosted && (
+            <IoLogoSlack
+              className="size-3.5 shrink-0 text-success-foreground"
+              aria-label="Action posted to Slack"
+            >
+              <title>Action posted to Slack</title>
+            </IoLogoSlack>
+          )}
           {!compact && isAutomation && (
             <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] text-muted-foreground group-hover:hidden">
               Automation

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -283,6 +283,7 @@ export interface AgentThread {
   triggerKind?: AgentTriggerKind | string
   automationId?: string | null
   automationName?: string | null
+  automationActionPosted?: boolean
   status: AgentStatus
   viewed: boolean
   viewedAt?: number | null

--- a/ui/src/features/automations/components/AutomationRuns.test.tsx
+++ b/ui/src/features/automations/components/AutomationRuns.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { AutomationRuns } from "./AutomationRuns"
+import type { AgentThread } from "@/features/agents/lib/types"
 import { useThreadsPage } from "@/features/agents/lib/queries"
 
 vi.mock("@tanstack/react-router", () => ({
@@ -37,5 +38,48 @@ describe("AutomationRuns", () => {
     expect(screen.queryByText("No automation runs yet.")).toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
     expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it("shows which automation runs posted an action to Slack", () => {
+    const run = {
+      id: "run-posted",
+      title: "Scheduled: Dependency check",
+      repo: "open-swe",
+      repoFullName: "langchain-ai/open-swe",
+      branch: "main",
+      model: "Default",
+      source: "schedule",
+      threadCategory: "automation",
+      triggerKind: "schedule",
+      automationId: "dependency-check",
+      automationName: "Dependency check",
+      status: "finished",
+      viewed: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      messages: [],
+      automationActionPosted: true,
+    } satisfies AgentThread
+    vi.mocked(useThreadsPage).mockReturnValue({
+      data: {
+        items: [
+          run,
+          {
+            ...run,
+            id: "run-read-only",
+            title: "Scheduled: Read-only check",
+            automationActionPosted: false,
+          },
+        ],
+        hasMore: false,
+      },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useThreadsPage>)
+
+    render(<AutomationRuns />)
+
+    expect(screen.getAllByLabelText("Action posted to Slack")).toHaveLength(1)
+    expect(screen.getByText("Posted to Slack")).toBeTruthy()
   })
 })

--- a/ui/src/features/automations/components/AutomationRuns.tsx
+++ b/ui/src/features/automations/components/AutomationRuns.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { ArrowSquareOutIcon, CircleNotchIcon } from "@phosphor-icons/react"
+import { IoLogoSlack } from "react-icons/io5"
 
 import type { AgentStatus, AgentThread } from "@/features/agents/lib/types"
 import { Button } from "@/components/ui/button"
@@ -144,6 +145,15 @@ function AutomationRunRow({ run }: { run: AgentThread }) {
         <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground/70">
           <span>{STATUS_LABELS[run.status]}</span>
           <span>{isTest ? "Test run" : "Scheduled run"}</span>
+          {run.automationActionPosted && (
+            <span
+              className="flex items-center gap-1 text-success-foreground"
+              aria-label="Action posted to Slack"
+            >
+              <IoLogoSlack className="size-3.5" />
+              Posted to Slack
+            </span>
+          )}
           {run.repoFullName && <span>{run.repoFullName}</span>}
           <span>{formatRelativeTime(run.updatedAt)}</span>
         </div>


### PR DESCRIPTION
## Description
Automation action notifications now mark thread metadata, and run history plus the sidebar show a Slack indicator for action-taking runs. [Screenshot](https://01a025cc-6c29-7a4d-922e-15810f3d8686--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGN6TkRFeU1qY3NJbXAwYVNJNklqQXhZVEF5TldRMkxXTTBZMll0TjJNME9DMDVNVFZsTFRNek9UQTJOVE01T0dNeE15SXNJbk5wWkNJNklqQXhZVEF5TldOakxUWmpNamt0TjJFMFpDMDVNakpsTFRFMU9ERXdaak5rT0RZNE5pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMkYxZEc5dFlYUnBiMjR0YzJ4aFkyc3RhVzVrYVdOaGRHOXlMbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5CcllqN3FhZlBSTFpCZFJkdmRtVU12NXF1Z2xxY3JnYjB2d0RjNWUyYjFMSEZuRGhGeEEwUzByNGtMR0kyNGg2T1ZlTmxEei1RaTBoRE1TZ2p4ZEVEZw).

## Release Note
Automation run history now identifies runs that posted an action to Slack.
## Test Plan
- [x] Focused Python, Vitest, and Playwright coverage for action-taking and read-only runs.

Made by [Open SWE](https://openswe.vercel.app/agents/79b68b45-ee95-50c2-9806-ecc455a4d614)