### PR TITLE
feat: let admin threads manage organization skills

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -464,7 +464,9 @@ Two things do not belong in a snapshot: secrets (they would be readable by every
 
 The environment prompt is appended verbatim to every run's system prompt. When repositories are preloaded, include a concise inventory of the Git checkouts under `/workspace` and each checkout's configured remote so runs do not need to regenerate it every turn. Keep the prompt about how to work in this environment — where checkouts live, how to build and test, what is pre-installed — not about a single task.
 
-Confirm the name, prompt, and provisioning steps with the user before capturing into `default`: it changes how everyone's runs start."""
+Confirm the name, prompt, and provisioning steps with the user before capturing into `default`: it changes how everyone's runs start.
+
+You can also manage organization skills with `save_organization_skill` and `delete_organization_skill`. They load into every user's runs and are readable under `/organization-skills/`, so read the current body before editing one, pass the complete replacement text, and confirm the wording with the user before saving or deleting."""
 
 
 def _render_user_instructions_section(instructions: str | None) -> str:

--- a/agent/server.py
+++ b/agent/server.py
@@ -130,6 +130,7 @@ from .tools import (
     capture_environment_snapshot,
     create_sandbox_file_download_url,
     delete_environment,
+    delete_organization_skill,
     delete_user_skill,
     enter_plan_mode,
     fetch_url,
@@ -155,6 +156,7 @@ from .tools import (
     report_platform_issue,
     request_pr_review,
     save_environment,
+    save_organization_skill,
     save_plan,
     save_user_instructions,
     save_user_skill,
@@ -828,11 +830,13 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
 
 
 # Added to an admin thread's tools; see the admin-thread section of the prompt.
-ENVIRONMENT_TOOLS = (
+ADMIN_TOOLS = (
     list_environments,
     save_environment,
     capture_environment_snapshot,
     delete_environment,
+    save_organization_skill,
+    delete_organization_skill,
 )
 
 
@@ -853,7 +857,7 @@ async def _workspace_admin(config: RunnableConfig, profile_login: str | None) ->
 
 
 async def _admin_thread(config: RunnableConfig, profile_login: str | None) -> bool:
-    """Whether this run may manage environments.
+    """Whether this run may manage environments and organization skills.
 
     The dashboard only stamps ``admin_thread`` for an admin session, but the flag
     is re-checked here against ``CONFIGURED_ADMINS`` so a thread cannot carry the
@@ -1481,9 +1485,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         PlanModeMiddleware(excluded=PLAN_MODE_EXCLUDED_TOOLS, initial=plan_mode)
     ]
 
-    admin_environments = await _admin_thread(config, profile_login)
-    if admin_environments:
-        logger.info("Admin thread %s: adding environment management tools", thread_id)
+    admin_thread = await _admin_thread(config, profile_login)
+    if admin_thread:
+        logger.info("Admin thread %s: adding workspace management tools", thread_id)
 
     stop_summary_mode = configurable.get("stop_summary") is True
     sandbox_file_downloads = _sandbox_file_downloads_enabled(configurable)
@@ -1561,7 +1565,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         slack_read_thread_messages,
         slack_start_new_thread,
         slack_thread_reply,
-        *(ENVIRONMENT_TOOLS if admin_environments else ()),
+        *(ADMIN_TOOLS if admin_thread else ()),
     ]
     if local_run:
         static_tools = [http_request, fetch_url, web_search]
@@ -1659,7 +1663,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     draft_prs=sender_draft_prs,
                     plan_mode=plan_mode,
                     corridor_enabled=bool(corridor_tools),
-                    admin_environments=admin_environments,
+                    admin_environments=admin_thread,
                 ),
                 *([dynamic_tool_middleware] if dynamic_tool_middleware else []),
                 SanitizeToolInputsMiddleware(),

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -40,7 +40,9 @@ _TOOL_MODULES = {
     "request_pr_review": ".request_pr_review",
     "reply_to_finding_thread": ".reply_to_finding_thread",
     "resolve_finding_thread": ".resolve_finding_thread",
+    "delete_organization_skill": ".organization_skills",
     "save_environment": ".environments",
+    "save_organization_skill": ".organization_skills",
     "save_plan": ".save_plan",
     "save_user_instructions": ".save_user_instructions",
     "save_user_skill": ".user_skills",
@@ -95,6 +97,8 @@ __all__ = [
     "reply_to_finding_thread",
     "resolve_finding_thread",
     "save_environment",
+    "save_organization_skill",
+    "delete_organization_skill",
     "save_plan",
     "save_user_instructions",
     "save_user_skill",
@@ -138,6 +142,7 @@ if TYPE_CHECKING:
     from .manage_baby_sit import manage_baby_sit
     from .notify_automation_channel import notify_automation_channel
     from .open_pull_request import open_pull_request
+    from .organization_skills import delete_organization_skill, save_organization_skill
     from .output_iframe import output_iframe
     from .publish_review import publish_review
     from .read_repo_file import read_repo_file

--- a/agent/tools/admin_gate.py
+++ b/agent/tools/admin_gate.py
@@ -1,0 +1,33 @@
+"""Admin gate for tools wired only into admin threads.
+
+Tools re-check the triggering user against ``CONFIGURED_ADMINS`` so a thread whose
+metadata says "admin" cannot act on behalf of someone who is not one.
+"""
+
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..dashboard.admin import is_admin
+
+
+def configurable() -> dict[str, Any]:
+    try:
+        config = get_config()
+    except Exception:
+        return {}
+    values = config.get("configurable") if isinstance(config, dict) else None
+    return values if isinstance(values, dict) else {}
+
+
+def require_admin(action: str) -> str | None:
+    """Return an error message when the triggering user is not an admin."""
+    values = configurable()
+    login = values.get("github_login")
+    email = values.get("user_email")
+    if is_admin(
+        email if isinstance(email, str) else None,
+        login=login if isinstance(login, str) else None,
+    ):
+        return None
+    return f"Only workspace admins can {action}."

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -8,36 +8,15 @@ metadata says "admin" cannot act on behalf of someone who is not one.
 import logging
 from typing import Any
 
-from langgraph.config import get_config
-
 from ..dashboard import environments as store
-from ..dashboard.admin import is_admin
+from .admin_gate import configurable as _configurable
+from .admin_gate import require_admin
 
 logger = logging.getLogger(__name__)
 
-_NOT_ADMIN = "Only workspace admins can manage environments."
-
-
-def _configurable() -> dict[str, Any]:
-    try:
-        config = get_config()
-    except Exception:
-        return {}
-    configurable = config.get("configurable") if isinstance(config, dict) else None
-    return configurable if isinstance(configurable, dict) else {}
-
 
 def _require_admin() -> str | None:
-    """Return an error message when the triggering user is not an admin."""
-    configurable = _configurable()
-    login = configurable.get("github_login")
-    email = configurable.get("user_email")
-    if is_admin(
-        email if isinstance(email, str) else None,
-        login=login if isinstance(login, str) else None,
-    ):
-        return None
-    return _NOT_ADMIN
+    return require_admin("manage environments")
 
 
 def _summary(record: dict[str, Any]) -> dict[str, Any]:

--- a/agent/tools/organization_skills.py
+++ b/agent/tools/organization_skills.py
@@ -1,0 +1,70 @@
+"""Admin-thread tools for managing organization-wide skills."""
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from ..dashboard import skills as store
+from .admin_gate import require_admin
+
+_ACTION = "manage organization skills"
+
+
+async def save_organization_skill(
+    name: str, description: str, instructions: str = ""
+) -> dict[str, Any]:
+    """Create or update an organization skill, for workspace admins only.
+
+    Organization skills are loaded into every user's runs, so confirm the name and
+    wording with the user before saving. Instructions are a full replacement of the
+    skill body, not a delta. Existing skills are readable under
+    ``/organization-skills/``.
+
+    Args:
+        name: Skill name using lowercase letters, numbers, and single hyphens.
+        description: One-line summary telling an agent when the skill applies.
+        instructions: The skill's full ``SKILL.md`` body.
+
+    Returns:
+        ``{"ok": True, "skill": {...}, "created": bool}``.
+    """
+    if error := require_admin(_ACTION):
+        return {"ok": False, "error": error}
+    try:
+        body = store.SkillCreate(name=name, description=description, instructions=instructions)
+        update = store.SkillUpdate(description=body.description, instructions=body.instructions)
+        try:
+            skill = await store.update_organization_skill(body.name, update)
+            created = False
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+            skill = await store.create_organization_skill(body)
+            created = True
+    except HTTPException as exc:
+        return {"ok": False, "error": str(exc.detail)}
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "skill": skill, "created": created}
+
+
+async def delete_organization_skill(name: str) -> dict[str, Any]:
+    """Delete an organization skill, for workspace admins only.
+
+    Every user's runs lose the skill, so confirm with the user first.
+
+    Args:
+        name: Name of the organization skill to delete.
+
+    Returns:
+        ``{"ok": True, "name": name}``.
+    """
+    if error := require_admin(_ACTION):
+        return {"ok": False, "error": error}
+    try:
+        await store.delete_organization_skill(name)
+    except HTTPException as exc:
+        return {"ok": False, "error": str(exc.detail)}
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "name": name}

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -6,6 +6,7 @@ from langgraph.graph.state import RunnableConfig
 
 from agent import server
 from agent.prompt import construct_sender_context, construct_system_prompt
+from agent.tools import admin_gate
 from agent.tools import environments as env_tools
 
 _READY = {"slug": "base", "name": "Base", "snapshot_status": "ready", "snapshot_id": "env-snap"}
@@ -141,7 +142,7 @@ async def test_workspace_admin_resolves_email_for_github_login(
 @pytest.mark.asyncio
 async def test_tools_refuse_non_admins(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
-    with patch.object(env_tools, "get_config", return_value=_config(github_login="someone-else")):
+    with patch.object(admin_gate, "get_config", return_value=_config(github_login="someone-else")):
         assert await env_tools.list_environments() == {
             "ok": False,
             "error": "Only workspace admins can manage environments.",
@@ -166,7 +167,7 @@ async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.Monk
         }
     )
     with (
-        patch.object(env_tools, "get_config", return_value=_config(github_login="ramonn")),
+        patch.object(admin_gate, "get_config", return_value=_config(github_login="ramonn")),
         patch.object(env_tools.store, "get_environment", new_callable=AsyncMock, return_value=None),
         patch.object(env_tools.store, "create_environment", create),
     ):
@@ -205,7 +206,7 @@ async def test_save_environment_can_clear_sandbox_sizing(monkeypatch: pytest.Mon
         }
     )
     with (
-        patch.object(env_tools, "get_config", return_value=_config(github_login="ramonn")),
+        patch.object(admin_gate, "get_config", return_value=_config(github_login="ramonn")),
         patch.object(
             env_tools.store,
             "get_environment",
@@ -237,7 +238,7 @@ async def test_save_environment_rejects_clear_sizing_with_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
-    with patch.object(env_tools, "get_config", return_value=_config(github_login="ramonn")):
+    with patch.object(admin_gate, "get_config", return_value=_config(github_login="ramonn")):
         result = await env_tools.save_environment("base", "prompt", vcpus=8, clear_sizing=True)
 
     assert result == {
@@ -251,7 +252,7 @@ async def test_capture_tool_requires_a_saved_environment(monkeypatch: pytest.Mon
     monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
     with (
         patch.object(
-            env_tools,
+            admin_gate,
             "get_config",
             return_value=_config(github_login="ramonn", thread_id="t-1"),
         ),

--- a/tests/agent/test_skills.py
+++ b/tests/agent/test_skills.py
@@ -10,6 +10,7 @@ from agent.dashboard.skills import (
     list_organization_skills,
     list_skills,
 )
+from agent.tools.organization_skills import save_organization_skill
 from agent.tools.user_skills import save_user_skill
 
 
@@ -122,3 +123,14 @@ async def test_skill_listing_returns_next_offset() -> None:
     client.store.search_items.assert_awaited_once_with(
         ["user_skills", "octocat"], limit=2, offset=3
     )
+
+
+async def test_save_organization_skill_requires_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    with patch(
+        "agent.tools.admin_gate.get_config",
+        return_value={"configurable": {"github_login": "someone-else"}},
+    ):
+        result = await save_organization_skill("deslop", "Minimize diffs")
+
+    assert result["ok"] is False


### PR DESCRIPTION
## Description
Organization skills were dashboard-only. Admin threads now get `save_organization_skill` / `delete_organization_skill` alongside the environment tools, re-checking the triggering user against `CONFIGURED_ADMINS` like the dashboard's admin-gated routes. The admin gate moved to `agent/tools/admin_gate.py` so both toolsets share it.

## Release Note
Workspace admins can create, update, and delete organization skills from an admin thread.

## Test Plan
- [ ] In an admin thread, ask the agent to add and then delete an organization skill; confirm it appears in the dashboard skills list.
- [ ] Non-admin in an admin thread gets refused.

Made by [Open SWE](https://openswe.vercel.app/agents/01a02645-4c40-7262-a710-7b10796c2211)