### PR TITLE
fix: dispatch runs with Protocol v2 event streaming

### DIFF
--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -722,7 +722,6 @@ async def _launch_agent_schedule_record(
             admin_thread=admin_thread,
         ),
         client=client,
-        stream_mode=["values", "updates", "messages-tuple"],
         stream_resumable=True,
     )
     run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)

--- a/agent/dispatch.py
+++ b/agent/dispatch.py
@@ -17,6 +17,12 @@ busy-check and the custom store-queue) with one function that uses:
   event that drives ``stream.isLoading`` when it can replay the run's events, so
   a Slack/Linear/GitHub-triggered run looked idle in the web UI (no stop button)
   until it happened to emit its next event.
+- the Protocol v2 run shape — the same ``stream_mode`` set, ``stream_subgraphs``
+  and ``configurable`` marker that ``langgraph_api``'s ``run.start`` command
+  applies when the dashboard submits a run. The server fixes a run's streaming
+  protocol at creation: without the marker a run streams ``values`` only, so
+  the dashboard saw no ``tools`` events and no subagent namespaces for runs
+  triggered outside it (subagent cards never showed nested activity).
 """
 
 import logging
@@ -43,6 +49,23 @@ logger = logging.getLogger(__name__)
 
 ContentBlocks = str | list[dict[str, Any]]
 RunConfig = dict[str, Any]
+
+# Mirrors ``langgraph_api.event_streaming``'s ``EVENT_STREAMING_V2_CONFIG_KEY``.
+# Not imported: ``langgraph-api`` is the serving runtime, not a dependency of
+# this package. The marker alone selects the v3 stream path, which emits every
+# protocol channel (``tools``, ``lifecycle``, namespaced subagent events)
+# regardless of ``stream_mode``.
+EVENT_STREAMING_V2_CONFIG_KEY = "__event_streaming_v2"
+# The dashboard's ``run.start`` defaults, minus ``tools`` / ``lifecycle``: those
+# are protocol channels the REST ``POST /runs`` schema does not accept.
+V2_RUN_STREAM_MODES: tuple[str, ...] = (
+    "values",
+    "updates",
+    "messages",
+    "custom",
+    "tasks",
+    "checkpoints",
+)
 
 
 def _dispatch_input(content: ContentBlocks, source: str, configurable: dict[str, Any]) -> RunInput:
@@ -196,6 +219,7 @@ def prepare_run_config(
     configurable = run_config.get("configurable")
     configurable = dict(configurable) if isinstance(configurable, dict) else {}
     configurable.setdefault("prepare_run_id", str(uuid.uuid4()))
+    configurable[EVENT_STREAMING_V2_CONFIG_KEY] = True
     run_config["configurable"] = configurable
     existing_metadata = run_config.get("metadata")
     merged_metadata = dict(existing_metadata) if isinstance(existing_metadata, dict) else {}
@@ -218,7 +242,6 @@ async def create_durable_run(
     multitask_strategy: str = "interrupt",
     durability: str = "sync",
     if_not_exists: str = "create",
-    stream_mode: Any | None = None,
     stream_resumable: bool = True,
     after_seconds: int | float | None = None,
 ) -> Run:
@@ -232,12 +255,12 @@ async def create_durable_run(
         "multitask_strategy": multitask_strategy,
         "durability": durability,
         "if_not_exists": if_not_exists,
+        "stream_mode": list(V2_RUN_STREAM_MODES),
+        "stream_subgraphs": True,
         "stream_resumable": stream_resumable,
     }
     if COMPLETION_WEBHOOK_URL:
         create_kwargs["webhook"] = COMPLETION_WEBHOOK_URL
-    if stream_mode is not None:
-        create_kwargs["stream_mode"] = stream_mode
     if after_seconds is not None:
         create_kwargs["after_seconds"] = after_seconds
 

--- a/tests/agent/test_dispatch.py
+++ b/tests/agent/test_dispatch.py
@@ -103,6 +103,18 @@ async def test_create_durable_run_applies_defaults(monkeypatch: pytest.MonkeyPat
     assert created["webhook"] == "https://app/webhooks/run-complete"
     # Resumable by default so the dashboard can join (and stop) a run it did not start.
     assert created["stream_resumable"] is True
+    # The Protocol v2 run shape, so the dashboard gets `tools` events and subagent
+    # namespaces from runs it did not start — exactly what its own `run.start` sends.
+    assert created["stream_mode"] == [
+        "values",
+        "updates",
+        "messages",
+        "custom",
+        "tasks",
+        "checkpoints",
+    ]
+    assert created["stream_subgraphs"] is True
+    assert created["config"]["configurable"]["__event_streaming_v2"] is True
     prepare_run_id = created["config"]["configurable"]["prepare_run_id"]
     assert created["config"]["metadata"] == {
         "kind": "test",
@@ -114,7 +126,7 @@ async def test_create_durable_run_applies_defaults(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
-async def test_create_durable_run_preserves_existing_prepare_id_and_stream_kwargs(
+async def test_create_durable_run_preserves_existing_prepare_id_and_resumable_opt_out(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _FakeClient()
@@ -126,16 +138,26 @@ async def test_create_durable_run_preserves_existing_prepare_id_and_stream_kwarg
         input={"messages": []},
         source="schedule",
         config={"configurable": {"prepare_run_id": "existing"}},
-        stream_mode=["values"],
         stream_resumable=False,
         client=client,
     )
 
     created = client.runs.created[0]
     assert "webhook" not in created
-    assert created["stream_mode"] == ["values"]
     assert created["stream_resumable"] is False
     assert created["config"]["configurable"]["prepare_run_id"] == "existing"
+    assert created["config"]["configurable"]["__event_streaming_v2"] is True
+
+
+def test_prepare_run_config_marks_every_run_as_protocol_v2() -> None:
+    # The marker is fixed per run by the server: a caller cannot opt a run out of
+    # v2 by passing its own `configurable`, or the dashboard silently loses `tools`.
+    run_config = dispatch.prepare_run_config(
+        {"configurable": {"__event_streaming_v2": False, "thread_id": "t"}}, None
+    )
+
+    assert run_config["configurable"]["__event_streaming_v2"] is True
+    assert run_config["configurable"]["thread_id"] == "t"
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -169,6 +169,8 @@ _THREAD_TOOLS_RE = re.compile(
     r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
 _THREAD_TOOLS_TARGET_TITLE = "E2E Thread Tools Target"
+DELEGATE_MARKER = "E2E_DELEGATE"
+SUBAGENT_TASK_MARKER = "E2E_SUBAGENT_TASK"
 
 ToolArgs = dict[str, Any]
 StepFactory = Callable[[list[BaseMessage]], AIMessage]
@@ -600,6 +602,51 @@ def _resolve_thread_step(messages: list[BaseMessage]) -> AIMessage:
 
 
 SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
+    # Parent turn: delegate to two general-purpose subagents in one step so the
+    # transcript renders a subagent card grid. The subagents run this same fake
+    # model; their task description carries the marker that selects the
+    # ``subagent_task`` script below.
+    "delegate": (
+        StepSpec(
+            content="Delegating the investigation to two subagents.",
+            tool_calls=(
+                _tool_call(
+                    "task",
+                    {
+                        "description": f"{SUBAGENT_TASK_MARKER} inspect the repository layout",
+                        "subagent_type": "general-purpose",
+                    },
+                    "call-subagent-layout",
+                ),
+                _tool_call(
+                    "task",
+                    {
+                        "description": f"{SUBAGENT_TASK_MARKER} list the top-level files",
+                        "subagent_type": "general-purpose",
+                    },
+                    "call-subagent-files",
+                ),
+            ),
+        ),
+        StepSpec(content="Both subagents finished their investigation."),
+    ),
+    # Subagent turn: a slow shell step first so a spec that opens the thread
+    # right after the run starts can watch the nested activity live.
+    "subagent_task": (
+        _tool_step(
+            "Looking around the workspace.",
+            "execute",
+            {"command": "sleep 12 && ls"},
+            "call-subagent-ls",
+        ),
+        _tool_step(
+            "Confirming the listing.",
+            "execute",
+            {"command": "echo subagent-done"},
+            "call-subagent-echo",
+        ),
+        StepSpec(content="Subagent finished: listed the workspace."),
+    ),
     "thread_tools": (
         _dynamic_step(_list_threads_step),
         _dynamic_step(_get_thread_step),
@@ -869,6 +916,11 @@ def _is_revision(text: str) -> bool:
 
 
 SCRIPT_RULES: tuple[ScriptRule, ...] = (
+    ScriptRule(
+        "subagent_task",
+        lambda ctx: ctx.human_count <= 1 and SUBAGENT_TASK_MARKER in ctx.first_text,
+    ),
+    ScriptRule("delegate", lambda ctx: ctx.human_count <= 1 and DELEGATE_MARKER in ctx.first_text),
     ScriptRule(
         "thread_tools",
         lambda ctx: ctx.human_count <= 1 and _is_thread_tools_request(ctx.first_text),

--- a/tests/e2e/tests/dispatched_run_events.spec.ts
+++ b/tests/e2e/tests/dispatched_run_events.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Runs that Open SWE dispatches itself (Slack, Linear, GitHub, schedules) must
+// stream the same Protocol v2 events as runs the dashboard starts: `tools`
+// events for the root agent and namespaced events for its subagents. The
+// server fixes a run's streaming protocol at creation, so a legacy-shaped
+// `runs.create` leaves the dashboard with `values` only — subagent cards then
+// never show nested activity, and tool status comes from message replay alone.
+const USER = { login: "alice", email: "alice@example.com" };
+
+interface ProtocolEvent {
+  method: string;
+  params?: { namespace?: string[]; data?: Record<string, unknown> };
+}
+
+async function login(page: Page) {
+  const response = await page.request.post("/control/login", { data: USER });
+  expect(response.ok()).toBeTruthy();
+}
+
+// Dispatch through the real Slack webhook path and return the thread id.
+async function dispatchFromSlack(page: Page, text: string): Promise<string> {
+  const send = await page.request.post("/mock/slack/send", { data: { text } });
+  expect(send.ok()).toBeTruthy();
+  const { thread_id: threadId } = (await send.json()) as { thread_id: string };
+  expect(threadId).toBeTruthy();
+  return threadId;
+}
+
+// Replay the thread's event stream from the beginning (what the dashboard's
+// `useStream` does when it joins a run it did not start) until the root run
+// completes, and return every event seen.
+async function replayEvents(page: Page, threadId: string) {
+  return page.evaluate(async (id) => {
+    const events: ProtocolEvent[] = [];
+    const controller = new AbortController();
+    const deadline = setTimeout(() => controller.abort(), 60_000);
+    try {
+      const response = await fetch(
+        `/dashboard/api/threads/${id}/stream/events`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "text/event-stream",
+          },
+          body: JSON.stringify({
+            channels: ["values", "lifecycle", "tools"],
+            namespaces: [[]],
+            depth: 5,
+            since: 0,
+          }),
+          signal: controller.signal,
+        },
+      );
+      if (!response.ok) {
+        throw new Error(
+          `events stream failed: ${response.status} ${await response.text()}`,
+        );
+      }
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let completed = false;
+      while (!completed) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let separator: number;
+        while ((separator = buffer.search(/\r?\n\r?\n/)) >= 0) {
+          const frame = buffer.slice(0, separator);
+          buffer = buffer.slice(separator).replace(/^\r?\n\r?\n/, "");
+          const data = frame
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith("data:"))
+            .map((line) => line.slice(5).trim())
+            .join("");
+          if (!data) continue;
+          const event = JSON.parse(data) as ProtocolEvent;
+          events.push(event);
+          if (
+            event.method === "lifecycle" &&
+            event.params?.data?.event === "completed" &&
+            (event.params.namespace ?? []).length === 0
+          ) {
+            completed = true;
+          }
+        }
+      }
+    } catch (error) {
+      // The deadline aborts the fetch; whatever was collected is still the
+      // evidence the assertions need (and a clearer failure than an abort).
+      if ((error as { name?: string }).name !== "AbortError") throw error;
+    } finally {
+      clearTimeout(deadline);
+      controller.abort();
+    }
+    return events;
+  }, threadId);
+}
+
+test.describe("dispatched run events", () => {
+  test("a Slack-dispatched run streams tool events for the root agent and its subagents", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/mock/slack");
+    await page.locator("#reset").click();
+    const threadId = await dispatchFromSlack(
+      page,
+      "<@U0BOT> E2E_DELEGATE investigate the repository",
+    );
+
+    const events = await replayEvents(page, threadId);
+
+    const toolEvents = events.filter((event) => event.method === "tools");
+    const namespaceOf = (event: ProtocolEvent) => event.params?.namespace ?? [];
+    // `tool-started` carries the name; `tool-finished` only the call id.
+    const startedNames = (scope: ProtocolEvent[]) =>
+      scope
+        .filter((event) => event.params?.data?.event === "tool-started")
+        .map((event) => event.params?.data?.tool_name);
+    const finishedIds = (scope: ProtocolEvent[]) =>
+      scope
+        .filter((event) => event.params?.data?.event === "tool-finished")
+        .map((event) => event.params?.data?.tool_call_id);
+
+    // The root agent's two `task` calls, started and finished.
+    const rootTools = toolEvents.filter(
+      (event) => namespaceOf(event).length === 0,
+    );
+    expect(startedNames(rootTools)).toEqual(["task", "task"]);
+    expect(finishedIds(rootTools).sort()).toEqual([
+      "call-subagent-files",
+      "call-subagent-layout",
+    ]);
+
+    // Each subagent runs under its own namespace and reports its own shell
+    // steps there — the events the dashboard's subagent cards subscribe to.
+    const nested = toolEvents.filter((event) => namespaceOf(event).length > 0);
+    const nestedNamespaces = new Set(
+      nested.map((event) => namespaceOf(event).join("/")),
+    );
+    expect(nestedNamespaces.size).toBe(2);
+    for (const namespace of nestedNamespaces) {
+      const scope = nested.filter(
+        (event) => namespaceOf(event).join("/") === namespace,
+      );
+      expect(startedNames(scope)).toEqual(["execute", "execute"]);
+      expect(finishedIds(scope).sort()).toEqual([
+        "call-subagent-echo",
+        "call-subagent-ls",
+      ]);
+    }
+
+    const subagentLifecycle = events
+      .filter(
+        (event) =>
+          event.method === "lifecycle" && namespaceOf(event).length > 0,
+      )
+      .map((event) => event.params?.data?.graph_name);
+    expect(subagentLifecycle).toContain("general-purpose");
+  });
+});


### PR DESCRIPTION
## Problem

langgraph-api fixes a run's streaming protocol when the run is created. Runs started from the dashboard go through the v2 `run.start` command (`langgraph_api/event_streaming/service.py`), which stamps `configurable.__event_streaming_v2 = True` and streams every protocol channel — `tools` events for the root agent and namespaced `tools`/`lifecycle`/`values` events for subagents.

Runs Open SWE dispatches itself (Slack, Linear, GitHub, schedules, baby-sit) went through the legacy REST `runs.create` with `stream_mode=values`. For those the dashboard's event stream only ever carried `values` snapshots: tool status had to be reconstructed from message replay, and subagent cards could never show nested activity (subagents aren't checkpointed subgraphs either — `"Subgraph tools not found"` on a scoped history read — so there is no replay fallback).

## Fix

`create_durable_run` now creates runs the way the dashboard does: the v2 marker in `configurable`, `stream_subgraphs=True`, and the same `stream_mode` set minus `tools`/`lifecycle` (the REST schema rejects those; the v3 stream path selected by the marker emits them regardless). `prepare_run_config` always sets the marker, so a caller-supplied `configurable` can't silently downgrade a run. The `schedules.py` `stream_mode` override is gone — it was the legacy shape.

## Tests

- `tests/agent/test_dispatch.py`: asserts the v2 shape on created runs and that the marker is forced on.
- `tests/e2e/tests/dispatched_run_events.spec.ts`: dispatches a run from mock Slack whose scripted model spawns two `general-purpose` subagents, replays the thread's `/stream/events` from seq 0 and asserts the root `task` start/finish events plus, per subagent namespace, the `execute` start/finish events and a `general-purpose` lifecycle event. Without the fix the replay contains only `lifecycle` + `values`.
- Full Playwright suite: 52 passed, 1 skipped (LangSmith-only). `pytest`: 1853 passed; the 3 failures in `test_background_execute.py` are the macOS `setsid` environment issue, unrelated.

Fake-LLM `delegate` / `subagent_task` scripts are shared with the in-flight AI Elements chat-UI branch (identical text) so they merge cleanly.
