### PR TITLE
fix: open thread actions from row context menu

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -183,12 +183,7 @@ async function openThreadActionsMenu(page: Page) {
   await page
     .getByRole("link", { name: /please add a greet/ })
     .first()
-    .hover();
-  const actionsButton = page
-    .getByRole("button", { name: "Thread actions" })
-    .first();
-  await expect(actionsButton).toBeVisible();
-  await actionsButton.click();
+    .click({ button: "right" });
 }
 
 test.describe("Slack → web handoff (real dashboard UI)", () => {

--- a/tests/e2e/tests/sandbox_id.spec.ts
+++ b/tests/e2e/tests/sandbox_id.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Locator, type Page } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 // Exercises the sidebar's "Copy sandbox ID" action against the REAL dashboard
 // UI and a REAL (local-provider) sandbox: the Slack flow runs the agent, which
@@ -39,13 +39,8 @@ async function createThreadWithSandbox(page: Page): Promise<string> {
 const copyItem = (page: Page) =>
   page.getByRole("menuitem", { name: "Copy sandbox ID" });
 
-// The kebab sits beside the row Link (not inside the anchor), so reach it via
-// their shared wrapper — the Link's parent.
-const kebabFor = (row: Locator) =>
-  row.locator("..").getByRole("button", { name: "Thread actions" });
-
 test.describe("thread sandbox id (real dashboard UI)", () => {
-  test("desktop: kebab menu copies the real sandbox id", async ({
+  test("desktop: context menu copies the real sandbox id", async ({
     page,
     baseURL,
   }) => {
@@ -59,9 +54,7 @@ test.describe("thread sandbox id (real dashboard UI)", () => {
 
     const row = page.locator(`a[href$="/agents/${threadId}"]`).first();
     await expect(row).toBeVisible();
-    // The kebab is revealed on hover on pointer devices.
-    await row.hover();
-    await kebabFor(row).click();
+    await row.click({ button: "right" });
 
     await expect(copyItem(page)).toBeEnabled();
     await copyItem(page).click();
@@ -70,13 +63,12 @@ test.describe("thread sandbox id (real dashboard UI)", () => {
     expect(clip.length).toBeGreaterThan(0);
   });
 
-  test("iPad: kebab copies the sandbox id without navigating", async ({
+  test("iPad: long press copies the sandbox id without navigating", async ({
     browser,
     baseURL,
   }) => {
-    // iPad-class device: Chromium in mobile mode reports (hover: none), which
-    // gates the touch-only kebab. 834px is wider than the 767px mobile
-    // breakpoint, so the sidebar renders inline.
+    // 834px is wider than the 767px mobile breakpoint, so the sidebar renders
+    // inline while Chromium still emits touch events for the long press.
     const context = await browser.newContext({
       baseURL,
       viewport: { width: 834, height: 1112 },
@@ -98,9 +90,30 @@ test.describe("thread sandbox id (real dashboard UI)", () => {
     const rowA = page.locator(`a[href$="/agents/${threadA}"]`).first();
     await expect(rowA).toBeVisible();
 
-    const kebab = kebabFor(rowA);
-    await expect(kebab).toBeVisible();
-    await kebab.tap();
+    await rowA.evaluate((element) => {
+      const touch = new Touch({
+        identifier: 0,
+        target: element,
+        clientX: 20,
+        clientY: 20,
+        radiusX: 1,
+        radiusY: 1,
+        rotationAngle: 0,
+        force: 1,
+      });
+      element.dispatchEvent(
+        new TouchEvent("touchstart", {
+          bubbles: true,
+          cancelable: true,
+          touches: [touch],
+          targetTouches: [touch],
+          changedTouches: [touch],
+        }),
+      );
+    });
+    await expect(copyItem(page)).toBeVisible();
+    await rowA.dispatchEvent("touchend", { changedTouches: [] });
+    await rowA.dispatchEvent("click");
 
     await expect(copyItem(page)).toBeEnabled();
     await copyItem(page).tap();
@@ -108,7 +121,6 @@ test.describe("thread sandbox id (real dashboard UI)", () => {
     const clip = await page.evaluate(() => navigator.clipboard.readText());
     expect(clip.length).toBeGreaterThan(0);
 
-    // Tapping the kebab must open the menu, not follow A's Link — we stay on B.
     await expect(page).toHaveURL(new RegExp(`/agents/${threadB}$`));
 
     await context.close();
@@ -133,8 +145,7 @@ test.describe("thread sandbox id (real dashboard UI)", () => {
 
     const row = bobPage.locator(`a[href$="/agents/${threadId}"]`).first();
     await expect(row).toBeVisible();
-    await row.hover();
-    await kebabFor(row).click();
+    await row.press("Shift+F10");
     await expect(copyItem(bobPage)).toBeEnabled();
 
     const screenshotPath = testInfo.outputPath(

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@base-ui/react/menu"
+import { ContextMenu } from "@base-ui/react/context-menu"
 import { Dialog } from "@base-ui/react/dialog"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
@@ -10,7 +10,6 @@ import {
   CheckCircleIcon,
   CircleNotchIcon,
   CopyIcon,
-  DotsThreeVerticalIcon,
   FolderOpenIcon,
   GitMergeIcon,
   GitPullRequestIcon,
@@ -664,63 +663,50 @@ function LocalThreadRow({
 
   return (
     <>
-      <div className={cn("group relative mb-0.5", isDeleting && "opacity-50")}>
-        <Link
-          to="/agents/local/$sessionId"
-          params={{ sessionId: session.id }}
-          onClick={onNavigate}
-          className={cn(
-            "flex items-center gap-2 rounded-lg px-2.5 transition-colors group-hover:pr-8 [@media(hover:none)]:pr-8",
-            compact ? "h-7 gap-1.5" : "h-8",
-            isActive
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground group-hover:bg-sidebar-row-hover"
-          )}
+      <ContextMenu.Root>
+        <ContextMenu.Trigger
+          className={cn("group relative mb-0.5", isDeleting && "opacity-50")}
         >
-          {running ? (
-            <CircleNotchIcon
-              className="size-3 shrink-0 animate-spin text-primary"
-              aria-label="Local thread running"
-            />
-          ) : (
-            <span className="size-2 shrink-0 rounded-full bg-border" />
-          )}
-          <span className="min-w-0 flex-1 truncate text-[13px]">
-            {session.title}
-          </span>
-        </Link>
-        <Menu.Root>
-          <Menu.Trigger
-            render={
-              <button
-                type="button"
-                aria-label="Local thread actions"
-                className="absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/70 group-hover:flex hover:bg-accent hover:text-foreground data-popup-open:flex [@media(hover:none)]:flex"
+          <Link
+            to="/agents/local/$sessionId"
+            params={{ sessionId: session.id }}
+            onClick={onNavigate}
+            className={cn(
+              "flex items-center gap-2 rounded-lg px-2.5 transition-colors",
+              compact ? "h-7 gap-1.5" : "h-8",
+              isActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground group-hover:bg-sidebar-row-hover"
+            )}
+          >
+            {running ? (
+              <CircleNotchIcon
+                className="size-3 shrink-0 animate-spin text-primary"
+                aria-label="Local thread running"
+              />
+            ) : (
+              <span className="size-2 shrink-0 rounded-full bg-border" />
+            )}
+            <span className="min-w-0 flex-1 truncate text-[13px]">
+              {session.title}
+            </span>
+          </Link>
+        </ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Positioner className="z-50 outline-none">
+            <ContextMenu.Popup className="min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+              <ContextMenu.Item
+                onClick={() => setDeleteOpen(true)}
+                disabled={isDeleting}
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
               >
-                <DotsThreeVerticalIcon className="size-4" weight="bold" />
-              </button>
-            }
-          />
-          <Menu.Portal>
-            <Menu.Positioner
-              align="end"
-              sideOffset={4}
-              className="z-50 outline-none"
-            >
-              <Menu.Popup className="min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
-                <Menu.Item
-                  onClick={() => setDeleteOpen(true)}
-                  disabled={isDeleting}
-                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
-                >
-                  <TrashIcon className="size-3.5" />
-                  Delete thread
-                </Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Portal>
-        </Menu.Root>
-      </div>
+                <TrashIcon className="size-3.5" />
+                Delete thread
+              </ContextMenu.Item>
+            </ContextMenu.Popup>
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>
       <DeleteThreadDialog
         open={deleteOpen}
         onOpenChange={(open) => {
@@ -976,164 +962,145 @@ function ThreadRow({
 
   return (
     <>
-      <div className={cn("group relative mb-0.5", isDeleting && "opacity-50")}>
-        <Link
-          to="/agents/$threadId"
-          params={{ threadId: thread.id }}
-          onClick={onNavigate}
-          className={cn(
-            "flex items-center gap-2 rounded-lg px-2.5 transition-colors group-hover:pr-8 [@media(hover:none)]:pr-8",
-            compact ? "h-7 gap-1.5" : "h-8",
-            isActive
-              ? thread.adminThread
-                ? "bg-destructive/10 text-foreground"
-                : "bg-accent text-foreground"
-              : thread.adminThread
-                ? "bg-destructive/5 text-muted-foreground group-hover:bg-destructive/10"
-                : "text-muted-foreground group-hover:bg-sidebar-row-hover"
-          )}
+      <ContextMenu.Root>
+        <ContextMenu.Trigger
+          className={cn("group relative mb-0.5", isDeleting && "opacity-50")}
         >
-          {thread.status === "running" ? (
-            <CircleNotchIcon
-              className="size-3 shrink-0 animate-spin text-primary"
-              aria-label="Thread running"
-            />
-          ) : (
-            <span
-              className={cn(
-                "size-2 shrink-0 rounded-full",
-                showFinishedIndicator ? "bg-primary" : "bg-border"
-              )}
-              aria-label={
-                showFinishedIndicator ? "Thread finished" : "Thread viewed"
-              }
-            />
-          )}
-          {source && SourceIcon && (
-            <SourceIcon
-              className="size-3.5 shrink-0 text-muted-foreground/70"
-              aria-label={source.label}
-            >
-              <title>{source.label}</title>
-            </SourceIcon>
-          )}
-          <span className="min-w-0 flex-1 truncate text-[13px]">
-            {thread.title}
-          </span>
-          {thread.automationActionPosted && (
-            <IoLogoSlack
-              className="size-3.5 shrink-0 text-success-foreground"
-              aria-label="Action posted to Slack"
-            >
-              <title>Action posted to Slack</title>
-            </IoLogoSlack>
-          )}
-          {!compact && isAutomation && (
-            <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] text-muted-foreground group-hover:hidden">
-              Automation
-            </span>
-          )}
-          {!compact && prMeta && PrIcon && (
-            <PrIcon
-              className={cn(
-                "size-3.5 shrink-0 group-hover:hidden",
-                prMeta.className
-              )}
-              aria-label={prMeta.label}
-            >
-              <title>{prMeta.label}</title>
-            </PrIcon>
-          )}
-          {!compact && badge && (
-            <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] text-success-foreground group-hover:hidden">
-              {badge}
-            </span>
-          )}
-        </Link>
-        {/* One actions menu for every input: revealed on hover, kept while
-            open, and always shown on devices that can't hover (touch). It sits
-            outside the Link so opening it never navigates the row. */}
-        <Menu.Root>
-          <Menu.Trigger
-            render={
-              <button
-                type="button"
-                aria-label="Thread actions"
-                className="absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/70 group-hover:flex hover:bg-accent hover:text-foreground data-popup-open:flex [@media(hover:none)]:flex"
+          <Link
+            to="/agents/$threadId"
+            params={{ threadId: thread.id }}
+            onClick={onNavigate}
+            className={cn(
+              "flex items-center gap-2 rounded-lg px-2.5 transition-colors",
+              compact ? "h-7 gap-1.5" : "h-8",
+              isActive
+                ? thread.adminThread
+                  ? "bg-destructive/10 text-foreground"
+                  : "bg-accent text-foreground"
+                : thread.adminThread
+                  ? "bg-destructive/5 text-muted-foreground group-hover:bg-destructive/10"
+                  : "text-muted-foreground group-hover:bg-sidebar-row-hover"
+            )}
+          >
+            {thread.status === "running" ? (
+              <CircleNotchIcon
+                className="size-3 shrink-0 animate-spin text-primary"
+                aria-label="Thread running"
+              />
+            ) : (
+              <span
+                className={cn(
+                  "size-2 shrink-0 rounded-full",
+                  showFinishedIndicator ? "bg-primary" : "bg-border"
+                )}
+                aria-label={
+                  showFinishedIndicator ? "Thread finished" : "Thread viewed"
+                }
+              />
+            )}
+            {source && SourceIcon && (
+              <SourceIcon
+                className="size-3.5 shrink-0 text-muted-foreground/70"
+                aria-label={source.label}
               >
-                <DotsThreeVerticalIcon className="size-4" weight="bold" />
-              </button>
-            }
-          />
-          <Menu.Portal>
-            <Menu.Positioner
-              align="end"
-              sideOffset={4}
-              className="z-50 outline-none"
-            >
-              <Menu.Popup className="min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
-                {thread.traceUrl && (
-                  <Menu.LinkItem
-                    href={thread.traceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    closeOnClick
-                    className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
-                  >
-                    <TreeStructureIcon className="size-3.5" />
-                    Open trace
-                  </Menu.LinkItem>
-                )}
-                {thread.sourceUrl && (
-                  <Menu.LinkItem
-                    href={thread.sourceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    closeOnClick
-                    className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
-                  >
-                    <IoLogoSlack className="size-3.5" />
-                    Open Slack thread
-                  </Menu.LinkItem>
-                )}
-                <Menu.Item
-                  disabled={!thread.sandboxId}
-                  onClick={copySandboxId}
-                  title={thread.sandboxId ?? undefined}
+                <title>{source.label}</title>
+              </SourceIcon>
+            )}
+            <span className="min-w-0 flex-1 truncate text-[13px]">
+              {thread.title}
+            </span>
+            {thread.automationActionPosted && (
+              <IoLogoSlack
+                className="size-3.5 shrink-0 text-success-foreground"
+                aria-label="Action posted to Slack"
+              >
+                <title>Action posted to Slack</title>
+              </IoLogoSlack>
+            )}
+            {!compact && isAutomation && (
+              <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                Automation
+              </span>
+            )}
+            {!compact && prMeta && PrIcon && (
+              <PrIcon
+                className={cn("size-3.5 shrink-0", prMeta.className)}
+                aria-label={prMeta.label}
+              >
+                <title>{prMeta.label}</title>
+              </PrIcon>
+            )}
+            {!compact && badge && (
+              <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] text-success-foreground">
+                {badge}
+              </span>
+            )}
+          </Link>
+        </ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Positioner className="z-50 outline-none">
+            <ContextMenu.Popup className="min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+              {thread.traceUrl && (
+                <ContextMenu.LinkItem
+                  href={thread.traceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  closeOnClick
+                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
+                >
+                  <TreeStructureIcon className="size-3.5" />
+                  Open trace
+                </ContextMenu.LinkItem>
+              )}
+              {thread.sourceUrl && (
+                <ContextMenu.LinkItem
+                  href={thread.sourceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  closeOnClick
+                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
+                >
+                  <IoLogoSlack className="size-3.5" />
+                  Open Slack thread
+                </ContextMenu.LinkItem>
+              )}
+              <ContextMenu.Item
+                disabled={!thread.sandboxId}
+                onClick={copySandboxId}
+                title={thread.sandboxId ?? undefined}
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
+              >
+                <CopyIcon className="size-3.5" />
+                Copy sandbox ID
+              </ContextMenu.Item>
+              {!isReadOnly && (
+                <ContextMenu.Item
+                  onClick={() => onToggleResolved()}
+                  disabled={resolveThread.isPending}
                   className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
                 >
-                  <CopyIcon className="size-3.5" />
-                  Copy sandbox ID
-                </Menu.Item>
-                {!isReadOnly && (
-                  <Menu.Item
-                    onClick={() => onToggleResolved()}
-                    disabled={resolveThread.isPending}
-                    className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
-                  >
-                    {isResolved ? (
-                      <ArrowCounterClockwiseIcon className="size-3.5" />
-                    ) : (
-                      <CheckCircleIcon className="size-3.5" />
-                    )}
-                    {isResolved ? "Unresolve thread" : "Resolve thread"}
-                  </Menu.Item>
-                )}
-                {!isReadOnly && (
-                  <Menu.Item
-                    onClick={() => onDelete()}
-                    disabled={isDeleting}
-                    className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
-                  >
-                    <TrashIcon className="size-3.5" />
-                    Delete thread
-                  </Menu.Item>
-                )}
-              </Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Portal>
-        </Menu.Root>
-      </div>
+                  {isResolved ? (
+                    <ArrowCounterClockwiseIcon className="size-3.5" />
+                  ) : (
+                    <CheckCircleIcon className="size-3.5" />
+                  )}
+                  {isResolved ? "Unresolve thread" : "Resolve thread"}
+                </ContextMenu.Item>
+              )}
+              {!isReadOnly && (
+                <ContextMenu.Item
+                  onClick={() => onDelete()}
+                  disabled={isDeleting}
+                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
+                >
+                  <TrashIcon className="size-3.5" />
+                  Delete thread
+                </ContextMenu.Item>
+              )}
+            </ContextMenu.Popup>
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>
       <DeleteThreadDialog
         open={deleteOpen}
         onOpenChange={setDeleteOpen}

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -121,6 +121,24 @@ const PR_STATE_META: Record<
   },
 }
 
+function openContextMenuFromKeyboard(
+  event: React.KeyboardEvent<HTMLAnchorElement>
+) {
+  if (event.key !== "ContextMenu" && !(event.shiftKey && event.key === "F10")) {
+    return
+  }
+  event.preventDefault()
+  const rect = event.currentTarget.getBoundingClientRect()
+  event.currentTarget.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    })
+  )
+}
+
 interface AgentsSidebarProps {
   user: SessionUser | null
   localOnly?: boolean
@@ -637,6 +655,7 @@ function LocalThreadRow({
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [contextMenuOpen, setContextMenuOpen] = useState(false)
   const running = useLocalThreadActivity()[session.id] === "running"
 
   const confirmDelete = async () => {
@@ -663,14 +682,21 @@ function LocalThreadRow({
 
   return (
     <>
-      <ContextMenu.Root>
+      <ContextMenu.Root onOpenChange={setContextMenuOpen}>
         <ContextMenu.Trigger
           className={cn("group relative mb-0.5", isDeleting && "opacity-50")}
         >
           <Link
             to="/agents/local/$sessionId"
             params={{ sessionId: session.id }}
-            onClick={onNavigate}
+            onClick={(event) => {
+              if (contextMenuOpen) {
+                event.preventDefault()
+                return
+              }
+              onNavigate?.()
+            }}
+            onKeyDown={openContextMenuFromKeyboard}
             className={cn(
               "flex items-center gap-2 rounded-lg px-2.5 transition-colors",
               compact ? "h-7 gap-1.5" : "h-8",
@@ -914,6 +940,7 @@ function ThreadRow({
   const deleteThread = useDeleteAgentThread()
   const resolveThread = useResolveAgentThread()
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [contextMenuOpen, setContextMenuOpen] = useState(false)
   const isReadOnly = thread.isOwner === false
   const badge =
     thread.diffStats && thread.diffStats.additions > 0
@@ -962,14 +989,21 @@ function ThreadRow({
 
   return (
     <>
-      <ContextMenu.Root>
+      <ContextMenu.Root onOpenChange={setContextMenuOpen}>
         <ContextMenu.Trigger
           className={cn("group relative mb-0.5", isDeleting && "opacity-50")}
         >
           <Link
             to="/agents/$threadId"
             params={{ threadId: thread.id }}
-            onClick={onNavigate}
+            onClick={(event) => {
+              if (contextMenuOpen) {
+                event.preventDefault()
+                return
+              }
+              onNavigate?.()
+            }}
+            onKeyDown={openContextMenuFromKeyboard}
             className={cn(
               "flex items-center gap-2 rounded-lg px-2.5 transition-colors",
               compact ? "h-7 gap-1.5" : "h-8",


### PR DESCRIPTION
## Description
Thread actions were only reachable through a small three-dot button. The full cloud and local thread rows now use the existing Base UI context menu on right-click or long-press.

## Release Note
Sidebar thread actions now open from the full thread-row context menu.

## Test Plan
- [ ] Right-click cloud and local thread rows and verify actions open at the pointer while left-click still navigates.

Made by [Open SWE](https://openswe.vercel.app/agents/04908cc2-6313-5f74-bb94-3fb8cd85bc50)