### PR TITLE
fix: recover new thread transcript hydration

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -20,6 +20,7 @@ import {
   writeStoredPanelCollapsed,
 } from "@/features/agents/lib/gitPanelPreferences"
 import { Messages } from "@/features/agents/components/messages"
+import { OptimisticThreadHydrationRecovery } from "@/features/agents/components/OptimisticThreadHydrationRecovery"
 import { latestContextTokens } from "@/features/agents/lib/contextUsage"
 import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
@@ -195,6 +196,10 @@ export function AgentThreadView({
 
   return (
     <div className="flex min-w-0 flex-1">
+      <OptimisticThreadHydrationRecovery
+        threadId={thread.id}
+        enabled={thread.messages.length > 0}
+      />
       <div
         className={cn(
           "flex min-w-0 flex-1 flex-col",

--- a/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.test.tsx
+++ b/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.test.tsx
@@ -36,6 +36,8 @@ afterEach(() => {
 
 describe("OptimisticThreadHydrationRecovery", () => {
   it("retries hydration after an optimistic thread races server creation", async () => {
+    mocks.stream.hydrationPromise = Promise.reject(new Error("not found"))
+
     render(
       <OptimisticThreadHydrationRecovery threadId="thread-1" enabled={true} />
     )

--- a/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.test.tsx
+++ b/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.test.tsx
@@ -1,0 +1,81 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, render } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { OptimisticThreadHydrationRecovery } from "./OptimisticThreadHydrationRecovery"
+
+const mocks = vi.hoisted(() => ({
+  controller: { hydrate: vi.fn().mockResolvedValue(undefined) },
+  streamController: Symbol("stream-controller"),
+  stream: {
+    hydrationPromise: Promise.resolve(),
+    messages: [] as Array<unknown>,
+  },
+}))
+
+vi.mock("@langchain/react", () => ({
+  STREAM_CONTROLLER: mocks.streamController,
+  useStreamContext: () => ({
+    ...mocks.stream,
+    [mocks.streamController]: mocks.controller,
+  }),
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.controller.hydrate.mockClear()
+  mocks.stream.hydrationPromise = Promise.resolve()
+  mocks.stream.messages = []
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("OptimisticThreadHydrationRecovery", () => {
+  it("retries hydration after an optimistic thread races server creation", async () => {
+    render(
+      <OptimisticThreadHydrationRecovery threadId="thread-1" enabled={true} />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(250)
+    })
+
+    expect(mocks.controller.hydrate).toHaveBeenCalledWith("thread-1")
+  })
+
+  it("stops retrying once the stream contains messages", async () => {
+    const view = render(
+      <OptimisticThreadHydrationRecovery threadId="thread-1" enabled={true} />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(250)
+    })
+    mocks.stream.messages = [{}]
+    view.rerender(
+      <OptimisticThreadHydrationRecovery threadId="thread-1" enabled={true} />
+    )
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    expect(mocks.controller.hydrate).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not retry hydration for a non-optimistic thread", async () => {
+    render(
+      <OptimisticThreadHydrationRecovery threadId="thread-1" enabled={false} />
+    )
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    expect(mocks.controller.hydrate).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.tsx
+++ b/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react"
+import { STREAM_CONTROLLER, useStreamContext } from "@langchain/react"
+
+const RETRY_DELAYS_MS = [250, 1_000, 2_500]
+
+export function OptimisticThreadHydrationRecovery({
+  threadId,
+  enabled,
+}: {
+  threadId: string
+  enabled: boolean
+}) {
+  const stream = useStreamContext()
+  const controller = stream[STREAM_CONTROLLER]
+
+  useEffect(() => {
+    if (!enabled || stream.messages.length > 0) return
+
+    let cancelled = false
+    let retry = 0
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const schedule = () => {
+      if (cancelled || retry >= RETRY_DELAYS_MS.length) return
+      timer = setTimeout(() => {
+        if (cancelled) return
+        retry += 1
+        void controller
+          .hydrate(threadId)
+          .catch(() => undefined)
+          .finally(schedule)
+      }, RETRY_DELAYS_MS[retry])
+    }
+
+    void stream.hydrationPromise.then(schedule, () => undefined)
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [
+    controller,
+    enabled,
+    stream.hydrationPromise,
+    stream.messages.length,
+    threadId,
+  ])
+
+  return null
+}

--- a/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.tsx
+++ b/ui/src/features/agents/components/OptimisticThreadHydrationRecovery.tsx
@@ -32,7 +32,7 @@ export function OptimisticThreadHydrationRecovery({
       }, RETRY_DELAYS_MS[retry])
     }
 
-    void stream.hydrationPromise.then(schedule, () => undefined)
+    void stream.hydrationPromise.then(schedule, schedule)
     return () => {
       cancelled = true
       if (timer) clearTimeout(timer)


### PR DESCRIPTION
## Description
New threads can navigate before the server row exists, leaving the nested stream parked after its initial 404. Retry hydration while the optimistic prompt is present so the transcript recovers once the row exists.

## Release Note
Fixed new dashboard threads occasionally appearing empty while an agent was running.

## Test Plan
- [x] Simulated missing-thread hydration and verified retry stops after messages arrive.

Made by [Open SWE](https://openswe.vercel.app/agents/5a837e8d-50e4-57b6-a936-867b5a15dcdc)