### PR TITLE
feat: inject Datadog auth through sandbox proxy

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -45,7 +45,24 @@ PROXY_CONFIG_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 5
 PROXY_CONFIG_NOT_READY_STATUS = 400
 PROXY_CONFIG_ERROR_BODY_CHARS = 500
 SANDBOX_START_TIMEOUT_SECONDS = 120
-PROXY_GH_TOKEN_PLACEHOLDER = "proxy-injected"
+PROXY_SECRET_PLACEHOLDER = "proxy-injected"
+PROXY_GH_TOKEN_PLACEHOLDER = PROXY_SECRET_PLACEHOLDER
+
+
+def _datadog_proxy_rule(site: str, api_key: str, app_key: str) -> dict[str, Any]:
+    return {
+        "name": "datadog-api",
+        "match_hosts": [f"api.{site}"],
+        "headers": [
+            {"name": "DD-API-KEY", "type": "opaque", "value": api_key},
+            {"name": "DD-APPLICATION-KEY", "type": "opaque", "value": app_key},
+        ],
+        "env_vars": {
+            "DD_API_KEY": PROXY_SECRET_PLACEHOLDER,
+            "DD_APP_KEY": PROXY_SECRET_PLACEHOLDER,
+            "DD_SITE": site,
+        },
+    }
 
 
 def _get_langsmith_api_key() -> str | None:
@@ -385,11 +402,10 @@ async def _configure_github_proxy(
     *,
     base_proxy_config: dict[str, Any] | None = None,
 ) -> None:
-    """Configure sandbox proxy to inject GitHub auth for GitHub traffic.
+    """Configure sandbox proxy to inject service credentials into outbound traffic.
 
-    Uses the LangSmith proxy-config API to set up header injection so that
-    git operations (clone, pull, push) authenticate via the proxy rather than
-    writing credentials to disk in the sandbox.
+    Uses the LangSmith proxy-config API so GitHub and connected Datadog operations
+    authenticate through the proxy rather than writing credentials to the sandbox.
 
     Args:
         sandbox_name: The sandbox name/ID returned by the LangSmith API.
@@ -402,10 +418,14 @@ async def _configure_github_proxy(
         return
     langsmith_endpoint = _get_sandbox_endpoint()
     url = f"{langsmith_endpoint}/v2/sandboxes/boxes/{sandbox_name}"
+    from agent.dashboard.team_credentials import get_datadog_credentials
+
     proxy_config = dict(base_proxy_config or {})
     custom_rules = proxy_config.get("rules")
+    datadog = await get_datadog_credentials()
     proxy_config["rules"] = [
         *(custom_rules if isinstance(custom_rules, list) else []),
+        *([_datadog_proxy_rule(datadog.site, datadog.api_key, datadog.app_key)] if datadog else []),
         *_github_proxy_rules(github_token),
     ]
     payload = {"proxy_config": proxy_config}

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -53,6 +53,7 @@ def _datadog_proxy_rule(site: str, api_key: str, app_key: str) -> dict[str, Any]
     return {
         "name": "datadog-api",
         "match_hosts": [f"api.{site}"],
+        "match_paths": ["/api/*"],
         "headers": [
             {"name": "DD-API-KEY", "type": "opaque", "value": api_key},
             {"name": "DD-APPLICATION-KEY", "type": "opaque", "value": app_key},
@@ -401,6 +402,7 @@ async def _configure_github_proxy(
     github_token: str,
     *,
     base_proxy_config: dict[str, Any] | None = None,
+    datadog_authorized: bool = False,
 ) -> None:
     """Configure sandbox proxy to inject service credentials into outbound traffic.
 
@@ -422,7 +424,7 @@ async def _configure_github_proxy(
 
     proxy_config = dict(base_proxy_config or {})
     custom_rules = proxy_config.get("rules")
-    datadog = await get_datadog_credentials()
+    datadog = await get_datadog_credentials() if datadog_authorized else None
     proxy_config["rules"] = [
         *(custom_rules if isinstance(custom_rules, list) else []),
         *([_datadog_proxy_rule(datadog.site, datadog.api_key, datadog.app_key)] if datadog else []),

--- a/agent/server.py
+++ b/agent/server.py
@@ -979,6 +979,18 @@ def _slack_tools_enabled(configurable: dict[str, Any]) -> bool:
     )
 
 
+def _environment_prompt(environment: dict[str, Any] | None, datadog_site: str | None) -> str | None:
+    instructions = environment_prompt(environment)
+    if not datadog_site:
+        return instructions
+    datadog = (
+        f"Datadog Pup CLI is authenticated through the sandbox proxy for "
+        f"`{datadog_site}`. `DD_API_KEY` and `DD_APP_KEY` are placeholders; never print or "
+        "treat them as credentials."
+    )
+    return f"{instructions}\n\n{datadog}" if instructions else datadog
+
+
 def _make_model_or_defer(
     model_id: str,
     *,
@@ -1208,6 +1220,9 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         del github_token
         work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
         environment = await resolve_environment(_environment_slug(configurable))
+        from .dashboard.team_credentials import get_datadog_credentials
+
+        datadog = await get_datadog_credentials()
         sender_instructions = await _resolve_user_custom_instructions(self._profile_login)
         sender_context = construct_sender_context(
             triggering_user_identity,
@@ -1267,7 +1282,9 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 repo_custom_instructions=self._repo_instructions,
                 corridor_enabled=self._corridor_enabled,
                 environment_name=(environment or {}).get("name"),
-                environment_instructions=environment_prompt(environment),
+                environment_instructions=_environment_prompt(
+                    environment, datadog.site if datadog else None
+                ),
                 admin_environments=self._admin_environments,
                 source=self._source,
                 slack_context=_slack_tools_enabled(configurable),

--- a/agent/server.py
+++ b/agent/server.py
@@ -348,6 +348,7 @@ async def _create_sandbox_with_proxy(
     github_proxy_repositories: Sequence[str] | None = None,
     repo: dict[str, str] | None = None,
     environment_slug: str | None = None,
+    datadog_authorized: bool = False,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
     snapshot_id, resources, create_params = await _resolve_sandbox_create_config(
@@ -375,7 +376,10 @@ async def _create_sandbox_with_proxy(
                 sandbox_backend.id,
                 token,
                 base_proxy_config=proxy_config,
+                **({"datadog_authorized": True} if datadog_authorized else {}),
             )
+        elif datadog_authorized:
+            await _configure_github_proxy(sandbox_backend.id, token, datadog_authorized=True)
         else:
             await _configure_github_proxy(sandbox_backend.id, token)
         record_proxy_token_expiry(
@@ -384,6 +388,7 @@ async def _create_sandbox_with_proxy(
             repositories=github_proxy_repositories,
             permissions=permissions,
             base_proxy_config=proxy_config,
+            datadog_authorized=datadog_authorized,
         )
 
     return sandbox_backend
@@ -396,6 +401,7 @@ async def _refresh_github_proxy(
     thread_id: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    datadog_authorized: bool = False,
 ) -> None:
     """Refresh GitHub proxy credentials for reused LangSmith sandboxes."""
     if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
@@ -415,7 +421,10 @@ async def _refresh_github_proxy(
             current_backend.id,
             token,
             base_proxy_config=base_proxy_config,
+            **({"datadog_authorized": True} if datadog_authorized else {}),
         )
+    elif datadog_authorized:
+        await _configure_github_proxy(current_backend.id, token, datadog_authorized=True)
     else:
         await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
@@ -424,6 +433,7 @@ async def _refresh_github_proxy(
         repositories=github_proxy_repositories,
         permissions=permissions,
         base_proxy_config=base_proxy_config,
+        datadog_authorized=datadog_authorized,
     )
 
 
@@ -433,6 +443,7 @@ async def _refresh_github_proxy_or_fail(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    datadog_authorized: bool = False,
 ) -> SandboxBackendProtocol:
     """Refresh proxy credentials; a sandbox we can't reconfigure is unreachable."""
     try:
@@ -442,6 +453,7 @@ async def _refresh_github_proxy_or_fail(
             thread_id=thread_id,
             github_proxy_repositories=github_proxy_repositories,
             base_proxy_config=base_proxy_config,
+            datadog_authorized=datadog_authorized,
         )
     except Exception as exc:
         logger.warning(
@@ -469,6 +481,7 @@ async def _connect_existing_sandbox(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    datadog_authorized: bool = False,
 ) -> SandboxBackendProtocol:
     """Reuse the sandbox already bound to ``thread_id``, or fail unreachable.
 
@@ -494,6 +507,7 @@ async def _connect_existing_sandbox(
         github_proxy_token,
         github_proxy_repositories,
         base_proxy_config,
+        datadog_authorized,
     )
 
 
@@ -505,6 +519,7 @@ async def ensure_sandbox_for_thread(
     repo: dict[str, str] | None = None,
     environment_slug: str | None = None,
     allow_replacement: bool = False,
+    datadog_authorized: bool = False,
 ) -> SandboxBackendProtocol:
     """Get-or-create a healthy sandbox bound to ``thread_id``.
 
@@ -559,6 +574,7 @@ async def ensure_sandbox_for_thread(
             github_proxy_repositories=github_proxy_repositories,
             repo=repo,
             environment_slug=environment_slug,
+            datadog_authorized=datadog_authorized,
         )
         created_proxy_config = get_recorded_proxy_base_config(thread_id)
         logger.info("Sandbox created: %s", sandbox_backend.id)
@@ -571,6 +587,7 @@ async def ensure_sandbox_for_thread(
                 github_proxy_token=github_proxy_token,
                 github_proxy_repositories=github_proxy_repositories,
                 base_proxy_config=base_proxy_config,
+                datadog_authorized=datadog_authorized,
             )
         except (SandboxGoneError, SandboxUnreachableError) as exc:
             gone = isinstance(exc, SandboxGoneError)
@@ -589,6 +606,7 @@ async def ensure_sandbox_for_thread(
                     github_proxy_repositories=github_proxy_repositories,
                     repo=repo,
                     environment_slug=environment_slug,
+                    datadog_authorized=datadog_authorized,
                 )
                 created_proxy_config = get_recorded_proxy_base_config(thread_id)
             except Exception as create_exc:
@@ -1023,6 +1041,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         plan_mode: bool,
         corridor_enabled: bool,
         admin_environments: bool,
+        observability_authorized: bool,
     ) -> None:
         self._thread_id = thread_id
         self._config = config
@@ -1039,6 +1058,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         self._plan_mode = plan_mode
         self._corridor_enabled = corridor_enabled
         self._admin_environments = admin_environments
+        self._observability_authorized = observability_authorized
 
     def _prepare_config_fingerprint(self) -> Any:
         configurable = (self._config or {}).get("configurable") or {}
@@ -1222,7 +1242,12 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         environment = await resolve_environment(_environment_slug(configurable))
         from .dashboard.team_credentials import get_datadog_credentials
 
-        datadog = await get_datadog_credentials()
+        datadog = (
+            await get_datadog_credentials()
+            if self._observability_authorized
+            and os.getenv("SANDBOX_TYPE", "langsmith") == "langsmith"
+            else None
+        )
         sender_instructions = await _resolve_user_custom_instructions(self._profile_login)
         sender_context = construct_sender_context(
             triggering_user_identity,
@@ -1307,6 +1332,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             tools=[],
         ).with_config(config)
 
+    local_run = is_desktop_run(configurable)
+    profile_login = resolve_github_login(as_json_object(config))
+    observability_authorized = not local_run and await _observability_authorized(
+        config, profile_login
+    )
+
     async def reconnect_backend(
         _thread_id: str = thread_id,
         _configurable: dict[str, Any] = configurable,
@@ -1318,6 +1349,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             _thread_id,
             repo=prompt_default_repo,
             environment_slug=_environment_slug(_configurable),
+            datadog_authorized=observability_authorized,
         )
 
     backend = _get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
@@ -1327,8 +1359,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     # authorization and credentialed integrations, which stay personal to them.
     # Everything else comes from the thread's own settings, resolved from the
     # owner's profile on the first run and frozen there afterwards.
-    local_run = is_desktop_run(configurable)
-    profile_login = resolve_github_login(as_json_object(config))
     thread_settings, settings_changed = normalize_thread_settings(
         {} if local_run else await load_thread_settings(client, thread_id)
     )
@@ -1514,7 +1544,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
     if not stop_summary_mode and not local_run:
-        observability_authorized = await _observability_authorized(config, profile_login)
         if observability_authorized:
             observability_tools = await _load_observability_tools(True, profile_login)
         elif await _allowed_org_member(config, profile_login):
@@ -1681,6 +1710,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     plan_mode=plan_mode,
                     corridor_enabled=bool(corridor_tools),
                     admin_environments=admin_thread,
+                    observability_authorized=observability_authorized,
                 ),
                 *([dynamic_tool_middleware] if dynamic_tool_middleware else []),
                 SanitizeToolInputsMiddleware(),

--- a/agent/utils/github_proxy.py
+++ b/agent/utils/github_proxy.py
@@ -33,6 +33,7 @@ _PROXY_TOKEN_EXPIRY: dict[
     str, tuple[datetime | None, datetime, tuple[str, ...] | None, PermissionKey]
 ] = {}
 _PROXY_BASE_CONFIGS: dict[str, dict[str, Any]] = {}
+_DATADOG_AUTHORIZED: set[str] = set()
 ProxyTokenRecord = tuple[datetime | None, datetime, tuple[str, ...] | None, PermissionKey]
 
 
@@ -68,6 +69,7 @@ def record_proxy_token_expiry(
     repositories: Sequence[str] | None = None,
     permissions: PermissionMap | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    datadog_authorized: bool = False,
 ) -> None:
     """Record when ``thread_id``'s proxy token expires and the repo scope it was minted with.
 
@@ -87,6 +89,10 @@ def record_proxy_token_expiry(
         _PROXY_BASE_CONFIGS[thread_id] = dict(base_proxy_config)
     else:
         _PROXY_BASE_CONFIGS.pop(thread_id, None)
+    if datadog_authorized:
+        _DATADOG_AUTHORIZED.add(thread_id)
+    else:
+        _DATADOG_AUTHORIZED.discard(thread_id)
 
 
 def get_recorded_proxy_base_config(thread_id: str | None) -> dict[str, Any] | None:
@@ -100,6 +106,7 @@ def clear_proxy_token_expiry(thread_id: str | None) -> None:
     if thread_id:
         _PROXY_TOKEN_EXPIRY.pop(thread_id, None)
         _PROXY_BASE_CONFIGS.pop(thread_id, None)
+        _DATADOG_AUTHORIZED.discard(thread_id)
 
 
 def _unpack_proxy_token_record(record: tuple[Any, ...]) -> ProxyTokenRecord:
@@ -161,7 +168,10 @@ async def refresh_proxy_token(
             current_backend.id,
             token,
             base_proxy_config=base_proxy_config,
+            **({"datadog_authorized": True} if thread_id in _DATADOG_AUTHORIZED else {}),
         )
+    elif thread_id in _DATADOG_AUTHORIZED:
+        await _configure_github_proxy(current_backend.id, token, datadog_authorized=True)
     else:
         await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -272,6 +272,19 @@ def test_sender_context_includes_workspace_admin_status() -> None:
     assert "Workspace admin: no." in construct_sender_context(None)
 
 
+def test_datadog_prompt_is_conditional_and_contains_no_secrets() -> None:
+    environment = {"prompt": "Checkouts live in /workspace/repos."}
+
+    prompt = server._environment_prompt(environment, "us5.datadoghq.com")
+
+    assert prompt is not None
+    assert "Datadog Pup CLI is authenticated through the sandbox proxy" in prompt
+    assert "`us5.datadoghq.com`" in prompt
+    assert "`DD_API_KEY` and `DD_APP_KEY` are placeholders" in prompt
+    assert "Checkouts live in /workspace/repos." in prompt
+    assert server._environment_prompt(environment, None) == "Checkouts live in /workspace/repos."
+
+
 def test_environment_instructions_render_in_system_prompt() -> None:
     prompt = construct_system_prompt(
         working_dir="/workspace",

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -10,7 +10,12 @@ from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.runnables import RunnableConfig
 from langgraph.runtime import Runtime
 
-from agent.integrations.langsmith import PROXY_GH_TOKEN_PLACEHOLDER, _configure_github_proxy
+from agent.integrations.langsmith import (
+    PROXY_GH_TOKEN_PLACEHOLDER,
+    PROXY_SECRET_PLACEHOLDER,
+    _configure_github_proxy,
+    _datadog_proxy_rule,
+)
 from agent.utils.sandbox_state import SandboxBackendProxy
 
 
@@ -68,6 +73,27 @@ class TestSandboxFactoryLoading:
         )
 
 
+class TestDatadogProxy:
+    def test_injects_credentials_without_exposing_them_as_environment_variables(self) -> None:
+        api_key = "api-secret"
+        app_key = "app-secret"
+
+        rule = _datadog_proxy_rule("us5.datadoghq.com", api_key, app_key)
+
+        assert rule["match_hosts"] == ["api.us5.datadoghq.com"]
+        assert rule["headers"] == [
+            {"name": "DD-API-KEY", "type": "opaque", "value": api_key},
+            {"name": "DD-APPLICATION-KEY", "type": "opaque", "value": app_key},
+        ]
+        assert rule["env_vars"] == {
+            "DD_API_KEY": PROXY_SECRET_PLACEHOLDER,
+            "DD_APP_KEY": PROXY_SECRET_PLACEHOLDER,
+            "DD_SITE": "us5.datadoghq.com",
+        }
+        assert api_key not in rule["env_vars"].values()
+        assert app_key not in rule["env_vars"].values()
+
+
 class TestConfigureGithubProxy:
     """Tests for _configure_github_proxy payload shape and error handling."""
 
@@ -118,6 +144,30 @@ class TestConfigureGithubProxy:
             assert headers[0]["name"] == "Authorization"
             assert headers[0]["type"] == "opaque"
             assert headers[0]["value"] == f"Basic {expected_basic}"
+
+    async def test_adds_connected_datadog_credentials(self) -> None:
+        credentials = MagicMock(
+            site="us5.datadoghq.com", api_key="api-secret", app_key="app-secret"
+        )
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "ls-api-key"}),
+            patch(
+                "agent.dashboard.team_credentials.get_datadog_credentials",
+                AsyncMock(return_value=credentials),
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            await _configure_github_proxy("sandbox-abc123", "token")
+
+        rules = mock_client.patch.call_args.kwargs["json"]["proxy_config"]["rules"]
+        assert [rule["name"] for rule in rules] == ["datadog-api", "github-api", "github"]
+        assert rules[0] == _datadog_proxy_rule("us5.datadoghq.com", "api-secret", "app-secret")
 
     async def test_preserves_custom_proxy_config_when_adding_github_auth(self) -> None:
         custom_rule = {"name": "public-api", "match_hosts": ["example.com"]}

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -81,6 +81,7 @@ class TestDatadogProxy:
         rule = _datadog_proxy_rule("us5.datadoghq.com", api_key, app_key)
 
         assert rule["match_hosts"] == ["api.us5.datadoghq.com"]
+        assert rule["match_paths"] == ["/api/*"]
         assert rule["headers"] == [
             {"name": "DD-API-KEY", "type": "opaque", "value": api_key},
             {"name": "DD-APPLICATION-KEY", "type": "opaque", "value": app_key},
@@ -163,7 +164,7 @@ class TestConfigureGithubProxy:
             mock_client.patch = AsyncMock(return_value=mock_response)
             _mock_async_client(mock_client_cls, mock_client)
 
-            await _configure_github_proxy("sandbox-abc123", "token")
+            await _configure_github_proxy("sandbox-abc123", "token", datadog_authorized=True)
 
         rules = mock_client.patch.call_args.kwargs["json"]["proxy_config"]["rules"]
         assert [rule["name"] for rule in rules] == ["datadog-api", "github-api", "github"]


### PR DESCRIPTION
## Description
Inject Datadog auth into authorized LangSmith sandboxes only. Pup uses proxy placeholders, the configured site, and API-path-scoped headers; real keys stay out of sandboxes and prompts.

## Test Plan
- [x] Verify authorized proxy injection and API path scoping
- [x] Verify unauthorized and unsupported runs receive no access or prompt

Made by [Open SWE](https://openswe.vercel.app/agents/01a02703-5331-707b-ae4e-ab14318fd2ff)