### PR TITLE
fix: keep active attention thread pinned

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -220,7 +220,22 @@ export function AgentsSidebar({
     prefs.group === "focus" && showResolved
       ? [...filteredActive, ...filteredResolved]
       : filteredActive
-  const sections = groupThreadsByMode(groupedThreads, prefs.group)
+  const naturalSections = groupThreadsByMode(groupedThreads, prefs.group)
+  const activeAttentionThread = naturalSections
+    .find((section) => section.key === "attention")
+    ?.threads.find((thread) => thread.id === activeThreadId)
+  const [previousActiveThreadId, setPreviousActiveThreadId] =
+    useState(activeThreadId)
+  const [pinnedAttentionThread, setPinnedAttentionThread] = useState(
+    activeAttentionThread
+  )
+  if (activeThreadId !== previousActiveThreadId) {
+    setPreviousActiveThreadId(activeThreadId)
+    setPinnedAttentionThread(activeAttentionThread)
+  }
+  const sections = pinnedAttentionThread
+    ? groupThreadsByMode(groupedThreads, prefs.group, pinnedAttentionThread)
+    : naturalSections
   const resolvedLoading =
     !sidebar.isPending && showResolved && sidebar.resolvedQuery.isLoading
   const isCloudEmpty =

--- a/ui/src/features/agents/lib/sidebarFilter.test.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.test.ts
@@ -210,6 +210,23 @@ describe("groupThreadsByMode", () => {
     })
   })
 
+  it("keeps the active finished thread in attention after it is viewed", () => {
+    const pinnedThread = makeThread({
+      id: "active",
+      status: "finished",
+      viewed: false,
+    })
+    const sections = groupThreadsByMode(
+      [{ ...pinnedThread, viewed: true }],
+      "focus",
+      pinnedThread
+    )
+
+    expect(sections).toHaveLength(1)
+    expect(sections[0]?.key).toBe("attention")
+    expect(sections[0]?.threads[0]?.id).toBe("active")
+  })
+
   it("buckets by date and drops empty buckets", () => {
     const now = Date.now()
     const sections = groupThreadsByMode(

--- a/ui/src/features/agents/lib/sidebarFilter.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.ts
@@ -187,7 +187,8 @@ function sortedByCreation(threads: Array<AgentThread>): Array<AgentThread> {
 /** Split threads into ordered, labelled sections according to the group mode. */
 export function groupThreadsByMode(
   threads: Array<AgentThread>,
-  mode: SidebarGroupMode
+  mode: SidebarGroupMode,
+  pinnedThread?: AgentThread
 ): Array<ThreadGroupSection> {
   if (threads.length === 0) return []
 
@@ -203,7 +204,14 @@ export function groupThreadsByMode(
   }
 
   if (mode === "focus") {
-    return groupThreadsForView(threads, "focus").map((group) => ({
+    const groupedThreads = pinnedThread
+      ? threads.map((thread) =>
+          thread.id === pinnedThread.id
+            ? { ...thread, ...pinnedThread }
+            : thread
+        )
+      : threads
+    return groupThreadsForView(groupedThreads, "focus").map((group) => ({
       ...group,
       threads: sortedByCreation(group.threads),
       defaultCollapsed: false,


### PR DESCRIPTION
## Description
Keep a selected Needs attention thread in its original sidebar group while it is open, then reconcile its viewed state after navigating away.

## Release Note
Prevent active attention threads from jumping in the sidebar when opened.

## Test Plan
- [x] Verify a finished unread thread remains in Needs attention after its selected snapshot becomes viewed.

Made by [Open SWE](https://openswe.vercel.app/agents/18e504da-6fac-590f-88d7-77c018039400)