### PR TITLE
fix: address attention pin review findings

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -47,6 +47,7 @@ import {
   filterThreads,
   groupThreadsByMode,
   hasActiveFilters,
+  reconcilePinnedAttentionThread,
 } from "@/features/agents/lib/sidebarFilter"
 import { useSidebarPrefs } from "@/features/agents/lib/sidebarPrefs"
 import {
@@ -224,15 +225,17 @@ export function AgentsSidebar({
   const activeAttentionThread = naturalSections
     .find((section) => section.key === "attention")
     ?.threads.find((thread) => thread.id === activeThreadId)
-  const [previousActiveThreadId, setPreviousActiveThreadId] =
-    useState(activeThreadId)
-  const [pinnedAttentionThread, setPinnedAttentionThread] = useState(
-    activeAttentionThread
-  )
-  if (activeThreadId !== previousActiveThreadId) {
-    setPreviousActiveThreadId(activeThreadId)
-    setPinnedAttentionThread(activeAttentionThread)
-  }
+  const [pinnedAttentionThread, setPinnedAttentionThread] =
+    useState<AgentThread>()
+  useEffect(() => {
+    setPinnedAttentionThread((current) =>
+      reconcilePinnedAttentionThread(
+        current,
+        activeThreadId,
+        activeAttentionThread
+      )
+    )
+  }, [activeAttentionThread, activeThreadId])
   const sections = pinnedAttentionThread
     ? groupThreadsByMode(groupedThreads, prefs.group, pinnedAttentionThread)
     : naturalSections

--- a/ui/src/features/agents/lib/sidebarFilter.test.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.test.ts
@@ -7,6 +7,7 @@ import {
   filterThreads,
   groupThreadsByMode,
   hasActiveFilters,
+  reconcilePinnedAttentionThread,
   toggleArrayValue,
 } from "./sidebarFilter"
 import type { SidebarFilters } from "./sidebarFilter"
@@ -217,14 +218,35 @@ describe("groupThreadsByMode", () => {
       viewed: false,
     })
     const sections = groupThreadsByMode(
-      [{ ...pinnedThread, viewed: true }],
+      [{ ...pinnedThread, title: "Fresh title", viewed: true }],
       "focus",
       pinnedThread
     )
 
     expect(sections).toHaveLength(1)
     expect(sections[0]?.key).toBe("attention")
-    expect(sections[0]?.threads[0]?.id).toBe("active")
+    expect(sections[0]?.threads[0]).toMatchObject({
+      id: "active",
+      title: "Fresh title",
+      viewed: true,
+    })
+  })
+
+  it("captures an asynchronously loaded active attention thread", () => {
+    const activeThread = makeThread({ id: "active", viewed: false })
+
+    expect(
+      reconcilePinnedAttentionThread(undefined, "active", undefined)
+    ).toBeUndefined()
+    expect(
+      reconcilePinnedAttentionThread(undefined, "active", activeThread)
+    ).toBe(activeThread)
+    expect(
+      reconcilePinnedAttentionThread(activeThread, "active", undefined)
+    ).toBe(activeThread)
+    expect(
+      reconcilePinnedAttentionThread(activeThread, "other", undefined)
+    ).toBeUndefined()
   })
 
   it("buckets by date and drops empty buckets", () => {

--- a/ui/src/features/agents/lib/sidebarFilter.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.ts
@@ -164,6 +164,15 @@ export interface ThreadGroupSection {
   defaultCollapsed: boolean
 }
 
+export function reconcilePinnedAttentionThread(
+  pinnedThread: AgentThread | undefined,
+  activeThreadId: string | undefined,
+  activeAttentionThread: AgentThread | undefined
+): AgentThread | undefined {
+  if (pinnedThread?.id === activeThreadId) return pinnedThread
+  return activeAttentionThread
+}
+
 const STATUS_GROUP_ORDER: Array<AgentStatus> = [
   "running",
   "finished",
@@ -204,16 +213,22 @@ export function groupThreadsByMode(
   }
 
   if (mode === "focus") {
-    const groupedThreads = pinnedThread
-      ? threads.map((thread) =>
-          thread.id === pinnedThread.id
-            ? { ...thread, ...pinnedThread }
-            : thread
-        )
-      : threads
+    const currentPinnedThread = pinnedThread
+      ? threads.find((thread) => thread.id === pinnedThread.id)
+      : undefined
+    const groupedThreads =
+      pinnedThread && currentPinnedThread
+        ? threads.map((thread) =>
+            thread.id === pinnedThread.id
+              ? { ...thread, viewed: pinnedThread.viewed }
+              : thread
+          )
+        : threads
     return groupThreadsForView(groupedThreads, "focus").map((group) => ({
       ...group,
-      threads: sortedByCreation(group.threads),
+      threads: sortedByCreation(group.threads).map((thread) =>
+        thread.id === currentPinnedThread?.id ? currentPinnedThread : thread
+      ),
       defaultCollapsed: false,
     }))
   }


### PR DESCRIPTION
## Description
Address follow-up findings from https://github.com/langchain-ai/open-swe/pull/2174 by initializing attention pins after async sidebar loads and using snapshots only for grouping, preserving live thread fields.

## Release Note
Fix active attention pinning on direct loads while keeping sidebar thread data fresh.

## Test Plan
- [x] Verify async active-thread pin reconciliation and fresh rendered thread fields.

Made by [Open SWE](https://openswe.vercel.app/agents/18e504da-6fac-590f-88d7-77c018039400)