### PR TITLE
feat: prototype thread projects

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -217,6 +217,7 @@ from .team_settings import (
 )
 from .thread_api import (
     ThreadMessageBody,
+    ThreadProjectBody,
     ThreadResolveBody,
     admin_cancel_dashboard_thread,
     cancel_dashboard_thread,
@@ -238,6 +239,7 @@ from .thread_api import (
     proxy_dashboard_thread_stream_events,
     resolve_dashboard_thread,
     send_dashboard_message,
+    set_dashboard_thread_project,
     stream_dashboard_thread,
 )
 from .user_credentials import (
@@ -2262,6 +2264,20 @@ async def api_resolve_thread(
         thread_id,
         session["sub"],
         resolved=body.resolved,
+        email=session.get("email"),
+    )
+
+
+@router.post("/threads/{thread_id}/project")
+async def api_set_thread_project(
+    thread_id: str,
+    body: ThreadProjectBody,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await set_dashboard_thread_project(
+        thread_id,
+        session["sub"],
+        project=body.project,
         email=session.get("email"),
     )
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -166,6 +166,10 @@ class ThreadResolveBody(BaseModel):
     resolved: bool = True
 
 
+class ThreadProjectBody(BaseModel):
+    project: str | None = Field(default=None, max_length=80)
+
+
 def _normalize_model_choice(
     model_id: str | None, effort: str | None
 ) -> tuple[str | None, str | None]:
@@ -581,6 +585,7 @@ async def _thread_summary(
             if isinstance(metadata.get("resolved_at_ms"), (int, float))
             else None
         ),
+        "project": _metadata_string(metadata, "board_project"),
         "createdAt": int(created_at) if isinstance(created_at, (int, float)) else _now_ms(),
         "updatedAt": int(updated_at) if isinstance(updated_at, (int, float)) else _now_ms(),
         "ownerLogin": _thread_owner_login(metadata),
@@ -1987,6 +1992,27 @@ async def resolve_dashboard_thread(
         await client.threads.update(thread_id=thread_id, metadata=metadata_update)
     except Exception as exc:  # noqa: BLE001
         logger.debug("Could not update resolved state for thread %s", thread_id, exc_info=True)
+        raise HTTPException(502, "failed to update thread") from exc
+    thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
+    return await _thread_summary(thread)
+
+
+async def set_dashboard_thread_project(
+    thread_id: str,
+    login: str,
+    *,
+    project: str | None,
+    email: str | None = None,
+) -> dict[str, Any]:
+    client = langgraph_client()
+    thread = await _authorized_thread(thread_id, login, email=email)
+    metadata = thread_metadata(thread)
+    normalized_project = project.strip() if isinstance(project, str) else None
+    metadata_update = {"board_project": normalized_project or None}
+    try:
+        await client.threads.update(thread_id=thread_id, metadata=metadata_update)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not update project for thread %s", thread_id, exc_info=True)
         raise HTTPException(502, "failed to update thread") from exc
     thread = {**as_thread_dict(thread), "metadata": {**metadata, **metadata_update}}
     return await _thread_summary(thread)

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1214,7 +1214,34 @@ async def list_dashboard_threads_page(
         )
         has_more = len(candidates) > safe_offset + safe_limit
 
-    return {"items": items, "limit": safe_limit, "offset": safe_offset, "hasMore": has_more}
+    project_candidates = candidates
+    if resolved is not None or source or query or automation_id:
+        project_candidates = await _collect_thread_candidates(
+            client,
+            searches,
+            include_all=include_all,
+            login=search_login,
+            email=search_email,
+            scope=scope,
+            surfaced_only=surfaced_only,
+            sort_by=sort_by,
+        )
+    projects = sorted(
+        {
+            project
+            for thread in project_candidates
+            if (project := _metadata_string(_thread_metadata(thread), "board_project"))
+        },
+        key=str.casefold,
+    )
+
+    return {
+        "items": items,
+        "projects": projects,
+        "limit": safe_limit,
+        "offset": safe_offset,
+        "hasMore": has_more,
+    }
 
 
 async def _mark_thread_viewed(

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1867,6 +1867,40 @@ async def test_list_dashboard_threads_page_pages_beyond_first_search_batch(monke
     assert run_list_calls == 0
 
 
+async def test_list_dashboard_threads_page_returns_projects_beyond_current_page(
+    monkeypatch,
+) -> None:
+    threads = _make_threads(3, resolved_before=1)
+    projects = ["Launch", "Quality", "No project"]
+    for thread, project in zip(threads, projects, strict=True):
+        metadata = cast(dict[str, object], thread["metadata"])
+        metadata.update({"latest_run_status": "success", "board_project": project})
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return threads[offset : offset + limit]
+
+        async def update(self, *, thread_id, metadata):
+            return None
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            return []
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    result = await thread_api.list_dashboard_threads_page(
+        "octocat", email=None, limit=1, offset=0, resolved=False
+    )
+
+    assert [item["id"] for item in result["items"]] == ["t1"]
+    assert result["projects"] == ["Launch", "No project", "Quality"]
+
+
 async def test_list_dashboard_threads_page_scopes_automation_runs(monkeypatch) -> None:
     threads = _make_threads(3, resolved_before=0)
     for thread in threads:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1647,6 +1647,60 @@ async def test_resolve_dashboard_thread_enforces_ownership(monkeypatch) -> None:
     assert exc_info.value.status_code == 404
 
 
+async def test_set_dashboard_thread_project_persists_trimmed_name(monkeypatch) -> None:
+    updates: list[dict[str, object]] = []
+
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {"source": "dashboard", "github_login": "octocat"},
+            }
+
+        async def update(self, *, thread_id: str, metadata: dict[str, object]) -> None:
+            updates.append(dict(metadata))
+
+    class FakeClient:
+        threads = FakeThreads()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    summary = await thread_api.set_dashboard_thread_project(
+        "tid", "octocat", project="  Launch week  "
+    )
+
+    assert updates == [{"board_project": "Launch week"}]
+    assert summary["project"] == "Launch week"
+
+
+async def test_set_dashboard_thread_project_clears_empty_name(monkeypatch) -> None:
+    updates: list[dict[str, object]] = []
+
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {
+                    "source": "dashboard",
+                    "github_login": "octocat",
+                    "board_project": "Launch week",
+                },
+            }
+
+        async def update(self, *, thread_id: str, metadata: dict[str, object]) -> None:
+            updates.append(dict(metadata))
+
+    class FakeClient:
+        threads = FakeThreads()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    summary = await thread_api.set_dashboard_thread_project("tid", "octocat", project=" ")
+
+    assert updates == [{"board_project": None}]
+    assert summary["project"] is None
+
+
 async def test_enrich_run_start_command_unresolves_thread(monkeypatch) -> None:
     updates: list[dict[str, object]] = []
 

--- a/ui/src/features/agents/components/AgentsThreadsPage.tsx
+++ b/ui/src/features/agents/components/AgentsThreadsPage.tsx
@@ -8,6 +8,7 @@ import {
   CheckCircleIcon,
   CircleNotchIcon,
   DotsSixVerticalIcon,
+  FolderSimpleIcon,
   KanbanIcon,
   ListBulletsIcon,
 } from "@phosphor-icons/react"
@@ -25,8 +26,10 @@ import type {
 } from "@/features/agents/lib/threadViews"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Popover, PopoverPopup, PopoverTrigger } from "@/components/ui/popover"
 import {
   useResolveAgentThread,
+  useSetAgentThreadProject,
   useThreadsPage,
 } from "@/features/agents/lib/queries"
 import {
@@ -144,6 +147,17 @@ export function AgentsThreadsPage({
   const groups = useMemo(
     () => groupThreadsForView(items, filters.group),
     [filters.group, items]
+  )
+  const projects = useMemo(
+    () =>
+      [
+        ...new Set(
+          items
+            .map((thread) => thread.project)
+            .filter((project): project is string => Boolean(project))
+        ),
+      ].sort((left, right) => left.localeCompare(right)),
+    [items]
   )
   const defaultKeys = groups.map((group) => group.key)
   const columnOrder = reconcileColumnOrder(
@@ -294,10 +308,11 @@ export function AgentsThreadsPage({
             <ThreadsBoard
               groups={orderedGroups}
               order={columnOrder}
+              projects={projects}
               onOrderChange={setColumnOrder}
             />
           ) : (
-            <ThreadsList groups={orderedGroups} />
+            <ThreadsList groups={orderedGroups} projects={projects} />
           )}
         </div>
 
@@ -338,10 +353,12 @@ export function AgentsThreadsPage({
 function ThreadsBoard({
   groups,
   order,
+  projects,
   onOrderChange,
 }: {
   groups: Array<ThreadViewGroup>
   order: Array<string>
+  projects: Array<string>
   onOrderChange: (order: Array<string>) => void
 }) {
   const [draggedKey, setDraggedKey] = useState<string | null>(null)
@@ -403,7 +420,7 @@ function ThreadsBoard({
           </div>
           <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
             {group.threads.map((thread) => (
-              <ThreadCard key={thread.id} thread={thread} />
+              <ThreadCard key={thread.id} thread={thread} projects={projects} />
             ))}
           </div>
         </section>
@@ -412,7 +429,13 @@ function ThreadsBoard({
   )
 }
 
-function ThreadsList({ groups }: { groups: Array<ThreadViewGroup> }) {
+function ThreadsList({
+  groups,
+  projects,
+}: {
+  groups: Array<ThreadViewGroup>
+  projects: Array<string>
+}) {
   return (
     <div className="h-full overflow-y-auto">
       {groups.map((group) => (
@@ -423,7 +446,11 @@ function ThreadsList({ groups }: { groups: Array<ThreadViewGroup> }) {
           </div>
           <div className="space-y-1">
             {group.threads.map((thread) => (
-              <ThreadListItem key={thread.id} thread={thread} />
+              <ThreadListItem
+                key={thread.id}
+                thread={thread}
+                projects={projects}
+              />
             ))}
           </div>
         </section>
@@ -432,7 +459,13 @@ function ThreadsList({ groups }: { groups: Array<ThreadViewGroup> }) {
   )
 }
 
-function ThreadCard({ thread }: { thread: AgentThread }) {
+function ThreadCard({
+  thread,
+  projects,
+}: {
+  thread: AgentThread
+  projects: Array<string>
+}) {
   const resolveThread = useResolveAgentThread()
   const isResolved = thread.resolved === true
   const isResolving =
@@ -484,23 +517,29 @@ function ThreadCard({ thread }: { thread: AgentThread }) {
         <span className="text-[10px] text-muted-foreground/70">
           {formatRelativeTime(thread.updatedAt)}
         </span>
-        <button
-          type="button"
-          aria-label={isResolved ? "Reopen thread" : "Resolve thread"}
-          title={isResolved ? "Reopen thread" : "Resolve thread"}
-          disabled={isResolving}
-          onClick={() =>
-            resolveThread.mutate({ threadId: thread.id, resolved: !isResolved })
-          }
-          className="flex items-center gap-1 rounded px-1.5 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
-        >
-          {isResolved ? (
-            <ArrowCounterClockwiseIcon className="size-3" />
-          ) : (
-            <CheckCircleIcon className="size-3" />
-          )}
-          {isResolved ? "Reopen" : "Resolve"}
-        </button>
+        <div className="flex items-center gap-1">
+          <ProjectPicker thread={thread} projects={projects} />
+          <button
+            type="button"
+            aria-label={isResolved ? "Reopen thread" : "Resolve thread"}
+            title={isResolved ? "Reopen thread" : "Resolve thread"}
+            disabled={isResolving}
+            onClick={() =>
+              resolveThread.mutate({
+                threadId: thread.id,
+                resolved: !isResolved,
+              })
+            }
+            className="flex items-center gap-1 rounded px-1.5 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
+          >
+            {isResolved ? (
+              <ArrowCounterClockwiseIcon className="size-3" />
+            ) : (
+              <CheckCircleIcon className="size-3" />
+            )}
+            {isResolved ? "Reopen" : "Resolve"}
+          </button>
+        </div>
       </div>
     </article>
   )
@@ -530,7 +569,13 @@ function StatusMark({ thread }: { thread: AgentThread }) {
   )
 }
 
-function ThreadListItem({ thread }: { thread: AgentThread }) {
+function ThreadListItem({
+  thread,
+  projects,
+}: {
+  thread: AgentThread
+  projects: Array<string>
+}) {
   const resolveThread = useResolveAgentThread()
   const isResolved = thread.resolved === true
 
@@ -548,6 +593,7 @@ function ThreadListItem({ thread }: { thread: AgentThread }) {
           {formatRelativeTime(thread.updatedAt)}
         </p>
       </Link>
+      <ProjectPicker thread={thread} projects={projects} />
       <button
         type="button"
         aria-label={isResolved ? "Reopen thread" : "Resolve thread"}
@@ -565,6 +611,88 @@ function ThreadListItem({ thread }: { thread: AgentThread }) {
         )}
       </button>
     </div>
+  )
+}
+
+function ProjectPicker({
+  thread,
+  projects,
+}: {
+  thread: AgentThread
+  projects: Array<string>
+}) {
+  const setProject = useSetAgentThreadProject()
+  const [name, setName] = useState("")
+  const isSaving =
+    setProject.isPending && setProject.variables.threadId === thread.id
+  const assign = (project: string | null) => {
+    setProject.mutate({ threadId: thread.id, project })
+    setName("")
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label={`Project: ${thread.project || "None"}`}
+        title={`Project: ${thread.project || "None"}`}
+        disabled={isSaving || thread.isOwner === false}
+        className={cn(
+          "flex h-6 max-w-32 items-center gap-1 rounded px-1.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40",
+          thread.project && "bg-primary/10 text-primary"
+        )}
+      >
+        <FolderSimpleIcon className="size-3" />
+        <span className="truncate">{thread.project || "Project"}</span>
+      </PopoverTrigger>
+      <PopoverPopup align="end" className="w-60 p-2">
+        <p className="px-1 pb-1.5 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+          Move to project
+        </p>
+        <div className="max-h-40 space-y-0.5 overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => assign(null)}
+            className="flex w-full rounded px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            No project
+          </button>
+          {projects.map((project) => (
+            <button
+              key={project}
+              type="button"
+              onClick={() => assign(project)}
+              className={cn(
+                "flex w-full rounded px-2 py-1.5 text-left text-xs hover:bg-accent",
+                project === thread.project
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground"
+              )}
+            >
+              {project}
+            </button>
+          ))}
+        </div>
+        <form
+          className="mt-2 flex gap-1 border-t border-border pt-2"
+          onSubmit={(event) => {
+            event.preventDefault()
+            const project = name.trim()
+            if (project) assign(project)
+          }}
+        >
+          <Input
+            value={name}
+            maxLength={80}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="New project"
+            className="h-7 text-xs"
+          />
+          <Button type="submit" size="sm" disabled={!name.trim()}>
+            Add
+          </Button>
+        </form>
+      </PopoverPopup>
+    </Popover>
   )
 }
 

--- a/ui/src/features/agents/components/AgentsThreadsPage.tsx
+++ b/ui/src/features/agents/components/AgentsThreadsPage.tsx
@@ -39,6 +39,7 @@ import {
   moveColumnBefore,
   parseColumnOrder,
   reconcileColumnOrder,
+  serializeColumnOrder,
 } from "@/features/agents/lib/threadViews"
 import { cn, formatRelativeTime } from "@/lib/utils"
 
@@ -148,17 +149,7 @@ export function AgentsThreadsPage({
     () => groupThreadsForView(items, filters.group),
     [filters.group, items]
   )
-  const projects = useMemo(
-    () =>
-      [
-        ...new Set(
-          items
-            .map((thread) => thread.project)
-            .filter((project): project is string => Boolean(project))
-        ),
-      ].sort((left, right) => left.localeCompare(right)),
-    [items]
-  )
+  const projects = data?.projects ?? []
   const defaultKeys = groups.map((group) => group.key)
   const columnOrder = reconcileColumnOrder(
     defaultKeys,
@@ -183,7 +174,7 @@ export function AgentsThreadsPage({
   }
 
   const setColumnOrder = (next: Array<string>) => {
-    const value = next.join("|")
+    const value = serializeColumnOrder(next)
     setPersonalOrder(value)
     if (typeof window !== "undefined") {
       window.localStorage.setItem(

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -280,6 +280,14 @@ export const agentsApi = {
         body: JSON.stringify({ resolved }),
       }
     ),
+  setThreadProject: (threadId: string, project: string | null) =>
+    agentsRequest<AgentThread>(
+      `/threads/${encodeURIComponent(threadId)}/project`,
+      {
+        method: "POST",
+        body: JSON.stringify({ project }),
+      }
+    ),
   listSchedules: () => agentsRequest<Array<AgentSchedule>>("/schedules"),
   createSchedule: (body: ScheduleCreateRequest) =>
     agentsRequest<AgentSchedule>("/schedules", {

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -133,6 +133,7 @@ export interface ThreadsPageParams {
 
 export interface ThreadsPage {
   items: Array<AgentThread>
+  projects?: Array<string>
   total?: number
   limit: number
   offset: number

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -692,6 +692,23 @@ export function useResolveAgentThread() {
   })
 }
 
+export function useSetAgentThreadProject() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (vars: { threadId: string; project: string | null }) =>
+      agentsApi.setThreadProject(vars.threadId, vars.project),
+    onSuccess: (thread, vars) => {
+      queryClient.setQueryData(agentThreadKeys.detail(vars.threadId), thread)
+      queryClient.setQueryData(
+        agentThreadKeys.sidebarActive(vars.threadId),
+        thread
+      )
+      invalidateAgentThreadLists(queryClient)
+    },
+  })
+}
+
 export function useInfiniteThreadsPages(
   params: Omit<ThreadsPageParams, "offset">,
   options: {

--- a/ui/src/features/agents/lib/threadViews.test.ts
+++ b/ui/src/features/agents/lib/threadViews.test.ts
@@ -89,6 +89,24 @@ describe("groupThreadsForView", () => {
       "z/repo",
     ])
   })
+
+  it("groups projects alphabetically and leaves unassigned threads last", () => {
+    const groups = groupThreadsForView(
+      [
+        thread({ id: "launch", project: "Launch week" }),
+        thread({ id: "none" }),
+        thread({ id: "quality", project: "Quality" }),
+      ],
+      "project"
+    )
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "Launch week",
+      "Quality",
+      "No project",
+    ])
+    expect(groups.at(-1)?.threads[0]?.id).toBe("none")
+  })
 })
 
 describe("column ordering", () => {

--- a/ui/src/features/agents/lib/threadViews.test.ts
+++ b/ui/src/features/agents/lib/threadViews.test.ts
@@ -6,6 +6,7 @@ import {
   moveColumnBefore,
   parseColumnOrder,
   reconcileColumnOrder,
+  serializeColumnOrder,
 } from "./threadViews"
 import type { AgentThread } from "./types"
 
@@ -90,22 +91,24 @@ describe("groupThreadsForView", () => {
     ])
   })
 
-  it("groups projects alphabetically and leaves unassigned threads last", () => {
+  it("keeps project labels separate from stable grouping keys", () => {
     const groups = groupThreadsForView(
       [
-        thread({ id: "launch", project: "Launch week" }),
+        thread({ id: "named-none", project: "No project" }),
         thread({ id: "none" }),
-        thread({ id: "quality", project: "Quality" }),
+        thread({ id: "pipe", project: "Launch | Quality 🚀" }),
       ],
       "project"
     )
 
     expect(groups.map((group) => group.label)).toEqual([
-      "Launch week",
-      "Quality",
+      "Launch | Quality 🚀",
+      "No project",
       "No project",
     ])
+    expect(new Set(groups.map((group) => group.key))).toHaveLength(3)
     expect(groups.at(-1)?.threads[0]?.id).toBe("none")
+    expect(groups.at(-2)?.threads[0]?.id).toBe("named-none")
   })
 })
 
@@ -123,6 +126,11 @@ describe("column ordering", () => {
         parseColumnOrder("ready|attention|stale|ready")
       )
     ).toEqual(["ready", "attention", "progress", "done"])
+
+    const projectOrder = ["project:bm8", "project:bGF1bmNofHF1YWxpdHk"]
+    expect(parseColumnOrder(serializeColumnOrder(projectOrder))).toEqual(
+      projectOrder
+    )
   })
 
   it("moves columns with buttons or drag targets", () => {

--- a/ui/src/features/agents/lib/threadViews.ts
+++ b/ui/src/features/agents/lib/threadViews.ts
@@ -2,7 +2,7 @@ import type { AgentSource, AgentStatus, AgentThread } from "./types"
 
 export type ThreadsLayout = "board" | "list"
 export type ThreadGrouping =
-  "focus" | "status" | "repo" | "source" | "pr" | "none"
+  "focus" | "project" | "status" | "repo" | "source" | "pr" | "none"
 
 export interface ThreadViewGroup {
   key: string
@@ -15,6 +15,7 @@ export const THREAD_GROUPING_OPTIONS: Array<{
   label: string
 }> = [
   { value: "focus", label: "Focus" },
+  { value: "project", label: "Project" },
   { value: "status", label: "Status" },
   { value: "repo", label: "Repository" },
   { value: "source", label: "Source" },
@@ -137,6 +138,23 @@ export function groupThreadsForView(
       PR_GROUPS,
       threads,
       (thread) => thread.pr?.state ?? "none"
+    )
+  }
+  if (grouping === "project") {
+    const labels = new Set(
+      threads.map((thread) => thread.project || "No project")
+    )
+    const definitions = [...labels]
+      .sort((left, right) => {
+        if (left === "No project") return 1
+        if (right === "No project") return -1
+        return left.localeCompare(right)
+      })
+      .map((label) => ({ key: label, label }))
+    return buildGroups(
+      definitions,
+      threads,
+      (thread) => thread.project || "No project"
     )
   }
   const labels = new Set(

--- a/ui/src/features/agents/lib/threadViews.ts
+++ b/ui/src/features/agents/lib/threadViews.ts
@@ -70,6 +70,16 @@ const PR_GROUPS = [
   { key: "closed", label: "Closed" },
 ]
 
+const NO_PROJECT_KEY = "project:none"
+
+function projectKey(project?: string | null): string {
+  if (!project) return NO_PROJECT_KEY
+  const bytes = new TextEncoder().encode(project)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return `project:${btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "")}`
+}
+
 function focusKey(thread: AgentThread): string {
   if (thread.resolved) return "done"
   if (thread.status === "running") return "progress"
@@ -141,20 +151,22 @@ export function groupThreadsForView(
     )
   }
   if (grouping === "project") {
-    const labels = new Set(
-      threads.map((thread) => thread.project || "No project")
-    )
-    const definitions = [...labels]
-      .sort((left, right) => {
-        if (left === "No project") return 1
-        if (right === "No project") return -1
-        return left.localeCompare(right)
-      })
-      .map((label) => ({ key: label, label }))
-    return buildGroups(
-      definitions,
-      threads,
-      (thread) => thread.project || "No project"
+    const projects = [
+      ...new Set(
+        threads
+          .map((thread) => thread.project)
+          .filter((project): project is string => Boolean(project))
+      ),
+    ].sort((left, right) => left.localeCompare(right))
+    const definitions = projects.map((project) => ({
+      key: projectKey(project),
+      label: project,
+    }))
+    if (threads.some((thread) => !thread.project)) {
+      definitions.push({ key: NO_PROJECT_KEY, label: "No project" })
+    }
+    return buildGroups(definitions, threads, (thread) =>
+      projectKey(thread.project)
     )
   }
   const labels = new Set(
@@ -170,8 +182,22 @@ export function groupThreadsForView(
   )
 }
 
+export function serializeColumnOrder(order: Array<string>): string {
+  return JSON.stringify(order)
+}
+
 export function parseColumnOrder(value?: string): Array<string> {
-  return value?.split("|").filter(Boolean) ?? []
+  if (!value) return []
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (key): key is string => typeof key === "string" && Boolean(key)
+        )
+      : []
+  } catch {
+    return value.split("|").filter(Boolean)
+  }
 }
 
 export function reconcileColumnOrder(

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -320,6 +320,7 @@ export interface AgentThread {
   viewedAt?: number | null
   resolved?: boolean
   resolvedAt?: number | null
+  project?: string | null
   isOwner?: boolean
   createdAt: number
   updatedAt: number

--- a/ui/src/routes/agents/threads.tsx
+++ b/ui/src/routes/agents/threads.tsx
@@ -24,6 +24,7 @@ const STATUSES: ReadonlyArray<AgentStatus> = [
 const LAYOUTS: ReadonlyArray<ThreadsLayout> = ["board", "list"]
 const GROUPINGS: ReadonlyArray<ThreadGrouping> = [
   "focus",
+  "project",
   "status",
   "repo",
   "source",


### PR DESCRIPTION
## Description
Prototype a single Project assignment for threads using existing thread metadata. Threads can create, select, or clear a project from board/list rows and use Project in the existing Group by view.

## Release Note
Added a proof of concept for organizing threads into projects.

## Test Plan
- [x] Verify project assignment persistence, clearing, and owner authorization
- [x] Verify dynamic project grouping and the No project fallback

Made by [Open SWE](https://openswe.vercel.app/agents/1639842a-2c4c-5993-8936-93069d31b5c3)