### PR TITLE
fix: resolve threads optimistically

### DIFF
--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -398,7 +398,7 @@ describe("useSidebarThreads", () => {
     expect(getThread).toHaveBeenCalledWith(opened.id, { markViewed: false })
   })
 
-  it("keeps the opened thread visible while resolving it", async () => {
+  it("keeps the opened thread visible while resolving it optimistically", async () => {
     const opened = {
       id: "opened-thread",
       status: "idle",
@@ -419,14 +419,12 @@ describe("useSidebarThreads", () => {
         offset: 0,
         hasMore: false,
       })
-    vi.spyOn(agentsApi, "resolveThread").mockResolvedValue(resolved)
-    let finishGetThread: ((thread: AgentThread) => void) | undefined
-    const getThreadRequest = new Promise<AgentThread>((resolve) => {
-      finishGetThread = resolve
+    let finishResolve: ((thread: AgentThread) => void) | undefined
+    const resolveRequest = new Promise<AgentThread>((resolve) => {
+      finishResolve = resolve
     })
-    const getThread = vi
-      .spyOn(agentsApi, "getThread")
-      .mockReturnValue(getThreadRequest)
+    vi.spyOn(agentsApi, "resolveThread").mockReturnValue(resolveRequest)
+    const getThread = vi.spyOn(agentsApi, "getThread")
     const client = testClient()
     let sidebar: ReturnType<typeof useSidebarThreads> | undefined
     let resolveThread: ReturnType<typeof useResolveAgentThread> | undefined
@@ -444,19 +442,74 @@ describe("useSidebarThreads", () => {
     )
 
     await waitFor(() => expect(sidebar?.data.active.items).toEqual([opened]))
-    await act(async () => {
-      await resolveThread?.mutateAsync({
-        threadId: opened.id,
-        resolved: true,
-      })
+    act(() => {
+      resolveThread?.mutate({ threadId: opened.id, resolved: true })
     })
 
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(2))
-    await waitFor(() => expect(getThread).toHaveBeenCalledTimes(1))
-    expect(sidebar?.data.active.items).toEqual([resolved])
+    await waitFor(() => expect(sidebar?.data.active.items).toEqual([resolved]))
+    expect(resolveThread?.isPending).toBe(true)
+    expect(getThread).not.toHaveBeenCalled()
+
     await act(async () => {
-      finishGetThread?.(resolved)
-      await getThreadRequest
+      finishResolve?.(resolved)
+      await resolveRequest
     })
+    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(2))
+  })
+
+  it("rolls back an optimistic resolution when the request fails", async () => {
+    const opened = {
+      id: "opened-thread",
+      status: "idle",
+      resolved: false,
+    } as AgentThread
+    let failResolve: ((error: Error) => void) | undefined
+    vi.spyOn(agentsApi, "resolveThread").mockReturnValue(
+      new Promise<AgentThread>((_resolve, reject) => {
+        failResolve = reject
+      })
+    )
+    const client = testClient()
+    const key = agentThreadKeys.page({ resolved: false })
+    client.setQueryData(agentThreadKeys.detail(opened.id), opened)
+    client.setQueryData(key, {
+      items: [opened],
+      limit: 25,
+      offset: 0,
+      hasMore: false,
+    })
+    let resolveThread: ReturnType<typeof useResolveAgentThread> | undefined
+
+    function Probe() {
+      resolveThread = useResolveAgentThread()
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+
+    act(() => {
+      resolveThread?.mutate({ threadId: opened.id, resolved: true })
+    })
+    await waitFor(() =>
+      expect(client.getQueryData<ThreadsPage>(key)?.items).toEqual([])
+    )
+    expect(
+      client.getQueryData<AgentThread>(agentThreadKeys.detail(opened.id))
+    ).toMatchObject({ resolved: true })
+
+    act(() => failResolve?.(new Error("request failed")))
+    await waitFor(() =>
+      expect(client.getQueryData<ThreadsPage>(key)?.items).toEqual([opened])
+    )
+    expect(
+      client.getQueryData<AgentThread>(agentThreadKeys.detail(opened.id))
+    ).toEqual(opened)
+    expect(
+      client.getQueryData(agentThreadKeys.sidebarActive(opened.id))
+    ).toBeUndefined()
   })
 })

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -471,7 +471,9 @@ describe("useSidebarThreads", () => {
     )
     const client = testClient()
     const key = agentThreadKeys.page({ resolved: false })
+    const unrelated = { ...opened, id: "unrelated-thread", title: "Before" }
     client.setQueryData(agentThreadKeys.detail(opened.id), opened)
+    client.setQueryData(agentThreadKeys.detail(unrelated.id), unrelated)
     client.setQueryData(key, {
       items: [opened],
       limit: 25,
@@ -500,6 +502,10 @@ describe("useSidebarThreads", () => {
     expect(
       client.getQueryData<AgentThread>(agentThreadKeys.detail(opened.id))
     ).toMatchObject({ resolved: true })
+    client.setQueryData(agentThreadKeys.detail(unrelated.id), {
+      ...unrelated,
+      title: "After",
+    })
 
     act(() => failResolve?.(new Error("request failed")))
     await waitFor(() =>
@@ -511,5 +517,8 @@ describe("useSidebarThreads", () => {
     expect(
       client.getQueryData(agentThreadKeys.sidebarActive(opened.id))
     ).toBeUndefined()
+    expect(
+      client.getQueryData<AgentThread>(agentThreadKeys.detail(unrelated.id))
+    ).toMatchObject({ title: "After" })
   })
 })

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -97,6 +97,83 @@ export function setAgentThreadStatus(
   )
 }
 
+function updateThreadPageResolved(
+  page: ThreadsPage,
+  params: ThreadsPageParams,
+  threadId: string,
+  resolved: boolean
+): ThreadsPage {
+  const thread = page.items.find((item) => item.id === threadId)
+  if (!thread) return page
+  if (params.resolved != null && params.resolved !== resolved) {
+    return {
+      ...page,
+      items: page.items.filter((item) => item.id !== threadId),
+      ...(page.total != null ? { total: Math.max(0, page.total - 1) } : {}),
+    }
+  }
+  return {
+    ...page,
+    items: page.items.map((item) =>
+      item.id === threadId ? { ...item, resolved } : item
+    ),
+  }
+}
+
+function setAgentThreadResolved(
+  queryClient: QueryClient,
+  threadId: string,
+  resolved: boolean
+): void {
+  const update = (thread: AgentThread) =>
+    thread.id === threadId ? { ...thread, resolved } : thread
+  const detail = queryClient.getQueryData<AgentThread>(
+    agentThreadKeys.detail(threadId)
+  )
+  const sidebarActive = queryClient.getQueryData<AgentThread>(
+    agentThreadKeys.sidebarActive(threadId)
+  )
+  let cachedThread = detail ?? sidebarActive
+
+  queryClient.setQueryData<AgentThread>(
+    agentThreadKeys.detail(threadId),
+    (prev) => (prev ? update(prev) : prev)
+  )
+  for (const [key, data] of queryClient.getQueriesData<
+    InfiniteData<ThreadsPage>
+  >({ queryKey: ["agent-threads", "lists", "infinite-pages"] })) {
+    const params = key[3] as Omit<ThreadsPageParams, "offset">
+    cachedThread ??= data?.pages
+      .flatMap((page) => page.items)
+      .find((thread) => thread.id === threadId)
+    queryClient.setQueryData<InfiniteData<ThreadsPage>>(key, (prev) =>
+      prev
+        ? {
+            ...prev,
+            pages: prev.pages.map((page) =>
+              updateThreadPageResolved(page, params, threadId, resolved)
+            ),
+          }
+        : prev
+    )
+  }
+  for (const [key, data] of queryClient.getQueriesData<ThreadsPage>({
+    queryKey: ["agent-threads", "lists", "page"],
+  })) {
+    const params = key[3] as ThreadsPageParams
+    cachedThread ??= data?.items.find((thread) => thread.id === threadId)
+    queryClient.setQueryData<ThreadsPage>(key, (prev) =>
+      prev ? updateThreadPageResolved(prev, params, threadId, resolved) : prev
+    )
+  }
+  if (cachedThread) {
+    queryClient.setQueryData(
+      agentThreadKeys.sidebarActive(threadId),
+      update(cachedThread)
+    )
+  }
+}
+
 export function seedAgentThreadLists(
   queryClient: QueryClient,
   thread: AgentThread
@@ -681,14 +758,36 @@ export function useResolveAgentThread() {
   return useMutation({
     mutationFn: (vars: { threadId: string; resolved: boolean }) =>
       agentsApi.resolveThread(vars.threadId, vars.resolved),
+    onMutate: async (vars) => {
+      await queryClient.cancelQueries({ queryKey: ["agent-threads"] })
+      const previous = queryClient.getQueriesData({
+        queryKey: ["agent-threads"],
+      })
+      const hadSidebarActive = Boolean(
+        queryClient.getQueryState(agentThreadKeys.sidebarActive(vars.threadId))
+      )
+      setAgentThreadResolved(queryClient, vars.threadId, vars.resolved)
+      return { previous, hadSidebarActive }
+    },
+    onError: (_error, vars, context) => {
+      for (const [key, data] of context?.previous ?? []) {
+        queryClient.setQueryData(key, data)
+      }
+      if (context && !context.hadSidebarActive) {
+        queryClient.removeQueries({
+          queryKey: agentThreadKeys.sidebarActive(vars.threadId),
+          exact: true,
+        })
+      }
+    },
     onSuccess: (thread, vars) => {
       queryClient.setQueryData(agentThreadKeys.detail(vars.threadId), thread)
       queryClient.setQueryData(
         agentThreadKeys.sidebarActive(vars.threadId),
         thread
       )
-      invalidateAgentThreadLists(queryClient)
     },
+    onSettled: () => invalidateAgentThreadLists(queryClient),
   })
 }
 

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -8,7 +8,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useRef } from "react"
 
 import { agentsApi } from "./api"
-import type { InfiniteData, QueryClient } from "@tanstack/react-query"
+import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query"
 import type {
   ScheduleUpdateRequest,
   SidebarThreads,
@@ -117,6 +117,45 @@ function updateThreadPageResolved(
     items: page.items.map((item) =>
       item.id === threadId ? { ...item, resolved } : item
     ),
+  }
+}
+
+type AgentThreadQuerySnapshot = [QueryKey, unknown, boolean]
+
+function snapshotAgentThreadQueries(
+  queryClient: QueryClient,
+  threadId: string
+): Array<AgentThreadQuerySnapshot> {
+  const directKeys = [
+    agentThreadKeys.detail(threadId),
+    agentThreadKeys.sidebarActive(threadId),
+  ]
+  const direct = directKeys.map((key): AgentThreadQuerySnapshot => {
+    const state = queryClient.getQueryState(key)
+    return [key, state?.data, Boolean(state)]
+  })
+  const lists = [
+    ...queryClient.getQueriesData({
+      queryKey: ["agent-threads", "lists", "infinite-pages"],
+    }),
+    ...queryClient.getQueriesData({
+      queryKey: ["agent-threads", "lists", "page"],
+    }),
+  ].map(([key, data]): AgentThreadQuerySnapshot => [key, data, true])
+  return [...direct, ...lists]
+}
+
+function restoreAgentThreadQueries(
+  queryClient: QueryClient,
+  snapshots: Array<AgentThreadQuerySnapshot>,
+  optimistic: Map<QueryKey, number | undefined>
+): void {
+  for (const [key, data, existed] of snapshots) {
+    if (queryClient.getQueryState(key)?.dataUpdatedAt !== optimistic.get(key)) {
+      continue
+    }
+    if (existed) queryClient.setQueryData(key, data)
+    else queryClient.removeQueries({ queryKey: key, exact: true })
   }
 }
 
@@ -759,25 +798,39 @@ export function useResolveAgentThread() {
     mutationFn: (vars: { threadId: string; resolved: boolean }) =>
       agentsApi.resolveThread(vars.threadId, vars.resolved),
     onMutate: async (vars) => {
-      await queryClient.cancelQueries({ queryKey: ["agent-threads"] })
-      const previous = queryClient.getQueriesData({
-        queryKey: ["agent-threads"],
-      })
-      const hadSidebarActive = Boolean(
-        queryClient.getQueryState(agentThreadKeys.sidebarActive(vars.threadId))
-      )
-      setAgentThreadResolved(queryClient, vars.threadId, vars.resolved)
-      return { previous, hadSidebarActive }
-    },
-    onError: (_error, vars, context) => {
-      for (const [key, data] of context?.previous ?? []) {
-        queryClient.setQueryData(key, data)
-      }
-      if (context && !context.hadSidebarActive) {
-        queryClient.removeQueries({
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: agentThreadKeys.detail(vars.threadId),
+          exact: true,
+        }),
+        queryClient.cancelQueries({
           queryKey: agentThreadKeys.sidebarActive(vars.threadId),
           exact: true,
-        })
+        }),
+        queryClient.cancelQueries({
+          queryKey: ["agent-threads", "lists", "infinite-pages"],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ["agent-threads", "lists", "page"],
+        }),
+      ])
+      const previous = snapshotAgentThreadQueries(queryClient, vars.threadId)
+      setAgentThreadResolved(queryClient, vars.threadId, vars.resolved)
+      const optimistic = new Map<QueryKey, number | undefined>(
+        previous.map(([key]) => [
+          key,
+          queryClient.getQueryState(key)?.dataUpdatedAt,
+        ])
+      )
+      return { previous, optimistic }
+    },
+    onError: (_error, _vars, context) => {
+      if (context) {
+        restoreAgentThreadQueries(
+          queryClient,
+          context.previous,
+          context.optimistic
+        )
       }
     },
     onSuccess: (thread, vars) => {


### PR DESCRIPTION
## Description
Thread resolution now updates cached detail, sidebar, and page data before the server responds, then reconciles with server state or rolls back on failure. Filtered lists remove resolved rows immediately while the opened thread stays pinned.

## Test Plan
- [x] `pnpm --dir ui exec vitest run src/features/agents/lib/queries.test.tsx --no-color`
- [x] Targeted ESLint and UI typecheck
- [ ] Full UI lint (blocked by pre-existing unrelated errors)

Made by [Open SWE](https://openswe.vercel.app/agents/25bf7ed9-6a8f-5276-af2d-8c989c162c7b)