### PR TITLE
fix: count sidebar focus groups on backend

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -8,7 +8,7 @@ import os
 import posixpath
 import shlex
 from time import perf_counter
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 
 import httpx
@@ -229,6 +229,7 @@ from .thread_api import (
     get_dashboard_thread_run_diff,
     get_dashboard_thread_state,
     get_dashboard_thread_working_tree_diff,
+    list_dashboard_thread_focus_counts,
     list_dashboard_threads,
     list_dashboard_threads_page,
     list_dashboard_threads_sidebar,
@@ -1956,6 +1957,38 @@ async def api_list_threads_sidebar(
     header = server_timing_header(timings, counts)
     logger.info("thread sidebar timings login=%s %s", session["sub"], header)
     return JSONResponse(payload, headers={"Server-Timing": header})
+
+
+@router.get("/threads/sidebar/counts")
+async def api_list_thread_focus_counts(
+    scope: Literal["all", "interactive", "automation"] = "interactive",
+    ownership: Literal["all", "mine", "shared"] = "all",
+    status: Annotated[list[str] | None, Query()] = None,
+    source: Annotated[list[str] | None, Query()] = None,
+    pr: Annotated[list[str] | None, Query()] = None,
+    model: Annotated[list[str] | None, Query()] = None,
+    repo: Annotated[list[str] | None, Query()] = None,
+    include_resolved: bool = False,
+    active_thread_id: str | None = None,
+    all: bool = False,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, int]:
+    if all and not _session_is_admin(session):
+        raise HTTPException(403, "admin only")
+    return await list_dashboard_thread_focus_counts(
+        session["sub"],
+        email=session.get("email"),
+        include_all=all,
+        scope=scope,
+        ownership=ownership,
+        statuses=set(status or []),
+        sources=set(source or []),
+        pr_states=set(pr or []),
+        models=set(model or []),
+        repos=set(repo or []),
+        include_resolved=include_resolved,
+        active_thread_id=active_thread_id,
+    )
 
 
 @router.get("/threads/page")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -405,6 +405,31 @@ def _is_thread_resolved(metadata: Mapping[str, Any]) -> bool:
     return metadata.get("resolved") is True
 
 
+def _thread_focus_key(
+    thread: ThreadLike, *, latest_run_status: str | None = None, latest_run_id: str | None = None
+) -> Literal["attention", "progress", "ready", "done"]:
+    metadata = _thread_metadata(thread)
+    if _is_thread_resolved(metadata):
+        return "done"
+    metadata_run_status = metadata.get("latest_run_status")
+    run_status = latest_run_status or (
+        metadata_run_status if isinstance(metadata_run_status, str) else None
+    )
+    status = _run_status_to_agent_status(
+        thread.get("status") if isinstance(thread.get("status"), str) else "idle",
+        run_status,
+    )
+    if status == "running":
+        return "progress"
+    if (
+        status in {"error", "interrupted"}
+        or metadata.get("plan_status") in {"ready", "shared"}
+        or (status == "finished" and not _is_thread_viewed(metadata, latest_run_id))
+    ):
+        return "attention"
+    return "ready"
+
+
 def _thread_source_url(metadata: Mapping[str, Any]) -> str | None:
     if metadata.get("repo_private") is not True:
         return None
@@ -897,6 +922,7 @@ async def _collect_thread_candidates(
     target_per_search: int | None = None,
     surfaced_only: bool = False,
     sort_by: _ThreadSortBy = "updated_at",
+    scan_cap: int | None = _THREADS_PAGE_SCAN_CAP,
 ) -> list[ThreadLike]:
     seen: dict[str, ThreadLike] = {}
     for owner_filter in searches:
@@ -908,7 +934,7 @@ async def _collect_thread_candidates(
             source=source,
             automation_id=automation_id,
         )
-        while offset < _THREADS_PAGE_SCAN_CAP:
+        while scan_cap is None or offset < scan_cap:
             batch = await _search_threads_batch(
                 client,
                 metadata_filter,
@@ -1131,6 +1157,103 @@ async def list_dashboard_threads_sidebar(
             "hasMore": resolved_has_more,
         },
     }
+
+
+async def list_dashboard_thread_focus_counts(
+    login: str,
+    *,
+    email: str | None = None,
+    include_all: bool = False,
+    scope: Literal["all", "interactive", "automation"] = "interactive",
+    ownership: Literal["all", "mine", "shared"] = "all",
+    statuses: set[str] | None = None,
+    sources: set[str] | None = None,
+    pr_states: set[str] | None = None,
+    models: set[str] | None = None,
+    repos: set[str] | None = None,
+    include_resolved: bool = False,
+    active_thread_id: str | None = None,
+) -> dict[str, int]:
+    client = langgraph_client()
+    searches = _owner_search_filters(login, email=email, include_all=include_all)
+    candidates = await _collect_thread_candidates(
+        client,
+        searches,
+        include_all=include_all,
+        login=login,
+        email=email,
+        scope=scope,
+        target_per_search=None,
+        scan_cap=None,
+    )
+    candidates_by_id = {
+        thread_id: thread for thread in candidates if (thread_id := _thread_id(thread)) is not None
+    }
+    if active_thread_id and active_thread_id not in candidates_by_id:
+        try:
+            active_thread = await client.threads.get(active_thread_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Could not fetch active sidebar count thread %s", active_thread_id, exc_info=True
+            )
+        else:
+            if isinstance(active_thread, Mapping):
+                metadata = _thread_metadata(active_thread)
+                if _thread_is_readable(metadata):
+                    candidates_by_id[active_thread_id] = active_thread
+
+    semaphore = asyncio.Semaphore(_RUN_REFRESH_CONCURRENCY)
+
+    async def classify(thread: ThreadLike) -> tuple[ThreadLike, str | None, str | None]:
+        if not _should_refresh_latest_run(thread):
+            return thread, None, None
+        async with semaphore:
+            return await _refresh_latest_run_metadata(client, thread)
+
+    filtered_candidates: list[ThreadLike] = []
+    for thread in candidates_by_id.values():
+        metadata = _thread_metadata(thread)
+        is_owner = _user_owns_thread(metadata, login, email)
+        if ownership == "mine" and not is_owner:
+            continue
+        if ownership == "shared" and is_owner:
+            continue
+        if not include_resolved and _is_thread_resolved(metadata):
+            continue
+        if sources and _thread_source(metadata) not in sources:
+            continue
+        model = metadata.get("model") if isinstance(metadata.get("model"), str) else "Default"
+        if models and model not in models:
+            continue
+        if repos and _metadata_repo(metadata)[2] not in repos:
+            continue
+        pr_state = metadata.get("pr_state") if metadata.get("pr_state") in _PR_STATES else "none"
+        if pr_states and pr_state not in pr_states:
+            continue
+        filtered_candidates.append(thread)
+
+    classified = await asyncio.gather(*(classify(thread) for thread in filtered_candidates))
+    counts = {"attention": 0, "progress": 0, "ready": 0, "done": 0}
+    for thread, latest_run_status, latest_run_id in classified:
+        metadata = _thread_metadata(thread)
+        status = _run_status_to_agent_status(
+            thread.get("status") if isinstance(thread.get("status"), str) else "idle",
+            latest_run_status
+            or (
+                metadata.get("latest_run_status")
+                if isinstance(metadata.get("latest_run_status"), str)
+                else None
+            ),
+        )
+        if statuses and status not in statuses:
+            continue
+        focus_key = _thread_focus_key(
+            thread,
+            latest_run_status=latest_run_status,
+            latest_run_id=latest_run_id,
+        )
+        counts[focus_key] += 1
+    return counts
 
 
 async def list_dashboard_threads_page(

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1199,16 +1199,14 @@ async def list_dashboard_thread_focus_counts(
         else:
             if isinstance(active_thread, Mapping):
                 metadata = _thread_metadata(active_thread)
-                if _thread_is_readable(metadata):
+                if _thread_is_readable(metadata) and _metadata_matches_filters(
+                    metadata,
+                    resolved=None,
+                    source=None,
+                    query=None,
+                    scope=scope,
+                ):
                     candidates_by_id[active_thread_id] = active_thread
-
-    semaphore = asyncio.Semaphore(_RUN_REFRESH_CONCURRENCY)
-
-    async def classify(thread: ThreadLike) -> tuple[ThreadLike, str | None, str | None]:
-        if not _should_refresh_latest_run(thread):
-            return thread, None, None
-        async with semaphore:
-            return await _refresh_latest_run_metadata(client, thread)
 
     filtered_candidates: list[ThreadLike] = []
     for thread in candidates_by_id.values():
@@ -1232,27 +1230,17 @@ async def list_dashboard_thread_focus_counts(
             continue
         filtered_candidates.append(thread)
 
-    classified = await asyncio.gather(*(classify(thread) for thread in filtered_candidates))
     counts = {"attention": 0, "progress": 0, "ready": 0, "done": 0}
-    for thread, latest_run_status, latest_run_id in classified:
+    for thread in filtered_candidates:
         metadata = _thread_metadata(thread)
+        metadata_run_status = metadata.get("latest_run_status")
         status = _run_status_to_agent_status(
             thread.get("status") if isinstance(thread.get("status"), str) else "idle",
-            latest_run_status
-            or (
-                metadata.get("latest_run_status")
-                if isinstance(metadata.get("latest_run_status"), str)
-                else None
-            ),
+            metadata_run_status if isinstance(metadata_run_status, str) else None,
         )
         if statuses and status not in statuses:
             continue
-        focus_key = _thread_focus_key(
-            thread,
-            latest_run_status=latest_run_status,
-            latest_run_id=latest_run_id,
-        )
-        counts[focus_key] += 1
+        counts[_thread_focus_key(thread)] += 1
     return counts
 
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2146,6 +2146,175 @@ async def test_list_dashboard_threads_sidebar_ignores_unreadable_active_thread(
     assert [item["id"] for item in result["active"]["items"]] == ["t0"]
 
 
+async def test_list_dashboard_thread_focus_counts_classifies_and_filters(monkeypatch) -> None:
+    def thread(thread_id: str, status: str, **metadata: object) -> dict[str, object]:
+        return {
+            "thread_id": thread_id,
+            "status": "idle",
+            "metadata": {
+                "source": "dashboard",
+                "github_login": "octocat",
+                "title": thread_id,
+                "updated_at_ms": 1,
+                "latest_run_id": f"run-{thread_id}",
+                "latest_run_status": status,
+                **metadata,
+            },
+        }
+
+    threads = [
+        thread("attention", "success"),
+        thread("error", "error"),
+        thread("interrupted", "interrupted"),
+        thread("plan", "success", plan_status="ready", last_viewed_run_id="run-plan"),
+        thread("progress", "running"),
+        thread("ready", "success", last_viewed_run_id="run-ready"),
+        thread("idle", "missing"),
+        thread("done", "success", resolved=True, last_viewed_run_id="run-done"),
+    ]
+    run_list_thread_ids: list[str] = []
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return threads[offset : offset + limit]
+
+        async def update(self, *, thread_id, metadata):
+            return None
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            run_list_thread_ids.append(thread_id)
+            return []
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    counts = await thread_api.list_dashboard_thread_focus_counts(
+        "octocat", email=None, include_resolved=True
+    )
+    filtered = await thread_api.list_dashboard_thread_focus_counts(
+        "octocat", email=None, statuses={"finished"}, include_resolved=True
+    )
+
+    assert counts == {"attention": 4, "progress": 1, "ready": 2, "done": 1}
+    assert filtered == {"attention": 2, "progress": 0, "ready": 1, "done": 1}
+    assert run_list_thread_ids == ["progress", "progress"]
+
+
+async def test_list_dashboard_thread_focus_counts_refreshes_unsettled_threads(monkeypatch) -> None:
+    threads = _make_threads(2, resolved_before=0)
+    settled = cast(dict[str, object], threads[0]["metadata"])
+    settled.update({"latest_run_id": "run-settled", "latest_run_status": "success"})
+    pending = cast(dict[str, object], threads[1]["metadata"])
+    pending.update({"latest_run_id": "run-pending", "latest_run_status": "pending"})
+    run_list_thread_ids: list[str] = []
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return threads[offset : offset + limit]
+
+        async def update(self, *, thread_id, metadata):
+            return None
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            run_list_thread_ids.append(thread_id)
+            return [{"id": "run-finished", "status": "success"}]
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    counts = await thread_api.list_dashboard_thread_focus_counts("octocat", email=None)
+
+    assert counts == {"attention": 2, "progress": 0, "ready": 0, "done": 0}
+    assert run_list_thread_ids == ["t1"]
+
+
+async def test_list_dashboard_thread_focus_counts_includes_readable_active_thread(
+    monkeypatch,
+) -> None:
+    active = _make_threads(1, resolved_before=0)[0]
+    active["thread_id"] = "shared"
+    metadata = cast(dict[str, object], active["metadata"])
+    metadata.update(
+        {
+            "github_login": "teammate",
+            "latest_run_id": "run-shared",
+            "latest_run_status": "success",
+        }
+    )
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return []
+
+        async def get(self, thread_id):
+            return active
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            raise AssertionError("settled threads must not refresh runs")
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    counts = await thread_api.list_dashboard_thread_focus_counts(
+        "octocat", email=None, ownership="shared", active_thread_id="shared"
+    )
+
+    assert counts == {"attention": 1, "progress": 0, "ready": 0, "done": 0}
+
+
+async def test_list_dashboard_thread_focus_counts_scans_and_deduplicates(monkeypatch) -> None:
+    page_size = thread_api._THREADS_SEARCH_PAGE
+    threads = _make_threads(page_size + 1, resolved_before=0)
+    for thread in threads:
+        metadata = cast(dict[str, object], thread["metadata"])
+        metadata.update(
+            {
+                "triggering_user_email": "octocat@example.com",
+                "latest_run_id": f"run-{thread['thread_id']}",
+                "latest_run_status": "success",
+            }
+        )
+    offsets: list[int] = []
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            offsets.append(offset)
+            return threads[offset : offset + limit]
+
+        async def update(self, *, thread_id, metadata):
+            return None
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            raise AssertionError("settled threads must not refresh runs")
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+
+    counts = await thread_api.list_dashboard_thread_focus_counts(
+        "octocat", email="octocat@example.com"
+    )
+
+    assert counts == {"attention": page_size + 1, "progress": 0, "ready": 0, "done": 0}
+    assert offsets.count(0) == 2
+    assert offsets.count(page_size) == 2
+
+
 async def test_list_dashboard_threads_page_can_sort_by_creation_time(monkeypatch) -> None:
     threads = _make_threads(2, resolved_before=0)
     older = cast(dict[str, object], threads[0]["metadata"])

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2172,19 +2172,14 @@ async def test_list_dashboard_thread_focus_counts_classifies_and_filters(monkeyp
         thread("idle", "missing"),
         thread("done", "success", resolved=True, last_viewed_run_id="run-done"),
     ]
-    run_list_thread_ids: list[str] = []
 
     class FakeThreads:
         async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
             return threads[offset : offset + limit]
 
-        async def update(self, *, thread_id, metadata):
-            return None
-
     class FakeRuns:
         async def list(self, thread_id, limit=1):
-            run_list_thread_ids.append(thread_id)
-            return []
+            raise AssertionError("focus counts must not refresh runs")
 
     class FakeClient:
         threads = FakeThreads()
@@ -2201,39 +2196,6 @@ async def test_list_dashboard_thread_focus_counts_classifies_and_filters(monkeyp
 
     assert counts == {"attention": 4, "progress": 1, "ready": 2, "done": 1}
     assert filtered == {"attention": 2, "progress": 0, "ready": 1, "done": 1}
-    assert run_list_thread_ids == ["progress", "progress"]
-
-
-async def test_list_dashboard_thread_focus_counts_refreshes_unsettled_threads(monkeypatch) -> None:
-    threads = _make_threads(2, resolved_before=0)
-    settled = cast(dict[str, object], threads[0]["metadata"])
-    settled.update({"latest_run_id": "run-settled", "latest_run_status": "success"})
-    pending = cast(dict[str, object], threads[1]["metadata"])
-    pending.update({"latest_run_id": "run-pending", "latest_run_status": "pending"})
-    run_list_thread_ids: list[str] = []
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            return threads[offset : offset + limit]
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            run_list_thread_ids.append(thread_id)
-            return [{"id": "run-finished", "status": "success"}]
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    counts = await thread_api.list_dashboard_thread_focus_counts("octocat", email=None)
-
-    assert counts == {"attention": 2, "progress": 0, "ready": 0, "done": 0}
-    assert run_list_thread_ids == ["t1"]
 
 
 async def test_list_dashboard_thread_focus_counts_includes_readable_active_thread(
@@ -2270,8 +2232,13 @@ async def test_list_dashboard_thread_focus_counts_includes_readable_active_threa
     counts = await thread_api.list_dashboard_thread_focus_counts(
         "octocat", email=None, ownership="shared", active_thread_id="shared"
     )
+    metadata["schedule_id"] = "schedule-1"
+    scoped_counts = await thread_api.list_dashboard_thread_focus_counts(
+        "octocat", email=None, ownership="shared", active_thread_id="shared"
+    )
 
     assert counts == {"attention": 1, "progress": 0, "ready": 0, "done": 0}
+    assert scoped_counts == {"attention": 0, "progress": 0, "ready": 0, "done": 0}
 
 
 async def test_list_dashboard_thread_focus_counts_scans_and_deduplicates(monkeypatch) -> None:

--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -193,6 +193,29 @@ function resolvedOverflowThreads(): Array<ThreadSeed> {
   });
 }
 
+function activeOverflowThreads(): Array<ThreadSeed> {
+  const now = Date.now();
+  return Array.from({ length: 7 }, (_, index) => {
+    const number = index + 1;
+    const runId = `e2e-run-active-overflow-${number}`;
+    return {
+      id: `75000000-0000-4000-8000-${String(number).padStart(12, "0")}`,
+      metadata: baseMetadata(
+        now,
+        `E2E Workspace Active overflow ${String(number).padStart(2, "0")}`,
+        number * 100,
+        {
+          created_at_ms: now - number * 100,
+          latest_run_id: runId,
+          latest_run_status: "success",
+          last_viewed_run_id: runId,
+          last_viewed_at_ms: now - number * 100,
+        },
+      ),
+    };
+  });
+}
+
 function automationThreads(): Array<ThreadSeed> {
   const now = Date.now();
   return [
@@ -680,6 +703,7 @@ test.describe("threads workspace", () => {
   }, testInfo) => {
     await seedThreads(request, [
       ...workspaceThreads(),
+      ...activeOverflowThreads(),
       ...resolvedOverflowThreads(),
     ]);
     await loginAs(page);
@@ -705,24 +729,34 @@ test.describe("threads workspace", () => {
     const ready = sidebarGroup(sidebar, "Ready");
     const done = sidebarGroup(sidebar, "Done");
 
+    await expect(attention.locator("> button > span").last()).toHaveText("1+");
+    await expect(progress).toContainText(TITLES.running);
+    await expect(progress.locator("> button > span").last()).toHaveText("1+");
+    await expect(ready).toContainText(TITLES.ready);
+    await expect(ready.locator("> button > span").last()).toHaveText("8+");
+    const loadMoreThreads = sidebar.getByRole("button", {
+      name: "Load more threads",
+      exact: true,
+    });
+    await loadMoreThreads.click();
     await expect(attention).toContainText(TITLES.attention);
     await expect(attention).toContainText(TITLES.error);
     await expect(attention).toContainText(TITLES.interrupted);
     await expect(attention.locator("> button > span").last()).toHaveText("3");
-    await expect(progress).toContainText(TITLES.running);
     await expect(progress.locator("> button > span").last()).toHaveText("1");
-    await expect(ready).toContainText(TITLES.ready);
-    await expect(ready.locator("> button > span").last()).toHaveText("1");
+    await expect(ready.locator("> button > span").last()).toHaveText("8");
+    await expect(loadMoreThreads).toHaveCount(0);
+
     await expect(done).toContainText("E2E Workspace Resolved overflow 21");
     await expect(done.locator("> button > span").last()).toHaveText("10+");
-    const loadMore = sidebar.getByRole("button", {
+    const loadMoreResolved = sidebar.getByRole("button", {
       name: "Load more resolved threads",
     });
-    await loadMore.click();
+    await loadMoreResolved.click();
     await expect(done.locator("> button > span").last()).toHaveText("20+");
-    await loadMore.click();
+    await loadMoreResolved.click();
     await expect(done.locator("> button > span").last()).toHaveText("22");
-    await expect(loadMore).toHaveCount(0);
+    await expect(loadMoreResolved).toHaveCount(0);
 
     const screenshotPath = testInfo.outputPath("focus-grouping-sidebar.png");
     await sidebar.screenshot({ path: screenshotPath });

--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -729,11 +729,11 @@ test.describe("threads workspace", () => {
     const ready = sidebarGroup(sidebar, "Ready");
     const done = sidebarGroup(sidebar, "Done");
 
-    await expect(attention.locator("> button > span").last()).toHaveText("1+");
+    await expect(attention.locator("> button > span").last()).toHaveText("3");
     await expect(progress).toContainText(TITLES.running);
-    await expect(progress.locator("> button > span").last()).toHaveText("1+");
+    await expect(progress.locator("> button > span").last()).toHaveText("1");
     await expect(ready).toContainText(TITLES.ready);
-    await expect(ready.locator("> button > span").last()).toHaveText("8+");
+    await expect(ready.locator("> button > span").last()).toHaveText("8");
     const loadMoreThreads = sidebar.getByRole("button", {
       name: "Load more threads",
       exact: true,
@@ -748,12 +748,12 @@ test.describe("threads workspace", () => {
     await expect(loadMoreThreads).toHaveCount(0);
 
     await expect(done).toContainText("E2E Workspace Resolved overflow 21");
-    await expect(done.locator("> button > span").last()).toHaveText("10+");
+    await expect(done.locator("> button > span").last()).toHaveText("22");
     const loadMoreResolved = sidebar.getByRole("button", {
       name: "Load more resolved threads",
     });
     await loadMoreResolved.click();
-    await expect(done.locator("> button > span").last()).toHaveText("20+");
+    await expect(done.locator("> button > span").last()).toHaveText("22");
     await loadMoreResolved.click();
     await expect(done.locator("> button > span").last()).toHaveText("22");
     await expect(loadMoreResolved).toHaveCount(0);

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -441,7 +441,7 @@ export function AgentsSidebar({
                       hasMore={
                         prefs.group === "focus" && section.key === "done"
                           ? resolvedHasMore
-                          : false
+                          : activeHasMore
                       }
                       count={
                         prefs.group === "focus" && section.key === "done"

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -53,6 +53,7 @@ import {
   useDeleteAgentThread,
   useResolveAgentThread,
   useSeedAgentThreadDetails,
+  useSidebarFocusCounts,
   useSidebarThreads,
 } from "@/features/agents/lib/queries"
 import { useRunCompletionNotifier } from "@/features/agents/lib/useRunCompletionNotifier"
@@ -172,14 +173,29 @@ export function AgentsSidebar({
   )
   const { prefs, setGroup, setCompact, setFilters, resetFilters } =
     useSidebarPrefs()
+  const includeAutomations =
+    prefs.filters.includeAutomations ||
+    prefs.filters.sources.includes("schedule")
   const sidebar = useSidebarThreads({
     activeThreadId,
-    includeAutomations:
-      prefs.filters.includeAutomations ||
-      prefs.filters.sources.includes("schedule"),
+    includeAutomations,
     includeResolved: prefs.filters.includeResolved,
     enabled: !localOnly,
   })
+  const focusCounts = useSidebarFocusCounts(
+    {
+      scope: includeAutomations ? "all" : "interactive",
+      ownership: prefs.filters.ownership,
+      statuses: prefs.filters.statuses,
+      sources: prefs.filters.sources,
+      pr: prefs.filters.pr,
+      models: prefs.filters.models,
+      repos: prefs.filters.repos,
+      includeResolved: prefs.filters.includeResolved,
+      activeThreadId,
+    },
+    !localOnly && prefs.group === "focus"
+  )
   const localSessions = useDesktopLocalThreads().data ?? []
   const activity = useLocalThreadActivity()
   const refreshLocalThreads = useRefreshLocalThreads()
@@ -439,14 +455,20 @@ export function AgentsSidebar({
                       defaultCollapsed={section.defaultCollapsed}
                       compact={prefs.compact}
                       hasMore={
-                        prefs.group === "focus" && section.key === "done"
-                          ? resolvedHasMore
-                          : activeHasMore
+                        prefs.group === "focus" && focusCounts.data
+                          ? false
+                          : prefs.group === "focus" && section.key === "done"
+                            ? resolvedHasMore
+                            : activeHasMore
                       }
                       count={
-                        prefs.group === "focus" && section.key === "done"
-                          ? filteredResolved.length
-                          : section.threads.length
+                        prefs.group === "focus" && focusCounts.data
+                          ? focusCounts.data[
+                              section.key as keyof typeof focusCounts.data
+                            ]
+                          : prefs.group === "focus" && section.key === "done"
+                            ? filteredResolved.length
+                            : section.threads.length
                       }
                     />
                   )))}

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -150,6 +150,25 @@ export interface SidebarThreads {
   resolved: SidebarThreadsGroup
 }
 
+export interface SidebarFocusCounts {
+  attention: number
+  progress: number
+  ready: number
+  done: number
+}
+
+export interface SidebarFocusCountParams {
+  scope?: ThreadScope
+  ownership?: "all" | "mine" | "shared"
+  statuses?: Array<string>
+  sources?: Array<string>
+  pr?: Array<string>
+  models?: Array<string>
+  repos?: Array<string>
+  includeResolved?: boolean
+  activeThreadId?: string
+}
+
 const API_BASE = dashboardApiBase()
 
 export const agentsLangGraphApiUrl = `${API_BASE}/dashboard/api`
@@ -236,6 +255,25 @@ function buildThreadsPageQuery(params: ThreadsPageParams): string {
   return query ? `?${query}` : ""
 }
 
+function buildSidebarFocusCountQuery(params: SidebarFocusCountParams): string {
+  const search = new URLSearchParams()
+  if (params.scope) search.set("scope", params.scope)
+  if (params.ownership) search.set("ownership", params.ownership)
+  for (const status of params.statuses ?? []) search.append("status", status)
+  for (const source of params.sources ?? []) search.append("source", source)
+  for (const pr of params.pr ?? []) search.append("pr", pr)
+  for (const model of params.models ?? []) search.append("model", model)
+  for (const repo of params.repos ?? []) search.append("repo", repo)
+  if (params.includeResolved != null) {
+    search.set("include_resolved", String(params.includeResolved))
+  }
+  if (params.activeThreadId) {
+    search.set("active_thread_id", params.activeThreadId)
+  }
+  const query = search.toString()
+  return query ? `?${query}` : ""
+}
+
 function buildSidebarThreadsQuery(params: {
   activeLimit?: number
   resolvedLimit?: number
@@ -261,6 +299,10 @@ function buildSidebarThreadsQuery(params: {
 
 export const agentsApi = {
   langGraphApiUrl: agentsLangGraphApiUrl,
+  listSidebarFocusCounts: (params: SidebarFocusCountParams = {}) =>
+    agentsRequest<SidebarFocusCounts>(
+      `/threads/sidebar/counts${buildSidebarFocusCountQuery(params)}`
+    ),
   listSidebarThreads: (params: {
     activeLimit?: number
     resolvedLimit?: number

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -306,8 +306,6 @@ export function useSidebarFocusCounts(
     queryKey: agentThreadKeys.sidebarFocusCounts(params),
     queryFn: () => agentsApi.listSidebarFocusCounts(params),
     enabled,
-    refetchInterval: (query) =>
-      (query.state.data?.progress ?? 0) > 0 ? 2000 : false,
     retry: false,
   })
 }

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -11,6 +11,7 @@ import { agentsApi } from "./api"
 import type { InfiniteData, QueryClient } from "@tanstack/react-query"
 import type {
   ScheduleUpdateRequest,
+  SidebarFocusCountParams,
   SidebarThreads,
   ThreadTurnDiffOptions,
   ThreadsPage,
@@ -36,6 +37,8 @@ export const agentThreadKeys = {
   }) => ["agent-threads", "lists", "sidebar", params] as const,
   sidebarActive: (threadId: string) =>
     ["agent-threads", "lists", "sidebar-active", threadId] as const,
+  sidebarFocusCounts: (params: SidebarFocusCountParams) =>
+    ["agent-threads", "lists", "sidebar-focus-counts", params] as const,
   detail: (threadId: string) => ["agent-threads", threadId] as const,
   pullRequestStatus: (threadId: string) =>
     ["agent-threads", threadId, "pull-request-status"] as const,
@@ -294,6 +297,20 @@ export function useSeedAgentThreadDetails(
 }
 
 export const SIDEBAR_PAGE_SIZE = 10
+
+export function useSidebarFocusCounts(
+  params: SidebarFocusCountParams,
+  enabled = true
+) {
+  return useQuery({
+    queryKey: agentThreadKeys.sidebarFocusCounts(params),
+    queryFn: () => agentsApi.listSidebarFocusCounts(params),
+    enabled,
+    refetchInterval: (query) =>
+      (query.state.data?.progress ?? 0) > 0 ? 2000 : false,
+    retry: false,
+  })
+}
 
 function infinitePageThreads(
   data?: InfiniteData<ThreadsPage>


### PR DESCRIPTION
## Description
Adds exact backend focus counts while keeping row pagination. Counting uses stored thread metadata, avoids per-thread run requests, and respects pinned-thread scope.

## Release Note
Sidebar focus groups now show exact filtered counts before all rows load.

## Test Plan
- [x] Verify exact counts before loading remaining rows.
- [x] Verify multi-page deduplication and pinned automation scope.

Made by [Open SWE](https://openswe.vercel.app/agents/1e4dc1fc-c554-584d-960e-5adceaa7d770)