### PR TITLE
fix: show hydrated new thread messages

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -24,6 +24,7 @@ import { OptimisticThreadHydrationRecovery } from "@/features/agents/components/
 import { latestContextTokens } from "@/features/agents/lib/contextUsage"
 import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
+import { threadMessages } from "@/features/agents/lib/threadMessages"
 import { useSubmitAgentMessage } from "@/features/agents/lib/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import {
@@ -148,12 +149,12 @@ export function AgentThreadView({
   )
 
   const baseMessages = useMemo<Array<Message>>(() => {
-    if (thread.messages.length > 0) return thread.messages
-    return streamMessagesToUi(
+    const liveMessages = streamMessagesToUi(
       stream.messages,
       stream.toolCalls,
       messageArrivalTimestamp
     )
+    return threadMessages(liveMessages, thread.messages)
   }, [stream.messages, stream.toolCalls, thread.messages])
 
   const isStreaming =

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -154,8 +154,18 @@ export function AgentThreadView({
       stream.toolCalls,
       messageArrivalTimestamp
     )
-    return selectThreadMessages(liveMessages, thread.messages)
-  }, [stream.messages, stream.toolCalls, thread.messages])
+    return selectThreadMessages(
+      liveMessages,
+      thread.messages,
+      stream.threadId === thread.id
+    )
+  }, [
+    stream.messages,
+    stream.threadId,
+    stream.toolCalls,
+    thread.id,
+    thread.messages,
+  ])
 
   const isStreaming =
     thread.status === "running" ||

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -24,7 +24,7 @@ import { OptimisticThreadHydrationRecovery } from "@/features/agents/components/
 import { latestContextTokens } from "@/features/agents/lib/contextUsage"
 import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
-import { threadMessages } from "@/features/agents/lib/threadMessages"
+import { selectThreadMessages } from "@/features/agents/lib/threadMessages"
 import { useSubmitAgentMessage } from "@/features/agents/lib/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import {
@@ -154,7 +154,7 @@ export function AgentThreadView({
       stream.toolCalls,
       messageArrivalTimestamp
     )
-    return threadMessages(liveMessages, thread.messages)
+    return selectThreadMessages(liveMessages, thread.messages)
   }, [stream.messages, stream.toolCalls, thread.messages])
 
   const isStreaming =

--- a/ui/src/features/agents/lib/threadMessages.test.ts
+++ b/ui/src/features/agents/lib/threadMessages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { threadMessages } from "./threadMessages"
+import { selectThreadMessages } from "./threadMessages"
 import type { Message } from "./types"
 
 const optimistic: Message = {
@@ -16,15 +16,15 @@ const response: Message = {
   chunks: [{ kind: "text", text: "Done" }],
 }
 
-describe("threadMessages", () => {
+describe("selectThreadMessages", () => {
   it("replaces the optimistic transcript after hydration", () => {
-    expect(threadMessages([optimistic, response], [optimistic])).toEqual([
+    expect(selectThreadMessages([optimistic, response], [optimistic])).toEqual([
       optimistic,
       response,
     ])
   })
 
   it("keeps the optimistic transcript while hydration is empty", () => {
-    expect(threadMessages([], [optimistic])).toEqual([optimistic])
+    expect(selectThreadMessages([], [optimistic])).toEqual([optimistic])
   })
 })

--- a/ui/src/features/agents/lib/threadMessages.test.ts
+++ b/ui/src/features/agents/lib/threadMessages.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { threadMessages } from "./threadMessages"
+import type { Message } from "./types"
+
+const optimistic: Message = {
+  id: "optimistic",
+  author: "user",
+  timestamp: "2026-08-22T00:00:00Z",
+  chunks: [{ kind: "text", text: "Initial prompt" }],
+}
+const response: Message = {
+  id: "response",
+  author: "agent",
+  timestamp: "2026-08-22T00:01:00Z",
+  chunks: [{ kind: "text", text: "Done" }],
+}
+
+describe("threadMessages", () => {
+  it("replaces the optimistic transcript after hydration", () => {
+    expect(threadMessages([optimistic, response], [optimistic])).toEqual([
+      optimistic,
+      response,
+    ])
+  })
+
+  it("keeps the optimistic transcript while hydration is empty", () => {
+    expect(threadMessages([], [optimistic])).toEqual([optimistic])
+  })
+})

--- a/ui/src/features/agents/lib/threadMessages.test.ts
+++ b/ui/src/features/agents/lib/threadMessages.test.ts
@@ -3,28 +3,24 @@ import { describe, expect, it } from "vitest"
 import { selectThreadMessages } from "./threadMessages"
 import type { Message } from "./types"
 
-const optimistic: Message = {
-  id: "optimistic",
-  author: "user",
-  timestamp: "2026-08-22T00:00:00Z",
-  chunks: [{ kind: "text", text: "Initial prompt" }],
-}
-const response: Message = {
-  id: "response",
+const previous: Message = {
+  id: "previous",
   author: "agent",
+  timestamp: "2026-08-22T00:00:00Z",
+  chunks: [{ kind: "text", text: "Previous thread" }],
+}
+const current: Message = {
+  id: "current",
+  author: "user",
   timestamp: "2026-08-22T00:01:00Z",
-  chunks: [{ kind: "text", text: "Done" }],
+  chunks: [{ kind: "text", text: "Current thread" }],
 }
 
 describe("selectThreadMessages", () => {
-  it("replaces the optimistic transcript after hydration", () => {
-    expect(selectThreadMessages([optimistic, response], [optimistic])).toEqual([
-      optimistic,
-      response,
+  it("ignores stale messages until the destination thread hydrates", () => {
+    expect(selectThreadMessages([previous], [current], false)).toEqual([
+      current,
     ])
-  })
-
-  it("keeps the optimistic transcript while hydration is empty", () => {
-    expect(selectThreadMessages([], [optimistic])).toEqual([optimistic])
+    expect(selectThreadMessages([current], [], true)).toEqual([current])
   })
 })

--- a/ui/src/features/agents/lib/threadMessages.ts
+++ b/ui/src/features/agents/lib/threadMessages.ts
@@ -2,7 +2,8 @@ import type { Message } from "./types"
 
 export function selectThreadMessages(
   hydrated: Array<Message>,
-  optimistic: Array<Message>
+  optimistic: Array<Message>,
+  hydratedThread: boolean
 ): Array<Message> {
-  return hydrated.length > 0 ? hydrated : optimistic
+  return hydratedThread && hydrated.length > 0 ? hydrated : optimistic
 }

--- a/ui/src/features/agents/lib/threadMessages.ts
+++ b/ui/src/features/agents/lib/threadMessages.ts
@@ -1,0 +1,8 @@
+import type { Message } from "./types"
+
+export function threadMessages(
+  hydrated: Array<Message>,
+  optimistic: Array<Message>
+): Array<Message> {
+  return hydrated.length > 0 ? hydrated : optimistic
+}

--- a/ui/src/features/agents/lib/threadMessages.ts
+++ b/ui/src/features/agents/lib/threadMessages.ts
@@ -1,6 +1,6 @@
 import type { Message } from "./types"
 
-export function threadMessages(
+export function selectThreadMessages(
   hydrated: Array<Message>,
   optimistic: Array<Message>
 ): Array<Message> {


### PR DESCRIPTION
## Description
New dashboard threads are inserted into the React Query cache with an optimistic transcript containing only the initial user prompt. `AgentThreadView` always preferred that cached transcript when it was non-empty, so it continued hiding the SDK-hydrated transcript—including the agent response—even after the run completed.

The view now prefers the SDK transcript after hydration and falls back to the optimistic prompt only while hydrated messages are unavailable. Because the stream provider persists across route changes, the hydrated transcript is used only when `stream.threadId` matches the displayed thread; this prevents the previous thread’s messages from flashing while the controller switches threads.

## Release Note
Fix missing agent responses in newly created dashboard threads without showing stale messages during thread navigation.

## Test Plan
- [x] Verify stale messages are ignored during a thread switch and the destination transcript replaces the optimistic prompt after hydration

Made by [Open SWE](https://openswe.vercel.app/agents/01a02aab-4cbd-740b-9cea-f1c8059a87d6)