### PR TITLE
feat: add optimistic cloud mutations

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -31,7 +31,6 @@ import {
   useAgentThreadPullRequestStatus,
 } from "@/features/agents/lib/queries"
 import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
-import { rejectPlan } from "@/lib/plan"
 import { useSession } from "@/lib/session"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
@@ -97,13 +96,13 @@ export function AgentThreadView({
   )
   const submitMessage = useCallback(
     async (content: string, images: Array<ImageChunk>) => {
-      if (planFeedbackPending) await rejectPlan(thread.id, false)
       await sendMessage.mutateAsync({
         content,
         images,
         model_id: activeSelection?.modelId ?? null,
         effort: activeSelection?.effort ?? null,
         plan_mode: activePlanMode,
+        reject_plan: planFeedbackPending,
       })
       setPlanFeedbackPending(false)
     },

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -298,6 +298,23 @@ export const ChatComposer = memo(function ChatComposer({
   useRegisterAppCommands(composerShortcuts)
 
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null)
+  const valueRef = useRef(value)
+  const pendingImagesRef = useRef(pendingImages)
+  valueRef.current = value
+  pendingImagesRef.current = pendingImages
+  const updatePendingImages = useCallback(
+    (
+      update:
+        Array<ImageChunk> | ((current: Array<ImageChunk>) => Array<ImageChunk>)
+    ) => {
+      setPendingImages((current) => {
+        const next = typeof update === "function" ? update(current) : update
+        pendingImagesRef.current = next
+        return next
+      })
+    },
+    []
+  )
   const fileInputRef = useRef<HTMLInputElement>(null)
   const dragDepthRef = useRef(0)
   const recorderRef = useRef<MediaRecorder | null>(null)
@@ -359,6 +376,7 @@ export const ChatComposer = memo(function ChatComposer({
     (value.trim().length > 0 || pendingImages.length > 0)
 
   const applyPrompt = useCallback((nextValue: string, nextCursor: number) => {
+    valueRef.current = nextValue
     setValue(nextValue)
     setCursor(nextCursor)
     setDismissedTriggerKey(null)
@@ -449,17 +467,27 @@ export const ChatComposer = memo(function ChatComposer({
     submittingRef.current = true
     setIsSubmitting(true)
     applyPrompt("", 0)
-    setPendingImages([])
+    updatePendingImages([])
     setDictationError(null)
     try {
       await onSubmit?.(trimmed, images)
     } catch {
-      // Caller surfaces send errors (e.g. via react-query mutation state).
+      if (!valueRef.current && pendingImagesRef.current.length === 0) {
+        applyPrompt(trimmed, trimmed.length)
+        updatePendingImages(images)
+      }
     } finally {
       submittingRef.current = false
       setIsSubmitting(false)
     }
-  }, [applyPrompt, disabled, onSubmit, pendingImages, value])
+  }, [
+    applyPrompt,
+    disabled,
+    onSubmit,
+    pendingImages,
+    updatePendingImages,
+    value,
+  ])
 
   const selectCommandItem = useCallback(
     (item: ComposerCommandItem) => {
@@ -546,18 +574,21 @@ export const ChatComposer = memo(function ChatComposer({
     ]
   )
 
-  const addFiles = useCallback(async (files: FileList | Array<File>) => {
-    const nextImages = await Promise.all(
-      Array.from(files).map(fileToImageChunk)
-    )
-    const validImages = nextImages.filter(
-      (image): image is ImageChunk => image !== null
-    )
-    if (validImages.length === 0) return
-    setPendingImages((prev) =>
-      [...prev, ...validImages].slice(0, MAX_IMAGE_COUNT)
-    )
-  }, [])
+  const addFiles = useCallback(
+    async (files: FileList | Array<File>) => {
+      const nextImages = await Promise.all(
+        Array.from(files).map(fileToImageChunk)
+      )
+      const validImages = nextImages.filter(
+        (image): image is ImageChunk => image !== null
+      )
+      if (validImages.length === 0) return
+      updatePendingImages((prev) =>
+        [...prev, ...validImages].slice(0, MAX_IMAGE_COUNT)
+      )
+    },
+    [updatePendingImages]
+  )
 
   const handleFileChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -778,7 +809,7 @@ export const ChatComposer = memo(function ChatComposer({
                   aria-label="Remove image"
                   className="absolute -top-1.5 -right-1.5 flex size-5 items-center justify-center rounded-full border border-border bg-card text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 hover:text-foreground"
                   onClick={() =>
-                    setPendingImages((prev) =>
+                    updatePendingImages((prev) =>
                       prev.filter((_, i) => i !== index)
                     )
                   }
@@ -797,6 +828,7 @@ export const ChatComposer = memo(function ChatComposer({
           disabled={disabled}
           editorRef={editorRef}
           onChange={(nextValue, nextCursor) => {
+            valueRef.current = nextValue
             setValue(nextValue)
             setCursor(nextCursor)
           }}

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -40,9 +40,11 @@ function QueuedMessages({
           >
             <div className="mb-1 flex items-center gap-2 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
               <span>
-                {queuedMessages.length > 1
-                  ? `Queued next #${index + 1}`
-                  : "Queued next"}
+                {message.status === "sending"
+                  ? "Sending"
+                  : queuedMessages.length > 1
+                    ? `Queued next #${index + 1}`
+                    : "Queued next"}
               </span>
               <span className="size-1.5 animate-status-pulse rounded-full bg-foreground/60" />
             </div>

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query"
 
 import { agentsApi } from "./api"
 import { agentThreadKeys, invalidateAgentThreadLists } from "./queries"
+import { notifyAgentRunCreated } from "./provider/runAcceptance"
 import type { ReactNode } from "react"
 
 const AGENT_ASSISTANT_ID = "agent"
@@ -79,7 +80,11 @@ export function AgentThreadStreamProvider({
   threadIdRef.current = threadId
 
   const onCreated = useCallback(() => {
-    if (transport === "cloud") invalidateAgentThreadLists(queryClient)
+    if (transport === "cloud") {
+      const id = threadIdRef.current
+      if (id) notifyAgentRunCreated(id)
+      invalidateAgentThreadLists(queryClient)
+    }
   }, [queryClient, transport])
 
   const onCompleted = useCallback(() => {

--- a/ui/src/features/agents/lib/provider/runAcceptance.ts
+++ b/ui/src/features/agents/lib/provider/runAcceptance.ts
@@ -1,0 +1,19 @@
+const listeners = new Map<string, Set<() => void>>()
+
+export function onAgentRunCreated(
+  threadId: string,
+  listener: () => void
+): () => void {
+  const threadListeners = listeners.get(threadId) ?? new Set()
+  threadListeners.add(listener)
+  listeners.set(threadId, threadListeners)
+  return () => {
+    threadListeners.delete(listener)
+    if (threadListeners.size === 0) listeners.delete(threadId)
+  }
+}
+
+export function notifyAgentRunCreated(threadId: string): void {
+  for (const listener of listeners.get(threadId) ?? []) listener()
+  listeners.delete(threadId)
+}

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
@@ -5,12 +5,21 @@ import { renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSubmitAgentMessage } from "./useSubmitAgentMessage"
+import { notifyAgentRunCreated } from "./runAcceptance"
+import type { SidebarThreads } from "@/features/agents/lib/api"
 import type { AgentThread } from "@/features/agents/lib/types"
 import { AgentsApiError } from "@/features/agents/lib/api"
-import type { SidebarThreads } from "@/features/agents/lib/api"
 import { agentThreadKeys } from "@/features/agents/lib/queries"
 
-const stream = { isLoading: false, submit: vi.fn(async () => undefined) }
+const stream = {
+  isLoading: false,
+  submit: vi.fn<
+    (
+      input?: unknown,
+      options?: { onError?: (error: unknown) => void }
+    ) => Promise<void>
+  >(async () => undefined),
+}
 
 vi.mock("@langchain/react", () => ({
   useStreamContext: () => stream,
@@ -19,7 +28,9 @@ vi.mock("@langchain/react", () => ({
 const queueMessage = vi.fn()
 
 vi.mock("@/features/agents/lib/api", () => ({
-  agentsApi: { queueMessage: () => queueMessage() },
+  agentsApi: {
+    queueMessage: (...args: Array<unknown>) => queueMessage(...args),
+  },
   AgentsApiError: class extends Error {
     constructor(
       public readonly status: number,
@@ -29,6 +40,8 @@ vi.mock("@/features/agents/lib/api", () => ({
     }
   },
 }))
+
+vi.mock("@/lib/plan", () => ({ rejectPlan: vi.fn() }))
 
 const THREAD_ID = "thread-1"
 
@@ -87,24 +100,72 @@ beforeEach(() => {
 })
 
 describe("useSubmitAgentMessage", () => {
-  it("never flashes a queued bubble when the send starts a new run", async () => {
+  it("shows a message immediately while probing an idle thread", async () => {
+    let acceptQueue: () => void = () => {}
+    queueMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          acceptQueue = () => resolve(undefined)
+        })
+    )
+    const { client, result } = setup()
+
+    const pending = result.current.mutateAsync({ content: "hi", images: [] })
+
+    await waitFor(() => expect(queuedMessages(client)).toHaveLength(1))
+    expect(queuedMessages(client)?.[0]?.status).toBe("sending")
+    acceptQueue()
+    await pending
+    expect(queuedMessages(client)?.[0]?.status).toBe("queued")
+  })
+
+  it("keeps the temporary message when the send starts a new run", async () => {
     queueMessage.mockRejectedValueOnce(new AgentsApiError(409, "no active run"))
     const { client, queuedCounts, result } = setup()
 
-    await result.current.mutateAsync({ content: "hi", images: [] })
-
+    const pending = result.current.mutateAsync({ content: "hi", images: [] })
     await waitFor(() => expect(stream.submit).toHaveBeenCalled())
+    notifyAgentRunCreated(THREAD_ID)
+    await pending
+
     expect(sidebarStatus(client)).toBe("running")
-    expect(queuedCounts.every((count) => count === 0)).toBe(true)
+    expect(queuedMessages(client)).toHaveLength(1)
+    expect(queuedCounts).toContain(1)
   })
 
-  it("shows the queued bubble once a run this client never joined accepts it", async () => {
+  it("keeps the message once a run this client never joined accepts it", async () => {
     const { client, result } = setup()
 
     await result.current.mutateAsync({ content: "hi", images: [] })
 
     expect(queuedMessages(client)).toHaveLength(1)
+    expect(queuedMessages(client)?.[0]?.status).toBe("queued")
     expect(stream.submit).not.toHaveBeenCalled()
+  })
+
+  it("rolls back a new-run message when startup fails", async () => {
+    queueMessage.mockRejectedValueOnce(new AgentsApiError(409, "no active run"))
+    stream.submit.mockImplementationOnce(async (_input, options) => {
+      options?.onError?.(new Error("start failed"))
+    })
+    const { client, result } = setup()
+
+    await expect(
+      result.current.mutateAsync({ content: "hi", images: [] })
+    ).rejects.toThrow("start failed")
+
+    expect(queuedMessages(client)).toHaveLength(0)
+  })
+
+  it("rolls back the message when queueing fails", async () => {
+    queueMessage.mockRejectedValueOnce(new Error("request failed"))
+    const { client, result } = setup()
+
+    await expect(
+      result.current.mutateAsync({ content: "hi", images: [] })
+    ).rejects.toThrow("request failed")
+
+    expect(queuedMessages(client)).toHaveLength(0)
   })
 
   it("shows the queued bubble immediately while this client streams", async () => {

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
@@ -8,13 +8,9 @@ import {
   agentThreadKeys,
   setAgentThreadStatus,
 } from "@/features/agents/lib/queries"
+import { PlanApiError, rejectPlan } from "@/lib/plan"
+import { onAgentRunCreated } from "@/features/agents/lib/provider/runAcceptance"
 
-/**
- * Construct the message content for the LangGraph run.
- *
- * @param vars - The variables for the message.
- * @returns The message content.
- */
 function messageContent(vars: SendAgentMessageVariables) {
   const text = vars.content.trim()
   const imageBlocks =
@@ -42,8 +38,22 @@ function appendQueuedMessage(
         content: vars.content.trim(),
         images: vars.images,
         createdAt,
+        status: "sending",
       },
     ],
+  }
+}
+
+function updateQueuedMessage(
+  thread: AgentThread,
+  id: string,
+  status: "sending" | "queued"
+): AgentThread {
+  return {
+    ...thread,
+    queuedMessages: thread.queuedMessages?.map((message) =>
+      message.id === id ? { ...message, status } : message
+    ),
   }
 }
 
@@ -56,71 +66,54 @@ function removeQueuedMessage(thread: AgentThread, id: string): AgentThread {
   }
 }
 
-/**
- * User-initiated sends from the prompt bar. Prefer this over calling `stream.submit`
- * directly so cache updates and the busy-thread queue path stay consistent.
- *
- * When the thread is idle, submits a new run via the stream commands endpoint.
- * When a run is already in flight (`stream.isLoading`), posts to the dashboard
- * `/messages` endpoint instead of using LangGraph `multitaskStrategy: "enqueue"`.
- * That endpoint writes to the thread store; `check_message_queue_before_model`
- * injects the message into the *current* run before the next model call — the
- * same mid-run follow-up path used by Slack, Linear, and GitHub webhooks.
- *
- * @param threadId - The ID of the thread to submit the message to.
- * @returns The mutation object.
- */
 export function useSubmitAgentMessage(threadId: string) {
   const queryClient = useQueryClient()
   const stream = useAgentThreadStream()
 
   return useMutation({
     mutationFn: async (vars: SendAgentMessageVariables) => {
-      // `optimistic` is only safe when a run is known to be in flight. Idle
-      // sends still probe `/messages` first (a run may have started elsewhere),
-      // and that probe answers 409 — showing the bubble up front would flash a
-      // "Queued next" card for the length of the round trip.
-      const queue = async (optimistic: boolean) => {
-        const queuedAt = Date.now()
-        const queuedId = `queued-${queuedAt}-${Math.random().toString(36).slice(2)}`
-        const showQueued = () =>
-          queryClient.setQueryData<AgentThread>(
-            agentThreadKeys.detail(threadId),
-            (prev) =>
-              prev ? appendQueuedMessage(prev, vars, queuedId, queuedAt) : prev
-          )
-        if (optimistic) showQueued()
-        try {
-          await agentsApi.queueMessage(threadId, {
-            content: vars.content,
-            images: vars.images,
-            model_id: vars.model_id,
-            effort: vars.effort,
-            plan_mode: vars.plan_mode,
-          })
-        } catch (error) {
-          if (optimistic) {
-            queryClient.setQueryData<AgentThread>(
-              agentThreadKeys.detail(threadId),
-              (prev) => (prev ? removeQueuedMessage(prev, queuedId) : prev)
-            )
-          }
-          throw error
-        }
-        if (!optimistic) showQueued()
-      }
-
-      if (stream.isLoading) {
-        await queue(true)
-        return
-      }
+      const queuedAt = Date.now()
+      const queuedId = `queued-${queuedAt}-${Math.random().toString(36).slice(2)}`
+      const removeOptimisticMessage = () =>
+        queryClient.setQueryData<AgentThread>(
+          agentThreadKeys.detail(threadId),
+          (prev) => (prev ? removeQueuedMessage(prev, queuedId) : prev)
+        )
+      queryClient.setQueryData<AgentThread>(
+        agentThreadKeys.detail(threadId),
+        (prev) =>
+          prev ? appendQueuedMessage(prev, vars, queuedId, queuedAt) : prev
+      )
 
       try {
-        await queue(false)
+        await agentsApi.queueMessage(threadId, {
+          content: vars.content,
+          images: vars.images,
+          model_id: vars.model_id,
+          effort: vars.effort,
+          plan_mode: vars.plan_mode,
+        })
+        queryClient.setQueryData<AgentThread>(
+          agentThreadKeys.detail(threadId),
+          (prev) =>
+            prev ? updateQueuedMessage(prev, queuedId, "queued") : prev
+        )
         return
       } catch (error) {
         if (!(error instanceof AgentsApiError) || error.status !== 409) {
+          removeOptimisticMessage()
           throw error
+        }
+      }
+
+      if (vars.reject_plan) {
+        try {
+          await rejectPlan(threadId, false)
+        } catch (error) {
+          if (!(error instanceof PlanApiError) || error.status !== 409) {
+            removeOptimisticMessage()
+            throw error
+          }
         }
       }
 
@@ -129,31 +122,39 @@ export function useSubmitAgentMessage(threadId: string) {
         configurable.agent_model_id = vars.model_id
         configurable.agent_effort = vars.effort
       }
-      if (vars.plan_mode) {
-        configurable.plan_mode = true
-      }
+      if (vars.plan_mode) configurable.plan_mode = true
       const config =
         Object.keys(configurable).length > 0 ? { configurable } : undefined
 
-      // Don't await: `stream.submit` resolves only when the run *finishes*, so
-      // awaiting would keep the mutation `isPending` (and the prompt bar
-      // disabled) for the entire run, blocking the user from queueing a
-      // follow-up while it streams.
-      void stream
-        .submit(
-          { messages: [{ type: "human", content: messageContent(vars) }] },
-          { config }
-        )
-        .catch(() => {
-          // The run failed to start (e.g. expired OAuth token → 401, or a
-          // 409 active-run race), but `onSuccess` already optimistically set
-          // `status: "running"`. Surface the failure and clear the busy state
-          // instead of leaving the thread falsely running.
-          setAgentThreadStatus(queryClient, threadId, "error")
+      const accepted = new Promise<void>((resolve, reject) => {
+        const unsubscribe = onAgentRunCreated(threadId, () => {
+          unsubscribe()
+          resolve()
         })
+        void stream
+          .submit(
+            { messages: [{ type: "human", content: messageContent(vars) }] },
+            {
+              config,
+              onError: (error) => {
+                unsubscribe()
+                reject(error)
+              },
+            }
+          )
+          .catch((error) => {
+            unsubscribe()
+            reject(error)
+          })
+      })
+      try {
+        await accepted
+      } catch (error) {
+        removeOptimisticMessage()
+        setAgentThreadStatus(queryClient, threadId, "error")
+        throw error
+      }
     },
-    onSuccess: () => {
-      setAgentThreadStatus(queryClient, threadId, "running")
-    },
+    onSuccess: () => setAgentThreadStatus(queryClient, threadId, "running"),
   })
 }

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -7,16 +7,24 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { agentsApi } from "./api"
 import {
   SIDEBAR_PAGE_SIZE,
+  agentScheduleKeys,
   agentThreadKeys,
   setAgentThreadStatus,
   useAgentThreadWorkingTreeDiff,
+  useDeleteAgentThread,
   useResolveAgentThread,
   useSidebarThreads,
   useThreadsPage,
+  useUpdateAgentSchedule,
+  useWorkflowApprovalDecision,
 } from "./queries"
 import type { InfiniteData } from "@tanstack/react-query"
 import type { ThreadTurnDiff, ThreadsPage, ThreadsPageParams } from "./api"
-import type { AgentThread } from "./types"
+import type {
+  AgentSchedule,
+  AgentThread,
+  WorkflowPushApprovalsResponse,
+} from "./types"
 
 const params: ThreadsPageParams = {
   limit: 100,
@@ -520,5 +528,141 @@ describe("useSidebarThreads", () => {
     expect(
       client.getQueryData<AgentThread>(agentThreadKeys.detail(unrelated.id))
     ).toMatchObject({ title: "After" })
+  })
+})
+
+describe("optimistic cloud mutations", () => {
+  it("removes a thread immediately and restores it when deletion fails", async () => {
+    const thread = { id: "thread-1", status: "idle" } as AgentThread
+    const key = agentThreadKeys.page({ resolved: false })
+    let failDelete: ((error: Error) => void) | undefined
+    vi.spyOn(agentsApi, "deleteThread").mockReturnValue(
+      new Promise<void>((_resolve, reject) => {
+        failDelete = reject
+      })
+    )
+    const client = testClient()
+    client.setQueryData(key, { ...page, items: [thread] })
+    client.setQueryData(agentThreadKeys.detail(thread.id), thread)
+    let mutation: ReturnType<typeof useDeleteAgentThread> | undefined
+
+    function Probe() {
+      mutation = useDeleteAgentThread()
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+    act(() => mutation?.mutate(thread.id))
+    await waitFor(() =>
+      expect(client.getQueryData<ThreadsPage>(key)?.items).toEqual([])
+    )
+    act(() => failDelete?.(new Error("request failed")))
+    await waitFor(() =>
+      expect(client.getQueryData<ThreadsPage>(key)?.items).toEqual([thread])
+    )
+  })
+
+  it("updates workflow decisions immediately and rolls them back", async () => {
+    const key = agentThreadKeys.workflowApprovals("thread-1")
+    const approvals: WorkflowPushApprovalsResponse = {
+      threadId: "thread-1",
+      isOwner: true,
+      approvals: [
+        {
+          fingerprint: "abc",
+          status: "pending",
+          repo: "langchain-ai/open-swe",
+          branch: "main",
+          baseSha: "a",
+          headSha: "b",
+          files: [],
+          diffStats: { files: 0, additions: 0, deletions: 0 },
+          diffPreview: "",
+          diffPreviewTruncated: false,
+          approvalUrl: null,
+          requestedAt: null,
+          decidedAt: null,
+          decidedBy: null,
+        },
+      ],
+    }
+    let failDecision: ((error: Error) => void) | undefined
+    vi.spyOn(agentsApi, "approveWorkflowPush").mockReturnValue(
+      new Promise((_resolve, reject) => {
+        failDecision = reject
+      })
+    )
+    const client = testClient()
+    client.setQueryData(key, approvals)
+    let mutation: ReturnType<typeof useWorkflowApprovalDecision> | undefined
+
+    function Probe() {
+      mutation = useWorkflowApprovalDecision("thread-1")
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+    act(() => mutation?.mutate({ fingerprint: "abc", decision: "approve" }))
+    await waitFor(() =>
+      expect(
+        client.getQueryData<WorkflowPushApprovalsResponse>(key)?.approvals[0]
+          ?.status
+      ).toBe("approved")
+    )
+    act(() => failDecision?.(new Error("request failed")))
+    await waitFor(() =>
+      expect(
+        client.getQueryData<WorkflowPushApprovalsResponse>(key)?.approvals[0]
+          ?.status
+      ).toBe("pending")
+    )
+  })
+
+  it("toggles an automation immediately and rolls it back", async () => {
+    const schedule = { id: "schedule-1", enabled: true } as AgentSchedule
+    let failUpdate: ((error: Error) => void) | undefined
+    vi.spyOn(agentsApi, "updateSchedule").mockReturnValue(
+      new Promise<AgentSchedule>((_resolve, reject) => {
+        failUpdate = reject
+      })
+    )
+    const client = testClient()
+    client.setQueryData(agentScheduleKeys.all, [schedule])
+    let mutation: ReturnType<typeof useUpdateAgentSchedule> | undefined
+
+    function Probe() {
+      mutation = useUpdateAgentSchedule()
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+    act(() =>
+      mutation?.mutate({ scheduleId: schedule.id, body: { enabled: false } })
+    )
+    await waitFor(() =>
+      expect(
+        client.getQueryData<Array<AgentSchedule>>(agentScheduleKeys.all)?.[0]
+          ?.enabled
+      ).toBe(false)
+    )
+    act(() => failUpdate?.(new Error("request failed")))
+    await waitFor(() =>
+      expect(
+        client.getQueryData<Array<AgentSchedule>>(agentScheduleKeys.all)?.[0]
+          ?.enabled
+      ).toBe(true)
+    )
   })
 })

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -17,11 +17,13 @@ import type {
   ThreadsPageParams,
 } from "./api"
 import type {
+  AgentSchedule,
   AgentStatus,
   AgentThread,
   Chunk,
   ImageChunk,
   Message,
+  WorkflowPushApprovalsResponse,
 } from "./types"
 import type { Skill, SkillInput } from "@/lib/api"
 import { api } from "@/lib/api"
@@ -157,6 +159,103 @@ function restoreAgentThreadQueries(
     if (existed) queryClient.setQueryData(key, data)
     else queryClient.removeQueries({ queryKey: key, exact: true })
   }
+}
+
+function restoreDeletedThreadInPage(
+  current: ThreadsPage | undefined,
+  previous: ThreadsPage,
+  threadId: string
+): ThreadsPage | undefined {
+  if (!current || current.items.some((thread) => thread.id === threadId)) {
+    return current
+  }
+  const index = previous.items.findIndex((thread) => thread.id === threadId)
+  if (index < 0) return current
+  const restored = previous.items[index]
+  if (!restored) return current
+  const items = [...current.items]
+  items.splice(Math.min(index, items.length), 0, restored)
+  return {
+    ...current,
+    items,
+    ...(current.total != null ? { total: current.total + 1 } : {}),
+  }
+}
+
+function restoreDeletedAgentThread(
+  queryClient: QueryClient,
+  snapshots: Array<AgentThreadQuerySnapshot>,
+  threadId: string
+): void {
+  for (const [key, data, existed] of snapshots) {
+    if (!existed) continue
+    if (key[2] === "infinite-pages") {
+      const previous = data as InfiniteData<ThreadsPage>
+      queryClient.setQueryData<InfiniteData<ThreadsPage>>(key, (current) =>
+        current
+          ? {
+              ...current,
+              pages: current.pages.map((page, index) => {
+                const previousPage = previous.pages[index]
+                return previousPage
+                  ? (restoreDeletedThreadInPage(page, previousPage, threadId) ??
+                      page)
+                  : page
+              }),
+            }
+          : previous
+      )
+    } else if (key[2] === "page") {
+      const previous = data as ThreadsPage
+      queryClient.setQueryData<ThreadsPage>(key, (current) =>
+        restoreDeletedThreadInPage(current, previous, threadId)
+      )
+    } else if (queryClient.getQueryData(key) === undefined) {
+      queryClient.setQueryData(key, data)
+    }
+  }
+}
+
+function removeAgentThreadFromLists(
+  queryClient: QueryClient,
+  threadId: string
+): void {
+  queryClient.setQueriesData<InfiniteData<ThreadsPage>>(
+    { queryKey: ["agent-threads", "lists", "infinite-pages"] },
+    (current) =>
+      current && {
+        ...current,
+        pages: current.pages.map((page) => {
+          const containsThread = page.items.some(
+            (thread) => thread.id === threadId
+          )
+          return {
+            ...page,
+            items: page.items.filter((thread) => thread.id !== threadId),
+            ...(containsThread && page.total != null
+              ? { total: Math.max(0, page.total - 1) }
+              : {}),
+          }
+        }),
+      }
+  )
+  queryClient.setQueriesData<ThreadsPage>(
+    { queryKey: ["agent-threads", "lists", "page"] },
+    (current) => {
+      const containsThread = current?.items.some(
+        (thread) => thread.id === threadId
+      )
+      return (
+        current && {
+          ...current,
+          items: current.items.filter((thread) => thread.id !== threadId),
+          ...(containsThread && current.total != null
+            ? { total: Math.max(0, current.total - 1) }
+            : {}),
+        }
+      )
+    }
+  )
 }
 
 function setAgentThreadResolved(
@@ -622,7 +721,36 @@ export function useWorkflowApprovalDecision(threadId: string) {
       vars.decision === "approve"
         ? agentsApi.approveWorkflowPush(threadId, vars.fingerprint)
         : agentsApi.rejectWorkflowPush(threadId, vars.fingerprint),
-    onSuccess: () => {
+    onMutate: async (vars) => {
+      const queryKey = agentThreadKeys.workflowApprovals(threadId)
+      await queryClient.cancelQueries({ queryKey })
+      const previous =
+        queryClient.getQueryData<WorkflowPushApprovalsResponse>(queryKey)
+      queryClient.setQueryData<WorkflowPushApprovalsResponse>(
+        queryKey,
+        (current) =>
+          current && {
+            ...current,
+            approvals: current.approvals.map((approval) =>
+              approval.fingerprint === vars.fingerprint
+                ? {
+                    ...approval,
+                    status:
+                      vars.decision === "approve" ? "approved" : "rejected",
+                  }
+                : approval
+            ),
+          }
+      )
+      return { previous }
+    },
+    onError: (_error, _vars, context) => {
+      queryClient.setQueryData(
+        agentThreadKeys.workflowApprovals(threadId),
+        context?.previous
+      )
+    },
+    onSettled: () => {
       void queryClient.invalidateQueries({
         queryKey: agentThreadKeys.workflowApprovals(threadId),
       })
@@ -658,8 +786,46 @@ export function useUpdateAgentSchedule() {
   return useMutation({
     mutationFn: (vars: { scheduleId: string; body: ScheduleUpdateRequest }) =>
       agentsApi.updateSchedule(vars.scheduleId, vars.body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: agentScheduleKeys.all })
+    onMutate: async (vars) => {
+      await queryClient.cancelQueries({ queryKey: agentScheduleKeys.all })
+      const previous = queryClient.getQueryData<Array<AgentSchedule>>(
+        agentScheduleKeys.all
+      )
+      if (vars.body.enabled != null) {
+        queryClient.setQueryData<Array<AgentSchedule>>(
+          agentScheduleKeys.all,
+          (current) =>
+            current?.map((schedule) =>
+              schedule.id === vars.scheduleId
+                ? { ...schedule, enabled: vars.body.enabled! }
+                : schedule
+            )
+        )
+      }
+      return { previous }
+    },
+    onError: (_error, vars, context) => {
+      const previous = context?.previous?.find(
+        (schedule) => schedule.id === vars.scheduleId
+      )
+      if (!previous) return
+      queryClient.setQueryData<Array<AgentSchedule>>(
+        agentScheduleKeys.all,
+        (current) =>
+          current?.map((schedule) =>
+            schedule.id === vars.scheduleId ? previous : schedule
+          )
+      )
+    },
+    onSuccess: (schedule) => {
+      queryClient.setQueryData<Array<AgentSchedule>>(
+        agentScheduleKeys.all,
+        (current) =>
+          current?.map((item) => (item.id === schedule.id ? schedule : item))
+      )
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: agentScheduleKeys.all })
     },
   })
 }
@@ -748,6 +914,7 @@ export interface SendAgentMessageVariables {
   model_id?: string | null
   effort?: string | null
   plan_mode?: boolean
+  reject_plan?: boolean
 }
 
 export function useCancelAgentThread(threadId: string) {
@@ -780,14 +947,41 @@ export function useDeleteAgentThread() {
 
   return useMutation({
     mutationFn: (threadId: string) => agentsApi.deleteThread(threadId),
-    onSuccess: (_, threadId) => {
-      queryClient.removeQueries({ queryKey: agentThreadKeys.detail(threadId) })
-      invalidateAgentThreadLists(queryClient)
-      const path = window.location.pathname
-      if (path.includes(`/agents/${threadId}`)) {
-        navigate({ to: "/agents" })
+    onMutate: async (threadId) => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: agentThreadKeys.lists }),
+        queryClient.cancelQueries({
+          queryKey: agentThreadKeys.detail(threadId),
+          exact: true,
+        }),
+        queryClient.cancelQueries({
+          queryKey: agentThreadKeys.sidebarActive(threadId),
+          exact: true,
+        }),
+      ])
+      const previous = snapshotAgentThreadQueries(queryClient, threadId)
+      removeAgentThreadFromLists(queryClient, threadId)
+      queryClient.removeQueries({
+        queryKey: agentThreadKeys.sidebarActive(threadId),
+        exact: true,
+      })
+      return { previous }
+    },
+    onError: (_error, threadId, context) => {
+      if (context) {
+        restoreDeletedAgentThread(queryClient, context.previous, threadId)
       }
     },
+    onSuccess: (_, threadId) => {
+      queryClient.removeQueries({
+        queryKey: agentThreadKeys.detail(threadId),
+        exact: true,
+      })
+      if (window.location.pathname.includes(`/agents/${threadId}`)) {
+        void navigate({ to: "/agents" })
+      }
+    },
+    onSettled: () => invalidateAgentThreadLists(queryClient),
   })
 }
 

--- a/ui/src/features/agents/lib/queuedMessages.test.ts
+++ b/ui/src/features/agents/lib/queuedMessages.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
 import type { Message, QueuedThreadMessage } from "@/features/agents/lib/types"
+import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
 
 describe("visibleQueuedMessages", () => {
   it("reconciles a queued follow-up with its streamed fallback timestamp", () => {
@@ -25,5 +25,43 @@ describe("visibleQueuedMessages", () => {
         [{ ...streamed, timestamp: new Date(500).toISOString() }]
       )
     ).toEqual([queued])
+  })
+
+  it("reconciles image-only messages", () => {
+    const image = {
+      kind: "image" as const,
+      base64: "abc",
+      mimeType: "image/png",
+    }
+    const queued: QueuedThreadMessage = {
+      id: "queued-1",
+      content: "",
+      images: [image],
+      createdAt: 2_000,
+    }
+    const streamed: Message = {
+      id: "message-1",
+      author: "user",
+      timestamp: new Date(3_000).toISOString(),
+      chunks: [image],
+    }
+
+    expect(visibleQueuedMessages([queued], [streamed])).toEqual([])
+  })
+
+  it("does not reconcile a substring match", () => {
+    const queued: QueuedThreadMessage = {
+      id: "queued-1",
+      content: "ok",
+      createdAt: 2_000,
+    }
+    const streamed: Message = {
+      id: "message-1",
+      author: "user",
+      timestamp: new Date(3_000).toISOString(),
+      chunks: [{ kind: "text", text: "looks ok" }],
+    }
+
+    expect(visibleQueuedMessages([queued], [streamed])).toEqual([queued])
   })
 })

--- a/ui/src/features/agents/lib/queuedMessages.ts
+++ b/ui/src/features/agents/lib/queuedMessages.ts
@@ -7,6 +7,10 @@ function messageText(message: Message): string {
     .trim()
 }
 
+function messageImageCount(message: Message): number {
+  return message.chunks.filter((chunk) => chunk.kind === "image").length
+}
+
 export function visibleQueuedMessages(
   queuedMessages: Array<QueuedThreadMessage> | undefined,
   messages: Array<Message>
@@ -18,16 +22,23 @@ export function visibleQueuedMessages(
     .filter((message) => message.author === "user")
     .map((message) => ({
       text: messageText(message),
+      imageCount: messageImageCount(message),
       timestamp: Date.parse(message.timestamp),
       consumed: false,
     }))
 
   return queued.filter((queuedMessage) => {
     const queuedText = queuedMessage.content.trim()
-    if (!queuedText) return true
+    const queuedImageCount = queuedMessage.images?.length ?? 0
 
     const match = userMessages.find((message) => {
-      if (message.consumed || !message.text.includes(queuedText)) return false
+      if (
+        message.consumed ||
+        message.text !== queuedText ||
+        message.imageCount !== queuedImageCount
+      ) {
+        return false
+      }
       if (!Number.isFinite(message.timestamp)) return true
       return message.timestamp >= queuedMessage.createdAt - 1000
     })

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -212,6 +212,7 @@ export interface QueuedThreadMessage {
   content: string
   images?: Array<ImageChunk>
   createdAt: number
+  status?: "sending" | "queued"
 }
 
 export type WorkflowApprovalStatus = "pending" | "approved" | "rejected"


### PR DESCRIPTION
## Description
Make cloud composer sends, workflow decisions, schedule toggles, and thread deletion update immediately with targeted rollback and server reconciliation. Keep external side-effect operations server-acknowledged.

## Release Note
Cloud agent interactions now update immediately while requests complete.

## Test Plan
- [x] Verify queued, failed, and run-start message paths restore or reconcile composer state
- [x] Verify workflow, schedule, and delete mutations rollback failed requests

Made by [Open SWE](https://openswe.vercel.app/agents/29423520-7b0b-59a2-9121-403cc5d6003b)