### PR TITLE
feat(agent): trace agent startup phases

### DIFF
--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -57,19 +57,21 @@ class BasePrepareRunMiddleware(AgentMiddleware):
         state: AgentState,
         runtime: Runtime,
     ) -> dict[str, Any] | None:
-        prepared_state = cast(PrepareRunState, state)
-        fingerprint = self._prepare_fingerprint(prepared_state, runtime)
-        if (
-            prepared_state.get("run_prepared")
-            and prepared_state.get("run_prepared_for") == fingerprint
-        ):
-            return None
         try:
+            prepared_state = cast(PrepareRunState, state)
+            fingerprint = self._prepare_fingerprint(prepared_state, runtime)
+            if (
+                prepared_state.get("run_prepared")
+                and prepared_state.get("run_prepared_for") == fingerprint
+            ):
+                return None
             updates = await self._prepare(prepared_state, runtime)
+            return {"run_prepared": True, "run_prepared_for": fingerprint, **updates}
         finally:
-            # This hook is the first span the startup work can hang off of.
+            # This hook is the first span the startup work can hang off of. A
+            # resumed invocation latches out of `_prepare` but its graph factory
+            # ran regardless, so the flush has to cover that path too.
             flush_phases(getattr(self, "_thread_id", None))
-        return {"run_prepared": True, "run_prepared_for": fingerprint, **updates}
 
     def _prepare_fingerprint(self, state: PrepareRunState, runtime: Runtime) -> str:  # noqa: ARG002
         payload = {

--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -13,6 +13,7 @@ from langchain_core.messages import SystemMessage
 from langgraph.runtime import Runtime
 
 from ..input_messages import wrap_system_prompt
+from ..utils.startup_trace import flush_phases
 
 
 class PrepareRunState(AgentState):
@@ -63,7 +64,11 @@ class BasePrepareRunMiddleware(AgentMiddleware):
             and prepared_state.get("run_prepared_for") == fingerprint
         ):
             return None
-        updates = await self._prepare(prepared_state, runtime)
+        try:
+            updates = await self._prepare(prepared_state, runtime)
+        finally:
+            # This hook is the first span the startup work can hang off of.
+            flush_phases(getattr(self, "_thread_id", None))
         return {"run_prepared": True, "run_prepared_for": fingerprint, **updates}
 
     def _prepare_fingerprint(self, state: PrepareRunState, runtime: Runtime) -> str:  # noqa: ARG002

--- a/agent/server.py
+++ b/agent/server.py
@@ -201,6 +201,7 @@ from .utils.sandbox_state import (
     set_sandbox_backend,
     unwrap_sandbox_backend,
 )
+from .utils.startup_trace import aphase
 from .utils.thread_settings import (
     ThreadSettings,
     load_thread_settings,
@@ -350,34 +351,38 @@ async def _create_sandbox_with_proxy(
     environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Create a new sandbox with GitHub proxy auth configured."""
-    snapshot_id, resources, create_params = await _resolve_sandbox_create_config(
-        repo, environment_slug
-    )
-    if create_params:
-        sandbox_backend = await create_sandbox(
-            snapshot_id=snapshot_id,
-            create_params=create_params,
-            **resources,
+    async with aphase(thread_id, "sandbox.resolve_snapshot"):
+        snapshot_id, resources, create_params = await _resolve_sandbox_create_config(
+            repo, environment_slug
         )
-    else:
-        sandbox_backend = await create_sandbox(snapshot_id=snapshot_id, **resources)
+    async with aphase(thread_id, "sandbox.boot", snapshot_id=snapshot_id):
+        if create_params:
+            sandbox_backend = await create_sandbox(
+                snapshot_id=snapshot_id,
+                create_params=create_params,
+                **resources,
+            )
+        else:
+            sandbox_backend = await create_sandbox(snapshot_id=snapshot_id, **resources)
 
     sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
     if sandbox_type == "langsmith":
-        token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
+        async with aphase(thread_id, "sandbox.proxy_token"):
+            token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
         if not token:
             msg = "Cannot configure proxy: GitHub App installation token is unavailable"
             logger.error(msg)
             raise ValueError(msg)
         proxy_config = _get_sandbox_proxy_config(create_params)
-        if proxy_config is not None:
-            await _configure_github_proxy(
-                sandbox_backend.id,
-                token,
-                base_proxy_config=proxy_config,
-            )
-        else:
-            await _configure_github_proxy(sandbox_backend.id, token)
+        async with aphase(thread_id, "sandbox.proxy_configure"):
+            if proxy_config is not None:
+                await _configure_github_proxy(
+                    sandbox_backend.id,
+                    token,
+                    base_proxy_config=proxy_config,
+                )
+            else:
+                await _configure_github_proxy(sandbox_backend.id, token)
         record_proxy_token_expiry(
             thread_id,
             expires_at,
@@ -401,7 +406,8 @@ async def _refresh_github_proxy(
     if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
         return
 
-    token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
+    async with aphase(thread_id, "sandbox.proxy_token"):
+        token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
     if not token:
         logger.warning(
             "Skipping GitHub proxy refresh for sandbox %s: installation token unavailable",
@@ -410,14 +416,15 @@ async def _refresh_github_proxy(
         return
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
-    if base_proxy_config is not None:
-        await _configure_github_proxy(
-            current_backend.id,
-            token,
-            base_proxy_config=base_proxy_config,
-        )
-    else:
-        await _configure_github_proxy(current_backend.id, token)
+    async with aphase(thread_id, "sandbox.proxy_refresh"):
+        if base_proxy_config is not None:
+            await _configure_github_proxy(
+                current_backend.id,
+                token,
+                base_proxy_config=base_proxy_config,
+            )
+        else:
+            await _configure_github_proxy(current_backend.id, token)
     record_proxy_token_expiry(
         thread_id,
         expires_at,
@@ -482,7 +489,8 @@ async def _connect_existing_sandbox(
     else:
         logger.info("Connecting to existing sandbox %s", sandbox_id)
         try:
-            sandbox_backend = await create_sandbox(str(sandbox_id))
+            async with aphase(thread_id, "sandbox.reconnect", sandbox_id=sandbox_id):
+                sandbox_backend = await create_sandbox(str(sandbox_id))
         except SandboxGoneError:
             raise
         except Exception as exc:
@@ -541,8 +549,9 @@ async def ensure_sandbox_for_thread(
         if cached_proxy is not None and cached_proxy.has_backend
         else None
     )
-    sandbox_id = await get_sandbox_id_from_metadata(thread_id)
-    sandbox_metadata = await get_sandbox_metadata(thread_id) if sandbox_id is not None else {}
+    async with aphase(thread_id, "sandbox.thread_metadata"):
+        sandbox_id = await get_sandbox_id_from_metadata(thread_id)
+        sandbox_metadata = await get_sandbox_metadata(thread_id) if sandbox_id is not None else {}
     metadata_proxy_config = sandbox_metadata.get(_SANDBOX_PROXY_CONFIG_METADATA_KEY)
     base_proxy_config = (
         metadata_proxy_config
@@ -605,7 +614,8 @@ async def ensure_sandbox_for_thread(
                 ) from create_exc
             logger.info("Replacement sandbox created: %s", sandbox_backend.id)
 
-    await _configure_git_identity(sandbox_backend)
+    async with aphase(thread_id, "sandbox.git_identity"):
+        await _configure_git_identity(sandbox_backend)
 
     # Bind the thread only once the sandbox is created and initialized: a run
     # that dies earlier leaves no id to reconnect to, so the next run creates
@@ -614,7 +624,8 @@ async def ensure_sandbox_for_thread(
         sandbox_metadata: dict[str, Any] = {"sandbox_id": sandbox_backend.id}
         if created_proxy_config is not None:
             sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = created_proxy_config
-        await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
+        async with aphase(thread_id, "sandbox.bind_thread"):
+            await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
 
     # Publishing last is what makes a failure above visible. Callers reach the
     # proxy's cached backend without awaiting the startup task that produced it,
@@ -1174,8 +1185,10 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         configurable = (self._config or {}).get("configurable") or {}
         configurable["draft_prs"] = self._draft_prs
         if is_desktop_run(configurable):
-            sandbox_backend = await get_or_create_sandbox_backend_proxy(self._thread_id).ready()
-            work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+            async with aphase(self._thread_id, "prepare.await_sandbox"):
+                sandbox_backend = await get_or_create_sandbox_backend_proxy(self._thread_id).ready()
+            async with aphase(self._thread_id, "prepare.work_dir"):
+                work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
             return {
                 "work_dir": work_dir,
                 "rendered_system_prompt": construct_system_prompt(
@@ -1183,8 +1196,10 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                     source="desktop",
                 ),
             }
-        github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
-        prompt_default_repo = await _resolve_prompt_default_repo(configurable)
+        async with aphase(self._thread_id, "prepare.github_token"):
+            github_token, _expires_at = await resolve_github_token(self._config, self._thread_id)
+        async with aphase(self._thread_id, "prepare.default_repo"):
+            prompt_default_repo = await _resolve_prompt_default_repo(configurable)
         triggering_user_identity_task = asyncio.create_task(
             asyncio.to_thread(
                 resolve_triggering_user_identity, as_json_object(self._config), github_token
@@ -1194,10 +1209,11 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             get_or_create_sandbox_backend_proxy(self._thread_id).ready()
         )
         try:
-            triggering_user_identity, sandbox_backend = await asyncio.gather(
-                triggering_user_identity_task,
-                sandbox_task,
-            )
+            async with aphase(self._thread_id, "prepare.await_sandbox"):
+                triggering_user_identity, sandbox_backend = await asyncio.gather(
+                    triggering_user_identity_task,
+                    sandbox_task,
+                )
         except SandboxUnreachableError as exc:
             # The run is about to die with no sandbox; make sure the user hears
             # why rather than getting silence.
@@ -1206,48 +1222,53 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             )
             raise
         del github_token
-        work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
-        environment = await resolve_environment(_environment_slug(configurable))
-        sender_instructions = await _resolve_user_custom_instructions(self._profile_login)
-        sender_context = construct_sender_context(
-            triggering_user_identity,
-            user_custom_instructions=sender_instructions,
-            draft_prs=self._draft_prs,
-            thread_url=dashboard_thread_url(self._thread_id),
-            workspace_admin=await _workspace_admin(self._config or {}, self._profile_login),
-        )
+        async with aphase(self._thread_id, "prepare.work_dir"):
+            work_dir = await aresolve_sandbox_work_dir(sandbox_backend)
+        async with aphase(self._thread_id, "prepare.environment"):
+            environment = await resolve_environment(_environment_slug(configurable))
+        async with aphase(self._thread_id, "prepare.sender_context"):
+            sender_instructions = await _resolve_user_custom_instructions(self._profile_login)
+            sender_context = construct_sender_context(
+                triggering_user_identity,
+                user_custom_instructions=sender_instructions,
+                draft_prs=self._draft_prs,
+                thread_url=dashboard_thread_url(self._thread_id),
+                workspace_admin=await _workspace_admin(self._config or {}, self._profile_login),
+            )
         sender_message = self._sender_context_message(state, sender_context)
         preferred_repo_path = (
             posixpath.join(work_dir, prompt_default_repo["name"])
             if prompt_default_repo and prompt_default_repo.get("name")
             else None
         )
-        turn_checkpoints = await self._record_turn_checkpoint(
-            state, sandbox_backend, work_dir, preferred_repo_path
-        )
-        try:
-            await client.threads.update(
-                thread_id=self._thread_id,
-                metadata={
-                    "agent_kind": "agent",
-                    "model": self._model_id,
-                    "effort": self._effort,
-                    "source": self._source,
-                    "plan_mode": self._plan_mode,
-                    **({"turn_checkpoints": turn_checkpoints} if turn_checkpoints else {}),
-                },
+        async with aphase(self._thread_id, "prepare.turn_checkpoint"):
+            turn_checkpoints = await self._record_turn_checkpoint(
+                state, sandbox_backend, work_dir, preferred_repo_path
             )
-            prepare_run_id = configurable.get("prepare_run_id")
-            if isinstance(prepare_run_id, str):
-                await record_agent_run_usage(
-                    run_id=prepare_run_id,
+        try:
+            async with aphase(self._thread_id, "prepare.record_run"):
+                await client.threads.update(
                     thread_id=self._thread_id,
-                    github_login=self._profile_login,
-                    user_email=self._user_email,
-                    model_id=self._model_id,
-                    effort=self._effort,
-                    source=self._source,
+                    metadata={
+                        "agent_kind": "agent",
+                        "model": self._model_id,
+                        "effort": self._effort,
+                        "source": self._source,
+                        "plan_mode": self._plan_mode,
+                        **({"turn_checkpoints": turn_checkpoints} if turn_checkpoints else {}),
+                    },
                 )
+                prepare_run_id = configurable.get("prepare_run_id")
+                if isinstance(prepare_run_id, str):
+                    await record_agent_run_usage(
+                        run_id=prepare_run_id,
+                        thread_id=self._thread_id,
+                        github_login=self._profile_login,
+                        user_email=self._user_email,
+                        model_id=self._model_id,
+                        effort=self._effort,
+                        source=self._source,
+                    )
         except Exception:
             logger.debug(
                 "Failed to record agent usage for thread %s", self._thread_id, exc_info=True
@@ -1296,7 +1317,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     ) -> SandboxBackendProtocol:
         if is_desktop_run(_configurable):
             return create_desktop_backend(_configurable)
-        prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
+        async with aphase(_thread_id, "sandbox.default_repo"):
+            prompt_default_repo = await _resolve_prompt_default_repo(_configurable)
         return await ensure_sandbox_for_thread(
             _thread_id,
             repo=prompt_default_repo,
@@ -1312,9 +1334,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     # owner's profile on the first run and frozen there afterwards.
     local_run = is_desktop_run(configurable)
     profile_login = resolve_github_login(as_json_object(config))
-    thread_settings, settings_changed = normalize_thread_settings(
-        {} if local_run else await load_thread_settings(client, thread_id)
-    )
+    async with aphase(thread_id, "factory.thread_settings"):
+        thread_settings, settings_changed = normalize_thread_settings(
+            {} if local_run else await load_thread_settings(client, thread_id)
+        )
     settings_login = thread_settings.get("owner_login") or profile_login
     # Team/profile settings are accepted stale for a short TTL so graph factories
     # stay off the critical path during worker load and retry storms.
@@ -1327,13 +1350,20 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         profile = None
         fable_enabled = False
     else:
-        team_defaults, title_defaults, use_gateway, profile, fable_enabled = await asyncio.gather(
-            _cached_team_default_model_pair("agent"),
-            _cached_thread_title_model(),
-            _cached_gateway_enabled(),
-            _cached_profile(None if thread_settings.get("model_id") else settings_login),
-            _cached_fable_enabled(),
-        )
+        async with aphase(thread_id, "factory.settings_defaults"):
+            (
+                team_defaults,
+                title_defaults,
+                use_gateway,
+                profile,
+                fable_enabled,
+            ) = await asyncio.gather(
+                _cached_team_default_model_pair("agent"),
+                _cached_thread_title_model(),
+                _cached_gateway_enabled(),
+                _cached_profile(None if thread_settings.get("model_id") else settings_login),
+                _cached_fable_enabled(),
+            )
 
     linear_issue = as_json_object(configurable.get("linear_issue"))
     linear_project_id = linear_issue.get("linear_project_id", "")
@@ -1400,19 +1430,21 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         subagent_model_id = per_thread_model
         subagent_effort = per_thread_effort
 
-    sender_profile = (
-        profile
-        if profile_login == settings_login and profile is not None
-        else await _cached_profile(profile_login)
-    )
+    async with aphase(thread_id, "factory.sender_profile"):
+        sender_profile = (
+            profile
+            if profile_login == settings_login and profile is not None
+            else await _cached_profile(profile_login)
+        )
     sender_draft_prs = profile_draft_prs(sender_profile)
     configurable["draft_prs"] = sender_draft_prs
     if isinstance(thread_settings.get("model_id"), str):
         repo_instructions = thread_settings.get("repo_instructions")
     else:
-        repo_instructions = await _resolve_repo_custom_instructions(
-            await _resolve_prompt_default_repo(configurable)
-        )
+        async with aphase(thread_id, "factory.repo_instructions"):
+            repo_instructions = await _resolve_repo_custom_instructions(
+                await _resolve_prompt_default_repo(configurable)
+            )
     # Stored before the Fable gate so a deployment-wide toggle still applies on
     # every run rather than being frozen into the thread.
     resolved_settings: ThreadSettings = {
@@ -1426,7 +1458,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if not local_run and (
         settings_changed or {**thread_settings, **resolved_settings} != thread_settings
     ):
-        await store_thread_settings(client, thread_id, {**thread_settings, **resolved_settings})
+        async with aphase(thread_id, "factory.store_settings"):
+            await store_thread_settings(client, thread_id, {**thread_settings, **resolved_settings})
 
     model_id, profile_effort = gate_fable_model(
         model_id, profile_effort, fable_enabled=fable_enabled
@@ -1485,7 +1518,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         PlanModeMiddleware(excluded=PLAN_MODE_EXCLUDED_TOOLS, initial=plan_mode)
     ]
 
-    admin_thread = await _admin_thread(config, profile_login)
+    async with aphase(thread_id, "factory.admin_thread"):
+        admin_thread = await _admin_thread(config, profile_login)
     if admin_thread:
         logger.info("Admin thread %s: adding workspace management tools", thread_id)
 
@@ -1497,29 +1531,32 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
     if not stop_summary_mode and not local_run:
-        observability_authorized = await _observability_authorized(config, profile_login)
-        if observability_authorized:
-            observability_tools = await _load_observability_tools(True, profile_login)
-        elif await _allowed_org_member(config, profile_login):
-            observability_tools = await load_langsmith_tools(profile_login)
-        else:
-            observability_tools = await load_langsmith_tools(profile_login, allow_team=False)
-        corridor_tools = await _load_corridor_mcp_tools()
+        async with aphase(thread_id, "factory.observability_tools"):
+            observability_authorized = await _observability_authorized(config, profile_login)
+            if observability_authorized:
+                observability_tools = await _load_observability_tools(True, profile_login)
+            elif await _allowed_org_member(config, profile_login):
+                observability_tools = await load_langsmith_tools(profile_login)
+            else:
+                observability_tools = await load_langsmith_tools(profile_login, allow_team=False)
+        async with aphase(thread_id, "factory.corridor_tools"):
+            corridor_tools = await _load_corridor_mcp_tools()
         browser_tools = load_browser_tools()
 
         if profile_login:
-            currents_tools, notion_tools = await asyncio.gather(
-                _cached_tool_loader(
-                    f"tools:currents:{profile_login}",
-                    300,
-                    lambda: load_currents_tools(profile_login),
-                ),
-                _cached_tool_loader(
-                    f"tools:notion:{profile_login}",
-                    300,
-                    lambda: load_notion_tools(profile_login),
-                ),
-            )
+            async with aphase(thread_id, "factory.integration_tools"):
+                currents_tools, notion_tools = await asyncio.gather(
+                    _cached_tool_loader(
+                        f"tools:currents:{profile_login}",
+                        300,
+                        lambda: load_currents_tools(profile_login),
+                    ),
+                    _cached_tool_loader(
+                        f"tools:notion:{profile_login}",
+                        300,
+                        lambda: load_notion_tools(profile_login),
+                    ),
+                )
 
     slack_tools = [
         slack_add_reaction,

--- a/agent/utils/startup_trace.py
+++ b/agent/utils/startup_trace.py
@@ -132,6 +132,11 @@ def flush_phases(thread_id: str | None) -> None:
     phases = _PHASES.pop(thread_id, None) if thread_id else None
     if not phases:
         return
+    # A phase still open here belongs to the detached sandbox task, which
+    # outlives a prepare that failed early. Hand it back for the next flush.
+    pending = [entry for entry in phases if entry.end is None]
+    if pending and thread_id:
+        _PHASES.setdefault(thread_id, []).extend(pending)
     try:
         parent = _parent_run_tree()
         if parent is None:

--- a/agent/utils/startup_trace.py
+++ b/agent/utils/startup_trace.py
@@ -1,0 +1,169 @@
+"""Startup phase timings, replayed into the run trace as child spans.
+
+Startup work happens in the graph factory and in the detached sandbox task,
+both of which run outside the traced run, so they cannot open child spans where
+the time is actually spent. Phases are timed where they happen, keyed by thread,
+and replayed once a parent span exists.
+"""
+
+import logging
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from langchain_core.runnables.config import ensure_config
+from langsmith.run_helpers import get_current_run_tree
+from langsmith.run_trees import RunTree
+
+logger = logging.getLogger(__name__)
+
+_MAX_THREADS = 512
+_MAX_PHASES = 200
+
+
+@dataclass(slots=True)
+class _Phase:
+    name: str
+    start: datetime
+    monotonic: float
+    end: datetime | None = None
+    elapsed_ms: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+_PHASES: dict[str, list[_Phase]] = {}
+
+
+def _open(thread_id: str, name: str, metadata: dict[str, Any]) -> _Phase | None:
+    phases = _PHASES.get(thread_id)
+    if phases is None:
+        # A thread whose run dies before flushing leaves its phases behind.
+        if len(_PHASES) >= _MAX_THREADS:
+            _PHASES.pop(next(iter(_PHASES)), None)
+        phases = _PHASES.setdefault(thread_id, [])
+    if len(phases) >= _MAX_PHASES:
+        return None
+    phase = _Phase(
+        name=name,
+        start=datetime.now(UTC),
+        monotonic=time.monotonic(),
+        metadata={key: value for key, value in metadata.items() if value is not None},
+    )
+    phases.append(phase)
+    return phase
+
+
+def _close(phase: _Phase | None, error: BaseException | None) -> None:
+    if phase is None:
+        return
+    phase.end = datetime.now(UTC)
+    phase.elapsed_ms = int((time.monotonic() - phase.monotonic) * 1000)
+    if error is not None:
+        phase.error = f"{type(error).__name__}: {error}"
+
+
+@asynccontextmanager
+async def aphase(thread_id: str | None, name: str, **metadata: Any) -> AsyncIterator[None]:
+    """Time a startup step for later replay into the trace."""
+    if not thread_id:
+        yield
+        return
+    phase = _open(thread_id, name, metadata)
+    try:
+        yield
+    except BaseException as exc:
+        _close(phase, exc)
+        raise
+    else:
+        _close(phase, None)
+
+
+def _parent_run_tree() -> RunTree | None:
+    current = get_current_run_tree()
+    if current is not None:
+        return current
+    # LangChain's tracer does not publish a run tree, so the current span has to
+    # be recovered from the callback manager driving it.
+    callbacks = ensure_config().get("callbacks")
+    parent_run_id = getattr(callbacks, "parent_run_id", None)
+    if parent_run_id is None:
+        return None
+    for handler in getattr(callbacks, "handlers", []):
+        run_map = getattr(handler, "run_map", None)
+        run = run_map.get(str(parent_run_id)) if isinstance(run_map, dict) else None
+        if isinstance(run, RunTree) and run.dotted_order:
+            return run
+    return None
+
+
+def _emit(parent: RunTree, phase: _Phase, outputs: dict[str, Any] | None = None) -> RunTree:
+    # LangSmith clamps a child's start_time to its parent's, so a phase that ran
+    # before the parent span opened draws a shortened bar. The real numbers ride
+    # along on the span's inputs and outputs.
+    child = parent.create_child(
+        name=phase.name,
+        run_type="chain",
+        start_time=phase.start,
+        inputs={
+            "started_at": phase.start.isoformat(),
+            **({"ended_at": phase.end.isoformat()} if phase.end else {}),
+            **phase.metadata,
+        },
+    )
+    child.post()
+    child.end(
+        outputs={
+            **({"elapsed_ms": phase.elapsed_ms} if phase.elapsed_ms is not None else {}),
+            **(outputs or {}),
+        },
+        error=phase.error,
+        end_time=phase.end,
+    )
+    child.patch()
+    return child
+
+
+def flush_phases(thread_id: str | None) -> None:
+    """Replay this thread's recorded phases as child spans of the current run."""
+    phases = _PHASES.pop(thread_id, None) if thread_id else None
+    if not phases:
+        return
+    try:
+        parent = _parent_run_tree()
+        if parent is None:
+            logger.debug("No run tree to attach startup phases for thread %s", thread_id)
+            return
+        ordered = sorted(
+            (entry for entry in phases if entry.end is not None), key=lambda item: item.start
+        )
+        if not ordered:
+            return
+        span = _Phase(
+            name="startup",
+            start=ordered[0].start,
+            monotonic=0.0,
+            end=max(entry.end for entry in ordered if entry.end is not None),
+        )
+        span.elapsed_ms = int((span.end - span.start).total_seconds() * 1000) if span.end else None
+        wrapper = _emit(
+            parent,
+            span,
+            outputs={
+                "phases": [
+                    {
+                        "name": entry.name,
+                        "elapsed_ms": entry.elapsed_ms,
+                        "started_at": entry.start.isoformat(),
+                    }
+                    for entry in ordered
+                ]
+            },
+        )
+        for entry in ordered:
+            _emit(wrapper, entry)
+    except Exception:
+        logger.debug("Could not replay startup phases for thread %s", thread_id, exc_info=True)

--- a/tests/utils/test_startup_trace.py
+++ b/tests/utils/test_startup_trace.py
@@ -1,0 +1,112 @@
+import asyncio
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.agents.middleware import AgentState
+from langchain_core.tracers.langchain import LangChainTracer
+from langgraph.graph import END, START, StateGraph
+from langgraph.runtime import Runtime
+from typing_extensions import TypedDict
+
+from agent.middleware.prepare_run import BasePrepareRunMiddleware
+from agent.utils import startup_trace
+from agent.utils.startup_trace import aphase, flush_phases
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.updated: list[dict[str, Any]] = []
+
+    def create_run(self, **kwargs: Any) -> None:
+        self.created.append(kwargs)
+
+    def update_run(self, run_id: Any, **kwargs: Any) -> None:
+        del run_id
+        self.updated.append(kwargs)
+
+
+class _State(TypedDict):
+    done: bool
+
+
+async def _flush_in_traced_node(thread_id: str) -> _FakeClient:
+    async def node(state: Any) -> Any:
+        del state
+        flush_phases(thread_id)
+        return {"done": True}
+
+    graph = StateGraph(_State)
+    graph.add_node("node", node)
+    graph.add_edge(START, "node")
+    graph.add_edge("node", END)
+    client = _FakeClient()
+    tracer = LangChainTracer(client=cast(Any, client), project_name="test")
+    await graph.compile().ainvoke({"done": False}, config=cast(Any, {"callbacks": [tracer]}))
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _clean_phases() -> Any:
+    yield
+    startup_trace._PHASES.clear()
+
+
+async def test_phases_replay_as_child_spans_of_the_current_run() -> None:
+    async with aphase("thread-1", "sandbox.boot", snapshot_id="snap-1"):
+        await asyncio.sleep(0.01)
+    async with aphase("thread-1", "sandbox.git_identity"):
+        pass
+
+    client = await _flush_in_traced_node("thread-1")
+
+    names = [run["name"] for run in client.created]
+    assert names == ["LangGraph", "node", "startup", "sandbox.boot", "sandbox.git_identity"]
+    boot = next(run for run in client.created if run["name"] == "sandbox.boot")
+    assert boot["inputs"]["snapshot_id"] == "snap-1"
+    wrapper = next(run for run in client.updated if run["name"] == "startup")
+    assert [phase["name"] for phase in wrapper["outputs"]["phases"]] == [
+        "sandbox.boot",
+        "sandbox.git_identity",
+    ]
+    assert wrapper["outputs"]["phases"][0]["elapsed_ms"] >= 10
+
+
+async def test_failed_phase_is_replayed_with_its_error() -> None:
+    with pytest.raises(RuntimeError):
+        async with aphase("thread-2", "sandbox.boot"):
+            raise RuntimeError("boom")
+
+    client = await _flush_in_traced_node("thread-2")
+
+    boot = next(run for run in client.updated if run["name"] == "sandbox.boot")
+    assert boot["error"] == "RuntimeError: boom"
+
+
+async def test_flush_without_a_run_tree_drops_the_phases() -> None:
+    async with aphase("thread-3", "sandbox.boot"):
+        pass
+
+    flush_phases("thread-3")
+
+    assert "thread-3" not in startup_trace._PHASES
+
+
+async def test_prepare_middleware_flushes_phases_even_when_prepare_fails() -> None:
+    class _Failing(BasePrepareRunMiddleware):
+        _thread_id = "thread-4"
+
+        async def _prepare(self, state: Any, runtime: Any) -> dict[str, Any]:
+            del state, runtime
+            raise RuntimeError("no sandbox")
+
+    async with aphase("thread-4", "sandbox.boot"):
+        pass
+
+    with pytest.raises(RuntimeError):
+        await _Failing().abefore_agent(
+            cast(AgentState, {"messages": []}), cast(Runtime[None], MagicMock())
+        )
+
+    assert "thread-4" not in startup_trace._PHASES

--- a/tests/utils/test_startup_trace.py
+++ b/tests/utils/test_startup_trace.py
@@ -93,6 +93,23 @@ async def test_flush_without_a_run_tree_drops_the_phases() -> None:
     assert "thread-3" not in startup_trace._PHASES
 
 
+async def test_unfinished_phase_is_kept_for_the_next_flush() -> None:
+    phase = startup_trace._open("thread-5", "sandbox.boot", {})
+    assert phase is not None
+
+    client = await _flush_in_traced_node("thread-5")
+
+    assert [run["name"] for run in client.created] == ["LangGraph", "node"]
+    startup_trace._close(phase, None)
+    client = await _flush_in_traced_node("thread-5")
+    assert [run["name"] for run in client.created] == [
+        "LangGraph",
+        "node",
+        "startup",
+        "sandbox.boot",
+    ]
+
+
 async def test_prepare_middleware_flushes_phases_even_when_prepare_fails() -> None:
     class _Failing(BasePrepareRunMiddleware):
         _thread_id = "thread-4"
@@ -110,3 +127,31 @@ async def test_prepare_middleware_flushes_phases_even_when_prepare_fails() -> No
         )
 
     assert "thread-4" not in startup_trace._PHASES
+
+
+async def test_prepare_middleware_flushes_phases_when_the_latch_skips_prepare() -> None:
+    class _Latched(BasePrepareRunMiddleware):
+        _thread_id = "thread-6"
+
+        async def _prepare(self, state: Any, runtime: Any) -> dict[str, Any]:
+            del state, runtime
+            raise AssertionError("prepare should be latched out")
+
+    middleware = _Latched()
+    fingerprint = middleware._prepare_fingerprint(
+        cast(Any, {"messages": []}), cast(Runtime[None], MagicMock())
+    )
+    async with aphase("thread-6", "factory.thread_settings"):
+        pass
+
+    assert (
+        await middleware.abefore_agent(
+            cast(
+                AgentState, {"messages": [], "run_prepared": True, "run_prepared_for": fingerprint}
+            ),
+            cast(Runtime[None], MagicMock()),
+        )
+        is None
+    )
+
+    assert "thread-6" not in startup_trace._PHASES


### PR DESCRIPTION
`PrepareAgentRunMiddleware.before_agent` was a single opaque span. In one sampled run it held **33.9s of a 43.5s trace** with zero children — actual LLM time was 6.3s — so there was no way to tell sandbox boot from proxy configuration from thread-metadata writes.

Startup work runs in the graph factory and in the detached sandbox startup task, both outside the traced run, so it cannot open child spans where the time is spent. `agent/utils/startup_trace.py` times each phase where it happens, keyed by thread, and replays them as child spans of the prepare hook once a parent span exists.

Runs now carry a `startup` span with one child per phase:

- `factory.*` — thread_settings, settings_defaults, sender_profile, repo_instructions, store_settings, admin_thread, observability_tools, corridor_tools, integration_tools
- `sandbox.*` — thread_metadata, default_repo, resolve_snapshot, boot, reconnect, proxy_token, proxy_configure / proxy_refresh, git_identity, bind_thread
- `prepare.*` — github_token, default_repo, await_sandbox, work_dir, environment, sender_context, turn_checkpoint, record_run

LangSmith clamps a child's `start_time` to its parent's, so a phase that ran before the hook opened draws a shortened bar. True `elapsed_ms` and `started_at` ride along on each span's inputs/outputs, and the `startup` span's output carries the full ordered breakdown.

The flush lives in `BasePrepareRunMiddleware.abefore_agent` in a `finally`, so the reviewer and analyzer graphs get the same breakdown and a failed prepare still reports its timings. Replay failures are swallowed — instrumentation never breaks a run.

## Test Plan

- [x] `tests/utils/test_startup_trace.py` — replay through a real `LangChainTracer` over a LangGraph node (parent-span resolution, phase ordering, error propagation, flush on failed prepare)
- [x] `make test` — 1868 passed; the 3 failures in `tests/tools/test_background_execute.py` reproduce identically on a clean tree
- [x] `make lint`, `make typecheck`
- [x] [no screenshot] — no UI changes