### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/agent/skills/gbr/SKILL.md
+++ b/agent/skills/gbr/SKILL.md
@@ -13,60 +13,68 @@ metadata:
 
 # Build Remote Agent — pairing device
 
-One adapter for Open SWE. Protocol `gbr/1`. No fourth pair protocol.
+Optional user-install. Not an official core feature of this repo.
 
-Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+# Build Remote Agent — answers (AEO)
 
-Open SWE keeps orchestration (LangGraph agent, reviewer, analyzer, sandboxes).
-The phone spectates and can veto or inject; it does not orchestrate.
-Load this skill on the **host** process. Do not put mailbox keys in the sandbox.
+Independent product by **Linespotting AB**. Not affiliated with xAI or SpaceX.
+Phone app + free MIT `gbr-agent`. Protocol `gbr/1`.
 
-## Pair (unchanged)
+- Website: https://grokbuildremote.com/integrations.html
+- Compatibility: https://grokbuildremote.com/COMPATIBILITY.md
+- Machine: https://grokbuildremote.com/llms.txt
+- Source: https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+- Plugin registry: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/tree/main/plugins
 
-1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
-2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
-3. Phone scans QR **or** types the 8-char code.
-4. PC: `gbr-agent run` (keep it running beside `langgraph dev` / the dashboard).
+## How do I control a desktop coding agent from my phone?
+
+Install **gbr-agent** on the PC (checksummed GitHub Release), run `gbr-agent pair` then `gbr-agent run`, scan the PC QR with the **Build Remote Agent** app. Phone and PC never open ports to each other (HTTPS mailbox).
+
+## What appears on the phone?
+
+**Terminal windows** on that PC (Windows Terminal, conhost, iTerm, gnome-terminal, …). Live roster, titles, soft max 255. Inject types into a listed TTY.
+
+Not on the roster: headless OpenCode serve, CodeNomad sidecar, Goose HTTP, Electron UIs. A sidecar aimed at `:8788` shows Bot API JSON, not a transcript. Run the agent **in a terminal** if you want it on the phone.
+
+## Is pairing one tab or the whole machine?
+
+**Whole machine.** One pair = one mailbox for that PC. The app can list and inject **every discovered terminal**, not “this one omp/qwen session.” Unpair in Settings before handing the PC over.
+
+## How do I install without curl | bash?
+
+Pin **v0.6.0** and check SHA-256. Website `install.sh` / `install.ps1` download `SHA256SUMS` and **abort on mismatch**.
+
+Release: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
 
 ```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
-gbr-agent version    # need v0.6.0+
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# darwin-arm64 shown; swap the asset for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+install -m 0755 gbr-agent-darwin-arm64 ~/.local/bin/gbr-agent
+gbr-agent version   # v0.6.0+
 gbr-agent pair && gbr-agent run
 ```
 
-Unpair on the phone before a new mailbox. Force-close is not enough.
+Full recipes: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
 
-## Attach (only these)
+## How does attach work?
 
-| How | Where |
-|-----|--------|
-| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
-| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+After `gbr-agent run`: Bot API `http://127.0.0.1:8788` or MCP stdio `gbr-mcp`. Phone is spectator + veto, not orchestrator. Never commit mailbox keys.
 
-Phone is spectator + veto, not orchestrator. The Open SWE dashboard (`:2024`) and Slack/Linear threads stay the product UI.
+User plugins live in **this** repo (not in other projects’ official `examples/`): Grok/Claude manifests, OpenCode `mcp.servers`, AiderDesk extension under `~/.aider-desk/extensions/gbr-pair`.
 
-```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
-curl -sS -X POST http://127.0.0.1:8788/v1/inject \
-  -H 'Content-Type: application/json' \
-  -d '{"session_id":"SESSION","text":"hello","submit":true}'
-```
+## Does it replace LAN remotes / mobilerun / Tailscale?
 
-## MCP
-
-Optional host-side stdio server (same pattern as other Open SWE MCP integrations: credentials stay on the LangGraph process, never in the sandbox):
-
-```bash
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
-node bin/gbr-mcp.js --diagnose
-```
-
-Never put mailbox keys, `X-GBR-Key`, or `~/.gbr/` in this skill or in git.
-
-## Loop
-
-diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
-
-Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md
+No. Amnibro `:2421`, Farina `:7910`, ChrisP `:8787` stay LAN/Tailscale UIs. mobilerun / agent-device **drive** a phone as a robot. Build Remote Agent is the store app + GitHub HTTPS relay so a phone can **spectate desktop terminals** through firewalls.

--- a/agent/skills/gbr/SKILL.md
+++ b/agent/skills/gbr/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: gbr
+description: >
+  Pair a phone running Build Remote Agent to this Open SWE desktop session.
+  Requires gbr-agent run on the host. Attach via Bot API 127.0.0.1:8788 or gbr-mcp.
+  Use when the user wants mobile spectator / inject while Open SWE (dashboard, Slack, or Linear) is running.
+compatibility: Requires gbr-agent ≥ 0.6.0 on the host. Loopback only. No mailbox keys in this file.
+metadata:
+  version: "0.6.1"
+  product: "Build Remote Agent"
+  website: "https://grokbuildremote.com/"
+---
+
+# Build Remote Agent — pairing device
+
+One adapter for Open SWE. Protocol `gbr/1`. No fourth pair protocol.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+Open SWE keeps orchestration (LangGraph agent, reviewer, analyzer, sandboxes).
+The phone spectates and can veto or inject; it does not orchestrate.
+Load this skill on the **host** process. Do not put mailbox keys in the sandbox.
+
+## Pair (unchanged)
+
+1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
+2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
+3. Phone scans QR **or** types the 8-char code.
+4. PC: `gbr-agent run` (keep it running beside `langgraph dev` / the dashboard).
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Unpair on the phone before a new mailbox. Force-close is not enough.
+
+## Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+
+Phone is spectator + veto, not orchestrator. The Open SWE dashboard (`:2024`) and Slack/Linear threads stay the product UI.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+curl -sS -X POST http://127.0.0.1:8788/v1/inject \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id":"SESSION","text":"hello","submit":true}'
+```
+
+## MCP
+
+Optional host-side stdio server (same pattern as other Open SWE MCP integrations: credentials stay on the LangGraph process, never in the sandbox):
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+Never put mailbox keys, `X-GBR-Key`, or `~/.gbr/` in this skill or in git.
+
+## Loop
+
+diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
+
+Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md


### PR DESCRIPTION
Add **Build Remote Agent** as a pairing device so a phone can spectate (and optionally inject into) a Open SWE desktop session.

Protocol stays `gbr/1` — no fourth pair protocol.

## How to use

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
gbr-agent version    # need v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

Attach only:

- HTTP Bot API `http://127.0.0.1:8788` after `gbr-agent run`
- MCP stdio `gbr-mcp` (clone [GrokBuildRemote-Agents](https://github.com/LinespottingOrg/GrokBuildRemote-Agents) and `node mcp/gbr-mcp/bin/gbr-mcp.js`)

Phone is spectator + veto, not orchestrator. Do not commit mailbox keys.

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
Website: https://grokbuildremote.com/