### PR TITLE
feat: add admin sandbox reset tool

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -441,6 +441,42 @@ async def connect_async_langsmith_sandbox(sandbox_id: str) -> tuple[AsyncSandbox
         raise
 
 
+async def create_langsmith_sandbox_from_params(
+    create_params: dict[str, Any],
+) -> SandboxBackendProtocol:
+    """Create a ready LangSmith sandbox from an unfiltered create-body object."""
+    params = _merge_sandbox_create_extra_fields(create_params)
+    sdk_keys = {
+        "snapshot_id",
+        "snapshot_name",
+        "name",
+        "timeout",
+        "wait_for_ready",
+        "idle_ttl_seconds",
+        "delete_after_stop_seconds",
+        "vcpus",
+        "mem_bytes",
+        "fs_capacity_bytes",
+        "mount_config",
+        "proxy_config",
+    }
+    sdk_params = {key: value for key, value in params.items() if key in sdk_keys}
+    extra_params = {key: value for key, value in params.items() if key not in sdk_keys}
+    wait_for_ready = sdk_params.get("wait_for_ready", True)
+    timeout = sdk_params.get("timeout", 180)
+    if not isinstance(timeout, int):
+        raise ValueError("timeout must be an integer")
+
+    async with AsyncSandboxClient(
+        api_key=_get_sandbox_api_key(), api_endpoint=_get_sandbox_api_endpoint()
+    ) as client:
+        _install_create_extra_fields(client, extra_params)
+        sandbox = await client.create_sandbox(**sdk_params)
+        if wait_for_ready is False:
+            sandbox = await client.wait_for_sandbox(sandbox.name, timeout=timeout)
+        return TimeoutLangSmithSandbox(sandbox.to_sync())
+
+
 async def create_langsmith_sandbox(
     sandbox_id: str | None = None,
     github_token: str | None = None,

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -455,7 +455,9 @@ ADMIN_ENVIRONMENT_SECTION = """---
 
 This is an admin thread. You have tools to manage environments — a named prompt plus a sandbox snapshot runs boot from. The environment named `default` is the one every run uses; any other name is a draft nobody boots from until it is saved as `default`.
 
-Build one by provisioning this sandbox and capturing it:
+Use `sandbox_reset` when you need this admin thread itself recreated from scratch with explicit sandbox-create options. It accepts every public create field plus hidden provider fields such as `_internal_runtime`; never include tokens, credentials, or other secrets. The old sandbox is detached but preserved.
+
+Build an environment by provisioning this sandbox and capturing it:
 
 1. `save_environment` to create or update the record (name, prompt, repos, optional VM sizing, and optional additional create parameters). Memory and filesystem capacity are bytes; vCPUs are a count. Sizing and `create_params` apply when new sandboxes are created for that environment, not to this already-running admin sandbox. Use `clear_sizing` and `clear_create_params` to restore defaults. Create parameters are persisted: use them for non-sensitive settings such as `_internal_runtime` or proxy routing, never for tokens, credentials, or other secrets.
 2. Provision this sandbox with ordinary commands: clone the repos the environment covers, install `rg`, `gh`, the required toolchains and dependencies, and warm caches. Every environment must include `rg` and `gh`. Everything on disk lands in the snapshot, so leave the sandbox in the state a run should start from.

--- a/agent/server.py
+++ b/agent/server.py
@@ -83,7 +83,11 @@ from .input_messages import append_message_data
 from .integrations.corridor_mcp import load_corridor_tools
 from .integrations.currents_tools import load_currents_tools
 from .integrations.datadog_mcp import load_datadog_tools
-from .integrations.langsmith import _configure_github_proxy, _get_sandbox_proxy_config
+from .integrations.langsmith import (
+    _configure_github_proxy,
+    _get_sandbox_proxy_config,
+    create_langsmith_sandbox_from_params,
+)
 from .integrations.langsmith_tools import load_langsmith_tools
 from .integrations.notion_mcp import load_notion_tools
 from .integrations.stagehand_browser import load_browser_tools
@@ -155,6 +159,7 @@ from .tools import (
     recreate_sandbox,
     report_platform_issue,
     request_pr_review,
+    sandbox_reset,
     save_environment,
     save_organization_skill,
     save_plan,
@@ -637,6 +642,54 @@ async def ensure_sandbox_for_thread(
     return set_sandbox_backend(thread_id, sandbox_backend)
 
 
+async def reset_sandbox_for_thread(
+    thread_id: str,
+    create_params: dict[str, Any],
+) -> tuple[str, str]:
+    """Bind a thread to a fresh sandbox created from raw provider options."""
+    if os.getenv("SANDBOX_TYPE", "langsmith") != "langsmith":
+        raise ValueError("sandbox_reset is only supported by the LangSmith sandbox provider")
+
+    cached = SANDBOX_BACKENDS.get(thread_id)
+    metadata_sandbox_id = await get_sandbox_id_from_metadata(thread_id)
+    old_sandbox_id = cached.id if cached is not None and cached.has_backend else metadata_sandbox_id
+    if not old_sandbox_id:
+        raise ValueError(f"Thread {thread_id} has no sandbox to reset")
+
+    new_sandbox = await create_langsmith_sandbox_from_params(create_params)
+    if new_sandbox.id == old_sandbox_id:
+        raise RuntimeError("Sandbox provider did not create a distinct sandbox")
+
+    proxy_config = _get_sandbox_proxy_config(create_params)
+    token, expires_at, permissions = await _resolve_proxy_token(None)
+    if not token:
+        raise ValueError("Cannot configure proxy: GitHub App installation token is unavailable")
+    if proxy_config is not None:
+        await _configure_github_proxy(new_sandbox.id, token, base_proxy_config=proxy_config)
+    else:
+        await _configure_github_proxy(new_sandbox.id, token)
+    record_proxy_token_expiry(
+        thread_id,
+        expires_at,
+        permissions=permissions,
+        base_proxy_config=proxy_config,
+    )
+
+    await _configure_git_identity(new_sandbox)
+    sandbox_metadata: dict[str, Any] = {"sandbox_id": new_sandbox.id}
+    if proxy_config is not None:
+        sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = proxy_config
+    await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
+    set_sandbox_backend(thread_id, new_sandbox)
+    logger.info(
+        "Reset thread %s from sandbox %s to sandbox %s",
+        thread_id,
+        old_sandbox_id,
+        new_sandbox.id,
+    )
+    return old_sandbox_id, new_sandbox.id
+
+
 async def recreate_sandbox_for_thread(
     thread_id: str,
     *,
@@ -697,6 +750,7 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
         "manage_thread",
         "open_pull_request",
         "recreate_sandbox",
+        "sandbox_reset",
         "request_pr_review",
         "save_user_skill",
         "delete_user_skill",
@@ -846,6 +900,7 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
 
 # Added to an admin thread's tools; see the admin-thread section of the prompt.
 ADMIN_TOOLS = (
+    sandbox_reset,
     list_environments,
     save_environment,
     capture_environment_snapshot,

--- a/agent/server.py
+++ b/agent/server.py
@@ -668,19 +668,19 @@ async def reset_sandbox_for_thread(
         await _configure_github_proxy(new_sandbox.id, token, base_proxy_config=proxy_config)
     else:
         await _configure_github_proxy(new_sandbox.id, token)
+    await _configure_git_identity(new_sandbox)
+    sandbox_metadata: dict[str, Any] = {
+        "sandbox_id": new_sandbox.id,
+        _SANDBOX_PROXY_CONFIG_METADATA_KEY: proxy_config,
+    }
+    await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
+    set_sandbox_backend(thread_id, new_sandbox)
     record_proxy_token_expiry(
         thread_id,
         expires_at,
         permissions=permissions,
         base_proxy_config=proxy_config,
     )
-
-    await _configure_git_identity(new_sandbox)
-    sandbox_metadata: dict[str, Any] = {"sandbox_id": new_sandbox.id}
-    if proxy_config is not None:
-        sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = proxy_config
-    await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
-    set_sandbox_backend(thread_id, new_sandbox)
     logger.info(
         "Reset thread %s from sandbox %s to sandbox %s",
         thread_id,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -44,6 +44,7 @@ _TOOL_MODULES = {
     "save_environment": ".environments",
     "save_organization_skill": ".organization_skills",
     "save_plan": ".save_plan",
+    "sandbox_reset": ".sandbox_reset",
     "save_user_instructions": ".save_user_instructions",
     "save_user_skill": ".user_skills",
     "delete_user_skill": ".user_skills",
@@ -100,6 +101,7 @@ __all__ = [
     "save_organization_skill",
     "delete_organization_skill",
     "save_plan",
+    "sandbox_reset",
     "save_user_instructions",
     "save_user_skill",
     "delete_user_skill",
@@ -152,6 +154,7 @@ if TYPE_CHECKING:
     from .report_platform_issue import report_platform_issue
     from .request_pr_review import request_pr_review
     from .resolve_finding_thread import resolve_finding_thread
+    from .sandbox_reset import sandbox_reset
     from .save_plan import save_plan
     from .save_user_instructions import save_user_instructions
     from .schedule_thread_wakeup import schedule_thread_wakeup

--- a/agent/tools/sandbox_reset.py
+++ b/agent/tools/sandbox_reset.py
@@ -1,0 +1,77 @@
+"""Admin tool for replacing the current thread's sandbox with raw create options."""
+
+import logging
+from typing import Any
+
+from langchain_core.tools import tool
+from pydantic import BaseModel, ConfigDict, Field
+
+from .admin_gate import configurable, require_admin
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxResetParams(BaseModel):
+    """LangSmith sandbox create-body options."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    snapshot_id: str | None = None
+    snapshot_name: str | None = None
+    snapshot: str | None = None
+    name: str | None = None
+    timeout: int | None = None
+    wait_for_ready: bool | None = None
+    idle_ttl_seconds: int | None = None
+    delete_after_stop_seconds: int | None = None
+    vcpus: int | None = None
+    cpu_millicores: int | None = None
+    mem_bytes: int | None = None
+    fs_capacity_bytes: int | None = None
+    env_vars: dict[str, str] | None = None
+    labels: dict[str, str] | None = None
+    mount_config: dict[str, Any] | None = None
+    proxy_config: dict[str, Any] | None = None
+    preserve_memory_on_stop: bool | None = None
+    restore_memory: bool | None = None
+    tag_value_ids: list[str] | None = None
+    internal_runtime: Any = Field(default=None, alias="_internal_runtime")
+
+
+@tool("sandbox_reset", args_schema=SandboxResetParams)
+async def sandbox_reset(**create_options: Any) -> dict[str, Any]:
+    """Replace this admin thread's sandbox using a complete create request.
+
+    Every supplied argument is forwarded to the LangSmith sandbox-create body.
+    The schema includes all public create fields and accepts additional hidden
+    fields such as ``_internal_runtime``. Omitted fields use platform defaults.
+    The new sandbox starts empty except for any requested snapshot, and the old
+    sandbox is preserved but detached from this thread. Never pass secrets,
+    credentials, or authentication tokens.
+    """
+    if error := require_admin("reset sandboxes"):
+        return {"success": False, "error": error}
+
+    values = configurable()
+    thread_id = values.get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        return {"success": False, "error": "No thread_id in current run config"}
+
+    create_params = {
+        ("_internal_runtime" if key == "internal_runtime" else key): value
+        for key, value in create_options.items()
+        if value is not None
+    }
+    try:
+        from ..server import reset_sandbox_for_thread
+
+        old_sandbox_id, new_sandbox_id = await reset_sandbox_for_thread(thread_id, create_params)
+    except Exception as exc:
+        logger.exception("Failed to reset sandbox for thread %s", thread_id)
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "old_sandbox_id": old_sandbox_id,
+        "new_sandbox_id": new_sandbox_id,
+    }

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -270,6 +270,28 @@ async def test_agent_includes_recreate_sandbox_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_includes_sandbox_reset_only_in_admin_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.tools import sandbox_reset
+
+    captured = await _capture_create_deep_agent_kwargs()
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+    assert sandbox_reset not in tools
+
+    monkeypatch.setenv("CONFIGURED_ADMINS", "octocat")
+    config = _base_config()
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    configurable["admin_thread"] = True
+    captured = await _capture_create_deep_agent_kwargs(config)
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+    assert sandbox_reset in tools
+
+
+@pytest.mark.asyncio
 async def test_agent_includes_sandbox_file_download_url_tools() -> None:
     from agent.tools import create_sandbox_file_download_url, output_iframe
 

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -22,6 +22,7 @@ from agent.integrations.langsmith import (
     _merge_sandbox_create_extra_fields,
     _reuse_existing_sandbox,
     create_langsmith_sandbox,
+    create_langsmith_sandbox_from_params,
 )
 from agent.utils.sandbox import SandboxGoneError
 
@@ -241,6 +242,47 @@ async def test_create_sandbox_with_retry_retries_transient_errors(monkeypatch) -
     assert result == {"sandbox": "snap-1"}
     assert client.calls == 3
     assert "name" not in client.last_kwargs
+
+
+@pytest.mark.asyncio
+async def test_create_from_params_forwards_public_and_hidden_options() -> None:
+    sandbox = MagicMock(name="sandbox-new")
+    sandbox.name = "sandbox-new"
+    sandbox.to_sync.return_value = MagicMock(id="sandbox-new")
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.create_sandbox = AsyncMock(return_value=sandbox)
+    client.wait_for_sandbox = AsyncMock(return_value=sandbox)
+
+    with (
+        patch("agent.integrations.langsmith.AsyncSandboxClient", return_value=client),
+        patch("agent.integrations.langsmith._install_create_extra_fields") as install,
+        patch(
+            "agent.integrations.langsmith._get_sandbox_create_extra_fields",
+            return_value={},
+        ),
+    ):
+        await create_langsmith_sandbox_from_params(
+            {
+                "snapshot_name": "python:latest",
+                "wait_for_ready": False,
+                "timeout": 240,
+                "cpu_millicores": 500,
+                "_internal_runtime": "v2",
+            }
+        )
+
+    client.create_sandbox.assert_awaited_once_with(
+        snapshot_name="python:latest",
+        wait_for_ready=False,
+        timeout=240,
+    )
+    client.wait_for_sandbox.assert_awaited_once_with("sandbox-new", timeout=240)
+    install.assert_called_once_with(
+        client,
+        {"cpu_millicores": 500, "_internal_runtime": "v2"},
+    )
 
 
 def test_extra_fields_unset_is_empty() -> None:

--- a/tests/sandbox/test_sandbox_reset.py
+++ b/tests/sandbox/test_sandbox_reset.py
@@ -1,0 +1,82 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.server import reset_sandbox_for_thread
+from agent.utils.sandbox_state import SANDBOX_BACKENDS, set_sandbox_backend
+
+
+@pytest.mark.asyncio
+async def test_reset_sandbox_hands_off_after_metadata_persists() -> None:
+    thread_id = "thread-reset"
+    create_params: dict[str, Any] = {
+        "snapshot_name": "python:latest",
+        "cpu_millicores": 500,
+        "_internal_runtime": "v2",
+        "proxy_config": {"rules": []},
+    }
+    SANDBOX_BACKENDS.clear()
+    old_sandbox = MagicMock(id="sandbox-old")
+    new_sandbox = MagicMock(id="sandbox-new")
+    proxy = set_sandbox_backend(thread_id, old_sandbox)
+
+    async def persist_metadata(**_kwargs: object) -> None:
+        assert proxy.current is old_sandbox
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-old",
+        ),
+        patch(
+            "agent.server.create_langsmith_sandbox_from_params",
+            new_callable=AsyncMock,
+            return_value=new_sandbox,
+        ) as create,
+        patch(
+            "agent.server._resolve_proxy_token",
+            new_callable=AsyncMock,
+            return_value=("ghs_install", "expiry", None),
+        ),
+        patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as proxy_configure,
+        patch("agent.server.record_proxy_token_expiry") as record_proxy,
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock) as configure,
+        patch(
+            "agent.server.client.threads.update",
+            new_callable=AsyncMock,
+            side_effect=persist_metadata,
+        ) as update,
+    ):
+        result = await reset_sandbox_for_thread(thread_id, create_params)
+
+    assert result == ("sandbox-old", "sandbox-new")
+    create.assert_awaited_once_with(create_params)
+    proxy_configure.assert_awaited_once_with(
+        "sandbox-new", "ghs_install", base_proxy_config={"rules": []}
+    )
+    record_proxy.assert_called_once_with(
+        thread_id,
+        "expiry",
+        permissions=None,
+        base_proxy_config={"rules": []},
+    )
+    configure.assert_awaited_once_with(new_sandbox)
+    update.assert_awaited_once_with(
+        thread_id=thread_id,
+        metadata={
+            "sandbox_id": "sandbox-new",
+            "sandbox_base_proxy_config": {"rules": []},
+        },
+    )
+    assert proxy.current is new_sandbox
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_reset_sandbox_rejects_other_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SANDBOX_TYPE", "modal")
+
+    with pytest.raises(ValueError, match="only supported by the LangSmith"):
+        await reset_sandbox_for_thread("thread-reset", {})

--- a/tests/sandbox/test_sandbox_reset.py
+++ b/tests/sandbox/test_sandbox_reset.py
@@ -75,6 +75,85 @@ async def test_reset_sandbox_hands_off_after_metadata_persists() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reset_sandbox_clears_stale_proxy_metadata() -> None:
+    thread_id = "thread-reset-default-proxy"
+    SANDBOX_BACKENDS.clear()
+    old_sandbox = MagicMock(id="sandbox-old")
+    new_sandbox = MagicMock(id="sandbox-new")
+    set_sandbox_backend(thread_id, old_sandbox)
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-old",
+        ),
+        patch(
+            "agent.server.create_langsmith_sandbox_from_params",
+            new_callable=AsyncMock,
+            return_value=new_sandbox,
+        ),
+        patch(
+            "agent.server._resolve_proxy_token",
+            new_callable=AsyncMock,
+            return_value=("ghs_install", "expiry", None),
+        ),
+        patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
+        patch("agent.server.record_proxy_token_expiry"),
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch("agent.server.client.threads.update", new_callable=AsyncMock) as update,
+    ):
+        await reset_sandbox_for_thread(thread_id, {})
+
+    update.assert_awaited_once_with(
+        thread_id=thread_id,
+        metadata={"sandbox_id": "sandbox-new", "sandbox_base_proxy_config": None},
+    )
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
+async def test_reset_sandbox_does_not_record_proxy_before_metadata_persists() -> None:
+    thread_id = "thread-reset-failure"
+    SANDBOX_BACKENDS.clear()
+    old_sandbox = MagicMock(id="sandbox-old")
+    new_sandbox = MagicMock(id="sandbox-new")
+    proxy = set_sandbox_backend(thread_id, old_sandbox)
+
+    with (
+        patch(
+            "agent.server.get_sandbox_id_from_metadata",
+            new_callable=AsyncMock,
+            return_value="sandbox-old",
+        ),
+        patch(
+            "agent.server.create_langsmith_sandbox_from_params",
+            new_callable=AsyncMock,
+            return_value=new_sandbox,
+        ),
+        patch(
+            "agent.server._resolve_proxy_token",
+            new_callable=AsyncMock,
+            return_value=("ghs_install", "expiry", None),
+        ),
+        patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
+        patch("agent.server.record_proxy_token_expiry") as record_proxy,
+        patch("agent.server._configure_git_identity", new_callable=AsyncMock),
+        patch(
+            "agent.server.client.threads.update",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("metadata unavailable"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="metadata unavailable"):
+            await reset_sandbox_for_thread(thread_id, {"proxy_config": {"rules": []}})
+
+    record_proxy.assert_not_called()
+    assert proxy.current is old_sandbox
+    SANDBOX_BACKENDS.clear()
+
+
+@pytest.mark.asyncio
 async def test_reset_sandbox_rejects_other_providers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SANDBOX_TYPE", "modal")
 

--- a/tests/tools/test_sandbox_reset_tool.py
+++ b/tests/tools/test_sandbox_reset_tool.py
@@ -1,0 +1,72 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.tools.sandbox_reset import SandboxResetParams, sandbox_reset
+
+
+@pytest.mark.asyncio
+async def test_sandbox_reset_forwards_public_and_hidden_create_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    config = {"configurable": {"thread_id": "thread-1", "github_login": "ramonn"}}
+    with (
+        patch("agent.tools.admin_gate.get_config", return_value=config),
+        patch(
+            "agent.server.reset_sandbox_for_thread",
+            new_callable=AsyncMock,
+            return_value=("sandbox-old", "sandbox-new"),
+        ) as reset,
+    ):
+        result = await sandbox_reset.ainvoke(
+            {
+                "snapshot_name": "python:latest",
+                "cpu_millicores": 500,
+                "_internal_runtime": "v2",
+                "preserve_memory_on_stop": True,
+            }
+        )
+
+    assert result == {
+        "success": True,
+        "old_sandbox_id": "sandbox-old",
+        "new_sandbox_id": "sandbox-new",
+    }
+    reset.assert_awaited_once_with(
+        "thread-1",
+        {
+            "snapshot_name": "python:latest",
+            "cpu_millicores": 500,
+            "_internal_runtime": "v2",
+            "preserve_memory_on_stop": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_sandbox_reset_rejects_non_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
+    config = {"configurable": {"thread_id": "thread-1", "github_login": "someone-else"}}
+    with patch("agent.tools.admin_gate.get_config", return_value=config):
+        result = await sandbox_reset.ainvoke({"_internal_runtime": "v2"})
+
+    assert result == {
+        "success": False,
+        "error": "Only workspace admins can reset sandboxes.",
+    }
+
+
+def test_sandbox_reset_schema_includes_hidden_and_public_options() -> None:
+    schema = SandboxResetParams.model_json_schema()
+
+    assert "_internal_runtime" in schema["properties"]
+    assert "cpu_millicores" in schema["properties"]
+    assert "snapshot_name" in schema["properties"]
+    assert schema["additionalProperties"] is True
+
+
+def test_sandbox_reset_exported() -> None:
+    from agent.tools import sandbox_reset as exported
+
+    assert exported is sandbox_reset


### PR DESCRIPTION
## Description
Adds an admin-thread-only `sandbox_reset` tool that atomically rebinds the thread to a newly created LangSmith sandbox. It exposes all public create options, accepts hidden passthrough fields such as `_internal_runtime`, and commits proxy state only after the new sandbox is bound.

## Release Note
Admin threads can reset their sandbox with explicit public or hidden create parameters.

## Test Plan
- [x] Verify public and hidden options reach the create request and only admin threads expose the tool.
- [x] Verify failed resets preserve live proxy state and omitted proxy options clear stale metadata.

Made by [Open SWE](https://openswe.vercel.app/agents/f2556495-0218-5560-8b13-4ad314362bc6)