### PR TITLE
refactor: run Stagehand in task sandboxes

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -6,6 +6,7 @@ ARG UV_VERSION=0.9.26
 ARG YARN_VERSION=4.12.0
 ARG GH_VERSION=2.83.1
 ARG SFW_VERSION=2.0.6
+ARG STAGEHAND_VERSION=3.22.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Skip sfw's daily background update check at runtime. The check hits
@@ -78,11 +79,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && sfw --version \
     && test -e "$(npm root -g)/sfw/.sfw-cache/latest"
 
-# Chromium for Stagehand LOCAL browser mode (STAGEHAND_ENV=LOCAL). Skipped at
-# runtime when STAGEHAND_ENV=BROWSERBASE (browser runs on Browserbase cloud).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends chromium \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && uv pip install --system --no-cache "stagehand==${STAGEHAND_VERSION}"
+COPY agent/resources/stagehand_runtime.py /opt/open-swe/stagehand_runtime.py
 ENV STAGEHAND_LOCAL_CHROME_PATH=/usr/bin/chromium
 
 ENV GO_VERSION=1.23.5

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -221,7 +221,11 @@ def _github_proxy_rules(github_token: str) -> list[dict[str, Any]]:
 def _stagehand_proxy_rules() -> list[dict[str, Any]]:
     model = os.getenv("STAGEHAND_MODEL", "anthropic/claude-sonnet-4-5")
     provider = model.split("/", 1)[0].split(":", 1)[0]
-    key = os.getenv("STAGEHAND_MODEL_API_KEY")
+    key = (
+        os.getenv("STAGEHAND_MODEL_API_KEY")
+        or os.getenv("MODEL_API_KEY")
+        or os.getenv("ANTHROPIC_API_KEY")
+    )
     if not key:
         return []
     if provider == "anthropic":

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -46,6 +46,7 @@ PROXY_CONFIG_NOT_READY_STATUS = 400
 PROXY_CONFIG_ERROR_BODY_CHARS = 500
 SANDBOX_START_TIMEOUT_SECONDS = 120
 PROXY_GH_TOKEN_PLACEHOLDER = "proxy-injected"
+PROXY_MODEL_KEY_PLACEHOLDER = "proxy-injected"
 
 
 def _get_langsmith_api_key() -> str | None:
@@ -214,6 +215,28 @@ def _github_proxy_rules(github_token: str) -> list[dict[str, Any]]:
                 }
             ],
         },
+    ]
+
+
+def _stagehand_proxy_rules() -> list[dict[str, Any]]:
+    model = os.getenv("STAGEHAND_MODEL", "anthropic/claude-sonnet-4-5")
+    provider = model.split("/", 1)[0].split(":", 1)[0]
+    key = os.getenv("STAGEHAND_MODEL_API_KEY")
+    if not key:
+        return []
+    if provider == "anthropic":
+        host, header, value = "api.anthropic.com", "x-api-key", key
+    elif provider == "openai":
+        host, header, value = "api.openai.com", "Authorization", f"Bearer {key}"
+    else:
+        return []
+    return [
+        {
+            "name": "stagehand-model",
+            "match_hosts": [host],
+            "headers": [{"name": header, "type": "opaque", "value": value}],
+            "env_vars": {"MODEL_API_KEY": PROXY_MODEL_KEY_PLACEHOLDER},
+        }
     ]
 
 
@@ -407,6 +430,7 @@ async def _configure_github_proxy(
     proxy_config["rules"] = [
         *(custom_rules if isinstance(custom_rules, list) else []),
         *_github_proxy_rules(github_token),
+        *_stagehand_proxy_rules(),
     ]
     payload = {"proxy_config": proxy_config}
     async with httpx.AsyncClient(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:

--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -1,60 +1,21 @@
-"""Native browser-automation tools backed by the Stagehand SDK.
+"""Stagehand browser tools executed inside the thread's task sandbox."""
 
-We drive a real browser via Stagehand's Python SDK directly (no MCP
-subprocess). Stagehand exposes high-level, model-driven primitives — ``act``,
-``observe``, ``extract`` — on top of a managed browser session.
-
-Two execution modes, selected by ``STAGEHAND_ENV`` (default ``LOCAL``):
-
-* ``LOCAL``  — Stagehand runs its bundled local engine in-process and drives a
-  local Chromium. Nothing leaves the host. Needs a Chrome/Chromium binary;
-  point at it with ``STAGEHAND_LOCAL_CHROME_PATH`` if auto-detection fails.
-* ``BROWSERBASE`` — the browser runs on Browserbase's cloud. Requires
-  ``BROWSERBASE_API_KEY``. ``BROWSERBASE_PROJECT_ID`` is forwarded when set.
-
-Stagehand's ``act``/``observe``/``extract`` call an LLM. In ``BROWSERBASE``
-mode the hosted Stagehand API ships with model support, so no model key is
-required — provide one only to override the model. In ``LOCAL`` mode the engine
-runs on the host, so a model key is required: ``STAGEHAND_MODEL_API_KEY``
-(falls back to ``MODEL_API_KEY`` then ``ANTHROPIC_API_KEY``). Override the model
-in either mode with ``STAGEHAND_MODEL`` (default ``anthropic/claude-sonnet-4-5``).
-
-The browser tools are gated on having a usable config: a model key (LOCAL) or
-Browserbase credentials (BROWSERBASE). When unconfigured the integration is a
-no-op.
-
-One browser session is kept per agent thread (keyed by ``thread_id`` from the
-run config) and reused across tool calls, so ``navigate`` → ``act`` → ``extract``
-operate on the same live page. Always finish with ``browser_close``.
-"""
-
-import asyncio
-import contextlib
-import inspect
+import base64
 import json
 import logging
 import os
+import shlex
 from typing import Any
 
 from langgraph.config import get_config
 
-from ..utils.url_safety import is_url_safe
+from ..utils.sandbox_state import get_sandbox_backend
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
-
-# thread_id -> (client, session)
-_SESSIONS: dict[str, tuple[Any, Any]] = {}
-_LOCK = asyncio.Lock()
-
-
-class BrowserNavigationBlocked(RuntimeError):
-    pass
-
-
-def _is_local() -> bool:
-    return os.getenv("STAGEHAND_ENV", "LOCAL").strip().upper() != "BROWSERBASE"
+_RUNTIME = "/opt/open-swe/stagehand_runtime.py"
+_SOCKET = "/tmp/open-swe-stagehand.sock"
 
 
 def _model_name() -> str:
@@ -62,815 +23,92 @@ def _model_name() -> str:
 
 
 def _model_api_key() -> str | None:
-    return (
-        os.getenv("STAGEHAND_MODEL_API_KEY")
-        or os.getenv("MODEL_API_KEY")
-        or os.getenv("ANTHROPIC_API_KEY")
-    )
+    return os.getenv("STAGEHAND_MODEL_API_KEY")
 
 
 def _headless() -> bool:
-    return os.getenv("STAGEHAND_HEADLESS", "true").strip().lower() not in (
-        "0",
-        "false",
-        "no",
-    )
+    return os.getenv("STAGEHAND_HEADLESS", "true").strip().lower() not in ("0", "false", "no")
 
 
 def browser_tools_enabled() -> bool:
-    """Whether the browser tools have enough configuration to run.
-
-    LOCAL mode needs a model key (the engine runs on the host). BROWSERBASE
-    mode only needs Browserbase credentials — the hosted Stagehand API ships
-    with model support, so a model key is optional there.
-    """
-    if _is_local():
-        return bool(_model_api_key())
-    return bool(os.getenv("BROWSERBASE_API_KEY"))
+    """Whether sandbox-local browser automation is configured."""
+    provider = _model_name().split("/", 1)[0].split(":", 1)[0]
+    return os.getenv("SANDBOX_TYPE", "langsmith") == "langsmith" and bool(
+        _model_api_key() and provider in {"anthropic", "openai"}
+    )
 
 
 def _thread_id() -> str:
-    try:
-        config = get_config()
-    except Exception:  # noqa: BLE001 - outside a run (tests); fall back to a shared key
-        return "default"
+    config = get_config()
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
     thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
-    return thread_id if isinstance(thread_id, str) and thread_id else "default"
+    if not isinstance(thread_id, str) or not thread_id:
+        raise RuntimeError("no thread_id in run config")
+    return thread_id
 
 
-def _build_client() -> Any:
-    from stagehand import AsyncStagehand
-
-    return AsyncStagehand(
-        server="local" if _is_local() else "remote",
-        browserbase_api_key=os.getenv("BROWSERBASE_API_KEY"),
-        browserbase_project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
-        model_api_key=_model_api_key(),
-        local_headless=_headless(),
-        local_chrome_path=os.getenv("STAGEHAND_LOCAL_CHROME_PATH"),
+async def _request(operation: str, **payload: Any) -> dict[str, Any]:
+    backend = await get_sandbox_backend(_thread_id())
+    request = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "operation": operation,
+                "model_name": _model_name(),
+                "headless": _headless(),
+                **payload,
+            }
+        ).encode()
+    ).decode()
+    runtime = shlex.quote(_RUNTIME)
+    socket = shlex.quote(_SOCKET)
+    encoded = shlex.quote(request)
+    command = (
+        f"if [ ! -S {socket} ]; then "
+        f"setsid python {runtime} serve {socket} >/tmp/open-swe-stagehand.log 2>&1 </dev/null & "
+        f"for i in $(seq 1 100); do [ -S {socket} ] && break; sleep .1; done; fi; "
+        f"python {runtime} request {socket} {encoded}"
     )
-
-
-def _browser_spec() -> dict[str, Any]:
-    """Build the ``browser`` argument for ``sessions.start``.
-
-    Local sessions must provide ``launch_options`` (or a CDP URL); we pass
-    headless + the Chrome executable path so the local engine launches it.
-    """
-    if not _is_local():
-        return {"type": "browserbase"}
-    launch_options: dict[str, Any] = {"headless": _headless()}
-    chrome_path = os.getenv("STAGEHAND_LOCAL_CHROME_PATH")
-    if chrome_path:
-        launch_options["executable_path"] = chrome_path
-    return {"type": "local", "launch_options": launch_options}
-
-
-def _browserbase_session_create_params() -> dict[str, Any]:
-    if _is_local():
-        return {}
-    project_id = os.getenv("BROWSERBASE_PROJECT_ID")
-    return {"project_id": project_id} if project_id else {}
-
-
-async def _maybe_await(value: Any) -> Any:
-    if inspect.isawaitable(value):
-        return await value
-    return value
-
-
-def _safe_attr(obj: Any, name: str) -> Any:
+    result = await backend.aexecute(command, timeout=180)
+    if result.exit_code != 0:
+        detail = result.output.strip() or f"sandbox command exited {result.exit_code}"
+        return {"success": False, "error": f"browser_{operation} failed: {detail}"}
     try:
-        return getattr(obj, name)
-    except Exception:  # noqa: BLE001
-        return None
-
-
-def _callable_attr(obj: Any, name: str) -> Any:
-    value = _safe_attr(obj, name)
-    return value if callable(value) else None
-
-
-def _request_url(route: Any, request: Any | None = None) -> str | None:
-    request = request or _safe_attr(route, "request")
-    if callable(request):
-        request = request()
-    url = _safe_attr(request, "url") if request is not None else None
-    if isinstance(url, str) and url:
-        return url
-    url = _safe_attr(route, "url")
-    return url if isinstance(url, str) and url else None
-
-
-async def _continue_route(route: Any) -> None:
-    continue_ = _callable_attr(route, "continue_") or _callable_attr(route, "fallback")
-    if continue_ is not None:
-        await _maybe_await(continue_())
-
-
-async def _abort_route(route: Any) -> None:
-    abort = _callable_attr(route, "abort")
-    if abort is not None:
-        await _maybe_await(abort())
-
-
-def _mark_blocked_request(session: Any, url: str, reason: str) -> None:
-    try:
-        session._open_swe_blocked_request = (url, reason)
-    except Exception:  # noqa: BLE001
-        pass
-
-
-def _clear_blocked_request(session: Any) -> None:
-    try:
-        if hasattr(session, "_open_swe_blocked_request"):
-            delattr(session, "_open_swe_blocked_request")
-    except Exception:  # noqa: BLE001
-        pass
-
-
-def _blocked_request_error(session: Any) -> str | None:
-    blocked = _safe_attr(session, "_open_swe_blocked_request")
-    if isinstance(blocked, tuple) and len(blocked) == 2:
-        url, reason = blocked
-        return f"blocked browser request to {url}: {reason}"
-    return None
-
-
-def _set_current_page_url(session: Any, url: str) -> None:
-    if not url or url == "about:blank":
-        return
-    try:
-        session._open_swe_current_page_url = url
-    except Exception:  # noqa: BLE001
-        pass
-
-
-def _cdp_url(session: Any) -> str | None:
-    url = _safe_attr(_safe_attr(session, "data"), "cdp_url")
-    return url if isinstance(url, str) and url else None
-
-
-async def _connect_cdp_websocket(cdp_url: str) -> Any:
-    import websockets
-
-    return await websockets.connect(cdp_url)
-
-
-class _CDPBrowserURLGuard:
-    def __init__(self, session: Any, cdp_url: str) -> None:
-        self._session = session
-        self._cdp_url = cdp_url
-        self._ws: Any | None = None
-        self._task: asyncio.Task[None] | None = None
-        self._send_lock = asyncio.Lock()
-        self._next_id = 0
-        self._pending: dict[int, asyncio.Future[Any]] = {}
-        self._attached_sessions: set[str] = set()
-        self._protected_target_ids: set[str] = set()
-        self._configuration_tasks: set[asyncio.Task[None]] = set()
-        self._fetch_tasks: dict[str, asyncio.Task[None]] = {}
-        self._failure: BaseException | None = None
-
-    async def start(self) -> None:
-        try:
-            self._ws = await _connect_cdp_websocket(self._cdp_url)
-            self._task = asyncio.create_task(self._run())
-            await self._send(
-                "Target.setAutoAttach",
-                {
-                    "autoAttach": True,
-                    "waitForDebuggerOnStart": True,
-                    "flatten": True,
-                },
-            )
-            await self._send("Target.setDiscoverTargets", {"discover": True})
-            await self._protect_initial_targets()
-        except BaseException:
-            await self.close()
-            raise
-
-    async def close(self) -> None:
-        for task in self._configuration_tasks:
-            task.cancel()
-        for task in self._fetch_tasks.values():
-            task.cancel()
-        if self._configuration_tasks:
-            await asyncio.gather(*self._configuration_tasks, return_exceptions=True)
-        if self._fetch_tasks:
-            await asyncio.gather(*self._fetch_tasks.values(), return_exceptions=True)
-        self._configuration_tasks.clear()
-        self._fetch_tasks.clear()
-        if self._task is not None:
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._task
-        if self._ws is not None:
-            close = _callable_attr(self._ws, "close")
-            if close is not None:
-                await _maybe_await(close())
-        for future in self._pending.values():
-            if not future.done():
-                future.cancel()
-        self._pending.clear()
-
-    async def _send(
-        self,
-        method: str,
-        params: dict[str, Any] | None = None,
-        *,
-        session_id: str | None = None,
-    ) -> Any:
-        if self._ws is None:
-            return None
-        self._next_id += 1
-        message_id = self._next_id
-        loop = asyncio.get_running_loop()
-        future: asyncio.Future[Any] = loop.create_future()
-        self._pending[message_id] = future
-        await self._send_message(message_id, method, params, session_id=session_id)
-        try:
-            return await asyncio.wait_for(future, timeout=10)
-        finally:
-            self._pending.pop(message_id, None)
-
-    async def _send_fire_and_forget(
-        self,
-        method: str,
-        params: dict[str, Any] | None = None,
-        *,
-        session_id: str | None = None,
-    ) -> None:
-        if self._ws is None:
-            return
-        self._next_id += 1
-        await self._send_message(self._next_id, method, params, session_id=session_id)
-
-    async def _send_message(
-        self,
-        message_id: int,
-        method: str,
-        params: dict[str, Any] | None,
-        *,
-        session_id: str | None,
-    ) -> None:
-        websocket = self._ws
-        if websocket is None:
-            raise RuntimeError("CDP websocket is not connected")
-        message: dict[str, Any] = {"id": message_id, "method": method}
-        if params is not None:
-            message["params"] = params
-        if session_id is not None:
-            message["sessionId"] = session_id
-        async with self._send_lock:
-            await websocket.send(json.dumps(message))
-
-    async def _run(self) -> None:
-        assert self._ws is not None
-        try:
-            async for raw_message in self._ws:
-                try:
-                    message = json.loads(raw_message)
-                except Exception:  # noqa: BLE001
-                    logger.debug("Ignoring malformed CDP message", exc_info=True)
-                    continue
-                message_id = message.get("id")
-                if isinstance(message_id, int):
-                    future = self._pending.pop(message_id, None)
-                    if future is not None and not future.done():
-                        if "error" in message:
-                            future.set_exception(RuntimeError(str(message["error"])))
-                        else:
-                            future.set_result(message.get("result"))
-                    continue
-                await self._handle_event(message)
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:  # noqa: BLE001
-            self._failure = e
-            logger.debug("CDP browser URL guard stopped", exc_info=True)
-            for future in self._pending.values():
-                if not future.done():
-                    future.set_exception(e)
-
-    async def _handle_event(self, message: dict[str, Any]) -> None:
-        method = message.get("method")
-        params = message.get("params")
-        if not isinstance(params, dict):
-            return
-        if method == "Target.attachedToTarget":
-            session_id = params.get("sessionId")
-            target_info = params.get("targetInfo")
-            if isinstance(session_id, str) and isinstance(target_info, dict):
-                url = target_info.get("url")
-                if isinstance(url, str):
-                    _set_current_page_url(self._session, url)
-                target_type = target_info.get("type")
-                waiting_for_debugger = params.get("waitingForDebugger") is True
-                if target_type in {"page", "iframe", "webview"} or waiting_for_debugger:
-                    self._schedule_target_configuration(
-                        session_id,
-                        target_info,
-                        waiting_for_debugger=waiting_for_debugger,
-                    )
-            return
-        if method == "Target.targetInfoChanged":
-            target_info = params.get("targetInfo")
-            if isinstance(target_info, dict):
-                url = target_info.get("url")
-                if isinstance(url, str):
-                    _set_current_page_url(self._session, url)
-            return
-        if method == "Page.frameNavigated":
-            frame = params.get("frame")
-            if isinstance(frame, dict):
-                url = frame.get("url")
-                if isinstance(url, str):
-                    _set_current_page_url(self._session, url)
-            return
-        if method == "Fetch.requestPaused":
-            session_id = message.get("sessionId")
-            if isinstance(session_id, str):
-                await self._handle_paused_request(session_id, params)
-
-    async def _protect_initial_targets(self) -> None:
-        targets = await self._target_infos()
-        for target_info in targets:
-            try:
-                await self._attach_to_target(target_info)
-            except Exception:  # noqa: BLE001
-                logger.debug("Initial CDP target disappeared before attachment", exc_info=True)
-        await self._wait_for_configuration_tasks()
-        self._raise_if_failed()
-
-        current_targets = await self._target_infos()
-        for target_info in current_targets:
-            target_id = target_info.get("targetId")
-            if not isinstance(target_id, str) or target_id in self._protected_target_ids:
-                continue
-            try:
-                await self._attach_to_target(target_info)
-            except Exception:  # noqa: BLE001
-                logger.debug("CDP target could not be protected", exc_info=True)
-        await self._wait_for_configuration_tasks()
-        self._raise_if_failed()
-
-        unprotected = {
-            target_info["targetId"]
-            for target_info in current_targets
-            if isinstance(target_info.get("targetId"), str)
-            and target_info["targetId"] not in self._protected_target_ids
-        }
-        if not self._attached_sessions or unprotected:
-            raise RuntimeError("CDP URL guard did not protect every live browser target")
-
-    async def _target_infos(self) -> list[dict[str, Any]]:
-        targets = await self._send("Target.getTargets")
-        if not isinstance(targets, dict):
-            return []
-        return [
-            target_info
-            for target_info in targets.get("targetInfos", [])
-            if isinstance(target_info, dict)
-            and target_info.get("type") in {"page", "iframe", "webview"}
-        ]
-
-    async def _attach_to_target(self, target_info: dict[str, Any]) -> None:
-        target_type = target_info.get("type")
-        target_id = target_info.get("targetId")
-        url = target_info.get("url")
-        if isinstance(url, str):
-            _set_current_page_url(self._session, url)
-        if target_type not in {"page", "iframe", "webview"} or not isinstance(target_id, str):
-            return
-        result = await self._send(
-            "Target.attachToTarget",
-            {"targetId": target_id, "flatten": True},
-        )
-        session_id = result.get("sessionId") if isinstance(result, dict) else None
-        if isinstance(session_id, str):
-            await self._enable_fetch(session_id)
-            self._protected_target_ids.add(target_id)
-
-    async def _enable_fetch(self, session_id: str) -> None:
-        if session_id in self._attached_sessions:
-            return
-        task = self._fetch_tasks.get(session_id)
-        if task is None:
-            task = asyncio.create_task(self._enable_fetch_commands(session_id))
-            self._fetch_tasks[session_id] = task
-        try:
-            await asyncio.shield(task)
-        finally:
-            if task.done():
-                self._fetch_tasks.pop(session_id, None)
-
-    async def _enable_fetch_commands(self, session_id: str) -> None:
-        await self._send("Page.enable", session_id=session_id)
-        await self._send(
-            "Fetch.enable",
-            {"patterns": [{"urlPattern": "*"}]},
-            session_id=session_id,
-        )
-        self._attached_sessions.add(session_id)
-
-    def _schedule_target_configuration(
-        self,
-        session_id: str,
-        target_info: dict[str, Any],
-        *,
-        waiting_for_debugger: bool,
-    ) -> None:
-        task = asyncio.create_task(
-            self._configure_attached_target(
-                session_id,
-                target_info,
-                waiting_for_debugger=waiting_for_debugger,
-            )
-        )
-        self._configuration_tasks.add(task)
-        task.add_done_callback(self._configuration_finished)
-
-    async def _configure_attached_target(
-        self,
-        session_id: str,
-        target_info: dict[str, Any],
-        *,
-        waiting_for_debugger: bool,
-    ) -> None:
-        if target_info.get("type") in {"page", "iframe", "webview"}:
-            await self._enable_fetch(session_id)
-            target_id = target_info.get("targetId")
-            if isinstance(target_id, str):
-                self._protected_target_ids.add(target_id)
-        if waiting_for_debugger:
-            await self._send("Runtime.runIfWaitingForDebugger", session_id=session_id)
-
-    def _configuration_finished(self, task: asyncio.Task[None]) -> None:
-        self._configuration_tasks.discard(task)
-        if task.cancelled():
-            return
-        error = task.exception()
-        if error is not None:
-            self._failure = error
-
-    async def _wait_for_configuration_tasks(self) -> None:
-        while self._configuration_tasks:
-            await asyncio.gather(*tuple(self._configuration_tasks), return_exceptions=True)
-
-    def _raise_if_failed(self) -> None:
-        if self._failure is not None:
-            raise RuntimeError("CDP URL guard failed") from self._failure
-
-    def failure(self) -> BaseException | None:
-        if self._failure is not None:
-            return self._failure
-        if self._task is not None and self._task.done() and not self._task.cancelled():
-            return self._task.exception() or RuntimeError("CDP URL guard stopped")
-        return None
-
-    async def _handle_paused_request(self, session_id: str, params: dict[str, Any]) -> None:
-        request_id = params.get("requestId")
-        request = params.get("request")
-        url = request.get("url") if isinstance(request, dict) else None
-        if not isinstance(request_id, str) or not isinstance(url, str):
-            return
-        safe, reason = is_url_safe(url)
-        if safe:
-            await self._send_fire_and_forget(
-                "Fetch.continueRequest",
-                {"requestId": request_id},
-                session_id=session_id,
-            )
-            return
-        _mark_blocked_request(self._session, url, reason)
-        logger.warning("Blocked unsafe browser request to %s: %s", url, reason)
-        await self._send_fire_and_forget(
-            "Fetch.failRequest",
-            {"requestId": request_id, "errorReason": "Aborted"},
-            session_id=session_id,
-        )
-
-
-def _guard_targets(session: Any) -> list[Any]:
-    targets: list[Any] = []
-    for candidate in (
-        session,
-        _safe_attr(session, "page"),
-        _safe_attr(session, "context"),
-        _safe_attr(session, "browser_context"),
-        _safe_attr(_safe_attr(session, "data"), "page"),
-        _safe_attr(_safe_attr(session, "data"), "context"),
-        _safe_attr(_safe_attr(session, "data"), "browser_context"),
-    ):
-        if candidate is None or any(candidate is target for target in targets):
-            continue
-        targets.append(candidate)
-    return targets
-
-
-async def _install_browser_url_guard(session: Any) -> None:
-    installed = False
-    cdp_url = _cdp_url(session)
-    if cdp_url is not None and not _safe_attr(session, "_open_swe_cdp_guard"):
-        cdp_guard: _CDPBrowserURLGuard | None = None
-        try:
-            cdp_guard = _CDPBrowserURLGuard(session, cdp_url)
-            await cdp_guard.start()
-            session._open_swe_cdp_guard = cdp_guard
-            installed = True
-        except Exception:  # noqa: BLE001
-            if cdp_guard is not None:
-                await cdp_guard.close()
-            logger.warning("Failed to install CDP browser URL guard", exc_info=True)
-
-    async def guarded_route(route: Any, request: Any | None = None) -> None:
-        url = _request_url(route, request)
-        if not url:
-            await _continue_route(route)
-            return
-        safe, reason = is_url_safe(url)
-        if safe:
-            await _continue_route(route)
-            return
-        _mark_blocked_request(session, url, reason)
-        logger.warning("Blocked unsafe browser request to %s: %s", url, reason)
-        await _abort_route(route)
-
-    for target in _guard_targets(session):
-        if _safe_attr(target, "_open_swe_url_guard_installed"):
-            installed = True
-            continue
-        route = _callable_attr(target, "route")
-        if route is None:
-            continue
-        try:
-            await _maybe_await(route("**/*", guarded_route))
-            target._open_swe_url_guard_installed = True
-            installed = True
-        except Exception:  # noqa: BLE001
-            logger.debug("Failed to install browser URL guard on %r", target, exc_info=True)
-    if not installed:
-        raise BrowserNavigationBlocked(
-            "Stagehand session does not expose a working browser request hook for URL guarding"
-        )
-
-
-def _current_page_url(session: Any) -> str | None:
-    cdp_url = _safe_attr(session, "_open_swe_current_page_url")
-    if isinstance(cdp_url, str) and cdp_url and cdp_url != "about:blank":
-        return cdp_url
-    for target in _guard_targets(session):
-        url = _safe_attr(target, "url")
-        if isinstance(url, str) and url and url != "about:blank":
-            return url
-    return None
-
-
-async def _raise_if_browser_blocked(session: Any, operation: str) -> None:
-    cdp_guard = _safe_attr(session, "_open_swe_cdp_guard")
-    guard_failure = cdp_guard.failure() if isinstance(cdp_guard, _CDPBrowserURLGuard) else None
-    if guard_failure is not None:
-        await browser_close()
-        raise BrowserNavigationBlocked(f"{operation} blocked: browser URL guard failed")
-
-    blocked_error = _blocked_request_error(session)
-    if blocked_error:
-        await browser_close()
-        raise BrowserNavigationBlocked(f"{operation} blocked: {blocked_error}")
-
-    current_url = _current_page_url(session)
-    if not current_url:
-        return
-    safe, reason = is_url_safe(current_url)
-    if not safe:
-        await browser_close()
-        raise BrowserNavigationBlocked(f"{operation} blocked after navigation: {reason}")
-
-
-async def _prepare_browser_operation(session: Any, operation: str) -> None:
-    await _raise_if_browser_blocked(session, operation)
-    _clear_blocked_request(session)
-
-
-async def _get_session(create: bool = True) -> Any:
-    """Return the live Stagehand session for this thread, creating one if needed."""
-    thread_id = _thread_id()
-    async with _LOCK:
-        existing = _SESSIONS.get(thread_id)
-        if existing is not None:
-            return existing[1]
-        if not create:
-            return None
-        client = _build_client()
-        session_kwargs: dict[str, Any] = {"model_name": _model_name(), "browser": _browser_spec()}
-        browserbase_session_create_params = _browserbase_session_create_params()
-        if browserbase_session_create_params:
-            session_kwargs["browserbase_session_create_params"] = browserbase_session_create_params
-        session = await client.sessions.start(**session_kwargs)
-        try:
-            await _install_browser_url_guard(session)
-        except BaseException:
-            with contextlib.suppress(Exception):
-                await session.end()
-            with contextlib.suppress(Exception):
-                await client.close()
-            raise
-        _SESSIONS[thread_id] = (client, session)
-        logger.info("Started Stagehand session %s for thread %s", session.id, thread_id)
-        return session
-
-
-def _session_meta(session: Any) -> dict[str, Any]:
-    meta: dict[str, Any] = {"session_id": getattr(session, "id", None)}
-    if not _is_local() and meta.get("session_id"):
-        meta["replay_url"] = f"https://www.browserbase.com/sessions/{meta['session_id']}"
-    return meta
+        response = json.loads(result.output)
+    except json.JSONDecodeError:
+        return {"success": False, "error": f"browser_{operation} returned an invalid response"}
+    return (
+        response if isinstance(response, dict) else {"success": False, "error": "invalid response"}
+    )
 
 
 async def browser_navigate(url: str) -> dict[str, Any]:
-    """Open a browser (if not already open) and navigate to a URL.
-
-    Starts a fresh browser session on first use within this task and reuses it
-    for subsequent browser tool calls. Use this before ``browser_act``,
-    ``browser_observe``, or ``browser_extract``.
-
-    Args:
-        url: The absolute URL to load (e.g. ``https://example.com``).
-
-    Returns:
-        ``{success, url, session_id, ...}`` on success, or ``{success: False,
-        error}`` on failure.
-    """
-    try:
-        safe, reason = is_url_safe(url)
-        if not safe:
-            return {"success": False, "error": f"browser_navigate blocked: {reason}"}
-        session = await _get_session()
-        await _prepare_browser_operation(session, "browser_navigate")
-        await session.navigate(url=url)
-        await _raise_if_browser_blocked(session, "browser_navigate")
-        return {"success": True, "url": url, **_session_meta(session)}
-    except BrowserNavigationBlocked as e:
-        return {"success": False, "error": str(e)}
-    except Exception as e:  # noqa: BLE001
-        return {"success": False, "error": f"browser_navigate failed: {e!s}"}
+    """Open sandbox-local Chromium and navigate to a URL, including localhost."""
+    return await _request("navigate", url=url)
 
 
 async def browser_act(action: str) -> dict[str, Any]:
-    """Perform a single natural-language action on the current page.
-
-    Examples: "click the Sign in button", "type 'hello' into the search box",
-    "select 'United States' from the country dropdown". Keep each call to one
-    discrete action and verify the result before the next step.
-
-    Args:
-        action: A concise, specific instruction describing one action.
-
-    Returns:
-        ``{success, result}`` on success, or ``{success: False, error}``.
-    """
-    try:
-        session = await _get_session(create=False)
-        if session is None:
-            return {"success": False, "error": "No active browser. Call browser_navigate first."}
-        await _prepare_browser_operation(session, "browser_act")
-        result = await session.act(input=action)
-        await _raise_if_browser_blocked(session, "browser_act")
-        return {"success": True, "result": _unwrap_result(_to_jsonable(result))}
-    except BrowserNavigationBlocked as e:
-        return {"success": False, "error": str(e)}
-    except Exception as e:  # noqa: BLE001
-        return {"success": False, "error": f"browser_act failed: {e!s}"}
+    """Perform one natural-language action on the current page."""
+    return await _request("act", action=action)
 
 
 async def browser_observe(instruction: str) -> dict[str, Any]:
-    """List actionable elements on the current page matching an instruction.
-
-    Use this to discover what can be clicked/typed before calling
-    ``browser_act`` on an unfamiliar page.
-
-    Args:
-        instruction: What to look for, e.g. "find the login form fields".
-
-    Returns:
-        ``{success, observations}`` on success, or ``{success: False, error}``.
-    """
-    try:
-        session = await _get_session(create=False)
-        if session is None:
-            return {"success": False, "error": "No active browser. Call browser_navigate first."}
-        await _prepare_browser_operation(session, "browser_observe")
-        result = await session.observe(instruction=instruction)
-        await _raise_if_browser_blocked(session, "browser_observe")
-        return {"success": True, "observations": _unwrap_result(_to_jsonable(result))}
-    except BrowserNavigationBlocked as e:
-        return {"success": False, "error": str(e)}
-    except Exception as e:  # noqa: BLE001
-        return {"success": False, "error": f"browser_observe failed: {e!s}"}
+    """List actionable elements on the current page matching an instruction."""
+    return await _request("observe", instruction=instruction)
 
 
 async def browser_extract(instruction: str, schema: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Extract structured data from the current page.
-
-    Args:
-        instruction: What to extract, e.g. "the title and price of each product".
-        schema: Optional JSON Schema describing the desired shape of the result.
-            When omitted, Stagehand returns its best-effort structured guess.
-
-    Returns:
-        ``{success, data}`` on success, or ``{success: False, error}``.
-    """
-    try:
-        session = await _get_session(create=False)
-        if session is None:
-            return {"success": False, "error": "No active browser. Call browser_navigate first."}
-        await _prepare_browser_operation(session, "browser_extract")
-        if schema is not None:
-            result = await session.extract(instruction=instruction, schema=schema)
-        else:
-            result = await session.extract(instruction=instruction)
-        await _raise_if_browser_blocked(session, "browser_extract")
-        return {"success": True, "data": _unwrap_result(_to_jsonable(result))}
-    except BrowserNavigationBlocked as e:
-        return {"success": False, "error": str(e)}
-    except Exception as e:  # noqa: BLE001
-        return {"success": False, "error": f"browser_extract failed: {e!s}"}
+    """Extract structured data from the current page."""
+    return await _request("extract", instruction=instruction, schema=schema)
 
 
 async def browser_close() -> dict[str, Any]:
-    """Close the current browser session and release its resources.
-
-    Call this when finished with browser work. Safe to call even if no session
-    is open.
-    """
-    thread_id = _thread_id()
-    async with _LOCK:
-        entry = _SESSIONS.pop(thread_id, None)
-    if entry is None:
-        return {"success": True, "closed": False}
-    client, session = entry
-    cdp_guard = _safe_attr(session, "_open_swe_cdp_guard")
-    close_cdp_guard = _callable_attr(cdp_guard, "close") if cdp_guard is not None else None
-    if close_cdp_guard is not None:
-        await _maybe_await(close_cdp_guard())
-    try:
-        await session.end()
-    except Exception:  # noqa: BLE001
-        logger.warning("Failed to end Stagehand session cleanly", exc_info=True)
-    try:
-        await client.close()
-    except Exception:  # noqa: BLE001
-        logger.debug("Failed to close Stagehand client", exc_info=True)
-    return {"success": True, "closed": True}
-
-
-def _unwrap_result(value: Any) -> Any:
-    """Peel Stagehand's ``{data: {result: ...}}`` envelope down to the payload."""
-    cur = value
-    for _ in range(3):
-        if isinstance(cur, dict) and "result" in cur:
-            return cur["result"]
-        if isinstance(cur, dict) and isinstance(cur.get("data"), dict):
-            cur = cur["data"]
-            continue
-        break
-    return value
-
-
-def _to_jsonable(result: Any) -> Any:
-    """Best-effort conversion of Stagehand response models to plain data."""
-    for attr in ("model_dump", "dict", "to_dict"):
-        method = getattr(result, attr, None)
-        if callable(method):
-            try:
-                return method()
-            except Exception:  # noqa: BLE001
-                pass
-    data = getattr(result, "data", None)
-    if data is not None and data is not result:
-        return _to_jsonable(data)
-    return (
-        result
-        if isinstance(result, (dict, list, str, int, float, bool, type(None)))
-        else str(result)
-    )
+    """Close the sandbox-local browser session."""
+    return await _request("close")
 
 
 def load_browser_tools() -> list[Any]:
-    """Return the Stagehand browser tools, or [] when unconfigured."""
+    """Return sandbox-local Stagehand tools when securely configured."""
     if not browser_tools_enabled():
         return []
-    logger.info(
-        "Stagehand browser tools enabled (mode=%s, model=%s)",
-        "LOCAL" if _is_local() else "BROWSERBASE",
-        _model_name(),
-    )
-    return [
-        browser_navigate,
-        browser_act,
-        browser_observe,
-        browser_extract,
-        browser_close,
-    ]
+    logger.info("Sandbox-local Stagehand tools enabled (model=%s)", _model_name())
+    return [browser_navigate, browser_act, browser_observe, browser_extract, browser_close]

--- a/agent/integrations/stagehand_browser.py
+++ b/agent/integrations/stagehand_browser.py
@@ -23,7 +23,11 @@ def _model_name() -> str:
 
 
 def _model_api_key() -> str | None:
-    return os.getenv("STAGEHAND_MODEL_API_KEY")
+    return (
+        os.getenv("STAGEHAND_MODEL_API_KEY")
+        or os.getenv("MODEL_API_KEY")
+        or os.getenv("ANTHROPIC_API_KEY")
+    )
 
 
 def _headless() -> bool:
@@ -62,10 +66,14 @@ async def _request(operation: str, **payload: Any) -> dict[str, Any]:
     runtime = shlex.quote(_RUNTIME)
     socket = shlex.quote(_SOCKET)
     encoded = shlex.quote(request)
+    health = base64.urlsafe_b64encode(b'{"operation":"health"}').decode()
     command = (
-        f"if [ ! -S {socket} ]; then "
+        f"python {runtime} request {socket} {health} >/dev/null 2>&1 || {{ "
+        f"rm -f {socket}; "
         f"setsid python {runtime} serve {socket} >/tmp/open-swe-stagehand.log 2>&1 </dev/null & "
-        f"for i in $(seq 1 100); do [ -S {socket} ] && break; sleep .1; done; fi; "
+        f"for i in $(seq 1 100); do "
+        f"python {runtime} request {socket} {health} >/dev/null 2>&1 && break; sleep .1; "
+        f"done; }}; "
         f"python {runtime} request {socket} {encoded}"
     )
     result = await backend.aexecute(command, timeout=180)

--- a/agent/resources/stagehand_runtime.py
+++ b/agent/resources/stagehand_runtime.py
@@ -166,6 +166,8 @@ async def _session(request: dict[str, Any]) -> Any:
 
 async def _handle(request: dict[str, Any]) -> dict[str, Any]:
     operation = request.get("operation")
+    if operation == "health":
+        return {"success": True}
     if operation == "close":
         return {"success": True, "closed": await _close()}
     if operation == "navigate":

--- a/agent/resources/stagehand_runtime.py
+++ b/agent/resources/stagehand_runtime.py
@@ -1,0 +1,230 @@
+import asyncio
+import base64
+import contextlib
+import ipaddress
+import json
+import os
+import socket
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+from stagehand import AsyncStagehand
+
+_CLIENT: Any = None
+_SESSION: Any = None
+_PROXY: asyncio.Server | None = None
+_PROXY_PORT: int | None = None
+
+
+def _resolve(url: str) -> tuple[bool, str, str | None]:
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return False, "unsupported or invalid URL", None
+        addresses = socket.getaddrinfo(parsed.hostname, None)
+        resolved = []
+        for address in addresses:
+            ip = ipaddress.ip_address(address[4][0])
+            if not ip.is_loopback and not ip.is_global:
+                return False, f"URL resolves to blocked address: {ip}", None
+            resolved.append(str(ip))
+        return True, "", resolved[0]
+    except Exception as exc:
+        return False, str(exc), None
+
+
+def _safe(url: str) -> tuple[bool, str]:
+    safe, reason, _ = _resolve(url)
+    return safe, reason
+
+
+def _jsonable(value: Any) -> Any:
+    for name in ("model_dump", "dict", "to_dict"):
+        method = getattr(value, name, None)
+        if callable(method):
+            with contextlib.suppress(Exception):
+                return method()
+    data = getattr(value, "data", None)
+    if data is not None and data is not value:
+        return _jsonable(data)
+    return (
+        value if isinstance(value, (dict, list, str, int, float, bool, type(None))) else str(value)
+    )
+
+
+def _result(value: Any) -> Any:
+    value = _jsonable(value)
+    for _ in range(3):
+        if isinstance(value, dict) and "result" in value:
+            return value["result"]
+        if isinstance(value, dict) and isinstance(value.get("data"), dict):
+            value = value["data"]
+            continue
+        break
+    return value
+
+
+async def _proxy_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        request = await reader.readuntil(b"\r\n\r\n")
+        first = request.split(b"\r\n", 1)[0].decode()
+        method, target, _ = first.split(" ", 2)
+        parsed = urlparse(f"https://{target}" if method == "CONNECT" else target)
+        if parsed.scheme not in {"http", "https"}:
+            raise RuntimeError("unsupported proxy request")
+        safe, reason, resolved = _resolve(parsed.geturl())
+        if not safe or resolved is None:
+            raise RuntimeError(reason)
+        remote_reader, remote_writer = await asyncio.open_connection(
+            resolved, parsed.port or (443 if method == "CONNECT" else 80)
+        )
+        if method == "CONNECT":
+            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            await writer.drain()
+
+            async def pipe(source: asyncio.StreamReader, destination: asyncio.StreamWriter) -> None:
+                while chunk := await source.read(65536):
+                    destination.write(chunk)
+                    await destination.drain()
+
+            await asyncio.gather(pipe(reader, remote_writer), pipe(remote_reader, writer))
+        else:
+            path = parsed.path or "/"
+            if parsed.query:
+                path += f"?{parsed.query}"
+            lines = request.split(b"\r\n")
+            lines[0] = f"{method} {path} HTTP/1.1".encode()
+            remote_writer.write(b"\r\n".join(lines))
+            await remote_writer.drain()
+            while chunk := await remote_reader.read(65536):
+                writer.write(chunk)
+                await writer.drain()
+        remote_writer.close()
+        await remote_writer.wait_closed()
+    except Exception as exc:
+        writer.write(
+            f"HTTP/1.1 403 Forbidden\r\nContent-Length: {len(str(exc))}\r\n\r\n{exc}".encode()
+        )
+        await writer.drain()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def _proxy() -> int:
+    global _PROXY, _PROXY_PORT
+    if _PROXY is None:
+        _PROXY = await asyncio.start_server(_proxy_client, "127.0.0.1", 0)
+        _PROXY_PORT = _PROXY.sockets[0].getsockname()[1]
+    assert _PROXY_PORT is not None
+    return _PROXY_PORT
+
+
+async def _close() -> bool:
+    global _CLIENT, _SESSION, _PROXY, _PROXY_PORT
+    existed = _SESSION is not None
+    if _SESSION is not None:
+        with contextlib.suppress(Exception):
+            await _SESSION.end()
+    if _CLIENT is not None:
+        with contextlib.suppress(Exception):
+            await _CLIENT.close()
+    if _PROXY is not None:
+        _PROXY.close()
+        await _PROXY.wait_closed()
+    _CLIENT = _SESSION = _PROXY = None
+    _PROXY_PORT = None
+    return existed
+
+
+async def _session(request: dict[str, Any]) -> Any:
+    global _CLIENT, _SESSION
+    if _SESSION is None:
+        proxy_port = await _proxy()
+        _CLIENT = AsyncStagehand(
+            server="local",
+            model_api_key=os.environ.get("MODEL_API_KEY", "proxy-injected"),
+            local_headless=request.get("headless", True),
+            local_chrome_path=os.environ.get("STAGEHAND_LOCAL_CHROME_PATH", "/usr/bin/chromium"),
+        )
+        _SESSION = await _CLIENT.sessions.start(
+            model_name=request["model_name"],
+            browser={
+                "type": "local",
+                "launch_options": {
+                    "headless": request.get("headless", True),
+                    "executable_path": os.environ.get(
+                        "STAGEHAND_LOCAL_CHROME_PATH", "/usr/bin/chromium"
+                    ),
+                    "args": [f"--proxy-server=http://127.0.0.1:{proxy_port}"],
+                },
+            },
+        )
+    return _SESSION
+
+
+async def _handle(request: dict[str, Any]) -> dict[str, Any]:
+    operation = request.get("operation")
+    if operation == "close":
+        return {"success": True, "closed": await _close()}
+    if operation == "navigate":
+        url = request.get("url", "")
+        safe, reason = _safe(url)
+        if not safe:
+            return {"success": False, "error": f"browser_navigate blocked: {reason}"}
+        session = await _session(request)
+        await session.navigate(url=url)
+        return {"success": True, "url": url, "session_id": session.id}
+    if _SESSION is None:
+        return {"success": False, "error": "No active browser. Call browser_navigate first."}
+    if operation == "act":
+        value = await _SESSION.act(input=request["action"])
+        return {"success": True, "result": _result(value)}
+    if operation == "observe":
+        value = await _SESSION.observe(instruction=request["instruction"])
+        return {"success": True, "observations": _result(value)}
+    if operation == "extract":
+        kwargs = {"instruction": request["instruction"]}
+        if request.get("schema") is not None:
+            kwargs["schema"] = request["schema"]
+        value = await _SESSION.extract(**kwargs)
+        return {"success": True, "data": _result(value)}
+    return {"success": False, "error": "unknown browser operation"}
+
+
+async def _client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        request = json.loads((await reader.readline()).decode())
+        response = await _handle(request)
+    except Exception as exc:
+        response = {"success": False, "error": str(exc)}
+    writer.write(json.dumps(response).encode() + b"\n")
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+
+async def _serve(path: str) -> None:
+    with contextlib.suppress(FileNotFoundError):
+        os.unlink(path)
+    server = await asyncio.start_unix_server(_client, path)
+    os.chmod(path, 0o600)
+    async with server:
+        await server.serve_forever()
+
+
+async def _request(path: str, encoded: str) -> None:
+    reader, writer = await asyncio.open_unix_connection(path)
+    writer.write(base64.urlsafe_b64decode(encoded.encode()) + b"\n")
+    await writer.drain()
+    response = await reader.readline()
+    writer.close()
+    await writer.wait_closed()
+    print(response.decode().strip())
+
+
+if __name__ == "__main__":
+    asyncio.run(
+        _serve(sys.argv[2]) if sys.argv[1] == "serve" else _request(sys.argv[2], sys.argv[3])
+    )

--- a/agent/server.py
+++ b/agent/server.py
@@ -819,7 +819,7 @@ def _general_purpose_subagent(
 
 
 BROWSER_SUBAGENT_DESCRIPTION = (
-    "Drives a real browser (Stagehand, running locally or on Browserbase) to "
+    "Drives sandbox-local Chromium with Stagehand to "
     "accomplish tasks that require interacting with live web pages: logging "
     "into dashboards, clicking through flows, filling forms, reading "
     "JS-rendered content, reproducing UI bugs, and extracting structured data. "

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -296,22 +296,19 @@ else:
 return create_deep_agent(tools=tools, ...)
 ```
 
-### Browser automation (Stagehand + Browserbase)
+### Browser automation (Stagehand)
 
-A `browser` subagent drives a real Chromium via the [Stagehand](https://github.com/browserbase/stagehand-python) SDK, exposing `browser_navigate`, `browser_act`, `browser_observe`, `browser_extract`, and `browser_close`. The main agent delegates to it for tasks that need live interaction or JS-rendered pages (logging in, clicking flows, reproducing UI bugs, scraping structured data); static reads should still use `fetch_url`.
+A `browser` subagent drives Chromium inside the task sandbox via the [Stagehand](https://github.com/browserbase/stagehand-python) SDK, exposing `browser_navigate`, `browser_act`, `browser_observe`, `browser_extract`, and `browser_close`. Because the browser shares the sandbox network namespace, it can test development servers on `localhost`. Static reads should still use `fetch_url`.
 
-The tools are added in `agent/server.py` (gated by `load_browser_tools()`), and live in `agent/integrations/stagehand_browser.py`. One browser session is kept per agent thread and reused across calls. The tools are a no-op unless configured:
+The tools require a LangSmith sandbox and a supported model credential. The real credential remains outside the sandbox and is injected by the sandbox egress proxy; only a placeholder is visible to sandbox processes.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `STAGEHAND_ENV` | `LOCAL` | `LOCAL` runs a local Chromium in-process; `BROWSERBASE` runs the browser on Browserbase cloud. |
-| `STAGEHAND_MODEL_API_KEY` | falls back to `MODEL_API_KEY`, then `ANTHROPIC_API_KEY` | LLM key Stagehand uses for `act`/`observe`/`extract`. Required for `LOCAL`; optional for `BROWSERBASE` (the hosted Stagehand API ships with model support). |
-| `STAGEHAND_MODEL` | `anthropic/claude-sonnet-4-5` | Model Stagehand uses. |
-| `BROWSERBASE_API_KEY` / `BROWSERBASE_PROJECT_ID` | — | `BROWSERBASE_API_KEY` is required when `STAGEHAND_ENV=BROWSERBASE`; `BROWSERBASE_PROJECT_ID` is forwarded when set. |
-| `STAGEHAND_LOCAL_CHROME_PATH` | `/usr/bin/chromium` in Docker | Path to the Chrome/Chromium binary for `LOCAL` mode. |
-| `STAGEHAND_HEADLESS` | `true` | Run the local browser headless. |
+| `STAGEHAND_MODEL_API_KEY` | — | Model key used by Stagehand. |
+| `STAGEHAND_MODEL` | `anthropic/claude-sonnet-4-5` | Stagehand model; Anthropic and OpenAI are supported. |
+| `STAGEHAND_HEADLESS` | `true` | Run Chromium headless. |
 
-For `LOCAL` mode the sandbox image in `Dockerfile.sandbox` installs `chromium`; for `BROWSERBASE` mode no browser binary is needed in the image.
+The sandbox snapshot must be built from `Dockerfile.sandbox`, which installs Chromium, Stagehand, and the browser runtime.
 
 ---
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -304,7 +304,7 @@ The tools require a LangSmith sandbox and a supported model credential. The real
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `STAGEHAND_MODEL_API_KEY` | — | Model key used by Stagehand. |
+| `STAGEHAND_MODEL_API_KEY` | falls back to `MODEL_API_KEY`, then `ANTHROPIC_API_KEY` | Model key used by Stagehand. |
 | `STAGEHAND_MODEL` | `anthropic/claude-sonnet-4-5` | Stagehand model; Anthropic and OpenAI are supported. |
 | `STAGEHAND_HEADLESS` | `true` | Run Chromium headless. |
 

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -10,7 +10,12 @@ from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.runnables import RunnableConfig
 from langgraph.runtime import Runtime
 
-from agent.integrations.langsmith import PROXY_GH_TOKEN_PLACEHOLDER, _configure_github_proxy
+from agent.integrations.langsmith import (
+    PROXY_GH_TOKEN_PLACEHOLDER,
+    PROXY_MODEL_KEY_PLACEHOLDER,
+    _configure_github_proxy,
+    _stagehand_proxy_rules,
+)
 from agent.utils.sandbox_state import SandboxBackendProxy
 
 
@@ -66,6 +71,19 @@ class TestSandboxFactoryLoading:
             fs_capacity_bytes=128,
             create_params={"_internal_runtime": "v2"},
         )
+
+
+def test_stagehand_proxy_rule_keeps_model_key_opaque() -> None:
+    with patch.dict(
+        "os.environ",
+        {"STAGEHAND_MODEL": "anthropic/claude-sonnet-4-5", "STAGEHAND_MODEL_API_KEY": "secret"},
+        clear=True,
+    ):
+        rule = _stagehand_proxy_rules()[0]
+
+    assert rule["headers"] == [{"name": "x-api-key", "type": "opaque", "value": "secret"}]
+    assert rule["env_vars"] == {"MODEL_API_KEY": PROXY_MODEL_KEY_PLACEHOLDER}
+    assert "secret" not in rule["env_vars"].values()
 
 
 class TestConfigureGithubProxy:

--- a/tests/tools/test_stagehand_browser.py
+++ b/tests/tools/test_stagehand_browser.py
@@ -37,6 +37,8 @@ async def test_browser_navigate_runs_in_thread_sandbox(monkeypatch: pytest.Monke
     request = json.loads(base64.urlsafe_b64decode(encoded).decode())
     assert result["success"] is True
     assert request["url"] == "http://localhost:3000"
+    assert "eyJvcGVyYXRpb24iOiJoZWFsdGgifQ==" in backend.command
+    assert "rm -f /tmp/open-swe-stagehand.sock" in backend.command
     assert "setsid python /opt/open-swe/stagehand_runtime.py serve" in backend.command
 
 
@@ -44,7 +46,8 @@ def test_browser_tools_require_secure_supported_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SANDBOX_TYPE", "langsmith")
-    monkeypatch.setenv("STAGEHAND_MODEL_API_KEY", "secret")
+    monkeypatch.delenv("STAGEHAND_MODEL_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
     monkeypatch.setenv("STAGEHAND_MODEL", "anthropic/claude-sonnet-4-5")
     assert stagehand_browser.browser_tools_enabled() is True
 

--- a/tests/tools/test_stagehand_browser.py
+++ b/tests/tools/test_stagehand_browser.py
@@ -1,473 +1,52 @@
-import asyncio
+import base64
 import json
-from collections.abc import Awaitable, Callable
 
 import pytest
 
 from agent.integrations import stagehand_browser
 
 
-@pytest.fixture(autouse=True)
-def clear_stagehand_sessions() -> None:
-    stagehand_browser._SESSIONS.clear()
+class Result:
+    exit_code = 0
+
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+
+class Backend:
+    command = ""
+
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> Result:
+        self.command = command
+        return Result('{"success":true,"url":"http://localhost:3000"}')
 
 
 @pytest.mark.asyncio
-async def test_browser_navigate_blocks_internal_urls(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fail_get_session(*_args: object, **_kwargs: object) -> object:
-        raise AssertionError("browser session should not start for blocked URLs")
+async def test_browser_navigate_runs_in_thread_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = Backend()
 
-    monkeypatch.setattr(stagehand_browser, "_get_session", fail_get_session)
+    async def get_backend(_thread_id: str) -> Backend:
+        return backend
 
-    result = await stagehand_browser.browser_navigate("http://127.0.0.1:8000")
+    monkeypatch.setattr(stagehand_browser, "get_sandbox_backend", get_backend)
+    monkeypatch.setattr(stagehand_browser, "_thread_id", lambda: "thread-1")
 
-    assert result["success"] is False
-    assert "blocked" in result["error"]
+    result = await stagehand_browser.browser_navigate("http://localhost:3000")
 
-
-def test_session_meta_does_not_return_cdp_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    class Data:
-        cdp_url = "wss://connect.browserbase.com/?signingKey=secret"
-
-    class Session:
-        id = "session-123"
-        data = Data()
-
-    monkeypatch.setattr(stagehand_browser, "_is_local", lambda: False)
-
-    assert stagehand_browser._session_meta(Session()) == {
-        "session_id": "session-123",
-        "replay_url": "https://www.browserbase.com/sessions/session-123",
-    }
+    encoded = backend.command.rsplit(" ", 1)[-1]
+    request = json.loads(base64.urlsafe_b64decode(encoded).decode())
+    assert result["success"] is True
+    assert request["url"] == "http://localhost:3000"
+    assert "setsid python /opt/open-swe/stagehand_runtime.py serve" in backend.command
 
 
-def test_browserbase_project_id_is_forwarded_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(stagehand_browser, "_is_local", lambda: False)
-    monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "project-123")
-
-    assert stagehand_browser._browserbase_session_create_params() == {"project_id": "project-123"}
-
-
-class FakeRequest:
-    def __init__(self, url: str) -> None:
-        self.url = url
-
-
-class FakeRoute:
-    def __init__(self, url: str) -> None:
-        self.request = FakeRequest(url)
-        self.aborted = False
-        self.continued = False
-
-    async def abort(self) -> None:
-        self.aborted = True
-
-    async def continue_(self) -> None:
-        self.continued = True
-
-
-class FakePage:
-    def __init__(self) -> None:
-        self.url = "about:blank"
-        self.handler: Callable[[FakeRoute, FakeRequest], Awaitable[None]] | None = None
-
-    async def route(
-        self, pattern: str, handler: Callable[[FakeRoute, FakeRequest], Awaitable[None]]
-    ) -> None:
-        self.pattern = pattern
-        self.handler = handler
-
-    async def request(self, url: str) -> FakeRoute:
-        assert self.handler is not None
-        route = FakeRoute(url)
-        await self.handler(route, route.request)
-        return route
-
-
-class FakeData:
-    cdp_url: str | None = None
-
-
-class FakeSession:
-    id = "session-123"
-    _open_swe_cdp_guard: stagehand_browser._CDPBrowserURLGuard
-
-    def __init__(self) -> None:
-        self.data = FakeData()
-        self.page = FakePage()
-        self.ended = False
-
-    async def navigate(self, url: str) -> None:
-        self.page.url = url
-
-    async def act(self, input: str) -> dict[str, object]:
-        self.page.url = input
-        return {"result": "ok"}
-
-    async def observe(self, instruction: str) -> dict[str, object]:
-        return {"result": instruction}
-
-    async def extract(
-        self, instruction: str, schema: dict[str, object] | None = None
-    ) -> dict[str, object]:
-        return {"result": {"instruction": instruction, "schema": schema}}
-
-    async def end(self) -> None:
-        self.ended = True
-
-
-class FakeCDPWebSocket:
-    def __init__(self) -> None:
-        self.sent: list[dict[str, object]] = []
-        self.incoming: asyncio.Queue[str | None] = asyncio.Queue()
-        self.responses: dict[str, dict[str, object]] = {}
-        self.response_sequences: dict[str, list[dict[str, object]]] = {}
-        self.method_errors: dict[str, dict[str, object]] = {}
-        self.target_errors: dict[str, dict[str, object]] = {}
-        self.target_responses: dict[str, dict[str, object]] = {}
-        self.held_methods: set[str] = set()
-        self.closed = False
-
-    def __aiter__(self) -> "FakeCDPWebSocket":
-        return self
-
-    async def __anext__(self) -> str:
-        message = await self.incoming.get()
-        if message is None:
-            raise StopAsyncIteration
-        return message
-
-    async def send(self, message: str) -> None:
-        parsed = json.loads(message)
-        self.sent.append(parsed)
-        method = parsed.get("method")
-        if isinstance(method, str) and method in self.held_methods:
-            return
-        await self.respond(parsed)
-
-    async def respond(self, parsed: dict[str, object]) -> None:
-        method = parsed.get("method")
-        message_id = parsed.get("id")
-        if not isinstance(message_id, int):
-            return
-        if isinstance(method, str) and method in self.method_errors:
-            await self.incoming.put(
-                json.dumps({"id": message_id, "error": self.method_errors[method]})
-            )
-            return
-        params = parsed.get("params")
-        target_id = params.get("targetId") if isinstance(params, dict) else None
-        if method == "Target.attachToTarget" and isinstance(target_id, str):
-            error = self.target_errors.get(target_id)
-            if error is not None:
-                await self.incoming.put(json.dumps({"id": message_id, "error": error}))
-                return
-            result = self.target_responses.get(
-                target_id, self.responses.get("Target.attachToTarget", {})
-            )
-        elif isinstance(method, str) and self.response_sequences.get(method):
-            result = self.response_sequences[method].pop(0)
-        else:
-            result = self.responses.get(method, {}) if isinstance(method, str) else {}
-        await self.incoming.put(json.dumps({"id": message_id, "result": result}))
-
-    async def respond_to_method(self, method: str) -> None:
-        for message in self.sent:
-            if message.get("method") == method:
-                await self.respond(message)
-                return
-        raise AssertionError(f"No CDP message sent for {method}")
-
-    async def close(self) -> None:
-        self.closed = True
-        await self.incoming.put(None)
-
-    async def emit(self, message: dict[str, object]) -> None:
-        await self.incoming.put(json.dumps(message))
-
-
-@pytest.mark.asyncio
-async def test_browser_url_guard_aborts_internal_browser_requests() -> None:
-    session = FakeSession()
-    await stagehand_browser._install_browser_url_guard(session)
-
-    route = await session.page.request("http://169.254.169.254/latest/meta-data/")
-
-    assert route.aborted is True
-    assert route.continued is False
-    assert stagehand_browser._blocked_request_error(session) is not None
-
-
-@pytest.mark.asyncio
-async def test_cdp_browser_url_guard_blocks_real_stagehand_requests(
+def test_browser_tools_require_secure_supported_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    session = FakeSession()
-    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
-    del session.page
-    websocket = FakeCDPWebSocket()
-    websocket.responses["Target.getTargets"] = {
-        "targetInfos": [
-            {
-                "targetId": "initial-target",
-                "type": "page",
-                "url": "about:blank",
-            }
-        ]
-    }
-    websocket.target_responses["initial-target"] = {"sessionId": "cdp-session-initial"}
+    monkeypatch.setenv("SANDBOX_TYPE", "langsmith")
+    monkeypatch.setenv("STAGEHAND_MODEL_API_KEY", "secret")
+    monkeypatch.setenv("STAGEHAND_MODEL", "anthropic/claude-sonnet-4-5")
+    assert stagehand_browser.browser_tools_enabled() is True
 
-    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
-        return websocket
-
-    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
-
-    await stagehand_browser._install_browser_url_guard(session)
-    await websocket.emit(
-        {
-            "method": "Target.attachedToTarget",
-            "params": {
-                "sessionId": "cdp-session-1",
-                "targetInfo": {
-                    "targetId": "new-target",
-                    "type": "page",
-                    "url": "https://example.com/",
-                },
-                "waitingForDebugger": True,
-            },
-        }
-    )
-    for _ in range(100):
-        if "cdp-session-1" in session._open_swe_cdp_guard._attached_sessions:
-            break
-        await asyncio.sleep(0.01)
-    await websocket.emit(
-        {
-            "method": "Fetch.requestPaused",
-            "sessionId": "cdp-session-1",
-            "params": {
-                "requestId": "request-1",
-                "request": {"url": "http://169.254.169.254/latest/meta-data/"},
-            },
-        }
-    )
-    await asyncio.sleep(0)
-
-    assert stagehand_browser._blocked_request_error(session) is not None
-    assert any(message["method"] == "Fetch.enable" for message in websocket.sent)
-    assert any(message["method"] == "Fetch.failRequest" for message in websocket.sent)
-
-    await session._open_swe_cdp_guard.close()
-
-
-@pytest.mark.asyncio
-async def test_cdp_browser_url_guard_waits_for_initial_fetch_enable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = FakeSession()
-    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
-    del session.page
-    websocket = FakeCDPWebSocket()
-    websocket.responses["Target.getTargets"] = {
-        "targetInfos": [
-            {
-                "targetId": "target-1",
-                "type": "page",
-                "url": "about:blank",
-            }
-        ]
-    }
-    websocket.responses["Target.attachToTarget"] = {"sessionId": "cdp-session-1"}
-    websocket.held_methods.add("Fetch.enable")
-
-    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
-        return websocket
-
-    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
-
-    install_task = asyncio.create_task(stagehand_browser._install_browser_url_guard(session))
-    for _ in range(100):
-        if any(message["method"] == "Fetch.enable" for message in websocket.sent):
-            break
-        await asyncio.sleep(0.01)
-
-    assert install_task.done() is False
-    assert any(message["method"] == "Fetch.enable" for message in websocket.sent)
-
-    websocket.held_methods.remove("Fetch.enable")
-    await websocket.respond_to_method("Fetch.enable")
-    await install_task
-
-    assert "cdp-session-1" in session._open_swe_cdp_guard._attached_sessions
-
-    await session._open_swe_cdp_guard.close()
-
-
-@pytest.mark.asyncio
-async def test_cdp_browser_url_guard_ignores_stale_initial_target(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = FakeSession()
-    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
-    del session.page
-    websocket = FakeCDPWebSocket()
-    stale_target = {"targetId": "stale-target", "type": "page", "url": "about:blank"}
-    live_target = {"targetId": "live-target", "type": "page", "url": "about:blank"}
-    websocket.response_sequences["Target.getTargets"] = [
-        {"targetInfos": [stale_target, live_target]},
-        {"targetInfos": [live_target]},
-    ]
-    websocket.target_errors["stale-target"] = {
-        "code": -32602,
-        "message": "No target with given id found",
-    }
-    websocket.target_responses["live-target"] = {"sessionId": "cdp-session-live"}
-
-    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
-        return websocket
-
-    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
-
-    await stagehand_browser._install_browser_url_guard(session)
-
-    guard = session._open_swe_cdp_guard
-    assert guard._protected_target_ids == {"live-target"}
-    assert "cdp-session-live" in guard._attached_sessions
-    assert any(
-        message["method"] == "Target.setAutoAttach"
-        and isinstance((params := message.get("params")), dict)
-        and params.get("waitForDebuggerOnStart") is True
-        for message in websocket.sent
-    )
-
-    await guard.close()
-
-
-@pytest.mark.asyncio
-async def test_get_session_fails_closed_when_fetch_interception_cannot_start(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = FakeSession()
-    session.data.cdp_url = "ws://browser.example/devtools/browser/session-123"
-    del session.page
-    websocket = FakeCDPWebSocket()
-    live_target = {"targetId": "live-target", "type": "page", "url": "about:blank"}
-    websocket.responses["Target.getTargets"] = {"targetInfos": [live_target]}
-    websocket.target_responses["live-target"] = {"sessionId": "cdp-session-live"}
-    websocket.method_errors["Fetch.enable"] = {
-        "code": -32000,
-        "message": "Fetch interception unavailable",
-    }
-
-    class FakeSessions:
-        async def start(self, **_kwargs: object) -> FakeSession:
-            return session
-
-    class FakeClient:
-        def __init__(self) -> None:
-            self.sessions = FakeSessions()
-            self.closed = False
-
-        async def close(self) -> None:
-            self.closed = True
-
-    client = FakeClient()
-
-    async def connect_cdp_websocket(_cdp_url: str) -> FakeCDPWebSocket:
-        return websocket
-
-    monkeypatch.setattr(stagehand_browser, "_connect_cdp_websocket", connect_cdp_websocket)
-    monkeypatch.setattr(stagehand_browser, "_build_client", lambda: client)
-
-    with pytest.raises(stagehand_browser.BrowserNavigationBlocked):
-        await stagehand_browser._get_session()
-
-    assert session.ended is True
-    assert client.closed is True
-    assert websocket.closed is True
-    assert stagehand_browser._SESSIONS == {}
-
-
-@pytest.mark.asyncio
-async def test_browser_url_guard_allows_public_browser_requests(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(stagehand_browser, "is_url_safe", lambda _url: (True, ""))
-    session = FakeSession()
-    await stagehand_browser._install_browser_url_guard(session)
-
-    route = await session.page.request("https://example.com/")
-
-    assert route.continued is True
-    assert route.aborted is False
-    assert stagehand_browser._blocked_request_error(session) is None
-
-
-@pytest.mark.asyncio
-async def test_browser_navigate_reports_blocked_redirect_request(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = FakeSession()
-    await stagehand_browser._install_browser_url_guard(session)
-
-    async def get_session(*_args: object, **_kwargs: object) -> FakeSession:
-        return session
-
-    async def navigate_with_redirect(url: str) -> None:
-        session.page.url = url
-        await session.page.request("http://169.254.169.254/latest/meta-data/")
-
-    def fake_is_url_safe(url: str) -> tuple[bool, str]:
-        if "169.254.169.254" in url:
-            return False, "metadata endpoint"
-        return True, ""
-
-    monkeypatch.setattr(stagehand_browser, "_get_session", get_session)
-    monkeypatch.setattr(stagehand_browser, "is_url_safe", fake_is_url_safe)
-    monkeypatch.setattr(session, "navigate", navigate_with_redirect)
-    stagehand_browser._SESSIONS["default"] = (object(), session)
-
-    result = await stagehand_browser.browser_navigate("https://example.com/")
-
-    assert result["success"] is False
-    assert "169.254.169.254" in result["error"]
-    assert session.ended is True
-
-
-@pytest.mark.asyncio
-async def test_browser_act_reports_unsafe_final_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    session = FakeSession()
-
-    async def get_session(*_args: object, **_kwargs: object) -> FakeSession:
-        return session
-
-    monkeypatch.setattr(stagehand_browser, "_get_session", get_session)
-    stagehand_browser._SESSIONS["default"] = (object(), session)
-
-    result = await stagehand_browser.browser_act("http://169.254.169.254/latest/meta-data/")
-
-    assert result["success"] is False
-    assert "blocked after navigation" in result["error"]
-    assert session.ended is True
-
-
-@pytest.mark.asyncio
-async def test_browser_act_fails_on_existing_blocked_background_request(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = FakeSession()
-    stagehand_browser._mark_blocked_request(
-        session, "http://169.254.169.254/latest/meta-data/", "metadata endpoint"
-    )
-
-    async def get_session(*_args: object, **_kwargs: object) -> FakeSession:
-        return session
-
-    monkeypatch.setattr(stagehand_browser, "_get_session", get_session)
-    stagehand_browser._SESSIONS["default"] = (object(), session)
-
-    result = await stagehand_browser.browser_act("click continue")
-
-    assert result["success"] is False
-    assert "blocked browser request" in result["error"]
-    assert session.ended is True
+    monkeypatch.setenv("SANDBOX_TYPE", "local")
+    assert stagehand_browser.browser_tools_enabled() is False


### PR DESCRIPTION
## Description
Run Stagehand and Chromium inside each task sandbox so browser tools can reach localhost dev servers. Remove the cloud execution path and keep model credentials behind opaque proxy injection.

## Release Note
Browser automation now runs locally in the task sandbox and supports localhost.

## Test Plan
- [x] Verify browser RPC routing and opaque model credential injection

Made by [Open SWE](https://openswe.vercel.app/agents/d007c164-9ace-5502-8673-f53a0d0b2cb7)