### PR TITLE
fix: prevent stale Slack thread replies

### DIFF
--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -488,6 +488,8 @@ def _scheduled_prompt(record: dict[str, Any], slack_thread: dict[str, Any] | Non
     if slack_thread:
         return (
             f"{prompt}\n\n"
+            "The connected Slack thread version is 0. Pass `thread_version=0` to "
+            "`slack_thread_reply`. "
             "Use `slack_thread_reply` for clarifying questions, essential progress updates, "
             "the pull request link, and the final outcome in the connected Slack thread."
         )
@@ -668,6 +670,7 @@ async def _launch_agent_schedule_record(
         slack_thread = {
             "channel_id": slack_channel_id,
             "thread_ts": message_ts,
+            "thread_version": 0,
             "triggering_event_ts": message_ts,
             "triggering_user_id": await slack_id_for_login(
                 record.get("created_by") if isinstance(record.get("created_by"), str) else None

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -156,7 +156,7 @@ DASHBOARD_SOURCE_GUIDANCE = """This run is being handled in the dashboard/Web UI
 
 SLACK_SOURCE_GUIDANCE = """This run was triggered from Slack.
 - Immediately send a brief first reply that rephrases your understanding of the request. Make `slack_thread_reply` your first tool call before investigation; never use only a generic acknowledgement such as `On it!`.
-- `slack_thread_reply` is the canonical user-facing output. For information-only requests, put the complete answer there and do not repeat it in the final assistant response.
+- `slack_thread_reply` is the canonical user-facing output. Pass the current Slack thread version shown in context; if the post reports a version mismatch, re-read the thread and retry with the returned version. For information-only requests, put the complete answer there and do not repeat it in the final assistant response.
 - Keep every `slack_thread_reply` as concise as possible: default to one sentence with only the outcome/status and link, or one blocking question. Omit greetings, preambles, headings, recaps, implementation details, and redundant context; use bullets only when multiple items are essential.
 - Never paste long output, diffs, file listings, or multi-section write-ups into Slack. Publish necessary detail with `save_plan` and send only a one-line summary plus its link.
 - For follow-ups that require action, use `slack_add_reaction` instead of a perfunctory status reply, then follow up with the outcome. A reaction commits you to taking action: never react to a message you will handle with `no_op`. Never use `white_check_mark`, because teams use it to indicate that a pull request is approved.

--- a/agent/tools/slack_add_reaction.py
+++ b/agent/tools/slack_add_reaction.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 from langgraph.config import get_config
-from langgraph_sdk import get_client
 
-from ..utils.slack import LANGGRAPH_URL, add_slack_reaction, get_active_slack_thread
+from ..utils.slack import add_slack_reaction, get_active_slack_thread
+from ..utils.thread_ops import langgraph_client
 
 
 async def slack_add_reaction(
@@ -25,7 +25,7 @@ async def slack_add_reaction(
     slack_thread = configurable.get("slack_thread", {})
     thread_id = configurable.get("thread_id")
     active = await get_active_slack_thread(
-        get_client(url=LANGGRAPH_URL),
+        langgraph_client(),
         thread_id if isinstance(thread_id, str) else None,
         slack_thread if isinstance(slack_thread, dict) else None,
     )

--- a/agent/tools/slack_move_thread.py
+++ b/agent/tools/slack_move_thread.py
@@ -1,10 +1,8 @@
-import os
 import re
 from collections.abc import Mapping
 from typing import Any
 
 from langgraph.config import get_config
-from langgraph_sdk import get_client
 
 from ..utils.dashboard_links import dashboard_thread_url
 from ..utils.slack import (
@@ -16,10 +14,8 @@ from ..utils.slack import (
     post_slack_top_level_message_with_ts,
     store_slack_run_mapping,
 )
+from ..utils.thread_ops import langgraph_client
 
-LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
-    "LANGGRAPH_URL_PROD", "http://localhost:2024"
-)
 _MESSAGE_MAX_CHARS = 2800
 _CHANNEL_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,100}$")
 
@@ -97,7 +93,7 @@ async def slack_move_thread(
             "actual_chars": len(clean_message),
         }
 
-    client = get_client(url=LANGGRAPH_URL)
+    client = langgraph_client()
     active = await get_active_slack_thread(client, thread_id, configured_slack)
     if not active:
         return {"success": False, "error": "Current Slack location is unavailable"}

--- a/agent/tools/slack_move_thread.py
+++ b/agent/tools/slack_move_thread.py
@@ -40,6 +40,7 @@ def _new_slack_context(
     return {
         "channel_id": channel_id,
         "thread_ts": thread_ts,
+        "thread_version": 0,
         "triggering_user_id": current.get("triggering_user_id", ""),
         "triggering_user_name": current.get("triggering_user_name", ""),
         "triggering_user_email": current.get("triggering_user_email", ""),

--- a/agent/tools/slack_read_thread_messages.py
+++ b/agent/tools/slack_read_thread_messages.py
@@ -1,7 +1,4 @@
-import os
 from typing import Any
-
-from langgraph_sdk import get_client
 
 from ..utils.slack import (
     SLACK_THREAD_MAX_MESSAGES,
@@ -10,10 +7,7 @@ from ..utils.slack import (
     get_slack_thread_version,
     get_slack_user_names,
 )
-
-LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
-    "LANGGRAPH_URL_PROD", "http://localhost:2024"
-)
+from ..utils.thread_ops import langgraph_client
 
 
 async def _fetch_and_format(channel_id: str, message_ts: str) -> dict[str, Any]:
@@ -71,6 +65,6 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
         }
 
     result["thread_version"] = await get_slack_thread_version(
-        get_client(url=LANGGRAPH_URL), clean_channel_id, clean_message_ts
+        langgraph_client(), clean_channel_id, clean_message_ts
     )
     return result

--- a/agent/tools/slack_read_thread_messages.py
+++ b/agent/tools/slack_read_thread_messages.py
@@ -56,6 +56,9 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
 
     clean_channel_id = channel_id.strip()
     clean_message_ts = message_ts.strip()
+    thread_version = await get_slack_thread_version(
+        langgraph_client(), clean_channel_id, clean_message_ts
+    )
     result = await _fetch_and_format(clean_channel_id, clean_message_ts)
     if not result.get("success"):
         return {
@@ -64,7 +67,5 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
             "that channel, or the message may have been deleted.",
         }
 
-    result["thread_version"] = await get_slack_thread_version(
-        langgraph_client(), clean_channel_id, clean_message_ts
-    )
+    result["thread_version"] = thread_version
     return result

--- a/agent/tools/slack_read_thread_messages.py
+++ b/agent/tools/slack_read_thread_messages.py
@@ -1,10 +1,18 @@
+import os
 from typing import Any
+
+from langgraph_sdk import get_client
 
 from ..utils.slack import (
     SLACK_THREAD_MAX_MESSAGES,
     fetch_slack_thread_messages,
     format_slack_messages_for_prompt,
+    get_slack_thread_version,
     get_slack_user_names,
+)
+
+LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
+    "LANGGRAPH_URL_PROD", "http://localhost:2024"
 )
 
 
@@ -45,13 +53,16 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
     you can extract the channel_id (C0AME1J0) and convert the timestamp
     by inserting a dot 6 digits from the end (1776281321.762829).
 
-    Returns formatted thread messages with author names and forwarded-message context."""
+    Returns formatted thread messages with author names, forwarded-message context,
+    and the current `thread_version` required by `slack_thread_reply`."""
     if not channel_id or not channel_id.strip():
         return {"success": False, "error": "channel_id is required"}
     if not message_ts or not message_ts.strip():
         return {"success": False, "error": "message_ts is required"}
 
-    result = await _fetch_and_format(channel_id.strip(), message_ts.strip())
+    clean_channel_id = channel_id.strip()
+    clean_message_ts = message_ts.strip()
+    result = await _fetch_and_format(clean_channel_id, clean_message_ts)
     if not result.get("success"):
         return {
             "success": False,
@@ -59,4 +70,7 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
             "that channel, or the message may have been deleted.",
         }
 
+    result["thread_version"] = await get_slack_thread_version(
+        get_client(url=LANGGRAPH_URL), clean_channel_id, clean_message_ts
+    )
     return result

--- a/agent/tools/slack_start_new_thread.py
+++ b/agent/tools/slack_start_new_thread.py
@@ -1,12 +1,10 @@
 import asyncio
-import os
 import re
 import uuid
 from typing import Any
 
 from fastapi import HTTPException
 from langgraph.config import get_config
-from langgraph_sdk import get_client
 
 from ..dashboard.repo_access import require_repo_access_for_user
 from ..dispatch import dispatch_agent_run
@@ -19,11 +17,8 @@ from ..utils.slack import (
     post_slack_top_level_message_with_ts,
     store_slack_run_mapping,
 )
+from ..utils.thread_ops import langgraph_client
 from ..webhooks.common import _is_repo_allowed
-
-LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
-    "LANGGRAPH_URL_PROD", "http://localhost:2024"
-)
 
 _TITLE_MAX_CHARS = 160
 _INSTRUCTIONS_MAX_CHARS = 12000
@@ -175,7 +170,7 @@ async def slack_start_new_thread(
     configured_slack_thread = configurable.get("slack_thread")
     if not isinstance(configured_slack_thread, dict):
         return {"success": False, "error": "Missing slack_thread config"}
-    client = get_client(url=LANGGRAPH_URL)
+    client = langgraph_client()
     thread_id_value = configurable.get("thread_id")
     current_slack_thread = await get_active_slack_thread(
         client,

--- a/agent/tools/slack_start_new_thread.py
+++ b/agent/tools/slack_start_new_thread.py
@@ -139,7 +139,8 @@ async def _run_prompt(
         "Use this repository unless the instructions below clearly identify a different repository.\n\n"
         "## Source Slack Thread\n"
         f"- Channel: {channel_id}\n"
-        f"- Thread TS: {thread_ts}\n\n"
+        f"- Thread TS: {thread_ts}\n"
+        "- Thread version: 0\n\n"
         f"{await _run_links_section(thread_id)}\n\n"
         "## Breakout Instructions\n"
         f"{instructions}"
@@ -155,6 +156,7 @@ def _new_slack_thread_context(
     return {
         "channel_id": channel_id,
         "thread_ts": thread_ts,
+        "thread_version": 0,
         "triggering_user_id": original.get("triggering_user_id", ""),
         "triggering_user_name": original.get("triggering_user_name", ""),
         "triggering_user_email": original.get("triggering_user_email", ""),

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -110,7 +110,7 @@ async def slack_thread_reply(
             "message_chars": len(message),
             "hint": _slack_reply_failure_hint(slack_error),
         }
-    return {"success": True}
+    return {"success": True, "thread_version": current_version}
 
 
 def _current_run_id(config: Mapping[str, Any]) -> str | None:

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -1,11 +1,9 @@
 import json
-import os
 from collections.abc import Mapping
 from typing import Annotated, Any
 
 from langgraph.config import get_config
 from langgraph.prebuilt import InjectedState
-from langgraph_sdk import get_client
 
 from ..utils.run_usage import RunUsageSummary, summarize_run_usage
 from ..utils.slack import (
@@ -15,10 +13,7 @@ from ..utils.slack import (
     post_slack_thread_reply_with_ts,
     store_slack_message_run_mapping,
 )
-
-LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
-    "LANGGRAPH_URL_PROD", "http://localhost:2024"
-)
+from ..utils.thread_ops import langgraph_client as get_langgraph_client
 
 
 async def slack_thread_reply(
@@ -62,9 +57,9 @@ async def slack_thread_reply(
     run_id = _current_run_id(config)
     slack_thread = configurable.get("slack_thread", {})
     thread_id = configurable.get("thread_id")
-    langgraph_client = get_client(url=LANGGRAPH_URL)
+    client = get_langgraph_client()
     active = await get_active_slack_thread(
-        langgraph_client,
+        client,
         thread_id if isinstance(thread_id, str) else None,
         slack_thread if isinstance(slack_thread, dict) else None,
     )
@@ -81,7 +76,7 @@ async def slack_thread_reply(
     if not message.strip():
         return {"success": False, "error": "Message cannot be empty"}
 
-    current_version = await get_slack_thread_version(langgraph_client, channel_id, thread_ts)
+    current_version = await get_slack_thread_version(client, channel_id, thread_ts)
     if thread_version != current_version:
         return {
             "success": False,
@@ -101,7 +96,7 @@ async def slack_thread_reply(
         blocks=slack_blocks,
         usage=usage,
         agent_thread_id=thread_id if isinstance(thread_id, str) else None,
-        langgraph_client=langgraph_client,
+        langgraph_client=client,
         run_id=run_id,
         triggering_user_id=_triggering_user_id(configurable),
     )
@@ -239,7 +234,7 @@ async def _post_and_store_mapping(
         agent_thread_id=agent_thread_id,
     )
     if message_ts:
-        resolved_client = langgraph_client or get_client(url=LANGGRAPH_URL)
+        resolved_client = langgraph_client or get_langgraph_client()
         await store_slack_message_run_mapping(
             resolved_client,
             channel_id,

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -11,6 +11,7 @@ from ..utils.slack import (
     get_active_slack_thread,
     get_slack_thread_version,
     post_slack_thread_reply_with_ts,
+    slack_thread_mutation_lock,
     store_slack_message_run_mapping,
 )
 from ..utils.thread_ops import langgraph_client as get_langgraph_client
@@ -76,30 +77,31 @@ async def slack_thread_reply(
     if not message.strip():
         return {"success": False, "error": "Message cannot be empty"}
 
-    current_version = await get_slack_thread_version(client, channel_id, thread_ts)
-    if thread_version != current_version:
-        return {
-            "success": False,
-            "error": "Slack thread version mismatch",
-            "expected_thread_version": current_version,
-            "provided_thread_version": thread_version,
-            "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
-        }
+    async with slack_thread_mutation_lock(client, channel_id, thread_ts):
+        current_version = await get_slack_thread_version(client, channel_id, thread_ts)
+        if thread_version != current_version:
+            return {
+                "success": False,
+                "error": "Slack thread version mismatch",
+                "expected_thread_version": current_version,
+                "provided_thread_version": thread_version,
+                "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
+            }
 
-    message = convert_mentions_to_slack_format(message)
-    slack_blocks = blocks or _build_option_blocks(message, options)
-    usage = summarize_run_usage(state)
-    message_ts, slack_error = await _post_and_store_mapping(
-        channel_id,
-        thread_ts,
-        message,
-        blocks=slack_blocks,
-        usage=usage,
-        agent_thread_id=thread_id if isinstance(thread_id, str) else None,
-        langgraph_client=client,
-        run_id=run_id,
-        triggering_user_id=_triggering_user_id(configurable),
-    )
+        message = convert_mentions_to_slack_format(message)
+        slack_blocks = blocks or _build_option_blocks(message, options)
+        usage = summarize_run_usage(state)
+        message_ts, slack_error = await _post_and_store_mapping(
+            channel_id,
+            thread_ts,
+            message,
+            blocks=slack_blocks,
+            usage=usage,
+            agent_thread_id=thread_id if isinstance(thread_id, str) else None,
+            langgraph_client=client,
+            run_id=run_id,
+            triggering_user_id=_triggering_user_id(configurable),
+        )
     if message_ts is None:
         return {
             "success": False,

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -11,6 +11,7 @@ from ..utils.run_usage import RunUsageSummary, summarize_run_usage
 from ..utils.slack import (
     convert_mentions_to_slack_format,
     get_active_slack_thread,
+    get_slack_thread_version,
     post_slack_thread_reply_with_ts,
     store_slack_message_run_mapping,
 )
@@ -22,6 +23,7 @@ LANGGRAPH_URL = os.environ.get("LANGGRAPH_URL") or os.environ.get(
 
 async def slack_thread_reply(
     message: str,
+    thread_version: int,
     options: list[str] | None = None,
     blocks: list[dict[str, Any]] | None = None,
     state: Annotated[dict[str, Any] | None, InjectedState] = None,
@@ -29,9 +31,11 @@ async def slack_thread_reply(
     """Post a message to the current Slack thread and the Web UI.
 
     Use this for clarifying questions, essential progress updates, and the final
-    answer or outcome. For Slack-triggered information-only requests, put the
-    complete answer in `message`, not merely a summary, and do not repeat it in
-    the final assistant response. Make `message` as concise as possible: default
+    answer or outcome. Pass the current `thread_version` from Slack context or
+    `slack_read_thread_messages`; if a newer message arrived, the post fails and
+    you must re-read the thread before retrying. For Slack-triggered information-only
+    requests, put the complete answer in `message`, not merely a summary, and do not
+    repeat it in the final assistant response. Make `message` as concise as possible: default
     to one sentence with only the outcome/status and link, or one blocking
     question. Omit greetings, preambles, headings, recaps, implementation
     details, and redundant context; use bullets only when multiple items are
@@ -76,6 +80,16 @@ async def slack_thread_reply(
 
     if not message.strip():
         return {"success": False, "error": "Message cannot be empty"}
+
+    current_version = await get_slack_thread_version(langgraph_client, channel_id, thread_ts)
+    if thread_version != current_version:
+        return {
+            "success": False,
+            "error": "Slack thread version mismatch",
+            "expected_thread_version": current_version,
+            "provided_thread_version": thread_version,
+            "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
+        }
 
     message = convert_mentions_to_slack_format(message)
     slack_blocks = blocks or _build_option_blocks(message, options)

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -45,6 +45,8 @@ SLACK_FORWARDED_ATTACHMENT_MAX_COUNT = 10
 SLACK_FORWARDED_ATTACHMENT_MAX_DEPTH = 4
 SLACK_FORWARDED_ATTACHMENT_MAX_NODES = 50
 SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS = 8000
+_SLACK_THREAD_VERSION_NAMESPACE = "slack_thread_versions"
+_SLACK_THREAD_VERSION_PAGE_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -1029,6 +1031,45 @@ async def fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[d
         messages = messages[-SLACK_THREAD_MAX_MESSAGES:]
     messages.sort(key=lambda item: _parse_ts(item.get("ts")))
     return messages
+
+
+def _slack_thread_version_namespace(channel_id: str, thread_ts: str) -> tuple[str, str, str]:
+    channel, timestamp = _normalize_slack_location(channel_id, thread_ts)
+    return (_SLACK_THREAD_VERSION_NAMESPACE, channel, timestamp.replace(".", "_"))
+
+
+async def get_slack_thread_version(
+    langgraph_client: LangGraphClient, channel_id: str, thread_ts: str
+) -> int:
+    """Return the number of distinct inbound messages recorded for a Slack thread."""
+    namespace = _slack_thread_version_namespace(channel_id, thread_ts)
+    offset = 0
+    version = 0
+    while True:
+        response = await langgraph_client.store.search_items(
+            namespace, limit=_SLACK_THREAD_VERSION_PAGE_SIZE, offset=offset
+        )
+        items = response.get("items") if isinstance(response, Mapping) else None
+        page = items if isinstance(items, list) else []
+        version += len(page)
+        if len(page) < _SLACK_THREAD_VERSION_PAGE_SIZE:
+            return version
+        offset += len(page)
+
+
+async def increment_slack_thread_version(
+    langgraph_client: LangGraphClient,
+    channel_id: str,
+    thread_ts: str,
+    message_ts: str,
+) -> int:
+    """Record one inbound Slack message and return the resulting thread version."""
+    message_key = message_ts.strip()
+    if not _SLACK_MESSAGE_TS_RE.fullmatch(message_key):
+        raise ValueError("A valid Slack message timestamp is required")
+    namespace = _slack_thread_version_namespace(channel_id, thread_ts)
+    await langgraph_client.store.put_item(namespace, message_key, {"message_ts": message_key})
+    return await get_slack_thread_version(langgraph_client, channel_id, thread_ts)
 
 
 async def fetch_slack_thread_message_by_ts(

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -9,13 +9,15 @@ import os
 import re
 import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
 from langgraph_sdk.client import LangGraphClient
+from langgraph_sdk.errors import ConflictError
 
 from agent.utils.dashboard_links import dashboard_thread_url
 from agent.utils.langsmith import get_langsmith_trace_url
@@ -47,6 +49,9 @@ SLACK_FORWARDED_ATTACHMENT_MAX_NODES = 50
 SLACK_FORWARDED_ATTACHMENT_TEXT_MAX_CHARS = 8000
 _SLACK_THREAD_VERSION_NAMESPACE = "slack_thread_versions"
 _SLACK_THREAD_VERSION_PAGE_SIZE = 100
+_SLACK_THREAD_MUTATION_LOCK_TTL_MINUTES = 1
+_SLACK_THREAD_MUTATION_LOCK_RETRY_SECONDS = 0.05
+_SLACK_THREAD_MUTATION_LOCK_TIMEOUT_SECONDS = 10
 
 
 @dataclass(frozen=True)
@@ -1038,6 +1043,42 @@ def _slack_thread_version_namespace(channel_id: str, thread_ts: str) -> tuple[st
     return (_SLACK_THREAD_VERSION_NAMESPACE, channel, timestamp.replace(".", "_"))
 
 
+@asynccontextmanager
+async def slack_thread_mutation_lock(
+    langgraph_client: LangGraphClient, channel_id: str, thread_ts: str
+) -> AsyncIterator[None]:
+    """Serialize inbound version updates with version-checked Slack posts."""
+    channel, timestamp = _normalize_slack_location(channel_id, thread_ts)
+    lock_id = str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:slack-thread-lock:{channel}:{timestamp}")
+    )
+    deadline = asyncio.get_running_loop().time() + _SLACK_THREAD_MUTATION_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            await langgraph_client.threads.create(
+                thread_id=lock_id,
+                if_exists="raise",
+                ttl=_SLACK_THREAD_MUTATION_LOCK_TTL_MINUTES,
+            )
+            break
+        except ConflictError:
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError("Timed out waiting for the Slack thread mutation lock") from None
+            await asyncio.sleep(_SLACK_THREAD_MUTATION_LOCK_RETRY_SECONDS)
+    try:
+        yield
+    finally:
+        try:
+            await langgraph_client.threads.delete(lock_id)
+        except Exception:
+            logger.warning(
+                "Failed to release Slack thread mutation lock for %s/%s",
+                channel,
+                timestamp,
+                exc_info=True,
+            )
+
+
 async def get_slack_thread_version(
     langgraph_client: LangGraphClient, channel_id: str, thread_ts: str
 ) -> int:
@@ -1063,13 +1104,14 @@ async def increment_slack_thread_version(
     thread_ts: str,
     message_ts: str,
 ) -> int:
-    """Record one inbound Slack message and return the resulting thread version."""
+    """Record one inbound Slack event and return the resulting thread version."""
     message_key = message_ts.strip()
     if not _SLACK_MESSAGE_TS_RE.fullmatch(message_key):
         raise ValueError("A valid Slack message timestamp is required")
-    namespace = _slack_thread_version_namespace(channel_id, thread_ts)
-    await langgraph_client.store.put_item(namespace, message_key, {"message_ts": message_key})
-    return await get_slack_thread_version(langgraph_client, channel_id, thread_ts)
+    async with slack_thread_mutation_lock(langgraph_client, channel_id, thread_ts):
+        namespace = _slack_thread_version_namespace(channel_id, thread_ts)
+        await langgraph_client.store.put_item(namespace, message_key, {"message_ts": message_key})
+        return await get_slack_thread_version(langgraph_client, channel_id, thread_ts)
 
 
 async def fetch_slack_thread_message_by_ts(

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -109,8 +109,10 @@ from ..utils.slack import (
     get_slack_channel_description,
     get_slack_channel_info,
     get_slack_permalink,
+    get_slack_thread_version,  # noqa: F401
     get_slack_user_info,
     get_slack_user_names,  # noqa: F401
+    increment_slack_thread_version,  # noqa: F401
     is_slack_channel_named,
     lookup_slack_run_mapping,  # noqa: F401
     lookup_slack_thread_id,  # noqa: F401

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -28,6 +28,7 @@ from agent.utils import slack as slack_utils
 from agent.utils.json_types import as_json_object
 from agent.utils.langsmith import get_langsmith_trace_url
 
+from ..utils.thread_ops import langgraph_client as get_langgraph_client
 from ..utils.user_messages import warning
 from . import common
 
@@ -196,7 +197,7 @@ async def _slack_user_can_reply_to_ready_plan(
 
     try:
         thread_id = await common.lookup_slack_thread_id(
-            common.get_client(url=common.LANGGRAPH_URL), channel_id, thread_ts
+            get_langgraph_client(), channel_id, thread_ts
         )
     except Exception:  # noqa: BLE001
         return False
@@ -468,7 +469,7 @@ async def _notify_slack_processing_error(
     if not isinstance(thread_id, str) or not thread_id:
         try:
             thread_id = await common.lookup_slack_thread_id(
-                common.get_client(url=common.LANGGRAPH_URL), channel_id, thread_ts
+                get_langgraph_client(), channel_id, thread_ts
             )
         except Exception:  # noqa: BLE001
             thread_id = None
@@ -499,7 +500,7 @@ async def _notify_slack_processing_error(
         )
 
     try:
-        await common.get_client(url=common.LANGGRAPH_URL).threads.update(
+        await get_langgraph_client().threads.update(
             thread_id=thread_id,
             metadata={
                 "latest_run_status": "error",
@@ -556,7 +557,7 @@ async def _process_slack_mention_impl(
         )
         return
 
-    langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
+    langgraph_client = get_langgraph_client()
     thread_id = event_data.get("thread_id")
     if not isinstance(thread_id, str) or not thread_id:
         thread_id = await common.resolve_slack_thread_id(langgraph_client, channel_id, thread_ts)
@@ -816,7 +817,7 @@ async def _process_slack_mention_impl(
         configurable["plan_mode"] = thread_plan_mode
 
     is_first_mention = not await common._thread_exists(thread_id)
-    langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
+    langgraph_client = get_langgraph_client()
     await common._upsert_slack_thread_repo_metadata(thread_id, repo_config, langgraph_client)
     # Pass the login resolved above (from the stable Slack user id) so the thread is
     # always tagged with github_login — the key the dashboard searches by. Without

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -214,6 +214,7 @@ async def _slack_user_can_reply_to_ready_plan(
 def _format_slack_thread_section(
     channel_id: str,
     thread_ts: str,
+    thread_version: int,
     context_source: str,
     channel_context: dict[str, Any] | None,
 ) -> str:
@@ -228,6 +229,7 @@ def _format_slack_thread_section(
     if channel_name:
         lines.append(f"- Channel name: #{channel_name}")
     lines.append(f"- Thread TS: {thread_ts}")
+    lines.append(f"- Thread version: {thread_version}")
     lines.append(f"- Context starts at: {context_source}")
     channel_description = common.get_slack_channel_context_description(channel_context)
     if channel_description:
@@ -558,6 +560,14 @@ async def _process_slack_mention_impl(
     thread_id = event_data.get("thread_id")
     if not isinstance(thread_id, str) or not thread_id:
         thread_id = await common.resolve_slack_thread_id(langgraph_client, channel_id, thread_ts)
+    supplied_thread_version = event_data.get("thread_version")
+    thread_version = (
+        supplied_thread_version
+        if isinstance(supplied_thread_version, int)
+        else await common.increment_slack_thread_version(
+            langgraph_client, channel_id, thread_ts, original_message_ts
+        )
+    )
 
     # Prime the user-mapping cache so login/email/slack-id lookups below are warm.
     try:
@@ -667,7 +677,7 @@ async def _process_slack_mention_impl(
     )
 
     slack_thread_section = _format_slack_thread_section(
-        channel_id, thread_ts, context_source, channel_context
+        channel_id, thread_ts, thread_version, context_source, channel_context
     )
     operational_context = (
         _slack_prompt_preamble(untagged_reply, message_update) + "## Default Repository Hint\n"
@@ -773,6 +783,7 @@ async def _process_slack_mention_impl(
         "channel_id": channel_id,
         "channel_context": channel_context,
         "thread_ts": thread_ts,
+        "thread_version": thread_version,
         "triggering_user_id": user_id,
         "triggering_user_name": user_name,
         "triggering_user_email": user_email,

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi import APIRouter
 from langgraph_sdk.client import LangGraphClient
 
+from ..utils.thread_ops import langgraph_client as get_langgraph_client
 from . import common
 from . import slack as service
 
@@ -51,7 +52,7 @@ async def _process_slack_message_update(
     message_ts: str,
     user_id: str,
 ) -> None:
-    langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
+    langgraph_client = get_langgraph_client()
     thread_id, delivered_message = await _lookup_delivered_message_update(
         langgraph_client,
         channel_id,
@@ -239,7 +240,7 @@ async def slack_webhook(
             )
         )
         if not should_handle_message:
-            langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
+            langgraph_client = get_langgraph_client()
             mapped_thread_id = await common.lookup_slack_thread_id(
                 langgraph_client, channel_id, thread_ts
             )
@@ -291,7 +292,7 @@ async def slack_webhook(
             return {"status": "accepted", "message": "Slack update queued"}
         return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
 
-    langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
+    langgraph_client = get_langgraph_client()
     thread_id: str | None = None
     channel_context = await common._get_slack_channel_context(channel_id)
 
@@ -400,7 +401,7 @@ async def slack_interactivity(
             return {"status": "ignored", "reason": "Missing workflow approval context"}
 
         thread_id = await common.lookup_slack_thread_id(
-            common.get_client(url=common.LANGGRAPH_URL), channel_id, thread_ts
+            get_langgraph_client(), channel_id, thread_ts
         )
         if not thread_id:
             return {"status": "ignored", "reason": "Slack thread is not associated"}
@@ -490,7 +491,7 @@ async def slack_interactivity(
             return {"status": "ignored", "reason": "Missing Slack action context"}
 
         thread_id = await common.lookup_slack_thread_id(
-            common.get_client(url=common.LANGGRAPH_URL), channel_id, thread_ts
+            get_langgraph_client(), channel_id, thread_ts
         )
         if not thread_id:
             return {"status": "ignored", "reason": "Slack thread is not associated"}
@@ -560,9 +561,7 @@ async def slack_interactivity(
     if not channel_id or not thread_ts or not event_ts or not user_id:
         return {"status": "ignored", "reason": "Missing Slack action context"}
 
-    thread_id = await common.lookup_slack_thread_id(
-        common.get_client(url=common.LANGGRAPH_URL), channel_id, thread_ts
-    )
+    thread_id = await common.lookup_slack_thread_id(get_langgraph_client(), channel_id, thread_ts)
     if not thread_id:
         return {"status": "ignored", "reason": "Slack thread is not associated"}
     channel_context = await common._get_slack_channel_context(channel_id)

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -68,6 +68,9 @@ async def _process_slack_message_update(
         )
         return
     event_data["thread_id"] = thread_id
+    event_data["thread_version"] = await common.increment_slack_thread_version(
+        langgraph_client, channel_id, thread_ts, str(event_data.get("event_ts") or "")
+    )
     channel_context = await common._get_slack_channel_context(channel_id)
     event_data["channel_context"] = channel_context
     repo_config = await common.get_slack_repo_config(

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -239,6 +239,21 @@ async def slack_webhook(
             )
         )
         if not should_handle_message:
+            langgraph_client = common.get_client(url=common.LANGGRAPH_URL)
+            mapped_thread_id = await common.lookup_slack_thread_id(
+                langgraph_client, channel_id, thread_ts
+            )
+            if (
+                mapped_thread_id
+                and user_id != bot_user_id
+                and event.get("subtype") != "bot_message"
+                and not event.get("bot_id")
+                and updated_message.get("subtype") != "bot_message"
+                and not updated_message.get("bot_id")
+            ):
+                await common.increment_slack_thread_version(
+                    langgraph_client, channel_id, thread_ts, original_message_ts
+                )
             return {"status": "ignored", "reason": "Not an app mention, DM, or plan reply"}
 
     if (
@@ -326,6 +341,9 @@ async def slack_webhook(
             thread_id=thread_id,
         )
         if await common.claim_slack_event(event_id, channel_id, event_ts):
+            event_data["thread_version"] = await common.increment_slack_thread_version(
+                langgraph_client, channel_id, thread_ts, original_message_ts
+            )
             background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
             return {"status": "accepted", "message": "Slack mention queued"}
 

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -902,6 +902,18 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
             "call-lock-ack",
         ),
         _tool_step(
+            "Waiting for a reaction that must not invalidate the thread version.",
+            "execute",
+            {"command": "sleep 3"},
+            "call-lock-reaction-wait",
+        ),
+        _tool_step(
+            "Confirming a reaction did not invalidate the thread version.",
+            "slack_thread_reply",
+            {"message": "A reaction did not invalidate the thread version."},
+            "call-lock-reaction-reply",
+        ),
+        _tool_step(
             "Waiting for a newer Slack message.",
             "execute",
             {"command": "sleep 5"},

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from e2e_env import (
     BASE_BRANCH,
+    DEMO_CHANNEL,
     FAKE_GITHUB_API,
     FEATURE_BRANCH,
     FEATURE_FILE,
@@ -39,12 +40,17 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-_THREAD_VERSION_RE = re.compile(r"Thread version: (\d+)")
+_THREAD_VERSION_RE = re.compile(r'(?:Thread version: |"thread_version"\s*:\s*)(\d+)')
 
 
 def _thread_version_args(messages: list[BaseMessage]) -> dict[str, int]:
-    match = _THREAD_VERSION_RE.search("\n".join(_text(message.content) for message in messages))
-    return {"thread_version": int(match.group(1)) if match else 0}
+    matches = _THREAD_VERSION_RE.findall("\n".join(_text(message.content) for message in messages))
+    return {"thread_version": int(matches[-1]) if matches else 0}
+
+
+def _slack_thread_ts(messages: list[BaseMessage]) -> str:
+    matches = re.findall(r"Thread TS: ([0-9.]+)", "\n".join(_text(m.content) for m in messages))
+    return matches[-1] if matches else ""
 
 
 _SETUP_SCRIPT = f"""
@@ -239,6 +245,10 @@ def _render_step(step: StepSpec, messages: list[BaseMessage]) -> AIMessage:
     for call in message.tool_calls:
         if call["name"] == "slack_thread_reply":
             call["args"].update(_thread_version_args(messages))
+        elif call["name"] == "slack_read_thread_messages":
+            call["args"].update(
+                {"channel_id": DEMO_CHANNEL, "message_ts": _slack_thread_ts(messages)}
+            )
     return message
 
 
@@ -884,6 +894,38 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
         ),
         StepSpec(content=f"The `{ENVIRONMENT_NAME}` environment is captured and live."),
     ),
+    "optimistic_lock": (
+        _tool_step(
+            "Acknowledging before testing the optimistic lock.",
+            "slack_thread_reply",
+            {"message": "Optimistic lock flow started."},
+            "call-lock-ack",
+        ),
+        _tool_step(
+            "Waiting for a newer Slack message.",
+            "execute",
+            {"command": "sleep 5"},
+            "call-lock-wait",
+        ),
+        _tool_step(
+            "Trying to post with the version from the triggering context.",
+            "slack_thread_reply",
+            {"message": "This stale reply must not be posted."},
+            "call-lock-stale",
+        ),
+        _tool_step(
+            "Re-reading the Slack thread after the version mismatch.",
+            "slack_read_thread_messages",
+            {},
+            "call-lock-read",
+        ),
+        _tool_step(
+            "Retrying with the refreshed Slack thread version.",
+            "slack_thread_reply",
+            {"message": "Re-read the thread and posted with the updated version."},
+            "call-lock-retry",
+        ),
+    ),
     "followup": (_dynamic_step(_followup_step),),
 }
 
@@ -938,6 +980,10 @@ SCRIPT_RULES: tuple[ScriptRule, ...] = (
     ScriptRule(
         "thread_tools",
         lambda ctx: ctx.human_count <= 1 and _is_thread_tools_request(ctx.first_text),
+    ),
+    ScriptRule(
+        "optimistic_lock",
+        lambda ctx: ctx.human_count <= 1 and "E2E_OPTIMISTIC_LOCK" in ctx.first_text,
     ),
     ScriptRule("iframe", lambda ctx: ctx.human_count <= 1 and _is_iframe_request(ctx.first_text)),
     ScriptRule(

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -39,6 +39,14 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, ChatResult
 
+_THREAD_VERSION_RE = re.compile(r"Thread version: (\d+)")
+
+
+def _thread_version_args(messages: list[BaseMessage]) -> dict[str, int]:
+    match = _THREAD_VERSION_RE.search("\n".join(_text(message.content) for message in messages))
+    return {"thread_version": int(match.group(1)) if match else 0}
+
+
 _SETUP_SCRIPT = f"""
 set -e
 rm -rf repo
@@ -217,15 +225,21 @@ def _dynamic_step(factory: StepFactory) -> StepSpec:
 
 
 def _render_step(step: StepSpec, messages: list[BaseMessage]) -> AIMessage:
-    if step.factory is not None:
-        return step.factory(messages)
-    return AIMessage(
-        content=step.content,
-        tool_calls=[
-            {"name": call.name, "args": dict(call.args), "id": call.call_id}
-            for call in step.tool_calls
-        ],
+    message = (
+        step.factory(messages)
+        if step.factory is not None
+        else AIMessage(
+            content=step.content,
+            tool_calls=[
+                {"name": call.name, "args": dict(call.args), "id": call.call_id}
+                for call in step.tool_calls
+            ],
+        )
     )
+    for call in message.tool_calls:
+        if call["name"] == "slack_thread_reply":
+            call["args"].update(_thread_version_args(messages))
+    return message
 
 
 def _text(content: Any) -> str:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -281,6 +281,31 @@ async def slack_send(request: Request) -> JSONResponse:
     return await _slack_send_result(payload, await _deliver_slack_event(payload))
 
 
+@app.post("/mock/slack/reaction")
+async def slack_reaction(request: Request) -> JSONResponse:
+    body = await request.json()
+    channel_id = str(CURRENT_THREAD.get("channel") or "")
+    thread_ts = str(body.get("thread_ts") or CURRENT_THREAD.get("thread_ts") or "")
+    message_ts = str(body.get("message_ts") or thread_ts)
+    user_id = str(body.get("user") or TEST_USERS[0]["slack_id"])
+    reaction = str(body.get("reaction") or "eyes")
+    payload = {
+        "type": "event_callback",
+        "event_id": f"Ev{EVENT_ID_SALT}{fakes.next_slack_ts()}",
+        "authorizations": [{"user_id": BOT_USER_ID}],
+        "event": {
+            "type": "reaction_added",
+            "user": user_id,
+            "reaction": reaction,
+            "item": {"type": "message", "channel": channel_id, "ts": message_ts},
+            "item_user": BOT_USER_ID,
+            "event_ts": fakes.next_slack_ts(),
+        },
+    }
+    response = await _deliver_slack_event(payload)
+    return JSONResponse(response.json(), status_code=response.status_code)
+
+
 @app.post("/mock/slack/action")
 async def slack_action(request: Request) -> JSONResponse:
     body = await request.json()

--- a/tests/e2e/tests/slack_optimistic_lock.spec.ts
+++ b/tests/e2e/tests/slack_optimistic_lock.spec.ts
@@ -20,7 +20,9 @@ async function botTexts(request: APIRequestContext): Promise<string[]> {
     text: string;
     is_bot: boolean;
   }>;
-  return messages.filter((message) => message.is_bot).map((message) => message.text);
+  return messages
+    .filter((message) => message.is_bot)
+    .map((message) => message.text);
 }
 
 async function stateText(
@@ -55,6 +57,19 @@ test("a stale Slack reply fails, re-reads the thread, and then succeeds", async 
       timeout: 30_000,
     })
     .toContain("Optimistic lock flow started.");
+
+  const reaction = await request.post("/mock/slack/reaction", {
+    data: { thread_ts: opened.thread_ts, reaction: "eyes" },
+  });
+  expect(await reaction.json()).toEqual({
+    status: "ignored",
+    reason: "Reaction not tracked for feedback",
+  });
+  await expect
+    .poll(async () => (await botTexts(request)).join("\n"), {
+      timeout: 30_000,
+    })
+    .toContain("A reaction did not invalidate the thread version.");
 
   const intervening = await send(request, {
     text: "<@U_BOB> adding new context while Open SWE is working",

--- a/tests/e2e/tests/slack_optimistic_lock.spec.ts
+++ b/tests/e2e/tests/slack_optimistic_lock.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+type SendResult = {
+  thread_ts: string;
+  thread_id: string;
+  webhook: { status: string; reason?: string };
+};
+
+async function send(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+): Promise<SendResult> {
+  const response = await request.post("/mock/slack/send", { data });
+  return (await response.json()) as SendResult;
+}
+
+async function botTexts(request: APIRequestContext): Promise<string[]> {
+  const response = await request.get("/mock/slack/messages");
+  const messages = (await response.json()) as Array<{
+    text: string;
+    is_bot: boolean;
+  }>;
+  return messages.filter((message) => message.is_bot).map((message) => message.text);
+}
+
+async function stateText(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<string> {
+  const response = await request.get(`/threads/${threadId}/state`);
+  const state = (await response.json()) as {
+    values?: { messages?: Array<{ content?: unknown }> };
+  };
+  return (state.values?.messages ?? [])
+    .map((message) =>
+      typeof message.content === "string"
+        ? message.content
+        : JSON.stringify(message.content),
+    )
+    .join("\n");
+}
+
+test("a stale Slack reply fails, re-reads the thread, and then succeeds", async ({
+  request,
+}) => {
+  await request.post("/control/reset");
+  const opened = await send(request, {
+    text: "<@U0BOT> E2E_OPTIMISTIC_LOCK exercise the versioned reply flow",
+    mention_bot: true,
+  });
+  expect(opened.webhook.status).toBe("accepted");
+
+  await expect
+    .poll(async () => (await botTexts(request)).join("\n"), {
+      timeout: 30_000,
+    })
+    .toContain("Optimistic lock flow started.");
+
+  const intervening = await send(request, {
+    text: "<@U_BOB> adding new context while Open SWE is working",
+    mention_bot: false,
+    thread_ts: opened.thread_ts,
+  });
+  expect(intervening.webhook).toEqual({
+    status: "ignored",
+    reason: "Not an app mention, DM, or plan reply",
+  });
+
+  await expect
+    .poll(() => stateText(request, opened.thread_id), { timeout: 60_000 })
+    .toContain("Slack thread version mismatch");
+  await expect
+    .poll(() => stateText(request, opened.thread_id), { timeout: 60_000 })
+    .toContain('"thread_version": 2');
+  await expect
+    .poll(async () => (await botTexts(request)).join("\n"), {
+      timeout: 60_000,
+    })
+    .toContain("Re-read the thread and posted with the updated version.");
+
+  expect((await botTexts(request)).join("\n")).not.toContain(
+    "This stale reply must not be posted.",
+  );
+});

--- a/tests/e2e/tests/slack_optimistic_lock.spec.ts
+++ b/tests/e2e/tests/slack_optimistic_lock.spec.ts
@@ -92,6 +92,9 @@ test("a stale Slack reply fails, re-reads the thread, and then succeeds", async 
       timeout: 60_000,
     })
     .toContain("Re-read the thread and posted with the updated version.");
+  await expect
+    .poll(() => stateText(request, opened.thread_id), { timeout: 60_000 })
+    .toContain('{"success": true, "thread_version": 2}');
 
   expect((await botTexts(request)).join("\n")).not.toContain(
     "This stale reply must not be posted.",

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -30,7 +30,15 @@ def _explicit_slack_thread_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
     async def resolve(*args: object, **kwargs: object) -> str:
         return "mapped-slack-thread"
 
+    async def lookup(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def increment_version(*args: object, **kwargs: object) -> int:
+        return 1
+
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", resolve)
+    monkeypatch.setattr(webhook_common, "lookup_slack_thread_id", lookup)
+    monkeypatch.setattr(webhook_common, "increment_slack_thread_version", increment_version)
 
 
 def _sign_body(body: bytes, secret: str = _TEST_WEBHOOK_SECRET) -> str:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -908,7 +908,9 @@ def _setup_slack_mention_fakes(
         webhook_common, "increment_slack_thread_version", fake_increment_slack_thread_version
     )
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", fake_resolve_slack_thread_id)
-    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeLangGraphClientForProcess())
+    client = _FakeLangGraphClientForProcess()
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: client)
+    monkeypatch.setattr(slack_webhooks, "get_langgraph_client", lambda: client)
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "login_for_email", fake_login_for_email)
     monkeypatch.setattr(webhook_common, "refresh_user_mapping_cache", fake_refresh_cache)

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -900,7 +900,13 @@ def _setup_slack_mention_fakes(
     async def fake_resolve_slack_thread_id(client, channel_id, thread_ts):
         return "mapped-thread"
 
+    async def fake_increment_slack_thread_version(*_args) -> int:
+        return 1
+
     monkeypatch.setattr(webhook_common, "post_slack_trace_reply", fake_post_slack_trace_reply)
+    monkeypatch.setattr(
+        webhook_common, "increment_slack_thread_version", fake_increment_slack_thread_version
+    )
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", fake_resolve_slack_thread_id)
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeLangGraphClientForProcess())
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
@@ -1012,6 +1018,7 @@ def test_process_slack_mention_creates_thread_first_run_without_trace_reply(
     assert kwargs["durability"] == "sync"
     slack_thread_context = kwargs["config"]["configurable"]["slack_thread"]
     assert slack_thread_context["thread_ts"] == thread_ts
+    assert slack_thread_context["thread_version"] == 1
     assert slack_thread_context["triggering_user_timezone"] == "America/New_York"
     messages = kwargs["input"]["messages"]
     entities = [
@@ -1040,6 +1047,7 @@ def test_process_slack_mention_creates_thread_first_run_without_trace_reply(
     )
     assert prompt.count("## Slack Thread") == 1
     assert f"Thread TS: {thread_ts}" in prompt
+    assert "Thread version: 1" in prompt
     assert "## Open SWE Links" in prompt
     assert f"- Web: https://app.example.com/agents/{expected_thread_id}" in prompt
     assert "- Trace: https://smith/x" in prompt

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -89,9 +89,13 @@ async def _post(
 
 
 @pytest.fixture(autouse=True)
-def _patch_slack_webhook(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+def _patch_slack_webhook(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> _FakeClient:
     slack_events.reset_slack_event_claims()
     client = _FakeClient()
+    increment_version = AsyncMock(return_value=1)
+    request.node.thread_version_increment = increment_version
 
     async def channel_context(_channel_id: str) -> dict[str, Any]:
         return {}
@@ -107,11 +111,13 @@ def _patch_slack_webhook(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", AsyncMock(return_value="t1"))
     monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
     monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
+
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
+    monkeypatch.setattr(webhook_common, "increment_slack_thread_version", increment_version)
     return client
 
 
-async def test_redelivered_event_starts_only_one_run() -> None:
+async def test_redelivered_event_starts_only_one_run(request: pytest.FixtureRequest) -> None:
     background_tasks = _FakeBackgroundTasks()
 
     first = await _post(_mention_payload(), background_tasks)
@@ -120,6 +126,7 @@ async def test_redelivered_event_starts_only_one_run() -> None:
     assert first["status"] == "accepted"
     assert second["status"] == "ignored"
     assert [task[0] for task in background_tasks.tasks] == [slack_service.process_slack_mention]
+    request.node.thread_version_increment.assert_awaited_once()
 
 
 async def test_redelivered_event_without_retry_header_is_deduped() -> None:

--- a/tests/slack/test_slack_interactivity.py
+++ b/tests/slack/test_slack_interactivity.py
@@ -87,7 +87,7 @@ async def test_option_interaction_schedules_update_before_agent_processing(
     update = AsyncMock()
     process = AsyncMock()
     monkeypatch.setattr(slack_routes.common, "verify_slack_signature", lambda **_kwargs: True)
-    monkeypatch.setattr(slack_routes.common, "get_client", lambda **_kwargs: object())
+    monkeypatch.setattr(slack_routes, "get_langgraph_client", lambda: object())
     monkeypatch.setattr(
         slack_routes.common, "lookup_slack_thread_id", AsyncMock(return_value="thread-1")
     )

--- a/tests/slack/test_slack_read_thread_messages_tool.py
+++ b/tests/slack/test_slack_read_thread_messages_tool.py
@@ -1,0 +1,29 @@
+import importlib
+from typing import Any
+
+import pytest
+
+slack_read_tool = importlib.import_module("agent.tools.slack_read_thread_messages")
+
+
+async def test_read_thread_returns_current_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fetch(channel_id: str, thread_ts: str) -> list[dict[str, Any]]:
+        return [{"ts": thread_ts, "text": "hello", "user": "U1"}]
+
+    async def names(user_ids: list[str]) -> dict[str, str]:
+        return {"U1": "Alice"}
+
+    async def version(_client: Any, channel_id: str, thread_ts: str) -> int:
+        assert (channel_id, thread_ts) == ("C1", "1.0")
+        return 3
+
+    monkeypatch.setattr(slack_read_tool, "fetch_slack_thread_messages", fetch)
+    monkeypatch.setattr(slack_read_tool, "get_slack_user_names", names)
+    monkeypatch.setattr(slack_read_tool, "get_slack_thread_version", version)
+    monkeypatch.setattr(slack_read_tool, "get_client", lambda **_kwargs: object())
+
+    result = await slack_read_tool.slack_read_thread_messages("C1", "1.0")
+
+    assert result["success"] is True
+    assert result["thread_version"] == 3
+    assert result["formatted"] == "@Alice(U1) [message_ts=1.0]: hello"

--- a/tests/slack/test_slack_read_thread_messages_tool.py
+++ b/tests/slack/test_slack_read_thread_messages_tool.py
@@ -20,7 +20,7 @@ async def test_read_thread_returns_current_version(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(slack_read_tool, "fetch_slack_thread_messages", fetch)
     monkeypatch.setattr(slack_read_tool, "get_slack_user_names", names)
     monkeypatch.setattr(slack_read_tool, "get_slack_thread_version", version)
-    monkeypatch.setattr(slack_read_tool, "get_client", lambda **_kwargs: object())
+    monkeypatch.setattr(slack_read_tool, "langgraph_client", object)
 
     result = await slack_read_tool.slack_read_thread_messages("C1", "1.0")
 

--- a/tests/slack/test_slack_read_thread_messages_tool.py
+++ b/tests/slack/test_slack_read_thread_messages_tool.py
@@ -6,8 +6,11 @@ import pytest
 slack_read_tool = importlib.import_module("agent.tools.slack_read_thread_messages")
 
 
-async def test_read_thread_returns_current_version(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_read_thread_returns_pre_fetch_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
     async def fetch(channel_id: str, thread_ts: str) -> list[dict[str, Any]]:
+        events.append("fetch")
         return [{"ts": thread_ts, "text": "hello", "user": "U1"}]
 
     async def names(user_ids: list[str]) -> dict[str, str]:
@@ -15,6 +18,7 @@ async def test_read_thread_returns_current_version(monkeypatch: pytest.MonkeyPat
 
     async def version(_client: Any, channel_id: str, thread_ts: str) -> int:
         assert (channel_id, thread_ts) == ("C1", "1.0")
+        events.append("version")
         return 3
 
     monkeypatch.setattr(slack_read_tool, "fetch_slack_thread_messages", fetch)
@@ -26,4 +30,5 @@ async def test_read_thread_returns_current_version(monkeypatch: pytest.MonkeyPat
 
     assert result["success"] is True
     assert result["thread_version"] == 3
+    assert events == ["version", "fetch"]
     assert result["formatted"] == "@Alice(U1) [message_ts=1.0]: hello"

--- a/tests/slack/test_slack_start_new_thread_tool.py
+++ b/tests/slack/test_slack_start_new_thread_tool.py
@@ -145,7 +145,7 @@ async def test_slack_start_new_thread_success(monkeypatch: pytest.MonkeyPatch) -
     fake_client = _FakeClient(captured)
     monkeypatch.setattr(slack_breakout_tool, "get_config", _config)
     monkeypatch.setattr(slack_breakout_tool, "bind_slack_thread_id", fake_bind)
-    monkeypatch.setattr(slack_breakout_tool, "get_client", lambda url: fake_client)
+    monkeypatch.setattr(slack_breakout_tool, "langgraph_client", lambda: fake_client)
     monkeypatch.setattr(
         slack_breakout_tool, "post_slack_top_level_message_with_ts", fake_post_top_level
     )

--- a/tests/slack/test_slack_thread_mapping.py
+++ b/tests/slack/test_slack_thread_mapping.py
@@ -6,6 +6,8 @@ from agent.utils.slack import (
     SlackThreadMappingError,
     bind_slack_thread_id,
     delete_slack_thread_associations,
+    get_slack_thread_version,
+    increment_slack_thread_version,
     lookup_slack_run_message_mapping,
     lookup_slack_thread_id,
     resolve_slack_thread_id,
@@ -71,6 +73,17 @@ def _legacy_thread(
             "source_context": {"slack_thread": {"channel_id": channel_id, "thread_ts": thread_ts}}
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_thread_version_counts_distinct_inbound_messages() -> None:
+    client: Any = _Client()
+
+    assert await increment_slack_thread_version(client, "C1", "1.0", "1.1") == 1
+    assert await increment_slack_thread_version(client, "C1", "1.0", "1.1") == 1
+    assert await increment_slack_thread_version(client, "C1", "1.0", "1.2") == 2
+    assert await get_slack_thread_version(client, "C1", "1.0") == 2
+    assert await get_slack_thread_version(client, "C1", "2.0") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_mapping.py
+++ b/tests/slack/test_slack_thread_mapping.py
@@ -1,6 +1,9 @@
+import asyncio
 from typing import Any
 
+import httpx
 import pytest
+from langgraph_sdk.errors import ConflictError
 
 from agent.utils.slack import (
     SlackThreadMappingError,
@@ -11,6 +14,7 @@ from agent.utils.slack import (
     lookup_slack_run_message_mapping,
     lookup_slack_thread_id,
     resolve_slack_thread_id,
+    slack_thread_mutation_lock,
     store_slack_message_run_mapping,
     store_slack_run_mapping,
 )
@@ -53,6 +57,16 @@ class _Store:
 class _Threads:
     def __init__(self, matches: list[dict[str, Any]] | None = None) -> None:
         self.matches = matches or []
+        self.lock_ids: set[str] = set()
+
+    async def create(self, *, thread_id: str, **_kwargs: Any) -> None:
+        if thread_id in self.lock_ids:
+            response = httpx.Response(409, request=httpx.Request("POST", "http://test/threads"))
+            raise ConflictError("already exists", response=response, body=None)
+        self.lock_ids.add(thread_id)
+
+    async def delete(self, thread_id: str) -> None:
+        self.lock_ids.discard(thread_id)
 
     async def search(self, **kwargs: Any) -> list[dict[str, Any]]:
         return self.matches
@@ -84,6 +98,33 @@ async def test_thread_version_counts_distinct_inbound_messages() -> None:
     assert await increment_slack_thread_version(client, "C1", "1.0", "1.2") == 2
     assert await get_slack_thread_version(client, "C1", "1.0") == 2
     assert await get_slack_thread_version(client, "C1", "2.0") == 0
+
+
+@pytest.mark.asyncio
+async def test_thread_mutation_lock_serializes_same_thread() -> None:
+    client: Any = _Client()
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    async def first() -> None:
+        async with slack_thread_mutation_lock(client, "C1", "1.0"):
+            first_entered.set()
+            await release_first.wait()
+
+    async def second() -> None:
+        await first_entered.wait()
+        async with slack_thread_mutation_lock(client, "C1", "1.0"):
+            second_entered.set()
+
+    first_task = asyncio.create_task(first())
+    second_task = asyncio.create_task(second())
+    await first_entered.wait()
+    await asyncio.sleep(0.01)
+    assert second_entered.is_set() is False
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+    assert second_entered.is_set() is True
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -9,6 +9,14 @@ from langchain_core.messages import AIMessage, HumanMessage
 slack_reply_tool = importlib.import_module("agent.tools.slack_thread_reply")
 
 
+@pytest.fixture(autouse=True)
+def _current_thread_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def current_version(*_args: Any) -> int:
+        return 1
+
+    monkeypatch.setattr(slack_reply_tool, "get_slack_thread_version", current_version)
+
+
 def _config() -> dict[str, Any]:
     return {
         "configurable": {
@@ -17,6 +25,26 @@ def _config() -> dict[str, Any]:
                 "thread_ts": "1.0",
             }
         }
+    }
+
+
+async def test_slack_thread_reply_rejects_stale_thread_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_if_posted(*_args: Any, **_kwargs: Any) -> tuple[str | None, str | None]:
+        pytest.fail("stale reply must not be posted")
+
+    monkeypatch.setattr(slack_reply_tool, "get_config", _config)
+    monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fail_if_posted)
+
+    result = await slack_reply_tool.slack_thread_reply("hello", 0)
+
+    assert result == {
+        "success": False,
+        "error": "Slack thread version mismatch",
+        "expected_thread_version": 1,
+        "provided_thread_version": 0,
+        "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
     }
 
 
@@ -36,7 +64,7 @@ async def test_slack_thread_reply_returns_structured_error_for_msg_too_long(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("hello")
+    result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
     assert result == {
         "success": False,
@@ -65,7 +93,7 @@ async def test_slack_thread_reply_hints_not_to_retry_channel_errors(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("hello")
+    result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
     assert result["success"] is False
     assert result["error"] == slack_error
@@ -91,7 +119,7 @@ async def test_slack_thread_reply_rate_limited_hint_includes_retry_after(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("hello")
+    result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
     assert result["success"] is False
     assert result["error"] == "rate_limited: 30"
@@ -116,7 +144,7 @@ async def test_slack_thread_reply_rate_limited_hint_without_retry_after(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("hello")
+    result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
     assert result["success"] is False
     assert result["slack_error"] == "rate_limited"
@@ -139,7 +167,7 @@ async def test_slack_thread_reply_uses_post_failed_without_slack_error(
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("hello")
+    result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
     assert result["success"] is False
     assert result["error"] == "post failed"
@@ -167,7 +195,7 @@ async def test_slack_thread_reply_passes_executing_run_id(
     monkeypatch.setattr(slack_reply_tool, "get_config", lambda: config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("hello")
+    result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
     assert result == {"success": True}
     assert captured["run_id"] == "12345678-1234-5678-1234-567812345678"
@@ -194,7 +222,7 @@ async def test_slack_thread_reply_posts_plain_text_without_options(
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
     result = await slack_reply_tool.slack_thread_reply(
-        "Plan ready: review it and reply to approve or request changes."
+        "Plan ready: review it and reply to approve or request changes.", 1
     )
 
     assert result == {"success": True}
@@ -220,7 +248,7 @@ async def test_slack_thread_reply_builds_option_blocks(monkeypatch: pytest.Monke
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    result = await slack_reply_tool.slack_thread_reply("Pick one", options=["A", "B"])
+    result = await slack_reply_tool.slack_thread_reply("Pick one", 1, options=["A", "B"])
 
     assert result == {"success": True}
     assert captured["channel_id"] == "C1"
@@ -274,7 +302,7 @@ async def test_slack_thread_reply_passes_live_run_id(
     monkeypatch.setattr(slack_reply_tool, "get_config", lambda: config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    assert await slack_reply_tool.slack_thread_reply("Done") == {"success": True}
+    assert await slack_reply_tool.slack_thread_reply("Done", 1) == {"success": True}
     assert captured["run_id"] == str(run_id)
 
 
@@ -305,7 +333,7 @@ async def test_slack_thread_reply_passes_model_reported_usage(
         ]
     }
 
-    result = await slack_reply_tool.slack_thread_reply("Done", state=state)
+    result = await slack_reply_tool.slack_thread_reply("Done", 1, state=state)
 
     assert result == {"success": True}
     usage = captured["usage"]

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -76,7 +76,10 @@ async def test_slack_thread_reply_holds_mutation_lock_while_posting(
     monkeypatch.setattr(slack_reply_tool, "slack_thread_mutation_lock", mutation_lock)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", post)
 
-    assert await slack_reply_tool.slack_thread_reply("hello", 1) == {"success": True}
+    assert await slack_reply_tool.slack_thread_reply("hello", 1) == {
+        "success": True,
+        "thread_version": 1,
+    }
     assert lock_held is False
 
 
@@ -229,7 +232,7 @@ async def test_slack_thread_reply_passes_executing_run_id(
 
     result = await slack_reply_tool.slack_thread_reply("hello", 1)
 
-    assert result == {"success": True}
+    assert result == {"success": True, "thread_version": 1}
     assert captured["run_id"] == "12345678-1234-5678-1234-567812345678"
     assert captured["triggering_user_id"] == "active-user"
 
@@ -257,7 +260,7 @@ async def test_slack_thread_reply_posts_plain_text_without_options(
         "Plan ready: review it and reply to approve or request changes.", 1
     )
 
-    assert result == {"success": True}
+    assert result == {"success": True, "thread_version": 1}
     assert captured["blocks"] is None
 
 
@@ -282,7 +285,7 @@ async def test_slack_thread_reply_builds_option_blocks(monkeypatch: pytest.Monke
 
     result = await slack_reply_tool.slack_thread_reply("Pick one", 1, options=["A", "B"])
 
-    assert result == {"success": True}
+    assert result == {"success": True, "thread_version": 1}
     assert captured["channel_id"] == "C1"
     assert captured["thread_ts"] == "1.0"
     assert captured["message"] == "Pick one"
@@ -334,7 +337,10 @@ async def test_slack_thread_reply_passes_live_run_id(
     monkeypatch.setattr(slack_reply_tool, "get_config", lambda: config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fake_post_and_store_mapping)
 
-    assert await slack_reply_tool.slack_thread_reply("Done", 1) == {"success": True}
+    assert await slack_reply_tool.slack_thread_reply("Done", 1) == {
+        "success": True,
+        "thread_version": 1,
+    }
     assert captured["run_id"] == str(run_id)
 
 
@@ -367,7 +373,7 @@ async def test_slack_thread_reply_passes_model_reported_usage(
 
     result = await slack_reply_tool.slack_thread_reply("Done", 1, state=state)
 
-    assert result == {"success": True}
+    assert result == {"success": True, "thread_version": 1}
     usage = captured["usage"]
     assert usage.models == ("model-a",)
     assert usage.main_agent_tokens == 110

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+from contextlib import asynccontextmanager
 from typing import Any
 from uuid import UUID
 
@@ -14,7 +15,12 @@ def _current_thread_version(monkeypatch: pytest.MonkeyPatch) -> None:
     async def current_version(*_args: Any) -> int:
         return 1
 
+    @asynccontextmanager
+    async def mutation_lock(*_args: Any):
+        yield
+
     monkeypatch.setattr(slack_reply_tool, "get_slack_thread_version", current_version)
+    monkeypatch.setattr(slack_reply_tool, "slack_thread_mutation_lock", mutation_lock)
 
 
 def _config() -> dict[str, Any]:
@@ -46,6 +52,32 @@ async def test_slack_thread_reply_rejects_stale_thread_version(
         "provided_thread_version": 0,
         "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
     }
+
+
+async def test_slack_thread_reply_holds_mutation_lock_while_posting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock_held = False
+
+    @asynccontextmanager
+    async def mutation_lock(*_args: Any):
+        nonlocal lock_held
+        lock_held = True
+        try:
+            yield
+        finally:
+            lock_held = False
+
+    async def post(*_args: Any, **_kwargs: Any) -> tuple[str | None, str | None]:
+        assert lock_held is True
+        return "2.0", None
+
+    monkeypatch.setattr(slack_reply_tool, "get_config", _config)
+    monkeypatch.setattr(slack_reply_tool, "slack_thread_mutation_lock", mutation_lock)
+    monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", post)
+
+    assert await slack_reply_tool.slack_thread_reply("hello", 1) == {"success": True}
+    assert lock_held is False
 
 
 async def test_slack_thread_reply_returns_structured_error_for_msg_too_long(

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -172,6 +172,7 @@ async def test_message_update_queues_only_the_new_text() -> None:
     event_data = background_tasks.tasks[0][1][0]
     assert event_data["message_update"] is True
     assert event_data["event_ts"] == "1786573400.000000"
+    assert "thread_version" not in event_data
     assert event_data["original_message_ts"] == "1786573369.551099"
     assert event_data["thread_ts"] == "1786573300.000000"
     assert event_data["text"] == "new corrected text"
@@ -181,6 +182,34 @@ async def test_message_update_queues_only_the_new_text() -> None:
 async def _run_message_update_task(background_tasks: _FakeBackgroundTasks) -> None:
     func, args = background_tasks.tasks[0]
     await func(*args)
+
+
+async def test_message_update_increments_version_with_edit_event_timestamp() -> None:
+    process = AsyncMock()
+    increment = cast(AsyncMock, webhook_common.increment_slack_thread_version)
+    increment.return_value = 2
+    background_tasks = _FakeBackgroundTasks()
+
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(_message_update_payload())),
+        cast(BackgroundTasks, background_tasks),
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(slack_service, "process_slack_mention", process)
+        await _run_message_update_task(background_tasks)
+
+    assert response["status"] == "accepted"
+    increment.assert_awaited_once()
+    assert increment.await_args is not None
+    assert increment.await_args.args[1:] == (
+        "C1",
+        "1786573300.000000",
+        "1786573400.000000",
+    )
+    process_call = process.await_args
+    assert process_call is not None
+    event_data = process_call.args[0]
+    assert event_data["thread_version"] == 2
 
 
 async def test_root_message_update_uses_original_message_as_thread() -> None:

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -127,6 +127,7 @@ def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
     monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
+    monkeypatch.setattr(webhook_common, "increment_slack_thread_version", AsyncMock(return_value=1))
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "BOT")
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "openswe")
     # The two-party gate would admit these messages on its own.

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -39,7 +39,7 @@ async def test_slack_processing_error_posts_dashboard_link(
         slack_webhook.common, "strip_bot_mention", lambda text, *_args, **_kwargs: text
     )
     monkeypatch.setattr(slack_webhook.common, "upsert_agent_thread_owner_metadata", upsert)
-    monkeypatch.setattr(slack_webhook.common, "get_client", lambda *, url: client)
+    monkeypatch.setattr(slack_webhook, "get_langgraph_client", lambda: client)
     monkeypatch.setattr(
         slack_webhook.common, "dashboard_thread_url", lambda thread_id: f"https://ui/{thread_id}"
     )
@@ -449,7 +449,7 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
     fetch_messages = AsyncMock(return_value=[{"ts": "1.0", "user": "U1", "text": "old text"}])
     dispatch = AsyncMock(return_value={"run_id": "run-1"})
     store_mapping = AsyncMock()
-    monkeypatch.setattr(slack_webhook.common, "get_client", lambda *, url: client)
+    monkeypatch.setattr(slack_webhook, "get_langgraph_client", lambda: client)
     monkeypatch.setattr(slack_webhook.common, "refresh_user_mapping_cache", AsyncMock())
     monkeypatch.setattr(slack_webhook.common, "get_slack_user_info", AsyncMock(return_value=None))
     monkeypatch.setattr(slack_webhook.common, "fetch_slack_thread_messages", fetch_messages)

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -486,6 +486,7 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
             "bot_user_id": "BOT",
             "thread_id": "t1",
             "message_update": True,
+            "thread_version": 1,
         },
         {"owner": "langchain-ai", "name": "open-swe"},
     )


### PR DESCRIPTION
## Description
Add durable per-thread inbound message versions so Slack replies use optimistic concurrency and cannot post after a newer human message arrives. Thread reads return the latest version and stale replies direct the agent to re-read before retrying.

## Release Note
Slack agents now avoid posting stale replies when newer thread messages arrive.

## Test Plan
- [x] Verify duplicate webhook deliveries increment a thread version only once.
- [x] Verify stale replies are rejected before posting.
- [x] Verify thread reads cannot return a version covering unread messages.
- [x] Verify edits invalidate stale replies while reactions do not.

Made by [Open SWE](https://openswe.vercel.app/agents/45c68683-eda3-5697-88ad-50780a51a5f0)