### PR TITLE
feat: reuse threads for recurring automations

### DIFF
--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -3,10 +3,13 @@
 import logging
 import re
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any, Literal
 
 from fastapi import HTTPException
+from langgraph_sdk.errors import ConflictError
 from langgraph_sdk.schema import Config
 from pydantic import BaseModel, Field, field_validator
 
@@ -14,6 +17,7 @@ from ..dispatch import create_durable_run
 from ..input_messages import InputMessageContext, build_run_input
 from ..utils.slack import (
     bind_slack_thread_id,
+    delete_slack_thread_associations,
     post_slack_top_level_message_with_ts,
     store_slack_run_mapping,
 )
@@ -41,7 +45,14 @@ _SCHEDULER_ASSISTANT_ID = "scheduler"
 _CRON_FIELD_RANGES = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
 _SLACK_CHANNEL_ID_RE = re.compile(r"^[CG][A-Z0-9]{8,}$")
 SlackNotificationMode = Literal["always", "on_action"]
+ThreadMode = Literal["new", "reuse"]
 _DEFAULT_SLACK_NOTIFICATION_MODE: SlackNotificationMode = "always"
+_DEFAULT_THREAD_MODE: ThreadMode = "new"
+_AUTOMATION_LAUNCH_LOCK_TTL_MINUTES = 5
+
+
+def _thread_mode(record: dict[str, Any]) -> ThreadMode:
+    return "reuse" if record.get("thread_mode") == "reuse" else "new"
 
 
 def _normalize_slack_channel_id(value: str | None) -> str | None:
@@ -66,6 +77,7 @@ class ScheduleCreateBody(BaseModel):
     effort: str | None = None
     slack_channel_id: str | None = None
     slack_notification_mode: SlackNotificationMode = _DEFAULT_SLACK_NOTIFICATION_MODE
+    thread_mode: ThreadMode = _DEFAULT_THREAD_MODE
     admin_thread: bool = False
 
     @field_validator("schedule")
@@ -89,6 +101,7 @@ class ScheduleUpdateBody(BaseModel):
     enabled: bool | None = None
     slack_channel_id: str | None = None
     slack_notification_mode: SlackNotificationMode | None = None
+    thread_mode: ThreadMode | None = None
     admin_thread: bool | None = None
 
     @field_validator("schedule")
@@ -186,6 +199,7 @@ def _schedule_summary(
         "repo": _repo_full_name(repo),
         "slackChannelId": record.get("slack_channel_id"),
         "slackNotificationMode": _slack_notification_mode(record),
+        "threadMode": _thread_mode(record),
         "adminThread": record.get("admin_thread") is True,
         "model": record.get("model"),
         "effort": record.get("effort"),
@@ -221,6 +235,36 @@ async def _get_run_state(schedule_id: str) -> dict[str, Any] | None:
         return None
     value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
     return value if isinstance(value, dict) else None
+
+
+@asynccontextmanager
+async def _automation_launch_lock(schedule_id: str) -> AsyncIterator[bool]:
+    client = _client()
+    lock_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:automation-launch:{schedule_id}"))
+    try:
+        await client.threads.create(
+            thread_id=lock_id,
+            if_exists="raise",
+            ttl=_AUTOMATION_LAUNCH_LOCK_TTL_MINUTES,
+        )
+    except ConflictError:
+        yield False
+        return
+    except Exception:
+        logger.warning(
+            "Failed to acquire automation launch lock for %s", schedule_id, exc_info=True
+        )
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        try:
+            await client.threads.delete(lock_id)
+        except Exception:
+            logger.warning(
+                "Failed to release automation launch lock for %s", schedule_id, exc_info=True
+            )
 
 
 async def _put_run_state(record: dict[str, Any], patch: dict[str, Any]) -> None:
@@ -372,6 +416,7 @@ async def create_agent_schedule(
         "repo": repo,
         "slack_channel_id": body.slack_channel_id,
         "slack_notification_mode": body.slack_notification_mode,
+        "thread_mode": body.thread_mode,
         "admin_thread": body.admin_thread,
         "model": chosen_model or profile.get("default_model") or "Default",
         "effort": chosen_effort or profile.get("reasoning_effort"),
@@ -398,6 +443,31 @@ async def create_agent_schedule(
         raise HTTPException(502, "failed to create schedule cron") from exc
     record = await _put_value({**record, "cron_id": cron_id})
     return _schedule_summary(record)
+
+
+async def _detach_reusable_slack_thread(schedule_id: str) -> None:
+    thread_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:automation:{schedule_id}"))
+    try:
+        thread = await _client().threads.get(thread_id)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not load reusable automation thread %s", thread_id)
+        return
+    metadata = thread.get("metadata")
+    source_context = metadata.get("source_context") if isinstance(metadata, dict) else None
+    slack_thread = source_context.get("slack_thread") if isinstance(source_context, dict) else None
+    if not (
+        isinstance(slack_thread, dict)
+        and isinstance(slack_thread.get("channel_id"), str)
+        and isinstance(slack_thread.get("thread_ts"), str)
+    ):
+        return
+    await delete_slack_thread_associations(
+        _client(),
+        slack_thread["channel_id"],
+        slack_thread["thread_ts"],
+        expected_thread_id=thread_id,
+    )
+    await _client().threads.update(thread_id=thread_id, metadata={"source_context": None})
 
 
 async def update_agent_schedule(
@@ -440,6 +510,21 @@ async def update_agent_schedule(
         patch["slack_notification_mode"] = (
             body.slack_notification_mode or _DEFAULT_SLACK_NOTIFICATION_MODE
         )
+    if "thread_mode" in body.model_fields_set:
+        patch["thread_mode"] = body.thread_mode or _DEFAULT_THREAD_MODE
+
+    detach_reusable_slack = existing.get("thread_mode") == "reuse" and (
+        patch.get("thread_mode", "reuse") != "reuse"
+        or patch.get("enabled") is False
+        or (
+            "slack_channel_id" in patch
+            and patch["slack_channel_id"] != existing.get("slack_channel_id")
+        )
+        or (
+            "slack_notification_mode" in patch
+            and patch["slack_notification_mode"] != existing.get("slack_notification_mode")
+        )
+    )
     if body.admin_thread is not None:
         patch["admin_thread"] = body.admin_thread
 
@@ -461,6 +546,8 @@ async def update_agent_schedule(
         updated["cron_id"] = None
 
     updated = await _put_value(updated)
+    if detach_reusable_slack:
+        await _detach_reusable_slack_thread(schedule_id)
     return _schedule_summary(updated, await _get_run_state(schedule_id))
 
 
@@ -468,6 +555,8 @@ async def delete_agent_schedule(schedule_id: str, login: str, *, email: str | No
     existing = await get_agent_schedule(schedule_id)
     _assert_schedule_owner(existing, login, email)
     assert existing is not None
+    if existing.get("thread_mode") == "reuse":
+        await _detach_reusable_slack_thread(schedule_id)
     await _delete_cron(existing.get("cron_id"))
     await _client().store.delete_item(SCHEDULES_NAMESPACE, schedule_id)
     await _client().store.delete_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
@@ -551,6 +640,8 @@ def _agent_run_metadata(
         metadata["repo_name"] = repo["name"]
     if slack_thread:
         metadata["source_context"] = {"slack_thread": slack_thread}
+    elif _thread_mode(record) == "reuse":
+        metadata["source_context"] = None
     if admin_thread:
         metadata["admin_thread"] = True
     return metadata
@@ -605,6 +696,21 @@ async def _agent_run_config(
 async def _launch_agent_schedule_record(
     record: dict[str, Any], *, test_run: bool = False
 ) -> dict[str, Any]:
+    if _thread_mode(record) == "reuse":
+        async with _automation_launch_lock(record["id"]) as acquired:
+            if not acquired:
+                return {
+                    "status": "busy",
+                    "schedule_id": record["id"],
+                    "error": "automation launch already in progress",
+                }
+            return await _launch_agent_schedule_record_unlocked(record, test_run=test_run)
+    return await _launch_agent_schedule_record_unlocked(record, test_run=test_run)
+
+
+async def _launch_agent_schedule_record_unlocked(
+    record: dict[str, Any], *, test_run: bool = False
+) -> dict[str, Any]:
     schedule_id = record["id"]
     if not test_run and not record.get("enabled"):
         return {"status": "disabled", "schedule_id": schedule_id}
@@ -644,38 +750,86 @@ async def _launch_agent_schedule_record(
             }
 
     client = _client()
-    thread_id = str(uuid.uuid4())
+    reuse_thread = _thread_mode(record) == "reuse"
+    thread_id = (
+        str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:automation:{schedule_id}"))
+        if reuse_thread
+        else str(uuid.uuid4())
+    )
+    existing_metadata: dict[str, Any] = {}
+    if reuse_thread:
+        try:
+            existing_thread = await client.threads.get(thread_id)
+        except Exception as exc:  # noqa: BLE001
+            if getattr(exc, "status_code", None) != 404:
+                error = "failed to load reusable automation thread"
+                logger.exception("Failed to load automation thread %s", thread_id)
+                await _put_run_state(
+                    record,
+                    {"last_error": error, "last_error_at": _now_iso()},
+                )
+                return {"status": "error", "schedule_id": schedule_id, "error": error}
+        else:
+            raw_metadata = existing_thread.get("metadata")
+            if isinstance(raw_metadata, dict):
+                existing_metadata = raw_metadata
+
     slack_thread: dict[str, Any] | None = None
+    source_context = existing_metadata.get("source_context")
+    existing_slack_thread = (
+        source_context.get("slack_thread") if isinstance(source_context, dict) else None
+    )
     slack_channel_id = record.get("slack_channel_id")
     if (
         _slack_notification_mode(record) == "always"
         and isinstance(slack_channel_id, str)
         and slack_channel_id
     ):
-        message_ts, slack_error = await post_slack_top_level_message_with_ts(
-            slack_channel_id,
-            _slack_root_message(record, test_run=test_run),
-            unfurl_links=False,
-            unfurl_media=False,
+        if (
+            isinstance(existing_slack_thread, dict)
+            and existing_slack_thread.get("channel_id") == slack_channel_id
+            and isinstance(existing_slack_thread.get("thread_ts"), str)
+        ):
+            slack_thread = existing_slack_thread
+        else:
+            message_ts, slack_error = await post_slack_top_level_message_with_ts(
+                slack_channel_id,
+                _slack_root_message(record, test_run=test_run),
+                unfurl_links=False,
+                unfurl_media=False,
+            )
+            if not message_ts:
+                error = f"Slack post failed: {slack_error or 'unknown error'}"
+                await _put_run_state(
+                    record,
+                    {"last_error": error, "last_error_at": _now_iso()},
+                )
+                return {"status": "error", "schedule_id": schedule_id, "error": error}
+            slack_thread = {
+                "channel_id": slack_channel_id,
+                "thread_ts": message_ts,
+                "triggering_event_ts": message_ts,
+                "triggering_user_id": await slack_id_for_login(
+                    record.get("created_by") if isinstance(record.get("created_by"), str) else None
+                )
+                or "",
+                "triggering_user_email": record.get("user_email") or "",
+            }
+            await bind_slack_thread_id(client, slack_channel_id, message_ts, thread_id)
+
+    if (
+        reuse_thread
+        and isinstance(existing_slack_thread, dict)
+        and existing_slack_thread is not slack_thread
+        and isinstance(existing_slack_thread.get("channel_id"), str)
+        and isinstance(existing_slack_thread.get("thread_ts"), str)
+    ):
+        await delete_slack_thread_associations(
+            client,
+            existing_slack_thread["channel_id"],
+            existing_slack_thread["thread_ts"],
+            expected_thread_id=thread_id,
         )
-        if not message_ts:
-            error = f"Slack post failed: {slack_error or 'unknown error'}"
-            await _put_run_state(
-                record,
-                {"last_error": error, "last_error_at": _now_iso()},
-            )
-            return {"status": "error", "schedule_id": schedule_id, "error": error}
-        slack_thread = {
-            "channel_id": slack_channel_id,
-            "thread_ts": message_ts,
-            "triggering_event_ts": message_ts,
-            "triggering_user_id": await slack_id_for_login(
-                record.get("created_by") if isinstance(record.get("created_by"), str) else None
-            )
-            or "",
-            "triggering_user_email": record.get("user_email") or "",
-        }
-        await bind_slack_thread_id(client, slack_channel_id, message_ts, thread_id)
 
     admin_thread = _admin_thread_enabled(record)
     metadata = _agent_run_metadata(
@@ -685,6 +839,8 @@ async def _launch_agent_schedule_record(
         test_run=test_run,
         admin_thread=admin_thread,
     )
+    if reuse_thread and isinstance(existing_metadata.get("created_at_ms"), (int, float)):
+        metadata["created_at_ms"] = existing_metadata["created_at_ms"]
     await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
     await client.threads.update(thread_id=thread_id, metadata=metadata)
     input_context: InputMessageContext = {
@@ -722,6 +878,7 @@ async def _launch_agent_schedule_record(
             admin_thread=admin_thread,
         ),
         client=client,
+        multitask_strategy="enqueue" if reuse_thread else "interrupt",
         stream_resumable=True,
     )
     run_id = run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import uuid
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
@@ -7,6 +8,7 @@ from weakref import WeakValueDictionary
 
 from langgraph.config import get_config
 from langgraph_sdk import get_client
+from langgraph_sdk.errors import ConflictError
 
 from ..utils.dashboard_links import dashboard_thread_url
 from ..utils.slack import append_slack_web_link_footer, post_slack_top_level_message_with_ts
@@ -15,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 _NOTIFICATION_NAMESPACE = ["automation_notifications"]
 _MAX_MESSAGE_CHARS = 3_000
+_NOTIFICATION_LOCK_TTL_MINUTES = 5
 _notification_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
 
 
@@ -39,6 +42,13 @@ async def _release_reservation(client: Any, thread_id: str) -> None:
         await client.store.delete_item(_NOTIFICATION_NAMESPACE, thread_id)
     except Exception:
         logger.exception("Failed to release automation notification for %s", thread_id)
+
+
+async def _release_notification_lock(client: Any, lock_id: str) -> None:
+    try:
+        await client.threads.delete(lock_id)
+    except Exception:
+        logger.exception("Failed to release automation notification lock %s", lock_id)
 
 
 async def _mark_action_posted(client: Any, thread_id: str, notified_at: str) -> None:
@@ -76,6 +86,12 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
     thread_id = configurable.get("thread_id")
     if not isinstance(thread_id, str) or not thread_id:
         return {"success": False, "error": "Missing scheduled thread ID"}
+    prepare_run_id = configurable.get("prepare_run_id")
+    notification_id = (
+        f"{thread_id}:{prepare_run_id}"
+        if isinstance(prepare_run_id, str) and prepare_run_id
+        else thread_id
+    )
 
     clean_message = message.strip()
     if not clean_message:
@@ -87,17 +103,45 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
         }
 
     client = get_client()
-    async with _notification_lock(thread_id):
+    async with _notification_lock(notification_id):
+        lock_id = str(
+            uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:automation-notification:{notification_id}")
+        )
         try:
-            item = await client.store.get_item(_NOTIFICATION_NAMESPACE, thread_id)
+            await client.threads.create(
+                thread_id=lock_id,
+                if_exists="raise",
+                ttl=_NOTIFICATION_LOCK_TTL_MINUTES,
+            )
+        except ConflictError:
+            try:
+                item = await client.store.get_item(_NOTIFICATION_NAMESPACE, notification_id)
+            except Exception:
+                logger.exception("Failed to check automation notification for %s", thread_id)
+                return {"success": False, "error": "Could not check the Slack notification state"}
+            existing = _stored_value(item)
+            if existing is not None:
+                return {
+                    "success": True,
+                    "already_notified": True,
+                    "message_ts": existing.get("message_ts"),
+                }
+            return {"success": False, "error": "Slack notification is already in progress"}
+        except Exception:
+            logger.exception("Failed to acquire automation notification lock for %s", thread_id)
+            return {"success": False, "error": "Could not reserve the Slack notification"}
+        try:
+            item = await client.store.get_item(_NOTIFICATION_NAMESPACE, notification_id)
         except Exception:
             logger.exception("Failed to check automation notification for %s", thread_id)
+            await _release_notification_lock(client, lock_id)
             return {"success": False, "error": "Could not check the Slack notification state"}
         existing = _stored_value(item)
         if existing is not None:
             notified_at = existing.get("notified_at")
             if existing.get("status") == "delivered" and isinstance(notified_at, str):
                 await _mark_action_posted(client, thread_id, notified_at)
+            await _release_notification_lock(client, lock_id)
             return {
                 "success": True,
                 "already_notified": True,
@@ -110,9 +154,10 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             "schedule_id": schedule_id,
         }
         try:
-            await client.store.put_item(_NOTIFICATION_NAMESPACE, thread_id, pending)
+            await client.store.put_item(_NOTIFICATION_NAMESPACE, notification_id, pending)
         except Exception:
             logger.exception("Failed to reserve automation notification for %s", thread_id)
+            await _release_notification_lock(client, lock_id)
             return {"success": False, "error": "Could not reserve the Slack notification"}
 
         schedule_name = notification.get("schedule_name")
@@ -128,10 +173,12 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             )
         except Exception:
             logger.exception("Automation Slack post raised for %s", thread_id)
-            await _release_reservation(client, thread_id)
+            await _release_reservation(client, notification_id)
+            await _release_notification_lock(client, lock_id)
             return {"success": False, "error": "Slack post failed unexpectedly"}
         if message_ts is None:
-            await _release_reservation(client, thread_id)
+            await _release_reservation(client, notification_id)
+            await _release_notification_lock(client, lock_id)
             return {
                 "success": False,
                 "error": f"Slack post failed: {slack_error or 'unknown error'}",
@@ -145,8 +192,9 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             "notified_at": datetime.now(UTC).isoformat(),
         }
         try:
-            await client.store.put_item(_NOTIFICATION_NAMESPACE, thread_id, delivered)
+            await client.store.put_item(_NOTIFICATION_NAMESPACE, notification_id, delivered)
         except Exception:
             logger.exception("Failed to finalize automation notification for %s", thread_id)
         await _mark_action_posted(client, thread_id, delivered["notified_at"])
+        await _release_notification_lock(client, lock_id)
         return {"success": True, "message_ts": message_ts}

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import Awaitable, Callable
 from typing import Any
 from xml.etree import ElementTree
 
@@ -60,16 +61,37 @@ class _FakeCrons:
         self.deleted.append(cron_id)
 
 
+class _NotFoundError(Exception):
+    status_code = 404
+
+
 class _FakeThreads:
     def __init__(self) -> None:
         self.created: list[dict[str, Any]] = []
         self.updated: list[dict[str, Any]] = []
+        self.items: dict[str, dict[str, Any]] = {}
+        self.get_hook: Callable[[str], Awaitable[None]] | None = None
+
+    async def get(self, thread_id: str) -> dict[str, Any]:
+        if self.get_hook:
+            await self.get_hook(thread_id)
+        if thread_id not in self.items:
+            raise _NotFoundError
+        return self.items[thread_id]
 
     async def create(self, **kwargs: Any) -> None:
         self.created.append(kwargs)
+        if kwargs.get("if_exists") == "raise" and kwargs["thread_id"] in self.items:
+            raise schedules.ConflictError("exists", response=None, body=None)  # type: ignore[arg-type]
+        self.items.setdefault(kwargs["thread_id"], {"metadata": kwargs.get("metadata", {})})
+
+    async def delete(self, thread_id: str) -> None:
+        self.items.pop(thread_id, None)
 
     async def update(self, **kwargs: Any) -> None:
         self.updated.append(kwargs)
+        thread = self.items.setdefault(kwargs["thread_id"], {"metadata": {}})
+        thread["metadata"] = {**thread["metadata"], **kwargs["metadata"]}
 
 
 class _FakeRuns:
@@ -150,20 +172,33 @@ def test_slack_channel_validation_normalizes_ids() -> None:
         ScheduleCreateBody(prompt="hello", schedule="0 9 * * *", slack_channel_id="#general")
 
 
-def test_slack_notification_mode_defaults_and_validates() -> None:
+def test_schedule_modes_default_and_validate() -> None:
     default_body = ScheduleCreateBody(prompt="hello", schedule="0 9 * * *")
-    conditional_body = ScheduleCreateBody(
-        prompt="hello", schedule="0 9 * * *", slack_notification_mode="on_action"
+    configured_body = ScheduleCreateBody(
+        prompt="hello",
+        schedule="0 9 * * *",
+        slack_notification_mode="on_action",
+        thread_mode="reuse",
     )
 
     assert default_body.slack_notification_mode == "always"
-    assert conditional_body.slack_notification_mode == "on_action"
+    assert default_body.thread_mode == "new"
+    assert configured_body.slack_notification_mode == "on_action"
+    assert configured_body.thread_mode == "reuse"
     with pytest.raises(ValidationError):
         ScheduleCreateBody.model_validate(
             {
                 "prompt": "hello",
                 "schedule": "0 9 * * *",
                 "slack_notification_mode": "sometimes",
+            }
+        )
+    with pytest.raises(ValidationError):
+        ScheduleCreateBody.model_validate(
+            {
+                "prompt": "hello",
+                "schedule": "0 9 * * *",
+                "thread_mode": "sometimes",
             }
         )
 
@@ -183,6 +218,7 @@ async def test_create_agent_schedule_registers_scheduler_cron(fake_client, auth)
     assert result["enabled"] is True
     assert result["slackChannelId"] == "C0123456789"
     assert result["slackNotificationMode"] == "always"
+    assert result["threadMode"] == "new"
     assert result["cronId"] == "cron_1"
     created = fake_client.crons.created[0]
     assert created["assistant_id"] == "scheduler"
@@ -314,6 +350,7 @@ async def test_list_agent_schedules_uses_owner_filters_and_paginates(fake_client
     assert len(result) == 125
     assert {item["id"] for item in result} == {f"alice_{i}" for i in range(125)}
     assert all(item["slackNotificationMode"] == "always" for item in result)
+    assert all(item["threadMode"] == "new" for item in result)
     assert all(item["adminThread"] is False for item in result)
     alice_zero = next(item for item in result if item["id"] == "alice_0")
     assert alice_zero["lastTriggeredAt"] == "2026-01-02T00:00:00+00:00"
@@ -411,6 +448,86 @@ async def test_update_agent_schedule_changes_slack_notification_mode(fake_client
     assert result["slackNotificationMode"] == "on_action"
     stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
     assert stored["slack_notification_mode"] == "on_action"
+
+
+async def test_update_agent_schedule_changes_thread_mode(fake_client) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Daily",
+        "prompt": "Run daily",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_old",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    result = await schedules.update_agent_schedule(
+        "sched_1",
+        "alice",
+        ScheduleUpdateBody(thread_mode="reuse"),
+        email="alice@example.com",
+    )
+
+    assert result["threadMode"] == "reuse"
+    stored = fake_client.store.items[(tuple(schedules.SCHEDULES_NAMESPACE), "sched_1")]
+    assert stored["thread_mode"] == "reuse"
+
+
+async def test_update_agent_schedule_detaches_reused_slack_thread_when_switching_to_new(
+    fake_client,
+) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Daily",
+        "prompt": "Run daily",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "thread_mode": "reuse",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_old",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+    thread_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "open-swe:automation:sched_1"))
+    fake_client.threads.items[thread_id] = {
+        "metadata": {
+            "source_context": {
+                "slack_thread": {
+                    "channel_id": "C0123456789",
+                    "thread_ts": "1784302353.900029",
+                }
+            }
+        }
+    }
+    await fake_client.store.put_item(
+        ["slack_thread_map", "C0123456789"],
+        "1784302353.900029",
+        {"thread_id": thread_id},
+    )
+
+    result = await schedules.update_agent_schedule(
+        "sched_1",
+        "alice",
+        ScheduleUpdateBody(thread_mode="new"),
+        email="alice@example.com",
+    )
+
+    assert result["threadMode"] == "new"
+    mapping = fake_client.store.items[(("slack_thread_map", "C0123456789"), "1784302353.900029")]
+    assert "thread_id" not in mapping
+    assert fake_client.threads.items[thread_id]["metadata"]["source_context"] is None
 
 
 async def test_update_agent_schedule_rejects_non_admin_elevation(fake_client) -> None:  # noqa: ANN001
@@ -692,6 +809,163 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(
     stored = fake_client.store.items[(tuple(schedules.SCHEDULE_RUN_STATE_NAMESPACE), "sched_1")]
     assert stored["last_thread_id"] == thread_id
     assert stored["last_run_id"] == "run_123"
+
+
+async def test_launch_scheduled_agent_run_reuses_thread_and_injects_each_trigger(
+    fake_client, auth
+) -> None:  # noqa: ANN001, ARG001
+    record = {
+        "id": "sched_1",
+        "name": "Daily report",
+        "prompt": "Summarize updates",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "thread_mode": "reuse",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_1",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    first = await schedules.launch_scheduled_agent_run("sched_1")
+    first_created_at = fake_client.threads.items[first["thread_id"]]["metadata"]["created_at_ms"]
+    second = await schedules.launch_scheduled_agent_run("sched_1")
+
+    expected_thread_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "open-swe:automation:sched_1"))
+    assert first["thread_id"] == expected_thread_id
+    assert second["thread_id"] == expected_thread_id
+    assert [run["thread_id"] for run in fake_client.runs.created] == [
+        expected_thread_id,
+        expected_thread_id,
+    ]
+    assert len(fake_client.threads.items) == 1
+    assert fake_client.threads.items[expected_thread_id]["metadata"]["created_at_ms"] == (
+        first_created_at
+    )
+    assert len(fake_client.runs.created) == 2
+    for run in fake_client.runs.created:
+        prompt = ElementTree.fromstring(run["input"]["messages"][-1]["content"])
+        assert prompt.findtext("content") == record["prompt"]
+        assert ElementTree.fromstring(run["input"]["messages"][0]["content"]).attrib["kind"] == (
+            "system"
+        )
+        assert run["multitask_strategy"] == "enqueue"
+
+
+async def test_launch_reused_automation_skips_concurrent_launch(fake_client) -> None:  # noqa: ANN001
+    record = {
+        "id": "sched_1",
+        "name": "Daily report",
+        "prompt": "Summarize updates",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "thread_mode": "reuse",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_1",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+    lock_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "open-swe:automation-launch:sched_1"))
+    fake_client.threads.items[lock_id] = {"metadata": {}}
+
+    result = await schedules.launch_scheduled_agent_run("sched_1")
+
+    assert result == {
+        "status": "busy",
+        "schedule_id": "sched_1",
+        "error": "automation launch already in progress",
+    }
+    assert fake_client.runs.created == []
+
+
+async def test_launch_reused_slack_automation_keeps_one_slack_thread(
+    fake_client, auth, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    record = {
+        "id": "sched_1",
+        "name": "Daily report",
+        "prompt": "Summarize updates",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "slack_channel_id": "C0123456789",
+        "thread_mode": "reuse",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_1",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+    posts = 0
+
+    async def fake_post(*args: Any, **kwargs: Any) -> tuple[str, None]:
+        nonlocal posts
+        posts += 1
+        return "1784302353.900029", None
+
+    monkeypatch.setattr(schedules, "post_slack_top_level_message_with_ts", fake_post)
+
+    first = await schedules.launch_scheduled_agent_run("sched_1")
+    second = await schedules.launch_scheduled_agent_run("sched_1")
+
+    assert first["thread_id"] == second["thread_id"]
+    assert posts == 1
+    assert len(fake_client.runs.created) == 2
+    assert all(
+        run["config"]["configurable"]["slack_thread"]["thread_ts"] == "1784302353.900029"
+        for run in fake_client.runs.created
+    )
+
+
+async def test_launch_reused_automation_detaches_old_slack_destination(
+    fake_client, auth, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    record = {
+        "id": "sched_1",
+        "name": "Daily report",
+        "prompt": "Summarize updates",
+        "schedule": "0 9 * * *",
+        "repo": None,
+        "slack_channel_id": "C0123456789",
+        "thread_mode": "reuse",
+        "model": "Default",
+        "effort": None,
+        "enabled": True,
+        "cron_id": "cron_1",
+        "created_by": "alice",
+        "user_email": "alice@example.com",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
+
+    async def fake_post(*args: Any, **kwargs: Any) -> tuple[str, None]:
+        return "1784302353.900029", None
+
+    monkeypatch.setattr(schedules, "post_slack_top_level_message_with_ts", fake_post)
+    first = await schedules.launch_scheduled_agent_run("sched_1")
+    await fake_client.store.put_item(
+        schedules.SCHEDULES_NAMESPACE,
+        "sched_1",
+        {**record, "slack_channel_id": None},
+    )
+
+    await schedules.launch_scheduled_agent_run("sched_1")
+
+    mapping = fake_client.store.items[(("slack_thread_map", "C0123456789"), "1784302353.900029")]
+    assert "thread_id" not in mapping
+    assert fake_client.threads.items[first["thread_id"]]["metadata"]["source_context"] is None
 
 
 async def test_launch_admin_schedule_without_current_admin_access_is_ordinary_thread(

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -24,6 +24,15 @@ class _FakeStore:
 class _FakeThreads:
     def __init__(self) -> None:
         self.updates: list[dict[str, Any]] = []
+        self.items: set[str] = set()
+
+    async def create(self, *, thread_id: str, **kwargs: Any) -> None:
+        if thread_id in self.items:
+            raise notification_tool.ConflictError("exists", response=None, body=None)  # type: ignore[arg-type]
+        self.items.add(thread_id)
+
+    async def delete(self, thread_id: str) -> None:
+        self.items.discard(thread_id)
 
     async def update(self, *, thread_id: str, metadata: dict[str, Any]) -> None:
         self.updates.append({"thread_id": thread_id, "metadata": metadata})
@@ -41,6 +50,7 @@ def _config(thread_id: str = "thread_1") -> dict[str, Any]:
             "source": "schedule",
             "schedule_id": "sched_1",
             "thread_id": thread_id,
+            "prepare_run_id": "prepare_1",
             "automation_slack_notification": {
                 "channel_id": "C0123456789",
                 "mode": "on_action",
@@ -140,7 +150,7 @@ async def test_notify_automation_channel_posts_to_trusted_destination(
     assert "Dependency check" in posted[0]["text"]
     assert "Opened a pull request" in posted[0]["text"]
     assert "https://example.com/agents/thread_1" in posted[0]["text"]
-    stored = fake_client.store.items[(("automation_notifications",), "thread_1")]
+    stored = fake_client.store.items[(("automation_notifications",), "thread_1:prepare_1")]
     assert stored["status"] == "delivered"
     assert stored["message_ts"] == "1786504009.596419"
     assert fake_client.threads.updates == [
@@ -174,6 +184,28 @@ async def test_notify_automation_channel_suppresses_duplicate_posts(
         "message_ts": "1786504009.596419",
     }
     assert post_count == 1
+
+
+async def test_notify_automation_channel_allows_one_post_per_reused_thread_run(
+    fake_client: _FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    posted: list[str] = []
+    config = _config()
+
+    async def fake_post(channel_id: str, text: str, **kwargs: Any) -> tuple[str, None]:
+        posted.append(text)
+        return f"1786504009.{len(posted)}", None
+
+    monkeypatch.setattr(notification_tool, "get_config", lambda: config)
+    monkeypatch.setattr(notification_tool, "post_slack_top_level_message_with_ts", fake_post)
+
+    first = await notification_tool.notify_automation_channel("First run")
+    config["configurable"]["prepare_run_id"] = "prepare_2"
+    second = await notification_tool.notify_automation_channel("Second run")
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert len(posted) == 2
 
 
 async def test_notify_automation_channel_allows_retry_after_slack_failure(

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AgentPullRequestStatusResponse,
   AgentSchedule,
   AgentThread,
+  AutomationThreadMode,
   ImageChunk,
   Message,
   SlackNotificationMode,
@@ -13,7 +14,13 @@ import {
   dashboardForwardedHeaders,
 } from "@/lib/dashboard-fetch"
 
-export type { AgentSchedule, AgentThread, Message, SlackNotificationMode }
+export type {
+  AgentSchedule,
+  AgentThread,
+  AutomationThreadMode,
+  Message,
+  SlackNotificationMode,
+}
 
 export class AgentsApiError extends Error {
   constructor(
@@ -40,6 +47,7 @@ export interface ScheduleCreateRequest {
   repo?: string | null
   slack_channel_id?: string | null
   slack_notification_mode?: SlackNotificationMode
+  thread_mode?: AutomationThreadMode
   admin_thread?: boolean
   model_id?: string | null
   effort?: string | null
@@ -52,6 +60,7 @@ export interface ScheduleUpdateRequest {
   repo?: string | null
   slack_channel_id?: string | null
   slack_notification_mode?: SlackNotificationMode
+  thread_mode?: AutomationThreadMode
   admin_thread?: boolean
   model_id?: string | null
   effort?: string | null

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -197,6 +197,7 @@ export interface Project {
 }
 
 export type SlackNotificationMode = "always" | "on_action"
+export type AutomationThreadMode = "new" | "reuse"
 
 export interface AgentSchedule {
   id: string
@@ -206,6 +207,7 @@ export interface AgentSchedule {
   repo: string | null
   slackChannelId?: string | null
   slackNotificationMode: SlackNotificationMode
+  threadMode: AutomationThreadMode
   adminThread: boolean
   model: string
   effort?: string | null

--- a/ui/src/features/automations/components/AutomationEditor.test.tsx
+++ b/ui/src/features/automations/components/AutomationEditor.test.tsx
@@ -75,6 +75,17 @@ afterEach(() => {
 })
 
 describe("AutomationEditor", () => {
+  it("shows both automation thread modes", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { is_admin: false },
+    } as unknown as ReturnType<typeof useSession>)
+
+    const markup = renderToStaticMarkup(<AutomationEditor mode="create" />)
+
+    expect(markup).toContain("Start a new thread")
+    expect(markup).toContain("Reuse one thread")
+  })
+
   it("shows the admin-thread checkbox only to admins", () => {
     vi.mocked(useSession).mockReturnValue({
       data: { is_admin: true },

--- a/ui/src/features/automations/components/AutomationEditor.tsx
+++ b/ui/src/features/automations/components/AutomationEditor.tsx
@@ -5,6 +5,7 @@ import { ClockIcon, TrashIcon } from "@phosphor-icons/react"
 import type { ModelOption } from "@/lib/api"
 import type {
   AgentSchedule,
+  AutomationThreadMode,
   SlackNotificationMode,
 } from "@/features/agents/lib/types"
 import type { AutomationTemplate } from "@/features/automations/lib/automation-templates"
@@ -84,6 +85,9 @@ export function AutomationEditor({
   )
   const [slackNotificationMode, setSlackNotificationMode] =
     useState<SlackNotificationMode>(schedule?.slackNotificationMode ?? "always")
+  const [threadMode, setThreadMode] = useState<AutomationThreadMode>(
+    schedule?.threadMode ?? "new"
+  )
   const [enabled, setEnabled] = useState(schedule?.enabled ?? true)
   const [adminThread, setAdminThread] = useState(schedule?.adminThread ?? false)
   // undefined = untouched (derive from the schedule / default as models load).
@@ -102,6 +106,7 @@ export function AutomationEditor({
     repo !== (schedule?.repo ?? null) ||
     slackChannelId !== (schedule?.slackChannelId ?? "") ||
     slackNotificationMode !== (schedule?.slackNotificationMode ?? "always") ||
+    threadMode !== (schedule?.threadMode ?? "new") ||
     enabled !== (schedule?.enabled ?? true) ||
     adminThread !== (schedule?.adminThread ?? false) ||
     activeSelection?.modelId !== initialSelection?.modelId ||
@@ -140,6 +145,7 @@ export function AutomationEditor({
           repo,
           slack_channel_id: slackChannelId.trim() || null,
           slack_notification_mode: slackNotificationMode,
+          thread_mode: threadMode,
           admin_thread: adminThread,
           model_id: modelId,
           effort,
@@ -164,6 +170,7 @@ export function AutomationEditor({
           repo: repo ?? "",
           slack_channel_id: slackChannelId.trim() || null,
           slack_notification_mode: slackNotificationMode,
+          thread_mode: threadMode,
           admin_thread: adminThread,
           model_id: modelId,
           effort,
@@ -288,6 +295,32 @@ export function AutomationEditor({
             onSelect={onPickTrigger}
             triggerLabel={cron ? "Change trigger" : "Add Trigger"}
           />
+        </div>
+
+        <SectionLabel>Thread history</SectionLabel>
+        <div className="rounded-xl border border-border bg-card p-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-muted-foreground">
+              On each trigger
+            </span>
+            <Select
+              value={threadMode}
+              onValueChange={(value) => value && setThreadMode(value)}
+            >
+              <SelectTrigger className="w-52">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="new">Start a new thread</SelectItem>
+                <SelectItem value="reuse">Reuse one thread</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground/70">
+            {threadMode === "reuse"
+              ? "Each trigger adds a new automation message to the same thread and keeps its sandbox and history."
+              : "Each trigger starts with a fresh thread, sandbox, and history."}
+          </p>
         </div>
 
         <SectionLabel>Slack destination</SectionLabel>


### PR DESCRIPTION
## Description
Adds an opt-in thread mode so recurring automations can keep one Open SWE thread, sandbox, and history while injecting a fresh system trigger message on every run. Reused launches are serialized, queued, and keep a single Slack root with safe mapping cleanup.

## Test Plan
- [x] Verify repeated triggers reuse one thread and enqueue synthetic messages
- [x] Verify Slack mappings and action-only notifications across reused runs
- [x] Verify dashboard thread-mode selection and TypeScript types

Made by [Open SWE](https://openswe.vercel.app/agents/5a7e990b-fb57-5cff-8f73-02da168de285)