### PR TITLE
perf(agent): load the factory's tool sets in parallel

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -935,10 +935,25 @@ async def _admin_thread(config: RunnableConfig, profile_login: str | None) -> bo
     )
 
 
-async def _allowed_org_member(config: RunnableConfig, profile_login: str | None) -> bool:
+async def _cached_allowed_org_member(config: RunnableConfig, profile_login: str | None) -> bool:
+    login = _org_member_login(config, profile_login)
+    if not login:
+        return False
+    return await ttl_cache.cached(
+        f"org-member:{login}",
+        300,
+        lambda: _allowed_org_member(config, profile_login),
+    )
+
+
+def _org_member_login(config: RunnableConfig, profile_login: str | None) -> str | None:
     configurable = (config or {}).get("configurable") or {}
     config_login = configurable.get("github_login")
-    login = profile_login or (config_login if isinstance(config_login, str) else None)
+    return profile_login or (config_login if isinstance(config_login, str) else None)
+
+
+async def _allowed_org_member(config: RunnableConfig, profile_login: str | None) -> bool:
+    login = _org_member_login(config, profile_login)
     if not login:
         return False
     orgs = dict.fromkeys(
@@ -966,15 +981,60 @@ async def _cached_tool_loader(key: str, ttl_seconds: float, loader: Any) -> list
         return []
 
 
+async def _cached_langsmith_tools(profile_login: str | None, *, allow_team: bool) -> list[Any]:
+    scope = "team" if allow_team else "solo"
+    return await _cached_tool_loader(
+        f"tools:langsmith:{profile_login or '-'}:{scope}",
+        300,
+        lambda: load_langsmith_tools(profile_login, allow_team=allow_team),
+    )
+
+
 async def _load_observability_tools(authorized: bool, profile_login: str | None) -> list[Any]:
     """Load team observability tools for an authorized triggering user."""
     if not authorized:
         return []
     datadog_tools, langsmith_tools = await asyncio.gather(
         _cached_tool_loader("tools:datadog", 600, load_datadog_tools),
-        load_langsmith_tools(profile_login),
+        _cached_langsmith_tools(profile_login, allow_team=True),
     )
     return [*datadog_tools, *langsmith_tools]
+
+
+async def _observability_tools_for(config: RunnableConfig, profile_login: str | None) -> list[Any]:
+    """Observability tools the triggering user is allowed to see.
+
+    The authorization gate itself stays uncached — it reads per-run config — so
+    only the credential and membership lookups behind it are reused.
+    """
+    if await _observability_authorized(config, profile_login):
+        return await _load_observability_tools(True, profile_login)
+    if await _cached_allowed_org_member(config, profile_login):
+        return await _cached_langsmith_tools(profile_login, allow_team=True)
+    return await _cached_langsmith_tools(profile_login, allow_team=False)
+
+
+async def _load_integration_tools(profile_login: str | None) -> tuple[list[Any], list[Any]]:
+    if not profile_login:
+        return [], []
+    currents_tools, notion_tools = await asyncio.gather(
+        _cached_tool_loader(
+            f"tools:currents:{profile_login}",
+            300,
+            lambda: load_currents_tools(profile_login),
+        ),
+        _cached_tool_loader(
+            f"tools:notion:{profile_login}",
+            300,
+            lambda: load_notion_tools(profile_login),
+        ),
+    )
+    return currents_tools, notion_tools
+
+
+async def _phase_result(thread_id: str | None, name: str, loader: Any) -> Any:
+    async with aphase(thread_id, name):
+        return await loader()
 
 
 async def _load_corridor_mcp_tools() -> list[Any]:
@@ -1485,32 +1545,20 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
     if not stop_summary_mode and not local_run:
-        async with aphase(thread_id, "factory.observability_tools"):
-            observability_authorized = await _observability_authorized(config, profile_login)
-            if observability_authorized:
-                observability_tools = await _load_observability_tools(True, profile_login)
-            elif await _allowed_org_member(config, profile_login):
-                observability_tools = await load_langsmith_tools(profile_login)
-            else:
-                observability_tools = await load_langsmith_tools(profile_login, allow_team=False)
-        async with aphase(thread_id, "factory.corridor_tools"):
-            corridor_tools = await _load_corridor_mcp_tools()
         browser_tools = load_browser_tools()
-
-        if profile_login:
-            async with aphase(thread_id, "factory.integration_tools"):
-                currents_tools, notion_tools = await asyncio.gather(
-                    _cached_tool_loader(
-                        f"tools:currents:{profile_login}",
-                        300,
-                        lambda: load_currents_tools(profile_login),
-                    ),
-                    _cached_tool_loader(
-                        f"tools:notion:{profile_login}",
-                        300,
-                        lambda: load_notion_tools(profile_login),
-                    ),
-                )
+        observability_tools, corridor_tools, (currents_tools, notion_tools) = await asyncio.gather(
+            _phase_result(
+                thread_id,
+                "factory.observability_tools",
+                lambda: _observability_tools_for(config, profile_login),
+            ),
+            _phase_result(thread_id, "factory.corridor_tools", _load_corridor_mcp_tools),
+            _phase_result(
+                thread_id,
+                "factory.integration_tools",
+                lambda: _load_integration_tools(profile_login),
+            ),
+        )
 
     slack_tools = [
         slack_add_reaction,

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -1,0 +1,85 @@
+"""The graph factory's three tool loaders must overlap, not run back-to-back.
+
+Each one is a cold-cache network round trip (MCP handshakes, credential store
+reads), and they sit on the critical path before the run's first model call.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langgraph.graph.state import RunnableConfig
+
+from agent.server import get_agent
+from agent.utils.sandbox_state import clear_sandbox_backend
+
+_START_TIMEOUT_SECONDS = 2.0
+
+
+class _DummyAgent:
+    def with_config(self, config: RunnableConfig) -> "_DummyAgent":
+        return self
+
+
+def _config() -> RunnableConfig:
+    return {
+        "configurable": {
+            "__is_for_execution__": True,
+            "thread_id": "thread-parallel-tools",
+            "github_login": "octocat",
+        },
+        "metadata": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_tool_loaders_run_concurrently() -> None:
+    barrier = asyncio.Barrier(3)
+
+    def rendezvous(result: Any) -> Any:
+        # Serial loaders never all reach the barrier, so a regression times out
+        # here instead of quietly costing a few seconds per run.
+        async def loader(*_args: Any) -> Any:
+            await asyncio.wait_for(barrier.wait(), timeout=_START_TIMEOUT_SECONDS)
+            return result
+
+        return loader
+
+    thread_id = "thread-parallel-tools"
+    clear_sandbox_backend(thread_id)
+    with (
+        patch(
+            "agent.server.resolve_github_token",
+            new_callable=AsyncMock,
+            return_value=("ghp", None),
+        ),
+        patch("agent.server.resolve_triggering_user_identity", return_value=None),
+        patch(
+            "agent.server.ensure_sandbox_for_thread",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "agent.server.aresolve_sandbox_work_dir",
+            new_callable=AsyncMock,
+            return_value="/workspace",
+        ),
+        patch(
+            "agent.server.get_team_default_model_pair",
+            new_callable=AsyncMock,
+            return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
+        ),
+        patch("agent.server.load_profile", new_callable=AsyncMock, return_value=None),
+        patch("agent.server.load_thread_settings", new_callable=AsyncMock, return_value={}),
+        patch("agent.server.fallback_model_id_for", return_value=None),
+        patch("agent.server.make_model", side_effect=[MagicMock(), MagicMock()]),
+        patch("agent.server.construct_system_prompt", return_value="prompt"),
+        patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
+        patch("agent.server._observability_tools_for", side_effect=rendezvous([])),
+        patch("agent.server._load_corridor_mcp_tools", side_effect=rendezvous([])),
+        patch("agent.server._load_integration_tools", side_effect=rendezvous(([], []))),
+    ):
+        await get_agent(_config())
+
+    clear_sandbox_backend(thread_id)

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -326,3 +326,56 @@ async def test_observability_authorized_accepts_admin_login(
 
     config = cast(RunnableConfig, {"configurable": {"github_login": "dev"}})
     assert await server._observability_authorized(config, "dev") is True
+
+
+@pytest.mark.asyncio
+async def test_org_membership_lookup_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALLOWED_GITHUB_ORGS", "primary")
+    membership = AsyncMock(return_value=True)
+    monkeypatch.setattr(server, "is_user_active_org_member", membership)
+
+    config = cast(RunnableConfig, {"configurable": {"github_login": "dev"}})
+    assert await server._cached_allowed_org_member(config, "dev") is True
+    assert await server._cached_allowed_org_member(config, "dev") is True
+    assert membership.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_observability_tools_reuse_the_credential_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin@example.com")
+    monkeypatch.delenv("OBSERVABILITY_AUTHORIZED_EMAILS", raising=False)
+    monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
+    langsmith = AsyncMock(return_value=["ls"])
+    monkeypatch.setattr(server, "load_langsmith_tools", langsmith)
+    monkeypatch.setattr(server, "load_datadog_tools", AsyncMock(return_value=["dd"]))
+
+    config = cast(RunnableConfig, {"configurable": {"user_email": "admin@example.com"}})
+    assert await server._observability_tools_for(config, "alice") == ["dd", "ls"]
+    assert await server._observability_tools_for(config, "alice") == ["dd", "ls"]
+    assert langsmith.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_observability_authorization_is_rechecked_per_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached tool list must never carry team access into an unauthorized run."""
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin@example.com")
+    monkeypatch.delenv("OBSERVABILITY_AUTHORIZED_EMAILS", raising=False)
+    monkeypatch.setenv("ALLOWED_GITHUB_ORGS", "primary")
+    monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
+    monkeypatch.setattr(server, "is_user_active_org_member", AsyncMock(return_value=False))
+    monkeypatch.setattr(server, "load_datadog_tools", AsyncMock(return_value=["dd"]))
+    monkeypatch.setattr(
+        server,
+        "load_langsmith_tools",
+        AsyncMock(side_effect=lambda _login, allow_team=True: ["team"] if allow_team else []),
+    )
+
+    admin = cast(RunnableConfig, {"configurable": {"user_email": "admin@example.com"}})
+    attacker = cast(RunnableConfig, {"configurable": {"user_email": "attacker@example.com"}})
+
+    assert await server._observability_tools_for(admin, "alice") == ["dd", "team"]
+    assert await server._observability_tools_for(attacker, "alice") == []


### PR DESCRIPTION
`get_agent` spends ~4.4s before the run's first model call, and 98% of it is three tool loaders running back-to-back. Measured from the `startup` phase spans on run `01a03464-72d3-7202-89e8-eb8eb83e4450`:

| phase | elapsed |
|---|---|
| `factory.thread_settings` / `settings_defaults` / `sender_profile` / `admin_thread` | 99ms total |
| `factory.observability_tools` | 1,587ms |
| `factory.corridor_tools` | 1,448ms |
| `factory.integration_tools` | 1,213ms |
| **total** | **4,352ms** |

Across the last 100 occurrences of each phase in `open-swe-agent`:

| phase | min | p50 | p90 | max | % under 20ms |
|---|---|---|---|---|---|
| `factory.observability_tools` | 23 | **702** | 1161 | 2157 | **0%** |
| `factory.corridor_tools` | 0 | 0 | 1791 | 2747 | 85% |
| `factory.integration_tools` | 0 | 19 | 1144 | 3659 | 52% |

Corridor and integration are already TTL-cached with stale-while-revalidate, so they are usually free and only cost on a cold worker. Observability had no cache at all, which is why it never drops near zero — every run redoes `email_for_login`, up to three GitHub API calls per entry in `ALLOWED_GITHUB_ORGS`, and one or two credential `store.get_item` round trips, to produce a fixed tool list. The tools resolve credentials at call time; the loader only decides whether to offer them.

Two changes:

1. **Cache the lookups behind the observability gate.** The LangSmith tool list is cached per login and team scope, and the org-membership check per login. The authorization gate itself (`_observability_authorized`) stays uncached because it reads per-run config — a cached tool list must never carry team access into a run whose config is not authorized. Team and solo tool lists use separate cache keys so the team list cannot be served to a solo caller.
2. **Gather the three phases** instead of awaiting them in sequence.

The `aphase` spans are preserved, so the waterfall now shows the three overlapping rather than stacked.

Note for reviewers: org membership is cached for 300s, matching the sibling tool caches. A membership revoked mid-window stays effective for up to 5 minutes. Say the word if you want that tighter.

## Test Plan

- [x] `tests/agent/test_factory_tool_loading.py` — the three loaders rendezvous at an `asyncio.Barrier`, so a regression to sequential awaits fails on a 2s timeout instead of silently costing seconds per run
- [x] `tests/tools/test_observability_tools.py` — membership lookup cached; credential lookup reused; authorization re-checked per run so an unauthorized config gets no team tools after an authorized one
- [x] `make test` — 1868 passed, 3 skipped
- [x] `make lint`
- [x] `make typecheck`