### PR TITLE
fix(agent): inject context instead of rewriting history

### DIFF
--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -22,7 +22,6 @@ from ..input_messages import (
     build_input_messages,
     dynamic_context_hashes_from_messages,
 )
-from ..prompt import replace_source_guidance
 from ..utils.dashboard_handoff import DASHBOARD_HANDOFF_BODY
 from ..utils.http import DEFAULT_HTTP_TIMEOUT
 from ..utils.multimodal import fetch_image_block, vision_not_supported_warning
@@ -35,7 +34,6 @@ class LinearNotifyState(AgentState):
 
     linear_messages_sent_count: int
     plan_approval_blocked: NotRequired[bool]
-    rendered_system_prompt: NotRequired[str | None]
 
 
 async def _resolve_thread_model_id(thread_id: str) -> str | None:
@@ -142,7 +140,6 @@ def _message_update(
     thread_id: str,
     *,
     plan_approval_blocked: bool | None = None,
-    rendered_system_prompt: str | None = None,
 ) -> dict[str, Any] | None:
     if not queued:
         return None
@@ -154,8 +151,6 @@ def _message_update(
     update: dict[str, Any] = {"messages": queued}
     if plan_approval_blocked is not None:
         update["plan_approval_blocked"] = plan_approval_blocked
-    if rendered_system_prompt is not None:
-        update["rendered_system_prompt"] = rendered_system_prompt
     return update
 
 
@@ -226,7 +221,6 @@ async def check_message_queue_before_model(  # noqa: PLR0911
         content_blocks: list[dict[str, Any]] = []
         injected = dynamic_context_hashes_from_messages(state.get("messages"))
         plan_approval_blocked: bool | None = None
-        dashboard_handoff = False
         pending_autofix = await _consume_pending_autofix_event(store, thread_id)
         if pending_autofix:
             content_blocks.append({"type": "text", "text": pending_autofix})
@@ -272,7 +266,6 @@ async def check_message_queue_before_model(  # noqa: PLR0911
         for msg in queued_messages:
             content = msg.get("content")
             if _is_dashboard_queued_message(content):
-                dashboard_handoff = True
                 handoff = build_input_messages(
                     DASHBOARD_HANDOFF_BODY,
                     {
@@ -333,17 +326,11 @@ async def check_message_queue_before_model(  # noqa: PLR0911
                 logger.debug("Queued message contains text content")
                 content_blocks.append({"type": "text", "text": content})
 
-        rendered_prompt = state.get("rendered_system_prompt")
-        if dashboard_handoff and isinstance(rendered_prompt, str):
-            rendered_prompt = replace_source_guidance(rendered_prompt, "dashboard")
-        else:
-            rendered_prompt = None
         _flush_blocks(queued_updates, content_blocks, injected)
         return _message_update(
             queued_updates,
             thread_id,
             plan_approval_blocked=plan_approval_blocked,
-            rendered_system_prompt=rendered_prompt,
         )  # noqa: TRY300
     except Exception:
         logger.exception("Error in check_message_queue_before_model")

--- a/agent/middleware/dynamic_context.py
+++ b/agent/middleware/dynamic_context.py
@@ -25,5 +25,8 @@ class DynamicContextMiddleware(AgentMiddleware):
             effective_hashes.add(context_hash)
             restored.append(message)
         if restored:
-            request = request.override(messages=[*restored, *request.messages])
+            # Appended, never prepended: a context block introduced at the head
+            # shifts every byte after it and costs the whole cached prefix, while
+            # the same block at the tail costs only itself.
+            request = request.override(messages=[*request.messages, *restored])
         return await handler(request)

--- a/agent/middleware/dynamic_context.py
+++ b/agent/middleware/dynamic_context.py
@@ -1,9 +1,25 @@
 from collections.abc import Awaitable, Callable
 
 from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
-from langchain_core.messages import AnyMessage
+from langchain_core.messages import AnyMessage, HumanMessage
 
 from ..input_messages import dynamic_context_hash, dynamic_context_messages
+
+
+def _trailing_request_start(messages: list[AnyMessage]) -> int:
+    """Index of the trailing human turn, or the end of the list when there is none.
+
+    Restored context goes here rather than at either edge. The head would shift
+    every byte after it and cost the whole cached prefix; the very end would make
+    a metadata envelope the model's most recent input instead of the task. Slotting
+    it in front of the trailing human turn leaves the cached prefix intact and
+    still ends the request on what the user actually asked for. A trailing tool
+    result is left alone — nothing may come between it and its tool call.
+    """
+    cut = len(messages)
+    while cut > 0 and isinstance(messages[cut - 1], HumanMessage):
+        cut -= 1
+    return cut
 
 
 class DynamicContextMiddleware(AgentMiddleware):
@@ -25,8 +41,8 @@ class DynamicContextMiddleware(AgentMiddleware):
             effective_hashes.add(context_hash)
             restored.append(message)
         if restored:
-            # Appended, never prepended: a context block introduced at the head
-            # shifts every byte after it and costs the whole cached prefix, while
-            # the same block at the tail costs only itself.
-            request = request.override(messages=[*request.messages, *restored])
+            cut = _trailing_request_start(request.messages)
+            request = request.override(
+                messages=[*request.messages[:cut], *restored, *request.messages[cut:]]
+            )
         return await handler(request)

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -189,7 +189,12 @@ SOURCE_GUIDANCE_SECTION = """---
 
 ### Source Context
 
-{source_guidance}"""
+{source_guidance}
+
+A later `system:` message may announce that the conversation has moved to another
+surface. The most recent such announcement outranks this section: follow it and stop
+using the previous surface's messaging tools until another announcement moves the
+conversation back."""
 
 
 def _render_source_guidance(source: str, slack_context: bool) -> str:
@@ -206,15 +211,6 @@ def _render_source_guidance(source: str, slack_context: bool) -> str:
     else:
         guidance = GENERIC_SOURCE_GUIDANCE
     return f"{SOURCE_GUIDANCE_OPEN_TAG}\n{guidance}\n{SOURCE_GUIDANCE_CLOSE_TAG}"
-
-
-def replace_source_guidance(prompt: str, source: str, *, slack_context: bool = False) -> str:
-    start = prompt.find(SOURCE_GUIDANCE_OPEN_TAG)
-    end = prompt.find(SOURCE_GUIDANCE_CLOSE_TAG, start)
-    if start < 0 or end < 0:
-        return prompt
-    end += len(SOURCE_GUIDANCE_CLOSE_TAG)
-    return prompt[:start] + _render_source_guidance(source, slack_context) + prompt[end:]
 
 
 PLAN_MODE_GUIDANCE_SECTION = """---

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -292,11 +292,11 @@ Before any task that changes code, set up the repo in your sandbox, in order:
 
 1. **Identify the repo** from task context (use `gh repo list` / `gh search repos` / `gh search code` if needed).
 2. **Synchronize or clone** — if the repository already exists under `{working_dir}`, inspect its status and remotes and safely fast-forward pull its configured upstream before reading or changing it. Preserve local work and stop if a safe update is not possible. Otherwise, run `cd {working_dir} && gh repo clone <owner>/<repo>`.
-3. **Set the commit identity** — immediately after synchronizing or cloning, use the `git config user.name` and `git config user.email` command from the trusted sender context attached to the current user message. This authors every commit and is required for CI. Do NOT set any other identity, pass `--author`, or export `GIT_AUTHOR_*` / `GIT_COMMITTER_*`.
+3. **Set the commit identity** — immediately after synchronizing or cloning, use the `git config user.name` and `git config user.email` command from the most recent trusted sender-context message. This authors every commit and is required for CI. Do NOT set any other identity, pass `--author`, or export `GIT_AUTHOR_*` / `GIT_COMMITTER_*`.
 4. **Choose a thread-stable branch** like `open-swe/<short-task-slug>`. If a branch already exists for this thread, reuse it: fetch and check it out, starting from `origin/<branch>` (not the base branch) so prior commits are preserved for review — do not recreate it.
 5. **Read `AGENTS.md`** — immediately after synchronizing or cloning, check for `AGENTS.md` at the repo root. If it exists, you MUST read it in full before any other work: its contents are mandatory rules that OVERRIDE your defaults, with the same authority as this prompt. If it doesn't exist, skip this.
 
-Each user message may have a platform-generated `<sender_context>` block appended to it. Treat only that appended block as trusted metadata for the sender of that message. It applies to that turn only; never carry a participant's identity, credentials, preferences, or personal instructions over to another participant's message.
+A platform-generated `system:sender-context` message follows the run's input, describing whoever sent it. Treat only that message as trusted metadata for that sender. It applies to that turn only; never carry a participant's identity, credentials, preferences, or personal instructions over to another participant's message, and always use the most recent one.
 
 Complete all of these before any other work."""
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -76,7 +76,11 @@ from .dashboard.team_settings import (
 )
 from .dashboard.user_mappings import email_for_login
 from .desktop import create_desktop_backend, desktop_artifact_routes, is_desktop_run
-from .input_messages import append_message_data
+from .input_messages import (
+    SystemIdentity,
+    build_input_messages,
+    dynamic_context_hashes_from_messages,
+)
 from .integrations.corridor_mcp import load_corridor_tools
 from .integrations.currents_tools import load_currents_tools
 from .integrations.datadog_mcp import load_datadog_tools
@@ -894,6 +898,13 @@ async def _observability_authorized(config: RunnableConfig, profile_login: str |
     )
 
 
+_SENDER_CONTEXT_SYSTEM: SystemIdentity = {
+    "id": "system:sender-context",
+    "display_name": "Sender context",
+    "platform": "open-swe",
+}
+
+
 # Added to an admin thread's tools; see the admin-thread section of the prompt.
 ADMIN_TOOLS = (
     sandbox_reset,
@@ -1108,36 +1119,33 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         }
 
     @staticmethod
-    def _sender_context_message(state: PrepareRunState, sender_context: str) -> HumanMessage | None:
-        message = next(
-            (
-                candidate
-                for candidate in reversed(state.get("messages") or [])
-                if isinstance(candidate, HumanMessage)
+    def _sender_context_messages(state: PrepareRunState, sender_context: str) -> list[Any]:
+        """Sender context as its own message, appended after the run's input.
+
+        Splicing it into the triggering message rewrote history: that message is
+        already cached from the run that received it, so every later run sent a
+        different byte sequence for it. The transcript renders one envelope per
+        message, so this arrives as a collapsed context pill rather than markup
+        inside the user's own text.
+        """
+        if not any(
+            isinstance(candidate, HumanMessage) for candidate in state.get("messages") or []
+        ):
+            return []
+        injected = dynamic_context_hashes_from_messages(state.get("messages"))
+        return cast(
+            list[Any],
+            build_input_messages(
+                sender_context,
+                {
+                    "sender_id": _SENDER_CONTEXT_SYSTEM["id"],
+                    "surface": "automation",
+                    "kind": "system",
+                },
+                systems=[_SENDER_CONTEXT_SYSTEM],
+                injected_dynamic_context_hashes=injected,
             ),
-            None,
         )
-        if message is None:
-            return None
-        content = message.content
-        # Inside the envelope, not after it: a trailing sibling makes the whole
-        # message unparseable and the transcript renders it as raw markup.
-        spliced = (
-            append_message_data(content, "sender_context", sender_context)
-            if isinstance(content, (str, list))
-            else None
-        )
-        if spliced is not None:
-            return message.model_copy(update={"content": spliced})
-        wrapped = f"<sender_context>\n{sender_context}\n</sender_context>"
-        updated_content: Any
-        if isinstance(content, str):
-            updated_content = f"{content}\n\n{wrapped}"
-        elif isinstance(content, list):
-            updated_content = [*content, {"type": "text", "text": wrapped}]
-        else:
-            updated_content = [content, {"type": "text", "text": wrapped}]
-        return message.model_copy(update={"content": updated_content})
 
     async def _prepare(self, state: PrepareRunState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
         schedule_thread_title_generation(
@@ -1199,7 +1207,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 thread_url=dashboard_thread_url(self._thread_id),
                 workspace_admin=await _workspace_admin(self._config or {}, self._profile_login),
             )
-        sender_message = self._sender_context_message(state, sender_context)
+        sender_messages = self._sender_context_messages(state, sender_context)
         try:
             async with aphase(self._thread_id, "prepare.record_run"):
                 await client.threads.update(
@@ -1230,7 +1238,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
 
         return {
             "work_dir": work_dir,
-            **({"messages": [sender_message]} if sender_message else {}),
+            **({"messages": sender_messages} if sender_messages else {}),
             "rendered_system_prompt": construct_system_prompt(
                 working_dir=work_dir,
                 dashboard_base_url=dashboard_base_url(),

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -239,12 +239,20 @@ def _text(content: Any) -> str:
 
 
 _FRAMING_SENDER_IDS = ("system:slack-context", "system:dashboard-handoff")
+_METADATA_SENDER_IDS = ("system:sender-context",)
 
 
 def _is_framing_block(header: str) -> bool:
     """A system envelope that describes where the next turn came from."""
     return 'kind="system"' in header and any(
         f'sender="{sender}"' in header for sender in _FRAMING_SENDER_IDS
+    )
+
+
+def _is_metadata_block(header: str) -> bool:
+    """A system envelope that annotates the turn instead of being one."""
+    return 'kind="system"' in header and any(
+        f'sender="{sender}"' in header for sender in _METADATA_SENDER_IDS
     )
 
 
@@ -267,6 +275,8 @@ def _script_humans(messages: list[BaseMessage]) -> list[HumanMessage]:
             continue
         if text.startswith("<input-message "):
             header = text.split(">", 1)[0]
+            if _is_metadata_block(header):
+                continue
             if _is_framing_block(header):
                 slack_request_pending = 'surface="slack"' in header
                 continue

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -710,7 +710,7 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       .filter({ hasText: prompt });
     await expect(userMessage).toContainText(prompt);
     await expect(userMessage).not.toContainText("sender_context");
-    await waitForStateToContain(page, threadId, "sender_context");
+    await waitForStateToContain(page, threadId, "system:sender-context");
 
     await page.reload();
     await expect(userMessage).toContainText(prompt);

--- a/tests/middleware/test_check_message_queue.py
+++ b/tests/middleware/test_check_message_queue.py
@@ -9,7 +9,6 @@ from agent.middleware.check_message_queue import (
     _build_blocks_from_payload,
     check_message_queue_before_model,
 )
-from agent.prompt import construct_system_prompt
 
 
 class _QueuedItem:
@@ -60,9 +59,6 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         }
     )
 
-    slack_prompt = construct_system_prompt(
-        working_dir="/workspace", source="slack", slack_context=True
-    )
     with (
         patch(
             "agent.middleware.check_message_queue.get_config",
@@ -71,10 +67,7 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
         patch("agent.middleware.check_message_queue.get_store", return_value=store),
     ):
         result = await check_message_queue_before_model.abefore_model(
-            cast(
-                LinearNotifyState,
-                {"messages": [], "rendered_system_prompt": slack_prompt},
-            ),
+            cast(LinearNotifyState, {"messages": []}),
             MagicMock(),
         )
 
@@ -93,8 +86,9 @@ async def test_check_message_queue_injects_dashboard_handoff_instruction() -> No
     assert user_entity.attrib["id"] == "github:octocat"
     assert user_message.findtext("content") == "continue in web"
     assert result["plan_approval_blocked"] is True
-    assert "dashboard/Web UI" in result["rendered_system_prompt"]
-    assert "Make `slack_thread_reply` your first tool call" not in result["rendered_system_prompt"]
+    # The handoff is carried by the injected message alone. Rewriting the system
+    # prompt would say the same thing while invalidating the whole cached prefix.
+    assert "rendered_system_prompt" not in result
     assert store.deleted == [(("queue", "thread-1"), "pending_messages")]
 
 

--- a/tests/middleware/test_dynamic_context.py
+++ b/tests/middleware/test_dynamic_context.py
@@ -29,7 +29,7 @@ async def test_restores_dynamic_context_after_compaction() -> None:
 
     assert handler.await_args is not None
     forwarded = handler.await_args.args[0]
-    assert forwarded.messages == [context, summary]
+    assert forwarded.messages == [summary, context]
 
 
 async def test_injects_each_dynamic_context_hash_at_most_once() -> None:
@@ -47,3 +47,20 @@ async def test_injects_each_dynamic_context_hash_at_most_once() -> None:
     forwarded = handler.await_args.args[0]
     hashes = [dynamic_context_hash(message.content) for message in forwarded.messages]
     assert len([value for value in hashes if value is not None]) == 1
+
+
+async def test_restored_context_is_appended_not_prepended() -> None:
+    """A block at the head shifts every cached byte after it; the tail costs only itself."""
+    context = _context_message()
+    latest = HumanMessage(content="latest")
+    request = ModelRequest(
+        model=AsyncMock(),
+        messages=[latest],
+        state={"messages": [context, HumanMessage(content="old"), latest]},
+    )
+    handler = AsyncMock(return_value=ModelResponse(result=[AIMessage(content="ok")]))
+
+    await DynamicContextMiddleware().awrap_model_call(request, handler)
+
+    assert handler.await_args is not None
+    assert handler.await_args.args[0].messages == [latest, context]

--- a/tests/middleware/test_dynamic_context.py
+++ b/tests/middleware/test_dynamic_context.py
@@ -29,7 +29,7 @@ async def test_restores_dynamic_context_after_compaction() -> None:
 
     assert handler.await_args is not None
     forwarded = handler.await_args.args[0]
-    assert forwarded.messages == [summary, context]
+    assert forwarded.messages == [context, summary]
 
 
 async def test_injects_each_dynamic_context_hash_at_most_once() -> None:
@@ -49,18 +49,36 @@ async def test_injects_each_dynamic_context_hash_at_most_once() -> None:
     assert len([value for value in hashes if value is not None]) == 1
 
 
-async def test_restored_context_is_appended_not_prepended() -> None:
-    """A block at the head shifts every cached byte after it; the tail costs only itself."""
+async def test_restored_context_lands_in_front_of_the_trailing_human_turn() -> None:
+    """The head would shift every cached byte; the tail would displace the task."""
     context = _context_message()
+    earlier = AIMessage(content="working on it")
     latest = HumanMessage(content="latest")
     request = ModelRequest(
         model=AsyncMock(),
-        messages=[latest],
-        state={"messages": [context, HumanMessage(content="old"), latest]},
+        messages=[earlier, latest],
+        state={"messages": [context, earlier, latest]},
     )
     handler = AsyncMock(return_value=ModelResponse(result=[AIMessage(content="ok")]))
 
     await DynamicContextMiddleware().awrap_model_call(request, handler)
 
     assert handler.await_args is not None
-    assert handler.await_args.args[0].messages == [latest, context]
+    assert handler.await_args.args[0].messages == [earlier, context, latest]
+
+
+async def test_restored_context_appends_when_the_request_ends_mid_turn() -> None:
+    """Nothing may come between a tool result and the call it answers."""
+    context = _context_message()
+    pending = AIMessage(content="thinking")
+    request = ModelRequest(
+        model=AsyncMock(),
+        messages=[HumanMessage(content="task"), pending],
+        state={"messages": [context, HumanMessage(content="task"), pending]},
+    )
+    handler = AsyncMock(return_value=ModelResponse(result=[AIMessage(content="ok")]))
+
+    await DynamicContextMiddleware().awrap_model_call(request, handler)
+
+    assert handler.await_args is not None
+    assert handler.await_args.args[0].messages[-1] is context

--- a/tests/middleware/test_prepare_run_middleware.py
+++ b/tests/middleware/test_prepare_run_middleware.py
@@ -102,7 +102,7 @@ async def test_prepare_prompt_injection():
     assert message.findtext("content") == "prepared prompt"
 
 
-def test_sender_context_updates_only_latest_human_message():
+def test_sender_context_arrives_as_its_own_message():
     first = HumanMessage("first", id="first")
     latest = HumanMessage(
         content=[{"type": "text", "text": "second"}],
@@ -110,37 +110,50 @@ def test_sender_context_updates_only_latest_human_message():
         name="participant",
     )
 
-    updated = PrepareAgentRunMiddleware._sender_context_message(
+    messages = PrepareAgentRunMiddleware._sender_context_messages(
         cast(PrepareRunState, {"messages": [first, latest]}),
         "sender",
     )
 
-    assert updated is not None
-    assert updated.id == latest.id
-    assert updated.name == latest.name
     assert first.content == "first"
-    assert updated.content == [
-        {"type": "text", "text": "second"},
-        {"type": "text", "text": "<sender_context>\nsender\n</sender_context>"},
-    ]
+    assert latest.content == [{"type": "text", "text": "second"}]
+    assert messages
+    envelope = ElementTree.fromstring(cast(str, messages[-1]["content"]))
+    assert envelope.attrib["sender"] == "system:sender-context"
+    assert envelope.attrib["kind"] == "system"
+    assert envelope.findtext("content") == "sender"
 
 
-def test_sender_context_goes_inside_the_envelope():
-    envelope = human_input(
-        "ship it <now> & fast",
-        {"sender_id": "slack:U1", "surface": "slack", "kind": "human"},
+def test_sender_context_escapes_untrusted_identity_text():
+    message = HumanMessage(
+        content=cast(
+            str,
+            human_input(
+                "ship it <now> & fast",
+                {"sender_id": "slack:U1", "surface": "slack", "kind": "human"},
+            )["content"],
+        ),
+        id="turn",
     )
-    message = HumanMessage(content=cast(str, envelope["content"]), id="turn")
+    original = message.content
 
-    updated = PrepareAgentRunMiddleware._sender_context_message(
+    messages = PrepareAgentRunMiddleware._sender_context_messages(
         cast(PrepareRunState, {"messages": [message]}),
         "identity: 'ramon' & <team>",
     )
 
-    assert updated is not None
-    root = ElementTree.fromstring(cast(str, updated.content))
-    assert root.findtext("content") == "ship it <now> & fast"
-    assert root.findtext("sender_context") == "identity: 'ramon' & <team>"
+    assert message.content == original
+    envelope = ElementTree.fromstring(cast(str, messages[-1]["content"]))
+    assert envelope.findtext("content") == "identity: 'ramon' & <team>"
+
+
+def test_sender_context_skipped_without_a_human_message():
+    assert (
+        PrepareAgentRunMiddleware._sender_context_messages(
+            cast(PrepareRunState, {"messages": []}), "sender"
+        )
+        == []
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The provider prompt cache is a byte-prefix match. Anything that rewrites a message the model has already seen — or the system prompt — discards the cached prefix from that point on. Three places did exactly that.

Measured across 25 consecutive main-agent run boundaries in `open-swe-agent` on 24 Aug: 10 held, 12 diverged from parallel tool-result ordering ([#2198](https://github.com/langchain-ai/open-swe/pull/2198)), and 3 diverged here — two from the system-prompt rewrite below, one from mid-thread summarization, which is a genuine content change and out of scope.

**Dynamic context is appended, not prepended.** `DynamicContextMiddleware` restored context messages at the head of the list. When a new participant joined a thread mid-conversation their `<dynamic-context>` block landed at index 1 and shifted every byte after it, costing the entire cached prefix; at the tail the same block costs only itself. Observed on thread `f0c4e9d4` when a second person replied.

**Sender context is its own message.** `_sender_context_messages` builds a `system:sender-context` envelope appended after the run's input, replacing the splice into the triggering `HumanMessage`. That message is already cached from the run that received it, so rewriting it on every subsequent run sent different bytes for content the model had seen. The transcript renders one envelope per message, so this arrives as the same collapsed context pill the dashboard handoff already uses rather than as markup inside the user's own text. The system prompt is updated to describe where the metadata now lives.

**The dashboard handoff no longer edits the system prompt.** `check_message_queue_before_model` swapped the `<source-guidance>` block inside `rendered_system_prompt` when a Slack thread moved to the web UI. It already injects a structured `system:dashboard-handoff` message saying the same thing, so the rewrite bought nothing and invalidated the entire prefix — that is the diff seen on threads `45c68683` and `d007c164`.

## Test Plan

- [x] `tests/middleware/test_dynamic_context.py` — restored context lands after the conversation, not before it
- [x] `tests/middleware/test_prepare_run_middleware.py` — sender context arrives as its own system envelope, the triggering message is left byte-identical, untrusted identity text stays escaped, and no message is emitted when the run has no human turn
- [x] `tests/middleware/test_check_message_queue.py` — the handoff emits no `rendered_system_prompt` update while still injecting the handoff message
- [x] `make test` — 1866 passed, 3 skipped
- [x] `make lint`
- [x] `make typecheck`