### PR TITLE
fix: submit queued message after stopping

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1925,12 +1925,13 @@ async def cancel_dashboard_thread(
         logger.exception("Failed to cancel active runs for thread %s", thread_id)
         raise HTTPException(502, "failed to request thread cancellation") from exc
 
-    queued = await client.store.get_item(("queue", thread_id), "pending_messages")
-    queued_messages = queued.get("value", {}).get("messages", []) if queued else []
     metadata_update: dict[str, Any] = {
         "latest_run_status": "interrupted",
         "updated_at_ms": _now_ms(),
     }
+    await client.threads.update(thread_id=thread_id, metadata=metadata_update)
+    queued = await client.store.get_item(("queue", thread_id), "pending_messages")
+    queued_messages = queued.get("value", {}).get("messages", []) if queued else []
     if queued_messages:
         try:
             configurable = await _build_dashboard_configurable(thread_id, login, metadata)
@@ -1948,7 +1949,8 @@ async def cancel_dashboard_thread(
         run_id = run.get("run_id") if isinstance(run, dict) else None
         metadata_update.update(latest_run_status="pending", latest_run_id=run_id)
 
-    await client.threads.update(thread_id=thread_id, metadata=metadata_update)
+    if queued_messages:
+        await client.threads.update(thread_id=thread_id, metadata=metadata_update)
     thread = await client.threads.get(thread_id)
     return await _thread_summary(thread)
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -17,6 +17,7 @@ from fastapi import HTTPException
 from langchain_core.messages.content import ImageContentBlock, create_image_block
 from pydantic import BaseModel, ConfigDict, Field
 
+from ..dispatch import dispatch_agent_run
 from ..input_messages import (
     PersonIdentity,
     build_input_messages,
@@ -1924,10 +1925,30 @@ async def cancel_dashboard_thread(
         logger.exception("Failed to cancel active runs for thread %s", thread_id)
         raise HTTPException(502, "failed to request thread cancellation") from exc
 
-    await client.threads.update(
-        thread_id=thread_id,
-        metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
-    )
+    queued = await client.store.get_item(("queue", thread_id), "pending_messages")
+    queued_messages = queued.get("value", {}).get("messages", []) if queued else []
+    metadata_update: dict[str, Any] = {
+        "latest_run_status": "interrupted",
+        "updated_at_ms": _now_ms(),
+    }
+    if queued_messages:
+        try:
+            configurable = await _build_dashboard_configurable(thread_id, login, metadata)
+            run = await dispatch_agent_run(
+                thread_id,
+                None,
+                configurable,
+                source=_DASHBOARD_SOURCE,
+                input={"messages": []},
+                client=client,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to submit queued follow-up for thread %s", thread_id)
+            raise HTTPException(502, "stopped run but failed to submit queued follow-up") from exc
+        run_id = run.get("run_id") if isinstance(run, dict) else None
+        metadata_update.update(latest_run_status="pending", latest_run_id=run_id)
+
+    await client.threads.update(thread_id=thread_id, metadata=metadata_update)
     thread = await client.threads.get(thread_id)
     return await _thread_summary(thread)
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2505,9 +2505,14 @@ async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypa
         async def cancel_many(self, **kwargs: object) -> None:
             calls.append(("cancel_many", kwargs))
 
+    class FakeStore:
+        async def get_item(self, namespace: tuple[str, str], key: str) -> None:
+            return None
+
     class FakeClient:
         threads = FakeThreads()
         runs = FakeRuns()
+        store = FakeStore()
 
     monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
 

--- a/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
+++ b/ui/src/features/agents/components/composer/ComposerPrimaryActions.tsx
@@ -160,9 +160,10 @@ function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
       // `stream.stop()` only cancels server-side when this client dispatched the
       // run, so cancel by thread first: a run started from Slack/Linear/GitHub
       // (or joined after a reload) has no client-side run id to cancel.
+      let cancelledThread
       if (threadId) {
         try {
-          await cancelThread.mutateAsync()
+          cancelledThread = await cancelThread.mutateAsync()
         } catch {
           // Cancellation failed (transient 5xx, or a non-owner viewer). Leave
           // the stream and the thread's status polling untouched: presenting a
@@ -171,7 +172,7 @@ function StreamPrimaryActions(props: ComposerPrimaryActionsProps) {
         }
       }
       await stream.disconnect()
-      if (threadId) {
+      if (threadId && cancelledThread?.status !== "running") {
         queryClient.setQueryData(agentThreadKeys.detail(threadId), (prev) =>
           prev ? { ...prev, status: "interrupted" as const } : prev
         )


### PR DESCRIPTION
## Description
Stopping a live run now starts a replacement run when a dashboard follow-up is queued, so the message is not lost. The UI preserves the replacement run's live status.

## Release Note
Queued dashboard follow-ups are submitted after stopping the active run.

## Test Plan
- [x] Stop a run with a queued follow-up and confirm the follow-up starts immediately.

Made by [Open SWE](https://openswe.vercel.app/agents/4119e41f-d6f5-593a-9158-caf0ae77113d)