### PR TITLE
perf(agent): write the git identity while the proxy is configured

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -12,6 +12,7 @@ import logging
 import os
 import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -374,31 +375,37 @@ async def _create_sandbox_with_proxy(
         else:
             sandbox_backend = await create_sandbox(snapshot_id=snapshot_id, **resources)
 
-    sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
-    if sandbox_type == "langsmith":
-        async with aphase(thread_id, "sandbox.proxy_token"):
-            token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
-        if not token:
-            msg = "Cannot configure proxy: GitHub App installation token is unavailable"
-            logger.error(msg)
-            raise ValueError(msg)
-        proxy_config = _get_sandbox_proxy_config(create_params)
-        async with aphase(thread_id, "sandbox.proxy_configure"):
-            if proxy_config is not None:
-                await _configure_github_proxy(
-                    sandbox_backend.id,
-                    token,
-                    base_proxy_config=proxy_config,
-                )
-            else:
-                await _configure_github_proxy(sandbox_backend.id, token)
-        record_proxy_token_expiry(
-            thread_id,
-            expires_at,
-            repositories=github_proxy_repositories,
-            permissions=permissions,
-            base_proxy_config=proxy_config,
-        )
+    identity = _start_git_identity(thread_id, sandbox_backend)
+    failed = True
+    try:
+        sandbox_type = os.getenv("SANDBOX_TYPE", "langsmith")
+        if sandbox_type == "langsmith":
+            async with aphase(thread_id, "sandbox.proxy_token"):
+                token, expires_at, permissions = await _resolve_proxy_token(github_proxy_token)
+            if not token:
+                msg = "Cannot configure proxy: GitHub App installation token is unavailable"
+                logger.error(msg)
+                raise ValueError(msg)
+            proxy_config = _get_sandbox_proxy_config(create_params)
+            async with aphase(thread_id, "sandbox.proxy_configure"):
+                if proxy_config is not None:
+                    await _configure_github_proxy(
+                        sandbox_backend.id,
+                        token,
+                        base_proxy_config=proxy_config,
+                    )
+                else:
+                    await _configure_github_proxy(sandbox_backend.id, token)
+            record_proxy_token_expiry(
+                thread_id,
+                expires_at,
+                repositories=github_proxy_repositories,
+                permissions=permissions,
+                base_proxy_config=proxy_config,
+            )
+        failed = False
+    finally:
+        await _settle_git_identity(identity, failed=failed)
 
     return sandbox_backend
 
@@ -477,6 +484,33 @@ async def _configure_git_identity(sandbox_backend: SandboxBackendProtocol) -> No
     )
 
 
+def _start_git_identity(
+    thread_id: str | None, sandbox_backend: SandboxBackendProtocol
+) -> asyncio.Task[None]:
+    """Write the bot identity while the proxy is being configured.
+
+    The identity needs the box, not the proxy, and the cost is the round trip
+    rather than the two `git config` calls — on a cold sandbox that round trip
+    is over a second of the critical path before the first model call.
+    """
+
+    async def run() -> None:
+        async with aphase(thread_id, "sandbox.git_identity"):
+            await _configure_git_identity(sandbox_backend)
+
+    return asyncio.create_task(run())
+
+
+async def _settle_git_identity(task: asyncio.Task[None], *, failed: bool) -> None:
+    """Join the identity write, or drop it when its sandbox is already lost."""
+    if failed:
+        task.cancel()
+        with suppress(asyncio.CancelledError, Exception):
+            await task
+        return
+    await task
+
+
 async def _connect_existing_sandbox(
     thread_id: str,
     *,
@@ -505,13 +539,20 @@ async def _connect_existing_sandbox(
         except Exception as exc:
             logger.warning("Failed to connect to existing sandbox %s", sandbox_id)
             raise SandboxUnreachableError(thread_id, sandbox_id, str(exc)) from exc
-    return await _refresh_github_proxy_or_fail(
-        sandbox_backend,
-        thread_id,
-        github_proxy_token,
-        github_proxy_repositories,
-        base_proxy_config,
-    )
+    identity = _start_git_identity(thread_id, sandbox_backend)
+    failed = True
+    try:
+        refreshed = await _refresh_github_proxy_or_fail(
+            sandbox_backend,
+            thread_id,
+            github_proxy_token,
+            github_proxy_repositories,
+            base_proxy_config,
+        )
+        failed = False
+    finally:
+        await _settle_git_identity(identity, failed=failed)
+    return refreshed
 
 
 async def ensure_sandbox_for_thread(
@@ -622,9 +663,6 @@ async def ensure_sandbox_for_thread(
                     thread_id, sandbox_id, str(create_exc)
                 ) from create_exc
             logger.info("Replacement sandbox created: %s", sandbox_backend.id)
-
-    async with aphase(thread_id, "sandbox.git_identity"):
-        await _configure_git_identity(sandbox_backend)
 
     # Bind the thread only once the sandbox is created and initialized: a run
     # that dies earlier leaves no id to reconnect to, so the next run creates

--- a/tests/sandbox/test_git_identity_overlap.py
+++ b/tests/sandbox/test_git_identity_overlap.py
@@ -1,0 +1,112 @@
+"""The bot's git identity is written while the GitHub proxy is being configured.
+
+The identity needs the sandbox, not the proxy, so running it after the proxy
+chain put a full sandbox round trip — over a second on a cold box — on the
+critical path before the run's first model call.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.server import _create_sandbox_with_proxy
+
+
+def _backend(started: asyncio.Event) -> MagicMock:
+    async def aexecute(_command: str) -> str:
+        started.set()
+        return "ok"
+
+    return MagicMock(id="sandbox-new", aexecute=AsyncMock(side_effect=aexecute))
+
+
+@pytest.mark.asyncio
+async def test_identity_is_written_while_the_proxy_is_configured() -> None:
+    started = asyncio.Event()
+    backend = _backend(started)
+
+    async def configure(*_args: object, **_kwargs: object) -> None:
+        # Serial ordering would leave the identity unstarted until this returns.
+        await asyncio.wait_for(started.wait(), timeout=2)
+
+    with (
+        patch("agent.server.create_sandbox", new_callable=AsyncMock, return_value=backend),
+        patch(
+            "agent.server._resolve_sandbox_create_config",
+            new_callable=AsyncMock,
+            return_value=("snap", {}, {}),
+        ),
+        patch(
+            "agent.server._resolve_proxy_token",
+            new_callable=AsyncMock,
+            return_value=("token", None, None),
+        ),
+        patch("agent.server._configure_github_proxy", side_effect=configure),
+        patch("agent.server.record_proxy_token_expiry"),
+    ):
+        assert await _create_sandbox_with_proxy(thread_id="thread-overlap") is backend
+
+    backend.aexecute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_identity_failure_fails_the_sandbox() -> None:
+    backend = MagicMock(
+        id="sandbox-new", aexecute=AsyncMock(side_effect=RuntimeError("identity failed"))
+    )
+
+    with (
+        patch("agent.server.create_sandbox", new_callable=AsyncMock, return_value=backend),
+        patch(
+            "agent.server._resolve_sandbox_create_config",
+            new_callable=AsyncMock,
+            return_value=("snap", {}, {}),
+        ),
+        patch(
+            "agent.server._resolve_proxy_token",
+            new_callable=AsyncMock,
+            return_value=("token", None, None),
+        ),
+        patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
+        patch("agent.server.record_proxy_token_expiry"),
+        pytest.raises(RuntimeError, match="identity failed"),
+    ):
+        await _create_sandbox_with_proxy(thread_id="thread-identity-fails")
+
+
+@pytest.mark.asyncio
+async def test_a_failed_proxy_does_not_leave_the_identity_write_running() -> None:
+    release = asyncio.Event()
+
+    async def aexecute(_command: str) -> str:
+        await release.wait()
+        return "ok"
+
+    backend = MagicMock(id="sandbox-new", aexecute=AsyncMock(side_effect=aexecute))
+
+    with (
+        patch("agent.server.create_sandbox", new_callable=AsyncMock, return_value=backend),
+        patch(
+            "agent.server._resolve_sandbox_create_config",
+            new_callable=AsyncMock,
+            return_value=("snap", {}, {}),
+        ),
+        patch(
+            "agent.server._resolve_proxy_token",
+            new_callable=AsyncMock,
+            return_value=("token", None, None),
+        ),
+        patch(
+            "agent.server._configure_github_proxy",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("proxy failed"),
+        ),
+        patch("agent.server.record_proxy_token_expiry"),
+        pytest.raises(RuntimeError, match="proxy failed"),
+    ):
+        await _create_sandbox_with_proxy(thread_id="thread-proxy-fails")
+
+    # Cancelled with the sandbox, rather than left behind to report into a run
+    # that has already given up on the box.
+    assert not release.is_set()

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -28,7 +28,7 @@ class TestSandboxFactoryLoading:
             patch.dict("os.environ", {"SANDBOX_TYPE": "local"}),
         ):
             module = MagicMock()
-            module.create_local_sandbox.return_value = MagicMock(id="local")
+            module.create_local_sandbox.return_value = MagicMock(id="local", aexecute=AsyncMock())
             mock_import_module.return_value = module
 
             from agent.utils.sandbox import create_sandbox
@@ -45,7 +45,9 @@ class TestSandboxFactoryLoading:
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
             module = MagicMock()
-            module.create_langsmith_sandbox = AsyncMock(return_value=MagicMock(id="langsmith"))
+            module.create_langsmith_sandbox = AsyncMock(
+                return_value=MagicMock(id="langsmith", aexecute=AsyncMock())
+            )
             mock_import_module.return_value = module
 
             from agent.utils.sandbox import create_sandbox
@@ -400,7 +402,7 @@ class TestCreateSandboxWithProxy:
             patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "LANGSMITH_API_KEY": "ls-key"}),
         ):
-            mock_create.return_value = MagicMock(id="sandbox-123")
+            mock_create.return_value = MagicMock(id="sandbox-123", aexecute=AsyncMock())
 
             from agent.server import _create_sandbox_with_proxy
 
@@ -438,7 +440,7 @@ class TestCreateSandboxWithProxy:
             ) as mock_configure_proxy,
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
-            mock_create.return_value = MagicMock(id="sandbox-123")
+            mock_create.return_value = MagicMock(id="sandbox-123", aexecute=AsyncMock())
 
             from agent.server import _create_sandbox_with_proxy
 
@@ -470,7 +472,7 @@ class TestCreateSandboxWithProxy:
             patch("agent.server._configure_github_proxy", new_callable=AsyncMock),
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith", "LANGSMITH_API_KEY": "ls-key"}),
         ):
-            mock_create.return_value = MagicMock(id="sandbox-123")
+            mock_create.return_value = MagicMock(id="sandbox-123", aexecute=AsyncMock())
 
             from agent.server import _create_sandbox_with_proxy
 
@@ -487,7 +489,7 @@ class TestCreateSandboxWithProxy:
             patch("agent.server._configure_github_proxy", new_callable=AsyncMock) as mock_proxy,
             patch.dict("os.environ", {"SANDBOX_TYPE": "daytona"}),
         ):
-            mock_create.return_value = MagicMock(id="sandbox-456")
+            mock_create.return_value = MagicMock(id="sandbox-456", aexecute=AsyncMock())
 
             from agent.server import _create_sandbox_with_proxy
 
@@ -508,7 +510,7 @@ class TestCreateSandboxWithProxy:
             ),
             patch.dict("os.environ", {"SANDBOX_TYPE": "langsmith"}),
         ):
-            mock_create.return_value = MagicMock(id="sandbox-789")
+            mock_create.return_value = MagicMock(id="sandbox-789", aexecute=AsyncMock())
 
             from agent.server import _create_sandbox_with_proxy
 
@@ -542,7 +544,7 @@ class TestRefreshProxyOnSandboxReuse:
     async def test_refreshes_proxy_for_cached_langsmith_sandbox(self) -> None:
         """Cached sandboxes should get a fresh proxy token before git operations."""
         config = self._execution_config()
-        mock_sandbox = MagicMock(id="sandbox-cached")
+        mock_sandbox = MagicMock(id="sandbox-cached", aexecute=AsyncMock())
         mock_sandbox.aexecute = AsyncMock()
         base_proxy_config = {"rules": [{"name": "public-api", "match_hosts": ["example.com"]}]}
         captured: dict[str, object] = {}
@@ -615,7 +617,7 @@ class TestRefreshProxyOnSandboxReuse:
     async def test_refreshes_proxy_when_reconnecting_to_existing_langsmith_sandbox(self) -> None:
         """Reconnected sandboxes should also get a fresh proxy token."""
         config = self._execution_config()
-        mock_sandbox = MagicMock(id="sandbox-existing")
+        mock_sandbox = MagicMock(id="sandbox-existing", aexecute=AsyncMock())
         mock_sandbox.aexecute = AsyncMock()
         captured: dict[str, object] = {}
 
@@ -681,7 +683,7 @@ class TestRefreshProxyOnSandboxReuse:
         Replacing it would hand the agent an empty filesystem and discard any
         work the old sandbox still held.
         """
-        mock_sandbox = MagicMock(id="sandbox-stale")
+        mock_sandbox = MagicMock(id="sandbox-stale", aexecute=AsyncMock())
         request = httpx.Request(
             "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-stale"
         )

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -239,13 +239,8 @@ async def test_deleted_sandbox_is_replaced_without_opting_in() -> None:
         patch(
             "agent.server._create_sandbox_with_proxy",
             new_callable=AsyncMock,
-            return_value=replacement,
+            side_effect=lambda *_a, **_k: (order.append("init"), replacement)[1],
         ) as create_replacement,
-        patch(
-            "agent.server._configure_git_identity",
-            new_callable=AsyncMock,
-            side_effect=lambda *_: order.append("init"),
-        ),
         patch(
             "agent.server.client.threads.update",
             new_callable=AsyncMock,
@@ -260,6 +255,7 @@ async def test_deleted_sandbox_is_replaced_without_opting_in() -> None:
         "thread_id": thread_id,
         "metadata": {"sandbox_id": "sandbox-replacement"},
     }
-    # The thread binds to the sandbox only once it is initialized.
+    # The thread binds to the sandbox only once it is created and initialized;
+    # the identity write is joined inside the creation step.
     assert order == ["init", "bind"]
     SANDBOX_BACKENDS.clear()

--- a/tests/sandbox/test_sandbox_publish_ordering.py
+++ b/tests/sandbox/test_sandbox_publish_ordering.py
@@ -15,7 +15,7 @@ from agent.utils.sandbox_state import get_or_create_sandbox_backend_proxy
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failing_step", ["_configure_git_identity", "client.threads.update"])
+@pytest.mark.parametrize("failing_step", ["_create_sandbox_with_proxy", "client.threads.update"])
 async def test_initialization_failure_publishes_nothing(failing_step: str) -> None:
     thread_id = "thread-init-fails"
     SANDBOX_BACKENDS.clear()
@@ -24,7 +24,7 @@ async def test_initialization_failure_publishes_nothing(failing_step: str) -> No
     created.id = "sandbox-new"
 
     steps = {
-        "_configure_git_identity": AsyncMock(),
+        "_create_sandbox_with_proxy": AsyncMock(return_value=created),
         "client.threads.update": AsyncMock(),
     }
     steps[failing_step].side_effect = RuntimeError("initialization failed")
@@ -35,12 +35,7 @@ async def test_initialization_failure_publishes_nothing(failing_step: str) -> No
             new_callable=AsyncMock,
             return_value=None,
         ),
-        patch(
-            "agent.server._create_sandbox_with_proxy",
-            new_callable=AsyncMock,
-            return_value=created,
-        ),
-        patch("agent.server._configure_git_identity", steps["_configure_git_identity"]),
+        patch("agent.server._create_sandbox_with_proxy", steps["_create_sandbox_with_proxy"]),
         patch("agent.server.client.threads.update", steps["client.threads.update"]),
         pytest.raises(RuntimeError, match="initialization failed"),
     ):


### PR DESCRIPTION
`sandbox.git_identity` runs two `git config --global` calls. On the cold-start trace `01a03573-f0f4-7f33-acba-6ebaa607b732` it took **1347ms**; the same phase on a warm sandbox takes 224ms. The cost is the sandbox round trip and process spawn, not the work.

It also sat at the end of a strictly serial chain, even though writing git config needs the box and not the proxy:

```
sandbox.boot          26.110 → 28.387   2277ms
sandbox.proxy_token   28.388 → 28.671    283ms
sandbox.proxy_config  28.672 → 28.936    264ms
sandbox.git_identity  28.936 → 30.283   1347ms   ← last thing before the root span opens
```

The identity write now starts as soon as the backend exists and is joined before the sandbox is published, in both the create and the reconnect paths. That overlaps it with the proxy token fetch and configure — roughly 0.55s off the cold-start critical path, and it stops being the tail of the chain.

Failure handling is unchanged in effect: a failed identity write still fails the sandbox (it is awaited before publish, so nothing is published half-built), and a failed proxy cancels the pending write rather than leaving it to report into a run that has already given up on the box.

### Not doing: skipping the write when the identity is unchanged

Recording the last-set identity on the thread and skipping the write looks tempting, but the comment introduced with this call in 743b2b9b says reused sandboxes "have lost their `--global` config **or had it overwritten**". The agent runs arbitrary shell in that box, so a *same-id* sandbox can lose the identity mid-run — which is exactly what a cached skip would assume cannot happen. A read-to-check costs the same round trip as the write, so it saves nothing either. Baking the identity into the sandbox snapshot is the change that would actually remove the round trip.

## Test Plan

- [x] `tests/sandbox/test_git_identity_overlap.py` — the write is in flight while `_configure_github_proxy` runs (a serial regression times out the rendezvous), a failed write fails the sandbox, and a failed proxy cancels the write
- [x] `tests/sandbox/` — 164 passed, including the publish-ordering and reviewer-recovery contracts updated for the new injection point
- [x] `make test` — 1879 passed, 3 skipped
- [x] `make lint`
- [x] `make typecheck`