### PR TITLE
perf(agent): let an integration describe itself without being built

### DIFF
--- a/agent/integrations/corridor_mcp.py
+++ b/agent/integrations/corridor_mcp.py
@@ -31,6 +31,7 @@ _URL_ENV_NAMES = (
     "CORRIDOR_MCP_SERVER_URL",
 )
 _ALLOWED_TOOL_NAMES = frozenset({"analyzePlan"})
+CORRIDOR_TOOL_NAMES = tuple(sorted(_ALLOWED_TOOL_NAMES))
 
 
 @dataclass(frozen=True)
@@ -103,6 +104,11 @@ async def _build_mcp_tools(config: CorridorMCPConfig) -> list[BaseTool]:
         )
     )
     return await client.get_tools()
+
+
+def corridor_configured() -> bool:
+    """Whether Corridor MCP is set up, without opening a session to find out."""
+    return load_corridor_mcp_config() is not None
 
 
 async def load_corridor_tools() -> list[BaseTool]:

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -6,6 +6,7 @@ _MIDDLEWARE_MODULES = {
     "check_message_queue_before_model": ".check_message_queue",
     "DynamicContextMiddleware": ".dynamic_context",
     "DynamicToolMiddleware": ".dynamic_tools",
+    "IntegrationGroup": ".dynamic_tools",
     "ensure_no_empty_msg": ".ensure_no_empty_msg",
     "ExcludeToolsMiddleware": ".exclude_tools",
     "ModelCallTimeoutMiddleware": ".model_call_timeout",
@@ -36,6 +37,7 @@ __all__ = [
     "DynamicContextMiddleware",
     "DynamicToolMiddleware",
     "ExcludeToolsMiddleware",
+    "IntegrationGroup",
     "ModelCallTimeoutMiddleware",
     "ModelFallbackMiddleware",
     "BasePrepareRunMiddleware",
@@ -65,7 +67,7 @@ __all__ = [
 if TYPE_CHECKING:
     from .check_message_queue import check_message_queue_before_model
     from .dynamic_context import DynamicContextMiddleware
-    from .dynamic_tools import DynamicToolMiddleware
+    from .dynamic_tools import DynamicToolMiddleware, IntegrationGroup
     from .ensure_no_empty_msg import ensure_no_empty_msg
     from .exclude_tools import ExcludeToolsMiddleware
     from .model_call_timeout import ModelCallTimeoutMiddleware

--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -1,6 +1,9 @@
 """Load optional integration tool schemas only when requested."""
 
+import asyncio
+import logging
 from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import Annotated, Any, NotRequired
 
 from langchain.agents.middleware.types import (
@@ -16,13 +19,34 @@ from langgraph.prebuilt import InjectedState
 from langgraph.runtime import Runtime
 from langgraph.types import Command, Overwrite
 
+logger = logging.getLogger(__name__)
+
 
 def _merge_tool_names(current: list[str], update: list[str]) -> list[str]:
     return sorted(set(current) | set(update))
 
 
+@dataclass(frozen=True)
+class IntegrationGroup:
+    """A connected integration, described by name and built on request.
+
+    Only the names reach the model up front. Building the tools is what costs —
+    an MCP handshake, a credential round trip — so it waits until the agent asks
+    for the group rather than running before the run's first model call.
+    """
+
+    tool_names: Sequence[str]
+    load: Callable[[], Awaitable[Sequence[BaseTool]]]
+
+
 class DynamicToolState(AgentState):
     loaded_integration_tools: NotRequired[Annotated[list[str], _merge_tool_names]]
+
+
+@dataclass
+class _Resolved:
+    tools: dict[str, BaseTool] = field(default_factory=dict)
+    done: bool = False
 
 
 class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
@@ -32,28 +56,35 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
 
     def __init__(
         self,
-        groups: Mapping[str, Sequence[BaseTool]],
+        groups: Mapping[str, IntegrationGroup | Sequence[BaseTool]],
         reserved_names: Collection[str] = (),
     ) -> None:
-        self._tools_by_name: dict[str, BaseTool] = {}
         reserved = {"load_integration_tools", *reserved_names}
+        self._groups: dict[str, IntegrationGroup] = {}
+        self._group_of: dict[str, str] = {}
+        self._resolved: dict[str, _Resolved] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
         catalog: list[str] = []
-        for group, tools in groups.items():
+
+        for group, spec in groups.items():
+            entry = spec if isinstance(spec, IntegrationGroup) else _eager_group(spec)
             names: list[str] = []
-            for tool in tools:
-                if tool.name in reserved or tool.name in self._tools_by_name:
-                    raise ValueError(f"Duplicate integration tool name: {tool.name}")
-                self._tools_by_name[tool.name] = tool
-                names.append(tool.name)
-            if names:
-                catalog.append(f"- {group}: {', '.join(sorted(names))}")
+            for name in entry.tool_names:
+                if name in reserved or name in self._group_of:
+                    raise ValueError(f"Duplicate integration tool name: {name}")
+                self._group_of[name] = group
+                names.append(name)
+            if not names:
+                continue
+            self._groups[group] = entry
+            catalog.append(f"- {group}: {', '.join(sorted(names))}")
 
         async def load_integration_tools(
             tool_names: list[str],
             state: Annotated[DynamicToolState | None, InjectedState] = None,
             tool_call_id: Annotated[str, InjectedToolCallId] = "",
         ) -> Command:
-            unknown = sorted(set(tool_names) - self._tools_by_name.keys())
+            unknown = sorted(set(tool_names) - self._group_of.keys())
             if unknown:
                 return Command(
                     update={
@@ -66,12 +97,27 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
                         ]
                     }
                 )
+            missing = await self._build(tool_names)
+            if missing:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content=(
+                                    "These integration tools are unavailable right now: "
+                                    f"{', '.join(missing)}. Continue without them."
+                                ),
+                                tool_call_id=tool_call_id,
+                                status="error",
+                            )
+                        ]
+                    }
+                )
             loaded = set(state.get("loaded_integration_tools", [])) if state else set()
             loaded.update(tool_names)
-            names = sorted(loaded)
             return Command(
                 update={
-                    "loaded_integration_tools": names,
+                    "loaded_integration_tools": sorted(loaded),
                     "messages": [
                         ToolMessage(
                             content=(
@@ -97,6 +143,39 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
             )
         ]
 
+    @property
+    def has_groups(self) -> bool:
+        return bool(self._groups)
+
+    async def _resolve(self, group: str) -> dict[str, BaseTool]:
+        resolved = self._resolved.setdefault(group, _Resolved())
+        if resolved.done:
+            return resolved.tools
+        lock = self._locks.setdefault(group, asyncio.Lock())
+        async with lock:
+            if resolved.done:
+                return resolved.tools
+            try:
+                tools = await self._groups[group].load()
+            except Exception:
+                logger.warning("Failed to load %s integration tools", group, exc_info=True)
+                tools = []
+            resolved.tools = {tool.name: tool for tool in tools}
+            resolved.done = True
+        return resolved.tools
+
+    async def _build(self, names: Sequence[str]) -> list[str]:
+        """Build the groups behind ``names``; return the names that did not appear."""
+        wanted = {self._group_of[name] for name in names if name in self._group_of}
+        await asyncio.gather(*(self._resolve(group) for group in sorted(wanted)))
+        return sorted(name for name in names if self._tool(name) is None)
+
+    def _tool(self, name: str) -> BaseTool | None:
+        group = self._group_of.get(name)
+        if group is None:
+            return None
+        return self._resolved.get(group, _Resolved()).tools.get(name)
+
     async def abefore_agent(self, state: DynamicToolState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
         return {"loaded_integration_tools": Overwrite([])}
 
@@ -106,7 +185,9 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         loaded = self._loaded_names(request.state)
-        tools = [self._tools_by_name[name] for name in loaded if name in self._tools_by_name]
+        if loaded:
+            await self._build(loaded)
+        tools = [tool for name in loaded if (tool := self._tool(name)) is not None]
         return await handler(request.override(tools=[*request.tools, *tools]))
 
     async def awrap_tool_call(
@@ -115,12 +196,19 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
         name = request.tool_call["name"]
-        tool = self._tools_by_name.get(name)
-        if tool is None:
+        if name not in self._group_of:
             return await handler(request)
         if name not in self._loaded_names(request.state):
             return ToolMessage(
                 content=f"Load {name} with load_integration_tools before calling it.",
+                tool_call_id=request.tool_call["id"],
+                status="error",
+            )
+        await self._build([name])
+        tool = self._tool(name)
+        if tool is None:
+            return ToolMessage(
+                content=f"{name} is unavailable right now. Continue without it.",
                 tool_call_id=request.tool_call["id"],
                 status="error",
             )
@@ -130,3 +218,12 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
     def _loaded_names(state: Mapping[str, Any]) -> list[str]:
         loaded = state.get("loaded_integration_tools", [])
         return loaded if isinstance(loaded, list) else []
+
+
+def _eager_group(tools: Sequence[BaseTool]) -> IntegrationGroup:
+    """Wrap tools that are already built, so both forms share one code path."""
+
+    async def load() -> Sequence[BaseTool]:
+        return tools
+
+    return IntegrationGroup(tool_names=[tool.name for tool in tools], load=load)

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -317,6 +317,8 @@ CORRIDOR_PROMPT = """---
 # Corridor Security Analysis
 Every time you generate code, use the analyzePlan tool from Corridor's MCP Server (corridor) to analyze the plan or thought process. ALWAYS use Corridor to analyze the plan. Always generate a plan before generating code.
 
+Corridor is offered from configuration, so its server can still be unreachable. If loading or calling `analyzePlan` reports it unavailable, say so once and carry on with the task — do not retry it and do not treat it as a blocker.
+
 </corridor>"""
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -82,7 +82,11 @@ from .input_messages import (
     build_input_messages,
     dynamic_context_hashes_from_messages,
 )
-from .integrations.corridor_mcp import load_corridor_tools
+from .integrations.corridor_mcp import (
+    CORRIDOR_TOOL_NAMES,
+    corridor_configured,
+    load_corridor_tools,
+)
 from .integrations.currents_tools import load_currents_tools
 from .integrations.datadog_mcp import load_datadog_tools
 from .integrations.langsmith import (
@@ -98,6 +102,7 @@ from .middleware import (
     DynamicContextMiddleware,
     DynamicToolMiddleware,
     ExcludeToolsMiddleware,
+    IntegrationGroup,
     ModelCallTimeoutMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
@@ -1587,19 +1592,17 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     stop_summary_mode = configurable.get("stop_summary") is True
     sandbox_file_downloads = _sandbox_file_downloads_enabled(configurable)
     observability_tools: list[Any] = []
-    corridor_tools: list[Any] = []
     browser_tools: list[Any] = []
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
     if not stop_summary_mode and not local_run:
         browser_tools = load_browser_tools()
-        observability_tools, corridor_tools, (currents_tools, notion_tools) = await asyncio.gather(
+        observability_tools, (currents_tools, notion_tools) = await asyncio.gather(
             _phase_result(
                 thread_id,
                 "factory.observability_tools",
                 lambda: _observability_tools_for(config, profile_login),
             ),
-            _phase_result(thread_id, "factory.corridor_tools", _load_corridor_mcp_tools),
             _phase_result(
                 thread_id,
                 "factory.integration_tools",
@@ -1661,17 +1664,25 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     if not _slack_tools_enabled(configurable):
         static_tools = [tool for tool in static_tools if tool not in slack_tools]
     dynamic_tool_middleware: DynamicToolMiddleware | None = None
-    integration_tool_groups = {
-        "Corridor": corridor_tools,
+    integration_tool_groups: dict[str, IntegrationGroup | Sequence[Any]] = {
         "Observability": observability_tools,
         "Currents": currents_tools,
         "Notion": notion_tools,
     }
-    if any(integration_tool_groups.values()):
-        dynamic_tool_middleware = DynamicToolMiddleware(
+    # Corridor's catalog is a static allowlist, so the MCP handshake that used to
+    # run before every first model call now waits until the agent asks for it.
+    if not stop_summary_mode and not local_run and corridor_configured():
+        integration_tool_groups["Corridor"] = IntegrationGroup(
+            tool_names=CORRIDOR_TOOL_NAMES,
+            load=_load_corridor_mcp_tools,
+        )
+    if integration_tool_groups:
+        candidate = DynamicToolMiddleware(
             integration_tool_groups,
             reserved_names={*DEEP_AGENT_TOOL_NAMES, *reserved_tool_names},
         )
+        if candidate.has_groups:
+            dynamic_tool_middleware = candidate
 
     logger.info("Returning agent with sandbox for thread %s", thread_id)
     agent_backend: BackendProtocol = backend
@@ -1748,7 +1759,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     linear_issue_number=linear_issue_number,
                     draft_prs=sender_draft_prs,
                     plan_mode=plan_mode,
-                    corridor_enabled=bool(corridor_tools),
+                    corridor_enabled="Corridor" in integration_tool_groups,
                     admin_environments=admin_thread,
                 ),
                 *([dynamic_tool_middleware] if dynamic_tool_middleware else []),

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -1,7 +1,8 @@
-"""The graph factory's three tool loaders must overlap, not run back-to-back.
+"""The graph factory's remaining tool loaders must overlap, not run back-to-back.
 
-Each one is a cold-cache network round trip (MCP handshakes, credential store
-reads), and they sit on the critical path before the run's first model call.
+Each is a cold-cache network round trip (an MCP handshake, credential store
+reads) sitting on the critical path before the run's first model call. Corridor
+no longer appears here: its catalog is static, so it loads on demand instead.
 """
 
 import asyncio
@@ -35,7 +36,7 @@ def _config() -> RunnableConfig:
 
 @pytest.mark.asyncio
 async def test_tool_loaders_run_concurrently() -> None:
-    barrier = asyncio.Barrier(3)
+    barrier = asyncio.Barrier(2)
 
     def rendezvous(result: Any) -> Any:
         # Serial loaders never all reach the barrier, so a regression times out
@@ -77,7 +78,6 @@ async def test_tool_loaders_run_concurrently() -> None:
         patch("agent.server.construct_system_prompt", return_value="prompt"),
         patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
         patch("agent.server._observability_tools_for", side_effect=rendezvous([])),
-        patch("agent.server._load_corridor_mcp_tools", side_effect=rendezvous([])),
         patch("agent.server._load_integration_tools", side_effect=rendezvous(([], []))),
     ):
         await get_agent(_config())

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -8,7 +8,7 @@ from langchain_core.messages import ToolMessage
 from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.types import Command
 
-from agent.middleware.dynamic_tools import DynamicToolMiddleware
+from agent.middleware.dynamic_tools import DynamicToolMiddleware, IntegrationGroup
 
 
 def _tool(name: str, description: str = "schema details that must stay hidden") -> BaseTool:
@@ -93,3 +93,76 @@ def test_general_purpose_subagent_includes_dynamic_tools() -> None:
     subagent = _general_purpose_subagent(MagicMock(), tools=[], dynamic_tools=middleware)
 
     assert middleware in subagent.get("middleware", [])
+
+
+async def test_a_lazy_group_is_not_built_until_it_is_loaded() -> None:
+    builds = 0
+
+    async def load() -> list[BaseTool]:
+        nonlocal builds
+        builds += 1
+        return [_tool("analyzePlan")]
+
+    middleware = DynamicToolMiddleware(
+        {"Corridor": IntegrationGroup(tool_names=("analyzePlan",), load=load)}
+    )
+    loader = cast(StructuredTool, middleware.tools[0])
+
+    # The catalog reaches the model without the group ever being built.
+    assert "- Corridor: analyzePlan" in loader.description
+    assert builds == 0
+
+    coroutine = cast(Any, loader.coroutine)
+    command = await coroutine(tool_names=["analyzePlan"], state={}, tool_call_id="load-1")
+    assert isinstance(command, Command)
+    assert builds == 1
+
+    loaded_state = cast(dict[str, Any], command.update)
+    routed: list[str] = []
+
+    async def tool_handler(request: ToolCallRequest) -> ToolMessage:
+        assert request.tool is not None
+        routed.append(request.tool.name)
+        return ToolMessage(content="ok", tool_call_id=request.tool_call["id"])
+
+    call = _Request(
+        state=loaded_state,
+        tools=[],
+        tool_call={"name": "analyzePlan", "args": {"value": "x"}, "id": "call-1"},
+    )
+    await middleware.awrap_tool_call(cast(ToolCallRequest, call), tool_handler)
+    assert routed == ["analyzePlan"]
+    # Built once and reused, not re-fetched per call.
+    assert builds == 1
+
+
+async def test_a_group_that_fails_to_build_is_reported_not_raised() -> None:
+    async def load() -> list[BaseTool]:
+        raise RuntimeError("mcp unreachable")
+
+    middleware = DynamicToolMiddleware(
+        {"Corridor": IntegrationGroup(tool_names=("analyzePlan",), load=load)}
+    )
+    coroutine = cast(Any, cast(StructuredTool, middleware.tools[0]).coroutine)
+
+    command = await coroutine(tool_names=["analyzePlan"], state={}, tool_call_id="load-1")
+    assert isinstance(command, Command)
+    message = cast(dict[str, Any], command.update)["messages"][0]
+    assert message.status == "error"
+    assert "unavailable right now" in message.content
+
+
+async def test_a_group_whose_catalog_is_empty_is_not_offered() -> None:
+    async def load() -> list[BaseTool]:
+        return []
+
+    middleware = DynamicToolMiddleware({"Corridor": IntegrationGroup(tool_names=(), load=load)})
+
+    assert not middleware.has_groups
+    assert "- Corridor" not in cast(StructuredTool, middleware.tools[0]).description
+
+
+def test_the_static_corridor_catalog_matches_what_the_loader_exposes() -> None:
+    from agent.integrations.corridor_mcp import _ALLOWED_TOOL_NAMES, CORRIDOR_TOOL_NAMES
+
+    assert set(CORRIDOR_TOOL_NAMES) == set(_ALLOWED_TOOL_NAMES)

--- a/tests/tools/test_corridor_mcp.py
+++ b/tests/tools/test_corridor_mcp.py
@@ -132,7 +132,7 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
 
         return _DummyAgent()
 
-    async def run_with_corridor_tools(corridor_tools: list[object]) -> bool:
+    async def run_with_corridor(configured: bool) -> bool:
         with (
             patch.object(
                 server,
@@ -170,12 +170,13 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
                 new_callable=AsyncMock,
                 return_value=False,
             ),
+            patch.object(server, "corridor_configured", return_value=configured),
             patch.object(
                 server,
                 "_load_corridor_mcp_tools",
                 new_callable=AsyncMock,
-                return_value=corridor_tools,
-            ),
+                return_value=[_FakeTool("analyzePlan")],
+            ) as load_corridor,
             patch.object(server, "construct_system_prompt", return_value="prompt") as prompt,
             patch.object(server, "create_deep_agent", side_effect=fake_create_deep_agent),
         ):
@@ -193,10 +194,16 @@ async def test_get_agent_passes_corridor_prompt_state() -> None:
                 cast(AgentState[object], {"messages": []}),
                 cast(Runtime[None], MagicMock()),
             )
-            if corridor_tools:
-                assert corridor_tools[0] not in cast(list[object], captured["tools"])
+            # The catalog is a static allowlist, so nothing opens an MCP session
+            # before the run's first model call.
+            load_corridor.assert_not_awaited()
+            if configured:
+                names = {
+                    getattr(tool, "name", None) for tool in cast(list[object], captured["tools"])
+                }
+                assert "analyzePlan" not in names
                 assert "DynamicToolMiddleware" in {type(item).__name__ for item in middleware}
         return bool(prompt.call_args.kwargs["corridor_enabled"])
 
-    assert await run_with_corridor_tools([]) is False
-    assert await run_with_corridor_tools([_FakeTool("analyzePlan")]) is True
+    assert await run_with_corridor(False) is False
+    assert await run_with_corridor(True) is True


### PR DESCRIPTION
`DynamicToolMiddleware` exists to keep integration schemas out of context until the agent asks for them — but the tools were still *built* before the first model call. On the cold-start trace `01a03573-f0f4-7f33-acba-6ebaa607b732` that was `factory.corridor_tools` 1448ms, `factory.observability_tools` 1763ms, `factory.integration_tools` 1600ms, overlapping into ~2.9s of critical path. Across today's traces only **29 of 85** sampled root runs ever called `load_integration_tools`.

Nothing needed those objects that early. `_tools_by_name` is read only in `awrap_model_call` and `awrap_tool_call`, both of which run after the agent has loaded a tool — turn 2 at the earliest — and `self.tools` contains only `load_integration_tools` itself. The one thing forcing the build was the catalog in that tool's description, which renders `tool.name` for each tool:

```
Available tools:
- Corridor: analyzePlan
```

It needs *names*, not tools. So a group can now supply both:

```python
IntegrationGroup(tool_names=CORRIDOR_TOOL_NAMES, load=_load_corridor_mcp_tools)
```

The loader runs on first use, memoized per group behind a lock, and a group that fails to build reports itself unavailable rather than raising into the run. Groups may still be passed as a plain sequence of already-built tools, so the other integrations are untouched.

**Corridor converts.** Its catalog is `_ALLOWED_TOOL_NAMES = frozenset({"analyzePlan"})` — the MCP handshake fetched the server's whole tool list only to filter it down to that one hardcoded name. Availability now comes from `corridor_configured()`, a pure env read. **~1.45s off every run**, paid instead by the runs that call `analyzePlan`.

### Not converting yet: Observability and Notion

Datadog and Notion are real MCP servers whose tool names are only knowable by completing a handshake, so they cannot supply a static catalog. Making them lazy needs a model-facing contract change — `load_integration_tools` accepting an integration name and reporting the tool names once loaded — which is a separate decision from this mechanism. LangSmith and Currents build locally and cost only a cached credential read, so there is little to reclaim there.

## Test Plan

- [x] `tests/middleware/test_dynamic_tools.py` — a lazy group renders its catalog without being built, builds once on load and is reused, reports a failed build instead of raising, and is not offered when its catalog is empty; the static Corridor catalog is asserted against `_ALLOWED_TOOL_NAMES` so the two cannot drift
- [x] `tests/tools/test_corridor_mcp.py` — `corridor_enabled` now follows configuration, `analyzePlan` stays out of the static tool list, and no MCP session is opened during `get_agent`
- [x] `tests/agent/test_factory_tool_loading.py` — the remaining two loaders still overlap
- [x] `make test` — 1883 passed, 3 skipped
- [x] `make lint`
- [x] `make typecheck`