### PR TITLE
docs: document workflow push approval gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,6 @@ The system prompt instructs the agent to call a tool every turn, and `ensure_no_
 
 Other middleware exists in `agent/middleware/` (`ExcludeToolsMiddleware`) but isn't wired into the default agent. The reviewer uses a leaner stack: `SanitizeToolInputsMiddleware`, `ModelCallLimitMiddleware`, `ToolErrorMiddleware`, `SanitizeThinkingBlocksMiddleware`.
 
-The agent is responsible for committing, pushing, opening/updating the draft PR, and replying in the source channel. In hosted sessions, `WorkflowPushGuardMiddleware` gates pushes containing `.github/workflows/` changes. Run such a push as a standalone `git push origin <branch>` or `git -C <repo> push origin <branch>` command. If it returns `WorkflowPushApprovalRequired`, do not bypass the gate or change the workflow diff; wait for the generated Slack/Web approval, then retry the same standalone push.
-
 ### Tools
 
 All tools live in `agent/tools/` and are flat-imported via `agent/tools/__init__.py`. The set is intentionally small and curated — see README "Tools — Curated, Not Accumulated".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ The system prompt instructs the agent to call a tool every turn, and `ensure_no_
 
 Other middleware exists in `agent/middleware/` (`ExcludeToolsMiddleware`) but isn't wired into the default agent. The reviewer uses a leaner stack: `SanitizeToolInputsMiddleware`, `ModelCallLimitMiddleware`, `ToolErrorMiddleware`, `SanitizeThinkingBlocksMiddleware`.
 
-There is intentionally no after-agent safety net that opens a PR for the agent. The agent itself is responsible for committing, pushing, opening/updating the draft PR, and replying in the source channel — all via `gh` and `slack_thread_reply` / `linear_comment`.
+The agent is responsible for committing, pushing, opening/updating the draft PR, and replying in the source channel. In hosted sessions, `WorkflowPushGuardMiddleware` gates pushes containing `.github/workflows/` changes. Run such a push as a standalone `git push origin <branch>` or `git -C <repo> push origin <branch>` command. If it returns `WorkflowPushApprovalRequired`, do not bypass the gate or change the workflow diff; wait for the generated Slack/Web approval, then retry the same standalone push.
 
 ### Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,6 @@ The system prompt instructs the agent to call a tool every turn, and `ensure_no_
 
 Other middleware exists in `agent/middleware/` (`ExcludeToolsMiddleware`) but isn't wired into the default agent. The reviewer uses a leaner stack: `SanitizeToolInputsMiddleware`, `ModelCallLimitMiddleware`, `ToolErrorMiddleware`.
 
-The agent is responsible for committing, pushing, opening/updating the draft PR, and replying in the source channel. In hosted sessions, `WorkflowPushGuardMiddleware` gates pushes containing `.github/workflows/` changes. Run such a push as a standalone `git push origin <branch>` or `git -C <repo> push origin <branch>` command. If it returns `WorkflowPushApprovalRequired`, do not bypass the gate or change the workflow diff; wait for the generated Slack/Web approval, then retry the same standalone push.
-
 ### Tools
 
 All tools live in `agent/tools/` and are flat-imported via `agent/tools/__init__.py`. The set is intentionally small and curated — see README "Tools — Curated, Not Accumulated".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ The system prompt instructs the agent to call a tool every turn, and `ensure_no_
 
 Other middleware exists in `agent/middleware/` (`ExcludeToolsMiddleware`) but isn't wired into the default agent. The reviewer uses a leaner stack: `SanitizeToolInputsMiddleware`, `ModelCallLimitMiddleware`, `ToolErrorMiddleware`.
 
-There is intentionally no after-agent safety net that opens a PR for the agent. The agent itself is responsible for committing, pushing, opening/updating the draft PR, and replying in the source channel — all via `gh` and `slack_thread_reply` / `linear_comment`.
+The agent is responsible for committing, pushing, opening/updating the draft PR, and replying in the source channel. In hosted sessions, `WorkflowPushGuardMiddleware` gates pushes containing `.github/workflows/` changes. Run such a push as a standalone `git push origin <branch>` or `git -C <repo> push origin <branch>` command. If it returns `WorkflowPushApprovalRequired`, do not bypass the gate or change the workflow diff; wait for the generated Slack/Web approval, then retry the same standalone push.
 
 ### Tools
 


### PR DESCRIPTION
## Description
Clarifies root agent guidance so hosted agents follow the workflow-push human approval gate instead of trying to bypass a blocked push. Keeps `AGENTS.md` and `CLAUDE.md` aligned on standalone push and retry behavior.

## Release Note
none

## Test Plan
- [x] Confirmed the workflow-push guidance is identical in both root instruction files
- [x] `git diff --check`

Made by [Open SWE](https://openswe.vercel.app/agents/1044e4a7-398c-5033-bdd3-11b2fc9bab8b)