### PR TITLE
refactor(store): one LangGraph Store helper with one error policy

### DIFF
--- a/agent/baby_sit.py
+++ b/agent/baby_sit.py
@@ -12,6 +12,7 @@ from langgraph_sdk import get_client
 from langgraph_sdk.errors import ConflictError
 
 from .dispatch import dispatch_agent_run
+from .store import delete_value, get_value, now_iso, put_value, search_all_values
 from .utils.github_app import get_github_app_installation_token
 from .utils.github_ci import (
     FAILING_CONCLUSIONS,
@@ -42,7 +43,7 @@ WATCH_LOCK_TTL_MINUTES = 5
 
 @asynccontextmanager
 async def _watch_lock(key: str) -> AsyncIterator[bool]:
-    client = _client()
+    client = get_client()
     lock_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"open-swe:baby-sit-lock:{key}"))
     try:
         await client.threads.create(
@@ -89,10 +90,6 @@ class BabySitWatch(TypedDict):
     updated_at: str
 
 
-def _client():
-    return get_client()
-
-
 def watch_key(owner: str, repo: str, pr_number: int) -> str:
     return f"{owner.strip().lower()}/{repo.strip().lower()}#{pr_number}"
 
@@ -101,25 +98,14 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
-def _now_iso() -> str:
-    return _now().isoformat()
-
-
-def _value(item: object) -> BabySitWatch | None:
-    if isinstance(item, dict):
-        value = item.get("value")
-    else:
-        value = getattr(item, "value", None)
-    return cast(BabySitWatch, value) if isinstance(value, dict) else None
-
-
 async def get_watch(key: str) -> BabySitWatch | None:
-    return _value(await _client().store.get_item(WATCH_NAMESPACE, key))
+    value = await get_value(WATCH_NAMESPACE, key)
+    return cast(BabySitWatch, value) if value is not None else None
 
 
 async def _put_watch(watch: BabySitWatch) -> BabySitWatch:
-    updated: BabySitWatch = {**watch, "updated_at": _now_iso()}
-    await _client().store.put_item(WATCH_NAMESPACE, updated["key"], updated)
+    updated: BabySitWatch = {**watch, "updated_at": now_iso()}
+    await put_value(WATCH_NAMESPACE, updated["key"], updated)
     return updated
 
 
@@ -131,28 +117,12 @@ async def list_active_watches(
         filter["owner"] = owner.strip().lower()
     if repo:
         filter["repo"] = repo.strip().lower()
-
-    watches: list[BabySitWatch] = []
-    offset = 0
-    while True:
-        result = await _client().store.search_items(
-            WATCH_NAMESPACE,
-            filter=filter,
-            limit=100,
-            offset=offset,
-        )
-        items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-        if not items:
-            break
-        watches.extend(value for item in items if (value := _value(item)) is not None)
-        if len(items) < 100:
-            break
-        offset += len(items)
-    return watches
+    values = await search_all_values(WATCH_NAMESPACE, filter=filter)
+    return [cast(BabySitWatch, value) for value in values]
 
 
 async def _create_watch_cron(key: str) -> str:
-    cron = await _client().crons.create(
+    cron = await get_client().crons.create(
         "scheduler",
         schedule=WATCH_SCHEDULE,
         input={"task": "baby_sit", "watch_key": key},
@@ -167,7 +137,7 @@ async def _create_watch_cron(key: str) -> str:
 
 
 async def _ensure_watch_cron(key: str) -> str:
-    crons = await _client().crons.search(
+    crons = await get_client().crons.search(
         assistant_id="scheduler",
         metadata={"kind": WATCH_CRON_KIND, "watch_key": key},
         limit=10,
@@ -180,7 +150,7 @@ async def _ensure_watch_cron(key: str) -> str:
     if cron_ids:
         for duplicate in cron_ids[1:]:
             try:
-                await _client().crons.delete(duplicate)
+                await get_client().crons.delete(duplicate)
             except Exception:
                 logger.warning("Failed to delete duplicate baby-sit cron %s", duplicate)
         return cron_ids[0]
@@ -202,7 +172,7 @@ async def start_watch(
     if existing and existing.get("active") and existing.get("thread_id") != thread_id:
         raise ValueError("This pull request is already monitored from another agent thread")
 
-    now = _now_iso()
+    now = now_iso()
     same_head = existing is not None and existing.get("head_sha") == head_sha
     watch: BabySitWatch = {
         "key": key,
@@ -239,10 +209,10 @@ async def start_watch(
             cron_id = watch.get("cron_id")
             if isinstance(cron_id, str) and cron_id:
                 try:
-                    await _client().crons.delete(cron_id)
+                    await get_client().crons.delete(cron_id)
                 except Exception:
                     logger.warning("Failed to roll back baby-sit cron %s", cron_id)
-            await _client().store.delete_item(WATCH_NAMESPACE, key)
+            await delete_value(WATCH_NAMESPACE, key)
         raise
 
 
@@ -253,13 +223,13 @@ async def stop_watch(key: str) -> bool:
     cron_id = watch.get("cron_id")
     if isinstance(cron_id, str) and cron_id:
         try:
-            await _client().crons.delete(cron_id)
+            await get_client().crons.delete(cron_id)
         except Exception:
             logger.warning("Failed to delete baby-sit cron %s", cron_id, exc_info=True)
             watch["active"] = False
             await _put_watch(watch)
             return True
-    await _client().store.delete_item(WATCH_NAMESPACE, key)
+    await delete_value(WATCH_NAMESPACE, key)
     return True
 
 
@@ -376,16 +346,16 @@ def _check_set_key(check_runs: list[dict[str, Any]], statuses: list[dict[str, An
 def _check_set_settled(watch: BabySitWatch, key: str) -> bool:
     if watch.get("settled_check_key") != key:
         watch["settled_check_key"] = key
-        watch["settled_check_at"] = _now_iso()
+        watch["settled_check_at"] = _now().isoformat()
         return False
     raw = watch.get("settled_check_at")
     if not isinstance(raw, str) or not raw:
-        watch["settled_check_at"] = _now_iso()
+        watch["settled_check_at"] = _now().isoformat()
         return False
     try:
         first_seen = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
-        watch["settled_check_at"] = _now_iso()
+        watch["settled_check_at"] = _now().isoformat()
         return False
     return _now() - first_seen >= timedelta(minutes=CHECK_SET_SETTLE_MINUTES)
 

--- a/agent/baby_sit.py
+++ b/agent/baby_sit.py
@@ -11,8 +11,9 @@ from typing import Any, TypedDict, cast
 from langgraph_sdk import get_client
 from langgraph_sdk.errors import ConflictError
 
+from agent.store import delete_value, get_value, now_iso, put_value, search_all_values
+
 from .dispatch import dispatch_agent_run
-from .store import delete_value, get_value, now_iso, put_value, search_all_values
 from .utils.github_app import get_github_app_installation_token
 from .utils.github_ci import (
     FAILING_CONCLUSIONS,

--- a/agent/dashboard/agent_instructions.py
+++ b/agent/dashboard/agent_instructions.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from ..store import KeyedRecordStore, now_iso
+from agent.store import KeyedRecordStore, now_iso
+
 from .review_styles import normalize_repo_full_name
 
 AGENT_INSTRUCTIONS_NAMESPACE: list[str] = ["agent_instructions"]

--- a/agent/dashboard/agent_instructions.py
+++ b/agent/dashboard/agent_instructions.py
@@ -4,16 +4,12 @@ Each record holds a user-authored instruction prompt (edited in the dashboard)
 that is appended to the main agent's system prompt for runs targeting that repo.
 """
 
-import logging
-from datetime import UTC, datetime
 from typing import Any
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, Field, field_validator
 
+from ..store import KeyedRecordStore, now_iso
 from .review_styles import normalize_repo_full_name
-
-logger = logging.getLogger(__name__)
 
 AGENT_INSTRUCTIONS_NAMESPACE: list[str] = ["agent_instructions"]
 
@@ -31,26 +27,6 @@ class AgentInstructionsUpdate(BaseModel):
     instructions: str = Field(default="")
 
 
-def _client():
-    return get_client()
-
-
-async def _get_value(key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(AGENT_INSTRUCTIONS_NAMESPACE, key)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("store get_item failed for %s: %s", key, e)
-        return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
-
-
 def _default_record(full_name: str, created_by: str) -> dict[str, Any]:
     owner, name = full_name.split("/", 1)
     return {
@@ -59,45 +35,36 @@ def _default_record(full_name: str, created_by: str) -> dict[str, Any]:
         "name": name,
         "instructions": "",
         "created_by": created_by,
-        "created_at": _now_iso(),
-        "updated_at": _now_iso(),
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
     }
 
 
+_RECORDS = KeyedRecordStore(
+    AGENT_INSTRUCTIONS_NAMESPACE,
+    sort_key="full_name",
+    default_factory=_default_record,
+)
+
+
 async def get_agent_instructions(full_name: str) -> dict[str, Any] | None:
-    return await _get_value(full_name)
+    return await _RECORDS.get(full_name)
 
 
 async def list_agent_instructions() -> list[dict[str, Any]]:
-    result = await _client().store.search_items(AGENT_INSTRUCTIONS_NAMESPACE, limit=1000)
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    out: list[dict[str, Any]] = []
-    for item in items or []:
-        value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-        if isinstance(value, dict):
-            out.append(value)
-    out.sort(key=lambda r: r.get("full_name", ""))
-    return out
+    return await _RECORDS.list()
 
 
 async def create_agent_instructions(full_name: str, created_by: str) -> dict[str, Any]:
-    existing = await get_agent_instructions(full_name)
-    if existing:
-        return existing
-    value = _default_record(full_name, created_by)
-    await _client().store.put_item(AGENT_INSTRUCTIONS_NAMESPACE, full_name, value)
-    return value
+    return await _RECORDS.create(full_name, created_by)
 
 
 async def set_agent_instructions(full_name: str, instructions: str) -> dict[str, Any]:
-    existing = await get_agent_instructions(full_name) or _default_record(full_name, "")
-    value = {**existing, "instructions": instructions, "updated_at": _now_iso()}
-    await _client().store.put_item(AGENT_INSTRUCTIONS_NAMESPACE, full_name, value)
-    return value
+    return await _RECORDS.update(full_name, {"instructions": instructions})
 
 
 async def delete_agent_instructions(full_name: str) -> None:
-    await _client().store.delete_item(AGENT_INSTRUCTIONS_NAMESPACE, full_name)
+    await _RECORDS.delete(full_name)
 
 
 async def get_repo_agent_instructions(owner: str, repo: str) -> str | None:

--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -3,7 +3,8 @@
 import logging
 from typing import Any
 
-from ..store import get_value
+from agent.store import get_value
+
 from .options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,

--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -3,9 +3,7 @@
 import logging
 from typing import Any
 
-import httpx
-from langgraph_sdk import get_client
-
+from ..store import get_value
 from .options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
@@ -72,17 +70,19 @@ async def get_profile_default_repo(login: str | None) -> dict[str, str] | None:
 
 
 async def load_profile(login: str) -> dict[str, Any] | None:
+    """The user's profile record, or ``None`` when it is missing or unreadable.
+
+    Fail-soft on purpose: every caller — ``agent.server.get_agent``,
+    :func:`get_profile_default_repo`, :func:`resolve_agent_model_id` — is on the
+    path that starts an agent run, and a store blip must cost the run its
+    per-user overrides, not the run itself. Dashboard reads that should surface
+    a failure use :func:`agent.dashboard.profiles.get_profile` instead.
+    """
     try:
-        item = await get_client().store.get_item(PROFILES_NAMESPACE, login)
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return None
-        logger.warning("profile lookup failed for %s: %s", login, e)
+        return await get_value(PROFILES_NAMESPACE, login)
+    except Exception:
+        logger.warning("profile lookup failed for %s", login, exc_info=True)
         return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
 
 
 def profile_draft_prs(profile: dict[str, Any] | None) -> bool:

--- a/agent/dashboard/autofix_state.py
+++ b/agent/dashboard/autofix_state.py
@@ -8,17 +8,12 @@ agent thread so a disable command is honored even before any fix run exists.
 """
 
 import logging
-from datetime import UTC, datetime
 
-from langgraph_sdk import get_client
+from ..store import get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 
 AUTOFIX_PR_STATE_NAMESPACE: list[str] = ["autofix_pr_state"]
-
-
-def _client():
-    return get_client()
 
 
 def _key(owner: str, repo: str, pr_number: int) -> str:
@@ -26,24 +21,24 @@ def _key(owner: str, repo: str, pr_number: int) -> str:
 
 
 async def is_pr_autofix_disabled(owner: str, repo: str, pr_number: int) -> bool:
-    """Return whether auto-fix has been turned off for a specific PR."""
+    """Return whether auto-fix has been turned off for a specific PR.
+
+    Fail-soft on purpose: this runs inside CI-failure webhook handling, and an
+    unreachable store must leave auto-fix at its configured default rather than
+    break the handler.
+    """
     try:
-        item = await _client().store.get_item(
-            AUTOFIX_PR_STATE_NAMESPACE, _key(owner, repo, pr_number)
-        )
-    except Exception as e:  # noqa: BLE001
-        logger.debug("autofix PR state lookup failed: %s", e)
+        record = await get_value(AUTOFIX_PR_STATE_NAMESPACE, _key(owner, repo, pr_number))
+    except Exception:
+        logger.warning("autofix PR state lookup failed", exc_info=True)
         return False
-    if item is None:
-        return False
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return bool(value.get("disabled")) if isinstance(value, dict) else False
+    return bool(record.get("disabled")) if record else False
 
 
 async def set_pr_autofix_disabled(owner: str, repo: str, pr_number: int, disabled: bool) -> None:
     """Persist the per-PR auto-fix opt-out flag."""
-    await _client().store.put_item(
+    await put_value(
         AUTOFIX_PR_STATE_NAMESPACE,
         _key(owner, repo, pr_number),
-        {"disabled": disabled, "updated_at": datetime.now(UTC).isoformat()},
+        {"disabled": disabled, "updated_at": now_iso()},
     )

--- a/agent/dashboard/autofix_state.py
+++ b/agent/dashboard/autofix_state.py
@@ -9,7 +9,7 @@ agent thread so a disable command is honored even before any fix run exists.
 
 import logging
 
-from ..store import get_value, now_iso, put_value
+from agent.store import get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/enabled_repos.py
+++ b/agent/dashboard/enabled_repos.py
@@ -7,10 +7,8 @@ review comments on every PR.
 """
 
 import logging
-from datetime import UTC, datetime
 
-from langgraph_sdk import get_client
-
+from ..store import get_value, now_iso, put_value
 from .review_styles import normalize_repo_full_name
 
 logger = logging.getLogger(__name__)
@@ -19,24 +17,9 @@ ENABLED_REVIEW_REPOS_NAMESPACE: list[str] = ["enabled_review_repos"]
 ENABLED_REVIEW_REPOS_KEY = "default"
 
 
-def _client():
-    return get_client()
-
-
 async def list_enabled_review_repos() -> list[str]:
-    try:
-        item = await _client().store.get_item(
-            ENABLED_REVIEW_REPOS_NAMESPACE, ENABLED_REVIEW_REPOS_KEY
-        )
-    except Exception as e:
-        logger.debug("enabled review repos lookup failed: %s", e)
-        return []
-    if item is None:
-        return []
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    if not isinstance(value, dict):
-        return []
-    repos = value.get("repos")
+    record = await get_value(ENABLED_REVIEW_REPOS_NAMESPACE, ENABLED_REVIEW_REPOS_KEY)
+    repos = record.get("repos") if record else None
     if not isinstance(repos, list):
         return []
     return [r for r in repos if isinstance(r, str)]
@@ -50,17 +33,26 @@ async def set_review_repo_enabled(full_name: str, enabled: bool) -> list[str]:
     else:
         current.discard(full_name)
     repos = sorted(current)
-    await _client().store.put_item(
+    await put_value(
         ENABLED_REVIEW_REPOS_NAMESPACE,
         ENABLED_REVIEW_REPOS_KEY,
-        {"repos": repos, "updated_at": datetime.now(UTC).isoformat()},
+        {"repos": repos, "updated_at": now_iso()},
     )
     return repos
 
 
 async def is_review_repo_enabled(owner: str, name: str) -> bool:
+    """Whether auto-review is opted in for a repo.
+
+    Fail-soft on purpose: this gates a GitHub webhook, and an unreachable store
+    must read as "not opted in" (skip the review) rather than 500 the webhook.
+    """
     if not owner or not name:
         return False
     full_name = f"{owner.lower()}/{name.lower()}"
-    enabled = await list_enabled_review_repos()
+    try:
+        enabled = await list_enabled_review_repos()
+    except Exception:
+        logger.warning("enabled review repos lookup failed; skipping auto-review", exc_info=True)
+        return False
     return any(r.lower() == full_name for r in enabled)

--- a/agent/dashboard/enabled_repos.py
+++ b/agent/dashboard/enabled_repos.py
@@ -8,7 +8,8 @@ review comments on every PR.
 
 import logging
 
-from ..store import get_value, now_iso, put_value
+from agent.store import get_value, now_iso, put_value
+
 from .review_styles import normalize_repo_full_name
 
 logger = logging.getLogger(__name__)

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -28,7 +28,8 @@ from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, Field, JsonValue, field_validator
 
-from ..store import KeyedRecordStore, now_iso
+from agent.store import KeyedRecordStore, now_iso
+
 from .review_styles import normalize_repo_full_name
 
 logger = logging.getLogger(__name__)

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -24,12 +24,11 @@ import json
 import logging
 import os
 import re
-from datetime import UTC, datetime
 from typing import Any, Literal, TypedDict
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, Field, JsonValue, field_validator
 
+from ..store import KeyedRecordStore, now_iso
 from .review_styles import normalize_repo_full_name
 
 logger = logging.getLogger(__name__)
@@ -276,40 +275,15 @@ class EnvironmentUpdate(BaseModel):
         return None if v is None else _validate_create_params(v)
 
 
-def _client():
-    return get_client()
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _item_value(item: Any) -> dict[str, Any] | None:
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
+_RECORDS = KeyedRecordStore(ENVIRONMENTS_NAMESPACE, sort_key="name")
 
 
 async def get_environment(slug: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(ENVIRONMENTS_NAMESPACE, slug)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("environment lookup failed for %s: %s", slug, e)
-        return None
-    return _item_value(item)
+    return await _RECORDS.get(slug)
 
 
 async def list_environments() -> list[dict[str, Any]]:
-    try:
-        result = await _client().store.search_items(ENVIRONMENTS_NAMESPACE, limit=1000)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("environment search failed: %s", e)
-        return []
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    out = [value for item in items or [] if (value := _item_value(item)) is not None]
-    out.sort(key=lambda record: record.get("name", ""))
-    return out
+    return await _RECORDS.list()
 
 
 async def create_environment(create: EnvironmentCreate, created_by: str) -> dict[str, Any]:
@@ -333,11 +307,10 @@ async def create_environment(create: EnvironmentCreate, created_by: str) -> dict
         "source_sandbox_id": None,
         "last_captured_at": None,
         "created_by": created_by,
-        "created_at": _now_iso(),
-        "updated_at": _now_iso(),
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
     }
-    await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
-    return record
+    return await _RECORDS.put(slug, record)
 
 
 async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, Any]:
@@ -346,7 +319,7 @@ async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, 
         raise ValueError(f"no environment named {slug!r}")
     if update.name is not None and slugify(update.name) != slug:
         raise ValueError("renaming an environment across slugs is not supported; create a new one")
-    record = {**existing, "updated_at": _now_iso()}
+    record = {**existing, "updated_at": now_iso()}
     if update.name is not None:
         record["name"] = update.name.strip()
     if update.prompt is not None:
@@ -356,19 +329,14 @@ async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, 
     for field in ("mem_bytes", "vcpus", "fs_capacity_bytes", "create_params"):
         if field in update.model_fields_set:
             record[field] = getattr(update, field)
-    await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
-    return record
+    return await _RECORDS.put(slug, record)
 
 
 async def delete_environment(slug: str) -> bool:
     existing = await get_environment(slug)
     if existing is None:
         return False
-    try:
-        await _client().store.delete_item(ENVIRONMENTS_NAMESPACE, slug)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("failed to delete environment %s: %s", slug, e)
-        return False
+    await _RECORDS.delete(slug)
     await _delete_snapshot(existing.get("snapshot_id"))
     return True
 
@@ -376,13 +344,14 @@ async def delete_environment(slug: str) -> bool:
 async def resolve_default_environment() -> dict[str, Any] | None:
     """Return the environment named ``default``, or ``None``.
 
-    Never raises: a store failure resolves to ``None`` so runs fall back to the
-    per-repo and base snapshots with no environment prompt.
+    Fail-soft on purpose: this runs while a sandbox is being created, and a
+    store failure must fall back to the per-repo and base snapshots with no
+    environment prompt rather than fail the run.
     """
     try:
         return await get_environment(DEFAULT_ENVIRONMENT_SLUG)
-    except Exception:  # noqa: BLE001
-        logger.debug("default environment resolution failed", exc_info=True)
+    except Exception:
+        logger.warning("default environment resolution failed", exc_info=True)
         return None
 
 
@@ -396,8 +365,8 @@ async def resolve_environment(slug: str | None) -> dict[str, Any] | None:
         return await resolve_default_environment()
     try:
         record = await get_environment(slug)
-    except Exception:  # noqa: BLE001
-        logger.debug("environment resolution failed for %s", slug, exc_info=True)
+    except Exception:
+        logger.warning("environment resolution failed for %s", slug, exc_info=True)
         record = None
     if record is None:
         logger.info("Environment %s is not configured; falling back to the default", slug)
@@ -497,11 +466,10 @@ async def _set_snapshot_state(
         **existing,
         "snapshot_status": status,
         "status_message": status_message,
-        "updated_at": _now_iso(),
+        "updated_at": now_iso(),
         **(extra or {}),
     }
-    await _client().store.put_item(ENVIRONMENTS_NAMESPACE, slug, record)
-    return record
+    return await _RECORDS.put(slug, record)
 
 
 def _require_capture_support() -> None:
@@ -602,7 +570,7 @@ async def capture_environment_snapshot(
             "snapshot_id": snapshot.id,
             "snapshot_name": snapshot_name,
             "source_sandbox_id": sandbox_id,
-            "last_captured_at": _now_iso(),
+            "last_captured_at": now_iso(),
         },
     )
     if previous_snapshot_id != snapshot.id:

--- a/agent/dashboard/eval_jobs.py
+++ b/agent/dashboard/eval_jobs.py
@@ -13,8 +13,6 @@ import os
 from datetime import UTC, datetime
 from typing import Any, Literal, TypedDict
 
-from langgraph_sdk import get_client
-
 from agent.review.eval_store import (
     _HEARTBEAT_STALE_SECONDS,
     DEFAULT_EVAL_PROJECT,
@@ -22,6 +20,7 @@ from agent.review.eval_store import (
     REVIEWER_EVAL_KEY,
 )
 from agent.review.findings import REVIEW_FINDING_CAP
+from agent.store import get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 
@@ -57,14 +56,6 @@ DEFAULT_REVIEWER_EVAL_CONFIG: ReviewerEvalConfig = {
     "severity_threshold": "low",
     "cap": REVIEW_FINDING_CAP,
 }
-
-
-def _client():
-    return get_client()
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def _resolve_langgraph_url() -> str | None:
@@ -108,28 +99,17 @@ def _idle_record() -> dict[str, Any]:
         "progress": None,
         "github_run_url": None,
         "trigger": None,
-        "updated_at": _now_iso(),
+        "updated_at": now_iso(),
     }
 
 
 async def _get_record() -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(EVALS_NAMESPACE, REVIEWER_EVAL_KEY)
-    except Exception as e:
-        logger.debug("store get_item failed for reviewer eval: %s", e)
-        return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
+    return await get_value(EVALS_NAMESPACE, REVIEWER_EVAL_KEY)
 
 
 async def _put_record(record: dict[str, Any]) -> dict[str, Any]:
-    record = {**record, "updated_at": _now_iso()}
-    try:
-        await _client().store.put_item(EVALS_NAMESPACE, REVIEWER_EVAL_KEY, record)
-    except Exception:
-        logger.exception("Failed to persist reviewer eval status")
+    record = {**record, "updated_at": now_iso()}
+    await put_value(EVALS_NAMESPACE, REVIEWER_EVAL_KEY, record)
     return record
 
 
@@ -171,7 +151,7 @@ async def get_reviewer_eval_status() -> dict[str, Any]:
         {
             **record,
             "status": "failed",
-            "finished_at": record.get("finished_at") or _now_iso(),
+            "finished_at": record.get("finished_at") or now_iso(),
             "error": "Eval process is no longer tracked (GitHub Action stopped?).",
         }
     )

--- a/agent/dashboard/notion_oauth.py
+++ b/agent/dashboard/notion_oauth.py
@@ -4,14 +4,13 @@ import base64
 import hashlib
 import os
 import secrets
-from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
 import httpx
-from langgraph_sdk import get_client
 
 from ..encryption import decrypt_token, encrypt_token
+from ..store import delete_value, get_value, now_iso, put_value
 
 NOTION_MCP_URL = "https://mcp.notion.com/mcp"
 NOTION_STATE_COOKIE_NAME = "osw_notion_oauth_state"
@@ -31,10 +30,6 @@ class NotionOAuthError(Exception):
         self.status_code = status_code
         self.detail = detail
         self.error_code = error_code
-
-
-def _client():
-    return get_client()
 
 
 def _is_notion_https_url(url: str) -> bool:
@@ -192,9 +187,9 @@ async def store_notion_oauth_flow(
         "encrypted_client_secret": encrypt_token(client_secret) if client_secret else None,
         "token_endpoint": str(metadata["token_endpoint"]),
         "redirect_uri": redirect_uri,
-        "created_at": datetime.now(UTC).isoformat(),
+        "created_at": now_iso(),
     }
-    await _client().store.put_item([*NOTION_OAUTH_FLOW_NAMESPACE, login], nonce_hash, value)
+    await put_value([*NOTION_OAUTH_FLOW_NAMESPACE, login], nonce_hash, value)
     return build_notion_authorize_url(
         authorization_endpoint=authorization_endpoint,
         client_id=client_id,
@@ -207,21 +202,9 @@ async def store_notion_oauth_flow(
 async def pop_notion_oauth_flow(login: str, nonce_hash: str) -> dict[str, Any] | None:
     """Read and delete a pending Notion OAuth flow."""
     namespace = [*NOTION_OAUTH_FLOW_NAMESPACE, login]
-    try:
-        item = await _client().store.get_item(namespace, nonce_hash)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 404:
-            return None
-        raise
-    try:
-        await _client().store.delete_item(namespace, nonce_hash)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 404:
-            raise
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    if not isinstance(value, dict):
+    value = await get_value(namespace, nonce_hash)
+    await delete_value(namespace, nonce_hash)
+    if value is None:
         return None
     encrypted_code_verifier = value.pop("encrypted_code_verifier", "")
     if encrypted_code_verifier:

--- a/agent/dashboard/notion_oauth.py
+++ b/agent/dashboard/notion_oauth.py
@@ -9,8 +9,9 @@ from urllib.parse import urlencode, urlparse
 
 import httpx
 
+from agent.store import delete_value, get_value, now_iso, put_value
+
 from ..encryption import decrypt_token, encrypt_token
-from ..store import delete_value, get_value, now_iso, put_value
 
 NOTION_MCP_URL = "https://mcp.notion.com/mcp"
 NOTION_STATE_COOKIE_NAME = "osw_notion_oauth_state"

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from langgraph_sdk import get_client
 
-from ..store import delete_value, get_value, now_iso, put_value, search_values
+from agent.store import delete_value, get_value, now_iso, put_value, search_values
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/plan_store.py
+++ b/agent/dashboard/plan_store.py
@@ -18,6 +18,8 @@ from typing import Any
 
 from langgraph_sdk import get_client
 
+from ..store import delete_value, get_value, now_iso, put_value, search_values
+
 logger = logging.getLogger(__name__)
 
 PLAN_CONTENT_NAMESPACE = ["plan", "content"]
@@ -52,22 +54,8 @@ def plan_file_path_for_thread(thread_id: str) -> str:
     return f"{PLAN_FILE_DIRECTORY}/{date}-{slug or 'plan'}.html"
 
 
-def _client() -> Any:
-    return get_client()
-
-
-def _item_value(item: Any) -> dict[str, Any] | None:
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-async def _stored_plan_file_path(client: Any, thread_id: str) -> str | None:
-    try:
-        value = _item_value(await client.store.get_item(PLAN_CONTENT_NAMESPACE, thread_id)) or {}
-    except Exception:
-        return None
+async def _stored_plan_file_path(thread_id: str) -> str | None:
+    value = await get_plan_content(thread_id) or {}
     path = value.get("plan_file_path")
     return path if isinstance(path, str) and path else None
 
@@ -88,9 +76,8 @@ async def save_plan_content(
     on it are cleared — otherwise stale feedback would resurface on the new plan
     and be fed back to the agent on the next approve/reject. A manual owner edit
     passes ``clear_comments=False`` so reviewer feedback survives the edit."""
-    client = _client()
     if plan_file_path is None:
-        plan_file_path = await _stored_plan_file_path(client, thread_id)
+        plan_file_path = await _stored_plan_file_path(thread_id)
     record: dict[str, Any] = {"status": status}
     if html is not None:
         record["html"] = html
@@ -98,11 +85,7 @@ async def save_plan_content(
         record["markdown"] = markdown
     if plan_file_path:
         record["plan_file_path"] = plan_file_path
-    await client.store.put_item(
-        PLAN_CONTENT_NAMESPACE,
-        thread_id,
-        record,
-    )
+    await put_value(PLAN_CONTENT_NAMESPACE, thread_id, record)
     if clear_comments:
         try:
             await clear_plan_comments(thread_id)
@@ -143,14 +126,13 @@ async def get_plan_content(
     With ``raise_on_error=True`` a store failure propagates instead of resolving
     to ``None``. Approve uses this so a transient failure aborts the decision
     rather than dispatching the agent without the (possibly edited) plan."""
-    client = _client()
     try:
-        item = await client.store.get_item(PLAN_CONTENT_NAMESPACE, thread_id)
+        return await get_value(PLAN_CONTENT_NAMESPACE, thread_id)
     except Exception:
         if raise_on_error:
             raise
+        logger.warning("plan content lookup failed for %s", thread_id, exc_info=True)
         return None
-    return _item_value(item)
 
 
 async def set_plan_status(
@@ -165,7 +147,6 @@ async def set_plan_status(
     entering_plan_after_share = (
         existing.get("status") == PLAN_STATUS_SHARED and status == PLAN_STATUS_PLANNING
     )
-    client = _client()
     record: dict[str, Any] = {"status": status}
     if not entering_plan_after_share:
         for field in ("html", "markdown"):
@@ -184,14 +165,10 @@ async def set_plan_status(
             name=str(approved_by.get("name") or ""),
             source=str(approved_by.get("source") or ""),
         )
-        approved_at = datetime.now(UTC).isoformat()
+        approved_at = now_iso()
         record.update(approved_by=approver, approved_at=approved_at)
         metadata.update(plan_approved_by=approver, plan_approved_at=approved_at)
-    await client.store.put_item(
-        PLAN_CONTENT_NAMESPACE,
-        thread_id,
-        record,
-    )
+    await put_value(PLAN_CONTENT_NAMESPACE, thread_id, record)
     if plan_mode is not None:
         metadata["plan_mode"] = plan_mode
     await _merge_thread_metadata(thread_id, metadata)
@@ -210,15 +187,13 @@ async def list_plan_comments(
     resolving to ``[]``. Approve/reject use this so a transient failure surfaces
     (the decision endpoint errors) rather than silently feeding the agent an
     empty comment set and dropping the reviewer's feedback."""
-    client = _client()
     try:
-        items = await client.store.search_items(_comments_namespace(thread_id), limit=1000)
+        comments = await search_values(_comments_namespace(thread_id), limit=1000)
     except Exception:
         if raise_on_error:
             raise
+        logger.warning("plan comment lookup failed for %s", thread_id, exc_info=True)
         return []
-    raw = items.get("items", []) if isinstance(items, dict) else getattr(items, "items", [])
-    comments = [v for v in (_item_value(item) for item in raw) if v]
     comments.sort(key=lambda c: str(c.get("created_at", "")))
     return comments
 
@@ -240,20 +215,19 @@ async def add_plan_comment(
         "author": author,
         "author_login": author_login,
         "body": body,
-        "created_at": datetime.now(UTC).isoformat(),
+        "created_at": now_iso(),
     }
-    await _client().store.put_item(_comments_namespace(thread_id), comment["id"], comment)
+    await put_value(_comments_namespace(thread_id), comment["id"], comment)
     return comment
 
 
 async def delete_plan_comment(thread_id: str, comment_id: str) -> None:
-    await _client().store.delete_item(_comments_namespace(thread_id), comment_id)
+    await delete_value(_comments_namespace(thread_id), comment_id)
 
 
 async def _merge_thread_metadata(thread_id: str, metadata: dict[str, Any]) -> None:
-    client = _client()
     try:
-        await client.threads.update(thread_id=thread_id, metadata=metadata)
+        await get_client().threads.update(thread_id=thread_id, metadata=metadata)
     except Exception:
         # The thread always exists by the time a plan is saved (the run created
         # it); a transient update failure must not crash the agent mid-run.

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -17,8 +17,9 @@ from typing import Any
 
 from pydantic import BaseModel, model_validator
 
+from agent.store import delete_value, get_value, now_iso, put_value, search_values
+
 from ..encryption import decrypt_token, encrypt_token
-from ..store import delete_value, get_value, now_iso, put_value, search_values
 from .oauth import (
     expires_at_from_github_response,
     is_unrecoverable_refresh_error,

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -15,11 +15,10 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import httpx
-from langgraph_sdk import get_client
 from pydantic import BaseModel, model_validator
 
 from ..encryption import decrypt_token, encrypt_token
+from ..store import delete_value, get_value, now_iso, put_value, search_values
 from .oauth import (
     expires_at_from_github_response,
     is_unrecoverable_refresh_error,
@@ -115,25 +114,13 @@ def normalize_profile_for_response(profile: dict[str, Any]) -> dict[str, Any]:
     return value
 
 
-def _client():
-    return get_client()
-
-
-async def _get_value(namespace: list[str], key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(namespace, key)
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return None
-        raise
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
 async def get_profile(login: str) -> dict[str, Any] | None:
-    return await _get_value(PROFILES_NAMESPACE, login)
+    return await get_value(PROFILES_NAMESPACE, login)
+
+
+async def get_oauth_token_record(login: str) -> dict[str, Any] | None:
+    """The raw encrypted-token record, for callers that need its expiry metadata."""
+    return await get_value(OAUTH_TOKENS_NAMESPACE, login)
 
 
 async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[str, Any]:
@@ -160,7 +147,7 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)
         ),
         "review_draft_prs": update.review_draft_prs,
-        "updated_at": datetime.now(UTC).isoformat(),
+        "updated_at": now_iso(),
     }
     for stale_field in (
         "first_name",
@@ -171,7 +158,7 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "create_prs",
     ):
         value.pop(stale_field, None)
-    await _client().store.put_item(PROFILES_NAMESPACE, login, value)
+    await put_value(PROFILES_NAMESPACE, login, value)
     return value
 
 
@@ -214,12 +201,12 @@ async def upsert_access_token(
     """
     if not access_token:
         return
-    existing = await _get_value(OAUTH_TOKENS_NAMESPACE, login) or {}
+    existing = await get_value(OAUTH_TOKENS_NAMESPACE, login) or {}
     value: dict[str, Any] = {
         "login": login,
         "email": email or existing.get("email", ""),
         "encrypted_gh_token": encrypt_token(access_token),
-        "updated_at": datetime.now(UTC).isoformat(),
+        "updated_at": now_iso(),
     }
     if refresh_token:
         value["encrypted_gh_refresh_token"] = encrypt_token(refresh_token)
@@ -229,7 +216,7 @@ async def upsert_access_token(
         value["token_expires_at"] = token_expires_at
     if refresh_token_expires_at:
         value["refresh_token_expires_at"] = refresh_token_expires_at
-    await _client().store.put_item(OAUTH_TOKENS_NAMESPACE, login, value)
+    await put_value(OAUTH_TOKENS_NAMESPACE, login, value)
 
 
 async def upsert_access_token_from_github_response(
@@ -258,11 +245,7 @@ async def delete_access_token(login: str) -> None:
     Used when a refresh token is permanently dead so we stop handing out a
     known-stale access token and callers prompt a clean re-login instead.
     """
-    try:
-        await _client().store.delete_item(OAUTH_TOKENS_NAMESPACE, login)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 404:
-            raise
+    await delete_value(OAUTH_TOKENS_NAMESPACE, login)
 
 
 def _decrypt_access_token(record: dict[str, Any]) -> str | None:
@@ -303,7 +286,7 @@ async def _refresh_stored_token(login: str, record: dict[str, Any]) -> tuple[str
 
 async def get_valid_access_token(login: str, *, force_refresh: bool = False) -> str | None:
     """Return a GitHub access token, refreshing proactively when near expiry."""
-    record = await _get_value(OAUTH_TOKENS_NAMESPACE, login)
+    record = await get_value(OAUTH_TOKENS_NAMESPACE, login)
     if not record:
         return None
 
@@ -318,7 +301,7 @@ async def get_valid_access_token(login: str, *, force_refresh: bool = False) -> 
         return access_token
 
     async with _refresh_lock(login):
-        record = await _get_value(OAUTH_TOKENS_NAMESPACE, login)
+        record = await get_value(OAUTH_TOKENS_NAMESPACE, login)
         if not record:
             return None
         access_token = _decrypt_access_token(record)
@@ -336,7 +319,7 @@ async def get_valid_access_token(login: str, *, force_refresh: bool = False) -> 
             # The OAuth callback can write a fresh authorization while the
             # refresh request is in flight (it doesn't take this lock), so only
             # delete if the stored record is still the one that failed.
-            latest = await _get_value(OAUTH_TOKENS_NAMESPACE, login)
+            latest = await get_value(OAUTH_TOKENS_NAMESPACE, login)
             if latest and latest.get("encrypted_gh_refresh_token") != record.get(
                 "encrypted_gh_refresh_token"
             ):
@@ -358,15 +341,8 @@ async def has_access_token_record(login: str) -> bool:
     "the stored authorization is present but no longer usable" (record exists
     but won't decrypt / was revoked), so callers can prompt accurately.
     """
-    return bool(await _get_value(OAUTH_TOKENS_NAMESPACE, login))
+    return bool(await get_value(OAUTH_TOKENS_NAMESPACE, login))
 
 
 async def list_profiles() -> list[dict[str, Any]]:
-    result = await _client().store.search_items(PROFILES_NAMESPACE, limit=1000)
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    out: list[dict[str, Any]] = []
-    for item in items or []:
-        value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-        if isinstance(value, dict):
-            out.append(value)
-    return out
+    return await search_values(PROFILES_NAMESPACE, limit=1000)

--- a/agent/dashboard/repo_cache.py
+++ b/agent/dashboard/repo_cache.py
@@ -17,7 +17,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from ..store import get_value, now_ms, put_value
+from agent.store import get_value, now_ms, put_value
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/repo_cache.py
+++ b/agent/dashboard/repo_cache.py
@@ -15,11 +15,9 @@ fresh on every call.
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
 from typing import Any
 
-import httpx
-from langgraph_sdk import get_client
+from ..store import get_value, now_ms, put_value
 
 logger = logging.getLogger(__name__)
 
@@ -31,39 +29,30 @@ _refreshing: set[str] = set()
 _refresh_tasks: set[asyncio.Task[None]] = set()
 
 
-def _client():
-    return get_client()
-
-
-def _now_ms() -> int:
-    return int(datetime.now(UTC).timestamp() * 1000)
-
-
 def _cache_key(login: str) -> str:
     return login.strip().lower()
 
 
 async def read_cached_repos(login: str) -> tuple[dict[str, Any], int] | None:
-    """Return ``(payload, age_ms)`` for a login, or ``None`` when unusable."""
+    """Return ``(payload, age_ms)`` for a login, or ``None`` when unusable.
+
+    Fail-soft on purpose, both ways: this is a cache, so an unreachable store
+    is a miss the caller serves by rebuilding the payload.
+    """
     if not login.strip():
         return None
     try:
-        item = await _client().store.get_item(REPO_LIST_CACHE_NAMESPACE, _cache_key(login))
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code != 404:
-            logger.debug("repo list cache lookup failed: %s", e)
+        value = await get_value(REPO_LIST_CACHE_NAMESPACE, _cache_key(login))
+    except Exception:
+        logger.warning("repo list cache lookup failed", exc_info=True)
         return None
-    except Exception as e:
-        logger.debug("repo list cache lookup failed: %s", e)
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    if not isinstance(value, dict):
+    if value is None:
         return None
     payload = value.get("payload")
     cached_at_ms = value.get("cached_at_ms")
     if not isinstance(payload, dict) or not isinstance(cached_at_ms, int):
         return None
-    age_ms = max(_now_ms() - cached_at_ms, 0)
+    age_ms = max(now_ms() - cached_at_ms, 0)
     if age_ms > REPO_LIST_MAX_AGE_MS:
         return None
     return payload, age_ms
@@ -73,13 +62,13 @@ async def write_cached_repos(login: str, payload: dict[str, Any]) -> None:
     if not login.strip():
         return
     try:
-        await _client().store.put_item(
+        await put_value(
             REPO_LIST_CACHE_NAMESPACE,
             _cache_key(login),
-            {"payload": payload, "cached_at_ms": _now_ms()},
+            {"payload": payload, "cached_at_ms": now_ms()},
         )
-    except Exception as e:
-        logger.debug("repo list cache write failed: %s", e)
+    except Exception:
+        logger.warning("repo list cache write failed", exc_info=True)
 
 
 def schedule_repo_cache_refresh(login: str, refresh: Callable[[], Awaitable[Any]]) -> None:

--- a/agent/dashboard/repo_snapshots.py
+++ b/agent/dashboard/repo_snapshots.py
@@ -18,9 +18,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, Field, field_validator
 
+from ..store import KeyedRecordStore, now_iso
 from .review_styles import normalize_repo_full_name
 
 logger = logging.getLogger(__name__)
@@ -137,14 +137,6 @@ class RepoSnapshotUpdate(BaseModel):
         return v
 
 
-def _client():
-    return get_client()
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
-
-
 def _parse_iso(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -177,18 +169,6 @@ def is_repo_snapshot_build_stale(record: dict[str, Any]) -> bool:
     return (datetime.now(UTC) - started_at).total_seconds() > _stale_build_seconds()
 
 
-async def _get_value(key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(REPO_SNAPSHOTS_NAMESPACE, key)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("store get_item failed for %s: %s", key, e)
-        return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
 def _default_record(full_name: str, created_by: str) -> dict[str, Any]:
     owner, name = full_name.split("/", 1)
     return {
@@ -209,100 +189,86 @@ def _default_record(full_name: str, created_by: str) -> dict[str, Any]:
         "build_started_at": None,
         "last_built_at": None,
         "created_by": created_by,
-        "created_at": _now_iso(),
-        "updated_at": _now_iso(),
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
     }
 
 
+_RECORDS = KeyedRecordStore(
+    REPO_SNAPSHOTS_NAMESPACE,
+    sort_key="full_name",
+    default_factory=_default_record,
+)
+
+
 async def get_repo_snapshot(full_name: str) -> dict[str, Any] | None:
-    return await _get_value(normalize_repo_full_name(full_name))
+    return await _RECORDS.get(normalize_repo_full_name(full_name))
 
 
 async def list_repo_snapshots() -> list[dict[str, Any]]:
-    try:
-        result = await _client().store.search_items(REPO_SNAPSHOTS_NAMESPACE, limit=1000)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("store search_items failed for repo_snapshots: %s", e)
-        return []
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    out: list[dict[str, Any]] = []
-    for item in items or []:
-        value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-        if isinstance(value, dict):
-            out.append(value)
-    out.sort(key=lambda r: r.get("full_name", ""))
-    return out
+    return await _RECORDS.list()
 
 
 async def create_repo_snapshot(full_name: str, created_by: str) -> dict[str, Any]:
-    full_name = normalize_repo_full_name(full_name)
-    existing = await get_repo_snapshot(full_name)
-    if existing:
-        return existing
-    value = _default_record(full_name, created_by)
-    await _client().store.put_item(REPO_SNAPSHOTS_NAMESPACE, full_name, value)
-    return value
+    return await _RECORDS.create(normalize_repo_full_name(full_name), created_by)
 
 
 async def update_repo_snapshot(full_name: str, update: RepoSnapshotUpdate) -> dict[str, Any]:
-    full_name = normalize_repo_full_name(full_name)
-    existing = await get_repo_snapshot(full_name) or _default_record(full_name, "")
-    value = {**existing, "dockerfile": update.dockerfile, "updated_at": _now_iso()}
-    if update.fs_capacity_bytes is not None:
-        value["fs_capacity_bytes"] = update.fs_capacity_bytes
-    if update.vcpus is not None:
-        value["vcpus"] = update.vcpus
-    if update.mem_bytes is not None:
-        value["mem_bytes"] = update.mem_bytes
-    value["target"] = update.target
-    value["build_args"] = update.build_args
-    await _client().store.put_item(REPO_SNAPSHOTS_NAMESPACE, full_name, value)
-    return value
+    patch: dict[str, Any] = {
+        "dockerfile": update.dockerfile,
+        "target": update.target,
+        "build_args": update.build_args,
+    }
+    for field, value in (
+        ("fs_capacity_bytes", update.fs_capacity_bytes),
+        ("vcpus", update.vcpus),
+        ("mem_bytes", update.mem_bytes),
+    ):
+        if value is not None:
+            patch[field] = value
+    return await _RECORDS.update(normalize_repo_full_name(full_name), patch)
 
 
 async def delete_repo_snapshot(full_name: str) -> bool:
     full_name = normalize_repo_full_name(full_name)
-    existing = await get_repo_snapshot(full_name)
-    if not existing:
+    if not await get_repo_snapshot(full_name):
         return False
-    try:
-        await _client().store.delete_item(REPO_SNAPSHOTS_NAMESPACE, full_name)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("Failed to delete repo snapshot %s: %s", full_name, e)
-        return False
+    await _RECORDS.delete(full_name)
     return True
 
 
 async def mark_repo_snapshot_building(full_name: str) -> dict[str, Any]:
     """Set a repo snapshot's status to ``building`` and return the record."""
     full_name = normalize_repo_full_name(full_name)
-    existing = await get_repo_snapshot(full_name)
+    existing = await _RECORDS.get(full_name)
     if existing is None:
         raise ValueError(f"no repo snapshot record for {full_name}")
-    value = {
-        **existing,
-        "status": "building",
-        "status_message": None,
-        "build_log": None,
-        "build_started_at": _now_iso(),
-        "updated_at": _now_iso(),
-    }
-    await _client().store.put_item(REPO_SNAPSHOTS_NAMESPACE, full_name, value)
-    return value
+    return await _RECORDS.put(
+        full_name,
+        {
+            **existing,
+            "status": "building",
+            "status_message": None,
+            "build_log": None,
+            "build_started_at": now_iso(),
+            "updated_at": now_iso(),
+        },
+    )
 
 
 async def resolve_repo_snapshot_id(owner: str | None, name: str | None) -> str | None:
     """Return a repo's ready snapshot id, or ``None`` to fall back to the default.
 
-    Never raises: any lookup failure resolves to ``None`` so sandbox creation
-    falls back to the configured ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
+    Fail-soft on purpose: this runs while a sandbox is being created, and a
+    lookup failure must fall back to the configured
+    ``DEFAULT_SANDBOX_SNAPSHOT_ID`` rather than fail the run.
     """
     if not owner or not name:
         return None
     try:
-        record = await _get_value(f"{owner}/{name}")
-    except Exception:  # noqa: BLE001
-        logger.debug("repo snapshot lookup failed for %s/%s", owner, name, exc_info=True)
+        record = await _RECORDS.get(f"{owner}/{name}")
+    except Exception:
+        logger.warning("repo snapshot lookup failed for %s/%s", owner, name, exc_info=True)
         return None
     if not record or record.get("status") != "ready":
         return None
@@ -317,20 +283,21 @@ async def _set_status(
     status_message: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> None:
-    existing = await get_repo_snapshot(full_name)
+    full_name = normalize_repo_full_name(full_name)
+    existing = await _RECORDS.get(full_name)
     if existing is None:
         return
     value = {
         **existing,
         "status": status,
         "status_message": status_message,
-        "updated_at": _now_iso(),
+        "updated_at": now_iso(),
     }
     if status != "building":
         value["build_started_at"] = None
     if extra:
         value.update(extra)
-    await _client().store.put_item(REPO_SNAPSHOTS_NAMESPACE, full_name, value)
+    await _RECORDS.put(full_name, value)
 
 
 def _build_snapshot_sync(record: dict[str, Any], snapshot_name: str) -> tuple[str, str]:
@@ -421,7 +388,7 @@ async def run_snapshot_build(full_name: str) -> None:
             "snapshot_id": snapshot_id,
             "snapshot_name": snapshot_name,
             "build_log": log_tail,
-            "last_built_at": _now_iso(),
+            "last_built_at": now_iso(),
         },
     )
     logger.info("Built snapshot %s for repo %s", snapshot_id, full_name)

--- a/agent/dashboard/repo_snapshots.py
+++ b/agent/dashboard/repo_snapshots.py
@@ -20,7 +20,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-from ..store import KeyedRecordStore, now_iso
+from agent.store import KeyedRecordStore, now_iso
+
 from .review_styles import normalize_repo_full_name
 
 logger = logging.getLogger(__name__)

--- a/agent/dashboard/review_styles.py
+++ b/agent/dashboard/review_styles.py
@@ -5,11 +5,11 @@ analysis metadata, and the status of the background style-analysis run.
 """
 
 import logging
-from datetime import UTC, datetime
 from typing import Any, Literal
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, Field, field_validator
+
+from ..store import KeyedRecordStore, now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -53,26 +53,6 @@ class ReviewStylePromptUpdate(BaseModel):
         return v
 
 
-def _client():
-    return get_client()
-
-
-async def _get_value(key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(REVIEW_STYLES_NAMESPACE, key)
-    except Exception as e:
-        logger.debug("store get_item failed for %s: %s", key, e)
-        return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
-
-
 def _default_record(full_name: str, created_by: str) -> dict[str, Any]:
     owner, name = full_name.split("/", 1)
     return {
@@ -90,43 +70,32 @@ def _default_record(full_name: str, created_by: str) -> dict[str, Any]:
         "continual_cron_id": None,
         "error": None,
         "created_by": created_by,
-        "created_at": _now_iso(),
-        "updated_at": _now_iso(),
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
     }
 
 
+_RECORDS = KeyedRecordStore(
+    REVIEW_STYLES_NAMESPACE,
+    sort_key="full_name",
+    default_factory=_default_record,
+)
+
+
 async def get_review_style(full_name: str) -> dict[str, Any] | None:
-    return await _get_value(full_name)
+    return await _RECORDS.get(full_name)
 
 
 async def list_review_styles() -> list[dict[str, Any]]:
-    result = await _client().store.search_items(REVIEW_STYLES_NAMESPACE, limit=1000)
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    out: list[dict[str, Any]] = []
-    for item in items or []:
-        value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-        if isinstance(value, dict):
-            out.append(value)
-    out.sort(key=lambda r: r.get("full_name", ""))
-    return out
+    return await _RECORDS.list()
 
 
 async def create_review_style(full_name: str, created_by: str) -> dict[str, Any]:
-    existing = await get_review_style(full_name)
-    if existing:
-        return existing
-    value = _default_record(full_name, created_by)
-    await _client().store.put_item(REVIEW_STYLES_NAMESPACE, full_name, value)
-    return value
+    return await _RECORDS.create(full_name, created_by)
 
 
 async def update_review_style(full_name: str, patch: dict[str, Any]) -> dict[str, Any]:
-    existing = await get_review_style(full_name) or _default_record(
-        full_name, patch.get("created_by", "")
-    )
-    value = {**existing, **patch, "updated_at": _now_iso()}
-    await _client().store.put_item(REVIEW_STYLES_NAMESPACE, full_name, value)
-    return value
+    return await _RECORDS.update(full_name, patch)
 
 
 def has_saved_prompt(record: dict[str, Any]) -> bool:
@@ -182,7 +151,7 @@ async def reconcile_running_status(
 
 
 async def delete_review_style(full_name: str) -> None:
-    await _client().store.delete_item(REVIEW_STYLES_NAMESPACE, full_name)
+    await _RECORDS.delete(full_name)
 
 
 async def mark_analysis_running(
@@ -236,9 +205,18 @@ async def mark_analysis_failed(full_name: str, error: str) -> dict[str, Any]:
 
 
 async def get_repo_custom_prompt(owner: str, repo: str) -> str | None:
-    """Return the custom prompt supplement for a repo, if configured."""
+    """Return the custom prompt supplement for a repo, if configured.
+
+    Fail-soft on purpose: this runs while the reviewer assembles its system
+    prompt, and a store blip should cost the run its style supplement, not the
+    whole review.
+    """
     full_name = f"{owner}/{repo}"
-    record = await get_review_style(full_name)
+    try:
+        record = await get_review_style(full_name)
+    except Exception:
+        logger.warning("review style lookup failed for %s", full_name, exc_info=True)
+        return None
     if not record:
         return None
     prompt = record.get("custom_prompt")

--- a/agent/dashboard/review_styles.py
+++ b/agent/dashboard/review_styles.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-from ..store import KeyedRecordStore, now_iso
+from agent.store import KeyedRecordStore, now_iso
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/sandbox_settings.py
+++ b/agent/dashboard/sandbox_settings.py
@@ -13,11 +13,11 @@ precedence over this base for runs that target a repo with a ready snapshot.
 
 import logging
 import os
-from datetime import UTC, datetime
 from typing import Any, Literal
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, field_validator
+
+from ..store import get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 
@@ -49,35 +49,29 @@ class SandboxSettingsUpdate(BaseModel):
         return text
 
 
-def _client():
-    return get_client()
-
-
 def env_base_snapshot_id() -> str | None:
     value = os.environ.get("DEFAULT_SANDBOX_SNAPSHOT_ID", "").strip()
     return value or None
 
 
+def _stored_base_snapshot_id(record: dict[str, Any] | None) -> str | None:
+    snapshot_id = record.get("base_snapshot_id") if record else None
+    return snapshot_id.strip() or None if isinstance(snapshot_id, str) else None
+
+
 async def get_admin_base_snapshot_id() -> str | None:
     """Return the admin-configured base snapshot, ignoring the env default.
 
-    Never raises: a store failure resolves to ``None`` so sandbox creation falls
-    back to ``DEFAULT_SANDBOX_SNAPSHOT_ID``.
+    Fail-soft on purpose: this runs while a sandbox is being created, and a
+    store failure must fall back to ``DEFAULT_SANDBOX_SNAPSHOT_ID`` rather than
+    fail the run.
     """
     try:
-        item = await _client().store.get_item(SANDBOX_SETTINGS_NAMESPACE, SANDBOX_SETTINGS_KEY)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("sandbox settings lookup failed: %s", e)
+        record = await get_value(SANDBOX_SETTINGS_NAMESPACE, SANDBOX_SETTINGS_KEY)
+    except Exception:
+        logger.warning("sandbox settings lookup failed", exc_info=True)
         return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    if not isinstance(value, dict):
-        return None
-    snapshot_id = value.get("base_snapshot_id")
-    if not isinstance(snapshot_id, str):
-        return None
-    return snapshot_id.strip() or None
+    return _stored_base_snapshot_id(record)
 
 
 async def resolve_base_snapshot_id() -> str | None:
@@ -87,20 +81,8 @@ async def resolve_base_snapshot_id() -> str | None:
 
 async def get_sandbox_settings() -> dict[str, Any]:
     """Return the stored settings plus the resolved effective base snapshot."""
-    try:
-        item = await _client().store.get_item(SANDBOX_SETTINGS_NAMESPACE, SANDBOX_SETTINGS_KEY)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("sandbox settings lookup failed: %s", e)
-        item = None
-    value = {}
-    if item is not None:
-        stored = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-        if isinstance(stored, dict):
-            value = stored
-    admin_snapshot_id = value.get("base_snapshot_id")
-    admin_snapshot_id = (
-        admin_snapshot_id.strip() or None if isinstance(admin_snapshot_id, str) else None
-    )
+    value = await get_value(SANDBOX_SETTINGS_NAMESPACE, SANDBOX_SETTINGS_KEY) or {}
+    admin_snapshot_id = _stored_base_snapshot_id(value)
     env_snapshot_id = env_base_snapshot_id()
     source: BaseSnapshotSource = (
         "admin" if admin_snapshot_id else ("env" if env_snapshot_id else "unset")
@@ -118,12 +100,12 @@ async def get_sandbox_settings() -> dict[str, Any]:
 async def upsert_sandbox_settings(
     update: SandboxSettingsUpdate, updated_by: str | None = None
 ) -> dict[str, Any]:
-    await _client().store.put_item(
+    await put_value(
         SANDBOX_SETTINGS_NAMESPACE,
         SANDBOX_SETTINGS_KEY,
         {
             "base_snapshot_id": update.base_snapshot_id,
-            "updated_at": datetime.now(UTC).isoformat(),
+            "updated_at": now_iso(),
             "updated_by": updated_by,
         },
     )

--- a/agent/dashboard/sandbox_settings.py
+++ b/agent/dashboard/sandbox_settings.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, field_validator
 
-from ..store import get_value, now_iso, put_value
+from agent.store import get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -9,9 +9,10 @@ from fastapi import HTTPException
 from langgraph_sdk.schema import Config
 from pydantic import BaseModel, Field, field_validator
 
+from agent.store import delete_value, get_value, now_iso, now_ms, put_value, search_all_values
+
 from ..dispatch import create_durable_run
 from ..input_messages import InputMessageContext, build_run_input
-from ..store import delete_value, get_value, now_iso, now_ms, put_value, search_all_values
 from ..utils.slack import (
     bind_slack_thread_id,
     post_slack_top_level_message_with_ts,

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -3,7 +3,6 @@
 import logging
 import re
 import uuid
-from datetime import UTC, datetime
 from typing import Any, Literal
 
 from fastapi import HTTPException
@@ -12,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ..dispatch import create_durable_run
 from ..input_messages import InputMessageContext, build_run_input
+from ..store import delete_value, get_value, now_iso, now_ms, put_value, search_all_values
 from ..utils.slack import (
     bind_slack_thread_id,
     post_slack_top_level_message_with_ts,
@@ -29,7 +29,7 @@ from .options import (
 from .profiles import get_profile, get_valid_access_token
 from .repo_access import repo_config_for_user, require_repo_access_for_user
 from .team_settings import get_team_fable_enabled
-from .thread_api import _agent_version_metadata, _now_ms, _resolve_run_email
+from .thread_api import _agent_version_metadata, _resolve_run_email
 from .user_mappings import slack_id_for_login
 
 logger = logging.getLogger(__name__)
@@ -100,14 +100,6 @@ class ScheduleUpdateBody(BaseModel):
     @classmethod
     def _valid_slack_channel_id(cls, value: str | None) -> str | None:
         return _normalize_slack_channel_id(value)
-
-
-def _client():
-    return langgraph_client()
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def _normalize_model_choice(
@@ -201,26 +193,14 @@ def _schedule_summary(
     }
 
 
-async def _get_value(schedule_id: str) -> dict[str, Any] | None:
-    item = await _client().store.get_item(SCHEDULES_NAMESPACE, schedule_id)
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-async def _put_value(record: dict[str, Any]) -> dict[str, Any]:
-    record = {**record, "updated_at": _now_iso()}
-    await _client().store.put_item(SCHEDULES_NAMESPACE, record["id"], record)
+async def _put_schedule(record: dict[str, Any]) -> dict[str, Any]:
+    record = {**record, "updated_at": now_iso()}
+    await put_value(SCHEDULES_NAMESPACE, record["id"], record)
     return record
 
 
 async def _get_run_state(schedule_id: str) -> dict[str, Any] | None:
-    item = await _client().store.get_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
+    return await get_value(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
 
 
 async def _put_run_state(record: dict[str, Any], patch: dict[str, Any]) -> None:
@@ -241,11 +221,11 @@ async def _put_run_state(record: dict[str, Any], patch: dict[str, Any]) -> None:
         "created_by": record.get("created_by"),
         "user_email": record.get("user_email"),
     }
-    await _client().store.put_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id, value)
+    await put_value(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id, value)
 
 
 async def get_agent_schedule(schedule_id: str) -> dict[str, Any] | None:
-    return await _get_value(schedule_id)
+    return await get_value(SCHEDULES_NAMESPACE, schedule_id)
 
 
 def _user_owns_schedule(record: dict[str, Any], login: str, email: str | None = None) -> bool:
@@ -262,30 +242,6 @@ def _assert_schedule_owner(
         raise HTTPException(404, "schedule not found")
 
 
-async def _search_values(namespace: list[str], filter: dict[str, Any]) -> list[dict[str, Any]]:
-    records: list[dict[str, Any]] = []
-    limit = 100
-    offset = 0
-    while True:
-        result = await _client().store.search_items(
-            namespace,
-            filter=filter,
-            limit=limit,
-            offset=offset,
-        )
-        items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-        if not items:
-            break
-        for item in items:
-            value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-            if isinstance(value, dict):
-                records.append(value)
-        if len(items) < limit:
-            break
-        offset += len(items)
-    return records
-
-
 async def list_agent_schedules(login: str, *, email: str | None = None) -> list[dict[str, Any]]:
     searches: list[dict[str, Any]] = [{"created_by": login}]
     if email and email.strip():
@@ -294,11 +250,11 @@ async def list_agent_schedules(login: str, *, email: str | None = None) -> list[
     seen: dict[str, dict[str, Any]] = {}
     run_states: dict[str, dict[str, Any]] = {}
     for filter in searches:
-        for record in await _search_values(SCHEDULES_NAMESPACE, filter):
+        for record in await search_all_values(SCHEDULES_NAMESPACE, filter=filter):
             schedule_id = record.get("id")
             if isinstance(schedule_id, str) and _user_owns_schedule(record, login, email):
                 seen[schedule_id] = record
-        for state in await _search_values(SCHEDULE_RUN_STATE_NAMESPACE, filter):
+        for state in await search_all_values(SCHEDULE_RUN_STATE_NAMESPACE, filter=filter):
             schedule_id = state.get("schedule_id")
             if isinstance(schedule_id, str):
                 run_states[schedule_id] = state
@@ -322,7 +278,7 @@ def _build_cron_config(record: dict[str, Any]) -> Config:
 
 
 async def _create_cron(record: dict[str, Any]) -> str:
-    cron = await _client().crons.create(
+    cron = await langgraph_client().crons.create(
         _SCHEDULER_ASSISTANT_ID,
         schedule=record["schedule"],
         input={"schedule_id": record["id"]},
@@ -344,7 +300,7 @@ async def _delete_cron(cron_id: str | None) -> None:
     if not cron_id:
         return
     try:
-        await _client().crons.delete(cron_id)
+        await langgraph_client().crons.delete(cron_id)
     except Exception:
         logger.debug("Could not delete schedule cron %s", cron_id, exc_info=True)
 
@@ -363,7 +319,7 @@ async def create_agent_schedule(
     chosen_model, chosen_effort = _normalize_model_choice(body.model_id, body.effort)
     repo = await repo_config_for_user(login, body.repo)
     schedule_id = str(uuid.uuid4())
-    now = _now_iso()
+    now = now_iso()
     record: dict[str, Any] = {
         "id": schedule_id,
         "name": (body.name or _derive_name(body.prompt)).strip(),
@@ -389,14 +345,14 @@ async def create_agent_schedule(
         "created_at": now,
         "updated_at": now,
     }
-    await _put_value(record)
+    await _put_schedule(record)
     try:
         cron_id = await _create_cron(record)
     except Exception as exc:
-        await _client().store.delete_item(SCHEDULES_NAMESPACE, schedule_id)
+        await delete_value(SCHEDULES_NAMESPACE, schedule_id)
         logger.exception("Failed to create schedule cron for %s", schedule_id)
         raise HTTPException(502, "failed to create schedule cron") from exc
-    record = await _put_value({**record, "cron_id": cron_id})
+    record = await _put_schedule({**record, "cron_id": cron_id})
     return _schedule_summary(record)
 
 
@@ -460,7 +416,7 @@ async def update_agent_schedule(
         await _delete_cron(existing.get("cron_id"))
         updated["cron_id"] = None
 
-    updated = await _put_value(updated)
+    updated = await _put_schedule(updated)
     return _schedule_summary(updated, await _get_run_state(schedule_id))
 
 
@@ -469,8 +425,8 @@ async def delete_agent_schedule(schedule_id: str, login: str, *, email: str | No
     _assert_schedule_owner(existing, login, email)
     assert existing is not None
     await _delete_cron(existing.get("cron_id"))
-    await _client().store.delete_item(SCHEDULES_NAMESPACE, schedule_id)
-    await _client().store.delete_item(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
+    await delete_value(SCHEDULES_NAMESPACE, schedule_id)
+    await delete_value(SCHEDULE_RUN_STATE_NAMESPACE, schedule_id)
 
 
 def _slack_root_message(record: dict[str, Any], *, test_run: bool = False) -> str:
@@ -527,7 +483,7 @@ def _agent_run_metadata(
     admin_thread: bool = False,
 ) -> dict[str, Any]:
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
-    now_ms = _now_ms()
+    created_ms = now_ms()
     title_prefix = "Test" if test_run else "Scheduled"
     metadata: dict[str, Any] = {
         "source": "schedule",
@@ -545,8 +501,8 @@ def _agent_run_metadata(
         "branch_prefix": record.get("branch_prefix"),
         "model": record.get("model") or "Default",
         "effort": record.get("effort"),
-        "created_at_ms": now_ms,
-        "updated_at_ms": now_ms,
+        "created_at_ms": created_ms,
+        "updated_at_ms": created_ms,
     }
     if repo and repo.get("owner") and repo.get("name"):
         metadata["repo_owner"] = repo["owner"]
@@ -620,7 +576,7 @@ async def _launch_agent_schedule_record(
                 record,
                 {
                     "last_error": "schedule owner unavailable",
-                    "last_error_at": _now_iso(),
+                    "last_error_at": now_iso(),
                 },
             )
             return {
@@ -635,7 +591,7 @@ async def _launch_agent_schedule_record(
                 record,
                 {
                     "last_error": str(exc.detail),
-                    "last_error_at": _now_iso(),
+                    "last_error_at": now_iso(),
                 },
             )
             return {
@@ -645,7 +601,7 @@ async def _launch_agent_schedule_record(
                 "status_code": exc.status_code,
             }
 
-    client = _client()
+    client = langgraph_client()
     thread_id = str(uuid.uuid4())
     slack_thread: dict[str, Any] | None = None
     slack_channel_id = record.get("slack_channel_id")
@@ -664,7 +620,7 @@ async def _launch_agent_schedule_record(
             error = f"Slack post failed: {slack_error or 'unknown error'}"
             await _put_run_state(
                 record,
-                {"last_error": error, "last_error_at": _now_iso()},
+                {"last_error": error, "last_error_at": now_iso()},
             )
             return {"status": "error", "schedule_id": schedule_id, "error": error}
         slack_thread = {
@@ -736,17 +692,20 @@ async def _launch_agent_schedule_record(
             run_id,
             message_ts=slack_thread["thread_ts"],
         )
-    now_ms = _now_ms()
     await client.threads.update(
         thread_id=thread_id,
-        metadata={"latest_run_id": run_id, "latest_run_status": "pending", "updated_at_ms": now_ms},
+        metadata={
+            "latest_run_id": run_id,
+            "latest_run_status": "pending",
+            "updated_at_ms": now_ms(),
+        },
     )
     await _put_run_state(
         record,
         {
             "last_thread_id": thread_id,
             "last_run_id": run_id,
-            "last_triggered_at": _now_iso(),
+            "last_triggered_at": now_iso(),
             "last_error": None,
             "last_error_at": None,
         },

--- a/agent/dashboard/skills.py
+++ b/agent/dashboard/skills.py
@@ -4,12 +4,12 @@ import base64
 import binascii
 import json
 import re
-from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import HTTPException
-from langgraph_sdk import get_client
 from pydantic import BaseModel, Field, field_validator
+
+from ..store import delete_value, get_value, now_iso, put_value, search_values
 
 SKILLS_NAMESPACE = "user_skills"
 ORGANIZATION_SKILLS_NAMESPACE = "organization_skills"
@@ -57,10 +57,6 @@ class SkillUpdate(BaseModel):
         return value
 
 
-def _client():
-    return get_client()
-
-
 def _namespace(login: str) -> list[str]:
     return [SKILLS_NAMESPACE, login]
 
@@ -71,10 +67,6 @@ def _organization_namespace() -> list[str]:
 
 def _key(name: str) -> str:
     return f"/{name}/SKILL.md"
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def _content(name: str, description: str, instructions: str) -> str:
@@ -90,7 +82,7 @@ def _content(name: str, description: str, instructions: str) -> str:
 def _record(
     name: str, description: str, instructions: str, existing: dict[str, Any] | None = None
 ) -> dict[str, Any]:
-    now = _now_iso()
+    now = now_iso()
     return {
         "name": name,
         "description": description,
@@ -102,25 +94,17 @@ def _record(
     }
 
 
-def _value(item: Any) -> dict[str, Any] | None:
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
 async def _get_skill(namespace: list[str], name: str) -> dict[str, Any] | None:
     SkillCreate(name=name, description="valid")
-    item = await _client().store.get_item(namespace, _key(name))
-    return _value(item) if item else None
+    return await get_value(namespace, _key(name))
 
 
 async def _list_skills(namespace: list[str], *, limit: int, offset: int) -> dict[str, Any]:
-    result = await _client().store.search_items(namespace, limit=limit + 1, offset=offset)
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    skills = [value for item in (items or [])[:limit] if (value := _value(item)) is not None]
-    skills.sort(key=lambda skill: skill.get("name", ""))
+    found = await search_values(namespace, limit=limit + 1, offset=offset)
+    skills = sorted(found[:limit], key=lambda skill: skill.get("name", ""))
     return {
         "items": skills,
-        "next_offset": offset + limit if len(items or []) > limit else None,
+        "next_offset": offset + limit if len(found) > limit else None,
     }
 
 
@@ -128,7 +112,7 @@ async def _create_skill(namespace: list[str], body: SkillCreate) -> dict[str, An
     if await _get_skill(namespace, body.name):
         raise HTTPException(409, "skill already exists")
     value = _record(body.name, body.description, body.instructions)
-    await _client().store.put_item(namespace, _key(body.name), value)
+    await put_value(namespace, _key(body.name), value)
     return value
 
 
@@ -138,7 +122,7 @@ async def _update_skill(namespace: list[str], name: str, body: SkillUpdate) -> d
     if not existing:
         raise HTTPException(404, "skill not found")
     value = _record(name, body.description, body.instructions, existing)
-    await _client().store.put_item(namespace, _key(name), value)
+    await put_value(namespace, _key(name), value)
     return value
 
 
@@ -146,7 +130,7 @@ async def _delete_skill(namespace: list[str], name: str) -> None:
     SkillCreate(name=name, description="valid")
     if not await _get_skill(namespace, name):
         raise HTTPException(404, "skill not found")
-    await _client().store.delete_item(namespace, _key(name))
+    await delete_value(namespace, _key(name))
 
 
 async def get_skill(login: str, name: str) -> dict[str, Any] | None:
@@ -205,18 +189,11 @@ def _decode_cursor(cursor: str | None) -> str:
 
 async def list_organization_skills(*, limit: int, cursor: str | None) -> dict[str, Any]:
     after = _decode_cursor(cursor)
-    result = await _client().store.search_items(
-        _organization_namespace(), limit=MAX_ORGANIZATION_SKILLS + 1
-    )
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    if len(items or []) > MAX_ORGANIZATION_SKILLS:
+    found = await search_values(_organization_namespace(), limit=MAX_ORGANIZATION_SKILLS + 1)
+    if len(found) > MAX_ORGANIZATION_SKILLS:
         raise HTTPException(409, "organization skill limit exceeded; delete a skill to continue")
     skills = sorted(
-        (
-            value
-            for item in items or []
-            if (value := _value(item)) is not None and value.get("name", "") > after
-        ),
+        (value for value in found if value.get("name", "") > after),
         key=lambda skill: skill.get("name", ""),
     )
     page = skills[:limit]
@@ -227,11 +204,8 @@ async def list_organization_skills(*, limit: int, cursor: str | None) -> dict[st
 
 
 async def create_organization_skill(body: SkillCreate) -> dict[str, Any]:
-    existing = await _client().store.search_items(
-        _organization_namespace(), limit=MAX_ORGANIZATION_SKILLS
-    )
-    items = existing.get("items") if isinstance(existing, dict) else getattr(existing, "items", [])
-    if len(items or []) >= MAX_ORGANIZATION_SKILLS:
+    existing = await search_values(_organization_namespace(), limit=MAX_ORGANIZATION_SKILLS)
+    if len(existing) >= MAX_ORGANIZATION_SKILLS:
         raise HTTPException(409, "organization skill limit reached")
     return await _create_skill(_organization_namespace(), body)
 

--- a/agent/dashboard/skills.py
+++ b/agent/dashboard/skills.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from ..store import delete_value, get_value, now_iso, put_value, search_values
+from agent.store import delete_value, get_value, now_iso, put_value, search_values
 
 SKILLS_NAMESPACE = "user_skills"
 ORGANIZATION_SKILLS_NAMESPACE = "organization_skills"

--- a/agent/dashboard/team_credentials.py
+++ b/agent/dashboard/team_credentials.py
@@ -12,8 +12,9 @@ from typing import Any
 
 from pydantic import BaseModel, field_validator
 
+from agent.store import delete_value, get_value, now_iso, put_value
+
 from ..encryption import decrypt_token, encrypt_token
-from ..store import delete_value, get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/team_credentials.py
+++ b/agent/dashboard/team_credentials.py
@@ -8,13 +8,12 @@ Datadog MCP tools and LangSmith read tools — the sandbox never sees these keys
 
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import Any
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, field_validator
 
 from ..encryption import decrypt_token, encrypt_token
+from ..store import delete_value, get_value, now_iso, put_value
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +34,6 @@ SUPPORTED_DD_SITES: frozenset[str] = frozenset(
         "ap2.datadoghq.com",
     }
 )
-
-
-def _client():
-    return get_client()
 
 
 class DatadogCredentialsUpdate(BaseModel):
@@ -124,26 +119,30 @@ def _last4(value: str) -> str:
 
 
 async def _get_provider(key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(TEAM_CREDENTIALS_NAMESPACE, key)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("team credentials lookup failed for %s: %s", key, e)
-        return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
+    return await get_value(TEAM_CREDENTIALS_NAMESPACE, key)
 
 
 async def _put_provider(key: str, value: dict[str, Any]) -> None:
-    await _client().store.put_item(TEAM_CREDENTIALS_NAMESPACE, key, value)
+    await put_value(TEAM_CREDENTIALS_NAMESPACE, key, value)
 
 
 async def _delete_provider(key: str) -> None:
+    await delete_value(TEAM_CREDENTIALS_NAMESPACE, key)
+
+
+async def _provider_for_tool_loading(key: str) -> dict[str, Any] | None:
+    """Read a provider record on the agent's tool-loading path.
+
+    Fail-soft on purpose: these credentials only decide whether an optional
+    integration's tools get loaded, so an unreachable store must cost a run
+    those tools rather than the run itself. Dashboard reads go through
+    :func:`_get_provider` and surface the failure.
+    """
     try:
-        await _client().store.delete_item(TEAM_CREDENTIALS_NAMESPACE, key)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("team credentials delete failed for %s: %s", key, e)
+        return await _get_provider(key)
+    except Exception:
+        logger.warning("team credentials lookup failed for %s", key, exc_info=True)
+        return None
 
 
 async def get_team_credentials_status() -> dict[str, Any]:
@@ -178,7 +177,7 @@ async def connect_datadog(update: DatadogCredentialsUpdate) -> dict[str, Any]:
             "encrypted_api_key": encrypt_token(update.api_key),
             "encrypted_app_key": encrypt_token(update.app_key),
             "api_key_last4": _last4(update.api_key),
-            "updated_at": datetime.now(UTC).isoformat(),
+            "updated_at": now_iso(),
         },
     )
     return await get_team_credentials_status()
@@ -196,7 +195,7 @@ async def connect_langsmith(update: LangSmithCredentialsUpdate) -> dict[str, Any
             "endpoint": update.endpoint or DEFAULT_LANGSMITH_ENDPOINT,
             "encrypted_api_key": encrypt_token(update.api_key),
             "api_key_last4": _last4(update.api_key),
-            "updated_at": datetime.now(UTC).isoformat(),
+            "updated_at": now_iso(),
         },
     )
     return await get_team_credentials_status()
@@ -209,7 +208,7 @@ async def disconnect_langsmith() -> dict[str, Any]:
 
 async def get_datadog_credentials() -> DatadogCredentials | None:
     """Return decrypted Datadog credentials, or ``None`` when not connected."""
-    datadog = await _get_provider(DATADOG_KEY)
+    datadog = await _provider_for_tool_loading(DATADOG_KEY)
     if not isinstance(datadog, dict):
         return None
     api_key = decrypt_token(datadog.get("encrypted_api_key", ""))
@@ -225,7 +224,7 @@ async def get_datadog_credentials() -> DatadogCredentials | None:
 
 async def get_langsmith_credentials() -> LangSmithCredentials | None:
     """Return decrypted LangSmith credentials, or ``None`` when not connected."""
-    langsmith = await _get_provider(LANGSMITH_KEY)
+    langsmith = await _provider_for_tool_loading(LANGSMITH_KEY)
     if not isinstance(langsmith, dict):
         return None
     api_key = decrypt_token(langsmith.get("encrypted_api_key", ""))

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -8,12 +8,11 @@ configuration in one place. Per-repo style prompts live in
 import logging
 import os
 import re
-from datetime import UTC, datetime
 from typing import Any, Literal
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, field_validator, model_validator
 
+from ..store import get_value, now_iso, put_value
 from ..utils.gateway import resolve_gateway_enabled
 from .options import (
     FABLE_MODEL_IDS,
@@ -252,10 +251,6 @@ def normalize_team_settings_for_response(settings: dict[str, Any]) -> dict[str, 
     return value
 
 
-def _client():
-    return get_client()
-
-
 def _env_default_repo() -> str | None:
     owner = os.environ.get("DEFAULT_REPO_OWNER", "").strip()
     name = os.environ.get("DEFAULT_REPO_NAME", "").strip()
@@ -305,16 +300,19 @@ def _default_settings() -> dict[str, Any]:
 
 
 async def get_team_settings() -> dict[str, Any]:
+    """The team record merged over the hardcoded defaults.
+
+    Fail-soft on purpose: the agent, the reviewer, and every webhook read this
+    to pick a model, so an unreachable store must degrade to the defaults
+    rather than fail every run at once.
+    """
     defaults = _default_settings()
     try:
-        item = await _client().store.get_item(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY)
-    except Exception as e:
-        logger.debug("team settings lookup failed: %s", e)
+        value = await get_value(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY)
+    except Exception:
+        logger.warning("team settings lookup failed; using defaults", exc_info=True)
         return defaults
-    if item is None:
-        return defaults
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    if not isinstance(value, dict):
+    if value is None:
         return defaults
     # Skip None-valued model fields so legacy records (or PUTs that cleared the
     # selection) still surface the hardcoded default instead of a null.
@@ -356,9 +354,9 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "default_chat_reasoning_effort": update.default_chat_reasoning_effort,
         "default_thread_title_model": update.default_thread_title_model,
         "default_thread_title_reasoning_effort": update.default_thread_title_reasoning_effort,
-        "updated_at": datetime.now(UTC).isoformat(),
+        "updated_at": now_iso(),
     }
-    await _client().store.put_item(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY, value)
+    await put_value(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY, value)
     return value
 
 

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -12,7 +12,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, field_validator, model_validator
 
-from ..store import get_value, now_iso, put_value
+from agent.store import get_value, now_iso, put_value
+
 from ..utils.gateway import resolve_gateway_enabled
 from .options import (
     FABLE_MODEL_IDS,

--- a/agent/dashboard/user_credentials.py
+++ b/agent/dashboard/user_credentials.py
@@ -8,8 +8,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from agent.store import delete_value, get_value, now_iso, put_value
+
 from ..encryption import decrypt_token, encrypt_token
-from ..store import delete_value, get_value, now_iso, put_value
 from .notion_oauth import is_reauth_required_error, refresh_notion_access_token
 from .team_credentials import DEFAULT_LANGSMITH_ENDPOINT, LangSmithCredentials
 

--- a/agent/dashboard/user_credentials.py
+++ b/agent/dashboard/user_credentials.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from langgraph_sdk import get_client
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from ..encryption import decrypt_token, encrypt_token
+from ..store import delete_value, get_value, now_iso, put_value
 from .notion_oauth import is_reauth_required_error, refresh_notion_access_token
 from .team_credentials import DEFAULT_LANGSMITH_ENDPOINT, LangSmithCredentials
 
@@ -24,35 +24,39 @@ CURRENTS_API_BASE = "https://api.currents.dev/v1"
 _NOTION_TOKEN_EXPIRY_SKEW_SECONDS = 300
 
 
-def _client():
-    return get_client()
-
-
 def _last4(value: str) -> str:
     return value[-4:] if len(value) >= 4 else value
 
 
+def _namespace(login: str) -> list[str]:
+    return [*USER_CREDENTIALS_NAMESPACE, login]
+
+
 async def _get_provider(login: str, key: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item([*USER_CREDENTIALS_NAMESPACE, login], key)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("user credentials lookup failed for %s/%s: %s", login, key, e)
-        return None
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
+    return await get_value(_namespace(login), key)
 
 
 async def _put_provider(login: str, key: str, value: dict[str, Any]) -> None:
-    await _client().store.put_item([*USER_CREDENTIALS_NAMESPACE, login], key, value)
+    await put_value(_namespace(login), key, value)
 
 
 async def _delete_provider(login: str, key: str) -> None:
+    await delete_value(_namespace(login), key)
+
+
+async def _provider_for_tool_loading(login: str, key: str) -> dict[str, Any] | None:
+    """Read a provider record on the agent's tool-loading path.
+
+    Fail-soft on purpose: these credentials only decide whether an optional
+    integration's tools get loaded, so an unreachable store must cost a run
+    those tools rather than the run itself. Dashboard reads go through
+    :func:`_get_provider` and surface the failure.
+    """
     try:
-        await _client().store.delete_item([*USER_CREDENTIALS_NAMESPACE, login], key)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("user credentials delete failed for %s/%s: %s", login, key, e)
+        return await _get_provider(login, key)
+    except Exception:
+        logger.warning("user credentials lookup failed for %s/%s", login, key, exc_info=True)
+        return None
 
 
 class CurrentsCredentialsUpdate(BaseModel):
@@ -142,7 +146,7 @@ def _notion_record_from_response(
         "encrypted_access_token": encrypt_token(access_token),
         "client_id": client_id or existing.get("client_id", ""),
         "token_endpoint": token_endpoint or existing.get("token_endpoint", ""),
-        "updated_at": datetime.now(UTC).isoformat(),
+        "updated_at": now_iso(),
     }
     token_type = data.get("token_type")
     if isinstance(token_type, str):
@@ -250,7 +254,22 @@ async def _refresh_stored_notion_token(
 async def get_notion_credentials(
     login: str, *, force_refresh: bool = False
 ) -> NotionCredentials | None:
-    """Return a valid Notion MCP credential set for a user."""
+    """Return a valid Notion MCP credential set for a user.
+
+    Fail-soft on purpose: this gates whether the Notion MCP tools get loaded
+    into a run, so a store (or refresh) failure must cost the run those tools
+    rather than the run itself.
+    """
+    try:
+        return await _load_notion_credentials(login, force_refresh=force_refresh)
+    except Exception:
+        logger.warning("Notion credential lookup failed for %s", login, exc_info=True)
+        return None
+
+
+async def _load_notion_credentials(
+    login: str, *, force_refresh: bool = False
+) -> NotionCredentials | None:
     record = await _get_provider(login, NOTION_KEY)
     if not record:
         return None
@@ -344,7 +363,7 @@ async def connect_currents(login: str, update: CurrentsCredentialsUpdate) -> dic
         {
             "encrypted_api_key": encrypt_token(update.api_key),
             "api_key_last4": _last4(update.api_key),
-            "updated_at": datetime.now(UTC).isoformat(),
+            "updated_at": now_iso(),
         },
     )
     return await get_currents_status(login)
@@ -357,7 +376,7 @@ async def disconnect_currents(login: str) -> dict[str, Any]:
 
 async def get_currents_api_key(login: str) -> str | None:
     """Return the decrypted Currents API key, or ``None`` when not connected."""
-    currents = await _get_provider(login, CURRENTS_KEY)
+    currents = await _provider_for_tool_loading(login, CURRENTS_KEY)
     if not isinstance(currents, dict):
         return None
     api_key = decrypt_token(currents.get("encrypted_api_key", ""))
@@ -385,7 +404,7 @@ async def connect_langsmith(login: str, update: UserLangSmithCredentialsUpdate) 
         {
             "encrypted_api_key": encrypt_token(update.api_key),
             "api_key_last4": _last4(update.api_key),
-            "updated_at": datetime.now(UTC).isoformat(),
+            "updated_at": now_iso(),
         },
     )
     return await get_langsmith_status(login)
@@ -398,7 +417,7 @@ async def disconnect_langsmith(login: str) -> dict[str, Any]:
 
 async def get_langsmith_credentials(login: str) -> LangSmithCredentials | None:
     """Return decrypted LangSmith credentials, or ``None`` when not connected."""
-    langsmith = await _get_provider(login, LANGSMITH_KEY)
+    langsmith = await _provider_for_tool_loading(login, LANGSMITH_KEY)
     if not isinstance(langsmith, dict):
         return None
     api_key = decrypt_token(langsmith.get("encrypted_api_key", ""))

--- a/agent/dashboard/user_instructions.py
+++ b/agent/dashboard/user_instructions.py
@@ -8,15 +8,11 @@ Stored in its own namespace rather than on the ``["profiles"]`` record so
 agent-written updates and dashboard profile saves can't clobber each other.
 """
 
-import logging
-from datetime import UTC, datetime
 from typing import Any
 
-import httpx
-from langgraph_sdk import get_client
 from pydantic import BaseModel, Field
 
-logger = logging.getLogger(__name__)
+from ..store import delete_value, get_value, now_iso, put_value
 
 USER_INSTRUCTIONS_NAMESPACE: list[str] = ["user_instructions"]
 
@@ -27,25 +23,8 @@ class UserInstructionsUpdate(BaseModel):
     instructions: str = Field(default="", max_length=MAX_USER_INSTRUCTIONS_CHARS)
 
 
-def _client():
-    return get_client()
-
-
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
-
-
 async def get_user_instructions(login: str) -> dict[str, Any] | None:
-    try:
-        item = await _client().store.get_item(USER_INSTRUCTIONS_NAMESPACE, login)
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return None
-        raise
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
+    return await get_value(USER_INSTRUCTIONS_NAMESPACE, login)
 
 
 async def set_user_instructions(
@@ -58,27 +37,23 @@ async def set_user_instructions(
         **existing,
         "login": login,
         "instructions": instructions[:MAX_USER_INSTRUCTIONS_CHARS],
-        "created_at": existing.get("created_at") or _now_iso(),
-        "updated_at": _now_iso(),
+        "created_at": existing.get("created_at") or now_iso(),
+        "updated_at": now_iso(),
         "updated_by": updated_by or login,
     }
-    await _client().store.put_item(USER_INSTRUCTIONS_NAMESPACE, login, value)
+    await put_value(USER_INSTRUCTIONS_NAMESPACE, login, value)
     return value
 
 
 async def delete_user_instructions(login: str) -> None:
-    await _client().store.delete_item(USER_INSTRUCTIONS_NAMESPACE, login)
+    await delete_value(USER_INSTRUCTIONS_NAMESPACE, login)
 
 
 async def get_user_custom_instructions(login: str | None) -> str | None:
     """Return the user's custom instructions for prompt injection, if any."""
     if not login:
         return None
-    try:
-        record = await get_user_instructions(login)
-    except Exception:
-        logger.debug("Failed to load user custom instructions for %s", login, exc_info=True)
-        return None
+    record = await get_user_instructions(login)
     if not record:
         return None
     instructions = record.get("instructions")

--- a/agent/dashboard/user_instructions.py
+++ b/agent/dashboard/user_instructions.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from ..store import delete_value, get_value, now_iso, put_value
+from agent.store import delete_value, get_value, now_iso, put_value
 
 USER_INSTRUCTIONS_NAMESPACE: list[str] = ["user_instructions"]
 

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -25,7 +25,7 @@ import logging
 import threading
 from typing import Any, Literal
 
-from ..store import delete_value, get_value, now_iso, put_value, search_values
+from agent.store import delete_value, get_value, now_iso, put_value, search_values
 
 logger = logging.getLogger(__name__)
 

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -23,11 +23,9 @@ dict entry).
 
 import logging
 import threading
-from datetime import UTC, datetime
 from typing import Any, Literal
 
-import httpx
-from langgraph_sdk import get_client
+from ..store import delete_value, get_value, now_iso, put_value, search_values
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +33,6 @@ USER_MAPPINGS_NAMESPACE: list[str] = ["user_mappings"]
 
 MappingSource = Literal["slack_oauth"]
 MappingStatus = Literal["active", "pending"]
-
-
-def _client():
-    return get_client()
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def _norm_login(login: str | None) -> str:
@@ -179,62 +169,38 @@ def is_login_mapped(login: str | None) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _record_from_item(item: Any) -> dict[str, Any] | None:
-    if item is None:
-        return None
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-async def _load_all_records() -> list[dict[str, Any]]:
-    result = await _client().store.search_items(USER_MAPPINGS_NAMESPACE, limit=1000)
-    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-    out: list[dict[str, Any]] = []
-    for item in items or []:
-        record = _record_from_item(item)
-        if record:
-            out.append(record)
-    return out
-
-
 async def refresh_cache() -> list[dict[str, Any]]:
     """Load every mapping from the Store and replace the in-process cache."""
-    records = await _load_all_records()
+    records = await search_values(USER_MAPPINGS_NAMESPACE, limit=1000)
     prime_cache(records)
     return records
 
 
 async def _ensure_cache_loaded() -> None:
+    """Prime the cache if it is cold.
+
+    Fail-soft on purpose: the async lookups below run on webhook and commit
+    paths where an unresolvable user is an expected outcome, so a store failure
+    degrades to "unmapped" instead of breaking the caller.
+    """
     with _cache_lock:
         loaded = _cache_loaded
     if not loaded:
         try:
             await refresh_cache()
-        except Exception as e:  # noqa: BLE001
-            logger.debug("user mapping cache load failed: %s", e)
+        except Exception:
+            logger.warning("user mapping cache load failed", exc_info=True)
 
 
 async def get_mapping(login: str) -> dict[str, Any] | None:
     norm = _norm_login(login)
     if not norm:
         return None
-    try:
-        item = await _client().store.get_item(USER_MAPPINGS_NAMESPACE, norm.lower())
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return None
-        logger.warning("user mapping lookup failed for %s: %s", norm, e)
-        return None
-    return _record_from_item(item)
+    return await get_value(USER_MAPPINGS_NAMESPACE, norm.lower())
 
 
 async def list_mappings() -> list[dict[str, Any]]:
-    try:
-        records = await _load_all_records()
-    except Exception as e:  # noqa: BLE001
-        logger.debug("user mapping list failed: %s", e)
-        return []
-    prime_cache(records)
+    records = await refresh_cache()
     return sorted(records, key=lambda r: _norm_login(r.get("github_login")).lower())
 
 
@@ -296,10 +262,10 @@ async def upsert_mapping(
         "slack_user_id": _norm_slack_id(slack_user_id) or existing.get("slack_user_id") or None,
         "source": source,
         "status": status,
-        "created_at": existing.get("created_at") or _now(),
-        "updated_at": _now(),
+        "created_at": existing.get("created_at") or now_iso(),
+        "updated_at": now_iso(),
     }
-    await _client().store.put_item(USER_MAPPINGS_NAMESPACE, login.lower(), record)
+    await put_value(USER_MAPPINGS_NAMESPACE, login.lower(), record)
     _deindex_login(login)
     _index_record(record)
     return record
@@ -309,12 +275,7 @@ async def delete_mapping(github_login: str) -> bool:
     login = _norm_login(github_login)
     if not login:
         return False
-    try:
-        await _client().store.delete_item(USER_MAPPINGS_NAMESPACE, login.lower())
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            _deindex_login(login)
-            return False
-        raise
+    existed = await get_mapping(login) is not None
+    await delete_value(USER_MAPPINGS_NAMESPACE, login.lower())
     _deindex_login(login)
-    return True
+    return existed

--- a/agent/dashboard/workflow_approval.py
+++ b/agent/dashboard/workflow_approval.py
@@ -1,10 +1,11 @@
 """Workflow-file push approval state."""
 
 from collections.abc import Mapping
-from datetime import UTC, datetime
 from typing import Any
 
 from langgraph_sdk import get_client
+
+from ..store import now_iso
 
 WORKFLOW_PUSH_APPROVALS_KEY = "workflow_push_approvals"
 WORKFLOW_APPROVAL_PENDING = "pending"
@@ -12,10 +13,6 @@ WORKFLOW_APPROVAL_APPROVED = "approved"
 WORKFLOW_APPROVAL_REJECTED = "rejected"
 _MAX_APPROVAL_RECORDS = 20
 _TERMINAL_STATUSES = {WORKFLOW_APPROVAL_APPROVED, WORKFLOW_APPROVAL_REJECTED}
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def _approvals_from_metadata(metadata: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
@@ -84,7 +81,7 @@ async def ensure_workflow_push_pending(
         "fingerprint": fingerprint,
         "status": WORKFLOW_APPROVAL_PENDING,
         **review_fields,
-        "requested_at": _now(),
+        "requested_at": now_iso(),
         "notified": False,
     }
     approvals[fingerprint] = record
@@ -150,7 +147,7 @@ async def mark_workflow_push_notified(thread_id: str, fingerprint: str) -> None:
     if not record:
         return
     record["notified"] = True
-    record["notified_at"] = _now()
+    record["notified_at"] = now_iso()
     approvals[fingerprint] = record
     await _save_approvals(thread_id, approvals)
 
@@ -167,7 +164,7 @@ async def decide_workflow_push_approval(
     if not record:
         return None
     record["status"] = WORKFLOW_APPROVAL_APPROVED if approved else WORKFLOW_APPROVAL_REJECTED
-    record["decided_at"] = _now()
+    record["decided_at"] = now_iso()
     record["decided_by"] = actor
     approvals[fingerprint] = record
     await _save_approvals(thread_id, approvals)

--- a/agent/dashboard/workflow_approval.py
+++ b/agent/dashboard/workflow_approval.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from langgraph_sdk import get_client
 
-from ..store import now_iso
+from agent.store import now_iso
 
 WORKFLOW_PUSH_APPROVALS_KEY = "workflow_push_approvals"
 WORKFLOW_APPROVAL_PENDING = "pending"

--- a/agent/store.py
+++ b/agent/store.py
@@ -1,0 +1,170 @@
+"""The one way to read and write the LangGraph Store.
+
+Error policy, applied everywhere: **a missing item reads as ``None``; every
+other failure raises.** A store outage is not the same thing as an empty
+record, and collapsing the two hides data loss behind an empty dashboard.
+
+Call sites that genuinely must survive an outage — the ones on the agent's
+critical path, where failing a run is worse than falling back to a default —
+wrap their call in their own ``try``/``except`` and say in a comment why.
+That keeps the swallow visible at the point where the choice is made.
+"""
+
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from langgraph_sdk import get_client
+from langgraph_sdk.client import LangGraphClient
+
+Namespace = Sequence[str]
+
+_DEFAULT_PAGE_SIZE = 100
+
+
+def store_client() -> LangGraphClient:
+    """The LangGraph client every store access goes through (one patch point)."""
+    return get_client()
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def now_ms() -> int:
+    return int(datetime.now(UTC).timestamp() * 1000)
+
+
+def _is_not_found(exc: httpx.HTTPStatusError) -> bool:
+    return getattr(exc.response, "status_code", None) == 404
+
+
+def _unwrap(item: Any) -> dict[str, Any] | None:
+    """The item's ``value`` — the SDK returns dicts or objects depending on transport."""
+    if item is None:
+        return None
+    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
+    return value if isinstance(value, dict) else None
+
+
+async def get_value(namespace: Namespace, key: str) -> dict[str, Any] | None:
+    try:
+        item = await store_client().store.get_item(list(namespace), key)
+    except httpx.HTTPStatusError as exc:
+        if _is_not_found(exc):
+            return None
+        raise
+    return _unwrap(item)
+
+
+async def put_value(namespace: Namespace, key: str, value: Mapping[str, Any]) -> None:
+    await store_client().store.put_item(list(namespace), key, value)
+
+
+async def delete_value(namespace: Namespace, key: str) -> None:
+    """Delete an item. Deleting one that is already gone is not an error."""
+    try:
+        await store_client().store.delete_item(list(namespace), key)
+    except httpx.HTTPStatusError as exc:
+        if not _is_not_found(exc):
+            raise
+
+
+async def _search_items(
+    namespace: Namespace,
+    filter: dict[str, Any] | None,
+    limit: int,
+    offset: int,
+) -> list[Any]:
+    result = await store_client().store.search_items(
+        list(namespace), filter=filter, limit=limit, offset=offset
+    )
+    items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+    return list(items or [])
+
+
+async def search_values(
+    namespace: Namespace,
+    *,
+    filter: dict[str, Any] | None = None,
+    limit: int = _DEFAULT_PAGE_SIZE,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """One page of values in ``namespace``, in store order."""
+    items = await _search_items(namespace, filter, limit, offset)
+    return [value for item in items if (value := _unwrap(item)) is not None]
+
+
+async def search_all_values(
+    namespace: Namespace,
+    *,
+    filter: dict[str, Any] | None = None,
+    page_size: int = _DEFAULT_PAGE_SIZE,
+) -> list[dict[str, Any]]:
+    """Every value in ``namespace``, paging until the store runs out."""
+    values: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        items = await _search_items(namespace, filter, page_size, offset)
+        if not items:
+            return values
+        values.extend(value for item in items if (value := _unwrap(item)) is not None)
+        if len(items) < page_size:
+            return values
+        offset += len(items)
+
+
+class KeyedRecordStore:
+    """Records keyed by a stable id, each stamped with ``created_at``/``updated_at``.
+
+    ``default_factory(key, created_by)`` seeds a record that does not exist yet,
+    so ``create`` is idempotent and ``update`` can patch a record the dashboard
+    never explicitly created.
+    """
+
+    def __init__(
+        self,
+        namespace: Namespace,
+        *,
+        sort_key: str | None = None,
+        default_factory: Callable[[str, str], dict[str, Any]] | None = None,
+    ) -> None:
+        self.namespace = list(namespace)
+        self._sort_key = sort_key
+        self._default_factory = default_factory
+
+    def _default_record(self, key: str, created_by: str) -> dict[str, Any]:
+        if self._default_factory is None:
+            raise RuntimeError(f"{self.namespace} has no default record factory")
+        return self._default_factory(key, created_by)
+
+    async def get(self, key: str) -> dict[str, Any] | None:
+        return await get_value(self.namespace, key)
+
+    async def list(self) -> list[dict[str, Any]]:
+        records = await search_values(self.namespace, limit=1000)
+        if self._sort_key is not None:
+            sort_key = self._sort_key
+            records.sort(key=lambda record: str(record.get(sort_key, "")))
+        return records
+
+    async def put(self, key: str, record: dict[str, Any]) -> dict[str, Any]:
+        await put_value(self.namespace, key, record)
+        return record
+
+    async def create(self, key: str, created_by: str = "") -> dict[str, Any]:
+        existing = await self.get(key)
+        if existing:
+            return existing
+        return await self.put(key, self._default_record(key, created_by))
+
+    async def update(self, key: str, patch: dict[str, Any]) -> dict[str, Any]:
+        created_by = patch.get("created_by")
+        existing = await self.get(key) or self._default_record(
+            key, created_by if isinstance(created_by, str) else ""
+        )
+        return await self.put(key, {**existing, **patch, "updated_at": now_iso()})
+
+    async def delete(self, key: str) -> None:
+        await delete_value(self.namespace, key)

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -7,7 +7,8 @@ from weakref import WeakValueDictionary
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
-from ..store import delete_value, get_value, now_iso, put_value
+from agent.store import delete_value, get_value, now_iso, put_value
+
 from ..utils.dashboard_links import dashboard_thread_url
 from ..utils.slack import append_slack_web_link_footer, post_slack_top_level_message_with_ts
 

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -5,8 +5,8 @@ from typing import Any
 from weakref import WeakValueDictionary
 
 from langgraph.config import get_config
+from langgraph_sdk import get_client
 
-from .. import store
 from ..store import delete_value, get_value, now_iso, put_value
 from ..utils.dashboard_links import dashboard_thread_url
 from ..utils.slack import append_slack_web_link_footer, post_slack_top_level_message_with_ts
@@ -35,7 +35,7 @@ async def _release_reservation(thread_id: str) -> None:
 
 async def _mark_action_posted(thread_id: str, notified_at: str) -> None:
     try:
-        await store.store_client().threads.update(
+        await get_client().threads.update(
             thread_id=thread_id,
             metadata={"automation_action_posted_at": notified_at},
         )

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -1,13 +1,13 @@
 import asyncio
 import logging
 from collections.abc import Mapping
-from datetime import UTC, datetime
 from typing import Any
 from weakref import WeakValueDictionary
 
 from langgraph.config import get_config
-from langgraph_sdk import get_client
 
+from .. import store
+from ..store import delete_value, get_value, now_iso, put_value
 from ..utils.dashboard_links import dashboard_thread_url
 from ..utils.slack import append_slack_web_link_footer, post_slack_top_level_message_with_ts
 
@@ -26,24 +26,16 @@ def _notification_lock(thread_id: str) -> asyncio.Lock:
     return lock
 
 
-def _stored_value(item: object) -> Mapping[str, Any] | None:
-    if isinstance(item, Mapping):
-        value = item.get("value")
-    else:
-        value = getattr(item, "value", None)
-    return value if isinstance(value, Mapping) else None
-
-
-async def _release_reservation(client: Any, thread_id: str) -> None:
+async def _release_reservation(thread_id: str) -> None:
     try:
-        await client.store.delete_item(_NOTIFICATION_NAMESPACE, thread_id)
+        await delete_value(_NOTIFICATION_NAMESPACE, thread_id)
     except Exception:
         logger.exception("Failed to release automation notification for %s", thread_id)
 
 
-async def _mark_action_posted(client: Any, thread_id: str, notified_at: str) -> None:
+async def _mark_action_posted(thread_id: str, notified_at: str) -> None:
     try:
-        await client.threads.update(
+        await store.store_client().threads.update(
             thread_id=thread_id,
             metadata={"automation_action_posted_at": notified_at},
         )
@@ -86,18 +78,16 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             "error": f"Message must be at most {_MAX_MESSAGE_CHARS} characters",
         }
 
-    client = get_client()
     async with _notification_lock(thread_id):
         try:
-            item = await client.store.get_item(_NOTIFICATION_NAMESPACE, thread_id)
+            existing = await get_value(_NOTIFICATION_NAMESPACE, thread_id)
         except Exception:
             logger.exception("Failed to check automation notification for %s", thread_id)
             return {"success": False, "error": "Could not check the Slack notification state"}
-        existing = _stored_value(item)
         if existing is not None:
             notified_at = existing.get("notified_at")
             if existing.get("status") == "delivered" and isinstance(notified_at, str):
-                await _mark_action_posted(client, thread_id, notified_at)
+                await _mark_action_posted(thread_id, notified_at)
             return {
                 "success": True,
                 "already_notified": True,
@@ -110,7 +100,7 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             "schedule_id": schedule_id,
         }
         try:
-            await client.store.put_item(_NOTIFICATION_NAMESPACE, thread_id, pending)
+            await put_value(_NOTIFICATION_NAMESPACE, thread_id, pending)
         except Exception:
             logger.exception("Failed to reserve automation notification for %s", thread_id)
             return {"success": False, "error": "Could not reserve the Slack notification"}
@@ -128,10 +118,10 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             )
         except Exception:
             logger.exception("Automation Slack post raised for %s", thread_id)
-            await _release_reservation(client, thread_id)
+            await _release_reservation(thread_id)
             return {"success": False, "error": "Slack post failed unexpectedly"}
         if message_ts is None:
-            await _release_reservation(client, thread_id)
+            await _release_reservation(thread_id)
             return {
                 "success": False,
                 "error": f"Slack post failed: {slack_error or 'unknown error'}",
@@ -142,11 +132,11 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
             **pending,
             "status": "delivered",
             "message_ts": message_ts,
-            "notified_at": datetime.now(UTC).isoformat(),
+            "notified_at": now_iso(),
         }
         try:
-            await client.store.put_item(_NOTIFICATION_NAMESPACE, thread_id, delivered)
+            await put_value(_NOTIFICATION_NAMESPACE, thread_id, delivered)
         except Exception:
             logger.exception("Failed to finalize automation notification for %s", thread_id)
-        await _mark_action_posted(client, thread_id, delivered["notified_at"])
+        await _mark_action_posted(thread_id, delivered["notified_at"])
         return {"success": True, "message_ts": message_ts}

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -400,13 +400,12 @@ async def _resolve_dashboard_user_token(
     if not login:
         raise ValueError("missing github_login")
 
-    from ..dashboard.profiles import OAUTH_TOKENS_NAMESPACE, get_valid_access_token
-    from ..dashboard.profiles import _get_value as get_oauth_record
+    from ..dashboard.profiles import get_oauth_token_record, get_valid_access_token
 
     token = await get_valid_access_token(login)
     if not token:
         return None
-    record = await get_oauth_record(OAUTH_TOKENS_NAMESPACE, login)
+    record = await get_oauth_token_record(login)
     expires_at = record.get("token_expires_at") if isinstance(record, dict) else None
     return _cache_resolved_github_token(
         thread_id,

--- a/tests/agent/test_agent_instructions.py
+++ b/tests/agent/test_agent_instructions.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -36,39 +36,31 @@ async def test_get_repo_agent_instructions_returns_none_when_empty() -> None:
     assert result is None
 
 
+def _fake_store_client(stored: dict[str, object] | None) -> MagicMock:
+    client = MagicMock()
+    client.store.get_item = AsyncMock(return_value={"value": stored} if stored else None)
+    client.store.put_item = AsyncMock()
+    return client
+
+
 @pytest.mark.asyncio
 async def test_create_agent_instructions_puts_new_record() -> None:
-    mock_put = AsyncMock()
-    with (
-        patch(
-            "agent.dashboard.agent_instructions._get_value",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch("agent.dashboard.agent_instructions._client") as mock_client,
-    ):
-        mock_client.return_value.store.put_item = mock_put
+    client = _fake_store_client(None)
+    with patch("agent.store.store_client", return_value=client):
         record = await create_agent_instructions("acme/repo", "octo")
     assert record["full_name"] == "acme/repo"
     assert record["instructions"] == ""
-    mock_put.assert_awaited_once()
+    assert record["created_by"] == "octo"
+    client.store.put_item.assert_awaited_once_with(["agent_instructions"], "acme/repo", record)
 
 
 @pytest.mark.asyncio
 async def test_set_agent_instructions_updates_store() -> None:
-    mock_put = AsyncMock()
-    with (
-        patch(
-            "agent.dashboard.agent_instructions.get_agent_instructions",
-            new_callable=AsyncMock,
-            return_value={"full_name": "acme/repo", "instructions": ""},
-        ),
-        patch("agent.dashboard.agent_instructions._client") as mock_client,
-    ):
-        mock_client.return_value.store.put_item = mock_put
+    client = _fake_store_client({"full_name": "acme/repo", "instructions": ""})
+    with patch("agent.store.store_client", return_value=client):
         record = await set_agent_instructions("acme/repo", "Use direct tone.")
     assert record["instructions"] == "Use direct tone."
-    mock_put.assert_awaited_once()
+    client.store.put_item.assert_awaited_once_with(["agent_instructions"], "acme/repo", record)
 
 
 def test_construct_system_prompt_contains_only_repository_instructions() -> None:

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
+from agent import store as agent_store
 from agent.dashboard import schedules
 from agent.dashboard.schedules import ScheduleCreateBody, ScheduleUpdateBody
 
@@ -92,7 +93,8 @@ class _FakeClient:
 @pytest.fixture
 def fake_client(monkeypatch) -> _FakeClient:  # noqa: ANN001
     client = _FakeClient()
-    monkeypatch.setattr(schedules, "_client", lambda: client)
+    monkeypatch.setattr(schedules, "langgraph_client", lambda: client)
+    monkeypatch.setattr(agent_store, "store_client", lambda: client)
     return client
 
 

--- a/tests/agent/test_baby_sit.py
+++ b/tests/agent/test_baby_sit.py
@@ -8,6 +8,7 @@ import pytest
 from langgraph_sdk.errors import ConflictError
 
 from agent import baby_sit, scheduler
+from agent import store as agent_store
 from agent.utils.slack import GitHubPrRef
 
 
@@ -81,10 +82,15 @@ class _Client:
         self.threads = _Threads(active_threads if active_threads is not None else set())
 
 
+def _use_client(monkeypatch: pytest.MonkeyPatch, client: _Client) -> None:
+    monkeypatch.setattr(baby_sit, "get_client", lambda: client)
+    monkeypatch.setattr(agent_store, "store_client", lambda: client)
+
+
 @pytest.fixture
 def watch_client(monkeypatch: pytest.MonkeyPatch) -> _Client:
     client = _Client()
-    monkeypatch.setattr(baby_sit, "_client", lambda: client)
+    _use_client(monkeypatch, client)
     return client
 
 
@@ -200,7 +206,7 @@ async def test_concurrent_failure_evaluations_dispatch_once(
     shared_watch_clients: tuple[_Client, _Client], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     first_client, second_client = shared_watch_clients
-    monkeypatch.setattr(baby_sit, "_client", lambda: first_client)
+    _use_client(monkeypatch, first_client)
     await _start_watch(first_client)
     monkeypatch.setattr(baby_sit, "get_github_app_installation_token", AsyncMock(return_value="t"))
     monkeypatch.setattr(
@@ -231,13 +237,13 @@ async def test_concurrent_failure_evaluations_dispatch_once(
 
     first = asyncio.create_task(baby_sit.evaluate_watch("acme/repo#7"))
     await dispatch_started.wait()
-    monkeypatch.setattr(baby_sit, "_client", lambda: second_client)
+    _use_client(monkeypatch, second_client)
     assert await baby_sit.evaluate_watch("acme/repo#7") == "busy"
     release_dispatch.set()
 
     assert await first == "dispatched"
     dispatch.assert_awaited_once()
-    monkeypatch.setattr(baby_sit, "_client", lambda: first_client)
+    _use_client(monkeypatch, first_client)
     assert await baby_sit.evaluate_watch("acme/repo#7") == "duplicate"
 
 

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from agent import store as agent_store
+
 
 def test_dashboard_plan_url_uses_plan_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DASHBOARD_BASE_URL", "https://example.test")
@@ -75,7 +77,7 @@ async def test_list_plan_comments_swallows_errors_by_default(
         async def search_items(self, *a: Any, **k: Any) -> Any:
             raise RuntimeError("boom")
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     assert await plan_store.list_plan_comments("t") == []
 
 
@@ -86,7 +88,7 @@ async def test_list_plan_comments_raises_with_flag(monkeypatch: pytest.MonkeyPat
         async def search_items(self, *a: Any, **k: Any) -> Any:
             raise RuntimeError("boom")
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     with pytest.raises(RuntimeError):
         await plan_store.list_plan_comments("t", raise_on_error=True)
 
@@ -103,7 +105,7 @@ async def test_clear_plan_comments_deletes_each(monkeypatch: pytest.MonkeyPatch)
         async def delete_item(self, _ns: Any, key: str) -> None:
             deleted.append(key)
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     await plan_store.clear_plan_comments("t")
     assert deleted == ["a", "b"]
 
@@ -483,7 +485,7 @@ async def test_set_plan_status_preserves_plan_file_path(monkeypatch: pytest.Monk
     async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
         return None
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
 
     await plan_store.set_plan_status("t", plan_store.PLAN_STATUS_REVISING, plan_mode=True)
@@ -513,7 +515,7 @@ async def test_set_plan_status_records_approver_audit(monkeypatch: pytest.Monkey
     async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
         merged.update(metadata)
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
 
     await plan_store.set_plan_status(
@@ -558,7 +560,7 @@ async def test_set_plan_status_clears_shared_content_when_entering_plan_mode(
     async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
         merged.update(metadata)
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
 
     await plan_store.set_plan_status("t", plan_store.PLAN_STATUS_PLANNING, plan_mode=True)
@@ -582,7 +584,7 @@ async def test_save_plan_content_clear_comments_flag(monkeypatch: pytest.MonkeyP
     async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
         return None
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     monkeypatch.setattr(plan_store, "clear_plan_comments", fake_clear)
     monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
 
@@ -610,7 +612,7 @@ async def test_save_plan_content_can_skip_plan_mode_metadata(
     async def fake_merge(thread_id: str, metadata: dict[str, Any]) -> None:
         merged.update(metadata)
 
-    monkeypatch.setattr(plan_store, "_client", lambda: _fake_client(_Store()))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _fake_client(_Store()))
     monkeypatch.setattr(plan_store, "clear_plan_comments", fake_clear)
     monkeypatch.setattr(plan_store, "_merge_thread_metadata", fake_merge)
 

--- a/tests/agent/test_skills.py
+++ b/tests/agent/test_skills.py
@@ -24,7 +24,7 @@ async def test_skill_validation_and_persistence() -> None:
 
     client.store.get_item.return_value = None
 
-    with patch("agent.dashboard.skills._client", return_value=client):
+    with patch("agent.store.store_client", return_value=client):
         record = await create_skill(
             "octocat",
             SkillCreate(
@@ -51,7 +51,7 @@ async def test_organization_skill_uses_singleton_namespace() -> None:
     client.store.get_item.return_value = None
     client.store.search_items.return_value = {"items": []}
 
-    with patch("agent.dashboard.skills._client", return_value=client):
+    with patch("agent.store.store_client", return_value=client):
         await create_organization_skill(
             SkillCreate(name="security-review", description="Apply organization security rules")
         )
@@ -72,7 +72,7 @@ async def test_organization_skill_listing_uses_opaque_cursor() -> None:
         ]
     }
 
-    with patch("agent.dashboard.skills._client", return_value=client):
+    with patch("agent.store.store_client", return_value=client):
         first_page = await list_organization_skills(limit=1, cursor=None)
         second_page = await list_organization_skills(limit=1, cursor=first_page["next_cursor"])
         for cursor in (
@@ -88,7 +88,9 @@ async def test_organization_skill_listing_uses_opaque_cursor() -> None:
 
     assert first_page == {"items": [{"name": "first"}], "next_cursor": "eyJuYW1lIjogImZpcnN0In0"}
     assert second_page == {"items": [{"name": "second"}], "next_cursor": None}
-    client.store.search_items.assert_awaited_with(["organization_skills"], limit=1001)
+    client.store.search_items.assert_awaited_with(
+        ["organization_skills"], filter=None, limit=1001, offset=0
+    )
 
 
 async def test_save_user_skill_uses_triggering_user_namespace() -> None:
@@ -116,12 +118,12 @@ async def test_skill_listing_returns_next_offset() -> None:
         ]
     }
 
-    with patch("agent.dashboard.skills._client", return_value=client):
+    with patch("agent.store.store_client", return_value=client):
         page = await list_skills("octocat", limit=1, offset=3)
 
     assert page == {"items": [{"name": "first"}], "next_offset": 4}
     client.store.search_items.assert_awaited_once_with(
-        ["user_skills", "octocat"], limit=2, offset=3
+        ["user_skills", "octocat"], filter=None, limit=2, offset=3
     )
 
 

--- a/tests/agent/test_user_instructions.py
+++ b/tests/agent/test_user_instructions.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,21 +11,15 @@ from agent.tools.save_user_instructions import save_user_instructions
 
 @pytest.mark.asyncio
 async def test_set_user_instructions_upserts_record() -> None:
-    mock_put = AsyncMock()
-    with (
-        patch(
-            "agent.dashboard.user_instructions.get_user_instructions",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch("agent.dashboard.user_instructions._client") as mock_client,
-    ):
-        mock_client.return_value.store.put_item = mock_put
+    client = MagicMock()
+    client.store.get_item = AsyncMock(return_value=None)
+    client.store.put_item = AsyncMock()
+    with patch("agent.store.store_client", return_value=client):
         record = await set_user_instructions("octo", "Always run the linter.")
     assert record["login"] == "octo"
     assert record["instructions"] == "Always run the linter."
     assert record["updated_by"] == "octo"
-    mock_put.assert_awaited_once()
+    client.store.put_item.assert_awaited_once_with(["user_instructions"], "octo", record)
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_auth_sources.py
+++ b/tests/auth/test_auth_sources.py
@@ -71,12 +71,12 @@ def _stub_dashboard_store(
     async def fake_get_valid(login: str):
         return token
 
-    async def fake_get_value(namespace, key):
+    async def fake_get_record(login: str):
         return {"token_expires_at": expires_at}
 
     monkeypatch.setattr(auth, "get_github_token_from_thread", fake_get_from_thread)
     monkeypatch.setattr(profiles, "get_valid_access_token", fake_get_valid)
-    monkeypatch.setattr(profiles, "_get_value", fake_get_value)
+    monkeypatch.setattr(profiles, "get_oauth_token_record", fake_get_record)
 
 
 def test_resolve_github_token_slack_uses_dashboard_store(

--- a/tests/auth/test_github_oauth_refresh.py
+++ b/tests/auth/test_github_oauth_refresh.py
@@ -38,7 +38,7 @@ async def test_get_valid_access_token_refreshes_when_near_expiry() -> None:
     }
     with (
         patch(
-            "agent.dashboard.profiles._get_value",
+            "agent.dashboard.profiles.get_value",
             new_callable=AsyncMock,
             return_value=record,
         ),
@@ -87,7 +87,7 @@ async def test_get_valid_access_token_drops_record_on_dead_refresh_token() -> No
     }
     with (
         patch(
-            "agent.dashboard.profiles._get_value",
+            "agent.dashboard.profiles.get_value",
             new_callable=AsyncMock,
             return_value=record,
         ),
@@ -127,7 +127,7 @@ async def test_get_valid_access_token_keeps_fresh_reauth_on_dead_refresh_token()
     }
     with (
         patch(
-            "agent.dashboard.profiles._get_value",
+            "agent.dashboard.profiles.get_value",
             new_callable=AsyncMock,
             side_effect=[stale, stale, reauthed],
         ),
@@ -164,7 +164,7 @@ async def test_get_valid_access_token_keeps_record_on_transient_refresh_failure(
     }
     with (
         patch(
-            "agent.dashboard.profiles._get_value",
+            "agent.dashboard.profiles.get_value",
             new_callable=AsyncMock,
             return_value=record,
         ),
@@ -195,7 +195,7 @@ async def test_get_valid_access_token_returns_stored_when_not_expiring() -> None
     }
     with (
         patch(
-            "agent.dashboard.profiles._get_value",
+            "agent.dashboard.profiles.get_value",
             new_callable=AsyncMock,
             return_value=record,
         ),

--- a/tests/auth/test_notion_oauth.py
+++ b/tests/auth/test_notion_oauth.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from cryptography.fernet import Fernet
 
+from agent import store as agent_store
 from agent.dashboard import notion_oauth as no
 
 
@@ -31,7 +32,7 @@ class _FakeClient:
 @pytest.fixture()
 def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
     store = _FakeStore()
-    monkeypatch.setattr(no, "_client", lambda: _FakeClient(store))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _FakeClient(store))
     monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
     return store
 

--- a/tests/auth/test_user_credentials.py
+++ b/tests/auth/test_user_credentials.py
@@ -6,6 +6,7 @@ import pytest
 from cryptography.fernet import Fernet
 from pydantic import ValidationError
 
+from agent import store as agent_store
 from agent.dashboard import user_credentials as uc
 from agent.dashboard.notion_oauth import NotionOAuthError
 from agent.dashboard.user_credentials import CurrentsCredentialsUpdate
@@ -34,7 +35,7 @@ class _FakeClient:
 @pytest.fixture()
 def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
     store = _FakeStore()
-    monkeypatch.setattr(uc, "_client", lambda: _FakeClient(store))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _FakeClient(store))
     monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
     return store
 

--- a/tests/dashboard/test_autofix_state.py
+++ b/tests/dashboard/test_autofix_state.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent import store as agent_store
 from agent.dashboard import autofix_state
 
 
@@ -23,7 +24,7 @@ async def test_set_and_check_pr_disabled() -> None:
     client.store.put_item = AsyncMock(side_effect=put_item)
     client.store.get_item = AsyncMock(side_effect=get_item)
 
-    with patch.object(autofix_state, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         assert await autofix_state.is_pr_autofix_disabled("O", "R", 5) is False
         await autofix_state.set_pr_autofix_disabled("O", "R", 5, True)
         assert await autofix_state.is_pr_autofix_disabled("o", "r", 5) is True

--- a/tests/dashboard/test_dashboard_repos.py
+++ b/tests/dashboard/test_dashboard_repos.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
+from agent import store
 from agent.dashboard import repo_cache, routes
 
 
@@ -163,7 +164,7 @@ async def test_list_repos_refresh_bypasses_cache_and_writes_it(monkeypatch) -> N
 
 @pytest.mark.asyncio
 async def test_read_cached_repos_rejects_expired_and_malformed_entries(monkeypatch) -> None:
-    now_ms = repo_cache._now_ms()
+    now_ms = store.now_ms()
 
     async def fake_get_item(namespace: list[str], key: str) -> dict[str, object]:
         assert namespace == repo_cache.REPO_LIST_CACHE_NAMESPACE
@@ -177,9 +178,9 @@ async def test_read_cached_repos_rejects_expired_and_malformed_entries(monkeypat
         },
         "malformed": {"payload": "nope", "cached_at_ms": now_ms},
     }
-    store = MagicMock()
-    store.get_item = fake_get_item
-    monkeypatch.setattr(repo_cache, "_client", lambda: MagicMock(store=store))
+    fake_store = MagicMock()
+    fake_store.get_item = fake_get_item
+    monkeypatch.setattr(store, "store_client", lambda: MagicMock(store=fake_store))
 
     fresh = await repo_cache.read_cached_repos("fresh")
     assert fresh is not None and fresh[0] == {"repositories": []}
@@ -189,9 +190,9 @@ async def test_read_cached_repos_rejects_expired_and_malformed_entries(monkeypat
 
 @pytest.mark.asyncio
 async def test_read_cached_repos_swallows_store_failures(monkeypatch) -> None:
-    store = MagicMock()
-    store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
-    monkeypatch.setattr(repo_cache, "_client", lambda: MagicMock(store=store))
+    fake_store = MagicMock()
+    fake_store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
+    monkeypatch.setattr(store, "store_client", lambda: MagicMock(store=fake_store))
 
     assert await repo_cache.read_cached_repos("octocat") is None
 

--- a/tests/dashboard/test_dashboard_run_email.py
+++ b/tests/dashboard/test_dashboard_run_email.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from agent import store as agent_store
 from agent.dashboard import thread_api
 from agent.dashboard import user_mappings as um
 
@@ -17,10 +18,17 @@ class _FakeStore:
     async def put_item(self, namespace: list[str], key: str, value: dict[str, Any]) -> None:
         self.items[(tuple(namespace), key)] = value
 
-    async def search_items(self, namespace: list[str], *, limit: int = 1000):
+    async def search_items(
+        self,
+        namespace: list[str],
+        *,
+        filter: dict[str, Any] | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ):
         ns = tuple(namespace)
         items = [{"value": v} for (n, _k), v in self.items.items() if n == ns]
-        return {"items": items[:limit]}
+        return {"items": items[offset : offset + limit]}
 
 
 class _FakeClient:
@@ -31,7 +39,7 @@ class _FakeClient:
 @pytest.fixture()
 def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
     store = _FakeStore()
-    monkeypatch.setattr(um, "_client", lambda: _FakeClient(store))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _FakeClient(store))
     um.clear_cache()
     return store
 

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent import store as agent_store
 from agent.dashboard import environments as env_store
 from agent.dashboard.environments import (
     EnvironmentCreate,
@@ -30,11 +31,17 @@ def _fake_client() -> tuple[MagicMock, dict[tuple[Any, ...], Any]]:
     async def delete_item(ns: list[str], key: str) -> None:
         store.pop((tuple(ns), key), None)
 
-    async def search_items(ns: list[str], limit: int = 100) -> dict[str, Any]:
+    async def search_items(
+        ns: list[str],
+        *,
+        filter: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
         items = [
             {"value": value} for (namespace, _key), value in store.items() if namespace == tuple(ns)
         ]
-        return {"items": items[:limit]}
+        return {"items": items[offset : offset + limit]}
 
     client.store.put_item = AsyncMock(side_effect=put_item)
     client.store.get_item = AsyncMock(side_effect=get_item)
@@ -179,7 +186,7 @@ def test_environment_prompt_blank_is_none() -> None:
 @pytest.mark.asyncio
 async def test_only_the_environment_named_default_is_resolved() -> None:
     client, _ = _fake_client()
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         await env_store.create_environment(EnvironmentCreate(name="Draft"), "ramon")
         assert await env_store.resolve_default_environment() is None
 
@@ -193,7 +200,7 @@ async def test_only_the_environment_named_default_is_resolved() -> None:
 @pytest.mark.asyncio
 async def test_create_rejects_duplicate_name() -> None:
     client, _ = _fake_client()
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
         with pytest.raises(ValueError, match="already exists"):
             await env_store.create_environment(EnvironmentCreate(name="Base"), "ramon")
@@ -202,7 +209,7 @@ async def test_create_rejects_duplicate_name() -> None:
 @pytest.mark.asyncio
 async def test_update_writes_only_provided_fields() -> None:
     client, _ = _fake_client()
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         await env_store.create_environment(
             EnvironmentCreate(
                 name="base",
@@ -238,7 +245,7 @@ async def test_update_writes_only_provided_fields() -> None:
 @pytest.mark.asyncio
 async def test_update_rejects_a_rename_across_slugs() -> None:
     client, _ = _fake_client()
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         await env_store.create_environment(EnvironmentCreate(name="draft"), "ramon")
         with pytest.raises(ValueError, match="renaming an environment"):
             await env_store.update_environment("draft", EnvironmentUpdate(name="default"))
@@ -249,7 +256,7 @@ async def test_delete_removes_record_and_snapshot() -> None:
     client, _ = _fake_client()
     delete_snapshot = AsyncMock()
     with (
-        patch.object(env_store, "get_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", delete_snapshot),
     ):
         await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
@@ -264,7 +271,7 @@ async def test_delete_removes_record_and_snapshot() -> None:
 async def test_resolve_default_environment_swallows_store_failures() -> None:
     client = MagicMock()
     client.store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         assert await env_store.resolve_default_environment() is None
 
 
@@ -291,7 +298,7 @@ async def test_capture_tags_latest_and_replaces_previous_snapshot() -> None:
     capture = AsyncMock(return_value=_FakeSnapshot("snap-2"))
     delete_snapshot = AsyncMock()
     with (
-        patch.object(env_store, "get_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", delete_snapshot),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
@@ -324,7 +331,7 @@ async def test_capture_walks_the_name_suffix_past_a_conflict() -> None:
     client, _ = _fake_client()
     capture = AsyncMock(side_effect=[_NameConflict("taken"), _FakeSnapshot("snap-2")])
     with (
-        patch.object(env_store, "get_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", AsyncMock()),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
@@ -348,7 +355,7 @@ async def test_failed_recapture_keeps_booting_from_the_previous_snapshot() -> No
     capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
     delete_snapshot = AsyncMock()
     with (
-        patch.object(env_store, "get_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", delete_snapshot),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
@@ -377,7 +384,7 @@ async def test_first_capture_failure_marks_the_environment_failed() -> None:
     client, _ = _fake_client()
     capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
     with (
-        patch.object(env_store, "get_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
@@ -402,7 +409,7 @@ async def test_capture_requires_the_langsmith_provider(monkeypatch: pytest.Monke
     client, _ = _fake_client()
     capture = AsyncMock()
     with (
-        patch.object(env_store, "get_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
@@ -436,7 +443,7 @@ def test_parse_environment_tag(text: str, expected_slug: str | None, expected_te
 @pytest.mark.asyncio
 async def test_resolve_environment_prefers_the_selection() -> None:
     client, _ = _fake_client()
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
         await env_store.create_environment(EnvironmentCreate(name="staging"), "ramon")
 
@@ -457,7 +464,7 @@ async def test_resolve_environment_prefers_the_selection() -> None:
 @pytest.mark.asyncio
 async def test_environment_options_omit_admin_only_settings() -> None:
     client, _ = _fake_client()
-    with patch.object(env_store, "get_client", return_value=client):
+    with patch.object(agent_store, "store_client", return_value=client):
         await env_store.create_environment(
             EnvironmentCreate(
                 name="default",

--- a/tests/dashboard/test_profile_draft_preference.py
+++ b/tests/dashboard/test_profile_draft_preference.py
@@ -16,7 +16,7 @@ async def test_omitted_draft_preference_preserves_existing_value() -> None:
             new_callable=AsyncMock,
             return_value={"draft_prs": False},
         ),
-        patch("agent.dashboard.profiles._client") as client,
+        patch("agent.store.store_client") as client,
     ):
         client.return_value.store.put_item = put_item
         profile = await upsert_profile("octocat", "octocat@example.com", update)
@@ -37,7 +37,7 @@ async def test_explicit_draft_preference_is_persisted() -> None:
 
     with (
         patch("agent.dashboard.profiles.get_profile", new_callable=AsyncMock, return_value=None),
-        patch("agent.dashboard.profiles._client") as client,
+        patch("agent.store.store_client") as client,
     ):
         client.return_value.store.put_item = put_item
         profile = await upsert_profile("octocat", "octocat@example.com", update)
@@ -64,7 +64,7 @@ async def test_profile_save_removes_legacy_create_prs_setting() -> None:
             new_callable=AsyncMock,
             return_value={"create_prs": True},
         ),
-        patch("agent.dashboard.profiles._client") as client,
+        patch("agent.store.store_client") as client,
     ):
         client.return_value.store.put_item = put_item
         profile = await upsert_profile("octocat", "octocat@example.com", update)

--- a/tests/dashboard/test_team_credentials.py
+++ b/tests/dashboard/test_team_credentials.py
@@ -4,6 +4,7 @@ import pytest
 from cryptography.fernet import Fernet
 from pydantic import ValidationError
 
+from agent import store as agent_store
 from agent.dashboard import team_credentials as tc
 from agent.dashboard.team_credentials import (
     DatadogCredentialsUpdate,
@@ -34,7 +35,7 @@ class _FakeClient:
 @pytest.fixture()
 def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
     store = _FakeStore()
-    monkeypatch.setattr(tc, "_client", lambda: _FakeClient(store))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _FakeClient(store))
     monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
     return store
 

--- a/tests/dashboard/test_user_mappings.py
+++ b/tests/dashboard/test_user_mappings.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from agent import store as agent_store
 from agent.dashboard import user_mappings as um
 
 
@@ -21,10 +22,17 @@ class _FakeStore:
     async def delete_item(self, namespace: list[str], key: str) -> None:
         self.items.pop((tuple(namespace), key), None)
 
-    async def search_items(self, namespace: list[str], *, limit: int = 1000):
+    async def search_items(
+        self,
+        namespace: list[str],
+        *,
+        filter: dict[str, Any] | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ):
         ns = tuple(namespace)
         items = [{"value": v} for (n, _k), v in self.items.items() if n == ns]
-        return {"items": items[:limit]}
+        return {"items": items[offset : offset + limit]}
 
 
 class _FakeClient:
@@ -35,7 +43,7 @@ class _FakeClient:
 @pytest.fixture()
 def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
     store = _FakeStore()
-    monkeypatch.setattr(um, "_client", lambda: _FakeClient(store))
+    monkeypatch.setattr(agent_store, "store_client", lambda: _FakeClient(store))
     um.clear_cache()
     return store
 

--- a/tests/sandbox/test_repo_snapshots.py
+++ b/tests/sandbox/test_repo_snapshots.py
@@ -59,37 +59,32 @@ async def test_create_endpoint_returns_configuration_error() -> None:
     assert "base image missing" in exc.value.detail
 
 
+def _fake_store_client(stored: dict[str, object] | None) -> MagicMock:
+    client = MagicMock()
+    client.store.get_item = AsyncMock(return_value={"value": stored} if stored else None)
+    client.store.put_item = AsyncMock()
+    return client
+
+
 @pytest.mark.asyncio
 async def test_resolve_returns_snapshot_id_when_ready() -> None:
-    with patch(
-        "agent.dashboard.repo_snapshots._get_value",
-        new_callable=AsyncMock,
-        return_value={"status": "ready", "snapshot_id": "snap-123"},
-    ):
-        result = await resolve_repo_snapshot_id("acme", "repo")
-    assert result == "snap-123"
+    client = _fake_store_client({"status": "ready", "snapshot_id": "snap-123"})
+    with patch("agent.store.store_client", return_value=client):
+        assert await resolve_repo_snapshot_id("acme", "repo") == "snap-123"
 
 
 @pytest.mark.asyncio
 async def test_resolve_returns_none_when_not_ready() -> None:
-    with patch(
-        "agent.dashboard.repo_snapshots._get_value",
-        new_callable=AsyncMock,
-        return_value={"status": "building", "snapshot_id": "snap-123"},
-    ):
-        result = await resolve_repo_snapshot_id("acme", "repo")
-    assert result is None
+    client = _fake_store_client({"status": "building", "snapshot_id": "snap-123"})
+    with patch("agent.store.store_client", return_value=client):
+        assert await resolve_repo_snapshot_id("acme", "repo") is None
 
 
 @pytest.mark.asyncio
 async def test_resolve_returns_none_without_record() -> None:
-    with patch(
-        "agent.dashboard.repo_snapshots._get_value",
-        new_callable=AsyncMock,
-        return_value=None,
-    ):
-        result = await resolve_repo_snapshot_id("acme", "repo")
-    assert result is None
+    client = _fake_store_client(None)
+    with patch("agent.store.store_client", return_value=client):
+        assert await resolve_repo_snapshot_id("acme", "repo") is None
 
 
 @pytest.mark.asyncio
@@ -100,71 +95,47 @@ async def test_resolve_returns_none_without_owner_or_name() -> None:
 
 @pytest.mark.asyncio
 async def test_resolve_swallows_errors() -> None:
-    with patch(
-        "agent.dashboard.repo_snapshots._get_value",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("store down"),
-    ):
+    client = MagicMock()
+    client.store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
+    with patch("agent.store.store_client", return_value=client):
         assert await resolve_repo_snapshot_id("acme", "repo") is None
 
 
 @pytest.mark.asyncio
 async def test_create_repo_snapshot_puts_new_record() -> None:
-    mock_put = AsyncMock()
+    client = _fake_store_client(None)
     with (
         patch.dict("os.environ", {"REPO_SNAPSHOT_BASE_IMAGE": "ghcr.io/acme/base:1"}),
-        patch(
-            "agent.dashboard.repo_snapshots.get_repo_snapshot",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch("agent.dashboard.repo_snapshots._client") as mock_client,
+        patch("agent.store.store_client", return_value=client),
     ):
-        mock_client.return_value.store.put_item = mock_put
         record = await create_repo_snapshot("acme/repo", "octo")
     assert record["full_name"] == "acme/repo"
     assert record["status"] == "none"
     assert "FROM" in record["dockerfile"]
-    mock_put.assert_awaited_once()
+    client.store.put_item.assert_awaited_once_with(["repo_snapshots"], "acme/repo", record)
 
 
 @pytest.mark.asyncio
 async def test_update_repo_snapshot_persists_fields() -> None:
-    mock_put = AsyncMock()
-    with (
-        patch(
-            "agent.dashboard.repo_snapshots.get_repo_snapshot",
-            new_callable=AsyncMock,
-            return_value={"full_name": "acme/repo", "status": "none"},
-        ),
-        patch("agent.dashboard.repo_snapshots._client") as mock_client,
-    ):
-        mock_client.return_value.store.put_item = mock_put
+    client = _fake_store_client({"full_name": "acme/repo", "status": "none"})
+    with patch("agent.store.store_client", return_value=client):
         record = await update_repo_snapshot(
             "acme/repo",
             RepoSnapshotUpdate(dockerfile="FROM python:3.12-slim\n", vcpus=4),
         )
     assert record["dockerfile"] == "FROM python:3.12-slim\n"
     assert record["vcpus"] == 4
-    mock_put.assert_awaited_once()
+    client.store.put_item.assert_awaited_once_with(["repo_snapshots"], "acme/repo", record)
 
 
 @pytest.mark.asyncio
 async def test_mark_building_sets_status() -> None:
-    mock_put = AsyncMock()
-    with (
-        patch(
-            "agent.dashboard.repo_snapshots.get_repo_snapshot",
-            new_callable=AsyncMock,
-            return_value={"full_name": "acme/repo", "status": "ready"},
-        ),
-        patch("agent.dashboard.repo_snapshots._client") as mock_client,
-    ):
-        mock_client.return_value.store.put_item = mock_put
+    client = _fake_store_client({"full_name": "acme/repo", "status": "ready"})
+    with patch("agent.store.store_client", return_value=client):
         record = await mark_repo_snapshot_building("acme/repo")
     assert record["status"] == "building"
     assert record["build_started_at"]
-    mock_put.assert_awaited_once()
+    client.store.put_item.assert_awaited_once_with(["repo_snapshots"], "acme/repo", record)
 
 
 def test_building_record_without_started_at_is_stale() -> None:

--- a/tests/sandbox/test_sandbox_settings.py
+++ b/tests/sandbox/test_sandbox_settings.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agent.dashboard import sandbox_settings
+from agent import store as agent_store
 from agent.dashboard.sandbox_settings import (
     SandboxSettingsUpdate,
     get_admin_base_snapshot_id,
@@ -32,8 +32,8 @@ def test_update_rejects_oversized_value() -> None:
 async def test_admin_value_wins_over_env() -> None:
     with (
         patch.object(
-            sandbox_settings,
-            "_client",
+            agent_store,
+            "store_client",
             return_value=_store({"value": {"base_snapshot_id": "admin-snap"}}),
         ),
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
@@ -44,7 +44,7 @@ async def test_admin_value_wins_over_env() -> None:
 
 async def test_falls_back_to_env_without_record() -> None:
     with (
-        patch.object(sandbox_settings, "_client", return_value=_store(None)),
+        patch.object(agent_store, "store_client", return_value=_store(None)),
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
     ):
         assert await get_admin_base_snapshot_id() is None
@@ -55,7 +55,7 @@ async def test_store_failure_falls_back_to_env() -> None:
     client = MagicMock()
     client.store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
     with (
-        patch.object(sandbox_settings, "_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
     ):
         assert await resolve_base_snapshot_id() == "env-snap"
@@ -63,7 +63,7 @@ async def test_store_failure_falls_back_to_env() -> None:
 
 async def test_settings_report_source() -> None:
     with (
-        patch.object(sandbox_settings, "_client", return_value=_store(None)),
+        patch.object(agent_store, "store_client", return_value=_store(None)),
         patch.dict("os.environ", {}, clear=True),
     ):
         unset = await get_sandbox_settings()
@@ -71,7 +71,7 @@ async def test_settings_report_source() -> None:
     assert unset["effective_base_snapshot_id"] is None
 
     with (
-        patch.object(sandbox_settings, "_client", return_value=_store(None)),
+        patch.object(agent_store, "store_client", return_value=_store(None)),
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
     ):
         from_env = await get_sandbox_settings()
@@ -82,7 +82,7 @@ async def test_settings_report_source() -> None:
 async def test_upsert_persists_and_returns_effective() -> None:
     client = _store({"value": {"base_snapshot_id": "admin-snap"}})
     with (
-        patch.object(sandbox_settings, "_client", return_value=client),
+        patch.object(agent_store, "store_client", return_value=client),
         patch.dict("os.environ", {"DEFAULT_SANDBOX_SNAPSHOT_ID": "env-snap"}, clear=True),
     ):
         result = await upsert_sandbox_settings(

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import pytest
 
+from agent import store as agent_store
+
 notification_tool = importlib.import_module("agent.tools.notify_automation_channel")
 
 
@@ -60,7 +62,7 @@ def test_notify_automation_channel_exported() -> None:
 @pytest.fixture
 def fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
     client = _FakeClient()
-    monkeypatch.setattr(notification_tool, "get_client", lambda: client)
+    monkeypatch.setattr(agent_store, "store_client", lambda: client)
     monkeypatch.setattr(
         notification_tool,
         "dashboard_thread_url",

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -63,6 +63,7 @@ def test_notify_automation_channel_exported() -> None:
 def fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
     client = _FakeClient()
     monkeypatch.setattr(agent_store, "store_client", lambda: client)
+    monkeypatch.setattr(notification_tool, "get_client", lambda: client)
     monkeypatch.setattr(
         notification_tool,
         "dashboard_thread_url",


### PR DESCRIPTION
## Summary

Third chunk of #2181. Net **−240 lines** across 45 files. Branched from `main`, independent of #2213 and #2214.

Twenty-two modules each had their own copy of `get_client().store`, their own `_item_value` / `_stored_value` unwrapper (the SDK returns dicts or objects depending on transport), their own paging loop, and their own idea of what a store failure means.

`agent/store.py` is now the only module that talks to the Store.

### The error policy is the point

**A missing item reads as `None`; every other failure raises.**

Several of the old call sites caught every exception and returned an empty result, so a store outage and an empty namespace were indistinguishable — an outage rendered as an empty dashboard rather than an error. That is the behavior this changes.

The call sites that genuinely must survive an outage keep their swallow, but now as an explicit `try`/`except` with a docstring saying why. Both are on the path that starts an agent run, where failing the run is worse than falling back to a default:

- `agent_overrides.load_profile` — a store blip costs the run its per-user overrides, not the run itself. Dashboard reads that *should* surface a failure use `profiles.get_profile` instead.
- `team_settings.get_team_settings` — the agent, the reviewer and every webhook read this to pick a model, so an unreachable store degrades to the hardcoded defaults rather than failing every run at once.

Keeping the swallow visible at the point where the choice is made is the intent; a helper that silently swallows for everyone is what this replaces.

### API

`get_value` · `put_value` · `delete_value` (deleting an absent item is not an error) · `search_values` (one page) · `search_all_values` (pages until exhausted) · `now_iso` / `now_ms` · `store_client()` as the single patch point.

`KeyedRecordStore` covers the recurring shape — records keyed by a stable id, stamped `created_at`/`updated_at`, with a `default_factory` so `create` is idempotent and `update` can patch a record the dashboard never explicitly created.

### Resolving against `main`

Two upstream features landed in files this touches, and both are preserved:

- `dashboard/environments.py` keeps the sandbox sizing fields (`mem_bytes`, `vcpus`, `fs_capacity_bytes`, `create_params`), now persisted through `KeyedRecordStore`.
- `tools/notify_automation_channel.py` — `_mark_action_posted` (upstream's automation action indicator) took a `client` argument sourced from a `get_client()` call the refactor removes. It writes thread metadata, not store data, so it keeps the module's existing `langgraph_sdk.get_client` import rather than reaching through `agent/store.py`; the test fixture patches that name alongside the store's.

## Test plan

- [x] `make lint` clean (ruff check + ruff format --diff)
- [x] `make typecheck` clean (0 errors, 0 warnings)
- [x] `uv run pytest tests/slack/test_notify_automation_channel_tool.py tests/dashboard tests/agent/test_agent_instructions.py tests/sandbox/test_repo_snapshots.py` — 341 passed
- [x] Full suite left to CI on this one — the targeted run above covers the two merge resolutions

[no screenshot] — no UI changes.
