### PR TITLE
refactor: centralize model choice normalization

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -280,6 +280,19 @@ def canonical_model_pair(model_id: object, effort: object = None) -> tuple[str, 
     return None
 
 
+def normalize_model_choice(
+    model_id: str | None, effort: str | None
+) -> tuple[str | None, str | None]:
+    if not isinstance(model_id, str):
+        return None, None
+    if model_id not in SUPPORTED_MODEL_IDS:
+        canonical = canonical_model_pair(model_id, effort)
+        return canonical if canonical is not None else (None, None)
+    if not isinstance(effort, str) or not model_supports_effort(model_id, effort):
+        return None, None
+    return model_id, effort
+
+
 def provider_fallback_pair(model_id: object, effort: object = None) -> tuple[str, str] | None:
     """Newest supported ``(model_id, effort)`` for the same provider/family.
 

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -20,12 +20,7 @@ from ..utils.slack import (
 from ..utils.thread_ops import langgraph_client
 from ..utils.thread_participants import PARTICIPANT_LOGINS_KEY
 from .admin import is_admin
-from .options import (
-    SUPPORTED_MODEL_IDS,
-    canonical_model_pair,
-    gate_fable_model,
-    model_supports_effort,
-)
+from .options import gate_fable_model, normalize_model_choice
 from .profiles import get_profile, get_valid_access_token
 from .repo_access import repo_config_for_user, require_repo_access_for_user
 from .team_settings import get_team_fable_enabled
@@ -108,19 +103,6 @@ def _client():
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
-
-
-def _normalize_model_choice(
-    model_id: str | None, effort: str | None
-) -> tuple[str | None, str | None]:
-    if not isinstance(model_id, str):
-        return None, None
-    if model_id not in SUPPORTED_MODEL_IDS:
-        canonical = canonical_model_pair(model_id, effort)
-        return canonical if canonical is not None else (None, None)
-    if not isinstance(effort, str) or not model_supports_effort(model_id, effort):
-        return None, None
-    return model_id, effort
 
 
 def _validate_cron_value(value: str, low: int, high: int) -> None:
@@ -360,7 +342,7 @@ async def create_agent_schedule(
         raise HTTPException(403, "admin only")
     await _ensure_dashboard_github_token(login)
     profile = await get_profile(login) or {}
-    chosen_model, chosen_effort = _normalize_model_choice(body.model_id, body.effort)
+    chosen_model, chosen_effort = normalize_model_choice(body.model_id, body.effort)
     repo = await repo_config_for_user(login, body.repo)
     schedule_id = str(uuid.uuid4())
     now = _now_iso()
@@ -428,7 +410,7 @@ async def update_agent_schedule(
     if body.repo is not None:
         patch["repo"] = await repo_config_for_user(login, body.repo)
     if body.model_id is not None or body.effort is not None:
-        model, effort = _normalize_model_choice(body.model_id, body.effort)
+        model, effort = normalize_model_choice(body.model_id, body.effort)
         if model and effort:
             patch["model"] = model
             patch["effort"] = effort
@@ -594,7 +576,7 @@ async def _agent_run_config(
             "schedule_id": record["id"],
             "schedule_name": record.get("name"),
         }
-    model, effort = _normalize_model_choice(record.get("model"), record.get("effort"))
+    model, effort = normalize_model_choice(record.get("model"), record.get("effort"))
     if model and effort:
         model, effort = gate_fable_model(
             model, effort, fable_enabled=await get_team_fable_enabled()

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -54,8 +54,8 @@ from .options import (
     canonical_model_pair,
     default_vision_model_pair,
     gate_fable_model,
-    model_supports_effort,
     model_supports_images,
+    normalize_model_choice,
 )
 from .pr_diff import build_compare_diff_files, build_pr_diff_files
 from .profiles import get_profile, get_valid_access_token
@@ -167,19 +167,6 @@ class ThreadResolveBody(BaseModel):
     resolved: bool = True
 
 
-def _normalize_model_choice(
-    model_id: str | None, effort: str | None
-) -> tuple[str | None, str | None]:
-    if not isinstance(model_id, str):
-        return None, None
-    if model_id not in SUPPORTED_MODEL_IDS:
-        canonical = canonical_model_pair(model_id, effort)
-        return canonical if canonical is not None else (None, None)
-    if not isinstance(effort, str) or not model_supports_effort(model_id, effort):
-        return None, None
-    return model_id, effort
-
-
 async def _resolve_agent_model_choice(
     profile: dict[str, Any],
     model_id: str | None,
@@ -189,7 +176,7 @@ async def _resolve_agent_model_choice(
     profile_model, profile_effort = normalize_profile_overrides(profile)
     if profile_model and profile_effort:
         resolved_model, resolved_effort = profile_model, profile_effort
-    chosen_model, chosen_effort = _normalize_model_choice(model_id, effort)
+    chosen_model, chosen_effort = normalize_model_choice(model_id, effort)
     if chosen_model and chosen_effort:
         resolved_model, resolved_effort = chosen_model, chosen_effort
     resolved_model, resolved_effort = gate_fable_model(
@@ -1348,7 +1335,7 @@ async def _create_dashboard_thread_record(
         has_images=bool(images),
     )
     _user_message_content(prompt, images or [], model_id=resolved_model)
-    chosen_model, chosen_effort = _normalize_model_choice(model_id, effort)
+    chosen_model, chosen_effort = normalize_model_choice(model_id, effort)
     metadata_model = chosen_model or profile.get("default_model") or "Default"
     metadata_effort = chosen_effort or profile.get("reasoning_effort")
     if images and not model_supports_images(str(metadata_model)):
@@ -1594,7 +1581,7 @@ async def _enrich_run_start_command(
     if not isinstance(client_configurable, dict):
         client_configurable = {}
 
-    chosen_model, chosen_effort = _normalize_model_choice(
+    chosen_model, chosen_effort = normalize_model_choice(
         client_configurable.get("agent_model_id"),
         client_configurable.get("agent_effort"),
     )
@@ -1823,7 +1810,7 @@ async def send_dashboard_message(
 
     prompt = body.content.strip()
     now_ms = _now_ms()
-    chosen_model, chosen_effort = _normalize_model_choice(body.model_id, body.effort)
+    chosen_model, chosen_effort = normalize_model_choice(body.model_id, body.effort)
     handoff_metadata = dict(metadata)
     metadata_update: dict[str, Any] = {
         "source": _DASHBOARD_SOURCE,

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -14,10 +14,10 @@ from agent.dashboard.options import (
     gate_fable_model,
     model_profile_context_window,
     models_with_profile_context_windows,
+    normalize_model_choice,
     provider_fallback_pair,
 )
 from agent.dashboard.profiles import ProfileUpdate, normalize_profile_for_response
-from agent.dashboard.schedules import _normalize_model_choice as normalize_schedule_model_choice
 from agent.dashboard.team_settings import (
     TeamSettingsUpdate,
     get_team_default_model,
@@ -74,13 +74,13 @@ def test_canonical_model_pair_falls_back_to_replacement_default_effort() -> None
     assert canonical_model_pair(DEPRECATED_ANTHROPIC, None) == (SUPPORTED_ANTHROPIC, "high")
 
 
-def test_schedule_model_choice_migrates_deprecated_ids() -> None:
-    assert normalize_schedule_model_choice(DEPRECATED_OPENAI, "high") == (SUPPORTED_OPENAI, "high")
-    assert normalize_schedule_model_choice(DEPRECATED_ANTHROPIC, "max") == (
+def test_normalize_model_choice_migrates_deprecated_ids() -> None:
+    assert normalize_model_choice(DEPRECATED_OPENAI, "high") == (SUPPORTED_OPENAI, "high")
+    assert normalize_model_choice(DEPRECATED_ANTHROPIC, "max") == (
         SUPPORTED_ANTHROPIC,
         "max",
     )
-    assert normalize_schedule_model_choice("mystery:model", "high") == (None, None)
+    assert normalize_model_choice("mystery:model", "high") == (None, None)
 
 
 def test_canonical_model_pair_ignores_live_and_unknown_ids() -> None:


### PR DESCRIPTION
## Description
Centralize identical dashboard and scheduler model-choice validation in the model options source of truth. This preserves behavior while removing duplicated validation logic and 18 net lines.

## Release Note
none

## Test Plan
- [x] Verify deprecated, unknown, and supported model choices across schedule and dashboard flows

Made by [Open SWE](https://openswe.vercel.app/agents/f7d6666b-add5-52c9-9300-761c62a65666)