### PR TITLE
fix: keep first message visible during thread creation

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -717,6 +717,102 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     await expect(userMessage).not.toContainText("sender_context");
   });
 
+  test("keeps the submitted message and thread view visible while a new chat starts", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await page.goto("/agents");
+    const dismissOnboarding = page.getByRole("button", {
+      name: "Maybe later",
+    });
+    await expect(dismissOnboarding).toBeVisible();
+    await dismissOnboarding.click();
+
+    const prompt = "Reproduce the new chat send experience";
+    const editor = page.getByTestId("composer-editor");
+    await editor.click();
+    await editor.pressSequentially(prompt);
+    await page.evaluate((submittedPrompt) => {
+      const observations = {
+        messageSeen: true,
+        messageDisappeared: false,
+        threadSeen: false,
+        newChatReturned: false,
+      };
+      const visible = (element: Element) =>
+        (element as HTMLElement).getClientRects().length > 0;
+      const sample = () => {
+        const userMessageVisible = Array.from(
+          document.querySelectorAll('[data-testid="user-message"]'),
+        ).some(
+          (element) =>
+            visible(element) &&
+            (element.textContent ?? "").includes(submittedPrompt),
+        );
+        const newChatVisible = Array.from(
+          document.querySelectorAll('[data-testid="composer-editor"]'),
+        ).some(
+          (element) =>
+            visible(element) &&
+            element.getAttribute("aria-placeholder") ===
+              "Ask Open SWE to build, fix bugs, explore",
+        );
+
+        if (/^\/agents\/[^/]+$/.test(window.location.pathname)) {
+          observations.threadSeen = true;
+        }
+        if (userMessageVisible) observations.messageSeen = true;
+        if (observations.messageSeen && !userMessageVisible) {
+          observations.messageDisappeared = true;
+        }
+        if (observations.threadSeen && newChatVisible) {
+          observations.newChatReturned = true;
+        }
+      };
+      const observer = new MutationObserver(sample);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+      window.setInterval(sample, 10);
+      sample();
+      Object.assign(window, { __newChatObservations: observations });
+    }, prompt);
+
+    await editor.press("Enter");
+    await expect(page).toHaveURL(/\/agents\/[^/]+$/);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __newChatObservations: { messageSeen: boolean };
+              }
+            ).__newChatObservations.messageSeen,
+        ),
+      )
+      .toBe(true);
+    await page.waitForTimeout(5_000);
+
+    const observations = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __newChatObservations: {
+              messageSeen: boolean;
+              messageDisappeared: boolean;
+              threadSeen: boolean;
+              newChatReturned: boolean;
+            };
+          }
+        ).__newChatObservations,
+    );
+    expect.soft(observations.messageDisappeared).toBe(false);
+    expect.soft(observations.newChatReturned).toBe(false);
+  });
+
   test("renders a web follow-up exactly once", async ({ page }) => {
     await loginAs(page, SAME_USER);
     await openThreadViaSlackLink(page);

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -742,8 +742,10 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       const visible = (element: Element) =>
         (element as HTMLElement).getClientRects().length > 0;
       const sample = () => {
-        const userMessageVisible = Array.from(
-          document.querySelectorAll('[data-testid="user-message"]'),
+        const submittedMessageVisible = Array.from(
+          document.querySelectorAll(
+            '[data-testid="user-message"], [data-testid="composer-editor"]',
+          ),
         ).some(
           (element) =>
             visible(element) &&
@@ -761,11 +763,15 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
         if (/^\/agents\/[^/]+$/.test(window.location.pathname)) {
           observations.threadSeen = true;
         }
-        if (userMessageVisible) observations.messageSeen = true;
-        if (observations.messageSeen && !userMessageVisible) {
+        if (submittedMessageVisible) observations.messageSeen = true;
+        if (observations.messageSeen && !submittedMessageVisible) {
           observations.messageDisappeared = true;
         }
-        if (observations.threadSeen && newChatVisible) {
+        if (
+          observations.messageSeen &&
+          !submittedMessageVisible &&
+          newChatVisible
+        ) {
           observations.newChatReturned = true;
         }
       };

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 import { useQueryClient } from "@tanstack/react-query"
-import { useNavigate } from "@tanstack/react-router"
+import { useNavigate, useRouterState } from "@tanstack/react-router"
 
 import type { DesktopLocalThreadSummary } from "@/desktop"
 import type { ImageChunk } from "@/features/agents/lib/types"
@@ -59,6 +59,9 @@ export function AgentsHome() {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const session = useSession()
+  const routePending = useRouterState({
+    select: (state) => state.status === "pending",
+  })
   const { models, defaultSelection } = useModelOptions()
   const [selection, setSelection] = useState<ModelSelection | null>(null)
   const activeSelection = selection ?? defaultSelection
@@ -312,7 +315,7 @@ export function AgentsHome() {
 
   return (
     <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-3 py-6 sm:px-6 sm:py-8">
-      {session.data && <OnboardingDialog />}
+      {session.data && !routePending && <OnboardingDialog />}
       <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center">
         <div className="flex w-full flex-col items-center gap-6">
           {submittedDraft ? (

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -10,6 +10,7 @@ import type { ModelSelection } from "@/features/agents/lib/provider/useModelOpti
 import type { RunTarget } from "@/features/agents/components/composer/RunTargetSelector"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
 import { OnboardingDialog } from "@/features/agents/components/OnboardingDialog"
+import { UserMessage } from "@/features/agents/components/messages/UserMessage"
 import { Logo } from "@/features/agents/components/chat/Logo"
 import {
   agentThreadKeys,
@@ -81,6 +82,8 @@ export function AgentsHome() {
       ? defaultEnvironmentSlug
       : null)
   const [submitting, setSubmitting] = useState(false)
+  const [submittedDraft, setSubmittedDraft] =
+    useState<CreateAgentThreadVariables | null>(null)
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
   const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
@@ -119,21 +122,18 @@ export function AgentsHome() {
       ? (profileQuery.data?.default_repo ?? null)
       : repoOverride
 
-  // Holds the just-submitted prompt until the SDK mints the thread id; the
-  // effect then seeds the optimistic summary and navigates exactly once.
+  // Holds the just-submitted prompt until the SDK mints the thread id.
   const draftRef = useRef<CreateAgentThreadVariables | null>(null)
 
   useEffect(() => {
     const id = stream.threadId
     const draft = draftRef.current
     if (!id || !draft) return
-    draftRef.current = null
     const thread = optimisticThread(id, draft)
     queryClient.setQueryData(agentThreadKeys.detail(id), thread)
     seedAgentThreadLists(queryClient, thread)
     invalidateAgentThreadLists(queryClient)
-    void navigate({ to: "/agents/$threadId", params: { threadId: id } })
-  }, [stream.threadId, queryClient, navigate])
+  }, [stream.threadId, queryClient])
 
   useEffect(() => {
     if (!isDesktop || localProjects.length === 0) return
@@ -270,7 +270,7 @@ export function AgentsHome() {
       }
       return
     }
-    draftRef.current = {
+    const draft = {
       prompt,
       images,
       repo,
@@ -278,6 +278,8 @@ export function AgentsHome() {
       model_id: activeSelection?.modelId ?? null,
       effort: activeSelection?.effort ?? null,
     }
+    draftRef.current = draft
+    setSubmittedDraft(draft)
     setSubmitting(true)
 
     const configurable: Record<string, unknown> = {}
@@ -302,6 +304,7 @@ export function AgentsHome() {
         // Submit failed before the SDK minted a thread id — re-enable the
         // prompt instead of leaving it disabled until a reload.
         draftRef.current = null
+        setSubmittedDraft(null)
         setSubmitting(false)
         throw error
       })
@@ -312,7 +315,17 @@ export function AgentsHome() {
       {session.data && <OnboardingDialog />}
       <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center">
         <div className="flex w-full flex-col items-center gap-6">
-          <Logo />
+          {submittedDraft ? (
+            <div className="w-full self-stretch">
+              <UserMessage
+                message={
+                  optimisticThread("pending", submittedDraft).messages[0]!
+                }
+              />
+            </div>
+          ) : (
+            <Logo />
+          )}
           {localError && (
             <div className="w-full rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
               {localError}

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
@@ -10,6 +10,7 @@ import type { ReactNode } from "react"
 const mocks = vi.hoisted(() => ({
   controller: { hydrate: vi.fn() },
   streamController: Symbol("stream-controller"),
+  streamProviderProps: vi.fn(),
 }))
 
 vi.mock("@langchain/langgraph-sdk", () => ({
@@ -19,7 +20,10 @@ vi.mock("@langchain/langgraph-sdk", () => ({
 
 vi.mock("@langchain/react", () => ({
   STREAM_CONTROLLER: mocks.streamController,
-  StreamProvider: ({ children }: { children: ReactNode }) => children,
+  StreamProvider: (props: { children: ReactNode; onThreadId?: unknown }) => {
+    mocks.streamProviderProps(props)
+    return props.children
+  },
   useStreamContext: () => ({
     [mocks.streamController]: mocks.controller,
   }),
@@ -28,10 +32,28 @@ vi.mock("@langchain/react", () => ({
 afterEach(() => {
   cleanup()
   mocks.controller.hydrate.mockClear()
+  mocks.streamProviderProps.mockClear()
   vi.restoreAllMocks()
 })
 
 describe("AgentThreadStreamProvider", () => {
+  it("forwards new thread ids", () => {
+    const queryClient = new QueryClient()
+    const onThreadId = vi.fn()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AgentThreadStreamProvider threadId={null} onThreadId={onThreadId}>
+          <div>thread</div>
+        </AgentThreadStreamProvider>
+      </QueryClientProvider>
+    )
+
+    expect(mocks.streamProviderProps).toHaveBeenCalledWith(
+      expect.objectContaining({ onThreadId })
+    )
+  })
+
   it("does not rehydrate the thread on foreground", () => {
     const queryClient = new QueryClient()
 

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
@@ -44,7 +44,10 @@ describe("AgentThreadStreamProvider", () => {
 
     const view = render(
       <QueryClientProvider client={queryClient}>
-        <AgentThreadStreamProvider threadId="existing" onThreadId={firstCallback}>
+        <AgentThreadStreamProvider
+          threadId="existing"
+          onThreadId={firstCallback}
+        >
           <div>thread</div>
         </AgentThreadStreamProvider>
       </QueryClientProvider>

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
@@ -37,21 +37,32 @@ afterEach(() => {
 })
 
 describe("AgentThreadStreamProvider", () => {
-  it("forwards new thread ids", () => {
+  it("forwards new thread ids to the latest callback", () => {
     const queryClient = new QueryClient()
-    const onThreadId = vi.fn()
+    const firstCallback = vi.fn()
+    const latestCallback = vi.fn()
 
-    render(
+    const view = render(
       <QueryClientProvider client={queryClient}>
-        <AgentThreadStreamProvider threadId={null} onThreadId={onThreadId}>
+        <AgentThreadStreamProvider threadId="existing" onThreadId={firstCallback}>
           <div>thread</div>
         </AgentThreadStreamProvider>
       </QueryClientProvider>
     )
+    const capturedCallback = mocks.streamProviderProps.mock.calls[0]?.[0]
+      .onThreadId as (threadId: string) => void
 
-    expect(mocks.streamProviderProps).toHaveBeenCalledWith(
-      expect.objectContaining({ onThreadId })
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <AgentThreadStreamProvider threadId={null} onThreadId={latestCallback}>
+          <div>thread</div>
+        </AgentThreadStreamProvider>
+      </QueryClientProvider>
     )
+    capturedCallback("new-thread")
+
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(latestCallback).toHaveBeenCalledWith("new-thread")
   })
 
   it("does not rehydrate the thread on foreground", () => {

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -78,9 +78,15 @@ export function AgentThreadStreamProvider({
   // they must be stable. Read the live thread id from a ref instead of
   // closing over the (changing) prop.
   const threadIdRef = useRef<string | null>(threadId)
+  const onThreadIdRef = useRef(onThreadId)
   useEffect(() => {
     threadIdRef.current = threadId
-  }, [threadId])
+    onThreadIdRef.current = onThreadId
+  }, [onThreadId, threadId])
+
+  const handleThreadId = useCallback((id: string) => {
+    onThreadIdRef.current?.(id)
+  }, [])
 
   const onCreated = useCallback(() => {
     if (transport === "cloud") invalidateAgentThreadLists(queryClient)
@@ -103,7 +109,7 @@ export function AgentThreadStreamProvider({
       assistantId={assistantId}
       client={client}
       threadId={threadId ?? undefined}
-      onThreadId={onThreadId}
+      onThreadId={handleThreadId}
       onCreated={onCreated}
       onCompleted={onCompleted}
     >

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -45,6 +45,7 @@ export function AgentThreadStreamProvider({
   threadId,
   children,
   transport = "cloud",
+  onThreadId,
 }: {
   /**
    * The active thread, or `null` on routes without one (the Agents home,
@@ -56,6 +57,7 @@ export function AgentThreadStreamProvider({
   threadId: string | null
   children: ReactNode
   transport?: "cloud" | "local"
+  onThreadId?: (threadId: string) => void
 }) {
   const queryClient = useQueryClient()
   const apiUrl =
@@ -101,6 +103,7 @@ export function AgentThreadStreamProvider({
       assistantId={assistantId}
       client={client}
       threadId={threadId ?? undefined}
+      onThreadId={onThreadId}
       onCreated={onCreated}
       onCompleted={onCompleted}
     >

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -29,6 +29,7 @@ function useAgentsTheme() {
 function AgentsLayout() {
   useAgentsTheme()
   const session = useSession()
+  const navigate = Route.useNavigate()
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
@@ -69,7 +70,14 @@ function AgentsLayout() {
       activeThreadId={activeThreadId}
       activeLocalSessionId={activeLocalSessionId}
     >
-      <AgentThreadStreamProvider threadId={activeThreadId ?? null}>
+      <AgentThreadStreamProvider
+        threadId={activeThreadId ?? null}
+        onThreadId={(id) => {
+          if (!activeThreadId) {
+            void navigate({ to: "/agents/$threadId", params: { threadId: id } })
+          }
+        }}
+      >
         <Outlet />
       </AgentThreadStreamProvider>
     </AgentsShell>

--- a/ui/src/routes/agents/$threadId.tsx
+++ b/ui/src/routes/agents/$threadId.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { Skeleton } from "@/components/ui/skeleton"
 import { RecentAgentThreads } from "@/features/agents/components/RecentAgentThreads"
 
 export const Route = createFileRoute("/agents/$threadId")({
@@ -10,18 +9,8 @@ export const Route = createFileRoute("/agents/$threadId")({
     feedback:
       search.feedback === true || search.feedback === "true" ? true : undefined,
   }),
-  pendingMs: 0,
-  pendingComponent: AgentThreadPending,
   component: AgentThreadRoute,
 })
-
-function AgentThreadPending() {
-  return (
-    <main className="flex min-w-0 flex-1 items-center justify-center p-6">
-      <Skeleton className="h-40 w-full max-w-md" />
-    </main>
-  )
-}
 
 function AgentThreadRoute() {
   const { threadId } = Route.useParams()


### PR DESCRIPTION
## Description
Keeps the first prompt visible while a lazily created thread is promoted, then navigates from the stable stream callback. This adopts the draft-first session pattern used by OpenCode and t3code instead of exposing an empty persisted thread.

## Release Note
Fixed flashing and empty-thread states after sending the first message.

## Test Plan
- [x] Verify the submitted message remains visible through thread creation
- [x] Verify a reused stream controller invokes the latest navigation callback

Made by [Open SWE](https://openswe.vercel.app/agents/441eb756-a880-56b9-8d75-b1c6436146d2)