### PR TITLE
refactor(review): one canonical record for a finding's GitHub identity

### DIFF
--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -13,6 +13,8 @@ from typing import Any, Literal
 import httpx
 from langgraph_sdk import get_client
 
+from agent.review.findings import coerce_finding, is_surfaced
+
 from ..utils.json_types import as_json_object, thread_metadata
 
 AGENT_RUN_NAMESPACE = ["usage", "v2", "agent_runs"]
@@ -424,13 +426,8 @@ async def update_agent_pr_usage_from_webhook(payload: dict[str, Any]) -> None:
 
 
 def _finding_surfaced(finding: Mapping[str, Any]) -> bool:
-    surface = as_json_object(finding.get("surface"))
-    return bool(
-        surface.get("state") in {"surfaced", "resolve_pending", "resolved"}
-        or isinstance(finding.get("github_review_id"), int)
-        or isinstance(finding.get("github_review_comment_id"), int)
-        or finding.get("github_review_comment_ids")
-    )
+    record = coerce_finding(dict(finding))
+    return record is not None and is_surfaced(record)
 
 
 async def record_reviewer_publication(

--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -17,7 +17,12 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from fastapi import HTTPException, Response
 
-from ..review.findings import REVIEWER_THREAD_KIND
+from ..review.findings import (
+    REVIEWER_THREAD_KIND,
+    coerce_finding,
+    comment_ids_for_finding,
+    is_thread_resolved,
+)
 from ..utils.github_app import get_github_app_installation_token
 from ..utils.github_checks import github_headers
 from ..utils.json_types import ThreadLike, as_json_object, thread_metadata
@@ -115,6 +120,9 @@ def _findings_list(metadata: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _serialize_finding(finding: dict[str, Any], head_sha: str | None) -> dict[str, Any]:
+    # Records persisted by older revisions carry the legacy GitHub-identity
+    # fields; normalize before reading them through the accessors.
+    coerce_finding(finding)
     last_confirmed = finding.get("last_confirmed_sha")
     outdated = bool(
         head_sha
@@ -123,6 +131,7 @@ def _serialize_finding(finding: dict[str, Any], head_sha: str | None) -> dict[st
         and last_confirmed != head_sha
     )
     interactions = finding.get("interactions")
+    comment_ids = comment_ids_for_finding(finding)
     return {
         "id": finding.get("id"),
         "severity": finding.get("severity", "low"),
@@ -140,12 +149,8 @@ def _serialize_finding(finding: dict[str, Any], head_sha: str | None) -> dict[st
         "outdated": outdated,
         "resolution_note": finding.get("resolution_note"),
         "diff_hunk": finding.get("diff_hunk"),
-        "github_thread_resolved": bool(finding.get("github_thread_resolved")),
-        "github_review_comment_id": (
-            finding["github_review_comment_id"]
-            if isinstance(finding.get("github_review_comment_id"), int)
-            else None
-        ),
+        "github_thread_resolved": is_thread_resolved(finding),
+        "github_review_comment_id": comment_ids[0] if comment_ids else None,
         "interactions": interactions if isinstance(interactions, list) else [],
     }
 

--- a/agent/review/findings.py
+++ b/agent/review/findings.py
@@ -16,7 +16,7 @@ import json
 import logging
 import uuid
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, Literal, TypedDict, cast
 
 from langgraph.config import get_config
@@ -82,7 +82,7 @@ Severity = Literal["low", "medium", "high", "critical"]
 Confidence = Literal["low", "medium", "high"]
 FindingStatus = Literal["open", "resolved", "dismissed"]
 DiffSide = Literal["LEFT", "RIGHT"]
-SurfaceState = Literal["not_surfaced", "surfaced", "resolve_pending", "resolved", "error"]
+SurfaceState = Literal["not_surfaced", "surfaced", "resolve_pending", "resolved"]
 InteractionKind = Literal["human_reply", "bot_reply"]
 
 SEVERITY_ORDER: dict[Severity, int] = {
@@ -90,6 +90,15 @@ SEVERITY_ORDER: dict[Severity, int] = {
     "medium": 1,
     "high": 2,
     "critical": 3,
+}
+
+# Surface states only ever move forward, so normalization of a legacy record can
+# reconcile contradictory leftovers by taking the furthest-along state.
+SURFACE_STATE_ORDER: dict[SurfaceState, int] = {
+    "not_surfaced": 0,
+    "surfaced": 1,
+    "resolve_pending": 2,
+    "resolved": 3,
 }
 
 # Confidence is recorded on every finding for post-hoc calibration analysis
@@ -100,8 +109,11 @@ SEVERITY_ORDER: dict[Severity, int] = {
 class Finding(TypedDict):
     """A single review finding.
 
-    Core fields are required for newly-created findings. Legacy and
-    publication-only fields remain optional while old thread metadata ages out.
+    Where a finding surfaced on GitHub is recorded exactly once, by the
+    ``github_*_ids`` lists plus ``surface_state``. Records persisted by older
+    revisions carry flat singulars and a nested ``surface`` record instead;
+    :func:`coerce_finding` folds those into the canonical fields on read, so
+    nothing outside this module ever sees the legacy shape.
     """
 
     id: str
@@ -120,14 +132,12 @@ class Finding(TypedDict):
     first_seen_sha: str
     last_confirmed_sha: str
     github_review_id: int | None
-    github_review_comment_id: int | None
-    github_review_comment_ids: list[int]
-    github_review_thread_id: str | None
-    github_review_thread_ids: list[str]
     github_review_run_id: str | None
-    github_thread_resolved: bool
+    github_review_comment_ids: list[int]
+    github_review_thread_ids: list[str]
     github_resolved_thread_ids: list[str]
     github_posted_resolution_comment_ids: list[int]
+    surface_state: SurfaceState
     last_human_reply_at: str | None
     last_human_reply_author: str | None
     last_human_reply_body: str | None
@@ -135,33 +145,12 @@ class Finding(TypedDict):
     resolution_note: str | None
     diff_hunk: str | None
     fingerprint: str
-    anchor: "FindingAnchor | None"
-    surface: "FindingSurface | None"
     interactions: "list[FindingInteraction]"
 
 
 class AppendFindingResult(TypedDict):
     finding: Finding
     created: bool
-
-
-class FindingAnchor(TypedDict):
-    file: str
-    start_line: int | None
-    end_line: int | None
-    side: DiffSide
-
-
-class FindingSurface(TypedDict, total=False):
-    finding_id: str
-    state: SurfaceState
-    github_review_id: int | None
-    github_review_comment_id: int | None
-    github_review_thread_id: str | None
-    severity_threshold_at_publish: Severity | None
-    surfaced_at_sha: str | None
-    last_github_sync_at: str | None
-    last_error: str | None
 
 
 class FindingInteraction(TypedDict, total=False):
@@ -224,23 +213,6 @@ def new_finding(
 ) -> Finding:
     """Construct a fully-populated ``Finding`` ready to persist."""
     resolved_id = finding_id or new_finding_id()
-    anchor: FindingAnchor = {
-        "file": file,
-        "start_line": start_line,
-        "end_line": end_line,
-        "side": side,
-    }
-    surface: FindingSurface = {
-        "finding_id": resolved_id,
-        "state": "not_surfaced",
-        "github_review_id": None,
-        "github_review_comment_id": None,
-        "github_review_thread_id": None,
-        "severity_threshold_at_publish": None,
-        "surfaced_at_sha": None,
-        "last_github_sync_at": None,
-        "last_error": None,
-    }
     finding: Finding = {
         "id": resolved_id,
         "severity": severity,
@@ -258,14 +230,12 @@ def new_finding(
         "first_seen_sha": sha,
         "last_confirmed_sha": sha,
         "github_review_id": None,
-        "github_review_comment_id": None,
-        "github_review_comment_ids": [],
-        "github_review_thread_id": None,
-        "github_review_thread_ids": [],
         "github_review_run_id": None,
-        "github_thread_resolved": False,
+        "github_review_comment_ids": [],
+        "github_review_thread_ids": [],
         "github_resolved_thread_ids": [],
         "github_posted_resolution_comment_ids": [],
+        "surface_state": "not_surfaced",
         "last_human_reply_at": None,
         "last_human_reply_author": None,
         "last_human_reply_body": None,
@@ -273,8 +243,6 @@ def new_finding(
         "resolution_note": None,
         "diff_hunk": diff_hunk,
         "fingerprint": _finding_fingerprint(file, side, start_line, end_line, description),
-        "anchor": anchor,
-        "surface": surface,
         "interactions": [],
     }
     return finding
@@ -299,20 +267,154 @@ def _finding_fingerprint(
     return f"v{FINDING_FINGERPRINT_VERSION}:{hashlib.sha256(encoded).hexdigest()}"
 
 
-def _coerce_finding(value: Any) -> Finding | None:
+def _int_list(value: Any) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, int) and not isinstance(item, bool)]
+
+
+def _str_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+# Read accessors take a plain mapping so callers holding a raw persisted record
+# (dashboard serializers, usage rollups) can use them without a cast.
+FindingLike = Mapping[str, Any]
+
+
+def comment_ids_for_finding(finding: FindingLike) -> list[int]:
+    """GitHub review comment ids this finding was posted as, oldest first."""
+    return _int_list(finding.get("github_review_comment_ids"))
+
+
+def thread_ids_for_finding(finding: FindingLike) -> list[str]:
+    """GitHub review thread node ids this finding lives in, oldest first."""
+    return _str_list(finding.get("github_review_thread_ids"))
+
+
+def resolved_thread_ids_for_finding(finding: FindingLike) -> list[str]:
+    return _str_list(finding.get("github_resolved_thread_ids"))
+
+
+def posted_resolution_comment_ids_for_finding(finding: FindingLike) -> list[int]:
+    return _int_list(finding.get("github_posted_resolution_comment_ids"))
+
+
+def review_id_for_finding(finding: FindingLike) -> int | None:
+    review_id = finding.get("github_review_id")
+    return review_id if isinstance(review_id, int) and not isinstance(review_id, bool) else None
+
+
+def surface_state_of(finding: FindingLike) -> SurfaceState:
+    state = finding.get("surface_state")
+    return state if state in SURFACE_STATE_ORDER else "not_surfaced"
+
+
+def is_surfaced(finding: FindingLike) -> bool:
+    """True once this finding has been posted to the PR."""
+    return surface_state_of(finding) != "not_surfaced"
+
+
+def is_thread_resolved(finding: FindingLike) -> bool:
+    """True once every GitHub review thread for this finding is resolved."""
+    return surface_state_of(finding) == "resolved"
+
+
+def mark_surfaced(finding: Finding) -> bool:
+    """Record that the finding is now on GitHub. Returns True when it changed."""
+    if is_surfaced(finding):
+        return False
+    finding["surface_state"] = "surfaced"
+    return True
+
+
+def set_surface_state(finding: Finding, state: SurfaceState) -> bool:
+    """Set the surface state outright. Returns True when it changed."""
+    if surface_state_of(finding) == state:
+        return False
+    finding["surface_state"] = state
+    return True
+
+
+def _legacy_surface_state(record: dict[str, Any], surface: dict[str, Any]) -> SurfaceState:
+    if record.get("github_thread_resolved") is True:
+        return "resolved"
+    if (
+        _int_list(record.get("github_review_comment_ids"))
+        or _str_list(record.get("github_review_thread_ids"))
+        or isinstance(record.get("github_review_id"), int)
+        or isinstance(surface.get("github_review_comment_id"), int)
+        or isinstance(surface.get("github_review_thread_id"), str)
+    ):
+        return "surfaced"
+    return "not_surfaced"
+
+
+def _normalize_publication_identity(record: dict[str, Any]) -> None:
+    """Fold legacy GitHub-identity fields into the canonical ones, in place.
+
+    Records written before the identity fields were unified carry flat
+    singulars (``github_review_comment_id``, …), a ``github_thread_resolved``
+    flag and a nested ``surface`` record. Every read passes through here, so
+    the rest of the codebase — and every subsequent write — only ever deals
+    with the lists plus ``surface_state``.
+    """
+    surface = record.pop("surface", None)
+    surface = surface if isinstance(surface, dict) else {}
+    record.pop("anchor", None)
+
+    comment_ids = _int_list(record.get("github_review_comment_ids"))
+    for legacy_comment_id in (
+        record.pop("github_review_comment_id", None),
+        surface.get("github_review_comment_id"),
+    ):
+        if isinstance(legacy_comment_id, int) and legacy_comment_id not in comment_ids:
+            comment_ids.insert(0, legacy_comment_id)
+    record["github_review_comment_ids"] = comment_ids
+
+    thread_ids = _str_list(record.get("github_review_thread_ids"))
+    for legacy_thread_id in (
+        record.pop("github_review_thread_id", None),
+        surface.get("github_review_thread_id"),
+    ):
+        if isinstance(legacy_thread_id, str) and legacy_thread_id not in ("", *thread_ids):
+            thread_ids.insert(0, legacy_thread_id)
+    record["github_review_thread_ids"] = thread_ids
+
+    if not isinstance(record.get("github_review_id"), int):
+        legacy_review_id = surface.get("github_review_id")
+        record["github_review_id"] = legacy_review_id if isinstance(legacy_review_id, int) else None
+
+    states: list[SurfaceState] = [_legacy_surface_state(record, surface)]
+    for candidate in (record.get("surface_state"), surface.get("state")):
+        if candidate in SURFACE_STATE_ORDER:
+            states.append(cast(SurfaceState, candidate))
+    record.pop("github_thread_resolved", None)
+    record["surface_state"] = max(states, key=lambda state: SURFACE_STATE_ORDER[state])
+
+
+def coerce_finding(value: Any) -> Finding | None:
+    """Normalize one persisted record into a canonical ``Finding``.
+
+    Returns ``None`` when the value isn't a finding record at all.
+    """
     if not isinstance(value, dict):
         return None
-    if "id" not in value or not isinstance(value["id"], str):
+    if not isinstance(value.get("id"), str):
         return None
+    _normalize_publication_identity(value)
     return cast(Finding, value)
 
 
-def _coerce_findings_list(value: Any) -> list[Finding]:
+def coerce_findings(value: Any) -> list[Finding]:
+    """Normalize a persisted findings blob into canonical ``Finding`` records."""
     if not isinstance(value, list):
         return []
     out: list[Finding] = []
     for entry in value:
-        finding = _coerce_finding(entry)
+        finding = coerce_finding(entry)
         if finding is not None:
             out.append(finding)
     return out
@@ -377,7 +479,7 @@ async def resolve_review_head_sha(thread_id: str, configurable: dict[str, Any]) 
 async def list_findings(thread_id: str) -> list[Finding]:
     """Return all findings persisted on the reviewer thread."""
     metadata = await get_thread_metadata(thread_id)
-    return _coerce_findings_list(metadata.get("findings"))
+    return coerce_findings(metadata.get("findings"))
 
 
 async def get_finding(thread_id: str, finding_id: str) -> Finding | None:
@@ -393,7 +495,7 @@ async def replace_findings(thread_id: str, findings: list[Finding]) -> None:
     """Merge a findings snapshot without dropping concurrently-added records."""
     async with _finding_mutation_lock(thread_id):
         metadata = await _get_thread_metadata_strict(thread_id)
-        latest = _coerce_findings_list(metadata.get("findings"))
+        latest = coerce_findings(metadata.get("findings"))
         incoming_by_id = {finding["id"]: finding for finding in findings}
         merged = [incoming_by_id.pop(finding["id"], finding) for finding in latest]
         merged.extend(incoming_by_id.values())
@@ -448,7 +550,7 @@ async def mutate_findings(
     """
     async with _finding_mutation_lock(thread_id):
         metadata = await _get_thread_metadata_strict(thread_id)
-        findings = _coerce_findings_list(metadata.get("findings"))
+        findings = coerce_findings(metadata.get("findings"))
         if mutator(findings):
             await _replace_findings_unlocked(thread_id, findings)
         return findings
@@ -514,30 +616,6 @@ async def update_finding_fields(
     return captured.get("finding")
 
 
-async def update_finding_surface(
-    thread_id: str,
-    finding_id: str,
-    updates: dict[str, Any],
-) -> Finding | None:
-    """Apply updates to the nested surface record and legacy GitHub fields."""
-    captured: dict[str, Finding] = {}
-
-    def _apply(findings: list[Finding]) -> bool:
-        for finding in findings:
-            if finding.get("id") != finding_id:
-                continue
-            surface = _coerce_surface(finding, finding_id)
-            surface.update(cast(FindingSurface, updates))
-            finding["surface"] = surface
-            _sync_legacy_surface_fields(finding, surface)
-            captured["finding"] = finding
-            return True
-        return False
-
-    await mutate_findings(thread_id, _apply)
-    return captured.get("finding")
-
-
 async def append_finding_interaction(
     thread_id: str,
     finding_id: str,
@@ -567,51 +645,6 @@ async def append_finding_interaction(
 
     await mutate_findings(thread_id, _apply)
     return captured.get("finding")
-
-
-def _coerce_surface(finding: Finding, finding_id: str) -> FindingSurface:
-    surface = finding.get("surface")
-    coerced: FindingSurface
-    if isinstance(surface, dict):
-        coerced = cast(FindingSurface, dict(surface))
-    else:
-        coerced = {"finding_id": finding_id}
-    if not coerced.get("state"):
-        if finding.get("github_thread_resolved"):
-            coerced["state"] = "resolved"
-        elif isinstance(finding.get("github_review_comment_id"), int):
-            coerced["state"] = "surfaced"
-        else:
-            coerced["state"] = "not_surfaced"
-    if "github_review_id" not in coerced:
-        coerced["github_review_id"] = finding.get("github_review_id")
-    if "github_review_comment_id" not in coerced:
-        coerced["github_review_comment_id"] = finding.get("github_review_comment_id")
-    if "github_review_thread_id" not in coerced:
-        coerced["github_review_thread_id"] = finding.get("github_review_thread_id")
-    if "severity_threshold_at_publish" not in coerced:
-        coerced["severity_threshold_at_publish"] = None
-    if "surfaced_at_sha" not in coerced:
-        coerced["surfaced_at_sha"] = None
-    if "last_github_sync_at" not in coerced:
-        coerced["last_github_sync_at"] = None
-    if "last_error" not in coerced:
-        coerced["last_error"] = None
-    return coerced
-
-
-def _sync_legacy_surface_fields(finding: Finding, surface: FindingSurface) -> None:
-    review_id = surface.get("github_review_id")
-    if isinstance(review_id, int) or review_id is None:
-        finding["github_review_id"] = review_id
-    comment_id = surface.get("github_review_comment_id")
-    if isinstance(comment_id, int) or comment_id is None:
-        finding["github_review_comment_id"] = comment_id
-    thread_id = surface.get("github_review_thread_id")
-    if isinstance(thread_id, str) or thread_id is None:
-        finding["github_review_thread_id"] = thread_id
-    if surface.get("state") == "resolved":
-        finding["github_thread_resolved"] = True
 
 
 async def set_reviewer_thread_metadata(

--- a/agent/review/reconcile.py
+++ b/agent/review/reconcile.py
@@ -3,9 +3,13 @@ from typing import Any
 from .findings import (
     Finding,
     FindingInteraction,
-    _coerce_surface,
+    comment_ids_for_finding,
     list_findings,
+    mark_surfaced,
     replace_findings,
+    resolved_thread_ids_for_finding,
+    set_surface_state,
+    thread_ids_for_finding,
 )
 from .publish import parse_review_comment_marker
 
@@ -15,18 +19,6 @@ ReviewThreadMatch = tuple[ReviewThread, int | None]
 
 def _is_open_swe_bot_comment(comment: ReviewThread) -> bool:
     return comment.get("author") in {"open-swe", "open-swe[bot]"}
-
-
-def _int_list(value: Any) -> list[int]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, int)]
-
-
-def _str_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str) and item]
 
 
 def _human_replies_after_bot_comment(
@@ -98,18 +90,17 @@ def _find_review_threads_for_finding(
         if marker_match:
             return marker_match
 
-    github_thread_id = finding.get("github_review_thread_id")
-    if isinstance(github_thread_id, str) and github_thread_id:
-        review_thread = by_thread_id.get(github_thread_id)
+    thread_ids = thread_ids_for_finding(finding)
+    comment_ids = comment_ids_for_finding(finding)
+    if thread_ids:
+        review_thread = by_thread_id.get(thread_ids[0])
         if review_thread is not None:
-            comment_id = finding.get("github_review_comment_id")
-            return [(review_thread, comment_id if isinstance(comment_id, int) else None)]
+            return [(review_thread, comment_ids[0] if comment_ids else None)]
 
-    github_comment_id = finding.get("github_review_comment_id")
-    if isinstance(github_comment_id, int):
-        review_thread = by_comment_id.get(github_comment_id)
+    if comment_ids:
+        review_thread = by_comment_id.get(comment_ids[0])
         if review_thread is not None:
-            return [(review_thread, github_comment_id)]
+            return [(review_thread, comment_ids[0])]
     return []
 
 
@@ -119,37 +110,19 @@ def _sync_publication_identity(
     comment_id: int | None,
 ) -> bool:
     updated = False
-    if isinstance(comment_id, int) and not isinstance(finding.get("github_review_comment_id"), int):
-        finding["github_review_comment_id"] = comment_id
-        updated = True
-    comment_ids = _int_list(finding.get("github_review_comment_ids"))
+    comment_ids = comment_ids_for_finding(finding)
     if isinstance(comment_id, int) and comment_id not in comment_ids:
         comment_ids.append(comment_id)
         finding["github_review_comment_ids"] = comment_ids
         updated = True
 
-    github_thread_id = finding.get("github_review_thread_id")
     new_thread_id = review_thread.get("id")
-    if not isinstance(github_thread_id, str) or not github_thread_id:
-        if isinstance(new_thread_id, str) and new_thread_id:
-            finding["github_review_thread_id"] = new_thread_id
-            updated = True
-    thread_ids = _str_list(finding.get("github_review_thread_ids"))
+    thread_ids = thread_ids_for_finding(finding)
     if isinstance(new_thread_id, str) and new_thread_id and new_thread_id not in thread_ids:
         thread_ids.append(new_thread_id)
         finding["github_review_thread_ids"] = thread_ids
         updated = True
-    if isinstance(finding.get("id"), str):
-        surface = _coerce_surface(finding, str(finding["id"]))
-        if isinstance(comment_id, int):
-            surface["github_review_comment_id"] = comment_id
-        if isinstance(new_thread_id, str) and new_thread_id:
-            surface["github_review_thread_id"] = new_thread_id
-        if surface.get("state") in {None, "not_surfaced"}:
-            surface["state"] = "surfaced"
-        finding["surface"] = surface
-        updated = True
-    return updated
+    return mark_surfaced(finding) or updated
 
 
 def _is_terminal_thread(review_thread: ReviewThread) -> bool:
@@ -161,34 +134,25 @@ def _sync_thread_status(finding: Finding, matches: list[ReviewThreadMatch]) -> b
         return False
 
     updated = False
-    resolved_thread_ids = _str_list(finding.get("github_resolved_thread_ids"))
+    resolved_thread_ids = resolved_thread_ids_for_finding(finding)
     all_resolved = True
     for review_thread, _comment_id in matches:
         thread_id = review_thread.get("id")
         if review_thread.get("is_resolved") and isinstance(thread_id, str) and thread_id:
             if thread_id not in resolved_thread_ids:
                 resolved_thread_ids.append(thread_id)
+                finding["github_resolved_thread_ids"] = resolved_thread_ids
                 updated = True
         else:
             all_resolved = False
 
-    if resolved_thread_ids != _str_list(finding.get("github_resolved_thread_ids")):
-        finding["github_resolved_thread_ids"] = resolved_thread_ids
     if not all_resolved:
         return updated
 
     if finding.get("status") == "open":
         finding["status"] = "resolved"
         updated = True
-    if not finding.get("github_thread_resolved"):
-        finding["github_thread_resolved"] = True
-        updated = True
-    if isinstance(finding.get("id"), str):
-        surface = _coerce_surface(finding, str(finding["id"]))
-        surface["state"] = "resolved"
-        finding["surface"] = surface
-        updated = True
-    return updated
+    return set_surface_state(finding, "resolved") or updated
 
 
 def _sync_latest_human_reply(
@@ -197,11 +161,13 @@ def _sync_latest_human_reply(
     *,
     comment_id: int | None,
 ) -> bool:
-    github_comment_id = (
-        comment_id if isinstance(comment_id, int) else finding.get("github_review_comment_id")
-    )
-    if not isinstance(github_comment_id, int):
-        return False
+    if isinstance(comment_id, int):
+        github_comment_id = comment_id
+    else:
+        recorded = comment_ids_for_finding(finding)
+        if not recorded:
+            return False
+        github_comment_id = recorded[0]
 
     replies = _human_replies_after_bot_comment(review_thread, bot_comment_id=github_comment_id)
     if not replies:

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -17,15 +17,21 @@ from ..review.findings import (
     Finding,
     ReviewerThreadMissingError,
     Severity,
-    _coerce_surface,
+    comment_ids_for_finding,
     filter_findings_for_publish,
     get_thread_id_from_runtime,
     get_thread_last_reviewed_sha,
     get_thread_metadata,
     get_thread_slack_ref,
+    mark_surfaced,
+    posted_resolution_comment_ids_for_finding,
     replace_findings,
     resolve_review_head_sha,
+    resolved_thread_ids_for_finding,
+    review_id_for_finding,
     set_reviewer_thread_metadata,
+    set_surface_state,
+    thread_ids_for_finding,
     thread_missing_tool_result,
 )
 from ..review.findings import (
@@ -283,13 +289,11 @@ async def _publish_review_async(
         token=token,
     )
 
-    # Re-reviews only post NEW findings. Anything with a github_review_comment_id
-    # already lives on GitHub from a prior publish — reposting would create
+    # Re-reviews only post NEW findings. Anything with a recorded review comment
+    # id already lives on GitHub from a prior publish — reposting would create
     # duplicate inline comments and break the resolve-on-fix flow (only
     # whichever duplicate id we'd cache last would resolve later).
-    unpublished_findings = [
-        f for f in findings if not isinstance(f.get("github_review_comment_id"), int)
-    ]
+    unpublished_findings = [f for f in findings if not comment_ids_for_finding(f)]
     if is_re_review:
         unpublished_findings = [
             f for f in unpublished_findings if f.get("first_seen_sha") == head_sha
@@ -612,37 +616,7 @@ async def _open_swe_already_reviewed(
 
 
 def _has_publication_identity(finding: Finding) -> bool:
-    return isinstance(finding.get("github_review_comment_id"), int) or isinstance(
-        finding.get("github_review_id"), int
-    )
-
-
-def _int_list(value: Any) -> list[int]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, int)]
-
-
-def _str_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str) and item]
-
-
-def _comment_ids_for_finding(finding: Finding) -> list[int]:
-    comment_ids = _int_list(finding.get("github_review_comment_ids"))
-    comment_id = finding.get("github_review_comment_id")
-    if isinstance(comment_id, int) and comment_id not in comment_ids:
-        comment_ids.insert(0, comment_id)
-    return comment_ids
-
-
-def _thread_ids_for_finding(finding: Finding) -> list[str]:
-    thread_ids = _str_list(finding.get("github_review_thread_ids"))
-    thread_id = finding.get("github_review_thread_id")
-    if isinstance(thread_id, str) and thread_id and thread_id not in thread_ids:
-        thread_ids.insert(0, thread_id)
-    return thread_ids
+    return bool(comment_ids_for_finding(finding)) or review_id_for_finding(finding) is not None
 
 
 async def _backfill_findings_from_pr_threads(
@@ -677,9 +651,7 @@ def _missing_comment_ids_for_published_findings(
         if isinstance(finding.get("id"), str)
     }
     for finding in findings:
-        if finding.get("id") in finding_ids and not isinstance(
-            finding.get("github_review_comment_id"), int
-        ):
+        if finding.get("id") in finding_ids and not comment_ids_for_finding(finding):
             return True
     return False
 
@@ -692,12 +664,9 @@ def _apply_review_id(
 ) -> bool:
     updated = False
     for finding in findings:
-        if finding.get("id") in finding_ids and finding.get("github_review_id") != review_id:
+        if finding.get("id") in finding_ids and review_id_for_finding(finding) != review_id:
             finding["github_review_id"] = review_id
-            if isinstance(finding.get("id"), str):
-                surface = _coerce_surface(finding, str(finding["id"]))
-                surface["github_review_id"] = review_id
-                finding["surface"] = surface
+            mark_surfaced(finding)
             updated = True
     return updated
 
@@ -716,19 +685,11 @@ def _apply_comment_ids(
         comment_id = comment_id_by_finding_id.get(finding_id)
         if comment_id is None:
             continue
-        finding["github_review_comment_id"] = comment_id
-        comment_ids = _int_list(finding.get("github_review_comment_ids"))
+        comment_ids = comment_ids_for_finding(finding)
         if comment_id not in comment_ids:
             comment_ids.append(comment_id)
             finding["github_review_comment_ids"] = comment_ids
-        surface = _coerce_surface(finding, finding_id)
-        surface["state"] = "surfaced"
-        surface["github_review_comment_id"] = comment_id
-        surface["severity_threshold_at_publish"] = finding.get("severity")
-        surface["surfaced_at_sha"] = finding.get("last_confirmed_sha") or finding.get(
-            "first_seen_sha"
-        )
-        finding["surface"] = surface
+        mark_surfaced(finding)
         if langgraph_run_id:
             finding["github_review_run_id"] = langgraph_run_id
         updated = True
@@ -938,8 +899,8 @@ async def _store_thread_ids_on_findings(
     comment_ids_by_finding_id: dict[str, list[int]] = {}
     for finding in findings:
         finding_id = finding.get("id")
-        comment_ids = _comment_ids_for_finding(finding)
-        if isinstance(finding_id, str) and comment_ids and not _thread_ids_for_finding(finding):
+        comment_ids = comment_ids_for_finding(finding)
+        if isinstance(finding_id, str) and comment_ids and not thread_ids_for_finding(finding):
             comment_ids_by_finding_id[finding_id] = comment_ids
     if not comment_ids_by_finding_id:
         return
@@ -967,22 +928,14 @@ async def _store_thread_ids_on_findings(
         finding_id = finding.get("id")
         if not isinstance(finding_id, str):
             continue
-        thread_ids = _thread_ids_for_finding(finding)
+        thread_ids = thread_ids_for_finding(finding)
         for comment_id in comment_ids_by_finding_id.get(finding_id, []):
             github_thread_id = thread_id_by_comment_id.get(comment_id)
-            if not github_thread_id:
+            if not github_thread_id or github_thread_id in thread_ids:
                 continue
-            if not isinstance(finding.get("github_review_thread_id"), str):
-                finding["github_review_thread_id"] = github_thread_id
-                updated = True
-            if github_thread_id not in thread_ids:
-                thread_ids.append(github_thread_id)
-                finding["github_review_thread_ids"] = thread_ids
-                updated = True
-            surface = _coerce_surface(finding, finding_id)
-            surface["state"] = "surfaced"
-            surface["github_review_thread_id"] = github_thread_id
-            finding["surface"] = surface
+            thread_ids.append(github_thread_id)
+            finding["github_review_thread_ids"] = thread_ids
+            mark_surfaced(finding)
             updated = True
 
     if updated:
@@ -1010,8 +963,8 @@ async def _resolve_threads_for_resolved_findings(
         if status not in {"resolved", "dismissed"}:
             continue
 
-        thread_node_ids = _thread_ids_for_finding(finding)
-        comment_ids = _comment_ids_for_finding(finding)
+        thread_node_ids = thread_ids_for_finding(finding)
+        comment_ids = comment_ids_for_finding(finding)
 
         for comment_id in comment_ids:
             thread_node_id = await fetch_review_thread_id_for_comment(
@@ -1027,10 +980,8 @@ async def _resolve_threads_for_resolved_findings(
         if not thread_node_ids:
             continue
 
-        resolved_thread_ids = _str_list(finding.get("github_resolved_thread_ids"))
-        posted_resolution_comment_ids = _int_list(
-            finding.get("github_posted_resolution_comment_ids")
-        )
+        resolved_thread_ids = resolved_thread_ids_for_finding(finding)
+        posted_resolution_comment_ids = posted_resolution_comment_ids_for_finding(finding)
 
         for idx, thread_node_id in enumerate(thread_node_ids):
             if thread_node_id in resolved_thread_ids:
@@ -1065,20 +1016,11 @@ async def _resolve_threads_for_resolved_findings(
             finding["github_resolved_thread_ids"] = resolved_thread_ids
         if posted_resolution_comment_ids:
             finding["github_posted_resolution_comment_ids"] = posted_resolution_comment_ids
-        if thread_node_ids:
-            finding["github_review_thread_ids"] = thread_node_ids
-            if not isinstance(finding.get("github_review_thread_id"), str):
-                finding["github_review_thread_id"] = thread_node_ids[0]
-        if thread_node_ids and all(
-            thread_id in resolved_thread_ids for thread_id in thread_node_ids
-        ):
-            finding["github_thread_resolved"] = True
-            if isinstance(finding.get("id"), str):
-                surface = _coerce_surface(finding, str(finding["id"]))
-                surface["state"] = "resolved"
-                if thread_node_ids:
-                    surface["github_review_thread_id"] = thread_node_ids[0]
-                finding["surface"] = surface
+        finding["github_review_thread_ids"] = thread_node_ids
+        if all(thread_id in resolved_thread_ids for thread_id in thread_node_ids):
+            set_surface_state(finding, "resolved")
+        else:
+            mark_surfaced(finding)
 
     if mutated:
         thread_id = get_thread_id_from_runtime()

--- a/agent/tools/reply_to_finding_thread.py
+++ b/agent/tools/reply_to_finding_thread.py
@@ -6,6 +6,7 @@ from ..review.findings import (
     FindingInteraction,
     ReviewerThreadMissingError,
     append_finding_interaction,
+    comment_ids_for_finding,
     get_finding,
     get_thread_id_from_runtime,
     thread_missing_tool_result,
@@ -63,9 +64,10 @@ async def _reply_to_finding_thread_async(
     if finding is None:
         return {"success": False, "error": f"No finding found with id {finding_id}"}
 
-    comment_id = finding.get("github_review_comment_id")
-    if not isinstance(comment_id, int):
+    comment_ids = comment_ids_for_finding(finding)
+    if not comment_ids:
         return {"success": False, "error": "Finding has no GitHub review comment mapping"}
+    comment_id = comment_ids[0]
 
     response = await reply_to_review_comment(
         owner=owner,

--- a/agent/tools/resolve_finding_thread.py
+++ b/agent/tools/resolve_finding_thread.py
@@ -5,11 +5,14 @@ from langgraph.config import get_config
 from ..review.findings import (
     Finding,
     ReviewerThreadMissingError,
+    comment_ids_for_finding,
     get_finding,
     get_thread_id_from_runtime,
+    posted_resolution_comment_ids_for_finding,
+    resolved_thread_ids_for_finding,
+    thread_ids_for_finding,
     thread_missing_tool_result,
     update_finding_fields,
-    update_finding_surface,
 )
 from ..review.publish import (
     fetch_pr_review_threads,
@@ -111,8 +114,8 @@ async def _resolve_finding_thread_async(
     if finding is None:
         return {"success": False, "error": f"No finding found with id {finding_id}"}
 
-    github_thread_ids = _thread_ids_for_finding(finding)
-    for comment_id in _comment_ids_for_finding(finding):
+    github_thread_ids = thread_ids_for_finding(finding)
+    for comment_id in comment_ids_for_finding(finding):
         thread_node_id = await fetch_review_thread_id_for_comment(
             owner=owner,
             repo=repo,
@@ -125,9 +128,9 @@ async def _resolve_finding_thread_async(
     if not github_thread_ids:
         return {"success": False, "error": "Could not resolve GitHub review thread id"}
 
-    resolved_thread_ids = _str_list(finding.get("github_resolved_thread_ids"))
-    posted_resolution_comment_ids = _int_list(finding.get("github_posted_resolution_comment_ids"))
-    comment_ids = _comment_ids_for_finding(finding)
+    resolved_thread_ids = resolved_thread_ids_for_finding(finding)
+    posted_resolution_comment_ids = posted_resolution_comment_ids_for_finding(finding)
+    comment_ids = comment_ids_for_finding(finding)
     resolution_body = render_resolution_comment(finding, status, note=note)
     if resolution_body is None:
         return {"success": False, "error": "Missing resolution note"}
@@ -157,29 +160,20 @@ async def _resolve_finding_thread_async(
     ):
         return {"success": False, "error": "GitHub did not resolve the review thread"}
 
+    fully_resolved = all(
+        github_thread_id in resolved_thread_ids for github_thread_id in github_thread_ids
+    )
     updates: dict[str, Any] = {
         "status": status,
-        "github_review_thread_id": github_thread_ids[0],
         "github_review_thread_ids": github_thread_ids,
         "github_resolved_thread_ids": resolved_thread_ids,
-        "github_thread_resolved": all(
-            github_thread_id in resolved_thread_ids for github_thread_id in github_thread_ids
-        ),
+        "surface_state": "resolved" if fully_resolved else "resolve_pending",
+        "last_reconciliation_note": note,
+        "resolution_note": note,
     }
-    updates["last_reconciliation_note"] = note
-    updates["resolution_note"] = note
     if posted_resolution_comment_ids:
         updates["github_posted_resolution_comment_ids"] = posted_resolution_comment_ids
     updated = await update_finding_fields(thread_id, finding_id, updates)
-    surface_updates: dict[str, Any] = {
-        "state": "resolved" if updates["github_thread_resolved"] else "resolve_pending",
-        "github_review_thread_id": github_thread_ids[0],
-        "last_error": None
-        if updates["github_thread_resolved"]
-        else "Not all GitHub threads resolved",
-    }
-    await update_finding_surface(thread_id, finding_id, surface_updates)
-    updated = await get_finding(thread_id, finding_id)
     return {"success": True, "finding": updated, "resolved_thread_count": resolved_count}
 
 
@@ -195,7 +189,7 @@ async def _get_finding_with_pr_backfill(
     finding = await get_finding(thread_id, finding_id)
     if finding is None:
         return None
-    if _thread_ids_for_finding(finding) or _comment_ids_for_finding(finding):
+    if thread_ids_for_finding(finding) or comment_ids_for_finding(finding):
         return finding
 
     review_threads = await fetch_pr_review_threads(
@@ -208,31 +202,3 @@ async def _get_finding_with_pr_backfill(
         await reconcile_findings_with_review_threads(thread_id, review_threads)
         finding = await get_finding(thread_id, finding_id)
     return finding
-
-
-def _int_list(value: Any) -> list[int]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, int)]
-
-
-def _str_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str) and item]
-
-
-def _comment_ids_for_finding(finding: Finding) -> list[int]:
-    comment_ids = _int_list(finding.get("github_review_comment_ids"))
-    comment_id = finding.get("github_review_comment_id")
-    if isinstance(comment_id, int) and comment_id not in comment_ids:
-        comment_ids.insert(0, comment_id)
-    return comment_ids
-
-
-def _thread_ids_for_finding(finding: Finding) -> list[str]:
-    thread_ids = _str_list(finding.get("github_review_thread_ids"))
-    thread_id = finding.get("github_review_thread_id")
-    if isinstance(thread_id, str) and thread_id and thread_id not in thread_ids:
-        thread_ids.insert(0, thread_id)
-    return thread_ids

--- a/agent/tools/update_finding.py
+++ b/agent/tools/update_finding.py
@@ -10,18 +10,16 @@ from ..review.findings import (
     Finding,
     ReviewerThreadMissingError,
     clip_suggestion,
+    comment_ids_for_finding,
     get_thread_id_from_runtime,
     list_findings,
     normalize_finding_title,
     resolve_review_head_sha,
+    thread_ids_for_finding,
     thread_missing_tool_result,
     update_finding_fields,
 )
 from ..utils.reviewer_outcomes import emit_finding_status_outcome
-
-
-def _is_non_empty_str(value: Any) -> bool:
-    return isinstance(value, str) and bool(value)
 
 
 def _normalize_note(note: str | None) -> str | None:
@@ -32,20 +30,7 @@ def _normalize_note(note: str | None) -> str | None:
 
 
 def _has_published_github_surface(finding: Finding) -> bool:
-    surface = finding.get("surface")
-    if isinstance(surface, dict) and (
-        isinstance(surface.get("github_review_comment_id"), int)
-        or _is_non_empty_str(surface.get("github_review_thread_id"))
-    ):
-        return True
-    comment_ids = finding.get("github_review_comment_ids")
-    thread_ids = finding.get("github_review_thread_ids")
-    return (
-        isinstance(finding.get("github_review_comment_id"), int)
-        or _is_non_empty_str(finding.get("github_review_thread_id"))
-        or (isinstance(comment_ids, list) and any(isinstance(item, int) for item in comment_ids))
-        or (isinstance(thread_ids, list) and any(_is_non_empty_str(item) for item in thread_ids))
-    )
+    return bool(comment_ids_for_finding(finding) or thread_ids_for_finding(finding))
 
 
 async def update_finding(

--- a/agent/utils/github_feedback.py
+++ b/agent/utils/github_feedback.py
@@ -8,7 +8,7 @@ from typing import Any
 from langgraph_sdk import get_client
 from langgraph_sdk.client import LangGraphClient
 
-from ..review.findings import list_findings
+from ..review.findings import comment_ids_for_finding, list_findings
 from .langsmith import create_langsmith_feedback, delete_langsmith_feedback
 from .reviewer_outcomes import outcome_from_score, upsert_finding_outcome
 
@@ -172,11 +172,7 @@ async def process_github_reaction(
     thread_id = _reviewer_thread_id(owner, repo_name, pr_number)
     findings = await list_findings(thread_id)
     finding = next(
-        (
-            candidate
-            for candidate in findings
-            if candidate.get("github_review_comment_id") == comment_id
-        ),
+        (candidate for candidate in findings if comment_id in comment_ids_for_finding(candidate)),
         None,
     )
     if finding is None:

--- a/tests/github/test_github_feedback.py
+++ b/tests/github/test_github_feedback.py
@@ -96,7 +96,7 @@ async def test_github_reaction_added_creates_langsmith_feedback(
         return [
             {
                 "id": "f1",
-                "github_review_comment_id": 123,
+                "github_review_comment_ids": [123],
                 "github_review_run_id": "run-1",
             }
         ]
@@ -145,7 +145,7 @@ async def test_github_reaction_removed_deletes_langsmith_feedback(
         return [
             {
                 "id": "f1",
-                "github_review_comment_id": 123,
+                "github_review_comment_ids": [123],
                 "github_review_run_id": "run-1",
             }
         ]

--- a/tests/reviewer/test_review_chat.py
+++ b/tests/reviewer/test_review_chat.py
@@ -224,7 +224,7 @@ async def test_list_review_findings_compacts_and_filters(monkeypatch) -> None:
                 "title": "Open one",
                 "status": "open",
                 "severity": "high",
-                "github_review_comment_id": 999,
+                "github_review_comment_ids": [999],
             },
             {"id": "f2", "title": "Closed one", "status": "resolved", "severity": "low"},
         ]
@@ -236,7 +236,7 @@ async def test_list_review_findings_compacts_and_filters(monkeypatch) -> None:
     finding = result["findings"][0]
     assert finding["id"] == "f1"
     # compact view drops GitHub plumbing fields
-    assert "github_review_comment_id" not in finding
+    assert "github_review_comment_ids" not in finding
 
 
 @pytest.mark.asyncio

--- a/tests/reviewer/test_reviewer_findings.py
+++ b/tests/reviewer/test_reviewer_findings.py
@@ -12,14 +12,20 @@ from agent.review.findings import (
     DiffSide,
     Finding,
     append_finding,
+    comment_ids_for_finding,
     filter_findings_for_publish,
+    is_surfaced,
+    is_thread_resolved,
     list_findings,
     mutate_findings,
     new_finding,
     new_finding_id,
     replace_findings,
     resolve_review_head_sha,
+    review_id_for_finding,
     set_reviewer_thread_metadata,
+    surface_state_of,
+    thread_ids_for_finding,
     update_finding_fields,
 )
 
@@ -52,13 +58,12 @@ def test_new_finding_defaults() -> None:
     assert finding["first_seen_sha"] == "abc123"
     assert finding["last_confirmed_sha"] == "abc123"
     assert finding["github_review_id"] is None
-    assert finding["github_review_comment_id"] is None
     assert finding["github_review_comment_ids"] == []
-    assert finding["github_review_thread_id"] is None
     assert finding["github_review_thread_ids"] == []
     assert finding["github_review_run_id"] is None
-    assert finding["github_thread_resolved"] is False
     assert finding["github_resolved_thread_ids"] == []
+    assert finding["github_posted_resolution_comment_ids"] == []
+    assert finding["surface_state"] == "not_surfaced"
     assert finding["last_human_reply_at"] is None
     assert finding["resolution_note"] is None
     assert finding["suggestion"] is None
@@ -138,6 +143,121 @@ async def test_list_findings_coerces_bad_entries() -> None:
     with patch("agent.review.findings.get_client", return_value=fake_client):
         findings = await list_findings("tid")
     assert [f["id"] for f in findings] == ["f_ok"]
+
+
+async def _read_persisted(record: dict[str, Any]) -> Finding:
+    fake_client = AsyncMock()
+    fake_client.threads.get.return_value = {"metadata": {"findings": [record]}}
+    with patch("agent.review.findings.get_client", return_value=fake_client):
+        findings = await list_findings("tid")
+    return findings[0]
+
+
+@pytest.mark.asyncio
+async def test_reading_legacy_singulars_folds_them_into_the_canonical_lists() -> None:
+    finding = await _read_persisted(
+        {
+            "id": "f_legacy",
+            "github_review_comment_id": 11,
+            "github_review_thread_id": "THREAD_1",
+            "github_review_comment_ids": [12],
+            "github_review_thread_ids": ["THREAD_2"],
+        }
+    )
+
+    assert comment_ids_for_finding(finding) == [11, 12]
+    assert thread_ids_for_finding(finding) == ["THREAD_1", "THREAD_2"]
+    assert "github_review_comment_id" not in finding
+    assert "github_review_thread_id" not in finding
+    assert surface_state_of(finding) == "surfaced"
+
+
+@pytest.mark.asyncio
+async def test_reading_legacy_resolved_flag_becomes_resolved_surface_state() -> None:
+    finding = await _read_persisted(
+        {
+            "id": "f_legacy",
+            "github_review_thread_ids": ["THREAD_1"],
+            "github_thread_resolved": True,
+        }
+    )
+
+    assert is_thread_resolved(finding) is True
+    assert is_surfaced(finding) is True
+    assert "github_thread_resolved" not in finding
+
+
+@pytest.mark.asyncio
+async def test_reading_legacy_surface_record_folds_ids_and_state() -> None:
+    finding = await _read_persisted(
+        {
+            "id": "f_legacy",
+            "anchor": {"file": "a.py", "start_line": 1, "end_line": 1, "side": "RIGHT"},
+            "surface": {
+                "finding_id": "f_legacy",
+                "state": "resolve_pending",
+                "github_review_id": 900,
+                "github_review_comment_id": 11,
+                "github_review_thread_id": "THREAD_1",
+                "severity_threshold_at_publish": "high",
+            },
+        }
+    )
+
+    assert comment_ids_for_finding(finding) == [11]
+    assert thread_ids_for_finding(finding) == ["THREAD_1"]
+    assert review_id_for_finding(finding) == 900
+    assert surface_state_of(finding) == "resolve_pending"
+    assert "surface" not in finding
+    assert "anchor" not in finding
+
+
+@pytest.mark.asyncio
+async def test_reading_a_never_published_legacy_record_stays_not_surfaced() -> None:
+    finding = await _read_persisted(
+        {
+            "id": "f_legacy",
+            "github_review_comment_id": None,
+            "github_review_thread_id": None,
+            "github_thread_resolved": False,
+            "surface": {"finding_id": "f_legacy", "state": "not_surfaced"},
+        }
+    )
+
+    assert comment_ids_for_finding(finding) == []
+    assert thread_ids_for_finding(finding) == []
+    assert review_id_for_finding(finding) is None
+    assert is_surfaced(finding) is False
+
+
+@pytest.mark.asyncio
+async def test_reading_a_legacy_record_persists_only_canonical_fields() -> None:
+    metadata: dict[str, Any] = {
+        "findings": [
+            {
+                "id": "f_legacy",
+                "status": "open",
+                "github_review_comment_id": 11,
+                "github_thread_resolved": True,
+                "surface": {"finding_id": "f_legacy", "state": "surfaced"},
+            }
+        ]
+    }
+    fake_client = AsyncMock()
+    fake_client.threads.get.return_value = {"metadata": metadata}
+
+    with patch("agent.review.findings.get_client", return_value=fake_client):
+        await update_finding_fields("tid", "f_legacy", {"status": "resolved"})
+
+    persisted = fake_client.threads.update.await_args.kwargs["metadata"]["findings"][0]
+    assert persisted == {
+        "id": "f_legacy",
+        "status": "resolved",
+        "github_review_id": None,
+        "github_review_comment_ids": [11],
+        "github_review_thread_ids": [],
+        "surface_state": "resolved",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/reviewer/test_reviewer_publish.py
+++ b/tests/reviewer/test_reviewer_publish.py
@@ -709,11 +709,11 @@ async def test_resolve_review_thread_returns_false_on_graphql_errors() -> None:
 
 @pytest.mark.asyncio
 async def test_publish_review_skips_findings_already_published() -> None:
-    """Re-runs must not re-post findings that already have a github_review_comment_id."""
+    """Re-runs must not re-post findings that already carry a review comment id."""
     from agent.tools.publish_review import _publish_review_async
 
     findings = [
-        _f(id="f_old", severity="high", file="a.py", github_review_comment_id=42),
+        _f(id="f_old", severity="high", file="a.py", github_review_comment_ids=[42]),
         _f(id="f_new", severity="high", file="b.py"),
     ]
 
@@ -762,7 +762,7 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
     """Re-review with nothing new to surface must not spam another comment."""
     from agent.tools.publish_review import _publish_review_async
 
-    # All findings already have github_review_comment_id from the prior publish
+    # All findings already carry a review comment id from the prior publish
     # (so none are "unpublished"), plus one previously-resolved finding whose
     # thread still needs to be resolved on GitHub.
     findings = [
@@ -779,7 +779,7 @@ async def test_publish_review_skips_post_on_re_review_with_no_new_findings() -> 
             "status": "resolved",
             "first_seen_sha": "s",
             "last_confirmed_sha": "s",
-            "github_review_comment_id": 100,
+            "github_review_comment_ids": [100],
         },
     ]
     list_async = AsyncMock(return_value=findings)
@@ -835,8 +835,6 @@ async def test_publish_review_does_not_surface_out_of_diff_finding() -> None:
             file="caller.py",
             in_diff=False,
             first_seen_sha="newsha",
-            github_review_comment_id=None,
-            github_review_id=None,
         )
     ]
     post_review = AsyncMock(return_value={"id": 555})
@@ -1153,7 +1151,7 @@ async def test_open_swe_review_exists_returns_none_on_http_error() -> None:
 async def test_re_review_backfills_existing_marker_and_skips_duplicate_post() -> None:
     from agent.tools.publish_review import _publish_review_async
 
-    finding = _f(id="f_old", first_seen_sha="oldsha", github_review_comment_id=None)
+    finding = _f(id="f_old", first_seen_sha="oldsha")
     findings = [finding]
     thread = {
         "id": "THREAD_1",
@@ -1199,8 +1197,8 @@ async def test_re_review_backfills_existing_marker_and_skips_duplicate_post() ->
 
     post_review.assert_not_called()
     assert result["skipped_empty_re_review"] is True
-    assert findings[0]["github_review_comment_id"] == 101
-    assert findings[0]["github_review_thread_id"] == "THREAD_1"
+    assert findings[0]["github_review_comment_ids"] == [101]
+    assert findings[0]["github_review_thread_ids"] == ["THREAD_1"]
 
 
 @pytest.mark.asyncio
@@ -1210,7 +1208,6 @@ async def test_re_review_backfills_and_resolves_duplicate_existing_threads() -> 
     finding = _f(
         id="f_old",
         first_seen_sha="oldsha",
-        github_review_comment_id=None,
         status="resolved",
         resolution_note="The duplicate threads are fixed by the latest commit.",
     )
@@ -1287,7 +1284,7 @@ async def test_re_review_backfills_and_resolves_duplicate_existing_threads() -> 
     assert findings[0]["github_review_thread_ids"] == ["THREAD_1", "THREAD_2"]
     assert findings[0]["github_resolved_thread_ids"] == ["THREAD_1", "THREAD_2"]
     assert findings[0]["github_posted_resolution_comment_ids"] == [101, 102]
-    assert findings[0]["github_thread_resolved"] is True
+    assert findings[0]["surface_state"] == "resolved"
 
 
 @pytest.mark.asyncio
@@ -1348,8 +1345,8 @@ async def test_publish_review_backfills_from_threads_when_review_comments_are_em
     assert result["review_id"] == 999
     assert fetch_threads.await_count == 2
     assert findings[0]["github_review_id"] == 999
-    assert findings[0]["github_review_comment_id"] == 202
-    assert findings[0]["github_review_thread_id"] == "THREAD_1"
+    assert findings[0]["github_review_comment_ids"] == [202]
+    assert findings[0]["github_review_thread_ids"] == ["THREAD_1"]
 
 
 @pytest.mark.asyncio
@@ -1401,7 +1398,7 @@ async def test_re_review_only_posts_current_head_unpublished_findings() -> None:
     assert [comment["path"] for comment in inline_comments] == ["new.py"]
     assert old["github_review_id"] is None
     assert new["github_review_id"] == 888
-    assert new["github_review_comment_id"] == 303
+    assert new["github_review_comment_ids"] == [303]
 
 
 @pytest.mark.asyncio
@@ -1452,8 +1449,8 @@ async def test_publish_review_matches_comment_ids_by_marker_not_path_line_body()
 
     assert result["success"] is True
     by_id = {f["id"]: f for f in findings}
-    assert by_id["f_one"]["github_review_comment_id"] == 901
-    assert by_id["f_two"]["github_review_comment_id"] == 902
+    assert by_id["f_one"]["github_review_comment_ids"] == [901]
+    assert by_id["f_two"]["github_review_comment_ids"] == [902]
 
 
 @pytest.mark.asyncio
@@ -1504,13 +1501,12 @@ async def test_publish_review_records_review_id_and_comment_id_in_single_write()
     # half-stamped intermediate state.
     persisted_snapshots = [call.args[1] for call in replace.await_args_list]
     assert any(
-        snap[0].get("github_review_id") == 555 and snap[0].get("github_review_comment_id") == 808
+        snap[0].get("github_review_id") == 555 and snap[0].get("github_review_comment_ids") == [808]
         for snap in persisted_snapshots
     )
     assert all(
         not (
-            snap[0].get("github_review_id") == 555
-            and snap[0].get("github_review_comment_id") is None
+            snap[0].get("github_review_id") == 555 and not snap[0].get("github_review_comment_ids")
         )
         for snap in persisted_snapshots
     )

--- a/tests/reviewer/test_reviewer_reconcile.py
+++ b/tests/reviewer/test_reviewer_reconcile.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from agent.review.findings import is_thread_resolved
 from agent.review.reconcile import reconcile_findings_with_review_threads
 
 
@@ -11,8 +12,9 @@ async def test_reconcile_marks_resolved_github_thread_resolved() -> None:
         {
             "id": "f1",
             "status": "open",
-            "github_review_comment_id": 11,
-            "github_review_thread_id": "THREAD_1",
+            "github_review_comment_ids": [11],
+            "github_review_thread_ids": ["THREAD_1"],
+            "surface_state": "surfaced",
         }
     ]
     replace = AsyncMock()
@@ -34,20 +36,13 @@ async def test_reconcile_marks_resolved_github_thread_resolved() -> None:
         )
 
     assert result[0]["status"] == "resolved"
-    assert result[0]["github_thread_resolved"] is True
+    assert result[0]["surface_state"] == "resolved"
     replace.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_reconcile_backfills_comment_and_thread_ids_from_bot_marker() -> None:
-    findings = [
-        {
-            "id": "f1",
-            "status": "open",
-            "github_review_comment_id": None,
-            "github_review_thread_id": None,
-        }
-    ]
+    findings = [{"id": "f1", "status": "open"}]
     replace = AsyncMock()
 
     with (
@@ -76,23 +71,15 @@ async def test_reconcile_backfills_comment_and_thread_ids_from_bot_marker() -> N
             ],
         )
 
-    assert result[0]["github_review_comment_id"] == 11
     assert result[0]["github_review_comment_ids"] == [11]
-    assert result[0]["github_review_thread_id"] == "THREAD_1"
     assert result[0]["github_review_thread_ids"] == ["THREAD_1"]
+    assert result[0]["surface_state"] == "surfaced"
     replace.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_reconcile_backfills_marker_from_graphql_app_login() -> None:
-    findings = [
-        {
-            "id": "f1",
-            "status": "open",
-            "github_review_comment_id": None,
-            "github_review_thread_id": None,
-        }
-    ]
+    findings = [{"id": "f1", "status": "open"}]
     replace = AsyncMock()
 
     with (
@@ -121,21 +108,14 @@ async def test_reconcile_backfills_marker_from_graphql_app_login() -> None:
             ],
         )
 
-    assert result[0]["github_review_comment_id"] == 11
-    assert result[0]["github_review_thread_id"] == "THREAD_1"
+    assert result[0]["github_review_comment_ids"] == [11]
+    assert result[0]["github_review_thread_ids"] == ["THREAD_1"]
     replace.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_reconcile_duplicate_markers_require_all_threads_terminal() -> None:
-    findings = [
-        {
-            "id": "f1",
-            "status": "open",
-            "github_review_comment_id": None,
-            "github_review_thread_id": None,
-        }
-    ]
+    findings = [{"id": "f1", "status": "open"}]
     replace = AsyncMock()
     marker = (
         '<!-- open-swe-review-comment {"id":"f1",'
@@ -173,14 +153,7 @@ async def test_reconcile_duplicate_markers_require_all_threads_terminal() -> Non
 
 @pytest.mark.asyncio
 async def test_reconcile_duplicate_markers_stay_open_when_some_threads_only_outdated() -> None:
-    findings = [
-        {
-            "id": "f1",
-            "status": "open",
-            "github_review_comment_id": None,
-            "github_review_thread_id": None,
-        }
-    ]
+    findings = [{"id": "f1", "status": "open"}]
     replace = AsyncMock()
     marker = (
         '<!-- open-swe-review-comment {"id":"f1",'
@@ -213,20 +186,13 @@ async def test_reconcile_duplicate_markers_stay_open_when_some_threads_only_outd
     assert result[0]["status"] == "open"
     assert "last_reconciliation_note" not in result[0]
     assert result[0]["github_resolved_thread_ids"] == ["THREAD_RESOLVED"]
-    assert result[0].get("github_thread_resolved") is not True
+    assert is_thread_resolved(result[0]) is False
     replace.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_reconcile_ignores_spoofed_non_bot_marker() -> None:
-    findings = [
-        {
-            "id": "f1",
-            "status": "open",
-            "github_review_comment_id": None,
-            "github_review_thread_id": None,
-        }
-    ]
+    findings = [{"id": "f1", "status": "open"}]
     replace = AsyncMock()
 
     with (
@@ -255,14 +221,14 @@ async def test_reconcile_ignores_spoofed_non_bot_marker() -> None:
             ],
         )
 
-    assert result[0]["github_review_comment_id"] is None
-    assert result[0]["github_review_thread_id"] is None
+    assert result[0].get("github_review_comment_ids") is None
+    assert result[0].get("github_review_thread_ids") is None
     replace.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_reconcile_records_latest_human_reply_after_bot_comment() -> None:
-    findings = [{"id": "f1", "status": "open", "github_review_comment_id": 11}]
+    findings = [{"id": "f1", "status": "open", "github_review_comment_ids": [11]}]
     replace = AsyncMock()
 
     with (
@@ -289,7 +255,7 @@ async def test_reconcile_records_latest_human_reply_after_bot_comment() -> None:
             ],
         )
 
-    assert result[0]["github_review_thread_id"] == "THREAD_1"
+    assert result[0]["github_review_thread_ids"] == ["THREAD_1"]
     assert result[0]["last_human_reply_author"] == "human"
     reply_body = result[0]["last_human_reply_body"]
     assert isinstance(reply_body, str)

--- a/tests/reviewer/test_reviewer_tools.py
+++ b/tests/reviewer/test_reviewer_tools.py
@@ -319,7 +319,6 @@ async def test_resolve_finding_thread_resolves_all_known_threads() -> None:
         patch("agent.tools.resolve_finding_thread.resolve_review_thread", resolve),
         patch("agent.tools.resolve_finding_thread.reply_to_review_comment", reply),
         patch("agent.tools.resolve_finding_thread.update_finding_fields", update),
-        patch("agent.tools.resolve_finding_thread.update_finding_surface", AsyncMock()),
     ):
         result = await resolve_finding_thread(
             "f1", status="resolved", note="Fixed in the latest commit"
@@ -337,7 +336,8 @@ async def test_resolve_finding_thread_resolves_all_known_threads() -> None:
     )
     assert update.await_args is not None
     updates = update.await_args.args[2]
-    assert updates["github_thread_resolved"] is True
+    assert updates["surface_state"] == "resolved"
+    assert updates["github_review_thread_ids"] == ["THREAD_1", "THREAD_2"]
     assert updates["github_resolved_thread_ids"] == ["THREAD_1", "THREAD_2"]
     assert updates["github_posted_resolution_comment_ids"] == [11, 12]
     assert updates["resolution_note"] == "Fixed in the latest commit"
@@ -582,7 +582,7 @@ async def test_update_finding_resolves_github_thread_when_pr_context_available()
         patch("agent.tools.update_finding.get_thread_id_from_runtime", return_value="tid-1"),
         patch(
             "agent.tools.update_finding.list_findings",
-            AsyncMock(return_value=[_existing_finding(github_review_thread_id="THREAD_1")]),
+            AsyncMock(return_value=[_existing_finding(github_review_thread_ids=["THREAD_1"])]),
         ),
         patch("agent.tools.resolve_finding_thread.get_config", return_value=cfg),
         patch("agent.tools.resolve_finding_thread.get_github_token", return_value="token"),
@@ -592,7 +592,7 @@ async def test_update_finding_resolves_github_thread_when_pr_context_available()
             new_callable=AsyncMock,
             return_value={
                 "success": True,
-                "finding": {"id": "f_a", "status": "resolved", "github_thread_resolved": True},
+                "finding": {"id": "f_a", "status": "resolved", "surface_state": "resolved"},
                 "resolved_thread_count": 1,
             },
         ) as resolve_async,
@@ -605,7 +605,7 @@ async def test_update_finding_resolves_github_thread_when_pr_context_available()
 
     assert result["success"] is True
     assert result["github_resolution"]["success"] is True
-    assert result["finding"]["github_thread_resolved"] is True
+    assert result["finding"]["surface_state"] == "resolved"
     resolve_async.assert_awaited_once()
     update.assert_not_awaited()
 
@@ -617,7 +617,7 @@ async def test_update_finding_leaves_open_when_github_resolution_fails() -> None
         patch("agent.tools.update_finding.get_thread_id_from_runtime", return_value="tid-1"),
         patch(
             "agent.tools.update_finding.list_findings",
-            AsyncMock(return_value=[_existing_finding(github_review_thread_id="THREAD_1")]),
+            AsyncMock(return_value=[_existing_finding(github_review_thread_ids=["THREAD_1"])]),
         ),
         patch("agent.tools.resolve_finding_thread.get_config", return_value=cfg),
         patch("agent.tools.resolve_finding_thread.get_github_token", return_value="token"),


### PR DESCRIPTION
## Summary

Fourth chunk of #2181. Net **−26 lines** across 15 files. Branched from `main`, independent of #2213, #2214 and #2215.

Where a finding surfaced on GitHub was recorded **three ways at once**: flat singulars (`github_review_comment_id`), plural lists (`github_review_comment_ids`), and a nested `FindingSurface` record duplicating all three plus a state enum. Every writer had to update all three; every reader had to check all three.

### Canonical shape

`github_review_comment_ids` · `github_review_thread_ids` · `github_resolved_thread_ids` · `github_posted_resolution_comment_ids` · `github_review_id` · `surface_state`

Legacy singulars, `github_thread_resolved` and the nested `surface` record are folded in **exactly once, at read time**, in `coerce_finding`. Persisted records stay readable; every write emits only the canonical fields. The tests in `tests/agent/test_agent_usage.py` still build findings with the legacy singular `github_review_comment_id` and pass unchanged, which is the fold-in working.

### What moved

- `findings.py` exports accessors — `comment_ids_for_finding`, `thread_ids_for_finding`, `resolved_thread_ids_for_finding`, `posted_resolution_comment_ids_for_finding`, `review_id_for_finding`, `surface_state_of`, `is_surfaced`, `is_thread_resolved` — plus the two writers `mark_surfaced` / `set_surface_state`.
- Deleted `FindingSurface`, `FindingAnchor`, the dead `anchor` field, `update_finding_surface`, `_coerce_surface` (which was being imported cross-module) and `_sync_legacy_surface_fields`. Dropped the never-written `"error"` surface state and the never-read surface metadata fields.
- `publish_review`, `reconcile` and `resolve_finding_thread` lost their duplicated identity blocks. `resolve_finding_thread` now persists **one** write instead of two plus a re-read.
- `update_finding._has_published_github_surface` and `review_api._serialize_finding` go through the accessors. **The dashboard's JSON keys are unchanged** — `review_api.py` still emits `github_thread_resolved` and `github_review_comment_id`, which is what `ui/src/lib/api.ts` and `ReviewMainBody.tsx` read.

### Resolving against `main`

`dashboard/agent_usage.py` was rewritten upstream as usage telemetry v2 (#2147), so the branch's edits target a file shape that no longer exists. Rather than force the conflict blob, I reset that file to `main` and applied the one thing this chunk actually needs there: `_finding_surfaced` now reads through `coerce_finding` + `is_surfaced` instead of hand-checking the nested `surface` dict and both id shapes.

### Deliberately left alone

`agent/webhooks/common.py:1544` `_finding_comment_ids` still reads both the singular and the plural by hand. It is correct as written (it unions both, so canonical-only records work), it is outside this chunk, and the later webhooks chunk dissolves that module entirely. Swapping it to `comment_ids_for_finding` would be a behavior change, not a cleanup — that accessor reads only the plural, and this call site is not guaranteed to receive a `coerce_finding`-normalized record.

## Test plan

- [x] `make lint` clean (ruff check + ruff format --diff)
- [x] `make typecheck` clean (0 errors, 0 warnings)
- [x] `uv run pytest tests/agent/test_agent_usage.py tests/reviewer tests/github/test_github_feedback.py` — 319 passed
- [x] `rg` confirms no remaining references to `FindingSurface`, `FindingAnchor`, `update_finding_surface`, `_coerce_surface` or `_sync_legacy_surface_fields` in `agent/`, `tests/` or `ui/`

[no screenshot] — no UI changes; the dashboard JSON contract is unchanged.