### PR TITLE
fix: keep changes toolbar responsive

### DIFF
--- a/ui/src/features/agents/components/ChangesPanel.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.tsx
@@ -85,7 +85,7 @@ function ScopeSwitcher(props: {
   return (
     <Menu open={open} onOpenChange={setOpen}>
       <MenuTrigger
-        className="flex h-6 min-w-0 cursor-pointer items-center gap-1 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        className="flex h-6 min-w-0 shrink cursor-pointer items-center gap-1 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
         aria-label={`Diff scope: ${label}`}
       >
         <span className="min-w-0 truncate">{label}</span>
@@ -142,7 +142,7 @@ export function ChangesPanel({
           title="Refresh changes"
           onClick={onRefresh}
           disabled={isFetching}
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
         >
           <RefreshCwIcon
             className={isFetching ? "size-3.5 animate-spin" : "size-3.5"}
@@ -154,10 +154,14 @@ export function ChangesPanel({
             href={pr.url}
             target="_blank"
             rel="noreferrer"
-            className="flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+            aria-label="View PR"
+            title="View PR"
+            className="flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium text-foreground transition-colors hover:bg-accent @max-[680px]:w-7 @max-[680px]:justify-center @max-[680px]:px-0"
           >
-            <GitPullRequestIcon className="size-3.5" />
-            View PR
+            <GitPullRequestIcon className="size-3.5 shrink-0" />
+            <span className="whitespace-nowrap @max-[680px]:hidden">
+              View PR
+            </span>
           </a>
         )}
       </>
@@ -180,14 +184,17 @@ export function ChangesPanel({
         emptyLabel={emptyLabel}
         truncated={truncated}
         leading={
-          <div className="flex min-w-0 items-center gap-1.5">
+          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
             <ScopeSwitcher
               scope={scope}
               branchScopeAvailable={branchScopeAvailable}
               onScopeChange={onScopeChange}
             />
             {branch && (
-              <span className="min-w-0 truncate text-xs text-muted-foreground">
+              <span
+                className="min-w-0 truncate text-xs text-muted-foreground @max-[520px]:hidden"
+                title={branch}
+              >
                 {branch}
               </span>
             )}

--- a/ui/src/features/agents/components/ChangesPanel.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react"
 import {
   ChevronDownIcon,
+  GitBranchIcon,
   GitPullRequestIcon,
   RefreshCwIcon,
 } from "lucide-react"
@@ -191,12 +192,23 @@ export function ChangesPanel({
               onScopeChange={onScopeChange}
             />
             {branch && (
-              <span
-                className="min-w-0 truncate text-xs text-muted-foreground @max-[520px]:hidden"
-                title={branch}
-              >
-                {branch}
-              </span>
+              <>
+                <span
+                  className="min-w-0 truncate text-xs text-muted-foreground @max-[520px]:hidden"
+                  title={branch}
+                >
+                  {branch}
+                </span>
+                <Tooltip>
+                  <TooltipTrigger
+                    aria-label={`Branch: ${branch}`}
+                    className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent @max-[520px]:flex"
+                  >
+                    <GitBranchIcon className="size-3.5" />
+                  </TooltipTrigger>
+                  <TooltipPopup>{branch}</TooltipPopup>
+                </Tooltip>
+              </>
             )}
           </div>
         }

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -198,14 +198,15 @@ export function DiffFilesView({
   return (
     <>
       {!hideHeader && (
-        <div className="flex min-h-9 items-center gap-1 border-b border-border px-3 py-1">
-          {leading}
-          <div className="ml-auto flex min-w-0 items-center gap-2">
+        <div className="@container flex min-h-9 flex-nowrap items-center gap-1 overflow-hidden border-b border-border px-3 py-1">
+          <div className="min-w-0 flex-1">{leading}</div>
+          <div className="ml-auto flex shrink-0 items-center gap-2">
             <DiffWrapToggle />
             {actions}
             {files.length > 0 && (
-              <span className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
+              <span className="flex shrink-0 items-center gap-2 text-[11px] whitespace-nowrap text-muted-foreground/70">
                 <span
+                  className="@max-[620px]:hidden"
                   title={
                     truncated ? "Only the first files are shown" : undefined
                   }


### PR DESCRIPTION
## Description
Keep the Changes toolbar on one line and progressively compact lower-priority labels based on panel width. Branch text remains discoverable through a focusable tooltip trigger at narrow widths, while PR and diff actions stay usable.

## Test Plan
- [x] Verify the dashboard flow in Chromium with the Playwright dashboard suite.
- [x] Verify the compact branch trigger with focused typecheck, lint, and unit tests.

Made by [Open SWE](https://openswe.vercel.app/agents/01a03902-fda8-766f-8a83-ba97e1142b5c)