### PR TITLE
fix: wait out a resuming sandbox instead of calling it unreachable

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -362,7 +362,9 @@ async def _patch_proxy_config(
     sandbox_name: str,
 ) -> None:
     attempt = 0
-    provisioning_waited = 0.0
+    provisioning_deadline = (
+        asyncio.get_running_loop().time() + PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS
+    )
     while True:
         try:
             response = await client.patch(
@@ -378,11 +380,8 @@ async def _patch_proxy_config(
             # it out here keeps a resume from being reported as an unreachable
             # sandbox, which ends the run.
             provisioning = _is_provisioning_proxy_config_error(exc)
-            exhausted = (
-                provisioning_waited >= PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS
-                if provisioning
-                else attempt >= PROXY_CONFIG_MAX_ATTEMPTS - 1
-            )
+            remaining = provisioning_deadline - asyncio.get_running_loop().time()
+            exhausted = remaining <= 0 if provisioning else attempt >= PROXY_CONFIG_MAX_ATTEMPTS - 1
             if exhausted or not _is_retryable_proxy_config_error(exc):
                 enriched = _with_response_body(exc)
                 if enriched is not None:
@@ -394,8 +393,10 @@ async def _patch_proxy_config(
                 else None
             )
             if provisioning:
-                delay = retry_after or PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS
-                provisioning_waited += delay
+                delay = min(
+                    retry_after or PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS,
+                    remaining,
+                )
                 logger.info(
                     "Sandbox %s is still provisioning; retrying GitHub proxy config in %.1fs",
                     sandbox_name,

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -43,6 +43,9 @@ PROXY_CONFIG_TIMEOUT_SECONDS = 10.0
 PROXY_CONFIG_RETRY_DELAYS_SECONDS = (0.5, 1.0)
 PROXY_CONFIG_RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
 PROXY_CONFIG_NOT_READY_STATUS = 400
+PROXY_CONFIG_PROVISIONING_STATUS = 409
+PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS = 30.0
+PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS = 2.0
 PROXY_CONFIG_ERROR_BODY_CHARS = 500
 SANDBOX_START_TIMEOUT_SECONDS = 120
 PROXY_GH_TOKEN_PLACEHOLDER = "proxy-injected"
@@ -257,6 +260,13 @@ def _retry_after_seconds(response: httpx.Response | None) -> float | None:
     return max(delay, 0.0)
 
 
+def _is_provisioning_proxy_config_error(exc: BaseException) -> bool:
+    return (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code == PROXY_CONFIG_PROVISIONING_STATUS
+    )
+
+
 def _is_retryable_proxy_config_error(exc: BaseException) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in PROXY_CONFIG_RETRYABLE_STATUS_CODES
@@ -351,7 +361,9 @@ async def _patch_proxy_config(
     api_key: str,
     sandbox_name: str,
 ) -> None:
-    for attempt in range(PROXY_CONFIG_MAX_ATTEMPTS):
+    attempt = 0
+    provisioning_waited = 0.0
+    while True:
         try:
             response = await client.patch(
                 url,
@@ -361,9 +373,17 @@ async def _patch_proxy_config(
             response.raise_for_status()
             return
         except Exception as exc:
-            if attempt == PROXY_CONFIG_MAX_ATTEMPTS - 1 or not _is_retryable_proxy_config_error(
-                exc
-            ):
+            # A box resuming from stop answers 409 until its microvm is up, which
+            # takes seconds longer than the general retry budget allows. Waiting
+            # it out here keeps a resume from being reported as an unreachable
+            # sandbox, which ends the run.
+            provisioning = _is_provisioning_proxy_config_error(exc)
+            exhausted = (
+                provisioning_waited >= PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS
+                if provisioning
+                else attempt >= PROXY_CONFIG_MAX_ATTEMPTS - 1
+            )
+            if exhausted or not _is_retryable_proxy_config_error(exc):
                 enriched = _with_response_body(exc)
                 if enriched is not None:
                     raise enriched from exc
@@ -373,18 +393,28 @@ async def _patch_proxy_config(
                 if isinstance(exc, httpx.HTTPStatusError)
                 else None
             )
-            delay = (
-                retry_after
-                or PROXY_CONFIG_RETRY_DELAYS_SECONDS[
-                    min(attempt, len(PROXY_CONFIG_RETRY_DELAYS_SECONDS) - 1)
-                ]
-            )
-            logger.warning(
-                "Failed to configure GitHub proxy for sandbox %s (%s); retrying in %.1fs",
-                sandbox_name,
-                type(exc).__name__,
-                delay,
-            )
+            if provisioning:
+                delay = retry_after or PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS
+                provisioning_waited += delay
+                logger.info(
+                    "Sandbox %s is still provisioning; retrying GitHub proxy config in %.1fs",
+                    sandbox_name,
+                    delay,
+                )
+            else:
+                delay = (
+                    retry_after
+                    or PROXY_CONFIG_RETRY_DELAYS_SECONDS[
+                        min(attempt, len(PROXY_CONFIG_RETRY_DELAYS_SECONDS) - 1)
+                    ]
+                )
+                attempt += 1
+                logger.warning(
+                    "Failed to configure GitHub proxy for sandbox %s (%s); retrying in %.1fs",
+                    sandbox_name,
+                    type(exc).__name__,
+                    delay,
+                )
             await asyncio.sleep(delay)
 
 

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -11,6 +11,8 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.runtime import Runtime
 
 from agent.integrations.langsmith import (
+    PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS,
+    PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS,
     PROXY_GH_TOKEN_PLACEHOLDER,
     PROXY_MODEL_KEY_PLACEHOLDER,
     _configure_github_proxy,
@@ -306,6 +308,95 @@ class TestConfigureGithubProxy:
 
             with pytest.raises(httpx.HTTPStatusError, match="another tenant"):
                 await _configure_github_proxy("sandbox-abc", "token")
+
+
+class TestConfigureGithubProxyWaitsOutProvisioning:
+    """A 409 means the box is mid-resume; wait for it instead of failing the run."""
+
+    @staticmethod
+    def _provisioning_error() -> httpx.HTTPStatusError:
+        request = httpx.Request(
+            "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
+        )
+        response = httpx.Response(
+            409,
+            request=request,
+            text='Sandbox "sandbox-abc" status changed to "provisioning" while updating.',
+        )
+        return httpx.HTTPStatusError("Conflict", request=request, response=response)
+
+    async def test_retries_past_the_general_attempt_budget(self) -> None:
+        """A cold resume outlasts PROXY_CONFIG_MAX_ATTEMPTS worth of 409s."""
+        error = self._provisioning_error()
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            provisioning = MagicMock()
+            provisioning.raise_for_status.side_effect = error
+            ready = MagicMock()
+            ready.raise_for_status = MagicMock()
+            mock_client.patch = AsyncMock(
+                side_effect=[provisioning, provisioning, provisioning, provisioning, ready]
+            )
+            _mock_async_client(mock_client_cls, mock_client)
+
+            await _configure_github_proxy("sandbox-abc", "token")
+
+            assert mock_client.patch.call_count == 5
+            assert mock_sleep.await_count == 4
+
+    async def test_gives_up_once_the_provisioning_budget_is_spent(self) -> None:
+        """A box that never leaves provisioning still surfaces the failure."""
+        error = self._provisioning_error()
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch("agent.integrations.langsmith.asyncio.sleep", new_callable=AsyncMock),
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            provisioning = MagicMock()
+            provisioning.raise_for_status.side_effect = error
+            mock_client.patch = AsyncMock(return_value=provisioning)
+            _mock_async_client(mock_client_cls, mock_client)
+
+            with pytest.raises(httpx.HTTPStatusError, match="provisioning"):
+                await _configure_github_proxy("sandbox-abc", "token")
+
+            expected_attempts = int(
+                PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS
+                / PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS
+            )
+            assert mock_client.patch.call_count == expected_attempts + 1
+
+    async def test_honors_retry_after_over_the_default_poll(self) -> None:
+        request = httpx.Request(
+            "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
+        )
+        response = httpx.Response(409, request=request, headers={"Retry-After": "5"})
+        error = httpx.HTTPStatusError("Conflict", request=request, response=response)
+        with (
+            patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "agent.integrations.langsmith.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
+        ):
+            mock_client = MagicMock()
+            provisioning = MagicMock()
+            provisioning.raise_for_status.side_effect = error
+            ready = MagicMock()
+            ready.raise_for_status = MagicMock()
+            mock_client.patch = AsyncMock(side_effect=[provisioning, ready])
+            _mock_async_client(mock_client_cls, mock_client)
+
+            await _configure_github_proxy("sandbox-abc", "token")
+
+            mock_sleep.assert_awaited_once_with(5.0)
 
 
 class TestConfigureGithubProxyStartsStoppedSandbox:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -356,8 +356,17 @@ class TestConfigureGithubProxyWaitsOutProvisioning:
         with (
             patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
             patch("agent.integrations.langsmith.asyncio.sleep", new_callable=AsyncMock),
+            patch("agent.integrations.langsmith.asyncio.get_running_loop") as mock_get_loop,
             patch.dict("os.environ", {"LANGSMITH_API_KEY": "api-key"}),
         ):
+            mock_get_loop.return_value.time.side_effect = [
+                0,
+                *range(
+                    0,
+                    int(PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS) + 1,
+                    int(PROXY_CONFIG_PROVISIONING_RETRY_DELAY_SECONDS),
+                ),
+            ]
             mock_client = MagicMock()
             provisioning = MagicMock()
             provisioning.raise_for_status.side_effect = error
@@ -373,11 +382,11 @@ class TestConfigureGithubProxyWaitsOutProvisioning:
             )
             assert mock_client.patch.call_count == expected_attempts + 1
 
-    async def test_honors_retry_after_over_the_default_poll(self) -> None:
+    async def test_caps_retry_after_at_the_provisioning_deadline(self) -> None:
         request = httpx.Request(
             "PATCH", "https://api.smith.langchain.com/v2/sandboxes/boxes/sandbox-abc"
         )
-        response = httpx.Response(409, request=request, headers={"Retry-After": "5"})
+        response = httpx.Response(409, request=request, headers={"Retry-After": "60"})
         error = httpx.HTTPStatusError("Conflict", request=request, response=response)
         with (
             patch("agent.integrations.langsmith.httpx.AsyncClient") as mock_client_cls,
@@ -396,7 +405,9 @@ class TestConfigureGithubProxyWaitsOutProvisioning:
 
             await _configure_github_proxy("sandbox-abc", "token")
 
-            mock_sleep.assert_awaited_once_with(5.0)
+            assert mock_sleep.await_args.args[0] == pytest.approx(
+                PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS, abs=0.01
+            )
 
 
 class TestConfigureGithubProxyStartsStoppedSandbox:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -405,8 +405,8 @@ class TestConfigureGithubProxyWaitsOutProvisioning:
 
             await _configure_github_proxy("sandbox-abc", "token")
 
-            assert mock_sleep.await_args.args[0] == pytest.approx(
-                PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS, abs=0.01
+            mock_sleep.assert_awaited_once_with(
+                pytest.approx(PROXY_CONFIG_PROVISIONING_BUDGET_SECONDS, abs=0.01)
             )
 
 


### PR DESCRIPTION
## Description
Wait through transient 409s while a sandbox resumes instead of terminating the run. Provisioning retries use a 30-second monotonic deadline and cap `Retry-After` sleeps to the remaining budget.

## Release Note
Sandbox-backed runs now recover when proxy configuration races sandbox provisioning.

## Test Plan
- [x] Focused provisioning retry tests

Made by [Open SWE](https://openswe.vercel.app/agents/ca1d3c3d-6053-5df2-a7d5-39b95edcd6d9)