### PR TITLE
feat: streamline cloud thread navigation

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -23,7 +23,7 @@ import {
 import { Kanban } from "lucide-react"
 import { IoLogoGithub, IoLogoSlack } from "react-icons/io5"
 import { SiLinear } from "react-icons/si"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { ComponentType, SVGProps } from "react"
 
 import type { SessionUser } from "@/lib/api"
@@ -217,6 +217,9 @@ export function AgentsSidebar({
       (a, b) => a.localeCompare(b)
     ),
   }
+  const cloudProjects = facets.repos.map((repo) => ({ cwd: repo, name: repo }))
+  const selectedCloudProject =
+    prefs.filters.repos.length === 1 ? (prefs.filters.repos[0] ?? null) : null
   const filteredActive = filterThreads(activeThreads, prefs.filters)
   const filteredResolved = filterThreads(resolvedThreads, prefs.filters)
   const showResolved = prefs.filters.includeResolved
@@ -269,6 +272,37 @@ export function AgentsSidebar({
     isDesktop && (localOnly || desktopThreadSource === "local")
   const showCloudThreads =
     !localOnly && (!isDesktop || desktopThreadSource === "cloud")
+  const cloudScrollRef = useRef<HTMLDivElement>(null)
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const target = loadMoreRef.current
+    const root = cloudScrollRef.current
+    if (!target || !root || (!activeHasMore && !resolvedHasMore)) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return
+        if (activeHasMore && !sidebar.activeQuery.isFetchingNextPage) {
+          void sidebar.activeQuery.fetchNextPage()
+        }
+        if (
+          showResolved &&
+          resolvedHasMore &&
+          !sidebar.resolvedQuery.isFetchingNextPage
+        ) {
+          void sidebar.resolvedQuery.fetchNextPage()
+        }
+      },
+      { root, rootMargin: "200px" }
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [
+    activeHasMore,
+    resolvedHasMore,
+    showResolved,
+    sidebar.activeQuery,
+    sidebar.resolvedQuery,
+  ])
 
   return (
     <SidebarFrame {...layout} className="border-r border-border bg-sidebar">
@@ -400,81 +434,76 @@ export function AgentsSidebar({
           </div>
         )}
         {showCloudThreads && (
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {sidebar.isPending && (
-              <ThreadListSkeleton compact={prefs.compact} />
-            )}
-            {!sidebar.isPending &&
-              (prefs.group === "none"
-                ? sections[0]?.threads.map((thread) => (
-                    <ThreadRow
-                      key={thread.id}
-                      thread={thread}
-                      isActive={thread.id === activeThreadId}
-                      onNavigate={layout.closeOnMobile}
-                      compact={prefs.compact}
-                    />
-                  ))
-                : sections.map((section) => (
-                    <ThreadGroup
-                      key={`${prefs.group}:${section.key}`}
-                      label={section.label}
-                      threads={section.threads}
-                      activeThreadId={activeThreadId}
-                      onNavigate={layout.closeOnMobile}
-                      defaultCollapsed={section.defaultCollapsed}
-                      compact={prefs.compact}
-                      hasMore={
-                        prefs.group === "focus" && section.key === "done"
-                          ? resolvedHasMore
-                          : false
-                      }
-                      count={
-                        prefs.group === "focus" && section.key === "done"
-                          ? filteredResolved.length
-                          : section.threads.length
-                      }
-                    />
-                  )))}
-            {!sidebar.isPending && activeHasMore && (
-              <LoadMoreThreadsButton
-                label="Load more threads"
-                loading={sidebar.activeQuery.isFetchingNextPage}
-                onClick={() => void sidebar.activeQuery.fetchNextPage()}
-              />
-            )}
-            {!sidebar.isPending &&
-              showResolved &&
-              prefs.group === "focus" &&
-              resolvedHasMore && (
-                <LoadMoreThreadsButton
-                  label="Load more resolved threads"
-                  loading={sidebar.resolvedQuery.isFetchingNextPage}
-                  onClick={() => void sidebar.resolvedQuery.fetchNextPage()}
+          <div className="flex min-h-0 flex-1 flex-col">
+            <SidebarProjectSelector
+              projects={cloudProjects}
+              selectedProjectPath={selectedCloudProject}
+              onSelectProject={(repo) =>
+                setFilters({ ...prefs.filters, repos: repo ? [repo] : [] })
+              }
+            />
+            <div
+              ref={cloudScrollRef}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              {sidebar.isPending && (
+                <ThreadListSkeleton compact={prefs.compact} />
+              )}
+              {!sidebar.isPending &&
+                (prefs.group === "none"
+                  ? sections[0]?.threads.map((thread) => (
+                      <ThreadRow
+                        key={thread.id}
+                        thread={thread}
+                        isActive={thread.id === activeThreadId}
+                        onNavigate={layout.closeOnMobile}
+                        compact={prefs.compact}
+                      />
+                    ))
+                  : sections.map((section) => (
+                      <ThreadGroup
+                        key={`${prefs.group}:${section.key}`}
+                        label={section.label}
+                        threads={section.threads}
+                        activeThreadId={activeThreadId}
+                        onNavigate={layout.closeOnMobile}
+                        defaultCollapsed={section.defaultCollapsed}
+                        compact={prefs.compact}
+                        hasMore={
+                          prefs.group === "focus" && section.key === "done"
+                            ? resolvedHasMore
+                            : false
+                        }
+                        count={
+                          prefs.group === "focus" && section.key === "done"
+                            ? filteredResolved.length
+                            : section.threads.length
+                        }
+                      />
+                    )))}
+
+              {showResolved && prefs.group !== "focus" && (
+                <ResolvedThreadGroup
+                  threads={filteredResolved}
+                  hasMore={resolvedHasMore}
+                  activeThreadId={activeThreadId}
+                  onNavigate={layout.closeOnMobile}
+                  compact={prefs.compact}
                 />
               )}
-            {showResolved && prefs.group !== "focus" && (
-              <ResolvedThreadGroup
-                threads={filteredResolved}
-                hasMore={resolvedHasMore}
-                activeThreadId={activeThreadId}
-                onNavigate={layout.closeOnMobile}
-                compact={prefs.compact}
-                onLoadMore={() => void sidebar.resolvedQuery.fetchNextPage()}
-                isLoadingMore={sidebar.resolvedQuery.isFetchingNextPage}
-              />
-            )}
-            {resolvedLoading && (
-              <div className="flex items-center gap-1.5 px-2.5 py-2 text-xs text-muted-foreground/70">
-                <CircleNotchIcon className="size-3.5 animate-spin" />
-                Loading resolved threads…
-              </div>
-            )}
-            {isCloudEmpty && (
-              <p className="px-2.5 py-6 text-center text-xs text-muted-foreground/70">
-                No threads match these filters.
-              </p>
-            )}
+              {resolvedLoading && (
+                <div className="flex items-center gap-1.5 px-2.5 py-2 text-xs text-muted-foreground/70">
+                  <CircleNotchIcon className="size-3.5 animate-spin" />
+                  Loading resolved threads…
+                </div>
+              )}
+              {isCloudEmpty && (
+                <p className="px-2.5 py-6 text-center text-xs text-muted-foreground/70">
+                  No threads match these filters.
+                </p>
+              )}
+              <div ref={loadMoreRef} className="h-px" />
+            </div>
           </div>
         )}
       </div>
@@ -853,16 +882,12 @@ function ResolvedThreadGroup({
   activeThreadId,
   onNavigate,
   compact = false,
-  onLoadMore,
-  isLoadingMore,
 }: {
   threads: Array<AgentThread>
   hasMore: boolean
   activeThreadId?: string
   onNavigate?: () => void
   compact?: boolean
-  onLoadMore: () => void
-  isLoadingMore: boolean
 }) {
   const [collapsed, setCollapsed] = useState(true)
   if (threads.length === 0 && !hasMore) return null
@@ -895,38 +920,9 @@ function ResolvedThreadGroup({
               compact={compact}
             />
           ))}
-          {hasMore && (
-            <LoadMoreThreadsButton
-              label="Load more resolved threads"
-              loading={isLoadingMore}
-              onClick={onLoadMore}
-            />
-          )}
         </>
       )}
     </div>
-  )
-}
-
-function LoadMoreThreadsButton({
-  label,
-  loading,
-  onClick,
-}: {
-  label: string
-  loading: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={loading}
-      className="mt-0.5 flex w-full items-center gap-1.5 rounded-md px-2.5 py-1.5 text-left text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground disabled:cursor-wait disabled:opacity-60"
-    >
-      {loading && <CircleNotchIcon className="size-3.5 animate-spin" />}
-      {loading ? "Loading…" : label}
-    </button>
   )
 }
 

--- a/ui/src/features/agents/components/SidebarProjectSelector.tsx
+++ b/ui/src/features/agents/components/SidebarProjectSelector.tsx
@@ -26,11 +26,11 @@ export function SidebarProjectSelector({
   onAddProject,
   onRemoveProject,
 }: {
-  projects: Array<DesktopProject>
+  projects: Array<Pick<DesktopProject, "cwd" | "name">>
   selectedProjectPath: string | null
   onSelectProject: (cwd: string | null) => void
-  onAddProject: () => void
-  onRemoveProject: (cwd: string) => void
+  onAddProject?: () => void
+  onRemoveProject?: (cwd: string) => void
 }) {
   const selectedProject = projects.find(
     (project) => project.cwd === selectedProjectPath
@@ -70,7 +70,7 @@ export function SidebarProjectSelector({
               </MenuItem>
             ))}
           </MenuGroup>
-          {projects.length > 0 && (
+          {projects.length > 0 && onRemoveProject && (
             <>
               <MenuSeparator />
               <MenuSub>
@@ -98,15 +98,17 @@ export function SidebarProjectSelector({
           )}
         </MenuPopup>
       </Menu>
-      <button
-        aria-label="Add project"
-        className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
-        onClick={onAddProject}
-        title="Add project"
-        type="button"
-      >
-        <FolderPlusIcon className="size-4" />
-      </button>
+      {onAddProject && (
+        <button
+          aria-label="Add project"
+          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+          onClick={onAddProject}
+          title="Add project"
+          type="button"
+        >
+          <FolderPlusIcon className="size-4" />
+        </button>
+      )}
     </div>
   )
 }

--- a/ui/src/features/agents/lib/sidebarFilter.test.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.test.ts
@@ -260,22 +260,12 @@ describe("groupThreadsByMode", () => {
       "date"
     )
     expect(sections.map((s) => s.key)).toEqual(["today", "last7", "older"])
-    expect(sections.find((s) => s.key === "last7")?.defaultCollapsed).toBe(true)
+    expect(sections.find((s) => s.key === "last7")?.defaultCollapsed).toBe(
+      false
+    )
     expect(sections.find((s) => s.key === "today")?.defaultCollapsed).toBe(
       false
     )
-  })
-
-  it("groups by status in a fixed order", () => {
-    const sections = groupThreadsByMode(
-      [
-        makeThread({ status: "idle" }),
-        makeThread({ status: "running" }),
-        makeThread({ status: "error" }),
-      ],
-      "status"
-    )
-    expect(sections.map((s) => s.key)).toEqual(["running", "error", "idle"])
   })
 
   it("groups by repo alphabetically with a fallback label", () => {
@@ -295,9 +285,9 @@ describe("groupThreadsByMode", () => {
   })
 
   it("sorts threads within a section by creation time", () => {
-    const older = makeThread({ status: "idle", createdAt: 1, updatedAt: 3 })
-    const newer = makeThread({ status: "idle", createdAt: 2, updatedAt: 2 })
-    const [section] = groupThreadsByMode([older, newer], "status")
+    const older = makeThread({ createdAt: 1, updatedAt: 3 })
+    const newer = makeThread({ createdAt: 2, updatedAt: 2 })
+    const [section] = groupThreadsByMode([older, newer], "none")
     expect(section?.threads).toEqual([newer, older])
   })
 })

--- a/ui/src/features/agents/lib/sidebarFilter.ts
+++ b/ui/src/features/agents/lib/sidebarFilter.ts
@@ -2,7 +2,7 @@ import { groupThreads } from "./api"
 import { groupThreadsForView } from "./threadViews"
 import type { AgentSource, AgentStatus, AgentThread } from "./types"
 
-export type SidebarGroupMode = "none" | "focus" | "date" | "status" | "repo"
+export type SidebarGroupMode = "none" | "focus" | "date" | "repo"
 
 export type SidebarOwnership = "all" | "mine" | "shared"
 
@@ -37,7 +37,6 @@ export const GROUP_MODE_OPTIONS: Array<{
   { value: "focus", label: "Focus" },
   { value: "repo", label: "Project" },
   { value: "date", label: "Date" },
-  { value: "status", label: "Status" },
   { value: "none", label: "None" },
 ]
 
@@ -173,22 +172,6 @@ export function reconcilePinnedAttentionThread(
   return activeAttentionThread
 }
 
-const STATUS_GROUP_ORDER: Array<AgentStatus> = [
-  "running",
-  "finished",
-  "interrupted",
-  "error",
-  "idle",
-]
-
-const STATUS_GROUP_LABEL: Record<AgentStatus, string> = {
-  running: "Running",
-  finished: "Finished",
-  interrupted: "Interrupted",
-  error: "Error",
-  idle: "Idle",
-}
-
 function sortedByCreation(threads: Array<AgentThread>): Array<AgentThread> {
   return [...threads].sort((a, b) => b.createdAt - a.createdAt)
 }
@@ -247,7 +230,7 @@ export function groupThreadsByMode(
           key: "last7",
           label: "Last 7 days",
           threads: groups.last7,
-          collapsed: true,
+          collapsed: false,
         },
         {
           key: "last30",
@@ -270,23 +253,6 @@ export function groupThreadsByMode(
         threads: section.threads,
         defaultCollapsed: section.collapsed,
       }))
-  }
-
-  if (mode === "status") {
-    const byStatus = new Map<AgentStatus, Array<AgentThread>>()
-    for (const thread of threads) {
-      const list = byStatus.get(thread.status) ?? []
-      list.push(thread)
-      byStatus.set(thread.status, list)
-    }
-    return STATUS_GROUP_ORDER.filter((status) => byStatus.has(status)).map(
-      (status) => ({
-        key: status,
-        label: STATUS_GROUP_LABEL[status],
-        threads: sortedByCreation(byStatus.get(status) ?? []),
-        defaultCollapsed: false,
-      })
-    )
   }
 
   const byRepo = new Map<string, Array<AgentThread>>()

--- a/ui/src/features/agents/lib/sidebarPrefs.ts
+++ b/ui/src/features/agents/lib/sidebarPrefs.ts
@@ -10,7 +10,6 @@ const GROUP_MODES: ReadonlyArray<SidebarGroupMode> = [
   "none",
   "focus",
   "date",
-  "status",
   "repo",
 ]
 

--- a/ui/src/features/agents/lib/threadViews.test.ts
+++ b/ui/src/features/agents/lib/threadViews.test.ts
@@ -51,28 +51,6 @@ describe("groupThreadsForView", () => {
     ).toEqual(threads.map((item) => item.id).sort())
   })
 
-  it("uses the canonical status order without treating resolved as a status", () => {
-    const groups = groupThreadsForView(
-      [
-        thread({ status: "idle", resolved: true }),
-        thread({ status: "error" }),
-        thread({ status: "interrupted" }),
-        thread({ status: "finished" }),
-        thread({ status: "running" }),
-      ],
-      "status"
-    )
-
-    expect(groups.map((group) => group.key)).toEqual([
-      "running",
-      "finished",
-      "interrupted",
-      "error",
-      "idle",
-    ])
-    expect(groups.at(-1)?.threads[0]?.resolved).toBe(true)
-  })
-
   it("groups dynamic repositories alphabetically with an empty fallback", () => {
     const groups = groupThreadsForView(
       [

--- a/ui/src/features/agents/lib/threadViews.ts
+++ b/ui/src/features/agents/lib/threadViews.ts
@@ -1,13 +1,7 @@
-import type { AgentSource, AgentStatus, AgentThread } from "./types"
+import type { AgentSource, AgentThread } from "./types"
 
 export type ThreadsLayout = "board" | "list"
-export type ThreadGrouping =
-  | "focus"
-  | "status"
-  | "repo"
-  | "source"
-  | "pr"
-  | "none"
+export type ThreadGrouping = "focus" | "repo" | "source" | "pr" | "none"
 
 export interface ThreadViewGroup {
   key: string
@@ -20,7 +14,6 @@ export const THREAD_GROUPING_OPTIONS: Array<{
   label: string
 }> = [
   { value: "focus", label: "Focus" },
-  { value: "status", label: "Status" },
   { value: "repo", label: "Repository" },
   { value: "source", label: "Source" },
   { value: "pr", label: "Pull request" },
@@ -33,22 +26,6 @@ const FOCUS_GROUPS = [
   { key: "ready", label: "Ready" },
   { key: "done", label: "Done" },
 ]
-
-const STATUS_ORDER: Array<AgentStatus> = [
-  "running",
-  "finished",
-  "interrupted",
-  "error",
-  "idle",
-]
-
-const STATUS_LABELS: Record<AgentStatus, string> = {
-  running: "Running",
-  finished: "Finished",
-  interrupted: "Interrupted",
-  error: "Error",
-  idle: "Idle",
-}
 
 const SOURCE_ORDER: Array<AgentSource> = [
   "dashboard",
@@ -122,13 +99,6 @@ export function groupThreadsForView(
   }
   if (grouping === "focus") {
     return buildGroups(FOCUS_GROUPS, threads, focusKey)
-  }
-  if (grouping === "status") {
-    return buildGroups(
-      STATUS_ORDER.map((key) => ({ key, label: STATUS_LABELS[key] })),
-      threads,
-      (thread) => thread.status
-    )
   }
   if (grouping === "source") {
     return buildGroups(

--- a/ui/src/routes/agents/threads.tsx
+++ b/ui/src/routes/agents/threads.tsx
@@ -24,7 +24,6 @@ const STATUSES: ReadonlyArray<AgentStatus> = [
 const LAYOUTS: ReadonlyArray<ThreadsLayout> = ["board", "list"]
 const GROUPINGS: ReadonlyArray<ThreadGrouping> = [
   "focus",
-  "status",
   "repo",
   "source",
   "pr",


### PR DESCRIPTION
## Description
Add project selection to Cloud, remove status grouping, expand the last seven days, and load more threads on scroll.

## Release Note
Cloud thread navigation now defaults to project selection and loads more threads automatically.

## Test Plan
- [x] Verify typecheck, lint, focused tests, and production build

Made by [Open SWE](https://openswe.vercel.app/agents/01a03986-40cf-76ad-8d1f-c57528523f1a)