### PR TITLE
fix: allow concurrent web and desktop development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: help
 ######################
 
 dev:
-	uv run langgraph dev
+	uv run langgraph dev --no-browser
 
 run:
 	uv run uvicorn agent.webapp:app --reload --port 8000

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ help:
 	@echo '----'
 	@echo 'dev                          - run LangGraph dev server'
 	@echo 'run                          - run webhook server'
-	@echo 'desktop                      - run the backend and Electron desktop app'
+	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
 	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
 	@echo 'install-checkout             - install the current checkout of Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev desktop install-desktop install-checkout
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web desktop install-desktop install-checkout
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -9,6 +9,9 @@ all: help
 
 dev:
 	uv run langgraph dev --no-browser --port 2024
+
+web:
+	pnpm run dev
 
 run:
 	uv run uvicorn agent.webapp:app --reload --port 8000
@@ -75,6 +78,7 @@ typecheck:
 help:
 	@echo '----'
 	@echo 'dev                          - run LangGraph dev server'
+	@echo 'web                          - run the dashboard web server'
 	@echo 'run                          - run webhook server'
 	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
 	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: help
 ######################
 
 dev:
-	uv run langgraph dev --no-browser
+	uv run langgraph dev --no-browser --port 2024
 
 run:
 	uv run uvicorn agent.webapp:app --reload --port 8000

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -57,6 +57,8 @@ backend settings, login sessions, and projects are preserved.
 Install the workspace dependencies, then run the backend, desktop app, and web UI independently:
 
 ```bash
+pnpm install # from the repo root
+
 # terminal 1
 make dev
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -64,7 +64,7 @@ make dev
 make desktop
 
 # terminal 3 (optional web UI)
-pnpm run dev
+make web
 ```
 
 `pnpm run dev:desktop` is equivalent to `make desktop`. The desktop app starts its private local-agent backend on a random loopback port while connecting cloud features and GitHub login to the shared backend at `http://localhost:2024`.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -54,15 +54,20 @@ backend settings, login sessions, and projects are preserved.
 
 ## Local development
 
-Install the workspace dependencies, then start the backend and Electron together:
+Install the workspace dependencies, then run the backend, desktop app, and web UI independently:
 
 ```bash
-pnpm install                  # from the repo root
+# terminal 1
+make dev
+
+# terminal 2
 make desktop
+
+# terminal 3 (optional web UI)
+pnpm run dev
 ```
 
-`pnpm run dev:desktop` is the equivalent workspace command. Both commands stop the backend when
-the desktop app exits, and stop the desktop app if the backend fails.
+`pnpm run dev:desktop` is equivalent to `make desktop`. The desktop app starts its private local-agent backend on a random loopback port while connecting cloud features and GitHub login to the shared backend at `http://localhost:2024`.
 
 Source launches use an isolated `Open SWE Development` Electron profile, so the dev app can run
 beside an installed `Open SWE` app without sharing its login session, backend configuration,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,7 +8,6 @@
     "build": "node scripts/build-main.cjs",
     "build:ui": "pnpm --filter open-swe-dashboard run build",
     "dev": "pnpm run build:ui && pnpm run build && electron . --dev",
-    "dev:full": "concurrently --kill-others --success first --names backend,desktop --prefix-colors blue,magenta \"uv --directory .. run langgraph dev --no-browser\" \"pnpm run dev\"",
     "start": "pnpm run build:ui && pnpm run build && electron .",
     "test:run": "node --test test/*.test.cjs",
     "test": "pnpm run build && pnpm run test:run",
@@ -101,7 +100,6 @@
   "devDependencies": {
     "@electron/notarize": "3.1.1",
     "@types/node": "22.20.1",
-    "concurrently": "10.0.5",
     "electron": "41.10.3",
     "electron-builder": "26.15.3",
     "typescript": "5.9.3"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -618,7 +618,7 @@ invalidating already-stored GitHub tokens:
 Make sure ngrok is still running from step 2, then start the backend in a second terminal:
 
 ```bash
-make dev          # uv run langgraph dev --no-browser
+make dev          # uv run langgraph dev --no-browser --port 2024
 ```
 
 `langgraph dev` serves **all three graphs** (`agent`, `reviewer`, `analyzer`) *and* the FastAPI app (`agent.webapp:app`) together on `http://localhost:2024`. The FastAPI app owns both the webhooks and the dashboard API:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -665,12 +665,14 @@ For the dashboard login to succeed, you need (from steps 3c / 6): `GITHUB_APP_CL
 > **Experimental:** The desktop wrapper is an early-access convenience surface. The web UI is
 > the recommended way to use Open SWE.
 
-The Electron app in `desktop/` includes the compiled dashboard UI. It only needs the Open SWE
-backend to be running:
+The Electron app in `desktop/` includes the compiled dashboard UI. Run it alongside the Open SWE
+backend (and, optionally, the web UI) in separate terminals:
 
 ```bash
 pnpm install                  # from the repo root
-pnpm run dev:desktop
+make dev                      # terminal 1
+pnpm run dev:desktop          # terminal 2
+pnpm run dev                  # terminal 3, optional web UI
 ```
 
 Development connects to `http://localhost:2024`. To use a hosted backend instead, run

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -644,10 +644,10 @@ The dashboard is the web app in `ui/`. It's a server-rendered TanStack Start app
 
 ```bash
 pnpm install          # from the repo root: ui/ and desktop/ are one pnpm workspace
-pnpm run dev          # turbo -> vite dev --port 3000 -> http://localhost:3000
+make web             # pnpm run dev -> Vite on http://localhost:3000
 ```
 
-No `ui/.env` is needed: the dev server proxies `/dashboard/api/*` to `DASHBOARD_API_URL`, which defaults to `http://localhost:2024`. Point it elsewhere by exporting that variable before `pnpm run dev`. It is read at request time, so the same build can front any backend.
+No `ui/.env` is needed: the dev server proxies `/dashboard/api/*` to `DASHBOARD_API_URL`, which defaults to `http://localhost:2024`. Point it elsewhere by exporting that variable before `make web` or `pnpm run dev`. It is read at request time, so the same build can front any backend.
 
 To enable Datadog browser RUM, set `VITE_DATADOG_APPLICATION_ID` and `VITE_DATADOG_CLIENT_TOKEN` when building the dashboard. Optional build-time settings are `VITE_DATADOG_SITE` (default `datadoghq.com`), `VITE_DATADOG_SERVICE` (default `open-swe-dashboard`), `VITE_DATADOG_ENV`, `VITE_DATADOG_VERSION`, `VITE_DATADOG_SESSION_SAMPLE_RATE` (default `100`), and `VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE` (default `100`). Session Replay is enabled by default for sampled RUM sessions with all content masked; telemetry also strips URL query strings and fragments. Values prefixed with `VITE_` are public in the browser bundle; use a Datadog client token, never an API or application key.
 
@@ -671,7 +671,7 @@ backend (and, optionally, the web UI) in separate terminals:
 pnpm install                  # from the repo root
 make dev                      # terminal 1
 pnpm run dev:desktop          # terminal 2
-pnpm run dev                  # terminal 3, optional web UI
+make web                      # terminal 3, optional web UI
 ```
 
 Development connects to `http://localhost:2024`. To use a hosted backend instead, run
@@ -791,7 +791,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 ### Dashboard UI can't reach the backend
 
 - Confirm the backend is running via `make dev` on `:2024` (not `make run` on `:8000`).
-- Confirm the dev server is proxying: `curl -i http://localhost:3000/dashboard/api/me` should return the backend's `401`, not an HTML page. If the backend is on another port, export `DASHBOARD_API_URL` before `pnpm run dev`.
+- Confirm the dev server is proxying: `curl -i http://localhost:3000/dashboard/api/me` should return the backend's `401`, not an HTML page. If the backend is on another port, export `DASHBOARD_API_URL` before `make web` or `pnpm run dev`.
 
 ### Sandbox creation failures
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -618,8 +618,7 @@ invalidating already-stored GitHub tokens:
 Make sure ngrok is still running from step 2, then start the backend in a second terminal:
 
 ```bash
-make dev          # uv run langgraph dev
-# or: uv run langgraph dev --no-browser
+make dev          # uv run langgraph dev --no-browser
 ```
 
 `langgraph dev` serves **all three graphs** (`agent`, `reviewer`, `analyzer`) *and* the FastAPI app (`agent.webapp:app`) together on `http://localhost:2024`. The FastAPI app owns both the webhooks and the dashboard API:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@11.18.0",
   "scripts": {
     "dev": "turbo run dev --filter=open-swe-dashboard",
-    "dev:desktop": "pnpm --dir desktop run dev:full",
+    "dev:desktop": "pnpm --dir desktop run dev",
     "dev:mock": "bash tests/e2e/dev-mock.sh",
     "build": "turbo run build",
     "check": "turbo run check",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       '@types/node':
         specifier: 22.20.1
         version: 22.20.1
-      concurrently:
-        specifier: 10.0.5
-        version: 10.0.5
       electron:
         specifier: 41.10.3
         version: 41.10.3(supports-color@10.2.2)
@@ -2577,10 +2574,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -2792,10 +2785,6 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
-
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
@@ -2853,11 +2842,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  concurrently@10.0.5:
-    resolution: {integrity: sha512-JaP/CoftUrCcAFW/g//RbgEGwlelnEae6cfBLgH6ZdO6s8jPkn6p9SB9u6pdVxYXoiSnFqseOlHfrEfF82TVOg==}
-    engines: {node: '>=22'}
-    hasBin: true
 
   conf@10.2.0:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
@@ -5178,9 +5162,6 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -5272,10 +5253,6 @@ packages:
 
   shell-quote@1.10.0:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
-    engines: {node: '>= 0.4'}
-
-  shell-quote@1.9.0:
-    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   shiki@4.4.3:
@@ -5522,10 +5499,6 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
-
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5941,10 +5914,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5997,17 +5966,9 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yjs@13.6.32:
     resolution: {integrity: sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==}
@@ -8295,8 +8256,6 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansi-styles@6.2.3: {}
-
   ansis@4.3.1: {}
 
   app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
@@ -8553,12 +8512,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
@@ -8598,15 +8551,6 @@ snapshots:
   compare-version@0.1.2: {}
 
   concat-map@0.0.1: {}
-
-  concurrently@10.0.5:
-    dependencies:
-      chalk: 5.6.2
-      rxjs: 7.8.2
-      shell-quote: 1.9.0
-      supports-color: 10.2.2
-      tree-kill: 1.2.2
-      yargs: 18.0.0
 
   conf@10.2.0:
     dependencies:
@@ -11301,10 +11245,6 @@ snapshots:
 
   rw@1.3.3: {}
 
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
-
   safe-buffer@5.1.2: {}
 
   safer-buffer@2.1.2: {}
@@ -11423,8 +11363,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.10.0: {}
-
-  shell-quote@1.9.0: {}
 
   shiki@4.4.3:
     dependencies:
@@ -11593,7 +11531,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supports-color@10.2.2: {}
+  supports-color@10.2.2:
+    optional: true
 
   supports-color@7.2.0:
     dependencies:
@@ -11681,8 +11620,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-
-  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -11961,12 +11898,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
 
   ws@8.21.3: {}
@@ -11999,8 +11930,6 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
-  yargs-parser@22.0.0: {}
-
   yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
@@ -12010,15 +11939,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yjs@13.6.32:
     dependencies:


### PR DESCRIPTION
## Description
Keep `make desktop` from launching a second dashboard backend on port 2024, so desktop and web development can share the backend started by `make dev`. The Electron-owned local-agent backend remains isolated on a random loopback port.

## Release Note
Local web and desktop development can now run concurrently.

## Test Plan
- [x] Run desktop unit tests and type checking
- [x] Verify formatting and linting