### PR TITLE
feat: add tab-based desktop threads

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -519,13 +519,18 @@ async function proxyBackendRequest(request) {
   const body = ["GET", "HEAD"].includes(request.method)
     ? undefined
     : request.body;
-  const upstream = await fetch(targetUrl, {
-    method: request.method,
-    headers,
-    body,
-    redirect: "manual",
-    ...(body ? { duplex: "half" } : {}),
-  });
+  let upstream;
+  try {
+    upstream = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body,
+      redirect: "manual",
+      ...(body ? { duplex: "half" } : {}),
+    });
+  } catch {
+    return new Response("Backend is unavailable", { status: 502 });
+  }
   await storeResponseCookies(targetUrl, upstream);
 
   const location = upstream.headers.get("location");

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -11,6 +11,7 @@ import type { RunTarget } from "@/features/agents/components/composer/RunTargetS
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
 import { OnboardingDialog } from "@/features/agents/components/OnboardingDialog"
 import { Logo } from "@/features/agents/components/chat/Logo"
+import { DesktopThreadsHome } from "@/features/agents/components/DesktopThreadsHome"
 import {
   agentThreadKeys,
   invalidateAgentThreadLists,
@@ -83,6 +84,13 @@ export function AgentsHome() {
   const [submitting, setSubmitting] = useState(false)
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
+  const [desktopCreating, setDesktopCreating] = useState(() => {
+    if (!isDesktop) return false
+    const creating =
+      window.sessionStorage.getItem("open-swe.desktop.new-thread") === "1"
+    window.sessionStorage.removeItem("open-swe.desktop.new-thread")
+    return creating
+  })
   const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
   const runTarget: RunTarget = isDesktop
     ? cloudEnabled
@@ -305,6 +313,15 @@ export function AgentsHome() {
         setSubmitting(false)
         throw error
       })
+  }
+
+  if (isDesktop && !desktopCreating) {
+    return (
+      <DesktopThreadsHome
+        cloudEnabled={cloudEnabled}
+        onNewThread={() => setDesktopCreating(true)}
+      />
+    )
   }
 
   return (

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -1184,13 +1184,15 @@ export function AgentsShell({
   return (
     <SidebarLayoutProvider value={layout}>
       <div className="agents-ui flex h-svh overflow-hidden bg-background">
-        <AgentsSidebar
-          user={user}
-          localOnly={localOnly}
-          activeThreadId={activeThreadId}
-          activeLocalSessionId={activeLocalSessionId}
-          layout={layout}
-        />
+        {!(typeof window !== "undefined" && window.openSweDesktop) && (
+          <AgentsSidebar
+            user={user}
+            localOnly={localOnly}
+            activeThreadId={activeThreadId}
+            activeLocalSessionId={activeLocalSessionId}
+            layout={layout}
+          />
+        )}
         <main className="surface-grain relative flex min-w-0 flex-1 overflow-hidden bg-background">
           {children}
         </main>

--- a/ui/src/features/agents/components/DesktopAgentTabs.tsx
+++ b/ui/src/features/agents/components/DesktopAgentTabs.tsx
@@ -1,0 +1,185 @@
+import { createContext, useContext, useEffect, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { Link, useNavigate } from "@tanstack/react-router"
+import { HouseIcon, PlusIcon, XIcon } from "@phosphor-icons/react"
+import { IoCloudOutline, IoDesktopOutline } from "react-icons/io5"
+
+import type { DesktopLocalThreadSummary } from "@/desktop"
+import type { AgentThread } from "@/features/agents/lib/types"
+import { agentThreadKeys } from "@/features/agents/lib/queries"
+import { localThreadKeys } from "@/features/agents/lib/desktopLocal"
+import { cn } from "@/lib/utils"
+
+export type DesktopAgentTab = {
+  id: string
+  source: "cloud" | "local"
+  title: string
+}
+const STORAGE_KEY = "open-swe.desktop.tabs"
+
+function readTabs(): Array<DesktopAgentTab> {
+  if (typeof window === "undefined") return []
+  try {
+    const value: unknown = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) ?? "[]"
+    )
+    if (!Array.isArray(value)) return []
+    return value.filter(
+      (tab): tab is DesktopAgentTab =>
+        typeof tab === "object" &&
+        tab !== null &&
+        typeof tab.id === "string" &&
+        (tab.source === "cloud" || tab.source === "local") &&
+        typeof tab.title === "string"
+    )
+  } catch {
+    return []
+  }
+}
+
+const DesktopAgentTabsContext = createContext<{
+  open: (tab: DesktopAgentTab) => void
+} | null>(null)
+export function useDesktopAgentTabs() {
+  return useContext(DesktopAgentTabsContext)
+}
+
+export function DesktopAgentTabsProvider({
+  activeThreadId,
+  activeLocalSessionId,
+  children,
+}: {
+  activeThreadId?: string
+  activeLocalSessionId?: string
+  cloudEnabled: boolean
+  children: React.ReactNode
+}) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [tabs, setTabs] = useState(readTabs)
+  const activeKey = activeLocalSessionId
+    ? `local:${activeLocalSessionId}`
+    : activeThreadId
+      ? `cloud:${activeThreadId}`
+      : null
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tabs))
+  }, [tabs])
+  useEffect(() => {
+    if (!activeKey) return
+    const [source, id] = activeKey.split(":") as ["cloud" | "local", string]
+    const cached =
+      source === "cloud"
+        ? queryClient.getQueryData<AgentThread>(agentThreadKeys.detail(id))
+        : queryClient.getQueryData<DesktopLocalThreadSummary>(
+            localThreadKeys.detail(id)
+          )
+    // oxlint-disable-next-line react/set-state-in-effect
+    setTabs((current) =>
+      current.some((tab) => `${tab.source}:${tab.id}` === activeKey)
+        ? current
+        : [...current, { id, source, title: cached?.title ?? "Thread" }]
+    )
+  }, [activeKey, queryClient])
+
+  const open = (tab: DesktopAgentTab) =>
+    setTabs((current) =>
+      current.some((item) => item.id === tab.id && item.source === tab.source)
+        ? current.map((item) =>
+            item.id === tab.id && item.source === tab.source ? tab : item
+          )
+        : [...current, tab]
+    )
+
+  const close = (tab: DesktopAgentTab) => {
+    const index = tabs.indexOf(tab)
+    const next = tabs.filter((item) => item !== tab)
+    setTabs(next)
+    if (`${tab.source}:${tab.id}` !== activeKey) return
+    const fallback = next[Math.min(index, next.length - 1)]
+    if (!fallback) {
+      void navigate({ to: "/agents" })
+      return
+    }
+    void navigate(
+      fallback.source === "local"
+        ? { to: "/agents/local/$sessionId", params: { sessionId: fallback.id } }
+        : { to: "/agents/$threadId", params: { threadId: fallback.id } }
+    )
+  }
+
+  return (
+    <DesktopAgentTabsContext.Provider value={{ open }}>
+      <div className="flex h-svh flex-col overflow-hidden">
+        <header
+          data-desktop-drag-region=""
+          className="flex h-9 shrink-0 items-center gap-1 border-b border-border bg-sidebar pr-2 pl-[90px]"
+        >
+          <Link
+            to="/agents"
+            aria-label="Home"
+            className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground",
+              !activeKey && "bg-accent text-foreground"
+            )}
+          >
+            <HouseIcon className="size-4" />
+          </Link>
+          <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-1">
+            {tabs.map((tab) => {
+              const key = `${tab.source}:${tab.id}`
+              const Icon =
+                tab.source === "cloud" ? IoCloudOutline : IoDesktopOutline
+              return (
+                <div
+                  key={key}
+                  className={cn(
+                    "group flex h-7 max-w-56 min-w-32 flex-1 items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground hover:bg-accent/70",
+                    key === activeKey && "bg-accent text-foreground"
+                  )}
+                >
+                  <Link
+                    to={
+                      tab.source === "local"
+                        ? "/agents/local/$sessionId"
+                        : "/agents/$threadId"
+                    }
+                    params={
+                      tab.source === "local"
+                        ? { sessionId: tab.id }
+                        : { threadId: tab.id }
+                    }
+                    className="flex min-w-0 flex-1 items-center gap-1.5"
+                  >
+                    <Icon className="size-3.5 shrink-0" />
+                    <span className="truncate">{tab.title}</span>
+                  </Link>
+                  <button
+                    type="button"
+                    aria-label={`Close ${tab.title}`}
+                    onClick={() => close(tab)}
+                    className="flex size-5 shrink-0 items-center justify-center rounded opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-background"
+                  >
+                    <XIcon className="size-3" />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+          <Link
+            to="/agents"
+            onClick={() =>
+              window.sessionStorage.setItem("open-swe.desktop.new-thread", "1")
+            }
+            aria-label="New thread"
+            className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <PlusIcon className="size-4" />
+          </Link>
+        </header>
+        <div className="flex min-h-0 flex-1">{children}</div>
+      </div>
+    </DesktopAgentTabsContext.Provider>
+  )
+}

--- a/ui/src/features/agents/components/DesktopThreadsHome.tsx
+++ b/ui/src/features/agents/components/DesktopThreadsHome.tsx
@@ -1,0 +1,121 @@
+import { Link } from "@tanstack/react-router"
+import { CircleNotchIcon } from "@phosphor-icons/react"
+import { IoCloudOutline, IoDesktopOutline } from "react-icons/io5"
+
+import { useDesktopAgentTabs } from "./DesktopAgentTabs"
+import {
+  useDesktopLocalThreads,
+  useLocalThreadActivity,
+} from "@/features/agents/lib/desktopLocal"
+import { useSidebarThreads } from "@/features/agents/lib/queries"
+import { cn, formatRelativeTime } from "@/lib/utils"
+
+export function DesktopThreadsHome({
+  cloudEnabled,
+  onNewThread,
+}: {
+  cloudEnabled: boolean
+  onNewThread: () => void
+}) {
+  const tabs = useDesktopAgentTabs()
+  const localThreads = useDesktopLocalThreads().data ?? []
+  const localActivity = useLocalThreadActivity()
+  const cloud = useSidebarThreads({
+    includeAutomations: true,
+    includeResolved: true,
+    enabled: cloudEnabled,
+  })
+  const threads = [
+    ...[...cloud.data.active.items, ...cloud.data.resolved.items].map(
+      (thread) => ({
+        id: thread.id,
+        source: "cloud" as const,
+        title: thread.title,
+        subtitle: thread.repoFullName || thread.repo || "Cloud",
+        updatedAt: thread.updatedAt,
+        running: thread.status === "running",
+      })
+    ),
+    ...localThreads.map((thread) => ({
+      id: thread.id,
+      source: "local" as const,
+      title: thread.title,
+      subtitle: thread.cwd,
+      updatedAt: thread.updatedAt,
+      running: localActivity[thread.id] === "running",
+    })),
+  ].sort((left, right) => right.updatedAt - left.updatedAt)
+
+  return (
+    <section className="mx-auto flex w-full max-w-4xl flex-col overflow-y-auto px-6 py-10">
+      <div className="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="font-heading text-2xl font-medium tracking-tight">
+            Home
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Cloud and local threads
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onNewThread}
+          className="rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground"
+        >
+          New thread
+        </button>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        {threads.map((thread) => {
+          const Icon =
+            thread.source === "cloud" ? IoCloudOutline : IoDesktopOutline
+          return (
+            <Link
+              key={`${thread.source}:${thread.id}`}
+              to={
+                thread.source === "local"
+                  ? "/agents/local/$sessionId"
+                  : "/agents/$threadId"
+              }
+              params={
+                thread.source === "local"
+                  ? { sessionId: thread.id }
+                  : { threadId: thread.id }
+              }
+              onClick={() => tabs?.open(thread)}
+              className="flex items-center gap-3 border-b border-border px-4 py-3 last:border-b-0 hover:bg-muted/40"
+            >
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <Icon className="size-4" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium">
+                  {thread.title}
+                </div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {thread.subtitle}
+                </div>
+              </div>
+              {thread.running && (
+                <CircleNotchIcon className="size-4 animate-spin text-primary" />
+              )}
+              <span
+                className={cn(
+                  "shrink-0 text-xs text-muted-foreground",
+                  thread.running && "hidden sm:block"
+                )}
+              >
+                {formatRelativeTime(thread.updatedAt)}
+              </span>
+            </Link>
+          )
+        })}
+        {!cloud.isPending && threads.length === 0 && (
+          <p className="px-4 py-12 text-center text-sm text-muted-foreground">
+            No threads yet
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -4,6 +4,7 @@ import { Outlet, createFileRoute, useRouterState } from "@tanstack/react-router"
 import { AgentsShell } from "@/features/agents/components/AgentsSidebar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AgentThreadStreamProvider } from "@/features/agents/lib/AgentThreadStreamProvider"
+import { DesktopAgentTabsProvider } from "@/features/agents/components/DesktopAgentTabs"
 import { RequireLogin } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
 import { isDesktopLocalModeEnabled } from "@/lib/desktop-local-mode"
@@ -62,7 +63,7 @@ function AgentsLayout() {
 
   if (!session.data && (!localOnly || !isLocalRoute)) return <RequireLogin />
 
-  return (
+  const content = (
     <AgentsShell
       user={session.data ?? null}
       localOnly={localOnly}
@@ -74,4 +75,17 @@ function AgentsLayout() {
       </AgentThreadStreamProvider>
     </AgentsShell>
   )
+
+  if (typeof window !== "undefined" && window.openSweDesktop) {
+    return (
+      <DesktopAgentTabsProvider
+        activeThreadId={activeThreadId}
+        activeLocalSessionId={activeLocalSessionId}
+        cloudEnabled={Boolean(session.data)}
+      >
+        {content}
+      </DesktopAgentTabsProvider>
+    )
+  }
+  return content
 }


### PR DESCRIPTION
## Description
Refactor the desktop agents UI around persistent thread tabs and a unified Home list for cloud and local sessions. Tabs use Ionicons cloud/computer indicators and retain recent tabs across restarts.

## Release Note
Desktop now presents cloud and local agent threads in one Home list with persistent tabs.

## Test Plan
- [x] Open cloud and local threads from Home, switch tabs, and close the active tab.
- [x] Build the production dashboard bundle.