### PR TITLE
fix: block external Slack channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Open SWE's orchestration has two layers:
 
 All three companies in the article converge on **Slack as the primary invocation surface**. Open SWE does the same:
 
-- **Slack** — Mention the bot in any thread. Supports `repo:owner/name` syntax to specify which repo to work on. The agent replies in-thread with status updates and PR links.
+- **Slack** — Mention the bot in any internal thread. Slack Connect channels are refused before a run starts, and channel-verification failures fail closed. Supports `repo:owner/name` syntax to specify which repo to work on. The agent replies in-thread with status updates and PR links.
 - **Linear** — Comment `@openswe` on any issue. The agent reads the full issue context, reacts with 👀 to acknowledge, and posts results back as comments.
 - **GitHub** — Tag `@openswe` in PR comments on agent-created PRs to have it address review feedback and push fixes to the same branch.
 

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -1005,6 +1005,9 @@ def normalize_slack_channel_context(
     purpose = _channel_section_value(channel, "purpose")
     description = "\n".join(value for value in (topic, purpose) if value)
     is_ext_shared = channel.get("is_ext_shared") if isinstance(channel, dict) else None
+    is_pending_ext_shared = (
+        channel.get("is_pending_ext_shared") if isinstance(channel, dict) else None
+    )
     is_im = channel.get("is_im") if isinstance(channel, dict) else None
     return {
         "id": channel_id,
@@ -1014,6 +1017,9 @@ def normalize_slack_channel_context(
         "purpose": purpose,
         "description": description,
         "is_ext_shared": is_ext_shared if isinstance(is_ext_shared, bool) else None,
+        "is_pending_ext_shared": (
+            is_pending_ext_shared if isinstance(is_pending_ext_shared, bool) else None
+        ),
         "is_im": is_im if isinstance(is_im, bool) else None,
     }
 
@@ -1022,7 +1028,10 @@ def slack_channel_allows_operations(channel_context: dict[str, Any] | None) -> b
     """Allow operations only when Slack confirms the channel is not externally shared."""
     if not isinstance(channel_context, dict):
         return False
-    return channel_context.get("is_im") is True or channel_context.get("is_ext_shared") is False
+    return channel_context.get("is_im") is True or (
+        channel_context.get("is_ext_shared") is False
+        and channel_context.get("is_pending_ext_shared") is False
+    )
 
 
 def get_slack_channel_context_description(channel_context: dict[str, Any] | None) -> str:

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -36,7 +36,7 @@ SLACK_THREAD_MAX_MESSAGES = 500
 SLACK_FILE_UPLOAD_MAX_BYTES = 16 * 1024 * 1024
 SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS = 300
 
-SlackChannelContext = dict[str, str]
+SlackChannelContext = dict[str, str | bool | None]
 _SLACK_CHANNEL_INFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 
 SLACK_WEB_LINK_FOOTER_LABEL = "Open in Web"
@@ -931,13 +931,14 @@ def _cache_slack_channel_info(channel_id: str, channel: dict[str, Any]) -> None:
     )
 
 
-async def get_slack_channel_info(channel_id: str) -> dict[str, Any] | None:
+async def get_slack_channel_info(
+    channel_id: str, *, use_cache: bool = True
+) -> dict[str, Any] | None:
     """Get Slack channel details (including topic/purpose) by channel ID."""
     if not SLACK_BOT_TOKEN or not channel_id:
         return None
 
-    cached = _cached_slack_channel_info(channel_id)
-    if cached is not None:
+    if use_cache and (cached := _cached_slack_channel_info(channel_id)) is not None:
         return cached
 
     async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
@@ -1003,6 +1004,8 @@ def normalize_slack_channel_context(
     topic = _channel_section_value(channel, "topic")
     purpose = _channel_section_value(channel, "purpose")
     description = "\n".join(value for value in (topic, purpose) if value)
+    is_ext_shared = channel.get("is_ext_shared") if isinstance(channel, dict) else None
+    is_im = channel.get("is_im") if isinstance(channel, dict) else None
     return {
         "id": channel_id,
         "name": name,
@@ -1010,7 +1013,16 @@ def normalize_slack_channel_context(
         "topic": topic,
         "purpose": purpose,
         "description": description,
+        "is_ext_shared": is_ext_shared if isinstance(is_ext_shared, bool) else None,
+        "is_im": is_im if isinstance(is_im, bool) else None,
     }
+
+
+def slack_channel_allows_operations(channel_context: dict[str, Any] | None) -> bool:
+    """Allow operations only when Slack confirms the channel is not externally shared."""
+    if not isinstance(channel_context, dict):
+        return False
+    return channel_context.get("is_im") is True or channel_context.get("is_ext_shared") is False
 
 
 def get_slack_channel_context_description(channel_context: dict[str, Any] | None) -> str:
@@ -1049,9 +1061,11 @@ def is_slack_channel_named(channel_context: dict[str, Any] | None, expected_name
     )
 
 
-async def get_slack_channel_context(channel_id: str) -> SlackChannelContext:
+async def get_slack_channel_context(
+    channel_id: str, *, use_cache: bool = True
+) -> SlackChannelContext:
     """Fetch and normalize Slack channel context."""
-    channel = await get_slack_channel_info(channel_id)
+    channel = await get_slack_channel_info(channel_id, use_cache=use_cache)
     return normalize_slack_channel_context(channel_id, channel)
 
 

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -120,6 +120,7 @@ from ..utils.slack import (
     resolve_slack_links_in_context,  # noqa: F401
     resolve_slack_thread_id,  # noqa: F401
     select_slack_context_messages,  # noqa: F401
+    slack_channel_allows_operations,  # noqa: F401
     store_slack_run_mapping,  # noqa: F401
     strip_bot_mention,  # noqa: F401
     update_slack_message,
@@ -264,6 +265,7 @@ __all__ = [
     "sanitize_github_comment_body",
     "select_slack_context_messages",
     "set_reviewer_thread_metadata",
+    "slack_channel_allows_operations",
     "slack_event_already_seen",
     "store_slack_run_mapping",
     "strip_bot_mention",
@@ -525,10 +527,10 @@ def _run_id_for_logging(run: Any) -> str:
     return run_id if isinstance(run_id, str) and run_id else "<unknown>"
 
 
-async def _get_slack_channel_context(channel_id: str) -> dict[str, str]:
+async def _get_slack_channel_context(channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
     """Fetch Slack channel context without blocking Slack-triggered runs on failure."""
     try:
-        return await get_slack_channel_context(channel_id)
+        return await get_slack_channel_context(channel_id, use_cache=use_cache)
     except Exception:  # noqa: BLE001
         logger.exception("Failed to resolve Slack channel context")
         return normalize_slack_channel_context(channel_id, None)

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -13,6 +13,17 @@ from . import slack as service
 router = APIRouter()
 
 _MESSAGE_UPDATE_RETRY_DELAYS = (0.1, 0.2, 0.5, 1, 2, 4, 8, 14)
+_EXTERNAL_CHANNEL_REFUSAL = "Open SWE does not operate in channels with external participants."
+
+
+def _event_channel_id(event: dict[str, Any]) -> str:
+    channel_id = event.get("channel")
+    if isinstance(channel_id, str):
+        return channel_id
+    item = event.get("item")
+    if isinstance(item, dict) and isinstance(item.get("channel"), str):
+        return item["channel"]
+    return ""
 
 
 async def _lookup_delivered_message_update(
@@ -67,11 +78,14 @@ async def _process_slack_message_update(
             message_ts,
         )
         return
+    channel_context = await common._get_slack_channel_context(channel_id, use_cache=False)
+    if not common.slack_channel_allows_operations(channel_context):
+        common.logger.warning("Blocked Slack message update in ineligible channel=%s", channel_id)
+        return
     event_data["thread_id"] = thread_id
     event_data["thread_version"] = await common.increment_slack_thread_version(
         langgraph_client, channel_id, thread_ts, str(event_data.get("event_ts") or "")
     )
-    channel_context = await common._get_slack_channel_context(channel_id)
     event_data["channel_context"] = channel_context
     repo_config = await common.get_slack_repo_config(
         channel_id,
@@ -115,6 +129,39 @@ async def slack_webhook(
         return {"status": "ignored", "reason": "Not an event callback"}
 
     event = payload.get("event", {})
+    if not isinstance(event, dict):
+        return {"status": "ignored", "reason": "Invalid Slack event"}
+
+    channel_id = _event_channel_id(event)
+    channel_context: dict[str, Any] | None = None
+    if channel_id:
+        channel_context = await common._get_slack_channel_context(channel_id, use_cache=False)
+        if not common.slack_channel_allows_operations(channel_context):
+            is_external = channel_context.get("is_ext_shared") is True
+            event_ts = str(event.get("event_ts") or event.get("ts") or "")
+            thread_ts = str(event.get("thread_ts") or event.get("ts") or "")
+            if (
+                is_external
+                and event.get("type") == "app_mention"
+                and event.get("subtype") is None
+                and isinstance(event.get("user"), str)
+                and thread_ts
+                and await common.claim_slack_event(
+                    str(payload.get("event_id") or ""), channel_id, event_ts
+                )
+            ):
+                background_tasks.add_task(
+                    common.post_slack_thread_reply,
+                    channel_id,
+                    thread_ts,
+                    _EXTERNAL_CHANNEL_REFUSAL,
+                )
+            common.logger.warning(
+                "Blocked Slack event in %s channel=%s",
+                "external" if is_external else "unverified",
+                channel_id,
+            )
+            return {"status": "ignored", "reason": "Slack channel is not eligible"}
 
     if event.get("type") == "reaction_added":
         reaction = event.get("reaction")
@@ -166,7 +213,6 @@ async def slack_webhook(
     if not isinstance(updated_message, dict):
         return {"status": "ignored", "reason": "Invalid updated message"}
 
-    channel_id = event.get("channel")
     event_ts = event.get("event_ts") or event.get("ts")
     original_message_ts = updated_message.get("ts")
     thread_ts = updated_message.get("thread_ts") or original_message_ts
@@ -297,7 +343,8 @@ async def slack_webhook(
 
     langgraph_client = get_langgraph_client()
     thread_id: str | None = None
-    channel_context = await common._get_slack_channel_context(channel_id)
+    if channel_context is None:
+        return {"status": "ignored", "reason": "Slack channel is not eligible"}
 
     if await common._is_docs_plz_slack_channel(channel_id, channel_context):
         if await common.claim_slack_event(event_id, channel_id, event_ts):
@@ -383,6 +430,16 @@ async def slack_interactivity(
     action = _first_open_swe_option_action(payload.get("actions"))
     if action is None:
         return {"status": "ignored", "reason": "No Open SWE action"}
+
+    channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
+    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
+    channel_id = str(channel.get("id") or container.get("channel_id") or "")
+    if not channel_id:
+        return {"status": "ignored", "reason": "Slack channel is not eligible"}
+    channel_context = await common._get_slack_channel_context(channel_id, use_cache=False)
+    if not common.slack_channel_allows_operations(channel_context):
+        common.logger.warning("Blocked Slack interaction in ineligible channel=%s", channel_id)
+        return {"status": "ignored", "reason": "Slack channel is not eligible"}
 
     try:
         action_value = common.json.loads(str(action.get("value") or "{}"))

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -439,6 +439,8 @@ Slack Block Kit option buttons only work when Interactivity is enabled and point
 
 Slack messages are routed to the Slack default repo (`SLACK_REPO_OWNER`/`SLACK_REPO_NAME`, falling back to `DEFAULT_REPO_OWNER`/`DEFAULT_REPO_NAME` — see step 6) unless the user specifies one with `repo:owner/name` in their message.
 
+Open SWE refuses Slack Connect channels when `conversations.info` reports `is_ext_shared`, before starting an agent run. If Slack cannot verify a channel, it fails closed and does not operate there.
+
 **"Sign in with Slack" account linking (optional):**
 
 The dashboard can let a user link their Slack identity to their GitHub login via Slack OIDC ("Sign in with Slack"). This is what lets a Slack-triggered run resolve to the right GitHub user. To enable it:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -851,6 +851,7 @@ async def slack_conversations_info(channel: str = "") -> JSONResponse:
                 "name": "demo",
                 "name_normalized": "demo",
                 "is_ext_shared": False,
+                "is_pending_ext_shared": False,
                 "topic": {"value": "Demo channel topic"},
                 "purpose": {"value": "Demo channel purpose"},
             }

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -850,6 +850,7 @@ async def slack_conversations_info(channel: str = "") -> JSONResponse:
                 "id": channel,
                 "name": "demo",
                 "name_normalized": "demo",
+                "is_ext_shared": False,
                 "topic": {"value": "Demo channel topic"},
                 "purpose": {"value": "Demo channel purpose"},
             }

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -37,9 +37,13 @@ def _explicit_slack_thread_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
     async def increment_version(*args: object, **kwargs: object) -> int:
         return 1
 
+    async def channel_context(*args: object, **kwargs: object) -> dict[str, bool]:
+        return {"is_ext_shared": False}
+
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", resolve)
     monkeypatch.setattr(webhook_common, "lookup_slack_thread_id", lookup)
     monkeypatch.setattr(webhook_common, "increment_slack_thread_version", increment_version)
+    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
 
 
 def _sign_body(body: bytes, secret: str = _TEST_WEBHOOK_SECRET) -> str:
@@ -599,7 +603,9 @@ def test_is_docs_plz_slack_channel_matches_normalized_name(monkeypatch) -> None:
 def test_slack_webhook_gates_docs_plz_channel(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    async def fake_get_slack_channel_context(channel_id: str) -> dict[str, str]:
+    async def fake_get_slack_channel_context(
+        channel_id: str, *, use_cache: bool = True
+    ) -> dict[str, str | bool]:
         captured["checked_channel_id"] = channel_id
         return {
             "id": channel_id,
@@ -608,6 +614,7 @@ def test_slack_webhook_gates_docs_plz_channel(monkeypatch) -> None:
             "topic": "",
             "purpose": "",
             "description": "",
+            "is_ext_shared": False,
         }
 
     async def fake_post_slack_thread_reply(channel_id: str, thread_ts: str, text: str) -> bool:
@@ -670,9 +677,12 @@ def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
         "topic": "Coordinate work",
         "purpose": "repo:langchain-ai/open-swe",
         "description": "Coordinate work\nrepo:langchain-ai/open-swe",
+        "is_ext_shared": False,
     }
 
-    async def fake_get_slack_channel_context(channel_id: str) -> dict[str, str]:
+    async def fake_get_slack_channel_context(
+        channel_id: str, *, use_cache: bool = True
+    ) -> dict[str, str | bool]:
         captured["channel_context_request"] = channel_id
         return channel_context
 

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -38,7 +38,7 @@ def _explicit_slack_thread_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
         return 1
 
     async def channel_context(*args: object, **kwargs: object) -> dict[str, bool]:
-        return {"is_ext_shared": False}
+        return {"is_ext_shared": False, "is_pending_ext_shared": False}
 
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", resolve)
     monkeypatch.setattr(webhook_common, "lookup_slack_thread_id", lookup)
@@ -615,6 +615,7 @@ def test_slack_webhook_gates_docs_plz_channel(monkeypatch) -> None:
             "purpose": "",
             "description": "",
             "is_ext_shared": False,
+            "is_pending_ext_shared": False,
         }
 
     async def fake_post_slack_thread_reply(channel_id: str, thread_ts: str, text: str) -> bool:
@@ -678,6 +679,7 @@ def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
         "purpose": "repo:langchain-ai/open-swe",
         "description": "Coordinate work\nrepo:langchain-ai/open-swe",
         "is_ext_shared": False,
+        "is_pending_ext_shared": False,
     }
 
     async def fake_get_slack_channel_context(

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -51,6 +51,24 @@ class _FakeClient:
         self.threads = threads_client
 
 
+def test_channel_context_preserves_external_sharing_status() -> None:
+    context = slack_utils.normalize_slack_channel_context(
+        "C123", {"name": "shared", "is_ext_shared": True}
+    )
+
+    assert context["is_ext_shared"] is True
+    assert not slack_utils.slack_channel_allows_operations(context)
+
+
+def test_channel_operations_fail_closed_without_external_sharing_status() -> None:
+    context = slack_utils.normalize_slack_channel_context("C123", None)
+
+    assert context["is_ext_shared"] is None
+    assert not slack_utils.slack_channel_allows_operations(context)
+    assert slack_utils.slack_channel_allows_operations({"is_ext_shared": False})
+    assert slack_utils.slack_channel_allows_operations({"is_im": True})
+
+
 def test_source_context_preserves_existing_slack_permalink_on_lookup_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -65,7 +65,12 @@ def test_channel_operations_fail_closed_without_external_sharing_status() -> Non
 
     assert context["is_ext_shared"] is None
     assert not slack_utils.slack_channel_allows_operations(context)
-    assert slack_utils.slack_channel_allows_operations({"is_ext_shared": False})
+    assert slack_utils.slack_channel_allows_operations(
+        {"is_ext_shared": False, "is_pending_ext_shared": False}
+    )
+    assert not slack_utils.slack_channel_allows_operations(
+        {"is_ext_shared": False, "is_pending_ext_shared": True}
+    )
     assert slack_utils.slack_channel_allows_operations({"is_im": True})
 
 

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -98,7 +98,7 @@ def _patch_slack_webhook(
     request.node.thread_version_increment = increment_version
 
     async def channel_context(_channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
-        return {"is_ext_shared": False}
+        return {"is_ext_shared": False, "is_pending_ext_shared": False}
 
     async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
         return False

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -97,8 +97,8 @@ def _patch_slack_webhook(
     increment_version = AsyncMock(return_value=1)
     request.node.thread_version_increment = increment_version
 
-    async def channel_context(_channel_id: str) -> dict[str, Any]:
-        return {}
+    async def channel_context(_channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
+        return {"is_ext_shared": False}
 
     async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
         return False
@@ -193,6 +193,53 @@ async def test_concurrent_cross_instance_redeliveries_start_one_run() -> None:
 
     assert [response["status"] for response in responses].count("accepted") == 1
     assert len(background_tasks.tasks) == 1
+
+
+async def test_external_channel_refuses_without_starting_a_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    background_tasks = _FakeBackgroundTasks()
+    post_reply = AsyncMock(return_value=True)
+    resolve_thread = cast(AsyncMock, webhook_common.resolve_slack_thread_id)
+    monkeypatch.setattr(
+        webhook_common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": True}),
+    )
+    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", post_reply)
+
+    response = await _post(_mention_payload(), background_tasks)
+
+    assert response == {"status": "ignored", "reason": "Slack channel is not eligible"}
+    assert len(background_tasks.tasks) == 1
+    await background_tasks.tasks[0][0](*background_tasks.tasks[0][1])
+    post_reply.assert_awaited_once_with(
+        "C1",
+        "1786573369.551099",
+        slack_routes._EXTERNAL_CHANNEL_REFUSAL,
+    )
+    resolve_thread.assert_not_awaited()
+
+
+async def test_unverified_channel_fails_closed_without_reply_or_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    background_tasks = _FakeBackgroundTasks()
+    post_reply = AsyncMock(return_value=True)
+    resolve_thread = cast(AsyncMock, webhook_common.resolve_slack_thread_id)
+    monkeypatch.setattr(
+        webhook_common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": None}),
+    )
+    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", post_reply)
+
+    response = await _post(_mention_payload(), background_tasks)
+
+    assert response == {"status": "ignored", "reason": "Slack channel is not eligible"}
+    assert background_tasks.tasks == []
+    post_reply.assert_not_awaited()
+    resolve_thread.assert_not_awaited()
 
 
 async def test_preprocessing_failure_does_not_claim_event(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/slack/test_slack_feedback.py
+++ b/tests/slack/test_slack_feedback.py
@@ -229,7 +229,7 @@ async def test_slack_webhook_queues_reaction_added(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(
         webhook_common,
         "_get_slack_channel_context",
-        AsyncMock(return_value={"is_ext_shared": False}),
+        AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
     response = await slack_routes.slack_webhook(
@@ -251,7 +251,7 @@ async def test_slack_webhook_queues_stop_reaction(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(
         webhook_common,
         "_get_slack_channel_context",
-        AsyncMock(return_value={"is_ext_shared": False}),
+        AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
     response = await slack_routes.slack_webhook(
@@ -275,7 +275,7 @@ async def test_slack_webhook_queues_reaction_removed(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(
         webhook_common,
         "_get_slack_channel_context",
-        AsyncMock(return_value={"is_ext_shared": False}),
+        AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
     response = await slack_routes.slack_webhook(
@@ -299,7 +299,7 @@ async def test_slack_webhook_ignores_untracked_reaction(monkeypatch: pytest.Monk
     monkeypatch.setattr(
         webhook_common,
         "_get_slack_channel_context",
-        AsyncMock(return_value={"is_ext_shared": False}),
+        AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
     response = await slack_routes.slack_webhook(

--- a/tests/slack/test_slack_feedback.py
+++ b/tests/slack/test_slack_feedback.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import BackgroundTasks
@@ -225,6 +226,11 @@ async def test_slack_webhook_queues_reaction_added(monkeypatch: pytest.MonkeyPat
     background_tasks = _FakeBackgroundTasks()
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
+    monkeypatch.setattr(
+        webhook_common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": False}),
+    )
 
     response = await slack_routes.slack_webhook(
         cast(Request, _FakeRequest(payload)),
@@ -242,6 +248,11 @@ async def test_slack_webhook_queues_stop_reaction(monkeypatch: pytest.MonkeyPatc
     background_tasks = _FakeBackgroundTasks()
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
+    monkeypatch.setattr(
+        webhook_common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": False}),
+    )
 
     response = await slack_routes.slack_webhook(
         cast(Request, _FakeRequest(payload)),
@@ -261,6 +272,11 @@ async def test_slack_webhook_queues_reaction_removed(monkeypatch: pytest.MonkeyP
     background_tasks = _FakeBackgroundTasks()
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
+    monkeypatch.setattr(
+        webhook_common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": False}),
+    )
 
     response = await slack_routes.slack_webhook(
         cast(Request, _FakeRequest(payload)),
@@ -280,6 +296,11 @@ async def test_slack_webhook_ignores_untracked_reaction(monkeypatch: pytest.Monk
     background_tasks = _FakeBackgroundTasks()
 
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
+    monkeypatch.setattr(
+        webhook_common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": False}),
+    )
 
     response = await slack_routes.slack_webhook(
         cast(Request, _FakeRequest(payload)),

--- a/tests/slack/test_slack_interactivity.py
+++ b/tests/slack/test_slack_interactivity.py
@@ -80,6 +80,28 @@ async def test_selected_option_updates_original_message(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_external_channel_interaction_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _option_payload()
+    lookup = AsyncMock(return_value="thread-1")
+    monkeypatch.setattr(slack_routes.common, "verify_slack_signature", lambda **_kwargs: True)
+    monkeypatch.setattr(slack_routes.common, "lookup_slack_thread_id", lookup)
+    monkeypatch.setattr(
+        slack_routes.common,
+        "_get_slack_channel_context",
+        AsyncMock(return_value={"is_ext_shared": True}),
+    )
+    background_tasks = BackgroundTasks()
+
+    result = await slack_routes.slack_interactivity(_request(payload), background_tasks)
+
+    assert result == {"status": "ignored", "reason": "Slack channel is not eligible"}
+    assert background_tasks.tasks == []
+    lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_option_interaction_schedules_update_before_agent_processing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -94,7 +116,7 @@ async def test_option_interaction_schedules_update_before_agent_processing(
     monkeypatch.setattr(
         slack_routes.common,
         "_get_slack_channel_context",
-        AsyncMock(return_value={"name": "proj-open-swe"}),
+        AsyncMock(return_value={"name": "proj-open-swe", "is_ext_shared": False}),
     )
     monkeypatch.setattr(
         slack_routes.common,

--- a/tests/slack/test_slack_interactivity.py
+++ b/tests/slack/test_slack_interactivity.py
@@ -116,7 +116,13 @@ async def test_option_interaction_schedules_update_before_agent_processing(
     monkeypatch.setattr(
         slack_routes.common,
         "_get_slack_channel_context",
-        AsyncMock(return_value={"name": "proj-open-swe", "is_ext_shared": False}),
+        AsyncMock(
+            return_value={
+                "name": "proj-open-swe",
+                "is_ext_shared": False,
+                "is_pending_ext_shared": False,
+            }
+        ),
     )
     monkeypatch.setattr(
         slack_routes.common,

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -99,7 +99,7 @@ def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
     slack_events.reset_slack_event_claims()
 
     async def channel_context(_channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
-        return {"is_ext_shared": False}
+        return {"is_ext_shared": False, "is_pending_ext_shared": False}
 
     async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
         return False

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -98,8 +98,8 @@ def _message_update_payload(*, bot_message: bool = False) -> dict[str, Any]:
 def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
     slack_events.reset_slack_event_claims()
 
-    async def channel_context(_channel_id: str) -> dict[str, Any]:
-        return {}
+    async def channel_context(_channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
+        return {"is_ext_shared": False}
 
     async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
         return False


### PR DESCRIPTION
## Description
Prevent Slack Connect channels from starting or mutating Open SWE runs by checking uncached `conversations.info` metadata at signed ingress and failing closed when eligibility is unknown. Direct messages remain supported; confirmed external mentions receive only a fixed refusal.

## Release Note
Open SWE now refuses to operate in Slack channels shared with external organizations.

## Test Plan
- [x] Verify external events and interactions are blocked before state mutation or dispatch.
- [x] Exercise internal-channel webhook fixtures and affected Slack browser flows.

Made by [Open SWE](https://openswe.vercel.app/agents/8f3eaa58-7246-5ff0-8132-26743f6ef34c)