### PR TITLE
feat: pin threads in the sidebar

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -231,6 +231,7 @@ from .thread_api import (
     list_dashboard_threads,
     list_dashboard_threads_page,
     list_dashboard_threads_sidebar,
+    pin_dashboard_thread,
     proxy_dashboard_thread_commands,
     proxy_dashboard_thread_history,
     proxy_dashboard_thread_run_cancel,
@@ -238,6 +239,7 @@ from .thread_api import (
     resolve_dashboard_thread,
     send_dashboard_message,
     stream_dashboard_thread,
+    unpin_dashboard_thread,
 )
 from .user_credentials import (
     CurrentsCredentialsUpdate,
@@ -1955,6 +1957,24 @@ async def api_list_threads_sidebar(
     header = server_timing_header(timings, counts)
     logger.info("thread sidebar timings login=%s %s", session["sub"], header)
     return JSONResponse(payload, headers={"Server-Timing": header})
+
+
+@router.post("/threads/{thread_id}/pin", status_code=204)
+async def api_pin_thread(
+    thread_id: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> Response:
+    await pin_dashboard_thread(thread_id, session["sub"])
+    return Response(status_code=204)
+
+
+@router.delete("/threads/{thread_id}/pin", status_code=204)
+async def api_unpin_thread(
+    thread_id: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> Response:
+    await unpin_dashboard_thread(thread_id, session["sub"])
+    return Response(status_code=204)
 
 
 @router.get("/threads/page")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -61,6 +61,7 @@ from .pr_diff import build_compare_diff_files, build_pr_diff_files
 from .profiles import get_profile, get_valid_access_token
 from .pull_request_status import get_pull_request_statuses
 from .team_settings import get_team_default_model, get_team_fable_enabled
+from .thread_pins import list_thread_pin_ids, pin_thread, unpin_thread
 from .ttft import AssistantTextEventDetector, record_dashboard_thread_ttft
 from .user_mappings import email_for_login
 
@@ -988,6 +989,32 @@ async def _sidebar_active_thread_summary(
     return summary, _is_thread_resolved(metadata)
 
 
+async def _pinned_thread_summaries(
+    client: Any,
+    login: str,
+    email: str | None,
+) -> list[dict[str, Any]]:
+    async def load(thread_id: str) -> dict[str, Any] | None:
+        try:
+            thread = await client.threads.get(thread_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("Could not fetch pinned sidebar thread %s", thread_id, exc_info=True)
+            return None
+        if not isinstance(thread, Mapping) or not _thread_is_readable(_thread_metadata(thread)):
+            return None
+        return await _summarize_thread(
+            client,
+            thread,
+            owner_login=login,
+            owner_email=email,
+        )
+
+    summaries = await asyncio.gather(
+        *(load(thread_id) for thread_id in await list_thread_pin_ids(login))
+    )
+    return [summary for summary in summaries if summary is not None]
+
+
 async def list_dashboard_threads_sidebar(
     login: str,
     *,
@@ -1058,7 +1085,7 @@ async def list_dashboard_threads_sidebar(
     )
     count_record["threads"] = len(active_window) + len(resolved_window)
     with phase(record, "summarize"):
-        active_items, resolved_items, active_thread = await asyncio.gather(
+        active_items, resolved_items, active_thread, pinned_items = await asyncio.gather(
             _summarize_threads(
                 client,
                 active_window,
@@ -1080,6 +1107,7 @@ async def list_dashboard_threads_sidebar(
                 email=email,
                 include_all=include_all,
             ),
+            _pinned_thread_summaries(client, login, email),
         )
     active_has_more = len(active_candidates) > safe_active_limit
     resolved_has_more = len(resolved_candidates) > safe_resolved_limit
@@ -1118,7 +1146,21 @@ async def list_dashboard_threads_sidebar(
             "limit": safe_resolved_limit,
             "hasMore": resolved_has_more,
         },
+        "pinned": pinned_items,
     }
+
+
+async def pin_dashboard_thread(thread_id: str, login: str) -> None:
+    client = langgraph_client()
+    thread = await client.threads.get(thread_id)
+    if not isinstance(thread, Mapping):
+        raise HTTPException(404, "thread not found")
+    _assert_thread_readable(_thread_metadata(thread))
+    await pin_thread(login, thread_id)
+
+
+async def unpin_dashboard_thread(thread_id: str, login: str) -> None:
+    await unpin_thread(login, thread_id)
 
 
 async def list_dashboard_threads_page(

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1152,7 +1152,10 @@ async def list_dashboard_threads_sidebar(
 
 async def pin_dashboard_thread(thread_id: str, login: str) -> None:
     client = langgraph_client()
-    thread = await client.threads.get(thread_id)
+    try:
+        thread = await client.threads.get(thread_id)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(404, "thread not found") from exc
     if not isinstance(thread, Mapping):
         raise HTTPException(404, "thread not found")
     _assert_thread_readable(_thread_metadata(thread))

--- a/agent/dashboard/thread_pins.py
+++ b/agent/dashboard/thread_pins.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from agent.store import delete_value, put_value, search_values
+
+THREAD_PINS_NAMESPACE = "thread_pins"
+
+
+def _namespace(login: str) -> list[str]:
+    return [THREAD_PINS_NAMESPACE, login]
+
+
+async def list_thread_pin_ids(login: str) -> list[str]:
+    records = await search_values(_namespace(login), limit=1000)
+    return [
+        thread_id
+        for record in records
+        if isinstance((thread_id := record.get("thread_id")), str) and thread_id
+    ]
+
+
+async def pin_thread(login: str, thread_id: str) -> dict[str, Any]:
+    record = {"thread_id": thread_id}
+    await put_value(_namespace(login), thread_id, record)
+    return record
+
+
+async def unpin_thread(login: str, thread_id: str) -> None:
+    await delete_value(_namespace(login), thread_id)

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -19,6 +19,14 @@ _FABLE = "anthropic:claude-fable-5"
 _PAIR = ("openai:gpt-5.6-sol", "medium")
 
 
+@pytest.fixture(autouse=True)
+def _empty_thread_pins(monkeypatch) -> None:
+    async def empty_pins(login: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(thread_api, "list_thread_pin_ids", empty_pins)
+
+
 def _image() -> thread_api.DashboardImageBody:
     return thread_api.DashboardImageBody(
         base64=base64.b64encode(b"image").decode("ascii"),
@@ -2051,6 +2059,94 @@ async def test_list_dashboard_threads_sidebar_excludes_automations_before_limiti
         f"t{index}" for index in range(page_size, page_size + 5)
     ]
     assert set(offsets) == {0, page_size}
+
+
+async def test_pin_dashboard_thread_allows_readable_non_owner(monkeypatch) -> None:
+    pinned: list[tuple[str, str]] = []
+
+    class FakeThreads:
+        async def get(self, thread_id):
+            return {
+                "thread_id": thread_id,
+                "metadata": {"source": "slack", "github_login": "other"},
+            }
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads()),
+    )
+
+    async def fake_pin(login: str, thread_id: str) -> None:
+        pinned.append((login, thread_id))
+
+    monkeypatch.setattr(thread_api, "pin_thread", fake_pin)
+
+    await thread_api.pin_dashboard_thread("shared-thread", "octocat")
+
+    assert pinned == [("octocat", "shared-thread")]
+
+
+async def test_pin_dashboard_thread_rejects_unreadable_thread(monkeypatch) -> None:
+    class FakeThreads:
+        async def get(self, thread_id):
+            return {"thread_id": thread_id, "metadata": {"source": "internal"}}
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads()),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.pin_dashboard_thread("private-thread", "octocat")
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_list_dashboard_threads_sidebar_includes_pinned_non_owner(monkeypatch) -> None:
+    owned = _make_threads(1, resolved_before=0)
+    shared = {
+        "thread_id": "shared-thread",
+        "metadata": {
+            "source": "slack",
+            "github_login": "teammate",
+            "title": "Pinned teammate thread",
+            "updated_at_ms": 100,
+            "latest_run_status": "success",
+        },
+    }
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return owned[offset : offset + limit]
+
+        async def get(self, thread_id):
+            assert thread_id == "shared-thread"
+            return shared
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            return []
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads(), runs=FakeRuns()),
+    )
+
+    async def fake_pin_ids(login: str) -> list[str]:
+        assert login == "octocat"
+        return ["shared-thread"]
+
+    monkeypatch.setattr(thread_api, "list_thread_pin_ids", fake_pin_ids)
+
+    result = await thread_api.list_dashboard_threads_sidebar(
+        "octocat", active_limit=5, resolved_limit=0
+    )
+
+    assert [item["id"] for item in result["pinned"]] == ["shared-thread"]
+    assert result["pinned"][0]["isOwner"] is False
 
 
 async def test_list_dashboard_threads_sidebar_includes_readable_active_thread(

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2087,6 +2087,24 @@ async def test_pin_dashboard_thread_allows_readable_non_owner(monkeypatch) -> No
     assert pinned == [("octocat", "shared-thread")]
 
 
+async def test_pin_dashboard_thread_returns_not_found_for_lookup_failure(monkeypatch) -> None:
+    class FakeThreads:
+        async def get(self, thread_id):
+            raise RuntimeError("thread missing")
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads()),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.pin_dashboard_thread("missing-thread", "octocat")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "thread not found"
+
+
 async def test_pin_dashboard_thread_rejects_unreadable_thread(monkeypatch) -> None:
     class FakeThreads:
         async def get(self, thread_id):

--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -21,6 +21,7 @@ const THREAD_IDS = {
   running: "71000000-0000-4000-8000-000000000003",
   ready: "71000000-0000-4000-8000-000000000004",
   done: "71000000-0000-4000-8000-000000000005",
+  shared: "71000000-0000-4000-8000-000000000007",
   dailyScheduled: "73000000-0000-4000-8000-000000000001",
   dailyTest: "73000000-0000-4000-8000-000000000002",
   weeklyRunning: "73000000-0000-4000-8000-000000000003",
@@ -33,6 +34,7 @@ const TITLES = {
   running: "E2E Workspace Running refactor",
   ready: "E2E Workspace Ready docs",
   done: "E2E Workspace Resolved cleanup",
+  shared: "E2E Workspace Teammate incident",
   dailyScheduled: "E2E Workspace Daily health scheduled run",
   dailyTest: "E2E Workspace Daily health test run",
   weeklyRunning: "E2E Workspace Weekly cleanup running",
@@ -380,6 +382,10 @@ async function deleteScheduleThreads(
 
 async function cleanupFixtures(request: APIRequestContext) {
   for (const threadId of createdThreadIds) {
+    const pinResponse = await request.delete("/store/items", {
+      data: { namespace: ["thread_pins", USER.login], key: threadId },
+    });
+    expect([200, 204, 404]).toContain(pinResponse.status());
     const response = await request.delete(`/threads/${threadId}`);
     expect([200, 204, 404]).toContain(response.status());
   }
@@ -437,6 +443,48 @@ test.afterEach(async ({ request }) => {
 });
 
 test.describe("threads workspace", () => {
+  test("pins and unpins a non-owned thread across sidebar views", async ({
+    page,
+    request,
+  }) => {
+    const thread = {
+      id: THREAD_IDS.shared,
+      metadata: {
+        ...baseMetadata(Date.now(), TITLES.shared, 1_000, {
+          github_login: "teammate",
+          triggering_user_email: "teammate@example.com",
+          source: "slack",
+          origin: "slack",
+          latest_run_id: "e2e-run-shared",
+          latest_run_status: "success",
+        }),
+      },
+    };
+    await seedThreads(request, [thread]);
+    await loginAs(page);
+    await page.goto(`/agents/${THREAD_IDS.shared}`);
+
+    const row = page.getByRole("link", { name: TITLES.shared }).first();
+    await expect(row).toBeVisible();
+    await row.click({ button: "right" });
+    await page.getByText("Pin thread", { exact: true }).click();
+
+    const pinned = sidebarGroup(page.locator("aside"), "Pinned");
+    await expect(
+      pinned.getByRole("link", { name: TITLES.shared }),
+    ).toBeVisible();
+    await page.getByRole("link", { name: "Kanban" }).click();
+    await expect(
+      pinned.getByRole("link", { name: TITLES.shared }),
+    ).toBeVisible();
+
+    await pinned
+      .getByRole("link", { name: TITLES.shared })
+      .click({ button: "right" });
+    await page.getByText("Unpin thread", { exact: true }).click();
+    await expect(pinned).toHaveCount(0);
+  });
+
   test("does not flash new-thread onboarding while a thread route loads", async ({
     page,
     request,

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -205,7 +205,8 @@ export function AgentsSidebar({
   }, [activeLocalSessionId, activeThreadId, isDesktop, setDesktopThreadSource])
   const pinnedThreads = sidebar.data.pinned ?? []
   const pinnedIds = new Set(pinnedThreads.map((thread) => thread.id))
-  const activeThreads = sidebar.data.active.items.filter(
+  const allActiveThreads = sidebar.data.active.items
+  const activeThreads = allActiveThreads.filter(
     (thread) => !pinnedIds.has(thread.id)
   )
   const resolvedThreads = sidebar.data.resolved.items.filter(
@@ -265,9 +266,9 @@ export function AgentsSidebar({
     (!showResolved || filteredResolved.length === 0) &&
     hasActiveFilters(prefs.filters)
   const cloudActivity = {
-    running: activeThreads.filter((thread) => thread.status === "running")
+    running: allActiveThreads.filter((thread) => thread.status === "running")
       .length,
-    completed: activeThreads.filter(
+    completed: allActiveThreads.filter(
       (thread) => thread.status === "finished" && !thread.viewed
     ).length,
   }

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -16,6 +16,8 @@ import {
   LightningIcon,
   MagnifyingGlassIcon,
   PlusIcon,
+  PushPinIcon,
+  PushPinSlashIcon,
   SparkleIcon,
   TrashIcon,
   TreeStructureIcon,
@@ -51,6 +53,7 @@ import {
 import { useSidebarPrefs } from "@/features/agents/lib/sidebarPrefs"
 import {
   useDeleteAgentThread,
+  usePinAgentThread,
   useResolveAgentThread,
   useSeedAgentThreadDetails,
   useSidebarThreads,
@@ -200,11 +203,21 @@ export function AgentsSidebar({
     if (activeLocalSessionId) setDesktopThreadSource("local")
     else if (activeThreadId) setDesktopThreadSource("cloud")
   }, [activeLocalSessionId, activeThreadId, isDesktop, setDesktopThreadSource])
-  const activeThreads = sidebar.data.active.items
-  const resolvedThreads = sidebar.data.resolved.items
+  const pinnedThreads = sidebar.data.pinned ?? []
+  const pinnedIds = new Set(pinnedThreads.map((thread) => thread.id))
+  const activeThreads = sidebar.data.active.items.filter(
+    (thread) => !pinnedIds.has(thread.id)
+  )
+  const resolvedThreads = sidebar.data.resolved.items.filter(
+    (thread) => !pinnedIds.has(thread.id)
+  )
   const activeHasMore = sidebar.data.active.hasMore
   const resolvedHasMore = sidebar.data.resolved.hasMore
-  const visibleThreads = [...activeThreads, ...resolvedThreads]
+  const visibleThreads = [
+    ...pinnedThreads,
+    ...activeThreads,
+    ...resolvedThreads,
+  ]
   useSeedAgentThreadDetails(visibleThreads, activeThreadId)
   useRunCompletionNotifier(visibleThreads, activeThreadId, openThread)
 
@@ -403,6 +416,15 @@ export function AgentsSidebar({
           <div className="min-h-0 flex-1 overflow-y-auto">
             {sidebar.isPending && (
               <ThreadListSkeleton compact={prefs.compact} />
+            )}
+            {!sidebar.isPending && pinnedThreads.length > 0 && (
+              <ThreadGroup
+                label="Pinned"
+                threads={pinnedThreads}
+                activeThreadId={activeThreadId}
+                onNavigate={layout.closeOnMobile}
+                compact={prefs.compact}
+              />
             )}
             {!sidebar.isPending &&
               (prefs.group === "none"
@@ -839,6 +861,7 @@ function ThreadGroup({
               isActive={thread.id === activeThreadId}
               onNavigate={onNavigate}
               compact={compact}
+              pinned={label === "Pinned"}
             />
           ))}
         </>
@@ -935,13 +958,16 @@ function ThreadRow({
   isActive,
   onNavigate,
   compact = false,
+  pinned = false,
 }: {
   thread: AgentThread
   isActive: boolean
   onNavigate?: () => void
   compact?: boolean
+  pinned?: boolean
 }) {
   const deleteThread = useDeleteAgentThread()
+  const pinThread = usePinAgentThread()
   const resolveThread = useResolveAgentThread()
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [contextMenuOpen, setContextMenuOpen] = useState(false)
@@ -965,6 +991,11 @@ function ThreadRow({
     deleteThread.mutate(thread.id, {
       onSuccess: () => setDeleteOpen(false),
     })
+  }
+
+  const onTogglePinned = () => {
+    if (pinThread.isPending) return
+    pinThread.mutate({ threadId: thread.id, pinned: !pinned })
   }
 
   const isResolved = thread.resolved === true
@@ -1020,6 +1051,12 @@ function ThreadRow({
                   : "text-muted-foreground group-hover:bg-sidebar-row-hover"
             )}
           >
+            {pinned && (
+              <PushPinIcon
+                className="size-3 shrink-0 text-primary"
+                aria-label="Pinned thread"
+              />
+            )}
             {thread.status === "running" ? (
               <CircleNotchIcon
                 className="size-3 shrink-0 animate-spin text-primary"
@@ -1102,6 +1139,18 @@ function ThreadRow({
                   Open Slack thread
                 </ContextMenu.LinkItem>
               )}
+              <ContextMenu.Item
+                onClick={onTogglePinned}
+                disabled={pinThread.isPending}
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted data-disabled:pointer-events-none data-disabled:opacity-50"
+              >
+                {pinned ? (
+                  <PushPinSlashIcon className="size-3.5" />
+                ) : (
+                  <PushPinIcon className="size-3.5" />
+                )}
+                {pinned ? "Unpin thread" : "Pin thread"}
+              </ContextMenu.Item>
               <ContextMenu.Item
                 disabled={!thread.sandboxId}
                 onClick={copySandboxId}

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -143,6 +143,7 @@ export interface SidebarThreadsGroup {
 export interface SidebarThreads {
   active: SidebarThreadsGroup
   resolved: SidebarThreadsGroup
+  pinned?: Array<AgentThread>
 }
 
 const API_BASE = dashboardApiBase()
@@ -275,6 +276,10 @@ export const agentsApi = {
         body: JSON.stringify({ resolved }),
       }
     ),
+  pinThread: (threadId: string, pinned: boolean) =>
+    agentsRequest<void>(`/threads/${encodeURIComponent(threadId)}/pin`, {
+      method: pinned ? "POST" : "DELETE",
+    }),
   listSchedules: () => agentsRequest<Array<AgentSchedule>>("/schedules"),
   createSchedule: (body: ScheduleCreateRequest) =>
     agentsRequest<AgentSchedule>("/schedules", {

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -454,7 +454,11 @@ export function useSeedAgentThreadDetails(
 export const SIDEBAR_PAGE_SIZE = 10
 
 function sidebarThreads(data?: SidebarThreads): Array<AgentThread> {
-  return [...(data?.active.items ?? []), ...(data?.resolved.items ?? [])]
+  return [
+    ...(data?.pinned ?? []),
+    ...(data?.active.items ?? []),
+    ...(data?.resolved.items ?? []),
+  ]
 }
 
 export function useSidebarThreads({
@@ -491,6 +495,7 @@ export function useSidebarThreads({
   const data = query.data ?? {
     active: { items: [], limit: activeLimit, hasMore: false },
     resolved: { items: [], limit: resolvedLimit, hasMore: false },
+    pinned: [],
   }
 
   return {
@@ -791,6 +796,16 @@ export function useDeleteAgentThread() {
         navigate({ to: "/agents" })
       }
     },
+  })
+}
+
+export function usePinAgentThread() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (vars: { threadId: string; pinned: boolean }) =>
+      agentsApi.pinThread(vars.threadId, vars.pinned),
+    onSettled: () => invalidateAgentThreadLists(queryClient),
   })
 }
 


### PR DESCRIPTION
## Description
Add user-scoped pinned threads that stay above sidebar filters and views. Any readable teammate thread can be pinned or unpinned from its right-click menu.

## Release Note
Pinned agent threads remain visible across sidebar views and filters.

## Test Plan
- [x] Playwright pin/unpin flow for a non-owned thread across navigation

Made by [Open SWE](https://openswe.vercel.app/agents/69c07012-ca76-586d-8523-4cc3a947c1eb)