### PR TITLE
chore: log legacy auth migration impact

### DIFF
--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -1,5 +1,6 @@
 """GitHub OAuth and LangSmith authentication utilities."""
 
+import asyncio
 import logging
 import os
 from collections.abc import Mapping
@@ -24,6 +25,7 @@ from .slack import LANGGRAPH_URL, get_active_slack_thread, post_slack_thread_rep
 from .user_messages import WARNING_ICON, warning
 
 logger = logging.getLogger(__name__)
+_legacy_auth_impact_tasks: set[asyncio.Task[None]] = set()
 
 client = get_client()
 
@@ -318,6 +320,32 @@ def _cache_resolved_github_token(
     return token, expires_at
 
 
+async def _log_legacy_auth_migration_impact(source: str, github_login: str) -> None:
+    from ..dashboard.profiles import get_valid_access_token
+
+    try:
+        open_swe_token = await get_valid_access_token(github_login)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "legacy_github_auth_migration_impact_unknown source=%s github_login=%s",
+            source,
+            github_login,
+        )
+        return
+    logger.info(
+        "legacy_github_auth_migration_impact source=%s github_login=%s requires_reauth=%s",
+        source,
+        github_login,
+        not open_swe_token,
+    )
+
+
+def _schedule_legacy_auth_migration_impact(source: str, github_login: str) -> None:
+    task = asyncio.create_task(_log_legacy_auth_migration_impact(source, github_login))
+    _legacy_auth_impact_tasks.add(task)
+    task.add_done_callback(_legacy_auth_impact_tasks.discard)
+
+
 async def resolve_token_from_email(
     email: str | None,
     source: str,
@@ -382,23 +410,7 @@ async def resolve_token_from_email(
 
     github_login = configurable.get("github_login")
     if isinstance(github_login, str) and github_login.strip():
-        from ..dashboard.profiles import get_valid_access_token
-
-        try:
-            open_swe_token = await get_valid_access_token(github_login.strip())
-        except Exception:  # noqa: BLE001
-            logger.exception(
-                "legacy_github_auth_migration_impact_unknown source=%s github_login=%s",
-                source,
-                github_login.strip(),
-            )
-        else:
-            logger.info(
-                "legacy_github_auth_migration_impact source=%s github_login=%s requires_reauth=%s",
-                source,
-                github_login.strip(),
-                not open_swe_token,
-            )
+        _schedule_legacy_auth_migration_impact(source, github_login.strip())
     else:
         logger.info(
             "legacy_github_auth_migration_impact source=%s email=%s requires_reauth=true",

--- a/agent/utils/auth.py
+++ b/agent/utils/auth.py
@@ -380,6 +380,32 @@ async def resolve_token_from_email(
         await leave_failure_comment(source, message)
         raise ValueError(f"No token found: {error}")
 
+    github_login = configurable.get("github_login")
+    if isinstance(github_login, str) and github_login.strip():
+        from ..dashboard.profiles import get_valid_access_token
+
+        try:
+            open_swe_token = await get_valid_access_token(github_login.strip())
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "legacy_github_auth_migration_impact_unknown source=%s github_login=%s",
+                source,
+                github_login.strip(),
+            )
+        else:
+            logger.info(
+                "legacy_github_auth_migration_impact source=%s github_login=%s requires_reauth=%s",
+                source,
+                github_login.strip(),
+                not open_swe_token,
+            )
+    else:
+        logger.info(
+            "legacy_github_auth_migration_impact source=%s email=%s requires_reauth=true",
+            source,
+            email,
+        )
+
     expires_at = auth_result.get("expires_at") if isinstance(auth_result, dict) else None
     return _cache_resolved_github_token(
         thread_id,

--- a/tests/auth/test_auth_sources.py
+++ b/tests/auth/test_auth_sources.py
@@ -46,7 +46,7 @@ def test_leave_failure_comment_posts_generic_token_free_slack_notice(
     assert "https://app.example.com/my-settings" in thread_called["message"]
 
 
-def test_resolve_token_from_email_logs_legacy_only_user(
+def test_resolve_token_from_email_logs_legacy_only_user_in_background(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     monkeypatch.setattr(
@@ -66,17 +66,30 @@ def test_resolve_token_from_email_logs_legacy_only_user(
     async def fake_legacy_token(user_id: str, tenant_id: str) -> dict[str, str]:
         return {"token": "legacy-token"}
 
-    async def fake_open_swe_token(login: str) -> None:
-        return None
-
     from agent.dashboard import profiles
 
     monkeypatch.setattr(auth, "get_ls_user_id_from_email", fake_user_info)
     monkeypatch.setattr(auth, "get_github_token_for_user", fake_legacy_token)
-    monkeypatch.setattr(profiles, "get_valid_access_token", fake_open_swe_token)
+
+    async def scenario() -> str:
+        lookup_started = asyncio.Event()
+        release_lookup = asyncio.Event()
+
+        async def fake_open_swe_token(login: str) -> None:
+            lookup_started.set()
+            await release_lookup.wait()
+
+        monkeypatch.setattr(profiles, "get_valid_access_token", fake_open_swe_token)
+        token, _ = await auth.resolve_token_from_email("mason@example.com", "github")
+        await lookup_started.wait()
+        assert "legacy_github_auth_migration_impact " not in caplog.text
+        tasks = list(auth._legacy_auth_impact_tasks)
+        release_lookup.set()
+        await asyncio.gather(*tasks)
+        return token
 
     with caplog.at_level(logging.INFO, logger=auth.logger.name):
-        token, _ = asyncio.run(auth.resolve_token_from_email("mason@example.com", "github"))
+        token = asyncio.run(scenario())
 
     assert token == "legacy-token"
     assert (

--- a/tests/auth/test_auth_sources.py
+++ b/tests/auth/test_auth_sources.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Any
 
 import pytest
@@ -43,6 +44,46 @@ def test_leave_failure_comment_posts_generic_token_free_slack_notice(
     assert thread_called["thread_ts"] == "1.2"
     assert "secret-token" not in thread_called["message"]
     assert "https://app.example.com/my-settings" in thread_called["message"]
+
+
+def test_resolve_token_from_email_logs_legacy_only_user(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        auth,
+        "get_config",
+        lambda: {
+            "configurable": {
+                "thread_id": "t1",
+                "github_login": "mason-gh",
+            }
+        },
+    )
+
+    async def fake_user_info(email: str) -> dict[str, str]:
+        return {"ls_user_id": "user-1", "tenant_id": "tenant-1"}
+
+    async def fake_legacy_token(user_id: str, tenant_id: str) -> dict[str, str]:
+        return {"token": "legacy-token"}
+
+    async def fake_open_swe_token(login: str) -> None:
+        return None
+
+    from agent.dashboard import profiles
+
+    monkeypatch.setattr(auth, "get_ls_user_id_from_email", fake_user_info)
+    monkeypatch.setattr(auth, "get_github_token_for_user", fake_legacy_token)
+    monkeypatch.setattr(profiles, "get_valid_access_token", fake_open_swe_token)
+
+    with caplog.at_level(logging.INFO, logger=auth.logger.name):
+        token, _ = asyncio.run(auth.resolve_token_from_email("mason@example.com", "github"))
+
+    assert token == "legacy-token"
+    assert (
+        "legacy_github_auth_migration_impact source=github github_login=mason-gh "
+        "requires_reauth=True" in caplog.text
+    )
+    assert "legacy-token" not in caplog.text
 
 
 def _slack_config(github_login: str | None = "mason-gh") -> dict:


### PR DESCRIPTION
## Description
Log successful legacy LangSmith GitHub auth usage and whether the user lacks an Open SWE OAuth token, so reauthentication impact can be measured without exposing credentials.

## Release Note
none

## Test Plan
- [x] Verify impact logs contain identity/status but not tokens

Made by [Open SWE](https://openswe.vercel.app/agents/cdfd2bd0-1461-5aaf-9fdf-7473c38bf166)