### PR TITLE
fix: arm scheduler cron monitors reliably

### DIFF
--- a/agent/baby_sit.py
+++ b/agent/baby_sit.py
@@ -196,7 +196,6 @@ async def _create_watch_cron(key: str) -> str:
 
 async def _ensure_watch_cron(key: str) -> str:
     crons = await get_client().crons.search(
-        assistant_id="scheduler",
         metadata={"kind": WATCH_CRON_KIND, "watch_key": key},
         limit=10,
     )

--- a/agent/background_tasks.py
+++ b/agent/background_tasks.py
@@ -28,7 +28,6 @@ def _client():
 async def ensure_background_task_cron(thread_id: str) -> str:
     client = _client()
     crons = await client.crons.search(
-        assistant_id="scheduler",
         metadata={"kind": CRON_KIND, "thread_id": thread_id},
         limit=10,
     )
@@ -58,7 +57,6 @@ async def ensure_background_task_cron(thread_id: str) -> str:
 async def _delete_crons(thread_id: str) -> None:
     client = _client()
     crons = await client.crons.search(
-        assistant_id="scheduler",
         metadata={"kind": CRON_KIND, "thread_id": thread_id},
         limit=10,
     )

--- a/agent/tools/background_execute.py
+++ b/agent/tools/background_execute.py
@@ -315,13 +315,20 @@ async def background_execute(
         state = await _execute(backend, _launch_command(task_id, command, timeout))
         wait = await backend.aexecute(wait_for_monitor, timeout=15)
         if getattr(wait, "exit_code", None) != 0:
-            state["warning"] = "automatic completion monitoring is busy"
-        else:
-            try:
-                await ensure_background_task_cron(thread_id)
-            except Exception:
-                logger.warning("Failed to schedule background-task monitor", exc_info=True)
-                state["warning"] = "automatic completion monitoring could not be scheduled"
+            return {
+                "success": False,
+                **state,
+                "error": "command started, but automatic completion monitoring is busy",
+            }
+        try:
+            await ensure_background_task_cron(thread_id)
+        except Exception:
+            logger.warning("Failed to schedule background-task monitor", exc_info=True)
+            return {
+                "success": False,
+                **state,
+                "error": "command started, but automatic completion monitoring could not be scheduled",
+            }
         return {"success": True, **state}
     except Exception as exc:
         logger.exception("Failed to start background command")

--- a/tests/agent/test_baby_sit.py
+++ b/tests/agent/test_baby_sit.py
@@ -40,12 +40,14 @@ class _Crons:
     def __init__(self) -> None:
         self.created: list[dict[str, Any]] = []
         self.deleted: list[str] = []
+        self.searches: list[dict[str, Any]] = []
 
     async def create(self, assistant_id: str, **kwargs: Any):
         self.created.append({"assistant_id": assistant_id, **kwargs})
         return {"cron_id": f"cron-{len(self.created)}"}
 
-    async def search(self, **_kwargs: Any):
+    async def search(self, **kwargs: Any):
+        self.searches.append(kwargs)
         return []
 
     async def delete(self, cron_id: str) -> None:
@@ -127,6 +129,10 @@ async def test_watch_lifecycle_creates_and_deletes_ten_minute_cron(
 
     assert watch.key == "acme/repo#7"
     assert watch_client.threads.deleted == []
+    assert watch_client.crons.searches == [
+        {"metadata": {"kind": "baby_sit_watch", "watch_key": "acme/repo#7"}, "limit": 10}
+    ]
+    assert watch_client.crons.created[0]["assistant_id"] == "scheduler"
     assert watch_client.crons.created[0]["schedule"] == "*/10 * * * *"
     assert watch_client.crons.created[0]["input"] == {
         "task": "baby_sit",

--- a/tests/tools/test_background_execute.py
+++ b/tests/tools/test_background_execute.py
@@ -9,8 +9,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from agent import background_tasks
 from agent.background_tasks import monitor_background_tasks
-from agent.tools.background_execute import TASK_ROOT, _control_script, _launch_command
+from agent.tools.background_execute import (
+    TASK_ROOT,
+    _control_script,
+    _launch_command,
+    background_execute,
+)
 
 # _launch_command refuses to run without setsid, which macOS does not ship; the
 # sandbox these tasks run in is always Linux.
@@ -103,6 +109,53 @@ def test_background_command_timeout_and_stop() -> None:
             assert state["status"] == expected
         finally:
             shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_background_task_cron_search_uses_metadata_not_graph_name() -> None:
+    client = AsyncMock()
+    client.crons.search.return_value = []
+    client.crons.create.return_value = {"cron_id": "cron-1"}
+
+    with patch("agent.background_tasks._client", return_value=client):
+        cron_id = await background_tasks.ensure_background_task_cron("thread-1")
+
+    assert cron_id == "cron-1"
+    client.crons.search.assert_awaited_once_with(
+        metadata={"kind": "background_tasks", "thread_id": "thread-1"}, limit=10
+    )
+    assert client.crons.create.await_args.args == ("scheduler",)
+
+
+async def test_background_execute_reports_monitor_scheduling_failure() -> None:
+    backend = AsyncMock()
+    backend.aexecute.return_value = SimpleNamespace(exit_code=0)
+
+    with (
+        patch(
+            "agent.tools.background_execute._current_backend", return_value=("thread-1", backend)
+        ),
+        patch(
+            "agent.tools.background_execute._execute",
+            AsyncMock(
+                side_effect=[
+                    {"tasks": []},
+                    {"task_id": "task-1", "status": "running"},
+                ]
+            ),
+        ),
+        patch(
+            "agent.background_tasks.ensure_background_task_cron",
+            AsyncMock(side_effect=RuntimeError("invalid assistant ID")),
+        ),
+    ):
+        result = await background_execute("sleep 10")
+
+    assert result == {
+        "success": False,
+        "task_id": "task-1",
+        "status": "running",
+        "error": "command started, but automatic completion monitoring could not be scheduled",
+    }
 
 
 async def test_monitor_enqueues_one_claimed_completion() -> None:


### PR DESCRIPTION
## Description
Cron searches now use their unique metadata instead of passing the `scheduler` graph name where the platform expects a UUID. Background commands also return a hard failure when completion monitoring cannot be armed, while preserving task state for recovery.

## Release Note
Fixed CI watch and background-task completion monitor scheduling.

## Test Plan
- [x] Verify baby-sit and background monitor cron searches omit graph-name assistant IDs
- [x] Verify monitor-arm failures are surfaced as unsuccessful background launches

Made by [Open SWE](https://openswe.vercel.app/agents/bba705b6-2f19-55b9-88f5-5103d06fce44)