### PR TITLE
fix: enable desktop gateway routing

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -194,6 +194,7 @@ from .utils.authorship import (
 )
 from .utils.dashboard_links import dashboard_base_url, dashboard_plan_url, dashboard_thread_url
 from .utils.deferred_model import make_deferred_error_model
+from .utils.gateway import gateway_env_default
 from .utils.github_app import get_github_app_installation_token_with_expiry
 from .utils.github_org_membership import is_user_active_org_member
 from .utils.github_proxy import get_recorded_proxy_base_config, record_proxy_token_expiry
@@ -1433,7 +1434,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
         team_defaults = (default_model_pair(), default_model_pair())
         title_defaults = team_defaults[0]
-        use_gateway = False
+        use_gateway = gateway_env_default()
         profile = None
         fable_enabled = False
     else:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -16,6 +16,11 @@ credentials are encrypted with the operating system's secure storage, refreshed 
 made available to the local model client through an authenticated loopback broker. Refresh tokens
 are never placed in the local backend environment or inherited by agent shell commands.
 
+Local model calls also honor `LANGSMITH_GATEWAY_*` configuration. On managed macOS installs, the
+app reads `LC_GATEWAY_KEY` from `launchctl` when no explicit gateway key is configured and enables
+gateway routing for the local backend. Gateway and provider credentials are not inherited by agent
+shell commands.
+
 The side panel's **Changes** tab diffs the project against a git snapshot taken when the session
 started, so it shows what the agent changed and not the working tree's prior state. It also shows
 the current branch and discovers its pull request when the GitHub CLI is installed and authenticated.

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -159,6 +159,17 @@ class BackendSupervisor {
     this.closing = false;
     this.ready = null;
     this.failure = null;
+    this.gatewayEnv = null;
+  }
+
+  gatewayEnvironment() {
+    if (this.gatewayEnv) return this.gatewayEnv;
+    const env = { ...process.env, ...this.options.env };
+    this.gatewayEnv = resolveGatewayEnvironment(
+      env,
+      this.options.gatewayEnvironment,
+    );
+    return this.gatewayEnv;
   }
 
   start() {
@@ -189,10 +200,7 @@ class BackendSupervisor {
       env: {
         ...process.env,
         ...this.options.env,
-        ...resolveGatewayEnvironment(
-          { ...process.env, ...this.options.env },
-          this.options.gatewayEnvironment,
-        ),
+        ...this.gatewayEnvironment(),
         ...this.options.providerEnv?.(),
         OPEN_SWE_LOCAL_AUTH_TOKEN: this.token,
         OPEN_SWE_LOCAL_PROJECTS_FILE: this.options.projectsFile,
@@ -261,12 +269,12 @@ class BackendSupervisor {
   }
 
   credentialStatus(modelId) {
-    const env = { ...process.env, ...this.options.env };
     return modelCredentialStatus(
       modelId,
       {
-        ...env,
-        ...resolveGatewayEnvironment(env, this.options.gatewayEnvironment),
+        ...process.env,
+        ...this.options.env,
+        ...this.gatewayEnvironment(),
       },
       { openAiOAuth: this.options.openAiOAuthAvailable?.() === true },
     );
@@ -412,6 +420,5 @@ module.exports = {
   localBackendTarget,
   modelCredentialStatus,
   packagedBackendTarget,
-  resolveGatewayEnvironment,
   reservePort,
 };

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -1,4 +1,7 @@
-const { spawn: spawnProcess } = require("node:child_process");
+const {
+  execFileSync: execFileSyncProcess,
+  spawn: spawnProcess,
+} = require("node:child_process");
 const { randomBytes } = require("node:crypto");
 const fs = require("node:fs");
 const http = require("node:http");
@@ -14,6 +17,11 @@ const PROVIDER_KEYS = {
   google_genai: ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
   openai: ["OPENAI_API_KEY"],
 };
+const GATEWAY_KEYS = [
+  "LANGSMITH_GATEWAY_API_KEY",
+  "LANGSMITH_API_KEY_PROD",
+  "LANGSMITH_API_KEY",
+];
 
 function devBackendTarget({ repoRoot, port, env = process.env }) {
   return {
@@ -98,12 +106,44 @@ function modelCredentialStatus(modelId, env, options = {}) {
   const variables = PROVIDER_KEYS[provider];
   if (!variables) return { available: true, variable: null };
   const variable = variables.find((key) => env[key]);
+  const gatewayAvailable =
+    ["1", "true", "yes", "on"].includes(
+      String(env.LANGSMITH_GATEWAY_ENABLED || "")
+        .trim()
+        .toLowerCase(),
+    ) && GATEWAY_KEYS.some((key) => env[key]);
   const oauthAvailable = provider === "openai" && options.openAiOAuth === true;
   return {
-    available: Boolean(variable) || oauthAvailable,
-    variable: variable || (oauthAvailable ? null : variables[0]),
-    ...(provider === "openai" && !variable ? { canSignIn: true } : {}),
+    available: Boolean(variable) || gatewayAvailable || oauthAvailable,
+    variable:
+      variable || (gatewayAvailable || oauthAvailable ? null : variables[0]),
+    ...(provider === "openai" && !variable && !gatewayAvailable
+      ? { canSignIn: true }
+      : {}),
   };
+}
+
+function resolveGatewayEnvironment(
+  env,
+  { platform = process.platform, execFileSync = execFileSyncProcess } = {},
+) {
+  if (env.LANGSMITH_GATEWAY_API_KEY || platform !== "darwin") return {};
+  try {
+    const key = execFileSync("/bin/launchctl", ["getenv", "LC_GATEWAY_KEY"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000,
+    }).trim();
+    if (!key) return {};
+    return {
+      LANGSMITH_GATEWAY_API_KEY: key,
+      ...(env.LANGSMITH_GATEWAY_ENABLED === undefined
+        ? { LANGSMITH_GATEWAY_ENABLED: "true" }
+        : {}),
+    };
+  } catch {
+    return {};
+  }
 }
 
 class BackendSupervisor {
@@ -149,6 +189,10 @@ class BackendSupervisor {
       env: {
         ...process.env,
         ...this.options.env,
+        ...resolveGatewayEnvironment(
+          { ...process.env, ...this.options.env },
+          this.options.gatewayEnvironment,
+        ),
         ...this.options.providerEnv?.(),
         OPEN_SWE_LOCAL_AUTH_TOKEN: this.token,
         OPEN_SWE_LOCAL_PROJECTS_FILE: this.options.projectsFile,
@@ -217,9 +261,13 @@ class BackendSupervisor {
   }
 
   credentialStatus(modelId) {
+    const env = { ...process.env, ...this.options.env };
     return modelCredentialStatus(
       modelId,
-      { ...process.env, ...this.options.env },
+      {
+        ...env,
+        ...resolveGatewayEnvironment(env, this.options.gatewayEnvironment),
+      },
       { openAiOAuth: this.options.openAiOAuthAvailable?.() === true },
     );
   }
@@ -364,5 +412,6 @@ module.exports = {
   localBackendTarget,
   modelCredentialStatus,
   packagedBackendTarget,
+  resolveGatewayEnvironment,
   reservePort,
 };

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -8,7 +8,6 @@ const {
   localBackendTarget,
   modelCredentialStatus,
   packagedBackendTarget,
-  resolveGatewayEnvironment,
 } = require("../src/backend-supervisor.cjs");
 
 test("development target runs the repository LangGraph app through uv", () => {
@@ -76,53 +75,25 @@ test("reports whether the selected provider is configured", () => {
     available: true,
     variable: null,
   });
-  for (const provider of ["openai", "anthropic", "fireworks", "google_genai"]) {
-    assert.deepEqual(
-      modelCredentialStatus(`${provider}:test`, {
-        LANGSMITH_GATEWAY_API_KEY: "gateway-key",
-        LANGSMITH_GATEWAY_ENABLED: "true",
-      }),
-      { available: true, variable: null },
-    );
-  }
   assert.deepEqual(
     modelCredentialStatus("anthropic:test", {
       LANGSMITH_GATEWAY_API_KEY: "gateway-key",
-      LANGSMITH_GATEWAY_ENABLED: "false",
+      LANGSMITH_GATEWAY_ENABLED: "true",
     }),
-    { available: false, variable: "ANTHROPIC_API_KEY" },
+    { available: true, variable: null },
   );
 });
 
-test("loads the managed macOS gateway key for the local backend", () => {
-  const calls = [];
-  const resolved = resolveGatewayEnvironment(
-    {},
-    {
-      platform: "darwin",
-      execFileSync: (...args) => {
-        calls.push(args);
-        return "managed-key\n";
-      },
-    },
-  );
-
-  assert.deepEqual(resolved, {
-    LANGSMITH_GATEWAY_API_KEY: "managed-key",
-    LANGSMITH_GATEWAY_ENABLED: "true",
-  });
-  assert.deepEqual(calls[0].slice(0, 2), [
-    "/bin/launchctl",
-    ["getenv", "LC_GATEWAY_KEY"],
-  ]);
-});
-
-test("supervisor reports a managed gateway credential", () => {
+test("caches the managed macOS gateway key", () => {
+  let probes = 0;
   const supervisor = new BackendSupervisor({
     env: {},
     gatewayEnvironment: {
       platform: "darwin",
-      execFileSync: () => "managed-key\n",
+      execFileSync: () => {
+        probes += 1;
+        return "managed-key\n";
+      },
     },
   });
 
@@ -130,58 +101,8 @@ test("supervisor reports a managed gateway credential", () => {
     available: true,
     variable: null,
   });
-});
-
-test("preserves explicit desktop gateway configuration", () => {
-  assert.deepEqual(
-    resolveGatewayEnvironment(
-      {
-        LANGSMITH_GATEWAY_API_KEY: "explicit-key",
-        LANGSMITH_GATEWAY_ENABLED: "false",
-      },
-      {
-        platform: "darwin",
-        execFileSync: () => assert.fail("must not probe launchctl"),
-      },
-    ),
-    {},
-  );
-  assert.deepEqual(
-    resolveGatewayEnvironment(
-      { LANGSMITH_GATEWAY_ENABLED: "false" },
-      { platform: "darwin", execFileSync: () => "managed-key\n" },
-    ),
-    { LANGSMITH_GATEWAY_API_KEY: "managed-key" },
-  );
-});
-
-test("ignores unavailable managed gateway keys", () => {
-  assert.deepEqual(
-    resolveGatewayEnvironment(
-      {},
-      { platform: "linux", execFileSync: () => assert.fail("macOS only") },
-    ),
-    {},
-  );
-  assert.deepEqual(
-    resolveGatewayEnvironment(
-      {},
-      { platform: "darwin", execFileSync: () => "\n" },
-    ),
-    {},
-  );
-  assert.deepEqual(
-    resolveGatewayEnvironment(
-      {},
-      {
-        platform: "darwin",
-        execFileSync: () => {
-          throw new Error("not managed");
-        },
-      },
-    ),
-    {},
-  );
+  supervisor.credentialStatus("openai:test");
+  assert.equal(probes, 1);
 });
 
 test("creates the local LangGraph thread before stream hydration", async () => {

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -8,6 +8,7 @@ const {
   localBackendTarget,
   modelCredentialStatus,
   packagedBackendTarget,
+  resolveGatewayEnvironment,
 } = require("../src/backend-supervisor.cjs");
 
 test("development target runs the repository LangGraph app through uv", () => {
@@ -75,6 +76,112 @@ test("reports whether the selected provider is configured", () => {
     available: true,
     variable: null,
   });
+  for (const provider of ["openai", "anthropic", "fireworks", "google_genai"]) {
+    assert.deepEqual(
+      modelCredentialStatus(`${provider}:test`, {
+        LANGSMITH_GATEWAY_API_KEY: "gateway-key",
+        LANGSMITH_GATEWAY_ENABLED: "true",
+      }),
+      { available: true, variable: null },
+    );
+  }
+  assert.deepEqual(
+    modelCredentialStatus("anthropic:test", {
+      LANGSMITH_GATEWAY_API_KEY: "gateway-key",
+      LANGSMITH_GATEWAY_ENABLED: "false",
+    }),
+    { available: false, variable: "ANTHROPIC_API_KEY" },
+  );
+});
+
+test("loads the managed macOS gateway key for the local backend", () => {
+  const calls = [];
+  const resolved = resolveGatewayEnvironment(
+    {},
+    {
+      platform: "darwin",
+      execFileSync: (...args) => {
+        calls.push(args);
+        return "managed-key\n";
+      },
+    },
+  );
+
+  assert.deepEqual(resolved, {
+    LANGSMITH_GATEWAY_API_KEY: "managed-key",
+    LANGSMITH_GATEWAY_ENABLED: "true",
+  });
+  assert.deepEqual(calls[0].slice(0, 2), [
+    "/bin/launchctl",
+    ["getenv", "LC_GATEWAY_KEY"],
+  ]);
+});
+
+test("supervisor reports a managed gateway credential", () => {
+  const supervisor = new BackendSupervisor({
+    env: {},
+    gatewayEnvironment: {
+      platform: "darwin",
+      execFileSync: () => "managed-key\n",
+    },
+  });
+
+  assert.deepEqual(supervisor.credentialStatus("anthropic:test"), {
+    available: true,
+    variable: null,
+  });
+});
+
+test("preserves explicit desktop gateway configuration", () => {
+  assert.deepEqual(
+    resolveGatewayEnvironment(
+      {
+        LANGSMITH_GATEWAY_API_KEY: "explicit-key",
+        LANGSMITH_GATEWAY_ENABLED: "false",
+      },
+      {
+        platform: "darwin",
+        execFileSync: () => assert.fail("must not probe launchctl"),
+      },
+    ),
+    {},
+  );
+  assert.deepEqual(
+    resolveGatewayEnvironment(
+      { LANGSMITH_GATEWAY_ENABLED: "false" },
+      { platform: "darwin", execFileSync: () => "managed-key\n" },
+    ),
+    { LANGSMITH_GATEWAY_API_KEY: "managed-key" },
+  );
+});
+
+test("ignores unavailable managed gateway keys", () => {
+  assert.deepEqual(
+    resolveGatewayEnvironment(
+      {},
+      { platform: "linux", execFileSync: () => assert.fail("macOS only") },
+    ),
+    {},
+  );
+  assert.deepEqual(
+    resolveGatewayEnvironment(
+      {},
+      { platform: "darwin", execFileSync: () => "\n" },
+    ),
+    {},
+  );
+  assert.deepEqual(
+    resolveGatewayEnvironment(
+      {},
+      {
+        platform: "darwin",
+        execFileSync: () => {
+          throw new Error("not managed");
+        },
+      },
+    ),
+    {},
+  );
 });
 
 test("creates the local LangGraph thread before stream hydration", async () => {

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -51,6 +51,10 @@ async def _capture_create_deep_agent_kwargs(
         captured.update(kwargs)
         return _DummyAgent()
 
+    def fake_make_model(model_id: str, **kwargs: object) -> MagicMock:
+        captured.setdefault("make_model_calls", []).append((model_id, kwargs))
+        return MagicMock()
+
     clear_sandbox_backend(thread_id)
     with (
         patch(
@@ -81,7 +85,7 @@ async def _capture_create_deep_agent_kwargs(
             return_value=thread_settings or {},
         ),
         patch("agent.server.fallback_model_id_for", return_value=None),
-        patch("agent.server.make_model", side_effect=[MagicMock(), MagicMock()]),
+        patch("agent.server.make_model", side_effect=fake_make_model),
         patch("agent.server.construct_system_prompt", return_value="prompt"),
         patch("agent.server.create_deep_agent", side_effect=fake_create_deep_agent),
     ):
@@ -195,6 +199,24 @@ async def test_desktop_agent_loads_snapshotted_and_bundled_skills() -> None:
     assert isinstance(backend, CompositeBackend)
     assert isinstance(backend.routes["/skills/"], ReadOnlyBackend)
     assert isinstance(backend.routes["/skills/"]._backend, StateBackend)
+
+
+@pytest.mark.asyncio
+async def test_desktop_agent_honors_gateway_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
+    config = _base_config()
+    config.setdefault("configurable", {}).update(
+        {"source": "desktop", "local_project_path": "/tmp"}
+    )
+    with patch("agent.server.create_desktop_backend", return_value=MagicMock()):
+        captured = await _capture_create_deep_agent_kwargs(config)
+
+    calls = captured["make_model_calls"]
+    assert isinstance(calls, list)
+    assert calls
+    assert all(kwargs["use_gateway"] is True for _, kwargs in calls)
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -44,6 +44,7 @@ async def _capture_create_deep_agent_kwargs(
     thread_settings: dict[str, object] | None = None,
 ) -> dict[str, object]:
     captured: dict[str, object] = {}
+    make_model_calls: list[tuple[str, dict[str, object]]] = []
     config = config or _base_config()
     thread_id = "thread-ctx"
 
@@ -52,7 +53,7 @@ async def _capture_create_deep_agent_kwargs(
         return _DummyAgent()
 
     def fake_make_model(model_id: str, **kwargs: object) -> MagicMock:
-        captured.setdefault("make_model_calls", []).append((model_id, kwargs))
+        make_model_calls.append((model_id, kwargs))
         return MagicMock()
 
     clear_sandbox_backend(thread_id)
@@ -92,6 +93,7 @@ async def _capture_create_deep_agent_kwargs(
         await get_agent(config)
 
     clear_sandbox_backend(thread_id)
+    captured["make_model_calls"] = make_model_calls
     return captured
 
 


### PR DESCRIPTION
## Description
Honor gateway configuration in desktop local runs and cache the managed macOS gateway key without exposing credentials to agent commands.

## Release Note
Desktop local agents can route supported models through the LangSmith LLM Gateway.

## Test Plan
- [x] Verify managed gateway preflight and model assembly

Made by [Open SWE](https://openswe.vercel.app/agents/6f0390cc-f65f-5b21-b334-4dda40a62fcb)