### PR TITLE
fix: align desktop filesystem paths with shell

### DIFF
--- a/agent/desktop.py
+++ b/agent/desktop.py
@@ -39,7 +39,7 @@ def resolve_desktop_project(configurable: dict[str, Any]) -> str:
 def create_desktop_backend(configurable: dict[str, Any]) -> LocalShellBackend:
     return LocalShellBackend(
         root_dir=resolve_desktop_project(configurable),
-        virtual_mode=True,
+        virtual_mode=False,
         env={key: value for key in SHELL_ENV_KEYS if (value := os.environ.get(key))},
     )
 

--- a/tests/agent/test_desktop.py
+++ b/tests/agent/test_desktop.py
@@ -29,6 +29,8 @@ def test_desktop_backend_allows_registered_project_without_provider_secrets(
 ) -> None:
     project = tmp_path / "project"
     project.mkdir()
+    marker = project / "marker.txt"
+    marker.write_text("marker")
     allowlist = tmp_path / "projects.json"
     allowlist.write_text(json.dumps([{"cwd": str(project)}]))
     monkeypatch.setenv("OPEN_SWE_LOCAL_PROJECTS_FILE", str(allowlist))
@@ -39,6 +41,7 @@ def test_desktop_backend_allows_registered_project_without_provider_secrets(
     backend = create_desktop_backend({"local_project_path": str(project)})
     assert backend._env.get("PATH") == "/bin"
     assert "OPENAI_API_KEY" not in backend._env
+    assert backend.read(str(marker)).file_data == {"content": "marker", "encoding": "utf-8"}
 
 
 def test_desktop_backend_rejects_unregistered_project(


### PR DESCRIPTION
## Summary

- use real absolute paths for desktop filesystem operations and shell execution
- cover absolute-path reads in the existing desktop backend test

## Testing

- `uv run pytest -q tests/agent/test_desktop.py`
- `uv run ruff check agent/desktop.py tests/agent/test_desktop.py`
- `uv run ruff format --check agent/desktop.py tests/agent/test_desktop.py`