### PR TITLE
refactor(environments): migrate to TypedStore and delete KeyedRecordStore

### DIFF
--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -276,7 +276,10 @@ class EnvironmentUpdate(BaseModel):
 
 
 class Environment(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    # Assignment is validated because the store mutates records in place, and an
+    # unvalidated write here is only caught on the next read — by which point the
+    # record is already unreadable.
+    model_config = ConfigDict(extra="ignore", validate_assignment=True)
 
     slug: str
     name: str = ""
@@ -295,6 +298,12 @@ class Environment(BaseModel):
     created_by: str = ""
     created_at: str = ""
     updated_at: str = ""
+
+    @field_validator("create_params", mode="before")
+    @classmethod
+    def _null_create_params_are_empty(cls, v: Any) -> Any:
+        """``EnvironmentUpdate`` clears create params with an explicit null."""
+        return {} if v is None else v
 
     @classmethod
     def seed(cls, create: EnvironmentCreate, created_by: str) -> "Environment":

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -25,9 +25,9 @@ import os
 import re
 from typing import Any, Literal, TypedDict
 
-from pydantic import BaseModel, Field, JsonValue, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 
-from agent.store import KeyedRecordStore, now_iso
+from agent.store import TypedStore, now_iso
 
 from .review_styles import normalize_repo_full_name
 
@@ -275,87 +275,184 @@ class EnvironmentUpdate(BaseModel):
         return None if v is None else _validate_create_params(v)
 
 
-_RECORDS = KeyedRecordStore(ENVIRONMENTS_NAMESPACE, sort_key="name")
+class Environment(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    slug: str
+    name: str = ""
+    prompt: str = ""
+    repos: list[str] = Field(default_factory=list)
+    mem_bytes: int | None = None
+    vcpus: int | None = None
+    fs_capacity_bytes: int | None = None
+    create_params: dict[str, JsonValue] = Field(default_factory=dict)
+    snapshot_id: str | None = None
+    snapshot_name: str | None = None
+    snapshot_status: SnapshotStatus = "none"
+    status_message: str | None = None
+    source_sandbox_id: str | None = None
+    last_captured_at: str | None = None
+    created_by: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+
+    @classmethod
+    def seed(cls, create: EnvironmentCreate, created_by: str) -> "Environment":
+        now = now_iso()
+        return cls(
+            slug=slugify(create.name),
+            name=create.name.strip(),
+            prompt=create.prompt,
+            repos=create.repos,
+            mem_bytes=create.mem_bytes,
+            vcpus=create.vcpus,
+            fs_capacity_bytes=create.fs_capacity_bytes,
+            create_params=create.create_params,
+            created_by=created_by,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @property
+    def ready_snapshot_id(self) -> str | None:
+        """The snapshot new sandboxes boot from, or ``None`` when not captured yet."""
+        if self.snapshot_status != "ready":
+            return None
+        return self.snapshot_id or None
+
+    @property
+    def instructions(self) -> str | None:
+        return self.prompt.strip() or None
+
+    def sandbox_resources(self) -> SandboxResources:
+        """VM sizing as sandbox-create kwargs, omitting anything unset."""
+        resources: SandboxResources = {}
+        for field in ("mem_bytes", "vcpus", "fs_capacity_bytes"):
+            value = getattr(self, field)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                resources[field] = value
+        return resources
+
+    def sandbox_create_params(self) -> dict[str, JsonValue]:
+        """Validated passthrough create-body fields.
+
+        Re-validated on read, not just on write: the rules (size cap, no
+        secrets) can tighten after a record was stored, and shipping a stale
+        record's params to the platform would bypass the newer rule.
+        """
+        try:
+            return _validate_create_params(self.create_params)
+        except ValueError:
+            logger.warning("Ignoring invalid sandbox create params for environment %s", self.slug)
+            return {}
+
+    def option(self) -> dict[str, Any]:
+        """Name/slug/snapshot-state only, for the non-admin environment picker."""
+        return {
+            "slug": self.slug,
+            "name": self.name,
+            "has_snapshot": self.snapshot_status == "ready",
+        }
 
 
-async def get_environment(slug: str) -> dict[str, Any] | None:
-    return await _RECORDS.get(slug)
+class EnvironmentStore(TypedStore[Environment]):
+    def __init__(self) -> None:
+        super().__init__(ENVIRONMENTS_NAMESPACE, Environment)
+
+    async def list_all(self) -> list[Environment]:
+        records = await self.search_all()
+        records.sort(key=lambda record: record.name)
+        return records
+
+    async def save(self, record: Environment) -> Environment:
+        record.updated_at = now_iso()
+        return await self.put(record.slug, record)
+
+    async def create(self, create: EnvironmentCreate, created_by: str) -> Environment:
+        record = Environment.seed(create, created_by)
+        if await self.get(record.slug) is not None:
+            raise ValueError(f"environment {create.name!r} already exists")
+        return await self.put(record.slug, record)
+
+    async def apply_update(self, slug: str, update: EnvironmentUpdate) -> Environment:
+        record = await self.get(slug)
+        if record is None:
+            raise ValueError(f"no environment named {slug!r}")
+        if update.name is not None and slugify(update.name) != slug:
+            raise ValueError(
+                "renaming an environment across slugs is not supported; create a new one"
+            )
+        if update.name is not None:
+            record.name = update.name.strip()
+        if update.prompt is not None:
+            record.prompt = update.prompt
+        if update.repos is not None:
+            record.repos = update.repos
+        for field in ("mem_bytes", "vcpus", "fs_capacity_bytes", "create_params"):
+            if field in update.model_fields_set:
+                setattr(record, field, getattr(update, field))
+        return await self.save(record)
+
+    async def remove(self, slug: str) -> bool:
+        record = await self.get(slug)
+        if record is None:
+            return False
+        await self.delete(slug)
+        await _delete_snapshot(record.snapshot_id)
+        return True
+
+    async def mark_capturing(self, slug: str) -> Environment | None:
+        record = await self.get(slug)
+        if record is None:
+            return None
+        record.snapshot_status = "capturing"
+        record.status_message = None
+        return await self.save(record)
+
+    async def mark_capture_settled(
+        self, slug: str, status: SnapshotStatus, message: str
+    ) -> Environment | None:
+        """Land a failed capture on ``status``, keeping a previously ready snapshot."""
+        record = await self.get(slug)
+        if record is None:
+            return None
+        record.snapshot_status = status
+        record.status_message = message
+        return await self.save(record)
+
+    async def mark_captured(
+        self, slug: str, *, snapshot_id: str, snapshot_name: str, source_sandbox_id: str
+    ) -> Environment | None:
+        record = await self.get(slug)
+        if record is None:
+            return None
+        record.snapshot_status = "ready"
+        record.status_message = None
+        record.snapshot_id = snapshot_id
+        record.snapshot_name = snapshot_name
+        record.source_sandbox_id = source_sandbox_id
+        record.last_captured_at = now_iso()
+        return await self.save(record)
 
 
-async def list_environments() -> list[dict[str, Any]]:
-    return await _RECORDS.list()
+ENVIRONMENTS = EnvironmentStore()
 
 
-async def create_environment(create: EnvironmentCreate, created_by: str) -> dict[str, Any]:
-    slug = slugify(create.name)
-    existing = await get_environment(slug)
-    if existing is not None:
-        raise ValueError(f"environment {create.name!r} already exists")
-    record = {
-        "slug": slug,
-        "name": create.name.strip(),
-        "prompt": create.prompt,
-        "repos": create.repos,
-        "mem_bytes": create.mem_bytes,
-        "vcpus": create.vcpus,
-        "fs_capacity_bytes": create.fs_capacity_bytes,
-        "create_params": create.create_params,
-        "snapshot_id": None,
-        "snapshot_name": None,
-        "snapshot_status": "none",
-        "status_message": None,
-        "source_sandbox_id": None,
-        "last_captured_at": None,
-        "created_by": created_by,
-        "created_at": now_iso(),
-        "updated_at": now_iso(),
-    }
-    return await _RECORDS.put(slug, record)
-
-
-async def update_environment(slug: str, update: EnvironmentUpdate) -> dict[str, Any]:
-    existing = await get_environment(slug)
-    if existing is None:
-        raise ValueError(f"no environment named {slug!r}")
-    if update.name is not None and slugify(update.name) != slug:
-        raise ValueError("renaming an environment across slugs is not supported; create a new one")
-    record = {**existing, "updated_at": now_iso()}
-    if update.name is not None:
-        record["name"] = update.name.strip()
-    if update.prompt is not None:
-        record["prompt"] = update.prompt
-    if update.repos is not None:
-        record["repos"] = update.repos
-    for field in ("mem_bytes", "vcpus", "fs_capacity_bytes", "create_params"):
-        if field in update.model_fields_set:
-            record[field] = getattr(update, field)
-    return await _RECORDS.put(slug, record)
-
-
-async def delete_environment(slug: str) -> bool:
-    existing = await get_environment(slug)
-    if existing is None:
-        return False
-    await _RECORDS.delete(slug)
-    await _delete_snapshot(existing.get("snapshot_id"))
-    return True
-
-
-async def resolve_default_environment() -> dict[str, Any] | None:
+async def resolve_default_environment() -> Environment | None:
     """Return the environment named ``default``, or ``None``.
 
     Fail-soft on purpose: this runs while a sandbox is being created, and a
-    store failure must fall back to the per-repo and base snapshots with no
-    environment prompt rather than fail the run.
+    store failure must fall back to the base snapshot with no environment
+    prompt rather than fail the run.
     """
     try:
-        return await get_environment(DEFAULT_ENVIRONMENT_SLUG)
+        return await ENVIRONMENTS.get(DEFAULT_ENVIRONMENT_SLUG)
     except Exception:
         logger.warning("default environment resolution failed", exc_info=True)
         return None
 
 
-async def resolve_environment(slug: str | None) -> dict[str, Any] | None:
+async def resolve_environment(slug: str | None) -> Environment | None:
     """Return the environment a run uses: the one it selected, else ``default``.
 
     Never raises, and a selection that no longer exists falls back to ``default``
@@ -364,7 +461,7 @@ async def resolve_environment(slug: str | None) -> dict[str, Any] | None:
     if not slug or slug == DEFAULT_ENVIRONMENT_SLUG:
         return await resolve_default_environment()
     try:
-        record = await get_environment(slug)
+        record = await ENVIRONMENTS.get(slug)
     except Exception:
         logger.warning("environment resolution failed for %s", slug, exc_info=True)
         record = None
@@ -380,15 +477,7 @@ async def list_environment_options() -> list[dict[str, Any]]:
     Prompts and snapshot ids stay admin-only; picking an environment needs
     neither.
     """
-    return [
-        {
-            "slug": record.get("slug"),
-            "name": record.get("name"),
-            "has_snapshot": record.get("snapshot_status") == "ready",
-        }
-        for record in await list_environments()
-        if isinstance(record.get("slug"), str)
-    ]
+    return [record.option() for record in await ENVIRONMENTS.list_all()]
 
 
 def parse_environment_tag(text: str) -> tuple[str | None, str]:
@@ -407,69 +496,6 @@ def parse_environment_tag(text: str) -> tuple[str | None, str]:
         return None, text
     before, after = text[: match.start()].rstrip(), text[match.end() :].lstrip()
     return slug, f"{before} {after}".strip() if before and after else f"{before}{after}".strip()
-
-
-def environment_snapshot_id(record: dict[str, Any] | None) -> str | None:
-    """The snapshot new sandboxes boot from, or ``None`` when not captured yet."""
-    if not record or record.get("snapshot_status") != "ready":
-        return None
-    snapshot_id = record.get("snapshot_id")
-    return snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None
-
-
-def environment_prompt(record: dict[str, Any] | None) -> str | None:
-    if not record:
-        return None
-    prompt = record.get("prompt")
-    return prompt.strip() or None if isinstance(prompt, str) else None
-
-
-def environment_sandbox_resources(record: dict[str, Any] | None) -> SandboxResources:
-    if not record:
-        return {}
-    resources: SandboxResources = {}
-    for field in ("mem_bytes", "vcpus", "fs_capacity_bytes"):
-        value = record.get(field)
-        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
-            resources[field] = value
-    return resources
-
-
-def environment_sandbox_create_params(
-    record: dict[str, Any] | None,
-) -> dict[str, JsonValue]:
-    if not record:
-        return {}
-    value = record.get("create_params")
-    if not isinstance(value, dict):
-        return {}
-    try:
-        return _validate_create_params(value)
-    except ValueError:
-        logger.warning(
-            "Ignoring invalid sandbox create params for environment %s", record.get("slug")
-        )
-        return {}
-
-
-async def _set_snapshot_state(
-    slug: str,
-    status: SnapshotStatus,
-    *,
-    status_message: str | None = None,
-    extra: dict[str, Any] | None = None,
-) -> dict[str, Any] | None:
-    existing = await get_environment(slug)
-    if existing is None:
-        return None
-    record = {
-        **existing,
-        "snapshot_status": status,
-        "status_message": status_message,
-        "updated_at": now_iso(),
-        **(extra or {}),
-    }
-    return await _RECORDS.put(slug, record)
 
 
 def _require_capture_support() -> None:
@@ -528,7 +554,7 @@ async def capture_environment_snapshot(
     sandbox_id: str,
     *,
     timeout: int = 600,
-) -> dict[str, Any]:
+) -> Environment:
     """Capture ``sandbox_id``'s filesystem as this environment's snapshot.
 
     The previous snapshot survives a failed capture, in both senses: it is deleted
@@ -542,13 +568,13 @@ async def capture_environment_snapshot(
 
     _require_capture_support()
 
-    record = await get_environment(slug)
+    record = await ENVIRONMENTS.get(slug)
     if record is None:
         raise ValueError(f"no environment named {slug!r}")
 
-    previous_snapshot_id = record.get("snapshot_id")
-    previous_was_ready = bool(previous_snapshot_id) and record.get("snapshot_status") == "ready"
-    await _set_snapshot_state(slug, "capturing")
+    previous_snapshot_id = record.snapshot_id
+    previous_was_ready = record.ready_snapshot_id is not None
+    await ENVIRONMENTS.mark_capturing(slug)
     try:
         async with get_async_sandbox_client() as client:
             snapshot, snapshot_name = await _capture_with_name_retry(
@@ -556,22 +582,18 @@ async def capture_environment_snapshot(
             )
     except Exception as exc:
         logger.warning("snapshot capture failed for environment %s", slug, exc_info=True)
-        await _set_snapshot_state(
+        await ENVIRONMENTS.mark_capture_settled(
             slug,
             "ready" if previous_was_ready else "failed",
-            status_message=str(exc)[:1000],
+            str(exc)[:1000],
         )
         raise
 
-    updated = await _set_snapshot_state(
+    updated = await ENVIRONMENTS.mark_captured(
         slug,
-        "ready",
-        extra={
-            "snapshot_id": snapshot.id,
-            "snapshot_name": snapshot_name,
-            "source_sandbox_id": sandbox_id,
-            "last_captured_at": now_iso(),
-        },
+        snapshot_id=snapshot.id,
+        snapshot_name=snapshot_name,
+        source_sandbox_id=sandbox_id,
     )
     if previous_snapshot_id != snapshot.id:
         await _delete_snapshot(previous_snapshot_id)

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -41,15 +41,12 @@ from .enabled_repos import (
 )
 from .environments import (
     DEFAULT_ENVIRONMENT_SLUG,
+    ENVIRONMENTS,
+    Environment,
     EnvironmentCreate,
     EnvironmentUpdate,
-    create_environment,
-    delete_environment,
-    get_environment,
     list_environment_options,
-    list_environments,
     slugify,
-    update_environment,
 )
 from .eval_jobs import (
     get_reviewer_eval_status,
@@ -968,7 +965,7 @@ async def api_list_environments(
     _admin: dict[str, Any] = _ADMIN_DEP,
 ) -> dict[str, Any]:
     return {
-        "environments": await list_environments(),
+        "environments": await ENVIRONMENTS.list_all(),
         "default_slug": DEFAULT_ENVIRONMENT_SLUG,
     }
 
@@ -977,9 +974,9 @@ async def api_list_environments(
 async def api_create_environment(
     body: EnvironmentCreate,
     _admin: dict[str, Any] = _ADMIN_DEP,
-) -> dict[str, Any]:
+) -> Environment:
     try:
-        return await create_environment(body, _admin["sub"])
+        return await ENVIRONMENTS.create(body, _admin["sub"])
     except ValueError as e:
         raise HTTPException(409, str(e)) from e
 
@@ -999,8 +996,8 @@ async def api_environment_options(
 async def api_get_environment(
     slug: str,
     _admin: dict[str, Any] = _ADMIN_DEP,
-) -> dict[str, Any]:
-    record = await get_environment(_normalized_slug(slug))
+) -> Environment:
+    record = await ENVIRONMENTS.get(_normalized_slug(slug))
     if not record:
         raise HTTPException(404, "environment not found")
     return record
@@ -1011,9 +1008,9 @@ async def api_update_environment(
     slug: str,
     body: EnvironmentUpdate,
     _admin: dict[str, Any] = _ADMIN_DEP,
-) -> dict[str, Any]:
+) -> Environment:
     try:
-        return await update_environment(_normalized_slug(slug), body)
+        return await ENVIRONMENTS.apply_update(_normalized_slug(slug), body)
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
 
@@ -1023,7 +1020,7 @@ async def api_delete_environment(
     slug: str,
     _admin: dict[str, Any] = _ADMIN_DEP,
 ) -> Response:
-    if not await delete_environment(_normalized_slug(slug)):
+    if not await ENVIRONMENTS.remove(_normalized_slug(slug)):
         raise HTTPException(404, "environment not found")
     return Response(status_code=204)
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -55,7 +55,7 @@ from ..utils.thread_participants import (
 from ..utils.timing import phase
 from .admin import is_admin
 from .agent_overrides import normalize_profile_overrides
-from .environments import get_environment, slugify
+from .environments import ENVIRONMENTS, slugify
 from .options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
@@ -1269,7 +1269,7 @@ async def _resolve_requested_environment(requested: Any) -> str | None:
         slug = slugify(requested)
     except ValueError:
         return None
-    return slug if await get_environment(slug) is not None else None
+    return slug if await ENVIRONMENTS.get(slug) is not None else None
 
 
 def _resolve_repo_config(repo: str | None) -> dict[str, str]:

--- a/agent/server.py
+++ b/agent/server.py
@@ -54,10 +54,6 @@ from .dashboard.agent_overrides import (
 from .dashboard.agent_usage import record_agent_run_usage
 from .dashboard.environments import (
     SandboxResources,
-    environment_prompt,
-    environment_sandbox_create_params,
-    environment_sandbox_resources,
-    environment_snapshot_id,
     resolve_environment,
 )
 from .dashboard.options import (
@@ -349,11 +345,10 @@ async def _resolve_sandbox_create_config(
 ) -> tuple[str | None, SandboxResources, dict[str, Any]]:
     """Resolve the snapshot, VM sizing, and create parameters for a new sandbox."""
     environment = await resolve_environment(environment_slug)
-    environment_snapshot = environment_snapshot_id(environment)
-    resources = environment_sandbox_resources(environment)
-    create_params = environment_sandbox_create_params(environment)
-    if environment_snapshot:
-        return environment_snapshot, resources, create_params
+    resources = environment.sandbox_resources() if environment else SandboxResources()
+    create_params = environment.sandbox_create_params() if environment else {}
+    if environment and environment.ready_snapshot_id:
+        return environment.ready_snapshot_id, resources, create_params
     return await get_admin_base_snapshot_id(), resources, create_params
 
 
@@ -1374,8 +1369,8 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 plan_url=dashboard_plan_url(self._thread_id),
                 repo_custom_instructions=self._repo_instructions,
                 corridor_enabled=self._corridor_enabled,
-                environment_name=(environment or {}).get("name"),
-                environment_instructions=environment_prompt(environment),
+                environment_name=environment.name if environment else None,
+                environment_instructions=environment.instructions if environment else None,
                 admin_environments=self._admin_environments,
                 source=self._source,
                 slack_context=_slack_tools_enabled(configurable),

--- a/agent/store.py
+++ b/agent/store.py
@@ -14,7 +14,7 @@ validated instead of as ``dict[str, Any]``.
 """
 
 import logging
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any, Generic, TypeVar
 
@@ -184,58 +184,3 @@ class TypedStore(Generic[RecordT]):
                     exc_info=True,
                 )
         return records
-
-
-class KeyedRecordStore:
-    """Records keyed by a stable id, each stamped with ``created_at``/``updated_at``.
-
-    ``default_factory(key, created_by)`` seeds a record that does not exist yet,
-    so ``create`` is idempotent and ``update`` can patch a record the dashboard
-    never explicitly created.
-    """
-
-    def __init__(
-        self,
-        namespace: Namespace,
-        *,
-        sort_key: str | None = None,
-        default_factory: Callable[[str, str], dict[str, Any]] | None = None,
-    ) -> None:
-        self.namespace = list(namespace)
-        self._sort_key = sort_key
-        self._default_factory = default_factory
-
-    def _default_record(self, key: str, created_by: str) -> dict[str, Any]:
-        if self._default_factory is None:
-            raise RuntimeError(f"{self.namespace} has no default record factory")
-        return self._default_factory(key, created_by)
-
-    async def get(self, key: str) -> dict[str, Any] | None:
-        return await get_value(self.namespace, key)
-
-    async def list(self) -> list[dict[str, Any]]:
-        records = await search_values(self.namespace, limit=1000)
-        if self._sort_key is not None:
-            sort_key = self._sort_key
-            records.sort(key=lambda record: str(record.get(sort_key, "")))
-        return records
-
-    async def put(self, key: str, record: dict[str, Any]) -> dict[str, Any]:
-        await put_value(self.namespace, key, record)
-        return record
-
-    async def create(self, key: str, created_by: str = "") -> dict[str, Any]:
-        existing = await self.get(key)
-        if existing:
-            return existing
-        return await self.put(key, self._default_record(key, created_by))
-
-    async def update(self, key: str, patch: dict[str, Any]) -> dict[str, Any]:
-        created_by = patch.get("created_by")
-        existing = await self.get(key) or self._default_record(
-            key, created_by if isinstance(created_by, str) else ""
-        )
-        return await self.put(key, {**existing, **patch, "updated_at": now_iso()})
-
-    async def delete(self, key: str) -> None:
-        await delete_value(self.namespace, key)

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -19,22 +19,27 @@ def _require_admin() -> str | None:
     return require_admin("manage environments")
 
 
-def _summary(record: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "name": record.get("name"),
-        "slug": record.get("slug"),
-        "prompt": record.get("prompt"),
-        "repos": record.get("repos") or [],
-        "mem_bytes": record.get("mem_bytes"),
-        "vcpus": record.get("vcpus"),
-        "fs_capacity_bytes": record.get("fs_capacity_bytes"),
-        "create_params": record.get("create_params") or {},
-        "snapshot_status": record.get("snapshot_status"),
-        "snapshot_id": record.get("snapshot_id"),
-        "snapshot_name": record.get("snapshot_name"),
-        "status_message": record.get("status_message"),
-        "last_captured_at": record.get("last_captured_at"),
-    }
+# Deliberately narrower than the record: the agent has no use for authorship
+# or the source sandbox.
+_SUMMARY_FIELDS = {
+    "name",
+    "slug",
+    "prompt",
+    "repos",
+    "mem_bytes",
+    "vcpus",
+    "fs_capacity_bytes",
+    "create_params",
+    "snapshot_status",
+    "snapshot_id",
+    "snapshot_name",
+    "status_message",
+    "last_captured_at",
+}
+
+
+def _summary(record: store.Environment) -> dict[str, Any]:
+    return record.model_dump(mode="json", include=_SUMMARY_FIELDS)
 
 
 async def list_environments() -> dict[str, Any]:
@@ -47,11 +52,11 @@ async def list_environments() -> dict[str, Any]:
     """
     if error := _require_admin():
         return {"ok": False, "error": error}
-    records = await store.list_environments()
+    records = await store.ENVIRONMENTS.list_all()
     return {
         "ok": True,
         "environments": [
-            {**_summary(record), "is_default": record.get("slug") == store.DEFAULT_ENVIRONMENT_SLUG}
+            {**_summary(record), "is_default": record.slug == store.DEFAULT_ENVIRONMENT_SLUG}
             for record in records
         ],
     }
@@ -117,11 +122,11 @@ async def save_environment(
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
 
-    existing = await store.get_environment(slug)
+    existing = await store.ENVIRONMENTS.get(slug)
     try:
         if existing is None:
             login = _configurable().get("github_login")
-            record = await store.create_environment(
+            record = await store.ENVIRONMENTS.create(
                 store.EnvironmentCreate(
                     name=name,
                     prompt=prompt,
@@ -144,7 +149,7 @@ async def save_environment(
                 update_values["create_params"] = create_params
             elif clear_create_params:
                 update_values["create_params"] = {}
-            record = await store.update_environment(
+            record = await store.ENVIRONMENTS.apply_update(
                 slug,
                 store.EnvironmentUpdate(**update_values),
             )
@@ -179,7 +184,7 @@ async def capture_environment_snapshot(name: str) -> dict[str, Any]:
         slug = store.slugify(name)
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
-    if await store.get_environment(slug) is None:
+    if await store.ENVIRONMENTS.get(slug) is None:
         return {"ok": False, "error": f"no environment named {name!r}; call save_environment first"}
 
     thread_id = _configurable().get("thread_id")
@@ -219,7 +224,7 @@ async def delete_environment(name: str) -> dict[str, Any]:
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     try:
-        deleted = await store.delete_environment(slug)
+        deleted = await store.ENVIRONMENTS.remove(slug)
     except Exception as exc:
         logger.exception("Failed to delete environment %s", slug)
         return {"ok": False, "error": f"failed to delete environment: {exc}"}

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 import httpx
 from langchain_core.messages.content import create_text_block
 
-from agent.dashboard.environments import get_environment, parse_environment_tag
+from agent.dashboard.environments import ENVIRONMENTS, parse_environment_tag
 from agent.input_messages import (
     InputMessageContext,
     MessageKind,
@@ -659,7 +659,7 @@ async def _process_slack_mention_impl(
     environment_slug: str | None = None
     if is_first_mention:
         tagged_slug, text_without_tag = parse_environment_tag(clean_text)
-        if tagged_slug and await get_environment(tagged_slug) is not None:
+        if tagged_slug and await ENVIRONMENTS.get(tagged_slug) is not None:
             environment_slug = tagged_slug
             clean_text = text_without_tag or "(no text in mention)"
         elif tagged_slug:

--- a/tests/agent/test_admin_environments.py
+++ b/tests/agent/test_admin_environments.py
@@ -5,11 +5,12 @@ import pytest
 from langgraph.graph.state import RunnableConfig
 
 from agent import server
+from agent.dashboard.environments import Environment
 from agent.prompt import construct_sender_context, construct_system_prompt
 from agent.tools import admin_gate
 from agent.tools import environments as env_tools
 
-_READY = {"slug": "base", "name": "Base", "snapshot_status": "ready", "snapshot_id": "env-snap"}
+_READY = Environment(slug="base", name="Base", snapshot_status="ready", snapshot_id="env-snap")
 
 
 def _config(**configurable: object) -> RunnableConfig:
@@ -32,7 +33,7 @@ async def test_default_environment_snapshot_wins_over_base() -> None:
 
 @pytest.mark.asyncio
 async def test_environment_without_ready_snapshot_falls_back_to_base() -> None:
-    capturing = {**_READY, "snapshot_status": "capturing"}
+    capturing = _READY.model_copy(update={"snapshot_status": "capturing"})
     with (
         patch.object(server, "resolve_environment", new_callable=AsyncMock, return_value=capturing),
         patch.object(
@@ -44,7 +45,9 @@ async def test_environment_without_ready_snapshot_falls_back_to_base() -> None:
 
 @pytest.mark.asyncio
 async def test_snapshot_resolution_passes_the_threads_environment() -> None:
-    resolve = AsyncMock(return_value={**_READY, "slug": "staging", "snapshot_id": "staging-snap"})
+    resolve = AsyncMock(
+        return_value=_READY.model_copy(update={"slug": "staging", "snapshot_id": "staging-snap"})
+    )
     with (
         patch.object(server, "resolve_environment", resolve),
         patch.object(
@@ -59,13 +62,14 @@ async def test_snapshot_resolution_passes_the_threads_environment() -> None:
 
 @pytest.mark.asyncio
 async def test_environment_sandbox_sizing_is_resolved_with_snapshot() -> None:
-    environment = {
-        **_READY,
-        "mem_bytes": 32 * 1024**3,
-        "vcpus": 16,
-        "fs_capacity_bytes": 512 * 1024**3,
-        "create_params": {"_internal_runtime": "v2"},
-    }
+    environment = _READY.model_copy(
+        update={
+            "mem_bytes": 32 * 1024**3,
+            "vcpus": 16,
+            "fs_capacity_bytes": 512 * 1024**3,
+            "create_params": {"_internal_runtime": "v2"},
+        }
+    )
     with patch.object(
         server, "resolve_environment", new_callable=AsyncMock, return_value=environment
     ):
@@ -144,21 +148,22 @@ async def test_tools_refuse_non_admins(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
     create = AsyncMock(
-        return_value={
-            "name": "base",
-            "slug": "base",
-            "prompt": "prompt",
-            "repos": [],
-            "mem_bytes": 16 * 1024**3,
-            "vcpus": 8,
-            "fs_capacity_bytes": 256 * 1024**3,
-            "create_params": {"_internal_runtime": "v2"},
-        }
+        return_value=Environment(
+            slug="base",
+            name="base",
+            prompt="prompt",
+            mem_bytes=16 * 1024**3,
+            vcpus=8,
+            fs_capacity_bytes=256 * 1024**3,
+            create_params={"_internal_runtime": "v2"},
+        )
     )
     with (
         patch.object(admin_gate, "get_config", return_value=_config(github_login="ramonn")),
-        patch.object(env_tools.store, "get_environment", new_callable=AsyncMock, return_value=None),
-        patch.object(env_tools.store, "create_environment", create),
+        patch.object(
+            env_tools.store.ENVIRONMENTS, "get", new_callable=AsyncMock, return_value=None
+        ),
+        patch.object(env_tools.store.ENVIRONMENTS, "create", create),
     ):
         result = await env_tools.save_environment(
             "base",
@@ -182,27 +187,16 @@ async def test_save_environment_persists_sandbox_sizing(monkeypatch: pytest.Monk
 @pytest.mark.asyncio
 async def test_save_environment_can_clear_sandbox_sizing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CONFIGURED_ADMINS", "ramonn")
-    update = AsyncMock(
-        return_value={
-            "name": "base",
-            "slug": "base",
-            "prompt": "prompt",
-            "repos": [],
-            "mem_bytes": None,
-            "vcpus": None,
-            "fs_capacity_bytes": None,
-            "create_params": {},
-        }
-    )
+    update = AsyncMock(return_value=Environment(slug="base", name="base", prompt="prompt"))
     with (
         patch.object(admin_gate, "get_config", return_value=_config(github_login="ramonn")),
         patch.object(
-            env_tools.store,
-            "get_environment",
+            env_tools.store.ENVIRONMENTS,
+            "get",
             new_callable=AsyncMock,
-            return_value={"slug": "base"},
+            return_value=Environment(slug="base"),
         ),
-        patch.object(env_tools.store, "update_environment", update),
+        patch.object(env_tools.store.ENVIRONMENTS, "apply_update", update),
     ):
         result = await env_tools.save_environment(
             "base",
@@ -245,7 +239,9 @@ async def test_capture_tool_requires_a_saved_environment(monkeypatch: pytest.Mon
             "get_config",
             return_value=_config(github_login="ramonn", thread_id="t-1"),
         ),
-        patch.object(env_tools.store, "get_environment", new_callable=AsyncMock, return_value=None),
+        patch.object(
+            env_tools.store.ENVIRONMENTS, "get", new_callable=AsyncMock, return_value=None
+        ),
     ):
         result = await env_tools.capture_environment_snapshot("base")
 

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -6,15 +6,14 @@ import pytest
 from agent import store as agent_store
 from agent.dashboard import environments as env_store
 from agent.dashboard.environments import (
+    ENVIRONMENTS,
+    Environment,
     EnvironmentCreate,
     EnvironmentUpdate,
-    environment_prompt,
-    environment_sandbox_create_params,
-    environment_sandbox_resources,
-    environment_snapshot_id,
     slugify,
     snapshot_name_for,
 )
+from tests.conftest import FakeStore
 
 
 def _fake_client() -> tuple[MagicMock, dict[tuple[Any, ...], Any]]:
@@ -96,19 +95,19 @@ def test_sandbox_resources_require_positive_integers() -> None:
 
 
 def test_environment_sandbox_resources_omits_invalid_stored_values() -> None:
-    assert environment_sandbox_resources(
-        {
-            "mem_bytes": 16 * 1024**3,
-            "vcpus": 8,
-            "fs_capacity_bytes": 256 * 1024**3,
-            "unexpected": 1,
-        }
-    ) == {
+    ready = Environment(
+        slug="env",
+        mem_bytes=16 * 1024**3,
+        vcpus=8,
+        fs_capacity_bytes=256 * 1024**3,
+    )
+    assert ready.sandbox_resources() == {
         "mem_bytes": 16 * 1024**3,
         "vcpus": 8,
         "fs_capacity_bytes": 256 * 1024**3,
     }
-    assert environment_sandbox_resources({"mem_bytes": -1, "vcpus": True}) == {}
+    assert Environment(slug="env").sandbox_resources() == {}
+    assert Environment(slug="env", mem_bytes=-1).sandbox_resources() == {}
 
 
 def test_create_params_accept_non_sensitive_runtime_and_proxy_settings() -> None:
@@ -121,7 +120,7 @@ def test_create_params_accept_non_sensitive_runtime_and_proxy_settings() -> None
     create = EnvironmentCreate(name="env", create_params=params)
 
     assert create.create_params == params
-    assert environment_sandbox_create_params({"create_params": params}) == params
+    assert Environment(slug="env", create_params=params).sandbox_create_params() == params
 
 
 @pytest.mark.parametrize(
@@ -170,105 +169,103 @@ def test_create_params_enforce_serialized_size_limit() -> None:
 
 
 def test_snapshot_id_only_resolves_when_ready() -> None:
-    assert environment_snapshot_id({"snapshot_status": "capturing", "snapshot_id": "s-1"}) is None
-    assert environment_snapshot_id({"snapshot_status": "ready", "snapshot_id": "s-1"}) == "s-1"
-    assert environment_snapshot_id(None) is None
+    assert (
+        Environment(slug="e", snapshot_status="capturing", snapshot_id="s-1").ready_snapshot_id
+        is None
+    )
+    assert (
+        Environment(slug="e", snapshot_status="ready", snapshot_id="s-1").ready_snapshot_id == "s-1"
+    )
+    assert Environment(slug="e", snapshot_status="ready").ready_snapshot_id is None
 
 
 def test_environment_prompt_blank_is_none() -> None:
-    assert environment_prompt({"prompt": "   "}) is None
-    assert environment_prompt({"prompt": " build with make "}) == "build with make"
+    assert Environment(slug="e", prompt="   ").instructions is None
+    assert Environment(slug="e", prompt=" build with make ").instructions == "build with make"
 
 
 # --- CRUD (patched store) ---
 
 
 @pytest.mark.asyncio
-async def test_only_the_environment_named_default_is_resolved() -> None:
-    client, _ = _fake_client()
-    with patch.object(agent_store, "store_client", return_value=client):
-        await env_store.create_environment(EnvironmentCreate(name="Draft"), "ramon")
-        assert await env_store.resolve_default_environment() is None
+async def test_only_the_environment_named_default_is_resolved(fake_store: FakeStore) -> None:
+    await ENVIRONMENTS.create(EnvironmentCreate(name="Draft"), "ramon")
+    assert await env_store.resolve_default_environment() is None
 
-        await env_store.create_environment(EnvironmentCreate(name="Default"), "ramon")
-        resolved = await env_store.resolve_default_environment()
+    await ENVIRONMENTS.create(EnvironmentCreate(name="Default"), "ramon")
+    resolved = await env_store.resolve_default_environment()
 
     assert resolved is not None
-    assert resolved["slug"] == "default"
+    assert resolved.slug == "default"
 
 
 @pytest.mark.asyncio
-async def test_create_rejects_duplicate_name() -> None:
-    client, _ = _fake_client()
-    with patch.object(agent_store, "store_client", return_value=client):
-        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
-        with pytest.raises(ValueError, match="already exists"):
-            await env_store.create_environment(EnvironmentCreate(name="Base"), "ramon")
+async def test_create_rejects_duplicate_name(fake_store: FakeStore) -> None:
+    await ENVIRONMENTS.create(EnvironmentCreate(name="base"), "ramon")
+    with pytest.raises(ValueError, match="already exists"):
+        await ENVIRONMENTS.create(EnvironmentCreate(name="Base"), "ramon")
 
 
 @pytest.mark.asyncio
-async def test_update_writes_only_provided_fields() -> None:
-    client, _ = _fake_client()
-    with patch.object(agent_store, "store_client", return_value=client):
-        await env_store.create_environment(
-            EnvironmentCreate(
-                name="base",
-                prompt="original",
-                repos=["o/r"],
-                mem_bytes=8 * 1024**3,
-                vcpus=4,
-                fs_capacity_bytes=128 * 1024**3,
-                create_params={"_internal_runtime": "v2"},
-            ),
-            "ramon",
-        )
-        updated = await env_store.update_environment(
-            "base", EnvironmentUpdate(prompt="replaced", vcpus=8)
-        )
-        assert updated["prompt"] == "replaced"
-        assert updated["repos"] == ["o/r"]
-        assert updated["mem_bytes"] == 8 * 1024**3
-        assert updated["vcpus"] == 8
-        assert updated["fs_capacity_bytes"] == 128 * 1024**3
-        assert updated["create_params"] == {"_internal_runtime": "v2"}
+async def test_update_writes_only_provided_fields(fake_store: FakeStore) -> None:
+    await ENVIRONMENTS.create(
+        EnvironmentCreate(
+            name="base",
+            prompt="original",
+            repos=["o/r"],
+            mem_bytes=8 * 1024**3,
+            vcpus=4,
+            fs_capacity_bytes=128 * 1024**3,
+            create_params={"_internal_runtime": "v2"},
+        ),
+        "ramon",
+    )
+    updated = await ENVIRONMENTS.apply_update("base", EnvironmentUpdate(prompt="replaced", vcpus=8))
+    assert updated.prompt == "replaced"
+    assert updated.repos == ["o/r"]
+    assert updated.mem_bytes == 8 * 1024**3
+    assert updated.vcpus == 8
+    assert updated.fs_capacity_bytes == 128 * 1024**3
+    assert updated.create_params == {"_internal_runtime": "v2"}
 
-        cleared = await env_store.update_environment(
-            "base",
-            EnvironmentUpdate(mem_bytes=None, create_params={}),
-        )
-        assert cleared["mem_bytes"] is None
-        assert cleared["vcpus"] == 8
-        assert cleared["fs_capacity_bytes"] == 128 * 1024**3
-        assert cleared["create_params"] == {}
+    cleared = await ENVIRONMENTS.apply_update(
+        "base",
+        EnvironmentUpdate(mem_bytes=None, create_params={}),
+    )
+    assert cleared.mem_bytes is None
+    assert cleared.vcpus == 8
+    assert cleared.fs_capacity_bytes == 128 * 1024**3
+    assert cleared.create_params == {}
 
 
 @pytest.mark.asyncio
-async def test_update_rejects_a_rename_across_slugs() -> None:
-    client, _ = _fake_client()
-    with patch.object(agent_store, "store_client", return_value=client):
-        await env_store.create_environment(EnvironmentCreate(name="draft"), "ramon")
-        with pytest.raises(ValueError, match="renaming an environment"):
-            await env_store.update_environment("draft", EnvironmentUpdate(name="default"))
+async def test_update_rejects_a_rename_across_slugs(fake_store: FakeStore) -> None:
+    await ENVIRONMENTS.create(EnvironmentCreate(name="draft"), "ramon")
+    with pytest.raises(ValueError, match="renaming an environment"):
+        await ENVIRONMENTS.apply_update("draft", EnvironmentUpdate(name="default"))
 
 
 @pytest.mark.asyncio
-async def test_delete_removes_record_and_snapshot() -> None:
-    client, _ = _fake_client()
+async def test_delete_removes_record_and_snapshot(fake_store: FakeStore) -> None:
     delete_snapshot = AsyncMock()
     with (
-        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", delete_snapshot),
     ):
-        await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
-        await env_store._set_snapshot_state("default", "ready", extra={"snapshot_id": "snap-1"})
+        await ENVIRONMENTS.create(EnvironmentCreate(name="default"), "ramon")
+        await ENVIRONMENTS.mark_captured(
+            "default",
+            snapshot_id="snap-1",
+            snapshot_name="prior",
+            source_sandbox_id="sb-prior",
+        )
 
-        assert await env_store.delete_environment("default") is True
+        assert await ENVIRONMENTS.remove("default") is True
         assert await env_store.resolve_default_environment() is None
         delete_snapshot.assert_awaited_once_with("snap-1")
 
 
 @pytest.mark.asyncio
-async def test_resolve_default_environment_swallows_store_failures() -> None:
+async def test_resolve_default_environment_swallows_store_failures(fake_store: FakeStore) -> None:
     client = MagicMock()
     client.store.get_item = AsyncMock(side_effect=RuntimeError("store down"))
     with patch.object(agent_store, "store_client", return_value=client):
@@ -293,29 +290,32 @@ def _sandbox_client(capture: AsyncMock) -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_capture_tags_latest_and_replaces_previous_snapshot() -> None:
-    client, _ = _fake_client()
+async def test_capture_tags_latest_and_replaces_previous_snapshot(fake_store: FakeStore) -> None:
     capture = AsyncMock(return_value=_FakeSnapshot("snap-2"))
     delete_snapshot = AsyncMock()
     with (
-        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", delete_snapshot),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
         ),
     ):
-        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
-        await env_store._set_snapshot_state("base", "ready", extra={"snapshot_id": "snap-1"})
+        await ENVIRONMENTS.create(EnvironmentCreate(name="base"), "ramon")
+        await ENVIRONMENTS.mark_captured(
+            "base",
+            snapshot_id="snap-1",
+            snapshot_name="prior",
+            source_sandbox_id="sb-prior",
+        )
 
         record = await env_store.capture_environment_snapshot("base", "sb-123")
 
     assert capture.await_args is not None
     assert capture.await_args.args == ("sb-123", "openswe-environment-base")
-    assert record["snapshot_status"] == "ready"
-    assert record["snapshot_id"] == "snap-2"
-    assert record["snapshot_name"] == "openswe-environment-base"
-    assert record["source_sandbox_id"] == "sb-123"
+    assert record.snapshot_status == "ready"
+    assert record.snapshot_id == "snap-2"
+    assert record.snapshot_name == "openswe-environment-base"
+    assert record.source_sandbox_id == "sb-123"
     delete_snapshot.assert_awaited_once_with("snap-1")
 
 
@@ -327,95 +327,96 @@ _NameConflict.__name__ = "ResourceAlreadyExistsError"
 
 
 @pytest.mark.asyncio
-async def test_capture_walks_the_name_suffix_past_a_conflict() -> None:
-    client, _ = _fake_client()
+async def test_capture_walks_the_name_suffix_past_a_conflict(fake_store: FakeStore) -> None:
     capture = AsyncMock(side_effect=[_NameConflict("taken"), _FakeSnapshot("snap-2")])
     with (
-        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", AsyncMock()),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
         ),
     ):
-        await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
+        await ENVIRONMENTS.create(EnvironmentCreate(name="default"), "ramon")
         record = await env_store.capture_environment_snapshot("default", "sb-123")
 
     assert [call.args[1] for call in capture.await_args_list] == [
         "openswe-environment-default",
         "openswe-environment-default-2",
     ]
-    assert record["snapshot_status"] == "ready"
-    assert record["snapshot_name"] == "openswe-environment-default-2"
+    assert record.snapshot_status == "ready"
+    assert record.snapshot_name == "openswe-environment-default-2"
 
 
 @pytest.mark.asyncio
-async def test_failed_recapture_keeps_booting_from_the_previous_snapshot() -> None:
-    client, _ = _fake_client()
+async def test_failed_recapture_keeps_booting_from_the_previous_snapshot(
+    fake_store: FakeStore,
+) -> None:
     capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
     delete_snapshot = AsyncMock()
     with (
-        patch.object(agent_store, "store_client", return_value=client),
         patch.object(env_store, "_delete_snapshot", delete_snapshot),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
         ),
     ):
-        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
-        await env_store._set_snapshot_state("base", "ready", extra={"snapshot_id": "snap-1"})
+        await ENVIRONMENTS.create(EnvironmentCreate(name="base"), "ramon")
+        await ENVIRONMENTS.mark_captured(
+            "base",
+            snapshot_id="snap-1",
+            snapshot_name="prior",
+            source_sandbox_id="sb-prior",
+        )
 
         with pytest.raises(RuntimeError, match="capture exploded"):
             await env_store.capture_environment_snapshot("base", "sb-123")
 
-        record = await env_store.get_environment("base")
+        record = await ENVIRONMENTS.get("base")
 
     assert record is not None
     # Still ready, so runs keep booting from snap-1 instead of dropping to the
     # base image; the error rides along in status_message.
-    assert record["snapshot_status"] == "ready"
-    assert environment_snapshot_id(record) == "snap-1"
-    assert record["status_message"] == "capture exploded"
+    assert record.snapshot_status == "ready"
+    assert record.ready_snapshot_id == "snap-1"
+    assert record.status_message == "capture exploded"
     delete_snapshot.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_first_capture_failure_marks_the_environment_failed() -> None:
-    client, _ = _fake_client()
+async def test_first_capture_failure_marks_the_environment_failed(fake_store: FakeStore) -> None:
     capture = AsyncMock(side_effect=RuntimeError("capture exploded"))
     with (
-        patch.object(agent_store, "store_client", return_value=client),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
         ),
     ):
-        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+        await ENVIRONMENTS.create(EnvironmentCreate(name="base"), "ramon")
 
         with pytest.raises(RuntimeError, match="capture exploded"):
             await env_store.capture_environment_snapshot("base", "sb-123")
 
-        record = await env_store.get_environment("base")
+        record = await ENVIRONMENTS.get("base")
 
     # Nothing to fall back to, so the record says so rather than claiming ready.
     assert record is not None
-    assert record["snapshot_status"] == "failed"
-    assert environment_snapshot_id(record) is None
+    assert record.snapshot_status == "failed"
+    assert record.ready_snapshot_id is None
 
 
 @pytest.mark.asyncio
-async def test_capture_requires_the_langsmith_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_capture_requires_the_langsmith_provider(
+    fake_store: FakeStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("SANDBOX_TYPE", "local")
-    client, _ = _fake_client()
     capture = AsyncMock()
     with (
-        patch.object(agent_store, "store_client", return_value=client),
         patch(
             "agent.integrations.langsmith.get_async_sandbox_client",
             return_value=_sandbox_client(capture),
         ),
     ):
-        await env_store.create_environment(EnvironmentCreate(name="base"), "ramon")
+        await ENVIRONMENTS.create(EnvironmentCreate(name="base"), "ramon")
         with pytest.raises(RuntimeError, match="SANDBOX_TYPE=langsmith"):
             await env_store.capture_environment_snapshot("base", "sb-123")
 
@@ -441,39 +442,40 @@ def test_parse_environment_tag(text: str, expected_slug: str | None, expected_te
 
 
 @pytest.mark.asyncio
-async def test_resolve_environment_prefers_the_selection() -> None:
-    client, _ = _fake_client()
-    with patch.object(agent_store, "store_client", return_value=client):
-        await env_store.create_environment(EnvironmentCreate(name="default"), "ramon")
-        await env_store.create_environment(EnvironmentCreate(name="staging"), "ramon")
+async def test_resolve_environment_prefers_the_selection(fake_store: FakeStore) -> None:
+    await ENVIRONMENTS.create(EnvironmentCreate(name="default"), "ramon")
+    await ENVIRONMENTS.create(EnvironmentCreate(name="staging"), "ramon")
 
-        selected = await env_store.resolve_environment("staging")
-        assert selected is not None
-        assert selected["slug"] == "staging"
+    selected = await env_store.resolve_environment("staging")
+    assert selected is not None
+    assert selected.slug == "staging"
 
-        unselected = await env_store.resolve_environment(None)
-        assert unselected is not None
-        assert unselected["slug"] == "default"
+    unselected = await env_store.resolve_environment(None)
+    assert unselected is not None
+    assert unselected.slug == "default"
 
-        # A selection that no longer exists falls back rather than failing the run.
-        stale = await env_store.resolve_environment("deleted")
-        assert stale is not None
-        assert stale["slug"] == "default"
+    # A selection that no longer exists falls back rather than failing the run.
+    stale = await env_store.resolve_environment("deleted")
+    assert stale is not None
+    assert stale.slug == "default"
 
 
 @pytest.mark.asyncio
-async def test_environment_options_omit_admin_only_settings() -> None:
-    client, _ = _fake_client()
-    with patch.object(agent_store, "store_client", return_value=client):
-        await env_store.create_environment(
-            EnvironmentCreate(
-                name="default",
-                prompt="secret-ish prompt",
-                create_params={"_internal_runtime": "v2"},
-            ),
-            "ramon",
-        )
-        await env_store._set_snapshot_state("default", "ready", extra={"snapshot_id": "snap-1"})
-        options = await env_store.list_environment_options()
+async def test_environment_options_omit_admin_only_settings(fake_store: FakeStore) -> None:
+    await ENVIRONMENTS.create(
+        EnvironmentCreate(
+            name="default",
+            prompt="secret-ish prompt",
+            create_params={"_internal_runtime": "v2"},
+        ),
+        "ramon",
+    )
+    await ENVIRONMENTS.mark_captured(
+        "default",
+        snapshot_id="snap-1",
+        snapshot_name="prior",
+        source_sandbox_id="sb-prior",
+    )
+    options = await env_store.list_environment_options()
 
     assert options == [{"slug": "default", "name": "default", "has_snapshot": True}]

--- a/tests/dashboard/test_environments.py
+++ b/tests/dashboard/test_environments.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from agent import store as agent_store
 from agent.dashboard import environments as env_store
@@ -421,6 +422,53 @@ async def test_capture_requires_the_langsmith_provider(
             await env_store.capture_environment_snapshot("base", "sb-123")
 
     capture.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_clearing_create_params_with_null_stays_readable(
+    fake_store: FakeStore,
+) -> None:
+    """An explicit ``create_params: null`` must not poison the record.
+
+    The store mutates records in place, so an unvalidated null would only
+    surface on the next read — as a ValidationError that makes the environment
+    unresolvable, unupdatable, and invisible to listings.
+    """
+    await ENVIRONMENTS.create(
+        EnvironmentCreate(name="base", create_params={"_internal_runtime": "v2"}), "ramon"
+    )
+
+    updated = await ENVIRONMENTS.apply_update("base", EnvironmentUpdate(create_params=None))
+
+    assert updated.create_params == {}
+    reread = await ENVIRONMENTS.get("base")
+    assert reread is not None
+    assert reread.create_params == {}
+    assert [record.slug for record in await ENVIRONMENTS.list_all()] == ["base"]
+
+
+@pytest.mark.asyncio
+async def test_a_record_stored_with_null_create_params_is_still_readable(
+    fake_store: FakeStore,
+) -> None:
+    """Records written before create_params was modelled can hold a null."""
+    fake_store.seed(
+        env_store.ENVIRONMENTS_NAMESPACE,
+        "legacy",
+        {"slug": "legacy", "name": "legacy", "create_params": None},
+    )
+
+    record = await ENVIRONMENTS.get("legacy")
+
+    assert record is not None
+    assert record.create_params == {}
+    assert record.sandbox_create_params() == {}
+
+
+def test_assignment_is_validated() -> None:
+    record = Environment(slug="base")
+    with pytest.raises(ValidationError):
+        record.vcpus = "not-an-int"  # type: ignore[assignment]
 
 
 # --- per-thread selection ---

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -1,7 +1,7 @@
 """Tests for GitHub proxy auth configuration."""
 
 import base64
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -10,6 +10,7 @@ from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.runnables import RunnableConfig
 from langgraph.runtime import Runtime
 
+from agent.dashboard.environments import Environment
 from agent.integrations.langsmith import (
     PROXY_GH_TOKEN_PLACEHOLDER,
     PROXY_MODEL_KEY_PLACEHOLDER,
@@ -432,17 +433,18 @@ class TestCreateSandboxWithProxy:
 
     @pytest.mark.asyncio
     async def test_passes_environment_resources_to_sandbox_creation(self) -> None:
-        environment: dict[str, Any] = {
-            "snapshot_status": "ready",
-            "snapshot_id": "env-snap",
-            "mem_bytes": 16,
-            "vcpus": 8,
-            "fs_capacity_bytes": 128,
-            "create_params": {
+        environment = Environment(
+            slug="env",
+            snapshot_status="ready",
+            snapshot_id="env-snap",
+            mem_bytes=16,
+            vcpus=8,
+            fs_capacity_bytes=128,
+            create_params={
                 "_internal_runtime": "v2",
                 "proxy_config": {"rules": [{"name": "public-api", "match_hosts": ["example.com"]}]},
             },
-        }
+        )
         with (
             patch(
                 "agent.server.resolve_environment", new_callable=AsyncMock, return_value=environment
@@ -469,12 +471,12 @@ class TestCreateSandboxWithProxy:
             mem_bytes=16,
             vcpus=8,
             fs_capacity_bytes=128,
-            create_params=environment["create_params"],
+            create_params=environment.create_params,
         )
         mock_configure_proxy.assert_awaited_once_with(
             "sandbox-123",
             "ghs_install",
-            base_proxy_config=environment["create_params"]["proxy_config"],
+            base_proxy_config=environment.create_params["proxy_config"],
         )
 
     @pytest.mark.asyncio
@@ -580,7 +582,7 @@ class TestRefreshProxyOnSandboxReuse:
             patch(
                 "agent.server.resolve_environment",
                 new_callable=AsyncMock,
-                return_value={"create_params": {"proxy_config": {}}},
+                return_value=Environment(slug="env", create_params={"proxy_config": {}}),
             ),
             patch(
                 "agent.server.get_sandbox_id_from_metadata",


### PR DESCRIPTION
Finishes what #2243 started. `environments` was the last `KeyedRecordStore` user, so **the class is deleted** and `agent/store.py` is down to the raw helpers plus `TypedStore`.

Not stacked — branches off `main`.

## The untyped patch API here was `_set_snapshot_state`

```python
await _set_snapshot_state(slug, "ready", extra={
    "snapshot_id": snapshot.id, "snapshot_name": snapshot_name,
    "source_sandbox_id": sandbox_id, "last_captured_at": now_iso(),
})
```

Now `mark_capturing` / `mark_captured` / `mark_capture_settled`. The third one is worth a look: it carries the rule that a **failed** capture lands on `ready` when the previous snapshot is still good. That's what keeps runs booting from the old snapshot instead of dropping to the base image, and it was previously a bare `"ready" if previous_was_ready else "failed"` ternary at the call site with the reasoning only in a docstring three functions away.

## Accessors became model members

`environment_snapshot_id`, `environment_prompt`, `environment_sandbox_resources`, `environment_sandbox_create_params` all took `record: dict[str, Any] | None` and re-derived the shape. They're now `ready_snapshot_id`, `instructions`, `sandbox_resources()`, `sandbox_create_params()`, plus `option()` for the non-admin picker.

## What deliberately stayed untyped

I said earlier that `environments` held "the last nested case". Having read it properly, that was overstated, and the two candidates split differently:

- **`SandboxResources`** stays a `TypedDict`. It isn't stored — it's a kwargs projection built at read time from three flat int fields, splatted into sandbox creation. Making it a model would add a layer to a kwargs bag.
- **`create_params`** stays `dict[str, JsonValue]`. It's opaque passthrough to the LangSmith sandbox create body; modeling its shape would mean a model change per platform field. It's validated (JSON-serializable, size cap, no credentials, `proxy_config` shape) but not modeled.

One behaviour worth calling out: `sandbox_create_params()` re-validates **on read**, not just on write. The rules can tighten after a record was stored — the secret-name blocklist is the case that matters — and shipping a stale record's params to the platform would bypass the newer rule. Invalid params log and resolve to `{}` rather than failing the run.

## Tests

Moved onto the shared `fake_store` fixture, retiring this file's own `_fake_client` (the 20th hand-rolled store fake in the suite; ~19 to go). Two other files patched the old free functions — `tests/agent/test_admin_environments.py` and `tests/sandbox/test_proxy_auth.py` — and now build real `Environment` objects instead of dict literals shaped like records.

## Test Plan

- [x] `make typecheck` — 0 errors
- [x] `make lint` — clean
- [x] `make test` — 1908 passed, 0 failed
