### PR TITLE
feat: move skills into settings

### DIFF
--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
   IoGitPullRequestOutline,
   IoOptionsOutline,
   IoSettingsOutline,
+  IoSparklesOutline,
   IoStatsChartOutline,
 } from "react-icons/io5"
 import type { ComponentType, SVGProps } from "react"
@@ -32,6 +33,7 @@ const NAV: Array<{ heading: string; items: Array<NavItem> }> = [
     heading: "Personal",
     items: [
       { to: "/my-settings", label: "Settings", icon: IoOptionsOutline },
+      { to: "/skills", label: "Skills", icon: IoSparklesOutline },
       { to: "/usage", label: "Usage", icon: IoStatsChartOutline },
     ],
   },

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -18,7 +18,6 @@ import {
   PlusIcon,
   PushPinIcon,
   PushPinSlashIcon,
-  SparkleIcon,
   TrashIcon,
   TreeStructureIcon,
 } from "@phosphor-icons/react"
@@ -139,7 +138,6 @@ interface AgentsSidebarProps {
 
 const NAV = [
   { to: "/agents/threads", label: "Kanban", icon: Kanban },
-  { to: "/agents/skills", label: "Skills", icon: SparkleIcon },
   { to: "/agents/automations", label: "Automations", icon: LightningIcon },
   { to: "/agents/reviews", label: "Reviews", icon: GitPullRequestIcon },
 ] as const

--- a/ui/src/features/agents/components/SkillsPage.tsx
+++ b/ui/src/features/agents/components/SkillsPage.tsx
@@ -101,7 +101,7 @@ export function SkillsPage() {
     }
   }
 
-  if (skills.isLoading) return <Skeleton className="m-6 h-64 flex-1" />
+  if (skills.isLoading) return <Skeleton className="h-64 w-full" />
 
   const dirty =
     selected != null &&
@@ -110,163 +110,149 @@ export function SkillsPage() {
   const creating = selectedName === null
 
   return (
-    <main className="min-w-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-4xl px-6 py-8">
-        <h1 className="font-heading text-base font-medium text-[var(--ui-text)]">
-          Skills
-        </h1>
-        <p className="mt-1 text-xs text-[var(--ui-text-muted)]">
-          Reusable instructions Open SWE loads when a task matches their
-          description.
-        </p>
+    <div>
+      <div className="flex gap-1">
+        <Button
+          size="sm"
+          variant={organization ? "ghost" : "default"}
+          onClick={() => selectScope(false)}
+        >
+          Personal
+        </Button>
+        <Button
+          size="sm"
+          variant={organization ? "default" : "ghost"}
+          onClick={() => selectScope(true)}
+        >
+          Organization
+        </Button>
+      </div>
 
-        <div className="mt-4 flex gap-1">
-          <Button
-            size="sm"
-            variant={organization ? "ghost" : "default"}
-            onClick={() => selectScope(false)}
-          >
-            Personal
-          </Button>
-          <Button
-            size="sm"
-            variant={organization ? "default" : "ghost"}
-            onClick={() => selectScope(true)}
-          >
-            Organization
-          </Button>
-        </div>
-
-        <div className="mt-6 grid gap-6 md:grid-cols-[220px_minmax(0,1fr)]">
-          <section>
-            {canEdit && (
-              <Button size="sm" className="w-full" onClick={clear}>
-                New skill
-              </Button>
+      <div className="mt-6 grid gap-6 md:grid-cols-[220px_minmax(0,1fr)]">
+        <section>
+          {canEdit && (
+            <Button size="sm" className="w-full" onClick={clear}>
+              New skill
+            </Button>
+          )}
+          <div className="mt-3 space-y-1">
+            {(skills.data ?? []).map((skill) => (
+              <button
+                key={skill.name}
+                type="button"
+                onClick={() => select(skill)}
+                className={cn(
+                  "w-full rounded-md px-2.5 py-2 text-left transition-colors",
+                  selectedName === skill.name ? "bg-muted" : "hover:bg-muted"
+                )}
+              >
+                <span className="block truncate text-xs font-medium text-foreground">
+                  {skill.name}
+                </span>
+                <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                  {skill.description}
+                </span>
+              </button>
+            ))}
+            {skills.data?.length === 0 && (
+              <p className="px-2.5 py-4 text-xs text-muted-foreground">
+                No skills yet.
+              </p>
             )}
-            <div className="mt-3 space-y-1">
-              {(skills.data ?? []).map((skill) => (
-                <button
-                  key={skill.name}
-                  type="button"
-                  onClick={() => select(skill)}
-                  className={cn(
-                    "w-full rounded-md px-2.5 py-2 text-left transition-colors",
-                    selectedName === skill.name
-                      ? "bg-[var(--ui-sidebar-hover)]"
-                      : "hover:bg-[var(--ui-sidebar-hover)]"
-                  )}
-                >
-                  <span className="block truncate text-xs font-medium text-[var(--ui-text)]">
-                    {skill.name}
-                  </span>
-                  <span className="mt-0.5 block truncate text-[10px] text-[var(--ui-text-muted)]">
-                    {skill.description}
-                  </span>
-                </button>
-              ))}
-              {skills.data?.length === 0 && (
-                <p className="px-2.5 py-4 text-xs text-[var(--ui-text-muted)]">
-                  No skills yet.
+          </div>
+        </section>
+
+        <section className="space-y-4 rounded-lg border border-border bg-card p-4">
+          {!canEdit && !selected ? (
+            <p className="text-xs text-muted-foreground">
+              Select an organization skill to view it.
+            </p>
+          ) : (
+            <>
+              {creating ? (
+                <div className="space-y-2">
+                  <Label htmlFor="skill-name">Name</Label>
+                  <Input
+                    id="skill-name"
+                    value={newName}
+                    onChange={(event) => setNewName(event.target.value)}
+                    placeholder="address-review-feedback"
+                  />
+                  <p className="text-[10px] text-muted-foreground">
+                    Lowercase letters, numbers, and single hyphens.
+                  </p>
+                </div>
+              ) : (
+                <p className="text-sm font-medium text-foreground">
+                  {selectedName}
                 </p>
               )}
-            </div>
-          </section>
 
-          <section className="space-y-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-panel)] p-4">
-            {!canEdit && !selected ? (
-              <p className="text-xs text-[var(--ui-text-muted)]">
-                Select an organization skill to view it.
-              </p>
-            ) : (
-              <>
-                {creating ? (
-                  <div className="space-y-2">
-                    <Label htmlFor="skill-name">Name</Label>
-                    <Input
-                      id="skill-name"
-                      value={newName}
-                      onChange={(event) => setNewName(event.target.value)}
-                      placeholder="address-review-feedback"
-                    />
-                    <p className="text-[10px] text-[var(--ui-text-muted)]">
-                      Lowercase letters, numbers, and single hyphens.
-                    </p>
-                  </div>
-                ) : (
-                  <p className="text-sm font-medium text-[var(--ui-text)]">
-                    {selectedName}
-                  </p>
-                )}
+              <div className="space-y-2">
+                <Label htmlFor="skill-description">Description</Label>
+                <Input
+                  id="skill-description"
+                  value={draft.description}
+                  onChange={(event) =>
+                    setDraft((value) => ({
+                      ...value,
+                      description: event.target.value,
+                    }))
+                  }
+                  disabled={!canEdit}
+                  placeholder="What this skill does and when Open SWE should use it"
+                />
+              </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="skill-description">Description</Label>
-                  <Input
-                    id="skill-description"
-                    value={draft.description}
-                    onChange={(event) =>
-                      setDraft((value) => ({
-                        ...value,
-                        description: event.target.value,
-                      }))
+              <div className="space-y-2">
+                <Label>Instructions</Label>
+                <InstructionsEditor
+                  value={draft.instructions}
+                  onChange={(instructions) =>
+                    setDraft((value) => ({ ...value, instructions }))
+                  }
+                  disabled={!canEdit}
+                  placeholder="Write the skill workflow in Markdown."
+                />
+              </div>
+
+              {canEdit && (
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    disabled={
+                      !draft.description.trim() ||
+                      (creating
+                        ? !newName.trim() || create.isPending
+                        : !dirty || update.isPending)
                     }
-                    disabled={!canEdit}
-                    placeholder="What this skill does and when Open SWE should use it"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Instructions</Label>
-                  <InstructionsEditor
-                    value={draft.instructions}
-                    onChange={(instructions) =>
-                      setDraft((value) => ({ ...value, instructions }))
-                    }
-                    disabled={!canEdit}
-                    placeholder="Write the skill workflow in Markdown."
-                  />
-                </div>
-
-                {canEdit && (
-                  <div className="flex items-center gap-2">
+                    onClick={() => void (creating ? add() : save())}
+                  >
+                    {creating ? "Create skill" : "Save skill"}
+                  </Button>
+                  {dirty && (
+                    <span className="text-xs text-muted-foreground">
+                      Unsaved changes
+                    </span>
+                  )}
+                  {!creating && (
                     <Button
                       size="sm"
-                      disabled={
-                        !draft.description.trim() ||
-                        (creating
-                          ? !newName.trim() || create.isPending
-                          : !dirty || update.isPending)
-                      }
-                      onClick={() => void (creating ? add() : save())}
+                      variant="destructive"
+                      className="ml-auto"
+                      disabled={remove.isPending}
+                      onClick={() => void onDelete()}
                     >
-                      {creating ? "Create skill" : "Save skill"}
+                      Delete
                     </Button>
-                    {dirty && (
-                      <span className="text-xs text-[var(--ui-text-muted)]">
-                        Unsaved changes
-                      </span>
-                    )}
-                    {!creating && (
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        className="ml-auto"
-                        disabled={remove.isPending}
-                        onClick={() => void onDelete()}
-                      >
-                        Delete
-                      </Button>
-                    )}
-                  </div>
-                )}
-                {error && (
-                  <p className="text-xs text-[var(--ui-danger)]">{error}</p>
-                )}
-              </>
-            )}
-          </section>
-        </div>
+                  )}
+                </div>
+              )}
+              {error && <p className="text-xs text-destructive">{error}</p>}
+            </>
+          )}
+        </section>
       </div>
-    </main>
+    </div>
   )
 }

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as IntegrationsRouteImport } from './routes/integrations'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as MySettingsRouteImport } from './routes/my-settings'
 import { Route as ReviewRouteImport } from './routes/review'
+import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as UsageRouteImport } from './routes/usage'
 import { Route as AdminEvalsRouteImport } from './routes/admin_.evals'
 import { Route as AgentsIndexRouteImport } from './routes/agents/index'
@@ -75,6 +76,11 @@ const MySettingsRoute = MySettingsRouteImport.update({
 const ReviewRoute = ReviewRouteImport.update({
   id: '/review',
   path: '/review',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SkillsRoute = SkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
   getParentRoute: () => rootRouteImport,
 } as any)
 const UsageRoute = UsageRouteImport.update({
@@ -184,6 +190,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/my-settings': typeof MySettingsRoute
   '/review': typeof ReviewRoute
+  '/skills': typeof SkillsRoute
   '/usage': typeof UsageRoute
   '/admin/evals': typeof AdminEvalsRoute
   '/agents/$threadId': typeof AgentsThreadIdRoute
@@ -212,6 +219,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/my-settings': typeof MySettingsRoute
   '/review': typeof ReviewRoute
+  '/skills': typeof SkillsRoute
   '/usage': typeof UsageRoute
   '/admin/evals': typeof AdminEvalsRoute
   '/agents/$threadId': typeof AgentsThreadIdRoute
@@ -242,6 +250,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/my-settings': typeof MySettingsRoute
   '/review': typeof ReviewRoute
+  '/skills': typeof SkillsRoute
   '/usage': typeof UsageRoute
   '/admin_/evals': typeof AdminEvalsRoute
   '/agents/$threadId': typeof AgentsThreadIdRoute
@@ -273,6 +282,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/my-settings'
     | '/review'
+    | '/skills'
     | '/usage'
     | '/admin/evals'
     | '/agents/$threadId'
@@ -301,6 +311,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/my-settings'
     | '/review'
+    | '/skills'
     | '/usage'
     | '/admin/evals'
     | '/agents/$threadId'
@@ -330,6 +341,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/my-settings'
     | '/review'
+    | '/skills'
     | '/usage'
     | '/admin_/evals'
     | '/agents/$threadId'
@@ -360,6 +372,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   MySettingsRoute: typeof MySettingsRoute
   ReviewRoute: typeof ReviewRoute
+  SkillsRoute: typeof SkillsRoute
   UsageRoute: typeof UsageRoute
   AdminEvalsRoute: typeof AdminEvalsRoute
   AgentsEnvironmentsRoute: typeof AgentsEnvironmentsRoute
@@ -426,6 +439,13 @@ declare module '@tanstack/react-router' {
       path: '/review'
       fullPath: '/review'
       preLoaderRoute: typeof ReviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/skills': {
+      id: '/skills'
+      path: '/skills'
+      fullPath: '/skills'
+      preLoaderRoute: typeof SkillsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/usage': {
@@ -604,6 +624,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   MySettingsRoute: MySettingsRoute,
   ReviewRoute: ReviewRoute,
+  SkillsRoute: SkillsRoute,
   UsageRoute: UsageRoute,
   AdminEvalsRoute: AdminEvalsRoute,
   AgentsEnvironmentsRoute: AgentsEnvironmentsRoute,

--- a/ui/src/routes/agents/skills.tsx
+++ b/ui/src/routes/agents/skills.tsx
@@ -1,7 +1,5 @@
-import { createFileRoute } from "@tanstack/react-router"
-
-import { SkillsPage } from "@/features/agents/components/SkillsPage"
+import { Navigate, createFileRoute } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/agents/skills")({
-  component: SkillsPage,
+  component: () => <Navigate to="/skills" replace />,
 })

--- a/ui/src/routes/skills.tsx
+++ b/ui/src/routes/skills.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { AppShell } from "@/components/AppShell"
+import { SkillsPage } from "@/features/agents/components/SkillsPage"
+import { RequireLogin } from "@/lib/auth-redirect"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useSession } from "@/lib/session"
+
+export const Route = createFileRoute("/skills")({
+  component: SkillsSettingsPage,
+})
+
+function SkillsSettingsPage() {
+  const session = useSession()
+
+  if (session.isLoading) {
+    return (
+      <main className="p-6">
+        <Skeleton className="h-40 w-full" />
+      </main>
+    )
+  }
+  if (!session.data) return <RequireLogin />
+
+  return (
+    <AppShell
+      user={session.data}
+      title="Skills"
+      description="Reusable instructions Open SWE loads when a task matches their description."
+    >
+      <SkillsPage />
+    </AppShell>
+  )
+}


### PR DESCRIPTION
## Description
Moves Skills from the agent sidebar into the settings dashboard. Existing `/agents/skills` links redirect to the new location.

## Release Note
Skills management now lives in the settings dashboard.

## Test Plan
- [x] Verify the dashboard builds and route types compile

Made by [Open SWE](https://openswe.vercel.app/agents/12f79175-0dc0-513a-a0d1-955d4ca41862)