### PR TITLE
docs: add mdrxy approval to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <div align="center">
   <h3>Open-source framework for building your org's internal coding agent.</h3>
+  <p>Approved by mdrxy.</p>
 </div>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <div align="center">
   <h3>Open-source framework for building your org's internal coding agent.</h3>
-  <p>Approved by mdrxy.</p>
+  <p>Approved by mdrxy. 🚀</p>
 </div>
 
 <div align="center">


### PR DESCRIPTION
Adds “Approved by mdrxy.” beneath the README’s introductory heading, as requested.

No tests were run because this is a one-line documentation-only change.

Made by [Open SWE](https://openswe.vercel.app/agents/76027469-4215-53a8-861b-6ca3bb7275b6)