### PR TITLE
feat: align code channel and thread titles

### DIFF
--- a/agent/thread_title.py
+++ b/agent/thread_title.py
@@ -130,7 +130,10 @@ async def generate_and_store_thread_title(
         thread_id=thread_id,
         metadata={"title": title, "title_seed": None},
     )
-    context = SourceContext.from_metadata(latest_metadata)
+    # Re-read after the update: the pre-update snapshot can be stale if the
+    # thread was promoted to a code channel between the check and the update.
+    latest = await client.threads.get(thread_id=thread_id)
+    context = SourceContext.from_metadata(_thread_metadata(latest))
     if context.slack_location and context.slack_location[1] == CODE_CHANNEL_SESSION_TS:
         await rename_session(context.slack_location[0], title)
 

--- a/agent/thread_title.py
+++ b/agent/thread_title.py
@@ -14,6 +14,8 @@ from .input_messages import (
     input_message_text,
     wrap_system_prompt,
 )
+from .source_context import SourceContext
+from .utils.slack_code_channels import CODE_CHANNEL_SESSION_TS, rename_session
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +130,9 @@ async def generate_and_store_thread_title(
         thread_id=thread_id,
         metadata={"title": title, "title_seed": None},
     )
+    context = SourceContext.from_metadata(latest_metadata)
+    if context.slack_location and context.slack_location[1] == CODE_CHANNEL_SESSION_TS:
+        await rename_session(context.slack_location[0], title)
 
 
 def schedule_thread_title_generation(

--- a/agent/tools/manage_code_channel.py
+++ b/agent/tools/manage_code_channel.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from contextlib import suppress
 from typing import Any, Literal
 
@@ -84,8 +85,8 @@ async def manage_code_channel(
 ) -> dict[str, Any]:
     """Manage the complete Slack code-channel surface for this session.
 
-    Use `create` to promote the current Slack thread. Use `status`, `rename`,
-    `context`, `summary`, `resource`, and `commands` for channel chrome. `view`
+    Use `create` to promote the current Slack thread using its generated title. Use
+    `status`, `rename`, `context`, `summary`, `resource`, and `commands` for channel chrome. `view`
     upserts an `html`, `diff`, `block_kit`, or `canvas` tab; HTML and diff content
     can be passed directly or read from `file_path`, while Block Kit uses `blocks`
     plus optional external-select `suggestions`, and canvas uses `canvas_id`. Use
@@ -121,7 +122,7 @@ async def manage_code_channel(
             client,
             thread_id,
             active,
-            title,
+            await _code_channel_title(client, thread_id, title),
             repo if isinstance(repo, dict) else None,
             team_id=team_id,
             is_private=is_private,
@@ -223,6 +224,16 @@ async def manage_code_channel(
             result["warnings"] = [f"Could not set session status to closed: {status_error}"]
         return result
     return {"success": False, "error": f"Unknown action {action}"}
+
+
+async def _code_channel_title(client: Any, thread_id: str, fallback: str) -> str:
+    try:
+        thread = await client.threads.get(thread_id=thread_id)
+    except Exception:  # noqa: BLE001
+        return fallback
+    metadata = thread.get("metadata") if isinstance(thread, Mapping) else None
+    title = metadata.get("title") if isinstance(metadata, Mapping) else None
+    return title.strip() if isinstance(title, str) and title.strip() else fallback
 
 
 def _result(

--- a/agent/tools/manage_code_channel.py
+++ b/agent/tools/manage_code_channel.py
@@ -232,7 +232,9 @@ async def _code_channel_title(client: Any, thread_id: str, fallback: str) -> str
     except Exception:  # noqa: BLE001
         return fallback
     metadata = thread.get("metadata") if isinstance(thread, Mapping) else None
-    title = metadata.get("title") if isinstance(metadata, Mapping) else None
+    if not isinstance(metadata, Mapping) or metadata.get("title_seed") is not None:
+        return fallback
+    title = metadata.get("title")
     return title.strip() if isinstance(title, str) and title.strip() else fallback
 
 

--- a/agent/tools/manage_code_channel.py
+++ b/agent/tools/manage_code_channel.py
@@ -231,8 +231,14 @@ async def _code_channel_title(client: Any, thread_id: str, fallback: str) -> str
         thread = await client.threads.get(thread_id=thread_id)
     except Exception:  # noqa: BLE001
         return fallback
+    # Only trust metadata written by title generation: a missing title_seed key
+    # (e.g. legacy title-only metadata) has no proof of a generated title.
     metadata = thread.get("metadata") if isinstance(thread, Mapping) else None
-    if not isinstance(metadata, Mapping) or metadata.get("title_seed") is not None:
+    if (
+        not isinstance(metadata, Mapping)
+        or "title_seed" not in metadata
+        or metadata["title_seed"] is not None
+    ):
         return fallback
     title = metadata.get("title")
     return title.strip() if isinstance(title, str) and title.strip() else fallback

--- a/tests/slack/test_manage_code_channel_tool.py
+++ b/tests/slack/test_manage_code_channel_tool.py
@@ -24,6 +24,9 @@ manage_tool = import_module("agent.tools.manage_code_channel")
             "Fallback title",
         ),
         ({}, "Fallback title", "Fallback title"),
+        # Legacy metadata written before title generation stored a seed: a
+        # title without a title_seed key is not provably generated.
+        ({"title": "Legacy hand-written title"}, "Fallback title", "Fallback title"),
     ],
 )
 async def test_code_channel_title_prefers_thread_title(

--- a/tests/slack/test_manage_code_channel_tool.py
+++ b/tests/slack/test_manage_code_channel_tool.py
@@ -14,9 +14,14 @@ manage_tool = import_module("agent.tools.manage_code_channel")
     ("metadata", "fallback", "expected"),
     [
         (
-            {"title": "  Match code channel and thread titles.  "},
+            {"title": "  Match code channel and thread titles.  ", "title_seed": None},
             "Different title",
             "Match code channel and thread titles.",
+        ),
+        (
+            {"title": "Original Slack message", "title_seed": "Original Slack message"},
+            "Fallback title",
+            "Fallback title",
         ),
         ({}, "Fallback title", "Fallback title"),
     ],

--- a/tests/slack/test_manage_code_channel_tool.py
+++ b/tests/slack/test_manage_code_channel_tool.py
@@ -10,6 +10,27 @@ import pytest
 manage_tool = import_module("agent.tools.manage_code_channel")
 
 
+@pytest.mark.parametrize(
+    ("metadata", "fallback", "expected"),
+    [
+        (
+            {"title": "  Match code channel and thread titles.  "},
+            "Different title",
+            "Match code channel and thread titles.",
+        ),
+        ({}, "Fallback title", "Fallback title"),
+    ],
+)
+async def test_code_channel_title_prefers_thread_title(
+    metadata: dict[str, Any], fallback: str, expected: str
+) -> None:
+    client = SimpleNamespace(
+        threads=SimpleNamespace(get=AsyncMock(return_value={"metadata": metadata}))
+    )
+
+    assert await manage_tool._code_channel_title(client, "thread-1", fallback) == expected
+
+
 async def test_sandbox_content_reader_enforces_source_and_size(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -88,6 +89,30 @@ async def test_generate_and_store_thread_title_only_replaces_explicit_seed(
     )
 
     assert threads.metadata == expected
+
+
+@pytest.mark.asyncio
+async def test_title_generation_renames_code_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    threads = _Threads(
+        {
+            "source": "slack",
+            "title": "please review title generation",
+            "title_seed": "please review title generation",
+            "source_context": {"slack_thread": {"channel_id": "C-code", "thread_ts": "0"}},
+        }
+    )
+    client = type("Client", (), {"threads": threads})()
+    rename = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr("agent.thread_title.rename_session", rename)
+
+    await generate_and_store_thread_title(
+        thread_id="thread-123",
+        conversation="please review title generation",
+        model=cast(BaseChatModel, _Model()),
+        client=client,
+    )
+
+    rename.assert_awaited_once_with("C-code", "Review thread title generation")
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_title.py
+++ b/tests/test_thread_title.py
@@ -115,6 +115,47 @@ async def test_title_generation_renames_code_channel(monkeypatch: pytest.MonkeyP
     rename.assert_awaited_once_with("C-code", "Review thread title generation")
 
 
+class _PromotingThreads(_Threads):
+    """Threads whose update promotes the thread into a code channel mid-flight."""
+
+    async def update(self, *, thread_id: str, metadata: dict[str, Any]) -> None:
+        await super().update(thread_id=thread_id, metadata=metadata)
+        self.metadata["source"] = "slack"
+        self.metadata["source_context"] = {
+            "slack_thread": {"channel_id": "C-code", "thread_ts": "0"}
+        }
+
+
+@pytest.mark.asyncio
+async def test_title_generation_renames_channel_promoted_during_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A promotion racing the title update must still rename the channel.
+
+    The pre-update metadata snapshot does not carry a Slack location, so the
+    rename decision has to come from a re-read after the update.
+    """
+    threads = _PromotingThreads(
+        {
+            "source": "dashboard",
+            "title": "please review title generation",
+            "title_seed": "please review title generation",
+        }
+    )
+    client = type("Client", (), {"threads": threads})()
+    rename = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr("agent.thread_title.rename_session", rename)
+
+    await generate_and_store_thread_title(
+        thread_id="thread-123",
+        conversation="please review title generation",
+        model=cast(BaseChatModel, _Model()),
+        client=client,
+    )
+
+    rename.assert_awaited_once_with("C-code", "Review thread title generation")
+
+
 @pytest.mark.asyncio
 async def test_title_generation_never_inherits_the_runs_context() -> None:
     """The background task must not run inside the caller's context.


### PR DESCRIPTION
### Summary
- create code channels with the generated dashboard thread title
- rename a code channel when delayed title generation completes
- retain the explicit title as a fallback for legacy or unavailable metadata

### Testing
- `make format`
- `make lint`
- `uv run pytest -q tests/slack/test_manage_code_channel_tool.py tests/test_thread_title.py`

Made by [Open SWE](https://openswe.vercel.app/agents/f80c159d-e43e-52d9-a8a6-f8afcfd40cd4)