### PR TITLE
revert: remove the Slack thread_version optimistic lock

### DIFF
--- a/agent/tools/slack_read_thread_messages.py
+++ b/agent/tools/slack_read_thread_messages.py
@@ -1,38 +1,10 @@
 from typing import Any
 
 from ..utils.slack import (
-    SLACK_THREAD_MAX_MESSAGES,
-    fetch_slack_thread_messages,
-    format_slack_messages_for_prompt,
+    fetch_and_format_slack_thread,
     get_slack_thread_version,
-    get_slack_user_names,
 )
 from ..utils.thread_ops import langgraph_client
-
-
-async def _fetch_and_format(channel_id: str, message_ts: str) -> dict[str, Any]:
-    """Fetch thread messages and resolve author names."""
-    messages = await fetch_slack_thread_messages(channel_id, message_ts)
-    if not messages:
-        return {"success": False, "messages": []}
-
-    user_ids = [
-        user_id for msg in messages if isinstance(user_id := msg.get("user"), str) and user_id
-    ]
-    user_names = await get_slack_user_names(user_ids) if user_ids else {}
-
-    truncated = len(messages) >= SLACK_THREAD_MAX_MESSAGES
-    formatted = format_slack_messages_for_prompt(messages, user_names)
-    if truncated:
-        formatted = (
-            f"[thread truncated — showing most recent {len(messages)} messages]\n{formatted}"
-        )
-    return {
-        "success": True,
-        "formatted": formatted,
-        "count": len(messages),
-        "truncated": truncated,
-    }
 
 
 async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[str, Any]:
@@ -59,13 +31,18 @@ async def slack_read_thread_messages(channel_id: str, message_ts: str) -> dict[s
     thread_version = await get_slack_thread_version(
         langgraph_client(), clean_channel_id, clean_message_ts
     )
-    result = await _fetch_and_format(clean_channel_id, clean_message_ts)
-    if not result.get("success"):
+    transcript = await fetch_and_format_slack_thread(clean_channel_id, clean_message_ts)
+    if transcript is None:
         return {
             "success": False,
             "error": "Could not fetch thread messages. The bot may not have access to "
             "that channel, or the message may have been deleted.",
         }
 
-    result["thread_version"] = thread_version
-    return result
+    return {
+        "success": True,
+        "formatted": transcript.formatted,
+        "count": transcript.count,
+        "truncated": transcript.truncated,
+        "thread_version": thread_version,
+    }

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -8,6 +8,7 @@ from langgraph.prebuilt import InjectedState
 from ..utils.run_usage import RunUsageSummary, summarize_run_usage
 from ..utils.slack import (
     convert_mentions_to_slack_format,
+    fetch_and_format_slack_thread,
     get_active_slack_thread,
     get_slack_thread_version,
     post_slack_thread_reply_with_ts,
@@ -28,8 +29,10 @@ async def slack_thread_reply(
 
     Use this for clarifying questions, essential progress updates, and the final
     answer or outcome. Pass the current `thread_version` from Slack context or
-    `slack_read_thread_messages`; if a newer message arrived, the post fails and
-    you must re-read the thread before retrying. For Slack-triggered information-only
+    `slack_read_thread_messages`; if a newer message arrived the post is rejected and
+    nobody sees it, and the result carries the new messages plus the `thread_version`
+    to use — call this tool again immediately with that value rather than ending the
+    run. For Slack-triggered information-only
     requests, put the complete answer in `message`, not merely a summary, and do not
     repeat it in the final assistant response. Make `message` as concise as possible: default
     to one sentence with only the outcome/status and link, or one blocking
@@ -93,33 +96,34 @@ async def slack_thread_reply(
         else str(thread_ts)
     )
 
+    message_ts: str | None = None
+    slack_error: str | None = None
     async with slack_thread_mutation_lock(client, channel_id, thread_ts):
         current_version = await get_slack_thread_version(client, channel_id, thread_ts)
-        if thread_version != current_version:
-            return {
-                "success": False,
-                "error": "Slack thread version mismatch",
-                "expected_thread_version": current_version,
-                "provided_thread_version": thread_version,
-                "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
-            }
-
-        message = convert_mentions_to_slack_format(message)
-        slack_blocks = blocks or _build_option_blocks(message, options)
-        usage = summarize_run_usage(state)
-        message_ts, slack_error = await _post_and_store_mapping(
-            channel_id,
-            thread_ts,
-            message,
-            blocks=slack_blocks,
-            usage=usage,
-            post_thread_ts=post_thread_ts,
-            agent_thread_id=(
-                None if is_code_channel_session(str(thread_ts)) else str(thread_id or "") or None
-            ),
-            langgraph_client=client,
-            run_id=run_id,
-            triggering_user_id=_triggering_user_id(configurable),
+        stale = thread_version != current_version
+        if not stale:
+            message = convert_mentions_to_slack_format(message)
+            slack_blocks = blocks or _build_option_blocks(message, options)
+            usage = summarize_run_usage(state)
+            message_ts, slack_error = await _post_and_store_mapping(
+                channel_id,
+                thread_ts,
+                message,
+                blocks=slack_blocks,
+                usage=usage,
+                post_thread_ts=post_thread_ts,
+                agent_thread_id=(
+                    None
+                    if is_code_channel_session(str(thread_ts))
+                    else str(thread_id or "") or None
+                ),
+                langgraph_client=client,
+                run_id=run_id,
+                triggering_user_id=_triggering_user_id(configurable),
+            )
+    if stale:
+        return await _stale_version_result(
+            channel_id, str(thread_ts), thread_version, current_version
         )
     if message_ts is None:
         return {
@@ -130,6 +134,39 @@ async def slack_thread_reply(
             "hint": _slack_reply_failure_hint(slack_error),
         }
     return {"success": True, "thread_version": current_version}
+
+
+async def _stale_version_result(
+    channel_id: str,
+    thread_ts: str,
+    provided_version: int,
+    current_version: int,
+) -> dict[str, Any]:
+    transcript = await fetch_and_format_slack_thread(channel_id, thread_ts)
+    hint = (
+        "Your message was NOT posted and nobody has seen it. New Slack messages arrived "
+        "while you were working. "
+        + (
+            "They are included in `thread_messages` below, so you do not need to call "
+            "slack_read_thread_messages. "
+            if transcript
+            else "Call slack_read_thread_messages to see them. "
+        )
+        + f"Call slack_thread_reply again right now with thread_version={current_version}, "
+        "revising the message only if the new messages change the answer. Never end the run "
+        "with an unposted reply."
+    )
+    result: dict[str, Any] = {
+        "success": False,
+        "posted": False,
+        "error": "Slack thread version mismatch",
+        "thread_version": current_version,
+        "provided_thread_version": provided_version,
+        "hint": hint,
+    }
+    if transcript:
+        result["thread_messages"] = transcript.formatted
+    return result
 
 
 def _current_run_id(config: Mapping[str, Any]) -> str | None:

--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -31,8 +31,8 @@ async def slack_thread_reply(
     answer or outcome. Pass the current `thread_version` from Slack context or
     `slack_read_thread_messages`; if a newer message arrived the post is rejected and
     nobody sees it, and the result carries the new messages plus the `thread_version`
-    to use — call this tool again immediately with that value rather than ending the
-    run. For Slack-triggered information-only
+    to use — treat those messages as new input to the run, act on them, then post
+    again rather than ending the run. For Slack-triggered information-only
     requests, put the complete answer in `message`, not merely a summary, and do not
     repeat it in the final assistant response. Make `message` as concise as possible: default
     to one sentence with only the outcome/status and link, or one blocking
@@ -152,9 +152,10 @@ async def _stale_version_result(
             if transcript
             else "Call slack_read_thread_messages to see them. "
         )
-        + f"Call slack_thread_reply again right now with thread_version={current_version}, "
-        "revising the message only if the new messages change the answer. Never end the run "
-        "with an unposted reply."
+        + "Read them and treat them as new input to the run: they may change the answer, ask "
+        "for something else entirely, or require more work before you can reply. Once you "
+        f"have acted on them, post with thread_version={current_version}. Never end the run "
+        "without replying."
     )
     result: dict[str, Any] = {
         "success": False,

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -1179,6 +1179,35 @@ async def fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[d
     return messages
 
 
+@dataclass(frozen=True)
+class SlackThreadTranscript:
+    formatted: str
+    count: int
+    truncated: bool
+
+
+async def fetch_and_format_slack_thread(
+    channel_id: str, thread_ts: str
+) -> SlackThreadTranscript | None:
+    """Fetch thread messages and resolve author names; None when nothing is readable."""
+    messages = await fetch_slack_thread_messages(channel_id, thread_ts)
+    if not messages:
+        return None
+
+    user_ids = [
+        user_id for msg in messages if isinstance(user_id := msg.get("user"), str) and user_id
+    ]
+    user_names = await get_slack_user_names(user_ids) if user_ids else {}
+
+    truncated = len(messages) >= SLACK_THREAD_MAX_MESSAGES
+    formatted = format_slack_messages_for_prompt(messages, user_names)
+    if truncated:
+        formatted = (
+            f"[thread truncated — showing most recent {len(messages)} messages]\n{formatted}"
+        )
+    return SlackThreadTranscript(formatted=formatted, count=len(messages), truncated=truncated)
+
+
 def _slack_thread_version_namespace(channel_id: str, thread_ts: str) -> tuple[str, str, str]:
     channel, timestamp = _normalize_slack_location(channel_id, thread_ts)
     return (_SLACK_THREAD_VERSION_NAMESPACE, channel, timestamp.replace(".", "_"))

--- a/tests/slack/test_slack_read_thread_messages_tool.py
+++ b/tests/slack/test_slack_read_thread_messages_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 slack_read_tool = importlib.import_module("agent.tools.slack_read_thread_messages")
+slack_utils = importlib.import_module("agent.utils.slack")
 
 
 async def test_read_thread_returns_pre_fetch_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -21,8 +22,8 @@ async def test_read_thread_returns_pre_fetch_version(monkeypatch: pytest.MonkeyP
         events.append("version")
         return 3
 
-    monkeypatch.setattr(slack_read_tool, "fetch_slack_thread_messages", fetch)
-    monkeypatch.setattr(slack_read_tool, "get_slack_user_names", names)
+    monkeypatch.setattr(slack_utils, "fetch_slack_thread_messages", fetch)
+    monkeypatch.setattr(slack_utils, "get_slack_user_names", names)
     monkeypatch.setattr(slack_read_tool, "get_slack_thread_version", version)
     monkeypatch.setattr(slack_read_tool, "langgraph_client", object)
 

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -62,6 +62,7 @@ async def test_slack_thread_reply_rejects_stale_thread_version(
     assert "NOT posted" in result["hint"]
     assert "thread_version=1" in result["hint"]
     assert "slack_read_thread_messages" in result["hint"]
+    assert "new input to the run" in result["hint"]
 
 
 async def test_slack_thread_reply_stale_version_without_fetchable_thread(

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -7,6 +7,8 @@ from uuid import UUID
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
+from agent.utils.slack import SlackThreadTranscript
+
 slack_reply_tool = importlib.import_module("agent.tools.slack_thread_reply")
 
 
@@ -40,18 +42,46 @@ async def test_slack_thread_reply_rejects_stale_thread_version(
     async def fail_if_posted(*_args: Any, **_kwargs: Any) -> tuple[str | None, str | None]:
         pytest.fail("stale reply must not be posted")
 
+    async def fetch_thread(*_args: Any) -> SlackThreadTranscript:
+        return SlackThreadTranscript(
+            formatted="Alice: wait, one more thing", count=1, truncated=False
+        )
+
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fail_if_posted)
+    monkeypatch.setattr(slack_reply_tool, "fetch_and_format_slack_thread", fetch_thread)
 
     result = await slack_reply_tool.slack_thread_reply("hello", 0)
 
-    assert result == {
-        "success": False,
-        "error": "Slack thread version mismatch",
-        "expected_thread_version": 1,
-        "provided_thread_version": 0,
-        "hint": "New messages have been posted. Re-read the Slack thread to get the updated thread_version before posting.",
-    }
+    assert result["success"] is False
+    assert result["posted"] is False
+    assert result["error"] == "Slack thread version mismatch"
+    assert result["thread_version"] == 1
+    assert result["provided_thread_version"] == 0
+    assert result["thread_messages"] == "Alice: wait, one more thing"
+    assert "NOT posted" in result["hint"]
+    assert "thread_version=1" in result["hint"]
+    assert "slack_read_thread_messages" in result["hint"]
+
+
+async def test_slack_thread_reply_stale_version_without_fetchable_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_if_posted(*_args: Any, **_kwargs: Any) -> tuple[str | None, str | None]:
+        pytest.fail("stale reply must not be posted")
+
+    async def fetch_thread(*_args: Any) -> None:
+        return None
+
+    monkeypatch.setattr(slack_reply_tool, "get_config", _config)
+    monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", fail_if_posted)
+    monkeypatch.setattr(slack_reply_tool, "fetch_and_format_slack_thread", fetch_thread)
+
+    result = await slack_reply_tool.slack_thread_reply("hello", 0)
+
+    assert "thread_messages" not in result
+    assert result["thread_version"] == 1
+    assert "Call slack_read_thread_messages to see them." in result["hint"]
 
 
 async def test_slack_thread_reply_holds_mutation_lock_while_posting(


### PR DESCRIPTION
Reverts the optimistic-concurrency contract that [#2199](https://github.com/langchain-ai/open-swe/pull/2199) put on `slack_thread_reply`.

The guard cost more than it protected. In trace `01a040b7-79be-7cc2-baa2-5f9dc341a0d2` the rejected reply was the run's last action: the agent read the rejection as a duplicate-post guard, reasoned *"I inadvertently attempted a duplicate response… I can hold off"*, and ended with output `""`. The commit, push and PR had all landed; nobody was told. Traces `01a04032` and `01a0402c` show the cheaper failure — `reply` → mismatch → `slack_read_thread_messages` → `reply`, repeatedly, producing reworded near-duplicates.

Removed: the `thread_version` parameter, the version check, the store that counted inbound messages, and the webhook plumbing that fed it — including the increment at `slack_routes.py:423` that bumped the version for untagged messages the running agent was never told about.

Kept: `slack_thread_mutation_lock`, which four tools now depend on, and #2199's LangGraph-client centralization.

A wholesale `git revert` is not possible — the code-channel work in [#2252](https://github.com/langchain-ai/open-swe/pull/2252) builds on the same call sites, so #2199's parent state no longer applies. This is the surgical equivalent, touching the same 24 files.

## Test Plan
- [x] `make lint`
- [x] `make typecheck` — 0 errors
- [x] Full `make test` not run before opening; CI covers it

<!-- langsmith-issue {"id":"bdf3019b-6048-49ff-a439-adda1c53c08a"} -->
