### PR TITLE
fix: return next required thread_version from slack_thread_reply

### DIFF
--- a/agent/tools/slack_thread_reply.py
+++ b/agent/tools/slack_thread_reply.py
@@ -102,6 +102,7 @@ async def slack_thread_reply(
             run_id=run_id,
             triggering_user_id=_triggering_user_id(configurable),
         )
+        next_version = await get_slack_thread_version(client, channel_id, thread_ts)
     if message_ts is None:
         return {
             "success": False,
@@ -110,7 +111,7 @@ async def slack_thread_reply(
             "message_chars": len(message),
             "hint": _slack_reply_failure_hint(slack_error),
         }
-    return {"success": True, "thread_version": current_version}
+    return {"success": True, "thread_version": next_version}
 
 
 def _current_run_id(config: Mapping[str, Any]) -> str | None:

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -72,13 +72,19 @@ async def test_slack_thread_reply_holds_mutation_lock_while_posting(
         assert lock_held is True
         return "2.0", None
 
+    versions = iter([1, 2])
+
+    async def current_version(*_args: Any) -> int:
+        return next(versions)
+
     monkeypatch.setattr(slack_reply_tool, "get_config", _config)
     monkeypatch.setattr(slack_reply_tool, "slack_thread_mutation_lock", mutation_lock)
+    monkeypatch.setattr(slack_reply_tool, "get_slack_thread_version", current_version)
     monkeypatch.setattr(slack_reply_tool, "_post_and_store_mapping", post)
 
     assert await slack_reply_tool.slack_thread_reply("hello", 1) == {
         "success": True,
-        "thread_version": 1,
+        "thread_version": 2,
     }
     assert lock_held is False
 


### PR DESCRIPTION
## Problem

`slack_thread_reply` documents that a successful return contains the `thread_version` to use on the **next** reply, but on success it returned the version the reply was posted with. A caller that trusts the returned value then sends a follow-up with a version that is one behind, gets rejected as stale, and — worst case — a run finishes the code work but never manages to deliver its Slack reply.

## Fix

In `agent/tools/slack_thread_reply.py`, after a successful post (and still inside the per-thread mutation lock), re-read the thread version from the store and return that as `thread_version` instead of the provided one:

- fresh read via `get_slack_thread_version` after `_post_and_store_mapping` succeeds
- success payload now returns this next-required version

## Tests

- `test_slack_thread_reply_holds_mutation_lock_while_posting` updated: `get_slack_thread_version` is stubbed to return `1` then `2`, so the success assertion checks `{"success": True, "thread_version": 2}` while the post still used version 1.
- `uv run pytest -q tests/slack/test_slack_thread_reply_tool.py` → 14 passed
- `ruff check`, `ruff format --check`, `basedpyright` on both changed files → clean

Made by [Open SWE](https://openswe.vercel.app/agents/0801c245-89f0-5c34-ab9f-410ef49eb3ea)