### PR TITLE
fix: Slack file upload: use form-encoded bodies

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import hashlib
 import hmac
+import json
 import logging
 import os
 import re
@@ -72,6 +73,12 @@ def _slack_headers() -> dict[str, str]:
         "Authorization": f"Bearer {SLACK_BOT_TOKEN}",
         "Content-Type": "application/json; charset=utf-8",
     }
+
+
+def _slack_auth_headers() -> dict[str, str]:
+    if not SLACK_BOT_TOKEN:
+        return {}
+    return {"Authorization": f"Bearer {SLACK_BOT_TOKEN}"}
 
 
 def _parse_ts(ts: str | None) -> float:
@@ -726,8 +733,8 @@ async def upload_slack_thread_file(
         async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
             ticket_response = await http_client.post(
                 f"{SLACK_API_BASE_URL}/files.getUploadURLExternal",
-                headers=_slack_headers(),
-                json={"filename": filename, "length": len(content)},
+                headers=_slack_auth_headers(),
+                data={"filename": filename, "length": str(len(content))},
             )
             ticket_error = _slack_response_error(ticket_response)
             if ticket_error:
@@ -752,17 +759,17 @@ async def upload_slack_thread_file(
                 return None, "upload_failed"
             upload_response.raise_for_status()
 
-            payload: dict[str, Any] = {
-                "files": [{"id": file_id, "title": title or filename}],
+            data: dict[str, str] = {
+                "files": json.dumps([{"id": file_id, "title": title or filename}]),
                 "channel_id": channel_id,
                 "thread_ts": thread_ts,
             }
             if initial_comment:
-                payload["initial_comment"] = initial_comment
+                data["initial_comment"] = initial_comment
             complete_response = await http_client.post(
                 f"{SLACK_API_BASE_URL}/files.completeUploadExternal",
-                headers=_slack_headers(),
-                json=payload,
+                headers=_slack_auth_headers(),
+                data=data,
             )
             complete_error = _slack_response_error(complete_response)
             if complete_error:

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -265,20 +265,28 @@ async def test_upload_slack_thread_file_completes_external_upload(
         )
 
     assert result == ("F1", None)
-    assert client_cm.post.call_args_list[0].args[0].endswith("/files.getUploadURLExternal")
-    assert client_cm.post.call_args_list[0].kwargs["json"] == {
+    ticket_call = client_cm.post.call_args_list[0]
+    assert ticket_call.args[0].endswith("/files.getUploadURLExternal")
+    assert ticket_call.kwargs["data"] == {
         "filename": "plan.html",
-        "length": 8,
+        "length": "8",
+    }
+    assert ticket_call.kwargs["headers"] == {
+        "Authorization": "Bearer xoxb-test",
     }
     safe_request.assert_awaited_once()
     assert safe_request.call_args.kwargs["content"] == b"<html />"
     assert safe_request.call_args.kwargs["validate_url"] is slack_utils._validate_slack_upload_url
-    assert client_cm.post.call_args_list[1].args[0].endswith("/files.completeUploadExternal")
-    assert client_cm.post.call_args_list[1].kwargs["json"] == {
-        "files": [{"id": "F1", "title": "Plan"}],
+    complete_call = client_cm.post.call_args_list[1]
+    assert complete_call.args[0].endswith("/files.completeUploadExternal")
+    assert complete_call.kwargs["data"] == {
+        "files": '[{"id": "F1", "title": "Plan"}]',
         "channel_id": "C1",
         "thread_ts": "1.0",
         "initial_comment": "Preview",
+    }
+    assert complete_call.kwargs["headers"] == {
+        "Authorization": "Bearer xoxb-test",
     }
 
 


### PR DESCRIPTION
## Summary

`slack_attach_html` was failing with Slack `invalid_arguments` when uploading HTML previews. `files.getUploadURLExternal` and `files.completeUploadExternal` only accept **form-encoded** parameters — the tool was posting JSON bodies.

### Changes

- `agent/utils/slack.py`:
  - Post form-encoded `data` (with only a Bearer auth header) to `files.getUploadURLExternal`, sending `filename` and `length` as string form fields.
  - For `files.completeUploadExternal`, send `files` as a JSON-encoded string inside the form field, plus `channel_id` / `thread_ts` / optional `initial_comment` form fields, per Slack's API contract.
  - Added a `_slack_auth_headers()` helper so auth headers aren't conflated with JSON content-type headers used by the message-update API.
- `tests/slack/test_slack_message_api.py`: updated the external-upload test to assert the exact form bodies and Authorization headers sent to both endpoints.

### Testing

- `uv run pytest tests/slack/test_slack_message_api.py tests/slack/test_slack_attach_html_tool.py -q` — 23 passed
- `make lint`, `make typecheck` — clean
- `make test` — 1895 passed, 2 failed. The 2 failures are pre-existing and unrelated: `tests/sandbox/test_proxy_auth.py::TestConfigureGithubProxy` expects two proxy entries but the source now adds a `stagehand-model` proxy. Confirmed pre-existing — this branch's diff vs `main` touches only the two Slack files above (no sandbox code).

Made by [Open SWE](https://openswe.vercel.app/agents/8b8ea6ab-1cf7-5791-a874-98c4d34fad90)
