### PR TITLE
fix: default Slack code channels to public

### DIFF
--- a/agent/tools/manage_code_channel.py
+++ b/agent/tools/manage_code_channel.py
@@ -61,7 +61,7 @@ async def manage_code_channel(
     ],
     title: str = "",
     team_id: str = "",
-    is_private: bool | None = None,
+    is_private: bool = False,
     status: SessionStatus = "active",
     items: list[dict[str, Any]] | None = None,
     summary_message_ts: str = "",
@@ -287,7 +287,7 @@ async def _create(
     repo: dict[str, Any] | None,
     *,
     team_id: str = "",
-    is_private: bool | None = None,
+    is_private: bool = False,
 ) -> dict[str, Any]:
     if not title.strip():
         return {"success": False, "error": "title is required"}

--- a/agent/utils/slack_code_channels.py
+++ b/agent/utils/slack_code_channels.py
@@ -139,7 +139,7 @@ async def create_code_channel(
     origin_channel_id: str,
     origin_message_ts: str,
     team_id: str = "",
-    is_private: bool | None = None,
+    is_private: bool = False,
 ) -> tuple[str | None, str | None]:
     """Create a code channel for a task and return its channel id."""
     if not 1 <= len(name.strip()) <= 200:
@@ -154,8 +154,7 @@ async def create_code_channel(
     }
     if team_id:
         payload["team_id"] = team_id
-    if is_private is not None:
-        payload["is_private"] = is_private
+    payload["is_private"] = is_private
     data, error = await _call("agents.conversations.create", payload)
     if error or data is None:
         return None, error

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -112,9 +112,9 @@ async def test_context_bar_action_routes_to_code_channel_session(
     assert "create-pr" in code_channel_route.await_args.args[0]["text"]
 
 
-@pytest.mark.parametrize(("kwargs", "expected"), [({}, False), ({"is_private": True}, True)])
+@pytest.mark.parametrize("is_private", [False, True])
 async def test_create_code_channel_sets_visibility(
-    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, bool], expected: bool
+    monkeypatch: pytest.MonkeyPatch, is_private: bool
 ) -> None:
     call = AsyncMock(return_value=({"channel": {"id": "C-code"}}, None))
     monkeypatch.setattr(slack_code_channels, "_call", call)
@@ -124,11 +124,11 @@ async def test_create_code_channel_sets_visibility(
         session_id="thread-1",
         origin_channel_id="C-origin",
         origin_message_ts="1.000",
-        **kwargs,
+        is_private=is_private,
     )
 
     assert (channel_id, error) == ("C-code", None)
-    assert call.await_args.args[1]["is_private"] is expected
+    assert call.await_args_list[0].args[1]["is_private"] is is_private
 
 
 async def test_set_view_rejects_content_over_one_megabyte(

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -112,6 +112,25 @@ async def test_context_bar_action_routes_to_code_channel_session(
     assert "create-pr" in code_channel_route.await_args.args[0]["text"]
 
 
+@pytest.mark.parametrize(("kwargs", "expected"), [({}, False), ({"is_private": True}, True)])
+async def test_create_code_channel_sets_visibility(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, bool], expected: bool
+) -> None:
+    call = AsyncMock(return_value=({"channel": {"id": "C-code"}}, None))
+    monkeypatch.setattr(slack_code_channels, "_call", call)
+
+    channel_id, error = await slack_code_channels.create_code_channel(
+        name="Fix flaky tests",
+        session_id="thread-1",
+        origin_channel_id="C-origin",
+        origin_message_ts="1.000",
+        **kwargs,
+    )
+
+    assert (channel_id, error) == ("C-code", None)
+    assert call.await_args.args[1]["is_private"] is expected
+
+
 async def test_set_view_rejects_content_over_one_megabyte(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Summary
- make newly created Slack code channels public by default
- preserve `is_private=true` as an explicit opt-in
- verify both visibility payloads with focused unit coverage

### Verification
- `uv run pytest -q --disable-warnings --no-header tests/slack/test_slack_code_channels.py tests/slack/test_manage_code_channel_tool.py`
- `make format`
- `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/067a36f6-4a9c-5748-81ea-e40e3c46d681)