### PR TITLE
feat: link code channels from web threads

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -70,6 +70,7 @@ from .pr_diff import build_compare_diff_files, build_pr_diff_files
 from .profiles import get_profile, get_valid_access_token
 from .pull_request_context import get_pull_request_context
 from .pull_request_status import get_pull_request_statuses
+from .slack_oauth import SLACK_TEAM_ID
 from .team_settings import get_team_default_model, get_team_fable_enabled
 from .thread_pins import list_thread_pin_ids, pin_thread, unpin_thread
 from .ttft import AssistantTextEventDetector, record_dashboard_thread_ttft
@@ -381,9 +382,10 @@ def _code_channel_url(metadata: Mapping[str, Any]) -> str | None:
     if slack_thread is None or slack_thread.thread_ts != CODE_CHANNEL_SESSION_TS:
         return None
     channel_id = slack_thread.channel_id.strip()
-    if not channel_id:
+    team_id = SLACK_TEAM_ID.strip()
+    if not channel_id or not team_id:
         return None
-    return f"https://slack.com/app_redirect?{urlencode({'channel': channel_id})}"
+    return f"https://slack.com/app_redirect?{urlencode({'channel': channel_id, 'team': team_id})}"
 
 
 def _metadata_string(metadata: Mapping[str, Any], key: str) -> str | None:

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -11,6 +11,7 @@ import uuid
 from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime
 from typing import Any, Literal
+from urllib.parse import urlencode
 
 import httpx
 from fastapi import HTTPException
@@ -40,6 +41,7 @@ from ..utils.slack import (
     parse_github_pr_url,
     update_slack_trace_reply_for_web_handoff,
 )
+from ..utils.slack_code_channels import CODE_CHANNEL_SESSION_TS
 from ..utils.thread_ops import (
     get_thread_active_status,
     langgraph_client,
@@ -374,6 +376,16 @@ def _thread_source_url(metadata: Mapping[str, Any]) -> str | None:
     return slack_thread.permalink.strip() or None
 
 
+def _code_channel_url(metadata: Mapping[str, Any]) -> str | None:
+    slack_thread = SourceContext.from_metadata(metadata).slack_thread
+    if slack_thread is None or slack_thread.thread_ts != CODE_CHANNEL_SESSION_TS:
+        return None
+    channel_id = slack_thread.channel_id.strip()
+    if not channel_id:
+        return None
+    return f"https://slack.com/app_redirect?{urlencode({'channel': channel_id})}"
+
+
 def _metadata_string(metadata: Mapping[str, Any], key: str) -> str | None:
     value = metadata.get(key)
     return value.strip() if isinstance(value, str) and value.strip() else None
@@ -535,6 +547,7 @@ async def _thread_summary(
         "updatedAt": int(updated_at) if isinstance(updated_at, (int, float)) else _now_ms(),
         "traceUrl": trace_url,
         "sourceUrl": _thread_source_url(metadata),
+        "codeChannelUrl": _code_channel_url(metadata),
         "sandboxId": sandbox_id,
     }
     raw_pull_requests = metadata.get("pull_requests")

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -497,7 +497,8 @@ async def test_thread_summary_omits_slack_source_url_for_public_repo() -> None:
     assert summary["sourceUrl"] is None
 
 
-async def test_thread_summary_includes_code_channel_url() -> None:
+async def test_thread_summary_includes_code_channel_url(monkeypatch) -> None:
+    monkeypatch.setattr(thread_api, "SLACK_TEAM_ID", "T team&workspace")
     summary = await thread_api._thread_summary(
         _thread_with_metadata(
             {
@@ -509,7 +510,22 @@ async def test_thread_summary_includes_code_channel_url() -> None:
         )
     )
 
-    assert summary["codeChannelUrl"] == ("https://slack.com/app_redirect?channel=C+code%26channel")
+    assert summary["codeChannelUrl"] == (
+        "https://slack.com/app_redirect?channel=C+code%26channel&team=T+team%26workspace"
+    )
+
+
+async def test_thread_summary_omits_code_channel_url_without_team() -> None:
+    summary = await thread_api._thread_summary(
+        _thread_with_metadata(
+            {
+                "source": "slack",
+                "source_context": {"slack_thread": {"channel_id": "C123", "thread_ts": "0"}},
+            }
+        )
+    )
+
+    assert summary["codeChannelUrl"] is None
 
 
 async def test_thread_summary_omits_code_channel_url_for_slack_thread() -> None:

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -497,6 +497,36 @@ async def test_thread_summary_omits_slack_source_url_for_public_repo() -> None:
     assert summary["sourceUrl"] is None
 
 
+async def test_thread_summary_includes_code_channel_url() -> None:
+    summary = await thread_api._thread_summary(
+        _thread_with_metadata(
+            {
+                "source": "slack",
+                "source_context": {
+                    "slack_thread": {"channel_id": "C code&channel", "thread_ts": "0"}
+                },
+            }
+        )
+    )
+
+    assert summary["codeChannelUrl"] == ("https://slack.com/app_redirect?channel=C+code%26channel")
+
+
+async def test_thread_summary_omits_code_channel_url_for_slack_thread() -> None:
+    summary = await thread_api._thread_summary(
+        _thread_with_metadata(
+            {
+                "source": "slack",
+                "source_context": {
+                    "slack_thread": {"channel_id": "C123", "thread_ts": "1700000000.000100"}
+                },
+            }
+        )
+    )
+
+    assert summary["codeChannelUrl"] is None
+
+
 async def test_recovery_patch_reaches_any_authenticated_user(monkeypatch) -> None:
     class FakeThreads:
         async def get(self, thread_id: str) -> dict[str, object]:

--- a/tests/e2e/e2e_env.py
+++ b/tests/e2e/e2e_env.py
@@ -56,6 +56,7 @@ _DEFAULTS = {
     "SLACK_BOT_TOKEN": "xoxb-test-token",
     "SLACK_BOT_USER_ID": BOT_USER_ID,
     "SLACK_BOT_USERNAME": BOT_USERNAME,
+    "SLACK_TEAM_ID": "T_TEST",
     # Slack runs resolve the repo from this when the channel/thread carry none.
     "DEFAULT_REPO_OWNER": OWNER,
     "DEFAULT_REPO_NAME": REPO,

--- a/tests/e2e/tests/slack_code_channels.spec.ts
+++ b/tests/e2e/tests/slack_code_channels.spec.ts
@@ -66,5 +66,22 @@ test.describe("Slack Code Channels", () => {
       path: "screenshots/slack-code-channel.png",
       fullPage: true,
     });
+
+    await page.request.post("/control/login", {
+      data: { login: "alice", email: "alice@example.com" },
+    });
+    await page.goto(`/agents/${initialResult.thread_id}`);
+    const codeChannelLink = page.getByRole("link", {
+      name: "Open code channel",
+    });
+    await expect(codeChannelLink).toBeVisible();
+    await expect(codeChannelLink).toHaveAttribute(
+      "href",
+      /https:\/\/slack\.com\/app_redirect\?channel=C_CODE_/,
+    );
+    await page.screenshot({
+      path: "screenshots/web-code-channel-link.png",
+      fullPage: true,
+    });
   });
 });

--- a/tests/e2e/tests/slack_code_channels.spec.ts
+++ b/tests/e2e/tests/slack_code_channels.spec.ts
@@ -77,7 +77,7 @@ test.describe("Slack Code Channels", () => {
     await expect(codeChannelLink).toBeVisible();
     await expect(codeChannelLink).toHaveAttribute(
       "href",
-      /https:\/\/slack\.com\/app_redirect\?channel=C_CODE_/,
+      /https:\/\/slack\.com\/app_redirect\?channel=C_CODE_\d+&team=T_TEST/,
     );
     await page.screenshot({
       path: "screenshots/web-code-channel-link.png",

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
-import { CircleAlert as CircleAlertIcon, FolderOpen } from "lucide-react"
+import {
+  ArrowUpRight,
+  CircleAlert as CircleAlertIcon,
+  FolderOpen,
+} from "lucide-react"
+import { IoLogoSlack } from "react-icons/io5"
 
 import type {
   AgentPullRequest,
@@ -54,6 +59,22 @@ function editedPaths(messages: Array<Message>): Array<string> {
     }
   }
   return [...paths]
+}
+
+function CodeChannelLink({ url }: { url?: string | null }) {
+  if (!url) return null
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className="mb-2 flex w-fit items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+    >
+      <IoLogoSlack className="size-3.5" />
+      Open code channel
+      <ArrowUpRight className="size-3" />
+    </a>
+  )
 }
 
 // The stream lives at the `/agents` layout (one persistent provider that
@@ -288,6 +309,7 @@ export function AgentThreadView({
             />
             <div className="shrink-0 px-4 pb-4">
               <div className="mx-auto w-full max-w-3xl min-w-0">
+                <CodeChannelLink url={thread.codeChannelUrl} />
                 <ThreadPullRequests
                   pullRequests={thread.pullRequests ?? []}
                   health={pullRequestHealth}
@@ -348,6 +370,7 @@ export function AgentThreadView({
               </p>
             )}
             <div className="w-full max-w-3xl">
+              <CodeChannelLink url={thread.codeChannelUrl} />
               <ThreadPullRequests
                 pullRequests={thread.pullRequests ?? []}
                 health={pullRequestHealth}

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -374,6 +374,7 @@ export interface AgentThread {
   updatedAt: number
   traceUrl?: string | null
   sourceUrl?: string | null
+  codeChannelUrl?: string | null
   sandboxId?: string | null
   messages: Array<Message>
   queuedMessages?: Array<QueuedThreadMessage>


### PR DESCRIPTION
### Summary
- expose a Slack app deep link for code-channel-backed threads
- target the configured Slack workspace as well as the channel
- render the link above the web composer alongside the existing PR surface
- cover URL generation and the Slack-to-web flow

### Verification
- `uv run pytest -q tests/dashboard/test_dashboard_thread_api.py -k 'code_channel_url or slack_source_url'` (5 passed)
- `uv run ruff check agent/dashboard/thread_api.py tests/dashboard/test_dashboard_thread_api.py tests/e2e/e2e_env.py`
- `uv run ruff format --check agent/dashboard/thread_api.py tests/dashboard/test_dashboard_thread_api.py tests/e2e/e2e_env.py`
- `pnpm exec oxlint tests/e2e/tests/slack_code_channels.spec.ts --deny-warnings`
- `pnpm run format:check`
- focused Playwright had already passed and CI was green on the original commit; local rerun after this fix hit the pre-existing mock channel-list race before reaching the updated assertion

Made by [Open SWE](https://openswe.vercel.app/agents/edde5012-1bc4-5781-9c11-f65ab6560c4c)
