### PR TITLE
feat: add sandbox service URL tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Slack **code channels** (`utils/slack_code_channels.py`) are a channel-per-task 
 - New dashboard endpoints: add to `agent/dashboard/routes.py`. The router is auto-mounted on the FastAPI app.
 - New graphs: register the entrypoint in `langgraph.json` under `graphs`.
 - Minimal-to-no code comments — only when the *why* isn't obvious from the code.
+- Python imports must be absolute. Do not use relative imports that start with `..`.
 
 <!-- OPENWIKI:START -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Slack **code channels** (`utils/slack_code_channels.py`) are a channel-per-task 
 - New dashboard endpoints: add to `agent/dashboard/routes.py`. The router is auto-mounted on the FastAPI app.
 - New graphs: register the entrypoint in `langgraph.json` under `graphs`.
 - Minimal-to-no code comments — only when the *why* isn't obvious from the code.
-- Python imports must be absolute. Do not use relative imports that start with `..`.
+- Do not use parent-relative Python imports that start with `..`; use absolute imports instead. Same-package imports with a single dot, such as `.foo`, are allowed.
 
 <!-- OPENWIKI:START -->
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -139,6 +139,7 @@ from .tools import (
     background_task,
     capture_environment_snapshot,
     create_sandbox_file_download_url,
+    create_sandbox_service_url,
     delete_environment,
     delete_organization_skill,
     delete_user_skill,
@@ -785,6 +786,7 @@ PLAN_MODE_EXCLUDED_TOOLS: frozenset[str] = frozenset(
         "task",
         "background_execute",
         "background_task",
+        "create_sandbox_service_url",
         "http_request",
         "manage_baby_sit",
         "manage_thread",
@@ -1654,7 +1656,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         manage_baby_sit,
         notify_automation_channel,
         open_pull_request,
-        *((output_iframe, create_sandbox_file_download_url) if sandbox_file_downloads else ()),
+        *(
+            (output_iframe, create_sandbox_file_download_url, create_sandbox_service_url)
+            if sandbox_file_downloads
+            else ()
+        ),
         read_user_settings,
         request_pr_review,
         recreate_sandbox,

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -9,6 +9,7 @@ _TOOL_MODULES = {
     "background_task": ".background_execute",
     "capture_environment_snapshot": ".environments",
     "create_sandbox_file_download_url": ".create_sandbox_file_download_url",
+    "create_sandbox_service_url": ".create_sandbox_service_url",
     "delete_environment": ".environments",
     "enter_plan_mode": ".enter_plan_mode",
     "fetch_review_diff": ".fetch_review_diff",
@@ -68,6 +69,7 @@ __all__ = [
     "background_task",
     "capture_environment_snapshot",
     "create_sandbox_file_download_url",
+    "create_sandbox_service_url",
     "delete_environment",
     "enter_plan_mode",
     "fetch_review_diff",
@@ -125,6 +127,7 @@ if TYPE_CHECKING:
     from .approve_plan import approve_plan
     from .background_execute import background_execute, background_task
     from .create_sandbox_file_download_url import create_sandbox_file_download_url
+    from .create_sandbox_service_url import create_sandbox_service_url
     from .enter_plan_mode import enter_plan_mode
     from .environments import (
         capture_environment_snapshot,

--- a/agent/tools/create_sandbox_service_url.py
+++ b/agent/tools/create_sandbox_service_url.py
@@ -12,8 +12,7 @@ async def create_sandbox_service_url(
 ) -> dict[str, Any]:
     """Create a browser URL for a service listening in the active LangSmith sandbox.
 
-    The service must listen on `0.0.0.0` at the specified port. Anyone with the returned URL can
-    access the service until it expires, so do not expose services containing secrets or credentials.
+    The service must listen on `0.0.0.0` at the specified port. Anyone with the URL can access it.
     """
     if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
         raise ValueError("port must be an integer between 1 and 65535")

--- a/agent/tools/create_sandbox_service_url.py
+++ b/agent/tools/create_sandbox_service_url.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+from langgraph.config import get_config
+
+from ..integrations.langsmith import get_async_sandbox_client
+from ..utils.sandbox_state import get_sandbox_backend, unwrap_sandbox_backend
+
+
+async def create_sandbox_service_url(
+    port: int,
+    expires_in_seconds: int = 600,
+) -> dict[str, Any]:
+    """Create a browser URL for a service listening in the active LangSmith sandbox.
+
+    The service must listen on `0.0.0.0` at the specified port. Anyone with the returned URL can
+    access the service until it expires, so do not expose services containing secrets or credentials.
+    """
+    if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+        raise ValueError("port must be an integer between 1 and 65535")
+    if (
+        isinstance(expires_in_seconds, bool)
+        or not isinstance(expires_in_seconds, int)
+        or not 1 <= expires_in_seconds <= 86400
+    ):
+        raise ValueError("expires_in_seconds must be an integer between 1 and 86400")
+
+    config = get_config()
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    thread_id = configurable.get("thread_id") if isinstance(configurable, dict) else None
+    if not isinstance(thread_id, str) or not thread_id:
+        raise ValueError("no thread_id in run config")
+
+    backend_proxy = await get_sandbox_backend(thread_id)
+    backend = unwrap_sandbox_backend(backend_proxy)
+    async with get_async_sandbox_client() as client:
+        service = await client.service(
+            backend.id,
+            port,
+            expires_in_seconds=expires_in_seconds,
+        )
+    if unwrap_sandbox_backend(backend_proxy) is not backend:
+        raise RuntimeError("sandbox changed while creating the service URL; retry")
+    if not service.browser_url:
+        raise RuntimeError("LangSmith did not return a service URL")
+
+    return {
+        "url": service.browser_url,
+        "port": port,
+        "expires_at": service.expires_at,
+    }

--- a/agent/tools/create_sandbox_service_url.py
+++ b/agent/tools/create_sandbox_service_url.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from langgraph.config import get_config
 
-from ..integrations.langsmith import get_async_sandbox_client
-from ..utils.sandbox_state import get_sandbox_backend, unwrap_sandbox_backend
+from agent.integrations.langsmith import get_async_sandbox_client
+from agent.utils.sandbox_state import get_sandbox_backend, unwrap_sandbox_backend
 
 
 async def create_sandbox_service_url(

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -319,12 +319,17 @@ async def test_agent_includes_sandbox_reset_only_in_admin_threads(
 
 @pytest.mark.asyncio
 async def test_agent_includes_sandbox_file_download_url_tools() -> None:
-    from agent.tools import create_sandbox_file_download_url, output_iframe
+    from agent.tools import (
+        create_sandbox_file_download_url,
+        create_sandbox_service_url,
+        output_iframe,
+    )
 
     captured = await _capture_create_deep_agent_kwargs()
     tools = captured["tools"]
     assert isinstance(tools, list)
     assert create_sandbox_file_download_url in tools
+    assert create_sandbox_service_url in tools
     assert output_iframe in tools
 
 
@@ -335,7 +340,11 @@ async def test_agent_excludes_sandbox_file_downloads_for_other_providers(
     from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
     from agent.prompt import OPEN_SWE_SHARED_BASE
-    from agent.tools import create_sandbox_file_download_url, output_iframe
+    from agent.tools import (
+        create_sandbox_file_download_url,
+        create_sandbox_service_url,
+        output_iframe,
+    )
 
     monkeypatch.setenv("SANDBOX_TYPE", "modal")
     captured = await _capture_create_deep_agent_kwargs()
@@ -344,9 +353,11 @@ async def test_agent_excludes_sandbox_file_downloads_for_other_providers(
     assert isinstance(tools, list)
     assert isinstance(subagents, list)
     assert create_sandbox_file_download_url not in tools
+    assert create_sandbox_service_url not in tools
     assert output_iframe not in tools
     general_purpose = next(item for item in subagents if item["name"] == "general-purpose")
     assert create_sandbox_file_download_url not in general_purpose["tools"]
+    assert create_sandbox_service_url not in general_purpose["tools"]
     assert output_iframe not in general_purpose["tools"]
     assert general_purpose["system_prompt"] == (
         f"{OPEN_SWE_SHARED_BASE}\n\n{GENERAL_PURPOSE_SUBAGENT['system_prompt']}"

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -447,10 +447,11 @@ def test_plan_file_path_for_thread_uses_plans_dir_and_slug() -> None:
     assert path.endswith("-thread-abc-123.html")
 
 
-def test_http_request_excluded_in_plan_mode() -> None:
+def test_external_mutations_excluded_in_plan_mode() -> None:
     from agent.server import PLAN_MODE_EXCLUDED_TOOLS
 
     assert "http_request" in PLAN_MODE_EXCLUDED_TOOLS
+    assert "create_sandbox_service_url" in PLAN_MODE_EXCLUDED_TOOLS
 
 
 def test_file_edit_tools_available_in_plan_mode_for_plan_file() -> None:

--- a/tests/tools/test_create_sandbox_service_url.py
+++ b/tests/tools/test_create_sandbox_service_url.py
@@ -1,0 +1,105 @@
+import importlib
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+service_tool = importlib.import_module("agent.tools.create_sandbox_service_url")
+
+
+class _AsyncClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, dict[str, Any]]] = []
+        self.closed = False
+
+    async def __aenter__(self) -> "_AsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.closed = True
+
+    async def service(self, name: str, port: int, **kwargs: Any) -> Any:
+        self.calls.append((name, port, kwargs))
+        return SimpleNamespace(
+            browser_url="https://service.example/auth?token=secret",
+            service_url="https://service.example",
+            token="secret",
+            expires_at="2026-08-27T15:00:00Z",
+        )
+
+
+class _Backend:
+    id = "sandbox-1"
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch) -> tuple[_Backend, _AsyncClient]:
+    monkeypatch.setattr(
+        service_tool,
+        "get_config",
+        lambda: {"configurable": {"thread_id": "thread-1"}},
+    )
+    backend = _Backend()
+
+    async def get_backend(_thread_id: str) -> _Backend:
+        return backend
+
+    client = _AsyncClient()
+    monkeypatch.setattr(service_tool, "get_sandbox_backend", get_backend)
+    monkeypatch.setattr(service_tool, "unwrap_sandbox_backend", lambda value: value)
+    monkeypatch.setattr(service_tool, "get_async_sandbox_client", lambda: client)
+    return backend, client
+
+
+async def test_create_sandbox_service_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _, client = _configure(monkeypatch)
+
+    result = await service_tool.create_sandbox_service_url(3000, expires_in_seconds=3600)
+
+    assert result == {
+        "url": "https://service.example/auth?token=secret",
+        "port": 3000,
+        "expires_at": "2026-08-27T15:00:00Z",
+    }
+    assert "token" not in result
+    assert "service_url" not in result
+    assert client.calls == [("sandbox-1", 3000, {"expires_in_seconds": 3600})]
+    assert client.closed is True
+
+
+@pytest.mark.parametrize("port", [True, 0, 65536, 3.5, "3000"])
+async def test_create_sandbox_service_url_rejects_invalid_port(
+    monkeypatch: pytest.MonkeyPatch,
+    port: Any,
+) -> None:
+    _, client = _configure(monkeypatch)
+
+    with pytest.raises(ValueError, match="port must be an integer between 1 and 65535"):
+        await service_tool.create_sandbox_service_url(port)
+
+    assert client.calls == []
+
+
+@pytest.mark.parametrize("expires_in_seconds", [True, 0, 86401, 3.5, "600"])
+async def test_create_sandbox_service_url_rejects_invalid_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+    expires_in_seconds: Any,
+) -> None:
+    _, client = _configure(monkeypatch)
+
+    with pytest.raises(
+        ValueError, match="expires_in_seconds must be an integer between 1 and 86400"
+    ):
+        await service_tool.create_sandbox_service_url(3000, expires_in_seconds)
+
+    assert client.calls == []
+
+
+async def test_create_sandbox_service_url_detects_sandbox_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend, _ = _configure(monkeypatch)
+    current = [backend, _Backend()]
+    monkeypatch.setattr(service_tool, "unwrap_sandbox_backend", lambda _value: current.pop(0))
+
+    with pytest.raises(RuntimeError, match="sandbox changed while creating the service URL"):
+        await service_tool.create_sandbox_service_url(3000)


### PR DESCRIPTION
### Summary
- add a LangSmith-only `create_sandbox_service_url` tool for exposing a sandbox service by port
- return the browser-authenticated URL without exposing the raw bearer token or internal service URL
- validate ports and expiry, detect sandbox replacement, and disable endpoint creation in plan mode
- ban parent-relative Python imports in `AGENTS.md` while allowing same-package single-dot imports

### Verification
- `make format`
- `NO_COLOR=1 make lint`
- `NO_COLOR=1 uv run pytest -q tests/tools/test_create_sandbox_service_url.py tests/tools/test_create_sandbox_file_download_url.py tests/agent/test_agent_assembly_context.py tests/agent/test_plan_review.py -k 'sandbox_service_url or create_download_url or sandbox_file_download_url_tools or sandbox_file_downloads_for_other_providers or external_mutations_excluded_in_plan_mode'` (24 passed)
- `NO_COLOR=1 uv run pytest -q tests/tools/test_create_sandbox_service_url.py` (12 passed)
- `NO_COLOR=1 uv run basedpyright agent/tools/create_sandbox_service_url.py tests/tools/test_create_sandbox_service_url.py`

Made by [Open SWE](https://openswe.vercel.app/agents/5100cc85-1401-5e3c-8214-781bbca4632f)