### PR TITLE
fix: make thread cancellation terminal

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -20,7 +20,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent.source_context import SourceContext
 
-from ..dispatch import dispatch_agent_run
 from ..input_messages import (
     PersonIdentity,
     build_input_messages,
@@ -1892,32 +1891,11 @@ async def cancel_dashboard_thread(
         logger.exception("Failed to cancel active runs for thread %s", thread_id)
         raise HTTPException(502, "failed to request thread cancellation") from exc
 
-    metadata_update: dict[str, Any] = {
-        "latest_run_status": "interrupted",
-        "updated_at_ms": _now_ms(),
-    }
-    await client.threads.update(thread_id=thread_id, metadata=metadata_update)
-    queued = await client.store.get_item(("queue", thread_id), "pending_messages")
-    queued_messages = queued.get("value", {}).get("messages", []) if queued else []
-    if queued_messages:
-        try:
-            configurable = await _build_dashboard_configurable(thread_id, login, metadata)
-            run = await dispatch_agent_run(
-                thread_id,
-                None,
-                configurable,
-                source=_DASHBOARD_SOURCE,
-                input={"messages": []},
-                client=client,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Failed to submit queued follow-up for thread %s", thread_id)
-            raise HTTPException(502, "stopped run but failed to submit queued follow-up") from exc
-        run_id = run.get("run_id") if isinstance(run, dict) else None
-        metadata_update.update(latest_run_status="pending", latest_run_id=run_id)
-
-    if queued_messages:
-        await client.threads.update(thread_id=thread_id, metadata=metadata_update)
+    await client.store.delete_item(("queue", thread_id), "pending_messages")
+    await client.threads.update(
+        thread_id=thread_id,
+        metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},
+    )
     thread = await client.threads.get(thread_id)
     return await _thread_summary(thread)
 
@@ -1935,6 +1913,7 @@ async def admin_cancel_dashboard_thread(thread_id: str) -> dict[str, Any]:
         logger.exception("Failed to cancel active runs for thread %s", thread_id)
         raise HTTPException(502, "failed to request thread cancellation") from exc
 
+    await client.store.delete_item(("queue", thread_id), "pending_messages")
     await client.threads.update(
         thread_id=thread_id,
         metadata={"latest_run_status": "interrupted", "updated_at_ms": _now_ms()},

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2696,8 +2696,8 @@ async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypa
             calls.append(("cancel_many", kwargs))
 
     class FakeStore:
-        async def get_item(self, namespace: tuple[str, str], key: str) -> None:
-            return None
+        async def delete_item(self, namespace: tuple[str, str], key: str) -> None:
+            calls.append(("delete_item", {"namespace": namespace, "key": key}))
 
     class FakeClient:
         threads = FakeThreads()
@@ -2715,6 +2715,10 @@ async def test_cancel_dashboard_thread_interrupts_runs_it_did_not_start(monkeypa
             "run_ids": ["pending-run", "running-run"],
             "action": "interrupt",
         },
+    )
+    assert calls[3] == (
+        "delete_item",
+        {"namespace": ("queue", "thread-1"), "key": "pending_messages"},
     )
     # Reported as interrupted even though the platform still says busy.
     assert result["status"] == "interrupted"
@@ -2782,9 +2786,14 @@ async def test_admin_cancel_dashboard_thread_interrupts_all_active_runs(monkeypa
         async def cancel_many(self, **kwargs: object) -> None:
             calls.append(("cancel_many", kwargs))
 
+    class FakeStore:
+        async def delete_item(self, namespace: tuple[str, str], key: str) -> None:
+            calls.append(("delete_item", {"namespace": namespace, "key": key}))
+
     class FakeClient:
         threads = FakeThreads()
         runs = FakeRuns()
+        store = FakeStore()
 
     monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
 
@@ -2798,7 +2807,11 @@ async def test_admin_cancel_dashboard_thread_interrupts_all_active_runs(monkeypa
             "action": "interrupt",
         },
     )
-    assert calls[3][0] == "update"
+    assert calls[3] == (
+        "delete_item",
+        {"namespace": ("queue", "thread-1"), "key": "pending_messages"},
+    )
+    assert calls[4][0] == "update"
     assert thread["metadata"]["latest_run_status"] == "interrupted"
     assert result["id"] == "thread-1"
 


### PR DESCRIPTION
Stop now clears queued message injections instead of launching another run after cancellation.

Tests: `make format`, `make lint`, focused dashboard cancellation tests (6 passed).

Made by [Open SWE](https://openswe.vercel.app/agents/d12b4809-f822-581b-8826-9ec87f5b6a68)