### PR TITLE
feat: restore Slack Thinking Steps

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -27,7 +27,11 @@ from .utils.dashboard_links import dashboard_thread_url
 from .utils.github_app import get_github_app_installation_token
 from .utils.github_comments import post_github_comment
 from .utils.linear import comment_on_linear_issue
-from .utils.slack import post_slack_thread_reply
+from .utils.slack import (
+    lookup_slack_run_message_mapping,
+    post_slack_thread_reply,
+    stop_slack_stream,
+)
 from .utils.slack_code_channels import is_code_channel_session, set_session_status
 from .utils.thread_ops import langgraph_client
 from .utils.user_messages import warning
@@ -288,6 +292,25 @@ async def _schedule_success_cost_refresh(
     return {"status": "ok", "reason": "cost refresh scheduled"}
 
 
+async def _settle_thinking_stream(
+    client: LangGraphClient, thread_id: str, run_id: str | None
+) -> None:
+    if run_id is None:
+        return
+    try:
+        thread = await client.threads.get(thread_id)
+        metadata = thread.get("metadata") if isinstance(thread, dict) else None
+        slack_thread = SourceContext.from_metadata(metadata).slack_thread
+        if slack_thread is None:
+            return
+        mapping = await lookup_slack_run_message_mapping(client, slack_thread.channel_id, run_id)
+        message_ts = mapping.get("thinking_message_ts") if mapping else None
+        if isinstance(message_ts, str) and message_ts:
+            await stop_slack_stream(slack_thread.channel_id, message_ts)
+    except Exception:  # noqa: BLE001
+        logger.debug("run-complete: could not settle Thinking Steps for %s", run_id, exc_info=True)
+
+
 async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     """Handle a platform run-completion webhook POST.
 
@@ -299,6 +322,8 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     run_id = raw_run_id if isinstance(raw_run_id, str) and raw_run_id else None
     if not isinstance(thread_id, str) or not thread_id:
         return {"status": "ignored", "reason": "missing thread_id"}
+    client = langgraph_client()
+    await _settle_thinking_stream(client, thread_id, run_id)
     if status == "success":
         return await _schedule_success_cost_refresh(thread_id, run_id, payload)
     payload_metadata = payload.get("metadata")
@@ -311,7 +336,6 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     if status not in _TERMINAL_FAILURE_STATUSES:
         return {"status": "ignored", "reason": f"non-failure status: {status}"}
 
-    client = langgraph_client()
     try:
         thread = await client.threads.get(thread_id)
     except Exception:  # noqa: BLE001

--- a/agent/completion.py
+++ b/agent/completion.py
@@ -27,11 +27,7 @@ from .utils.dashboard_links import dashboard_thread_url
 from .utils.github_app import get_github_app_installation_token
 from .utils.github_comments import post_github_comment
 from .utils.linear import comment_on_linear_issue
-from .utils.slack import (
-    lookup_slack_run_message_mapping,
-    post_slack_thread_reply,
-    stop_slack_stream,
-)
+from .utils.slack import post_slack_thread_reply
 from .utils.slack_code_channels import is_code_channel_session, set_session_status
 from .utils.thread_ops import langgraph_client
 from .utils.user_messages import warning
@@ -292,25 +288,6 @@ async def _schedule_success_cost_refresh(
     return {"status": "ok", "reason": "cost refresh scheduled"}
 
 
-async def _settle_thinking_stream(
-    client: LangGraphClient, thread_id: str, run_id: str | None
-) -> None:
-    if run_id is None:
-        return
-    try:
-        thread = await client.threads.get(thread_id)
-        metadata = thread.get("metadata") if isinstance(thread, dict) else None
-        slack_thread = SourceContext.from_metadata(metadata).slack_thread
-        if slack_thread is None:
-            return
-        mapping = await lookup_slack_run_message_mapping(client, slack_thread.channel_id, run_id)
-        message_ts = mapping.get("thinking_message_ts") if mapping else None
-        if isinstance(message_ts, str) and message_ts:
-            await stop_slack_stream(slack_thread.channel_id, message_ts)
-    except Exception:  # noqa: BLE001
-        logger.debug("run-complete: could not settle Thinking Steps for %s", run_id, exc_info=True)
-
-
 async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     """Handle a platform run-completion webhook POST.
 
@@ -322,8 +299,6 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     run_id = raw_run_id if isinstance(raw_run_id, str) and raw_run_id else None
     if not isinstance(thread_id, str) or not thread_id:
         return {"status": "ignored", "reason": "missing thread_id"}
-    client = langgraph_client()
-    await _settle_thinking_stream(client, thread_id, run_id)
     if status == "success":
         return await _schedule_success_cost_refresh(thread_id, run_id, payload)
     payload_metadata = payload.get("metadata")
@@ -336,6 +311,7 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     if status not in _TERMINAL_FAILURE_STATUSES:
         return {"status": "ignored", "reason": f"non-failure status: {status}"}
 
+    client = langgraph_client()
     try:
         thread = await client.threads.get(thread_id)
     except Exception:  # noqa: BLE001

--- a/agent/slack_thinking.py
+++ b/agent/slack_thinking.py
@@ -31,6 +31,7 @@ class Step:
     title: str
     status: StepStatus
     details: str = ""
+    output: str = ""
 
     def chunk(self) -> dict[str, Any]:
         chunk: dict[str, Any] = {
@@ -41,6 +42,8 @@ class Step:
         }
         if self.details:
             chunk["details"] = self.details[:256]
+        if self.output:
+            chunk["output"] = self.output[:256]
         return chunk
 
 
@@ -55,7 +58,7 @@ def _basename(value: str) -> str:
     return PurePath(value).name if value else "file"
 
 
-def _tool_title(name: str, tool_input: Any) -> str:
+def _tool_step(name: str, tool_input: Any) -> tuple[str, str]:
     if name in {"read_file", "write_file", "edit_file", "delete"}:
         action = {
             "read_file": "Reading",
@@ -63,22 +66,24 @@ def _tool_title(name: str, tool_input: Any) -> str:
             "edit_file": "Editing",
             "delete": "Removing",
         }[name]
-        return f"{action} {_basename(_text_arg(tool_input, 'file_path'))}"
-    if name in {"glob", "grep", "web_search", "fetch_url"}:
-        return "Searching for relevant context"
+        return f"{action} {_basename(_text_arg(tool_input, 'file_path'))}", "Repository file"
+    if name in {"glob", "grep"}:
+        return "Searching repository files", "Search details hidden"
+    if name in {"web_search", "fetch_url"}:
+        return "Searching external documentation", "External source lookup"
     if name in {"execute", "background_execute"}:
-        return "Running a development command"
+        return "Running a development command", "Command details hidden"
     if name == "task":
         agent = _text_arg(tool_input, "subagent_type").replace("-", " ")
-        return f"Delegating to {agent or 'a specialist'}"
+        return f"Delegating to {agent or 'a specialist'}", "Specialized agent task"
     labels = {
-        "ls": "Inspecting repository files",
-        "open_pull_request": "Opening pull request",
-        "request_pr_review": "Starting pull request review",
-        "save_plan": "Publishing implementation plan",
-        "analyzePlan": "Checking implementation security",
+        "ls": ("Inspecting repository files", "Repository directory"),
+        "open_pull_request": ("Opening pull request", "GitHub operation"),
+        "request_pr_review": ("Starting pull request review", "GitHub operation"),
+        "save_plan": ("Publishing implementation plan", "Plan artifact"),
+        "analyzePlan": ("Checking implementation security", "Security analysis"),
     }
-    return labels.get(name, "Working on the request")
+    return labels.get(name, (f"Using {name.replace('_', ' ')}", "Tool call"))
 
 
 def _step_id(run_id: str, namespace: tuple[str, ...], call_id: str) -> str:
@@ -180,10 +185,12 @@ class SlackThinkingStream:
             if startup and startup.status == "in_progress":
                 startup.status = "complete"
                 self.pending[startup.task_id] = startup
+            title, details = _tool_step(name, data.get("input"))
             step = Step(
                 _step_id(self.run_id, namespace, call_id),
-                _tool_title(name, data.get("input")),
+                title,
                 "in_progress",
+                details,
             )
             self.steps[key] = step
             self.pending[step.task_id] = step
@@ -193,6 +200,7 @@ class SlackThinkingStream:
                 step = Step(_step_id(self.run_id, namespace, call_id), "Agent step", "complete")
                 self.steps[key] = step
             step.status = "error" if event == "tool-error" else "complete"
+            step.output = "Failed" if event == "tool-error" else "Completed"
             self.pending[step.task_id] = step
 
     async def flush(self, *, force: bool = False) -> None:
@@ -222,11 +230,14 @@ class SlackThinkingStream:
         for step in self.steps.values():
             if step.status == "in_progress":
                 step.status = "complete" if status == "success" else "error"
+                step.output = "Completed" if status == "success" else "Interrupted"
                 self.pending[step.task_id] = step
-        await self.flush(force=True)
         if self.message_ts:
-            ok, error = await stop_slack_stream(self.channel_id, self.message_ts)
-            if not ok:
+            chunks = [step.chunk() for step in self.pending.values()]
+            ok, error = await stop_slack_stream(self.channel_id, self.message_ts, chunks)
+            if ok:
+                self.pending.clear()
+            else:
                 logger.warning(
                     "Could not stop Slack Thinking Steps for run %s: %s", self.run_id, error
                 )

--- a/agent/slack_thinking.py
+++ b/agent/slack_thinking.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 from langgraph_sdk.client import LangGraphClient
 
 from .utils.slack import (
+    SlackStreamError,
     append_slack_stream,
     start_slack_stream,
     stop_slack_stream,
@@ -144,15 +145,16 @@ class SlackThinkingStream:
         initial = Step(
             _step_id(self.run_id, (), "startup"), "Preparing the agent workspace", "in_progress"
         )
-        self.message_ts, error = await start_slack_stream(
-            self.channel_id,
-            self.thread_ts,
-            [initial.chunk()],
-            recipient_user_id=self.recipient_user_id,
-            recipient_team_id=self.recipient_team_id,
-        )
-        if not self.message_ts:
-            logger.info("Slack Thinking Steps unavailable for run %s: %s", self.run_id, error)
+        try:
+            self.message_ts = await start_slack_stream(
+                self.channel_id,
+                self.thread_ts,
+                [initial.chunk()],
+                recipient_user_id=self.recipient_user_id,
+                recipient_team_id=self.recipient_team_id,
+            )
+        except SlackStreamError as exc:
+            logger.info("Slack Thinking Steps unavailable for run %s: %s", self.run_id, exc.code)
             return False
         self.steps[((), "startup")] = initial
         await store_slack_run_mapping(
@@ -210,21 +212,21 @@ class SlackThinkingStream:
         if now < self.retry_at or (not force and now - self.last_flush < _FLUSH_INTERVAL_SECONDS):
             return
         chunks = [step.chunk() for step in self.pending.values()]
-        ok, error = await append_slack_stream(self.channel_id, self.message_ts, chunks)
-        if ok:
-            self.pending.clear()
-            self.last_flush = monotonic()
-            self.retry_at = 0.0
-        elif (error or "").startswith("rate_limited"):
-            _, _, raw_delay = (error or "").partition(":")
-            try:
-                delay = float(raw_delay.strip()) if raw_delay else _DEFAULT_RETRY_SECONDS
-            except ValueError:
-                delay = _DEFAULT_RETRY_SECONDS
-            self.retry_at = monotonic() + min(max(delay, 1.0), _MAX_RETRY_SECONDS)
-        else:
-            logger.warning("Disabling Slack Thinking Steps for run %s: %s", self.run_id, error)
-            self.disabled = True
+        try:
+            await append_slack_stream(self.channel_id, self.message_ts, chunks)
+        except SlackStreamError as exc:
+            if exc.code == "rate_limited":
+                delay = exc.retry_after if exc.retry_after is not None else _DEFAULT_RETRY_SECONDS
+                self.retry_at = monotonic() + min(max(delay, 1.0), _MAX_RETRY_SECONDS)
+            else:
+                logger.warning(
+                    "Disabling Slack Thinking Steps for run %s: %s", self.run_id, exc.code
+                )
+                self.disabled = True
+            return
+        self.pending.clear()
+        self.last_flush = monotonic()
+        self.retry_at = 0.0
 
     async def stop(self, status: str) -> None:
         for step in self.steps.values():
@@ -234,13 +236,14 @@ class SlackThinkingStream:
                 self.pending[step.task_id] = step
         if self.message_ts:
             chunks = [step.chunk() for step in self.pending.values()]
-            ok, error = await stop_slack_stream(self.channel_id, self.message_ts, chunks)
-            if ok:
-                self.pending.clear()
-            else:
+            try:
+                await stop_slack_stream(self.channel_id, self.message_ts, chunks)
+            except SlackStreamError as exc:
                 logger.warning(
-                    "Could not stop Slack Thinking Steps for run %s: %s", self.run_id, error
+                    "Could not stop Slack Thinking Steps for run %s: %s", self.run_id, exc.code
                 )
+            else:
+                self.pending.clear()
 
 
 async def stream_slack_thinking_steps(

--- a/agent/slack_thinking.py
+++ b/agent/slack_thinking.py
@@ -1,0 +1,278 @@
+"""Stream sanitized LangGraph tool progress into Slack Thinking Steps."""
+
+import asyncio
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import PurePath
+from time import monotonic
+from typing import Any, Literal
+
+from langgraph_sdk.client import LangGraphClient
+
+from .utils.slack import (
+    append_slack_stream,
+    start_slack_stream,
+    stop_slack_stream,
+    store_slack_run_mapping,
+)
+
+logger = logging.getLogger(__name__)
+
+StepStatus = Literal["in_progress", "complete", "error"]
+_FLUSH_INTERVAL_SECONDS = 1.0
+_DEFAULT_RETRY_SECONDS = 30.0
+_MAX_RETRY_SECONDS = 300.0
+
+
+@dataclass
+class Step:
+    task_id: str
+    title: str
+    status: StepStatus
+    details: str = ""
+
+    def chunk(self) -> dict[str, Any]:
+        chunk: dict[str, Any] = {
+            "type": "task_update",
+            "id": self.task_id,
+            "title": self.title[:256],
+            "status": self.status,
+        }
+        if self.details:
+            chunk["details"] = self.details[:256]
+        return chunk
+
+
+def _text_arg(value: Any, key: str) -> str:
+    if not isinstance(value, dict):
+        return ""
+    item = value.get(key)
+    return item if isinstance(item, str) else ""
+
+
+def _basename(value: str) -> str:
+    return PurePath(value).name if value else "file"
+
+
+def _tool_title(name: str, tool_input: Any) -> str:
+    if name in {"read_file", "write_file", "edit_file", "delete"}:
+        action = {
+            "read_file": "Reading",
+            "write_file": "Writing",
+            "edit_file": "Editing",
+            "delete": "Removing",
+        }[name]
+        return f"{action} {_basename(_text_arg(tool_input, 'file_path'))}"
+    if name in {"glob", "grep", "web_search", "fetch_url"}:
+        return "Searching for relevant context"
+    if name in {"execute", "background_execute"}:
+        return "Running a development command"
+    if name == "task":
+        agent = _text_arg(tool_input, "subagent_type").replace("-", " ")
+        return f"Delegating to {agent or 'a specialist'}"
+    labels = {
+        "ls": "Inspecting repository files",
+        "open_pull_request": "Opening pull request",
+        "request_pr_review": "Starting pull request review",
+        "save_plan": "Publishing implementation plan",
+        "analyzePlan": "Checking implementation security",
+    }
+    return labels.get(name, "Working on the request")
+
+
+def _step_id(run_id: str, namespace: tuple[str, ...], call_id: str) -> str:
+    value = "\0".join((run_id, *namespace, call_id))
+    return f"step-{hashlib.sha256(value.encode()).hexdigest()[:24]}"
+
+
+def _part_value(part: Any, key: str) -> Any:
+    return part.get(key) if isinstance(part, dict) else getattr(part, key, None)
+
+
+def _event_data(part: Any) -> tuple[tuple[str, ...], dict[str, Any]] | None:
+    event = _part_value(part, "event")
+    raw = _part_value(part, "data")
+    if not isinstance(event, str) or not event.startswith("tools") or not isinstance(raw, dict):
+        return None
+    namespace = tuple(segment for segment in event.split("|")[1:] if segment)
+    params = raw.get("params")
+    if isinstance(params, dict):
+        nested_namespace = params.get("namespace")
+        if isinstance(nested_namespace, list):
+            namespace = tuple(str(value) for value in nested_namespace)
+        raw = params.get("data")
+    return (namespace, raw) if isinstance(raw, dict) else None
+
+
+class SlackThinkingStream:
+    def __init__(
+        self,
+        *,
+        client: LangGraphClient,
+        thread_id: str,
+        run_id: str,
+        channel_id: str,
+        thread_ts: str,
+        recipient_user_id: str,
+        recipient_team_id: str,
+        mapping_thread_ts: str,
+        original_message_ts: str,
+    ) -> None:
+        self.client = client
+        self.thread_id = thread_id
+        self.run_id = run_id
+        self.channel_id = channel_id
+        self.thread_ts = thread_ts
+        self.recipient_user_id = recipient_user_id
+        self.recipient_team_id = recipient_team_id
+        self.mapping_thread_ts = mapping_thread_ts
+        self.original_message_ts = original_message_ts
+        self.message_ts: str | None = None
+        self.steps: dict[tuple[tuple[str, ...], str], Step] = {}
+        self.pending: dict[str, Step] = {}
+        self.last_flush = monotonic()
+        self.retry_at = 0.0
+        self.disabled = False
+
+    async def start(self) -> bool:
+        initial = Step(
+            _step_id(self.run_id, (), "startup"), "Preparing the agent workspace", "in_progress"
+        )
+        self.message_ts, error = await start_slack_stream(
+            self.channel_id,
+            self.thread_ts,
+            [initial.chunk()],
+            recipient_user_id=self.recipient_user_id,
+            recipient_team_id=self.recipient_team_id,
+        )
+        if not self.message_ts:
+            logger.info("Slack Thinking Steps unavailable for run %s: %s", self.run_id, error)
+            return False
+        self.steps[((), "startup")] = initial
+        await store_slack_run_mapping(
+            self.client,
+            self.channel_id,
+            self.mapping_thread_ts,
+            self.run_id,
+            message_ts=self.original_message_ts,
+            triggering_user_id=self.recipient_user_id,
+            agent_thread_id=self.thread_id,
+            thinking_message_ts=self.message_ts,
+        )
+        return True
+
+    def consume(self, part: Any) -> None:
+        parsed = _event_data(part)
+        if parsed is None:
+            return
+        namespace, data = parsed
+        event = data.get("event")
+        call_id = data.get("tool_call_id")
+        if not isinstance(call_id, str) or not call_id:
+            return
+        key = (namespace, call_id)
+        if event == "tool-started":
+            name = data.get("tool_name")
+            if not isinstance(name, str):
+                return
+            startup = self.steps.get(((), "startup"))
+            if startup and startup.status == "in_progress":
+                startup.status = "complete"
+                self.pending[startup.task_id] = startup
+            step = Step(
+                _step_id(self.run_id, namespace, call_id),
+                _tool_title(name, data.get("input")),
+                "in_progress",
+            )
+            self.steps[key] = step
+            self.pending[step.task_id] = step
+        elif event in {"tool-finished", "tool-error"}:
+            step = self.steps.get(key)
+            if step is None:
+                step = Step(_step_id(self.run_id, namespace, call_id), "Agent step", "complete")
+                self.steps[key] = step
+            step.status = "error" if event == "tool-error" else "complete"
+            self.pending[step.task_id] = step
+
+    async def flush(self, *, force: bool = False) -> None:
+        if self.disabled or not self.message_ts or not self.pending:
+            return
+        now = monotonic()
+        if now < self.retry_at or (not force and now - self.last_flush < _FLUSH_INTERVAL_SECONDS):
+            return
+        chunks = [step.chunk() for step in self.pending.values()]
+        ok, error = await append_slack_stream(self.channel_id, self.message_ts, chunks)
+        if ok:
+            self.pending.clear()
+            self.last_flush = monotonic()
+            self.retry_at = 0.0
+        elif (error or "").startswith("rate_limited"):
+            _, _, raw_delay = (error or "").partition(":")
+            try:
+                delay = float(raw_delay.strip()) if raw_delay else _DEFAULT_RETRY_SECONDS
+            except ValueError:
+                delay = _DEFAULT_RETRY_SECONDS
+            self.retry_at = monotonic() + min(max(delay, 1.0), _MAX_RETRY_SECONDS)
+        else:
+            logger.warning("Disabling Slack Thinking Steps for run %s: %s", self.run_id, error)
+            self.disabled = True
+
+    async def stop(self, status: str) -> None:
+        for step in self.steps.values():
+            if step.status == "in_progress":
+                step.status = "complete" if status == "success" else "error"
+                self.pending[step.task_id] = step
+        await self.flush(force=True)
+        if self.message_ts:
+            ok, error = await stop_slack_stream(self.channel_id, self.message_ts)
+            if not ok:
+                logger.warning(
+                    "Could not stop Slack Thinking Steps for run %s: %s", self.run_id, error
+                )
+
+
+async def stream_slack_thinking_steps(
+    *,
+    client: LangGraphClient,
+    thread_id: str,
+    run_id: str,
+    channel_id: str,
+    thread_ts: str,
+    mapping_thread_ts: str,
+    original_message_ts: str,
+    recipient_user_id: str = "",
+    recipient_team_id: str = "",
+) -> None:
+    """Mirror one run's structured tool lifecycle into a Slack timeline."""
+    stream = SlackThinkingStream(
+        client=client,
+        thread_id=thread_id,
+        run_id=run_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        recipient_user_id=recipient_user_id,
+        recipient_team_id=recipient_team_id,
+        mapping_thread_ts=mapping_thread_ts,
+        original_message_ts=original_message_ts,
+    )
+    if not await stream.start():
+        return
+    status = "error"
+    try:
+        async for part in client.runs.join_stream(thread_id, run_id):
+            stream.consume(part)
+            await stream.flush()
+        run = await client.runs.get(thread_id, run_id)
+        run_status = run.get("status") if isinstance(run, dict) else None
+        status = "success" if run_status == "success" else str(run_status or "error")
+    except asyncio.CancelledError:
+        status = "interrupted"
+        raise
+    except Exception:
+        logger.warning("Slack Thinking Steps observer failed for run %s", run_id, exc_info=True)
+    finally:
+        try:
+            await asyncio.shield(stream.stop(status))
+        except Exception:
+            logger.warning("Slack Thinking Steps cleanup failed for run %s", run_id, exc_info=True)

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -669,30 +669,41 @@ async def post_slack_top_level_message_with_ts(
     )
 
 
-async def _slack_stream_call(
-    method: str, payload: dict[str, Any]
-) -> tuple[dict[str, Any] | None, str | None]:
+class SlackStreamError(Exception):
+    def __init__(self, code: str, *, retry_after: float | None = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retry_after = retry_after
+
+
+async def _slack_stream_call(method: str, payload: dict[str, Any]) -> dict[str, Any]:
     if not SLACK_BOT_TOKEN:
-        return None, "missing_slack_bot_token"
+        raise SlackStreamError("missing_slack_bot_token")
     async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
         try:
             response = await http_client.post(
                 f"{SLACK_API_BASE_URL}/{method}", headers=_slack_headers(), json=payload
             )
             if response.status_code == 429:
-                retry_after = response.headers.get("Retry-After")
-                return None, f"rate_limited: {retry_after}" if retry_after else "rate_limited"
+                raw_retry_after = response.headers.get("Retry-After")
+                try:
+                    retry_after = float(raw_retry_after) if raw_retry_after else None
+                except ValueError:
+                    retry_after = None
+                raise SlackStreamError("rate_limited", retry_after=retry_after)
             response.raise_for_status()
             data = response.json()
+        except SlackStreamError:
+            raise
         except (httpx.HTTPError, ValueError) as exc:
             logger.exception("Slack %s request failed", method)
-            return None, f"http_error: {type(exc).__name__}"
+            raise SlackStreamError(f"http_error:{type(exc).__name__}") from exc
         if not isinstance(data, dict):
-            return None, "invalid_response"
+            raise SlackStreamError("invalid_response")
         if not data.get("ok"):
             error = str(data.get("error") or "unknown_error")
-            return None, "rate_limited" if error == "ratelimited" else error
-        return data, None
+            raise SlackStreamError("rate_limited" if error == "ratelimited" else error)
+        return data
 
 
 async def start_slack_stream(
@@ -702,7 +713,7 @@ async def start_slack_stream(
     *,
     recipient_user_id: str = "",
     recipient_team_id: str = "",
-) -> tuple[str | None, str | None]:
+) -> str:
     """Start a Slack Thinking Steps stream and return its message timestamp."""
     from .slack_code_channels import is_code_channel_session
 
@@ -717,19 +728,20 @@ async def start_slack_stream(
         payload["recipient_user_id"] = recipient_user_id
     if recipient_team_id:
         payload["recipient_team_id"] = recipient_team_id
-    data, error = await _slack_stream_call("chat.startStream", payload)
-    message_ts = data.get("ts") if data else None
-    return (message_ts if isinstance(message_ts, str) and message_ts else None), error
+    data = await _slack_stream_call("chat.startStream", payload)
+    message_ts = data.get("ts")
+    if not isinstance(message_ts, str) or not message_ts:
+        raise SlackStreamError("missing_message_ts")
+    return message_ts
 
 
 async def append_slack_stream(
     channel_id: str, message_ts: str, chunks: list[dict[str, Any]]
-) -> tuple[bool, str | None]:
+) -> None:
     """Append structured chunks to a Slack stream."""
-    _, error = await _slack_stream_call(
+    await _slack_stream_call(
         "chat.appendStream", {"channel": channel_id, "ts": message_ts, "chunks": chunks}
     )
-    return error is None, error
 
 
 async def stop_slack_stream(
@@ -738,7 +750,7 @@ async def stop_slack_stream(
     chunks: list[dict[str, Any]] | None = None,
     *,
     session_status: str = "active",
-) -> tuple[bool, str | None]:
+) -> None:
     """Finalize a Slack stream."""
     payload: dict[str, Any] = {
         "channel": channel_id,
@@ -747,10 +759,11 @@ async def stop_slack_stream(
     }
     if chunks:
         payload["chunks"] = chunks
-    _, error = await _slack_stream_call("chat.stopStream", payload)
-    if error in {"message_not_in_streaming_state", "stopped_by_user"}:
-        return True, None
-    return error is None, error
+    try:
+        await _slack_stream_call("chat.stopStream", payload)
+    except SlackStreamError as exc:
+        if exc.code not in {"message_not_in_streaming_state", "stopped_by_user"}:
+            raise
 
 
 async def update_slack_message(

--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -669,6 +669,90 @@ async def post_slack_top_level_message_with_ts(
     )
 
 
+async def _slack_stream_call(
+    method: str, payload: dict[str, Any]
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not SLACK_BOT_TOKEN:
+        return None, "missing_slack_bot_token"
+    async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
+        try:
+            response = await http_client.post(
+                f"{SLACK_API_BASE_URL}/{method}", headers=_slack_headers(), json=payload
+            )
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After")
+                return None, f"rate_limited: {retry_after}" if retry_after else "rate_limited"
+            response.raise_for_status()
+            data = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.exception("Slack %s request failed", method)
+            return None, f"http_error: {type(exc).__name__}"
+        if not isinstance(data, dict):
+            return None, "invalid_response"
+        if not data.get("ok"):
+            error = str(data.get("error") or "unknown_error")
+            return None, "rate_limited" if error == "ratelimited" else error
+        return data, None
+
+
+async def start_slack_stream(
+    channel_id: str,
+    thread_ts: str,
+    chunks: list[dict[str, Any]],
+    *,
+    recipient_user_id: str = "",
+    recipient_team_id: str = "",
+) -> tuple[str | None, str | None]:
+    """Start a Slack Thinking Steps stream and return its message timestamp."""
+    from .slack_code_channels import is_code_channel_session
+
+    payload: dict[str, Any] = {
+        "channel": channel_id,
+        "chunks": chunks,
+        "task_display_mode": "timeline",
+    }
+    if not is_code_channel_session(thread_ts):
+        payload["thread_ts"] = thread_ts
+    if recipient_user_id:
+        payload["recipient_user_id"] = recipient_user_id
+    if recipient_team_id:
+        payload["recipient_team_id"] = recipient_team_id
+    data, error = await _slack_stream_call("chat.startStream", payload)
+    message_ts = data.get("ts") if data else None
+    return (message_ts if isinstance(message_ts, str) and message_ts else None), error
+
+
+async def append_slack_stream(
+    channel_id: str, message_ts: str, chunks: list[dict[str, Any]]
+) -> tuple[bool, str | None]:
+    """Append structured chunks to a Slack stream."""
+    _, error = await _slack_stream_call(
+        "chat.appendStream", {"channel": channel_id, "ts": message_ts, "chunks": chunks}
+    )
+    return error is None, error
+
+
+async def stop_slack_stream(
+    channel_id: str,
+    message_ts: str,
+    chunks: list[dict[str, Any]] | None = None,
+    *,
+    session_status: str = "active",
+) -> tuple[bool, str | None]:
+    """Finalize a Slack stream."""
+    payload: dict[str, Any] = {
+        "channel": channel_id,
+        "ts": message_ts,
+        "session_status": session_status,
+    }
+    if chunks:
+        payload["chunks"] = chunks
+    _, error = await _slack_stream_call("chat.stopStream", payload)
+    if error in {"message_not_in_streaming_state", "stopped_by_user"}:
+        return True, None
+    return error is None, error
+
+
 async def update_slack_message(
     channel_id: str,
     message_ts: str,
@@ -1756,6 +1840,7 @@ async def store_slack_run_mapping(
     triggering_user_id: str | None = None,
     trace_message_ts: str | None = None,
     agent_thread_id: str | None = None,
+    thinking_message_ts: str | None = None,
 ) -> None:
     """Persist Slack thread/message to LangGraph run mapping."""
     namespace = (_SLACK_RUN_MAP_NAMESPACE, channel_id)
@@ -1772,6 +1857,8 @@ async def store_slack_run_mapping(
         value["trace_message_ts"] = trace_message_ts
     if agent_thread_id:
         value["agent_thread_id"] = agent_thread_id
+    if thinking_message_ts:
+        value["thinking_message_ts"] = thinking_message_ts
     try:
         await langgraph_client.store.put_item(
             namespace, f"{_THREAD_RUN_KEY_PREFIX}{thread_ts}", value

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -24,6 +24,7 @@ from agent.input_messages import (
     system_input,
     system_introduction,
 )
+from agent.slack_thinking import stream_slack_thinking_steps
 from agent.source_context import SlackThreadRef, SourceContext
 from agent.utils import slack as slack_utils
 from agent.utils.json_types import as_json_object
@@ -35,7 +36,6 @@ from . import common
 
 STALE_PARTICIPANT_SECONDS = 15 * 60
 RAPID_FOLLOWUP_SECONDS = 60
-
 _MENTION_PREAMBLE = "You were mentioned in Slack.\n\n"
 
 _UNTAGGED_REPLY_PREAMBLE = (
@@ -906,6 +906,19 @@ async def _process_slack_mention_impl(
         thread_id,
     )
     run_id = run.get("run_id")
+    if code_channel and isinstance(run_id, str) and run_id:
+        stream_thread_ts = reply_thread_ts or thread_ts
+        await stream_slack_thinking_steps(
+            client=langgraph_client,
+            thread_id=thread_id,
+            run_id=run_id,
+            channel_id=channel_id,
+            thread_ts=stream_thread_ts,
+            mapping_thread_ts=thread_ts,
+            original_message_ts=original_message_ts,
+            recipient_user_id=user_id,
+            recipient_team_id=str(event_data.get("team_id") or ""),
+        )
     if is_first_mention:
         if isinstance(run_id, str) and run_id:
             await common.store_slack_run_mapping(

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -50,6 +50,7 @@ async def _queue_code_channel_turn(
     event_id: str,
     event_ts: str,
     explicit_request: bool,
+    team_id: str = "",
 ) -> dict[str, str]:
     if not channel_id or not user_id or not text or not event_id or not event_ts:
         return {"status": "ignored", "reason": "Missing code channel interaction fields"}
@@ -89,6 +90,7 @@ async def _queue_code_channel_turn(
             "treat_all_messages_as_mentions": True,
             "code_channel": True,
             "explicit_request": explicit_request,
+            "team_id": team_id,
         },
         repo_config,
     )
@@ -199,6 +201,7 @@ async def slack_webhook(
         return {"status": "ignored", "reason": "Invalid Slack event"}
 
     event_id = str(payload.get("event_id") or "")
+    team_id = str(payload.get("team_id") or event.get("team") or "")
     channel_id = _event_channel_id(event)
     channel_context: dict[str, Any] | None = None
     if channel_id:
@@ -259,6 +262,7 @@ async def slack_webhook(
             event_id=event_id or f"code-channel-action:{action_channel_id}:{event_ts}",
             event_ts=event_ts,
             explicit_request=True,
+            team_id=team_id,
         )
 
     if event.get("type") == "reaction_added":
@@ -484,6 +488,8 @@ async def slack_webhook(
             "message_update": is_message_update,
             "code_channel": in_code_channel,
             "reply_thread_ts": reply_thread_ts if in_code_channel else "",
+            "team_id": team_id,
+            "app_context": updated_message.get("app_context") or event.get("app_context"),
         }
         repo_config = await common.get_slack_repo_config(
             channel_id,
@@ -524,6 +530,7 @@ async def slack_code_channel_command(
     command = value("command").removeprefix("/")
     command_text = value("text")
     trigger_id = value("trigger_id")
+    team_id = value("team_id")
     if not (channel_id and user_id and 1 <= len(command) <= 31 and len(command_text) <= 4000):
         return {"response_type": "ephemeral", "text": "That code-channel command was invalid."}
 
@@ -538,6 +545,7 @@ async def slack_code_channel_command(
         event_id=event_id,
         event_ts=event_ts,
         explicit_request=True,
+        team_id=team_id,
     )
     if result["status"] != "accepted":
         return {

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -49,9 +49,9 @@ async def test_thinking_steps_stream_api_payloads(monkeypatch: pytest.MonkeyPatc
         appended = await slack_utils.append_slack_stream("C1", "1.0", chunks)
         stopped = await slack_utils.stop_slack_stream("C1", "1.0", chunks)
 
-    assert started == ("1.0", None)
-    assert appended == (True, None)
-    assert stopped == (True, None)
+    assert started == "1.0"
+    assert appended is None
+    assert stopped is None
     calls = client_cm.post.await_args_list
     assert calls[0].args[0].endswith("/chat.startStream")
     assert calls[0].kwargs["json"] == {
@@ -80,6 +80,23 @@ async def test_code_channel_stream_is_top_level(monkeypatch: pytest.MonkeyPatch)
         await slack_utils.start_slack_stream("C1", "0", [])
 
     assert "thread_ts" not in client_cm.post.await_args.kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_slack_stream_rate_limit_preserves_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    client_cm = _async_client_cm(_rate_limited_response(retry_after="30"))
+
+    with (
+        patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm),
+        pytest.raises(slack_utils.SlackStreamError) as raised,
+    ):
+        await slack_utils.append_slack_stream("C1", "1.0", [])
+
+    assert raised.value.code == "rate_limited"
+    assert raised.value.retry_after == 30
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -37,6 +37,47 @@ def _async_client_cm(post_response: MagicMock) -> AsyncMock:
 
 
 @pytest.mark.asyncio
+async def test_thinking_steps_stream_api_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    client_cm = _async_client_cm(_ok_response())
+    chunks = [{"type": "task_update", "id": "step-1", "title": "Reading", "status": "in_progress"}]
+
+    with patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm):
+        started = await slack_utils.start_slack_stream(
+            "C1", "1.0", chunks, recipient_user_id="U1", recipient_team_id="T1"
+        )
+        appended = await slack_utils.append_slack_stream("C1", "1.0", chunks)
+        stopped = await slack_utils.stop_slack_stream("C1", "1.0")
+
+    assert started == ("1.0", None)
+    assert appended == (True, None)
+    assert stopped == (True, None)
+    calls = client_cm.post.await_args_list
+    assert calls[0].args[0].endswith("/chat.startStream")
+    assert calls[0].kwargs["json"] == {
+        "channel": "C1",
+        "chunks": chunks,
+        "task_display_mode": "timeline",
+        "thread_ts": "1.0",
+        "recipient_user_id": "U1",
+        "recipient_team_id": "T1",
+    }
+    assert calls[1].args[0].endswith("/chat.appendStream")
+    assert calls[2].kwargs["json"]["session_status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_code_channel_stream_is_top_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    client_cm = _async_client_cm(_ok_response())
+
+    with patch.object(slack_utils.httpx, "AsyncClient", return_value=client_cm):
+        await slack_utils.start_slack_stream("C1", "0", [])
+
+    assert "thread_ts" not in client_cm.post.await_args.kwargs["json"]
+
+
+@pytest.mark.asyncio
 async def test_update_slack_message_calls_chat_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -47,7 +47,7 @@ async def test_thinking_steps_stream_api_payloads(monkeypatch: pytest.MonkeyPatc
             "C1", "1.0", chunks, recipient_user_id="U1", recipient_team_id="T1"
         )
         appended = await slack_utils.append_slack_stream("C1", "1.0", chunks)
-        stopped = await slack_utils.stop_slack_stream("C1", "1.0")
+        stopped = await slack_utils.stop_slack_stream("C1", "1.0", chunks)
 
     assert started == ("1.0", None)
     assert appended == (True, None)
@@ -63,7 +63,12 @@ async def test_thinking_steps_stream_api_payloads(monkeypatch: pytest.MonkeyPatc
         "recipient_team_id": "T1",
     }
     assert calls[1].args[0].endswith("/chat.appendStream")
-    assert calls[2].kwargs["json"]["session_status"] == "active"
+    assert calls[2].kwargs["json"] == {
+        "channel": "C1",
+        "ts": "1.0",
+        "chunks": chunks,
+        "session_status": "active",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -51,13 +51,52 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
     )
 
     start.assert_awaited_once()
-    assert append.await_args is not None
-    chunks = append.await_args.args[2]
-    serialized = str(chunks)
+    stop.assert_awaited_once()
+    final_chunks = stop.await_args.args[2]
+    serialized = str(final_chunks)
     assert "Running a development command" in serialized
+    assert "Command details hidden" in serialized
     assert "secret-token" not in serialized
-    assert chunks[-1]["status"] == "complete"
-    stop.assert_awaited_once_with("C1", "2.0")
+    assert final_chunks[-1]["status"] == "complete"
+    assert final_chunks[-1]["output"] == "Completed"
+
+
+async def test_stop_sends_pending_updates_despite_append_backoff(monkeypatch) -> None:
+    stop = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)
+    stream = slack_thinking.SlackThinkingStream(
+        client=AsyncMock(),
+        thread_id="thread-1",
+        run_id="run-1",
+        channel_id="C1",
+        thread_ts="0",
+        recipient_user_id="U1",
+        recipient_team_id="T1",
+        mapping_thread_ts="0",
+        original_message_ts="1.1",
+    )
+    stream.message_ts = "2.0"
+    stream.retry_at = float("inf")
+    step = slack_thinking.Step("step-1", "Reading", "in_progress")
+    stream.steps[((), "call-1")] = step
+    stream.pending[step.task_id] = step
+
+    await stream.stop("success")
+
+    stop.assert_awaited_once_with(
+        "C1",
+        "2.0",
+        [
+            {
+                "type": "task_update",
+                "id": "step-1",
+                "title": "Reading",
+                "status": "complete",
+                "output": "Completed",
+            }
+        ],
+    )
+    assert not stream.pending
 
 
 async def test_rate_limit_defers_append_until_retry_after(monkeypatch) -> None:

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -30,9 +30,9 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
     client = AsyncMock()
     client.runs.join_stream = join_stream
     client.runs.get.return_value = {"status": "success"}
-    start = AsyncMock(return_value=("2.0", None))
-    append = AsyncMock(return_value=(True, None))
-    stop = AsyncMock(return_value=(True, None))
+    start = AsyncMock(return_value="2.0")
+    append = AsyncMock()
+    stop = AsyncMock()
     monkeypatch.setattr(slack_thinking, "start_slack_stream", start)
     monkeypatch.setattr(slack_thinking, "append_slack_stream", append)
     monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)
@@ -63,7 +63,7 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
 
 
 async def test_stop_sends_pending_updates_despite_append_backoff(monkeypatch) -> None:
-    stop = AsyncMock(return_value=(True, None))
+    stop = AsyncMock()
     monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)
     stream = slack_thinking.SlackThinkingStream(
         client=AsyncMock(),
@@ -103,7 +103,9 @@ async def test_stop_sends_pending_updates_despite_append_backoff(monkeypatch) ->
 async def test_rate_limit_defers_append_until_retry_after(monkeypatch) -> None:
     clock = 10.0
     monkeypatch.setattr(slack_thinking, "monotonic", lambda: clock)
-    append = AsyncMock(side_effect=[(False, "rate_limited: 30"), (True, None)])
+    append = AsyncMock(
+        side_effect=[slack_thinking.SlackStreamError("rate_limited", retry_after=30), None]
+    )
     monkeypatch.setattr(slack_thinking, "append_slack_stream", append)
     stream = slack_thinking.SlackThinkingStream(
         client=AsyncMock(),

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -1,0 +1,118 @@
+from unittest.mock import AsyncMock
+
+from agent import slack_thinking
+
+
+class _Part:
+    def __init__(self, event: str, data: dict) -> None:
+        self.event = event
+        self.data = data
+
+
+async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
+    parts = [
+        _Part(
+            "tools",
+            {
+                "event": "tool-started",
+                "tool_call_id": "call-1",
+                "tool_name": "execute",
+                "input": {"command": "echo secret-token"},
+            },
+        ),
+        _Part("tools", {"event": "tool-finished", "tool_call_id": "call-1"}),
+    ]
+
+    async def join_stream(*_args, **_kwargs):
+        for part in parts:
+            yield part
+
+    client = AsyncMock()
+    client.runs.join_stream = join_stream
+    client.runs.get.return_value = {"status": "success"}
+    start = AsyncMock(return_value=("2.0", None))
+    append = AsyncMock(return_value=(True, None))
+    stop = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr(slack_thinking, "start_slack_stream", start)
+    monkeypatch.setattr(slack_thinking, "append_slack_stream", append)
+    monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)
+    monkeypatch.setattr(slack_thinking, "store_slack_run_mapping", AsyncMock())
+
+    await slack_thinking.stream_slack_thinking_steps(
+        client=client,
+        thread_id="thread-1",
+        run_id="run-1",
+        channel_id="C1",
+        thread_ts="1.0",
+        mapping_thread_ts="1.0",
+        original_message_ts="1.1",
+        recipient_user_id="U1",
+        recipient_team_id="T1",
+    )
+
+    start.assert_awaited_once()
+    assert append.await_args is not None
+    chunks = append.await_args.args[2]
+    serialized = str(chunks)
+    assert "Running a development command" in serialized
+    assert "secret-token" not in serialized
+    assert chunks[-1]["status"] == "complete"
+    stop.assert_awaited_once_with("C1", "2.0")
+
+
+async def test_rate_limit_defers_append_until_retry_after(monkeypatch) -> None:
+    clock = 10.0
+    monkeypatch.setattr(slack_thinking, "monotonic", lambda: clock)
+    append = AsyncMock(side_effect=[(False, "rate_limited: 30"), (True, None)])
+    monkeypatch.setattr(slack_thinking, "append_slack_stream", append)
+    stream = slack_thinking.SlackThinkingStream(
+        client=AsyncMock(),
+        thread_id="thread-1",
+        run_id="run-1",
+        channel_id="C1",
+        thread_ts="0",
+        recipient_user_id="U1",
+        recipient_team_id="T1",
+        mapping_thread_ts="0",
+        original_message_ts="1.1",
+    )
+    stream.message_ts = "2.0"
+    step = slack_thinking.Step("step-1", "Reading", "in_progress")
+    stream.pending[step.task_id] = step
+
+    await stream.flush(force=True)
+    clock = 39.0
+    await stream.flush(force=True)
+    assert append.await_count == 1
+
+    clock = 40.0
+    await stream.flush(force=True)
+    assert append.await_count == 2
+    assert not stream.pending
+
+
+def test_namespaced_tool_events_have_stable_distinct_ids() -> None:
+    stream = slack_thinking.SlackThinkingStream(
+        client=AsyncMock(),
+        thread_id="thread-1",
+        run_id="run-1",
+        channel_id="C1",
+        thread_ts="1.0",
+        recipient_user_id="U1",
+        recipient_team_id="T1",
+        mapping_thread_ts="1.0",
+        original_message_ts="1.1",
+    )
+    event = {
+        "event": "tool-started",
+        "tool_call_id": "same-call",
+        "tool_name": "read_file",
+        "input": {"file_path": "/workspace/app/auth.py"},
+    }
+
+    stream.consume(_Part("tools|subagent:a", event))
+    stream.consume(_Part("tools|subagent:b", event))
+
+    assert len(stream.steps) == 2
+    assert {step.title for step in stream.steps.values()} == {"Reading auth.py"}
+    assert len({step.task_id for step in stream.steps.values()}) == 2

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -52,6 +52,7 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
 
     start.assert_awaited_once()
     stop.assert_awaited_once()
+    assert stop.await_args is not None
     final_chunks = stop.await_args.args[2]
     serialized = str(final_chunks)
     assert "Running a development command" in serialized

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -472,6 +472,8 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
     monkeypatch.setattr(slack_webhook.common, "_upsert_slack_thread_repo_metadata", AsyncMock())
     monkeypatch.setattr(slack_webhook.common, "upsert_agent_thread_metadata", AsyncMock())
     monkeypatch.setattr(slack_webhook, "_dispatch_or_queue_slack_run", dispatch)
+    thinking = AsyncMock()
+    monkeypatch.setattr(slack_webhook, "stream_slack_thinking_steps", thinking)
     monkeypatch.setattr(slack_webhook.common, "store_slack_run_mapping", store_mapping)
 
     await slack_webhook._process_slack_mention_impl(
@@ -499,6 +501,7 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
     assert "old text" not in serialized
     assert "## Conversation Context" not in serialized
     assert await_args.kwargs["explicitly_tagged"] is False
+    thinking.assert_not_awaited()
     store_args = store_mapping.await_args
     assert store_args is not None
     assert store_args.kwargs["message_ts"] == "1.0"


### PR DESCRIPTION
Re-applies the Slack Thinking Steps changes from #2258 without restoring the separately reverted Agent View changes.

Uses Slack task cards to show sanitized tool names, safe context, status, and outcomes. Final updates are sent atomically with `chat.stopStream`.

Tests: 48 focused Slack tests; lint, format, and focused typecheck.

Made by [Open SWE](https://openswe.vercel.app/agents/01a0453c-6ef9-75bf-8ba9-8764ace4f066)