### PR TITLE
fix: Group Slack thinking steps by run

### DIFF
--- a/agent/utils/slack.py
+++ b/agent/utils/slack.py
@@ -720,7 +720,7 @@ async def start_slack_stream(
     payload: dict[str, Any] = {
         "channel": channel_id,
         "chunks": chunks,
-        "task_display_mode": "timeline",
+        "task_display_mode": "plan",
     }
     if not is_code_channel_session(thread_ts):
         payload["thread_ts"] = thread_ts

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -57,7 +57,7 @@ async def test_thinking_steps_stream_api_payloads(monkeypatch: pytest.MonkeyPatc
     assert calls[0].kwargs["json"] == {
         "channel": "C1",
         "chunks": chunks,
-        "task_display_mode": "timeline",
+        "task_display_mode": "plan",
         "thread_ts": "1.0",
         "recipient_user_id": "U1",
         "recipient_team_id": "T1",


### PR DESCRIPTION
Use Slack's plan display mode so a run's tool calls appear in one dropdown instead of separate timeline dropdowns.

Test: `uv run pytest -q --disable-warnings tests/slack/test_slack_message_api.py`

Made by [Open SWE](https://openswe.vercel.app/agents/01a045b9-a7be-70b8-b19e-22dfac4dd177)