### PR TITLE
Fix command palette shortcut in focused inputs

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 import uuid
 from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime
@@ -734,6 +735,63 @@ def _thread_updated_ms(thread: ThreadLike) -> int:
     return _thread_timestamp_ms(thread, "updated_at")
 
 
+def _pull_request_query(query: str) -> tuple[str | None, int] | None:
+    number_match = re.fullmatch(r"#?([1-9][0-9]*)", query.strip())
+    if number_match:
+        return None, int(number_match.group(1))
+    pr_ref = parse_github_pr_url(query)
+    if pr_ref:
+        return f"{pr_ref.owner}/{pr_ref.repo}".lower(), pr_ref.number
+    return None
+
+
+def _pull_request_matches_query(record: object, query: tuple[str | None, int]) -> bool:
+    if not isinstance(record, Mapping):
+        return False
+    repo_full_name, number = query
+    if record.get("number") != number:
+        return False
+    if repo_full_name is None:
+        return True
+    record_repo = record.get("repo_full_name") or record.get("repoFullName")
+    return isinstance(record_repo, str) and record_repo.lower() == repo_full_name
+
+
+def _metadata_matches_query(metadata: Mapping[str, Any], query: str) -> bool:
+    pr_query = _pull_request_query(query)
+    if pr_query:
+        records = metadata.get("pull_requests")
+        if isinstance(records, list) and any(
+            _pull_request_matches_query(record, pr_query) for record in records
+        ):
+            return True
+        legacy_record = {
+            "repo_full_name": metadata.get("repo_full_name"),
+            "number": metadata.get("pr_number"),
+        }
+        if pr_ref := parse_github_pr_url(str(metadata.get("pr_url") or "")):
+            legacy_record["repo_full_name"] = f"{pr_ref.owner}/{pr_ref.repo}"
+        if _pull_request_matches_query(legacy_record, pr_query):
+            return True
+    title = metadata.get("title")
+    title = title if isinstance(title, str) else "Untitled agent"
+    return query.lower() in title.lower()
+
+
+def _summary_matches_query(summary: Mapping[str, Any], query: str) -> bool:
+    pr_query = _pull_request_query(query)
+    if pr_query:
+        records = summary.get("pullRequests")
+        if isinstance(records, list) and any(
+            _pull_request_matches_query(record, pr_query) for record in records
+        ):
+            return True
+        if _pull_request_matches_query(summary.get("pr"), pr_query):
+            return True
+    title = summary.get("title")
+    return isinstance(title, str) and query.lower() in title.lower()
+
+
 def _metadata_matches_filters(
     metadata: Mapping[str, Any],
     *,
@@ -755,11 +813,8 @@ def _metadata_matches_filters(
         return False
     if source and _thread_source(metadata) != source:
         return False
-    if query:
-        title = metadata.get("title")
-        title = title if isinstance(title, str) else "Untitled agent"
-        if query.lower() not in title.lower():
-            return False
+    if query and not _metadata_matches_query(metadata, query):
+        return False
     return True
 
 
@@ -780,10 +835,8 @@ def _summary_matches_filters(
         return False
     if status and summary.get("status") != status:
         return False
-    if query:
-        title = summary.get("title")
-        if not isinstance(title, str) or query.lower() not in title.lower():
-            return False
+    if query and not _summary_matches_query(summary, query):
+        return False
     return True
 
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1685,6 +1685,43 @@ async def test_enrich_run_start_command_unresolves_thread(monkeypatch) -> None:
     assert updates[-1]["resolved_at_ms"] is None
 
 
+def test_pr_query_matches_legacy_and_current_thread_metadata() -> None:
+    metadata = {
+        "title": "Unrelated title",
+        "repo_full_name": "langchain-ai/open-swe",
+        "pr_number": 42,
+        "pr_url": "https://github.com/langchain-ai/open-swe/pull/42",
+        "pull_requests": [
+            {
+                "repo_full_name": "langchain-ai/langchain",
+                "number": 42,
+                "url": "https://github.com/langchain-ai/langchain/pull/42",
+            }
+        ],
+    }
+
+    assert thread_api._metadata_matches_query(metadata, "42")
+    assert thread_api._metadata_matches_query(metadata, "#42")
+    assert thread_api._metadata_matches_query(
+        metadata, "https://github.com/langchain-ai/open-swe/pull/42"
+    )
+    assert thread_api._metadata_matches_query(
+        metadata, "https://github.com/langchain-ai/langchain/pull/42"
+    )
+    assert not thread_api._metadata_matches_query(
+        metadata, "https://github.com/langchain-ai/deepagents/pull/42"
+    )
+    assert not thread_api._metadata_matches_query(metadata, "43")
+    summary = {
+        "title": "Unrelated title",
+        "pullRequests": [{"repoFullName": "langchain-ai/open-swe", "number": 42}],
+    }
+    assert thread_api._summary_matches_query(summary, "42")
+    assert thread_api._summary_matches_query(
+        summary, "https://github.com/langchain-ai/open-swe/pull/42"
+    )
+
+
 def test_summary_matches_filters() -> None:
     summary = {
         "resolved": True,

--- a/ui/src/components/AppCommandPalette.tsx
+++ b/ui/src/components/AppCommandPalette.tsx
@@ -53,6 +53,48 @@ function commandMatches(command: AppCommand, query: string): boolean {
   return haystack.includes(query.toLowerCase())
 }
 
+function parsePullRequestQuery(
+  query: string
+): { repoFullName?: string; number: number } | null {
+  const trimmed = query.trim()
+  const numberMatch = /^#?([1-9]\d*)$/.exec(trimmed)
+  if (numberMatch) return { number: Number(numberMatch[1]) }
+  const urlMatch =
+    /^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/pull\/([1-9]\d*)(?:[/?#].*)?$/i.exec(
+      trimmed
+    )
+  if (!urlMatch) return null
+  return {
+    repoFullName: `${urlMatch[1]}/${urlMatch[2]}`.toLowerCase(),
+    number: Number(urlMatch[3]),
+  }
+}
+
+function cloudThreadMatches(thread: AgentThread, query: string): boolean {
+  const titleMatches = thread.title.toLowerCase().includes(query.toLowerCase())
+  const prQuery = parsePullRequestQuery(query)
+  if (!prQuery) return titleMatches
+  const pullRequests =
+    thread.pullRequests ??
+    (thread.pr
+      ? [
+          {
+            ...thread.pr,
+            repoFullName: thread.repoFullName,
+          },
+        ]
+      : [])
+  return (
+    titleMatches ||
+    pullRequests.some(
+      (pullRequest) =>
+        pullRequest.number === prQuery.number &&
+        (!prQuery.repoFullName ||
+          pullRequest.repoFullName.toLowerCase() === prQuery.repoFullName)
+    )
+  )
+}
+
 export function buildPaletteResults(
   commands: ReadonlyArray<AppCommand>,
   cloudThreads: ReadonlyArray<AgentThread>,
@@ -76,7 +118,7 @@ export function buildPaletteResults(
   const cloudResults: Array<CloudThreadResult> = cloudThreads
     .filter(
       (thread) =>
-        !normalizedQuery || thread.title.toLowerCase().includes(normalizedQuery)
+        !normalizedQuery || cloudThreadMatches(thread, normalizedQuery)
     )
     .map((thread) => ({
       id: `cloud:${thread.id}`,

--- a/ui/src/lib/appCommands.test.ts
+++ b/ui/src/lib/appCommands.test.ts
@@ -82,6 +82,56 @@ describe("app commands", () => {
     ).toEqual([])
   })
 
+  it("finds associated threads by PR number or URL", () => {
+    const cloud = {
+      id: "cloud-1",
+      title: "Unrelated work",
+    } as AgentThread
+    const pullRequest: NonNullable<AgentThread["pullRequests"]>[number] = {
+      repoFullName: "langchain-ai/langchain",
+      number: 2295,
+      title: "Other PR",
+      state: "open",
+      headRef: "feature",
+      baseRef: "main",
+      url: "https://github.com/langchain-ai/langchain/pull/2295",
+      author: null,
+      authorAvatarUrl: null,
+      createdAt: null,
+      diffStats: { files: 1, additions: 1, deletions: 0 },
+    }
+    const otherRepo: AgentThread = {
+      ...cloud,
+      id: "cloud-2",
+      pullRequests: [pullRequest],
+    }
+    const matchingPr: AgentThread = {
+      ...cloud,
+      id: "cloud-3",
+      pullRequests: [
+        {
+          ...pullRequest,
+          repoFullName: "langchain-ai/open-swe",
+          url: "https://github.com/langchain-ai/open-swe/pull/2295",
+        },
+      ],
+    }
+
+    expect(
+      buildPaletteResults([], [otherRepo, matchingPr], [], "2295").map(
+        (item) => item.id
+      )
+    ).toEqual(["cloud:cloud-2", "cloud:cloud-3"])
+    expect(
+      buildPaletteResults(
+        [],
+        [otherRepo, matchingPr],
+        [],
+        "https://github.com/langchain-ai/open-swe/pull/2295"
+      ).map((item) => item.id)
+    ).toEqual(["cloud:cloud-3"])
+  })
+
   it("filters commands and merges cloud and local thread results", () => {
     const cloud = {
       id: "cloud-1",

--- a/ui/src/lib/appCommands.test.ts
+++ b/ui/src/lib/appCommands.test.ts
@@ -1,6 +1,12 @@
+/** @vitest-environment jsdom */
+
 import { describe, expect, it, vi } from "vitest"
 
-import { createNewThreadCommand, resolveAppCommands } from "./appCommands"
+import {
+  createNewThreadCommand,
+  resolveAppCommands,
+  resolveKeyboardCommand,
+} from "./appCommands"
 import type { DesktopLocalThreadSummary } from "@/desktop"
 import type { AgentThread } from "@/features/agents/lib/types"
 import type { AppCommand } from "./appCommands"
@@ -17,6 +23,39 @@ describe("app commands", () => {
     expect(newThread.shortcuts).toEqual(["c"])
     expect(newThread.desktopShortcuts).toBeUndefined()
     expect(newThread.desktopId).toBe("new-thread")
+  })
+
+  it("allows opted-in shortcuts in form fields without enabling single-key commands", () => {
+    const input = document.createElement("input")
+    const palette = {
+      ...command("search-commands"),
+      shortcuts: ["mod+k"],
+      alwaysAvailable: true,
+    }
+    const newThread = createNewThreadCommand(vi.fn())
+    const paletteEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      ctrlKey: true,
+    })
+    Object.defineProperty(paletteEvent, "target", { value: input })
+    const newThreadEvent = new KeyboardEvent("keydown", { key: "c" })
+    Object.defineProperty(newThreadEvent, "target", { value: input })
+
+    expect(
+      resolveKeyboardCommand([palette, newThread], paletteEvent, false)
+    ).toBe(palette)
+    expect(
+      resolveKeyboardCommand([palette, newThread], newThreadEvent, false)
+    ).toBeUndefined()
+    const composingEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      ctrlKey: true,
+      isComposing: true,
+    })
+    Object.defineProperty(composingEvent, "target", { value: input })
+    expect(
+      resolveKeyboardCommand([palette, newThread], composingEvent, false)
+    ).toBeUndefined()
   })
 
   it("lets the latest contextual registration replace a command", () => {

--- a/ui/src/lib/appCommands.tsx
+++ b/ui/src/lib/appCommands.tsx
@@ -26,6 +26,7 @@ export interface AppCommand {
   showInPalette?: boolean
   desktopId?: DesktopCommandId
   desktopShortcuts?: ReadonlyArray<string>
+  alwaysAvailable?: boolean
 }
 
 export function createNewThreadCommand(run: () => void): AppCommand {
@@ -67,6 +68,25 @@ export function resolveAppCommands(
   return [...resolved.values()].filter((command) => command.available !== false)
 }
 
+export function resolveKeyboardCommand(
+  commands: ReadonlyArray<AppCommand>,
+  event: KeyboardEvent,
+  desktop: boolean
+): AppCommand | undefined {
+  return commands.find(
+    (candidate) =>
+      candidate.run &&
+      (candidate.alwaysAvailable
+        ? !event.defaultPrevented && !event.isComposing && !event.repeat
+        : !shouldIgnoreHotkey(event)) &&
+      candidate.shortcuts?.some(
+        (shortcut) =>
+          !(desktop && candidate.desktopShortcuts?.includes(shortcut)) &&
+          eventMatchesShortcut(event, shortcut)
+      )
+  )
+}
+
 export function AppCommandProvider({
   children,
 }: {
@@ -100,6 +120,7 @@ export function AppCommandProvider({
         showInPalette: false,
         desktopId: "show-command-palette",
         desktopShortcuts: ["mod+k"],
+        alwaysAvailable: true,
       },
       createNewThreadCommand(() => void navigate({ to: "/agents" })),
       {
@@ -150,23 +171,18 @@ export function AppCommandProvider({
   useEffect(() => {
     if (!enabled || paletteOpen || shortcutReferenceOpen) return
     const onKeyDown = (event: KeyboardEvent) => {
-      if (shouldIgnoreHotkey(event)) return
-      const desktop = Boolean(window.openSweDesktop)
-      const command = commandsRef.current.find(
-        (candidate) =>
-          candidate.run &&
-          candidate.shortcuts?.some(
-            (shortcut) =>
-              !(desktop && candidate.desktopShortcuts?.includes(shortcut)) &&
-              eventMatchesShortcut(event, shortcut)
-          )
+      const command = resolveKeyboardCommand(
+        commandsRef.current,
+        event,
+        Boolean(window.openSweDesktop)
       )
       if (!command?.run) return
       event.preventDefault()
+      event.stopPropagation()
       void command.run()
     }
-    window.addEventListener("keydown", onKeyDown)
-    return () => window.removeEventListener("keydown", onKeyDown)
+    window.addEventListener("keydown", onKeyDown, true)
+    return () => window.removeEventListener("keydown", onKeyDown, true)
   }, [enabled, paletteOpen, shortcutReferenceOpen])
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
- make the command palette shortcut available from focused inputs, including the new-thread composer
- handle the shortcut during capture so nested editors cannot intercept it
- keep single-key commands suppressed while typing and ignore composing/repeated events

### Testing
- `pnpm --dir ui exec vitest run src/lib/appCommands.test.ts src/lib/hotkeys.test.ts --no-color`
- `pnpm --dir ui run typecheck`
- `pnpm exec oxfmt --check ui/src/lib/appCommands.tsx ui/src/lib/appCommands.test.ts`
- `pnpm exec oxlint ui/src/lib/appCommands.tsx ui/src/lib/appCommands.test.ts`

Made by [Open SWE](https://openswe.vercel.app/agents/01a0487e-3fb4-75b2-b595-357dec973c29)