### PR TITLE
fix(sandbox): don't treat retryable sandbox errors as fatal

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -20,6 +20,7 @@ from langsmith.sandbox import (
 )
 
 from agent.utils.sandbox import SandboxGoneError
+from agent.utils.sandbox_retry import retry_transient_sandbox_errors
 
 logger = logging.getLogger(__name__)
 
@@ -642,6 +643,17 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
         raise NotImplementedError("TimeoutLangSmithSandbox is async-only; use aexecute.")
 
     async def aexecute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,  # noqa: ASYNC109 - forwarded semantic timeout, not an asyncio contract
+    ) -> ExecuteResponse:
+        return await retry_transient_sandbox_errors(
+            lambda: self._aexecute_once(command, timeout=timeout),
+            description="Sandbox command",
+        )
+
+    async def _aexecute_once(
         self,
         command: str,
         *,

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -19,7 +19,11 @@ from langchain_core.messages import ToolMessage
 from langgraph.config import get_config
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
-from langsmith.sandbox import SandboxClientError
+from langsmith.sandbox import (
+    ResourceNotFoundError,
+    SandboxConnectionError,
+    SandboxServerReloadError,
+)
 
 from agent.utils.sandbox_retry import is_transient_sandbox_error
 
@@ -68,7 +72,7 @@ def _to_error_payload(e: Exception, request: ToolCallRequest | None = None) -> d
 
 
 def _to_transient_sandbox_payload(
-    e: SandboxClientError,
+    e: Exception,
     request: ToolCallRequest | None = None,
 ) -> dict[str, str]:
     data: dict[str, str] = {
@@ -88,6 +92,19 @@ def _to_transient_sandbox_payload(
     if tool_name:
         data["name"] = tool_name
     return data
+
+
+def _is_sandbox_unreachable(e: Exception) -> bool:
+    """Whether the failure means the sandbox itself did not answer.
+
+    A connection error does, once the two that carry their own meaning are
+    excluded: a retryable rejection never started the command, and a server
+    reload left it running. ``ResourceNotFoundError`` qualifies only for the
+    sandbox itself — a missing file is a tool-local failure.
+    """
+    if isinstance(e, SandboxConnectionError):
+        return not isinstance(e, SandboxServerReloadError)
+    return isinstance(e, ResourceNotFoundError) and e.resource_type == "sandbox"
 
 
 def _get_tool_call_id(request: ToolCallRequest) -> str | None:
@@ -120,7 +137,7 @@ def _get_thread_id(request: ToolCallRequest) -> str | None:
 
 
 def _transient_sandbox_tool_message(
-    e: SandboxClientError,
+    e: Exception,
     request: ToolCallRequest,
 ) -> ToolMessage:
     data = _to_transient_sandbox_payload(e, request)
@@ -161,7 +178,7 @@ class ToolErrorMiddleware(AgentMiddleware):
     ) -> ToolMessage | Command:
         try:
             return await handler(request)
-        except SandboxClientError as e:
+        except Exception as e:
             # The command never started, so nothing is known to be wrong with the
             # sandbox: ending the run here would turn a gateway blip into an
             # abandoned one.
@@ -170,6 +187,9 @@ class ToolErrorMiddleware(AgentMiddleware):
                     "Transient sandbox error during tool call; request=%r", request, exc_info=True
                 )
                 return _transient_sandbox_tool_message(e, request)
+            if not _is_sandbox_unreachable(e):
+                logger.exception("Error during tool call handling; request=%r", request)
+                return _generic_error_tool_message(e, request)
             logger.exception("Sandbox error during tool call handling; request=%r", request)
             thread_id = _get_thread_id(request)
             config = _get_run_config(request)
@@ -183,6 +203,3 @@ class ToolErrorMiddleware(AgentMiddleware):
             # Every later sandbox call would hit the same dead backend and notify
             # again, so end the run here now that the user has been told once.
             raise
-        except Exception as e:
-            logger.exception("Error during tool call handling; request=%r", request)
-            return _generic_error_tool_message(e, request)

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -23,7 +23,6 @@ from langsmith.sandbox import SandboxClientError
 
 from agent.utils.sandbox_retry import is_transient_sandbox_error
 
-from ..utils.sandbox_state import unregister_sandbox_backend_proxy
 from .sandbox_circuit_breaker import (
     extract_sandbox_id,
     post_sandbox_unreachable_notification,
@@ -164,8 +163,8 @@ class ToolErrorMiddleware(AgentMiddleware):
             return await handler(request)
         except SandboxClientError as e:
             # The command never started, so nothing is known to be wrong with the
-            # sandbox: unregistering it and ending the run would turn a gateway
-            # blip into an abandoned one.
+            # sandbox: ending the run here would turn a gateway blip into an
+            # abandoned one.
             if is_transient_sandbox_error(e):
                 logger.warning(
                     "Transient sandbox error during tool call; request=%r", request, exc_info=True
@@ -173,8 +172,6 @@ class ToolErrorMiddleware(AgentMiddleware):
                 return _transient_sandbox_tool_message(e, request)
             logger.exception("Sandbox error during tool call handling; request=%r", request)
             thread_id = _get_thread_id(request)
-            if thread_id:
-                unregister_sandbox_backend_proxy(thread_id)
             config = _get_run_config(request)
             if config is not None:
                 try:

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -1,7 +1,9 @@
 """Tool error handling middleware.
 
-Wraps all tool calls in try/except so that unhandled exceptions are
-returned as error ToolMessages instead of crashing the agent run.
+Wraps all tool calls in try/except so that unhandled exceptions are returned as
+error ToolMessages instead of crashing the agent run. A sandbox that stopped
+answering is the exception: nothing the model does next can succeed, so the user
+is notified and the error propagates.
 """
 
 import json
@@ -19,7 +21,9 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 from langsmith.sandbox import SandboxClientError
 
-from ..utils.sandbox_state import clear_sandbox_backend
+from agent.utils.sandbox_retry import is_transient_sandbox_error
+
+from ..utils.sandbox_state import unregister_sandbox_backend_proxy
 from .sandbox_circuit_breaker import (
     extract_sandbox_id,
     post_sandbox_unreachable_notification,
@@ -27,7 +31,7 @@ from .sandbox_circuit_breaker import (
 
 logger = logging.getLogger(__name__)
 
-SANDBOX_UNREACHABLE = "sandbox_unreachable"
+SANDBOX_TRANSIENT = "sandbox_transient"
 
 
 def _get_name(candidate: object) -> str | None:
@@ -64,26 +68,21 @@ def _to_error_payload(e: Exception, request: ToolCallRequest | None = None) -> d
     return data
 
 
-def _to_sandbox_unreachable_payload(
+def _to_transient_sandbox_payload(
     e: SandboxClientError,
     request: ToolCallRequest | None = None,
 ) -> dict[str, str]:
-    sandbox_id = extract_sandbox_id(str(e))
-    which = f" ({sandbox_id})" if sandbox_id else ""
     data: dict[str, str] = {
         "status": "error",
         "error_type": e.__class__.__name__,
         "previous_error": str(e),
-        "recovery": SANDBOX_UNREACHABLE,
+        "recovery": SANDBOX_TRANSIENT,
         "error": (
-            f"The sandbox for this thread{which} stopped responding. It will not be "
-            "replaced automatically: a fresh sandbox is empty, so swapping one in "
-            "would discard any uncommitted work while looking like a recovery. Stop "
-            "calling sandbox tools and tell the user their sandbox stopped "
-            "responding, naming it, and that retriggering the thread retries the "
-            "same sandbox while a new thread gets a fresh one."
+            "The sandbox connection was rejected before this command started, so "
+            "nothing ran and nothing changed."
         ),
     }
+    sandbox_id = extract_sandbox_id(str(e))
     if sandbox_id:
         data["sandbox_id"] = sandbox_id
     tool_name = _extract_tool_name(request)
@@ -121,11 +120,11 @@ def _get_thread_id(request: ToolCallRequest) -> str | None:
     return thread_id if isinstance(thread_id, str) and thread_id else None
 
 
-def _sandbox_unreachable_tool_message(
+def _transient_sandbox_tool_message(
     e: SandboxClientError,
     request: ToolCallRequest,
 ) -> ToolMessage:
-    data = _to_sandbox_unreachable_payload(e, request)
+    data = _to_transient_sandbox_payload(e, request)
     return ToolMessage(
         content=json.dumps(data),
         tool_call_id=_get_tool_call_id(request),
@@ -148,6 +147,10 @@ class ToolErrorMiddleware(AgentMiddleware):
     Catches any exception thrown during a tool call and converts it into
     a ToolMessage with status="error" so the LLM can see the failure and
     self-correct, rather than crashing the entire agent run.
+
+    An unreachable sandbox is the one error that is not survivable, so it is
+    re-raised instead: every later sandbox call would fail the same way and
+    notify the user again.
     """
 
     state_schema = AgentState
@@ -160,10 +163,18 @@ class ToolErrorMiddleware(AgentMiddleware):
         try:
             return await handler(request)
         except SandboxClientError as e:
+            # The command never started, so nothing is known to be wrong with the
+            # sandbox: unregistering it and ending the run would turn a gateway
+            # blip into an abandoned one.
+            if is_transient_sandbox_error(e):
+                logger.warning(
+                    "Transient sandbox error during tool call; request=%r", request, exc_info=True
+                )
+                return _transient_sandbox_tool_message(e, request)
             logger.exception("Sandbox error during tool call handling; request=%r", request)
             thread_id = _get_thread_id(request)
             if thread_id:
-                clear_sandbox_backend(thread_id)
+                unregister_sandbox_backend_proxy(thread_id)
             config = _get_run_config(request)
             if config is not None:
                 try:
@@ -172,7 +183,9 @@ class ToolErrorMiddleware(AgentMiddleware):
                     )
                 except Exception:
                     logger.exception("Failed to notify user of dead sandbox for %s", thread_id)
-            return _sandbox_unreachable_tool_message(e, request)
+            # Every later sandbox call would hit the same dead backend and notify
+            # again, so end the run here now that the user has been told once.
+            raise
         except Exception as e:
             logger.exception("Error during tool call handling; request=%r", request)
             return _generic_error_tool_message(e, request)

--- a/agent/utils/sandbox_retry.py
+++ b/agent/utils/sandbox_retry.py
@@ -1,0 +1,61 @@
+"""Bounded retry for the sandbox failures the SDK marks as transient."""
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from langsmith.sandbox import SandboxRetryableConnectionError
+
+logger = logging.getLogger(__name__)
+
+MAX_TRANSIENT_ATTEMPTS = 4
+_BASE_BACKOFF = 0.5
+_MAX_BACKOFF = 8.0
+_JITTER_FACTOR = 0.2
+
+T = TypeVar("T")
+
+
+def is_transient_sandbox_error(exc: BaseException) -> bool:
+    """Whether the SDK guarantees this failure happened before the command started.
+
+    ``SandboxRetryableConnectionError`` covers a WebSocket upgrade rejected with a
+    gateway status (500/502/503/504): the execute frame never went out, so no
+    attempt can have run the command, and re-issuing it cannot double-run it.
+    """
+    return isinstance(exc, SandboxRetryableConnectionError)
+
+
+def _compute_backoff(attempt: int) -> float:
+    base = min(_BASE_BACKOFF * (2 ** (attempt - 1)), _MAX_BACKOFF)
+    jitter = base * random.uniform(-_JITTER_FACTOR, _JITTER_FACTOR)
+    return min(base + jitter, _MAX_BACKOFF)
+
+
+async def retry_transient_sandbox_errors(
+    operation: Callable[[], Awaitable[T]],
+    *,
+    description: str,
+    max_attempts: int = MAX_TRANSIENT_ATTEMPTS,
+) -> T:
+    """Run ``operation``, retrying it with backoff while it fails transiently."""
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return await operation()
+        except Exception as exc:
+            if attempt >= max_attempts or not is_transient_sandbox_error(exc):
+                raise
+            delay = _compute_backoff(attempt)
+            logger.warning(
+                "%s hit a transient sandbox error (%s), retrying in %.1fs (attempt %d/%d)",
+                description,
+                exc,
+                delay,
+                attempt,
+                max_attempts,
+            )
+            await asyncio.sleep(delay)

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -362,7 +362,13 @@ def get_or_create_sandbox_backend_proxy(
     return sandbox_backend
 
 
-def clear_sandbox_backend(thread_id: str) -> None:
+def unregister_sandbox_backend_proxy(thread_id: str) -> None:
+    """Drop the thread's registry entry so the next run rebuilds its proxy.
+
+    Does not detach the backend from the proxy this run already handed to the
+    tools: they hold that object directly, and the id it points at is the one a
+    reconnect would resolve to anyway.
+    """
     sandbox_backend = SANDBOX_BACKENDS.pop(thread_id, None)
     if sandbox_backend is not None:
         sandbox_backend.cancel_startup()

--- a/agent/utils/sandbox_state.py
+++ b/agent/utils/sandbox_state.py
@@ -362,18 +362,6 @@ def get_or_create_sandbox_backend_proxy(
     return sandbox_backend
 
 
-def unregister_sandbox_backend_proxy(thread_id: str) -> None:
-    """Drop the thread's registry entry so the next run rebuilds its proxy.
-
-    Does not detach the backend from the proxy this run already handed to the
-    tools: they hold that object directly, and the id it points at is the one a
-    reconnect would resolve to anyway.
-    """
-    sandbox_backend = SANDBOX_BACKENDS.pop(thread_id, None)
-    if sandbox_backend is not None:
-        sandbox_backend.cancel_startup()
-
-
 async def get_sandbox_metadata(thread_id: str) -> dict[str, Any]:
     """Fetch sandbox metadata from the run config or live thread."""
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "markdownify>=1.2.3",
     "langchain-anthropic>=1.5.4",
     "langgraph-cli[inmem]>=0.4.31",
-    "langsmith>=0.11.1",
+    "langsmith>=0.11.2",
     "langchain-openai>=1.4.1,<2.0.0",
     "langchain-fireworks>=1.5.2",
     # langchain-fireworks 1.4.2 pins a pre-release fireworks-ai; opt in explicitly so uv resolves it.

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -17,7 +17,7 @@ from langgraph.graph.state import RunnableConfig
 
 from agent.server import _registered_tool_name, get_agent
 from agent.utils.read_only_backend import ReadOnlyBackend
-from agent.utils.sandbox_state import SandboxBackendProxy, clear_sandbox_backend
+from agent.utils.sandbox_state import SandboxBackendProxy, unregister_sandbox_backend_proxy
 
 
 class _DummyAgent:
@@ -56,7 +56,7 @@ async def _capture_create_deep_agent_kwargs(
         make_model_calls.append((model_id, kwargs))
         return MagicMock()
 
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
     with (
         patch(
             "agent.server.resolve_github_token",
@@ -92,7 +92,7 @@ async def _capture_create_deep_agent_kwargs(
     ):
         await get_agent(config)
 
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
     captured["make_model_calls"] = make_model_calls
     return captured
 
@@ -132,7 +132,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
         await started.wait()
         return (("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low"))
 
-    clear_sandbox_backend("thread-ctx")
+    unregister_sandbox_backend_proxy("thread-ctx")
     with (
         patch("agent.server.ensure_sandbox_for_thread", side_effect=ensure_sandbox),
         patch("agent.server._cached_team_default_model_pair", side_effect=load_defaults),
@@ -153,7 +153,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
         release.set()
         await agent_task
 
-    clear_sandbox_backend("thread-ctx")
+    unregister_sandbox_backend_proxy("thread-ctx")
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -17,7 +17,7 @@ from langgraph.graph.state import RunnableConfig
 
 from agent.server import _registered_tool_name, get_agent
 from agent.utils.read_only_backend import ReadOnlyBackend
-from agent.utils.sandbox_state import SandboxBackendProxy, unregister_sandbox_backend_proxy
+from agent.utils.sandbox_state import SANDBOX_BACKENDS, SandboxBackendProxy
 
 
 class _DummyAgent:
@@ -56,7 +56,7 @@ async def _capture_create_deep_agent_kwargs(
         make_model_calls.append((model_id, kwargs))
         return MagicMock()
 
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
     with (
         patch(
             "agent.server.resolve_github_token",
@@ -92,7 +92,7 @@ async def _capture_create_deep_agent_kwargs(
     ):
         await get_agent(config)
 
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
     captured["make_model_calls"] = make_model_calls
     return captured
 
@@ -132,7 +132,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
         await started.wait()
         return (("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low"))
 
-    unregister_sandbox_backend_proxy("thread-ctx")
+    SANDBOX_BACKENDS.pop("thread-ctx", None)
     with (
         patch("agent.server.ensure_sandbox_for_thread", side_effect=ensure_sandbox),
         patch("agent.server._cached_team_default_model_pair", side_effect=load_defaults),
@@ -153,7 +153,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
         release.set()
         await agent_task
 
-    unregister_sandbox_backend_proxy("thread-ctx")
+    SANDBOX_BACKENDS.pop("thread-ctx", None)
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -13,7 +13,7 @@ import pytest
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import get_agent
-from agent.utils.sandbox_state import unregister_sandbox_backend_proxy
+from agent.utils.sandbox_state import SANDBOX_BACKENDS
 
 _START_TIMEOUT_SECONDS = 2.0
 
@@ -48,7 +48,7 @@ async def test_tool_loaders_run_concurrently() -> None:
         return loader
 
     thread_id = "thread-parallel-tools"
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
     with (
         patch(
             "agent.server.resolve_github_token",
@@ -82,4 +82,4 @@ async def test_tool_loaders_run_concurrently() -> None:
     ):
         await get_agent(_config())
 
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -13,7 +13,7 @@ import pytest
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import get_agent
-from agent.utils.sandbox_state import clear_sandbox_backend
+from agent.utils.sandbox_state import unregister_sandbox_backend_proxy
 
 _START_TIMEOUT_SECONDS = 2.0
 
@@ -48,7 +48,7 @@ async def test_tool_loaders_run_concurrently() -> None:
         return loader
 
     thread_id = "thread-parallel-tools"
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
     with (
         patch(
             "agent.server.resolve_github_token",
@@ -82,4 +82,4 @@ async def test_tool_loaders_run_concurrently() -> None:
     ):
         await get_agent(_config())
 
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)

--- a/tests/sandbox/test_langsmith_sandbox_timeout.py
+++ b/tests/sandbox/test_langsmith_sandbox_timeout.py
@@ -4,9 +4,14 @@ import asyncio
 import time
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
-from langsmith.sandbox import CommandTimeoutError, SandboxConnectionError
+from langsmith.sandbox import (
+    CommandTimeoutError,
+    SandboxConnectionError,
+    SandboxRetryableConnectionError,
+)
 
 from agent.integrations.langsmith import TimeoutLangSmithSandbox
 
@@ -136,3 +141,35 @@ async def test_aexecute_midstream_ws_drop_falls_back_to_base(
 def test_execute_is_async_only() -> None:
     with pytest.raises(NotImplementedError):
         _backend(_FakeHandle()).execute("echo hi", timeout=5)
+
+
+async def test_aexecute_retries_a_transient_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 503 on the WebSocket upgrade is a blip, not a dead sandbox.
+
+    The command never started, so re-issuing it cannot double-run anything.
+    """
+    handle = _FakeHandle(result=SimpleNamespace(stdout="out", stderr="", exit_code=0))
+    sb = _backend(handle)
+    sandbox = cast(_FakeSandbox, sb._async_sandbox)
+    attempts = 0
+
+    async def flaky_run(command: str, *, timeout: int, wait: bool) -> _FakeHandle:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise SandboxRetryableConnectionError("WebSocket upgrade temporarily rejected (503)")
+        return handle
+
+    async def failing_base_execute(self: Any, command: str, *, timeout: int | None = None) -> Any:
+        raise SandboxRetryableConnectionError("WebSocket upgrade temporarily rejected (503)")
+
+    monkeypatch.setattr(
+        "agent.integrations.langsmith.LangSmithSandbox.aexecute", failing_base_execute
+    )
+    monkeypatch.setattr(sandbox, "run", flaky_run)
+    monkeypatch.setattr("agent.utils.sandbox_retry.asyncio.sleep", AsyncMock(), raising=True)
+
+    resp = await sb.aexecute("git status", timeout=5)
+
+    assert resp.exit_code == 0
+    assert attempts == 2

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -15,7 +15,6 @@ from agent.middleware.tool_error_handler import ToolErrorMiddleware
 from agent.utils.sandbox_state import (
     SANDBOX_BACKENDS,
     set_sandbox_backend,
-    unregister_sandbox_backend_proxy,
 )
 
 
@@ -70,10 +69,8 @@ async def test_sandbox_client_error_notifies_then_ends_the_run() -> None:
 
         mock_create.assert_not_awaited()
         mock_notify.assert_awaited_once()
-        # The dead backend must not linger for the next tool call.
-        assert "thread-1" not in SANDBOX_BACKENDS
     finally:
-        unregister_sandbox_backend_proxy("thread-1")
+        SANDBOX_BACKENDS.pop("thread-1", None)
 
 
 def test_unreachable_message_names_the_sandbox_without_claiming_permanence() -> None:
@@ -155,4 +152,4 @@ async def test_transient_sandbox_error_keeps_the_sandbox_and_asks_for_a_retry() 
         assert "nothing ran and nothing changed" in payload["error"]
         assert "will not be replaced" not in payload["error"]
     finally:
-        unregister_sandbox_backend_proxy("thread-transient")
+        SANDBOX_BACKENDS.pop("thread-transient", None)

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -5,14 +5,18 @@ import pytest
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
-from langsmith.sandbox import SandboxClientError
+from langsmith.sandbox import SandboxClientError, SandboxRetryableConnectionError
 
 from agent.middleware.sandbox_circuit_breaker import (
     post_sandbox_unreachable_notification,
     sandbox_unreachable_message,
 )
 from agent.middleware.tool_error_handler import ToolErrorMiddleware
-from agent.utils.sandbox_state import SANDBOX_BACKENDS, clear_sandbox_backend, set_sandbox_backend
+from agent.utils.sandbox_state import (
+    SANDBOX_BACKENDS,
+    set_sandbox_backend,
+    unregister_sandbox_backend_proxy,
+)
 
 
 class FakeSandboxBackend(SandboxBackendProtocol):
@@ -38,11 +42,13 @@ def _tool_request(thread_id: str = "thread-1") -> ToolCallRequest:
 
 
 @pytest.mark.asyncio
-async def test_sandbox_client_error_notifies_and_never_recreates() -> None:
-    """A dead sandbox surfaces an error to the user; it is never swapped out.
+async def test_sandbox_client_error_notifies_then_ends_the_run() -> None:
+    """A dead sandbox tells the user once, then kills the run; it is never swapped out.
 
     Replacing it mid-run gives the agent an empty filesystem while it still
     believes its working tree is intact, silently destroying uncommitted work.
+    Handing the model an error message instead would leave every later sandbox
+    call hitting the same dead backend and notifying the user again.
     """
     middleware = ToolErrorMiddleware()
     request = _tool_request()
@@ -58,24 +64,16 @@ async def test_sandbox_client_error_notifies_and_never_recreates() -> None:
                 new_callable=AsyncMock,
             ) as mock_notify,
             patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as mock_create,
+            pytest.raises(SandboxClientError),
         ):
-            result = await middleware.awrap_tool_call(request, handler)
+            await middleware.awrap_tool_call(request, handler)
 
         mock_create.assert_not_awaited()
         mock_notify.assert_awaited_once()
         # The dead backend must not linger for the next tool call.
         assert "thread-1" not in SANDBOX_BACKENDS
-
-        assert isinstance(result, ToolMessage)
-        assert isinstance(result.content, str)
-        payload = json.loads(result.content)
-        assert payload["status"] == "error"
-        assert payload["error_type"] == "SandboxClientError"
-        assert payload["recovery"] == "sandbox_unreachable"
-        assert payload["previous_error"] == "Sandbox request timed out: sb-dead"
-        assert "will not be replaced" in payload["error"]
     finally:
-        clear_sandbox_backend("thread-1")
+        unregister_sandbox_backend_proxy("thread-1")
 
 
 def test_unreachable_message_names_the_sandbox_without_claiming_permanence() -> None:
@@ -120,3 +118,41 @@ async def test_unreachable_notification_goes_to_slack_only() -> None:
     )
     mock_linear.assert_not_called()
     mock_github.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_transient_sandbox_error_keeps_the_sandbox_and_asks_for_a_retry() -> None:
+    """A rejected WebSocket upgrade is a gateway blip, not a dead sandbox.
+
+    The command never started, so the backend stays bound and the user is not
+    told their sandbox went quiet — the model is told to retry the tool call.
+    """
+    middleware = ToolErrorMiddleware()
+    request = _tool_request("thread-transient")
+    set_sandbox_backend("thread-transient", FakeSandboxBackend("sb-live"))
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        raise SandboxRetryableConnectionError(
+            "WebSocket upgrade temporarily rejected by server (HTTP 503): "
+            "server rejected WebSocket connection: HTTP 503"
+        )
+
+    try:
+        with patch(
+            "agent.middleware.tool_error_handler.post_sandbox_unreachable_notification",
+            new_callable=AsyncMock,
+        ) as mock_notify:
+            result = await middleware.awrap_tool_call(request, handler)
+
+        mock_notify.assert_not_awaited()
+        assert "thread-transient" in SANDBOX_BACKENDS
+
+        assert isinstance(result, ToolMessage)
+        assert isinstance(result.content, str)
+        payload = json.loads(result.content)
+        assert payload["recovery"] == "sandbox_transient"
+        assert payload["error_type"] == "SandboxRetryableConnectionError"
+        assert "nothing ran and nothing changed" in payload["error"]
+        assert "will not be replaced" not in payload["error"]
+    finally:
+        unregister_sandbox_backend_proxy("thread-transient")

--- a/tests/sandbox/test_sandbox_recovery.py
+++ b/tests/sandbox/test_sandbox_recovery.py
@@ -5,7 +5,11 @@ import pytest
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
-from langsmith.sandbox import SandboxClientError, SandboxRetryableConnectionError
+from langsmith.sandbox import (
+    SandboxConnectionError,
+    SandboxOperationError,
+    SandboxRetryableConnectionError,
+)
 
 from agent.middleware.sandbox_circuit_breaker import (
     post_sandbox_unreachable_notification,
@@ -41,7 +45,7 @@ def _tool_request(thread_id: str = "thread-1") -> ToolCallRequest:
 
 
 @pytest.mark.asyncio
-async def test_sandbox_client_error_notifies_then_ends_the_run() -> None:
+async def test_unreachable_sandbox_notifies_then_ends_the_run() -> None:
     """A dead sandbox tells the user once, then kills the run; it is never swapped out.
 
     Replacing it mid-run gives the agent an empty filesystem while it still
@@ -54,7 +58,7 @@ async def test_sandbox_client_error_notifies_then_ends_the_run() -> None:
     set_sandbox_backend("thread-1", FakeSandboxBackend("sb-old"))
 
     async def handler(_request: ToolCallRequest) -> ToolMessage:
-        raise SandboxClientError("Sandbox request timed out: sb-dead")
+        raise SandboxConnectionError("WebSocket upgrade to sb-dead failed (no valid HTTP response)")
 
     try:
         with (
@@ -63,7 +67,7 @@ async def test_sandbox_client_error_notifies_then_ends_the_run() -> None:
                 new_callable=AsyncMock,
             ) as mock_notify,
             patch("agent.server._create_sandbox_with_proxy", new_callable=AsyncMock) as mock_create,
-            pytest.raises(SandboxClientError),
+            pytest.raises(SandboxConnectionError),
         ):
             await middleware.awrap_tool_call(request, handler)
 
@@ -153,3 +157,32 @@ async def test_transient_sandbox_error_keeps_the_sandbox_and_asks_for_a_retry() 
         assert "will not be replaced" not in payload["error"]
     finally:
         SANDBOX_BACKENDS.pop("thread-transient", None)
+
+
+@pytest.mark.asyncio
+async def test_command_level_sandbox_error_does_not_end_the_run() -> None:
+    """A failed command says nothing about whether the sandbox is reachable.
+
+    ``SandboxOperationError`` covers command error frames — a missing binary, an
+    expired session — so killing the run and telling the user their sandbox died
+    would be both wrong and unrecoverable.
+    """
+    middleware = ToolErrorMiddleware()
+    request = _tool_request("thread-op")
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        raise SandboxOperationError("CommandNotFound: no such file or directory: fzf")
+
+    with patch(
+        "agent.middleware.tool_error_handler.post_sandbox_unreachable_notification",
+        new_callable=AsyncMock,
+    ) as mock_notify:
+        result = await middleware.awrap_tool_call(request, handler)
+
+    mock_notify.assert_not_awaited()
+    assert isinstance(result, ToolMessage)
+    assert isinstance(result.content, str)
+    payload = json.loads(result.content)
+    assert payload["status"] == "error"
+    assert payload["error_type"] == "SandboxOperationError"
+    assert "recovery" not in payload

--- a/tests/sandbox/test_sandbox_retry.py
+++ b/tests/sandbox/test_sandbox_retry.py
@@ -1,0 +1,66 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langsmith.sandbox import SandboxClientError, SandboxRetryableConnectionError
+
+from agent.utils.sandbox_retry import (
+    MAX_TRANSIENT_ATTEMPTS,
+    is_transient_sandbox_error,
+    retry_transient_sandbox_errors,
+)
+
+
+def _transient() -> SandboxRetryableConnectionError:
+    return SandboxRetryableConnectionError(
+        "WebSocket upgrade temporarily rejected by server (HTTP 503)"
+    )
+
+
+def test_only_the_pre_start_failure_counts_as_transient() -> None:
+    assert is_transient_sandbox_error(_transient())
+    assert not is_transient_sandbox_error(SandboxClientError("Sandbox request timed out: sb-dead"))
+
+
+@pytest.mark.asyncio
+async def test_a_gateway_blip_is_retried_until_it_clears() -> None:
+    attempts = 0
+
+    async def operation() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise _transient()
+        return "ok"
+
+    with patch("agent.utils.sandbox_retry.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await retry_transient_sandbox_errors(operation, description="test")
+
+    assert result == "ok"
+    assert attempts == 3
+    assert mock_sleep.await_count == 2
+    # Backoff grows so a sustained outage is not hammered.
+    delays = [call.args[0] for call in mock_sleep.await_args_list]
+    assert delays[1] > delays[0]
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_sandbox_error_is_not_retried() -> None:
+    operation = AsyncMock(side_effect=SandboxClientError("Sandbox request timed out: sb-dead"))
+
+    with pytest.raises(SandboxClientError):
+        await retry_transient_sandbox_errors(operation, description="test")
+
+    operation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_retries_are_bounded() -> None:
+    operation = AsyncMock(side_effect=_transient())
+
+    with (
+        patch("agent.utils.sandbox_retry.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(SandboxRetryableConnectionError),
+    ):
+        await retry_transient_sandbox_errors(operation, description="test")
+
+    assert operation.await_count == MAX_TRANSIENT_ATTEMPTS

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -16,10 +16,10 @@ from deepagents.backends.sandbox import BaseSandbox
 from agent.utils.sandbox_state import (
     SANDBOX_BACKENDS,
     SandboxBackendProxy,
-    clear_sandbox_backend,
     get_or_create_sandbox_backend_proxy,
     get_sandbox_backend,
     get_sandbox_id_from_metadata,
+    unregister_sandbox_backend_proxy,
 )
 
 
@@ -121,7 +121,7 @@ async def test_sandbox_proxy_offload_falls_back_when_backend_lacks_it() -> None:
 @pytest.mark.asyncio
 async def test_sandbox_proxy_reconnects_from_metadata_once(monkeypatch: pytest.MonkeyPatch) -> None:
     thread_id = "thread-1"
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
     created: list[str] = []
 
     async def get_sandbox_id_from_metadata(requested_thread_id: str) -> str:
@@ -153,7 +153,7 @@ async def test_sandbox_proxy_reconnects_from_metadata_once(monkeypatch: pytest.M
         "sandbox-1: cmd-4: None",
     ]
     assert proxy.current.id == "sandbox-1"
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
 
 
 @pytest.mark.asyncio
@@ -161,7 +161,7 @@ async def test_sandbox_proxy_uses_registered_reconnect_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     thread_id = "thread-1"
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
     reconnected: list[str] = []
 
     async def reconnect():
@@ -188,7 +188,7 @@ async def test_sandbox_proxy_uses_registered_reconnect_once(
         "sandbox-1: cmd-3: None",
         "sandbox-1: cmd-4: None",
     ]
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
 
 
 @pytest.mark.asyncio
@@ -311,7 +311,7 @@ async def test_sandbox_proxy_delegates_delete_after_lazy_startup() -> None:
 @pytest.mark.asyncio
 async def test_get_sandbox_backend_awaits_registered_startup() -> None:
     thread_id = "thread-1"
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
     release = asyncio.Event()
 
     async def reconnect():
@@ -329,7 +329,7 @@ async def test_get_sandbox_backend_awaits_registered_startup() -> None:
 
     release.set()
     assert await waiter is proxy
-    clear_sandbox_backend(thread_id)
+    unregister_sandbox_backend_proxy(thread_id)
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_sandbox_state.py
+++ b/tests/sandbox/test_sandbox_state.py
@@ -19,7 +19,6 @@ from agent.utils.sandbox_state import (
     get_or_create_sandbox_backend_proxy,
     get_sandbox_backend,
     get_sandbox_id_from_metadata,
-    unregister_sandbox_backend_proxy,
 )
 
 
@@ -121,7 +120,7 @@ async def test_sandbox_proxy_offload_falls_back_when_backend_lacks_it() -> None:
 @pytest.mark.asyncio
 async def test_sandbox_proxy_reconnects_from_metadata_once(monkeypatch: pytest.MonkeyPatch) -> None:
     thread_id = "thread-1"
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
     created: list[str] = []
 
     async def get_sandbox_id_from_metadata(requested_thread_id: str) -> str:
@@ -153,7 +152,7 @@ async def test_sandbox_proxy_reconnects_from_metadata_once(monkeypatch: pytest.M
         "sandbox-1: cmd-4: None",
     ]
     assert proxy.current.id == "sandbox-1"
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
 
 
 @pytest.mark.asyncio
@@ -161,7 +160,7 @@ async def test_sandbox_proxy_uses_registered_reconnect_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     thread_id = "thread-1"
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
     reconnected: list[str] = []
 
     async def reconnect():
@@ -188,7 +187,7 @@ async def test_sandbox_proxy_uses_registered_reconnect_once(
         "sandbox-1: cmd-3: None",
         "sandbox-1: cmd-4: None",
     ]
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
 
 
 @pytest.mark.asyncio
@@ -311,7 +310,7 @@ async def test_sandbox_proxy_delegates_delete_after_lazy_startup() -> None:
 @pytest.mark.asyncio
 async def test_get_sandbox_backend_awaits_registered_startup() -> None:
     thread_id = "thread-1"
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
     release = asyncio.Event()
 
     async def reconnect():
@@ -329,7 +328,7 @@ async def test_get_sandbox_backend_awaits_registered_startup() -> None:
 
     release.set()
     assert await waiter is proxy
-    unregister_sandbox_backend_proxy(thread_id)
+    SANDBOX_BACKENDS.pop(thread_id, None)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1769,7 +1769,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.11.1"
+version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1787,9 +1787,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/57/7b6c11080c9e082ebf1456a2e2372fae8f23a85a5ae2869bdd5ab9a6507d/langsmith-0.11.1.tar.gz", hash = "sha256:47998977366acb3ba3093881fd465cbf11a5f8c2f4e87e40a17dda203f6dedf4", size = 4814724, upload-time = "2026-08-19T15:47:44.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/0a/1acb2a3ffbccbe8f8dc358778967c9d2979e8a59b67ceba6eb54474324ab/langsmith-0.11.2.tar.gz", hash = "sha256:927694c939c9fb44187e0126cf718413c45ffce2324d480438e70eb0526e1380", size = 4841592, upload-time = "2026-08-27T22:31:34.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/85/0ad6df25588122760b2b40ec182eafc55532c9e66015c83e16675bd34a29/langsmith-0.11.1-py3-none-any.whl", hash = "sha256:cfc3437a9cf27440cd0095c24df945edbceb6df10b579bc8b3980b4ad367835f", size = 744589, upload-time = "2026-08-19T15:47:42.043Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d9/cec0c1d24dda8c67a23ad204d0167e50aee202460e9388488661d94513f5/langsmith-0.11.2-py3-none-any.whl", hash = "sha256:75258142d27dffcc5df331479704b23fc3fd812cfca0469119bb9055a842882f", size = 753928, upload-time = "2026-08-27T22:31:31.644Z" },
 ]
 
 [package.optional-dependencies]
@@ -2159,7 +2159,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.2.10" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.31" },
     { name = "langgraph-sdk", specifier = ">=0.4.2" },
-    { name = "langsmith", specifier = ">=0.11.1" },
+    { name = "langsmith", specifier = ">=0.11.2" },
     { name = "markdownify", specifier = ">=1.2.3" },
     { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.1" },


### PR DESCRIPTION
A WebSocket upgrade rejected with a gateway status (500/502/503/504) raises `SandboxRetryableConnectionError`, and a blanket `except SandboxClientError` in `ToolErrorMiddleware` treated it as a dead sandbox: unregister the backend, tell the user their sandbox stopped responding, tell the model to stop calling sandbox tools. A 503 blip ended the run and left merge-conflict resolutions and reviewer fixes uncommitted.

The linked traces show it firing on `execute` and `read_file` mid-run, and on the startup `git config` write inside `_connect_existing_sandbox`.

**Retry.** `agent/utils/sandbox_retry.py` retries `SandboxRetryableConnectionError` four times with exponential backoff and jitter, wired into `TimeoutLangSmithSandbox.aexecute` — the choke point every sandbox command in the repo goes through, tool calls and the startup identity write alike. The SDK raises this error only when the execute frame never went out, so re-issuing the same command cannot double-run it.

**Discrimination.** The middleware no longer treats every `SandboxClientError` the same:

- Transient: report that nothing ran, leave the backend registered, no user notification. No instructions — the model decides.
- Terminal: notify the user once, then propagate. `ToolNode` is built without `handle_tool_errors`, so its default handler re-raises anything that is not a `ToolInvocationError` and the run ends. Previously it returned an error message and the model kept calling a dead backend, re-notifying the user on every attempt until the step limit.

Also drops `clear_sandbox_backend`. It never protected the next agent run — `get_agent` calls `backend.start()` every run, which re-runs `ensure_sandbox_for_thread` whether or not the registry entry survived — and there is no evidence popping the entry ever resolved anything.

`langsmith` is pinned to `>=0.11.2` so `SandboxRetryableConnectionError` can be imported directly.

## Test Plan

- [x] `make test` — full suite green; `tests/sandbox` and `tests/agent` re-run after the final change
- [x] `make lint` and `make typecheck` clean
- [x] New coverage: retry helper (backoff growth, terminal errors not retried, bounded attempts), `aexecute` retrying a 503 and succeeding, middleware keeping the backend on a transient error, middleware raising on a terminal one

<!-- langsmith-issue {"id":"f23d2f11-5e8f-4d93-8cb4-6674eb9c5218"} -->

