### PR TITLE
fix(slack): queue message edits instead of running them

### DIFF
--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -359,6 +359,7 @@ def _slack_context_input(
     channel_id: str,
     bot_user_id: str,
     event_ts: str,
+    trigger_user_id: str = "",
     request_text: str,
     request_blocks: list[dict[str, Any]],
     operational_context: str,
@@ -408,11 +409,17 @@ def _slack_context_input(
             },
         )
     )
-    trigger_id = next(
+    # An edit's `event_ts` matches no message, and the approve-button path passes
+    # the ts of Open SWE's own button message, so matching history attributes the
+    # run to nobody or to the bot. The caller already knows who triggered it.
+    trigger_id = trigger_user_id or next(
         (
             str(message.get("user"))
             for message in messages
-            if str(message.get("ts", "")) == str(event_ts) and message.get("user")
+            if str(message.get("ts", "")) == str(event_ts)
+            and message.get("user")
+            and not slack_utils.is_own_slack_message(message, bot_user_id)
+            and not slack_utils.slack_message_bot_id(message)
         ),
         "unknown",
     )
@@ -872,6 +879,7 @@ async def _process_slack_mention_impl(
         channel_id=channel_id,
         bot_user_id=bot_user_id,
         event_ts=event_ts,
+        trigger_user_id=user_id,
         request_text=clean_text,
         request_blocks=content_blocks,
         operational_context=operational_context,

--- a/agent/webhooks/slack.py
+++ b/agent/webhooks/slack.py
@@ -29,8 +29,11 @@ from agent.source_context import SlackThreadRef, SourceContext
 from agent.utils import slack as slack_utils
 from agent.utils.json_types import as_json_object
 from agent.utils.langsmith import get_langsmith_trace_url
+from agent.utils.thread_ops import (
+    langgraph_client as get_langgraph_client,
+)
+from agent.utils.thread_ops import queue_message_for_thread
 
-from ..utils.thread_ops import langgraph_client as get_langgraph_client
 from ..utils.user_messages import warning
 from . import common
 
@@ -863,6 +866,16 @@ async def _process_slack_mention_impl(
         source_context=SourceContext.parse({"slack_thread": configurable["slack_thread"]}),
         environment=environment_slug,
     )
+
+    # An edit corrects a request the agent already has, so it belongs in the
+    # thread's message queue rather than in a run of its own. Nothing drains that
+    # queue while the thread is idle; an edit made after the agent finished waits
+    # for the next message.
+    if message_update and await queue_message_for_thread(
+        thread_id, [{"type": "text", "text": _MESSAGE_UPDATE_PREAMBLE.strip()}, *content_blocks]
+    ):
+        common.logger.info("Queued Slack message edit for thread %s", thread_id)
+        return
 
     explicitly_tagged = _interrupts_active_run(
         text,

--- a/agent/webhooks/slack_routes.py
+++ b/agent/webhooks/slack_routes.py
@@ -357,9 +357,9 @@ async def slack_webhook(
             or previous_thread_ts != thread_ts
         ):
             return {"status": "ignored", "reason": "Updated message identity changed"}
-        if text == previous_message.get("text") and attachments == previous_message.get(
-            "attachments", []
-        ):
+        # Link unfurls arrive as edits that only add `attachments`, so comparing
+        # them starts a run for text the agent has already been given.
+        if text == previous_message.get("text"):
             return {"status": "ignored", "reason": "No user-visible message changes"}
 
     # A code channel is one session for the whole channel, so every message in it

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1732,3 +1732,83 @@ def test_slack_trigger_is_never_attributed_to_open_swe() -> None:
     assert not any('id="slack:UBOT"' in text for text in contents)
     assert not any('sender="slack:UBOT"' in text for text in contents)
     assert any('id="slack:U123"' in text for text in contents)
+
+
+def test_process_slack_mention_queues_a_message_edit_instead_of_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An edit is a correction to work already in flight, not a new request."""
+    captured: dict[str, object] = {}
+    _setup_slack_mention_fakes(monkeypatch, captured)
+
+    async def fake_thread_exists(thread_id: str) -> bool:
+        return True
+
+    async def fake_queue_message_for_thread(thread_id: str, content: object) -> bool:
+        captured["queued"] = {"thread_id": thread_id, "content": content}
+        return True
+
+    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(slack_webhooks, "queue_message_for_thread", fake_queue_message_for_thread)
+
+    asyncio.run(
+        slack_webhooks.process_slack_mention(
+            {
+                "channel_id": "C123",
+                "thread_ts": "1700000000.000100",
+                "event_ts": "1700000000.000300",
+                "user_id": "U123",
+                "text": "<@UBOT> actually use PR 5889",
+                "bot_user_id": "UBOT",
+                "message_update": True,
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    assert "run_create" not in captured
+    queued = captured["queued"]
+    assert isinstance(queued, dict)
+    assert queued["thread_id"] == "mapped-thread"
+    blocks = cast(list, queued["content"])
+    text = "\n".join(
+        block["text"] for block in blocks if isinstance(block, dict) and block.get("text")
+    )
+    assert "actually use PR 5889" in text
+    assert "edited" in text
+
+
+def test_process_slack_mention_runs_an_edit_when_queueing_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A store outage must not swallow the correction outright."""
+    captured: dict[str, object] = {}
+    _setup_slack_mention_fakes(monkeypatch, captured)
+
+    async def fake_thread_exists(thread_id: str) -> bool:
+        return True
+
+    async def fake_queue_message_for_thread(thread_id: str, content: object) -> bool:
+        return False
+
+    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(slack_webhooks, "queue_message_for_thread", fake_queue_message_for_thread)
+
+    asyncio.run(
+        slack_webhooks.process_slack_mention(
+            {
+                "channel_id": "C123",
+                "thread_ts": "1700000000.000100",
+                "event_ts": "1700000000.000300",
+                "user_id": "U123",
+                "text": "<@UBOT> actually use PR 5889",
+                "bot_user_id": "UBOT",
+                "message_update": True,
+            },
+            {"owner": "langchain-ai", "name": "open-swe"},
+        )
+    )
+
+    run_create = captured["run_create"]
+    assert isinstance(run_create, dict)
+    assert run_create["kwargs"]["multitask_strategy"] == "enqueue"

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1668,3 +1668,67 @@ def test_format_slack_messages_for_prompt_does_not_label_a_lookalike_as_self() -
     )
 
     assert formatted == "@Open SWE(bot) [message_ts=1.0]: impersonating"
+
+
+def _trigger_identities(
+    messages: list[dict],
+    *,
+    event_ts: str,
+    trigger_user_id: str,
+    user_names_by_id: dict | None = None,
+    logins_by_user_id: dict | None = None,
+) -> list[str]:
+    run_input = slack_webhooks._slack_context_input(
+        messages,
+        user_names_by_id if user_names_by_id is not None else {"U123": "Alice", "UBOT": "Open SWE"},
+        logins_by_user_id if logins_by_user_id is not None else {},
+        channel_id="C123",
+        bot_user_id="UBOT",
+        event_ts=event_ts,
+        trigger_user_id=trigger_user_id,
+        request_text="do the thing",
+        request_blocks=[{"type": "text", "text": "do the thing"}],
+        operational_context="## Open SWE Links",
+    )
+    return [cast(str, message["content"]) for message in run_input["messages"]]
+
+
+def test_slack_trigger_resolves_from_the_triggering_user_not_the_event_ts() -> None:
+    """A `message_changed` event's `event_ts` matches no message in the window.
+
+    Keying the trigger off `event_ts` yields `slack:unknown`, so the agent is
+    told the request came from nobody and the sender-context dedupe misses.
+    """
+    contents = _trigger_identities(
+        [{"ts": "1.0", "text": "please fix it", "user": "U123"}],
+        event_ts="9.5",
+        trigger_user_id="U123",
+        user_names_by_id={"U123": "Alice"},
+        logins_by_user_id={"U123": "alice-gh"},
+    )
+
+    assert not any("slack:unknown" in text for text in contents)
+    trigger = next(text for text in contents if 'id="slack:U123"' in text)
+    assert "<display_name>Alice</display_name>" in trigger
+    assert "<github_login>alice-gh</github_login>" in trigger
+
+
+def test_slack_trigger_is_never_attributed_to_open_swe() -> None:
+    """The approve-button path passes the ts of Open SWE's own button message.
+
+    Matching that ts against thread history attributes the run to the bot as a
+    person, so the prompt claims a human asked for the retry.
+    """
+    contents = _trigger_identities(
+        [
+            {"ts": "1.0", "text": "please fix it", "user": "U123"},
+            {"ts": "9.0", "text": "Approve workflow push", "user": "UBOT", "bot_id": "B1"},
+        ],
+        event_ts="9.0",
+        trigger_user_id="U123",
+        user_names_by_id={"U123": "Alice", "UBOT": "Open SWE"},
+    )
+
+    assert not any('id="slack:UBOT"' in text for text in contents)
+    assert not any('sender="slack:UBOT"' in text for text in contents)
+    assert any('id="slack:U123"' in text for text in contents)

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1713,11 +1713,11 @@ def test_slack_trigger_resolves_from_the_triggering_user_not_the_event_ts() -> N
     assert "<github_login>alice-gh</github_login>" in trigger
 
 
-def test_slack_trigger_is_never_attributed_to_open_swe() -> None:
-    """The approve-button path passes the ts of Open SWE's own button message.
+def test_slack_trigger_falls_back_past_open_swes_own_message() -> None:
+    """`event_ts` can name Open SWE's own message, as the approve-button path does.
 
-    Matching that ts against thread history attributes the run to the bot as a
-    person, so the prompt claims a human asked for the retry.
+    Covers the fallback with no explicit trigger user, so the self/bot checks
+    decide: without them the bot is attributed as a `kind="human"` person.
     """
     contents = _trigger_identities(
         [
@@ -1725,13 +1725,12 @@ def test_slack_trigger_is_never_attributed_to_open_swe() -> None:
             {"ts": "9.0", "text": "Approve workflow push", "user": "UBOT", "bot_id": "B1"},
         ],
         event_ts="9.0",
-        trigger_user_id="U123",
+        trigger_user_id="",
         user_names_by_id={"U123": "Alice", "UBOT": "Open SWE"},
     )
 
     assert not any('id="slack:UBOT"' in text for text in contents)
     assert not any('sender="slack:UBOT"' in text for text in contents)
-    assert any('id="slack:U123"' in text for text in contents)
 
 
 def test_process_slack_mention_queues_a_message_edit_instead_of_running(

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -350,27 +350,11 @@ async def test_message_update_from_a_bot_is_ignored() -> None:
     assert background_tasks.tasks == []
 
 
-async def test_message_update_ignores_metadata_only_changes() -> None:
-    """Restores the case #2287 added the guard for and then deleted the test for."""
-    payload = _message_update_payload()
-    payload["event"]["previous_message"]["text"] = "new corrected text"
-    payload["event"]["message"]["app_context"] = {"payload": {"version": 2}}
-    background_tasks = _FakeBackgroundTasks()
-
-    response = await slack_routes.slack_webhook(
-        cast(Request, _FakeRequest(payload)),
-        cast(BackgroundTasks, background_tasks),
-    )
-
-    assert response == {"status": "ignored", "reason": "No user-visible message changes"}
-    assert background_tasks.tasks == []
-
-
 async def test_message_update_ignores_link_unfurl_attachments() -> None:
     """Slack unfurls a link by editing the message to add `attachments`.
 
-    The text the user wrote is unchanged, so there is nothing new to act on,
-    but comparing `attachments` lets the edit through and starts a second run.
+    Stands in for every metadata-only edit: the text the user wrote is
+    unchanged, so there is nothing new to act on whatever else moved.
     """
     payload = _message_update_payload()
     payload["event"]["previous_message"]["text"] = "new corrected text"

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -348,3 +348,45 @@ async def test_message_update_from_a_bot_is_ignored() -> None:
 
     assert response == {"status": "ignored", "reason": "Event from a bot"}
     assert background_tasks.tasks == []
+
+
+async def test_message_update_ignores_metadata_only_changes() -> None:
+    """Restores the case #2287 added the guard for and then deleted the test for."""
+    payload = _message_update_payload()
+    payload["event"]["previous_message"]["text"] = "new corrected text"
+    payload["event"]["message"]["app_context"] = {"payload": {"version": 2}}
+    background_tasks = _FakeBackgroundTasks()
+
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload)),
+        cast(BackgroundTasks, background_tasks),
+    )
+
+    assert response == {"status": "ignored", "reason": "No user-visible message changes"}
+    assert background_tasks.tasks == []
+
+
+async def test_message_update_ignores_link_unfurl_attachments() -> None:
+    """Slack unfurls a link by editing the message to add `attachments`.
+
+    The text the user wrote is unchanged, so there is nothing new to act on,
+    but comparing `attachments` lets the edit through and starts a second run.
+    """
+    payload = _message_update_payload()
+    payload["event"]["previous_message"]["text"] = "new corrected text"
+    payload["event"]["message"]["attachments"] = [
+        {
+            "service_name": "GitHub",
+            "title": "Fix the thing by someone · Pull Request #5888",
+            "title_link": "https://github.com/langchain-ai/deepagents/pull/5888",
+        }
+    ]
+    background_tasks = _FakeBackgroundTasks()
+
+    response = await slack_routes.slack_webhook(
+        cast(Request, _FakeRequest(payload)),
+        cast(BackgroundTasks, background_tasks),
+    )
+
+    assert response == {"status": "ignored", "reason": "No user-visible message changes"}
+    assert background_tasks.tasks == []


### PR DESCRIPTION
Slack thread [9bea18fb](https://smith.langchain.com/o/ebbaf2eb-769b-4505-aca2-d11de10372a4/projects/p/59d8eede-6867-4113-8733-70d74486770e/t/9bea18fb-eb29-5147-ae5e-300082fe8376) ran four agent turns from a single mention. Two were link-unfurl edits; one was the approve-workflow-push button. Two of the four produced no output at all.

## Edits queue instead of running

An edit corrects a request the agent already has, so it no longer gets a run of its own. It goes into the thread's message queue and `check_message_queue_before_model` picks it up on the next model call:

```python
if message_update and await queue_message_for_thread(
    thread_id, [{"type": "text", "text": _MESSAGE_UPDATE_PREAMBLE.strip()}, *content_blocks]
):
```

Previously edits went through `dispatch_agent_run(multitask_strategy="enqueue")`, which always creates a run — it just waits for the active one to drain. In the traced thread that produced two runs at 18:28:41 and 18:28:57, firing the instant the main run finished, both emitting nothing.

**Known tradeoff:** the queue's consumer is a before-model hook, so nothing drains it while the thread is idle. An edit made after the agent finished waits for the next message. This is deliberate — the alternative was waking a run just to drain the queue. A *failed store write* still falls back to a run, so a transient outage doesn't drop the correction.

Reactions already never triggered a work run — feedback reactions record LangSmith feedback, `x` cancels and posts a deliberate summary, everything else is ignored — so they are unchanged.

## Trigger identity

`_slack_context_input` derived the run's trigger by matching `event_ts` against fetched thread history:

```python
trigger_id = next(
    (str(message.get("user")) for message in messages
     if str(message.get("ts", "")) == str(event_ts) and message.get("user")),
    "unknown",
)
```

Two paths pass a ts that is not a message in that window:

| Path | `event_ts` points at | Result |
|---|---|---|
| `message_changed` | the edit event | no match → `slack:unknown` |
| Approve workflow push | Open SWE's own button message | the bot, as a `kind="human"` person |

Downstream in that thread: `slack_add_reaction` failed against an event ts, and sender-context was re-sent three times byte-identically because `subject_id` differed on every run.

The webhook already knows the triggering user and persists it — all four runs recorded `triggering_user_id: U0917JZ8NLB`, so the right value sat in `source_context` and never reached the prompt. It is now passed through. The history fallback also applies the `is_own_slack_message` / `bot_id` checks `_slack_sender` already used, so the bot cannot be attributed as a person even with no explicit id.

[#2107](https://github.com/langchain-ai/open-swe/pull/2107) built that self/bot classification but wired it only into the history loop; this line bypassed it.

## Metadata-only edit guard

[#2287](https://github.com/langchain-ai/open-swe/pull/2287) added:

```python
if text == previous_message.get("text") and attachments == previous_message.get("attachments", []):
```

Slack unfurls a link by editing the message to add `attachments`, so the `and` short-circuits and the edit passes. Now compares `text` alone — a text-identical edit has nothing actionable regardless of which metadata field moved.

#2287 also deleted its own regression test in a follow-up commit (`8cef2cf8c` added it, `3a7c287a5` removed it). The unfurl test here guards the same branch, so it covers metadata-only edits generally.

For the record, #2287 was not live for the thread above: all four runs report `LANGSMITH_LANGGRAPH_GIT_REF_SHA = 4388627d0`, which predates it.

## Test Plan

- [x] `uv run pytest tests/` — 1979 passed, 3 skipped
- [x] `tests/slack/test_slack_context.py`: edit queues without creating a run; a failed queue write still dispatches; trigger identity on the edit path (`event_ts` matching nothing) and the button path (`event_ts` on the bot's own message)
- [x] `tests/slack/test_slack_untagged_flag.py`: metadata-only edit (link unfurl) ignored
- [x] Mutation-checked the trigger fallback: deleting the self/bot conditions fails `test_slack_trigger_falls_back_past_open_swes_own_message`
- [x] `make lint`, `uv run basedpyright agent/webhooks/slack.py agent/webhooks/slack_routes.py`

[no screenshot]
