### PR TITLE
fix: show Slack command details

### DIFF
--- a/agent/slack_thinking.py
+++ b/agent/slack_thinking.py
@@ -73,7 +73,7 @@ def _tool_step(name: str, tool_input: Any) -> tuple[str, str]:
     if name in {"web_search", "fetch_url"}:
         return "Searching external documentation", "External source lookup"
     if name in {"execute", "background_execute"}:
-        return "Running a development command", "Command details hidden"
+        return "Running a development command", _text_arg(tool_input, "command")
     if name == "task":
         agent = _text_arg(tool_input, "subagent_type").replace("-", " ")
         return f"Delegating to {agent or 'a specialist'}", "Specialized agent task"

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -56,8 +56,7 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
     final_chunks = stop.await_args.args[2]
     serialized = str(final_chunks)
     assert "Running a development command" in serialized
-    assert "Command details hidden" in serialized
-    assert "secret-token" not in serialized
+    assert "echo secret-token" in serialized
     assert final_chunks[-1]["status"] == "complete"
     assert final_chunks[-1]["output"] == "Completed"
 


### PR DESCRIPTION
### Summary
- show the full `execute` and `background_execute` command in code-channel Thinking Steps
- retain Slack’s existing 256-character task-detail limit
- update focused stream coverage to verify command details are rendered

### Testing
- `uv run pytest -vvv tests/slack/test_slack_thinking.py`
- `make lint`
- `uv run basedpyright agent/slack_thinking.py tests/slack/test_slack_thinking.py`

Made by [Open SWE](https://openswe.vercel.app/agents/5ac95680-451b-5662-a10f-8c86a70479f1)