### PR TITLE
fix: read DEFAULT_PROMPT_PATH as UTF-8 and log why a prompt was skipped

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -25,7 +25,7 @@ def _load_default_prompt() -> str:
     """
     try:
         if DEFAULT_PROMPT_PATH:
-            content = Path(DEFAULT_PROMPT_PATH).read_text().strip()
+            content = Path(DEFAULT_PROMPT_PATH).read_text(encoding="utf-8").strip()
         else:
             content = (
                 resources.files("agent.resources")
@@ -40,9 +40,9 @@ def _load_default_prompt() -> str:
 ### Custom Instructions
 
 {escaped}"""
-    except Exception:
-        logger.warning(
-            "Failed to read default prompt from %s",
+    except (OSError, UnicodeDecodeError):
+        logger.exception(
+            "Failed to read default prompt from %s; continuing without custom instructions",
             DEFAULT_PROMPT_PATH or "agent.resources/default_prompt.md",
         )
     return ""

--- a/tests/agent/test_default_prompt.py
+++ b/tests/agent/test_default_prompt.py
@@ -1,0 +1,38 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from agent import prompt as prompt_mod
+
+# U+00CD encodes to C3 8D in UTF-8, and 0x8D is undefined in cp1252 — the byte the
+# original report failed on. Reading this with the Windows locale encoding raises
+# rather than quietly producing mojibake, so it pins the encoding rather than the
+# happy path.
+_NON_CP1252_TEXT = "Prefer ÍSO dates — always."
+
+
+def test_default_prompt_path_is_read_as_utf8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prompt_file = tmp_path / "org-prompt.md"
+    prompt_file.write_text(_NON_CP1252_TEXT, encoding="utf-8")
+    monkeypatch.setattr(prompt_mod, "DEFAULT_PROMPT_PATH", str(prompt_file))
+
+    section = prompt_mod._load_default_prompt()
+
+    assert _NON_CP1252_TEXT in section
+    assert "### Custom Instructions" in section
+
+
+def test_unreadable_default_prompt_path_logs_the_cause_and_keeps_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(prompt_mod, "DEFAULT_PROMPT_PATH", str(tmp_path / "absent.md"))
+
+    with caplog.at_level(logging.ERROR, logger=prompt_mod.logger.name):
+        assert prompt_mod._load_default_prompt() == ""
+
+    assert "Failed to read default prompt" in caplog.text
+    # The traceback is what tells an operator why their file was skipped.
+    assert "FileNotFoundError" in caplog.text


### PR DESCRIPTION
Fixes #2304.

## Problem

`_load_default_prompt()` reads the same kind of file down two branches of one `if/else`, and only one of them specifies an encoding:

```python
if DEFAULT_PROMPT_PATH:
    content = Path(DEFAULT_PROMPT_PATH).read_text().strip()          # no encoding
else:
    content = (
        resources.files("agent.resources")
        .joinpath("default_prompt.md")
        .read_text(encoding="utf-8")                                  # encoding
        .strip()
    )
```

`Path.read_text()` defaults to `locale.getencoding()`, which is cp1252 on a typical Windows host. So an operator who follows [CUSTOMIZATION.md](../blob/main/docs/CUSTOMIZATION.md#default-prompt-file) and points `DEFAULT_PROMPT_PATH` at a UTF-8 prompt file containing any non-ASCII character — a curly quote, an em dash, an accented name — gets a `UnicodeDecodeError`.

The bare `except Exception` then swallowed it, logged a single line with no cause, and returned `""`.

The result is the failure mode that matters here: **the agent runs with the operator's org-level instructions silently missing.** Nothing is raised, nothing distinguishes it from a healthy deployment, and the one log line does not say why. `_load_default_prompt()` is called from `construct_system_prompt`, so this happens on every run.

The bundled default is unaffected — it is ASCII and already passed `encoding="utf-8"`.

## Change

**1. `encoding="utf-8"` on the operator branch**, so the documented customization path works regardless of host locale. This is the substantive fix.

**2. `logger.exception` instead of `logger.warning`**, and a message that says the run is continuing without custom instructions. A missing file, a permission error and a decode error previously produced identical output; now the traceback says which.

**3. The catch narrows to `(OSError, UnicodeDecodeError)`** — the realistic failures for a file read — so an unexpected error surfaces instead of being absorbed into a silent empty string.

## On what I did *not* do

The issue also floated raising when `DEFAULT_PROMPT_PATH` is explicitly set. I did not, because `_load_default_prompt()` runs on every prompt construction rather than once at startup, so a raise turns a config typo into a total outage rather than a loud startup failure. Warn-and-continue seems right at that call site. Happy to switch if you would rather fail fast — it is a one-line change.

Point 3 is worth a second opinion. It means a `ModuleNotFoundError` from `resources.files("agent.resources")` would now propagate instead of being swallowed. That seems correct to me — if the bundled resources package is missing the app is broken and should say so — but it is a behaviour change on the packaged/frozen path, so say the word if you would rather keep the broad catch with just the better logging.

## Tests

New `tests/agent/test_default_prompt.py`, two cases:

- The operator file is read as UTF-8. The fixture text contains `Í`, which encodes to `C3 8D`; byte `0x8D` is undefined in cp1252, so this decodes correctly under UTF-8 and raises under the Windows locale rather than quietly producing mojibake. It pins the encoding rather than the happy path.
- An unreadable path returns `""` without raising, and the log carries `FileNotFoundError` — covering the logging change.

Confirmed the first test actually catches the bug by reverting the one-line fix:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 8: character maps to <undefined>
FAILED tests/agent/test_default_prompt.py::test_default_prompt_path_is_read_as_utf8
1 failed, 1 passed
```

and with the fix restored: `2 passed`.

`ruff check`, `ruff format --diff` and `basedpyright agent tests` are all clean.
