### PR TITLE
test: skip the POSIX-shell html artifact tests on Windows

### DIFF
--- a/tests/utils/test_html_artifact.py
+++ b/tests/utils/test_html_artifact.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 
@@ -42,6 +43,17 @@ def test_scripts_and_forms_survive_wrapping() -> None:
     assert f"<title>{DEFAULT_TITLE}</title>" in wrapped
 
 
+# sandbox_wrap_command emits a POSIX pipeline (printf | base64 -d | python3 -) for
+# the Linux sandbox to run. subprocess.run(shell=True) sends it through cmd.exe on
+# Windows, which has neither base64 nor python3 and does not treat ' as a quote.
+# Deliberately keyed on the platform rather than on tool availability, so a POSIX
+# CI box missing python3 fails loudly instead of quietly skipping.
+_requires_posix_shell = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="sandbox_wrap_command is a POSIX shell pipeline",
+)
+
+
 @pytest.mark.parametrize(
     "content",
     [
@@ -54,6 +66,7 @@ def test_scripts_and_forms_survive_wrapping() -> None:
         "<h1>caf\u00e9 \u2014 na\u00efve</h1>",
     ],
 )
+@_requires_posix_shell
 def test_sandbox_command_matches_in_process_wrapping(content: str, tmp_path) -> None:
     source = tmp_path / "artifact.html"
     destination = tmp_path / "snapshot.html"
@@ -69,6 +82,7 @@ def test_sandbox_command_matches_in_process_wrapping(content: str, tmp_path) -> 
     assert int(result.stdout.strip()) == len(expected.encode())
 
 
+@_requires_posix_shell
 def test_sandbox_command_truncates_at_the_limit(tmp_path) -> None:
     source = tmp_path / "artifact.html"
     destination = tmp_path / "snapshot.html"


### PR DESCRIPTION
Fixes #2306.

## Problem

`sandbox_wrap_command` emits a POSIX pipeline for the Linux sandbox to run:

```
printf %s <base64 blob> | base64 -d | python3 - '<src>' '<dst>' 32 '<prefix>' '<suffix>'
```

Two tests execute it on the *host* with `subprocess.run(shell=True, check=True)`. On Windows that goes through `cmd.exe`, which has neither `base64` nor `python3` and does not treat `'` as a quote character. All eight tests (one is parametrized ×7) fail:

```
subprocess.CalledProcessError: Command 'printf %s ... | base64 -d | python3 - ...'
returned non-zero exit status 1
```

None of the failures say anything about the code under test, which is what makes them worth fixing rather than tolerating: a contributor on Windows cannot tell a standing red suite from one their change caused.

## Change

`skipif(sys.platform == "win32")` on the two shell-dependent functions.

## Two deliberate departures from the issue text

I wrote that issue, and following its suggestion literally would have been wrong on both counts.

**1. Per-function marks, not `pytestmark`.** The issue proposed a module-level `pytestmark`, then said in the next sentence that "the in-process wrapping logic these tests compare against is platform-independent and can keep running everywhere". Those contradict each other — a module-level mark would skip all fourteen tests in the file, including the six that exercise `wrap_html_artifact` purely in process and have no shell dependency at all. The mark is applied to the two shell tests only.

**2. Keyed on platform, not on tool availability.** `shutil.which("base64")` / `which("python3")` would be the more general condition, but it degrades badly: a POSIX CI box missing `python3` would silently skip the tests rather than fail. Since these tests are the only coverage of the sandbox command's behaviour, a loud failure is the right outcome there. `sys.platform == "win32"` skips exactly the environment that genuinely cannot run the pipeline.

## Effect

Windows, this file: **6 passed / 8 failed → 6 passed / 8 skipped.**

```
....ssssssss..
SKIPPED [7] tests/utils/test_html_artifact.py:57: sandbox_wrap_command is a POSIX shell pipeline
SKIPPED [1] tests/utils/test_html_artifact.py:85: sandbox_wrap_command is a POSIX shell pipeline
6 passed, 8 skipped
```

CI runs `ubuntu-latest`, so all fourteen still execute there — **no CI coverage is lost**. Collection count is unchanged at 14.

`ruff check`, `ruff format --diff` and `basedpyright agent tests` are clean. The change touches one test file and nothing under `agent/`, so there is no regression surface beyond it.
