### PR TITLE
fix: warn when ALLOWED_GITHUB_ORGS leaves dashboard login unrestricted

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -9,6 +9,7 @@ import re
 import secrets
 import time
 from datetime import UTC, datetime, timedelta
+from functools import cache
 from typing import Any
 from urllib.parse import quote, urlparse
 
@@ -169,15 +170,38 @@ def _allowed_login_orgs() -> frozenset[str]:
     )
 
 
+@cache
+def _warn_login_gate_disabled() -> None:
+    """Announce the fail-open login gate once per process.
+
+    Every other unset secret here says so in the log — see the
+    ``GITHUB_WEBHOOK_SECRET``/``SLACK_SIGNING_SECRET`` warnings and the one in
+    ``agent.completion``. Those all fail closed, so a missed warning costs a
+    rejected request. This gate fails open, so a missed warning costs an
+    unrestricted dashboard, which is the case that most needs saying out loud.
+
+    Cached rather than logged per call because ``enforce_org_login_gate`` also
+    runs from the thread tools, not only from the OAuth callback.
+    """
+    logger.warning(
+        "ALLOWED_GITHUB_ORGS is not configured — dashboard login is open to any GitHub "
+        "account, and every logged-in user can read all surfaced threads. Set it to "
+        "restrict logins to members of your organization(s)."
+    )
+
+
 async def enforce_org_login_gate(login: str) -> None:
     """Reject dashboard login for users outside the allowed GitHub org(s).
 
-    No-op when ``ALLOWED_GITHUB_ORGS`` is unset. Otherwise the user must be an
-    active member of at least one configured org; membership is checked with
-    the GitHub App installation token (fail-closed on any API error).
+    No-op when ``ALLOWED_GITHUB_ORGS`` is unset, which leaves login open to any
+    GitHub account; that case warns once per process rather than passing
+    silently. Otherwise the user must be an active member of at least one
+    configured org; membership is checked with the GitHub App installation
+    token (fail-closed on any API error).
     """
     orgs = _allowed_login_orgs()
     if not orgs:
+        _warn_login_gate_disabled()
         return
     for org in orgs:
         if await is_user_active_org_member(login, org):

--- a/tests/dashboard/test_dashboard_org_login_gate.py
+++ b/tests/dashboard/test_dashboard_org_login_gate.py
@@ -1,5 +1,7 @@
 """Tests for the dashboard GitHub-org login gate (ALLOWED_GITHUB_ORGS)."""
 
+import logging
+
 import pytest
 from fastapi import HTTPException
 
@@ -75,3 +77,52 @@ async def test_gate_rejects_when_member_of_no_configured_org(monkeypatch) -> Non
 
     assert exc.value.status_code == 403
     assert {org for _, org in seen["calls"]} == {"langchain-ai", "anthropics"}
+
+
+def _gate_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if "ALLOWED_GITHUB_ORGS is not configured" in record.getMessage()
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gate_warns_once_when_unset(monkeypatch, caplog) -> None:
+    """The gate fails open when unset, so it has to say so — every other unset
+    secret in the codebase logs a warning, and those all fail closed."""
+    monkeypatch.delenv("ALLOWED_GITHUB_ORGS", raising=False)
+    oauth._warn_login_gate_disabled.cache_clear()
+    _stub_membership(monkeypatch, {})
+
+    with caplog.at_level(logging.WARNING, logger=oauth.logger.name):
+        await oauth.enforce_org_login_gate("anyone")
+        await oauth.enforce_org_login_gate("someone-else")
+
+    # Once per process, not once per call: the gate also runs from the thread
+    # tools, which would otherwise flood the log.
+    assert len(_gate_warnings(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_warns_when_blank(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("ALLOWED_GITHUB_ORGS", "  ,  ")
+    oauth._warn_login_gate_disabled.cache_clear()
+    _stub_membership(monkeypatch, {})
+
+    with caplog.at_level(logging.WARNING, logger=oauth.logger.name):
+        await oauth.enforce_org_login_gate("anyone")
+
+    assert len(_gate_warnings(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_stays_quiet_when_configured(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("ALLOWED_GITHUB_ORGS", "langchain-ai")
+    oauth._warn_login_gate_disabled.cache_clear()
+    _stub_membership(monkeypatch, {"langchain-ai": {"insider"}})
+
+    with caplog.at_level(logging.WARNING, logger=oauth.logger.name):
+        await oauth.enforce_org_login_gate("insider")
+
+    assert _gate_warnings(caplog) == []


### PR DESCRIPTION
Fixes #2307.

## Problem

Every unset secret in this codebase announces itself:

```python
# agent/utils/github_comments.py
logger.warning("GITHUB_WEBHOOK_SECRET is not configured — rejecting webhook request")
# agent/utils/slack.py, agent/webhooks/common.py — same shape
# agent/completion.py — logs one at import for RUN_COMPLETE_WEBHOOK_SECRET
```

`enforce_org_login_gate` was the exception. With `ALLOWED_GITHUB_ORGS` unset it returned immediately and said nothing:

```python
orgs = _allowed_login_orgs()
if not orgs:
    return
```

The asymmetry runs the wrong way. Those other gates **fail closed**, so a missed warning costs a rejected request. This one **fails open**, so a missed warning costs an unrestricted dashboard — every GitHub account on the internet can complete OAuth and get a session.

That matters more than it looks because a second control is built on top of this one. `_thread_is_readable` grants blanket read access to every surfaced thread and cites this gate as its justification:

```python
def _thread_is_readable(metadata) -> bool:
    """Any surfaced-source thread is readable by authenticated users.

    Dashboard login is already gated by ``ALLOWED_GITHUB_ORGS`` ...
    so any logged-in user is a trusted org member.
    """
```

When the gate is a no-op that premise does not hold, and nothing in the logs tells an operator which state their deployment is in.

## Change

Log a warning on the fail-open path.

**Behaviour is unchanged** — still a no-op, still open by default, still the documented back-compat default in `docs/INSTALLATION.md`. It is now merely visible. I deliberately did not make it fail closed: that would break every existing deployment that has not set the variable, and it is not a call an outside contributor should make in a bug-fix PR.

The issue also floated an explicit `ALLOW_UNRESTRICTED_DASHBOARD_LOGIN=true` opt-in, so the open configuration is chosen rather than inherited. That is the stronger fix and I am happy to add it here or in a follow-up — it just needs a maintainer's decision on the compatibility break, so this PR stops at the part that is safe to merge unconditionally.

The warning fires **once per process, not per call**: `enforce_org_login_gate` also runs from the thread tools (`agent/tools/threads.py:108`), not only from the OAuth callback, so a per-call warning would flood the log.

## Tests

Three cases added to the existing `tests/dashboard/test_dashboard_org_login_gate.py`:

- unset → warns, and only once across two calls
- blank/whitespace-only → warns (the existing `_allowed_login_orgs` parsing already treats `"  ,  "` as empty)
- configured → stays quiet

All three fail against unpatched `oauth.py`:

```
FAILED test_gate_warns_once_when_unset
FAILED test_gate_warns_when_blank
FAILED test_gate_stays_quiet_when_configured
3 failed, 6 passed
```

Full dashboard suite **314 passed**; `tests/tools/test_threads.py` (the other call site) 20 passed. `ruff check`, `ruff format --diff` and `basedpyright agent tests` are clean.

## Related, not fixed here

`_is_repo_allowed` and `_is_sender_allowed_for_public_repo` in `agent/webhooks/common.py` fail open the same way when their allowlists are empty. Those sit behind verified webhook signatures so the exposure is narrower, and the docs call that default out explicitly. Happy to give them the same treatment if you want it — I left them out to keep this reviewable.
