### PR TITLE
ci: type-check the dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,22 @@ jobs:
       - name: Run tests
         run: pnpm --filter open-swe-dashboard run test
 
+  ui-typecheck:
+    name: UI typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+      - run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter open-swe-dashboard... --filter open-swe
+      # `js-lint` is oxlint and `build` is Vite, which strips types via esbuild
+      # without checking them, so this is the only job that runs tsc over ui/.
+      - name: Run typecheck
+        run: pnpm --filter open-swe-dashboard run typecheck
+
   desktop:
     name: Desktop checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #2308.

## Problem

The scripts and the turbo task already exist:

```jsonc
// package.json
"typecheck": "turbo run typecheck",
// ui/package.json
"typecheck": "tsc --noEmit",
// turbo.json
"typecheck": {},
```

Nothing in `.github/workflows` invoked them. Grepping the workflow directory for `typecheck` returns only the Python job:

```
.github/workflows/ci.yml:39:  typecheck:
.github/workflows/ci.yml:40:    name: Agent typecheck
.github/workflows/ci.yml:48:        run: make typecheck      # basedpyright, agent/ and tests/ only
```

None of the three jobs that touch `ui/` type-check it:

| Job | Runs | Checks types? |
|---|---|---|
| `js-lint` | `oxlint` | no — lint rules, not types |
| `ui-tests` | `vitest run` | no |
| `desktop` | `pnpm run check` → `turbo run check` | no — `ui` has no `check` script, so turbo skips it |

`desktop`'s own `check` is `typecheck && test && build:ui`, and `build:ui` is a **Vite** build — esbuild strips types without checking them, so it will happily emit a bundle for code that does not type-check. Net effect: `tsc` ran for `desktop/` and never for `ui/`.

That is the larger of the two TypeScript surfaces, and the one pulling the heavy typed dependencies — `@tanstack/react-router`, `@tanstack/react-query`, `@langchain/langgraph-sdk`, `monaco-editor`, `@base-ui/react` — where breakage from a bump usually shows up as a type error first and a runtime error later.

## Change

One job, mirroring the existing `ui-tests` job exactly: same runner, same node 24, same `--frozen-lockfile` filter. The only added comment records why the job needs to exist, since that is the non-obvious part.

## It lands green

The issue predicted this would surface a backlog. **It does not** — I was wrong about that, and it is worth stating plainly since it changes what merging this costs you.

Run locally against `main`:

```
$ pnpm --filter open-swe-dashboard run typecheck
$ tsc --noEmit
=== exit: 0 ===
```

TypeScript 5.9.3, **291 files** under `ui/src` covered, zero errors. So this pins the current clean state rather than importing a backlog, and needs no follow-up fixes.

The job is not vacuous either. Appending one bad line to `ui/src/client.tsx`:

```
src/client.tsx(12,7): error TS2322: Type 'string' is not assignable to type 'number'.
src/client.tsx(12,7): error TS6133: '__typecheck_probe' is declared but its value is never read.
```

Both fire — the second confirms `ui/tsconfig.json`'s `noUnusedLocals` is live, so the job enforces the strict options that config already sets (`strict`, `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`, `noUncheckedSideEffectImports`).

One caveat on the evidence: my local run was on node v22 against CI's node 24. `typescript` and `@types/node` are both lockfile-pinned so I would not expect a difference, but the node version is the one thing my run did not reproduce exactly.
