### PR TITLE
fix: verify Slack signatures over the raw request body

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -176,11 +176,8 @@ def verify_slack_signature(
     if abs(int(time.time()) - request_timestamp) > max_age_seconds:
         return False
 
-    base_string = f"v0:{timestamp}:{body.decode('utf-8', errors='replace')}"
-    expected = (
-        "v0="
-        + hmac.new(secret.encode("utf-8"), base_string.encode("utf-8"), hashlib.sha256).hexdigest()
-    )
+    base_string = b"v0:" + timestamp.encode("utf-8") + b":" + body
+    expected = "v0=" + hmac.new(secret.encode("utf-8"), base_string, hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature)
 
 

--- a/tests/slack/test_slack_signature.py
+++ b/tests/slack/test_slack_signature.py
@@ -1,0 +1,30 @@
+import hashlib
+import hmac
+import time
+
+from agent.utils.slack import verify_slack_signature
+
+
+def _slack_signature(secret: str, timestamp: str, body: bytes) -> str:
+    """HMAC over the raw request body, matching Slack's signing scheme."""
+    base_string = b"v0:" + timestamp.encode("utf-8") + b":" + body
+    return "v0=" + hmac.new(secret.encode("utf-8"), base_string, hashlib.sha256).hexdigest()
+
+
+def test_verify_slack_signature_accepts_valid_utf8_body() -> None:
+    secret = "test-signing-secret"
+    timestamp = str(int(time.time()))
+    body = b'{"type":"url_verification","challenge":"ok"}'
+    signature = _slack_signature(secret, timestamp, body)
+
+    assert verify_slack_signature(body, timestamp, signature, secret) is True
+
+
+def test_verify_slack_signature_accepts_non_utf8_body() -> None:
+    """Slack signs the raw bytes. Invalid UTF-8 must not be lossily re-decoded."""
+    secret = "test-signing-secret"
+    timestamp = str(int(time.time()))
+    body = b"payload=\xff\xfe not utf-8"
+    signature = _slack_signature(secret, timestamp, body)
+
+    assert verify_slack_signature(body, timestamp, signature, secret) is True


### PR DESCRIPTION
Slack signs `v0:{timestamp}:{raw body}`. `verify_slack_signature` decoded the body with `errors="replace"` and re-encoded it before HMAC, so any non-UTF-8 payload produced a different digest than Slack.

Hash the raw bytes instead, matching Slack and the GitHub/Linear verifiers in this repo.

Fixes #2310