### PR TITLE
chore(ui): pin nitro instead of tracking the latest dist-tag

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         specifier: ^0.52.2
         version: 0.52.2
       nitro:
-        specifier: latest
+        specifier: 3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.4)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2))
       react:
         specifier: ^19.2.4

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,7 @@
     "lexical": "^0.41.0",
     "lucide-react": "^1.16.0",
     "monaco-editor": "^0.52.2",
-    "nitro": "latest",
+    "nitro": "3.0.260610-beta",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.6.0",


### PR DESCRIPTION
Fixes #2309.

## Problem

```jsonc
// ui/package.json
"nitro": "latest",
```

This is the only floating specifier in the workspace — `grep -rn '": *"\(latest\|\*\|x\)"' --include=package.json .` matches this line and nothing else.

`pnpm-lock.yaml` holds the resolution today, so ordinary installs are reproducible. The exposure is any operation that refreshes the lock — `pnpm update`, a Dependabot/Renovate lock refresh, or a conflict resolved by regenerating. Each silently accepts whatever the newest published `nitro` is, **including a new major**, with no range to reject it and no signal in the diff beyond a lockfile line.

Two things make it sharper than a typical floating pin:

- **It is on the build and request path.** `nitro` is the server runtime under the TanStack Start dashboard and is imported directly: `ui/vite.config.ts:7` does `import { nitro } from "nitro/vite"`, and it is configured at `:178`. A surprise version lands there, not in a leaf utility.
- **`latest` currently resolves to a pre-release**: `3.0.260610-beta`. The dist-tag points at a v3 beta, so this specifier is tracking a moving beta rather than a stable line.

## Change

Pin exactly at the version already installed:

```diff
-    "nitro": "latest",
+    "nitro": "3.0.260610-beta",
```

**Exact, not a caret range.** The issue suggested `^3.x.y`, but a caret over a pre-release only matches pre-releases of the same `major.minor.patch` — surprising semantics, and not the intent. Exact is also what this file already does for its other pre-release dependencies:

```jsonc
"@pierre/trees": "1.0.0-beta.4",
"h3": "2.0.1-rc.22",
```

`h3` is the closest precedent — same unjs ecosystem as `nitro`, pinned exactly at an rc.

## No dependency moves

The lockfile diff is the specifier string only. The resolved version is byte-identical before and after:

```diff
       nitro:
-        specifier: latest
+        specifier: 3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(...)
```

Regenerated with `pnpm install --lockfile-only`; two files change by one line each.

## Verification

- `pnpm install --frozen-lockfile --filter open-swe-dashboard... --filter open-swe` — "Lockfile is up to date, resolution step is skipped". This is the path every JS CI job takes, and it is the thing a package.json edit most easily breaks.
- Installed version after the change: `3.0.260610-beta`, unchanged.
- `pnpm --filter open-swe-dashboard run typecheck` — exit 0.
- `pnpm --filter open-swe-dashboard run test` — 66 files, 303 tests passed.

One note on the test evidence, since I hit it and it would be misleading to omit: two of my local runs of the full UI suite were flaky under load on Windows — one reported 6 worker errors, another a 5000ms timeout in `src/routes/-admin.test.tsx`. Run in isolation that file passes on this branch *and* on unmodified `main`, so it is machine contention rather than anything here. Worth saying plainly: since the resolved dependency tree does not change at all, this PR cannot affect test behaviour either way.
