### PR TITLE
fix: Render composer project picker upward

### DIFF
--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -686,6 +686,7 @@ export const ChatComposer = memo(function ChatComposer({
               repos={repos}
               searchPlaceholder="Search projects…"
               selectedRepo={selectedRepo}
+              side="top"
             />
           )}
           {runTarget === "local" &&
@@ -698,6 +699,7 @@ export const ChatComposer = memo(function ChatComposer({
                 onSelectProject={onSelectLocalProject}
                 projects={localProjects}
                 selectedProjectPath={selectedLocalProjectPath}
+                side="top"
               />
             )}
           {runTarget && onRunTargetChange && (

--- a/ui/src/features/agents/components/composer/RunTargetSelector.tsx
+++ b/ui/src/features/agents/components/composer/RunTargetSelector.tsx
@@ -67,6 +67,7 @@ export function LocalProjectSelector({
   onRemoveProject,
   placeholder = "Select project",
   triggerClassName,
+  side = "bottom",
 }: {
   projects: Array<DesktopProject>
   selectedProjectPath: string | null
@@ -75,6 +76,7 @@ export function LocalProjectSelector({
   onRemoveProject: (cwd: string) => void
   placeholder?: string
   triggerClassName?: string
+  side?: "top" | "bottom"
 }) {
   const selectedProject = projects.find(
     (project) => project.cwd === selectedProjectPath
@@ -92,7 +94,7 @@ export function LocalProjectSelector({
         <span className="truncate">{selectedProject?.name ?? placeholder}</span>
         <ComposerControlChevron />
       </MenuTrigger>
-      <MenuPopup align="start" className="w-64" sideOffset={7}>
+      <MenuPopup align="start" className="w-64" side={side} sideOffset={7}>
         <MenuGroup>
           <MenuGroupLabel>Projects</MenuGroupLabel>
           {projects.length === 0 && (

--- a/ui/src/features/settings/components/RepoSelector.tsx
+++ b/ui/src/features/settings/components/RepoSelector.tsx
@@ -22,6 +22,7 @@ interface RepoSelectorProps {
   className?: string
   triggerClassName?: string
   dropdownClassName?: string
+  side?: "top" | "bottom"
   disabled?: boolean
 }
 
@@ -37,6 +38,7 @@ export function RepoSelector({
   className,
   triggerClassName,
   dropdownClassName,
+  side = "bottom",
   disabled = false,
 }: RepoSelectorProps) {
   const [open, setOpen] = useState(false)
@@ -82,7 +84,8 @@ export function RepoSelector({
       {open && (
         <div
           className={cn(
-            "absolute top-full left-0 z-50 mt-1 flex max-h-72 w-72 flex-col overflow-hidden rounded border border-border bg-popover text-xs text-popover-foreground shadow-lg",
+            "absolute left-0 z-50 flex max-h-72 w-72 flex-col overflow-hidden rounded border border-border bg-popover text-xs text-popover-foreground shadow-lg",
+            side === "top" ? "bottom-full mb-1" : "top-full mt-1",
             dropdownClassName
           )}
         >


### PR DESCRIPTION
Makes cloud and local project pickers open above the composer while preserving existing placement elsewhere.

![Project picker opening above the composer](https://01a053a6-8119-708d-b3b9-ef61a7b2abcb--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd5TVRjNE9UY3NJbXAwYVNJNklqQXhZVEExWVRFM0xXSXlaR1l0TnpobU1DMWhPV1F5TFRRd1pqUXdNVFJsTXprek1TSXNJbk5wWkNJNklqQXhZVEExTTJFMkxUZ3hNVGt0TnpBNFpDMWlNMkk1TFdWbU5qRmhOMkl5WVdKallpSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMMkZ5ZEdsbVlXTjBjeTloYkdsalpTMXdjbTlxWldOMExYQnBZMnRsY2kxMWNIZGhjbVF1Y0c1bklpd2lZM1FpT2lKcGJXRm5aUzl3Ym1jaUxDSmpaQ0k2SW1sdWJHbHVaU0o5LnVzZlpfamdzc3JIZ2xoektVZGVaaDBxMGpCQ2lCNVZYenYxSUc3bE95b3dyeXAxQVZLeGlyMzIyS2I0aVR5ZW94Q0dzZjEyczB1blBxR1Z5OTh3bkFB)

Validation: UI typecheck, targeted format and lint checks.

Made by [Open SWE](https://openswe.vercel.app/agents/01a053a6-7b52-777c-8736-ac7f88c9d326)
