### PR TITLE
fix(ui): deduplicate sidebar show more action

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -653,20 +653,21 @@ export function AgentsSidebar({
                     {grouped.recents.map((item) => (
                       <SidebarThreadRow key={item.key} {...rowProps(item)} />
                     ))}
-                    {hasMoreActive && (
+                    {(hasMoreActive || hasMoreArchived) && (
                       <LoadMoreThreadsButton
-                        label="Load more cloud threads"
-                        loading={sidebar.activeQuery.isFetchingNextPage}
-                        onClick={() => void sidebar.activeQuery.fetchNextPage()}
-                      />
-                    )}
-                    {hasMoreArchived && (
-                      <LoadMoreThreadsButton
-                        label="Load more archived cloud threads"
-                        loading={sidebar.resolvedQuery.isFetchingNextPage}
-                        onClick={() =>
-                          void sidebar.resolvedQuery.fetchNextPage()
+                        label="Load more threads"
+                        loading={
+                          sidebar.activeQuery.isFetchingNextPage ||
+                          sidebar.resolvedQuery.isFetchingNextPage
                         }
+                        onClick={() => {
+                          if (hasMoreActive) {
+                            void sidebar.activeQuery.fetchNextPage()
+                          }
+                          if (hasMoreArchived) {
+                            void sidebar.resolvedQuery.fetchNextPage()
+                          }
+                        }}
                       />
                     )}
                     {resolvedLoading && (


### PR DESCRIPTION
Render one Recents “Show more” action and load every paginated thread source that still has results.

Made by [Open SWE](https://openswe.vercel.app/agents/01a053ab-f3d1-76b6-8582-37a7d78757e6)