### PR TITLE
fix: preserve new thread stream during navigation

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -847,7 +847,10 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     const dismissOnboarding = page.getByRole("button", {
       name: "Maybe later",
     });
-    if (await dismissOnboarding.isVisible()) await dismissOnboarding.click();
+    await dismissOnboarding.waitFor({ state: "visible", timeout: 5_000 }).then(
+      () => dismissOnboarding.click(),
+      () => undefined,
+    );
 
     const prompt = "Reproduce the new chat send experience";
     const editor = page.getByTestId("composer-editor");

--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -154,7 +154,7 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
       page.getByRole("button", { name: /This Mac threads, \d+/ }),
     ).toHaveCount(0);
     const sidebar = page.locator("[data-sidebar-frame]");
-    const composer = page.locator("main");
+    const composer = page.getByTestId("composer-editor").locator("../../..");
     await expect(
       composer.getByRole("button", { name: "This Mac", exact: true }),
     ).toBeVisible();

--- a/ui/src/features/agents/components/RecentAgentThreads.test.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.test.tsx
@@ -6,6 +6,12 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { RecentAgentThreads } from "./RecentAgentThreads"
 import type { ReactNode } from "react"
 
+const mocks = vi.hoisted(() => ({ inheritedThreadId: "one" }))
+
+vi.mock("@langchain/react", () => ({
+  useStreamContext: () => ({ threadId: mocks.inheritedThreadId }),
+}))
+
 vi.mock("@/features/agents/lib/AgentThreadStreamProvider", () => ({
   AgentThreadStreamProvider: ({
     threadId,
@@ -34,7 +40,14 @@ describe("RecentAgentThreads", () => {
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="two" />))
     expect(screen.getByText("thread one").dataset.active).toBe("false")
+    expect(screen.getByText("thread one").closest("[data-provider]")).toBeNull()
     expect(screen.getByText("thread two").dataset.active).toBe("true")
+    expect(
+      screen
+        .getByText("thread two")
+        .closest("[data-provider]")
+        ?.getAttribute("data-provider")
+    ).toBe("two")
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
     act(() => view.rerender(<RecentAgentThreads activeThreadId="four" />))

--- a/ui/src/features/agents/components/RecentAgentThreads.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.tsx
@@ -30,19 +30,26 @@ export function RecentAgentThreads({
 
   return visibleThreadIds.map((threadId) => {
     const active = threadId === activeThreadId
+    const page = (
+      <AgentThreadPage
+        threadId={threadId}
+        active={active}
+        autoFocusComposer={active && autoFocusComposer}
+      />
+    )
     return (
       <div
         key={threadId}
         className={cn(active ? "contents" : "hidden")}
         aria-hidden={!active}
       >
-        <AgentThreadStreamProvider threadId={threadId}>
-          <AgentThreadPage
-            threadId={threadId}
-            active={active}
-            autoFocusComposer={active && autoFocusComposer}
-          />
-        </AgentThreadStreamProvider>
+        {active ? (
+          page
+        ) : (
+          <AgentThreadStreamProvider threadId={threadId}>
+            {page}
+          </AgentThreadStreamProvider>
+        )}
       </div>
     )
   })

--- a/ui/src/features/agents/components/RecentAgentThreads.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 
 import { AgentThreadPage } from "@/features/agents/components/AgentThreadPage"
 import { AgentThreadStreamProvider } from "@/features/agents/lib/AgentThreadStreamProvider"
@@ -20,6 +21,7 @@ export function RecentAgentThreads({
   activeThreadId: string
   autoFocusComposer?: boolean
 }) {
+  const inheritedThreadId = useAgentThreadStream().threadId
   const [recentThreadIds, setRecentThreadIds] = useState(() => [activeThreadId])
   const visibleThreadIds = addRecentThread(recentThreadIds, activeThreadId)
 
@@ -43,7 +45,7 @@ export function RecentAgentThreads({
         className={cn(active ? "contents" : "hidden")}
         aria-hidden={!active}
       >
-        {active ? (
+        {threadId === inheritedThreadId ? (
           page
         ) : (
           <AgentThreadStreamProvider threadId={threadId}>

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Outlet, createFileRoute, useRouterState } from "@tanstack/react-router"
 
 import { AgentsShell } from "@/features/agents/components/AgentsSidebar"
@@ -47,6 +47,19 @@ function AgentsLayout() {
       : undefined
   const activeLocalSessionId =
     section === "agents" && threadId === "local" ? nestedRoute : undefined
+  const [streamTarget, setStreamTarget] = useState({
+    activeThreadId,
+    threadId: activeThreadId,
+  })
+  if (streamTarget.activeThreadId !== activeThreadId) {
+    setStreamTarget({
+      activeThreadId,
+      threadId:
+        streamTarget.activeThreadId && activeThreadId
+          ? streamTarget.threadId
+          : activeThreadId,
+    })
+  }
   const localOnly = !session.data && isDesktopLocalModeEnabled()
   const isLocalRoute =
     pathname === "/agents" ||
@@ -71,8 +84,9 @@ function AgentsLayout() {
       activeLocalSessionId={activeLocalSessionId}
     >
       <AgentThreadStreamProvider
-        threadId={activeThreadId ?? null}
+        threadId={streamTarget.threadId ?? null}
         onThreadId={(id) => {
+          setStreamTarget({ activeThreadId: id, threadId: id })
           if (!activeThreadId) {
             void navigate({ to: "/agents/$threadId", params: { threadId: id } })
           }


### PR DESCRIPTION
Preserve the layout stream when opening a newly created thread, so its messages continue rendering after navigation. Stabilize the affected onboarding and desktop E2E selectors.

Checks:
- UI unit tests
- UI typecheck
- Focused format and lint

Made by [Open SWE](https://openswe.vercel.app/agents/01a053b7-c5be-743d-b83d-15958250017f)