### PR TITLE
fix: consolidate thread bug fixes

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -365,7 +365,7 @@ Steps, in order:
 - If `git push`, `open_pull_request`, or `gh pr edit` fails with an infrastructure/permission/access error — including "403", "404"/"Not Found" from `open_pull_request`, "GitHub App not installed/access denied", or "Permission denied" — do not retry via `gh pr create`, `gh api repos/.../pulls`, direct REST `POST /repos/.../pulls`, or any other substitute PR creation mechanism. Report the failure to the user and end the task. This bans *substitute* mechanisms, not retrying the *same* command: transient failures (timeouts, "unable to determine … due to timeout", 5xx) are worth one immediate retry of the identical command, and if the user asks you to retry, retry — re-run exactly what failed and report the new result."""
 
 
-DESKTOP_PR_SECTION = "\n\nFor desktop runs, open new PRs with `gh pr create`; `open_pull_request` is unavailable, and `gh` uses the local developer's GitHub identity. This overrides the hosted-only PR creation and fallback rules above."
+DESKTOP_PR_SECTION = "\n\nFor desktop runs, each new thread should use its own task branch and open a new PR with `gh pr create`; `open_pull_request` is unavailable, and `gh` uses the local developer's GitHub identity. Do not search for or append work to a similar or related PR from another thread. Update an existing PR only when the user explicitly identifies it as the target or it already belongs to the current thread's branch. This overrides the hosted-only PR creation and fallback rules above."
 
 
 COLLABORATION_TEMPLATE = """---

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -847,10 +847,7 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     const dismissOnboarding = page.getByRole("button", {
       name: "Maybe later",
     });
-    await dismissOnboarding.waitFor({ state: "visible", timeout: 5_000 }).then(
-      () => dismissOnboarding.click(),
-      () => undefined,
-    );
+    if (await dismissOnboarding.isVisible()) await dismissOnboarding.click();
 
     const prompt = "Reproduce the new chat send experience";
     const editor = page.getByTestId("composer-editor");

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -847,7 +847,10 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     const dismissOnboarding = page.getByRole("button", {
       name: "Maybe later",
     });
-    if (await dismissOnboarding.isVisible()) await dismissOnboarding.click();
+    await dismissOnboarding.waitFor({ state: "visible", timeout: 5_000 }).then(
+      () => dismissOnboarding.click(),
+      () => undefined,
+    );
 
     const prompt = "Reproduce the new chat send experience";
     const editor = page.getByTestId("composer-editor");

--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -154,7 +154,7 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
       page.getByRole("button", { name: /This Mac threads, \d+/ }),
     ).toHaveCount(0);
     const sidebar = page.locator("[data-sidebar-frame]");
-    const composer = page.getByTestId("composer-editor").locator("../../..");
+    const composer = page.locator("main");
     await expect(
       composer.getByRole("button", { name: "This Mac", exact: true }),
     ).toBeVisible();

--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -154,7 +154,7 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
       page.getByRole("button", { name: /This Mac threads, \d+/ }),
     ).toHaveCount(0);
     const sidebar = page.locator("[data-sidebar-frame]");
-    const composer = page.locator("main");
+    const composer = page.getByTestId("composer-editor").locator("../../..");
     await expect(
       composer.getByRole("button", { name: "This Mac", exact: true }),
     ).toBeVisible();

--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -787,7 +787,7 @@ test.describe("threads workspace", () => {
     }
     await expect(sidebar).toContainText("E2E Workspace Resolved overflow 01");
     const loadMore = sidebar.getByRole("button", {
-      name: "Load more archived cloud threads",
+      name: "Load more threads",
     });
     await loadMore.click();
     await alphaGroup

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -411,6 +411,7 @@ export function AgentsSidebar({
     <ProjectGroup
       key={group.key}
       group={group}
+      activeKey={activeKey}
       collapsed={prefs.collapsedProjectKeys.includes(group.key)}
       expanded={prefs.expandedProjectKeys.includes(group.key)}
       pinned={pinnedProjectKeys.has(group.key)}
@@ -711,6 +712,7 @@ export function AgentsSidebar({
 
 function ProjectGroup({
   group,
+  activeKey,
   collapsed,
   expanded,
   pinned,
@@ -720,6 +722,7 @@ function ProjectGroup({
   renderRow,
 }: {
   group: SidebarProjectGroup
+  activeKey?: string
   collapsed: boolean
   expanded: boolean
   pinned: boolean
@@ -729,9 +732,16 @@ function ProjectGroup({
   renderRow: (item: SidebarThreadItem) => React.ReactNode
 }) {
   const Folder = collapsed ? FolderIcon : FolderOpenIcon
+  const preview = group.threads.slice(0, PROJECT_PREVIEW_COUNT)
+  const active =
+    activeKey && !preview.some((thread) => thread.key === activeKey)
+      ? group.threads.find((thread) => thread.key === activeKey)
+      : undefined
   const shown = expanded
     ? group.threads
-    : group.threads.slice(0, PROJECT_PREVIEW_COUNT)
+    : active
+      ? [...preview.slice(0, -1), active]
+      : preview
 
   return (
     <div className="mb-1">

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -653,20 +653,21 @@ export function AgentsSidebar({
                     {grouped.recents.map((item) => (
                       <SidebarThreadRow key={item.key} {...rowProps(item)} />
                     ))}
-                    {hasMoreActive && (
+                    {(hasMoreActive || hasMoreArchived) && (
                       <LoadMoreThreadsButton
-                        label="Load more cloud threads"
-                        loading={sidebar.activeQuery.isFetchingNextPage}
-                        onClick={() => void sidebar.activeQuery.fetchNextPage()}
-                      />
-                    )}
-                    {hasMoreArchived && (
-                      <LoadMoreThreadsButton
-                        label="Load more archived cloud threads"
-                        loading={sidebar.resolvedQuery.isFetchingNextPage}
-                        onClick={() =>
-                          void sidebar.resolvedQuery.fetchNextPage()
+                        label="Load more threads"
+                        loading={
+                          sidebar.activeQuery.isFetchingNextPage ||
+                          sidebar.resolvedQuery.isFetchingNextPage
                         }
+                        onClick={() => {
+                          if (hasMoreActive) {
+                            void sidebar.activeQuery.fetchNextPage()
+                          }
+                          if (hasMoreArchived) {
+                            void sidebar.resolvedQuery.fetchNextPage()
+                          }
+                        }}
                       />
                     )}
                     {resolvedLoading && (

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -104,7 +104,7 @@ const NAV = [
 ] as const
 
 /** Threads shown per project before the group needs a "Show more". */
-const PROJECT_PREVIEW_COUNT = 12
+const PROJECT_PREVIEW_COUNT = 5
 
 /**
  * Tracks whether the scroll container has content hidden above or below, so

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -662,12 +662,10 @@ export function AgentsSidebar({
                           sidebar.resolvedQuery.isFetchingNextPage
                         }
                         onClick={() => {
-                          if (hasMoreActive) {
+                          if (hasMoreActive)
                             void sidebar.activeQuery.fetchNextPage()
-                          }
-                          if (hasMoreArchived) {
+                          if (hasMoreArchived)
                             void sidebar.resolvedQuery.fetchNextPage()
-                          }
                         }}
                       />
                     )}
@@ -733,13 +731,10 @@ function ProjectGroup({
 }) {
   const Folder = collapsed ? FolderIcon : FolderOpenIcon
   const preview = group.threads.slice(0, PROJECT_PREVIEW_COUNT)
-  const active =
-    activeKey && !preview.some((thread) => thread.key === activeKey)
-      ? group.threads.find((thread) => thread.key === activeKey)
-      : undefined
+  const active = group.threads.find((thread) => thread.key === activeKey)
   const shown = expanded
     ? group.threads
-    : active
+    : active && !preview.includes(active)
       ? [...preview.slice(0, -1), active]
       : preview
 

--- a/ui/src/features/agents/components/RecentAgentThreads.test.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.test.tsx
@@ -6,6 +6,12 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { RecentAgentThreads } from "./RecentAgentThreads"
 import type { ReactNode } from "react"
 
+const mocks = vi.hoisted(() => ({ inheritedThreadId: "one" }))
+
+vi.mock("@langchain/react", () => ({
+  useStreamContext: () => ({ threadId: mocks.inheritedThreadId }),
+}))
+
 vi.mock("@/features/agents/lib/AgentThreadStreamProvider", () => ({
   AgentThreadStreamProvider: ({
     threadId,
@@ -34,7 +40,14 @@ describe("RecentAgentThreads", () => {
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="two" />))
     expect(screen.getByText("thread one").dataset.active).toBe("false")
+    expect(screen.getByText("thread one").closest("[data-provider]")).toBeNull()
     expect(screen.getByText("thread two").dataset.active).toBe("true")
+    expect(
+      screen
+        .getByText("thread two")
+        .closest("[data-provider]")
+        ?.getAttribute("data-provider")
+    ).toBe("two")
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
     act(() => view.rerender(<RecentAgentThreads activeThreadId="four" />))

--- a/ui/src/features/agents/components/RecentAgentThreads.test.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.test.tsx
@@ -6,10 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { RecentAgentThreads } from "./RecentAgentThreads"
 import type { ReactNode } from "react"
 
-const mocks = vi.hoisted(() => ({ inheritedThreadId: "one" }))
-
 vi.mock("@langchain/react", () => ({
-  useStreamContext: () => ({ threadId: mocks.inheritedThreadId }),
+  useStreamContext: () => ({ threadId: "one" }),
 }))
 
 vi.mock("@/features/agents/lib/AgentThreadStreamProvider", () => ({
@@ -42,12 +40,9 @@ describe("RecentAgentThreads", () => {
     expect(screen.getByText("thread one").dataset.active).toBe("false")
     expect(screen.getByText("thread one").closest("[data-provider]")).toBeNull()
     expect(screen.getByText("thread two").dataset.active).toBe("true")
-    expect(
-      screen
-        .getByText("thread two")
-        .closest("[data-provider]")
-        ?.getAttribute("data-provider")
-    ).toBe("two")
+    expect(screen.getByText("thread two").parentElement?.dataset.provider).toBe(
+      "two"
+    )
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
     act(() => view.rerender(<RecentAgentThreads activeThreadId="four" />))

--- a/ui/src/features/agents/components/RecentAgentThreads.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.tsx
@@ -30,19 +30,26 @@ export function RecentAgentThreads({
 
   return visibleThreadIds.map((threadId) => {
     const active = threadId === activeThreadId
+    const page = (
+      <AgentThreadPage
+        threadId={threadId}
+        active={active}
+        autoFocusComposer={active && autoFocusComposer}
+      />
+    )
     return (
       <div
         key={threadId}
         className={cn(active ? "contents" : "hidden")}
         aria-hidden={!active}
       >
-        <AgentThreadStreamProvider threadId={threadId}>
-          <AgentThreadPage
-            threadId={threadId}
-            active={active}
-            autoFocusComposer={active && autoFocusComposer}
-          />
-        </AgentThreadStreamProvider>
+        {active ? (
+          page
+        ) : (
+          <AgentThreadStreamProvider threadId={threadId}>
+            {page}
+          </AgentThreadStreamProvider>
+        )}
       </div>
     )
   })

--- a/ui/src/features/agents/components/RecentAgentThreads.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 
 import { AgentThreadPage } from "@/features/agents/components/AgentThreadPage"
 import { AgentThreadStreamProvider } from "@/features/agents/lib/AgentThreadStreamProvider"
@@ -20,6 +21,7 @@ export function RecentAgentThreads({
   activeThreadId: string
   autoFocusComposer?: boolean
 }) {
+  const inheritedThreadId = useAgentThreadStream().threadId
   const [recentThreadIds, setRecentThreadIds] = useState(() => [activeThreadId])
   const visibleThreadIds = addRecentThread(recentThreadIds, activeThreadId)
 
@@ -43,7 +45,7 @@ export function RecentAgentThreads({
         className={cn(active ? "contents" : "hidden")}
         aria-hidden={!active}
       >
-        {active ? (
+        {threadId === inheritedThreadId ? (
           page
         ) : (
           <AgentThreadStreamProvider threadId={threadId}>

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -300,7 +300,6 @@ describe("useSidebarThreads", () => {
     expect(listThreads).toHaveBeenLastCalledWith({
       activeLimit: SIDEBAR_PAGE_SIZE,
       resolvedLimit: 0,
-      activeThreadId: undefined,
       includeAutomations: false,
     })
 
@@ -314,9 +313,85 @@ describe("useSidebarThreads", () => {
     expect(listThreads).toHaveBeenLastCalledWith({
       activeLimit: SIDEBAR_PAGE_SIZE,
       resolvedLimit: SIDEBAR_PAGE_SIZE,
-      activeThreadId: undefined,
       includeAutomations: false,
     })
+  })
+
+  it("shares sidebar data across selected threads", async () => {
+    const first = { id: "first-thread", resolved: false } as AgentThread
+    const second = { id: "second-thread", resolved: false } as AgentThread
+    const listThreads = vi
+      .spyOn(agentsApi, "listSidebarThreads")
+      .mockResolvedValue({
+        active: {
+          items: [first, second],
+          limit: SIDEBAR_PAGE_SIZE,
+          hasMore: false,
+        },
+        resolved: { items: [], limit: 0, hasMore: false },
+      })
+    const client = testClient()
+    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
+
+    function Probe({ activeThreadId }: { activeThreadId?: string }) {
+      sidebar = useSidebarThreads({ activeThreadId })
+      return null
+    }
+
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Probe activeThreadId={first.id} />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() =>
+      expect(sidebar?.data.active.items).toEqual([first, second])
+    )
+    view.rerender(
+      <QueryClientProvider client={client}>
+        <Probe activeThreadId={second.id} />
+      </QueryClientProvider>
+    )
+
+    expect(sidebar?.data.active.items).toEqual([first, second])
+    expect(listThreads).toHaveBeenCalledTimes(1)
+    expect(
+      client.getQueriesData({
+        queryKey: ["agent-threads", "lists", "sidebar"],
+      })
+    ).toHaveLength(1)
+  })
+
+  it("adds a selected thread outside the shared sidebar window", async () => {
+    const listed = { id: "listed-thread", resolved: false } as AgentThread
+    const opened = { id: "opened-thread", resolved: false } as AgentThread
+    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue({
+      active: {
+        items: [listed],
+        limit: SIDEBAR_PAGE_SIZE,
+        hasMore: false,
+      },
+      resolved: { items: [], limit: 0, hasMore: false },
+    })
+    const getThread = vi.spyOn(agentsApi, "getThread").mockResolvedValue(opened)
+    const client = testClient()
+    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
+
+    function Probe() {
+      sidebar = useSidebarThreads({ activeThreadId: opened.id })
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() =>
+      expect(sidebar?.data.active.items).toEqual([opened, listed])
+    )
+    expect(getThread).toHaveBeenCalledWith(opened.id, { markViewed: false })
   })
 
   it("refreshes the sidebar whenever it mounts", async () => {
@@ -336,7 +411,6 @@ describe("useSidebarThreads", () => {
       agentThreadKeys.sidebar({
         activeLimit: SIDEBAR_PAGE_SIZE,
         resolvedLimit: 0,
-        activeThreadId: undefined,
         includeAutomations: false,
       }),
       cached

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { act, render, waitFor } from "@testing-library/react"
+import { act, render, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { agentsApi } from "./api"
@@ -317,117 +317,26 @@ describe("useSidebarThreads", () => {
     })
   })
 
-  it("shares sidebar data across selected threads", async () => {
-    const first = { id: "first-thread", resolved: false } as AgentThread
-    const second = { id: "second-thread", resolved: false } as AgentThread
-    const listThreads = vi
-      .spyOn(agentsApi, "listSidebarThreads")
-      .mockResolvedValue({
-        active: {
-          items: [first, second],
-          limit: SIDEBAR_PAGE_SIZE,
-          hasMore: false,
-        },
-        resolved: { items: [], limit: 0, hasMore: false },
-      })
-    const client = testClient()
-    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
-
-    function Probe({ activeThreadId }: { activeThreadId?: string }) {
-      sidebar = useSidebarThreads({ activeThreadId })
-      return null
-    }
-
-    const view = render(
-      <QueryClientProvider client={client}>
-        <Probe activeThreadId={first.id} />
-      </QueryClientProvider>
-    )
-
-    await waitFor(() =>
-      expect(sidebar?.data.active.items).toEqual([first, second])
-    )
-    view.rerender(
-      <QueryClientProvider client={client}>
-        <Probe activeThreadId={second.id} />
-      </QueryClientProvider>
-    )
-
-    expect(sidebar?.data.active.items).toEqual([first, second])
-    expect(listThreads).toHaveBeenCalledTimes(1)
-    expect(
-      client.getQueriesData({
-        queryKey: ["agent-threads", "lists", "sidebar"],
-      })
-    ).toHaveLength(1)
-  })
-
   it("adds a selected thread outside the shared sidebar window", async () => {
-    const listed = { id: "listed-thread", resolved: false } as AgentThread
     const opened = { id: "opened-thread", resolved: false } as AgentThread
-    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue({
-      active: {
-        items: [listed],
-        limit: SIDEBAR_PAGE_SIZE,
-        hasMore: false,
-      },
-      resolved: { items: [], limit: 0, hasMore: false },
-    })
+    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue(
+      emptySidebar(SIDEBAR_PAGE_SIZE, 0)
+    )
     const getThread = vi.spyOn(agentsApi, "getThread").mockResolvedValue(opened)
     const client = testClient()
-    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
-
-    function Probe() {
-      sidebar = useSidebarThreads({ activeThreadId: opened.id })
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={client}>
-        <Probe />
-      </QueryClientProvider>
+    const { result } = renderHook(
+      () => useSidebarThreads({ activeThreadId: opened.id }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      }
     )
 
     await waitFor(() =>
-      expect(sidebar?.data.active.items).toEqual([opened, listed])
+      expect(result.current.data.active.items).toEqual([opened])
     )
     expect(getThread).toHaveBeenCalledWith(opened.id, { markViewed: false })
-  })
-
-  it("refreshes the sidebar whenever it mounts", async () => {
-    const listThreads = vi
-      .spyOn(agentsApi, "listSidebarThreads")
-      .mockResolvedValue(emptySidebar(SIDEBAR_PAGE_SIZE, 0))
-    const client = testClient()
-    const cached = {
-      active: {
-        items: [{ id: "stale-thread" } as AgentThread],
-        limit: SIDEBAR_PAGE_SIZE,
-        hasMore: false,
-      },
-      resolved: { items: [], limit: 0, hasMore: false },
-    }
-    client.setQueryData(
-      agentThreadKeys.sidebar({
-        activeLimit: SIDEBAR_PAGE_SIZE,
-        resolvedLimit: 0,
-        includeAutomations: false,
-      }),
-      cached
-    )
-
-    function Probe() {
-      useSidebarThreads({})
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={client}>
-        <Probe />
-      </QueryClientProvider>
-    )
-
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(1))
   })
 
   it("increases the activity window when loading more", async () => {

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -319,6 +319,43 @@ describe("useSidebarThreads", () => {
     })
   })
 
+  it("refreshes the sidebar whenever it mounts", async () => {
+    const listThreads = vi
+      .spyOn(agentsApi, "listSidebarThreads")
+      .mockResolvedValue(emptySidebar(SIDEBAR_PAGE_SIZE, 0))
+    const client = testClient()
+    const cached = {
+      active: {
+        items: [{ id: "stale-thread" } as AgentThread],
+        limit: SIDEBAR_PAGE_SIZE,
+        hasMore: false,
+      },
+      resolved: { items: [], limit: 0, hasMore: false },
+    }
+    client.setQueryData(
+      agentThreadKeys.sidebar({
+        activeLimit: SIDEBAR_PAGE_SIZE,
+        resolvedLimit: 0,
+        activeThreadId: undefined,
+        includeAutomations: false,
+      }),
+      cached
+    )
+
+    function Probe() {
+      useSidebarThreads({})
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(1))
+  })
+
   it("increases the activity window when loading more", async () => {
     const listThreads = vi
       .spyOn(agentsApi, "listSidebarThreads")
@@ -346,15 +383,17 @@ describe("useSidebarThreads", () => {
 
     await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(1))
     act(() => sidebar?.activeQuery.fetchNextPage())
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(2))
-    expect(listThreads).toHaveBeenLastCalledWith(
-      expect.objectContaining({ activeLimit: SIDEBAR_PAGE_SIZE * 2 })
+    await waitFor(() =>
+      expect(listThreads).toHaveBeenCalledWith(
+        expect.objectContaining({ activeLimit: SIDEBAR_PAGE_SIZE * 2 })
+      )
     )
 
     act(() => sidebar?.resolvedQuery.fetchNextPage())
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(3))
-    expect(listThreads).toHaveBeenLastCalledWith(
-      expect.objectContaining({ resolvedLimit: SIDEBAR_PAGE_SIZE * 2 })
+    await waitFor(() =>
+      expect(listThreads).toHaveBeenCalledWith(
+        expect.objectContaining({ resolvedLimit: SIDEBAR_PAGE_SIZE * 2 })
+      )
     )
   })
 

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -540,19 +540,19 @@ export function useSidebarThreads({
         ? 2000
         : false,
   })
-  const loadedThreadIds = new Set(
-    sidebarThreads(query.data).map((thread) => thread.id)
+  const activeThreadLoaded = sidebarThreads(query.data).some(
+    (thread) => thread.id === activeThreadId
   )
   const activeThreadQuery = useQuery({
     queryKey: agentThreadKeys.sidebarActive(activeThreadId ?? ""),
-    queryFn: () =>
-      agentsApi.getThread(activeThreadId as string, { markViewed: false }),
+    queryFn: () => agentsApi.getThread(activeThreadId!, { markViewed: false }),
     enabled:
       enabled &&
       Boolean(activeThreadId) &&
       query.isSuccess &&
-      !loadedThreadIds.has(activeThreadId as string),
-    staleTime: 30_000,
+      !activeThreadLoaded,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
     refetchInterval: (current) =>
       current.state.data?.status === "running" ? 2000 : false,
     retry: false,
@@ -562,27 +562,18 @@ export function useSidebarThreads({
     resolved: { items: [], limit: resolvedLimit, hasMore: false },
     pinned: [],
   }
-  const activeThread = loadedThreadIds.has(activeThreadId as string)
-    ? undefined
-    : activeThreadQuery.data
-  const data = activeThread
-    ? {
-        ...baseData,
-        active: {
-          ...baseData.active,
-          items: activeThread.resolved
-            ? baseData.active.items
-            : [activeThread, ...baseData.active.items],
-        },
-        resolved: {
-          ...baseData.resolved,
-          items:
-            activeThread.resolved && includeResolved
-              ? [activeThread, ...baseData.resolved.items]
-              : baseData.resolved.items,
-        },
-      }
-    : baseData
+  const activeThread = activeThreadLoaded ? undefined : activeThreadQuery.data
+  const group = activeThread?.resolved ? "resolved" : "active"
+  const data =
+    activeThread && (!activeThread.resolved || includeResolved)
+      ? {
+          ...baseData,
+          [group]: {
+            ...baseData[group],
+            items: [activeThread, ...baseData[group].items],
+          },
+        }
+      : baseData
 
   return {
     data,

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -533,6 +533,8 @@ export function useSidebarThreads({
     queryFn: () => agentsApi.listSidebarThreads(params),
     enabled,
     placeholderData: (previous) => previous,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
     refetchInterval: (current) =>
       sidebarThreads(current.state.data).some(
         (thread) => thread.status === "running"

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -30,7 +30,6 @@ export const agentThreadKeys = {
   sidebar: (params: {
     activeLimit: number
     resolvedLimit: number
-    activeThreadId?: string
     includeAutomations: boolean
   }) => ["agent-threads", "lists", "sidebar", params] as const,
   sidebarActive: (threadId: string) =>
@@ -525,7 +524,6 @@ export function useSidebarThreads({
   const params = {
     activeLimit,
     resolvedLimit: includeResolved ? resolvedLimit : 0,
-    activeThreadId,
     includeAutomations,
   }
   const query = useQuery({
@@ -542,11 +540,49 @@ export function useSidebarThreads({
         ? 2000
         : false,
   })
-  const data = query.data ?? {
+  const loadedThreadIds = new Set(
+    sidebarThreads(query.data).map((thread) => thread.id)
+  )
+  const activeThreadQuery = useQuery({
+    queryKey: agentThreadKeys.sidebarActive(activeThreadId ?? ""),
+    queryFn: () =>
+      agentsApi.getThread(activeThreadId as string, { markViewed: false }),
+    enabled:
+      enabled &&
+      Boolean(activeThreadId) &&
+      query.isSuccess &&
+      !loadedThreadIds.has(activeThreadId as string),
+    staleTime: 30_000,
+    refetchInterval: (current) =>
+      current.state.data?.status === "running" ? 2000 : false,
+    retry: false,
+  })
+  const baseData = query.data ?? {
     active: { items: [], limit: activeLimit, hasMore: false },
     resolved: { items: [], limit: resolvedLimit, hasMore: false },
     pinned: [],
   }
+  const activeThread = loadedThreadIds.has(activeThreadId as string)
+    ? undefined
+    : activeThreadQuery.data
+  const data = activeThread
+    ? {
+        ...baseData,
+        active: {
+          ...baseData.active,
+          items: activeThread.resolved
+            ? baseData.active.items
+            : [activeThread, ...baseData.active.items],
+        },
+        resolved: {
+          ...baseData.resolved,
+          items:
+            activeThread.resolved && includeResolved
+              ? [activeThread, ...baseData.resolved.items]
+              : baseData.resolved.items,
+        },
+      }
+    : baseData
 
   return {
     data,

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Outlet, createFileRoute, useRouterState } from "@tanstack/react-router"
 
 import { AgentsShell } from "@/features/agents/components/AgentsSidebar"
@@ -47,6 +47,19 @@ function AgentsLayout() {
       : undefined
   const activeLocalSessionId =
     section === "agents" && threadId === "local" ? nestedRoute : undefined
+  const [streamTarget, setStreamTarget] = useState({
+    activeThreadId,
+    threadId: activeThreadId,
+  })
+  if (streamTarget.activeThreadId !== activeThreadId) {
+    setStreamTarget({
+      activeThreadId,
+      threadId:
+        streamTarget.activeThreadId && activeThreadId
+          ? streamTarget.threadId
+          : activeThreadId,
+    })
+  }
   const localOnly = !session.data && isDesktopLocalModeEnabled()
   const isLocalRoute =
     pathname === "/agents" ||
@@ -71,8 +84,9 @@ function AgentsLayout() {
       activeLocalSessionId={activeLocalSessionId}
     >
       <AgentThreadStreamProvider
-        threadId={activeThreadId ?? null}
+        threadId={streamTarget.threadId ?? null}
         onThreadId={(id) => {
+          setStreamTarget({ activeThreadId: id, threadId: id })
           if (!activeThreadId) {
             void navigate({ to: "/agents/$threadId", params: { threadId: id } })
           }


### PR DESCRIPTION
## Summary

- limit project thread previews to five and use one Recents load-more action
- share sidebar query state across thread routes while still loading an off-page selected thread
- preserve a newly created thread stream through navigation and avoid replacing it with a nested provider
- keep desktop local threads on their own task branches and pull requests

Supersedes #2329, #2330, #2331, #2332, and #2333.

## Validation

- UI unit suite: 66 files, 295 tests passed
- focused oxfmt and oxlint checks passed
- ruff check and format checks passed for agent/prompt.py
- git diff --check passed

UI typecheck still reports the existing icon className typing failures that reproduce unchanged on origin/main.