### PR TITLE
fix: stabilize desktop login and local development

### DIFF
--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -23,12 +23,18 @@ const GATEWAY_KEYS = [
   "LANGSMITH_API_KEY",
 ];
 
-function devBackendTarget({ repoRoot, port, env = process.env }) {
+function devBackendTarget({ repoRoot, port, stateDir, env = process.env }) {
+  const configuredPath =
+    env.OPEN_SWE_LOCAL_BACKEND_CONFIG || "langgraph.desktop.json";
+  const configPath = path.isAbsolute(configuredPath)
+    ? configuredPath
+    : path.resolve(repoRoot, configuredPath);
   return {
     command:
       env.OPEN_SWE_LOCAL_BACKEND_COMMAND || env.OPEN_SWE_UV_COMMAND || "uv",
     args: [
       "run",
+      ...(stateDir ? ["--project", repoRoot] : []),
       "langgraph",
       "dev",
       "--no-browser",
@@ -38,10 +44,9 @@ function devBackendTarget({ repoRoot, port, env = process.env }) {
       "--port",
       String(port),
       "--config",
-      env.OPEN_SWE_LOCAL_BACKEND_CONFIG ||
-        path.join(repoRoot, "langgraph.desktop.json"),
+      configPath,
     ],
-    cwd: repoRoot,
+    cwd: stateDir || repoRoot,
   };
 }
 

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -24,11 +24,7 @@ const GATEWAY_KEYS = [
 ];
 
 function devBackendTarget({ repoRoot, port, stateDir, env = process.env }) {
-  const configuredPath =
-    env.OPEN_SWE_LOCAL_BACKEND_CONFIG || "langgraph.desktop.json";
-  const configPath = path.isAbsolute(configuredPath)
-    ? configuredPath
-    : path.resolve(repoRoot, configuredPath);
+  const config = env.OPEN_SWE_LOCAL_BACKEND_CONFIG || "langgraph.desktop.json";
   return {
     command:
       env.OPEN_SWE_LOCAL_BACKEND_COMMAND || env.OPEN_SWE_UV_COMMAND || "uv",
@@ -44,7 +40,7 @@ function devBackendTarget({ repoRoot, port, stateDir, env = process.env }) {
       "--port",
       String(port),
       "--config",
-      configPath,
+      path.resolve(repoRoot, config),
     ],
     cwd: stateDir || repoRoot,
   };

--- a/desktop/src/config.cts
+++ b/desktop/src/config.cts
@@ -78,6 +78,9 @@ function isAppLoginUrl(value) {
 
 function desktopLoginUrl(backendUrl, { challenge, port }) {
   const target = new URL(LOGIN_PATH, backendUrl);
+  // The backend derives the OAuth redirect_uri from this request's own origin,
+  // so login follows the backend the app is pointed at.
+  target.searchParams.set("desktop", "true");
   target.searchParams.set("desktop_handoff", challenge);
   target.searchParams.set("desktop_port", String(port));
   return target.toString();

--- a/desktop/src/config.cts
+++ b/desktop/src/config.cts
@@ -78,8 +78,7 @@ function isAppLoginUrl(value) {
 
 function desktopLoginUrl(backendUrl, { challenge, port }) {
   const target = new URL(LOGIN_PATH, backendUrl);
-  // The backend derives the OAuth redirect_uri from this request's own origin,
-  // so login follows the backend the app is pointed at.
+  // Make OAuth redirect back through this backend's origin.
   target.searchParams.set("desktop", "true");
   target.searchParams.set("desktop_handoff", challenge);
   target.searchParams.set("desktop_port", String(port));

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -43,6 +43,29 @@ test("development target accepts an explicit LangGraph config", () => {
   assert.equal(target.args.at(-1), config);
 });
 
+test("development target isolates LangGraph runtime state", () => {
+  const repoRoot = path.resolve("/work/open-swe");
+  const stateDir = path.resolve("/tmp/open-swe-state");
+  const target = devBackendTarget({
+    repoRoot,
+    stateDir,
+    port: 49152,
+    env: { OPEN_SWE_LOCAL_BACKEND_CONFIG: "tests/e2e/langgraph.e2e.json" },
+  });
+
+  assert.equal(target.cwd, stateDir);
+  assert.deepEqual(target.args.slice(0, 4), [
+    "run",
+    "--project",
+    repoRoot,
+    "langgraph",
+  ]);
+  assert.equal(
+    target.args.at(-1),
+    path.join(repoRoot, "tests/e2e/langgraph.e2e.json"),
+  );
+});
+
 test("reports whether the selected provider is configured", () => {
   assert.deepEqual(modelCredentialStatus("openai:gpt-test", {}), {
     available: false,

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -10,12 +10,16 @@ const {
   packagedBackendTarget,
 } = require("../src/backend-supervisor.cjs");
 
-test("development target runs the repository LangGraph app through uv", () => {
+test("development target isolates repository LangGraph state", () => {
   const repoRoot = path.resolve("/work/open-swe");
-  assert.deepEqual(devBackendTarget({ repoRoot, port: 49152, env: {} }), {
+  const stateDir = path.resolve("/tmp/open-swe-state");
+  const target = devBackendTarget({ repoRoot, stateDir, port: 49152, env: {} });
+  assert.deepEqual(target, {
     command: "uv",
     args: [
       "run",
+      "--project",
+      repoRoot,
       "langgraph",
       "dev",
       "--no-browser",
@@ -27,7 +31,7 @@ test("development target runs the repository LangGraph app through uv", () => {
       "--config",
       path.join(repoRoot, "langgraph.desktop.json"),
     ],
-    cwd: repoRoot,
+    cwd: stateDir,
   });
 });
 
@@ -41,29 +45,6 @@ test("development target accepts an explicit LangGraph config", () => {
   });
 
   assert.equal(target.args.at(-1), config);
-});
-
-test("development target isolates LangGraph runtime state", () => {
-  const repoRoot = path.resolve("/work/open-swe");
-  const stateDir = path.resolve("/tmp/open-swe-state");
-  const target = devBackendTarget({
-    repoRoot,
-    stateDir,
-    port: 49152,
-    env: { OPEN_SWE_LOCAL_BACKEND_CONFIG: "tests/e2e/langgraph.e2e.json" },
-  });
-
-  assert.equal(target.cwd, stateDir);
-  assert.deepEqual(target.args.slice(0, 4), [
-    "run",
-    "--project",
-    repoRoot,
-    "langgraph",
-  ]);
-  assert.equal(
-    target.args.at(-1),
-    path.join(repoRoot, "tests/e2e/langgraph.e2e.json"),
-  );
 });
 
 test("reports whether the selected provider is configured", () => {

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -167,7 +167,7 @@ test("carries the loopback port and PKCE challenge into the browser login", () =
       challenge: "abc",
       port: 51234,
     }),
-    "https://backend.example/dashboard/api/auth/login?desktop_handoff=abc&desktop_port=51234",
+    "https://backend.example/dashboard/api/auth/login?desktop=true&desktop_handoff=abc&desktop_port=51234",
   );
   assert.equal(
     desktopExchangeUrl("https://backend.example/base/"),

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -18,11 +18,12 @@ export default async function globalSetup() {
   // A hard-killed run leaves this server bound, and the replacement would exit
   // with EADDRINUSE. Test-only port, so reclaim it.
   try {
-    execFileSync(
-      "bash",
-      ["-c", `pids=$(lsof -ti tcp:${uiPort}) && kill -9 $pids`],
-      { stdio: "ignore" },
-    );
+    const listeners = execFileSync("lsof", ["-ti", `tcp:${uiPort}`], {
+      encoding: "utf8",
+    });
+    for (const pid of listeners.split(/\s+/)) {
+      if (/^\d+$/.test(pid)) process.kill(Number(pid), "SIGKILL");
+    }
   } catch {
     // nothing listening
   }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -15,6 +15,18 @@ export default async function globalSetup() {
   const uiPort = process.env.E2E_UI_PORT ?? "3100";
   const harness = `http://127.0.0.1:${port}`;
 
+  // A hard-killed run leaves this server bound, and the replacement would exit
+  // with EADDRINUSE. Test-only port, so reclaim it.
+  try {
+    execFileSync(
+      "bash",
+      ["-c", `pids=$(lsof -ti tcp:${uiPort}) && kill -9 $pids`],
+      { stdio: "ignore" },
+    );
+  } catch {
+    // nothing listening
+  }
+
   if (!existsSync(server) || process.env.E2E_FORCE_UI_BUILD) {
     if (!existsSync(resolve(ui, "node_modules"))) {
       execFileSync(

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,6 +2,37 @@ import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
+function listeningPids(port: string): number[] {
+  let output: string;
+  try {
+    output = execFileSync(
+      "lsof",
+      ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"],
+      { encoding: "utf8" },
+    );
+  } catch (error) {
+    if ((error as { status?: number }).status === 1) return [];
+    throw error;
+  }
+  return [...new Set(output.match(/\d+/g)?.map(Number) ?? [])];
+}
+
+export function reclaimStaleUiServer(port: string, server: string) {
+  const listeners = listeningPids(port).map((pid) => ({
+    pid,
+    command: execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf8",
+    }).trim(),
+  }));
+  const unrelated = listeners.find(({ command }) => !command.includes(server));
+  if (unrelated) {
+    throw new Error(
+      `E2E UI port ${port} is already in use by PID ${unrelated.pid}`,
+    );
+  }
+  for (const { pid } of listeners) process.kill(pid, "SIGKILL");
+}
+
 // Build the real ui/ app once, then run its Nitro server so the harness can
 // proxy page requests to it — the tests exercise server rendering, not a
 // prerendered shell. Both API bases are baked in at build time, so they must
@@ -15,18 +46,9 @@ export default async function globalSetup() {
   const uiPort = process.env.E2E_UI_PORT ?? "3100";
   const harness = `http://127.0.0.1:${port}`;
 
-  // A hard-killed run leaves this server bound, and the replacement would exit
-  // with EADDRINUSE. Test-only port, so reclaim it.
-  try {
-    const listeners = execFileSync("lsof", ["-ti", `tcp:${uiPort}`], {
-      encoding: "utf8",
-    });
-    for (const pid of listeners.split(/\s+/)) {
-      if (/^\d+$/.test(pid)) process.kill(Number(pid), "SIGKILL");
-    }
-  } catch {
-    // nothing listening
-  }
+  // Reclaim only the Nitro server from a hard-killed prior run. Refuse to
+  // terminate unrelated processes using the configured port.
+  reclaimStaleUiServer(uiPort, server);
 
   if (!existsSync(server) || process.env.E2E_FORCE_UI_BUILD) {
     if (!existsSync(resolve(ui, "node_modules"))) {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,7 +2,7 @@ import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-function listeningPids(port: string): number[] {
+function reclaimStaleUiServer(port: string, server: string) {
   let output: string;
   try {
     output = execFileSync(
@@ -11,26 +11,19 @@ function listeningPids(port: string): number[] {
       { encoding: "utf8" },
     );
   } catch (error) {
-    if ((error as { status?: number }).status === 1) return [];
+    if ((error as { status?: number }).status === 1) return;
     throw error;
   }
-  return [...new Set(output.match(/\d+/g)?.map(Number) ?? [])];
-}
-
-export function reclaimStaleUiServer(port: string, server: string) {
-  const listeners = listeningPids(port).map((pid) => ({
-    pid,
-    command: execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+  const pids = new Set(output.match(/\d+/g) ?? []);
+  for (const pid of pids) {
+    const command = execFileSync("ps", ["-p", pid, "-o", "command="], {
       encoding: "utf8",
-    }).trim(),
-  }));
-  const unrelated = listeners.find(({ command }) => !command.includes(server));
-  if (unrelated) {
-    throw new Error(
-      `E2E UI port ${port} is already in use by PID ${unrelated.pid}`,
-    );
+    }).trim();
+    if (!command.includes(server)) {
+      throw new Error(`E2E UI port ${port} is already in use by PID ${pid}`);
+    }
   }
-  for (const { pid } of listeners) process.kill(pid, "SIGKILL");
+  for (const pid of pids) process.kill(Number(pid), "SIGKILL");
 }
 
 // Build the real ui/ app once, then run its Nitro server so the harness can
@@ -46,8 +39,6 @@ export default async function globalSetup() {
   const uiPort = process.env.E2E_UI_PORT ?? "3100";
   const harness = `http://127.0.0.1:${port}`;
 
-  // Reclaim only the Nitro server from a hard-killed prior run. Refuse to
-  // terminate unrelated processes using the configured port.
   reclaimStaleUiServer(uiPort, server);
 
   if (!existsSync(server) || process.env.E2E_FORCE_UI_BUILD) {

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -40,7 +40,7 @@ from e2e_env import (  # noqa: E402
     REPO_ROOT,
     TEST_USERS,
 )
-from fastapi import HTTPException, Request  # noqa: E402
+from fastapi import HTTPException, Query, Request  # noqa: E402
 from fastapi.responses import (  # noqa: E402
     FileResponse,
     HTMLResponse,
@@ -383,7 +383,9 @@ async def control_login_get(login: str = "", email: str = "", next_url: str = ""
 
 @app.get("/dashboard/api/auth/login")
 async def mock_github_login(
-    redirect_to: str = "", desktop_handoff: str = "", desktop_port: int = 0
+    redirect_to: str = "",
+    desktop_handoff: str = "",
+    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
 ) -> Response:
     """E2E stand-in for the dashboard OAuth start route.
 
@@ -393,20 +395,33 @@ async def mock_github_login(
     """
     ui = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
     dest = redirect_to or (f"{ui}/agents" if ui else "/agents")
-    query = urlencode(
-        {"redirect_to": dest, "desktop_handoff": desktop_handoff, "desktop_port": desktop_port}
-    )
+    params: dict[str, str | int] = {"redirect_to": dest}
+    if desktop_handoff:
+        params["desktop_handoff"] = desktop_handoff
+    if desktop_port is not None:
+        params["desktop_port"] = desktop_port
+    query = urlencode(params)
     return RedirectResponse(f"/fake-gh/login/oauth/authorize?{query}", 302)
 
 
 @app.get("/fake-gh/login/oauth/authorize")
 async def fake_github_authorize(
-    redirect_to: str = "", login: str = "", desktop_handoff: str = "", desktop_port: int = 0
+    redirect_to: str = "",
+    login: str = "",
+    desktop_handoff: str = "",
+    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
 ) -> Response:
     """Fake GitHub OAuth consent/login page for dashboard e2e tests."""
     ui = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
     dest = redirect_to or (f"{ui}/agents" if ui else "/agents")
     if not login:
+        handoff_inputs = ""
+        if desktop_handoff and desktop_port is not None:
+            handoff_inputs = (
+                f'<input type=hidden name=desktop_handoff value="'
+                f'{escape(desktop_handoff, quote=True)}">'
+                f'<input type=hidden name=desktop_port value="{desktop_port}">'
+            )
         options = "".join(
             f'<option value="{escape(u["login"], quote=True)}">'
             f"{escape(u['name'])} (@{escape(u['login'])})</option>"
@@ -420,8 +435,7 @@ async def fake_github_authorize(
               <p style="color:#888;font-size:0.9rem">Pick a fake GitHub account to continue.</p>
               <form method=get action=/fake-gh/login/oauth/authorize>
                 <input type=hidden name=redirect_to value="{escape(dest, quote=True)}">
-                <input type=hidden name=desktop_handoff value="{escape(desktop_handoff, quote=True)}">
-                <input type=hidden name=desktop_port value="{desktop_port}">
+                {handoff_inputs}
                 <label>GitHub user
                   <select name=login style="font:inherit;padding:0.4rem">{options}</select>
                 </label>
@@ -433,7 +447,7 @@ async def fake_github_authorize(
     match = next((u for u in TEST_USERS if u["login"] == login), None)
     email = match["email"] if match else f"{login}@example.com"
     challenge = valid_handoff_challenge(desktop_handoff)
-    if challenge and desktop_port:
+    if challenge and desktop_port is not None:
         # Desktop login belongs to the app, not this browser: hand a PKCE-bound
         # code back to its loopback listener and leave no session cookie here.
         code = issue_desktop_handoff(login=login, email=email, avatar_url=None, challenge=challenge)

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -86,9 +86,7 @@ EVENT_ID_SALT = uuid.uuid4().hex[:8]
 fakes.seed_bare_remotes()
 
 if os.environ.get("E2E_EXIT_WHEN_ORPHANED"):
-    # Playwright pipes this process's stdin, so the pipe hits EOF the moment the
-    # runner dies. A hard-killed runner never tears its webServer down, and the
-    # orphan keeps the harness port — which then shadows `make dev`.
+    # Playwright closes the webServer stdin pipe when its runner exits.
     def _exit_when_orphaned() -> None:
         try:
             sys.stdin.buffer.read()
@@ -400,8 +398,7 @@ async def mock_github_login(
         params["desktop_handoff"] = desktop_handoff
     if desktop_port is not None:
         params["desktop_port"] = desktop_port
-    query = urlencode(params)
-    return RedirectResponse(f"/fake-gh/login/oauth/authorize?{query}", 302)
+    return RedirectResponse(f"/fake-gh/login/oauth/authorize?{urlencode(params)}", 302)
 
 
 @app.get("/fake-gh/login/oauth/authorize")
@@ -446,10 +443,8 @@ async def fake_github_authorize(
         )
     match = next((u for u in TEST_USERS if u["login"] == login), None)
     email = match["email"] if match else f"{login}@example.com"
-    challenge = valid_handoff_challenge(desktop_handoff)
-    if challenge and desktop_port is not None:
-        # Desktop login belongs to the app, not this browser: hand a PKCE-bound
-        # code back to its loopback listener and leave no session cookie here.
+    if desktop_port is not None and (challenge := valid_handoff_challenge(desktop_handoff)):
+        # Return the PKCE-bound code to the app without setting a browser session.
         code = issue_desktop_handoff(login=login, email=email, avatar_url=None, challenge=challenge)
         return RedirectResponse(desktop_callback_url(desktop_port, code), status_code=303)
     token = issue_session(login=login, email=email, avatar_url=None)

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -21,7 +21,7 @@ import uuid
 from html import escape
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -40,7 +40,7 @@ from e2e_env import (  # noqa: E402
     REPO_ROOT,
     TEST_USERS,
 )
-from fastapi import HTTPException, Query, Request  # noqa: E402
+from fastapi import HTTPException, Request  # noqa: E402
 from fastapi.responses import (  # noqa: E402
     FileResponse,
     HTMLResponse,
@@ -62,13 +62,7 @@ _SLACK_USERS: dict[str, dict[str, str]] = {
 from langgraph_sdk import get_client  # noqa: E402
 
 from agent.api.app import app  # noqa: E402
-from agent.dashboard.oauth import (  # noqa: E402
-    COOKIE_NAME,
-    desktop_callback_url,
-    issue_desktop_handoff,
-    issue_session,
-    valid_handoff_challenge,
-)
+from agent.dashboard.oauth import COOKIE_NAME, issue_session  # noqa: E402
 from agent.utils.slack import lookup_slack_thread_id  # noqa: E402
 
 GITHUB_WEBHOOK_SECRET = os.environ["GITHUB_WEBHOOK_SECRET"]
@@ -380,11 +374,7 @@ async def control_login_get(login: str = "", email: str = "", next_url: str = ""
 
 
 @app.get("/dashboard/api/auth/login")
-async def mock_github_login(
-    redirect_to: str = "",
-    desktop_handoff: str = "",
-    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
-) -> Response:
+async def mock_github_login(redirect_to: str = "") -> Response:
     """E2E stand-in for the dashboard OAuth start route.
 
     The real route would redirect to github.com. Keep the dashboard-facing URL
@@ -393,32 +383,15 @@ async def mock_github_login(
     """
     ui = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
     dest = redirect_to or (f"{ui}/agents" if ui else "/agents")
-    params: dict[str, str | int] = {"redirect_to": dest}
-    if desktop_handoff:
-        params["desktop_handoff"] = desktop_handoff
-    if desktop_port is not None:
-        params["desktop_port"] = desktop_port
-    return RedirectResponse(f"/fake-gh/login/oauth/authorize?{urlencode(params)}", 302)
+    return RedirectResponse(f"/fake-gh/login/oauth/authorize?redirect_to={quote(dest)}", 302)
 
 
 @app.get("/fake-gh/login/oauth/authorize")
-async def fake_github_authorize(
-    redirect_to: str = "",
-    login: str = "",
-    desktop_handoff: str = "",
-    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
-) -> Response:
+async def fake_github_authorize(redirect_to: str = "", login: str = "") -> Response:
     """Fake GitHub OAuth consent/login page for dashboard e2e tests."""
     ui = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
     dest = redirect_to or (f"{ui}/agents" if ui else "/agents")
     if not login:
-        handoff_inputs = ""
-        if desktop_handoff and desktop_port is not None:
-            handoff_inputs = (
-                f'<input type=hidden name=desktop_handoff value="'
-                f'{escape(desktop_handoff, quote=True)}">'
-                f'<input type=hidden name=desktop_port value="{desktop_port}">'
-            )
         options = "".join(
             f'<option value="{escape(u["login"], quote=True)}">'
             f"{escape(u['name'])} (@{escape(u['login'])})</option>"
@@ -432,7 +405,6 @@ async def fake_github_authorize(
               <p style="color:#888;font-size:0.9rem">Pick a fake GitHub account to continue.</p>
               <form method=get action=/fake-gh/login/oauth/authorize>
                 <input type=hidden name=redirect_to value="{escape(dest, quote=True)}">
-                {handoff_inputs}
                 <label>GitHub user
                   <select name=login style="font:inherit;padding:0.4rem">{options}</select>
                 </label>
@@ -443,10 +415,6 @@ async def fake_github_authorize(
         )
     match = next((u for u in TEST_USERS if u["login"] == login), None)
     email = match["email"] if match else f"{login}@example.com"
-    if desktop_port is not None and (challenge := valid_handoff_challenge(desktop_handoff)):
-        # Return the PKCE-bound code to the app without setting a browser session.
-        code = issue_desktop_handoff(login=login, email=email, avatar_url=None, challenge=challenge)
-        return RedirectResponse(desktop_callback_url(desktop_port, code), status_code=303)
     token = issue_session(login=login, email=email, avatar_url=None)
     resp = RedirectResponse(url=dest, status_code=303)
     resp.set_cookie(COOKIE_NAME, token, httponly=True, samesite="lax", secure=False, path="/")

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -20,7 +20,7 @@ import uuid
 from html import escape
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -61,7 +61,13 @@ _SLACK_USERS: dict[str, dict[str, str]] = {
 from langgraph_sdk import get_client  # noqa: E402
 
 from agent.api.app import app  # noqa: E402
-from agent.dashboard.oauth import COOKIE_NAME, issue_session  # noqa: E402
+from agent.dashboard.oauth import (  # noqa: E402
+    COOKIE_NAME,
+    desktop_callback_url,
+    issue_desktop_handoff,
+    issue_session,
+    valid_handoff_challenge,
+)
 from agent.utils.slack import lookup_slack_thread_id  # noqa: E402
 
 GITHUB_WEBHOOK_SECRET = os.environ["GITHUB_WEBHOOK_SECRET"]
@@ -362,7 +368,9 @@ async def control_login_get(login: str = "", email: str = "", next_url: str = ""
 
 
 @app.get("/dashboard/api/auth/login")
-async def mock_github_login(redirect_to: str = "") -> Response:
+async def mock_github_login(
+    redirect_to: str = "", desktop_handoff: str = "", desktop_port: int = 0
+) -> Response:
     """E2E stand-in for the dashboard OAuth start route.
 
     The real route would redirect to github.com. Keep the dashboard-facing URL
@@ -371,11 +379,16 @@ async def mock_github_login(redirect_to: str = "") -> Response:
     """
     ui = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
     dest = redirect_to or (f"{ui}/agents" if ui else "/agents")
-    return RedirectResponse(f"/fake-gh/login/oauth/authorize?redirect_to={quote(dest)}", 302)
+    query = urlencode(
+        {"redirect_to": dest, "desktop_handoff": desktop_handoff, "desktop_port": desktop_port}
+    )
+    return RedirectResponse(f"/fake-gh/login/oauth/authorize?{query}", 302)
 
 
 @app.get("/fake-gh/login/oauth/authorize")
-async def fake_github_authorize(redirect_to: str = "", login: str = "") -> Response:
+async def fake_github_authorize(
+    redirect_to: str = "", login: str = "", desktop_handoff: str = "", desktop_port: int = 0
+) -> Response:
     """Fake GitHub OAuth consent/login page for dashboard e2e tests."""
     ui = os.environ.get("DASHBOARD_BASE_URL", "").rstrip("/")
     dest = redirect_to or (f"{ui}/agents" if ui else "/agents")
@@ -393,6 +406,8 @@ async def fake_github_authorize(redirect_to: str = "", login: str = "") -> Respo
               <p style="color:#888;font-size:0.9rem">Pick a fake GitHub account to continue.</p>
               <form method=get action=/fake-gh/login/oauth/authorize>
                 <input type=hidden name=redirect_to value="{escape(dest, quote=True)}">
+                <input type=hidden name=desktop_handoff value="{escape(desktop_handoff, quote=True)}">
+                <input type=hidden name=desktop_port value="{desktop_port}">
                 <label>GitHub user
                   <select name=login style="font:inherit;padding:0.4rem">{options}</select>
                 </label>
@@ -403,6 +418,12 @@ async def fake_github_authorize(redirect_to: str = "", login: str = "") -> Respo
         )
     match = next((u for u in TEST_USERS if u["login"] == login), None)
     email = match["email"] if match else f"{login}@example.com"
+    challenge = valid_handoff_challenge(desktop_handoff)
+    if challenge and desktop_port:
+        # Desktop login belongs to the app, not this browser: hand a PKCE-bound
+        # code back to its loopback listener and leave no session cookie here.
+        code = issue_desktop_handoff(login=login, email=email, avatar_url=None, challenge=challenge)
+        return RedirectResponse(desktop_callback_url(desktop_port, code), status_code=303)
     token = issue_session(login=login, email=email, avatar_url=None)
     resp = RedirectResponse(url=dest, status_code=303)
     resp.set_cookie(COOKIE_NAME, token, httponly=True, samesite="lax", secure=False, path="/")

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -15,6 +15,7 @@ import hmac
 import json
 import os
 import sys
+import threading
 import time
 import uuid
 from html import escape
@@ -83,6 +84,19 @@ LAST_SLACK_EVENT: dict[str, Any] = {"payload": None}
 EVENT_ID_SALT = uuid.uuid4().hex[:8]
 
 fakes.seed_bare_remotes()
+
+if os.environ.get("E2E_EXIT_WHEN_ORPHANED"):
+    # Playwright pipes this process's stdin, so the pipe hits EOF the moment the
+    # runner dies. A hard-killed runner never tears its webServer down, and the
+    # orphan keeps the harness port — which then shadows `make dev`.
+    def _exit_when_orphaned() -> None:
+        try:
+            sys.stdin.buffer.read()
+        except Exception:
+            return
+        os._exit(0)
+
+    threading.Thread(target=_exit_when_orphaned, daemon=True).start()
 
 
 # --- control + Slack compose (the test driver) -----------------------------

--- a/tests/e2e/langgraph.desktop.json
+++ b/tests/e2e/langgraph.desktop.json
@@ -3,7 +3,7 @@
   "python_version": "3.12",
   "api_version": "0.12.6",
   "graphs": {
-    "agent": "./tests/e2e/agent_entrypoint.py:traced_agent"
+    "agent": "agent_entrypoint:traced_agent"
   },
   "dependencies": ["."],
   "auth": {

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -45,11 +45,14 @@ export default defineConfig({
     // Deterministic busy window for the interrupt-debounce spec: the fake LLM
     // holds the first run open this long so follow-ups reliably land mid-run.
     // E2E_UI_SERVER is where the harness proxies page requests for rendering;
-    // global-setup starts that server on the same port.
+    // global-setup starts that server on the same port. E2E_EXIT_WHEN_ORPHANED
+    // makes the harness exit when this runner's stdin pipe closes, so a
+    // hard-killed run cannot leave the port bound in the background.
     env: {
       ...process.env,
       E2E_BUSY_HOLD_SECONDS: "20",
       E2E_UI_SERVER: `http://127.0.0.1:${UI_PORT}`,
+      E2E_EXIT_WHEN_ORPHANED: "1",
     },
   },
 });

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -45,9 +45,7 @@ export default defineConfig({
     // Deterministic busy window for the interrupt-debounce spec: the fake LLM
     // holds the first run open this long so follow-ups reliably land mid-run.
     // E2E_UI_SERVER is where the harness proxies page requests for rendering;
-    // global-setup starts that server on the same port. E2E_EXIT_WHEN_ORPHANED
-    // makes the harness exit when this runner's stdin pipe closes, so a
-    // hard-killed run cannot leave the port bound in the background.
+    // global-setup starts that server on the same port.
     env: {
       ...process.env,
       E2E_BUSY_HOLD_SECONDS: "20",

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -843,11 +843,33 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     page,
   }) => {
     await loginAs(page, SAME_USER);
+    const [sessionResponse, profileResponse, mappingResponse] =
+      await Promise.all([
+        page.request.get("/dashboard/api/me"),
+        page.request.get("/dashboard/api/profile"),
+        page.request.get("/dashboard/api/my-mapping"),
+      ]);
+    const session = (await sessionResponse.json()) as {
+      slack_oauth_enabled?: boolean;
+    };
+    const profile = (await profileResponse.json()) as {
+      default_model?: string;
+    };
+    const mapping = (await mappingResponse.json()) as {
+      slack_user_id?: string;
+    };
+    const needsOnboarding =
+      !profile.default_model ||
+      (session.slack_oauth_enabled && !mapping.slack_user_id);
     await page.goto("/agents");
     const dismissOnboarding = page.getByRole("button", {
       name: "Maybe later",
     });
-    if (await dismissOnboarding.isVisible()) await dismissOnboarding.click();
+    if (needsOnboarding) {
+      await expect(dismissOnboarding).toBeVisible();
+      await dismissOnboarding.click();
+      await expect(dismissOnboarding).toBeHidden();
+    }
 
     const prompt = "Reproduce the new chat send experience";
     const editor = page.getByTestId("composer-editor");


### PR DESCRIPTION
Fixes three local desktop issues:

- route desktop OAuth through the selected backend and preserve PKCE handoff in E2E
- stop orphaned E2E servers without killing unrelated port owners
- isolate desktop LangGraph state from `make dev`

Validated with desktop and OAuth tests, lint/type checks, and concurrent local servers.