### PR TITLE
fix(ui): align sidebar hover actions with status icons

### DIFF
--- a/ui/src/features/agents/components/SidebarThreadRow.tsx
+++ b/ui/src/features/agents/components/SidebarThreadRow.tsx
@@ -339,7 +339,7 @@ export function SidebarThreadRow({
         ) : null}
       </span>
 
-      <span className="hidden shrink-0 items-center gap-0.5 group-hover/row:flex">
+      <span className="-mr-[3px] hidden shrink-0 items-center gap-0.5 group-hover/row:flex">
         <button
           type="button"
           aria-label={pinned ? "Unpin thread" : "Pin thread"}


### PR DESCRIPTION
The pin/archive hover buttons are 20px wide around 14px icons, so their icons sat 3px further right than the 14px status icons on non-hovered rows. Pulls the hover group in by 3px so the columns line up.

Made by [Open SWE](https://openswe.vercel.app/agents/01a058c0-6f61-711b-be44-1f1601e51305)