### PR TITLE
perf(ui): resume thread streams instead of replaying them

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -206,6 +206,7 @@ from .thread_api import (
     get_dashboard_thread_pull_request_status,
     get_dashboard_thread_recovery_patch,
     get_dashboard_thread_state,
+    get_dashboard_thread_statuses,
     get_dashboard_thread_working_tree_diff,
     list_dashboard_threads,
     list_dashboard_threads_page,
@@ -1944,6 +1945,18 @@ async def api_get_pull_request_checks(
     )
 
 
+class ThreadStatusesRequest(BaseModel):
+    threadIds: list[str] = Field(default_factory=list, max_length=200)
+
+
+@router.post("/threads/statuses")
+async def api_get_thread_statuses(
+    payload: ThreadStatusesRequest,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await get_dashboard_thread_statuses(payload.threadIds)
+
+
 @router.get("/threads/{thread_id}/pull-request-status")
 async def api_get_thread_pull_request_status(
     thread_id: str,
@@ -1976,6 +1989,7 @@ async def api_get_thread_pull_request_context(
 async def api_get_thread(
     thread_id: str,
     mark_viewed: bool = True,
+    include_transcript: bool = True,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     return await get_dashboard_thread(
@@ -1983,6 +1997,7 @@ async def api_get_thread(
         session["sub"],
         email=session.get("email"),
         mark_viewed=mark_viewed,
+        include_transcript=include_transcript,
     )
 
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1105,10 +1105,14 @@ async def list_dashboard_threads_sidebar(
                     break
                 offset += _THREADS_SEARCH_PAGE
 
-    active_candidates = sorted(active.values(), key=_thread_sidebar_anchor_ms, reverse=True)
-    resolved_candidates = sorted(
-        resolved_threads.values(), key=_thread_sidebar_anchor_ms, reverse=True
-    )
+    # Which threads make the window is a recency question, and stays one: a
+    # thread worked on today belongs in the sidebar however long ago it was
+    # created. Only the *order* uses the stable anchor, and the client applies
+    # that itself — sorting the window by the anchor here would drop an old
+    # thread the user is actively using out of the window entirely, leaving it
+    # visible only while open.
+    active_candidates = sorted(active.values(), key=_thread_updated_ms, reverse=True)
+    resolved_candidates = sorted(resolved_threads.values(), key=_thread_updated_ms, reverse=True)
     active_window = active_candidates[:safe_active_limit]
     resolved_window = resolved_candidates[:safe_resolved_limit]
     active_ids = {thread_id for thread in active_window if (thread_id := _thread_id(thread))}

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -109,6 +109,10 @@ _PR_STATES: frozenset[str] = frozenset({"draft", "open", "merged", "closed"})
 _RECOVERY_PATCH_LIMIT_BYTES = 25 * 1024 * 1024
 _RECOVERY_PATCH_TIMEOUT_SECONDS = 120
 _SANDBOX_CREATING_SENTINEL = "__creating__"
+# Turns of transcript the detail endpoint returns so the UI can paint the
+# thread before the streaming SDK has hydrated it. Sized to cover the tail a
+# user actually looks at on open; the SDK's own hydrate fills in the rest.
+_TRANSCRIPT_TURN_LIMIT = 10
 
 
 async def create_sandbox(*args: Any, **kwargs: Any) -> Any:
@@ -472,6 +476,55 @@ def _pull_request_summary(record: object, fallback_title: str) -> dict[str, Any]
     }
 
 
+def _message_type(message: object) -> str | None:
+    """Role of a state message, over both the HTTP (dict) and in-process shapes."""
+    if isinstance(message, Mapping):
+        raw = message.get("type")
+        return raw if isinstance(raw, str) else None
+    raw = getattr(message, "type", None)
+    return raw if isinstance(raw, str) else None
+
+
+def _transcript_window(messages: Sequence[Any], *, turn_limit: int) -> tuple[list[Any], bool]:
+    """Trim a transcript to its last ``turn_limit`` human-anchored turns.
+
+    A turn starts at a human message and runs through the agent and tool
+    messages that answer it, so cutting on human anchors never leaves a tool
+    result whose call was trimmed away.
+    """
+    anchors = [index for index, message in enumerate(messages) if _message_type(message) == "human"]
+    if len(anchors) <= turn_limit:
+        return list(messages), False
+    return list(messages[anchors[-turn_limit] :]), True
+
+
+async def _thread_transcript(client: Any, thread_id: str) -> dict[str, Any]:
+    """The tail of a thread's transcript, for the UI's first paint.
+
+    The streaming SDK hydrates the authoritative transcript client-side, but it
+    cannot start until the view mounts. Returning the tail here lets an opened
+    thread render immediately instead of holding a blank pane through a
+    ``getState`` round trip. Failure is not fatal: the SDK still hydrates, so a
+    miss costs the fast paint and nothing else.
+    """
+    try:
+        state = await client.threads.get_state(thread_id)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not read transcript for %s", thread_id, exc_info=True)
+        return {"messages": [], "hasMore": False, "available": False}
+    values = state.get("values") if isinstance(state, Mapping) else None
+    messages = values.get("messages") if isinstance(values, Mapping) else None
+    if not isinstance(messages, list):
+        return {"messages": [], "hasMore": False, "available": False}
+    window, has_more = _transcript_window(messages, turn_limit=_TRANSCRIPT_TURN_LIMIT)
+    return {"messages": window, "hasMore": has_more, "available": True}
+
+
+async def _no_transcript() -> None:
+    """Stand-in for the transcript read when the caller opted out."""
+    return None
+
+
 async def _thread_summary(
     thread: ThreadLike,
     *,
@@ -552,6 +605,10 @@ async def _thread_summary(
         ),
         "createdAt": int(created_at) if isinstance(created_at, (int, float)) else _now_ms(),
         "updatedAt": int(updated_at) if isinstance(updated_at, (int, float)) else _now_ms(),
+        # What the sidebar orders on. Kept separate from `updatedAt` so the
+        # list holds still while a run writes state; see
+        # `_thread_sidebar_anchor_ms`.
+        "sortAnchorAt": _thread_sidebar_anchor_ms(thread),
         "traceUrl": trace_url,
         "sourceUrl": _thread_source_url(metadata),
         "codeChannelUrl": _code_channel_url(metadata),
@@ -737,6 +794,23 @@ def _thread_timestamp_ms(thread: ThreadLike, field: _ThreadSortBy) -> int:
 
 def _thread_updated_ms(thread: ThreadLike) -> int:
     return _thread_timestamp_ms(thread, "updated_at")
+
+
+def _thread_sidebar_anchor_ms(thread: ThreadLike) -> int:
+    """Sort position for a sidebar row, stable while the agent works.
+
+    Ordering by ``updated_at`` makes a running thread climb the list on every
+    state write, so rows shuffle under the pointer for as long as the agent is
+    busy. Anchoring on the thread's creation, re-anchored when the user last
+    said something, moves a row only on the events a user causes — the list
+    holds still between them.
+    """
+    metadata = _thread_metadata(thread)
+    last_user_ms = metadata.get("last_user_message_at_ms")
+    return max(
+        _thread_timestamp_ms(thread, "created_at"),
+        int(last_user_ms) if isinstance(last_user_ms, (int, float)) else 0,
+    )
 
 
 def _metadata_matches_filters(
@@ -1031,8 +1105,10 @@ async def list_dashboard_threads_sidebar(
                     break
                 offset += _THREADS_SEARCH_PAGE
 
-    active_candidates = sorted(active.values(), key=_thread_updated_ms, reverse=True)
-    resolved_candidates = sorted(resolved_threads.values(), key=_thread_updated_ms, reverse=True)
+    active_candidates = sorted(active.values(), key=_thread_sidebar_anchor_ms, reverse=True)
+    resolved_candidates = sorted(
+        resolved_threads.values(), key=_thread_sidebar_anchor_ms, reverse=True
+    )
     active_window = active_candidates[:safe_active_limit]
     resolved_window = resolved_candidates[:safe_resolved_limit]
     active_ids = {thread_id for thread in active_window if (thread_id := _thread_id(thread))}
@@ -1238,7 +1314,12 @@ async def get_dashboard_terminal_sandbox(
 
 
 async def get_dashboard_thread(
-    thread_id: str, login: str, *, email: str | None = None, mark_viewed: bool = True
+    thread_id: str,
+    login: str,
+    *,
+    email: str | None = None,
+    mark_viewed: bool = True,
+    include_transcript: bool = True,
 ) -> dict[str, Any]:
     client = langgraph_client()
     try:
@@ -1250,10 +1331,17 @@ async def get_dashboard_thread(
     metadata = thread_metadata(thread)
     _assert_thread_readable(metadata)
 
-    # The transcript is hydrated client-side by the SDK (`StreamProvider` reads
-    # `GET …/state` → `stream.messages`), so the detail endpoint returns
-    # metadata only — no server-side message conversion.
-    thread, latest_run_status, latest_run_id = await _refresh_latest_run_metadata(client, thread)
+    # Read the transcript tail alongside the run refresh so the detail response
+    # carries enough to paint the thread. The SDK still hydrates the full,
+    # authoritative transcript once the view mounts.
+    #
+    # The client asks for it once per open and opts out on the polls that follow,
+    # since this endpoint doubles as the run-status heartbeat while a run is live
+    # and a snapshot on every beat would be a `get_state` every few seconds.
+    (thread, latest_run_status, latest_run_id), transcript = await asyncio.gather(
+        _refresh_latest_run_metadata(client, thread),
+        _thread_transcript(client, thread_id) if include_transcript else _no_transcript(),
+    )
     metadata = thread_metadata(thread)
     status = _run_status_to_agent_status(
         thread.get("status") if isinstance(thread.get("status"), str) else "idle",
@@ -1273,11 +1361,14 @@ async def get_dashboard_thread(
         )
         thread = {**as_thread_dict(thread), "metadata": metadata}
 
-    return await _thread_summary(
+    summary = await _thread_summary(
         thread,
         latest_run_status=latest_run_status,
         latest_run_id=latest_run_id,
     )
+    if transcript is not None:
+        summary["transcript"] = transcript
+    return summary
 
 
 async def _resolve_requested_environment(requested: Any) -> str | None:
@@ -1719,6 +1810,9 @@ async def _enrich_run_start_command(
         metadata_update["resolved"] = False
         metadata_update["resolved_at_ms"] = None
     metadata_update["updated_at_ms"] = _now_ms()
+    # Re-anchors the thread's sidebar position: the list moves for what the
+    # user did, not for every write the run makes afterwards.
+    metadata_update["last_user_message_at_ms"] = metadata_update["updated_at_ms"]
     metadata = {**metadata, **metadata_update}
     await client.threads.update(thread_id=thread_id, metadata=metadata)
 
@@ -1804,6 +1898,7 @@ async def send_dashboard_message(
     metadata_update: dict[str, Any] = {
         "source": _DASHBOARD_SOURCE,
         "updated_at_ms": now_ms,
+        "last_user_message_at_ms": now_ms,
         "plan_mode": body.plan_mode,
         PARTICIPANT_LOGINS_KEY: merge_participants(metadata.get(PARTICIPANT_LOGINS_KEY), login),
         PARTICIPANT_EMAILS_KEY: merge_participants(metadata.get(PARTICIPANT_EMAILS_KEY), email),
@@ -2013,6 +2108,53 @@ def _tracked_pull_requests(metadata: Mapping[str, Any]) -> list[object]:
             "number": pr_ref.number,
         }
     ]
+
+
+async def get_dashboard_thread_statuses(thread_ids: Sequence[str]) -> dict[str, Any]:
+    """Live status for named threads, so the sidebar can poll without refetching.
+
+    Refetching the whole sidebar to learn that one thread is still running
+    replaces every row's identity and re-renders the list; this returns only
+    the fields that move while a run is in flight.
+
+    The ids come from the caller, so each thread's readability is checked
+    individually — a thread the caller cannot read is omitted rather than
+    refused, since one stale id should not fail the whole poll.
+    """
+    client = langgraph_client()
+
+    async def load(thread_id: str) -> dict[str, Any] | None:
+        try:
+            thread = await client.threads.get(thread_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("Status lookup failed for %s", thread_id, exc_info=True)
+            return None
+        metadata = thread_metadata(thread)
+        if not _thread_is_readable(metadata):
+            return None
+        thread, latest_run_status, latest_run_id = await _refresh_latest_run_metadata(
+            client, thread
+        )
+        metadata = thread_metadata(thread)
+        return {
+            "id": thread_id,
+            "status": _run_status_to_agent_status(
+                thread.get("status") if isinstance(thread.get("status"), str) else "idle",
+                latest_run_status
+                or (
+                    metadata.get("latest_run_status")
+                    if isinstance(metadata.get("latest_run_status"), str)
+                    else None
+                ),
+            ),
+            "updatedAt": _thread_updated_ms(thread),
+            "viewed": _is_thread_viewed(metadata, latest_run_id),
+            "resolved": _is_thread_resolved(metadata),
+            "planStatus": metadata.get("plan_status"),
+        }
+
+    results = await asyncio.gather(*(load(thread_id) for thread_id in thread_ids))
+    return {"threads": [result for result in results if result is not None]}
 
 
 async def get_dashboard_thread_pull_request_status(

--- a/tests/dashboard/test_dashboard_thread_lifecycle.py
+++ b/tests/dashboard/test_dashboard_thread_lifecycle.py
@@ -1,0 +1,224 @@
+"""Thread lifecycle: transcript snapshots, stable sidebar order, status polling."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.dashboard import thread_api
+
+
+def _messages(*types: str) -> list[dict[str, str]]:
+    return [{"type": kind, "content": kind, "id": f"{kind}-{i}"} for i, kind in enumerate(types)]
+
+
+def test_transcript_window_keeps_everything_below_the_limit() -> None:
+    messages = _messages("human", "ai", "tool", "human", "ai")
+
+    window, has_more = thread_api._transcript_window(messages, turn_limit=10)
+
+    assert window == messages
+    assert has_more is False
+
+
+def test_transcript_window_cuts_on_human_anchors() -> None:
+    messages = _messages("human", "ai", "human", "ai", "tool", "human", "ai")
+
+    window, has_more = thread_api._transcript_window(messages, turn_limit=2)
+
+    assert has_more is True
+    # Starts at the second-to-last human, so no tool result outlives its call.
+    assert [message["type"] for message in window] == ["human", "ai", "tool", "human", "ai"]
+
+
+def test_transcript_window_handles_a_transcript_with_no_human_anchor() -> None:
+    messages = _messages("ai", "tool")
+
+    window, has_more = thread_api._transcript_window(messages, turn_limit=1)
+
+    assert window == messages
+    assert has_more is False
+
+
+async def test_thread_transcript_reports_unavailable_when_state_fails() -> None:
+    client = SimpleNamespace(threads=SimpleNamespace(get_state=AsyncMock(side_effect=RuntimeError)))
+
+    result = await thread_api._thread_transcript(client, "thread-1")
+
+    assert result == {"messages": [], "hasMore": False, "available": False}
+
+
+async def test_thread_transcript_returns_the_tail() -> None:
+    messages = _messages("human", "ai", "human", "ai")
+    client = SimpleNamespace(
+        threads=SimpleNamespace(
+            get_state=AsyncMock(return_value={"values": {"messages": messages}})
+        )
+    )
+
+    result = await thread_api._thread_transcript(client, "thread-1")
+
+    assert result["available"] is True
+    assert result["messages"] == messages
+
+
+async def test_thread_transcript_survives_a_state_without_messages() -> None:
+    client = SimpleNamespace(
+        threads=SimpleNamespace(get_state=AsyncMock(return_value={"values": {}}))
+    )
+
+    result = await thread_api._thread_transcript(client, "thread-1")
+
+    assert result == {"messages": [], "hasMore": False, "available": False}
+
+
+def _thread(**metadata: object) -> dict[str, object]:
+    return {"thread_id": "t1", "metadata": metadata}
+
+
+def test_sidebar_anchor_ignores_updated_at() -> None:
+    """A run bumping updated_at must not move the row."""
+    thread = _thread(created_at_ms=100, updated_at_ms=9_000)
+
+    assert thread_api._thread_sidebar_anchor_ms(thread) == 100
+
+
+def test_sidebar_anchor_re_anchors_on_a_user_message() -> None:
+    thread = _thread(created_at_ms=100, last_user_message_at_ms=500, updated_at_ms=9_000)
+
+    assert thread_api._thread_sidebar_anchor_ms(thread) == 500
+
+
+def test_sidebar_anchor_keeps_creation_when_it_is_the_later_of_the_two() -> None:
+    thread = _thread(created_at_ms=900, last_user_message_at_ms=100)
+
+    assert thread_api._thread_sidebar_anchor_ms(thread) == 900
+
+
+def test_sidebar_anchor_tolerates_missing_metadata() -> None:
+    assert thread_api._thread_sidebar_anchor_ms(_thread()) == 0
+
+
+async def test_thread_statuses_skips_threads_the_caller_cannot_read(monkeypatch) -> None:
+    readable = {"source": "dashboard", "latest_run_status": "success"}
+    hidden = {"source": "reviewer"}
+
+    async def get(thread_id: str) -> dict[str, object]:
+        return {
+            "thread_id": thread_id,
+            "status": "idle",
+            "metadata": readable if thread_id == "visible" else hidden,
+        }
+
+    async def refresh(_client: object, thread: dict[str, object]):
+        return thread, "success", "run-1"
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=SimpleNamespace(get=get)),
+    )
+    monkeypatch.setattr(thread_api, "_refresh_latest_run_metadata", refresh)
+
+    result = await thread_api.get_dashboard_thread_statuses(["visible", "hidden"])
+
+    assert [row["id"] for row in result["threads"]] == ["visible"]
+
+
+async def test_thread_statuses_drops_a_thread_that_cannot_be_loaded(monkeypatch) -> None:
+    async def get(thread_id: str) -> dict[str, object]:
+        raise RuntimeError("gone")
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=SimpleNamespace(get=get)),
+    )
+
+    result = await thread_api.get_dashboard_thread_statuses(["missing"])
+
+    assert result == {"threads": []}
+
+
+@pytest.mark.parametrize("thread_ids", [[], ["a", "b", "c"]])
+async def test_thread_statuses_returns_a_row_per_readable_id(monkeypatch, thread_ids) -> None:
+    async def get(thread_id: str) -> dict[str, object]:
+        return {"thread_id": thread_id, "status": "busy", "metadata": {"source": "dashboard"}}
+
+    async def refresh(_client: object, thread: dict[str, object]):
+        return thread, "running", "run-1"
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=SimpleNamespace(get=get)),
+    )
+    monkeypatch.setattr(thread_api, "_refresh_latest_run_metadata", refresh)
+
+    result = await thread_api.get_dashboard_thread_statuses(thread_ids)
+
+    assert [row["id"] for row in result["threads"]] == thread_ids
+    assert all(row["status"] == "running" for row in result["threads"])
+
+
+async def test_detail_skips_the_transcript_read_when_the_caller_opts_out(monkeypatch) -> None:
+    """The run-status heartbeat must not re-read state every few seconds."""
+    get_state = AsyncMock(return_value={"values": {"messages": _messages("human")}})
+    thread = {"thread_id": "t1", "status": "idle", "metadata": {"source": "dashboard"}}
+
+    async def refresh(_client: object, value: dict[str, object]):
+        return value, "success", "run-1"
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(get=AsyncMock(return_value=thread), get_state=get_state)
+        ),
+    )
+    monkeypatch.setattr(thread_api, "_refresh_latest_run_metadata", refresh)
+    monkeypatch.setattr(thread_api, "get_langsmith_trace_url", AsyncMock(return_value=None))
+
+    without = await thread_api.get_dashboard_thread(
+        "t1", "someone", mark_viewed=False, include_transcript=False
+    )
+    assert "transcript" not in without
+    assert get_state.await_count == 0
+
+    with_transcript = await thread_api.get_dashboard_thread(
+        "t1", "someone", mark_viewed=False, include_transcript=True
+    )
+    assert with_transcript["transcript"]["available"] is True
+    assert get_state.await_count == 1
+
+
+async def test_detail_carries_the_stable_sort_anchor(monkeypatch) -> None:
+    thread = {
+        "thread_id": "t1",
+        "status": "idle",
+        "metadata": {
+            "source": "dashboard",
+            "created_at_ms": 100,
+            "updated_at_ms": 9_000,
+        },
+    }
+
+    async def refresh(_client: object, value: dict[str, object]):
+        return value, "success", "run-1"
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(get=AsyncMock(return_value=thread), get_state=AsyncMock())
+        ),
+    )
+    monkeypatch.setattr(thread_api, "_refresh_latest_run_metadata", refresh)
+    monkeypatch.setattr(thread_api, "get_langsmith_trace_url", AsyncMock(return_value=None))
+
+    summary = await thread_api.get_dashboard_thread(
+        "t1", "someone", mark_viewed=False, include_transcript=False
+    )
+
+    assert summary["sortAnchorAt"] == 100
+    assert summary["updatedAt"] == 9_000

--- a/tests/dashboard/test_dashboard_thread_lifecycle.py
+++ b/tests/dashboard/test_dashboard_thread_lifecycle.py
@@ -222,3 +222,103 @@ async def test_detail_carries_the_stable_sort_anchor(monkeypatch) -> None:
 
     assert summary["sortAnchorAt"] == 100
     assert summary["updatedAt"] == 9_000
+
+
+def _sidebar_client(threads: list[dict[str, object]]):
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return threads[offset : offset + limit] if offset == 0 else []
+
+        async def update(self, *, thread_id, metadata):
+            return None
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            return []
+
+    class FakeClient:
+        threads = FakeThreads()
+        runs = FakeRuns()
+
+    return FakeClient()
+
+
+@pytest.fixture()
+def _no_pins(monkeypatch):
+    async def empty_pins(login: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(thread_api, "list_thread_pin_ids", empty_pins)
+
+
+async def test_sidebar_window_keeps_an_old_thread_used_today(monkeypatch, _no_pins) -> None:
+    """Membership is recency; only the display order uses the stable anchor.
+
+    Windowing on the anchor would drop a thread created long ago but worked on
+    today out of the sidebar, leaving it visible only while open.
+    """
+    threads = [
+        {
+            "thread_id": f"new-{index}",
+            "metadata": {
+                "source": "dashboard",
+                "github_login": "octocat",
+                "created_at_ms": 5_000 + index,
+                "updated_at_ms": 5_000 + index,
+            },
+        }
+        for index in range(3)
+    ]
+    threads.append(
+        {
+            "thread_id": "old-but-active",
+            "metadata": {
+                "source": "dashboard",
+                "github_login": "octocat",
+                "created_at_ms": 1,
+                "updated_at_ms": 9_999,
+            },
+        }
+    )
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: _sidebar_client(threads))
+
+    result = await thread_api.list_dashboard_threads_sidebar(
+        "octocat", email=None, active_limit=2, resolved_limit=0
+    )
+
+    assert "old-but-active" in [item["id"] for item in result["active"]["items"]]
+
+
+async def test_sidebar_returns_threads_with_no_repository(monkeypatch, _no_pins) -> None:
+    threads = [
+        {
+            "thread_id": "no-repo",
+            "metadata": {
+                "source": "dashboard",
+                "github_login": "octocat",
+                "created_at_ms": 2_000,
+                "updated_at_ms": 2_000,
+            },
+        },
+        {
+            "thread_id": "with-repo",
+            "metadata": {
+                "source": "dashboard",
+                "github_login": "octocat",
+                "repo_owner": "acme",
+                "repo_name": "api",
+                "created_at_ms": 1_000,
+                "updated_at_ms": 1_000,
+            },
+        },
+    ]
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: _sidebar_client(threads))
+
+    # No active thread: nothing is open in the chat window.
+    result = await thread_api.list_dashboard_threads_sidebar(
+        "octocat", email=None, active_limit=10, resolved_limit=0
+    )
+
+    items = {item["id"]: item for item in result["active"]["items"]}
+    assert set(items) == {"no-repo", "with-repo"}
+    assert items["no-repo"]["repoFullName"] == ""

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -26,6 +26,7 @@ import { Messages } from "@/features/agents/components/messages"
 import { OptimisticThreadHydrationRecovery } from "@/features/agents/components/OptimisticThreadHydrationRecovery"
 import { latestContextTokens } from "@/features/agents/lib/contextUsage"
 import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
+import { transcriptToUiMessages } from "@/features/agents/lib/threadTranscript"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { useSubmitAgentMessage } from "@/features/agents/lib/provider/useSubmitAgentMessage"
 import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
@@ -173,14 +174,23 @@ export function AgentThreadView({
     [handlePanelCollapsedChange]
   )
 
+  // The server's transcript tail, kept apart from the live stream so it can
+  // paint on the first frame and be dropped the moment the SDK hydrates.
+  const snapshotMessages = useMemo(
+    () => transcriptToUiMessages(thread.transcript),
+    [thread.transcript]
+  )
   const baseMessages = useMemo<Array<Message>>(() => {
     if (thread.messages.length > 0) return thread.messages
-    return streamMessagesToUi(
-      stream.messages,
-      stream.toolCalls,
-      messageArrivalTimestamp
-    )
-  }, [stream.messages, stream.toolCalls, thread.messages])
+    if (stream.messages.length > 0) {
+      return streamMessagesToUi(
+        stream.messages,
+        stream.toolCalls,
+        messageArrivalTimestamp
+      )
+    }
+    return snapshotMessages
+  }, [snapshotMessages, stream.messages, stream.toolCalls, thread.messages])
 
   const isStreaming =
     thread.status === "running" ||
@@ -202,7 +212,8 @@ export function AgentThreadView({
   const isThinking = stream.isLoading
   const settingUpSandbox = isThinking && baseMessages.length === 0
   // The transcript hydrates from the SDK (`GET …/state` → `stream.messages`).
-  // Show a loading state during that one-time fetch instead of the empty state.
+  // Show a loading state during that one-time fetch only when there is nothing
+  // to show yet — with a snapshot the thread is already on screen.
   const isHydrating = stream.isThreadLoading && !hasMessages
   // A failed hydrate is indistinguishable from an empty thread in the snapshot,
   // so say so rather than claiming the thread has no messages. `stream.error`

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -19,6 +19,7 @@ import { AgentRightPanel } from "@/features/agents/components/panel/AgentRightPa
 import {
   agentThreadKeys,
   invalidateAgentThreadLists,
+  markAgentThreadPending,
   optimisticThread,
   seedAgentThreadLists,
   useAgentSkills,
@@ -155,6 +156,10 @@ export function AgentsHome() {
     const thread = optimisticThread(id, draft)
     queryClient.setQueryData(agentThreadKeys.detail(id), thread)
     seedAgentThreadLists(queryClient, thread)
+    // Hold the row until a list response actually carries it. The invalidate
+    // below races the run's own metadata write, so without this the seeded row
+    // is dropped by the very refetch it triggers.
+    markAgentThreadPending(queryClient, thread)
     invalidateAgentThreadLists(queryClient)
   }, [stream.threadId, queryClient])
 

--- a/ui/src/features/agents/components/RecentAgentThreads.test.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.test.tsx
@@ -21,35 +21,35 @@ vi.mock("@/features/agents/lib/AgentThreadStreamProvider", () => ({
 }))
 
 vi.mock("@/features/agents/components/AgentThreadPage", () => ({
-  AgentThreadPage: ({
-    threadId,
-    active,
-  }: {
-    threadId: string
-    active: boolean
-  }) => <div data-active={active}>thread {threadId}</div>,
+  AgentThreadPage: ({ threadId }: { threadId: string }) => (
+    <div>thread {threadId}</div>
+  ),
 }))
 
 afterEach(cleanup)
 
 describe("RecentAgentThreads", () => {
-  it("keeps the three most recently viewed threads mounted", () => {
+  it("mounts only the active thread", () => {
     const view = render(<RecentAgentThreads activeThreadId="one" />)
 
     act(() => view.rerender(<RecentAgentThreads activeThreadId="two" />))
-    expect(screen.getByText("thread one").dataset.active).toBe("false")
+    expect(screen.queryByText("thread one")).toBeNull()
+    expect(screen.getByText("thread two")).toBeTruthy()
+
+    act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
+    expect(screen.queryByText("thread two")).toBeNull()
+    expect(screen.getByText("thread three")).toBeTruthy()
+  })
+
+  it("renders the layout's own thread without a second provider", () => {
+    render(<RecentAgentThreads activeThreadId="one" />)
     expect(screen.getByText("thread one").closest("[data-provider]")).toBeNull()
-    expect(screen.getByText("thread two").dataset.active).toBe("true")
+  })
+
+  it("gives every other thread its own provider", () => {
+    render(<RecentAgentThreads activeThreadId="two" />)
     expect(screen.getByText("thread two").parentElement?.dataset.provider).toBe(
       "two"
     )
-
-    act(() => view.rerender(<RecentAgentThreads activeThreadId="three" />))
-    act(() => view.rerender(<RecentAgentThreads activeThreadId="four" />))
-
-    expect(screen.queryByText("thread one")).toBeNull()
-    expect(screen.getByText("thread two")).toBeTruthy()
-    expect(screen.getByText("thread three")).toBeTruthy()
-    expect(screen.getByText("thread four")).toBeTruthy()
   })
 })

--- a/ui/src/features/agents/components/RecentAgentThreads.tsx
+++ b/ui/src/features/agents/components/RecentAgentThreads.tsx
@@ -1,19 +1,22 @@
-import { useEffect, useState } from "react"
 import { useStreamContext as useAgentThreadStream } from "@langchain/react"
 
 import { AgentThreadPage } from "@/features/agents/components/AgentThreadPage"
 import { AgentThreadStreamProvider } from "@/features/agents/lib/AgentThreadStreamProvider"
-import { cn } from "@/lib/utils"
 
-const MAX_MOUNTED_THREADS = 3
-
-function addRecentThread(recentThreadIds: Array<string>, threadId: string) {
-  return [threadId, ...recentThreadIds.filter((id) => id !== threadId)].slice(
-    0,
-    MAX_MOUNTED_THREADS
-  )
-}
-
+/**
+ * The opened thread, in its own stream.
+ *
+ * Each thread gets a provider of its own rather than re-pointing a shared one:
+ * the SDK's thread switch clears the transcript and cancels whatever runs the
+ * user had queued on the thread being left, so a follow-up typed during a run
+ * would vanish on navigation. A provider per thread never switches.
+ *
+ * Only the active thread is mounted. Keeping recently-viewed threads mounted
+ * used to be what made switching back feel instant, at the cost of a live SSE
+ * connection and a hidden DOM tree per retained thread; the cached detail and
+ * the server's transcript snapshot now cover that first paint without holding
+ * streams open.
+ */
 export function RecentAgentThreads({
   activeThreadId,
   autoFocusComposer = false,
@@ -22,37 +25,19 @@ export function RecentAgentThreads({
   autoFocusComposer?: boolean
 }) {
   const inheritedThreadId = useAgentThreadStream().threadId
-  const [recentThreadIds, setRecentThreadIds] = useState(() => [activeThreadId])
-  const visibleThreadIds = addRecentThread(recentThreadIds, activeThreadId)
-
-  useEffect(() => {
-    // oxlint-disable-next-line react/set-state-in-effect
-    setRecentThreadIds((current) => addRecentThread(current, activeThreadId))
-  }, [activeThreadId])
-
-  return visibleThreadIds.map((threadId) => {
-    const active = threadId === activeThreadId
-    const page = (
-      <AgentThreadPage
-        threadId={threadId}
-        active={active}
-        autoFocusComposer={active && autoFocusComposer}
-      />
-    )
-    return (
-      <div
-        key={threadId}
-        className={cn(active ? "contents" : "hidden")}
-        aria-hidden={!active}
-      >
-        {threadId === inheritedThreadId ? (
-          page
-        ) : (
-          <AgentThreadStreamProvider threadId={threadId}>
-            {page}
-          </AgentThreadStreamProvider>
-        )}
-      </div>
-    )
-  })
+  const page = (
+    <AgentThreadPage
+      threadId={activeThreadId}
+      autoFocusComposer={autoFocusComposer}
+    />
+  )
+  // A thread the layout's provider already owns — the one it just minted for a
+  // brand new thread — is rendered against that provider, so the run it started
+  // keeps streaming instead of being re-joined by a second one.
+  if (activeThreadId === inheritedThreadId) return page
+  return (
+    <AgentThreadStreamProvider key={activeThreadId} threadId={activeThreadId}>
+      {page}
+    </AgentThreadStreamProvider>
+  )
 }

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -4,6 +4,7 @@ import { Client, overrideFetchImplementation } from "@langchain/langgraph-sdk"
 import { useQueryClient } from "@tanstack/react-query"
 
 import { agentsApi } from "./api"
+import { withStreamResume } from "./streamResume"
 import { agentThreadKeys, invalidateAgentThreadLists } from "./queries"
 import type { ReactNode } from "react"
 
@@ -66,11 +67,13 @@ export function AgentThreadStreamProvider({
     transport === "local" ? LOCAL_AGENT_ASSISTANT_ID : AGENT_ASSISTANT_ID
   const client = useMemo(
     () =>
-      new Client({
-        apiUrl,
-        apiKey: null,
-        ...(transport === "cloud" ? { onRequest: dashboardRequest } : {}),
-      }),
+      withStreamResume(
+        new Client({
+          apiUrl,
+          apiKey: null,
+          ...(transport === "cloud" ? { onRequest: dashboardRequest } : {}),
+        })
+      ),
     [apiUrl, transport]
   )
 

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AgentPullRequestContextResponse,
   AgentPullRequestStatusResponse,
   AgentSchedule,
+  AgentStatus,
   AgentThread,
   ImageChunk,
   Message,
@@ -148,6 +149,16 @@ export interface SidebarThreads {
   pinned?: Array<AgentThread>
 }
 
+/** The fields of a thread that move while a run is in flight. */
+export interface ThreadStatusUpdate {
+  id: string
+  status: AgentStatus
+  updatedAt: number
+  viewed: boolean
+  resolved: boolean
+  planStatus?: string | null
+}
+
 const API_BASE = dashboardApiBase()
 
 export const agentsLangGraphApiUrl = `${API_BASE}/dashboard/api`
@@ -282,6 +293,11 @@ export const agentsApi = {
     agentsRequest<SidebarThreads>(
       `/threads/sidebar${buildSidebarThreadsQuery(params)}`
     ),
+  listThreadStatuses: (threadIds: Array<string>) =>
+    agentsRequest<{ threads: Array<ThreadStatusUpdate> }>("/threads/statuses", {
+      method: "POST",
+      body: JSON.stringify({ threadIds }),
+    }),
   listThreadsPage: (params: ThreadsPageParams = {}) =>
     agentsRequest<ThreadsPage>(`/threads/page${buildThreadsPageQuery(params)}`),
   resolveThread: (threadId: string, resolved: boolean) =>
@@ -319,12 +335,20 @@ export const agentsApi = {
     agentsRequest<void>(`/schedules/${encodeURIComponent(scheduleId)}`, {
       method: "DELETE",
     }),
-  getThread: (threadId: string, options?: { markViewed?: boolean }) =>
-    agentsRequest<AgentThread>(
-      `/threads/${encodeURIComponent(threadId)}${
-        options?.markViewed === false ? "?mark_viewed=false" : ""
-      }`
-    ),
+  getThread: (
+    threadId: string,
+    options?: { markViewed?: boolean; includeTranscript?: boolean }
+  ) => {
+    const query = new URLSearchParams()
+    if (options?.markViewed === false) query.set("mark_viewed", "false")
+    if (options?.includeTranscript === false) {
+      query.set("include_transcript", "false")
+    }
+    const suffix = query.size > 0 ? `?${query.toString()}` : ""
+    return agentsRequest<AgentThread>(
+      `/threads/${encodeURIComponent(threadId)}${suffix}`
+    )
+  },
   getPullRequestChecks: (
     pullRequests: Array<{ repoFullName: string; number: number }>
   ) =>

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -8,6 +8,7 @@ import { agentsApi } from "./api"
 import {
   SIDEBAR_PAGE_SIZE,
   agentThreadKeys,
+  markAgentThreadPending,
   markAgentThreadViewed,
   setAgentThreadStatus,
   useAgentThreadWorkingTreeDiff,
@@ -315,6 +316,68 @@ describe("useSidebarThreads", () => {
       resolvedLimit: SIDEBAR_PAGE_SIZE,
       includeAutomations: false,
     })
+  })
+
+  it("keeps a just-created thread listed after navigating away from it", async () => {
+    // The server list lags the run's own metadata write, so it comes back
+    // without the thread the user just started.
+    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue(
+      emptySidebar(SIDEBAR_PAGE_SIZE, 0)
+    )
+    const client = testClient()
+    const created = {
+      id: "brand-new",
+      resolved: false,
+      status: "running",
+      createdAt: Date.now(),
+    } as AgentThread
+
+    // No activeThreadId: the user has navigated back to start another thread.
+    const { result } = renderHook(() => useSidebarThreads({}), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    act(() => markAgentThreadPending(client, created))
+
+    await waitFor(() =>
+      expect(result.current.data.active.items.map((t) => t.id)).toEqual([
+        "brand-new",
+      ])
+    )
+  })
+
+  it("drops a pending thread once the server list carries it", async () => {
+    const created = {
+      id: "brand-new",
+      resolved: false,
+      status: "running",
+      createdAt: Date.now(),
+    } as AgentThread
+    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue({
+      active: { items: [created], limit: SIDEBAR_PAGE_SIZE, hasMore: false },
+      resolved: { items: [], limit: 0, hasMore: false },
+    })
+    const client = testClient()
+
+    const { result } = renderHook(() => useSidebarThreads({}), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    act(() => markAgentThreadPending(client, created))
+
+    // Listed exactly once — the held copy must not double up the server row.
+    await waitFor(() =>
+      expect(result.current.data.active.items.map((t) => t.id)).toEqual([
+        "brand-new",
+      ])
+    )
+    expect(client.getQueryData(["agent-threads", "pending"])).toEqual([])
   })
 
   it("adds a selected thread outside the shared sidebar window", async () => {

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -53,22 +53,21 @@ export function invalidateAgentThreadLists(queryClient: QueryClient): void {
   void queryClient.invalidateQueries({ queryKey: agentThreadKeys.lists })
 }
 
-export function setAgentThreadStatus(
+/**
+ * Apply one edit to every cached thread list. The sidebar and the paged views
+ * each hold their own copy of a thread, so an edit has to reach all of them or
+ * the row it touches snaps back as soon as another list repaints.
+ */
+function mapCachedThreadLists(
   queryClient: QueryClient,
-  threadId: string,
-  status: AgentStatus
+  update: (thread: AgentThread) => AgentThread
 ): void {
-  const update = (thread: AgentThread) =>
-    thread.id === threadId ? { ...thread, status } : thread
-  queryClient.setQueryData<AgentThread>(
-    agentThreadKeys.detail(threadId),
-    (prev) => (prev ? update(prev) : prev)
-  )
   queryClient.setQueriesData<SidebarThreads>(
     { queryKey: ["agent-threads", "lists", "sidebar"] },
     (prev) =>
       prev && {
         ...prev,
+        ...(prev.pinned ? { pinned: prev.pinned.map(update) } : {}),
         active: { ...prev.active, items: prev.active.items.map(update) },
         resolved: { ...prev.resolved, items: prev.resolved.items.map(update) },
       }
@@ -84,6 +83,20 @@ export function setAgentThreadStatus(
         })),
       }
   )
+}
+
+export function setAgentThreadStatus(
+  queryClient: QueryClient,
+  threadId: string,
+  status: AgentStatus
+): void {
+  const update = (thread: AgentThread) =>
+    thread.id === threadId ? { ...thread, status } : thread
+  queryClient.setQueryData<AgentThread>(
+    agentThreadKeys.detail(threadId),
+    (prev) => (prev ? update(prev) : prev)
+  )
+  mapCachedThreadLists(queryClient, update)
   queryClient.setQueryData<AgentThread>(
     agentThreadKeys.sidebarActive(threadId),
     (prev) => (prev ? update(prev) : prev)
@@ -508,6 +521,62 @@ function sidebarThreads(data?: SidebarThreads): Array<AgentThread> {
   ]
 }
 
+/** Interval for watching a live run, matching the previous whole-list cadence. */
+const RUNNING_STATUS_POLL_MS = 2000
+
+/**
+ * Keep the running rows of a loaded sidebar current without refetching it.
+ *
+ * Only the threads that are actually running are polled, and the response
+ * carries just the fields that move, so a repaint touches those rows instead of
+ * rebuilding every list the thread appears in.
+ */
+function useRunningThreadStatuses(
+  data: SidebarThreads | undefined,
+  enabled: boolean
+): void {
+  const queryClient = useQueryClient()
+  const runningIds = sidebarThreads(data)
+    .filter((thread) => thread.status === "running")
+    .map((thread) => thread.id)
+    .sort()
+  const idsKey = runningIds.join(",")
+
+  const { data: statuses } = useQuery({
+    queryKey: ["agent-threads", "statuses", idsKey],
+    // Split from the key rather than closing over `runningIds`, so the fetched
+    // ids and the cache key can never disagree.
+    queryFn: () => agentsApi.listThreadStatuses(idsKey.split(",")),
+    enabled: enabled && idsKey.length > 0,
+    refetchInterval: RUNNING_STATUS_POLL_MS,
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (!statuses?.threads.length) return
+    const byId = new Map(statuses.threads.map((row) => [row.id, row]))
+    let settled = false
+    mapCachedThreadLists(queryClient, (thread) => {
+      const update = byId.get(thread.id)
+      if (!update) return thread
+      if (update.status !== "running" && thread.status === "running") {
+        settled = true
+      }
+      // A new object only where something actually changed, so untouched rows
+      // keep their identity and skip re-rendering.
+      return update.status === thread.status &&
+        update.viewed === thread.viewed &&
+        update.resolved === thread.resolved &&
+        update.planStatus === thread.planStatus
+        ? thread
+        : { ...thread, ...update }
+    })
+    // A run ending can add or remove rows (a PR opened, a thread resolved),
+    // which a status patch cannot express — reconcile once, on that edge only.
+    if (settled) invalidateAgentThreadLists(queryClient)
+  }, [queryClient, statuses])
+}
+
 export function useSidebarThreads({
   activeThreadId,
   includeAutomations = false,
@@ -533,13 +602,12 @@ export function useSidebarThreads({
     placeholderData: (previous) => previous,
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
-    refetchInterval: (current) =>
-      sidebarThreads(current.state.data).some(
-        (thread) => thread.status === "running"
-      )
-        ? 2000
-        : false,
+    // Deliberately no interval. Re-fetching the whole list to watch one thread
+    // replaced every row's identity twice a second, so the list re-rendered
+    // (and re-sorted) continuously while an agent worked. `useRunningThreadStatuses`
+    // polls just the running rows and patches them in place instead.
   })
+  useRunningThreadStatuses(query.data, enabled)
   const activeThreadLoaded = sidebarThreads(query.data).some(
     (thread) => thread.id === activeThreadId
   )
@@ -553,8 +621,6 @@ export function useSidebarThreads({
       !activeThreadLoaded,
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
-    refetchInterval: (current) =>
-      current.state.data?.status === "running" ? 2000 : false,
     retry: false,
   })
   const baseData = query.data ?? {
@@ -596,19 +662,49 @@ export function useSidebarThreads({
   }
 }
 
+/**
+ * A thread the sidebar has already loaded, used to paint an opened thread's
+ * chrome while its detail request is in flight. It carries metadata only — no
+ * transcript — so the view still shows a hydrating transcript, not a wrong one.
+ */
+function listedThread(
+  queryClient: QueryClient,
+  threadId: string
+): AgentThread | undefined {
+  for (const [, data] of queryClient.getQueriesData<SidebarThreads>({
+    queryKey: ["agent-threads", "lists", "sidebar"],
+  })) {
+    const match = sidebarThreads(data).find((thread) => thread.id === threadId)
+    if (match) return match
+  }
+  return undefined
+}
+
 export function useAgentThread(threadId: string) {
   const queryClient = useQueryClient()
   const queryKey = agentThreadKeys.detail(threadId)
+  // Resolved per render rather than inside `placeholderData` so the query's
+  // data type stays `AgentThread` — a resolver returning `undefined` widens it.
+  const placeholder = listedThread(queryClient, threadId)
 
   return useQuery({
     queryKey,
     queryFn: async ({ queryKey: key }) => {
-      const thread = await agentsApi.getThread(threadId)
-      const queuedMessages =
-        queryClient.getQueryData<AgentThread>(key)?.queuedMessages
-      return thread.status === "running" && queuedMessages?.length
-        ? { ...thread, queuedMessages }
-        : thread
+      const cached = queryClient.getQueryData<AgentThread>(key)
+      // The snapshot is only needed to paint a thread that has nothing on
+      // screen yet. Asking again on the run-status heartbeat would cost a
+      // `getState` every few seconds for no visible gain.
+      const transcript = cached?.transcript
+      const thread = await agentsApi.getThread(threadId, {
+        includeTranscript: !transcript?.available,
+      })
+      return {
+        ...thread,
+        ...(thread.transcript ? {} : transcript ? { transcript } : {}),
+        ...(thread.status === "running" && cached?.queuedMessages?.length
+          ? { queuedMessages: cached.queuedMessages }
+          : {}),
+      }
     },
     // Server truth heartbeat while a run is live. The SDK's SSE transport does
     // not reconnect once a custom `fetch` is supplied (it needs the dashboard
@@ -620,6 +716,15 @@ export function useAgentThread(threadId: string) {
     // proxied run.start stamps the server-side thread; an immediate refetch
     // would 404 and bounce the route back to /agents.
     staleTime: 30_000,
+    // Switching threads must not throw away the thread being left: coming back
+    // to it should paint from cache instead of showing a skeleton through
+    // another round trip. Thread details are small and bounded by how many
+    // threads one session opens.
+    gcTime: Infinity,
+    // First open of a thread the sidebar already lists: show its chrome now
+    // rather than a skeleton. Placeholder data is not written to the cache, so
+    // the real response still lands normally.
+    placeholderData: placeholder,
   })
 }
 

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -341,6 +341,40 @@ export function seedAgentThreadLists(
   queryClient.setQueryData(agentThreadKeys.sidebarActive(thread.id), thread)
 }
 
+/**
+ * Threads created in this session that the server's list has not caught up to.
+ *
+ * A new thread exists in LangGraph the moment the SDK mints its id, but the
+ * sidebar is built from a metadata search that the run's own metadata write
+ * lands in a beat later. Without somewhere to hold it, the row a user just
+ * created shows up, gets replaced by the next list response that predates it,
+ * and vanishes until something else refetches.
+ */
+const pendingThreadsKey = ["agent-threads", "pending"] as const
+
+/** How long an unconfirmed thread stays pinned before we stop waiting for it. */
+const PENDING_THREAD_TTL_MS = 2 * 60_000
+
+export function markAgentThreadPending(
+  queryClient: QueryClient,
+  thread: AgentThread
+): void {
+  queryClient.setQueryData<Array<AgentThread>>(pendingThreadsKey, (prev) => [
+    thread,
+    ...(prev ?? []).filter((item) => item.id !== thread.id),
+  ])
+}
+
+function usePendingThreads(): Array<AgentThread> {
+  const { data } = useQuery({
+    queryKey: pendingThreadsKey,
+    queryFn: () => [] as Array<AgentThread>,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  })
+  return data ?? []
+}
+
 export const agentScheduleKeys = {
   all: ["agent-schedules"] as const,
 }
@@ -588,6 +622,7 @@ export function useSidebarThreads({
   includeResolved?: boolean
   enabled?: boolean
 }) {
+  const queryClient = useQueryClient()
   const [activeLimit, setActiveLimit] = useState(SIDEBAR_PAGE_SIZE)
   const [resolvedLimit, setResolvedLimit] = useState(SIDEBAR_PAGE_SIZE)
   const params = {
@@ -602,13 +637,40 @@ export function useSidebarThreads({
     placeholderData: (previous) => previous,
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
-    // Deliberately no interval. Re-fetching the whole list to watch one thread
-    // replaced every row's identity twice a second, so the list re-rendered
-    // (and re-sorted) continuously while an agent worked. `useRunningThreadStatuses`
-    // polls just the running rows and patches them in place instead.
+    // No interval for watching a run: re-fetching the whole list to learn one
+    // thread is still going replaced every row's identity twice a second, and
+    // `useRunningThreadStatuses` patches those rows in place instead. The list
+    // is still refetched while a just-created thread is missing from it, which
+    // is the one case a status patch cannot express.
+    // Read from the cache at call time rather than from a render value: the
+    // pending list is only known after this query's own response.
+    refetchInterval: () =>
+      (queryClient.getQueryData<Array<AgentThread>>(pendingThreadsKey)
+        ?.length ?? 0) > 0
+        ? 2000
+        : false,
   })
   useRunningThreadStatuses(query.data, enabled)
-  const activeThreadLoaded = sidebarThreads(query.data).some(
+  const listed = sidebarThreads(query.data)
+  const listedIds = new Set(listed.map((thread) => thread.id))
+  const pendingThreads = usePendingThreads()
+  const unconfirmed = pendingThreads.filter(
+    (thread) => !listedIds.has(thread.id)
+  )
+  // Stop holding a thread as soon as the list carries it, or once it has waited
+  // long enough that it is never arriving, so the held copy never outlives the
+  // server's own row. Ageing happens here rather than in the filter above
+  // because the clock has no place in render.
+  useEffect(() => {
+    if (pendingThreads.length === 0) return
+    const now = Date.now()
+    const keep = unconfirmed.filter(
+      (thread) => now - thread.createdAt < PENDING_THREAD_TTL_MS
+    )
+    if (keep.length === pendingThreads.length) return
+    queryClient.setQueryData<Array<AgentThread>>(pendingThreadsKey, keep)
+  }, [pendingThreads.length, queryClient, unconfirmed])
+  const activeThreadLoaded = listed.some(
     (thread) => thread.id === activeThreadId
   )
   const activeThreadQuery = useQuery({
@@ -630,7 +692,7 @@ export function useSidebarThreads({
   }
   const activeThread = activeThreadLoaded ? undefined : activeThreadQuery.data
   const group = activeThread?.resolved ? "resolved" : "active"
-  const data =
+  const withActive =
     activeThread && (!activeThread.resolved || includeResolved)
       ? {
           ...baseData,
@@ -640,6 +702,21 @@ export function useSidebarThreads({
           },
         }
       : baseData
+  // A just-created thread stays visible wherever the user navigates, not only
+  // while it happens to be the open one.
+  const stillMissing = unconfirmed.filter(
+    (thread) => thread.id !== activeThread?.id
+  )
+  const data =
+    stillMissing.length > 0
+      ? {
+          ...withActive,
+          active: {
+            ...withActive.active,
+            items: [...stillMissing, ...withActive.active.items],
+          },
+        }
+      : withActive
 
   return {
     data,

--- a/ui/src/features/agents/lib/sidebarThreads.test.ts
+++ b/ui/src/features/agents/lib/sidebarThreads.test.ts
@@ -9,6 +9,7 @@ import {
   groupSidebarThreadsByProject,
   localSidebarThread,
   sidebarProjectOptions,
+  sortSidebarThreads,
 } from "./sidebarThreads"
 
 function cloudThread(overrides: Partial<AgentThread> = {}): AgentThread {
@@ -121,6 +122,48 @@ describe("sidebar thread adapters", () => {
   })
 })
 
+describe("sortSidebarThreads", () => {
+  it("holds its order while a running thread's updatedAt climbs", () => {
+    const older = cloudSidebarThread(
+      cloudThread({ id: "older", createdAt: 10, sortAnchorAt: 10 })
+    )
+    const newer = cloudSidebarThread(
+      cloudThread({ id: "newer", createdAt: 20, sortAnchorAt: 20 })
+    )
+    const before = sortSidebarThreads([older, newer], "updated")
+    expect(before.map((thread) => thread.id)).toEqual(["newer", "older"])
+
+    // A run writing state bumps updatedAt on the older thread; the sidebar
+    // must not lift it above the newer one.
+    const busy = cloudSidebarThread(
+      cloudThread({
+        id: "older",
+        createdAt: 10,
+        sortAnchorAt: 10,
+        updatedAt: 9999,
+      })
+    )
+    const after = sortSidebarThreads([busy, newer], "updated")
+    expect(after.map((thread) => thread.id)).toEqual(["newer", "older"])
+  })
+
+  it("re-anchors a thread when the user sends a message", () => {
+    const older = cloudSidebarThread(
+      cloudThread({ id: "older", createdAt: 10, sortAnchorAt: 10 })
+    )
+    const newer = cloudSidebarThread(
+      cloudThread({ id: "newer", createdAt: 20, sortAnchorAt: 20 })
+    )
+    const replied = cloudSidebarThread(
+      cloudThread({ id: "older", createdAt: 10, sortAnchorAt: 30 })
+    )
+    expect(
+      sortSidebarThreads([replied, newer], "updated").map((t) => t.id)
+    ).toEqual(["older", "newer"])
+    expect(older.sortAnchorAt).toBe(10)
+  })
+})
+
 describe("groupSidebarThreadsByProject", () => {
   it("buckets threads per project and ranks projects by their freshest thread", () => {
     const alphaOld = cloudSidebarThread(
@@ -128,7 +171,7 @@ describe("groupSidebarThreadsByProject", () => {
         id: "alpha-old",
         repo: "alpha",
         repoFullName: "acme/alpha",
-        updatedAt: 5,
+        sortAnchorAt: 5,
       })
     )
     const alphaNew = cloudSidebarThread(
@@ -136,7 +179,7 @@ describe("groupSidebarThreadsByProject", () => {
         id: "alpha-new",
         repo: "alpha",
         repoFullName: "acme/alpha",
-        updatedAt: 40,
+        sortAnchorAt: 40,
       })
     )
     const beta = cloudSidebarThread(
@@ -144,7 +187,7 @@ describe("groupSidebarThreadsByProject", () => {
         id: "beta",
         repo: "beta",
         repoFullName: "acme/beta",
-        updatedAt: 50,
+        sortAnchorAt: 50,
       })
     )
     const items = [alphaOld, alphaNew, beta]

--- a/ui/src/features/agents/lib/sidebarThreads.ts
+++ b/ui/src/features/agents/lib/sidebarThreads.ts
@@ -22,6 +22,8 @@ interface SidebarThreadItemBase {
   resolved?: boolean
   createdAt: number
   updatedAt: number
+  /** Stable ordering key; see `AgentThread.sortAnchorAt`. */
+  sortAnchorAt: number
   planStatus?: string | null
   pr?: AgentThread["pr"]
   /** `owner/repo` + number of `pr`, when the thread carries a full PR record. */
@@ -91,6 +93,7 @@ export function cloudSidebarThread(
     resolved: thread.resolved,
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
+    sortAnchorAt: thread.sortAnchorAt ?? thread.createdAt,
     planStatus: thread.planStatus,
     pr: thread.pr,
     prRef: pullRequestRef(thread),
@@ -126,6 +129,7 @@ export function localSidebarThread(
     resolved: thread.archived === true,
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
+    sortAnchorAt: thread.createdAt,
     thread,
   }
 }
@@ -215,7 +219,8 @@ export function groupSidebarThreadsByProject(
       .filter((group) => group.threads.length > 0)
       .sort(
         (left, right) =>
-          (right.threads[0]?.updatedAt ?? 0) - (left.threads[0]?.updatedAt ?? 0)
+          (right.threads[0]?.sortAnchorAt ?? 0) -
+          (left.threads[0]?.sortAnchorAt ?? 0)
       ),
     recents,
   }
@@ -235,7 +240,7 @@ function priorityRank(thread: SidebarThreadItem): number {
 
 function byRecency(left: SidebarThreadItem, right: SidebarThreadItem): number {
   return (
-    right.updatedAt - left.updatedAt ||
+    right.sortAnchorAt - left.sortAnchorAt ||
     right.createdAt - left.createdAt ||
     left.key.localeCompare(right.key)
   )

--- a/ui/src/features/agents/lib/streamResume.test.ts
+++ b/ui/src/features/agents/lib/streamResume.test.ts
@@ -1,0 +1,139 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  forgetStreamEvents,
+  recallStreamEvent,
+  rememberStreamEvent,
+  withStreamResume,
+} from "./streamResume"
+import type { Client } from "@langchain/langgraph-sdk"
+
+interface JoinCall {
+  runId: string
+  options: { lastEventId?: string } | undefined
+}
+
+function fakeClient(events: Array<{ id?: string }>) {
+  const joinCalls: Array<JoinCall> = []
+  const runs = {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    joinStream: async function* (
+      _threadId: string | undefined | null,
+      runId: string,
+      options?: { lastEventId?: string }
+    ) {
+      joinCalls.push({ runId, options })
+      yield* events
+    },
+    stream: async function* (
+      _threadId: string | null,
+      _assistantId: string,
+      payload?: Record<string, unknown>
+    ) {
+      const onRunCreated = payload?.["onRunCreated"] as
+        | ((p: { run_id: string; thread_id: string }) => void)
+        | undefined
+      onRunCreated?.({ run_id: "run-1", thread_id: "thread-1" })
+      yield* events
+      await Promise.resolve()
+    },
+  }
+  return { client: { runs } as unknown as Client, joinCalls }
+}
+
+async function drain(generator: AsyncGenerator<unknown>) {
+  for await (const _ of generator) {
+    // consume
+  }
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+})
+
+describe("withStreamResume", () => {
+  it("resumes a rejoin from the last event the run delivered", async () => {
+    const { client, joinCalls } = fakeClient([{ id: "1" }, { id: "2" }])
+    withStreamResume(client)
+
+    await drain(client.runs.joinStream("thread-1", "run-1"))
+    await drain(client.runs.joinStream("thread-1", "run-1"))
+
+    expect(joinCalls[0]?.options?.lastEventId).toBeUndefined()
+    expect(joinCalls[1]?.options?.lastEventId).toBe("2")
+  })
+
+  it("records ids from the initial run stream too", async () => {
+    const { client } = fakeClient([{ id: "7" }])
+    withStreamResume(client)
+
+    await drain(
+      client.runs.stream("thread-1", "agent") as AsyncGenerator<unknown>
+    )
+
+    expect(recallStreamEvent("thread-1", "run-1")).toBe("7")
+  })
+
+  it("treats the SDK's own -1 default as no resume point", async () => {
+    const { client, joinCalls } = fakeClient([{ id: "3" }])
+    withStreamResume(client)
+    rememberStreamEvent("thread-1", "run-1", "3")
+
+    await drain(
+      client.runs.joinStream("thread-1", "run-1", { lastEventId: "-1" })
+    )
+
+    expect(joinCalls[0]?.options?.lastEventId).toBe("3")
+  })
+
+  it("keeps an explicit caller-supplied resume point", async () => {
+    const { client, joinCalls } = fakeClient([{ id: "9" }])
+    withStreamResume(client)
+    rememberStreamEvent("thread-1", "run-1", "3")
+
+    await drain(
+      client.runs.joinStream("thread-1", "run-1", { lastEventId: "5" })
+    )
+
+    expect(joinCalls[0]?.options?.lastEventId).toBe("5")
+  })
+
+  it("does not resume across different runs", async () => {
+    const { client, joinCalls } = fakeClient([{ id: "4" }])
+    withStreamResume(client)
+
+    await drain(client.runs.joinStream("thread-1", "run-1"))
+    await drain(client.runs.joinStream("thread-1", "run-2"))
+
+    expect(joinCalls[1]?.options?.lastEventId).toBeUndefined()
+  })
+
+  it("wraps a client only once", () => {
+    const { client } = fakeClient([])
+    const first = client.runs.joinStream
+    withStreamResume(client)
+    const wrapped = client.runs.joinStream
+    withStreamResume(client)
+
+    expect(wrapped).not.toBe(first)
+    expect(client.runs.joinStream).toBe(wrapped)
+  })
+
+  it("leaves a client without a runs namespace alone", () => {
+    const stub = {} as Client
+    expect(withStreamResume(stub)).toBe(stub)
+  })
+
+  it("forgets a thread's resume points", async () => {
+    const { client } = fakeClient([{ id: "6" }])
+    withStreamResume(client)
+
+    await drain(client.runs.joinStream("thread-1", "run-1"))
+    expect(recallStreamEvent("thread-1", "run-1")).toBe("6")
+
+    forgetStreamEvents("thread-1")
+    expect(recallStreamEvent("thread-1", "run-1")).toBeUndefined()
+  })
+})

--- a/ui/src/features/agents/lib/streamResume.ts
+++ b/ui/src/features/agents/lib/streamResume.ts
@@ -1,0 +1,193 @@
+import type { Client } from "@langchain/langgraph-sdk"
+
+/**
+ * Resume a run's SSE stream where it left off instead of replaying it.
+ *
+ * `client.runs.joinStream` defaults `lastEventId` to `"-1"`, so every rejoin —
+ * remounting the thread view, switching back to a running thread, a dropped
+ * event stream — re-delivers the run's whole event history and re-animates
+ * every tool call the user already watched. The SDK does track a last event id,
+ * but only within one `joinStream` call, so it is lost across mounts.
+ *
+ * Recording the last id each run reaches, and handing it back on the next
+ * rejoin, turns a rejoin into "send me what I missed". A server that ignores
+ * `Last-Event-ID` just replays as before, so this can only narrow the payload.
+ */
+
+const STORAGE_KEY = "open-swe:stream-resume"
+/** Enough for far more concurrent runs than a session realistically opens. */
+const MAX_ENTRIES = 64
+
+type ResumeMap = Record<string, string>
+
+function storage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage
+  } catch {
+    // Private windows and blocked site data throw on access, not just on use.
+    return null
+  }
+}
+
+function readMap(): ResumeMap {
+  const store = storage()
+  if (!store) return {}
+  try {
+    const raw = store.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as ResumeMap)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeMap(map: ResumeMap): void {
+  const store = storage()
+  if (!store) return
+  try {
+    store.setItem(STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // A full or unavailable store costs a replay, not correctness.
+  }
+}
+
+function resumeKey(threadId: string | undefined | null, runId: string): string {
+  return `${threadId ?? "-"}:${runId}`
+}
+
+export function recallStreamEvent(
+  threadId: string | undefined | null,
+  runId: string
+): string | undefined {
+  return readMap()[resumeKey(threadId, runId)]
+}
+
+export function rememberStreamEvent(
+  threadId: string | undefined | null,
+  runId: string,
+  eventId: string
+): void {
+  const map = readMap()
+  const key = resumeKey(threadId, runId)
+  // Re-insert last so the oldest key is the one dropped when trimming.
+  delete map[key]
+  map[key] = eventId
+  const keys = Object.keys(map)
+  for (const stale of keys.slice(0, Math.max(0, keys.length - MAX_ENTRIES))) {
+    delete map[stale]
+  }
+  writeMap(map)
+}
+
+export function forgetStreamEvents(threadId: string): void {
+  const map = readMap()
+  const prefix = `${threadId}:`
+  let changed = false
+  for (const key of Object.keys(map)) {
+    if (key.startsWith(prefix)) {
+      delete map[key]
+      changed = true
+    }
+  }
+  if (changed) writeMap(map)
+}
+
+interface ResumableRuns {
+  joinStream: (
+    threadId: string | undefined | null,
+    runId: string,
+    options?: unknown
+  ) => AsyncGenerator<{ id?: string }>
+  stream: (
+    threadId: string | null,
+    assistantId: string,
+    payload?: Record<string, unknown>
+  ) => AsyncGenerator<{ id?: string }>
+  __openSweResume?: boolean
+}
+
+/**
+ * Wrap a client so both the initial run stream and every rejoin record the ids
+ * they see, and so a rejoin resumes from the last one. Mutates the client's
+ * `runs` namespace in place — the SDK holds its own reference to it, so
+ * returning a copy would not be seen.
+ *
+ * The initial `stream` has to record too: without it the first rejoin after a
+ * submit has nothing to resume from and replays the run in full, which is the
+ * common case (send a message, navigate away, come back).
+ */
+export function withStreamResume(client: Client): Client {
+  const runs = client.runs as unknown as ResumableRuns | undefined
+  // A client without a `runs` namespace is a stub (tests) or a shape this
+  // wrapper does not understand; leave it exactly as it was.
+  if (!runs?.joinStream || !runs.stream) return client
+  if (runs.__openSweResume) return client
+  runs.__openSweResume = true
+
+  const run = runs.stream.bind(runs)
+  runs.stream = async function* (threadId, assistantId, payload) {
+    // The run id only exists once the server has created the run, so the ids
+    // seen before that are buffered and flushed when `onRunCreated` fires.
+    let activeRunId: string | null = null
+    let activeThreadId = threadId
+    let pendingEventId: string | null = null
+    const callerOnRunCreated = payload?.["onRunCreated"]
+    const nextPayload = {
+      ...payload,
+      onRunCreated: (params: { run_id?: string; thread_id?: string }) => {
+        activeRunId = params.run_id ?? null
+        activeThreadId = params.thread_id ?? activeThreadId
+        if (activeRunId && pendingEventId) {
+          rememberStreamEvent(activeThreadId, activeRunId, pendingEventId)
+          pendingEventId = null
+        }
+        if (typeof callerOnRunCreated === "function") {
+          ;(callerOnRunCreated as (p: unknown) => void)(params)
+        }
+      },
+    }
+
+    for await (const value of run(threadId, assistantId, nextPayload)) {
+      if (value.id) {
+        if (activeRunId)
+          rememberStreamEvent(activeThreadId, activeRunId, value.id)
+        else pendingEventId = value.id
+      }
+      yield value
+    }
+  }
+
+  const join = runs.joinStream.bind(runs)
+  runs.joinStream = async function* (threadId, runId, options) {
+    // An AbortSignal in the options slot is the SDK's legacy call shape. It has
+    // no field to carry a resume point, so it passes through untouched.
+    const isSignal = options instanceof AbortSignal
+    const supplied =
+      !isSignal && typeof options === "object" && options !== null
+        ? (options as { lastEventId?: string }).lastEventId
+        : undefined
+    // `"-1"` is the SDK's own "from the beginning" default rather than a real
+    // caller intent, so it is treated as absent. The reconnect-on-mount path
+    // passes no options at all, which is the case that matters most.
+    const resumeFrom =
+      supplied && supplied !== "-1"
+        ? supplied
+        : recallStreamEvent(threadId, runId)
+    const nextOptions = isSignal
+      ? options
+      : {
+          ...(typeof options === "object" && options !== null ? options : {}),
+          ...(resumeFrom ? { lastEventId: resumeFrom } : {}),
+        }
+
+    for await (const value of join(threadId, runId, nextOptions)) {
+      if (value.id) rememberStreamEvent(threadId, runId, value.id)
+      yield value
+    }
+  }
+
+  return client
+}

--- a/ui/src/features/agents/lib/threadTranscript.test.ts
+++ b/ui/src/features/agents/lib/threadTranscript.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+
+import { transcriptToUiMessages } from "./threadTranscript"
+
+describe("transcriptToUiMessages", () => {
+  it("renders a snapshot's turns through the live-stream pipeline", () => {
+    const messages = transcriptToUiMessages({
+      available: true,
+      hasMore: false,
+      messages: [
+        { type: "human", content: "fix the build", id: "m1" },
+        { type: "ai", content: "on it", id: "m2" },
+      ],
+    })
+
+    expect(messages.map((message) => message.author)).toEqual(["user", "agent"])
+    expect(messages[0]?.chunks[0]).toMatchObject({
+      kind: "text",
+      text: "fix the build",
+    })
+  })
+
+  it("carries tool calls through as tool-execution chunks", () => {
+    const messages = transcriptToUiMessages({
+      available: true,
+      hasMore: false,
+      messages: [
+        { type: "human", content: "read it", id: "m1" },
+        {
+          type: "ai",
+          content: "",
+          id: "m2",
+          tool_calls: [
+            { id: "call-1", name: "read_file", args: { file_path: "a.ts" } },
+          ],
+        },
+        {
+          type: "tool",
+          content: "contents",
+          id: "m3",
+          tool_call_id: "call-1",
+        },
+      ],
+    })
+
+    const chunks = messages.flatMap((message) => message.chunks)
+    expect(
+      chunks.some(
+        (chunk) => chunk.kind === "tool-execution" && chunk.toolKind === "read"
+      )
+    ).toBe(true)
+  })
+
+  it("returns nothing when the server could not read the transcript", () => {
+    expect(
+      transcriptToUiMessages({ available: false, hasMore: false, messages: [] })
+    ).toEqual([])
+    expect(transcriptToUiMessages(undefined)).toEqual([])
+  })
+
+  it("falls back to empty rather than throwing on an unreadable shape", () => {
+    expect(
+      transcriptToUiMessages({
+        available: true,
+        hasMore: false,
+        messages: [{ nonsense: true }],
+      })
+    ).toEqual([])
+  })
+})

--- a/ui/src/features/agents/lib/threadTranscript.ts
+++ b/ui/src/features/agents/lib/threadTranscript.ts
@@ -1,0 +1,35 @@
+import { ensureMessageInstances } from "@langchain/langgraph-sdk/ui"
+
+import { messageArrivalTimestamp } from "./messageTimestamps"
+import { streamMessagesToUi } from "./streamMessagesToUi"
+import type { BaseMessage } from "@langchain/core/messages"
+import type { Message, ThreadTranscript } from "./types"
+
+/**
+ * Render the server's transcript snapshot through the same pipeline the live
+ * stream uses.
+ *
+ * The snapshot exists so an opened thread paints immediately instead of
+ * waiting on the SDK's `getState`. Running it through `streamMessagesToUi`
+ * rather than converting server-side is what keeps the two paths from
+ * drifting: there is one definition of how a message becomes a chunk, and the
+ * snapshot inherits every fix made for the live path — including treating
+ * message content as untrusted data that the React tree escapes.
+ */
+export function transcriptToUiMessages(
+  transcript: ThreadTranscript | undefined
+): Array<Message> {
+  if (!transcript?.available || transcript.messages.length === 0) return []
+  try {
+    const revived = ensureMessageInstances(
+      transcript.messages as Parameters<typeof ensureMessageInstances>[0]
+    ) as Array<BaseMessage>
+    // No assembled tool calls: those are a live-stream concept, and the
+    // snapshot's tool results are already in the messages themselves.
+    return streamMessagesToUi(revived, [], messageArrivalTimestamp)
+  } catch {
+    // A shape the coercion cannot read costs the fast paint, not the thread —
+    // the SDK hydrate is still on its way.
+    return []
+  }
+}

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -348,6 +348,15 @@ export interface AgentPullRequestContextResponse {
   prompt: string
 }
 
+export interface ThreadTranscript {
+  /** Serialized LangChain messages, revived client-side before rendering. */
+  messages: Array<unknown>
+  /** Whether older turns exist above this window. */
+  hasMore: boolean
+  /** False when the transcript could not be read; the SDK is then the only source. */
+  available: boolean
+}
+
 export interface AgentThread {
   id: string
   title: string
@@ -373,11 +382,23 @@ export interface AgentThread {
   resolvedAt?: number | null
   createdAt: number
   updatedAt: number
+  /**
+   * What the sidebar orders on: the thread's creation, re-anchored when the
+   * user last spoke. Distinct from `updatedAt`, which a running agent bumps
+   * constantly and which would reorder the list under the pointer.
+   */
+  sortAnchorAt?: number
   traceUrl?: string | null
   sourceUrl?: string | null
   codeChannelUrl?: string | null
   sandboxId?: string | null
   messages: Array<Message>
+  /**
+   * Tail of the thread's transcript, as serialized LangChain messages, so an
+   * opened thread paints before the streaming SDK has hydrated. The SDK's
+   * `stream.messages` supersede it as soon as they arrive.
+   */
+  transcript?: ThreadTranscript
   queuedMessages?: Array<QueuedThreadMessage>
   pr?: AgentPullRequestSummary
   pullRequests?: Array<AgentPullRequest>


### PR DESCRIPTION
Switching between threads was slow, flickered, and replayed the whole run — re-animating tool calls the user had already watched.

## The problem

Four separate causes, all on the thread lifecycle:

1. **Replay.** The SDK's `joinStream` defaults `lastEventId` to `"-1"`, and its internal last-event tracking lives only inside a single `joinStream` call. Every rejoin — remount, switching back, a dropped stream — therefore re-delivered the run from event 0.
2. **Blank pane.** The detail endpoint set `summary["messages"] = []` and left the transcript entirely to the SDK's client-side hydrate, so an opened thread showed nothing until `getState` returned. `RecentAgentThreads` worked around this by keeping three thread trees mounted, at the cost of a live SSE connection and a hidden DOM tree each.
3. **Sidebar churn.** `useSidebarThreads` refetched the whole list every 2s while anything ran, replacing every row's identity and re-rendering the list.
4. **Reordering.** The sidebar sorted on `updated_at`, which a running agent bumps continuously, so rows shuffled under the pointer for as long as the agent worked.

## The changes

**Resume instead of replay** (`ui/src/features/agents/lib/streamResume.ts`) — wraps the client so the initial run stream and every rejoin record the ids they see, and a rejoin resumes from the last one. The SDK sends it as a `Last-Event-ID` header; a server that ignores it behaves exactly as before, so this can only narrow the payload.

**Transcript snapshot** — the detail endpoint returns the last 10 human-anchored turns, so an opened thread paints immediately. Cutting on human anchors means no tool result outlives its call. It's rendered through the existing `streamMessagesToUi` pipeline rather than converted server-side, so there's one definition of how a message becomes a chunk and the snapshot inherits every fix made for the live path.

The client asks for it once per open and opts out afterwards (`include_transcript=false`), because this endpoint doubles as the run-status heartbeat while a run is live — a snapshot on every beat would be a `get_state` every three seconds.

**Cache and mount less** — thread details are retained (`gcTime: Infinity`) and an opening thread is seeded from its sidebar row, so returning to a thread paints from cache. Only the active thread is mounted now. Each thread still gets its own stream provider rather than re-pointing a shared one: the SDK's thread switch clears the transcript *and cancels whatever runs the user had queued on the thread being left*, so a follow-up typed during a run would vanish on navigation.

**Targeted status polling** — a batch `POST /threads/statuses` returns only the fields that move while a run is in flight. The sidebar polls just the running rows and patches them into the cached lists, building a new object only where something actually changed so untouched rows keep their identity. Since the ids come from the caller, each thread's readability is checked individually, and the id list is capped. A run *ending* can add or remove rows, which a status patch can't express, so that edge reconciles once with a full invalidate.

**Stable sort anchor** — the sidebar now orders on `max(created_at, last_user_message_at)`. A row moves for what the user did, not for every write the run makes afterwards.

## Testing

- 311 UI tests and the Python suite pass. `ruff`, `basedpyright`, `oxlint` and `oxfmt` clean.
- New coverage: the resume layer (including the no-options rejoin path, which is the one `tryReconnect` actually uses), transcript windowing and conversion, the stable anchor, the transcript opt-out, and per-thread authz on the status endpoint.
- Pre-existing on `main`, unrelated to this change: `tests/dashboard/test_voice.py::test_transcribe_audio_validates_and_forwards`, two `tests/sandbox/test_proxy_auth.py` cases, and some react-icons `className` type errors.

Not yet verified in a running app — worth exercising thread switching during a live run, and confirming a rejoin no longer replays.