### PR TITLE
fix: remove sidebar scroll shadow gap

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -491,7 +491,7 @@ export function AgentsSidebar({
         <div className="relative flex min-h-0 flex-1 flex-col">
           {scrollEdges.top && (
             <>
-              <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-px bg-border" />
+              <div className="pointer-events-none absolute inset-x-0 top-0 z-20 h-px bg-border" />
               <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-3 bg-gradient-to-b from-sidebar to-transparent" />
             </>
           )}

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -492,7 +492,7 @@ export function AgentsSidebar({
           {scrollEdges.top && (
             <>
               <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-px bg-border" />
-              <div className="pointer-events-none absolute inset-x-0 top-px z-10 h-3 bg-gradient-to-b from-sidebar to-transparent" />
+              <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-3 bg-gradient-to-b from-sidebar to-transparent" />
             </>
           )}
           {scrollEdges.bottom && (


### PR DESCRIPTION
Overlaps the top scroll gradient with its border to remove the visible 1px gap.

**Checks:** UI typecheck, targeted format and lint.

Made by [Open SWE](https://openswe.vercel.app/agents/01a05a04-6ae2-72c9-9415-8c0ef7ce1d4d)