### PR TITLE
refactor(ui): split sidebar pagination by project

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -207,9 +207,10 @@ from .thread_api import (
     get_dashboard_thread_recovery_patch,
     get_dashboard_thread_state,
     get_dashboard_thread_working_tree_diff,
+    list_dashboard_pinned_threads,
+    list_dashboard_thread_projects,
     list_dashboard_threads,
     list_dashboard_threads_page,
-    list_dashboard_threads_sidebar,
     pin_dashboard_thread,
     proxy_dashboard_thread_commands,
     proxy_dashboard_thread_history,
@@ -1842,35 +1843,29 @@ async def api_list_threads(
     return await list_dashboard_threads(session["sub"], email=session.get("email"), include_all=all)
 
 
-@router.get("/threads/sidebar")
-async def api_list_threads_sidebar(
-    active_limit: int = 50,
-    resolved_limit: int = 20,
-    active_thread_id: str | None = None,
+@router.get("/threads/projects")
+async def api_list_thread_projects(
+    include_resolved: bool = False,
     include_automations: bool = False,
     all: bool = False,
     session: dict[str, Any] = _SESSION_DEP,
-) -> Response:
+) -> list[dict[str, Any]]:
     if all and not _session_is_admin(session):
         raise HTTPException(403, "admin only")
-    timings: dict[str, float] = {}
-    counts: dict[str, int] = {}
-    started = perf_counter()
-    payload = await list_dashboard_threads_sidebar(
+    return await list_dashboard_thread_projects(
         session["sub"],
         email=session.get("email"),
-        active_limit=active_limit,
-        resolved_limit=resolved_limit,
-        active_thread_id=active_thread_id,
+        include_resolved=include_resolved,
         include_automations=include_automations,
         include_all=all,
-        timings=timings,
-        counts=counts,
     )
-    timings["total"] = (perf_counter() - started) * 1000
-    header = server_timing_header(timings, counts)
-    logger.info("thread sidebar timings login=%s %s", session["sub"], header)
-    return JSONResponse(payload, headers={"Server-Timing": header})
+
+
+@router.get("/threads/pinned")
+async def api_list_pinned_threads(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> list[dict[str, Any]]:
+    return await list_dashboard_pinned_threads(session["sub"], email=session.get("email"))
 
 
 @router.post("/threads/{thread_id}/pin", status_code=204)
@@ -1903,11 +1898,20 @@ async def api_list_threads_page(
     q: str | None = None,
     scope: Literal["all", "interactive", "automation"] = "all",
     automation_id: str | None = None,
+    repo: str | None = None,
+    ownerless: bool = False,
     sort_by: Literal["created_at", "updated_at"] = "updated_at",
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     if all and not _session_is_admin(session):
         raise HTTPException(403, "admin only")
+    if repo and ownerless:
+        raise HTTPException(400, "repo and ownerless are mutually exclusive")
+    if repo:
+        owner, separator, name = repo.strip().partition("/")
+        if not separator or not owner or not name or "/" in name:
+            raise HTTPException(400, "repo must be owner/name")
+        repo = f"{owner}/{name}"
     return await list_dashboard_threads_page(
         session["sub"],
         email=session.get("email"),
@@ -1921,6 +1925,8 @@ async def api_list_threads_page(
         query=q,
         scope=scope,
         automation_id=automation_id,
+        repo=repo,
+        ownerless=ownerless,
         sort_by=sort_by,
     )
 

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -684,14 +684,13 @@ def _participant_search_filters(
     return filters
 
 
-def _search_metadata_filters(
+def _search_metadata_filter(
     search_filter: dict[str, Any],
     *,
     resolved: bool | None = None,
     source: str | None = None,
     automation_id: str | None = None,
-    repo: str | None = None,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     metadata = dict(search_filter)
     if resolved is True:
         metadata["resolved"] = True
@@ -699,13 +698,7 @@ def _search_metadata_filters(
         metadata["source"] = source
     if automation_id:
         metadata["schedule_id"] = automation_id
-    if not repo:
-        return [metadata]
-    owner, name = repo.split("/", 1)
-    return [
-        {**metadata, "repo_owner": owner, "repo_name": name},
-        {**metadata, "repo": {"owner": owner, "name": name}},
-    ]
+    return metadata
 
 
 async def _search_threads_batch(
@@ -873,20 +866,15 @@ async def _collect_thread_candidates(
     sort_by: _ThreadSortBy = "updated_at",
 ) -> list[ThreadLike]:
     seen: dict[str, ThreadLike] = {}
-    metadata_filters = [
-        metadata_filter
-        for search_filter in searches
-        for metadata_filter in _search_metadata_filters(
+    for search_filter in searches:
+        matched_for_search = 0
+        offset = 0
+        metadata_filter = _search_metadata_filter(
             search_filter,
             resolved=resolved,
             source=source,
             automation_id=automation_id,
-            repo=repo,
         )
-    ]
-    for metadata_filter in metadata_filters:
-        matched_for_search = 0
-        offset = 0
         while offset < _THREADS_PAGE_SCAN_CAP:
             batch = await _search_threads_batch(
                 client,

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -684,13 +684,14 @@ def _participant_search_filters(
     return filters
 
 
-def _search_metadata_filter(
+def _search_metadata_filters(
     search_filter: dict[str, Any],
     *,
     resolved: bool | None = None,
     source: str | None = None,
     automation_id: str | None = None,
-) -> dict[str, Any]:
+    repo: str | None = None,
+) -> list[dict[str, Any]]:
     metadata = dict(search_filter)
     if resolved is True:
         metadata["resolved"] = True
@@ -698,7 +699,13 @@ def _search_metadata_filter(
         metadata["source"] = source
     if automation_id:
         metadata["schedule_id"] = automation_id
-    return metadata
+    if not repo:
+        return [metadata]
+    owner, name = repo.split("/", 1)
+    return [
+        {**metadata, "repo_owner": owner, "repo_name": name},
+        {**metadata, "repo": {"owner": owner, "name": name}},
+    ]
 
 
 async def _search_threads_batch(
@@ -747,8 +754,15 @@ def _metadata_matches_filters(
     query: str | None,
     scope: Literal["all", "interactive", "automation"] = "all",
     automation_id: str | None = None,
+    repo: str | None = None,
+    ownerless: bool = False,
 ) -> bool:
     """Metadata-only filters that don't require fetching the latest run."""
+    thread_repo = _metadata_repo(metadata)[2]
+    if repo and thread_repo.lower() != repo.lower():
+        return False
+    if ownerless and thread_repo:
+        return False
     is_automation = _is_automation_thread(metadata)
     if scope == "interactive" and is_automation:
         return False
@@ -852,20 +866,27 @@ async def _collect_thread_candidates(
     query: str | None = None,
     scope: Literal["all", "interactive", "automation"] = "all",
     automation_id: str | None = None,
+    repo: str | None = None,
+    ownerless: bool = False,
     target_per_search: int | None = None,
     surfaced_only: bool = False,
     sort_by: _ThreadSortBy = "updated_at",
 ) -> list[ThreadLike]:
     seen: dict[str, ThreadLike] = {}
-    for search_filter in searches:
-        matched_for_search = 0
-        offset = 0
-        metadata_filter = _search_metadata_filter(
+    metadata_filters = [
+        metadata_filter
+        for search_filter in searches
+        for metadata_filter in _search_metadata_filters(
             search_filter,
             resolved=resolved,
             source=source,
             automation_id=automation_id,
+            repo=repo,
         )
+    ]
+    for metadata_filter in metadata_filters:
+        matched_for_search = 0
+        offset = 0
         while offset < _THREADS_PAGE_SCAN_CAP:
             batch = await _search_threads_batch(
                 client,
@@ -887,6 +908,8 @@ async def _collect_thread_candidates(
                     query=query,
                     scope=scope,
                     automation_id=automation_id,
+                    repo=repo,
+                    ownerless=ownerless,
                 ):
                     continue
                 thread_id = _thread_id(thread)
@@ -917,41 +940,6 @@ async def list_dashboard_threads(
     return page["items"]
 
 
-async def _sidebar_active_thread_summary(
-    client: Any,
-    active_thread_id: str | None,
-    *,
-    fallback_threads: Mapping[str, ThreadLike],
-    visible_thread_ids: set[str],
-    include_all: bool,
-) -> tuple[dict[str, Any], bool] | None:
-    if not active_thread_id or active_thread_id in visible_thread_ids:
-        return None
-    thread = fallback_threads.get(active_thread_id)
-    if thread is None:
-        try:
-            fetched = await client.threads.get(active_thread_id)
-        except Exception:  # noqa: BLE001
-            logger.debug(
-                "Could not fetch active sidebar thread %s", active_thread_id, exc_info=True
-            )
-            return None
-        if not isinstance(fetched, Mapping):
-            return None
-        thread = fetched
-    metadata = _thread_metadata(thread)
-    if not include_all:
-        try:
-            _assert_thread_readable(metadata)
-        except HTTPException:
-            return None
-    summary = await _summarize_thread(
-        client,
-        thread,
-    )
-    return summary, _is_thread_resolved(metadata)
-
-
 async def _pinned_thread_summaries(
     client: Any,
     login: str,
@@ -973,133 +961,43 @@ async def _pinned_thread_summaries(
     return [summary for summary in summaries if summary is not None]
 
 
-async def list_dashboard_threads_sidebar(
+async def list_dashboard_pinned_threads(
     login: str,
     *,
     email: str | None = None,
-    active_limit: int = 50,
-    resolved_limit: int = 20,
-    active_thread_id: str | None = None,
+) -> list[dict[str, Any]]:
+    return await _pinned_thread_summaries(langgraph_client(), login, email)
+
+
+async def list_dashboard_thread_projects(
+    login: str,
+    *,
+    email: str | None = None,
+    include_resolved: bool = False,
     include_automations: bool = False,
     include_all: bool = False,
-    timings: dict[str, float] | None = None,
-    counts: dict[str, int] | None = None,
-) -> dict[str, Any]:
-    record = timings if timings is not None else {}
-    count_record = counts if counts is not None else {}
-    client = langgraph_client()
-    searches = _participant_search_filters(login, email=email, include_all=include_all)
-    safe_active_limit = min(max(active_limit, 1), _THREADS_PAGE_SCAN_CAP)
-    safe_resolved_limit = min(max(resolved_limit, 0), _THREADS_PAGE_SCAN_CAP)
-    active_target = safe_active_limit + 1
-    # A zero limit means the caller wants no resolved threads at all, so nothing
-    # should keep scanning for one after the active bucket fills.
-    resolved_target = safe_resolved_limit + 1 if safe_resolved_limit else 0
-    active: dict[str, ThreadLike] = {}
-    resolved_threads: dict[str, ThreadLike] = {}
-
-    with phase(record, "search"):
-        for search_filter in searches:
-            local_active = 0
-            local_resolved = 0
-            offset = 0
-            while offset < _THREADS_PAGE_SCAN_CAP and (
-                local_active < active_target or local_resolved < resolved_target
-            ):
-                batch = await _search_threads_batch(
-                    client,
-                    search_filter,
-                    limit=_THREADS_SEARCH_PAGE,
-                    offset=offset,
-                )
-                if not batch:
-                    break
-                for thread in batch:
-                    metadata = _thread_metadata(thread)
-                    if not include_automations and _is_automation_thread(metadata):
-                        continue
-                    thread_id = _thread_id(thread)
-                    if not thread_id or thread_id in active or thread_id in resolved_threads:
-                        continue
-                    if _is_thread_resolved(metadata):
-                        local_resolved += 1
-                        resolved_threads[thread_id] = thread
-                    else:
-                        local_active += 1
-                        active[thread_id] = thread
-                if len(batch) < _THREADS_SEARCH_PAGE:
-                    break
-                offset += _THREADS_SEARCH_PAGE
-
-    active_candidates = sorted(active.values(), key=_thread_updated_ms, reverse=True)
-    resolved_candidates = sorted(resolved_threads.values(), key=_thread_updated_ms, reverse=True)
-    active_window = active_candidates[:safe_active_limit]
-    resolved_window = resolved_candidates[:safe_resolved_limit]
-    active_ids = {thread_id for thread in active_window if (thread_id := _thread_id(thread))}
-    # The dominant cost when a user's threads have no cached run status: one
-    # `runs.list` per thread, eight at a time.
-    count_record["run_refreshes"] = sum(
-        _should_refresh_latest_run(thread) for thread in (*active_window, *resolved_window)
+) -> list[dict[str, Any]]:
+    candidates = await _collect_thread_candidates(
+        langgraph_client(),
+        _participant_search_filters(login, email=email, include_all=include_all),
+        resolved=None if include_resolved else False,
+        scope="all" if include_automations else "interactive",
     )
-    count_record["threads"] = len(active_window) + len(resolved_window)
-    with phase(record, "summarize"):
-        active_items, resolved_items, active_thread, pinned_items = await asyncio.gather(
-            _summarize_threads(
-                client,
-                active_window,
-            ),
-            _summarize_threads(
-                client,
-                resolved_window,
-            ),
-            _sidebar_active_thread_summary(
-                client,
-                active_thread_id,
-                fallback_threads={**active, **resolved_threads},
-                visible_thread_ids=active_ids,
-                include_all=include_all,
-            ),
-            _pinned_thread_summaries(client, login, email),
-        )
-    active_has_more = len(active_candidates) > safe_active_limit
-    resolved_has_more = len(resolved_candidates) > safe_resolved_limit
-    if active_thread:
-        active_thread_summary, is_resolved_active_thread = active_thread
-        if is_resolved_active_thread:
-            resolved_items = [
-                active_thread_summary,
-                *[item for item in resolved_items if item["id"] != active_thread_summary["id"]],
-            ]
-            active_items = [
-                item for item in active_items if item["id"] != active_thread_summary["id"]
-            ]
-            if len(resolved_items) > safe_resolved_limit:
-                resolved_items = resolved_items[:safe_resolved_limit]
-                resolved_has_more = True
-        else:
-            active_items = [
-                active_thread_summary,
-                *[item for item in active_items if item["id"] != active_thread_summary["id"]],
-            ]
-            resolved_items = [
-                item for item in resolved_items if item["id"] != active_thread_summary["id"]
-            ]
-            if len(active_items) > safe_active_limit:
-                active_items = active_items[:safe_active_limit]
-                active_has_more = True
-    return {
-        "active": {
-            "items": active_items,
-            "limit": safe_active_limit,
-            "hasMore": active_has_more,
-        },
-        "resolved": {
-            "items": resolved_items,
-            "limit": safe_resolved_limit,
-            "hasMore": resolved_has_more,
-        },
-        "pinned": pinned_items,
-    }
+    projects: dict[str, dict[str, Any]] = {}
+    for thread in candidates:
+        _, name, full_name = _metadata_repo(_thread_metadata(thread))
+        if not full_name:
+            continue
+        key = full_name.lower()
+        updated_at = _thread_updated_ms(thread)
+        current = projects.get(key)
+        if current is None or updated_at > current["updatedAt"]:
+            projects[key] = {
+                "repoFullName": full_name,
+                "name": name,
+                "updatedAt": updated_at,
+            }
+    return sorted(projects.values(), key=lambda project: project["updatedAt"], reverse=True)
 
 
 async def pin_dashboard_thread(thread_id: str, login: str) -> None:
@@ -1132,6 +1030,8 @@ async def list_dashboard_threads_page(
     query: str | None = None,
     scope: Literal["all", "interactive", "automation"] = "all",
     automation_id: str | None = None,
+    repo: str | None = None,
+    ownerless: bool = False,
     filter_participant_login: str | None = None,
     surfaced_only: bool = False,
     sort_by: _ThreadSortBy = "updated_at",
@@ -1157,6 +1057,8 @@ async def list_dashboard_threads_page(
         query=query,
         scope=scope,
         automation_id=automation_id,
+        repo=repo,
+        ownerless=ownerless,
         target_per_search=target,
         surfaced_only=surfaced_only,
         sort_by=sort_by,

--- a/desktop/test/manual/stub-backend.cjs
+++ b/desktop/test/manual/stub-backend.cjs
@@ -30,9 +30,13 @@ const SIGNED_IN_ROUTES = {
     is_admin: false,
     slack_oauth_enabled: false,
   },
-  "/dashboard/api/threads/sidebar": {
-    active: { items: [], limit: 50, hasMore: false },
-    resolved: { items: [], limit: 20, hasMore: false },
+  "/dashboard/api/threads/projects": [],
+  "/dashboard/api/threads/pinned": [],
+  "/dashboard/api/threads/page": {
+    items: [],
+    limit: 10,
+    offset: 0,
+    hasMore: false,
   },
   "/dashboard/api/my-mapping": {},
   "/dashboard/api/profile": {},

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1982,7 +1982,15 @@ async def test_list_dashboard_threads_page_filters_flat_and_legacy_repo_metadata
     class FakeThreads:
         async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
             searches.append(metadata)
-            return threads[offset : offset + limit]
+            matches = [
+                thread
+                for thread in threads
+                if all(
+                    cast(dict[str, object], thread["metadata"]).get(key) == value
+                    for key, value in metadata.items()
+                )
+            ]
+            return matches[offset : offset + limit]
 
     class FakeRuns:
         async def list(self, thread_id, limit=1):
@@ -1999,13 +2007,10 @@ async def test_list_dashboard_threads_page_filters_flat_and_legacy_repo_metadata
     )
 
     assert [item["id"] for item in result["items"]] == ["t0", "t1"]
-    assert any(
-        search.get("repo_owner") == "langchain-ai" and search.get("repo_name") == "open-swe"
-        for search in searches
-    )
-    assert any(
-        search.get("repo") == {"owner": "langchain-ai", "name": "open-swe"} for search in searches
-    )
+    assert searches == [
+        {"participant_logins": {"octocat": True}},
+        {"github_login": "octocat"},
+    ]
 
 
 async def test_list_dashboard_thread_projects_discovers_metadata_without_summaries(

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1930,172 +1930,131 @@ async def test_list_dashboard_threads_page_scopes_search_to_requested_participan
     assert [item["id"] for item in result["items"]] == ["surfaced"]
 
 
-async def test_list_dashboard_threads_sidebar_fills_buckets_with_one_endpoint(monkeypatch) -> None:
-    page_size = thread_api._THREADS_SEARCH_PAGE
-    threads = _make_threads(page_size + 10, resolved_before=page_size)
+async def test_list_dashboard_threads_page_filters_ownerless_threads(monkeypatch) -> None:
+    threads = _make_threads(3, resolved_before=0)
+    for thread in threads:
+        cast(dict[str, object], thread["metadata"])["latest_run_status"] = "success"
+    cast(dict[str, object], threads[0]["metadata"]).update(
+        {"repo_owner": "langchain-ai", "repo_name": "open-swe"}
+    )
+    cast(dict[str, object], threads[1]["metadata"])["repo"] = {
+        "owner": "langchain-ai",
+        "name": "langgraph",
+    }
+
+    class FakeThreads:
+        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
+            return threads[offset : offset + limit]
+
+    class FakeRuns:
+        async def list(self, thread_id, limit=1):
+            return []
+
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads(), runs=FakeRuns()),
+    )
+
+    result = await thread_api.list_dashboard_threads_page("octocat", email=None, ownerless=True)
+
+    assert [item["id"] for item in result["items"]] == ["t2"]
+
+
+async def test_list_dashboard_threads_page_filters_flat_and_legacy_repo_metadata(
+    monkeypatch,
+) -> None:
+    threads = _make_threads(4, resolved_before=0)
+    for thread in threads:
+        cast(dict[str, object], thread["metadata"])["latest_run_status"] = "success"
+    cast(dict[str, object], threads[0]["metadata"]).update(
+        {"repo_owner": "langchain-ai", "repo_name": "open-swe"}
+    )
+    cast(dict[str, object], threads[1]["metadata"])["repo"] = {
+        "owner": "LANGCHAIN-AI",
+        "name": "OPEN-SWE",
+    }
+    cast(dict[str, object], threads[2]["metadata"]).update(
+        {"repo_owner": "langchain-ai", "repo_name": "langgraph"}
+    )
     searches: list[dict[str, object]] = []
 
     class FakeThreads:
         async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            searches.append({"metadata": metadata, "offset": offset})
-            assert select == thread_api._THREAD_LIST_SELECT
+            searches.append(metadata)
             return threads[offset : offset + limit]
-
-        async def update(self, *, thread_id, metadata):
-            return None
 
     class FakeRuns:
         async def list(self, thread_id, limit=1):
             return []
 
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat", email=None, active_limit=5, resolved_limit=5
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads(), runs=FakeRuns()),
     )
 
-    assert len(result["active"]["items"]) == 5
-    assert len(result["resolved"]["items"]) == 5
-    assert result["active"]["hasMore"] is True
-    assert result["resolved"]["hasMore"] is True
-    assert {call["offset"] for call in searches} == {0, page_size}
+    result = await thread_api.list_dashboard_threads_page(
+        "octocat", email=None, repo="langchain-ai/open-swe"
+    )
+
+    assert [item["id"] for item in result["items"]] == ["t0", "t1"]
+    assert any(
+        search.get("repo_owner") == "langchain-ai" and search.get("repo_name") == "open-swe"
+        for search in searches
+    )
+    assert any(
+        search.get("repo") == {"owner": "langchain-ai", "name": "open-swe"} for search in searches
+    )
 
 
-async def test_list_dashboard_threads_sidebar_stops_scanning_when_resolved_hidden(
+async def test_list_dashboard_thread_projects_discovers_metadata_without_summaries(
     monkeypatch,
 ) -> None:
-    """`resolved_limit=0` must not keep paging in search of a resolved thread."""
-    page_size = thread_api._THREADS_SEARCH_PAGE
-    threads = _make_threads(page_size + 10, resolved_before=0)
-    offsets: list[int] = []
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            offsets.append(offset)
-            return threads[offset : offset + limit]
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat", email=None, active_limit=5, resolved_limit=0
+    threads = _make_threads(5, resolved_before=0)
+    cast(dict[str, object], threads[0]["metadata"]).update(
+        {"repo_owner": "langchain-ai", "repo_name": "open-swe", "updated_at_ms": 50}
     )
-
-    assert len(result["active"]["items"]) == 5
-    assert result["resolved"]["items"] == []
-    # The first filter stops after one page: the active bucket is full and no
-    # resolved thread was ever wanted. Waiting on one paged to the scan cap.
-    assert offsets[1] == 0
-
-
-async def test_list_dashboard_threads_sidebar_allows_limits_beyond_100(monkeypatch) -> None:
-    threads = _make_threads(120, resolved_before=0)
+    cast(dict[str, object], threads[1]["metadata"])["repo"] = {
+        "owner": "LANGCHAIN-AI",
+        "name": "OPEN-SWE",
+    }
+    cast(dict[str, object], threads[2]["metadata"]).update(
+        {"repo_owner": "langchain-ai", "repo_name": "langgraph", "updated_at_ms": 30}
+    )
+    cast(dict[str, object], threads[3]["metadata"]).update(
+        {
+            "repo_owner": "langchain-ai",
+            "repo_name": "private",
+            "resolved": True,
+            "updated_at_ms": 60,
+        }
+    )
 
     class FakeThreads:
         async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
             return threads[offset : offset + limit]
 
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat", email=None, active_limit=110, resolved_limit=0
+    monkeypatch.setattr(
+        thread_api,
+        "langgraph_client",
+        lambda: SimpleNamespace(threads=FakeThreads()),
     )
 
-    assert result["active"]["limit"] == 110
-    assert len(result["active"]["items"]) == 110
-    assert result["active"]["hasMore"] is True
+    result = await thread_api.list_dashboard_thread_projects("octocat")
 
-
-async def test_list_dashboard_threads_sidebar_accepts_zero_resolved_limit(monkeypatch) -> None:
-    threads = _make_threads(2, resolved_before=1)
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            return threads[offset : offset + limit]
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat", email=None, active_limit=1, resolved_limit=0
-    )
-
-    assert result["active"]["limit"] == 1
-    assert result["resolved"] == {"items": [], "limit": 0, "hasMore": True}
-
-
-async def test_list_dashboard_threads_sidebar_excludes_automations_before_limiting(
-    monkeypatch,
-) -> None:
-    page_size = thread_api._THREADS_SEARCH_PAGE
-    threads = _make_threads(page_size + 5, resolved_before=0)
-    for thread in threads[:page_size]:
-        metadata = cast(dict[str, object], thread["metadata"])
-        metadata["source"] = "schedule"
-        metadata["schedule_id"] = f"schedule-{thread['thread_id']}"
-    offsets: list[int] = []
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            offsets.append(offset)
-            return threads[offset : offset + limit]
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat", email=None, active_limit=5, resolved_limit=5
-    )
-
-    assert [item["id"] for item in result["active"]["items"]] == [
-        f"t{index}" for index in range(page_size, page_size + 5)
+    assert result == [
+        {
+            "repoFullName": "langchain-ai/open-swe",
+            "name": "open-swe",
+            "updatedAt": 50,
+        },
+        {
+            "repoFullName": "langchain-ai/langgraph",
+            "name": "langgraph",
+            "updatedAt": 30,
+        },
     ]
-    assert set(offsets) == {0, page_size}
 
 
 async def test_pin_dashboard_thread_allows_readable_non_owner(monkeypatch) -> None:
@@ -2159,26 +2118,31 @@ async def test_pin_dashboard_thread_rejects_unreadable_thread(monkeypatch) -> No
     assert exc_info.value.status_code == 404
 
 
-async def test_list_dashboard_threads_sidebar_includes_pinned_thread(monkeypatch) -> None:
-    owned = _make_threads(1, resolved_before=0)
-    shared = {
-        "thread_id": "shared-thread",
-        "metadata": {
-            "source": "slack",
-            "github_login": "teammate",
-            "title": "Pinned teammate thread",
-            "updated_at_ms": 100,
-            "latest_run_status": "success",
+async def test_list_dashboard_pinned_threads_returns_only_readable_threads(
+    monkeypatch,
+) -> None:
+    threads = {
+        "shared-thread": {
+            "thread_id": "shared-thread",
+            "metadata": {
+                "source": "slack",
+                "github_login": "teammate",
+                "title": "Pinned teammate thread",
+                "updated_at_ms": 100,
+                "latest_run_status": "success",
+            },
+        },
+        "private-thread": {
+            "thread_id": "private-thread",
+            "metadata": {"source": "reviewer"},
         },
     }
 
     class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            return owned[offset : offset + limit]
-
         async def get(self, thread_id):
-            assert thread_id == "shared-thread"
-            return shared
+            if thread_id == "missing-thread":
+                raise RuntimeError("missing")
+            return threads[thread_id]
 
     class FakeRuns:
         async def list(self, thread_id, limit=1):
@@ -2192,168 +2156,13 @@ async def test_list_dashboard_threads_sidebar_includes_pinned_thread(monkeypatch
 
     async def fake_pin_ids(login: str) -> list[str]:
         assert login == "octocat"
-        return ["shared-thread"]
+        return ["shared-thread", "private-thread", "missing-thread"]
 
     monkeypatch.setattr(thread_api, "list_thread_pin_ids", fake_pin_ids)
 
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat", active_limit=5, resolved_limit=0
-    )
+    result = await thread_api.list_dashboard_pinned_threads("octocat")
 
-    assert [item["id"] for item in result["pinned"]] == ["shared-thread"]
-
-
-async def test_list_dashboard_threads_sidebar_includes_readable_active_thread(
-    monkeypatch,
-) -> None:
-    threads = _make_threads(1, resolved_before=0)
-    shared_thread = {
-        "thread_id": "shared-thread",
-        "metadata": {
-            "source": "slack",
-            "github_login": "teammate",
-            "title": "Teammate thread",
-            "updated_at_ms": 100,
-            "latest_run_status": "success",
-            "sandbox_id": "sandbox-123",
-        },
-    }
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            assert select == thread_api._THREAD_LIST_SELECT
-            return threads[offset : offset + limit]
-
-        async def get(self, thread_id):
-            assert thread_id == "shared-thread"
-            return shared_thread
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat",
-        email=None,
-        active_limit=5,
-        resolved_limit=5,
-        active_thread_id="shared-thread",
-    )
-
-    assert [item["id"] for item in result["active"]["items"]] == ["shared-thread", "t0"]
-    shared = result["active"]["items"][0]
-    assert shared["sandboxId"] == "sandbox-123"
-
-
-async def test_list_dashboard_threads_sidebar_keeps_resolved_active_thread_resolved(
-    monkeypatch,
-) -> None:
-    threads = _make_threads(1, resolved_before=0)
-    shared_thread = {
-        "thread_id": "shared-resolved-thread",
-        "metadata": {
-            "source": "slack",
-            "github_login": "teammate",
-            "title": "Resolved teammate thread",
-            "updated_at_ms": 100,
-            "latest_run_status": "success",
-            "resolved": True,
-            "sandbox_id": "sandbox-456",
-        },
-    }
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            assert select == thread_api._THREAD_LIST_SELECT
-            return threads[offset : offset + limit]
-
-        async def get(self, thread_id):
-            assert thread_id == "shared-resolved-thread"
-            return shared_thread
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat",
-        email=None,
-        active_limit=5,
-        resolved_limit=5,
-        active_thread_id="shared-resolved-thread",
-    )
-
-    assert [item["id"] for item in result["active"]["items"]] == ["t0"]
-    assert [item["id"] for item in result["resolved"]["items"]] == ["shared-resolved-thread"]
-    shared = result["resolved"]["items"][0]
-    assert shared["resolved"] is True
-    assert shared["sandboxId"] == "sandbox-456"
-
-
-async def test_list_dashboard_threads_sidebar_ignores_unreadable_active_thread(
-    monkeypatch,
-) -> None:
-    threads = _make_threads(1, resolved_before=0)
-    private_thread = {
-        "thread_id": "private-thread",
-        "metadata": {
-            "source": "internal",
-            "github_login": "teammate",
-            "title": "Private thread",
-            "updated_at_ms": 100,
-            "latest_run_status": "success",
-        },
-    }
-
-    class FakeThreads:
-        async def search(self, *, metadata, limit, offset, sort_by, sort_order, select):
-            assert select == thread_api._THREAD_LIST_SELECT
-            return threads[offset : offset + limit]
-
-        async def get(self, thread_id):
-            assert thread_id == "private-thread"
-            return private_thread
-
-        async def update(self, *, thread_id, metadata):
-            return None
-
-    class FakeRuns:
-        async def list(self, thread_id, limit=1):
-            return []
-
-    class FakeClient:
-        threads = FakeThreads()
-        runs = FakeRuns()
-
-    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
-
-    result = await thread_api.list_dashboard_threads_sidebar(
-        "octocat",
-        email=None,
-        active_limit=5,
-        resolved_limit=5,
-        active_thread_id="private-thread",
-    )
-
-    assert [item["id"] for item in result["active"]["items"]] == ["t0"]
+    assert [item["id"] for item in result] == ["shared-thread"]
 
 
 async def test_list_dashboard_threads_page_can_sort_by_creation_time(monkeypatch) -> None:

--- a/tests/e2e/tests/ownerless.spec.ts
+++ b/tests/e2e/tests/ownerless.spec.ts
@@ -52,17 +52,24 @@ async function expectComposerReady(page: Page) {
 }
 
 async function sidebarThreadIds(page: Page): Promise<Array<string>> {
-  const res = await page.request.get(
-    "/dashboard/api/threads/sidebar?active_limit=50&resolved_limit=50",
-  );
-  expect(res.ok(), await res.text()).toBeTruthy();
-  const payload = (await res.json()) as {
-    active: { items: Array<{ id: string }> };
-    resolved: { items: Array<{ id: string }> };
-  };
-  return [...payload.active.items, ...payload.resolved.items].map(
-    (item) => item.id,
-  );
+  const ids: Array<string> = [];
+  for (const resolved of [false, true]) {
+    let offset = 0;
+    while (true) {
+      const res = await page.request.get(
+        `/dashboard/api/threads/page?limit=50&offset=${offset}&resolved=${resolved}&scope=interactive`,
+      );
+      expect(res.ok(), await res.text()).toBeTruthy();
+      const payload = (await res.json()) as {
+        items: Array<{ id: string }>;
+        hasMore?: boolean;
+      };
+      ids.push(...payload.items.map((item) => item.id));
+      if (!payload.hasMore) break;
+      offset += payload.items.length;
+    }
+  }
+  return ids;
 }
 
 async function typeIntoComposer(page: Page, text: string) {

--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -786,18 +786,17 @@ test.describe("threads workspace", () => {
       ).toHaveCount(0);
     }
     await expect(sidebar).toContainText("E2E Workspace Resolved overflow 01");
-    const loadMore = sidebar.getByRole("button", {
-      name: "Load more threads",
+    const showMore = alphaGroup.getByRole("button", {
+      name: "Show more",
+      exact: true,
     });
-    await loadMore.click();
-    await alphaGroup
-      .getByRole("button", { name: "Show more", exact: true })
-      .click();
-    await expect(sidebar).toContainText("E2E Workspace Resolved overflow 20");
-    await loadMore.click();
+    await showMore.click();
+    await showMore.click();
+    await expect(sidebar).toContainText("E2E Workspace Resolved overflow 19");
+    await showMore.click();
     await expect(sidebar).toContainText("E2E Workspace Resolved overflow 21");
     await expect(sidebar).toContainText(TITLES.done);
-    await expect(loadMore).toHaveCount(0);
+    await expect(showMore).toHaveCount(0);
 
     const screenshotPath = testInfo.outputPath("unified-thread-sidebar.png");
     await sidebar.screenshot({ path: screenshotPath });

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -18,6 +18,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type { SessionUser } from "@/lib/api"
 import type {
+  PullRequestSnapshot,
+  SidebarProject,
+} from "@/features/agents/lib/api"
+import type { AgentThread } from "@/features/agents/lib/types"
+import type {
   SidebarProjectGroup,
   SidebarThreadItem,
 } from "@/features/agents/lib/sidebarThreads"
@@ -61,7 +66,11 @@ import {
   usePinAgentThread,
   useResolveAgentThread,
   useSeedAgentThreadDetails,
-  useSidebarThreads,
+  useSidebarActiveThread,
+  useSidebarPinnedThreads,
+  useSidebarProjects,
+  useSidebarProjectThreads,
+  useSidebarRecents,
 } from "@/features/agents/lib/queries"
 import { useSidebarPullRequests } from "@/features/agents/lib/prChecks"
 import { useRunCompletionNotifier } from "@/features/agents/lib/useRunCompletionNotifier"
@@ -73,10 +82,10 @@ import {
 import { useDesktopProjects } from "@/features/agents/lib/desktopProjects"
 import {
   applyProjectKeyAliases,
-  cloudProjectKeysByLabel,
   cloudSidebarThread,
   groupSidebarThreadsByProject,
   localSidebarThread,
+  sidebarProjectKey,
   sidebarProjectOptions,
   sortSidebarThreads,
 } from "@/features/agents/lib/sidebarThreads"
@@ -96,6 +105,12 @@ interface AgentsSidebarProps {
   layout: SidebarLayout
 }
 
+interface HydratedProjectGroup extends SidebarProjectGroup {
+  repoFullName: string | null
+  updatedAt: number
+  activeThread?: AgentThread
+}
+
 const NAV = [
   { to: "/agents/threads", label: "Kanban", icon: Kanban },
   { to: "/agents/skills", label: "Skills", icon: SparkleIcon },
@@ -105,6 +120,22 @@ const NAV = [
 
 /** Threads shown per project before the group needs a "Show more". */
 const PROJECT_PREVIEW_COUNT = 5
+
+function cloudProjectAliases(
+  projects: ReadonlyArray<SidebarProject>
+): Map<string, string> {
+  const keys = new Map<string, Array<string>>()
+  for (const project of projects) {
+    const label = project.name.trim().toLowerCase()
+    const key = sidebarProjectKey(project.repoFullName)
+    if (label && key) keys.set(label, [...(keys.get(label) ?? []), key])
+  }
+  return new Map(
+    [...keys].flatMap(([label, values]) =>
+      values.length === 1 ? [[label, values[0] as string]] : []
+    )
+  )
+}
 
 /**
  * Tracks whether the scroll container has content hidden above or below, so
@@ -173,13 +204,21 @@ export function AgentsSidebar({
   } = useSidebarPrefs()
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
-  const sidebar = useSidebarThreads({
-    activeThreadId,
-    includeAutomations:
-      prefs.filters.includeAutomations ||
-      prefs.filters.sources.includes("schedule"),
+  const projectMode = prefs.organize === "project"
+  const includeAutomations =
+    prefs.filters.includeAutomations ||
+    prefs.filters.sources.includes("schedule")
+  const pinnedQuery = useSidebarPinnedThreads({ enabled: !localOnly })
+  const recentsQuery = useSidebarRecents({
+    projectMode,
+    includeAutomations,
     includeResolved: prefs.filters.includeResolved,
     enabled: !localOnly,
+  })
+  const projectsQuery = useSidebarProjects({
+    includeAutomations,
+    includeResolved: prefs.filters.includeResolved,
+    enabled: !localOnly && projectMode,
   })
   const localThreads = useDesktopLocalThreads({ enabled: isDesktop })
   const localSessions = localThreads.data ?? []
@@ -193,19 +232,25 @@ export function AgentsSidebar({
     removeProject: removeLocalProject,
   } = useDesktopProjects()
 
-  const pinnedThreads = sidebar.data.pinned ?? []
+  const pinnedThreads = pinnedQuery.data ?? []
   const cloudPinnedIds = new Set(pinnedThreads.map((thread) => thread.id))
-  const activeThreads = sidebar.data.active.items.filter(
+  const pageThreads = recentsQuery.items.filter(
     (thread) => !cloudPinnedIds.has(thread.id)
   )
-  const resolvedThreads = sidebar.data.resolved.items.filter(
-    (thread) => !cloudPinnedIds.has(thread.id)
+  const activeThread = useSidebarActiveThread({
+    activeThreadId,
+    loadedThreads: [...pinnedThreads, ...pageThreads],
+    includeResolved: prefs.filters.includeResolved,
+    enabled: !localOnly,
+  })
+  const activeInProject = Boolean(
+    projectMode && activeThread?.repoFullName.trim()
   )
-  const visibleThreads = [
-    ...pinnedThreads,
-    ...activeThreads,
-    ...resolvedThreads,
+  const recentThreads = [
+    ...(activeThread && !activeInProject ? [activeThread] : []),
+    ...pageThreads.filter((thread) => thread.id !== activeThread?.id),
   ]
+  const visibleThreads = [...pinnedThreads, ...recentThreads]
   useSeedAgentThreadDetails(visibleThreads, activeThreadId)
   useRunCompletionNotifier(visibleThreads, activeThreadId, openThread)
 
@@ -227,49 +272,95 @@ export function AgentsSidebar({
     // Cloud threads are omitted server-side unless includeResolved; local
     // archiving is client-side, so it has to honour the same switch here.
     .filter((item) => prefs.filters.includeResolved || !item.resolved)
-  const cloudItems = [
-    ...pinnedThreads.map(cloudSidebarThread),
-    ...activeThreads.map(cloudSidebarThread),
-    ...resolvedThreads.map(cloudSidebarThread),
-  ]
   // Fold a local checkout into the cloud project of the same name so the repo
   // renders as one folder; project keys are otherwise full identities.
-  const aliases = cloudProjectKeysByLabel(cloudItems)
+  const serverProjects = projectsQuery.data ?? []
+  const activeProject = activeThread?.repoFullName.trim()
+    ? {
+        repoFullName: activeThread.repoFullName,
+        name: activeThread.repo,
+        updatedAt: activeThread.updatedAt,
+      }
+    : undefined
+  const cloudProjects =
+    activeProject &&
+    !serverProjects.some(
+      (project) =>
+        project.repoFullName.toLowerCase() ===
+        activeProject.repoFullName.toLowerCase()
+    )
+      ? [activeProject, ...serverProjects]
+      : serverProjects
+  const aliases = cloudProjectAliases(cloudProjects)
   const alignedLocalItems = applyProjectKeyAliases(localItems, aliases)
   const pinnedItems = [
     ...pinnedThreads.map(cloudSidebarThread),
     ...alignedLocalItems.filter((item) => localPinnedIds.has(item.id)),
   ]
   const threadItems: Array<SidebarThreadItem> = [
-    ...activeThreads.map(cloudSidebarThread),
-    ...resolvedThreads.map(cloudSidebarThread),
-    ...alignedLocalItems.filter((item) => !localPinnedIds.has(item.id)),
+    ...recentThreads.map(cloudSidebarThread),
+    ...(projectMode
+      ? []
+      : alignedLocalItems.filter((item) => !localPinnedIds.has(item.id))),
   ]
   const allItems = [...pinnedItems, ...threadItems]
-  const projects = sidebarProjectOptions(allItems, localProjects)
   const filteredPinnedItems = sortSidebarThreads(
     filterThreads(pinnedItems, prefs.filters),
     prefs.sortPinned
   )
-  const filteredThreadItems = filterThreads(threadItems, prefs.filters)
-  // "In one list" drops the per-project buckets and pours everything into
-  // Recents, so the Projects section disappears along with its groups.
-  const grouped =
-    prefs.organize === "list"
-      ? {
-          projects: [],
-          recents: sortSidebarThreads(filteredThreadItems, prefs.sortChats),
-        }
-      : groupSidebarThreadsByProject(
-          filteredThreadItems,
-          projects,
-          prefs.sortChats
-        )
+  const recents = sortSidebarThreads(
+    filterThreads(threadItems, prefs.filters),
+    prefs.sortChats
+  )
+  const unpinnedLocalItems = alignedLocalItems.filter(
+    (item) => !localPinnedIds.has(item.id)
+  )
+  const localGroups = projectMode
+    ? groupSidebarThreadsByProject(
+        filterThreads(unpinnedLocalItems, prefs.filters),
+        sidebarProjectOptions(unpinnedLocalItems, localProjects),
+        prefs.sortChats
+      ).projects
+    : []
+  const projectGroups: Array<HydratedProjectGroup> = projectMode
+    ? [
+        ...cloudProjects.map((project) => {
+          const key = sidebarProjectKey(project.repoFullName)!
+          return {
+            key,
+            label: project.name,
+            repoFullName: project.repoFullName,
+            updatedAt: project.updatedAt,
+            activeThread:
+              activeInProject &&
+              activeThread?.repoFullName.toLowerCase() ===
+                project.repoFullName.toLowerCase()
+                ? activeThread
+                : undefined,
+            threads:
+              localGroups.find((group) => group.key === key)?.threads ?? [],
+          }
+        }),
+        ...localGroups
+          .filter(
+            (group) =>
+              !cloudProjects.some(
+                (project) =>
+                  sidebarProjectKey(project.repoFullName) === group.key
+              )
+          )
+          .map((group) => ({
+            ...group,
+            repoFullName: null,
+            updatedAt: group.threads[0]?.updatedAt ?? 0,
+          })),
+      ].sort((left, right) => right.updatedAt - left.updatedAt)
+    : []
   const pinnedProjectKeys = new Set(prefs.pinnedProjectKeys)
-  const pinnedGroups = grouped.projects.filter((group) =>
+  const pinnedGroups = projectGroups.filter((group) =>
     pinnedProjectKeys.has(group.key)
   )
-  const unpinnedGroups = grouped.projects.filter(
+  const unpinnedGroups = projectGroups.filter(
     (group) => !pinnedProjectKeys.has(group.key)
   )
 
@@ -315,12 +406,15 @@ export function AgentsSidebar({
       ? `cloud:${activeThreadId}`
       : undefined
 
-  const rowProps = (item: SidebarThreadItem) => ({
+  const rowProps = (
+    item: SidebarThreadItem,
+    live: PullRequestSnapshot | undefined = pullRequestFor(item)
+  ) => ({
     item,
     isActive: item.key === activeKey,
     pinned: isPinned(item),
     archived: isArchived(item),
-    live: pullRequestFor(item),
+    live,
     compact: prefs.compact,
     onNavigate: layout.closeOnMobile,
     onDeleteLocal: refreshLocalThreads,
@@ -330,6 +424,13 @@ export function AgentsSidebar({
 
   const sectionCollapsed = (key: string) =>
     prefs.collapsedSectionKeys.includes(key)
+  const hydrateProjectThreads = (threads: Array<AgentThread>) =>
+    filterThreads(
+      threads
+        .filter((thread) => !cloudPinnedIds.has(thread.id))
+        .map(cloudSidebarThread),
+      prefs.filters
+    )
 
   // Projects and Recents share one menu: both control the same list.
   const removeProjectItems = isDesktop && localProjects.length > 0 && (
@@ -407,7 +508,7 @@ export function AgentsSidebar({
     </>
   )
 
-  const renderProjectGroup = (group: SidebarProjectGroup) => (
+  const renderProjectGroup = (group: HydratedProjectGroup) => (
     <ProjectGroup
       key={group.key}
       group={group}
@@ -415,34 +516,37 @@ export function AgentsSidebar({
       collapsed={prefs.collapsedProjectKeys.includes(group.key)}
       expanded={prefs.expandedProjectKeys.includes(group.key)}
       pinned={pinnedProjectKeys.has(group.key)}
+      includeResolved={prefs.filters.includeResolved}
+      includeAutomations={includeAutomations}
+      sort={prefs.sortChats}
+      activeThreadId={activeThreadId}
+      openThread={openThread}
+      hydrate={hydrateProjectThreads}
       onToggleCollapsed={() => toggleProjectCollapsed(group.key)}
       onExpand={() => expandProject(group.key)}
       onTogglePin={() => toggleProjectPin(group.key)}
-      renderRow={(item) => (
-        <SidebarThreadRow key={item.key} {...rowProps(item)} indent />
+      renderRow={(item, live) => (
+        <SidebarThreadRow key={item.key} {...rowProps(item, live)} indent />
       )}
     />
   )
 
-  const cloudPending = !localOnly && sidebar.isPending
-  const resolvedLoading =
+  const cloudPending =
     !localOnly &&
-    !sidebar.isPending &&
-    prefs.filters.includeResolved &&
-    sidebar.resolvedQuery.isLoading
+    (pinnedQuery.isPending ||
+      recentsQuery.isPending ||
+      (projectMode && projectsQuery.isPending))
+  const cloudError =
+    pinnedQuery.isError ||
+    recentsQuery.isError ||
+    (projectMode && projectsQuery.isError)
   const sourcesLoading = cloudPending || (isDesktop && localThreads.isPending)
-  const hasMoreActive = !sidebar.isPending && sidebar.data.active.hasMore
-  const hasMoreArchived =
-    !sidebar.isPending &&
-    prefs.filters.includeResolved &&
-    sidebar.data.resolved.hasMore
   const isEmpty =
     !cloudPending &&
     (!isDesktop || !localThreads.isPending) &&
-    !resolvedLoading &&
     filteredPinnedItems.length === 0 &&
-    grouped.projects.length === 0 &&
-    grouped.recents.length === 0
+    projectGroups.length === 0 &&
+    recents.length === 0
 
   return (
     <SidebarFrame {...layout} className="border-r border-border bg-sidebar">
@@ -536,10 +640,14 @@ export function AgentsSidebar({
             {sourcesLoading && allItems.length === 0 && (
               <ThreadListSkeleton compact={prefs.compact} />
             )}
-            {sidebar.isError && (
+            {cloudError && (
               <ThreadSourceError
                 label="Cloud threads unavailable"
-                onRetry={() => void sidebar.refetch()}
+                onRetry={() => {
+                  void pinnedQuery.refetch()
+                  void recentsQuery.refetch()
+                  if (projectMode) void projectsQuery.refetch()
+                }}
               />
             )}
             {localThreads.isError && (
@@ -596,38 +704,34 @@ export function AgentsSidebar({
               </section>
             )}
 
-            {prefs.organize === "project" &&
-              (unpinnedGroups.length > 0 || isDesktop) && (
-                <section className="mb-3">
-                  <SidebarSectionHeader
-                    label="Projects"
-                    collapsed={sectionCollapsed("projects")}
-                    onToggleCollapsed={() => toggleSectionCollapsed("projects")}
-                    menu={
-                      <SidebarSectionMenu label="Projects options">
-                        {viewMenuItems}
-                        {removeProjectItems}
-                      </SidebarSectionMenu>
-                    }
-                    action={
-                      isDesktop ? (
-                        <SidebarSectionAction
-                          label="Add project"
-                          icon={<PlusIcon className="size-4" />}
-                          onClick={() => void addLocalProject()}
-                        />
-                      ) : undefined
-                    }
-                  />
-                  {!sectionCollapsed("projects") &&
-                    unpinnedGroups.map(renderProjectGroup)}
-                </section>
-              )}
+            {projectMode && (unpinnedGroups.length > 0 || isDesktop) && (
+              <section className="mb-3">
+                <SidebarSectionHeader
+                  label="Projects"
+                  collapsed={sectionCollapsed("projects")}
+                  onToggleCollapsed={() => toggleSectionCollapsed("projects")}
+                  menu={
+                    <SidebarSectionMenu label="Projects options">
+                      {viewMenuItems}
+                      {removeProjectItems}
+                    </SidebarSectionMenu>
+                  }
+                  action={
+                    isDesktop ? (
+                      <SidebarSectionAction
+                        label="Add project"
+                        icon={<PlusIcon className="size-4" />}
+                        onClick={() => void addLocalProject()}
+                      />
+                    ) : undefined
+                  }
+                />
+                {!sectionCollapsed("projects") &&
+                  unpinnedGroups.map(renderProjectGroup)}
+              </section>
+            )}
 
-            {(grouped.recents.length > 0 ||
-              hasMoreActive ||
-              hasMoreArchived ||
-              resolvedLoading) && (
+            {(recents.length > 0 || recentsQuery.hasMore) && (
               <section className="mb-3">
                 <SidebarSectionHeader
                   label="Recents"
@@ -651,35 +755,22 @@ export function AgentsSidebar({
                 />
                 {!sectionCollapsed("recents") && (
                   <>
-                    {grouped.recents.map((item) => (
+                    {recents.map((item) => (
                       <SidebarThreadRow key={item.key} {...rowProps(item)} />
                     ))}
-                    {(hasMoreActive || hasMoreArchived) && (
-                      <LoadMoreThreadsButton
+                    {recentsQuery.hasMore && (
+                      <LoadMoreThreadsOnScroll
                         label="Load more threads"
-                        loading={
-                          sidebar.activeQuery.isFetchingNextPage ||
-                          sidebar.resolvedQuery.isFetchingNextPage
-                        }
-                        onClick={() => {
-                          if (hasMoreActive)
-                            void sidebar.activeQuery.fetchNextPage()
-                          if (hasMoreArchived)
-                            void sidebar.resolvedQuery.fetchNextPage()
-                        }}
+                        root={scrollViewport}
+                        loading={recentsQuery.isFetchingNextPage}
+                        onLoadMore={recentsQuery.fetchNextPage}
                       />
-                    )}
-                    {resolvedLoading && (
-                      <div className="flex items-center gap-1.5 px-2.5 py-2 text-xs text-muted-foreground/70">
-                        <CircleNotchIcon className="size-3.5 animate-spin" />
-                        Loading archived threads…
-                      </div>
                     )}
                   </>
                 )}
               </section>
             )}
-            {isEmpty && !sidebar.isError && !localThreads.isError && (
+            {isEmpty && !cloudError && !localThreads.isError && (
               <p className="px-2.5 py-6 text-center text-xs text-muted-foreground/70">
                 {hasActiveFilters(prefs.filters)
                   ? "No threads match these filters."
@@ -714,29 +805,70 @@ function ProjectGroup({
   collapsed,
   expanded,
   pinned,
+  includeResolved,
+  includeAutomations,
+  sort,
+  activeThreadId,
+  openThread,
+  hydrate,
   onToggleCollapsed,
   onExpand,
   onTogglePin,
   renderRow,
 }: {
-  group: SidebarProjectGroup
+  group: HydratedProjectGroup
   activeKey?: string
   collapsed: boolean
   expanded: boolean
   pinned: boolean
+  includeResolved: boolean
+  includeAutomations: boolean
+  sort: ChatSort
+  activeThreadId?: string
+  openThread: (threadId: string) => void
+  hydrate: (threads: Array<AgentThread>) => Array<SidebarThreadItem>
   onToggleCollapsed: () => void
   onExpand: () => void
   onTogglePin: () => void
-  renderRow: (item: SidebarThreadItem) => React.ReactNode
+  renderRow: (
+    item: SidebarThreadItem,
+    live: PullRequestSnapshot | undefined
+  ) => React.ReactNode
 }) {
   const Folder = collapsed ? FolderIcon : FolderOpenIcon
-  const preview = group.threads.slice(0, PROJECT_PREVIEW_COUNT)
-  const active = group.threads.find((thread) => thread.key === activeKey)
+  const project = useSidebarProjectThreads({
+    repoFullName: group.repoFullName,
+    includeResolved,
+    includeAutomations,
+    enabled: !collapsed,
+  })
+  const cloudThreads = [
+    ...(group.activeThread ? [group.activeThread] : []),
+    ...project.items.filter((thread) => thread.id !== group.activeThread?.id),
+  ]
+  useSeedAgentThreadDetails(cloudThreads, activeThreadId)
+  useRunCompletionNotifier(cloudThreads, activeThreadId, openThread)
+  const threads = sortSidebarThreads(
+    [...hydrate(cloudThreads), ...group.threads],
+    sort
+  )
+  const pullRequestFor = useSidebarPullRequests(
+    threads,
+    Boolean(group.repoFullName)
+  )
+  const preview = threads.slice(0, PROJECT_PREVIEW_COUNT)
+  const active = threads.find((thread) => thread.key === activeKey)
   const shown = expanded
-    ? group.threads
+    ? threads
     : active && !preview.includes(active)
       ? [...preview.slice(0, -1), active]
       : preview
+  const loading =
+    project.isFetchingNextPage ||
+    (Boolean(group.repoFullName) && !collapsed && project.isPending)
+  const hasMore = expanded
+    ? project.hasMore
+    : threads.length > PROJECT_PREVIEW_COUNT || project.hasMore
 
   return (
     <div className="mb-1">
@@ -766,14 +898,39 @@ function ProjectGroup({
       </div>
       {!collapsed && (
         <>
-          {shown.map(renderRow)}
-          {shown.length < group.threads.length && (
+          {shown.map((item) => renderRow(item, pullRequestFor(item)))}
+          {shown.length === 0 && loading && (
+            <div className="flex items-center gap-1.5 py-1 pr-2.5 pl-6 text-[13px] text-muted-foreground/70">
+              <CircleNotchIcon className="size-3.5 animate-spin" />
+              Loading chats…
+            </div>
+          )}
+          {shown.length === 0 && !loading && !project.isError && (
+            <p className="py-1 pr-2.5 pl-6 text-[13px] text-muted-foreground/60">
+              No chats
+            </p>
+          )}
+          {project.isError && (
             <button
               type="button"
-              onClick={onExpand}
-              className="flex w-full items-center rounded-lg py-1 pr-2.5 pl-6 text-left text-[13px] text-muted-foreground/70 transition-colors hover:text-foreground"
+              onClick={() => void project.refetch()}
+              className="w-full py-1 pr-2.5 pl-6 text-left text-[13px] text-destructive"
             >
-              Show more
+              Retry loading chats
+            </button>
+          )}
+          {hasMore && (
+            <button
+              type="button"
+              onClick={() => {
+                if (!expanded) onExpand()
+                else project.fetchNextPage()
+              }}
+              disabled={loading}
+              className="flex w-full items-center gap-1.5 rounded-lg py-1 pr-2.5 pl-6 text-left text-[13px] text-muted-foreground/70 transition-colors hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+            >
+              {loading && <CircleNotchIcon className="size-3.5 animate-spin" />}
+              {loading ? "Loading…" : "Show more"}
             </button>
           )}
         </>
@@ -841,26 +998,51 @@ function ThreadSourceError({
   )
 }
 
-function LoadMoreThreadsButton({
+function LoadMoreThreadsOnScroll({
   label,
+  root,
   loading,
-  onClick,
+  onLoadMore,
 }: {
-  /** Screen-reader label; the button itself just reads "Show more". */
   label: string
+  root: React.RefObject<HTMLDivElement | null>
   loading: boolean
-  onClick: () => void
+  onLoadMore: () => void
 }) {
+  const sentinel = useRef<HTMLButtonElement>(null)
+  const load = useRef(onLoadMore)
+  useEffect(() => {
+    load.current = onLoadMore
+  })
+  useEffect(() => {
+    const node = sentinel.current
+    if (!node || typeof IntersectionObserver === "undefined") return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!loading && entries.some((entry) => entry.isIntersecting)) {
+          load.current()
+        }
+      },
+      { root: root.current, rootMargin: "200px" }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [loading, root])
+
   return (
     <button
+      ref={sentinel}
       type="button"
-      onClick={onClick}
+      onClick={() => load.current()}
       disabled={loading}
       aria-label={label}
-      className="mt-0.5 flex w-full items-center gap-1.5 rounded-lg py-1 pr-2.5 pl-2.5 text-left text-[13px] text-muted-foreground/70 transition-colors hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+      className="flex w-full items-center justify-center gap-1.5 py-2 text-[13px] text-muted-foreground/70"
     >
-      {loading && <CircleNotchIcon className="size-3.5 animate-spin" />}
-      {loading ? "Loading…" : "Show more"}
+      {loading ? (
+        <CircleNotchIcon className="size-3.5 animate-spin" />
+      ) : (
+        <span className="sr-only">{label}</span>
+      )}
     </button>
   )
 }

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -125,6 +125,8 @@ export interface ThreadsPageParams {
   q?: string
   scope?: ThreadScope
   automationId?: string
+  repo?: string
+  ownerless?: boolean
   sortBy?: ThreadSortBy
 }
 
@@ -136,16 +138,10 @@ export interface ThreadsPage {
   hasMore?: boolean
 }
 
-export interface SidebarThreadsGroup {
-  items: Array<AgentThread>
-  limit: number
-  hasMore: boolean
-}
-
-export interface SidebarThreads {
-  active: SidebarThreadsGroup
-  resolved: SidebarThreadsGroup
-  pinned?: Array<AgentThread>
+export interface SidebarProject {
+  repoFullName: string
+  name: string
+  updatedAt: number
 }
 
 const API_BASE = dashboardApiBase()
@@ -229,27 +225,21 @@ function buildThreadsPageQuery(params: ThreadsPageParams): string {
   if (params.q) search.set("q", params.q)
   if (params.scope) search.set("scope", params.scope)
   if (params.automationId) search.set("automation_id", params.automationId)
+  if (params.repo) search.set("repo", params.repo)
+  if (params.ownerless != null)
+    search.set("ownerless", String(params.ownerless))
   if (params.sortBy) search.set("sort_by", params.sortBy)
   const query = search.toString()
   return query ? `?${query}` : ""
 }
 
-function buildSidebarThreadsQuery(params: {
-  activeLimit?: number
-  resolvedLimit?: number
-  activeThreadId?: string
+function buildProjectsQuery(params: {
+  includeResolved?: boolean
   includeAutomations?: boolean
 }): string {
   const search = new URLSearchParams()
-  if (params.activeLimit != null) {
-    search.set("active_limit", String(params.activeLimit))
-  }
-  if (params.resolvedLimit != null) {
-    search.set("resolved_limit", String(params.resolvedLimit))
-  }
-  if (params.activeThreadId) {
-    search.set("active_thread_id", params.activeThreadId)
-  }
+  if (params.includeResolved != null)
+    search.set("include_resolved", String(params.includeResolved))
   if (params.includeAutomations != null) {
     search.set("include_automations", String(params.includeAutomations))
   }
@@ -273,15 +263,16 @@ export interface PullRequestSnapshot {
 
 export const agentsApi = {
   langGraphApiUrl: agentsLangGraphApiUrl,
-  listSidebarThreads: (params: {
-    activeLimit?: number
-    resolvedLimit?: number
-    activeThreadId?: string
-    includeAutomations?: boolean
-  }) =>
-    agentsRequest<SidebarThreads>(
-      `/threads/sidebar${buildSidebarThreadsQuery(params)}`
+  listThreadProjects: (
+    params: {
+      includeResolved?: boolean
+      includeAutomations?: boolean
+    } = {}
+  ) =>
+    agentsRequest<Array<SidebarProject>>(
+      `/threads/projects${buildProjectsQuery(params)}`
     ),
+  listPinnedThreads: () => agentsRequest<Array<AgentThread>>("/threads/pinned"),
   listThreadsPage: (params: ThreadsPageParams = {}) =>
     agentsRequest<ThreadsPage>(`/threads/page${buildThreadsPageQuery(params)}`),
   resolveThread: (threadId: string, resolved: boolean) =>

--- a/ui/src/features/agents/lib/apiWarmup.test.ts
+++ b/ui/src/features/agents/lib/apiWarmup.test.ts
@@ -31,7 +31,8 @@ function stubFetch() {
 
 /** What the app itself requests, captured through the real api client. */
 async function recordedSidebarUrl(
-  includeAutomations: boolean
+  includeAutomations: boolean,
+  projectMode = true
 ): Promise<string> {
   const spy = stubFetch()
   await agentsApi
@@ -40,6 +41,7 @@ async function recordedSidebarUrl(
       offset: 0,
       resolved: false,
       scope: includeAutomations ? "all" : "interactive",
+      ownerless: projectMode,
     })
     .catch(() => undefined)
   const called = spy.mock.calls[0]?.[0]
@@ -129,19 +131,26 @@ describe("apiWarmupScript", () => {
   // has to be checked against the request the api client actually makes —
   // a mismatch would silently fetch the sidebar twice.
   it.each([
-    { includeAutomations: false, prefs: undefined },
+    { includeAutomations: false, projectMode: true, prefs: undefined },
     {
       includeAutomations: true,
+      projectMode: true,
       prefs: { filters: { includeAutomations: true } },
     },
     {
       includeAutomations: true,
+      projectMode: true,
       prefs: { filters: { sources: ["schedule"] } },
     },
+    {
+      includeAutomations: false,
+      projectMode: false,
+      prefs: { organize: "list" },
+    },
   ])(
-    "warms the exact sidebar URL the app requests (automations: $includeAutomations)",
-    async ({ includeAutomations, prefs }) => {
-      const expected = await recordedSidebarUrl(includeAutomations)
+    "warms the exact sidebar URL the app requests (automations: $includeAutomations, project mode: $projectMode)",
+    async ({ includeAutomations, projectMode, prefs }) => {
+      const expected = await recordedSidebarUrl(includeAutomations, projectMode)
 
       setReadyState("loading")
       stubPrefs(prefs)

--- a/ui/src/features/agents/lib/apiWarmup.ts
+++ b/ui/src/features/agents/lib/apiWarmup.ts
@@ -23,9 +23,12 @@ function warmApiRequests(
   const targets = urls.slice()
   if (sidebarUrl) {
     let includeAutomations = false
+    let projectMode = true
     try {
       const raw = localStorage.getItem(prefsKey)
-      const filters = raw ? JSON.parse(raw).filters : null
+      const prefs = raw ? JSON.parse(raw) : null
+      const filters = prefs?.filters
+      projectMode = prefs?.organize !== "list"
       if (filters) {
         includeAutomations =
           filters.includeAutomations === true ||
@@ -36,10 +39,12 @@ function warmApiRequests(
       // An unreadable preference just means the default (false).
     }
     targets.push(
-      sidebarUrl.replace(
-        "__SIDEBAR_SCOPE__",
-        includeAutomations ? "all" : "interactive"
-      )
+      sidebarUrl
+        .replace(
+          "__SIDEBAR_SCOPE__",
+          includeAutomations ? "all" : "interactive"
+        )
+        .replace("__SIDEBAR_OWNERLESS__", String(projectMode))
     )
   }
 
@@ -100,6 +105,7 @@ function sidebarUrlTemplate(): string {
   search.set("offset", "0")
   search.set("resolved", "false")
   search.set("scope", "__SIDEBAR_SCOPE__")
+  search.set("ownerless", "__SIDEBAR_OWNERLESS__")
   return `${agentsLangGraphApiUrl}/threads/page?${search.toString()}`
 }
 

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
@@ -5,10 +5,14 @@ import { renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSubmitAgentMessage } from "./useSubmitAgentMessage"
+import type { InfiniteData } from "@tanstack/react-query"
 import type { AgentThread } from "@/features/agents/lib/types"
-import type { SidebarThreads } from "@/features/agents/lib/api"
+import type { ThreadsPage } from "@/features/agents/lib/api"
 import { AgentsApiError } from "@/features/agents/lib/api"
-import { agentThreadKeys } from "@/features/agents/lib/queries"
+import {
+  SIDEBAR_PAGE_SIZE,
+  agentThreadKeys,
+} from "@/features/agents/lib/queries"
 
 const stream = {
   isLoading: false,
@@ -34,6 +38,11 @@ vi.mock("@/features/agents/lib/api", () => ({
 }))
 
 const THREAD_ID = "thread-1"
+const SIDEBAR_PARAMS = {
+  limit: SIDEBAR_PAGE_SIZE,
+  resolved: false,
+  scope: "interactive" as const,
+}
 
 function setup() {
   const client = new QueryClient({
@@ -45,15 +54,18 @@ function setup() {
     messages: [],
   } as unknown as AgentThread
   client.setQueryData(agentThreadKeys.detail(THREAD_ID), thread)
-  client.setQueryData<SidebarThreads>(
-    agentThreadKeys.sidebar({
-      activeLimit: 50,
-      resolvedLimit: 20,
-      includeAutomations: false,
-    }),
+  client.setQueryData<InfiniteData<ThreadsPage>>(
+    agentThreadKeys.infinitePages(SIDEBAR_PARAMS),
     {
-      active: { items: [thread], limit: 50, hasMore: false },
-      resolved: { items: [], limit: 20, hasMore: false },
+      pages: [
+        {
+          items: [thread],
+          limit: SIDEBAR_PAGE_SIZE,
+          offset: 0,
+          hasMore: false,
+        },
+      ],
+      pageParams: [0],
     }
   )
   const queuedCounts: Array<number> = []
@@ -77,9 +89,9 @@ function queuedMessages(client: QueryClient) {
 }
 
 function sidebarStatus(client: QueryClient) {
-  return client.getQueriesData<SidebarThreads>({
-    queryKey: ["agent-threads", "lists", "sidebar"],
-  })[0]?.[1]?.active.items[0]?.status
+  return client.getQueryData<InfiniteData<ThreadsPage>>(
+    agentThreadKeys.infinitePages(SIDEBAR_PARAMS)
+  )?.pages[0]?.items[0]?.status
 }
 
 beforeEach(() => {

--- a/ui/src/features/agents/lib/queries.test.tsx
+++ b/ui/src/features/agents/lib/queries.test.tsx
@@ -12,7 +12,9 @@ import {
   setAgentThreadStatus,
   useAgentThreadWorkingTreeDiff,
   useResolveAgentThread,
-  useSidebarThreads,
+  useSidebarActiveThread,
+  useSidebarProjectThreads,
+  useSidebarRecents,
   useThreadsPage,
 } from "./queries"
 import type { InfiniteData } from "@tanstack/react-query"
@@ -266,66 +268,70 @@ describe("setAgentThreadStatus", () => {
   })
 })
 
-describe("useSidebarThreads", () => {
-  const emptySidebar = (activeLimit: number, resolvedLimit: number) => ({
-    active: { items: [], limit: activeLimit, hasMore: false },
-    resolved: { items: [], limit: resolvedLimit, hasMore: false },
-  })
-
-  it("defers resolved threads and includes them when requested", async () => {
+describe("sidebar queries", () => {
+  it("scopes Recents to ownerless threads only in project mode", async () => {
     const listThreads = vi
-      .spyOn(agentsApi, "listSidebarThreads")
-      .mockImplementation((request) =>
-        Promise.resolve(
-          emptySidebar(
-            request.activeLimit ?? SIDEBAR_PAGE_SIZE,
-            request.resolvedLimit ?? SIDEBAR_PAGE_SIZE
-          )
-        )
-      )
+      .spyOn(agentsApi, "listThreadsPage")
+      .mockResolvedValue(page)
     const client = testClient()
-
-    function Probe({ includeResolved }: { includeResolved: boolean }) {
-      useSidebarThreads({ includeResolved })
-      return null
-    }
-
-    const view = render(
-      <QueryClientProvider client={client}>
-        <Probe includeResolved={false} />
-      </QueryClientProvider>
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    const { rerender } = renderHook(
+      ({ projectMode }) => useSidebarRecents({ projectMode }),
+      { wrapper, initialProps: { projectMode: true } }
     )
 
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(1))
-    expect(listThreads).toHaveBeenLastCalledWith({
-      activeLimit: SIDEBAR_PAGE_SIZE,
-      resolvedLimit: 0,
-      includeAutomations: false,
-    })
-
-    view.rerender(
-      <QueryClientProvider client={client}>
-        <Probe includeResolved />
-      </QueryClientProvider>
+    await waitFor(() =>
+      expect(listThreads).toHaveBeenCalledWith({
+        limit: SIDEBAR_PAGE_SIZE,
+        offset: 0,
+        resolved: false,
+        scope: "interactive",
+        ownerless: true,
+      })
     )
 
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(2))
-    expect(listThreads).toHaveBeenLastCalledWith({
-      activeLimit: SIDEBAR_PAGE_SIZE,
-      resolvedLimit: SIDEBAR_PAGE_SIZE,
-      includeAutomations: false,
-    })
+    rerender({ projectMode: false })
+
+    await waitFor(() =>
+      expect(listThreads).toHaveBeenCalledWith({
+        limit: SIDEBAR_PAGE_SIZE,
+        offset: 0,
+        resolved: false,
+        scope: "interactive",
+      })
+    )
   })
 
-  it("adds a selected thread outside the shared sidebar window", async () => {
-    const opened = { id: "opened-thread", resolved: false } as AgentThread
-    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue(
-      emptySidebar(SIDEBAR_PAGE_SIZE, 0)
-    )
-    const getThread = vi.spyOn(agentsApi, "getThread").mockResolvedValue(opened)
+  it("paginates each project through an independent query", async () => {
+    const listThreads = vi
+      .spyOn(agentsApi, "listThreadsPage")
+      .mockImplementation(async (request) => {
+        const requestParams = request ?? {}
+        const offset = requestParams.offset ?? 0
+        return {
+          items: [
+            {
+              id: `${requestParams.repo}-${offset}`,
+              repoFullName: requestParams.repo,
+            } as AgentThread,
+          ],
+          limit: requestParams.limit ?? SIDEBAR_PAGE_SIZE,
+          offset,
+          hasMore: offset === 0,
+        }
+      })
     const client = testClient()
     const { result } = renderHook(
-      () => useSidebarThreads({ activeThreadId: opened.id }),
+      () => ({
+        first: useSidebarProjectThreads({
+          repoFullName: "langchain-ai/first",
+        }),
+        second: useSidebarProjectThreads({
+          repoFullName: "langchain-ai/second",
+        }),
+      }),
       {
         wrapper: ({ children }) => (
           <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -333,138 +339,52 @@ describe("useSidebarThreads", () => {
       }
     )
 
+    await waitFor(() => {
+      expect(result.current.first.items[0]?.id).toBe("langchain-ai/first-0")
+      expect(result.current.second.items[0]?.id).toBe("langchain-ai/second-0")
+    })
+
+    act(() => result.current.first.fetchNextPage())
+
     await waitFor(() =>
-      expect(result.current.data.active.items).toEqual([opened])
+      expect(listThreads).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repo: "langchain-ai/first",
+          offset: 1,
+        })
+      )
     )
+    expect(listThreads).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: "langchain-ai/second",
+        offset: 1,
+      })
+    )
+  })
+
+  it("fetches the active thread when it is outside the loaded pages", async () => {
+    const opened = { id: "opened-thread", resolved: false } as AgentThread
+    const getThread = vi.spyOn(agentsApi, "getThread").mockResolvedValue(opened)
+    const client = testClient()
+    const { result } = renderHook(
+      () =>
+        useSidebarActiveThread({
+          activeThreadId: opened.id,
+          loadedThreads: [],
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      }
+    )
+
+    await waitFor(() => expect(result.current).toEqual(opened))
     expect(getThread).toHaveBeenCalledWith(opened.id, { markViewed: false })
   })
+})
 
-  it("increases the activity window when loading more", async () => {
-    const listThreads = vi
-      .spyOn(agentsApi, "listSidebarThreads")
-      .mockImplementation((request) =>
-        Promise.resolve(
-          emptySidebar(
-            request.activeLimit ?? SIDEBAR_PAGE_SIZE,
-            request.resolvedLimit ?? SIDEBAR_PAGE_SIZE
-          )
-        )
-      )
-    const client = testClient()
-    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
-
-    function Probe() {
-      sidebar = useSidebarThreads({ includeResolved: true })
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={client}>
-        <Probe />
-      </QueryClientProvider>
-    )
-
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(1))
-    act(() => sidebar?.activeQuery.fetchNextPage())
-    await waitFor(() =>
-      expect(listThreads).toHaveBeenCalledWith(
-        expect.objectContaining({ activeLimit: SIDEBAR_PAGE_SIZE * 2 })
-      )
-    )
-
-    act(() => sidebar?.resolvedQuery.fetchNextPage())
-    await waitFor(() =>
-      expect(listThreads).toHaveBeenCalledWith(
-        expect.objectContaining({ resolvedLimit: SIDEBAR_PAGE_SIZE * 2 })
-      )
-    )
-  })
-
-  it("hides an opened resolved thread when resolved threads are hidden", async () => {
-    const opened = {
-      id: "opened-thread",
-      status: "idle",
-      resolved: true,
-    } as AgentThread
-    vi.spyOn(agentsApi, "listSidebarThreads").mockResolvedValue({
-      active: { items: [], limit: SIDEBAR_PAGE_SIZE, hasMore: false },
-      resolved: { items: [opened], limit: 1, hasMore: true },
-    })
-    const client = testClient()
-    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
-
-    function Probe() {
-      sidebar = useSidebarThreads({ activeThreadId: opened.id })
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={client}>
-        <Probe />
-      </QueryClientProvider>
-    )
-
-    await waitFor(() => expect(sidebar?.isPending).toBe(false))
-    expect(sidebar?.data.active.items).toEqual([])
-    expect(sidebar?.data.resolved.items).toEqual([opened])
-  })
-
-  it("hides the opened thread while resolving it optimistically", async () => {
-    const opened = {
-      id: "opened-thread",
-      status: "idle",
-      resolved: false,
-    } as AgentThread
-    const resolved = { ...opened, resolved: true }
-    const listThreads = vi
-      .spyOn(agentsApi, "listSidebarThreads")
-      .mockResolvedValueOnce({
-        active: {
-          items: [opened],
-          limit: SIDEBAR_PAGE_SIZE,
-          hasMore: false,
-        },
-        resolved: { items: [], limit: 1, hasMore: false },
-      })
-      .mockResolvedValue(emptySidebar(SIDEBAR_PAGE_SIZE, 1))
-    let finishResolve: ((thread: AgentThread) => void) | undefined
-    const resolveRequest = new Promise<AgentThread>((resolve) => {
-      finishResolve = resolve
-    })
-    vi.spyOn(agentsApi, "resolveThread").mockReturnValue(resolveRequest)
-    const getThread = vi.spyOn(agentsApi, "getThread")
-    const client = testClient()
-    let sidebar: ReturnType<typeof useSidebarThreads> | undefined
-    let resolveThread: ReturnType<typeof useResolveAgentThread> | undefined
-
-    function Probe() {
-      sidebar = useSidebarThreads({ activeThreadId: opened.id })
-      resolveThread = useResolveAgentThread()
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={client}>
-        <Probe />
-      </QueryClientProvider>
-    )
-
-    await waitFor(() => expect(sidebar?.data.active.items).toEqual([opened]))
-    act(() => {
-      resolveThread?.mutate({ threadId: opened.id, resolved: true })
-    })
-
-    await waitFor(() => expect(sidebar?.data.active.items).toEqual([]))
-    expect(resolveThread?.isPending).toBe(true)
-    expect(getThread).not.toHaveBeenCalled()
-
-    await act(async () => {
-      finishResolve?.(resolved)
-      await resolveRequest
-    })
-    await waitFor(() => expect(listThreads).toHaveBeenCalledTimes(2))
-  })
-
+describe("useResolveAgentThread", () => {
   it("rolls back an optimistic resolution when the request fails", async () => {
     const opened = {
       id: "opened-thread",
@@ -488,21 +408,14 @@ describe("useSidebarThreads", () => {
       offset: 0,
       hasMore: false,
     })
-    let resolveThread: ReturnType<typeof useResolveAgentThread> | undefined
-
-    function Probe() {
-      resolveThread = useResolveAgentThread()
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={client}>
-        <Probe />
-      </QueryClientProvider>
-    )
+    const { result } = renderHook(() => useResolveAgentThread(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    })
 
     act(() => {
-      resolveThread?.mutate({ threadId: opened.id, resolved: true })
+      result.current.mutate({ threadId: opened.id, resolved: true })
     })
     await waitFor(() =>
       expect(client.getQueryData<ThreadsPage>(key)?.items).toEqual([])
@@ -536,23 +449,25 @@ describe("markAgentThreadViewed", () => {
 
   it("clears the unread flag across the caches, leaving the detail stale", () => {
     const client = testClient()
-    const sidebarKey = [...agentThreadKeys.lists, "sidebar", { limit: 10 }]
-    client.setQueryData(sidebarKey, {
-      pinned: [unread],
-      active: { items: [unread], limit: 10, hasMore: false },
-      resolved: { items: [], limit: 10, hasMore: false },
+    const pagesKey = agentThreadKeys.infinitePages({ limit: 10 })
+    client.setQueryData<Array<AgentThread>>(agentThreadKeys.pinned, [unread])
+    client.setQueryData<InfiniteData<ThreadsPage>>(pagesKey, {
+      pages: [{ items: [unread], limit: 10, offset: 0, hasMore: false }],
+      pageParams: [0],
     })
     client.setQueryData(agentThreadKeys.sidebarActive("thread-1"), unread)
     client.setQueryData(agentThreadKeys.detail("thread-1"), unread)
 
     markAgentThreadViewed(client, "thread-1")
 
-    const sidebar = client.getQueryData<{
-      pinned: Array<AgentThread>
-      active: { items: Array<AgentThread> }
-    }>(sidebarKey)
-    expect(sidebar?.pinned[0]?.viewed).toBe(true)
-    expect(sidebar?.active.items[0]?.viewed).toBe(true)
+    expect(
+      client.getQueryData<Array<AgentThread>>(agentThreadKeys.pinned)?.[0]
+        ?.viewed
+    ).toBe(true)
+    expect(
+      client.getQueryData<InfiniteData<ThreadsPage>>(pagesKey)?.pages[0]
+        ?.items[0]?.viewed
+    ).toBe(true)
     expect(
       client.getQueryData<AgentThread>(
         agentThreadKeys.sidebarActive("thread-1")

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -5,13 +5,12 @@ import {
   useQueryClient,
 } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 
 import { agentsApi } from "./api"
 import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query"
 import type {
   ScheduleUpdateRequest,
-  SidebarThreads,
   ThreadsPage,
   ThreadsPageParams,
 } from "./api"
@@ -27,11 +26,11 @@ import { api } from "@/lib/api"
 
 export const agentThreadKeys = {
   lists: ["agent-threads", "lists"] as const,
-  sidebar: (params: {
-    activeLimit: number
-    resolvedLimit: number
+  pinned: ["agent-threads", "lists", "pinned"] as const,
+  projects: (params: {
+    includeResolved: boolean
     includeAutomations: boolean
-  }) => ["agent-threads", "lists", "sidebar", params] as const,
+  }) => ["agent-threads", "lists", "projects", params] as const,
   sidebarActive: (threadId: string) =>
     ["agent-threads", "lists", "sidebar-active", threadId] as const,
   detail: (threadId: string) => ["agent-threads", threadId] as const,
@@ -64,14 +63,8 @@ export function setAgentThreadStatus(
     agentThreadKeys.detail(threadId),
     (prev) => (prev ? update(prev) : prev)
   )
-  queryClient.setQueriesData<SidebarThreads>(
-    { queryKey: ["agent-threads", "lists", "sidebar"] },
-    (prev) =>
-      prev && {
-        ...prev,
-        active: { ...prev.active, items: prev.active.items.map(update) },
-        resolved: { ...prev.resolved, items: prev.resolved.items.map(update) },
-      }
+  queryClient.setQueryData<Array<AgentThread>>(agentThreadKeys.pinned, (prev) =>
+    prev?.map(update)
   )
   queryClient.setQueriesData<InfiniteData<ThreadsPage>>(
     { queryKey: ["agent-threads", "lists", "infinite-pages"] },
@@ -129,7 +122,7 @@ function snapshotAgentThreadQueries(
   })
   const lists = [
     ...queryClient.getQueriesData({
-      queryKey: ["agent-threads", "lists", "sidebar"],
+      queryKey: agentThreadKeys.pinned,
     }),
     ...queryClient.getQueriesData({
       queryKey: ["agent-threads", "lists", "infinite-pages"],
@@ -183,24 +176,25 @@ export function markAgentThreadViewed(
     agentThreadKeys.sidebarActive(threadId),
     (prev) => (prev ? view(prev) : prev)
   )
-  for (const [key, data] of queryClient.getQueriesData<SidebarThreads>({
-    queryKey: ["agent-threads", "lists", "sidebar"],
-  })) {
-    if (!data) continue
-    queryClient.setQueryData<SidebarThreads>(key, (prev) =>
-      prev
-        ? {
-            ...prev,
-            pinned: prev.pinned && viewList(prev.pinned),
-            active: { ...prev.active, items: viewList(prev.active.items) },
-            resolved: {
-              ...prev.resolved,
-              items: viewList(prev.resolved.items),
-            },
-          }
-        : prev
-    )
-  }
+  queryClient.setQueryData<Array<AgentThread>>(
+    agentThreadKeys.pinned,
+    (prev) => (prev ? viewList(prev) : prev)
+  )
+  queryClient.setQueriesData<InfiniteData<ThreadsPage>>(
+    { queryKey: ["agent-threads", "lists", "infinite-pages"] },
+    (prev) =>
+      prev && {
+        ...prev,
+        pages: prev.pages.map((page) => ({
+          ...page,
+          items: viewList(page.items),
+        })),
+      }
+  )
+  queryClient.setQueriesData<ThreadsPage>(
+    { queryKey: ["agent-threads", "lists", "page"] },
+    (prev) => prev && { ...prev, items: viewList(prev.items) }
+  )
 }
 
 function setAgentThreadResolved(
@@ -222,52 +216,13 @@ function setAgentThreadResolved(
     agentThreadKeys.detail(threadId),
     (prev) => (prev ? update(prev) : prev)
   )
-  for (const [key, data] of queryClient.getQueriesData<SidebarThreads>({
-    queryKey: ["agent-threads", "lists", "sidebar"],
-  })) {
-    cachedThread ??= [
-      ...(data?.active.items ?? []),
-      ...(data?.resolved.items ?? []),
-    ].find((thread) => thread.id === threadId)
-    queryClient.setQueryData<SidebarThreads>(key, (prev) => {
-      if (!prev) return prev
-      const move = (source: Array<AgentThread>, target: Array<AgentThread>) => {
-        const thread = source.find((item) => item.id === threadId)
-        return thread
-          ? [update(thread), ...target.filter((item) => item.id !== threadId)]
-          : target
-      }
-      return resolved
-        ? {
-            ...prev,
-            active: {
-              ...prev.active,
-              items: prev.active.items.filter((item) => item.id !== threadId),
-            },
-            resolved: {
-              ...prev.resolved,
-              items: move(prev.active.items, prev.resolved.items).slice(
-                0,
-                prev.resolved.limit
-              ),
-            },
-          }
-        : {
-            ...prev,
-            active: {
-              ...prev.active,
-              items: move(prev.resolved.items, prev.active.items).slice(
-                0,
-                prev.active.limit
-              ),
-            },
-            resolved: {
-              ...prev.resolved,
-              items: prev.resolved.items.filter((item) => item.id !== threadId),
-            },
-          }
-    })
-  }
+  const pinned = queryClient.getQueryData<Array<AgentThread>>(
+    agentThreadKeys.pinned
+  )
+  cachedThread ??= pinned?.find((thread) => thread.id === threadId)
+  queryClient.setQueryData<Array<AgentThread>>(agentThreadKeys.pinned, (prev) =>
+    prev?.map(update)
+  )
   for (const [key, data] of queryClient.getQueriesData<
     InfiniteData<ThreadsPage>
   >({ queryKey: ["agent-threads", "lists", "infinite-pages"] })) {
@@ -307,24 +262,6 @@ export function seedAgentThreadLists(
   queryClient: QueryClient,
   thread: AgentThread
 ): void {
-  queryClient.setQueriesData<SidebarThreads>(
-    { queryKey: ["agent-threads", "lists", "sidebar"] },
-    (prev) => {
-      if (!prev) return prev
-      const activeItems = [
-        thread,
-        ...prev.active.items.filter((item) => item.id !== thread.id),
-      ].slice(0, prev.active.limit)
-      const resolvedItems = prev.resolved.items.filter(
-        (item) => item.id !== thread.id
-      )
-      return {
-        ...prev,
-        active: { ...prev.active, items: activeItems },
-        resolved: { ...prev.resolved, items: resolvedItems },
-      }
-    }
-  )
   queryClient.setQueryData(agentThreadKeys.sidebarActive(thread.id), thread)
 }
 
@@ -500,100 +437,139 @@ export function useSeedAgentThreadDetails(
 
 export const SIDEBAR_PAGE_SIZE = 10
 
-function sidebarThreads(data?: SidebarThreads): Array<AgentThread> {
-  return [
-    ...(data?.pinned ?? []),
-    ...(data?.active.items ?? []),
-    ...(data?.resolved.items ?? []),
-  ]
+function sidebarPageParams({
+  includeAutomations,
+  includeResolved,
+}: {
+  includeAutomations: boolean
+  includeResolved: boolean
+}): Omit<ThreadsPageParams, "offset"> {
+  return {
+    limit: SIDEBAR_PAGE_SIZE,
+    ...(includeResolved ? {} : { resolved: false }),
+    scope: includeAutomations ? "all" : "interactive",
+  }
 }
 
-export function useSidebarThreads({
-  activeThreadId,
+export function useSidebarPinnedThreads({ enabled = true } = {}) {
+  return useQuery({
+    queryKey: agentThreadKeys.pinned,
+    queryFn: agentsApi.listPinnedThreads,
+    enabled,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
+    refetchInterval: (query) =>
+      query.state.data?.some((thread) => thread.status === "running")
+        ? 2000
+        : false,
+  })
+}
+
+export function useSidebarProjects({
   includeAutomations = false,
   includeResolved = false,
   enabled = true,
 }: {
-  activeThreadId?: string
   includeAutomations?: boolean
   includeResolved?: boolean
   enabled?: boolean
 }) {
-  const [activeLimit, setActiveLimit] = useState(SIDEBAR_PAGE_SIZE)
-  const [resolvedLimit, setResolvedLimit] = useState(SIDEBAR_PAGE_SIZE)
-  const params = {
-    activeLimit,
-    resolvedLimit: includeResolved ? resolvedLimit : 0,
-    includeAutomations,
-  }
-  const query = useQuery({
-    queryKey: agentThreadKeys.sidebar(params),
-    queryFn: () => agentsApi.listSidebarThreads(params),
+  const params = { includeAutomations, includeResolved }
+  return useQuery({
+    queryKey: agentThreadKeys.projects(params),
+    queryFn: () => agentsApi.listThreadProjects(params),
     enabled,
     placeholderData: (previous) => previous,
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
-    refetchInterval: (current) =>
-      sidebarThreads(current.state.data).some(
-        (thread) => thread.status === "running"
-      )
-        ? 2000
-        : false,
   })
-  const activeThreadLoaded = sidebarThreads(query.data).some(
-    (thread) => thread.id === activeThreadId
-  )
-  const activeThreadQuery = useQuery({
+}
+
+export function useSidebarActiveThread({
+  activeThreadId,
+  loadedThreads,
+  includeResolved = false,
+  enabled = true,
+}: {
+  activeThreadId?: string
+  loadedThreads: Array<AgentThread>
+  includeResolved?: boolean
+  enabled?: boolean
+}): AgentThread | undefined {
+  const loaded = loadedThreads.some((thread) => thread.id === activeThreadId)
+  const query = useQuery({
     queryKey: agentThreadKeys.sidebarActive(activeThreadId ?? ""),
     queryFn: () => agentsApi.getThread(activeThreadId!, { markViewed: false }),
-    enabled:
-      enabled &&
-      Boolean(activeThreadId) &&
-      query.isSuccess &&
-      !activeThreadLoaded,
+    enabled: enabled && Boolean(activeThreadId) && !loaded,
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
     refetchInterval: (current) =>
       current.state.data?.status === "running" ? 2000 : false,
     retry: false,
   })
-  const baseData = query.data ?? {
-    active: { items: [], limit: activeLimit, hasMore: false },
-    resolved: { items: [], limit: resolvedLimit, hasMore: false },
-    pinned: [],
-  }
-  const activeThread = activeThreadLoaded ? undefined : activeThreadQuery.data
-  const group = activeThread?.resolved ? "resolved" : "active"
-  const data =
-    activeThread && (!activeThread.resolved || includeResolved)
-      ? {
-          ...baseData,
-          [group]: {
-            ...baseData[group],
-            items: [activeThread, ...baseData[group].items],
-          },
-        }
-      : baseData
+  return !loaded && (!query.data?.resolved || includeResolved)
+    ? query.data
+    : undefined
+}
 
+function useSidebarThreadPages(
+  params: Omit<ThreadsPageParams, "offset">,
+  enabled: boolean
+) {
+  const query = useInfiniteThreadsPages(params, {
+    enabled,
+    pollWhileRunning: true,
+  })
   return {
-    data,
-    activeQuery: {
-      isFetchingNextPage:
-        query.isFetching && (query.data?.active.limit ?? 0) < activeLimit,
-      fetchNextPage: () => setActiveLimit((limit) => limit + SIDEBAR_PAGE_SIZE),
-    },
-    resolvedQuery: {
-      isLoading: includeResolved && query.isPending,
-      isFetchingNextPage:
-        query.isFetching && (query.data?.resolved.limit ?? 0) < resolvedLimit,
-      fetchNextPage: () =>
-        setResolvedLimit((limit) => limit + SIDEBAR_PAGE_SIZE),
-    },
+    items: query.data?.pages.flatMap((page) => page.items) ?? [],
+    hasMore: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
     isPending: query.isPending,
     isError: query.isError,
     error: query.error,
     refetch: query.refetch,
+    fetchNextPage: () => void query.fetchNextPage(),
   }
+}
+
+export function useSidebarRecents({
+  projectMode,
+  includeAutomations = false,
+  includeResolved = false,
+  enabled = true,
+}: {
+  projectMode: boolean
+  includeAutomations?: boolean
+  includeResolved?: boolean
+  enabled?: boolean
+}) {
+  return useSidebarThreadPages(
+    {
+      ...sidebarPageParams({ includeAutomations, includeResolved }),
+      ...(projectMode ? { ownerless: true } : {}),
+    },
+    enabled
+  )
+}
+
+export function useSidebarProjectThreads({
+  repoFullName,
+  includeAutomations = false,
+  includeResolved = false,
+  enabled = true,
+}: {
+  repoFullName: string | null
+  includeAutomations?: boolean
+  includeResolved?: boolean
+  enabled?: boolean
+}) {
+  return useSidebarThreadPages(
+    {
+      ...sidebarPageParams({ includeAutomations, includeResolved }),
+      ...(repoFullName ? { repo: repoFullName } : {}),
+    },
+    enabled && Boolean(repoFullName)
+  )
 }
 
 export function useAgentThread(threadId: string) {

--- a/ui/src/features/agents/lib/sidebarThreads.ts
+++ b/ui/src/features/agents/lib/sidebarThreads.ts
@@ -55,7 +55,7 @@ export interface SidebarProjectGroup extends SidebarProjectOption {
  * `other/api`, and two local projects both called `api`, into one folder that
  * cannot be told apart.
  */
-function projectKey(identity?: string | null): string | null {
+export function sidebarProjectKey(identity?: string | null): string | null {
   const normalized = identity?.trim().toLowerCase()
   return normalized ? `project:${normalized}` : null
 }
@@ -81,7 +81,7 @@ export function cloudSidebarThread(
     id: thread.id,
     location: "cloud",
     title: thread.title,
-    projectKey: projectKey(thread.repoFullName.trim() || projectLabel),
+    projectKey: sidebarProjectKey(thread.repoFullName.trim() || projectLabel),
     projectLabel,
     model: thread.model,
     source: thread.source,
@@ -109,7 +109,7 @@ export function localSidebarThread(
     id: thread.id,
     location: "local",
     title: thread.title,
-    projectKey: projectKey(project?.cwd ?? thread.cwd),
+    projectKey: sidebarProjectKey(project?.cwd ?? thread.cwd),
     projectLabel,
     model: thread.modelId ?? "Default",
     source: "dashboard",
@@ -141,7 +141,7 @@ export function sidebarProjectOptions(
     }
   }
   for (const project of localProjects) {
-    const key = projectKey(project.cwd)
+    const key = sidebarProjectKey(project.cwd)
     if (key) projects.set(key, project.name)
   }
   return [...projects]


### PR DESCRIPTION
Replaces #2337 with a clean implementation on top of the thread runtime lifecycle from #2345.

## Summary

- replace the shared sidebar bucket endpoint with metadata-only project discovery, pinned threads, and the existing paginated thread endpoint
- give Recents and every project an independent infinite query and pagination state
- keep ownerless threads in the project-mode Recents list and auto-load more on scroll
- poll only pages that contain running threads and keep the active thread visible outside loaded pages
- preserve cloud/local project merging and the existing thread UI

## Validation

- make lint
- UI test suite: 296 passed
- focused dashboard thread API tests: 90 passed
- focused sidebar UI tests: 31 passed
- UI production build