### PR TITLE
feat: link pull requests from Slack channel cards

### DIFF
--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -17,6 +17,7 @@ from ..utils.slack import get_active_slack_thread, get_slack_permalink, parse_gi
 from ..utils.slack_code_channels import (
     is_code_channel_session,
     repo_context_bar_items,
+    set_agent_resource,
     set_context_bar,
     set_view,
 )
@@ -653,6 +654,20 @@ async def _record_pr_telemetry(
                         dashboard_url=dashboard_thread_url(thread_id) or "",
                     ),
                 )
+                if isinstance(pr_url, str):
+                    await set_agent_resource(
+                        channel_id,
+                        {
+                            "url": pr_url,
+                            "resource_type": "pull_request",
+                            "title": (
+                                pr_title[:255]
+                                if isinstance(pr_title, str) and pr_title
+                                else "Pull request"
+                            ),
+                            "provider": "GitHub",
+                        },
+                    )
                 response = await client.get(
                     f"{GITHUB_API}/repos/{owner}/{repo}/pulls/{pr_number}",
                     headers={**_auth_headers(token), "Accept": "application/vnd.github.v3.diff"},


### PR DESCRIPTION
Exposes the resulting GitHub pull request as the Slack code channel’s agent resource, making its direct link available on the original-channel card.

Tests: `make lint`; `uv run pytest -q tests/github/test_open_pull_request.py`

Made by [Open SWE](https://openswe.vercel.app/agents/2c7e9e6a-9f0a-5d2f-99a1-c42478f75497)