### PR TITLE
fix: align collapsed sidebar button

### DIFF
--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -125,8 +125,8 @@ export function SidebarFrame({
         data-sidebar-expand=""
         onClick={toggle}
         className={cn(
-          "fixed top-3 left-3 z-30 flex size-7 cursor-pointer items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm hover:bg-accent hover:text-foreground",
-          isDesktop && "top-2 left-[90px] border-0 bg-transparent shadow-none"
+          "fixed top-2 left-2 z-30 flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground",
+          isDesktop && "left-[90px]"
         )}
       >
         <SidebarSimpleIcon className="size-4" />


### PR DESCRIPTION
Aligns the left sidebar expand control with the right panel control and removes its mismatched border/background.

Screenshot fixture: https://01a05d92-7fc4-7ec1-abf3-eaa5718d6304--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd5Tnpjd01qUXNJbXAwYVNJNklqQXhZVEExWkRsa0xXVTFOVEV0TjJJeFlTMDVPV1psTFRVeE1UWmtOMkZtTURaallpSXNJbk5wWkNJNklqQXhZVEExWkRreUxUZG1ZelF0TjJWak1TMWhZbVl6TFdWaFlUVTNNVGhrTmpNd05DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMMkZ5ZEdsbVlXTjBjeTl6YVdSbFltRnlMV0oxZEhSdmJuTXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuY0QtbUVZYy1WczB3Y0xpOGZHSk5leU8xTFJlWlJvdGFJRnNlSVhnQWxLeExiZ2lZVjRuQlNOWmNTbkhnS2ZSRFQ1cUtoejZGN09DRm9XRFpxUzRNQlE

Validation: `pnpm --dir ui run typecheck`; `pnpm --dir ui run build`.

Made by [Open SWE](https://openswe.vercel.app/agents/01a05d93-a418-77ef-9019-876a5ac9de1d)