### PR TITLE
fix(ui): clarify settings scope

### DIFF
--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -29,16 +29,16 @@ interface NavItem {
 
 const NAV: Array<{ heading: string; items: Array<NavItem> }> = [
   {
-    heading: "Personal",
+    heading: "User settings",
     items: [
-      { to: "/my-settings", label: "Settings", icon: IoOptionsOutline },
+      { to: "/my-settings", label: "Profile", icon: IoOptionsOutline },
+      { to: "/cloud-agents", label: "Open SWE Agent", icon: IoCloudOutline },
       { to: "/usage", label: "Usage", icon: IoStatsChartOutline },
     ],
   },
   {
-    heading: "Workspace",
+    heading: "Workspace settings",
     items: [
-      { to: "/cloud-agents", label: "Open SWE Agent", icon: IoCloudOutline },
       {
         to: "/review",
         label: "Open SWE Review",

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -142,7 +142,7 @@ function CloudAgentsPage() {
     <AppShell
       user={session.data}
       title="Open SWE Agent"
-      description="Configure how the Open SWE Agent picks a model, repository, and PR defaults."
+      description="Personal defaults for Open SWE Agent runs you trigger. These settings only apply to your account."
     >
       <SettingsSection title="Defaults">
         <div className="divide-y divide-border">


### PR DESCRIPTION
Moves Open SWE Agent under explicit user settings and labels workspace settings separately. Clarifies that agent defaults apply only to the signed-in user.

Verified with typecheck, lint, formatting, production build, and an Alice mock-login browser smoke test.

![Settings organized by user and workspace scope](https://raw.githubusercontent.com/langchain-ai/open-swe/1a83fe18c20b5438feea4fa8c6c4273d370ebcc2/docs/assets/pr-2357-settings-scope.png)

Made by [Open SWE](https://openswe.vercel.app/agents/c7848275-1fd2-5650-b0ac-240999f1baf0)