### PR TITLE
feat: expand command palette actions

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -751,6 +751,11 @@ def _thread_updated_ms(thread: ThreadLike) -> int:
     return _thread_timestamp_ms(thread, "updated_at")
 
 
+def _search_matches(values: Sequence[object], query: str) -> bool:
+    needle = query.lower()
+    return any(isinstance(value, (str, int)) and needle in str(value).lower() for value in values)
+
+
 def _metadata_matches_filters(
     metadata: Mapping[str, Any],
     *,
@@ -780,9 +785,25 @@ def _metadata_matches_filters(
     if source and _thread_source(metadata) != source:
         return False
     if query:
-        title = metadata.get("title")
-        title = title if isinstance(title, str) else "Untitled agent"
-        if query.lower() not in title.lower():
+        pull_requests = metadata.get("pull_requests")
+        pull_requests = pull_requests if isinstance(pull_requests, list) else []
+        if not _search_matches(
+            [
+                metadata.get("title", "Untitled agent"),
+                *_metadata_repo(metadata),
+                metadata.get("branch_name"),
+                metadata.get("base_branch"),
+                metadata.get("pr_url"),
+                metadata.get("pr_number"),
+                *(
+                    value
+                    for record in pull_requests
+                    if isinstance(record, dict)
+                    for value in record.values()
+                ),
+            ],
+            query,
+        ):
             return False
     return True
 
@@ -805,8 +826,25 @@ def _summary_matches_filters(
     if status and summary.get("status") != status:
         return False
     if query:
-        title = summary.get("title")
-        if not isinstance(title, str) or query.lower() not in title.lower():
+        pull_requests = summary.get("pullRequests")
+        pull_requests = pull_requests if isinstance(pull_requests, list) else []
+        pr = summary.get("pr")
+        if not _search_matches(
+            [
+                summary.get("title"),
+                summary.get("repo"),
+                summary.get("repoFullName"),
+                summary.get("branch"),
+                *(pr.values() if isinstance(pr, dict) else ()),
+                *(
+                    value
+                    for record in pull_requests
+                    if isinstance(record, dict)
+                    for value in record.values()
+                ),
+            ],
+            query,
+        ):
             return False
     return True
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1727,6 +1727,9 @@ def test_summary_matches_filters() -> None:
         "source": "github",
         "status": "finished",
         "title": "Fix the flaky test",
+        "repoFullName": "langchain-ai/open-swe",
+        "branch": "open-swe/fix-flake",
+        "pr": {"number": 123, "url": "https://github.com/langchain-ai/open-swe/pull/123"},
     }
 
     assert thread_api._summary_matches_filters(
@@ -1741,10 +1744,27 @@ def test_summary_matches_filters() -> None:
     assert not thread_api._summary_matches_filters(
         summary, resolved=None, viewed=None, source=None, status=None, query="missing"
     )
+    assert thread_api._summary_matches_filters(
+        summary, resolved=None, viewed=None, source=None, status=None, query="pull/123"
+    )
 
 
 def test_metadata_matches_filters() -> None:
-    metadata = {"source": "dashboard", "title": "Fix login bug", "resolved": True}
+    metadata = {
+        "source": "dashboard",
+        "title": "Fix login bug",
+        "resolved": True,
+        "repo_owner": "langchain-ai",
+        "repo_name": "open-swe",
+        "branch_name": "open-swe/fix-login",
+        "pull_requests": [
+            {
+                "repo_full_name": "langchain-ai/open-swe",
+                "number": 123,
+                "url": "https://github.com/langchain-ai/open-swe/pull/123",
+            }
+        ],
+    }
     automation = {
         "source": "schedule",
         "schedule_id": "schedule-1",
@@ -1761,6 +1781,10 @@ def test_metadata_matches_filters() -> None:
     assert not thread_api._metadata_matches_filters(
         metadata, resolved=None, source="github", query=None
     )
+    for query in ("langchain-ai/open-swe", "fix-login", "pull/123"):
+        assert thread_api._metadata_matches_filters(
+            metadata, resolved=None, source=None, query=query
+        )
     assert thread_api._metadata_matches_filters(
         metadata, resolved=None, source=None, query=None, scope="interactive"
     )

--- a/ui/src/components/AppCommandPalette.tsx
+++ b/ui/src/components/AppCommandPalette.tsx
@@ -60,12 +60,16 @@ export function buildPaletteResults(
   query: string
 ): Array<PaletteResult> {
   const normalizedQuery = query.trim().toLowerCase()
+  const actionsOnly = normalizedQuery.startsWith(">")
+  const searchQuery = actionsOnly
+    ? normalizedQuery.slice(1).trim()
+    : normalizedQuery
   const commandResults: Array<CommandResult> = commands
     .filter(
       (command) =>
         command.run &&
         command.showInPalette !== false &&
-        (!normalizedQuery || commandMatches(command, normalizedQuery))
+        (!searchQuery || commandMatches(command, searchQuery))
     )
     .map((command) => ({
       id: `command:${command.id}`,
@@ -76,7 +80,19 @@ export function buildPaletteResults(
   const cloudResults: Array<CloudThreadResult> = cloudThreads
     .filter(
       (thread) =>
-        !normalizedQuery || thread.title.toLowerCase().includes(normalizedQuery)
+        !actionsOnly &&
+        (!searchQuery ||
+          [
+            thread.title,
+            thread.repo,
+            thread.repoFullName,
+            thread.branch,
+            thread.pr?.url ?? "",
+            `${thread.repoFullName}#${thread.pr?.number ?? ""}`,
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(searchQuery))
     )
     .map((thread) => ({
       id: `cloud:${thread.id}`,
@@ -87,7 +103,12 @@ export function buildPaletteResults(
   const localResults: Array<LocalThreadResult> = localThreads
     .filter(
       (thread) =>
-        !normalizedQuery || thread.title.toLowerCase().includes(normalizedQuery)
+        !actionsOnly &&
+        (!searchQuery ||
+          [thread.title, thread.cwd]
+            .join(" ")
+            .toLowerCase()
+            .includes(searchQuery))
     )
     .map((thread) => ({
       id: `local:${thread.id}`,
@@ -238,7 +259,7 @@ export function AppCommandPalette({
               className="h-12 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
               onChange={(event) => setQuery(event.target.value)}
               onKeyDown={onInputKeyDown}
-              placeholder="Search commands and threads"
+              placeholder="Search commands, projects, and threads…"
               role="combobox"
               value={query}
             />

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -231,6 +231,24 @@ export function AgentsSidebar({
     addProject: addLocalProject,
     removeProject: removeLocalProject,
   } = useDesktopProjects()
+  const projectCommands = useMemo(
+    () =>
+      isDesktop
+        ? [
+            {
+              id: "add-project",
+              label: "Add project",
+              aliases: ["open folder", "add folder", "repository", "repo"],
+              group: "Workspace",
+              run: async () => {
+                await addLocalProject()
+              },
+            },
+          ]
+        : [],
+    [addLocalProject, isDesktop]
+  )
+  useRegisterAppCommands(projectCommands)
 
   const pinnedThreads = pinnedQuery.data ?? []
   const cloudPinnedIds = new Set(pinnedThreads.map((thread) => thread.id))
@@ -1061,8 +1079,19 @@ export function AgentsShell({
   children: React.ReactNode
 }) {
   const layout = useSidebarLayout()
-  const sidebarCommands = useMemo(
-    () => [
+  const pinThread = usePinAgentThread()
+  const resolveThread = useResolveAgentThread()
+  const pinnedThreads = useSidebarPinnedThreads({
+    enabled: Boolean(activeThreadId),
+  })
+  const activeThread = useSidebarActiveThread({
+    activeThreadId,
+    loadedThreads: [],
+    includeResolved: true,
+    enabled: Boolean(activeThreadId),
+  })
+  const sidebarCommands = useMemo(() => {
+    const commands = [
       {
         id: "toggle-sidebar",
         label: "Toggle sidebar",
@@ -1073,9 +1102,61 @@ export function AgentsShell({
         desktopId: "toggle-sidebar" as const,
         desktopShortcuts: ["mod+b"],
       },
-    ],
-    [layout.toggle]
-  )
+    ]
+    if (!activeThread) return commands
+    const reference =
+      activeThread.pullRequests?.at(-1)?.url ??
+      activeThread.pr?.url ??
+      activeThread.id
+    return [
+      ...commands,
+      {
+        id: "copy-thread-reference",
+        label:
+          reference === activeThread.id ? "Copy thread ID" : "Copy PR link",
+        aliases: ["copy reference", "pull request", "pr link"],
+        shortcuts: ["mod+shift+c"],
+        group: "Thread",
+        run: () => navigator.clipboard.writeText(reference),
+      },
+      {
+        id: "pin-thread",
+        label: pinnedThreads.data?.some(
+          (thread) => thread.id === activeThread.id
+        )
+          ? "Unpin thread"
+          : "Pin thread",
+        aliases: ["pin thread", "unpin thread"],
+        shortcuts: ["mod+shift+p"],
+        group: "Thread",
+        run: () =>
+          pinThread.mutate({
+            threadId: activeThread.id,
+            pinned: !pinnedThreads.data?.some(
+              (thread) => thread.id === activeThread.id
+            ),
+          }),
+      },
+      {
+        id: "archive-thread",
+        label: activeThread.resolved ? "Unarchive thread" : "Archive thread",
+        aliases: ["resolve thread", "settle thread", "restore thread"],
+        shortcuts: ["mod+shift+s"],
+        group: "Thread",
+        run: () =>
+          resolveThread.mutate({
+            threadId: activeThread.id,
+            resolved: !activeThread.resolved,
+          }),
+      },
+    ]
+  }, [
+    activeThread,
+    layout.toggle,
+    pinThread,
+    pinnedThreads.data,
+    resolveThread,
+  ])
   useRegisterAppCommands(sidebarCommands)
 
   return (

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -281,6 +281,14 @@ export const ChatComposer = memo(function ChatComposer({
         group: "Composer",
         showInPalette: false,
       },
+      {
+        id: "open-model-picker",
+        label: "Choose model",
+        aliases: ["model picker", "change model", "reasoning effort"],
+        shortcuts: ["mod+shift+m"],
+        group: "Composer",
+        run: () => setModelPickerOpen(true),
+      },
       ...(activeRun?.running
         ? [
             {

--- a/ui/src/features/agents/components/panel/AgentRightPanel.tsx
+++ b/ui/src/features/agents/components/panel/AgentRightPanel.tsx
@@ -201,25 +201,52 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
         {
           id: "toggle-work-panel",
           label: "Toggle work panel",
-          aliases: ["show panel", "hide panel", "changes panel"],
+          aliases: ["show panel", "hide panel", "right panel"],
           shortcuts: ["mod+alt+b"],
           group: "Workspace",
           run: () => onCollapsedChange(!collapsed),
         },
+        ...(diffAvailable
+          ? [
+              {
+                id: "toggle-changes",
+                label: "Toggle changes",
+                aliases: ["diff", "review changes"],
+                shortcuts: ["mod+d"],
+                group: "Workspace",
+                run: () => {
+                  if (!collapsed && activeSurface?.kind === "diff") {
+                    onCollapsedChange(true)
+                  } else {
+                    onCollapsedChange(false)
+                    handleAddDiff()
+                  }
+                },
+              },
+            ]
+          : []),
         ...(terminalAvailable
           ? [
               {
                 id: "toggle-terminal",
                 label: "Toggle terminal",
                 aliases: ["open terminal", "hide terminal"],
-                shortcuts: ["ctrl+`"],
+                shortcuts: ["mod+j", "ctrl+`"],
                 group: "Workspace",
                 run: toggleTerminal,
               },
             ]
           : []),
       ],
-      [collapsed, onCollapsedChange, terminalAvailable, toggleTerminal]
+      [
+        activeSurface?.kind,
+        collapsed,
+        diffAvailable,
+        handleAddDiff,
+        onCollapsedChange,
+        terminalAvailable,
+        toggleTerminal,
+      ]
     )
   )
 

--- a/ui/src/lib/appCommands.test.ts
+++ b/ui/src/lib/appCommands.test.ts
@@ -14,7 +14,7 @@ describe("app commands", () => {
   it("uses Linear-style C for new threads on web and desktop", () => {
     const newThread = createNewThreadCommand(vi.fn())
 
-    expect(newThread.shortcuts).toEqual(["c"])
+    expect(newThread.shortcuts).toEqual(["c", "mod+n", "mod+shift+o"])
     expect(newThread.desktopShortcuts).toBeUndefined()
     expect(newThread.desktopId).toBe("new-thread")
   })

--- a/ui/src/lib/appCommands.tsx
+++ b/ui/src/lib/appCommands.tsx
@@ -14,6 +14,7 @@ import { AppCommandPalette } from "@/components/AppCommandPalette"
 import { AppShortcutReference } from "@/components/AppShortcutReference"
 import { useSession } from "@/lib/session"
 import { eventMatchesShortcut, shouldIgnoreHotkey } from "@/lib/hotkeys"
+import { useTheme } from "@/lib/theme"
 
 export interface AppCommand {
   id: string
@@ -33,7 +34,7 @@ export function createNewThreadCommand(run: () => void): AppCommand {
     id: "new-thread",
     label: "New thread",
     aliases: ["new chat", "start thread"],
-    shortcuts: ["c"],
+    shortcuts: ["c", "mod+n", "mod+shift+o"],
     group: "General",
     run,
     desktopId: "new-thread",
@@ -74,6 +75,7 @@ export function AppCommandProvider({
 }) {
   const navigate = useNavigate()
   const session = useSession()
+  const { toggleTheme } = useTheme()
   const enabled = Boolean(session.data)
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [shortcutReferenceOpen, setShortcutReferenceOpen] = useState(false)
@@ -103,6 +105,51 @@ export function AppCommandProvider({
       },
       createNewThreadCommand(() => void navigate({ to: "/agents" })),
       {
+        id: "open-threads",
+        label: "Open threads",
+        aliases: ["home", "chats", "agents"],
+        group: "Navigation",
+        run: () => void navigate({ to: "/agents" }),
+      },
+      {
+        id: "open-kanban",
+        label: "Open Kanban",
+        aliases: ["board", "all threads"],
+        group: "Navigation",
+        run: () =>
+          void navigate({
+            to: "/agents/threads",
+            search: { page: 1, layout: "board", group: "focus" },
+          }),
+      },
+      {
+        id: "open-skills",
+        label: "Open skills",
+        group: "Navigation",
+        run: () => void navigate({ to: "/agents/skills" }),
+      },
+      {
+        id: "open-automations",
+        label: "Open automations",
+        aliases: ["schedules"],
+        group: "Navigation",
+        run: () => void navigate({ to: "/agents/automations" }),
+      },
+      {
+        id: "open-reviews",
+        label: "Open reviews",
+        aliases: ["pull requests", "prs"],
+        group: "Navigation",
+        run: () => void navigate({ to: "/agents/reviews" }),
+      },
+      {
+        id: "toggle-theme",
+        label: "Toggle color theme",
+        aliases: ["dark mode", "light mode", "appearance"],
+        group: "General",
+        run: toggleTheme,
+      },
+      {
         id: "open-settings",
         label: "Open settings",
         aliases: ["preferences", "dashboard"],
@@ -123,7 +170,7 @@ export function AppCommandProvider({
         desktopShortcuts: ["mod+/"],
       },
     ],
-    [navigate, openPalette, openShortcutReference]
+    [navigate, openPalette, openShortcutReference, toggleTheme]
   )
 
   const register = useCallback((commands: ReadonlyArray<AppCommand>) => {


### PR DESCRIPTION
Ports the command palette's applicable actions and shortcuts into the existing Open SWE command system.

Adds wired navigation, theme, project, thread, model, changes, panel, and terminal commands; action-only search; and richer thread matching.

Verification: UI typecheck, focused lint, 13 focused tests, and manual Alice browser check.

Made by [Open SWE](https://openswe.vercel.app/agents/01a05e3f-b313-76df-9183-ce3c88e72fd5)

### Screenshot

![Command palette](https://01a05e3f-b6cb-7ee4-a349-806ef68ea7d8--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd5T0RnNE16QXNJbXAwYVNJNklqQXhZVEExWlRVeUxUQmtOV1l0TnpNMVpTMDVOamcwTFRJd05tWmtZemRpWW1JME15SXNJbk5wWkNJNklqQXhZVEExWlRObUxXSTJZMkl0TjJWbE5DMWhNelE1TFRnd05tVm1OamhsWVRka09DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMk52YlcxaGJtUXRjR0ZzWlhSMFpTNXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC5XcEhVT3VuaUJEVVdzVWFIaTl1STlhUFNZY1ExWGJvSjhmZ2JZSy1EOWctU1p0aVFTb3Q4XzI4Xzhhb1JIaVdFWXJINXZEMmpPSnhkRzI4NTloVWZBQQ)
