### PR TITLE
feat: implement desktop release and nightly workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -6,6 +6,9 @@ on:
       release_ref:
         type: string
         default: main
+      nightly:
+        type: boolean
+        default: false
   workflow_dispatch:
 
 permissions:
@@ -33,23 +36,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           stable_version=$(node -p "require('./desktop/package.json').version")
-          stable_tag="desktop-v${stable_version}"
-          if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
-            if ! gh release view "$stable_tag" --json assets --jq '.assets | length >= 3' | grep -qx true; then
-              git checkout --detach "$stable_tag"
-              version="$stable_version"
-              prerelease=false
-              label="Open SWE Desktop v${version}"
-            else
-              timestamp=$(date -u +%Y%m%d%H%M%S)
-              version="${stable_version}-nightly.${timestamp}"
-              prerelease=true
-              label="Open SWE Desktop Nightly ${timestamp}"
-            fi
+          if [ "${{ inputs.nightly }}" = "true" ]; then
+            timestamp=$(date -u +%Y%m%d%H%M%S)
+            version="${stable_version}-nightly.${timestamp}"
+            prerelease=true
+            label="Open SWE Desktop Nightly ${timestamp}"
           else
+            stable_tag="desktop-v${stable_version}"
             version="$stable_version"
             prerelease=false
             label="Open SWE Desktop v${version}"
+            if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
+              if gh release view "$stable_tag" --json assets --jq '.assets | length >= 3' | grep -qx true; then
+                echo "$stable_tag already has a complete release"
+                exit 1
+              fi
+              git checkout --detach "$stable_tag"
+            fi
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=desktop-v${version}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -10,6 +10,11 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - desktop/package.json
 
 permissions:
   contents: write

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,16 +1,8 @@
 name: Release Desktop
 
 on:
+  workflow_call:
   workflow_dispatch:
-    inputs:
-      version_bump:
-        description: "Version increment type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 permissions:
   contents: write
@@ -30,7 +22,29 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Resolve desktop release
+        id: release
+        run: |
+          stable_version=$(node -p "require('./desktop/package.json').version")
+          if git rev-parse "refs/tags/desktop-v${stable_version}" >/dev/null 2>&1; then
+            timestamp=$(date -u +%Y%m%d%H%M%S)
+            version="${stable_version}-nightly.${timestamp}"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "label=Open SWE Desktop Nightly ${timestamp}" >> "$GITHUB_OUTPUT"
+          else
+            version="$stable_version"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "label=Open SWE Desktop v${version}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=desktop-v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set build version
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          node -e "const fs=require('fs'); const path='desktop/package.json'; const pkg=require('./'+path); pkg.version=process.env.VERSION; fs.writeFileSync(path, JSON.stringify(pkg, null, 2)+'\n')"
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -42,54 +56,6 @@ jobs:
       - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
         with:
           mode: firewall-free
-
-      - name: Bump desktop version
-        id: bump
-        env:
-          BUMP_TYPE: ${{ inputs.version_bump }}
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const path = 'desktop/package.json';
-          const bump = process.env.BUMP_TYPE;
-
-          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-          const current = pkg.version;
-          const parts = current.split('.').map(Number);
-
-          if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) {
-            throw new Error(`Invalid semver in ${path}: ${current}`);
-          }
-
-          let [major, minor, patch] = parts;
-          if (bump === 'major') {
-            major += 1;
-            minor = 0;
-            patch = 0;
-          } else if (bump === 'minor') {
-            minor += 1;
-            patch = 0;
-          } else if (bump === 'patch') {
-            patch += 1;
-          } else {
-            throw new Error(`Unsupported bump type: ${bump}`);
-          }
-
-          const next = `${major}.${minor}.${patch}`;
-          pkg.version = next;
-          fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `new_version=${next}\n`);
-          NODE
-
-      - name: Commit desktop version
-        env:
-          VERSION: ${{ steps.bump.outputs.new_version }}
-        run: |
-          git add desktop/package.json
-          git -c user.name="github-actions[bot]" \
-            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-            commit -m "chore(desktop): release v${VERSION}"
-          git push origin HEAD:main
 
       - name: Install workspace dependencies
         env:
@@ -133,7 +99,7 @@ jobs:
       - name: Verify and package release assets
         id: assets
         env:
-          VERSION: ${{ steps.bump.outputs.new_version }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           shopt -s nullglob
           mac_zips=(desktop/dist/"Open SWE-${VERSION}"-*-mac.zip)
@@ -170,16 +136,17 @@ jobs:
 
       - name: Tag desktop version
         env:
-          VERSION: ${{ steps.bump.outputs.new_version }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          git tag "desktop-v${VERSION}"
-          git push origin "desktop-v${VERSION}"
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          tag_name: desktop-v${{ steps.bump.outputs.new_version }}
-          name: Open SWE Desktop v${{ steps.bump.outputs.new_version }}
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.label }}
+          prerelease: ${{ steps.release.outputs.prerelease }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -10,11 +10,6 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - desktop/package.json
 
 permissions:
   contents: write
@@ -24,62 +19,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  promote-desktop:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Promote latest matching nightly
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          stable_version=$(node -p "require('./desktop/package.json').version")
-          [[ "$stable_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
-          stable_tag="desktop-v${stable_version}"
-          prefix="${stable_tag}-nightly."
-          nightly_tag=""
-          while read -r candidate; do
-            if gh release view "$candidate" --json assets --jq '.assets | length >= 3' | grep -qx true; then
-              nightly_tag="$candidate"
-              break
-            fi
-          done < <(gh release list --limit 1000 --json tagName,isPrerelease \
-            --jq ".[] | select(.isPrerelease and (.tagName | startswith(\"${prefix}\"))) | .tagName")
-
-          if [ -z "$nightly_tag" ]; then
-            echo "No complete prerelease found matching ${prefix}*"
-            exit 1
-          fi
-          if gh release view "$stable_tag" >/dev/null 2>&1; then
-            echo "$stable_tag already has a release"
-            exit 1
-          fi
-
-          nightly_sha=$(git rev-parse "${nightly_tag}^{commit}")
-          git fetch origin prod
-          if [ "$nightly_sha" != "$(git rev-parse FETCH_HEAD)" ]; then
-            echo "$nightly_tag was not built from the currently deployed prod commit"
-            exit 1
-          fi
-          if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
-            test "$(git rev-parse "${stable_tag}^{commit}")" = "$nightly_sha"
-          else
-            git tag "$stable_tag" "$nightly_sha"
-            git push origin "$stable_tag"
-          fi
-          gh release edit "$nightly_tag" \
-            --tag "$stable_tag" \
-            --title "Open SWE Desktop v${stable_version}" \
-            --prerelease=false \
-            --latest
-
   release-desktop:
-    if: github.event_name != 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: macos-latest
 
     steps:
@@ -99,22 +40,21 @@ jobs:
           [[ "$stable_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
           if [ "$NIGHTLY" = "true" ]; then
             timestamp=$(date -u +%Y%m%d%H%M%S)
-            version=$(node -p "const [major, minor, patch] = '${stable_version}'.split('.').map(Number); [major, minor, patch + 1].join('.')")
-            tag="desktop-v${version}-nightly.${timestamp}"
+            version="${stable_version}-nightly.${timestamp}"
+            tag="desktop-v${version}"
             prerelease=true
             label="Open SWE Desktop Nightly ${timestamp}"
           else
-            stable_tag="desktop-v${stable_version}"
+            tag="desktop-v${stable_version}"
             version="$stable_version"
-            tag="$stable_tag"
             prerelease=false
             label="Open SWE Desktop v${version}"
-            if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
-              if gh release view "$stable_tag" --json assets --jq '.assets | length >= 3' | grep -qx true; then
-                echo "$stable_tag already has a complete release"
+            if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
+              if gh release view "$tag" --json assets --jq '.assets | length >= 3' | grep -qx true; then
+                echo "$tag already has a complete release"
                 exit 1
               fi
-              git checkout --detach "$stable_tag"
+              git checkout --detach "$tag"
             fi
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -2,6 +2,10 @@ name: Release Desktop
 
 on:
   workflow_call:
+    inputs:
+      release_ref:
+        type: string
+        default: main
   workflow_dispatch:
 
 permissions:
@@ -17,28 +21,40 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Checkout main
+      - name: Checkout release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ inputs.release_ref || 'main' }}
           fetch-depth: 0
 
       - name: Resolve desktop release
         id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           stable_version=$(node -p "require('./desktop/package.json').version")
-          if git rev-parse "refs/tags/desktop-v${stable_version}" >/dev/null 2>&1; then
-            timestamp=$(date -u +%Y%m%d%H%M%S)
-            version="${stable_version}-nightly.${timestamp}"
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-            echo "label=Open SWE Desktop Nightly ${timestamp}" >> "$GITHUB_OUTPUT"
+          stable_tag="desktop-v${stable_version}"
+          if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
+            if ! gh release view "$stable_tag" --json assets --jq '.assets | length >= 3' | grep -qx true; then
+              git checkout --detach "$stable_tag"
+              version="$stable_version"
+              prerelease=false
+              label="Open SWE Desktop v${version}"
+            else
+              timestamp=$(date -u +%Y%m%d%H%M%S)
+              version="${stable_version}-nightly.${timestamp}"
+              prerelease=true
+              label="Open SWE Desktop Nightly ${timestamp}"
+            fi
           else
             version="$stable_version"
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-            echo "label=Open SWE Desktop v${version}" >> "$GITHUB_OUTPUT"
+            prerelease=false
+            label="Open SWE Desktop v${version}"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=desktop-v${version}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
 
       - name: Set build version
         env:
@@ -138,8 +154,10 @@ jobs:
         env:
           TAG: ${{ steps.release.outputs.tag }}
         run: |
-          git tag "$TAG"
-          git push origin "$TAG"
+          if ! git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -10,11 +10,6 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - desktop/package.json
 
 permissions:
   contents: write

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,8 +24,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  promote-desktop:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Promote latest matching nightly
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          stable_version=$(node -p "require('./desktop/package.json').version")
+          [[ "$stable_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
+          stable_tag="desktop-v${stable_version}"
+          prefix="${stable_tag}-nightly."
+          nightly_tag=""
+          while read -r candidate; do
+            if gh release view "$candidate" --json assets --jq '.assets | length >= 3' | grep -qx true; then
+              nightly_tag="$candidate"
+              break
+            fi
+          done < <(gh release list --limit 1000 --json tagName,isPrerelease \
+            --jq ".[] | select(.isPrerelease and (.tagName | startswith(\"${prefix}\"))) | .tagName")
+
+          if [ -z "$nightly_tag" ]; then
+            echo "No complete prerelease found matching ${prefix}*"
+            exit 1
+          fi
+          if gh release view "$stable_tag" >/dev/null 2>&1; then
+            echo "$stable_tag already has a release"
+            exit 1
+          fi
+
+          nightly_sha=$(git rev-parse "${nightly_tag}^{commit}")
+          git fetch origin prod
+          if [ "$nightly_sha" != "$(git rev-parse FETCH_HEAD)" ]; then
+            echo "$nightly_tag was not built from the currently deployed prod commit"
+            exit 1
+          fi
+          if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
+            test "$(git rev-parse "${stable_tag}^{commit}")" = "$nightly_sha"
+          else
+            git tag "$stable_tag" "$nightly_sha"
+            git push origin "$stable_tag"
+          fi
+          gh release edit "$nightly_tag" \
+            --tag "$stable_tag" \
+            --title "Open SWE Desktop v${stable_version}" \
+            --prerelease=false \
+            --latest
+
   release-desktop:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'push' && github.ref == 'refs/heads/main'
     runs-on: macos-latest
 
     steps:
@@ -39,16 +93,20 @@ jobs:
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
+          NIGHTLY: ${{ inputs.nightly }}
         run: |
           stable_version=$(node -p "require('./desktop/package.json').version")
-          if [ "${{ inputs.nightly }}" = "true" ]; then
+          [[ "$stable_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
+          if [ "$NIGHTLY" = "true" ]; then
             timestamp=$(date -u +%Y%m%d%H%M%S)
-            version="${stable_version}-nightly.${timestamp}"
+            version=$(node -p "const [major, minor, patch] = '${stable_version}'.split('.').map(Number); [major, minor, patch + 1].join('.')")
+            tag="desktop-v${version}-nightly.${timestamp}"
             prerelease=true
             label="Open SWE Desktop Nightly ${timestamp}"
           else
             stable_tag="desktop-v${stable_version}"
             version="$stable_version"
+            tag="$stable_tag"
             prerelease=false
             label="Open SWE Desktop v${version}"
             if git rev-parse "refs/tags/${stable_tag}" >/dev/null 2>&1; then
@@ -60,7 +118,7 @@ jobs:
             fi
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=desktop-v${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
           echo "label=$label" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -17,31 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       promoted_sha: ${{ steps.promoted.outputs.sha }}
-      nightly: ${{ steps.promoted.outputs.nightly }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
           ref: main
           fetch-depth: 0
-      - name: Resolve desktop release type
+      - name: Record promoted commit
         id: promoted
-        run: |
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          previous_version=$(git show origin/prod:desktop/package.json 2>/dev/null | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data).version))" || true)
-          current_version=$(node -p "require('./desktop/package.json').version")
-          if [ "$current_version" = "$previous_version" ]; then
-            echo "nightly=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "nightly=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Force-push main to prod
         run: |
           git push --force origin HEAD:refs/heads/prod
 
-  release-desktop:
+  release-desktop-nightly:
     needs: promote
     uses: ./.github/workflows/desktop-release.yml
     with:
       release_ref: ${{ needs.promote.outputs.promoted_sha }}
-      nightly: ${{ needs.promote.outputs.nightly == 'true' }}
+      nightly: true
     secrets: inherit

--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -34,4 +34,5 @@ jobs:
     uses: ./.github/workflows/desktop-release.yml
     with:
       release_ref: ${{ needs.promote.outputs.promoted_sha }}
+      nightly: true
     secrets: inherit

--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -15,11 +15,16 @@ concurrency:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    outputs:
+      promoted_sha: ${{ steps.promoted.outputs.sha }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
           ref: main
           fetch-depth: 0
+      - name: Record promoted commit
+        id: promoted
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Force-push main to prod
         run: |
           git push --force origin HEAD:refs/heads/prod
@@ -27,4 +32,6 @@ jobs:
   release-desktop:
     needs: promote
     uses: ./.github/workflows/desktop-release.yml
+    with:
+      release_ref: ${{ needs.promote.outputs.promoted_sha }}
     secrets: inherit

--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -17,14 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       promoted_sha: ${{ steps.promoted.outputs.sha }}
+      nightly: ${{ steps.promoted.outputs.nightly }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
           ref: main
           fetch-depth: 0
-      - name: Record promoted commit
+      - name: Resolve desktop release type
         id: promoted
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          previous_version=$(git show origin/prod:desktop/package.json 2>/dev/null | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data).version))" || true)
+          current_version=$(node -p "require('./desktop/package.json').version")
+          if [ "$current_version" = "$previous_version" ]; then
+            echo "nightly=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "nightly=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Force-push main to prod
         run: |
           git push --force origin HEAD:refs/heads/prod
@@ -34,5 +43,5 @@ jobs:
     uses: ./.github/workflows/desktop-release.yml
     with:
       release_ref: ${{ needs.promote.outputs.promoted_sha }}
-      nightly: true
+      nightly: ${{ needs.promote.outputs.nightly == 'true' }}
     secrets: inherit

--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -23,3 +23,8 @@ jobs:
       - name: Force-push main to prod
         run: |
           git push --force origin HEAD:refs/heads/prod
+
+  release-desktop:
+    needs: promote
+    uses: ./.github/workflows/desktop-release.yml
+    secrets: inherit

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -105,14 +105,14 @@ to `desktop/dist/`.
 
 ## macOS releases
 
-`desktop/package.json` is the latest stable version. Every **Promote main to prod** run publishes a
-prerelease nightly from the promoted commit with a UTC timestamp, such as
-`desktop-v0.2.3-nightly.20260902080000`. Nightly releases never publish the stable version.
+`desktop/package.json` is the latest stable version. When **Promote main to prod** runs, it compares
+that version with the version currently on `prod`. If the version changed, it publishes the new
+stable version from the promoted commit. Otherwise, it publishes a prerelease nightly with a UTC
+timestamp, such as `desktop-v0.2.3-nightly.20260902080000`.
 
-To publish a stable release, bump `desktop/package.json` in a normal pull request. Merging that
-change to `main` automatically runs **Release Desktop** for the exact package version. The workflow
-fails if that stable release is already complete and remains manually runnable to retry a partial
-release.
+To publish a stable release, bump `desktop/package.json` in a normal pull request, merge it, and let
+the next scheduled or manual promotion deploy it and create the release. **Release Desktop** remains
+manually runnable to retry a partial stable release.
 
 Both paths build the current `ui/` bundle, sign and notarize the Electron app, verify the resulting
 app and DMG, create the tag, and publish the DMG, macOS zip, and app zip to a GitHub release.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -105,17 +105,18 @@ to `desktop/dist/`.
 
 ## macOS releases
 
-`desktop/package.json` is the latest stable version. When **Promote main to prod** runs, it publishes
-that stable version if its `desktop-vX.Y.Z` tag does not exist. Otherwise, it publishes a prerelease
-nightly from the same commit with a UTC timestamp, such as
-`desktop-v0.2.3-nightly.20260902080000`. Bump the stable version in a normal pull request whenever a
-new stable release is wanted.
+`desktop/package.json` is the latest stable version. Every **Promote main to prod** run publishes a
+prerelease nightly from the promoted commit with a UTC timestamp, such as
+`desktop-v0.2.3-nightly.20260902080000`. Nightly releases never publish the stable version.
 
-The release workflow builds the current `ui/` bundle, signs and notarizes the Electron app, verifies
-the resulting app and DMG, creates the tag, and publishes the DMG, macOS zip, and app zip to a GitHub
-release. It remains manually runnable from the Actions page. Desktop-prefixed tags keep this release
-stream separate from web and backend releases; the workflow packages the web UI but does not deploy
-or otherwise change the hosted web app.
+To publish a stable release, bump `desktop/package.json` in a normal pull request, merge it, then run
+**Release Desktop** manually from `main`. The workflow publishes the exact package version and fails
+if that stable release is already complete.
+
+Both paths build the current `ui/` bundle, sign and notarize the Electron app, verify the resulting
+app and DMG, create the tag, and publish the DMG, macOS zip, and app zip to a GitHub release.
+Desktop-prefixed tags keep this release stream separate from web and backend releases; the workflow
+packages the web UI but does not deploy or otherwise change the hosted web app.
 
 The workflow requires these GitHub Actions secrets:
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -109,9 +109,10 @@ to `desktop/dist/`.
 prerelease nightly from the promoted commit with a UTC timestamp, such as
 `desktop-v0.2.3-nightly.20260902080000`. Nightly releases never publish the stable version.
 
-To publish a stable release, bump `desktop/package.json` in a normal pull request, merge it, then run
-**Release Desktop** manually from `main`. The workflow publishes the exact package version and fails
-if that stable release is already complete.
+To publish a stable release, bump `desktop/package.json` in a normal pull request. Merging that
+change to `main` automatically runs **Release Desktop** for the exact package version. The workflow
+fails if that stable release is already complete and remains manually runnable to retry a partial
+release.
 
 Both paths build the current `ui/` bundle, sign and notarize the Electron app, verify the resulting
 app and DMG, create the tag, and publish the DMG, macOS zip, and app zip to a GitHub release.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -106,15 +106,17 @@ to `desktop/dist/`.
 ## macOS releases
 
 `desktop/package.json` is the latest stable version. Every **Promote main to prod** run publishes a
-prerelease nightly from the promoted commit with a UTC timestamp, such as
-`desktop-v0.2.3-nightly.20260902080000`. Nightly releases never publish the stable version.
+prerelease nightly from the promoted commit for the next patch version with a UTC timestamp, such as
+`desktop-v0.2.4-nightly.20260902080000` when the stable version is `0.2.3`.
 
-To publish a stable release, bump `desktop/package.json` in a normal pull request. Merging that
-change to `main` automatically runs **Release Desktop** for the exact package version. The workflow
-remains manually runnable to retry a partial stable release.
+To publish a stable release, bump `desktop/package.json` to that patch version in a normal pull
+request. Merging it to `main` promotes the latest complete matching nightly built from the currently
+deployed `prod` commit, preserving its tested artifacts instead of rebuilding them. The workflow
+remains manually runnable to build a stable release when recovery is needed.
 
-Both paths build the current `ui/` bundle, sign and notarize the Electron app, verify the resulting
-app and DMG, create the tag, and publish the DMG, macOS zip, and app zip to a GitHub release.
+Both build paths compile the current `ui/` bundle, sign and notarize the Electron app, verify the
+resulting app and DMG, create the tag, and publish the DMG, macOS zip, and app zip. Promotion retags
+an existing nightly release without modifying those artifacts.
 Desktop-prefixed tags keep this release stream separate from web and backend releases; the workflow
 packages the web UI but does not deploy or otherwise change the hosted web app.
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -105,14 +105,13 @@ to `desktop/dist/`.
 
 ## macOS releases
 
-`desktop/package.json` is the latest stable version. When **Promote main to prod** runs, it compares
-that version with the version currently on `prod`. If the version changed, it publishes the new
-stable version from the promoted commit. Otherwise, it publishes a prerelease nightly with a UTC
-timestamp, such as `desktop-v0.2.3-nightly.20260902080000`.
+`desktop/package.json` is the latest stable version. Every **Promote main to prod** run publishes a
+prerelease nightly from the promoted commit with a UTC timestamp, such as
+`desktop-v0.2.3-nightly.20260902080000`. Nightly releases never publish the stable version.
 
-To publish a stable release, bump `desktop/package.json` in a normal pull request, merge it, and let
-the next scheduled or manual promotion deploy it and create the release. **Release Desktop** remains
-manually runnable to retry a partial stable release.
+To publish a stable release, bump `desktop/package.json` in a normal pull request. Merging that
+change to `main` automatically runs **Release Desktop** for the exact package version. The workflow
+remains manually runnable to retry a partial stable release.
 
 Both paths build the current `ui/` bundle, sign and notarize the Electron app, verify the resulting
 app and DMG, create the tag, and publish the DMG, macOS zip, and app zip to a GitHub release.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -105,16 +105,20 @@ to `desktop/dist/`.
 
 ## macOS releases
 
-Maintainers can run **Release Desktop** from the GitHub Actions page on `main` and choose a patch,
-minor, or major version bump. The workflow builds the current `ui/` bundle, signs and notarizes the
-Electron app, verifies the resulting app and DMG, bumps `desktop/package.json`, creates a
-`desktop-vX.Y.Z` tag, and publishes the DMG, macOS zip, and app zip to a GitHub release. The
-desktop-prefixed tags keep this release stream separate from web and backend releases; the workflow
-packages the web UI but does not deploy or otherwise change the hosted web app.
+`desktop/package.json` is the latest stable version. When **Promote main to prod** runs, it publishes
+that stable version if its `desktop-vX.Y.Z` tag does not exist. Otherwise, it publishes a prerelease
+nightly from the same commit with a UTC timestamp, such as
+`desktop-v0.2.3-nightly.20260902080000`. Bump the stable version in a normal pull request whenever a
+new stable release is wanted.
+
+The release workflow builds the current `ui/` bundle, signs and notarizes the Electron app, verifies
+the resulting app and DMG, creates the tag, and publishes the DMG, macOS zip, and app zip to a GitHub
+release. It remains manually runnable from the Actions page. Desktop-prefixed tags keep this release
+stream separate from web and backend releases; the workflow packages the web UI but does not deploy
+or otherwise change the hosted web app.
 
 The workflow requires these GitHub Actions secrets:
 
-- `RELEASE_PAT`: token allowed to push to `main` and create tags
 - `APPLE_SIGNING_CERT`: base64-encoded Developer ID Application `.p12` certificate
 - `APPLE_SIGNING_CERT_PASSWORD`: password for the certificate
 - `APPLE_API_KEY`: App Store Connect `.p8` key contents

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -106,19 +106,18 @@ to `desktop/dist/`.
 ## macOS releases
 
 `desktop/package.json` is the latest stable version. Every **Promote main to prod** run publishes a
-prerelease nightly from the promoted commit for the next patch version with a UTC timestamp, such as
-`desktop-v0.2.4-nightly.20260902080000` when the stable version is `0.2.3`.
+prerelease nightly from the promoted commit with a UTC timestamp, such as
+`desktop-v0.2.3-nightly.20260902080000`. Nightly releases never publish the stable version.
 
-To publish a stable release, bump `desktop/package.json` to that patch version in a normal pull
-request. Merging it to `main` promotes the latest complete matching nightly built from the currently
-deployed `prod` commit, preserving its tested artifacts instead of rebuilding them. The workflow
-remains manually runnable to build a stable release when recovery is needed.
+Stable releases use a deliberate bump, test, release process: bump `desktop/package.json` in a normal
+pull request, merge it to `main`, test the resulting code as needed, then run **Release Desktop**
+manually. The workflow publishes the exact package version and fails if that stable release is
+already complete. A partial stable release remains manually retryable.
 
-Both build paths compile the current `ui/` bundle, sign and notarize the Electron app, verify the
-resulting app and DMG, create the tag, and publish the DMG, macOS zip, and app zip. Promotion retags
-an existing nightly release without modifying those artifacts.
-Desktop-prefixed tags keep this release stream separate from web and backend releases; the workflow
-packages the web UI but does not deploy or otherwise change the hosted web app.
+Both paths compile the current `ui/` bundle, sign and notarize the Electron app, verify the resulting
+app and DMG, create the tag, and publish the DMG, macOS zip, and app zip. Desktop-prefixed tags keep
+this release stream separate from web and backend releases; the workflow packages the web UI but
+does not deploy or otherwise change the hosted web app.
 
 The workflow requires these GitHub Actions secrets:
 


### PR DESCRIPTION
### Summary

Adds signed and notarized macOS desktop releases with separate nightly and stable release processes.

### Nightly releases

- Every scheduled or manual **Promote main to prod** run invokes the desktop release workflow in nightly mode.
- The nightly is built from the exact commit promoted to `prod`.
- Its embedded version and tag use the current stable version plus a UTC timestamp, for example `desktop-v0.2.3-nightly.20260902080000`.
- The GitHub release is marked as a prerelease.

### Stable releases

- `desktop/package.json` is the source of truth for the stable desktop version.
- Stable releases follow a deliberate **bump → test → release** process.
- Maintainers bump the version in a normal PR and merge it to `main`.
- After testing, a maintainer manually runs **Release Desktop** from `main`.
- The workflow publishes the exact package version and refuses to overwrite an already complete stable release.
- A manually rerun workflow can recover a partial stable release.

### Build and verification

Both paths:

- Build the bundled UI and Electron app.
- Sign with the Developer ID certificate.
- Notarize and staple through App Store Connect.
- Verify the signature, Gatekeeper assessment, stapling, and DMG.
- Publish the DMG, macOS zip, and app zip to GitHub Releases.

### Credentials

Uses repository secrets for the signing certificate, certificate password, and App Store Connect API credentials. Tags and releases use the built-in `GITHUB_TOKEN`; no release PAT is required.

### Scope

This does not promote nightly artifacts to stable, automatically release on a version bump, or add a production-backend compatibility gate.