### PR TITLE
fix(ui): queue mid-run follow-ups in local threads

### DIFF
--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -7,7 +7,11 @@ import type {
   DesktopLocalPromptInput,
   DesktopLocalThreadSummary,
 } from "@/desktop"
-import type { ImageChunk, Message } from "@/features/agents/lib/types"
+import type {
+  ImageChunk,
+  Message,
+  QueuedThreadMessage,
+} from "@/features/agents/lib/types"
 import type { ModelSelection } from "@/features/agents/lib/provider/useModelOptions"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
@@ -42,20 +46,27 @@ import {
   writeStoredPanelCollapsed,
 } from "@/features/agents/lib/gitPanelPreferences"
 import { streamMessagesToUi } from "@/features/agents/lib/streamMessagesToUi"
+import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
 import { messageArrivalTimestamp } from "@/features/agents/lib/messageTimestamps"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { useSession } from "@/lib/session"
 import { useAgentThreadRuntime } from "@/features/agents/lib/AgentThreadStreamProvider"
 
-function promptContent(text: string, images: Array<ImageChunk>) {
-  const trimmed = text.trim()
-  const imageBlocks = images.map((image) => ({
+function imageBlocks(images: Array<ImageChunk>) {
+  return images.map((image) => ({
     type: "image",
     base64: image.base64,
     mime_type: image.mimeType,
     ...(image.fileName ? { file_name: image.fileName } : {}),
   }))
-  return [...imageBlocks, ...(trimmed ? [{ type: "text", text: trimmed }] : [])]
+}
+
+function promptContent(text: string, images: Array<ImageChunk>) {
+  const trimmed = text.trim()
+  return [
+    ...imageBlocks(images),
+    ...(trimmed ? [{ type: "text", text: trimmed }] : []),
+  ]
 }
 
 function skillFiles(skills: DesktopLocalPromptInput["skills"]) {
@@ -76,6 +87,7 @@ function errorMessage(error: unknown): string {
 
 export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const session = useSession()
+  const login = session.data?.login
   const stream = useAgentThreadRuntime()
   const threadQuery = useDesktopLocalThread(sessionId)
   const thread = threadQuery.data
@@ -109,6 +121,11 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const initialPromptRef = useRef<string | null>(null)
   const acknowledgedRef = useRef<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [queuedState, setQueuedState] = useState<{
+    sessionId: string
+    items: Array<QueuedThreadMessage>
+  }>({ sessionId, items: [] })
+  const queued = queuedState.sessionId === sessionId ? queuedState.items : []
   const isMobile = useIsMobile()
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed(sessionId)
@@ -280,6 +297,46 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     [activeSelection, rememberSelection, stream, thread]
   )
 
+  // Mid-run follow-ups go to the thread's store queue, which
+  // `check_message_queue_before_model` drains into the running agent, rather
+  // than starting a second run on a busy thread.
+  const enqueue = useCallback(
+    async (prompt: string, images: Array<ImageChunk>) => {
+      const text = prompt.trim()
+      const namespace = ["queue", sessionId]
+      const key = "pending_messages"
+      const existing = await stream.client.store.getItem(namespace, key)
+      const pending = existing?.value?.messages
+      await stream.client.store.putItem(namespace, key, {
+        messages: [
+          ...(Array.isArray(pending) ? pending : []),
+          {
+            content: {
+              text,
+              images: imageBlocks(images),
+              ...(login && {
+                sender: {
+                  id: `github:${login}`,
+                  platform: "github",
+                  github_login: login,
+                },
+              }),
+            },
+          },
+        ],
+      })
+      const createdAt = Date.now()
+      setQueuedState((current) => ({
+        sessionId,
+        items: [
+          ...(current.sessionId === sessionId ? current.items : []),
+          { id: `queued-${createdAt}`, content: text, images, createdAt },
+        ],
+      }))
+    },
+    [login, sessionId, stream.client]
+  )
+
   useEffect(() => {
     if (modelsLoading || !thread || initialPromptRef.current === sessionId)
       return
@@ -363,6 +420,9 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             isThinking={isRunning}
             messages={messages}
             onOpenFile={handleOpenFile}
+            queuedMessages={
+              isRunning ? visibleQueuedMessages(queued, messages) : []
+            }
             streamIsLoading={stream.isLoading}
           />
           <AgentComposerDock>
@@ -409,12 +469,18 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
               onSubmit={async (prompt, images) => {
                 const terminalContext = terminalContexts.join("\n\n")
                 setTerminalContexts([])
-                await submit(
-                  terminalContext
-                    ? `${prompt}\n\nTerminal selection:\n\`\`\`\n${terminalContext}\n\`\`\``
-                    : prompt,
-                  images
-                )
+                const text = terminalContext
+                  ? `${prompt}\n\nTerminal selection:\n\`\`\`\n${terminalContext}\n\`\`\``
+                  : prompt
+                if (!isRunning) {
+                  await submit(text, images)
+                  return
+                }
+                try {
+                  await enqueue(text, images)
+                } catch (cause) {
+                  setError(errorMessage(cause))
+                }
               }}
               placeholder="Add a follow up"
               skills={skills.data}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -61,6 +61,28 @@ function imageBlocks(images: Array<ImageChunk>) {
   }))
 }
 
+const QUEUE_KEY = "pending_messages"
+
+type QueuedPayload = {
+  text?: string
+  images?: Array<{ base64?: string; mime_type?: string; file_name?: string }>
+}
+
+function payloadImages(payload: QueuedPayload): Array<ImageChunk> {
+  return (payload.images ?? []).flatMap((block) =>
+    block.base64 && block.mime_type
+      ? [
+          {
+            kind: "image" as const,
+            base64: block.base64,
+            mimeType: block.mime_type,
+            ...(block.file_name ? { fileName: block.file_name } : {}),
+          },
+        ]
+      : []
+  )
+}
+
 function promptContent(text: string, images: Array<ImageChunk>) {
   const trimmed = text.trim()
   return [
@@ -126,6 +148,9 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     items: Array<QueuedThreadMessage>
   }>({ sessionId, items: [] })
   const queued = queuedState.sessionId === sessionId ? queuedState.items : []
+  const queueNamespace = useMemo(() => ["queue", sessionId], [sessionId])
+  const stoppedRef = useRef(false)
+  const handoffRef = useRef(false)
   const isMobile = useIsMobile()
   const [panelCollapsed, setPanelCollapsed] = useState(() =>
     readStoredPanelCollapsed(sessionId)
@@ -259,6 +284,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     ) => {
       if (!thread) return false
       setError(null)
+      stoppedRef.current = false
       const credentialError = await ensureDesktopModelCredential(
         activeSelection?.modelId
       )
@@ -303,11 +329,12 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   const enqueue = useCallback(
     async (prompt: string, images: Array<ImageChunk>) => {
       const text = prompt.trim()
-      const namespace = ["queue", sessionId]
-      const key = "pending_messages"
-      const existing = await stream.client.store.getItem(namespace, key)
+      const existing = await stream.client.store.getItem(
+        queueNamespace,
+        QUEUE_KEY
+      )
       const pending = existing?.value?.messages
-      await stream.client.store.putItem(namespace, key, {
+      await stream.client.store.putItem(queueNamespace, QUEUE_KEY, {
         messages: [
           ...(Array.isArray(pending) ? pending : []),
           {
@@ -334,8 +361,42 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         ],
       }))
     },
-    [login, sessionId, stream.client]
+    [login, queueNamespace, sessionId, stream.client]
   )
+
+  // A live run does not guarantee another queue check: a follow-up written
+  // after its last model call is never read. Once the run ends, take back
+  // whatever the agent left behind and send it as a fresh run — unless the
+  // user stopped the run, in which case the pending work is discarded.
+  const flushUndrainedQueue = useCallback(async () => {
+    const item = await stream.client.store.getItem(queueNamespace, QUEUE_KEY)
+    if (!item) return
+    await stream.client.store.deleteItem(queueNamespace, QUEUE_KEY)
+    const pending = item.value?.messages
+    if (stoppedRef.current || !Array.isArray(pending)) return
+    const payloads = pending.map(
+      (entry) =>
+        ((entry as { content?: QueuedPayload }).content ?? {}) as QueuedPayload
+    )
+    const text = payloads
+      .map((payload) => payload.text?.trim())
+      .filter(Boolean)
+      .join("\n\n")
+    const images = payloads.flatMap(payloadImages)
+    if (text || images.length > 0) await submit(text, images)
+  }, [queueNamespace, stream.client, submit])
+
+  useEffect(() => {
+    if (isRunning || queued.length === 0 || handoffRef.current) return
+    handoffRef.current = true
+    // oxlint-disable-next-line react/set-state-in-effect
+    setQueuedState({ sessionId, items: [] })
+    void flushUndrainedQueue()
+      .catch((cause) => setError(errorMessage(cause)))
+      .finally(() => {
+        handoffRef.current = false
+      })
+  }, [flushUndrainedQueue, isRunning, queued.length, sessionId])
 
   useEffect(() => {
     if (modelsLoading || !thread || initialPromptRef.current === sessionId)
@@ -461,6 +522,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
               onSelectionChange={setSelection}
               onStop={async () => {
                 try {
+                  stoppedRef.current = true
                   await stream.stop()
                 } catch (cause) {
                   setError(errorMessage(cause))


### PR DESCRIPTION
Local ("This Mac") threads always called `stream.submit`, even while a run was in flight — so the composer said "Send a message to queue next…" but the message never reached the running agent (cloud threads go through the dashboard `/messages` endpoint instead).

`LocalAgentThreadView` now writes mid-run follow-ups to the thread's store queue (`("queue", <thread_id>)` / `pending_messages`) via the local-graph SDK client, the same payload the dashboard endpoint writes, so `check_message_queue_before_model` injects them into the current run. Queued sends render the existing "Queued next" card.

Verified with the desktop e2e harness: typing a follow-up during a held run shows the queued card and the message lands in the running agent, attributed to the signed-in user.

<img src="https://01a05e9b-3828-73b1-804d-f6c17498f1c3--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd5T1RVeU1qTXNJbXAwYVNJNklqQXhZVEExWldJekxUazVNVGt0TnpsaE5DMDRZemxqTFRobE5qTXlPV0pqTURNMVlpSXNJbk5wWkNJNklqQXhZVEExWlRsaUxUTTRNamd0TnpOaU1TMDRNRFJrTFdZMll6RTNORGs0WmpGak15SXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDNGMVpYVmxaQzFzYjJOaGJDNXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC5SaE5weHUxaXdOVzhMRWE4ZXBQRU03ZDZMTC1qVElvWlpKZ0V3WTBkZlp2SkpLS2kzazdfcnhKbVAxTzZRcTZMUkZDbklFaGFvbjNhSTVWY2lTOHVEZw" width="800" />

Made by [Open SWE](https://openswe.vercel.app/agents/01a05e9b-31df-70e9-91b9-c8fa41b3e895)