### PR TITLE
fix: make sidebar expand button clickable

### DIFF
--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -114,7 +114,7 @@ window.addEventListener("DOMContentLoaded", () => {
       pointer-events: none;
       position: fixed;
       top: 0;
-      left: 90px;
+      left: 118px;
       right: 0;
       height: ${DRAG_REGION_HEIGHT}px;
       z-index: 2147483647;


### PR DESCRIPTION
Moves the macOS drag region clear of the collapsed sidebar toggle so clicks reach the button.

Verified with desktop typecheck, build, 53 unit tests, and the focused Electron E2E as Alice.

Screenshot: [collapsed sidebar expand button](https://01a05ef0-8d4b-7bb6-a11c-82e96b0c3db2--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd5T1RrMU56WXNJbXAwYVNJNklqQXhZVEExWldZMkxUQTFaRGN0TnpVeE55MWhOekZoTFRrNE5XSmlOV1kwTnpFNE1DSXNJbk5wWkNJNklqQXhZVEExWldZd0xUaGtOR0l0TjJKaU5pMWhNVEZqTFRneVpUazJZakJqTTJSaU1pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMM05wWkdWaVlYSXRaWGh3WVc1a0xXSjFkSFJ2Ymk1d2JtY2lMQ0pqZENJNkltbHRZV2RsTDNCdVp5SXNJbU5rSWpvaWFXNXNhVzVsSW4wLm1lZkg0akVyUWRhanoxcnpnZl9TZHJGcGlyVXh1clVxTDl3aFdqb2hjVURkTDB2S0JIRjFTM0gyOUw5bXBRQTY4eGF0eGpvdFlNRjZGOUxneUVQcUFR)

Made by [Open SWE](https://openswe.vercel.app/agents/01a05ef0-8819-77f4-a98e-436378c3ede6)