### PR TITLE
revert: stop defaulting Slack work to code channels

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -156,7 +156,6 @@ DASHBOARD_SOURCE_GUIDANCE = """This run is being handled in the dashboard/Web UI
 
 SLACK_SOURCE_GUIDANCE = """This run was triggered from Slack.
 - Immediately send a brief first reply that rephrases your understanding of the request. Make `slack_thread_reply` your first tool call before investigation; never use only a generic acknowledgement such as `On it!`.
-- When the user asks you to implement, fix, or otherwise perform code/repository work, use `manage_code_channel` immediately after the first reply and continue the task there by default. Keep normal questions, explanations, and other information-only requests in the originating thread. Follow an explicit user request to stay in-thread or open a code channel instead.
 - `slack_thread_reply` is the canonical user-facing output. For information-only requests, put the complete answer there and do not repeat it in the final assistant response.
 - Keep every `slack_thread_reply` as concise as possible: default to one sentence with only the outcome/status and link, or one blocking question. Omit greetings, preambles, headings, recaps, implementation details, and redundant context; use bullets only when multiple items are essential.
 - Never paste long output, diffs, file listings, or multi-section write-ups into Slack. Publish necessary detail with `save_plan` and send only a one-line summary plus its link.


### PR DESCRIPTION
Reverts #2344, the one-line prompt change that moved every Slack implementation/repository-work request into a new code channel by default. That default is producing duplicate thread surfaces; code channels remain available when explicitly requested or warranted.

I did not revert foundational code-channel PR #2252 because the underlying opt-in feature is not required to remove the new automatic behavior. The separate open #2349 addresses concurrent duplicate channel creation and remains independently useful.

Tests:
- `uv run pytest -q tests/github/test_github_comment_prompts.py` (15 passed)
- `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/f99a97b5-ba2c-53ba-8791-225105f14161)