### PR TITLE
feat: replace Gemini 3.7 Flash with 3.8 Flash

### DIFF
--- a/agent/dashboard/eval_jobs.py
+++ b/agent/dashboard/eval_jobs.py
@@ -50,7 +50,7 @@ DEFAULT_REVIEWER_EVAL_CONFIG: ReviewerEvalConfig = {
     "langsmith_project": DEFAULT_EVAL_PROJECT,
     "langgraph_url": "",
     "assistant_id": "reviewer",
-    "model_id": "google_genai:gemini-3.7-flash",
+    "model_id": "google_genai:gemini-3.8-flash",
     "reasoning_effort": "medium",
     "score_mode": "surfaced_findings",
     "severity_threshold": "low",

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -59,8 +59,8 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "supports_images": True,
     },
     {
-        "id": "google_genai:gemini-3.7-flash",
-        "label": "Gemini 3.7 Flash",
+        "id": "google_genai:gemini-3.8-flash",
+        "label": "Gemini 3.8 Flash",
         "efforts": ["minimal", "low", "medium", "high"],
         "default_effort": "medium",
         "supports_images": True,
@@ -108,6 +108,7 @@ DEPRECATED_MODEL_IDS: frozenset[str] = frozenset(
         "openai:gpt-5.5",
         "google_genai:gemini-3.5-flash",
         "google_genai:gemini-3.6-flash",
+        "google_genai:gemini-3.7-flash",
         "fireworks:accounts/fireworks/models/kimi-k2p7-code",
         "fireworks:accounts/fireworks/models/kimi-k3-code",
         "fireworks:accounts/fireworks/models/glm-5p2",

--- a/evals/reviewer/config.toml
+++ b/evals/reviewer/config.toml
@@ -9,8 +9,8 @@ langsmith_project = "open-swe-evals"
 # Leave blank to use LANGGRAPH_URL or local dev.
 langgraph_url = ""
 assistant_id = "reviewer"
-# models: openai:gpt-5.6-sol, anthropic:claude-opus-5, google_genai:gemini-3.7-flash
-model_id = "google_genai:gemini-3.7-flash"
+# models: openai:gpt-5.6-sol, anthropic:claude-opus-5, google_genai:gemini-3.8-flash
+model_id = "google_genai:gemini-3.8-flash"
 reasoning_effort = "medium"
 
 # score_mode:

--- a/evals/reviewer/run_eval.py
+++ b/evals/reviewer/run_eval.py
@@ -77,7 +77,7 @@ DEFAULT_CONFIG: ReviewerEvalConfig = {
     "langgraph_url": "",
     "langsmith_project": DEFAULT_LANGSMITH_PROJECT,
     "assistant_id": "reviewer",
-    "model_id": "google_genai:gemini-3.7-flash",
+    "model_id": "google_genai:gemini-3.8-flash",
     "reasoning_effort": "medium",
     "score_mode": "surfaced_findings",
     "severity_threshold": "low",

--- a/tests/dashboard/test_team_settings_grouping.py
+++ b/tests/dashboard/test_team_settings_grouping.py
@@ -9,7 +9,7 @@ from agent.dashboard.team_settings import (
 )
 
 _REVIEWER_SUBAGENT_PAIR = ("openai:gpt-5.6-sol", "low")
-_GROUPING_PAIR = ("google_genai:gemini-3.7-flash", "low")
+_GROUPING_PAIR = ("google_genai:gemini-3.8-flash", "low")
 
 
 def _settings(**overrides: object) -> dict[str, object]:

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -250,7 +250,7 @@ async def test_fireworks_gateway_strips_legacy_function_call() -> None:
 
 def test_google_genai_routes_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
-    overrides = gateway.gateway_overrides("google_genai:gemini-3.7-flash")
+    overrides = gateway.gateway_overrides("google_genai:gemini-3.8-flash")
     assert overrides == {
         "base_url": "https://gateway.smith.langchain.com/gemini",
         "api_key": "ls-key",
@@ -461,7 +461,7 @@ def test_make_model_gateway_google_genai(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
     captured, fake = _capture_init_chat_model()
     with patch.object(model, "init_chat_model", fake):
-        model.make_model("google_genai:gemini-3.7-flash", use_gateway=True)
+        model.make_model("google_genai:gemini-3.8-flash", use_gateway=True)
     assert captured["base_url"] == "https://gateway.smith.langchain.com/gemini"
     assert captured["api_key"] == "ls-key"
 

--- a/ui/src/features/agents/components/ModelPicker.test.tsx
+++ b/ui/src/features/agents/components/ModelPicker.test.tsx
@@ -24,8 +24,8 @@ const MODELS: Array<ModelOption> = [
     context_window: 272_000,
   },
   {
-    id: "google_genai:gemini-3.7-flash",
-    label: "Gemini 3.7 Flash",
+    id: "google_genai:gemini-3.8-flash",
+    label: "Gemini 3.8 Flash",
     efforts: ["minimal", "low", "medium", "high"],
     default_effort: "medium",
     supports_images: true,
@@ -90,7 +90,7 @@ describe("ModelPicker", () => {
 
   it("omits the context section for models without a context window", () => {
     openPicker({
-      selection: { modelId: "google_genai:gemini-3.7-flash", effort: "medium" },
+      selection: { modelId: "google_genai:gemini-3.8-flash", effort: "medium" },
     })
 
     expect(screen.getByTestId("model-picker-panel").textContent).not.toContain(
@@ -123,7 +123,7 @@ describe("ModelPicker", () => {
       within(models)
         .getAllByRole("option")
         .map((option) => option.textContent)
-    ).toEqual(["GPT-5.6 Sol High", "Gemini 3.7 Flash Medium", "Kimi K3 High"])
+    ).toEqual(["GPT-5.6 Sol High", "Gemini 3.8 Flash Medium", "Kimi K3 High"])
 
     fireEvent.change(screen.getByLabelText("Search models"), {
       target: { value: "kimi" },


### PR DESCRIPTION
Replaces Gemini 3.7 Flash with 3.8 Flash in supported models and reviewer eval defaults. Deprecates the 3.7 model ID.

Screenshot: [Gemini 3.8 Flash model picker](https://01a062d2-1950-7528-bad3-91ec12e0d47e--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd6TmpVeU1qRXNJbXAwYVNJNklqQXhZVEEyTW1SbUxXRmxNVGd0TnpFd1lpMWhOV1ZqTFRFMU56RmxNbVl5T1RCbU5DSXNJbk5wWkNJNklqQXhZVEEyTW1ReUxURTVOVEF0TnpVeU9DMWlZV1F6TFRreFpXTXhNbVV3WkRRM1pTSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMMmRsYldsdWFTMHpMVGd0Wm14aGMyZ3VjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuaS1TYWFUeFhSb25YMUh4UjJSUFlReUdGT0dGajc2QW1SMlA5bU9mMGJkdHdTUHBGX2Nsc2ExMnhxcjJ0N2ZjUjFybU1vd0JXWlNJUUZmMWQzTDNiQ0E)

Made by [Open SWE](https://openswe.vercel.app/agents/c23c2ef0-5cba-5aa3-b168-aed9219dc56e)