### PR TITLE
feat: add desktop auto-updates

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -50,7 +50,14 @@ jobs:
             prerelease=false
             label="Open SWE Desktop v${version}"
             if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
-              if gh release view "$tag" --json assets --jq '.assets | length >= 3' | grep -qx true; then
+              if gh release view "$tag" --json assets | jq -e --arg v "$version" '
+                [.assets[].name] as $names |
+                ($names | index("Open SWE-\($v).app.zip")) != null and
+                ($names | index("latest-mac.yml")) != null and
+                any($names[]; test("^Open SWE-\($v)-.*-mac\\.zip$")) and
+                any($names[]; test("^Open SWE-\($v)-.*\\.dmg$")) and
+                any($names[]; test("^Open SWE-\($v)-.*-mac\\.zip\\.blockmap$"))
+              ' >/dev/null; then
                 echo "$tag already has a complete release"
                 exit 1
               fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -155,6 +155,12 @@ jobs:
           echo "mac_zip=${mac_zips[0]}" >> "$GITHUB_OUTPUT"
           echo "mac_dmg=${mac_dmgs[0]}" >> "$GITHUB_OUTPUT"
           echo "app_zip=$app_zip" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.release.outputs.prerelease }}" = "false" ]; then
+            test -f desktop/dist/latest-mac.yml
+            test -f "${mac_zips[0]}.blockmap"
+            echo "update_metadata=desktop/dist/latest-mac.yml" >> "$GITHUB_OUTPUT"
+            echo "update_blockmap=${mac_zips[0]}.blockmap" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Tag desktop version
         env:
@@ -177,6 +183,8 @@ jobs:
             ${{ steps.assets.outputs.mac_zip }}
             ${{ steps.assets.outputs.mac_dmg }}
             ${{ steps.assets.outputs.app_zip }}
+            ${{ steps.assets.outputs.update_metadata }}
+            ${{ steps.assets.outputs.update_blockmap }}
 
       - name: Remove signing credentials
         if: always()

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -93,6 +93,19 @@ pnpm --dir desktop run start -- --backend-url=https://open-swe-api.example.com
 environment variable, saved first-launch configuration, then the local development default.
 The original `--url` and `OPEN_SWE_DESKTOP_URL` names remain accepted for compatibility.
 
+Development builds hardcode the update UI to the ready state. The install action remains disabled
+because Electron updates require a packaged app. To exercise the full download and install flow,
+build two packaged versions and serve the newer build's update metadata and archive locally:
+
+```bash
+python3 -m http.server 8080 --directory /path/to/newer/desktop/dist
+OPEN_SWE_DESKTOP_UPDATE_URL=http://127.0.0.1:8080 \
+  "/path/to/older/Open SWE.app/Contents/MacOS/Open SWE"
+```
+
+The older app's version must be lower than the version in `latest-mac.yml`. It downloads the archive
+and enables **Update** when it is ready to install.
+
 ## Packaging
 
 ```bash

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -93,19 +93,6 @@ pnpm --dir desktop run start -- --backend-url=https://open-swe-api.example.com
 environment variable, saved first-launch configuration, then the local development default.
 The original `--url` and `OPEN_SWE_DESKTOP_URL` names remain accepted for compatibility.
 
-Development builds hardcode the update UI to the ready state. The install action remains disabled
-because Electron updates require a packaged app. To exercise the full download and install flow,
-build two packaged versions and serve the newer build's update metadata and archive locally:
-
-```bash
-python3 -m http.server 8080 --directory /path/to/newer/desktop/dist
-OPEN_SWE_DESKTOP_UPDATE_URL=http://127.0.0.1:8080 \
-  "/path/to/older/Open SWE.app/Contents/MacOS/Open SWE"
-```
-
-The older app's version must be lower than the version in `latest-mac.yml`. It downloads the archive
-and enables **Update** when it is ready to install.
-
 ## Packaging
 
 ```bash

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -20,6 +20,11 @@
   "build": {
     "appId": "com.langchain.openswe",
     "productName": "Open SWE",
+    "publish": {
+      "provider": "github",
+      "owner": "langchain-ai",
+      "repo": "open-swe"
+    },
     "asar": true,
     "asarUnpack": [
       "node_modules/node-pty/**/*"
@@ -105,6 +110,7 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
+    "electron-updater": "6.8.9",
     "node-pty": "1.1.0"
   }
 }

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -97,10 +97,7 @@ let localThreadStore = null;
 let lastActivity = {};
 let backendSupervisor = null;
 let openAiOAuth = null;
-const localUpdateUrl = process.env.OPEN_SWE_DESKTOP_UPDATE_URL?.trim();
-let updateState = isDevelopment
-  ? { status: "ready", version: "local-test" }
-  : { status: "idle" };
+let updateState = { status: "idle" };
 
 function setUpdateState(status, version) {
   updateState = { status, ...(version ? { version } : {}) };
@@ -114,10 +111,6 @@ function configureAutoUpdater() {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.allowPrerelease = false;
-  if (localUpdateUrl) {
-    autoUpdater.setFeedURL({ provider: "generic", url: localUpdateUrl });
-    setUpdateState("downloading", "local-test");
-  }
   autoUpdater.on("update-available", (info) =>
     setUpdateState("downloading", info.version),
   );
@@ -244,7 +237,7 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:install-update", async (event) => {
     requireTrustedDesktopIpc(event);
-    if (updateState.status !== "ready" || !app.isPackaged) return false;
+    if (updateState.status !== "ready") return false;
     quitting = true;
     await Promise.all([
       closeAllTerminals(),

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -14,6 +14,7 @@ const {
   session,
   shell,
 } = require("electron");
+const { autoUpdater } = require("electron-updater");
 const { BackendSupervisor } = require("./backend-supervisor.cjs");
 const { LocalThreadStore } = require("./local-thread-store.cjs");
 const {
@@ -96,6 +97,36 @@ let localThreadStore = null;
 let lastActivity = {};
 let backendSupervisor = null;
 let openAiOAuth = null;
+let updateState = { status: "idle" };
+
+function setUpdateState(status, version) {
+  updateState = { status, ...(version ? { version } : {}) };
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("desktop:update-state", updateState);
+  }
+}
+
+function configureAutoUpdater() {
+  if (!app.isPackaged) return;
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.allowPrerelease = false;
+  autoUpdater.on("update-available", (info) =>
+    setUpdateState("downloading", info.version),
+  );
+  autoUpdater.on("update-downloaded", (info) =>
+    setUpdateState("ready", info.version),
+  );
+  autoUpdater.on("error", (error) => {
+    console.warn("Desktop update failed", error);
+    setUpdateState("idle", undefined);
+  });
+  void autoUpdater
+    .checkForUpdates()
+    .catch((error) =>
+      console.warn("Could not check for desktop updates", error),
+    );
+}
 
 function sendDesktopCommand(commandId) {
   if (!isDesktopCommandId(commandId) || !mainWindow || mainWindow.isDestroyed())
@@ -200,6 +231,23 @@ async function diffThread(threadId) {
 }
 
 function configureDesktopIpc() {
+  ipcMain.handle("desktop:update-state", (event) => {
+    requireTrustedDesktopIpc(event);
+    return updateState;
+  });
+  ipcMain.handle("desktop:install-update", async (event) => {
+    requireTrustedDesktopIpc(event);
+    if (updateState.status !== "ready") return false;
+    quitting = true;
+    await Promise.all([
+      closeAllTerminals(),
+      backendSupervisor?.close(),
+      openAiOAuth?.close(),
+    ]);
+    autoUpdater.quitAndInstall(false, true);
+    return true;
+  });
+
   ipcMain.handle("desktop:projects", (event) => {
     requireTrustedDesktopIpc(event);
     return listProjects();
@@ -1052,6 +1100,7 @@ if (!hasSingleInstanceLock) {
     configureDesktopIpc();
     createMenu();
     createWindow();
+    configureAutoUpdater();
     configureTerminalIpc({
       ipcMain,
       requireTrusted: requireTrustedDesktopIpc,

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -97,7 +97,10 @@ let localThreadStore = null;
 let lastActivity = {};
 let backendSupervisor = null;
 let openAiOAuth = null;
-let updateState = { status: "idle" };
+const localUpdateUrl = process.env.OPEN_SWE_DESKTOP_UPDATE_URL?.trim();
+let updateState = isDevelopment
+  ? { status: "ready", version: "local-test" }
+  : { status: "idle" };
 
 function setUpdateState(status, version) {
   updateState = { status, ...(version ? { version } : {}) };
@@ -111,6 +114,10 @@ function configureAutoUpdater() {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.allowPrerelease = false;
+  if (localUpdateUrl) {
+    autoUpdater.setFeedURL({ provider: "generic", url: localUpdateUrl });
+    setUpdateState("downloading", "local-test");
+  }
   autoUpdater.on("update-available", (info) =>
     setUpdateState("downloading", info.version),
   );
@@ -237,7 +244,7 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:install-update", async (event) => {
     requireTrustedDesktopIpc(event);
-    if (updateState.status !== "ready") return false;
+    if (updateState.status !== "ready" || !app.isPackaged) return false;
     quitting = true;
     await Promise.all([
       closeAllTerminals(),

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -231,6 +231,10 @@ async function diffThread(threadId) {
 }
 
 function configureDesktopIpc() {
+  ipcMain.handle("desktop:version", (event) => {
+    requireTrustedDesktopIpc(event);
+    return app.getVersion();
+  });
   ipcMain.handle("desktop:update-state", (event) => {
     requireTrustedDesktopIpc(event);
     return updateState;

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -27,6 +27,7 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
     ipcRenderer.invoke("desktop:checkout-project-branch", { ...input }),
   addProject: () => ipcRenderer.invoke("desktop:add-project"),
   removeProject: (cwd) => ipcRenderer.invoke("desktop:remove-project", cwd),
+  getVersion: () => ipcRenderer.invoke("desktop:version"),
   getUpdateState: () => ipcRenderer.invoke("desktop:update-state"),
   installUpdate: () => ipcRenderer.invoke("desktop:install-update"),
   onUpdateState: (callback) => {

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -27,6 +27,13 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
     ipcRenderer.invoke("desktop:checkout-project-branch", { ...input }),
   addProject: () => ipcRenderer.invoke("desktop:add-project"),
   removeProject: (cwd) => ipcRenderer.invoke("desktop:remove-project", cwd),
+  getUpdateState: () => ipcRenderer.invoke("desktop:update-state"),
+  installUpdate: () => ipcRenderer.invoke("desktop:install-update"),
+  onUpdateState: (callback) => {
+    const listener = (_event, state) => callback(state);
+    ipcRenderer.on("desktop:update-state", listener);
+    return () => ipcRenderer.removeListener("desktop:update-state", listener);
+  },
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
   resolveLocalProjectPath: (input) =>
     ipcRenderer.invoke("desktop:resolve-local-project-path", { ...input }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
 
   desktop:
     dependencies:
+      electron-updater:
+        specifier: 6.8.9
+        version: 6.8.9(supports-color@10.2.2)
       node-pty:
         specifier: 1.1.0
         version: 1.1.0
@@ -3283,6 +3286,9 @@ packages:
   electron-to-chromium@1.5.404:
     resolution: {integrity: sha512-3WJtd7/lVq2Jnuz6wed1l9+1ZD2u2Tet1/1NBc4Iedkmgbu+I7YuAqdAQ8T+VZtnwysMsAf3IqSq9D1gyZjA2g==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -4290,6 +4296,13 @@ packages:
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -5476,6 +5489,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -9023,6 +9039,19 @@ snapshots:
 
   electron-to-chromium@1.5.404: {}
 
+  electron-updater@6.8.9(supports-color@10.2.2):
+    dependencies:
+      builder-util-runtime: 9.7.0(supports-color@10.2.2)
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-winstaller@5.4.0(supports-color@10.2.2):
     dependencies:
       '@electron/asar': 3.4.1
@@ -10057,6 +10086,10 @@ snapshots:
       p-locate: 5.0.0
 
   lodash-es@4.18.1: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash@4.18.1: {}
 
@@ -11622,6 +11655,8 @@ snapshots:
       semver: 5.7.2
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -104,7 +104,7 @@ export type DesktopUpdateState = {
   version?: string
 }
 
-interface DesktopTerminalBridge {
+export interface DesktopTerminalBridge {
   attach: (
     input: DesktopTerminalTarget & {
       cwd?: string

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -156,6 +156,7 @@ declare global {
       }) => Promise<string>
       addProject: () => Promise<DesktopProject | null>
       removeProject: (cwd: string) => Promise<boolean>
+      getVersion: () => Promise<string>
       getUpdateState: () => Promise<DesktopUpdateState>
       installUpdate: () => Promise<boolean>
       onUpdateState: (

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -99,7 +99,12 @@ export type DesktopTerminalMetadataEvent =
   | { type: "upsert"; terminal: DesktopTerminalSummary }
   | (DesktopTerminalTarget & { type: "remove" })
 
-export interface DesktopTerminalBridge {
+export type DesktopUpdateState = {
+  status: "idle" | "downloading" | "ready"
+  version?: string
+}
+
+interface DesktopTerminalBridge {
   attach: (
     input: DesktopTerminalTarget & {
       cwd?: string
@@ -151,6 +156,11 @@ declare global {
       }) => Promise<string>
       addProject: () => Promise<DesktopProject | null>
       removeProject: (cwd: string) => Promise<boolean>
+      getUpdateState: () => Promise<DesktopUpdateState>
+      installUpdate: () => Promise<boolean>
+      onUpdateState: (
+        callback: (state: DesktopUpdateState) => void
+      ) => () => void
       onProjectsChanged: (
         callback: (projects: Array<DesktopProject>) => void
       ) => () => void

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
   CircleNotchIcon,
+  DownloadSimpleIcon,
   FolderIcon,
   FolderOpenIcon,
   GitPullRequestIcon,
@@ -16,6 +17,7 @@ import {
 import { Kanban } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
+import type { DesktopUpdateState } from "@/desktop"
 import type { SessionUser } from "@/lib/api"
 import type {
   PullRequestSnapshot,
@@ -204,6 +206,15 @@ export function AgentsSidebar({
   } = useSidebarPrefs()
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
+  const [updateState, setUpdateState] = useState<DesktopUpdateState>({
+    status: "idle",
+  })
+  useEffect(() => {
+    const desktop = window.openSweDesktop
+    if (!desktop) return
+    void desktop.getUpdateState().then(setUpdateState)
+    return desktop.onUpdateState(setUpdateState)
+  }, [])
   const projectMode = prefs.organize === "project"
   const includeAutomations =
     prefs.filters.includeAutomations ||
@@ -800,6 +811,29 @@ export function AgentsSidebar({
       </TooltipProvider>
 
       <div className="p-2">
+        {updateState.status !== "idle" && (
+          <button
+            type="button"
+            title={
+              updateState.status === "ready" ? "Update" : "Downloading update…"
+            }
+            aria-label={
+              updateState.status === "ready" ? "Update" : "Downloading update"
+            }
+            disabled={updateState.status !== "ready"}
+            onClick={() => void window.openSweDesktop?.installUpdate()}
+            className="group mb-1 flex h-9 w-full items-center justify-end rounded-md px-2 text-primary hover:bg-sidebar-accent disabled:opacity-60"
+          >
+            <span className="mr-2 hidden text-xs font-medium group-hover:inline">
+              {updateState.status === "ready" ? "Update" : "Downloading…"}
+            </span>
+            {updateState.status === "downloading" ? (
+              <CircleNotchIcon className="size-5 animate-spin" />
+            ) : (
+              <DownloadSimpleIcon className="size-5" />
+            )}
+          </button>
+        )}
         <div className="min-w-0">
           {user ? (
             <SidebarUserMenu user={user} showSettingsLink />

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -834,7 +834,7 @@ export function AgentsSidebar({
             }
             disabled={updateState.status !== "ready"}
             onClick={() => void window.openSweDesktop?.installUpdate()}
-            className="group flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground hover:w-auto hover:px-3 hover:bg-primary/90 disabled:opacity-60"
+            className="group flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground hover:w-auto hover:bg-primary/90 hover:px-3 disabled:opacity-60"
           >
             {updateState.status === "downloading" ? (
               <CircleNotchIcon className="size-4 animate-spin group-hover:hidden" />

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -810,31 +810,8 @@ export function AgentsSidebar({
         </div>
       </TooltipProvider>
 
-      <div className="p-2">
-        {updateState.status !== "idle" && (
-          <button
-            type="button"
-            title={
-              updateState.status === "ready" ? "Update" : "Downloading update…"
-            }
-            aria-label={
-              updateState.status === "ready" ? "Update" : "Downloading update"
-            }
-            disabled={updateState.status !== "ready"}
-            onClick={() => void window.openSweDesktop?.installUpdate()}
-            className="group mb-1 flex h-9 w-full items-center justify-end rounded-md px-2 text-primary hover:bg-sidebar-accent disabled:opacity-60"
-          >
-            <span className="mr-2 hidden text-xs font-medium group-hover:inline">
-              {updateState.status === "ready" ? "Update" : "Downloading…"}
-            </span>
-            {updateState.status === "downloading" ? (
-              <CircleNotchIcon className="size-5 animate-spin" />
-            ) : (
-              <DownloadSimpleIcon className="size-5" />
-            )}
-          </button>
-        )}
-        <div className="min-w-0">
+      <div className="flex items-center gap-2 p-2">
+        <div className="min-w-0 flex-1">
           {user ? (
             <SidebarUserMenu user={user} showSettingsLink />
           ) : (
@@ -846,6 +823,29 @@ export function AgentsSidebar({
             </Link>
           )}
         </div>
+        {updateState.status !== "idle" && (
+          <button
+            type="button"
+            title={
+              updateState.status === "ready" ? "Update" : "Downloading update…"
+            }
+            aria-label={
+              updateState.status === "ready" ? "Update" : "Downloading update"
+            }
+            disabled={updateState.status !== "ready"}
+            onClick={() => void window.openSweDesktop?.installUpdate()}
+            className="group flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground hover:w-auto hover:px-3 hover:bg-primary/90 disabled:opacity-60"
+          >
+            {updateState.status === "downloading" ? (
+              <CircleNotchIcon className="size-4 animate-spin group-hover:hidden" />
+            ) : (
+              <DownloadSimpleIcon className="size-4 group-hover:hidden" />
+            )}
+            <span className="hidden group-hover:inline">
+              {updateState.status === "ready" ? "Update" : "Downloading…"}
+            </span>
+          </button>
+        )}
       </div>
     </SidebarFrame>
   )

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -29,7 +29,9 @@ function DesktopVersionSection() {
       <SettingsRow
         label="Open SWE Desktop"
         control={
-          <span className="text-xs text-muted-foreground">Version {version}</span>
+          <span className="text-xs text-muted-foreground">
+            Version {version}
+          </span>
         }
       />
     </SettingsSection>

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
 
 import { AccountSection } from "@/features/settings/components/AccountSection"
-import { AppShell } from "@/components/AppShell"
+import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell"
 import { ConnectionsSection } from "@/features/settings/components/ConnectionsSection"
 import { EnvironmentsSection } from "@/features/settings/components/EnvironmentsSection"
 import { PersonalInstructionsSection } from "@/features/settings/components/PersonalInstructionsSection"
@@ -14,6 +15,26 @@ import { useSession } from "@/lib/session"
 export const Route = createFileRoute("/my-settings")({
   component: MySettingsPage,
 })
+
+function DesktopVersionSection() {
+  const [version, setVersion] = useState<string>()
+
+  useEffect(() => {
+    void window.openSweDesktop?.getVersion().then(setVersion)
+  }, [])
+
+  if (!version) return null
+  return (
+    <SettingsSection title="About">
+      <SettingsRow
+        label="Open SWE Desktop"
+        control={
+          <span className="text-xs text-muted-foreground">Version {version}</span>
+        }
+      />
+    </SettingsSection>
+  )
+}
 
 function MySettingsPage() {
   const session = useSession()
@@ -39,6 +60,7 @@ function MySettingsPage() {
       <EnvironmentsSection isAdmin={session.data.is_admin} />
       <ConnectionsSection user={session.data} />
       <PersonalInstructionsSection />
+      <DesktopVersionSection />
     </AppShell>
   )
 }


### PR DESCRIPTION
Adds background stable-release downloads and an updater control in the desktop sidebar. Once downloaded, clicking Update closes local processes, installs, and relaunches the app.

Publishes macOS updater metadata with stable GitHub releases.

Screenshot: [Update hover state](https://01a05f32-fa66-73fb-a68a-456c586218bb--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd6TnpJME16UXNJbXAwYVNJNklqQXhZVEEyTXpSa0xXSm1ZVGt0TnpSbE5pMWlPRE5oTFRaaE5qZGxaRFJpWVdabU1pSXNJbk5wWkNJNklqQXhZVEExWmpNeUxXWmhOall0TnpObVlpMWhOamhoTFRRMU5tTTFPRFl5TVRoaVlpSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMMkZ5ZEdsbVlXTjBjeTloWjJWdWRITXRkWEJrWVhSbExXaHZkbVZ5TFhSbGVIUXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuTlI4ZWdyR0xMXzREbndrZklDSGZxb055NXJpVDBrd00yVGI1eWFWWloyUndja2dmTnpBMjlPSEtISHBUaXFjaHMyVHhXMTl3RG03dVZGQ1FtMjNSQXc)

Dependency: `electron-updater@6.8.9` (MIT), maintained with the existing electron-builder stack. Electron’s built-in updater would require a custom feed implementation.

Made by [Open SWE](https://openswe.vercel.app/agents/01a05f32-f6ad-75b0-8c87-47f5fc5d8fd9)