### PR TITLE
chore(desktop): bump version to 0.2.4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",


### PR DESCRIPTION
Bump the desktop patch version from `0.2.3` to `0.2.4`.

Validation: parsed `desktop/package.json` and confirmed the new version.

Made by [Open SWE](https://openswe.vercel.app/agents/01a0634d-54cc-749c-b117-472bad20d652)