### PR TITLE
fix(ui): make dropdown menus opaque

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -121,8 +121,6 @@
     /* Height of the right panel's tab bar; the empty-state launcher offsets by
        it so its cards center against the whole panel. */
     --workspace-topbar-height: 2.25rem;
-    --glass-blur: 12px;
-    --glass-opacity: 80%;
     --chart-1: oklch(0.872 0 0);
     --chart-2: oklch(0.556 0 0);
     --chart-3: oklch(0.45 0 0);
@@ -170,7 +168,6 @@
     --border: oklch(1 0 0 / 12%);
     --input: oklch(1 0 0 / 16%);
     --ring: oklch(0.556 0 0);
-    --glass-blur: 16px;
     --chart-1: oklch(0.872 0 0);
     --chart-2: oklch(0.556 0 0);
     --chart-3: oklch(0.45 0 0);
@@ -192,18 +189,11 @@
 
 @layer utilities {
   /*
-   * Elevated glass needs a denser tint than broad ambient surfaces. Nesting the
-   * opacity mix inside an 18% popover tint keeps high-contrast page content
-   * from blooming through menus.
+   * Menus are opaque: blurring a translucent tint still let high-contrast page
+   * content bleed through and made stacked panes (model picker submenu) unreadable.
    */
   .dropdown-glass {
-    background: color-mix(
-      in srgb,
-      var(--popover) 18%,
-      color-mix(in srgb, var(--popover) var(--glass-opacity), transparent)
-    );
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    backdrop-filter: blur(var(--glass-blur));
+    background: var(--popover);
     border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
     box-shadow: 0 16px 40px -18px rgb(0 0 0 / 55%);
   }


### PR DESCRIPTION
`.dropdown-glass` painted menus at ~84% alpha with a backdrop blur, so page text bled through the model picker — worst on the stacked model-list submenu, where the blur can't hide high-contrast content behind it. Menus now use a solid `--popover` background; the unused `--glass-blur` / `--glass-opacity` tokens are dropped.

Verified in the mock harness as Alice (dark mode) — both panes are pixel-identical over different backdrops, i.e. fully opaque: [screenshot](https://01a063ab-cfee-73c4-b223-edba3c0e9ba3--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGd6T0RFd016a3NJbXAwYVNJNklqQXhZVEEyTTJReExUQTVZakl0TjJKbFl5MWlNemczTFRBeFkyVmtNV1l3Wm1FNU55SXNJbk5wWkNJNklqQXhZVEEyTTJGaUxXTm1aV1V0TnpOak5DMWlNakl6TFdWa1ltRXpZekJsT1dKaE15SXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMMkZ5ZEdsbVlXTjBjeTl0YjJSbGJDMXdhV05yWlhJdGIzQmhjWFZsTG5CdVp5SXNJbU4wSWpvaWFXMWhaMlV2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEuTXhDQmZxN0MxT2ltYnp2cEJJSThYMWdVUFBQdFpqTnROZWZQZnJKTnRrTGNaZTlfamhhcjJVOTVPSW1zeTJHX3Z4dnZBOHZzZlB0dUFreUw3a1JWQlE).

Made by [Open SWE](https://openswe.vercel.app/agents/01a063ab-cb9e-7679-97e8-092ac7d80a47)