### PR TITLE
fix: derive Slack error status from run outcome

### DIFF
--- a/agent/slack_thinking.py
+++ b/agent/slack_thinking.py
@@ -33,6 +33,7 @@ class Step:
     status: StepStatus
     details: str = ""
     output: str = ""
+    failed: bool = False
 
     def chunk(self) -> dict[str, Any]:
         chunk: dict[str, Any] = {
@@ -201,8 +202,9 @@ class SlackThinkingStream:
             if step is None:
                 step = Step(_step_id(self.run_id, namespace, call_id), "Agent step", "complete")
                 self.steps[key] = step
-            step.status = "error" if event == "tool-error" else "complete"
-            step.output = "Failed" if event == "tool-error" else "Completed"
+            step.failed = event == "tool-error"
+            step.status = "complete"
+            step.output = "Failed" if step.failed else "Completed"
             self.pending[step.task_id] = step
 
     async def flush(self, *, force: bool = False) -> None:
@@ -230,7 +232,10 @@ class SlackThinkingStream:
 
     async def stop(self, status: str) -> None:
         for step in self.steps.values():
-            if step.status == "in_progress":
+            if step.failed:
+                step.status = "complete" if status == "success" else "error"
+                self.pending[step.task_id] = step
+            elif step.status == "in_progress":
                 step.status = "complete" if status == "success" else "error"
                 step.output = "Completed" if status == "success" else "Interrupted"
                 self.pending[step.task_id] = step

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -61,6 +61,35 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
     assert final_chunks[-1]["output"] == "Completed"
 
 
+async def test_successful_run_does_not_mark_failed_tool_as_error(monkeypatch) -> None:
+    stop = AsyncMock()
+    monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)
+    stream = slack_thinking.SlackThinkingStream(
+        client=AsyncMock(),
+        thread_id="thread-1",
+        run_id="run-1",
+        channel_id="C1",
+        thread_ts="0",
+        recipient_user_id="U1",
+        recipient_team_id="T1",
+        mapping_thread_ts="0",
+        original_message_ts="1.1",
+    )
+    stream.message_ts = "2.0"
+    stream.consume(
+        _Part(
+            "tools",
+            {"event": "tool-started", "tool_call_id": "call-1", "tool_name": "execute"},
+        )
+    )
+    stream.consume(_Part("tools", {"event": "tool-error", "tool_call_id": "call-1"}))
+
+    await stream.stop("success")
+
+    assert stop.await_args.args[2][-1]["status"] == "complete"
+    assert stop.await_args.args[2][-1]["output"] == "Failed"
+
+
 async def test_stop_sends_pending_updates_despite_append_backoff(monkeypatch) -> None:
     stop = AsyncMock()
     monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -61,35 +61,6 @@ async def test_streams_sanitized_tool_steps(monkeypatch) -> None:
     assert final_chunks[-1]["output"] == "Completed"
 
 
-async def test_successful_run_does_not_mark_failed_tool_as_error(monkeypatch) -> None:
-    stop = AsyncMock()
-    monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)
-    stream = slack_thinking.SlackThinkingStream(
-        client=AsyncMock(),
-        thread_id="thread-1",
-        run_id="run-1",
-        channel_id="C1",
-        thread_ts="0",
-        recipient_user_id="U1",
-        recipient_team_id="T1",
-        mapping_thread_ts="0",
-        original_message_ts="1.1",
-    )
-    stream.message_ts = "2.0"
-    stream.consume(
-        _Part(
-            "tools",
-            {"event": "tool-started", "tool_call_id": "call-1", "tool_name": "execute"},
-        )
-    )
-    stream.consume(_Part("tools", {"event": "tool-error", "tool_call_id": "call-1"}))
-
-    await stream.stop("success")
-
-    assert stop.await_args.args[2][-1]["status"] == "complete"
-    assert stop.await_args.args[2][-1]["output"] == "Failed"
-
-
 async def test_stop_sends_pending_updates_despite_append_backoff(monkeypatch) -> None:
     stop = AsyncMock()
     monkeypatch.setattr(slack_thinking, "stop_slack_stream", stop)


### PR DESCRIPTION
Keep recovered tool-call failures non-error in Slack Thinking Steps, while preserving error status when the overall run fails.

Test: `uv run pytest -q tests/slack/test_slack_thinking.py --disable-warnings --color=no`

Made by [Open SWE](https://openswe.vercel.app/agents/0a66b434-59b9-55e7-9f3f-49292af82189)