### PR TITLE
chore(desktop): bump version to 0.2.5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",


### PR DESCRIPTION
Patch bump of the desktop app: `0.2.4` -> `0.2.5`.

No other file carries the authoritative desktop version. Validated that `desktop/package.json` parses and `git diff --check` passes.

Made by [Open SWE](https://openswe.vercel.app/agents/01a063e5-d414-74cf-988e-0bc9ca4b5da5)