### PR TITLE
fix(ui): tweak themes

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -1203,7 +1203,7 @@ export function AgentsShell({
           activeLocalSessionId={activeLocalSessionId}
           layout={layout}
         />
-        <main className="surface-grain relative flex min-w-0 flex-1 overflow-hidden bg-background">
+        <main className="relative flex min-w-0 flex-1 overflow-hidden bg-background">
           {children}
         </main>
       </div>

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -613,7 +613,7 @@ export function AgentsSidebar({
         <Link
           to="/agents"
           onClick={layout.closeOnMobile}
-          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
+          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
         >
           <NotePencilIcon className="size-4" />
           New Thread
@@ -653,10 +653,9 @@ export function AgentsSidebar({
                       key={item.to}
                       to={item.to}
                       onClick={layout.closeOnMobile}
-                      className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground"
+                      className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm text-foreground transition-colors hover:bg-sidebar-row-hover"
                       activeProps={{
-                        className:
-                          "bg-sidebar-row-hover !text-foreground font-medium",
+                        className: "bg-sidebar-row-hover font-medium",
                       }}
                     >
                       <Icon className="size-4" />
@@ -924,7 +923,7 @@ function ProjectGroup({
 
   return (
     <div className="mb-1">
-      <div className="group/folder flex items-center gap-1.5 rounded-md pr-1 pl-2 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-foreground">
+      <div className="group/folder flex items-center gap-1.5 rounded-md pr-1 pl-2 text-sm text-foreground transition-colors hover:bg-sidebar-row-hover">
         <button
           type="button"
           onClick={onToggleCollapsed}

--- a/ui/src/features/agents/components/SidebarThreadRow.tsx
+++ b/ui/src/features/agents/components/SidebarThreadRow.tsx
@@ -292,7 +292,7 @@ export function SidebarThreadRow({
         <span
           ref={marquee.text}
           className={cn(
-            "block w-max text-[13px] whitespace-nowrap will-change-transform",
+            "block w-max text-sm whitespace-nowrap will-change-transform",
             marquee.shift !== 0 && "sidebar-title-marquee"
           )}
           style={
@@ -377,13 +377,14 @@ export function SidebarThreadRow({
     // archived row is indistinguishable from a live one.
     archived && "opacity-55",
     compact ? "h-7 gap-1.5" : "h-8",
+    "text-foreground",
     isActive
       ? thread?.adminThread
-        ? "bg-destructive/10 text-foreground"
-        : "bg-accent text-foreground"
+        ? "bg-destructive/10"
+        : "bg-accent"
       : thread?.adminThread
-        ? "bg-destructive/5 text-muted-foreground group-hover/row:bg-destructive/10"
-        : "text-muted-foreground group-hover/row:bg-sidebar-row-hover group-hover/row:text-foreground"
+        ? "bg-destructive/5 group-hover/row:bg-destructive/10"
+        : "group-hover/row:bg-sidebar-row-hover"
   )
 
   const link =
@@ -423,7 +424,7 @@ export function SidebarThreadRow({
               side="right"
               align="start"
               sideOffset={8}
-              className="pointer-events-auto max-w-80 rounded-xl p-3"
+              className="pointer-events-auto max-w-80 rounded-xl p-3 [--dropdown-glass-background:var(--sidebar)]"
             >
               <ThreadHoverCard item={item} live={live} />
             </TooltipPopup>

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -44,16 +44,16 @@ function terminalTheme() {
   const dark = document.documentElement.classList.contains("dark")
   return dark
     ? {
-        background: { r: 0, g: 0, b: 0 },
-        foreground: { r: 229, g: 231, b: 235 },
-        cursor: { r: 229, g: 231, b: 235 },
-        selectionBackground: "rgba(147, 197, 253, 0.25)",
+        background: { r: 10, g: 10, b: 10 },
+        foreground: { r: 245, g: 245, b: 245 },
+        cursor: { r: 180, g: 203, b: 255 },
+        selectionBackground: "rgba(180, 203, 255, 0.25)",
       }
     : {
-        background: { r: 255, g: 255, b: 255 },
-        foreground: { r: 31, g: 41, b: 55 },
-        cursor: { r: 31, g: 41, b: 55 },
-        selectionBackground: "rgba(37, 99, 235, 0.2)",
+        background: { r: 253, g: 253, b: 253 },
+        foreground: { r: 39, g: 39, b: 42 },
+        cursor: { r: 38, g: 56, b: 78 },
+        selectionBackground: "rgba(37, 63, 99, 0.2)",
       }
 }
 
@@ -195,7 +195,7 @@ function TerminalViewport({
 
   return (
     <div
-      className="relative h-full min-h-0 min-w-0 bg-black dark:bg-black"
+      className="relative h-full min-h-0 min-w-0 bg-background"
       onMouseDown={onFocus}
     >
       <div ref={mountRef} className="h-full w-full overflow-hidden" />

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -44,7 +44,7 @@ function terminalTheme() {
   const dark = document.documentElement.classList.contains("dark")
   return dark
     ? {
-        background: { r: 33, g: 33, b: 33 },
+        background: { r: 24, g: 24, b: 24 },
         foreground: { r: 229, g: 231, b: 235 },
         cursor: { r: 229, g: 231, b: 235 },
         selectionBackground: "rgba(147, 197, 253, 0.25)",
@@ -195,7 +195,7 @@ function TerminalViewport({
 
   return (
     <div
-      className="relative h-full min-h-0 min-w-0 bg-[#212121] dark:bg-[#212121]"
+      className="relative h-full min-h-0 min-w-0 bg-[#181818] dark:bg-[#181818]"
       onMouseDown={onFocus}
     >
       <div ref={mountRef} className="h-full w-full overflow-hidden" />

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -44,7 +44,7 @@ function terminalTheme() {
   const dark = document.documentElement.classList.contains("dark")
   return dark
     ? {
-        background: { r: 0, g: 0, b: 0 },
+        background: { r: 26, g: 26, b: 26 },
         foreground: { r: 229, g: 231, b: 235 },
         cursor: { r: 229, g: 231, b: 235 },
         selectionBackground: "rgba(147, 197, 253, 0.25)",
@@ -195,7 +195,7 @@ function TerminalViewport({
 
   return (
     <div
-      className="relative h-full min-h-0 min-w-0 bg-black dark:bg-black"
+      className="relative h-full min-h-0 min-w-0 bg-[#1a1a1a] dark:bg-[#1a1a1a]"
       onMouseDown={onFocus}
     >
       <div ref={mountRef} className="h-full w-full overflow-hidden" />

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -44,7 +44,7 @@ function terminalTheme() {
   const dark = document.documentElement.classList.contains("dark")
   return dark
     ? {
-        background: { r: 24, g: 24, b: 24 },
+        background: { r: 0, g: 0, b: 0 },
         foreground: { r: 229, g: 231, b: 235 },
         cursor: { r: 229, g: 231, b: 235 },
         selectionBackground: "rgba(147, 197, 253, 0.25)",
@@ -195,7 +195,7 @@ function TerminalViewport({
 
   return (
     <div
-      className="relative h-full min-h-0 min-w-0 bg-[#181818] dark:bg-[#181818]"
+      className="relative h-full min-h-0 min-w-0 bg-black dark:bg-black"
       onMouseDown={onFocus}
     >
       <div ref={mountRef} className="h-full w-full overflow-hidden" />

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -44,7 +44,7 @@ function terminalTheme() {
   const dark = document.documentElement.classList.contains("dark")
   return dark
     ? {
-        background: { r: 28, g: 28, b: 28 },
+        background: { r: 33, g: 33, b: 33 },
         foreground: { r: 229, g: 231, b: 235 },
         cursor: { r: 229, g: 231, b: 235 },
         selectionBackground: "rgba(147, 197, 253, 0.25)",
@@ -195,7 +195,7 @@ function TerminalViewport({
 
   return (
     <div
-      className="relative h-full min-h-0 min-w-0 bg-[#1c1c1c] dark:bg-[#1c1c1c]"
+      className="relative h-full min-h-0 min-w-0 bg-[#212121] dark:bg-[#212121]"
       onMouseDown={onFocus}
     >
       <div ref={mountRef} className="h-full w-full overflow-hidden" />

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -44,7 +44,7 @@ function terminalTheme() {
   const dark = document.documentElement.classList.contains("dark")
   return dark
     ? {
-        background: { r: 26, g: 26, b: 26 },
+        background: { r: 0, g: 0, b: 0 },
         foreground: { r: 229, g: 231, b: 235 },
         cursor: { r: 229, g: 231, b: 235 },
         selectionBackground: "rgba(147, 197, 253, 0.25)",
@@ -195,7 +195,7 @@ function TerminalViewport({
 
   return (
     <div
-      className="relative h-full min-h-0 min-w-0 bg-[#1a1a1a] dark:bg-[#1a1a1a]"
+      className="relative h-full min-h-0 min-w-0 bg-black dark:bg-black"
       onMouseDown={onFocus}
     >
       <div ref={mountRef} className="h-full w-full overflow-hidden" />

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -755,7 +755,7 @@ export const ChatComposer = memo(function ChatComposer({
 
       <div
         className={cn(
-          "relative z-10 flex flex-col rounded-2xl border-[0.75px] border-foreground/[0.06] bg-card px-3 py-2.5 shadow-[0_1px_2px_rgba(0,0,0,0.045)] transition-colors dark:shadow-none",
+          "relative z-10 flex flex-col rounded-2xl border-[0.75px] border-foreground/[0.06] bg-card px-3 py-2.5 shadow-[0_1px_2px_rgba(0,0,0,0.045)] transition-colors dark:bg-[#222] dark:shadow-none",
           compact ? "min-h-[88px]" : "min-h-[106px]",
           dragKind && "border border-primary"
         )}

--- a/ui/src/lib/ThemeSync.test.tsx
+++ b/ui/src/lib/ThemeSync.test.tsx
@@ -4,7 +4,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ThemeSync } from "./ThemeSync"
-import { useTheme } from "./theme"
+import { THEME_COLOR, useTheme } from "./theme"
+
+function themeColor() {
+  return document
+    .querySelector('meta[name="theme-color"]')
+    ?.getAttribute("content")
+}
 
 function ThemeControl() {
   const { setTheme } = useTheme()
@@ -29,12 +35,17 @@ describe("ThemeSync", () => {
       configurable: true,
       value: storage,
     })
+    const meta = document.createElement("meta")
+    meta.setAttribute("name", "theme-color")
+    meta.setAttribute("content", THEME_COLOR.light)
+    document.head.append(meta)
   })
 
   afterEach(() => {
     window.localStorage.clear()
     document.documentElement.classList.remove("dark")
     document.documentElement.style.colorScheme = ""
+    document.querySelector('meta[name="theme-color"]')?.remove()
     vi.restoreAllMocks()
   })
 
@@ -53,6 +64,7 @@ describe("ThemeSync", () => {
     await waitFor(() => {
       expect(document.documentElement.classList.contains("dark")).toBe(true)
       expect(document.documentElement.style.colorScheme).toBe("dark")
+      expect(themeColor()).toBe(THEME_COLOR.dark)
     })
   })
 
@@ -85,6 +97,7 @@ describe("ThemeSync", () => {
     await waitFor(() => {
       expect(document.documentElement.classList.contains("dark")).toBe(false)
       expect(document.documentElement.style.colorScheme).toBe("light")
+      expect(themeColor()).toBe(THEME_COLOR.light)
     })
   })
 })

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -32,11 +32,17 @@ export function resolveTheme(theme: Theme): ResolvedTheme {
   return theme
 }
 
+/** Browser chrome colour per resolved theme, mirroring `--background`. */
+export const THEME_COLOR = { light: "#fcfcfc", dark: "#0a0a0a" } as const
+
 function applyTheme(resolved: ResolvedTheme) {
   if (typeof document === "undefined") return
   const root = document.documentElement
   root.classList.toggle("dark", resolved === "dark")
   root.style.colorScheme = resolved
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", THEME_COLOR[resolved])
 }
 
 /**

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import type { QueryClient } from "@tanstack/react-query"
 import { AppCommandProvider } from "@/lib/appCommands"
 import { resolveSessionOnServer } from "@/lib/session-ssr"
 import { ThemeSync } from "@/lib/ThemeSync"
+import { THEME_COLOR } from "@/lib/theme"
 import { apiWarmupScript } from "@/features/agents/lib/apiWarmup"
 
 const themeInitScript = `(function(){try{var t=localStorage.getItem("open-swe-theme");var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);var r=document.documentElement;r.classList.toggle("dark",d);r.style.colorScheme=d?"dark":"light";}catch(e){}})();`
@@ -32,7 +33,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#fafafa" },
+      { name: "theme-color", content: THEME_COLOR.light },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#000000" },
+      { name: "theme-color", content: "#1a1a1a" },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#1a1a1a" },
+      { name: "theme-color", content: "#000000" },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#181818" },
+      { name: "theme-color", content: "#000000" },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#000000" },
+      { name: "theme-color", content: "#fafafa" },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#212121" },
+      { name: "theme-color", content: "#181818" },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{
         name: "viewport",
         content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
-      { name: "theme-color", content: "#1c1c1c" },
+      { name: "theme-color", content: "#212121" },
       { title: "Open SWE" },
     ],
     links: [

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -114,7 +114,6 @@
     --ring: oklch(0.708 0 0);
     --app-chrome-background: var(--background);
     --surface-raised: color-mix(in srgb, var(--card) 20%, transparent);
-    --surface-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
     /* Compact control geometry — keep semantic so chat controls, menus, and
        tooltips cannot quietly drift apart. */
     --control-radius: 0.5rem;
@@ -200,17 +199,6 @@
 
   .dark .dropdown-glass {
     box-shadow: 0 18px 44px -18px rgb(0 0 0 / 80%);
-  }
-
-  /*
-   * App-chrome grain, baked into the surface's own background rather than laid
-   * over the page: a fixed full-viewport overlay makes the compositor re-blend
-   * on every frame any animation produces. The 3.5% opacity lives in the SVG.
-   */
-  .surface-grain {
-    background-image: var(--surface-grain);
-    background-repeat: repeat;
-    background-size: 256px 256px;
   }
 }
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -142,7 +142,7 @@
 }
 
 .dark {
-    --background: oklch(0.218 0 0);
+    --background: oklch(0 0 0);
     --foreground: oklch(0.904 0 0);
     --card: oklch(0.248 0 0);
     --card-foreground: oklch(0.904 0 0);
@@ -172,7 +172,7 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0.248 0 0);
+    --sidebar: oklch(0.209 0 0);
     --sidebar-foreground: oklch(0.904 0 0);
     --sidebar-primary: oklch(0.946 0 0);
     --sidebar-primary-foreground: oklch(0.209 0 0);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -172,7 +172,7 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: var(--background);
+    --sidebar: oklch(0.209 0 0);
     --sidebar-foreground: oklch(0.904 0 0);
     --sidebar-primary: oklch(0.946 0 0);
     --sidebar-primary-foreground: oklch(0.209 0 0);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -142,7 +142,7 @@
 }
 
 .dark {
-    --background: oklch(0 0 0);
+    --background: oklch(0.218 0 0);
     --foreground: oklch(0.904 0 0);
     --card: oklch(0.248 0 0);
     --card-foreground: oklch(0.904 0 0);
@@ -172,7 +172,7 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0.209 0 0);
+    --sidebar: oklch(0.248 0 0);
     --sidebar-foreground: oklch(0.904 0 0);
     --sidebar-primary: oklch(0.946 0 0);
     --sidebar-primary-foreground: oklch(0.209 0 0);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -142,7 +142,7 @@
 }
 
 .dark {
-    --background: oklch(0.209 0 0);
+    --background: oklch(0 0 0);
     --foreground: oklch(0.904 0 0);
     --card: oklch(0.248 0 0);
     --card-foreground: oklch(0.904 0 0);
@@ -172,7 +172,7 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0 0 0);
+    --sidebar: var(--background);
     --sidebar-foreground: oklch(0.904 0 0);
     --sidebar-primary: oklch(0.946 0 0);
     --sidebar-primary-foreground: oklch(0.209 0 0);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -143,20 +143,20 @@
 }
 
 .dark {
-    --background: oklch(0.226 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.262 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.262 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.92 0 0);
-    --primary-foreground: oklch(0.21 0 0);
-    --secondary: oklch(0.31 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.31 0 0);
-    --muted-foreground: oklch(0.72 0 0);
-    --accent: oklch(0.31 0 0);
-    --accent-foreground: oklch(0.985 0 0);
+    --background: oklch(0.248 0 0);
+    --foreground: oklch(1 0 0);
+    --card: oklch(0.309 0 0);
+    --card-foreground: oklch(1 0 0);
+    --popover: oklch(0.309 0 0);
+    --popover-foreground: oklch(1 0 0);
+    --primary: oklch(0.946 0 0);
+    --primary-foreground: oklch(0.209 0 0);
+    --secondary: oklch(0.345 0 0);
+    --secondary-foreground: oklch(1 0 0);
+    --muted: oklch(0.345 0 0);
+    --muted-foreground: oklch(0.786 0 0);
+    --accent: oklch(0.345 0 0);
+    --accent-foreground: oklch(1 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.704 0.191 22.216);
     --success: oklch(0.696 0.17 162.48);
@@ -173,18 +173,18 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0.262 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.92 0 0);
-    --sidebar-primary-foreground: oklch(0.21 0 0);
-    --sidebar-accent: oklch(0.31 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar: oklch(0.209 0 0);
+    --sidebar-foreground: oklch(1 0 0);
+    --sidebar-primary: oklch(0.946 0 0);
+    --sidebar-primary-foreground: oklch(0.209 0 0);
+    --sidebar-accent: oklch(0.345 0 0);
+    --sidebar-accent-foreground: oklch(1 0 0);
     --sidebar-border: oklch(1 0 0 / 12%);
     --sidebar-ring: oklch(0.556 0 0);
-    --sidebar-control-surface: var(--accent);
-    --sidebar-row-hover: var(--accent);
-    --sidebar-row-active: var(--accent);
-    --sidebar-row-selected: var(--accent);
+    --sidebar-control-surface: oklch(1 0 0 / 6%);
+    --sidebar-row-hover: oklch(1 0 0 / 6%);
+    --sidebar-row-active: oklch(1 0 0 / 8%);
+    --sidebar-row-selected: oklch(1 0 0 / 10%);
 }
 
 @layer utilities {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -172,7 +172,7 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: var(--card);
+    --sidebar: oklch(0 0 0);
     --sidebar-foreground: oklch(0.97 0 0);
     --sidebar-primary: oklch(0.571 0.21 264);
     --sidebar-primary-foreground: oklch(1 0 0);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -87,20 +87,20 @@
 }
 
 :root {
-    --background: oklch(0.974 0.002 106);
-    --foreground: oklch(0.148 0 0);
-    --card: oklch(0.994 0.001 106);
-    --card-foreground: oklch(0.148 0 0);
-    --popover: oklch(0.994 0.001 106);
-    --popover-foreground: oklch(0.148 0 0);
-    --primary: oklch(0.21 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.95 0.002 106);
-    --secondary-foreground: oklch(0.21 0 0);
-    --muted: oklch(0.945 0.002 106);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.945 0.002 106);
-    --accent-foreground: oklch(0.21 0 0);
+    --background: oklch(0.992 0 0);
+    --foreground: oklch(0.274 0.006 286.033);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.274 0.006 286.033);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.274 0.006 286.033);
+    --primary: oklch(0.488 0.217 264);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.985 0 0);
+    --secondary-foreground: oklch(0.274 0.006 286.033);
+    --muted: oklch(0.985 0 0);
+    --muted-foreground: oklch(0.552 0.016 285.938);
+    --accent: oklch(0.967 0.001 286.375);
+    --accent-foreground: oklch(0.21 0.006 285.885);
     --destructive: oklch(0.577 0.245 27.325);
     --destructive-foreground: oklch(0.505 0.213 27.518);
     --success: oklch(0.696 0.17 162.48);
@@ -109,9 +109,9 @@
     --warning-foreground: oklch(0.555 0.163 48.998);
     --info: oklch(0.623 0.214 259.815);
     --info-foreground: oklch(0.488 0.243 264.376);
-    --border: oklch(0.906 0.003 106);
-    --input: oklch(0.906 0.003 106);
-    --ring: oklch(0.708 0 0);
+    --border: oklch(0.92 0.004 286.32);
+    --input: oklch(0.871 0.006 286.286);
+    --ring: oklch(0.488 0.217 264);
     --app-chrome-background: var(--background);
     --surface-raised: color-mix(in srgb, var(--card) 20%, transparent);
     /* Compact control geometry — keep semantic so chat controls, menus, and
@@ -126,14 +126,14 @@
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
     --radius: 0.625rem;
-    --sidebar: oklch(0.963 0.002 106);
-    --sidebar-foreground: oklch(0.148 0 0);
-    --sidebar-primary: oklch(0.21 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.945 0.002 106);
-    --sidebar-accent-foreground: oklch(0.21 0 0);
-    --sidebar-border: oklch(0.906 0.003 106);
-    --sidebar-ring: oklch(0.708 0 0);
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.274 0.006 286.033);
+    --sidebar-primary: oklch(0.488 0.217 264);
+    --sidebar-primary-foreground: oklch(1 0 0);
+    --sidebar-accent: oklch(0.967 0.001 286.375);
+    --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+    --sidebar-border: oklch(0.92 0.004 286.32);
+    --sidebar-ring: oklch(0.488 0.217 264);
     --sidebar-muted-foreground: var(--muted-foreground);
     --sidebar-control-surface: var(--accent);
     --sidebar-row-hover: var(--accent);
@@ -142,20 +142,20 @@
 }
 
 .dark {
-    --background: oklch(0 0 0);
-    --foreground: oklch(0.904 0 0);
-    --card: oklch(0.248 0 0);
-    --card-foreground: oklch(0.904 0 0);
-    --popover: oklch(0.277 0 0);
-    --popover-foreground: oklch(0.904 0 0);
-    --primary: oklch(0.946 0 0);
-    --primary-foreground: oklch(0.209 0 0);
-    --secondary: oklch(0.277 0 0);
-    --secondary-foreground: oklch(0.904 0 0);
-    --muted: oklch(0.277 0 0);
-    --muted-foreground: oklch(0.767 0 0);
-    --accent: oklch(0.309 0 0);
-    --accent-foreground: oklch(0.904 0 0);
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.97 0 0);
+    --card: color-mix(in srgb, var(--background) 97%, white);
+    --card-foreground: oklch(0.97 0 0);
+    --popover: color-mix(in srgb, var(--background) 97%, white);
+    --popover-foreground: oklch(0.97 0 0);
+    --primary: oklch(0.571 0.21 264);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(1 0 0 / 3%);
+    --secondary-foreground: oklch(0.97 0 0);
+    --muted: oklch(1 0 0 / 3%);
+    --muted-foreground: color-mix(in srgb, oklch(0.556 0 0) 90%, white);
+    --accent: oklch(1 0 0 / 4%);
+    --accent-foreground: oklch(0.97 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.704 0.191 22.216);
     --success: oklch(0.696 0.17 162.48);
@@ -164,26 +164,26 @@
     --warning-foreground: oklch(0.828 0.189 84.429);
     --info: oklch(0.623 0.214 259.815);
     --info-foreground: oklch(0.707 0.165 254.624);
-    --border: oklch(1 0 0 / 8%);
-    --input: oklch(1 0 0 / 16%);
-    --ring: oklch(0.556 0 0);
+    --border: oklch(1 0 0 / 6%);
+    --input: oklch(1 0 0 / 8%);
+    --ring: oklch(0.571 0.21 264);
     --chart-1: oklch(0.872 0 0);
     --chart-2: oklch(0.556 0 0);
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0.209 0 0);
-    --sidebar-foreground: oklch(0.904 0 0);
-    --sidebar-primary: oklch(0.946 0 0);
-    --sidebar-primary-foreground: oklch(0.209 0 0);
-    --sidebar-accent: oklch(0.309 0 0);
-    --sidebar-accent-foreground: oklch(0.904 0 0);
-    --sidebar-border: oklch(1 0 0 / 8%);
-    --sidebar-ring: oklch(0.556 0 0);
-    --sidebar-control-surface: oklch(1 0 0 / 5%);
-    --sidebar-row-hover: oklch(1 0 0 / 5%);
-    --sidebar-row-active: oklch(1 0 0 / 8%);
-    --sidebar-row-selected: oklch(1 0 0 / 10%);
+    --sidebar: var(--card);
+    --sidebar-foreground: oklch(0.97 0 0);
+    --sidebar-primary: oklch(0.571 0.21 264);
+    --sidebar-primary-foreground: oklch(1 0 0);
+    --sidebar-accent: oklch(1 0 0 / 4%);
+    --sidebar-accent-foreground: oklch(0.97 0 0);
+    --sidebar-border: oklch(1 0 0 / 6%);
+    --sidebar-ring: oklch(0.571 0.21 264);
+    --sidebar-control-surface: var(--muted);
+    --sidebar-row-hover: var(--accent);
+    --sidebar-row-active: var(--accent);
+    --sidebar-row-selected: var(--muted);
 }
 
 @layer utilities {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -143,20 +143,20 @@
 }
 
 .dark {
-    --background: oklch(0.248 0 0);
-    --foreground: oklch(1 0 0);
-    --card: oklch(0.309 0 0);
-    --card-foreground: oklch(1 0 0);
-    --popover: oklch(0.309 0 0);
-    --popover-foreground: oklch(1 0 0);
+    --background: oklch(0.209 0 0);
+    --foreground: oklch(0.904 0 0);
+    --card: oklch(0.248 0 0);
+    --card-foreground: oklch(0.904 0 0);
+    --popover: oklch(0.277 0 0);
+    --popover-foreground: oklch(0.904 0 0);
     --primary: oklch(0.946 0 0);
     --primary-foreground: oklch(0.209 0 0);
-    --secondary: oklch(0.345 0 0);
-    --secondary-foreground: oklch(1 0 0);
-    --muted: oklch(0.345 0 0);
-    --muted-foreground: oklch(0.786 0 0);
-    --accent: oklch(0.345 0 0);
-    --accent-foreground: oklch(1 0 0);
+    --secondary: oklch(0.277 0 0);
+    --secondary-foreground: oklch(0.904 0 0);
+    --muted: oklch(0.277 0 0);
+    --muted-foreground: oklch(0.767 0 0);
+    --accent: oklch(0.309 0 0);
+    --accent-foreground: oklch(0.904 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.704 0.191 22.216);
     --success: oklch(0.696 0.17 162.48);
@@ -165,7 +165,7 @@
     --warning-foreground: oklch(0.828 0.189 84.429);
     --info: oklch(0.623 0.214 259.815);
     --info-foreground: oklch(0.707 0.165 254.624);
-    --border: oklch(1 0 0 / 12%);
+    --border: oklch(1 0 0 / 8%);
     --input: oklch(1 0 0 / 16%);
     --ring: oklch(0.556 0 0);
     --chart-1: oklch(0.872 0 0);
@@ -173,16 +173,16 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0.209 0 0);
-    --sidebar-foreground: oklch(1 0 0);
+    --sidebar: oklch(0 0 0);
+    --sidebar-foreground: oklch(0.904 0 0);
     --sidebar-primary: oklch(0.946 0 0);
     --sidebar-primary-foreground: oklch(0.209 0 0);
-    --sidebar-accent: oklch(0.345 0 0);
-    --sidebar-accent-foreground: oklch(1 0 0);
-    --sidebar-border: oklch(1 0 0 / 12%);
+    --sidebar-accent: oklch(0.309 0 0);
+    --sidebar-accent-foreground: oklch(0.904 0 0);
+    --sidebar-border: oklch(1 0 0 / 8%);
     --sidebar-ring: oklch(0.556 0 0);
-    --sidebar-control-surface: oklch(1 0 0 / 6%);
-    --sidebar-row-hover: oklch(1 0 0 / 6%);
+    --sidebar-control-surface: oklch(1 0 0 / 5%);
+    --sidebar-row-hover: oklch(1 0 0 / 5%);
     --sidebar-row-active: oklch(1 0 0 / 8%);
     --sidebar-row-selected: oklch(1 0 0 / 10%);
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -172,7 +172,7 @@
     --chart-3: oklch(0.45 0 0);
     --chart-4: oklch(0.378 0 0);
     --chart-5: oklch(0.275 0 0);
-    --sidebar: oklch(0 0 0);
+    --sidebar: oklch(0.248 0 0);
     --sidebar-foreground: oklch(0.97 0 0);
     --sidebar-primary: oklch(0.571 0.21 264);
     --sidebar-primary-foreground: oklch(1 0 0);
@@ -192,7 +192,7 @@
    * content bleed through and made stacked panes (model picker submenu) unreadable.
    */
   .dropdown-glass {
-    background: var(--popover);
+    background: var(--dropdown-glass-background, var(--popover));
     border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
     box-shadow: 0 16px 40px -18px rgb(0 0 0 / 55%);
   }

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,9 +8,9 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
- * The dark neutrals follow Codex's `.electron-dark` layer — the desktop app
- * re-points its surface at a darker step than the Codex *web* tokens do: black
- * chrome under a #181818 content surface, elevated at #212121 / #282828.
+ * The dark neutrals follow Codex's `.electron-dark` layer: the desktop shell
+ * paints one flat black canvas (`background-surface-under`) for both chrome and
+ * content, and only lifts cards, menus and the composer off it.
  *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
@@ -75,7 +75,7 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: #181818; /* background-surface */
+  --background: #000; /* background-surface-under */
   --app-chrome-background: var(--background);
   --foreground: #dfdfdf;
   --card: #212121; /* background-elevated-secondary-opaque */
@@ -105,7 +105,7 @@ html.dark[data-agents-theme] {
   --input: color-mix(in srgb, #fff 16%, transparent);
   --ring: oklch(0.588 0.217 264);
 
-  --sidebar: #000; /* background-surface-under: chrome sits below the content surface */
+  --sidebar: var(--background);
   --sidebar-control-surface: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-hover: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -101,7 +101,7 @@ html.dark[data-agents-theme] {
   --input: color-mix(in srgb, #fff 8%, transparent);
   --ring: oklch(0.571 0.21 264);
 
-  --sidebar: var(--card);
+  --sidebar: #000;
   --sidebar-control-surface: var(--muted);
   --sidebar-row-hover: var(--accent);
   --sidebar-row-active: var(--accent);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,8 +8,9 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
- * The dark neutrals follow Codex's grey ramp (#181818 chrome / #212121 content
- * surface / #303030 elevated) so the two apps read the same side by side.
+ * The dark neutrals follow Codex's `.electron-dark` layer — the desktop app
+ * re-points its surface at a darker step than the Codex *web* tokens do: black
+ * chrome under a #181818 content surface, elevated at #212121 / #282828.
  *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
@@ -74,20 +75,20 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: #212121; /* surface */
+  --background: #181818; /* background-surface */
   --app-chrome-background: var(--background);
-  --foreground: #fff;
-  --card: #303030; /* surface-elevated */
+  --foreground: #dfdfdf;
+  --card: #212121; /* background-elevated-secondary-opaque */
   --card-foreground: var(--foreground);
   --surface-raised: var(--secondary);
-  --popover: #303030;
+  --popover: #282828; /* background-elevated-primary-opaque */
   --popover-foreground: var(--foreground);
   --primary: oklch(0.588 0.217 264);
   --primary-foreground: #fff;
-  --secondary: color-mix(in srgb, #fff 8%, transparent);
+  --secondary: color-mix(in srgb, #fff 5%, transparent);
   --secondary-foreground: var(--foreground);
-  --muted: color-mix(in srgb, #fff 8%, transparent);
-  --muted-foreground: oklch(78.6% 0 0);
+  --muted: color-mix(in srgb, #fff 5%, transparent);
+  --muted-foreground: color-mix(in srgb, #fff 70%, transparent);
   --accent: color-mix(in srgb, #fff 8%, transparent);
   --accent-foreground: var(--foreground);
   --destructive: color-mix(in srgb, oklch(63.7% 0.237 25.331) 90%, #fff);
@@ -100,13 +101,13 @@ html.dark[data-agents-theme] {
   --success-foreground: oklch(76.5% 0.177 163.223); /* emerald-400 */
   --warning: oklch(76.9% 0.188 70.08);
   --warning-foreground: oklch(82.8% 0.189 84.429); /* amber-400 */
-  --border: color-mix(in srgb, #fff 12%, transparent);
+  --border: color-mix(in srgb, #fff 8%, transparent);
   --input: color-mix(in srgb, #fff 16%, transparent);
   --ring: oklch(0.588 0.217 264);
 
-  --sidebar: #181818; /* surface-secondary: chrome sits below the content surface */
-  --sidebar-control-surface: color-mix(in srgb, #fff 6%, transparent);
-  --sidebar-row-hover: color-mix(in srgb, #fff 6%, transparent);
+  --sidebar: #000; /* background-surface-under: chrome sits below the content surface */
+  --sidebar-control-surface: color-mix(in srgb, #fff 5%, transparent);
+  --sidebar-row-hover: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);
   --sidebar-row-selected: color-mix(in srgb, #fff 10%, transparent);
   --sidebar-border: var(--border);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,10 +8,9 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
- * The dark neutrals follow Codex's `.electron-dark` layer. Codex itself paints
- * no canvas at all on macOS — it runs a transparent window over the native
- * `menu` vibrancy material — so `--background` is a solid stand-in for it, with
- * the sidebar, cards and menus lifted above it.
+ * The dark neutrals follow Codex's `.electron-dark` layer: the chat canvas is
+ * the black `background-surface-under`, the sidebar the `background-surface`
+ * above it, with cards, menus and the composer lifted further.
  *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
@@ -76,7 +75,7 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: #1a1a1a; /* stand-in for Codex's `menu` vibrancy material */
+  --background: #000; /* background-surface-under */
   --app-chrome-background: var(--background);
   --foreground: #dfdfdf;
   --card: #212121; /* background-elevated-secondary-opaque */
@@ -106,7 +105,7 @@ html.dark[data-agents-theme] {
   --input: color-mix(in srgb, #fff 16%, transparent);
   --ring: oklch(0.588 0.217 264);
 
-  --sidebar: #212121; /* background-elevated-secondary-opaque */
+  --sidebar: #181818; /* background-surface, one step above the canvas */
   --sidebar-control-surface: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-hover: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,9 +8,10 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
- * The dark neutrals follow Codex's `.electron-dark` layer: the chat canvas is
- * the black `background-surface-under`, the sidebar the `background-surface`
- * above it, with cards, menus and the composer lifted further.
+ * The dark neutrals follow Codex's `.electron-dark` layer. Codex itself paints
+ * no canvas at all on macOS — it runs a transparent window over the native
+ * `menu` vibrancy material — so `--background` is a solid stand-in for it, with
+ * the sidebar, cards and menus lifted above it.
  *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
@@ -75,7 +76,7 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: #000; /* background-surface-under */
+  --background: #1a1a1a; /* stand-in for Codex's `menu` vibrancy material */
   --app-chrome-background: var(--background);
   --foreground: #dfdfdf;
   --card: #212121; /* background-elevated-secondary-opaque */
@@ -105,7 +106,7 @@ html.dark[data-agents-theme] {
   --input: color-mix(in srgb, #fff 16%, transparent);
   --ring: oklch(0.588 0.217 264);
 
-  --sidebar: #181818; /* background-surface, one step above the canvas */
+  --sidebar: #212121; /* background-elevated-secondary-opaque */
   --sidebar-control-surface: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-hover: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,10 +8,6 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
- * The dark neutrals follow Codex's `.electron-dark` layer: the chat canvas is
- * the black `background-surface-under`, the sidebar the `background-surface`
- * above it, with cards, menus and the composer lifted further.
- *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
  *
@@ -25,21 +21,21 @@
 html[data-agents-theme] {
   color-scheme: light;
 
-  --background: oklch(97.4% 0.002 106); /* soft warm off-white */
+  --background: oklch(99.2% 0 0); /* zinc-25 */
   --app-chrome-background: var(--background);
   --foreground: oklch(27.4% 0.006 286.033); /* zinc-800 */
-  --card: oklch(99.3% 0.001 106);
+  --card: #fff;
   --card-foreground: var(--foreground);
   --surface-raised: color-mix(in srgb, var(--card) 20%, transparent);
-  --popover: oklch(99.3% 0.001 106);
+  --popover: #fff;
   --popover-foreground: var(--foreground);
   --primary: oklch(0.488 0.217 264);
   --primary-foreground: #fff;
-  --secondary: oklch(96.3% 0.002 106);
+  --secondary: oklch(98.5% 0 0); /* zinc-50 */
   --secondary-foreground: var(--foreground);
-  --muted: oklch(96.3% 0.002 106);
-  --muted-foreground: oklch(48% 0.016 285.938); /* zinc-600 */
-  --accent: oklch(94.2% 0.003 106);
+  --muted: oklch(98.5% 0 0); /* zinc-50 */
+  --muted-foreground: oklch(55.2% 0.016 285.938); /* zinc-500 */
+  --accent: oklch(96.7% 0.001 286.375); /* zinc-100 */
   --accent-foreground: oklch(21% 0.006 285.885); /* zinc-900 */
   --destructive: oklch(63.7% 0.237 25.331); /* red-500 */
   --destructive-foreground: oklch(50.5% 0.213 27.518); /* red-700 */
@@ -51,15 +47,15 @@ html[data-agents-theme] {
   --success-foreground: oklch(50.8% 0.118 165.612); /* emerald-700 */
   --warning: oklch(76.9% 0.188 70.08); /* amber-500 */
   --warning-foreground: oklch(55.5% 0.163 48.998); /* amber-700 */
-  --border: oklch(90.6% 0.003 106);
-  --input: oklch(86.5% 0.004 106);
+  --border: oklch(92% 0.004 286.32); /* zinc-200 */
+  --input: oklch(87.1% 0.006 286.286); /* zinc-300 */
   --ring: oklch(0.488 0.217 264);
 
-  --sidebar: oklch(96.3% 0.002 106);
+  --sidebar: oklch(98.5% 0 0); /* zinc-50 */
   --sidebar-foreground: var(--foreground);
   --sidebar-muted-foreground: var(--muted-foreground);
-  --sidebar-control-surface: oklch(94.2% 0.003 106);
-  --sidebar-row-hover: oklch(93.8% 0.003 106);
+  --sidebar-control-surface: oklch(96.7% 0.001 286.375); /* zinc-100 */
+  --sidebar-row-hover: oklch(99.2% 0 0); /* zinc-25 */
   --sidebar-row-active: var(--card);
   --sidebar-row-selected: var(--card);
   --sidebar-border: var(--border);
@@ -75,21 +71,21 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: #000; /* background-surface-under */
+  --background: oklch(14.5% 0 0); /* neutral-950 */
   --app-chrome-background: var(--background);
-  --foreground: #dfdfdf;
-  --card: #212121; /* background-elevated-secondary-opaque */
+  --foreground: oklch(97% 0 0); /* neutral-100 */
+  --card: color-mix(in srgb, var(--background) 97%, #fff);
   --card-foreground: var(--foreground);
-  --surface-raised: var(--secondary);
-  --popover: #282828; /* background-elevated-primary-opaque */
+  --surface-raised: var(--card);
+  --popover: var(--card);
   --popover-foreground: var(--foreground);
-  --primary: oklch(0.588 0.217 264);
+  --primary: oklch(0.571 0.21 264);
   --primary-foreground: #fff;
-  --secondary: color-mix(in srgb, #fff 5%, transparent);
+  --secondary: color-mix(in srgb, #fff 3%, transparent);
   --secondary-foreground: var(--foreground);
-  --muted: color-mix(in srgb, #fff 5%, transparent);
-  --muted-foreground: color-mix(in srgb, #fff 70%, transparent);
-  --accent: color-mix(in srgb, #fff 8%, transparent);
+  --muted: color-mix(in srgb, #fff 3%, transparent);
+  --muted-foreground: color-mix(in srgb, oklch(55.6% 0 0) 90%, #fff);
+  --accent: color-mix(in srgb, #fff 4%, transparent);
   --accent-foreground: var(--foreground);
   --destructive: color-mix(in srgb, oklch(63.7% 0.237 25.331) 90%, #fff);
   --destructive-foreground: oklch(70.4% 0.191 22.216); /* red-400 */
@@ -101,15 +97,15 @@ html.dark[data-agents-theme] {
   --success-foreground: oklch(76.5% 0.177 163.223); /* emerald-400 */
   --warning: oklch(76.9% 0.188 70.08);
   --warning-foreground: oklch(82.8% 0.189 84.429); /* amber-400 */
-  --border: color-mix(in srgb, #fff 8%, transparent);
-  --input: color-mix(in srgb, #fff 16%, transparent);
-  --ring: oklch(0.588 0.217 264);
+  --border: color-mix(in srgb, #fff 6%, transparent);
+  --input: color-mix(in srgb, #fff 8%, transparent);
+  --ring: oklch(0.571 0.21 264);
 
-  --sidebar: #181818; /* background-surface, one step above the canvas */
-  --sidebar-control-surface: color-mix(in srgb, #fff 5%, transparent);
-  --sidebar-row-hover: color-mix(in srgb, #fff 5%, transparent);
-  --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);
-  --sidebar-row-selected: color-mix(in srgb, #fff 10%, transparent);
+  --sidebar: var(--card);
+  --sidebar-control-surface: var(--muted);
+  --sidebar-row-hover: var(--accent);
+  --sidebar-row-active: var(--accent);
+  --sidebar-row-selected: var(--muted);
   --sidebar-border: var(--border);
 }
 

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,9 +8,9 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
- * The dark neutrals follow Codex's `.electron-dark` layer: the desktop shell
- * paints one flat black canvas (`background-surface-under`) for both chrome and
- * content, and only lifts cards, menus and the composer off it.
+ * The dark neutrals follow Codex's `.electron-dark` layer: the chat canvas is
+ * the black `background-surface-under`, the sidebar the `background-surface`
+ * above it, with cards, menus and the composer lifted further.
  *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
@@ -105,7 +105,7 @@ html.dark[data-agents-theme] {
   --input: color-mix(in srgb, #fff 16%, transparent);
   --ring: oklch(0.588 0.217 264);
 
-  --sidebar: var(--background);
+  --sidebar: #181818; /* background-surface, one step above the canvas */
   --sidebar-control-surface: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-hover: color-mix(in srgb, #fff 5%, transparent);
   --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -8,6 +8,9 @@
  * already styles itself with `bg-card` / `text-muted-foreground` / …, so one
  * block of values recolours the whole surface.
  *
+ * The dark neutrals follow Codex's grey ramp (#181818 chrome / #212121 content
+ * surface / #303030 elevated) so the two apps read the same side by side.
+ *
  * Colour stops are written as literals rather than `var(--color-zinc-200)`
  * because Tailwind tree-shakes unreferenced theme colours out of the build.
  *
@@ -71,21 +74,21 @@ html[data-agents-theme] {
 html.dark[data-agents-theme] {
   color-scheme: dark;
 
-  --background: oklch(22.6% 0 0); /* soft charcoal, not black */
+  --background: #212121; /* surface */
   --app-chrome-background: var(--background);
   --foreground: #fff;
-  --card: color-mix(in srgb, var(--background) 92%, #fff);
+  --card: #303030; /* surface-elevated */
   --card-foreground: var(--foreground);
   --surface-raised: var(--secondary);
-  --popover: color-mix(in srgb, var(--background) 88%, #fff);
+  --popover: #303030;
   --popover-foreground: var(--foreground);
   --primary: oklch(0.588 0.217 264);
   --primary-foreground: #fff;
-  --secondary: color-mix(in srgb, #fff 4%, transparent);
+  --secondary: color-mix(in srgb, #fff 8%, transparent);
   --secondary-foreground: var(--foreground);
-  --muted: color-mix(in srgb, #fff 4%, transparent);
-  --muted-foreground: oklch(85% 0 0);
-  --accent: color-mix(in srgb, #fff 4%, transparent);
+  --muted: color-mix(in srgb, #fff 8%, transparent);
+  --muted-foreground: oklch(78.6% 0 0);
+  --accent: color-mix(in srgb, #fff 8%, transparent);
   --accent-foreground: var(--foreground);
   --destructive: color-mix(in srgb, oklch(63.7% 0.237 25.331) 90%, #fff);
   --destructive-foreground: oklch(70.4% 0.191 22.216); /* red-400 */
@@ -97,15 +100,15 @@ html.dark[data-agents-theme] {
   --success-foreground: oklch(76.5% 0.177 163.223); /* emerald-400 */
   --warning: oklch(76.9% 0.188 70.08);
   --warning-foreground: oklch(82.8% 0.189 84.429); /* amber-400 */
-  --border: color-mix(in srgb, #fff 14%, transparent);
-  --input: color-mix(in srgb, #fff 12%, transparent);
+  --border: color-mix(in srgb, #fff 12%, transparent);
+  --input: color-mix(in srgb, #fff 16%, transparent);
   --ring: oklch(0.588 0.217 264);
 
-  --sidebar: var(--card);
-  --sidebar-control-surface: var(--muted);
-  --sidebar-row-hover: var(--accent);
-  --sidebar-row-active: var(--accent);
-  --sidebar-row-selected: var(--muted);
+  --sidebar: #181818; /* surface-secondary: chrome sits below the content surface */
+  --sidebar-control-surface: color-mix(in srgb, #fff 6%, transparent);
+  --sidebar-row-hover: color-mix(in srgb, #fff 6%, transparent);
+  --sidebar-row-active: color-mix(in srgb, #fff 8%, transparent);
+  --sidebar-row-selected: color-mix(in srgb, #fff 10%, transparent);
   --sidebar-border: var(--border);
 }
 

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -101,7 +101,7 @@ html.dark[data-agents-theme] {
   --input: color-mix(in srgb, #fff 8%, transparent);
   --ring: oklch(0.571 0.21 264);
 
-  --sidebar: #000;
+  --sidebar: #222; /* matches the composer surface */
   --sidebar-control-surface: var(--muted);
   --sidebar-row-hover: var(--accent);
   --sidebar-row-active: var(--accent);


### PR DESCRIPTION
- **Light theme:** zinc-25 canvas, zinc-50 sidebar and secondary surfaces, white cards and popovers, zinc-800 text, zinc-200 borders.
- **Dark theme:** neutral-950 chat canvas with a `#222` sidebar that matches the input composer, low-opacity white controls and borders, neutral-100 text.
- **Sidebar typography:** thread titles, nav items, and project folders go from 13px to 14px and render at full brightness by default; hover now only changes the row background, matching Codex.
- **Terminal and hover card** follow the same surfaces, and the `theme-color` meta tag now tracks the resolved theme instead of being hard-coded (covered by `ThemeSync` tests).

## Screenshots
### Dark
<img width="1442" height="901" alt="Screenshot 2026-09-03 at 4 32 41 PM" src="https://github.com/user-attachments/assets/d765bb54-9fc2-4651-8e57-5b0a3c250a8e" />

### Light
<img width="1443" height="903" alt="Screenshot 2026-09-03 at 4 32 28 PM" src="https://github.com/user-attachments/assets/cf734fab-cdf3-466f-b392-0c4e60ce0860" />
