### PR TITLE
fix(desktop): stop the activity poll from pulling full thread state

### DIFF
--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -318,7 +318,13 @@ class BackendSupervisor {
             authorization: `Bearer ${this.token}`,
             "content-type": "application/json",
           },
-          body: JSON.stringify({ limit: 1_000 }),
+          // Polled every second: without `select` the backend serializes every
+          // thread's whole state — the full message history — on the same event
+          // loop that is streaming the running agent's output.
+          body: JSON.stringify({
+            limit: 1_000,
+            select: ["thread_id", "status"],
+          }),
           signal: AbortSignal.timeout(2_000),
         },
       );


### PR DESCRIPTION
`BackendSupervisor.threadActivity()` runs every second (UI activity poll, plus every diff/branch/workspace check) and searched `/threads/search` with no `select`. The local LangGraph server therefore serialized each thread's full `values` — the entire message history and `files` channel — on the same event loop that is streaming the running agent, so the response grows with the conversation and the stream stalls in bursts. Only `thread_id` and `status` are used.

Cloud threads have no equivalent poll, which is why they stay smooth.

Made by [Open SWE](https://openswe.vercel.app/agents/01a0641a-9e38-72e8-a4b4-03651fd69757)