### PR TITLE
fix: support the default root sandbox snapshot

### DIFF
--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -772,15 +772,16 @@ class LangSmithProvider(SandboxProvider):
                 sandbox = await _reuse_existing_sandbox(client, sandbox_id)
                 return TimeoutLangSmithSandbox(sandbox.to_sync())
 
+            effective_snapshot_id = snapshot_id or ""
             extra_fields = _merge_sandbox_create_extra_fields(create_params)
-            if snapshot_id == "":
+            if not effective_snapshot_id:
                 extra_fields["snapshot_id"] = ""
             _install_create_extra_fields(client, extra_fields)
 
             try:
                 sandbox = await _create_sandbox_with_retry(
                     client,
-                    snapshot_id=snapshot_id,
+                    snapshot_id=effective_snapshot_id,
                     fs_capacity_bytes=fs_capacity_bytes,
                     vcpus=vcpus,
                     mem_bytes=mem_bytes,

--- a/agent/integrations/langsmith.py
+++ b/agent/integrations/langsmith.py
@@ -528,7 +528,7 @@ async def create_langsmith_sandbox(
         github_token: Optional GitHub token. Used to configure proxy auth on
                       new sandboxes. Ignored when connecting to an existing sandbox.
         snapshot_id: Optional repo-scoped snapshot to boot from. When omitted,
-            falls back to DEFAULT_SANDBOX_SNAPSHOT_ID.
+            uses DEFAULT_SANDBOX_SNAPSHOT_ID or the API's root snapshot.
         mem_bytes: Optional memory capacity override for a newly-created sandbox.
         vcpus: Optional virtual CPU count override for a newly-created sandbox.
         fs_capacity_bytes: Optional filesystem capacity override for a newly-created sandbox.
@@ -547,7 +547,7 @@ async def create_langsmith_sandbox(
         delete_after_stop_seconds,
     ) = _get_sandbox_snapshot_config()
 
-    effective_snapshot_id = snapshot_id or default_snapshot_id
+    effective_snapshot_id = snapshot_id or default_snapshot_id or ""
     if mem_bytes is None and vcpus is None:
         effective_mem_bytes = default_mem_bytes
         effective_vcpus = default_vcpus
@@ -714,13 +714,6 @@ class LangSmithProvider(SandboxProvider):
     @classmethod
     def validate_startup_config(cls) -> None:
         """Validate env-var configuration at server startup. Raises ValueError if invalid."""
-        if not os.environ.get("DEFAULT_SANDBOX_SNAPSHOT_ID"):
-            # Not fatal: an admin can set the base snapshot at runtime from the
-            # dashboard, which is stored outside the environment.
-            logger.warning(
-                "DEFAULT_SANDBOX_SNAPSHOT_ID is not set; sandbox creation will fail until a "
-                "base snapshot is configured in admin settings"
-            )
         for name in (
             "DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES",
             "DEFAULT_SANDBOX_VCPUS",
@@ -779,17 +772,10 @@ class LangSmithProvider(SandboxProvider):
                 sandbox = await _reuse_existing_sandbox(client, sandbox_id)
                 return TimeoutLangSmithSandbox(sandbox.to_sync())
 
-            if not snapshot_id:
-                msg = (
-                    "No base snapshot configured: set it in admin settings or via "
-                    "DEFAULT_SANDBOX_SNAPSHOT_ID"
-                )
-                raise ValueError(msg)
-
-            _install_create_extra_fields(
-                client,
-                _merge_sandbox_create_extra_fields(create_params),
-            )
+            extra_fields = _merge_sandbox_create_extra_fields(create_params)
+            if snapshot_id == "":
+                extra_fields["snapshot_id"] = ""
+            _install_create_extra_fields(client, extra_fields)
 
             try:
                 sandbox = await _create_sandbox_with_retry(

--- a/agent/sandboxes/providers.py
+++ b/agent/sandboxes/providers.py
@@ -64,7 +64,7 @@ async def create_sandbox(
         sandbox_id: Optional existing sandbox ID to reconnect to.
         snapshot_id: Optional snapshot to boot a new sandbox from. Only the
             langsmith provider honors this; others ignore it. When omitted the
-            langsmith provider falls back to DEFAULT_SANDBOX_SNAPSHOT_ID.
+            langsmith provider uses DEFAULT_SANDBOX_SNAPSHOT_ID or its root snapshot.
         mem_bytes: Optional memory capacity override for a new LangSmith sandbox.
         vcpus: Optional virtual CPU count override for a new LangSmith sandbox.
         fs_capacity_bytes: Optional filesystem capacity override for a new LangSmith sandbox.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -33,7 +33,7 @@ By default, Open SWE runs each task in a [LangSmith cloud sandbox](https://docs.
 Build a snapshot in LangSmith (UI or `SandboxClient.create_snapshot`) from your Docker image and point Open SWE at its UUID:
 
 ```bash
-DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"                      # Required unless an admin sets the base snapshot at runtime
+DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"                      # Optional; defaults to LangSmith's root snapshot
 DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES="137438953472"          # Optional, default 128 GiB
 DEFAULT_SANDBOX_VCPUS="4"                                          # Optional, default 4
 DEFAULT_SANDBOX_MEM_BYTES="17179869184"                            # Optional, default 16 GiB

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -199,7 +199,7 @@ DEFAULT_SANDBOX_IDLE_TTL_SECONDS="7200"
 DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="2592000"
 ```
 
-A base snapshot is required when `SANDBOX_TYPE=langsmith` — either `DEFAULT_SANDBOX_SNAPSHOT_ID` or the runtime setting described below. The server logs a warning at startup when neither the env var nor a stored setting is present, and sandbox creation fails until one is. The snapshot must include the GitHub CLI; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
+`DEFAULT_SANDBOX_SNAPSHOT_ID` is optional when `SANDBOX_TYPE=langsmith`. When no selected environment snapshot, admin setting, or environment variable supplies one, LangSmith's root snapshot is used. Custom snapshots must include the GitHub CLI; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
 
 ### Environments
 
@@ -566,7 +566,7 @@ PUBLIC_REPO_ORG_GATE=""
 # === Sandbox (optional) ===
 # Provider: langsmith (default), modal, daytona, runloop, e2b, or local. See CUSTOMIZATION.md.
 SANDBOX_TYPE="langsmith"
-DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Required when SANDBOX_TYPE=langsmith unless set at runtime by an admin (see step 4c)
+DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Optional custom base snapshot; defaults to LangSmith's root snapshot
 DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES=""  # Root FS size in bytes (default: 128 GiB)
 DEFAULT_SANDBOX_VCPUS=""               # vCPUs per sandbox (default: 4)
 DEFAULT_SANDBOX_MEM_BYTES=""           # Memory in bytes per sandbox (default: 16 GiB)
@@ -786,7 +786,7 @@ Alternatively, you can have the browser call the backend cross-origin: set `VITE
 
 - Verify `LANGSMITH_API_KEY_PROD` is set and valid
 - Check LangSmith sandbox quotas in your workspace settings
-- If sandbox creation fails with `No base snapshot configured`, build a snapshot (see step 4c) and either export its UUID as `DEFAULT_SANDBOX_SNAPSHOT_ID` or set it as the base snapshot on the admin **Sandbox** page
+- If a custom sandbox snapshot fails to boot, verify that its UUID belongs to the workspace selected by the sandbox LangSmith credentials
 - If you see `Failed to create sandbox from snapshot '<id>'`, confirm the snapshot exists in your workspace and has status `ready`
 - If you get a 403 Forbidden error on the sandbox endpoints, your LangSmith workspace may not have sandbox access enabled — contact LangSmith support
 

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -121,6 +121,23 @@ async def test_create_langsmith_sandbox_prefers_resource_overrides() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_langsmith_sandbox_uses_root_snapshot_when_unset() -> None:
+    provider = MagicMock()
+    provider.get_or_create = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            "agent.integrations.langsmith._get_sandbox_snapshot_config",
+            return_value=(None, 100, 2, 200, 300, 400),
+        ),
+        patch("agent.integrations.langsmith.LangSmithProvider", return_value=provider),
+    ):
+        await create_langsmith_sandbox()
+
+    assert provider.get_or_create.await_args is not None
+    assert provider.get_or_create.await_args.kwargs["snapshot_id"] == ""
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("overrides", "expected_vcpus", "expected_mem_bytes"),
     [
@@ -221,6 +238,30 @@ class _FakeSandboxClient:
         if self.calls <= self.failures:
             raise _RetryableCreateError("try again")
         return {"sandbox": kwargs["snapshot_id"]}
+
+
+@pytest.mark.asyncio
+async def test_provider_passes_empty_snapshot_id_to_api() -> None:
+    sandbox = MagicMock()
+    sandbox.to_sync.return_value = MagicMock()
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("agent.integrations.langsmith.AsyncSandboxClient", return_value=client),
+        patch("agent.integrations.langsmith._install_create_extra_fields") as install,
+        patch(
+            "agent.integrations.langsmith._create_sandbox_with_retry",
+            new_callable=AsyncMock,
+            return_value=sandbox,
+        ) as create,
+    ):
+        await LangSmithProvider(api_key="key").get_or_create(snapshot_id="")
+
+    install.assert_called_once_with(client, {"snapshot_id": ""})
+    assert create.await_args is not None
+    assert create.await_args.kwargs["snapshot_id"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -241,7 +241,8 @@ class _FakeSandboxClient:
 
 
 @pytest.mark.asyncio
-async def test_provider_passes_empty_snapshot_id_to_api() -> None:
+@pytest.mark.parametrize("snapshot_id", [None, ""])
+async def test_provider_passes_empty_snapshot_id_to_api(snapshot_id: str | None) -> None:
     client = AsyncSandboxClient(api_key="key", api_endpoint="https://example.com/v2/sandboxes")
     response = MagicMock()
     response.raise_for_status.return_value = None
@@ -250,7 +251,7 @@ async def test_provider_passes_empty_snapshot_id_to_api() -> None:
     client._http.post = post
 
     with patch("agent.integrations.langsmith.AsyncSandboxClient", return_value=client):
-        await LangSmithProvider(api_key="key").get_or_create(snapshot_id="")
+        await LangSmithProvider(api_key="key").get_or_create(snapshot_id=snapshot_id)
 
     assert post.await_args is not None
     assert post.await_args.kwargs["json"]["snapshot_id"] == ""

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -242,26 +242,18 @@ class _FakeSandboxClient:
 
 @pytest.mark.asyncio
 async def test_provider_passes_empty_snapshot_id_to_api() -> None:
-    sandbox = MagicMock()
-    sandbox.to_sync.return_value = MagicMock()
-    client = MagicMock()
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
+    client = AsyncSandboxClient(api_key="key", api_endpoint="https://example.com/v2/sandboxes")
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"name": "sandbox-new", "status": "ready"}
+    post = AsyncMock(return_value=response)
+    client._http.post = post
 
-    with (
-        patch("agent.integrations.langsmith.AsyncSandboxClient", return_value=client),
-        patch("agent.integrations.langsmith._install_create_extra_fields") as install,
-        patch(
-            "agent.integrations.langsmith._create_sandbox_with_retry",
-            new_callable=AsyncMock,
-            return_value=sandbox,
-        ) as create,
-    ):
+    with patch("agent.integrations.langsmith.AsyncSandboxClient", return_value=client):
         await LangSmithProvider(api_key="key").get_or_create(snapshot_id="")
 
-    install.assert_called_once_with(client, {"snapshot_id": ""})
-    assert create.await_args is not None
-    assert create.await_args.kwargs["snapshot_id"] == ""
+    assert post.await_args is not None
+    assert post.await_args.kwargs["json"]["snapshot_id"] == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

- pass an empty snapshot ID through to the LangSmith Sandbox API when no admin or environment snapshot is configured
- remove the obsolete startup warning and creation error that required a configured base snapshot
- preserve configured snapshot precedence and add focused root-snapshot coverage

### Testing

- `make format`
- `make lint`
- `uv run pytest -q tests/sandbox/test_langsmith_sandbox_config.py tests/sandbox/test_sandbox_settings.py tests/agent/test_admin_environments.py` (50 passed)

Made by [Open SWE](https://openswe.vercel.app/agents/cd55ad0b-d599-5e72-9ccc-6cea9c018f3c)