### PR TITLE
feat: classify run failures and say why in the failure reply

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -28,6 +28,7 @@ from agent.slack.client import post_slack_thread_reply
 from agent.slack.code_channels import is_code_channel_session, set_session_status
 from agent.source_context import SourceContext
 from agent.utils.dashboard_links import dashboard_thread_url
+from agent.utils.errors import LAST_MODEL_ERROR_KEY, code_for_error_type
 from agent.utils.thread_ops import langgraph_client
 from agent.utils.user_messages import warning
 
@@ -70,20 +71,57 @@ def verify_run_complete_token(token: str | None) -> bool:
     return token is not None and hmac.compare_digest(token, secret)
 
 
-def _failure_text(status: str, dashboard_url: str | None = None) -> str:
-    if status == "timeout":
-        reason = "timed out"
-    elif status == "interrupted":
-        reason = "was interrupted before it could finish"
-    else:
-        reason = "hit an unexpected error"
-    text = warning(
-        f"Open SWE wasn't able to finish that — the run {reason}. "
-        "Send another message and it will pick this back up."
-    )
+_REASON_TEXT = {
+    "provider_overloaded": "the model provider was overloaded and never recovered",
+    "provider_rate_limited": "the model provider rate-limited it",
+    "provider_unavailable": "the model provider kept returning errors",
+    "provider_timeout": "a model call timed out",
+    "context_too_long": "the conversation outgrew the model's context window",
+    "model_unavailable": "the selected model isn't available to this workspace",
+    "sandbox_unreachable": "the run lost its sandbox",
+    "step_limit": "the run hit its step limit",
+}
+_DEFAULT_FOLLOW_UP = "Send another message and it will pick this back up."
+_REASON_FOLLOW_UP = {
+    "context_too_long": "Start a new thread to continue.",
+    "model_unavailable": "Pick a different model in Open SWE Web, then retry.",
+}
+
+
+def _failure_text(
+    status: str, dashboard_url: str | None = None, reason_code: str | None = None
+) -> str:
+    reason = _REASON_TEXT.get(reason_code or "")
+    if reason is None:
+        if status == "timeout":
+            reason = "the run timed out"
+        elif status == "interrupted":
+            reason = "the run was interrupted before it could finish"
+        else:
+            reason = "the run hit an unexpected error"
+    follow_up = _REASON_FOLLOW_UP.get(reason_code or "", _DEFAULT_FOLLOW_UP)
+    text = warning(f"Open SWE wasn't able to finish that — {reason}. {follow_up}")
     if dashboard_url:
         text += f" You can view the error in <{dashboard_url}|Open SWE Web>."
     return text
+
+
+def _failure_reason_code(error: Any, metadata: dict[str, Any], run_id: str | None) -> str | None:
+    """Classify the failure, preferring the in-run record over the class name alone.
+
+    The recorded classification is only trusted when it names the same exception
+    the run actually died with — a run can log a transient error, recover from it,
+    and then fail for an unrelated reason.
+    """
+    error_type = error.get("error") if isinstance(error, dict) else None
+    error_type = error_type if isinstance(error_type, str) else None
+    recorded = metadata.get(LAST_MODEL_ERROR_KEY)
+    if isinstance(recorded, dict) and recorded.get("error_type") == error_type:
+        recorded_run = recorded.get("run_id")
+        code = recorded.get("code")
+        if isinstance(code, str) and (recorded_run is None or recorded_run == run_id):
+            return code
+    return code_for_error_type(error_type)
 
 
 async def _settle_failed_reviewer_check(thread_id: str, metadata: dict[str, Any]) -> None:
@@ -135,16 +173,18 @@ async def _settle_failed_reviewer_check(thread_id: str, metadata: dict[str, Any]
         )
 
 
-async def _post_failure_reply(thread_id: str, metadata: dict[str, Any], status: str) -> bool:
+async def _post_failure_reply(
+    thread_id: str, metadata: dict[str, Any], status: str, reason_code: str | None = None
+) -> bool:
     """Post a failure reply to the run's originating channel. Best-effort."""
     source = metadata.get("source")
     ctx = SourceContext.from_metadata(metadata)
-    text = _failure_text(status)
+    text = _failure_text(status, reason_code=reason_code)
 
     if source == "slack" or ctx.slack_thread is not None:
         location = ctx.slack_location
         if location is not None:
-            slack_text = _failure_text(status, dashboard_thread_url(thread_id))
+            slack_text = _failure_text(status, dashboard_thread_url(thread_id), reason_code)
             return await post_slack_thread_reply(
                 location[0], location[1], slack_text, agent_thread_id=thread_id
             )
@@ -310,6 +350,27 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     if status not in _TERMINAL_FAILURE_STATUSES:
         return {"status": "ignored", "reason": f"non-failure status: {status}"}
 
+    error = payload.get("error")
+    # The platform serializes the exception (class name, and the message when its
+    # type is allowlisted) — there is no traceback to attach on this side.
+    error_attributes = (
+        {"error": {"kind": error.get("error"), "message": error.get("message")}}
+        if isinstance(error, dict)
+        else {}
+    )
+    logger.error(
+        "Run failed",
+        extra={
+            **error_attributes,
+            "run_failure": {
+                "run_id": run_id,
+                "thread_id": thread_id,
+                "status": status,
+                "error": error,
+            },
+        },
+    )
+
     client = langgraph_client()
     try:
         thread = await client.threads.get(thread_id)
@@ -329,7 +390,8 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     elif run_id in _posted_failure_run_ids(metadata):
         return {"status": "ignored", "reason": "failure reply already posted for run"}
 
-    posted = await _post_failure_reply(thread_id, metadata, status)
+    reason_code = _failure_reason_code(error, metadata, run_id)
+    posted = await _post_failure_reply(thread_id, metadata, status, reason_code)
     if not posted:
         return {"status": "ignored", "reason": "no reply posted"}
 
@@ -340,5 +402,8 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
         )
     except Exception:  # noqa: BLE001
         logger.warning("run-complete: could not flag thread %s", thread_id, exc_info=True)
-    logger.info("Posted failure reply for thread %s (status=%s)", thread_id, status)
+    logger.info(
+        "Posted failure reply",
+        extra={"failure_reply": {"thread_id": thread_id, "status": status, "code": reason_code}},
+    )
     return {"status": "ok", "reason": "failure reply posted"}

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -8,6 +8,7 @@ _MIDDLEWARE_MODULES = {
     "IntegrationGroup": ".dynamic_tools",
     "ExcludeToolsMiddleware": ".exclude_tools",
     "ModelCallTimeoutMiddleware": ".model_call_timeout",
+    "ModelErrorMiddleware": ".model_errors",
     "ModelFallbackMiddleware": ".model_fallback",
     "notify_step_limit_reached": ".notify_step_limit",
     "PlanModeMiddleware": ".plan_mode",
@@ -35,6 +36,7 @@ __all__ = [
     "ExcludeToolsMiddleware",
     "IntegrationGroup",
     "ModelCallTimeoutMiddleware",
+    "ModelErrorMiddleware",
     "ModelFallbackMiddleware",
     "BasePrepareRunMiddleware",
     "PlanModeMiddleware",
@@ -63,6 +65,7 @@ if TYPE_CHECKING:
     from agent.middleware.dynamic_tools import DynamicToolMiddleware, IntegrationGroup
     from agent.middleware.exclude_tools import ExcludeToolsMiddleware
     from agent.middleware.model_call_timeout import ModelCallTimeoutMiddleware
+    from agent.middleware.model_errors import ModelErrorMiddleware
     from agent.middleware.model_fallback import ModelFallbackMiddleware
     from agent.middleware.notify_step_limit import notify_step_limit_reached
     from agent.middleware.plan_mode import PlanModeMiddleware

--- a/agent/middleware/model_errors.py
+++ b/agent/middleware/model_errors.py
@@ -1,0 +1,95 @@
+"""Observability for failed model calls: full logs, plus a reason the reply can use.
+
+``ModelFallbackMiddleware`` is only attached when a fallback model is configured,
+and it logs exception class names rather than provider bodies — so a model error
+can end a run leaving nothing behind but the platform's own traceback.
+
+The run-completion webhook only ever sees the exception's class name (the platform
+scrubs the message of any type outside its allowlist), so the classification that
+distinguishes "provider overloaded" from every other ``APIError`` has to be made
+here, while the exception is intact, and left on the thread for the reply to read.
+"""
+
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langgraph.config import get_config
+from langgraph_sdk import get_client
+
+from agent.utils.errors import (
+    LAST_MODEL_ERROR_KEY,
+    classify_exception,
+    error_tracking_fields,
+    exception_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _model_name(model: Any) -> str:
+    return getattr(model, "model_name", None) or getattr(model, "model", None) or "unknown"
+
+
+def _run_context() -> tuple[str | None, str | None]:
+    try:
+        config = get_config()
+    except Exception:  # noqa: BLE001
+        return None, None
+    if not isinstance(config, Mapping):
+        return None, None
+    configurable = config.get("configurable")
+    configurable = configurable if isinstance(configurable, Mapping) else {}
+    thread_id = configurable.get("thread_id")
+    run_id = config.get("run_id") or configurable.get("run_id")
+    return (
+        thread_id if isinstance(thread_id, str) and thread_id else None,
+        str(run_id) if run_id else None,
+    )
+
+
+class ModelErrorMiddleware(AgentMiddleware):
+    """Log a model-call exception in full and record why, then re-raise it unchanged."""
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        try:
+            return await handler(request)
+        except Exception as exc:
+            model = _model_name(request.model)
+            fields = exception_fields(exc)
+            code = classify_exception(exc)
+            logger.exception(
+                "Model call failed",
+                extra={
+                    **error_tracking_fields(exc),
+                    "model_call_failure": {"model": model, "code": code, **fields},
+                },
+            )
+            await _record_model_error(exc, code)
+            raise
+
+
+async def _record_model_error(exc: BaseException, code: str | None) -> None:
+    """Leave the classification on the thread for the run-completion reply."""
+    thread_id, run_id = _run_context()
+    if thread_id is None or code is None:
+        return
+    try:
+        await get_client().threads.update(
+            thread_id=thread_id,
+            metadata={
+                LAST_MODEL_ERROR_KEY: {
+                    "run_id": run_id,
+                    "error_type": type(exc).__name__,
+                    "code": code,
+                }
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to record model error for thread %s", thread_id)

--- a/agent/middleware/model_fallback.py
+++ b/agent/middleware/model_fallback.py
@@ -39,6 +39,8 @@ from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 
+from agent.utils.errors import error_tracking_fields, exception_fields
+
 logger = logging.getLogger(__name__)
 
 _RETRYABLE_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504, 529}
@@ -177,9 +179,13 @@ class ModelFallbackMiddleware(AgentMiddleware):
             try:
                 return await handler(attempt_request)
             except Exception as exc:
+                fields = exception_fields(exc)
                 access_error_message = _provider_access_error_message(exc)
                 if access_error_message is not None:
-                    logger.warning("Model access error surfaced to user: %s", type(exc).__name__)
+                    logger.warning(
+                        "Model access error surfaced to user",
+                        extra={**error_tracking_fields(exc), "model_access_error": fields},
+                    )
                     return AIMessage(content=access_error_message)
                 if not _should_fallback(exc):
                     raise
@@ -189,25 +195,39 @@ class ModelFallbackMiddleware(AgentMiddleware):
                 delay = self._backoff_schedule[attempt]
                 if delay > 0:
                     delay += random.uniform(0, delay * 0.25)
+                failed_on = "fallback" if use_fallback else "primary"
+                retry_with = "primary" if use_fallback else "fallback"
                 logger.warning(
-                    "Model call failed transiently (%s) on %s model "
-                    "(attempt %d/%d); retrying %s model in %.1fs",
-                    type(exc).__name__,
-                    "fallback" if use_fallback else "primary",
-                    attempt + 1,
-                    total_attempts,
-                    "primary" if use_fallback else f"fallback ({self._fallback_name()})",
-                    delay,
+                    "Model call failed transiently; retrying",
+                    extra={
+                        **error_tracking_fields(exc),
+                        "model_call_retry": {
+                            "failed_on": failed_on,
+                            "attempt": attempt + 1,
+                            "attempts": total_attempts,
+                            "retry_with": retry_with,
+                            "fallback_model": self._fallback_name(),
+                            "delay_seconds": delay,
+                            **fields,
+                        },
+                    },
                 )
                 if delay > 0:
                     await asyncio.sleep(delay)
 
         assert last_exc is not None  # loop always sets it before breaking
+        last_fields = exception_fields(last_exc)
         logger.error(
-            "Model call failed after %d attempts across primary and fallback (%s): %s",
-            total_attempts,
-            self._fallback_name(),
-            last_exc,
+            "Model call failed after retries across primary and fallback",
+            exc_info=last_exc,
+            extra={
+                **error_tracking_fields(last_exc),
+                "model_call_failure": {
+                    "attempts": total_attempts,
+                    "fallback_model": self._fallback_name(),
+                    **last_fields,
+                },
+            },
         )
         if self._surface_outage_message:
             return AIMessage(content=MODEL_OUTAGE_MESSAGE)

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -52,6 +52,7 @@ from agent.github.thread_token import cache_github_token_for_thread
 from agent.middleware import (
     BasePrepareRunMiddleware,
     ModelCallTimeoutMiddleware,
+    ModelErrorMiddleware,
     RepairOrphanedToolCallsMiddleware,
     SanitizeFireworksMessagesMiddleware,
     SanitizeOpenAIResponsesMiddleware,
@@ -363,7 +364,11 @@ def _reviewer_subagent(model: BaseChatModel) -> SubAgent:
         # middleware never wraps their model calls.
         "middleware": cast(
             list[AgentMiddleware[Any, Any, Any]],
-            [SanitizeOpenAIResponsesMiddleware(), ModelCallTimeoutMiddleware()],
+            [
+                SanitizeOpenAIResponsesMiddleware(),
+                ModelErrorMiddleware(),
+                ModelCallTimeoutMiddleware(),
+            ],
         ),
     }
 
@@ -1433,6 +1438,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
                 SanitizeThinkingBlocksMiddleware(),
                 RepairOrphanedToolCallsMiddleware(),
                 StableToolResultOrderMiddleware(),
+                ModelErrorMiddleware(),
                 ModelCallTimeoutMiddleware(),
                 settle_review_check_on_exit,
             ],

--- a/agent/server.py
+++ b/agent/server.py
@@ -89,6 +89,7 @@ from agent.middleware import (
     ExcludeToolsMiddleware,
     IntegrationGroup,
     ModelCallTimeoutMiddleware,
+    ModelErrorMiddleware,
     ModelFallbackMiddleware,
     PlanModeMiddleware,
     PullRequestCreationGuardMiddleware,
@@ -380,7 +381,11 @@ def _subagent_model_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
     """
     return cast(
         list[AgentMiddleware[Any, Any, Any]],
-        [SanitizeOpenAIResponsesMiddleware(), ModelCallTimeoutMiddleware()],
+        [
+            SanitizeOpenAIResponsesMiddleware(),
+            ModelErrorMiddleware(),
+            ModelCallTimeoutMiddleware(),
+        ],
     )
 
 
@@ -1341,6 +1346,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 SanitizeOpenAIResponsesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),
                 StableToolResultOrderMiddleware(),
+                ModelErrorMiddleware(),
                 # Innermost, so the deadline covers the provider call itself and a
                 # timeout escalates outward to the fallback model.
                 ModelCallTimeoutMiddleware(),

--- a/agent/utils/errors.py
+++ b/agent/utils/errors.py
@@ -1,0 +1,114 @@
+"""Structured detail and coarse classification for provider exceptions."""
+
+import json
+import traceback
+from typing import Any
+
+_MAX_BODY_CHARS = 2000
+
+# Thread-metadata key holding the classification of the run's last model error,
+# written while the exception is intact and read back by the completion webhook.
+LAST_MODEL_ERROR_KEY = "last_model_error"
+
+# Exception class names, the only failure signal the run-completion webhook gets:
+# the platform serializes the class name but scrubs the message of any exception
+# type outside its allowlist.
+_ERROR_TYPE_CODES = {
+    "RateLimitError": "provider_rate_limited",
+    "OverloadedError": "provider_overloaded",
+    "APIConnectionError": "provider_unavailable",
+    "APIError": "provider_unavailable",
+    "APIStatusError": "provider_unavailable",
+    "InternalServerError": "provider_unavailable",
+    "APITimeoutError": "provider_timeout",
+    "ModelCallTimeoutError": "provider_timeout",
+    "GraphRecursionError": "step_limit",
+    "RecursionError": "step_limit",
+    "SandboxConnectionError": "sandbox_unreachable",
+    "SandboxUnreachableError": "sandbox_unreachable",
+}
+
+
+def code_for_error_type(error_type: str | None) -> str | None:
+    """Failure code for a bare exception class name."""
+    return _ERROR_TYPE_CODES.get(error_type) if error_type else None
+
+
+def classify_exception(exc: BaseException) -> str | None:
+    """Failure code for a live exception, using status and provider error body.
+
+    Provider-agnostic on purpose: a gateway can surface an overload as anything
+    from a 529 to a bare ``APIError`` carrying ``overloaded_error`` in its body.
+    """
+    status = getattr(exc, "status_code", None)
+    body = getattr(exc, "body", None)
+    provider_code = ""
+    if isinstance(body, dict):
+        inner = body.get("error")
+        if isinstance(inner, dict):
+            provider_code = str(inner.get("type") or inner.get("code") or "")
+    haystack = f"{provider_code} {exc}".lower()
+
+    if status == 429 or "rate_limit" in haystack:
+        return "provider_rate_limited"
+    if status == 529 or "overloaded" in haystack:
+        return "provider_overloaded"
+    if "context_length_exceeded" in haystack or "prompt is too long" in haystack:
+        return "context_too_long"
+    if "model_not_available" in haystack or "model_not_found" in haystack:
+        return "model_unavailable"
+    if isinstance(status, int) and status >= 500:
+        return "provider_unavailable"
+    return code_for_error_type(type(exc).__name__)
+
+
+def error_tracking_fields(exc: BaseException) -> dict[str, Any]:
+    """Datadog's standard ``error`` attributes for a log record.
+
+    Datadog Error Tracking groups an issue and renders a stack trace only from
+    ``error.kind``/``error.message``/``error.stack``; the ``exception`` key that
+    structlog's ``format_exc_info`` emits is ignored.
+    """
+    return {
+        "error": {
+            "kind": type(exc).__name__,
+            "message": str(exc),
+            "stack": "".join(traceback.format_exception(exc)),
+        }
+    }
+
+
+def exception_fields(exc: BaseException) -> dict[str, Any]:
+    """Class, message, and any HTTP status / request id / response body on ``exc``.
+
+    Provider SDKs put the useful part of a failure (``overloaded_error``, a
+    rate-limit window, a rejected model id) in the response body, which
+    ``str(exc)`` frequently omits.
+    """
+    try:
+        fields: dict[str, Any] = {"error_type": type(exc).__name__, "error_message": str(exc)}
+        status = getattr(exc, "status_code", None)
+        if status is not None:
+            fields["status"] = status
+        request_id = getattr(exc, "request_id", None)
+        if request_id:
+            fields["request_id"] = request_id
+        body = getattr(exc, "body", None)
+        if body is not None:
+            fields["body"] = _bounded(body)
+        cause = exc.__cause__ or exc.__context__
+        if cause is not None:
+            fields["cause"] = f"{type(cause).__name__}: {cause}"
+        return fields
+    except Exception:  # noqa: BLE001
+        return {"error_type": type(exc).__name__, "error_message": repr(exc)}
+
+
+def _bounded(body: Any) -> Any:
+    try:
+        rendered = json.dumps(body, default=str)
+    except (TypeError, ValueError):
+        rendered = str(body)
+    if len(rendered) <= _MAX_BODY_CHARS:
+        return body
+    return rendered[:_MAX_BODY_CHARS]


### PR DESCRIPTION
A run killed by a model error left almost nothing behind. `ModelFallbackMiddleware` logged only `type(exc).__name__` — no message, no provider body, no traceback — and it is only attached when a fallback model is configured. The run-completion webhook discarded the platform's serialized error outright and replied with the same generic sentence for every failure:

> Open SWE wasn't able to finish that — the run hit an unexpected error.

An Anthropic overload now reads:

> Open SWE wasn't able to finish that — the model provider was overloaded and never recovered. Send another message and it will pick this back up.

## Logging

New always-on `ModelErrorMiddleware` (wired into the agent, reviewer, and both subagent stacks) logs every model-call exception with its class, message, HTTP status, request id and response body. `ModelFallbackMiddleware`'s retry and give-up logs carry the same detail.

Messages are fixed strings; everything variable is a structured attribute. Each error record also carries Datadog's standard `error.kind` / `error.message` / `error.stack`, which is what Error Tracking groups on and renders as a stack trace — the `exception` key structlog emits from `exc_info` is ignored by Datadog.

## Classification

The webhook only ever receives the exception class name: the platform serializes the class but scrubs the message for any type outside its allowlist, so `anthropic.APIError` arrives as `{"error": "APIError", "message": "An internal error occurred"}`. Distinguishing "overloaded" from every other `APIError` therefore has to happen in-process.

`ModelErrorMiddleware` classifies the live exception from its status code, provider `error.type` body field and message text, then records `{run_id, error_type, code}` on the thread. The reply uses that record only when its `error_type` matches the class the run actually died with — a run can log a transient error, recover, then fail for an unrelated reason. Failing that it falls back to a class-name table (`GraphRecursionError` → step limit, `SandboxUnreachableError` → lost sandbox, …), and failing that keeps the existing wording unchanged.

Two codes get different follow-up advice, because "send another message" is wrong for them: `context_too_long` → "Start a new thread to continue", `model_unavailable` → "Pick a different model in Open SWE Web, then retry."

## Test Plan

- [x] `make lint`
- [x] `make typecheck`
- [x] Exercised `_failure_reason_code` / `_failure_text` across all branches (in-run record, class-name-only, stale record, timeout status, unrecognized error) and confirmed the unrecognized case is byte-identical to today's message
- [x] Verified `classify_exception` returns `provider_overloaded` for a 529 `APIStatusError` carrying an `overloaded_error` body
