### PR TITLE
Keep active attention threads stable in the sidebar

### DIFF
--- a/tests/e2e/tests/threads_workspace.spec.ts
+++ b/tests/e2e/tests/threads_workspace.spec.ts
@@ -717,6 +717,40 @@ test.describe("threads workspace", () => {
     await expect(main).not.toContainText(TITLES.running);
   });
 
+  test("keeps the active attention thread in its priority position", async ({
+    page,
+    request,
+  }, testInfo) => {
+    const fixtures = workspaceThreads();
+    const attention = fixtures.find(
+      (thread) => thread.id === THREAD_IDS.attention,
+    )!;
+    const ready = fixtures.find((thread) => thread.id === THREAD_IDS.ready)!;
+    ready.metadata.repo_name = "alpha";
+    ready.metadata.updated_at_ms = Date.now();
+    await seedThreads(request, [attention, ready]);
+    await loginAs(page);
+    await page.goto("/agents/threads");
+
+    const sidebar = page.locator("[data-sidebar-frame]");
+    const titles = () =>
+      sidebar
+        .locator(`a[href^="/agents/"]:has-text("${WORKSPACE_QUERY}")`)
+        .allTextContents();
+    await expect.poll(titles).toEqual([TITLES.attention, TITLES.ready]);
+
+    await sidebar.getByRole("link", { name: TITLES.attention }).click();
+    await expect(page).toHaveURL(`/agents/${THREAD_IDS.attention}`);
+    await expect.poll(titles).toEqual([TITLES.attention, TITLES.ready]);
+
+    const screenshotPath = testInfo.outputPath("stable-attention-thread.png");
+    await sidebar.screenshot({ path: screenshotPath });
+    await testInfo.attach("stable-attention-thread", {
+      path: screenshotPath,
+      contentType: "image/png",
+    });
+  });
+
   test("shows a recency-sorted project list in the sidebar", async ({
     page,
     request,

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -214,6 +214,7 @@ export function AgentsSidebar({
   const [updateState, setUpdateState] = useState<DesktopUpdateState>({
     status: "idle",
   })
+  const [keptAttentionKey, setKeptAttentionKey] = useState<string>()
   useEffect(() => {
     const desktop = window.openSweDesktop
     if (!desktop) return
@@ -337,14 +338,23 @@ export function AgentsSidebar({
       ? []
       : alignedLocalItems.filter((item) => !localPinnedIds.has(item.id))),
   ]
+  const activeKey = activeLocalSessionId
+    ? `local:${activeLocalSessionId}`
+    : activeThreadId
+      ? `cloud:${activeThreadId}`
+      : undefined
   const allItems = [...pinnedItems, ...threadItems]
+  const activeAttentionKey =
+    keptAttentionKey === activeKey ? keptAttentionKey : undefined
   const filteredPinnedItems = sortSidebarThreads(
     filterThreads(pinnedItems, prefs.filters),
-    prefs.sortPinned
+    prefs.sortPinned,
+    activeAttentionKey
   )
   const recents = sortSidebarThreads(
     filterThreads(threadItems, prefs.filters),
-    prefs.sortChats
+    prefs.sortChats,
+    activeAttentionKey
   )
   const unpinnedLocalItems = alignedLocalItems.filter(
     (item) => !localPinnedIds.has(item.id)
@@ -434,12 +444,6 @@ export function AgentsSidebar({
     }
   }
 
-  const activeKey = activeLocalSessionId
-    ? `local:${activeLocalSessionId}`
-    : activeThreadId
-      ? `cloud:${activeThreadId}`
-      : undefined
-
   const rowProps = (
     item: SidebarThreadItem,
     live: PullRequestSnapshot | undefined = pullRequestFor(item)
@@ -451,6 +455,10 @@ export function AgentsSidebar({
     live,
     compact: prefs.compact,
     onNavigate: layout.closeOnMobile,
+    onMarkViewed:
+      item.status === "running"
+        ? undefined
+        : () => setKeptAttentionKey(item.key),
     onDeleteLocal: refreshLocalThreads,
     onTogglePin: () => togglePin(item),
     onToggleArchived: () => toggleArchived(item),
@@ -553,6 +561,7 @@ export function AgentsSidebar({
       includeResolved={prefs.filters.includeResolved}
       includeAutomations={includeAutomations}
       sort={prefs.sortChats}
+      activeAttentionKey={activeAttentionKey}
       activeThreadId={activeThreadId}
       openThread={openThread}
       hydrate={hydrateProjectThreads}
@@ -870,6 +879,7 @@ function ProjectGroup({
   includeResolved,
   includeAutomations,
   sort,
+  activeAttentionKey,
   activeThreadId,
   openThread,
   hydrate,
@@ -886,6 +896,7 @@ function ProjectGroup({
   includeResolved: boolean
   includeAutomations: boolean
   sort: ChatSort
+  activeAttentionKey?: string
   activeThreadId?: string
   openThread: (threadId: string) => void
   hydrate: (threads: Array<AgentThread>) => Array<SidebarThreadItem>
@@ -912,7 +923,8 @@ function ProjectGroup({
   useRunCompletionNotifier(cloudThreads, activeThreadId, openThread)
   const threads = sortSidebarThreads(
     [...hydrate(cloudThreads), ...group.threads],
-    sort
+    sort,
+    activeAttentionKey
   )
   const pullRequestFor = useSidebarPullRequests(
     threads,

--- a/ui/src/features/agents/components/SidebarThreadRow.tsx
+++ b/ui/src/features/agents/components/SidebarThreadRow.tsx
@@ -176,6 +176,7 @@ export function SidebarThreadRow({
   compact = false,
   indent = false,
   onNavigate,
+  onMarkViewed,
   onDeleteLocal,
   onTogglePin,
   onToggleArchived,
@@ -189,6 +190,7 @@ export function SidebarThreadRow({
   /** Nested under a project: indent the content, not the highlight box. */
   indent?: boolean
   onNavigate?: () => void
+  onMarkViewed?: () => void
   onDeleteLocal: (threadId?: string) => void
   onTogglePin: () => void
   onToggleArchived: () => void
@@ -219,6 +221,8 @@ export function SidebarThreadRow({
       deleteThread.variables === item.id)
 
   const markViewed = () => {
+    if (item.viewed) return
+    onMarkViewed?.()
     if (item.location === "cloud") markAgentThreadViewed(queryClient, item.id)
     else markLocalViewed(item.id)
   }

--- a/ui/src/features/agents/lib/sidebarThreads.test.ts
+++ b/ui/src/features/agents/lib/sidebarThreads.test.ts
@@ -9,6 +9,7 @@ import {
   groupSidebarThreadsByProject,
   localSidebarThread,
   sidebarProjectOptions,
+  sortSidebarThreads,
 } from "./sidebarThreads"
 
 function cloudThread(overrides: Partial<AgentThread> = {}): AgentThread {
@@ -119,6 +120,35 @@ describe("sidebar thread adapters", () => {
     expect(applyProjectKeyAliases([local], aliases)[0]?.projectKey).toBe(
       local.projectKey
     )
+  })
+})
+
+describe("sortSidebarThreads", () => {
+  it("keeps the active attention thread in place after it is viewed", () => {
+    const newerUnread = cloudSidebarThread(
+      cloudThread({ id: "newer-unread", viewed: false, updatedAt: 30 })
+    )
+    const opened = cloudSidebarThread(
+      cloudThread({ id: "opened", viewed: false, updatedAt: 20 })
+    )
+    const viewed = cloudSidebarThread(
+      cloudThread({ id: "viewed", viewed: true, updatedAt: 40 })
+    )
+
+    expect(
+      sortSidebarThreads([viewed, opened, newerUnread], "priority").map(
+        (thread) => thread.id
+      )
+    ).toEqual(["newer-unread", "opened", "viewed"])
+
+    opened.viewed = true
+    expect(
+      sortSidebarThreads(
+        [viewed, opened, newerUnread],
+        "priority",
+        opened.key
+      ).map((thread) => thread.id)
+    ).toEqual(["newer-unread", "opened", "viewed"])
   })
 })
 

--- a/ui/src/features/agents/lib/sidebarThreads.ts
+++ b/ui/src/features/agents/lib/sidebarThreads.ts
@@ -228,9 +228,12 @@ export type SidebarSort = "priority" | "updated" | "manual"
  * anything unread, then everything else. Within a rank it falls back to
  * recency, so the ordering only ever reorders across those three bands.
  */
-function priorityRank(thread: SidebarThreadItem): number {
+function priorityRank(
+  thread: SidebarThreadItem,
+  keepAttentionKey?: string
+): number {
   if (thread.status === "running") return 0
-  return thread.viewed ? 2 : 1
+  return thread.key === keepAttentionKey || !thread.viewed ? 1 : 2
 }
 
 function byRecency(left: SidebarThreadItem, right: SidebarThreadItem): number {
@@ -243,7 +246,8 @@ function byRecency(left: SidebarThreadItem, right: SidebarThreadItem): number {
 
 export function sortSidebarThreads(
   threads: ReadonlyArray<SidebarThreadItem>,
-  mode: SidebarSort = "updated"
+  mode: SidebarSort = "updated",
+  keepAttentionKey?: string
 ): Array<SidebarThreadItem> {
   // "manual" keeps the order the caller supplied — for pins that is the stored
   // pin order, which is the only manual ordering the user can actually set.
@@ -251,7 +255,8 @@ export function sortSidebarThreads(
   if (mode === "updated") return [...threads].sort(byRecency)
   return [...threads].sort(
     (left, right) =>
-      priorityRank(left) - priorityRank(right) || byRecency(left, right)
+      priorityRank(left, keepAttentionKey) -
+        priorityRank(right, keepAttentionKey) || byRecency(left, right)
   )
 }
 


### PR DESCRIPTION
### Summary

- keep an unread attention thread in its priority position while it is the active thread
- preserve existing running, unread, viewed, recency, and manual sorting behavior
- cover the behavior with focused unit and browser tests

### Verification

- `pnpm --dir ui exec vitest run src/features/agents/lib/sidebarThreads.test.ts --no-color`
- `pnpm --dir ui run typecheck`
- `pnpm exec oxlint ui/src/features/agents/components/AgentsSidebar.tsx ui/src/features/agents/components/SidebarThreadRow.tsx ui/src/features/agents/lib/sidebarThreads.ts ui/src/features/agents/lib/sidebarThreads.test.ts tests/e2e/tests/threads_workspace.spec.ts --deny-warnings`
- `E2E_ARTIFACTS=1 pnpm --dir tests/e2e exec playwright test tests/threads_workspace.spec.ts --grep "keeps the active attention thread" --project=chromium`

### UI evidence

- [Video: active attention thread stays in place](https://01a06714-f2bd-7dd5-9941-c7208f56cc74--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGcwTXpjeU5UZ3NJbXAwYVNJNklqQXhZVEEyTnpKaExXVXdaamN0TnpWbVl5MDROakV3TFdKbU9XSTJPR0kzTlRZd05pSXNJbk5wWkNJNklqQXhZVEEyTnpFMExXWXlZbVF0TjJSa05TMDVPVFF4TFdNM01qQTRaalUyWTJNM05DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMM1JsYzNSekwyVXlaUzkwWlhOMExYSmxjM1ZzZEhNdmRHaHlaV0ZrYzE5M2IzSnJjM0JoWTJVdGRHaHlaV0ZrY3kwdFlURTROMlF0WVdRdGFXNHRhWFJ6TFhCeWFXOXlhWFI1TFhCdmMybDBhVzl1TFdOb2NtOXRhWFZ0TDNacFpHVnZMbmRsWW0waUxDSmpkQ0k2SW5acFpHVnZMM2RsWW0waUxDSmpaQ0k2SW1sdWJHbHVaU0o5LjNvOEFqZFhVX01YM0pDODZEeTk3ZFQ1dm5qWUZkN3lIa2lRLUxxX3VrckJLMTd0R0lsOXJxVTZ2TFVyUkl1ZzdzX2JtMHVtQWE3MEppb1c2X1FHLUJn)
- [Screenshot: active row retained above viewed row](https://01a06714-f2bd-7dd5-9941-c7208f56cc74--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGcwTXpjeU9EUXNJbXAwYVNJNklqQXhZVEEyTnpKaUxUUTNaamt0TnpRd1l5MDROV00wTFRCbFpqZzBPVEpsTWpkaE5TSXNJbk5wWkNJNklqQXhZVEEyTnpFMExXWXlZbVF0TjJSa05TMDVPVFF4TFdNM01qQTRaalUyWTJNM05DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMM1JsYzNSekwyVXlaUzkwWlhOMExYSmxjM1ZzZEhNdmRHaHlaV0ZrYzE5M2IzSnJjM0JoWTJVdGRHaHlaV0ZrY3kwdFlURTROMlF0WVdRdGFXNHRhWFJ6TFhCeWFXOXlhWFI1TFhCdmMybDBhVzl1TFdOb2NtOXRhWFZ0TDNOMFlXSnNaUzFoZEhSbGJuUnBiMjR0ZEdoeVpXRmtMbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5OT3pRdkpVeTFmclN3QnoyNVY3RVNtamJPSkxOcjRBODRnVlhpak1MbnhvYmlpVWxMSmltMU1WS3NLVUV3VHpWUF9ZMmJqR3Fvcjc3WW1ocVE0SzRBZw)

Made by [Open SWE](https://openswe.vercel.app/agents/2d7e30e1-6cd9-56b8-acf2-3b7da331d149)