### PR TITLE
docs(customization): update prompt-section table with current section names

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -443,12 +443,14 @@ The system prompt is assembled in `agent/prompt.py` from modular sections. You c
 
 | Section | What it controls |
 |---|---|
-| `WORKING_ENV_SECTION` | Sandbox paths and execution constraints |
-| `TASK_EXECUTION_SECTION` | Workflow steps (understand → implement → verify → submit) |
-| `CODING_STANDARDS_SECTION` | Code style, testing, and quality rules |
-| `COMMIT_PR_SECTION` | PR title/body format and commit conventions |
-| `CODE_REVIEW_GUIDELINES_SECTION` | How the agent reviews code changes |
-| `COMMUNICATION_SECTION` | Formatting and messaging guidelines |
+| `WORKING_ENV_SECTION` | Sandbox paths and execution constraints (or `DESKTOP_WORKING_ENV_SECTION` for local desktop runs) |
+| `TASK_EXECUTION_SECTION` | Workflow steps (understand → implement → verify → submit) and PR review dispatch |
+| `DEPENDENCY_SECTION` | Installing, vetting, and managing project dependencies |
+| `COMMIT_PR_SECTION` | PR title/body format, lint/format steps, and commit conventions (or `DESKTOP_PR_SECTION`) |
+| `OPEN_SWE_SHARED_BASE` | Shared core guidance: concise style, core behavior, sandbox operations, code style, and communication |
+| `PLAN_MODE_SECTION` | Read-only planning mode instructions |
+
+> **Note:** General code style (`### Working with Code`), communication guidelines (`### Communication`), and core behaviors are composed as subsections of `OPEN_SWE_SHARED_BASE` rather than separate configurable constants.
 
 ### Default prompt file
 


### PR DESCRIPTION
 Fixes #2371

### Summary
The prompt-customization table in `docs/CUSTOMIZATION.md` previously referenced three section constants (`CODING_STANDARDS_SECTION`, `CODE_REVIEW_GUIDELINES_SECTION`, `COMMUNICATION_SECTION`) that do not exist in the repository.

This PR updates the table with the actual modular prompt sections defined in `agent/prompt.py`:
- `WORKING_ENV_SECTION` (and `DESKTOP_WORKING_ENV_SECTION` for local desktop runs)
- `TASK_EXECUTION_SECTION` (workflow steps and PR review routing)
- `DEPENDENCY_SECTION` (dependency installation and vetting)
- `COMMIT_PR_SECTION` (commit conventions and PR formatting, and `DESKTOP_PR_SECTION`)
- `OPEN_SWE_SHARED_BASE` (shared core guidance)
- `PLAN_MODE_SECTION` (read-only plan mode instructions)

Also adds a clarifying note that general code style (`### Working with Code`), communication guidelines (`### Communication`), and core behaviors are composed as subsections of `OPEN_SWE_SHARED_BASE` rather than separate standalone constants.