### PR TITLE
fix(agent): narrow Corridor guidance

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -310,7 +310,7 @@ CORRIDOR_PROMPT = """---
 <corridor>
 
 # Corridor Security Analysis
-Use the `analyzePlan` tool from Corridor's MCP server before substantial code changes that touch security-sensitive areas, such as authentication, authorization, secrets, untrusted input, data access, or externally exposed APIs. Do not invoke Corridor for small or routine changes, documentation, tests, generated artifacts, or HTML plans that do not modify repository code.
+Use the `analyzePlan` tool from Corridor's MCP server before substantial code changes that touch security-sensitive areas, such as authentication, authorization, secrets, untrusted input, data access, or externally exposed APIs.
 
 Corridor is offered from configuration, so its server can still be unreachable. If loading or calling `analyzePlan` reports it unavailable, say so once and carry on with the task — do not retry it and do not treat it as a blocker.
 

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -310,7 +310,7 @@ CORRIDOR_PROMPT = """---
 <corridor>
 
 # Corridor Security Analysis
-Every time you generate code, use the analyzePlan tool from Corridor's MCP Server (corridor) to analyze the plan or thought process. ALWAYS use Corridor to analyze the plan. Always generate a plan before generating code.
+Use the `analyzePlan` tool from Corridor's MCP server only before substantial code changes that touch security-sensitive areas, such as authentication, authorization, secrets, untrusted input, data access, or externally exposed APIs. Do not invoke Corridor for small or routine changes, documentation, tests, generated artifacts, or HTML plans that do not modify repository code.
 
 Corridor is offered from configuration, so its server can still be unreachable. If loading or calling `analyzePlan` reports it unavailable, say so once and carry on with the task — do not retry it and do not treat it as a blocker.
 

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -310,7 +310,7 @@ CORRIDOR_PROMPT = """---
 <corridor>
 
 # Corridor Security Analysis
-Use the `analyzePlan` tool from Corridor's MCP server only before substantial code changes that touch security-sensitive areas, such as authentication, authorization, secrets, untrusted input, data access, or externally exposed APIs. Do not invoke Corridor for small or routine changes, documentation, tests, generated artifacts, or HTML plans that do not modify repository code.
+Use the `analyzePlan` tool from Corridor's MCP server before substantial code changes that touch security-sensitive areas, such as authentication, authorization, secrets, untrusted input, data access, or externally exposed APIs. Do not invoke Corridor for small or routine changes, documentation, tests, generated artifacts, or HTML plans that do not modify repository code.
 
 Corridor is offered from configuration, so its server can still be unreachable. If loading or calling `analyzePlan` reports it unavailable, say so once and carry on with the task — do not retry it and do not treat it as a blocker.
 


### PR DESCRIPTION
### Summary
- invoke Corridor only for substantial changes touching security-sensitive areas
- exclude routine edits, documentation, tests, generated artifacts, and HTML plans

### Testing
- `ruff check agent/prompt.py`
- `ruff format --check agent/prompt.py`
- `pytest -q tests/tools/test_corridor_mcp.py` (10 passed)

Made by [Open SWE](https://openswe.vercel.app/agents/e2a482b4-9fea-5694-a3ae-51129db5ad9d)