### PR TITLE
Document automatic thread resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Each cloud coding thread is bound to its own persistent sandbox, so the agent ca
 
 - Investigates repositories, plans work, edits code, and runs focused validation
 - Commits and pushes changes, then opens or updates pull requests
+- Links delivery pull requests to their originating threads so those threads can resolve automatically when the pull requests are merged or closed
 - Uses subagents to parallelize research and independent work
 - Supports reusable skills, repository instructions, and custom environments
 


### PR DESCRIPTION
### Summary

- Document that delivery pull requests can automatically resolve their originating agent threads after merge or close.
- Serve as a live example of a PR opened with thread auto-resolution enabled.

### Validation

- `make format`
- `make lint`
- `git diff --check`

Made by [Open SWE](https://dev.open-swe.langchain.dev/agents/5136fd32-6da4-5b97-b3e3-4d969a8d99be)