### PR TITLE
fix: use bare code fences in Slack replies

### DIFF
--- a/agent/slack/tools/thread_reply.py
+++ b/agent/slack/tools/thread_reply.py
@@ -36,7 +36,8 @@ async def slack_thread_reply(
 
     Format messages using Slack's mrkdwn format, NOT standard Markdown.
     Key differences: *bold*, _italic_, ~strikethrough~, <url|link text>,
-    bullet lists with "• ", ```code blocks```, > blockquotes.
+    bullet lists with "• ", ```code blocks```, > blockquotes. Code fences must be
+    bare triple backticks; do not add a language identifier such as ```sql.
     Do NOT use **bold**, [link](url), or other standard Markdown syntax.
 
     To ask a user to choose from predefined options, pass `options`. Slack will


### PR DESCRIPTION
Clarify Slack reply formatting so fenced code blocks omit Markdown language identifiers that Slack renders as content.

Validation: `make format`; `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/7ac64053-b417-5456-90de-f6107892d091)