### PR TITLE
feat(ui): move workflow approval into transcript

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -20,7 +20,6 @@ import { SIBLING_COLUMN_MIN_WIDTH } from "@/features/agents/components/panel/Rig
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
 import { AgentComposerDock } from "@/features/agents/components/composer/AgentComposerDock"
 import { ThreadPullRequests } from "@/features/agents/components/ThreadPullRequests"
-import { WorkflowApprovalCard } from "@/features/agents/components/WorkflowApprovalCard"
 import {
   readStoredPanelCollapsed,
   writeStoredPanelCollapsed,
@@ -286,10 +285,6 @@ export function AgentThreadView({
             </Alert>
           </div>
         )}
-        <WorkflowApprovalCard
-          threadId={thread.id}
-          pollWhileActive={isStreaming}
-        />
         <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
           {hasConversation ? (
             <Messages
@@ -304,6 +299,7 @@ export function AgentThreadView({
               streamIsLoading={stream.isLoading}
               isThinking={isThinking}
               settingUpSandbox={settingUpSandbox}
+              pollWorkflowApprovalsWhileActive={isStreaming}
               contentWidthClass="max-w-3xl"
             />
           ) : isHydrating ? (

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -286,12 +286,39 @@ export function AgentThreadView({
           </div>
         )}
         <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-          {hasConversation ? (
+          {isHydrating ? (
+            <div className="flex flex-1 items-center justify-center px-6">
+              <img
+                src="/logo-mark.png"
+                alt="Loading conversation"
+                className="size-12 animate-pulse"
+              />
+            </div>
+          ) : (
             <Messages
               messages={baseMessages}
               threadId={thread.id}
               showPlanArtifact={
                 thread.planStatus === "ready" || thread.planStatus === "shared"
+              }
+              emptyState={
+                <div className="flex min-h-60 items-center justify-center">
+                  {hydrationFailed ? (
+                    <Alert variant="error" className="max-w-3xl">
+                      <CircleAlertIcon />
+                      <AlertDescription>
+                        <span>
+                          This thread&apos;s messages could not be loaded.
+                          Reload to try again.
+                        </span>
+                      </AlertDescription>
+                    </Alert>
+                  ) : (
+                    <p className="text-xs text-muted-foreground/70">
+                      This thread has no messages yet.
+                    </p>
+                  )}
+                </div>
               }
               onOpenFile={handleOpenFile}
               queuedMessages={queuedMessages}
@@ -302,32 +329,6 @@ export function AgentThreadView({
               pollWorkflowApprovalsWhileActive={isStreaming}
               contentWidthClass="max-w-3xl"
             />
-          ) : isHydrating ? (
-            <div className="flex flex-1 items-center justify-center px-6">
-              <img
-                src="/logo-mark.png"
-                alt="Loading conversation"
-                className="size-12 animate-pulse"
-              />
-            </div>
-          ) : (
-            <div className="flex min-h-0 flex-1 items-center justify-center px-6">
-              {hydrationFailed ? (
-                <Alert variant="error" className="max-w-3xl">
-                  <CircleAlertIcon />
-                  <AlertDescription>
-                    <span>
-                      This thread&apos;s messages could not be loaded. Reload to
-                      try again.
-                    </span>
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <p className="text-xs text-muted-foreground/70">
-                  This thread has no messages yet.
-                </p>
-              )}
-            </div>
           )}
           {!isHydrating && (
             <AgentComposerDock>

--- a/ui/src/features/agents/components/WorkflowApprovalCard.test.tsx
+++ b/ui/src/features/agents/components/WorkflowApprovalCard.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { WorkflowApprovalCard } from "./WorkflowApprovalCard"
+import type { WorkflowPushApproval } from "@/features/agents/lib/types"
+
+const mocks = vi.hoisted(() => ({
+  mutateAsync: vi.fn(),
+  useWorkflowApprovals: vi.fn(),
+  useWorkflowApprovalDecision: vi.fn(),
+}))
+
+vi.mock("@/features/agents/lib/queries", () => ({
+  useWorkflowApprovals: mocks.useWorkflowApprovals,
+  useWorkflowApprovalDecision: mocks.useWorkflowApprovalDecision,
+}))
+
+const approval: WorkflowPushApproval = {
+  fingerprint: "fingerprint-1",
+  status: "pending",
+  repo: "langchain-ai/open-swe",
+  branch: "open-swe/inline-workflow-approval",
+  baseSha: "1234567890",
+  headSha: "abcdef1234",
+  files: [".github/workflows/ci.yml"],
+  diffStats: { files: 1, additions: 3, deletions: 1 },
+  diffPreview:
+    "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml",
+  diffPreviewTruncated: false,
+  approvalUrl: null,
+  requestedAt: null,
+  decidedAt: null,
+  decidedBy: null,
+}
+
+beforeEach(() => {
+  mocks.mutateAsync.mockResolvedValue({})
+  mocks.useWorkflowApprovals.mockReturnValue({
+    data: { approvals: [approval] },
+  })
+  mocks.useWorkflowApprovalDecision.mockReturnValue({
+    mutateAsync: mocks.mutateAsync,
+    isPending: false,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("WorkflowApprovalCard", () => {
+  it("renders the pending approval as a compact inline card", () => {
+    render(<WorkflowApprovalCard threadId="thread-1" pollWhileActive />)
+
+    const group = screen.getByTestId("workflow-approval-group")
+    expect(group.className).toContain("mt-4")
+    expect(screen.getByText("Workflow file approval required")).toBeTruthy()
+    expect(screen.getByText("1 file changed")).toBeTruthy()
+    expect(screen.getByText("Diff preview").closest("details")?.open).toBe(
+      false
+    )
+    expect(mocks.useWorkflowApprovals).toHaveBeenCalledWith("thread-1", {
+      pollWhileActive: true,
+    })
+  })
+
+  it("submits the selected decision with the server fingerprint", async () => {
+    render(<WorkflowApprovalCard threadId="thread-1" />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }))
+
+    await waitFor(() =>
+      expect(mocks.mutateAsync).toHaveBeenCalledWith({
+        fingerprint: "fingerprint-1",
+        decision: "approve",
+      })
+    )
+  })
+})

--- a/ui/src/features/agents/components/WorkflowApprovalCard.tsx
+++ b/ui/src/features/agents/components/WorkflowApprovalCard.tsx
@@ -56,113 +56,108 @@ export function WorkflowApprovalCard({
   }
 
   return (
-    <div className="border-b border-border bg-card px-4 py-3">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
-        {approvals.map((approval) => {
-          const busy = decision.isPending
-          return (
-            <section
-              key={approval.fingerprint}
-              data-testid="workflow-approval-card"
-              className="rounded-lg border border-border bg-background p-3 shadow-sm"
-            >
-              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                <div className="min-w-0 space-y-1">
-                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                    <ShieldCheck className="size-4 text-primary" />
-                    Workflow file approval required
-                  </div>
-                  <p className="text-xs text-muted-foreground/70">
-                    {approval.repo || "Repository"} on{" "}
-                    {approval.branch || "Current branch"} ·{" "}
-                    {shortSha(approval.baseSha)} → {shortSha(approval.headSha)}
-                  </p>
-                  <p className="font-mono text-[0.68rem] break-all text-muted-foreground/70">
-                    Fingerprint: {approval.fingerprint}
-                  </p>
+    <div
+      data-testid="workflow-approval-group"
+      className="mt-4 flex w-full flex-col gap-3"
+    >
+      {approvals.map((approval) => {
+        const busy = decision.isPending
+        return (
+          <section
+            key={approval.fingerprint}
+            data-testid="workflow-approval-card"
+            className="rounded-xl border border-border bg-card p-4 shadow-sm"
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div className="min-w-0 space-y-1">
+                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                  <ShieldCheck className="size-4 text-primary" />
+                  Workflow file approval required
                 </div>
-                <div className="flex shrink-0 flex-wrap gap-2">
-                  {approval.approvalUrl && (
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        window.location.href = approval.approvalUrl ?? ""
-                      }}
-                    >
-                      Open in Web
-                    </Button>
+                <p className="text-xs text-muted-foreground/70">
+                  {approval.repo || "Repository"} on{" "}
+                  {approval.branch || "Current branch"} ·{" "}
+                  {shortSha(approval.baseSha)} → {shortSha(approval.headSha)}
+                </p>
+                <p className="font-mono text-[0.68rem] break-all text-muted-foreground/70">
+                  Fingerprint: {approval.fingerprint}
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                {approval.approvalUrl && (
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      window.location.href = approval.approvalUrl ?? ""
+                    }}
+                  >
+                    Open in Web
+                  </Button>
+                )}
+                <Button
+                  disabled={busy}
+                  onClick={() => void decide(approval, "approve")}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() => void decide(approval, "reject")}
+                >
+                  Reject
+                </Button>
+              </div>
+            </div>
+
+            {error && <p className="mt-3 text-xs text-destructive">{error}</p>}
+
+            <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+              <div className="min-w-0">
+                <p className="text-xs font-medium text-foreground">
+                  {fileLabel(approval.files.length)} changed
+                </p>
+                <ul className="mt-1 space-y-1 text-xs text-muted-foreground/70">
+                  {approval.files.slice(0, 8).map((file) => (
+                    <li key={file} className="truncate font-mono" title={file}>
+                      {file}
+                    </li>
+                  ))}
+                  {approval.files.length > 8 && (
+                    <li>…and {approval.files.length - 8} more</li>
                   )}
-                  <Button
-                    disabled={busy}
-                    onClick={() => void decide(approval, "approve")}
-                  >
-                    Approve
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    disabled={busy}
-                    onClick={() => void decide(approval, "reject")}
-                  >
-                    Reject
-                  </Button>
-                </div>
+                </ul>
               </div>
-
-              {error && (
-                <p className="mt-3 text-xs text-destructive">{error}</p>
-              )}
-
-              <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
-                <div className="min-w-0">
-                  <p className="text-xs font-medium text-foreground">
-                    {fileLabel(approval.files.length)} changed
-                  </p>
-                  <ul className="mt-1 space-y-1 text-xs text-muted-foreground/70">
-                    {approval.files.slice(0, 8).map((file) => (
-                      <li
-                        key={file}
-                        className="truncate font-mono"
-                        title={file}
-                      >
-                        {file}
-                      </li>
-                    ))}
-                    {approval.files.length > 8 && (
-                      <li>…and {approval.files.length - 8} more</li>
-                    )}
-                  </ul>
-                </div>
-                <div className="rounded-md border border-border px-3 py-2 text-xs text-muted-foreground/70">
-                  <span>{approval.diffStats.files} files</span>
-                  <span className="mx-2 text-success-foreground">
-                    +{approval.diffStats.additions}
-                  </span>
-                  <span className="text-destructive">
-                    -{approval.diffStats.deletions}
-                  </span>
-                </div>
+              <div className="rounded-md border border-border px-3 py-2 text-xs text-muted-foreground/70">
+                <span>{approval.diffStats.files} files</span>
+                <span className="mx-2 text-success-foreground">
+                  +{approval.diffStats.additions}
+                </span>
+                <span className="text-destructive">
+                  -{approval.diffStats.deletions}
+                </span>
               </div>
+            </div>
 
-              {approval.diffPreview && (
-                <details className="mt-3" open>
-                  <summary className="cursor-pointer text-xs font-medium text-foreground">
-                    Diff preview
-                    {approval.diffPreviewTruncated ? " (truncated)" : ""}
-                  </summary>
-                  <pre
-                    className={cn(
-                      "mt-2 max-h-72 overflow-auto rounded-md border border-border",
-                      "bg-card p-3 text-[0.68rem] leading-relaxed text-foreground"
-                    )}
-                  >
-                    {approval.diffPreview}
-                  </pre>
-                </details>
-              )}
-            </section>
-          )
-        })}
-      </div>
+            {approval.diffPreview && (
+              <details className="mt-3">
+                <summary className="cursor-pointer text-xs font-medium text-foreground">
+                  Diff preview
+                  {approval.diffPreviewTruncated ? " (truncated)" : ""}
+                </summary>
+                <pre
+                  className={cn(
+                    "mt-2 max-h-72 overflow-auto rounded-md border border-border",
+                    "bg-background p-3 text-[0.68rem] leading-relaxed text-foreground"
+                  )}
+                >
+                  {approval.diffPreview}
+                </pre>
+              </details>
+            )}
+          </section>
+        )
+      })}
     </div>
   )
 }

--- a/ui/src/features/agents/components/messages/Messages.test.tsx
+++ b/ui/src/features/agents/components/messages/Messages.test.tsx
@@ -1,9 +1,15 @@
 /** @vitest-environment jsdom */
 
 import { cleanup, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { Messages } from "./Messages"
+
+vi.mock("@/features/agents/components/WorkflowApprovalCard", () => ({
+  WorkflowApprovalCard: ({ threadId }: { threadId: string }) => (
+    <div data-testid="workflow-approval-card">Approval for {threadId}</div>
+  ),
+}))
 
 afterEach(() => cleanup())
 
@@ -12,5 +18,21 @@ describe("Messages", () => {
     render(<Messages messages={[]} isStreaming />)
 
     expect(screen.getByRole("status").textContent).toBe("Working…")
+  })
+
+  it("keeps workflow approval available alongside an empty-state error", () => {
+    render(
+      <Messages
+        messages={[]}
+        threadId="thread-1"
+        emptyState={<div>Messages could not be loaded</div>}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByText("Messages could not be loaded")).toBeTruthy()
+    expect(screen.getByTestId("workflow-approval-card").textContent).toBe(
+      "Approval for thread-1"
+    )
   })
 })

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -68,6 +68,7 @@ export const Messages = memo(function MessagesComponent({
   messages,
   threadId,
   showPlanArtifact = false,
+  emptyState,
   pollWorkflowApprovalsWhileActive = false,
   queuedMessages = [],
   isStreaming,
@@ -276,6 +277,7 @@ export const Messages = memo(function MessagesComponent({
             className={`w-full ${contentWidthClass} mx-auto min-w-0 ${contentPaddingClass}`}
             style={bottomInset > 0 ? { paddingBottom: bottomInset } : undefined}
           >
+            {visibleMessages.length === 0 && emptyState}
             {visibleMessages.map((message, index) => {
               const isLastMessage = index === visibleMessages.length - 1
               const messageIsStreaming = isStreaming && isLastMessage

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -17,6 +17,7 @@ import { UserMessage } from "./UserMessage"
 import type { MessagesProps } from "./types"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { InlinePlanArtifact } from "@/features/agents/components/InlinePlanArtifact"
+import { WorkflowApprovalCard } from "@/features/agents/components/WorkflowApprovalCard"
 import { useLiveMarkdownMessageId } from "@/features/agents/lib/provider/useLiveMarkdownMessageId"
 
 const BOTTOM_LOCK_THRESHOLD_PX = 24
@@ -67,6 +68,7 @@ export const Messages = memo(function MessagesComponent({
   messages,
   threadId,
   showPlanArtifact = false,
+  pollWorkflowApprovalsWhileActive = false,
   queuedMessages = [],
   isStreaming,
   streamIsLoading,
@@ -303,6 +305,12 @@ export const Messages = memo(function MessagesComponent({
             })}
             {threadId && showPlanArtifact && (
               <InlinePlanArtifact threadId={threadId} />
+            )}
+            {threadId && (
+              <WorkflowApprovalCard
+                threadId={threadId}
+                pollWhileActive={pollWorkflowApprovalsWhileActive}
+              />
             )}
             <QueuedMessages queuedMessages={queuedMessages} />
             <ThinkingSpinner

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -21,6 +21,7 @@ export interface MessagesProps extends ApprovalCallbacks {
   /** Cloud threads only; enables the git-sourced changed-files card per turn. */
   threadId?: string
   showPlanArtifact?: boolean
+  emptyState?: React.ReactNode
   pollWorkflowApprovalsWhileActive?: boolean
   queuedMessages?: Array<QueuedThreadMessage>
   isStreaming: boolean

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -21,6 +21,7 @@ export interface MessagesProps extends ApprovalCallbacks {
   /** Cloud threads only; enables the git-sourced changed-files card per turn. */
   threadId?: string
   showPlanArtifact?: boolean
+  pollWorkflowApprovalsWhileActive?: boolean
   queuedMessages?: Array<QueuedThreadMessage>
   isStreaming: boolean
   /** Live run signal from `useStream().isLoading` — drives Streamdown token animation. */


### PR DESCRIPTION
- render pending workflow-file approvals inline in the scrollable conversation instead of above it
- keep the file summary and Approve/Reject actions visible while collapsing the diff preview by default
- preserve the existing polling and fingerprint-backed decision flow

### Screenshot

![Inline workflow approval](https://01a06853-c919-7d3b-9410-dfdd45257b53--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGcwTlRjM05EVXNJbXAwYVNJNklqQXhZVEEyT0RZekxUZGpOMlV0TjJFNE55MWhabUV5TFdKa056UXlZakppWlRRMk9TSXNJbk5wWkNJNklqQXhZVEEyT0RVekxXTTVNVGt0TjJRellpMDVOREV3TFdSbVpHUTBOVEkxTjJJMU15SXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMM1JsYzNSekwyVXlaUzkwWlhOMExYSmxjM1ZzZEhNdmQyOXlhMlpzYjNjdFlYQndjbTkyWVd3dGFXNXNhVzVsTG5CdVp5SXNJbU4wSWpvaWFXMWhaMlV2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEuZFlIVjNQV0VwTWtUMENUaGxaV2NESWkyNldKeHk3NWpSMkJYQTFSb1prTS1GbEJVNmNWUDNkWFl0VXpaNFlFd0h5MlBVVW45azhNYVdhWk5fbzVUQmc)

Made by [Open SWE](https://openswe.vercel.app/agents/80cbd300-400d-5503-9ad7-d60ba4e6e3ea)