### PR TITLE
fix(desktop): connect Slack and Notion through a loopback handoff

### DIFF
--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -345,6 +345,62 @@ def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
     )
 
 
+def issue_connect_handoff(*, provider: str, challenge: str, claims: dict[str, Any]) -> str:
+    """Mint the code the browser hands back after a desktop *connect* flow.
+
+    Carries what finishing the connection needs and nothing that says who to
+    connect it to: the account is read from the desktop app's own session
+    cookie when the code is redeemed. That is what keeps a leaked code inert —
+    it can't attach the leaker's Slack or Notion account to someone else's
+    login, which is exactly what an identity embedded in the state or in this
+    payload would allow.
+    """
+    now = int(time.time())
+    return jwt.encode(
+        {
+            **claims,
+            "provider": provider,
+            "challenge": challenge,
+            "iat": now,
+            "exp": now + HANDOFF_TTL_SECONDS,
+        },
+        _secret(),
+        algorithm=JWT_ALG,
+    )
+
+
+def redeem_connect_handoff(*, provider: str, code: str, verifier: str) -> dict[str, Any]:
+    """Validate a connect handoff code and return its claims.
+
+    Like the login handoff, the code reaches a loopback port through the user's
+    browser, so redeeming it also requires the verifier the challenge committed
+    to — and that never leaves the desktop app. ``provider`` is checked so a
+    code minted by one connect flow can't be redeemed by another's endpoint.
+    """
+    try:
+        payload = jwt.decode(code, _secret(), algorithms=[JWT_ALG])
+    except jwt.PyJWTError as e:
+        raise HTTPException(400, f"invalid handoff code: {e}") from e
+    challenge = payload.get("challenge")
+    code_provider = payload.get("provider")
+    if not isinstance(challenge, str) or not isinstance(code_provider, str):
+        raise HTTPException(400, "malformed handoff code")
+    if not hmac.compare_digest(code_provider, provider):
+        raise HTTPException(400, "handoff provider mismatch")
+    if not hmac.compare_digest(_s256(verifier), challenge):
+        raise HTTPException(400, "handoff verifier mismatch")
+    return payload
+
+
+def desktop_handoff_from_state(state_payload: dict[str, Any]) -> tuple[str, int] | None:
+    """Return the PKCE challenge and loopback port a desktop flow was started with."""
+    challenge = state_payload.get("handoff_challenge")
+    port = state_payload.get("handoff_port")
+    if isinstance(challenge, str) and isinstance(port, int):
+        return challenge, port
+    return None
+
+
 # Dashboard route where users manage their GitHub↔Slack link.
 PROFILE_SETTINGS_PATH = "/my-settings"
 

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -297,30 +297,24 @@ def desktop_callback_url(port: int, code: str) -> str:
     return f"http://127.0.0.1:{port}/callback?code={quote(code, safe='')}"
 
 
-def issue_desktop_handoff(
-    *, login: str, email: str | None, avatar_url: str | None, challenge: str
-) -> str:
-    """Mint the code the browser hands back to the desktop app.
+def _mint_handoff(*, challenge: str, claims: dict[str, Any]) -> str:
+    """Sign a PKCE-bound code for the browser to hand back to the desktop app.
 
-    Carries the identity a session will be minted from, never a session
-    itself: a JWT is signed but not encrypted, so anything that sees the
-    loopback URL — browser history, an extension — can read the payload, and a
-    session in there would be a bearer token that makes the verifier pointless.
+    A JWT is signed but not encrypted, and this one rides in a URL the browser
+    records, so its claims have to be inert to whoever reads them: the identity
+    a session is minted from, never a session itself; what was connected, never
+    whose account to connect it to.
     """
     now = int(time.time())
-    payload = {
-        "sub": login,
-        "email": email,
-        "avatar_url": avatar_url,
-        "challenge": challenge,
-        "iat": now,
-        "exp": now + HANDOFF_TTL_SECONDS,
-    }
-    return jwt.encode(payload, _secret(), algorithm=JWT_ALG)
+    return jwt.encode(
+        {**claims, "challenge": challenge, "iat": now, "exp": now + HANDOFF_TTL_SECONDS},
+        _secret(),
+        algorithm=JWT_ALG,
+    )
 
 
-def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
-    """Mint the session a desktop handoff code was issued for.
+def _decode_handoff(*, code: str, verifier: str) -> dict[str, Any]:
+    """Return a handoff code's claims, proving the caller holds the verifier.
 
     The code reaches a loopback port through the user's browser, so redeeming
     it also requires the verifier the challenge committed to — and that never
@@ -331,11 +325,29 @@ def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
     except jwt.PyJWTError as e:
         raise HTTPException(400, f"invalid handoff code: {e}") from e
     challenge = payload.get("challenge")
-    login = payload.get("sub")
-    if not isinstance(challenge, str) or not isinstance(login, str) or not login:
+    if not isinstance(challenge, str):
         raise HTTPException(400, "malformed handoff code")
     if not hmac.compare_digest(_s256(verifier), challenge):
         raise HTTPException(400, "handoff verifier mismatch")
+    return payload
+
+
+def issue_desktop_handoff(
+    *, login: str, email: str | None, avatar_url: str | None, challenge: str
+) -> str:
+    """Mint the code the browser hands back after a desktop login."""
+    return _mint_handoff(
+        challenge=challenge,
+        claims={"sub": login, "email": email, "avatar_url": avatar_url},
+    )
+
+
+def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
+    """Mint the session a desktop handoff code was issued for."""
+    payload = _decode_handoff(code=code, verifier=verifier)
+    login = payload.get("sub")
+    if not isinstance(login, str) or not login:
+        raise HTTPException(400, "malformed handoff code")
     email = payload.get("email")
     avatar_url = payload.get("avatar_url")
     return issue_session(
@@ -346,49 +358,20 @@ def redeem_desktop_handoff(*, code: str, verifier: str) -> str:
 
 
 def issue_connect_handoff(*, provider: str, challenge: str, claims: dict[str, Any]) -> str:
-    """Mint the code the browser hands back after a desktop *connect* flow.
-
-    Carries what finishing the connection needs and nothing that says who to
-    connect it to: the account is read from the desktop app's own session
-    cookie when the code is redeemed. That is what keeps a leaked code inert —
-    it can't attach the leaker's Slack or Notion account to someone else's
-    login, which is exactly what an identity embedded in the state or in this
-    payload would allow.
-    """
-    now = int(time.time())
-    return jwt.encode(
-        {
-            **claims,
-            "provider": provider,
-            "challenge": challenge,
-            "iat": now,
-            "exp": now + HANDOFF_TTL_SECONDS,
-        },
-        _secret(),
-        algorithm=JWT_ALG,
-    )
+    """Mint the code the browser hands back after a desktop connect flow."""
+    return _mint_handoff(challenge=challenge, claims={**claims, "provider": provider})
 
 
 def redeem_connect_handoff(*, provider: str, code: str, verifier: str) -> dict[str, Any]:
-    """Validate a connect handoff code and return its claims.
+    """Return a connect code's claims, pinned to the provider that minted them.
 
-    Like the login handoff, the code reaches a loopback port through the user's
-    browser, so redeeming it also requires the verifier the challenge committed
-    to — and that never leaves the desktop app. ``provider`` is checked so a
-    code minted by one connect flow can't be redeemed by another's endpoint.
+    Without the pin, a code from one connect flow could be redeemed by another
+    provider's endpoint.
     """
-    try:
-        payload = jwt.decode(code, _secret(), algorithms=[JWT_ALG])
-    except jwt.PyJWTError as e:
-        raise HTTPException(400, f"invalid handoff code: {e}") from e
-    challenge = payload.get("challenge")
+    payload = _decode_handoff(code=code, verifier=verifier)
     code_provider = payload.get("provider")
-    if not isinstance(challenge, str) or not isinstance(code_provider, str):
-        raise HTTPException(400, "malformed handoff code")
-    if not hmac.compare_digest(code_provider, provider):
+    if not isinstance(code_provider, str) or not hmac.compare_digest(code_provider, provider):
         raise HTTPException(400, "handoff provider mismatch")
-    if not hmac.compare_digest(_s256(verifier), challenge):
-        raise HTTPException(400, "handoff verifier mismatch")
     return payload
 
 

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -60,15 +60,18 @@ from agent.dashboard.oauth import (
     decode_state,
     decode_terminal_ticket,
     desktop_callback_url,
+    desktop_handoff_from_state,
     enforce_org_login_gate,
     exchange_code,
     fetch_github_user,
     hash_state_nonce,
+    issue_connect_handoff,
     issue_desktop_handoff,
     issue_session,
     issue_state,
     issue_terminal_ticket,
     new_state_nonce,
+    redeem_connect_handoff,
     redeem_desktop_handoff,
     require_same_origin_for_mutations,
     require_session,
@@ -494,10 +497,8 @@ async def auth_callback(request: Request, code: str, state: str) -> Response:
     state_payload = decode_state(state)
     state_nonce_hash = state_payload.get("nonce_hash")
     cookie_nonce = request.cookies.get(STATE_COOKIE_NAME)
-    is_desktop = isinstance(state_payload.get("handoff_challenge"), str) and isinstance(
-        state_payload.get("handoff_port"), int
-    )
-    if not is_desktop and (
+    handoff = desktop_handoff_from_state(state_payload)
+    if handoff is None and (
         not isinstance(state_nonce_hash, str)
         or not cookie_nonce
         or not hmac.compare_digest(hash_state_nonce(cookie_nonce), state_nonce_hash)
@@ -521,19 +522,18 @@ async def auth_callback(request: Request, code: str, state: str) -> Response:
 
     await upsert_access_token_from_github_response(login, email or "", token_data)
 
-    challenge = state_payload.get("handoff_challenge")
-    port = state_payload.get("handoff_port")
-    if isinstance(challenge, str) and isinstance(port, int):
+    if handoff is not None:
         # Desktop login runs in the user's own browser, so the session belongs to
         # the app rather than to this browser: hand back a PKCE-bound code the
         # app redeems for one, and leave no session cookie behind here.
-        handoff = issue_desktop_handoff(
+        challenge, port = handoff
+        handoff_code = issue_desktop_handoff(
             login=login,
             email=email,
             avatar_url=user.get("avatar_url"),
             challenge=challenge,
         )
-        response = RedirectResponse(desktop_callback_url(port, handoff), status_code=302)
+        response = RedirectResponse(desktop_callback_url(port, handoff_code), status_code=302)
         _clear_state_cookie(response)
         return response
 
@@ -730,8 +730,17 @@ async def disconnect_my_notion(
     return status.get("notion", {"connected": False})
 
 
+class DesktopConnectExchange(BaseModel):
+    """Body of a desktop connect handoff redemption."""
+
+    code: str
+    verifier: str
+
+
 @router.get("/notion/login")
 async def notion_login(
+    desktop_handoff: str | None = None,
+    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
     session: dict[str, Any] = _SESSION_DEP,
 ) -> RedirectResponse:
     redirect_uri = f"{_api_base_url()}/dashboard/api/notion/callback"
@@ -740,6 +749,8 @@ async def notion_login(
     state = issue_state(
         redirect_to=f"{_frontend_base_url()}/my-settings",
         nonce_hash=nonce_hash,
+        handoff_challenge=valid_handoff_challenge(desktop_handoff),
+        handoff_port=desktop_port,
     )
     try:
         url = await store_notion_oauth_flow(
@@ -762,34 +773,39 @@ async def notion_callback(
     code: str | None = None,
     error: str | None = None,
     error_description: str | None = None,
-    session: dict[str, Any] = _SESSION_DEP,
 ) -> RedirectResponse:
     state_payload = decode_state(state)
     nonce_hash = state_payload.get("nonce_hash")
-    cookie_nonce = request.cookies.get(NOTION_STATE_COOKIE_NAME)
-    if (
-        not isinstance(nonce_hash, str)
-        or not cookie_nonce
-        or not hmac.compare_digest(hash_state_nonce(cookie_nonce), nonce_hash)
-    ):
+    handoff = desktop_handoff_from_state(state_payload)
+    if not isinstance(nonce_hash, str):
         raise HTTPException(400, "oauth state mismatch — please retry")
-
-    flow = await pop_notion_oauth_flow(session["sub"], nonce_hash)
-    if flow is None:
-        raise HTTPException(400, "oauth flow expired — please retry")
     if error:
         detail = error_description or error
         raise HTTPException(400, f"Notion OAuth failed: {detail}")
     if not code:
         raise HTTPException(400, "Notion OAuth callback missing code")
 
-    try:
-        token_data = await exchange_notion_code(code, flow)
-        await connect_notion(session["sub"], token_data, flow)
-    except NotionOAuthError as exc:
-        raise HTTPException(exc.status_code, exc.detail) from exc
-    except ValueError as exc:
-        raise HTTPException(400, str(exc)) from exc
+    if handoff is not None:
+        # The pending flow is stored under the login that started it, which
+        # this browser can't prove it is. Carry the authorization code back
+        # over the loopback port and exchange it under the app's session; the
+        # code is useless without the PKCE verifier that stayed in that flow.
+        challenge, port = handoff
+        handoff_code = issue_connect_handoff(
+            provider="notion",
+            challenge=challenge,
+            claims={"nonce_hash": nonce_hash, "code": code},
+        )
+        response = RedirectResponse(desktop_callback_url(port, handoff_code), status_code=302)
+        _clear_notion_state_cookie(response)
+        return response
+
+    session = require_session(request)
+    cookie_nonce = request.cookies.get(NOTION_STATE_COOKIE_NAME)
+    if not cookie_nonce or not hmac.compare_digest(hash_state_nonce(cookie_nonce), nonce_hash):
+        raise HTTPException(400, "oauth state mismatch — please retry")
+
+    await _complete_notion_connection(session["sub"], nonce_hash, code)
 
     redirect_to = sanitize_redirect_to(state_payload.get("redirect_to")) or _frontend_base_url()
     response = RedirectResponse(redirect_to, status_code=302)
@@ -797,8 +813,39 @@ async def notion_callback(
     return response
 
 
+async def _complete_notion_connection(login: str, nonce_hash: str, code: str) -> None:
+    flow = await pop_notion_oauth_flow(login, nonce_hash)
+    if flow is None:
+        raise HTTPException(400, "oauth flow expired — please retry")
+    try:
+        token_data = await exchange_notion_code(code, flow)
+        await connect_notion(login, token_data, flow)
+    except NotionOAuthError as exc:
+        raise HTTPException(exc.status_code, exc.detail) from exc
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+
+@router.post("/notion/desktop/exchange")
+async def notion_desktop_exchange(
+    body: DesktopConnectExchange,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    """Finish a desktop Notion connection with the app's own session."""
+    claims = redeem_connect_handoff(provider="notion", code=body.code, verifier=body.verifier)
+    nonce_hash = claims.get("nonce_hash")
+    notion_code = claims.get("code")
+    if not isinstance(nonce_hash, str) or not isinstance(notion_code, str):
+        raise HTTPException(400, "malformed handoff code")
+
+    await _complete_notion_connection(session["sub"], nonce_hash, notion_code)
+    return {"connected": True}
+
+
 @router.get("/slack/login")
 async def slack_login(
+    desktop_handoff: str | None = None,
+    desktop_port: int | None = Query(default=None, ge=1024, le=65535),
     _session: dict[str, Any] = _SESSION_DEP,
 ) -> RedirectResponse:
     """Start the Sign in with Slack flow to link the current GitHub account."""
@@ -809,6 +856,8 @@ async def slack_login(
     state = issue_state(
         redirect_to=f"{_frontend_base_url()}/my-settings",
         nonce_hash=hash_state_nonce(nonce),
+        handoff_challenge=valid_handoff_challenge(desktop_handoff),
+        handoff_port=desktop_port,
     )
     response = RedirectResponse(
         build_authorize_url(redirect_uri=redirect_uri, state=state), status_code=302
@@ -822,7 +871,6 @@ async def slack_callback(
     request: Request,
     code: str,
     state: str,
-    session: dict[str, Any] = _SESSION_DEP,
 ) -> RedirectResponse:
     """Link the verified Slack identity to the logged-in GitHub user.
 
@@ -830,6 +878,25 @@ async def slack_callback(
     user can only ever link their own Slack account — no self-asserted values.
     """
     state_payload = decode_state(state)
+    handoff = desktop_handoff_from_state(state_payload)
+
+    if handoff is not None:
+        # Slack consent runs in the user's own browser, which holds neither the
+        # desktop app's session nor its state cookie. Hand the verified
+        # identity back over the loopback port instead, and let the app redeem
+        # it under the session it already has.
+        challenge, port = handoff
+        slack_user_id, work_email = await _verified_slack_identity(code)
+        handoff_code = issue_connect_handoff(
+            provider="slack",
+            challenge=challenge,
+            claims={"slack_user_id": slack_user_id, "email": work_email},
+        )
+        response = RedirectResponse(desktop_callback_url(port, handoff_code), status_code=302)
+        _clear_slack_state_cookie(response)
+        return response
+
+    session = require_session(request)
     nonce_hash = state_payload.get("nonce_hash")
     cookie_nonce = request.cookies.get(SLACK_STATE_COOKIE_NAME)
     if (
@@ -839,26 +906,51 @@ async def slack_callback(
     ):
         raise HTTPException(400, "oauth state mismatch — please retry")
 
-    redirect_to = sanitize_redirect_to(state_payload.get("redirect_to")) or _frontend_base_url()
-    redirect_uri = f"{_api_base_url()}/dashboard/api/slack/callback"
-
-    access_token = await exchange_slack_code(code, redirect_uri)
-    identity = await fetch_slack_identity(access_token)
-    verify_team(identity)
-    if not identity.email or not identity.email_verified:
-        raise HTTPException(400, "your Slack account has no verified email to link")
-
+    slack_user_id, work_email = await _verified_slack_identity(code)
     await upsert_mapping(
         github_login=session["sub"],
-        work_email=identity.email,
-        slack_user_id=identity.user_id,
+        work_email=work_email,
+        slack_user_id=slack_user_id,
         source="slack_oauth",
         status="active",
     )
 
+    redirect_to = sanitize_redirect_to(state_payload.get("redirect_to")) or _frontend_base_url()
     response = RedirectResponse(redirect_to, status_code=302)
     _clear_slack_state_cookie(response)
     return response
+
+
+async def _verified_slack_identity(code: str) -> tuple[str, str]:
+    """Resolve an authorization code to a Slack member id and verified email."""
+    redirect_uri = f"{_api_base_url()}/dashboard/api/slack/callback"
+    identity = await fetch_slack_identity(await exchange_slack_code(code, redirect_uri))
+    verify_team(identity)
+    if not identity.email or not identity.email_verified:
+        raise HTTPException(400, "your Slack account has no verified email to link")
+    return identity.user_id, identity.email
+
+
+@router.post("/slack/desktop/exchange")
+async def slack_desktop_exchange(
+    body: DesktopConnectExchange,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    """Finish a desktop Slack link with the app's own session."""
+    claims = redeem_connect_handoff(provider="slack", code=body.code, verifier=body.verifier)
+    slack_user_id = claims.get("slack_user_id")
+    email = claims.get("email")
+    if not isinstance(slack_user_id, str) or not isinstance(email, str):
+        raise HTTPException(400, "malformed handoff code")
+
+    await upsert_mapping(
+        github_login=session["sub"],
+        work_email=email,
+        slack_user_id=slack_user_id,
+        source="slack_oauth",
+        status="active",
+    )
+    return {"connected": True, "slack_user_id": slack_user_id, "work_email": email}
 
 
 @router.get("/team-settings")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -786,10 +786,9 @@ async def notion_callback(
         raise HTTPException(400, "Notion OAuth callback missing code")
 
     if handoff is not None:
-        # The pending flow is stored under the login that started it, which
-        # this browser can't prove it is. Carry the authorization code back
-        # over the loopback port and exchange it under the app's session; the
-        # code is useless without the PKCE verifier that stayed in that flow.
+        # This browser can't prove it is the login the pending flow is stored
+        # under, so carry the code back over the loopback port and exchange it
+        # under the session the desktop app already holds.
         challenge, port = handoff
         handoff_code = issue_connect_handoff(
             provider="notion",
@@ -881,10 +880,8 @@ async def slack_callback(
     handoff = desktop_handoff_from_state(state_payload)
 
     if handoff is not None:
-        # Slack consent runs in the user's own browser, which holds neither the
-        # desktop app's session nor its state cookie. Hand the verified
-        # identity back over the loopback port instead, and let the app redeem
-        # it under the session it already has.
+        # Same as the Notion flow: hand the verified identity back over the
+        # loopback port, for the app to redeem under the session it holds.
         challenge, port = handoff
         slack_user_id, work_email = await _verified_slack_identity(code)
         handoff_code = issue_connect_handoff(
@@ -950,7 +947,7 @@ async def slack_desktop_exchange(
         source="slack_oauth",
         status="active",
     )
-    return {"connected": True, "slack_user_id": slack_user_id, "work_email": email}
+    return {"connected": True}
 
 
 @router.get("/team-settings")

--- a/desktop/src/config.cts
+++ b/desktop/src/config.cts
@@ -15,6 +15,7 @@ const ALLOWED_PERMISSIONS = new Set([
 const SESSION_COOKIE_NAME = "osw_session";
 const LOGIN_PATH = "/dashboard/api/auth/login";
 const DESKTOP_EXCHANGE_PATH = "/dashboard/api/auth/desktop/exchange";
+const CONNECT_PROVIDERS = new Set(["slack", "notion"]);
 
 function resolveAppRuntime({ argv, isPackaged, appDataPath }) {
   const isDevelopment = !isPackaged || argv.includes("--dev");
@@ -83,6 +84,33 @@ function desktopLoginUrl(backendUrl, { challenge, port }) {
   target.searchParams.set("desktop_handoff", challenge);
   target.searchParams.set("desktop_port", String(port));
   return target.toString();
+}
+
+function isConnectProvider(value) {
+  return typeof value === "string" && CONNECT_PROVIDERS.has(value);
+}
+
+/**
+ * Start URL for a desktop connect flow.
+ *
+ * The app requests this itself, with its own session cookie, and opens only
+ * the provider URL it redirects to — the browser never sees an endpoint that
+ * needs the session.
+ */
+function connectLoginUrl(backendUrl, provider, { challenge, port }) {
+  if (!isConnectProvider(provider)) throw new Error("Unknown connect provider");
+  const target = new URL(`/dashboard/api/${provider}/login`, backendUrl);
+  target.searchParams.set("desktop_handoff", challenge);
+  target.searchParams.set("desktop_port", String(port));
+  return target.toString();
+}
+
+function connectExchangeUrl(backendUrl, provider) {
+  if (!isConnectProvider(provider)) throw new Error("Unknown connect provider");
+  return new URL(
+    `/dashboard/api/${provider}/desktop/exchange`,
+    backendUrl,
+  ).toString();
 }
 
 function desktopExchangeUrl(backendUrl) {
@@ -159,12 +187,15 @@ module.exports = {
   DEFAULT_DEVELOPMENT_BACKEND_URL,
   SESSION_COOKIE_NAME,
   appRedirectUrl,
+  connectExchangeUrl,
+  connectLoginUrl,
   desktopExchangeUrl,
   desktopLoginUrl,
   resolveAppRuntime,
   backendRequestUrl,
   isAppLoginUrl,
   isAppUrl,
+  isConnectProvider,
   isTrustedPermissionRequest,
   isTrustedProxyRequest,
   localCallbackUrl,

--- a/desktop/src/config.cts
+++ b/desktop/src/config.cts
@@ -90,15 +90,10 @@ function isConnectProvider(value) {
   return typeof value === "string" && CONNECT_PROVIDERS.has(value);
 }
 
-/**
- * Start URL for a desktop connect flow.
- *
- * The app requests this itself, with its own session cookie, and opens only
- * the provider URL it redirects to — the browser never sees an endpoint that
- * needs the session.
- */
+// The app requests this itself, with its own session cookie, and opens only
+// the provider URL it redirects to — the browser never sees an endpoint that
+// needs the session.
 function connectLoginUrl(backendUrl, provider, { challenge, port }) {
-  if (!isConnectProvider(provider)) throw new Error("Unknown connect provider");
   const target = new URL(`/dashboard/api/${provider}/login`, backendUrl);
   target.searchParams.set("desktop_handoff", challenge);
   target.searchParams.set("desktop_port", String(port));
@@ -106,7 +101,6 @@ function connectLoginUrl(backendUrl, provider, { challenge, port }) {
 }
 
 function connectExchangeUrl(backendUrl, provider) {
-  if (!isConnectProvider(provider)) throw new Error("Unknown connect provider");
   return new URL(
     `/dashboard/api/${provider}/desktop/exchange`,
     backendUrl,

--- a/desktop/src/login-server.cts
+++ b/desktop/src/login-server.cts
@@ -66,6 +66,10 @@ async function beginLogin({ connect = false } = {}) {
     resolveCode = resolve;
   });
 
+  const [okPage, failedPage] = connect
+    ? [CONNECTED_PAGE, CONNECT_FAILED_PAGE]
+    : [SIGNED_IN_PAGE, FAILED_PAGE];
+
   const server = http.createServer((request, response) => {
     const url = new URL(request.url, "http://127.0.0.1");
     if (url.pathname !== "/callback") {
@@ -74,15 +78,7 @@ async function beginLogin({ connect = false } = {}) {
     }
     const value = url.searchParams.get("code");
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-    response.end(
-      value
-        ? connect
-          ? CONNECTED_PAGE
-          : SIGNED_IN_PAGE
-        : connect
-          ? CONNECT_FAILED_PAGE
-          : FAILED_PAGE,
-    );
+    response.end(value ? okPage : failedPage);
     finish(value || null);
   });
 

--- a/desktop/src/login-server.cts
+++ b/desktop/src/login-server.cts
@@ -38,9 +38,11 @@ const FAILED_PAGE = page(
   "Sign-in failed",
   "Open SWE did not receive a sign-in code. Try again from the app.",
 );
+// The app still has to redeem this code, and that can fail — so this says
+// what actually happened here rather than claiming the account is connected.
 const CONNECTED_PAGE = page(
-  "You're connected",
-  "You can close this tab and return to Open SWE.",
+  "Approval received",
+  "You can close this tab. Open SWE is finishing the connection.",
 );
 const CONNECT_FAILED_PAGE = page(
   "Connection failed",

--- a/desktop/src/login-server.cts
+++ b/desktop/src/login-server.cts
@@ -38,16 +38,24 @@ const FAILED_PAGE = page(
   "Sign-in failed",
   "Open SWE did not receive a sign-in code. Try again from the app.",
 );
+const CONNECTED_PAGE = page(
+  "You're connected",
+  "You can close this tab and return to Open SWE.",
+);
+const CONNECT_FAILED_PAGE = page(
+  "Connection failed",
+  "Open SWE did not receive a code. Try again from the app.",
+);
 
 /**
- * Bind a loopback listener for one GitHub sign-in, so the login itself can run
- * in the user's own browser and hand the result back to the app.
+ * Bind a loopback listener for one browser handoff, so the OAuth leg itself can
+ * run in the user's own browser and hand the result back to the app.
  *
  * Resolves to the flow's PKCE material, the bound port, and a `code` promise
  * that yields the handoff code — or `null` if the flow timed out or was
  * superseded by `cancel()`.
  */
-async function beginLogin() {
+async function beginLogin({ connect = false } = {}) {
   const verifier = randomBytes(32).toString("base64url");
   const challenge = createHash("sha256").update(verifier).digest("base64url");
 
@@ -64,7 +72,15 @@ async function beginLogin() {
     }
     const value = url.searchParams.get("code");
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-    response.end(value ? SIGNED_IN_PAGE : FAILED_PAGE);
+    response.end(
+      value
+        ? connect
+          ? CONNECTED_PAGE
+          : SIGNED_IN_PAGE
+        : connect
+          ? CONNECT_FAILED_PAGE
+          : FAILED_PAGE,
+    );
     finish(value || null);
   });
 

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -54,9 +54,12 @@ const {
   appRedirectUrl,
   backendRequestUrl,
   desktopExchangeUrl,
+  connectExchangeUrl,
+  connectLoginUrl,
   desktopLoginUrl,
   isAppLoginUrl,
   isAppUrl,
+  isConnectProvider,
   isTrustedPermissionRequest,
   isTrustedProxyRequest,
   localCallbackUrl,
@@ -97,6 +100,7 @@ let backendUrl = null;
 let mainWindow = null;
 let setupWindow = null;
 let loginFlow = null;
+const connectFlows = new Map();
 let quitting = false;
 let localThreadStore = null;
 let lastActivity = {};
@@ -436,6 +440,11 @@ function configureDesktopIpc() {
     const removed = removeProject(projectsPath(), project.cwd);
     if (removed) sendProjectsChanged();
     return removed;
+  });
+
+  ipcMain.handle("desktop:connect-service", async (event, provider) => {
+    requireTrustedDesktopIpc(event);
+    return startConnectFlow(provider);
   });
 
   ipcMain.handle("desktop:open-external", async (event, value) => {
@@ -1003,6 +1012,86 @@ async function startExternalLogin() {
   } catch (error) {
     dialog.showErrorBox(`${appRuntime.name} sign-in failed`, error.message);
   }
+}
+
+/**
+ * Link a Slack or Notion account from the desktop app.
+ *
+ * The consent leg has to run in the user's own browser, which carries neither
+ * the app's session cookie nor the flow's state cookie — that mismatch is why
+ * connecting used to fail here. So the app starts the flow itself, sends the
+ * browser only to the provider, and redeems the loopback handoff under its own
+ * session, which is also what decides whose account the connection lands on.
+ */
+async function startConnectFlow(provider) {
+  if (!backendUrl || !isConnectProvider(provider)) return false;
+  connectFlows.get(provider)?.cancel();
+  connectFlows.delete(provider);
+
+  let flow;
+  try {
+    flow = await beginLogin({ connect: true });
+  } catch (error) {
+    dialog.showErrorBox(
+      `${appRuntime.name} could not connect ${provider}`,
+      `Could not open a local listener: ${error.message}`,
+    );
+    return false;
+  }
+  connectFlows.set(provider, flow);
+  try {
+    const started = await backendFetch(
+      connectLoginUrl(backendUrl, provider, flow),
+      { redirect: "manual" },
+    );
+    const location = started.headers.get("location");
+    if (!location) {
+      throw new Error(`Backend did not start the flow (${started.status})`);
+    }
+    await shell.openExternal(location);
+
+    const code = await flow.code;
+    if (connectFlows.get(provider) !== flow) return false;
+    if (!code) return false;
+
+    const exchange = await backendFetch(
+      connectExchangeUrl(backendUrl, provider),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ code, verifier: flow.verifier }),
+      },
+    );
+    if (!exchange.ok) {
+      throw new Error(`Backend rejected the connection (${exchange.status})`);
+    }
+    return true;
+  } catch (error) {
+    dialog.showErrorBox(
+      `${appRuntime.name} could not connect ${provider}`,
+      error.message,
+    );
+    return false;
+  } finally {
+    if (connectFlows.get(provider) === flow) {
+      flow.cancel();
+      connectFlows.delete(provider);
+    }
+  }
+}
+
+/** Call the backend as the app: its own origin, and the session it holds. */
+async function backendFetch(url, init: any = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("origin", APP_ORIGIN);
+  const cookies = await session.defaultSession.cookies.get({ url });
+  if (cookies.length) {
+    headers.set(
+      "cookie",
+      cookies.map(({ name, value }) => `${name}=${value}`).join("; "),
+    );
+  }
+  return fetch(url, { ...init, headers });
 }
 
 async function completeExternalLogin(verifier, code) {

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -37,6 +37,8 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
     ipcRenderer.on("desktop:update-state", listener);
     return () => ipcRenderer.removeListener("desktop:update-state", listener);
   },
+  connectService: (provider) =>
+    ipcRenderer.invoke("desktop:connect-service", provider),
   openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
   resolveLocalProjectPath: (input) =>
     ipcRenderer.invoke("desktop:resolve-local-project-path", { ...input }),

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -8,6 +8,8 @@ const {
   backendRequestUrl,
   desktopExchangeUrl,
   desktopLoginUrl,
+  connectExchangeUrl,
+  connectLoginUrl,
   isAppLoginUrl,
   isTrustedPermissionRequest,
   isTrustedProxyRequest,
@@ -233,4 +235,27 @@ test("keeps static file resolution inside the bundled UI root", () => {
     path.join(root, "assets/app.js"),
   );
   assert.equal(staticFilePath(root, `${APP_URL}%2e%2e%2fsecret`), null);
+});
+
+test("builds connect flow URLs only for known providers", () => {
+  assert.equal(
+    connectLoginUrl("https://backend.example", "slack", {
+      challenge: "abc",
+      port: 51234,
+    }),
+    "https://backend.example/dashboard/api/slack/login?desktop_handoff=abc&desktop_port=51234",
+  );
+  assert.equal(
+    connectExchangeUrl("https://backend.example", "notion"),
+    "https://backend.example/dashboard/api/notion/desktop/exchange",
+  );
+  assert.throws(() =>
+    connectExchangeUrl("https://backend.example", "../auth/desktop"),
+  );
+  assert.throws(() =>
+    connectLoginUrl("https://backend.example", "github", {
+      challenge: "abc",
+      port: 51234,
+    }),
+  );
 });

--- a/desktop/test/config.test.cjs
+++ b/desktop/test/config.test.cjs
@@ -175,6 +175,17 @@ test("carries the loopback port and PKCE challenge into the browser login", () =
     desktopExchangeUrl("https://backend.example/base/"),
     "https://backend.example/dashboard/api/auth/desktop/exchange",
   );
+  assert.equal(
+    connectLoginUrl("https://backend.example", "slack", {
+      challenge: "abc",
+      port: 51234,
+    }),
+    "https://backend.example/dashboard/api/slack/login?desktop_handoff=abc&desktop_port=51234",
+  );
+  assert.equal(
+    connectExchangeUrl("https://backend.example", "notion"),
+    "https://backend.example/dashboard/api/notion/desktop/exchange",
+  );
 });
 
 test("maps desktop API requests to the selected backend", () => {
@@ -235,27 +246,4 @@ test("keeps static file resolution inside the bundled UI root", () => {
     path.join(root, "assets/app.js"),
   );
   assert.equal(staticFilePath(root, `${APP_URL}%2e%2e%2fsecret`), null);
-});
-
-test("builds connect flow URLs only for known providers", () => {
-  assert.equal(
-    connectLoginUrl("https://backend.example", "slack", {
-      challenge: "abc",
-      port: 51234,
-    }),
-    "https://backend.example/dashboard/api/slack/login?desktop_handoff=abc&desktop_port=51234",
-  );
-  assert.equal(
-    connectExchangeUrl("https://backend.example", "notion"),
-    "https://backend.example/dashboard/api/notion/desktop/exchange",
-  );
-  assert.throws(() =>
-    connectExchangeUrl("https://backend.example", "../auth/desktop"),
-  );
-  assert.throws(() =>
-    connectLoginUrl("https://backend.example", "github", {
-      challenge: "abc",
-      port: 51234,
-    }),
-  );
 });

--- a/tests/dashboard/test_desktop_connect_handoff.py
+++ b/tests/dashboard/test_desktop_connect_handoff.py
@@ -1,0 +1,149 @@
+"""The desktop Slack connect flow hands off through the loopback port.
+
+Consent runs in the user's own browser, which holds neither the desktop app's
+session cookie nor the flow's state cookie — the mismatch that made connecting
+fail with "oauth state mismatch". What replaces the cookie check is a PKCE
+handoff whose code says what was connected but never whose account to connect
+it to, so the link can only ever land on the session the app itself holds.
+"""
+
+import base64
+import hashlib
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agent.dashboard import routes
+from agent.dashboard.oauth import COOKIE_NAME, issue_session
+from agent.slack.oauth import SlackIdentity
+
+_VERIFIER = "desktop-connect-verifier"
+_CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(_VERIFIER.encode()).digest()).decode().rstrip("=")
+)
+_APP_ORIGIN = {"origin": "open-swe://app"}
+
+
+@pytest.fixture
+def links(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Stub the Slack legs and collect the account links they produce."""
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://dashboard.example")
+    monkeypatch.setenv("DASHBOARD_JWT_SECRET", "test-secret")
+
+    async def fake_exchange(code: str, redirect_uri: str) -> str:
+        return "xoxp-test"
+
+    async def fake_identity(access_token: str) -> SlackIdentity:
+        return SlackIdentity(
+            user_id="U123",
+            team_id="T1",
+            email="alice@slack.example",
+            email_verified=True,
+            name="alice",
+        )
+
+    collected: list[dict[str, Any]] = []
+
+    async def fake_upsert_mapping(**kwargs: Any) -> None:
+        collected.append(kwargs)
+
+    monkeypatch.setattr(routes, "slack_oauth_configured", lambda: True)
+    monkeypatch.setattr(
+        routes,
+        "build_authorize_url",
+        lambda *, redirect_uri, state: f"https://slack.example/authorize?state={state}",
+    )
+    monkeypatch.setattr(routes, "exchange_slack_code", fake_exchange)
+    monkeypatch.setattr(routes, "fetch_slack_identity", fake_identity)
+    monkeypatch.setattr(routes, "verify_team", lambda identity: None)
+    monkeypatch.setattr(routes, "upsert_mapping", fake_upsert_mapping)
+    return collected
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(routes.router)
+    return TestClient(app, base_url="https://dashboard.example")
+
+
+def _start_desktop_slack_flow(client: TestClient) -> str:
+    """Run the login and callback legs; return the loopback handoff code."""
+    login = client.get(
+        "/dashboard/api/slack/login",
+        params={"desktop_handoff": _CHALLENGE, "desktop_port": 51234},
+        follow_redirects=False,
+    )
+    state = parse_qs(urlparse(login.headers["location"]).query)["state"][0]
+
+    # The browser that follows this carries no state cookie, as a real one won't.
+    callback = _client().get(
+        "/dashboard/api/slack/callback",
+        params={"code": "slack-code", "state": state},
+        follow_redirects=False,
+    )
+    assert callback.status_code == 302
+    location = urlparse(callback.headers["location"])
+    assert (location.scheme, location.netloc, location.path) == (
+        "http",
+        "127.0.0.1:51234",
+        "/callback",
+    )
+    return parse_qs(location.query)["code"][0]
+
+
+def test_desktop_slack_connect_links_under_the_session_the_app_holds(
+    links: list[dict[str, Any]],
+) -> None:
+    with _client() as client:
+        client.cookies.set(COOKIE_NAME, issue_session(login="alice", email=None, avatar_url=None))
+        handoff = _start_desktop_slack_flow(client)
+        assert links == [], "the callback alone must not link an account"
+
+        wrong_verifier = client.post(
+            "/dashboard/api/slack/desktop/exchange",
+            json={"code": handoff, "verifier": "not-the-verifier"},
+            headers=_APP_ORIGIN,
+        )
+        assert wrong_verifier.status_code == 400
+
+        wrong_provider = client.post(
+            "/dashboard/api/notion/desktop/exchange",
+            json={"code": handoff, "verifier": _VERIFIER},
+            headers=_APP_ORIGIN,
+        )
+        assert wrong_provider.status_code == 400
+
+        exchange = client.post(
+            "/dashboard/api/slack/desktop/exchange",
+            json={"code": handoff, "verifier": _VERIFIER},
+            headers=_APP_ORIGIN,
+        )
+        assert exchange.status_code == 200
+        assert links == [
+            {
+                "github_login": "alice",
+                "work_email": "alice@slack.example",
+                "slack_user_id": "U123",
+                "source": "slack_oauth",
+                "status": "active",
+            }
+        ]
+
+
+def test_desktop_connect_handoff_code_names_no_account(links: list[dict[str, Any]]) -> None:
+    """The code rides in a URL the browser records, so it must not name a login.
+
+    A login in there — signed but readable, since a JWT is not encrypted —
+    would let anyone who saw the URL attach their own Slack account to it.
+    """
+    with _client() as client:
+        client.cookies.set(COOKIE_NAME, issue_session(login="alice", email=None, avatar_url=None))
+        payload = jwt.decode(_start_desktop_slack_flow(client), "test-secret", algorithms=["HS256"])
+
+    assert "alice" not in payload.values()
+    assert set(payload) == {"slack_user_id", "email", "provider", "challenge", "iat", "exp"}

--- a/tests/dashboard/test_desktop_connect_handoff.py
+++ b/tests/dashboard/test_desktop_connect_handoff.py
@@ -134,16 +134,9 @@ def test_desktop_slack_connect_links_under_the_session_the_app_holds(
             }
         ]
 
-
-def test_desktop_connect_handoff_code_names_no_account(links: list[dict[str, Any]]) -> None:
-    """The code rides in a URL the browser records, so it must not name a login.
-
-    A login in there — signed but readable, since a JWT is not encrypted —
-    would let anyone who saw the URL attach their own Slack account to it.
-    """
-    with _client() as client:
-        client.cookies.set(COOKIE_NAME, issue_session(login="alice", email=None, avatar_url=None))
-        payload = jwt.decode(_start_desktop_slack_flow(client), "test-secret", algorithms=["HS256"])
-
+    # A JWT is signed but not encrypted, and this one rides in a URL the browser
+    # records — so a login in there would let anyone who saw it attach their own
+    # Slack account to that login instead.
+    payload = jwt.decode(handoff, "test-secret", algorithms=["HS256"])
     assert "alice" not in payload.values()
     assert set(payload) == {"slack_user_id", "email", "provider", "challenge", "iat", "exp"}

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -181,6 +181,7 @@ declare global {
         callback: (projects: Array<DesktopProject>) => void
       ) => () => void
       openExternal: (url: string) => Promise<boolean>
+      connectService: (provider: "slack" | "notion") => Promise<boolean>
       resolveLocalProjectPath: (input: {
         localSessionId: string
         path: string

--- a/ui/src/features/agents/components/OnboardingDialog.tsx
+++ b/ui/src/features/agents/components/OnboardingDialog.tsx
@@ -12,7 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { api, desktopConnect, slackConnectUrl } from "@/lib/api"
+import { api, connectService } from "@/lib/api"
 import {
   buildProfileUpdate,
   useOptions,
@@ -212,14 +212,11 @@ export function OnboardingDialog() {
                 </Button>
                 <Button
                   size="sm"
-                  onClick={() => {
-                    const pending = desktopConnect("slack")
-                    if (!pending) {
-                      window.location.assign(slackConnectUrl())
-                      return
-                    }
-                    void pending.finally(() => void mapping.refetch())
-                  }}
+                  onClick={() =>
+                    void connectService("slack")?.finally(
+                      () => void mapping.refetch(),
+                    )
+                  }
                 >
                   <IoLogoSlack className="size-4" />
                   Connect Slack

--- a/ui/src/features/agents/components/OnboardingDialog.tsx
+++ b/ui/src/features/agents/components/OnboardingDialog.tsx
@@ -12,7 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { api, slackConnectUrl } from "@/lib/api"
+import { api, desktopConnect, slackConnectUrl } from "@/lib/api"
 import {
   buildProfileUpdate,
   useOptions,
@@ -212,7 +212,14 @@ export function OnboardingDialog() {
                 </Button>
                 <Button
                   size="sm"
-                  onClick={() => window.location.assign(slackConnectUrl())}
+                  onClick={() => {
+                    const pending = desktopConnect("slack")
+                    if (!pending) {
+                      window.location.assign(slackConnectUrl())
+                      return
+                    }
+                    void pending.finally(() => void mapping.refetch())
+                  }}
                 >
                   <IoLogoSlack className="size-4" />
                   Connect Slack

--- a/ui/src/features/agents/components/OnboardingDialog.tsx
+++ b/ui/src/features/agents/components/OnboardingDialog.tsx
@@ -214,7 +214,7 @@ export function OnboardingDialog() {
                   size="sm"
                   onClick={() =>
                     void connectService("slack")?.finally(
-                      () => void mapping.refetch(),
+                      () => void mapping.refetch()
                     )
                   }
                 >

--- a/ui/src/features/settings/components/ConnectionsSection.tsx
+++ b/ui/src/features/settings/components/ConnectionsSection.tsx
@@ -7,7 +7,12 @@ import type { ApiKeyCredentialStatus, SessionUser } from "@/lib/api"
 import { SettingsRow, SettingsSection } from "@/components/AppShell"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { api, notionConnectUrl, slackConnectUrl } from "@/lib/api"
+import {
+  api,
+  desktopConnect,
+  notionConnectUrl,
+  slackConnectUrl,
+} from "@/lib/api"
 import { cn } from "@/lib/utils"
 
 type SetError = (message: string | null) => void
@@ -40,7 +45,15 @@ function SlackRow({ user }: { user: SessionUser }) {
     setConnecting(true)
     // Refresh the cached mapping when the user returns from the OAuth redirect.
     void qc.invalidateQueries({ queryKey: ["myMapping"] })
-    window.location.assign(slackConnectUrl())
+    const pending = desktopConnect("slack")
+    if (!pending) {
+      window.location.assign(slackConnectUrl())
+      return
+    }
+    void pending.finally(() => {
+      setConnecting(false)
+      void qc.invalidateQueries({ queryKey: ["myMapping"] })
+    })
   }
 
   return (
@@ -100,7 +113,15 @@ function NotionRow({ setError }: { setError: SetError }) {
   const connect = () => {
     setConnecting(true)
     void qc.invalidateQueries({ queryKey: ["myNotion"] })
-    window.location.assign(notionConnectUrl())
+    const pending = desktopConnect("notion")
+    if (!pending) {
+      window.location.assign(notionConnectUrl())
+      return
+    }
+    void pending.finally(() => {
+      setConnecting(false)
+      void qc.invalidateQueries({ queryKey: ["myNotion"] })
+    })
   }
 
   return (

--- a/ui/src/features/settings/components/ConnectionsSection.tsx
+++ b/ui/src/features/settings/components/ConnectionsSection.tsx
@@ -7,12 +7,7 @@ import type { ApiKeyCredentialStatus, SessionUser } from "@/lib/api"
 import { SettingsRow, SettingsSection } from "@/components/AppShell"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import {
-  api,
-  desktopConnect,
-  notionConnectUrl,
-  slackConnectUrl,
-} from "@/lib/api"
+import { api, connectService } from "@/lib/api"
 import { cn } from "@/lib/utils"
 
 type SetError = (message: string | null) => void
@@ -45,12 +40,7 @@ function SlackRow({ user }: { user: SessionUser }) {
     setConnecting(true)
     // Refresh the cached mapping when the user returns from the OAuth redirect.
     void qc.invalidateQueries({ queryKey: ["myMapping"] })
-    const pending = desktopConnect("slack")
-    if (!pending) {
-      window.location.assign(slackConnectUrl())
-      return
-    }
-    void pending.finally(() => {
+    void connectService("slack")?.finally(() => {
       setConnecting(false)
       void qc.invalidateQueries({ queryKey: ["myMapping"] })
     })
@@ -113,12 +103,7 @@ function NotionRow({ setError }: { setError: SetError }) {
   const connect = () => {
     setConnecting(true)
     void qc.invalidateQueries({ queryKey: ["myNotion"] })
-    const pending = desktopConnect("notion")
-    if (!pending) {
-      window.location.assign(notionConnectUrl())
-      return
-    }
-    void pending.finally(() => {
+    void connectService("notion")?.finally(() => {
       setConnecting(false)
       void qc.invalidateQueries({ queryKey: ["myNotion"] })
     })

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -915,3 +915,15 @@ export function slackConnectUrl(): string {
 export function notionConnectUrl(): string {
   return `${API_BASE}/dashboard/api/notion/login`
 }
+
+/**
+ * Hand an OAuth connect flow to the desktop app, or `undefined` on the web.
+ *
+ * The web flow is a redirect that comes back to the page that started it. The
+ * desktop app can't use that: its window and the browser that shows the
+ * provider's consent page have separate cookie jars, so the app runs the flow
+ * itself and resolves once the connection is stored.
+ */
+export function desktopConnect(provider: "slack" | "notion") {
+  return window.openSweDesktop?.connectService(provider)
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -908,22 +908,18 @@ export function loginUrl(redirectTo?: string): string {
   return `${API_BASE}/dashboard/api/auth/login${qs}`
 }
 
-export function slackConnectUrl(): string {
-  return `${API_BASE}/dashboard/api/slack/login`
-}
-
-export function notionConnectUrl(): string {
-  return `${API_BASE}/dashboard/api/notion/login`
-}
-
 /**
- * Hand an OAuth connect flow to the desktop app, or `undefined` on the web.
+ * Start an OAuth connect flow, returning a promise only the desktop app has.
  *
  * The web flow is a redirect that comes back to the page that started it. The
  * desktop app can't use that: its window and the browser that shows the
- * provider's consent page have separate cookie jars, so the app runs the flow
+ * provider's consent page have separate cookie jars, so it runs the flow
  * itself and resolves once the connection is stored.
  */
-export function desktopConnect(provider: "slack" | "notion") {
-  return window.openSweDesktop?.connectService(provider)
+export function connectService(provider: "slack" | "notion") {
+  const pending = window.openSweDesktop?.connectService(provider)
+  if (!pending) {
+    window.location.assign(`${API_BASE}/dashboard/api/${provider}/login`)
+  }
+  return pending
 }


### PR DESCRIPTION
Connecting Slack or Notion from the desktop app failed with `oauth state mismatch`. The app proxies `/dashboard/api/*` to the backend, so starting the flow in-window set the state cookie in Electron's jar — but Chromium hands the provider's authorize URL to the system browser, which finishes the callback without that cookie or a session.

Fixed the same way as the GitHub desktop login: the app starts the flow with its own session, opens only the provider URL, and gets a PKCE-bound code back on a loopback port. Redeeming it takes the verifier that never leaves the app, and the account comes from the app's session at redeem time — so a leaked code links nothing. Web flow unchanged.