### PR TITLE
chore(desktop): bump version to 0.2.6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",


### PR DESCRIPTION
Bumps the desktop app from `0.2.5` to `0.2.6`.

Validation: JSON parse/version assertion and `git diff --check`. The repository formatter excludes this file.

Made by [Open SWE](https://openswe.vercel.app/agents/9eb483ed-08a9-5c64-8991-56632ba226bd)