### PR TITLE
fix(ui): correct misleading cursor targets

### DIFF
--- a/ui/src/features/agents/components/SidebarThreadRow.tsx
+++ b/ui/src/features/agents/components/SidebarThreadRow.tsx
@@ -438,7 +438,7 @@ export function SidebarThreadRow({
                   target="_blank"
                   rel="noreferrer"
                   closeOnClick
-                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
+                  className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
                 >
                   <TreeStructureIcon className="size-3.5" />
                   Open trace
@@ -448,7 +448,7 @@ export function SidebarThreadRow({
                 <ContextMenu.LinkItem
                   href={thread.sourceAppUrl ?? thread.sourceUrl}
                   closeOnClick
-                  className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
+                  className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
                 >
                   <IoLogoSlack className="size-3.5" />
                   Open in Slack

--- a/ui/src/features/reviews/components/ReviewMainBody.tsx
+++ b/ui/src/features/reviews/components/ReviewMainBody.tsx
@@ -1741,21 +1741,23 @@ const FileDiffCard = memo(function FileDiffCard({
             {findings.length}
           </span>
         )}
-        <label className="ml-auto inline-flex cursor-pointer items-center gap-1.5 text-[11px] text-muted-foreground">
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={viewed}
+          onClick={() => onToggleViewed(file.path)}
+          className="ml-auto inline-flex cursor-pointer items-center gap-1.5 text-[11px] text-muted-foreground"
+        >
           Mark as viewed
-          <button
-            type="button"
-            role="checkbox"
-            aria-checked={viewed}
-            onClick={() => onToggleViewed(file.path)}
+          <span
             className={cn(
               "flex size-4 items-center justify-center rounded border border-border",
               viewed && "bg-foreground text-background"
             )}
           >
             {viewed && <CheckIcon className="size-3" />}
-          </button>
-        </label>
+          </span>
+        </button>
       </div>
       {expanded &&
         (file.unrenderable ? (


### PR DESCRIPTION
- In an agent thread’s right-click menu, **Open trace** and **Open in Slack** now show the pointing-hand cursor because they are links.
- In the review file header, **Mark as viewed** is now one semantic checkbox button, so clicking either the text or checkbox toggles it.
- Removes the invalid label/button nesting and preserves keyboard and assistive-technology behavior.
- Leaves other buttons, menu commands, drag cursors, and resize cursors unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/01a068e3-796e-73dc-b82a-5cb02788d438)