### PR TITLE
fix(desktop): preserve adaptive macOS Dock icon

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1315,7 +1315,6 @@ if (!hasSingleInstanceLock) {
       return;
     }
 
-    if (process.platform === "darwin") app.dock.setIcon(iconPath());
     localThreadStore = new LocalThreadStore(
       path.join(app.getPath("userData"), "desktop-local-threads.json"),
     );


### PR DESCRIPTION
- stop overriding the macOS Dock icon with the legacy PNG at runtime
- allow macOS to render the bundled adaptive icon according to the user's icon appearance preferences
- preserve the existing PNG icon path for window icons on other platforms

Made by [Open SWE](https://openswe.vercel.app/agents/01a068f6-5b2b-77ee-8ec1-0f285cac33b4)