### PR TITLE
fix(desktop): keep updater artifact names consistent

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -52,11 +52,11 @@ jobs:
             if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
               if gh release view "$tag" --json assets | jq -e --arg v "$version" '
                 [.assets[].name] as $names |
-                ($names | index("Open SWE-\($v).app.zip")) != null and
+                ($names | index("Open-SWE-\($v).app.zip")) != null and
                 ($names | index("latest-mac.yml")) != null and
-                any($names[]; test("^Open SWE-\($v)-.*-mac\\.zip$")) and
-                any($names[]; test("^Open SWE-\($v)-.*\\.dmg$")) and
-                any($names[]; test("^Open SWE-\($v)-.*-mac\\.zip\\.blockmap$"))
+                any($names[]; test("^Open-SWE-\($v)-.*-mac\\.zip$")) and
+                any($names[]; test("^Open-SWE-\($v)-.*\\.dmg$")) and
+                any($names[]; test("^Open-SWE-\($v)-.*-mac\\.zip\\.blockmap$"))
               ' >/dev/null; then
                 echo "$tag already has a complete release"
                 exit 1
@@ -134,8 +134,8 @@ jobs:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           shopt -s nullglob
-          mac_zips=(desktop/dist/"Open SWE-${VERSION}"-*-mac.zip)
-          mac_dmgs=(desktop/dist/"Open SWE-${VERSION}"-*.dmg)
+          mac_zips=(desktop/dist/"Open-SWE-${VERSION}"-*-mac.zip)
+          mac_dmgs=(desktop/dist/"Open-SWE-${VERSION}"-*-mac.dmg)
 
           if [ "${#mac_zips[@]}" -ne 1 ] || [ "${#mac_dmgs[@]}" -ne 1 ]; then
             echo "Expected one macOS zip and one DMG for version ${VERSION}"
@@ -160,7 +160,7 @@ jobs:
           spctl --assess --type execute --verbose=2 "${apps[0]}"
           hdiutil verify "${mac_dmgs[0]}"
 
-          app_zip="desktop/dist/Open SWE-${VERSION}.app.zip"
+          app_zip="desktop/dist/Open-SWE-${VERSION}.app.zip"
           ditto -c -k --sequesterRsrc --keepParent "${apps[0]}" "$app_zip"
 
           echo "mac_zip=${mac_zips[0]}" >> "$GITHUB_OUTPUT"
@@ -169,6 +169,11 @@ jobs:
           if [ "${{ steps.release.outputs.prerelease }}" = "false" ]; then
             test -f desktop/dist/latest-mac.yml
             test -f "${mac_zips[0]}.blockmap"
+            zip_name=$(basename "${mac_zips[0]}")
+            dmg_name=$(basename "${mac_dmgs[0]}")
+            grep -Fqx "path: ${zip_name}" desktop/dist/latest-mac.yml
+            grep -Fq "url: ${zip_name}" desktop/dist/latest-mac.yml
+            grep -Fq "url: ${dmg_name}" desktop/dist/latest-mac.yml
             echo "update_metadata=desktop/dist/latest-mac.yml" >> "$GITHUB_OUTPUT"
             echo "update_blockmap=${mac_zips[0]}.blockmap" >> "$GITHUB_OUTPUT"
           fi

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -74,6 +74,7 @@
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
+      "artifactName": "Open-SWE-${version}-${arch}-mac.${ext}",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Open SWE uses the microphone for message dictation."
       },

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -106,9 +106,16 @@ let localThreadStore = null;
 let lastActivity = {};
 let backendSupervisor = null;
 let openAiOAuth = null;
-let updateState = { status: "idle" };
+type DesktopUpdateState = {
+  status: "idle" | "downloading" | "ready" | "installing";
+  version?: string;
+};
+let updateState: DesktopUpdateState = { status: "idle" };
 
-function setUpdateState(status, version) {
+function setUpdateState(
+  status: DesktopUpdateState["status"],
+  version?: string,
+) {
   updateState = { status, ...(version ? { version } : {}) };
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send("desktop:update-state", updateState);
@@ -367,15 +374,24 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:install-update", async (event) => {
     requireTrustedDesktopIpc(event);
+    if (updateState.status === "installing") return true;
     if (updateState.status !== "ready") return false;
+    const version = updateState.version;
+    setUpdateState("installing", version);
     quitting = true;
-    await Promise.all([
-      closeAllTerminals(),
-      backendSupervisor?.close(),
-      openAiOAuth?.close(),
-    ]);
-    autoUpdater.quitAndInstall(false, true);
-    return true;
+    try {
+      await Promise.all([
+        closeAllTerminals(),
+        backendSupervisor?.close(),
+        openAiOAuth?.close(),
+      ]);
+      autoUpdater.quitAndInstall(false, true);
+      return true;
+    } catch (error) {
+      quitting = false;
+      setUpdateState("ready", version);
+      throw error;
+    }
   });
 
   ipcMain.handle("desktop:projects", (event) => {

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -112,7 +112,7 @@ export type DesktopTerminalMetadataEvent =
   | (DesktopTerminalTarget & { type: "remove" })
 
 export type DesktopUpdateState = {
-  status: "idle" | "downloading" | "ready"
+  status: "idle" | "downloading" | "ready" | "installing"
   version?: string
 }
 

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -220,6 +220,17 @@ export function AgentsSidebar({
     void desktop.getUpdateState().then(setUpdateState)
     return desktop.onUpdateState(setUpdateState)
   }, [])
+  const installUpdate = useCallback(async () => {
+    const desktop = window.openSweDesktop
+    if (!desktop || updateState.status !== "ready") return
+    const readyState = updateState
+    setUpdateState({ ...readyState, status: "installing" })
+    if (await desktop.installUpdate().catch(() => false)) return
+    setUpdateState((current) =>
+      current.status === "installing" ? readyState : current
+    )
+  }, [updateState])
+  const updateInstalling = updateState.status === "installing"
   const projectMode = prefs.organize === "project"
   const includeAutomations =
     prefs.filters.includeAutomations ||
@@ -833,27 +844,29 @@ export function AgentsSidebar({
             </Link>
           )}
         </div>
-        {updateState.status !== "idle" && (
+        {(updateState.status === "ready" || updateInstalling) && (
           <button
             type="button"
-            title={
-              updateState.status === "ready" ? "Update" : "Downloading update…"
-            }
-            aria-label={
-              updateState.status === "ready" ? "Update" : "Downloading update"
-            }
-            disabled={updateState.status !== "ready"}
-            onClick={() => void window.openSweDesktop?.installUpdate()}
-            className="group flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground hover:w-auto hover:bg-primary/90 hover:px-3 disabled:opacity-60"
-          >
-            {updateState.status === "downloading" ? (
-              <CircleNotchIcon className="size-4 animate-spin group-hover:hidden" />
-            ) : (
-              <DownloadSimpleIcon className="size-4 group-hover:hidden" />
+            title={updateInstalling ? "Installing update…" : "Update"}
+            aria-label={updateInstalling ? "Installing update" : "Update"}
+            disabled={updateInstalling}
+            onClick={() => void installUpdate()}
+            className={cn(
+              "group flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground hover:w-auto hover:bg-primary/90 hover:px-3 disabled:opacity-60",
+              updateInstalling && "w-auto gap-2 px-3"
             )}
-            <span className="hidden group-hover:inline">
-              {updateState.status === "ready" ? "Update" : "Downloading…"}
-            </span>
+          >
+            {updateInstalling ? (
+              <>
+                <CircleNotchIcon className="size-4 animate-spin" />
+                <span>Installing…</span>
+              </>
+            ) : (
+              <>
+                <DownloadSimpleIcon className="size-4 group-hover:hidden" />
+                <span className="hidden group-hover:inline">Update</span>
+              </>
+            )}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary

- give macOS release artifacts deterministic hyphenated filenames that match electron-builder update metadata
- update release completeness checks and asset discovery for the new naming
- fail stable releases before upload when `latest-mac.yml` does not reference the exact generated ZIP and DMG
- hide the updater control while an update downloads in the background
- immediately show a disabled `Installing…` spinner while shutdown cleanup runs, with re-entrant installs blocked and failure recovery back to ready

## Live release repair

Renamed the v0.2.6 GitHub release assets to the filenames already referenced by `latest-mac.yml`. Both updater asset URLs return HTTP 200.

## Validation

- desktop typecheck and build
- desktop tests: 55 passed
- UI typecheck and lint
- UI tests: 302 passed
- formatting and `git diff --check`
- verified electron-builder macro expansion for ZIP and DMG names
- verified every v0.2.6 updater manifest URL returns HTTP 200