### PR TITLE
fix: filter run config before serialization

### DIFF
--- a/agent/run_config.py
+++ b/agent/run_config.py
@@ -219,9 +219,9 @@ class RunConfig(BaseModel):
         """Parse the running graph's own ``configurable``."""
         return cls.from_config(get_config())
 
-    def dump(self) -> dict[str, Any]:
+    def dump(self, *, include: set[str] | None = None) -> dict[str, Any]:
         """The JSON value to store, preserving exactly the keys that were set."""
-        return self.model_dump(mode="json", exclude_unset=True)
+        return self.model_dump(mode="json", exclude_unset=True, include=include)
 
     def get(self, key: str) -> Any:
         """Value for ``key``, whether it is a declared field or an extra."""

--- a/agent/tools/manage_baby_sit.py
+++ b/agent/tools/manage_baby_sit.py
@@ -40,20 +40,17 @@ def _run_config(cfg: RunConfig, thread_id: str) -> dict[str, Any]:
         "agent_model_id",
         "agent_effort",
     )
-    dumped = cfg.dump()
+    dumped = cfg.dump(include=set(allowed))
     result = {key: dumped[key] for key in allowed if dumped.get(key) is not None}
     result["thread_id"] = thread_id
     return result
 
 
 def _source_context(cfg: RunConfig) -> SourceContext:
-    dumped = cfg.dump()
+    allowed = {"slack_thread", "linear_issue", "github_issue"}
+    dumped = cfg.dump(include=allowed)
     return SourceContext.parse(
-        {
-            key: dumped[key]
-            for key in ("slack_thread", "linear_issue", "github_issue")
-            if isinstance(dumped.get(key), Mapping)
-        }
+        {key: dumped[key] for key in allowed if isinstance(dumped.get(key), Mapping)}
     )
 
 

--- a/agent/tools/schedule_thread_wakeup.py
+++ b/agent/tools/schedule_thread_wakeup.py
@@ -295,7 +295,7 @@ async def schedule_thread_wakeup(delay_minutes: int, prompt: str | None = None) 
         "user_email",
         "schedule_id",
     )
-    dumped = cfg.dump()
+    dumped = cfg.dump(include=set(passthrough_keys))
     wakeup_configurable: dict[str, Any] = {"thread_id": thread_id}
     for key in passthrough_keys:
         value = dumped.get(key)

--- a/tests/tools/test_manage_baby_sit.py
+++ b/tests/tools/test_manage_baby_sit.py
@@ -17,6 +17,7 @@ async def test_manage_baby_sit_starts_watch_from_current_thread(
         "github_login": "octocat",
         "repo": {"owner": "acme", "name": "repo"},
         "slack_thread": {"channel_id": "C1", "thread_ts": "1.2"},
+        "langgraph_auth_user": object(),
     }
     monkeypatch.setattr(manage_tool, "get_config", lambda: {"configurable": configurable})
     monkeypatch.setattr(

--- a/tests/tools/test_schedule_thread_wakeup.py
+++ b/tests/tools/test_schedule_thread_wakeup.py
@@ -114,6 +114,7 @@ def _config(**overrides: Any) -> dict[str, Any]:
             "slack_thread": {"channel_id": "C1", "thread_ts": "1.0"},
             "github_login": "johannes117",
             "user_email": "johannes@example.com",
+            "langgraph_auth_user": object(),
         }
     }
     base["configurable"].update(overrides)


### PR DESCRIPTION
Filter persisted run config to each tool’s allow-list before JSON serialization, preventing platform-injected objects from breaking baby-sit watches or scheduled wakeups.

Tests: `25 passed`; Ruff and ty pass.

Made by [Open SWE](https://openswe.vercel.app/agents/65a1cf45-ff5a-58e5-8b20-f89ae5563947)