### PR TITLE
docs: restore OpenWiki guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,6 @@ The main agent and middleware stack are assembled in `agent/server.py`. Middlewa
 - Add sandbox providers under `agent/sandboxes/providers/` and register them in `registry.py`.
 - Add dashboard endpoints through `agent/dashboard/routes.py` and graph entrypoints through `langgraph.json`.
 - Do not add tests that only restate static prompt text; test rendering, composition, precedence, or behavior.
-- Do not hand-edit generated `openwiki/` content unless explicitly asked.
 
 <!-- OPENWIKI:START -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,16 @@ The main agent and middleware stack are assembled in `agent/server.py`. Middlewa
 - Add dashboard endpoints through `agent/dashboard/routes.py` and graph entrypoints through `langgraph.json`.
 - Do not add tests that only restate static prompt text; test rendering, composition, precedence, or behavior.
 - Do not hand-edit generated `openwiki/` content unless explicitly asked.
+
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+This repository has a generated `openwiki/` evidence index. It is optional just-in-time context, not required startup reading.
+
+- Treat source code and tests as authoritative. A brief's unknowns and review items are verification gaps, not automatic requirements.
+- Prefer the narrowest quiet validation that proves the changed behavior. Preserve complete failure output.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+<!-- OPENWIKI:END -->


### PR DESCRIPTION
Restores the OpenWiki guidance block removed by #2423 so future OpenWiki runs retain their generated-index and refresh instructions.

### Verification

- `make format`
- `make lint`
- `git diff --check`

Made by [Open SWE](https://openswe.vercel.app/agents/1944bec3-c068-5aa6-b9e2-92d9b419b084)