### PR TITLE
fix: remove sidebar bottom scroll shadow gap

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -635,8 +635,8 @@ export function AgentsSidebar({
           )}
           {scrollEdges.bottom && (
             <>
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-px bg-border" />
-              <div className="pointer-events-none absolute inset-x-0 bottom-px z-10 h-3 bg-gradient-to-t from-sidebar to-transparent" />
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-px bg-border" />
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-3 bg-gradient-to-t from-sidebar to-transparent" />
             </>
           )}
           <div


### PR DESCRIPTION
The bottom scroll edge in `AgentsSidebar` still had the 1px gap fixed for the top edge in #2346: the fade started at `bottom-px` and sat at the same z-index as the border. Mirrored the top-edge fix — fade anchored at `bottom-0` with the border on `z-20`.

## screenshot
### before
<img width="317" height="100" alt="download" src="https://github.com/user-attachments/assets/aec5ce2e-a16c-491a-a57c-82c2596ae8d1" />

### after
<img width="344" height="113" alt="Screenshot 2026-09-03 at 4 59 37 PM" src="https://github.com/user-attachments/assets/845a1b4e-befe-4de0-8290-7cc7ccd8fb80" />

Made by [Open SWE](https://openswe.vercel.app/agents/01a06977-cf24-751e-b3c4-849a029171e1)