### PR TITLE
fix: verify Slack signatures from raw request bytes

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -176,10 +176,10 @@ def verify_slack_signature(
     if abs(int(time.time()) - request_timestamp) > max_age_seconds:
         return False
 
-    base_string = f"v0:{timestamp}:{body.decode('utf-8', errors='replace')}"
+    base_string = b"v0:" + timestamp.encode("utf-8") + b":" + body
     expected = (
         "v0="
-        + hmac.new(secret.encode("utf-8"), base_string.encode("utf-8"), hashlib.sha256).hexdigest()
+        + hmac.new(secret.encode("utf-8"), base_string, hashlib.sha256).hexdigest()
     )
     return hmac.compare_digest(expected, signature)
 

--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -177,10 +177,7 @@ def verify_slack_signature(
         return False
 
     base_string = b"v0:" + timestamp.encode("utf-8") + b":" + body
-    expected = (
-        "v0="
-        + hmac.new(secret.encode("utf-8"), base_string, hashlib.sha256).hexdigest()
-    )
+    expected = "v0=" + hmac.new(secret.encode("utf-8"), base_string, hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature)
 
 

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import hmac
 from typing import cast
 from xml.etree import ElementTree
 
@@ -15,6 +17,7 @@ from agent.slack.client import (
     replace_bot_mention_with_username,
     select_slack_context_messages,
     strip_bot_mention,
+    verify_slack_signature,
 )
 from agent.source_context import SourceContext
 from agent.utils.run_usage import RunUsageSummary
@@ -23,6 +26,20 @@ from agent.webhooks import common as webhook_common
 
 async def _fake_trace_url(thread_id: str, **kwargs: object) -> str:
     return "https://smith/x"
+
+
+def test_verify_slack_signature_uses_raw_request_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    timestamp = "1700000000"
+    secret = "secret"
+    body = b"payload=\xff"
+    signature = "v0=" + hmac.new(
+        secret.encode("utf-8"),
+        b"v0:" + timestamp.encode("utf-8") + b":" + body,
+        hashlib.sha256,
+    ).hexdigest()
+    monkeypatch.setattr(slack_utils.time, "time", lambda: int(timestamp))
+
+    assert verify_slack_signature(body, timestamp, signature, secret)
 
 
 class _FakeNotFoundError(Exception):

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -32,11 +32,14 @@ def test_verify_slack_signature_uses_raw_request_body(monkeypatch: pytest.Monkey
     timestamp = "1700000000"
     secret = "secret"
     body = b"payload=\xff"
-    signature = "v0=" + hmac.new(
-        secret.encode("utf-8"),
-        b"v0:" + timestamp.encode("utf-8") + b":" + body,
-        hashlib.sha256,
-    ).hexdigest()
+    signature = (
+        "v0="
+        + hmac.new(
+            secret.encode("utf-8"),
+            b"v0:" + timestamp.encode("utf-8") + b":" + body,
+            hashlib.sha256,
+        ).hexdigest()
+    )
     monkeypatch.setattr(slack_utils.time, "time", lambda: int(timestamp))
 
     assert verify_slack_signature(body, timestamp, signature, secret)


### PR DESCRIPTION
Fixes #2310.

## Summary
- Build Slack's signed payload from the original request bytes.
- Add a regression test with an invalid UTF-8 byte, signed as Slack signs it.

## Testing
- uff format agent/slack/client.py tests/slack/test_slack_context.py`n- uff check agent/slack/client.py tests/slack/test_slack_context.py`n- Full pytest is blocked locally: the Windows host lacks MSVC link.exe, required to build the transitive obstore dependency.