### PR TITLE
fix: read custom prompts as UTF-8

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -25,7 +25,7 @@ def _load_default_prompt() -> str:
     """
     try:
         if DEFAULT_PROMPT_PATH:
-            content = Path(DEFAULT_PROMPT_PATH).read_text().strip()
+            content = Path(DEFAULT_PROMPT_PATH).read_text(encoding="utf-8").strip()
         else:
             content = (
                 resources.files("agent.resources")

--- a/tests/agent/test_default_prompt.py
+++ b/tests/agent/test_default_prompt.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+from agent import prompt
+
+
+def test_custom_default_prompt_is_read_as_utf8(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_bytes("Use an em dash â€” safely.".encode())
+    monkeypatch.setattr(prompt, "DEFAULT_PROMPT_PATH", str(prompt_path))
+
+    assert "Use an em dash â€” safely." in prompt._load_default_prompt()


### PR DESCRIPTION
Fixes #2304.

## Summary
- Read DEFAULT_PROMPT_PATH with the same UTF-8 encoding as bundled prompts.
- Add regression coverage for non-ASCII custom instructions.

## Testing
- uff format agent/prompt.py tests/agent/test_default_prompt.py`n- uff check agent/prompt.py tests/agent/test_default_prompt.py`n- Full pytest is blocked locally: the Windows host lacks MSVC link.exe, required to build the transitive obstore dependency.