### PR TITLE
fix: support desktop artifact paths on Windows

### DIFF
--- a/agent/desktop.py
+++ b/agent/desktop.py
@@ -1,4 +1,5 @@
 import asyncio
+import getpass
 import json
 import os
 import re
@@ -71,7 +72,9 @@ def _artifacts_root() -> Path:
     configured = os.environ.get("OPEN_SWE_LOCAL_ARTIFACTS_DIR")
     if configured:
         return Path(configured)
-    return Path(tempfile.gettempdir()) / f"open-swe-artifacts-{os.getuid()}"
+    uid = getattr(os, "getuid", None)
+    identity = str(uid()) if uid else getpass.getuser()
+    return Path(tempfile.gettempdir()) / f"open-swe-artifacts-{identity}"
 
 
 async def desktop_artifact_routes(thread_id: str) -> dict[str, FilesystemBackend]:

--- a/tests/agent/test_desktop.py
+++ b/tests/agent/test_desktop.py
@@ -7,6 +7,7 @@ import pytest
 from blockbuster import BlockBuster
 
 from agent.desktop import (
+    _artifacts_root,
     create_desktop_backend,
     desktop_artifact_routes,
     resolve_desktop_project,
@@ -69,6 +70,14 @@ def test_desktop_backend_rejects_an_unregistered_directory(
 
     with pytest.raises(ValueError, match="not an allowed project directory"):
         resolve_desktop_project(RunConfig(local_project_path=str(project)))
+
+
+def test_artifacts_root_uses_username_without_posix_uid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPEN_SWE_LOCAL_ARTIFACTS_DIR", raising=False)
+    monkeypatch.delattr("agent.desktop.os.getuid", raising=False)
+    monkeypatch.setattr("agent.desktop.getpass.getuser", lambda: "desktop-user")
+
+    assert _artifacts_root().name == "open-swe-artifacts-desktop-user"
 
 
 async def test_artifact_routes_stay_out_of_the_project(


### PR DESCRIPTION
Fixes #2302.

## Summary
- Use the POSIX UID when available and the current username otherwise.
- Add a no-os.getuid regression test.

## Testing
- uff format agent/desktop.py tests/agent/test_desktop.py`n- uff check agent/desktop.py tests/agent/test_desktop.py`n- Full pytest is blocked locally: the Windows host lacks MSVC link.exe, required to build the transitive obstore dependency.