### PR TITLE
feat: support OpenAI chat completions gateways

### DIFF
--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -110,11 +110,15 @@ _ANTHROPIC_EFFORTS: set[AnthropicEffort] = {"low", "medium", "high", "xhigh", "m
 
 
 def _openai_responses_api_enabled() -> bool:
-    return os.environ.get("OPENAI_USE_RESPONSES_API", "true").lower() not in {
-        "0",
-        "false",
-        "no",
-    }
+    raw = os.environ.get("OPENAI_USE_RESPONSES_API")
+    if raw is None:
+        return True
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes"}:
+        return True
+    if normalized in {"0", "false", "no"}:
+        return False
+    raise ValueError("OPENAI_USE_RESPONSES_API must be true or false")
 
 
 def _coerce_openai_chat_completions_kwargs(model_kwargs: dict[str, object]) -> None:

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -109,6 +109,14 @@ class ModelKwargs(TypedDict, total=False):
 _ANTHROPIC_EFFORTS: set[AnthropicEffort] = {"low", "medium", "high", "xhigh", "max"}
 
 
+def _openai_responses_api_enabled() -> bool:
+    return os.environ.get("OPENAI_USE_RESPONSES_API", "true").lower() not in {
+        "0",
+        "false",
+        "no",
+    }
+
+
 def _coerce_openai_chat_completions_kwargs(model_kwargs: dict[str, object]) -> None:
     if model_kwargs.get("use_responses_api") is not False:
         return
@@ -150,7 +158,7 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
             or os.environ.get("OPENAI_API_BASE")
             or OPENAI_RESPONSES_WS_BASE_URL
         )
-        model_kwargs["use_responses_api"] = True
+        model_kwargs["use_responses_api"] = _openai_responses_api_enabled()
 
     enabled = gateway_env_default() if use_gateway is None else use_gateway
     gateway_applied = False

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -422,6 +422,7 @@ ANTHROPIC_API_KEY=""                   # Anthropic API key
 BASETEN_API_KEY=""                     # Baseten models when not using LangSmith Gateway
 OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dictation
 # OPENAI_BASE_URL="https://api.openai.com/v1"  # Optional OpenAI-compatible API base URL
+# OPENAI_USE_RESPONSES_API="false"  # Use Chat Completions for compatible gateways
 GOOGLE_API_KEY=""                      # Google AI API key (when using google_genai: models)
 FIREWORKS_API_KEY=""                   # Fireworks API key (when using fireworks: models)
 # Voice dictation uses this OpenAI configuration.

--- a/tests/models/test_model_request_timeout.py
+++ b/tests/models/test_model_request_timeout.py
@@ -60,3 +60,10 @@ def test_openai_base_url_can_use_chat_completions(monkeypatch: pytest.MonkeyPatc
 
     assert captured["base_url"] == "https://gateway.example/v1"
     assert captured["use_responses_api"] is False
+
+
+def test_openai_responses_api_flag_rejects_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_USE_RESPONSES_API", "sometimes")
+
+    with pytest.raises(ValueError, match="must be true or false"):
+        _make_model("openai:compatible-model")

--- a/tests/models/test_model_request_timeout.py
+++ b/tests/models/test_model_request_timeout.py
@@ -1,6 +1,8 @@
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from agent.utils import model
 
 
@@ -48,3 +50,13 @@ def test_explicit_timeout_wins() -> None:
 
 def test_unknown_provider_gets_no_timeout() -> None:
     assert "timeout" not in _make_model("ollama:llama4")
+
+
+def test_openai_base_url_can_use_chat_completions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+    monkeypatch.setenv("OPENAI_USE_RESPONSES_API", "false")
+
+    captured = _make_model("openai:compatible-model")
+
+    assert captured["base_url"] == "https://gateway.example/v1"
+    assert captured["use_responses_api"] is False


### PR DESCRIPTION
Fixes #2292.

## Summary
- Add OPENAI_USE_RESPONSES_API=false for OpenAI-compatible Chat Completions gateways.
- Document the configuration and test the constructed model kwargs.

## Testing
- uff format agent/utils/model.py tests/models/test_model_request_timeout.py`n- uff check agent/utils/model.py tests/models/test_model_request_timeout.py`n- Full pytest is blocked locally: the Windows host lacks MSVC link.exe, required to build the transitive obstore dependency.