### PR TITLE
feat: Haiku thread-title fallback for Anthropic-only deployments

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -40,6 +40,15 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "can_be_default": False,
     },
     {
+        "id": "anthropic:claude-haiku-4-5",
+        "label": "Haiku 4.5",
+        # Haiku 4.5 predates the adaptive-thinking/effort params the other
+        # Claude entries rely on, so it is offered without reasoning.
+        "efforts": ["none"],
+        "default_effort": "none",
+        "supports_images": True,
+    },
+    {
         "id": "openai:gpt-5.6-sol",
         "label": "GPT-5.6 Sol",
         "efforts": ["none", "low", "medium", "high", "xhigh"],

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -25,7 +25,6 @@ from agent.dashboard.options import (
 )
 from agent.store import get_value, now_iso, put_value
 from agent.utils.gateway import gateway_overrides, resolve_gateway_enabled
-from agent.utils.openai_oauth import desktop_openai_oauth_available
 
 logger = logging.getLogger(__name__)
 
@@ -478,6 +477,8 @@ def _gate_openai_title_model(pair: tuple[str, str], *, gateway_enabled: bool) ->
     # bypassed and the call still needs a real OpenAI credential.
     if gateway_enabled and gateway_overrides(pair[0]) is not None:
         return pair
+    from agent.utils.openai_oauth import desktop_openai_oauth_available
+
     if os.environ.get("OPENAI_API_KEY") or desktop_openai_oauth_available():
         return pair
     if not os.environ.get("ANTHROPIC_API_KEY"):

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -38,7 +38,7 @@ ORG_GUIDELINES_MAX_CHARS = 10_000
 REVIEW_TRACING_PROJECT_MAX_CHARS = 256
 DEFAULT_THREAD_TITLE_MODEL = "openai:gpt-5.6-luna"
 DEFAULT_THREAD_TITLE_REASONING_EFFORT = "low"
-ANTHROPIC_THREAD_TITLE_MODEL = "anthropic:claude-haiku-5"
+ANTHROPIC_THREAD_TITLE_MODEL = "anthropic:claude-haiku-4-5"
 # Titles are a one-shot classification; no extended thinking needed.
 ANTHROPIC_THREAD_TITLE_REASONING_EFFORT = "none"
 DEFAULT_TRANSCRIPTION_MODEL = "gpt-transcribe"

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -24,7 +24,7 @@ from agent.dashboard.options import (
     provider_fallback_pair,
 )
 from agent.store import get_value, now_iso, put_value
-from agent.utils.gateway import resolve_gateway_enabled
+from agent.utils.gateway import gateway_overrides, resolve_gateway_enabled
 from agent.utils.openai_oauth import desktop_openai_oauth_available
 
 logger = logging.getLogger(__name__)
@@ -472,15 +472,17 @@ def _gate_openai_title_model(pair: tuple[str, str], *, gateway_enabled: bool) ->
     Anthropic-only install would otherwise fail every title with a missing
     OPENAI_API_KEY.
     """
-    if (
-        pair[0].startswith("openai:")
-        and not gateway_enabled
-        and not os.environ.get("OPENAI_API_KEY")
-        and not desktop_openai_oauth_available()
-        and os.environ.get("ANTHROPIC_API_KEY")
-    ):
-        return ANTHROPIC_THREAD_TITLE_MODEL, ANTHROPIC_THREAD_TITLE_REASONING_EFFORT
-    return pair
+    if not pair[0].startswith("openai:"):
+        return pair
+    # The toggle alone isn't enough: without a LangSmith key the gateway is
+    # bypassed and the call still needs a real OpenAI credential.
+    if gateway_enabled and gateway_overrides(pair[0]) is not None:
+        return pair
+    if os.environ.get("OPENAI_API_KEY") or desktop_openai_oauth_available():
+        return pair
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return pair
+    return ANTHROPIC_THREAD_TITLE_MODEL, ANTHROPIC_THREAD_TITLE_REASONING_EFFORT
 
 
 async def get_team_default_thread_title_model() -> tuple[str, str]:

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -25,6 +25,7 @@ from agent.dashboard.options import (
 )
 from agent.store import get_value, now_iso, put_value
 from agent.utils.gateway import resolve_gateway_enabled
+from agent.utils.openai_oauth import desktop_openai_oauth_available
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,9 @@ ORG_GUIDELINES_MAX_CHARS = 10_000
 REVIEW_TRACING_PROJECT_MAX_CHARS = 256
 DEFAULT_THREAD_TITLE_MODEL = "openai:gpt-5.6-luna"
 DEFAULT_THREAD_TITLE_REASONING_EFFORT = "low"
+ANTHROPIC_THREAD_TITLE_MODEL = "anthropic:claude-haiku-5"
+# Titles are a one-shot classification; no extended thinking needed.
+ANTHROPIC_THREAD_TITLE_REASONING_EFFORT = "none"
 DEFAULT_TRANSCRIPTION_MODEL = "gpt-transcribe"
 TRANSCRIPTION_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 
@@ -461,6 +465,24 @@ async def get_team_default_grouping_model() -> tuple[str, str]:
     )
 
 
+def _gate_openai_title_model(pair: tuple[str, str], *, gateway_enabled: bool) -> tuple[str, str]:
+    """Swap an OpenAI title model for Haiku on Anthropic-only deployments.
+
+    Title generation is the one model choice users rarely revisit, so an
+    Anthropic-only install would otherwise fail every title with a missing
+    OPENAI_API_KEY.
+    """
+    if (
+        pair[0].startswith("openai:")
+        and not gateway_enabled
+        and not os.environ.get("OPENAI_API_KEY")
+        and not desktop_openai_oauth_available()
+        and os.environ.get("ANTHROPIC_API_KEY")
+    ):
+        return ANTHROPIC_THREAD_TITLE_MODEL, ANTHROPIC_THREAD_TITLE_REASONING_EFFORT
+    return pair
+
+
 async def get_team_default_thread_title_model() -> tuple[str, str]:
     settings = await get_team_settings()
     model = settings.get("default_thread_title_model")
@@ -472,8 +494,12 @@ async def get_team_default_thread_title_model() -> tuple[str, str]:
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
     ):
-        return _resolve_default_pair(model, effort)
-    return DEFAULT_THREAD_TITLE_MODEL, DEFAULT_THREAD_TITLE_REASONING_EFFORT
+        pair = _resolve_default_pair(model, effort)
+    else:
+        pair = DEFAULT_THREAD_TITLE_MODEL, DEFAULT_THREAD_TITLE_REASONING_EFFORT
+    return _gate_openai_title_model(
+        pair, gateway_enabled=resolve_gateway_enabled(settings.get("gateway_enabled"))
+    )
 
 
 async def get_team_review_trace_links_enabled() -> bool:


### PR DESCRIPTION
The thread-title default is `openai:gpt-5.6-luna`, so a deployment configured with only `ANTHROPIC_API_KEY` fails every title generation.

- `get_team_default_thread_title_model` swaps an OpenAI title model for `anthropic:claude-haiku-4-5` when gateway routing is off, there is no `OPENAI_API_KEY` or desktop OAuth, and `ANTHROPIC_API_KEY` is set.
- Adds `anthropic:claude-haiku-4-5` ("Haiku 4.5") to the supported models so it can also be picked explicitly. Offered without reasoning effort (`none`) because it predates the adaptive-thinking/effort params the other Claude entries use.

Explicit non-OpenAI choices and admin validation are untouched. No UI code changed; the picker is driven by the backend options list.

Made by [Open SWE](https://openswe.vercel.app/agents/01a069fc-507c-7104-bd1b-2b6bba4bfeb0)