### PR TITLE
fix: enforce public-repo gate for push webhooks

### DIFF
--- a/agent/github/routes.py
+++ b/agent/github/routes.py
@@ -93,6 +93,9 @@ async def github_webhook(
     if event_type == "push":
         if not await common._is_repo_auto_review_enabled(webhook_repo_config):
             return {"status": "ignored", "reason": "Automatic review disabled for repository"}
+        gate_rejection = await common._enforce_public_repo_org_gate(payload, "push")
+        if gate_rejection is not None:
+            return gate_rejection
         common.logger.info("Accepted GitHub push webhook, scheduling reviewer watch evaluation")
         background_tasks.add_task(service.process_github_push_event, payload)
         return {"status": "accepted", "message": "Processing GitHub push for reviewer watch"}

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import logging
 from typing import cast
+from unittest.mock import AsyncMock
 from xml.etree import ElementTree
 
 import pytest
@@ -167,6 +168,74 @@ def test_github_webhook_skips_automatic_review_when_disabled(monkeypatch) -> Non
         "reason": "Automatic review disabled for repository",
     }
     assert called is False
+
+
+def test_github_webhook_push_rejects_non_member_for_public_repo(monkeypatch) -> None:
+    process_push = AsyncMock()
+    monkeypatch.setattr(webhook_common, "GITHUB_WEBHOOK_SECRET", _TEST_WEBHOOK_SECRET)
+    monkeypatch.setattr(webhook_common, "PUBLIC_REPO_ORG_GATE", "trusted-org")
+    monkeypatch.setattr(
+        webhook_common, "_is_repo_auto_review_enabled", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(webhook_common, "is_user_active_org_member", AsyncMock(return_value=False))
+    monkeypatch.setattr(github_webhooks, "process_github_push_event", process_push)
+
+    client = TestClient(app)
+    response = _post_github_webhook(
+        client,
+        "push",
+        {
+            "repository": {
+                "owner": {"login": "langchain-ai"},
+                "name": "open-swe",
+                "private": False,
+            },
+            "sender": {"login": "external-user"},
+            "ref": "refs/heads/feature",
+            "after": "deadbeef",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ignored",
+        "reason": "Sender is not a member of the allowed organization for public-repo triggers",
+    }
+    process_push.assert_not_awaited()
+
+
+def test_github_webhook_push_accepts_allowed_sender(monkeypatch) -> None:
+    process_push = AsyncMock()
+    monkeypatch.setattr(webhook_common, "GITHUB_WEBHOOK_SECRET", _TEST_WEBHOOK_SECRET)
+    monkeypatch.setattr(webhook_common, "PUBLIC_REPO_ORG_GATE", "trusted-org")
+    monkeypatch.setattr(
+        webhook_common, "_is_repo_auto_review_enabled", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(webhook_common, "is_user_active_org_member", AsyncMock(return_value=True))
+    monkeypatch.setattr(github_webhooks, "process_github_push_event", process_push)
+
+    client = TestClient(app)
+    response = _post_github_webhook(
+        client,
+        "push",
+        {
+            "repository": {
+                "owner": {"login": "langchain-ai"},
+                "name": "open-swe",
+                "private": False,
+            },
+            "sender": {"login": "trusted-user"},
+            "ref": "refs/heads/feature",
+            "after": "deadbeef",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "accepted",
+        "message": "Processing GitHub push for reviewer watch",
+    }
+    process_push.assert_awaited_once()
 
 
 def test_github_webhook_accepts_issue_events(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #2452

Push webhooks now enforce the configured public-repository organization gate before scheduling reviewer-watch evaluation.

## Changes

- Call _enforce_public_repo_org_gate for push events after automatic-review opt-in is confirmed.
- Reject non-members on public repositories without scheduling a reviewer run.
- Add regression coverage for rejected non-members and accepted organization members.

## Testing

- Targeted tests: 2 passed.
- Full pytest: 2008 passed, 11 skipped, 5 pre-existing Windows failures unrelated to this change.
- Ruff check: passed.
- Ruff format check: passed.
- Targeted ty check for changed files: passed.
- Full ty check still reports existing diagnostics in desktop.py, stagehand_runtime.py, and the excluded Daytona provider.
