### PR TITLE
fix(integrations): retry transient tool loader failures

### DIFF
--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -174,7 +174,7 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
                 tools = await self._groups[group].load()
             except Exception:
                 logger.warning("Failed to load %s integration tools", group, exc_info=True)
-                tools = []
+                return resolved.tools
             resolved.tools = {tool.name: tool for tool in tools}
             resolved.done = True
         return resolved.tools

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -217,6 +217,32 @@ async def test_a_group_that_fails_to_build_is_reported_not_raised() -> None:
     assert "unavailable right now" in message.content
 
 
+async def test_a_group_that_fails_to_build_is_retried() -> None:
+    attempts = 0
+
+    async def load() -> list[BaseTool]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("mcp temporarily unreachable")
+        return [_tool("analyzePlan")]
+
+    middleware = DynamicToolMiddleware(
+        {"Corridor": IntegrationGroup(tool_names=("analyzePlan",), load=load)}
+    )
+    coroutine = cast(Any, cast(StructuredTool, middleware.tools[0]).coroutine)
+
+    first = await coroutine(tool_names=["analyzePlan"], state={}, tool_call_id="load-1")
+    second = await coroutine(tool_names=["analyzePlan"], state={}, tool_call_id="load-2")
+
+    first_message = cast(dict[str, Any], first.update)["messages"][0]
+    assert first_message.status == "error"
+    second_update = cast(dict[str, Any], second.update)
+    assert second_update["loaded_integration_tools"] == ["analyzePlan"]
+    assert second_update["messages"][0].status == "success"
+    assert attempts == 2
+
+
 async def test_a_group_whose_catalog_is_empty_is_not_offered() -> None:
     async def load() -> list[BaseTool]:
         return []


### PR DESCRIPTION
Fixes #2453

Transient integration loader failures no longer become process-lifetime empty tool caches. A later request retries the loader and can restore the integration without restarting the worker.

---

The failure path now leaves the group unresolved while successful empty results remain cacheable. The regression test exercises a loader that fails once and succeeds on the next request.

Local verification: focused middleware tests (10 passed), Ruff check, Ruff format check, and ty check. The repository-wide ty command completed with two pre-existing warnings outside this change.

## AI Disclosure

This change was implemented and tested with AI assistance.
