### PR TITLE
fix: retry transient integration tool loads

### DIFF
--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -174,7 +174,7 @@ class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
                 tools = await self._groups[group].load()
             except Exception:
                 logger.warning("Failed to load %s integration tools", group, exc_info=True)
-                tools = []
+                return resolved.tools
             resolved.tools = {tool.name: tool for tool in tools}
             resolved.done = True
         return resolved.tools

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -217,6 +217,26 @@ async def test_a_group_that_fails_to_build_is_reported_not_raised() -> None:
     assert "unavailable right now" in message.content
 
 
+async def test_a_group_retries_after_a_transient_build_failure() -> None:
+    attempts = 0
+    tool = _tool("analyzePlan")
+
+    async def load() -> list[BaseTool]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("mcp temporarily unreachable")
+        return [tool]
+
+    middleware = DynamicToolMiddleware(
+        {"Corridor": IntegrationGroup(tool_names=("analyzePlan",), load=load)}
+    )
+
+    assert await middleware._build(["analyzePlan"]) == ["analyzePlan"]
+    assert await middleware._build(["analyzePlan"]) == []
+    assert attempts == 2
+
+
 async def test_a_group_whose_catalog_is_empty_is_not_offered() -> None:
     async def load() -> list[BaseTool]:
         return []


### PR DESCRIPTION
## Summary

Fixes #2453

Transient integration-loader failures no longer permanently disable a tool group for the lifetime of the process. Failed resolutions remain eligible for a later retry, while successful resolutions, including intentionally empty catalogs, remain cached.

## Changes

- Leave a failed DynamicToolMiddleware resolution unresolved instead of marking it complete.
- Add regression coverage for a loader that fails once and succeeds on the next request.

## Testing

- Dynamic-tool tests: 10 passed.
- Full pytest: 2007 passed, 11 skipped, 5 pre-existing Windows failures unrelated to this change.
- Ruff check: passed.
- Ruff format check: passed.
- Targeted ty check for changed files: passed.
- Full ty check reports existing diagnostics in desktop.py, stagehand_runtime.py, and the excluded Daytona provider.
