### PR TITLE
fix: release idle plan approval locks

### DIFF
--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from typing import Any
+from weakref import WeakValueDictionary
 
 from fastapi import APIRouter, Depends, HTTPException
 from langgraph_sdk import get_client
@@ -37,7 +38,7 @@ from agent.slack.client import post_slack_thread_reply
 from agent.source_context import SourceContext
 
 logger = logging.getLogger(__name__)
-_plan_approval_locks: dict[str, asyncio.Lock] = {}
+_plan_approval_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
 
 plan_router = APIRouter(
     prefix="/dashboard/api/plan",

--- a/tests/agent/test_plan_review.py
+++ b/tests/agent/test_plan_review.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
@@ -945,6 +946,24 @@ async def test_concurrent_plan_approvals_dispatch_once(monkeypatch: pytest.Monke
     assert dispatches == ["t1"]
     assert results[0] == {"status": "approved", "run_id": "run-1"}
     assert results[1] == {"status": "approved", "already_approved": True}
+
+
+def test_plan_approval_locks_are_not_retained_when_idle() -> None:
+    import gc
+    import weakref
+
+    from agent.dashboard import plan_api
+
+    plan_api._plan_approval_locks.clear()
+    lock = asyncio.Lock()
+    plan_api._plan_approval_locks["thread-1"] = lock
+    lock_ref = weakref.ref(lock)
+
+    del lock
+    gc.collect()
+
+    assert lock_ref() is None
+    assert "thread-1" not in plan_api._plan_approval_locks
 
 
 async def test_failed_approval_dispatch_rolls_back_and_can_retry(


### PR DESCRIPTION
## Summary

Fixes #2454

Plan approval locks are now stored in a weak-value registry. Active approval and rejection calls retain their lock while in flight, but idle locks are garbage-collected instead of accumulating for every historical thread.

## Changes

- Replace the process-global strong lock dictionary with WeakValueDictionary.
- Preserve the existing per-thread serialization behavior.
- Add regression coverage proving idle locks are not retained.

## Testing

- Focused approval tests: 3 passed.
- Full pytest: 2007 passed, 11 skipped, 5 pre-existing Windows failures unrelated to this change.
- Ruff check: passed.
- Ruff format check: passed.
- Targeted ty check for changed files: passed.
- Full ty check reports existing diagnostics in desktop.py, stagehand_runtime.py, and the excluded Daytona provider.
