### PR TITLE
fix: bound Slack channel info cache

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -36,6 +36,7 @@ SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 SLACK_THREAD_MAX_MESSAGES = 500
 SLACK_FILE_UPLOAD_MAX_BYTES = 16 * 1024 * 1024
 SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS = 300
+SLACK_CHANNEL_INFO_CACHE_MAX_ENTRIES = 256
 
 SlackChannelContext = dict[str, str | bool | None]
 _SLACK_CHANNEL_INFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
@@ -1035,8 +1036,16 @@ def _cached_slack_channel_info(channel_id: str) -> dict[str, Any] | None:
 
 
 def _cache_slack_channel_info(channel_id: str, channel: dict[str, Any]) -> None:
+    now = time.time()
+    for cached_id, (expires_at, _cached_channel) in tuple(_SLACK_CHANNEL_INFO_CACHE.items()):
+        if expires_at <= now:
+            _SLACK_CHANNEL_INFO_CACHE.pop(cached_id, None)
+    _SLACK_CHANNEL_INFO_CACHE.pop(channel_id, None)
+    while len(_SLACK_CHANNEL_INFO_CACHE) >= SLACK_CHANNEL_INFO_CACHE_MAX_ENTRIES:
+        oldest_id = next(iter(_SLACK_CHANNEL_INFO_CACHE))
+        _SLACK_CHANNEL_INFO_CACHE.pop(oldest_id, None)
     _SLACK_CHANNEL_INFO_CACHE[channel_id] = (
-        time.time() + SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS,
+        now + SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS,
         dict(channel),
     )
 

--- a/tests/slack/test_slack_channel_info_cache.py
+++ b/tests/slack/test_slack_channel_info_cache.py
@@ -1,0 +1,36 @@
+import agent.slack.client as slack_client
+
+
+def test_channel_info_cache_write_prunes_expired_entries(monkeypatch) -> None:
+    now = 1_000.0
+    monkeypatch.setattr(slack_client.time, "time", lambda: now)
+    slack_client.clear_slack_channel_info_cache()
+    try:
+        slack_client._cache_slack_channel_info("stale", {"name": "old"})
+        monkeypatch.setattr(
+            slack_client.time,
+            "time",
+            lambda: now + slack_client.SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS + 1,
+        )
+
+        slack_client._cache_slack_channel_info("fresh", {"name": "new"})
+
+        assert "stale" not in slack_client._SLACK_CHANNEL_INFO_CACHE
+        assert slack_client._cached_slack_channel_info("fresh") == {"name": "new"}
+    finally:
+        slack_client.clear_slack_channel_info_cache()
+
+
+def test_channel_info_cache_is_bounded(monkeypatch) -> None:
+    monkeypatch.setattr(slack_client, "SLACK_CHANNEL_INFO_CACHE_MAX_ENTRIES", 2)
+    slack_client.clear_slack_channel_info_cache()
+    try:
+        for channel_id in ("first", "second", "third"):
+            slack_client._cache_slack_channel_info(channel_id, {"name": channel_id})
+
+        assert len(slack_client._SLACK_CHANNEL_INFO_CACHE) == 2
+        assert "first" not in slack_client._SLACK_CHANNEL_INFO_CACHE
+        assert "second" in slack_client._SLACK_CHANNEL_INFO_CACHE
+        assert "third" in slack_client._SLACK_CHANNEL_INFO_CACHE
+    finally:
+        slack_client.clear_slack_channel_info_cache()


### PR DESCRIPTION
## Summary

Prevent expired Slack channel metadata entries from accumulating in the process-global cache.

## Changes

- Prune expired entries whenever channel metadata is cached.
- Bound the cache to 256 entries with oldest-entry eviction.
- Add regression tests for expiry pruning and capacity eviction.

## Testing

- `.venv\Scripts\python.exe -m pytest -vv tests/`: 2008 passed, 11 skipped, 5 pre-existing Windows/Python 3.14 failures.
- Ruff format/check passed.
- Targeted `ty check` passed; full `ty check` retains six existing diagnostics.

Fixes #2455
