### PR TITLE
feat(github): discover the GitHub App installation at runtime

### DIFF
--- a/agent/chat.py
+++ b/agent/chat.py
@@ -174,7 +174,9 @@ class PrepareChatRunMiddleware(BasePrepareRunMiddleware):
         cfg = RunConfig.parse(configurable)
         repo_name = cfg.chat_repo_name or ""
         token = await get_github_app_installation_token(
-            repositories=[repo_name] if repo_name else None
+            repositories=[repo_name] if repo_name else None,
+            owner=cfg.chat_repo_owner or None,
+            repo=repo_name or None,
         )
         if isinstance(token, str) and token:
             configurable["chat_github_token"] = token

--- a/agent/config.py
+++ b/agent/config.py
@@ -239,7 +239,14 @@ ENV.var(
 )
 
 # --- GitHub ------------------------------------------------------------------------------
-ENV.var("GITHUB_APP_ID", "Numeric GitHub App id used as the JWT issuer.")
+ENV.var(
+    "GITHUB_APP_ID",
+    "Numeric GitHub App id.",
+    deprecated=(
+        "GITHUB_APP_CLIENT_ID is the GitHub App JWT issuer; GITHUB_APP_ID is only used when "
+        "GITHUB_APP_CLIENT_ID is unset."
+    ),
+)
 ENV.var("GITHUB_APP_CLIENT_ID", "GitHub App client id for the dashboard OAuth flow.")
 ENV.var(
     "GITHUB_APP_CLIENT_SECRET",
@@ -249,7 +256,11 @@ ENV.var(
 ENV.var(
     "GITHUB_APP_PRIVATE_KEY", "GitHub App private key (PEM) used to sign app JWTs.", secret=True
 )
-ENV.var("GITHUB_APP_INSTALLATION_ID", "GitHub App installation used when a run names none.")
+ENV.var(
+    "GITHUB_APP_INSTALLATION_ID",
+    "GitHub App installation used when a run names none; discovered when the app has a "
+    "single installation.",
+)
 ENV.var("GITHUB_WEBHOOK_SECRET", "HMAC secret for GitHub webhook deliveries.", secret=True)
 ENV.var(
     "GITHUB_OAUTH_PROVIDER_ID", "LangSmith OAuth provider id for the legacy brokered GitHub auth."

--- a/agent/dashboard/review_api.py
+++ b/agent/dashboard/review_api.py
@@ -758,7 +758,7 @@ async def dry_run_trace_resolution(owner: str, repo: str, pr_number: int) -> dic
         number=pr_number,
         url=f"https://github.com/{owner}/{repo}/pull/{pr_number}",
     )
-    token, _ = await get_github_app_installation_token_with_expiry()
+    token, _ = await get_github_app_installation_token_with_expiry(owner=owner, repo=repo)
     if not token:
         raise HTTPException(502, "No GitHub App token available")
     pr_metadata = await fetch_github_pr_metadata(pr_ref, token=token)

--- a/agent/dashboard/review_chat_api.py
+++ b/agent/dashboard/review_chat_api.py
@@ -387,7 +387,9 @@ async def _enrich_chat_command(
 
     if needs_seed:
         try:
-            token = await get_github_app_installation_token(repositories=[repo])
+            token = await get_github_app_installation_token(
+                repositories=[repo], owner=owner, repo=repo
+            )
             if not token:
                 raise HTTPException(503, "GitHub App token unavailable")
             pr_files, head_sha = await _build_pr_context(

--- a/agent/github/app.py
+++ b/agent/github/app.py
@@ -201,21 +201,27 @@ def _installation_account(installation: Mapping[str, Any]) -> str:
 async def _discover_single_installation() -> str | None:
     """The app's only installation, or ``None`` when there are zero or several.
 
-    Failures and ambiguous results are remembered for a few minutes so a busy
-    webhook path does not re-list installations on every token mint.
+    A found installation is re-checked after ``_INSTALLATION_CACHE_TTL`` so a
+    removed, replaced, or newly added installation is noticed without a restart;
+    failures and ambiguous results are remembered for a few minutes so a busy
+    webhook path does not re-list installations on every token mint. When the
+    re-check itself fails, the last known installation stays in use.
     """
     global _SINGLE_INSTALLATION
     now = datetime.now(UTC)
+    last_known: str | None = None
     if _SINGLE_INSTALLATION is not None:
         cached_id, checked_at = _SINGLE_INSTALLATION
-        if cached_id is not None or now - checked_at < _DISCOVERY_RETRY_INTERVAL:
+        ttl = _INSTALLATION_CACHE_TTL if cached_id is not None else _DISCOVERY_RETRY_INTERVAL
+        if now - checked_at < ttl:
             return cached_id
+        last_known = cached_id
     try:
         installations = await list_app_installations()
     except Exception:
         logger.warning("Failed to list GitHub App installations", exc_info=True)
-        _SINGLE_INSTALLATION = (None, now)
-        return None
+        _SINGLE_INSTALLATION = (last_known, now)
+        return last_known
     ids = [
         str(item["id"])
         for item in installations

--- a/agent/github/app.py
+++ b/agent/github/app.py
@@ -16,8 +16,11 @@ from agent.utils.http import DEFAULT_HTTP_TIMEOUT
 logger = logging.getLogger(__name__)
 
 GITHUB_APP_ID = ENV.GITHUB_APP_ID.get()
+GITHUB_APP_CLIENT_ID = ENV.GITHUB_APP_CLIENT_ID.get()
 GITHUB_APP_PRIVATE_KEY = ENV.GITHUB_APP_PRIVATE_KEY.get()
 GITHUB_APP_INSTALLATION_ID = ENV.GITHUB_APP_INSTALLATION_ID.get()
+
+GITHUB_API_BASE_URL = "https://api.github.com"
 
 # Installation tokens are valid for 1 hour. Reuse a minted token until it is
 # within this window of expiring so chat/review requests don't pay a fresh
@@ -25,12 +28,33 @@ GITHUB_APP_INSTALLATION_ID = ENV.GITHUB_APP_INSTALLATION_ID.get()
 # 5-minute refresh window (``github_proxy.PROXY_TOKEN_REFRESH_WINDOW``) so a
 # near-expiry proxy refresh still mints a genuinely fresh token.
 _TOKEN_CACHE_MARGIN = timedelta(minutes=10)
+_INSTALLATION_CACHE_TTL = timedelta(hours=1)
+_DISCOVERY_RETRY_INTERVAL = timedelta(minutes=5)
+_INSTALLATIONS_PAGE_SIZE = 100
+_INSTALLATIONS_MAX_PAGES = 10
 PermissionMap = Mapping[str, str]
 PermissionKey = tuple[tuple[str, str], ...]
 ScopeKey = tuple[str, tuple[int, ...], tuple[str, ...], PermissionKey]
 
 # scope key -> (token, expires_at, good_until). In-process only; never persisted.
 _TOKEN_CACHE: dict[ScopeKey, tuple[str, str | None, datetime]] = {}
+# (owner, repo or "") -> (installation id, cached_at)
+_INSTALLATION_ID_CACHE: dict[tuple[str, str], tuple[str, datetime]] = {}
+# Outcome of the app-wide single-installation lookup: (id or None, checked_at)
+_SINGLE_INSTALLATION: tuple[str | None, datetime] | None = None
+
+
+def _app_jwt_issuer() -> str:
+    """GitHub accepts either the client ID or the numeric app ID as ``iss``.
+
+    The client ID is the documented recommendation and is already required for
+    dashboard login, so ``GITHUB_APP_ID`` is only consulted when it is unset.
+    """
+    return GITHUB_APP_CLIENT_ID or GITHUB_APP_ID
+
+
+def _app_credentials_configured() -> bool:
+    return bool(_app_jwt_issuer() and GITHUB_APP_PRIVATE_KEY)
 
 
 def normalize_permissions(permissions: PermissionMap | None) -> PermissionKey:
@@ -80,8 +104,11 @@ def _cached_token(key: ScopeKey, *, now: datetime) -> tuple[str, str | None] | N
 
 
 def clear_app_token_cache() -> None:
-    """Drop all cached installation tokens (test/maintenance hook)."""
+    """Drop cached installation tokens and discovery results (test/maintenance hook)."""
+    global _SINGLE_INSTALLATION
     _TOKEN_CACHE.clear()
+    _INSTALLATION_ID_CACHE.clear()
+    _SINGLE_INSTALLATION = None
 
 
 def _generate_app_jwt() -> str:
@@ -90,25 +117,29 @@ def _generate_app_jwt() -> str:
     payload = {
         "iat": now - 60,  # issued 60s ago to account for clock skew
         "exp": now + 540,  # expires in 9 minutes (max is 10)
-        "iss": GITHUB_APP_ID,
+        "iss": _app_jwt_issuer(),
     }
     private_key = GITHUB_APP_PRIVATE_KEY.replace("\\n", "\n")
     return jwt.encode(payload, private_key, algorithm="RS256")
 
 
+def _app_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_generate_app_jwt()}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
 async def get_github_app_installation_id_for_org(org: str) -> int | None:
     """Resolve the GitHub App installation for an organization."""
-    if not GITHUB_APP_ID or not GITHUB_APP_PRIVATE_KEY or not org.strip():
+    if not _app_credentials_configured() or not org.strip():
         return None
     try:
         async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as client:
             response = await client.get(
-                f"https://api.github.com/orgs/{quote(org.strip(), safe='')}/installation",
-                headers={
-                    "Authorization": f"Bearer {_generate_app_jwt()}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
+                f"{GITHUB_API_BASE_URL}/orgs/{quote(org.strip(), safe='')}/installation",
+                headers=_app_headers(),
             )
         response.raise_for_status()
         installation_id = response.json().get("id")
@@ -120,22 +151,15 @@ async def get_github_app_installation_id_for_org(org: str) -> int | None:
 
 async def get_github_app_installation_id_for_repo(owner: str, repo: str) -> int | None:
     """Resolve the GitHub App installation that can access a repository."""
-    if not GITHUB_APP_ID or not GITHUB_APP_PRIVATE_KEY or not owner.strip() or not repo.strip():
+    if not _app_credentials_configured() or not owner.strip() or not repo.strip():
         return None
     url = (
-        "https://api.github.com/repos/"
+        f"{GITHUB_API_BASE_URL}/repos/"
         f"{quote(owner.strip(), safe='')}/{quote(repo.strip(), safe='')}/installation"
     )
     try:
         async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as client:
-            response = await client.get(
-                url,
-                headers={
-                    "Authorization": f"Bearer {_generate_app_jwt()}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
+            response = await client.get(url, headers=_app_headers())
         response.raise_for_status()
         installation_id = response.json().get("id")
         return installation_id if isinstance(installation_id, int) and installation_id > 0 else None
@@ -146,12 +170,123 @@ async def get_github_app_installation_id_for_repo(owner: str, repo: str) -> int 
         return None
 
 
+async def list_app_installations() -> list[dict[str, Any]]:
+    """Every installation of this GitHub App, across all accounts."""
+    if not _app_credentials_configured():
+        return []
+    installations: list[dict[str, Any]] = []
+    async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as client:
+        for page in range(1, _INSTALLATIONS_MAX_PAGES + 1):
+            response = await client.get(
+                f"{GITHUB_API_BASE_URL}/app/installations"
+                f"?per_page={_INSTALLATIONS_PAGE_SIZE}&page={page}",
+                headers=_app_headers(),
+            )
+            response.raise_for_status()
+            batch = response.json()
+            if not isinstance(batch, list):
+                break
+            installations.extend(item for item in batch if isinstance(item, dict))
+            if len(batch) < _INSTALLATIONS_PAGE_SIZE:
+                break
+    return installations
+
+
+def _installation_account(installation: Mapping[str, Any]) -> str:
+    account = installation.get("account")
+    login = account.get("login") if isinstance(account, Mapping) else None
+    return str(login) if login else "?"
+
+
+async def _discover_single_installation() -> str | None:
+    """The app's only installation, or ``None`` when there are zero or several.
+
+    Failures and ambiguous results are remembered for a few minutes so a busy
+    webhook path does not re-list installations on every token mint.
+    """
+    global _SINGLE_INSTALLATION
+    now = datetime.now(UTC)
+    if _SINGLE_INSTALLATION is not None:
+        cached_id, checked_at = _SINGLE_INSTALLATION
+        if cached_id is not None or now - checked_at < _DISCOVERY_RETRY_INTERVAL:
+            return cached_id
+    try:
+        installations = await list_app_installations()
+    except Exception:
+        logger.warning("Failed to list GitHub App installations", exc_info=True)
+        _SINGLE_INSTALLATION = (None, now)
+        return None
+    ids = [
+        str(item["id"])
+        for item in installations
+        if isinstance(item.get("id"), int) and item["id"] > 0
+    ]
+    if len(ids) == 1:
+        logger.info(
+            "Using the GitHub App's only installation (id %s, account %s)",
+            ids[0],
+            _installation_account(installations[0]),
+        )
+        _SINGLE_INSTALLATION = (ids[0], now)
+        return ids[0]
+    if not ids:
+        logger.warning("The GitHub App is not installed on any account yet")
+    else:
+        logger.warning(
+            "The GitHub App has %d installations (%s); set GITHUB_APP_INSTALLATION_ID or "
+            "rely on repository context to choose one",
+            len(ids),
+            ", ".join(_installation_account(item) for item in installations),
+        )
+    _SINGLE_INSTALLATION = (None, now)
+    return None
+
+
+async def _cached_context_installation(owner: str, repo: str | None) -> str | None:
+    key = (owner.strip().lower(), (repo or "").strip().lower())
+    now = datetime.now(UTC)
+    cached = _INSTALLATION_ID_CACHE.get(key)
+    if cached is not None and now - cached[1] < _INSTALLATION_CACHE_TTL:
+        return cached[0]
+    resolved = (
+        await get_github_app_installation_id_for_repo(owner, repo)
+        if repo
+        else await get_github_app_installation_id_for_org(owner)
+    )
+    if resolved is None:
+        return None
+    _INSTALLATION_ID_CACHE[key] = (str(resolved), now)
+    return str(resolved)
+
+
+async def resolve_default_installation_id(
+    *, owner: str | None = None, repo: str | None = None
+) -> str | None:
+    """Installation to mint tokens under when the caller did not name one.
+
+    Precedence: ``GITHUB_APP_INSTALLATION_ID`` → the installation that owns
+    ``owner/repo`` (or ``owner``) → the app's only installation → ``None``.
+    """
+    env_id = GITHUB_APP_INSTALLATION_ID.strip()
+    if env_id:
+        return env_id
+    if not _app_credentials_configured():
+        return None
+    if owner and owner.strip():
+        contextual = await _cached_context_installation(owner, repo)
+        if contextual:
+            return contextual
+    return await _discover_single_installation()
+
+
 async def get_github_app_installation_token(
     *,
     installation_id: str | int | None = None,
     repository_ids: Sequence[int] | None = None,
     repositories: Sequence[str] | None = None,
     permissions: PermissionMap | None = None,
+    owner: str | None = None,
+    repo: str | None = None,
     log_errors: bool = True,
 ) -> str | None:
     """Exchange the GitHub App JWT for an installation access token."""
@@ -160,6 +295,8 @@ async def get_github_app_installation_token(
         repository_ids=repository_ids,
         repositories=repositories,
         permissions=permissions,
+        owner=owner,
+        repo=repo,
         log_errors=log_errors,
     )
     return token
@@ -171,19 +308,26 @@ async def get_github_app_installation_token_with_expiry(
     repository_ids: Sequence[int] | None = None,
     repositories: Sequence[str] | None = None,
     permissions: PermissionMap | None = None,
+    owner: str | None = None,
+    repo: str | None = None,
     log_errors: bool = True,
 ) -> tuple[str | None, str | None]:
-    """Exchange the GitHub App JWT for an installation access token and its expiry."""
-    resolved_installation_id = str(
-        GITHUB_APP_INSTALLATION_ID if installation_id is None else installation_id
-    ).strip()
+    """Exchange the GitHub App JWT for an installation access token and its expiry.
+
+    ``owner``/``repo`` only steer installation discovery when ``installation_id``
+    is omitted; they do not scope the token (use ``repositories`` for that).
+    """
+    if installation_id is None:
+        resolved = await resolve_default_installation_id(owner=owner, repo=repo)
+    else:
+        resolved = str(installation_id)
+    resolved_installation_id = (resolved or "").strip()
     if (
-        not GITHUB_APP_ID
-        or not GITHUB_APP_PRIVATE_KEY
+        not _app_credentials_configured()
         or not resolved_installation_id.isdigit()
         or int(resolved_installation_id) <= 0
     ):
-        logger.debug("GitHub App env vars not fully configured, skipping app token")
+        logger.debug("GitHub App not fully configured, skipping app token")
         return None, None
 
     key = _scope_key(resolved_installation_id, repository_ids, repositories, permissions)
@@ -202,15 +346,10 @@ async def get_github_app_installation_token_with_expiry(
         body["permissions"] = dict(permission_key)
 
     try:
-        app_jwt = _generate_app_jwt()
         async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as client:
             response = await client.post(
-                f"https://api.github.com/app/installations/{resolved_installation_id}/access_tokens",
-                headers={
-                    "Authorization": f"Bearer {app_jwt}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
+                f"{GITHUB_API_BASE_URL}/app/installations/{resolved_installation_id}/access_tokens",
+                headers=_app_headers(),
                 json=body or None,
             )
             response.raise_for_status()

--- a/agent/github/token.py
+++ b/agent/github/token.py
@@ -459,7 +459,8 @@ async def _resolve_bot_installation_token(thread_id: str) -> tuple[str, str | No
         raise RuntimeError(
             "Bot-token-only mode is active (LANGSMITH_API_KEY set without "
             "X_SERVICE_AUTH_JWT_SECRET) but the GitHub App is not configured. "
-            "Set GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID."
+            "Set GITHUB_APP_CLIENT_ID and GITHUB_APP_PRIVATE_KEY (and "
+            "GITHUB_APP_INSTALLATION_ID when the app has more than one installation)."
         )
     logger.info(
         "Using GitHub App installation token for thread %s (bot-token-only mode)", thread_id

--- a/agent/github/webhook.py
+++ b/agent/github/webhook.py
@@ -243,7 +243,9 @@ async def trigger_pr_review_from_ref(
 
     # Full token to read PR metadata (privacy/id aren't in the trigger ref);
     # re-scoped below once we know whether the repo is public.
-    app_token, app_token_expires_at = await common.get_github_app_installation_token_with_expiry()
+    app_token, app_token_expires_at = await common.get_github_app_installation_token_with_expiry(
+        owner=pr_ref.owner, repo=pr_ref.repo
+    )
     if not app_token:
         common.logger.warning("No GitHub App token available for PR reviewer request")
         return {"success": False, "error": "No GitHub App token available"}
@@ -1111,7 +1113,9 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
     thread_id = github_issue_thread_id(issue_id)
     existing_thread = await common._thread_exists(thread_id)
     github_token = await common._get_or_resolve_thread_github_token(thread_id, email)
-    app_token = await common.get_github_app_installation_token()
+    app_token = await common.get_github_app_installation_token(
+        owner=repo_config.get("owner") or None, repo=repo_config.get("name") or None
+    )
     reaction_token = github_token or app_token
     comment = payload.get("comment", {})
     comment_id = comment.get("id")

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -936,11 +936,14 @@ async def _ensure_reviewer_sandbox_for_thread(
     thread_id: str,
     cfg: RunConfig,
 ) -> tuple[SandboxBackendProtocol, str | None]:
+    repo_owner = cfg.repo.owner if cfg.repo else ""
     repo_name = cfg.repo.name if cfg.repo else ""
     github_token: str | None = None
     if cfg.source:
         github_token, expires_at = await get_github_app_installation_token_with_expiry(
-            repositories=[repo_name] if repo_name else None
+            repositories=[repo_name] if repo_name else None,
+            owner=repo_owner or None,
+            repo=repo_name or None,
         )
         if not github_token:
             raise RuntimeError(

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -1210,13 +1210,18 @@ async def _reviewer_token_for_repo(
     repo_private: bool | None,
     repo_id: int | None = None,
 ) -> tuple[str | None, str | None]:
+    owner = repo_config.get("owner")
+    repo_name = repo_config.get("name")
     if repo_private is False:
         if repo_id is not None:
-            return await get_github_app_installation_token_with_expiry(repository_ids=[repo_id])
-        repo_name = repo_config.get("name")
+            return await get_github_app_installation_token_with_expiry(
+                repository_ids=[repo_id], owner=owner, repo=repo_name
+            )
         if repo_name:
-            return await get_github_app_installation_token_with_expiry(repositories=[repo_name])
-    return await get_github_app_installation_token_with_expiry()
+            return await get_github_app_installation_token_with_expiry(
+                repositories=[repo_name], owner=owner, repo=repo_name
+            )
+    return await get_github_app_installation_token_with_expiry(owner=owner, repo=repo_name)
 
 
 async def _store_current_reviewer_run_id(thread_id: str, run: Any) -> None:

--- a/tests/github/test_github_app_discovery.py
+++ b/tests/github/test_github_app_discovery.py
@@ -103,6 +103,29 @@ async def test_single_installation_is_used_and_cached(monkeypatch: pytest.Monkey
     assert client.gets == ["https://api.github.com/app/installations?per_page=100&page=1"]
 
 
+async def test_single_installation_is_rechecked_after_the_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A removed or added installation is noticed without a restart."""
+    from datetime import UTC, datetime, timedelta
+
+    client = _client_factory({"/app/installations": [{"id": 42, "account": {"login": "acme"}}]})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() == "42"
+    stale = datetime.now(UTC) - github_app._INSTALLATION_CACHE_TTL - timedelta(seconds=1)
+    github_app._SINGLE_INSTALLATION = ("42", stale)
+
+    assert await github_app.resolve_default_installation_id() == "42"
+    assert len(client.gets) == 2
+
+    # A failed re-check keeps the last known installation rather than dropping it.
+    github_app._SINGLE_INSTALLATION = ("42", stale)
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", _client_factory({}))
+    assert await github_app.resolve_default_installation_id() == "42"
+    assert await github_app.resolve_default_installation_id() == "42"
+
+
 async def test_single_installation_mints_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
     client = _client_factory({"/app/installations": [{"id": 42, "account": {"login": "acme"}}]})
     monkeypatch.setattr(github_app.httpx, "AsyncClient", client)

--- a/tests/github/test_github_app_discovery.py
+++ b/tests/github/test_github_app_discovery.py
@@ -1,0 +1,237 @@
+"""GitHub App JWT issuer selection and installation auto-discovery."""
+
+from typing import Any
+
+import pytest
+
+from agent.github import app as github_app
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch: pytest.MonkeyPatch) -> Any:
+    github_app.clear_app_token_cache()
+    monkeypatch.setattr(github_app, "GITHUB_APP_ID", "")
+    monkeypatch.setattr(github_app, "GITHUB_APP_CLIENT_ID", "Iv1.client")
+    monkeypatch.setattr(github_app, "GITHUB_APP_PRIVATE_KEY", "key")
+    monkeypatch.setattr(github_app, "GITHUB_APP_INSTALLATION_ID", "")
+    monkeypatch.setattr(github_app, "_generate_app_jwt", lambda: "jwt")
+    yield
+    github_app.clear_app_token_cache()
+
+
+class _Response:
+    def __init__(self, payload: Any, status: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _client_factory(routes: dict[str, Any]) -> type:
+    class Client:
+        gets: list[str] = []
+        posts: list[str] = []
+
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _Response:
+            type(self).gets.append(url)
+            path = url.split("api.github.com", 1)[1].split("?", 1)[0]
+            payload = routes.get(path)
+            if payload is None:
+                return _Response({"message": "Not Found"}, 404)
+            return _Response(payload)
+
+        async def post(self, url: str, **kwargs: Any) -> _Response:
+            type(self).posts.append(url)
+            return _Response({"token": "tok", "expires_at": "2099-01-01T00:00:00Z"})
+
+    return Client
+
+
+def test_issuer_prefers_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_ID", "12345")
+    assert github_app._app_jwt_issuer() == "Iv1.client"
+
+
+def test_issuer_falls_back_to_app_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_CLIENT_ID", "")
+    monkeypatch.setattr(github_app, "GITHUB_APP_ID", "12345")
+    assert github_app._app_jwt_issuer() == "12345"
+    assert github_app._app_credentials_configured()
+
+
+def test_not_configured_without_issuer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_CLIENT_ID", "")
+    assert not github_app._app_credentials_configured()
+
+
+def test_not_configured_without_private_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_PRIVATE_KEY", "")
+    assert not github_app._app_credentials_configured()
+
+
+async def test_env_installation_id_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_INSTALLATION_ID", "77")
+    client = _client_factory({})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() == "77"
+    assert client.gets == []
+
+
+async def test_single_installation_is_used_and_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory(
+        {"/app/installations": [{"id": 42, "account": {"login": "acme", "type": "Organization"}}]}
+    )
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() == "42"
+    assert await github_app.resolve_default_installation_id() == "42"
+    assert client.gets == ["https://api.github.com/app/installations?per_page=100&page=1"]
+
+
+async def test_single_installation_mints_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory({"/app/installations": [{"id": 42, "account": {"login": "acme"}}]})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    token, expires_at = await github_app.get_github_app_installation_token_with_expiry()
+
+    assert (token, expires_at) == ("tok", "2099-01-01T00:00:00Z")
+    assert client.posts == ["https://api.github.com/app/installations/42/access_tokens"]
+
+
+async def test_multiple_installations_do_not_auto_select(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory(
+        {
+            "/app/installations": [
+                {"id": 1, "account": {"login": "a"}},
+                {"id": 2, "account": {"login": "b"}},
+            ]
+        }
+    )
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() is None
+    token, _ = await github_app.get_github_app_installation_token_with_expiry()
+    assert token is None
+    assert client.posts == []
+
+
+async def test_zero_installations_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory({"/app/installations": []})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() is None
+
+
+async def test_failed_discovery_is_throttled(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory({})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() is None
+    assert await github_app.resolve_default_installation_id() is None
+    assert len(client.gets) == 1
+
+
+async def test_installations_paginate(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_page = [{"id": i, "account": {"login": f"o{i}"}} for i in range(1, 101)]
+    gets: list[str] = []
+
+    class Client:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _Response:
+            gets.append(url)
+            if url.endswith("page=1"):
+                return _Response(first_page)
+            return _Response([{"id": 101, "account": {"login": "o101"}}])
+
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", Client)
+
+    installations = await github_app.list_app_installations()
+
+    assert len(installations) == 101
+    assert len(gets) == 2
+
+
+async def test_repo_context_wins_over_single_installation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_factory(
+        {
+            "/app/installations": [{"id": 1, "account": {"login": "a"}}],
+            "/repos/acme/widgets/installation": {"id": 9},
+        }
+    )
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id(owner="acme", repo="widgets") == "9"
+    token, _ = await github_app.get_github_app_installation_token_with_expiry(
+        owner="acme", repo="widgets"
+    )
+    assert token == "tok"
+    assert client.posts == ["https://api.github.com/app/installations/9/access_tokens"]
+
+
+async def test_repo_context_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory({"/repos/acme/widgets/installation": {"id": 9}})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    await github_app.resolve_default_installation_id(owner="acme", repo="widgets")
+    await github_app.resolve_default_installation_id(owner="Acme", repo="Widgets")
+
+    assert len(client.gets) == 1
+
+
+async def test_org_context_without_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client_factory({"/orgs/acme/installation": {"id": 11}})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id(owner="acme") == "11"
+
+
+async def test_unknown_repo_falls_back_to_single_installation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_factory({"/app/installations": [{"id": 1, "account": {"login": "a"}}]})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id(owner="acme", repo="missing") == "1"
+
+
+async def test_env_override_beats_repo_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_INSTALLATION_ID", "5")
+    client = _client_factory({"/repos/acme/widgets/installation": {"id": 9}})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id(owner="acme", repo="widgets") == "5"
+    assert client.gets == []
+
+
+async def test_unconfigured_app_skips_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_app, "GITHUB_APP_CLIENT_ID", "")
+    client = _client_factory({"/app/installations": [{"id": 1}]})
+    monkeypatch.setattr(github_app.httpx, "AsyncClient", client)
+
+    assert await github_app.resolve_default_installation_id() is None
+    assert client.gets == []

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -4,7 +4,7 @@ import hmac
 import importlib
 import json
 import logging
-from typing import cast
+from typing import Any, cast
 from xml.etree import ElementTree
 
 import pytest
@@ -354,7 +354,7 @@ def test_process_github_review_finding_reply_uses_rereview_config(monkeypatch) -
     async def fake_get_thread_metadata_safe(_thread_id: str) -> dict[str, object]:
         return {"kind": webhook_common.REVIEWER_THREAD_KIND}
 
-    async def fake_get_token_with_expiry() -> tuple[str, str]:
+    async def fake_get_token_with_expiry(**_kwargs: Any) -> tuple[str, str]:
         return "app-token", "2026-01-01T00:00:00Z"
 
     def fake_cache_token(thread_id: str, token: str, *, expires_at: str | None = None) -> None:
@@ -435,7 +435,7 @@ def test_process_github_review_finding_reply_dispatches_sanitized_reply_body(mon
     async def fake_get_thread_metadata_safe(_thread_id: str) -> dict[str, object]:
         return {"kind": webhook_common.REVIEWER_THREAD_KIND}
 
-    async def fake_get_token_with_expiry() -> tuple[str, str]:
+    async def fake_get_token_with_expiry(**_kwargs: Any) -> tuple[str, str]:
         return "app-token", "2026-01-01T00:00:00Z"
 
     def fake_cache_token(_thread_id: str, _token: str, *, expires_at: str | None = None) -> None:
@@ -1040,7 +1040,9 @@ def test_slack_webhook_ignores_unmentioned_non_plan_reply(monkeypatch) -> None:
 def test_process_github_pr_ready_creates_reviewer_run(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    async def fake_get_github_app_installation_token_with_expiry() -> tuple[str | None, str | None]:
+    async def fake_get_github_app_installation_token_with_expiry(
+        **_kwargs: Any,
+    ) -> tuple[str | None, str | None]:
         return "app-token", None
 
     def fake_cache_github_token(
@@ -1134,7 +1136,9 @@ def test_trigger_pr_review_from_ref_creates_reviewer_run(monkeypatch) -> None:
     async def fake_get_github_app_installation_token() -> str | None:
         return "app-token"
 
-    async def fake_get_github_app_installation_token_with_expiry() -> tuple[str | None, str | None]:
+    async def fake_get_github_app_installation_token_with_expiry(
+        **_kwargs: Any,
+    ) -> tuple[str | None, str | None]:
         return "app-token", None
 
     async def fake_fetch_github_pr_metadata(

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -1133,7 +1133,7 @@ def test_trigger_pr_review_from_ref_creates_reviewer_run(monkeypatch) -> None:
         auto_review_checked = True
         return False
 
-    async def fake_get_github_app_installation_token() -> str | None:
+    async def fake_get_github_app_installation_token(**_kwargs: Any) -> str | None:
         return "app-token"
 
     async def fake_get_github_app_installation_token_with_expiry(
@@ -1350,7 +1350,7 @@ def test_process_github_issue_uses_resolved_user_token_for_reaction(monkeypatch)
         captured["email"] = email
         return "user-token"
 
-    async def fake_get_github_app_installation_token() -> str | None:
+    async def fake_get_github_app_installation_token(**_kwargs: Any) -> str | None:
         return None
 
     async def fake_react_to_github_comment(
@@ -1431,7 +1431,7 @@ def test_process_github_issue_existing_thread_uses_followup_prompt(monkeypatch) 
     async def fake_get_or_resolve_thread_github_token(thread_id: str, email: str) -> str | None:
         return "user-token"
 
-    async def fake_get_github_app_installation_token() -> str | None:
+    async def fake_get_github_app_installation_token(**_kwargs: Any) -> str | None:
         return None
 
     async def fake_react_to_github_comment(

--- a/tests/reviewer/test_pr_ready_auto_review.py
+++ b/tests/reviewer/test_pr_ready_auto_review.py
@@ -90,7 +90,7 @@ async def test_pr_ready_public_repo_uses_scoped_reviewer_token(
         _pr_payload(action="opened", draft=False, private=False)
     )
 
-    get_token.assert_awaited_once_with(repository_ids=[123])
+    get_token.assert_awaited_once_with(repository_ids=[123], owner="lc", repo="repo")
     assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is False
@@ -117,7 +117,7 @@ async def test_pr_ready_private_repo_uses_full_reviewer_token(
         _pr_payload(action="opened", draft=False, private=True)
     )
 
-    get_token.assert_awaited_once_with()
+    get_token.assert_awaited_once_with(owner="lc", repo="repo")
     assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is True

--- a/tests/reviewer/test_review_chat.py
+++ b/tests/reviewer/test_review_chat.py
@@ -422,7 +422,7 @@ def _patch_enrich_deps(
     async def fake_diff(*, owner, repo, pr_number, token):
         return "diff --git a/x b/x\n+added\n"
 
-    async def fake_token(repositories=None):
+    async def fake_token(repositories=None, **_kwargs):
         return "app-token"
 
     async def fake_head(owner, repo, pr_number):

--- a/tests/reviewer/test_reviewer.py
+++ b/tests/reviewer/test_reviewer.py
@@ -98,7 +98,7 @@ async def test_reviewer_resolves_app_installation_token_at_run_start() -> None:
     assert "github_token_encrypted" not in metadata
     # Token is resolved in this process at run start (scoped to the repo), not read
     # from a cache the webhook handler populated in a different process.
-    mock_app_token.assert_awaited_once_with(repositories=["repo"])
+    mock_app_token.assert_awaited_once_with(repositories=["repo"], owner="acme", repo="repo")
     mock_cache_token.assert_called_once_with(
         "reviewer-thread-id", "app-token", expires_at=None, is_bot_token=True
     )

--- a/tests/reviewer/test_reviewer_watch.py
+++ b/tests/reviewer/test_reviewer_watch.py
@@ -316,7 +316,7 @@ async def test_reviewer_token_for_repo_public_scopes_by_id() -> None:
             {"owner": "lc", "name": "repo"}, repo_private=False, repo_id=123
         )
     assert (token, expires) == ("scoped", "exp")
-    get_token.assert_awaited_once_with(repository_ids=[123])
+    get_token.assert_awaited_once_with(repository_ids=[123], owner="lc", repo="repo")
 
 
 @pytest.mark.asyncio
@@ -326,7 +326,7 @@ async def test_reviewer_token_for_repo_public_scopes_by_name_without_id() -> Non
         await webhook_common._reviewer_token_for_repo(
             {"owner": "lc", "name": "repo"}, repo_private=False, repo_id=None
         )
-    get_token.assert_awaited_once_with(repositories=["repo"])
+    get_token.assert_awaited_once_with(repositories=["repo"], owner="lc", repo="repo")
 
 
 @pytest.mark.asyncio
@@ -336,7 +336,7 @@ async def test_reviewer_token_for_repo_private_uses_full_token() -> None:
         await webhook_common._reviewer_token_for_repo(
             {"owner": "lc", "name": "repo"}, repo_private=True, repo_id=123
         )
-    get_token.assert_awaited_once_with()
+    get_token.assert_awaited_once_with(owner="lc", repo="repo")
 
 
 @pytest.mark.asyncio
@@ -346,7 +346,7 @@ async def test_reviewer_token_for_repo_unknown_privacy_uses_full_token() -> None
         await webhook_common._reviewer_token_for_repo(
             {"owner": "lc", "name": "repo"}, repo_private=None, repo_id=123
         )
-    get_token.assert_awaited_once_with()
+    get_token.assert_awaited_once_with(owner="lc", repo="repo")
 
 
 @pytest.mark.asyncio
@@ -398,7 +398,7 @@ async def test_push_event_public_repo_uses_scoped_token() -> None:
     ):
         await github_webhooks.process_github_push_event(payload)
 
-    get_token.assert_awaited_once_with(repository_ids=[123])
+    get_token.assert_awaited_once_with(repository_ids=[123], owner="lc", repo="repo")
     assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is False
@@ -453,7 +453,10 @@ async def test_push_event_rescopes_token_when_pr_metadata_reveals_public() -> No
     ):
         await github_webhooks.process_github_push_event(payload)
 
-    assert get_token.await_args_list == [call(), call(repository_ids=[456])]
+    assert get_token.await_args_list == [
+        call(owner="lc", repo="repo"),
+        call(repository_ids=[456], owner="lc", repo="repo"),
+    ]
     assert fake_client.runs.create.await_args is not None
     _, kwargs = fake_client.runs.create.await_args
     assert kwargs["config"]["configurable"]["repo_private"] is False


### PR DESCRIPTION
## Summary

Second PR of the install-simplification stack, on main. The GitHub App installation is discovered at runtime, with explicit env values still winning everywhere.

- `GITHUB_APP_CLIENT_ID` is the JWT issuer (GitHub's recommended form); `GITHUB_APP_ID` still works as a deprecated fallback.
- The installation id is resolved from the repository or organization of the run, else from the app's only installation. Both results are cached; the single-installation result is re-listed after an hour so a removed, replaced, or added installation is noticed without a restart, and a failed re-check keeps the last known installation.
- With several installations and no context, token minting is skipped with a warning naming the accounts. Token mints that already know the repository (PR review triggers, the trace dry run, reviewer sandbox setup, the chat graph, the review chat seed, the issue-webhook reaction token) pass its owner and name, so they reach the context-aware resolver.
- `GITHUB_APP_INSTALLATION_ID` remains an override that short-circuits discovery.

Precedence: explicit env → repo/org context → single installation → none.

## Testing

- New: `tests/github/test_github_app_discovery.py` (issuer selection, single installation, caching and TTL, multiple installations, pagination, repo/org context, env override).
- `uv run pytest tests/`: green apart from the 8 Slack webhook cases that already fail on a clean `main`.
- Verified against the real API from a local checkout (values never printed): installation listing and token mint for the app's single installation; signed webhooks accepted.

## Stack

1. #2463 unified config + standard LangSmith env (merged)
2. **this PR** GitHub App discovery
3. #2487 Slack bot discovery and repository defaults
4. #2488 startup report and `make setup`
5. #2489 LangSmith tenant discovery and `LANGSMITH_PROJECT` tracing
6. #2486 single-origin dashboard
7. #2466 installation docs rewrite
