### PR TITLE
feat: team default repository, startup configuration report, and guided make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web desktop install-desktop install-checkout
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web desktop install-desktop install-checkout setup
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -30,6 +30,9 @@ install-checkout:
 
 install:
 	uv sync --extra dev
+
+setup:
+	uv run python scripts/setup_env.py
 
 ######################
 # TESTING
@@ -84,6 +87,7 @@ help:
 	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
 	@echo 'install-checkout             - install the current checkout of Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'
+	@echo 'setup                        - guided .env setup for the GitHub + Slack install'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'typecheck                    - run ty on agent/ and tests/'

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -17,6 +17,7 @@ from agent.github.routes import router as github_webhook_router
 from agent.linear.routes import router as linear_webhook_router
 from agent.slack.routes import router as slack_webhook_router
 from agent.utils.event_loop import pin_single_event_loop
+from agent.utils.startup_config import log_startup_configuration
 from agent.webhooks.common import ensure_slack_bot_identity
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     pin_single_event_loop()
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
+    log_startup_configuration()
     try:
         await ensure_slack_bot_identity()
     except Exception:  # noqa: BLE001

--- a/agent/config.py
+++ b/agent/config.py
@@ -160,7 +160,7 @@ ENV.var(
 )
 ENV.var(
     "LANGSMITH_TENANT_ID",
-    "LangSmith workspace id used in trace links.",
+    "LangSmith workspace id used in trace links; discovered from the workspace when unset.",
     aliases=("LANGSMITH_TENANT_ID_PROD",),
 )
 ENV.var(
@@ -239,7 +239,14 @@ ENV.var(
 )
 
 # --- GitHub ------------------------------------------------------------------------------
-ENV.var("GITHUB_APP_ID", "Numeric GitHub App id used as the JWT issuer.")
+ENV.var(
+    "GITHUB_APP_ID",
+    "Numeric GitHub App id.",
+    deprecated=(
+        "GITHUB_APP_CLIENT_ID is the GitHub App JWT issuer; GITHUB_APP_ID is only used when "
+        "GITHUB_APP_CLIENT_ID is unset."
+    ),
+)
 ENV.var("GITHUB_APP_CLIENT_ID", "GitHub App client id for the dashboard OAuth flow.")
 ENV.var(
     "GITHUB_APP_CLIENT_SECRET",
@@ -249,7 +256,11 @@ ENV.var(
 ENV.var(
     "GITHUB_APP_PRIVATE_KEY", "GitHub App private key (PEM) used to sign app JWTs.", secret=True
 )
-ENV.var("GITHUB_APP_INSTALLATION_ID", "GitHub App installation used when a run names none.")
+ENV.var(
+    "GITHUB_APP_INSTALLATION_ID",
+    "GitHub App installation used when a run names none; discovered when the app has a "
+    "single installation.",
+)
 ENV.var("GITHUB_WEBHOOK_SECRET", "HMAC secret for GitHub webhook deliveries.", secret=True)
 ENV.var(
     "GITHUB_OAUTH_PROVIDER_ID", "LangSmith OAuth provider id for the legacy brokered GitHub auth."
@@ -272,17 +283,35 @@ ENV.var("PUBLIC_REPO_ORG_GATE", "Single org whose members may trigger runs on pu
 ENV.var(
     "DEFAULT_REPO_OWNER",
     "Default GitHub owner when a run names no repository.",
-    default="langchain-ai",
+    deprecated="set the default repository in Admin → Team settings instead.",
 )
-ENV.var("DEFAULT_REPO_NAME", "Default GitHub repository when a run names none.")
-ENV.var("SLACK_REPO_OWNER", "Slack-specific default repository owner.")
-ENV.var("SLACK_REPO_NAME", "Slack-specific default repository name.")
+ENV.var(
+    "DEFAULT_REPO_NAME",
+    "Default GitHub repository when a run names none.",
+    deprecated="set the default repository in Admin → Team settings instead.",
+)
+ENV.var(
+    "SLACK_REPO_OWNER",
+    "Slack-specific default repository owner.",
+    deprecated="set the default repository in Admin → Team settings instead.",
+)
+ENV.var(
+    "SLACK_REPO_NAME",
+    "Slack-specific default repository name.",
+    deprecated="set the default repository in Admin → Team settings instead.",
+)
 
 # --- Slack and Linear ----------------------------------------------------------------------
 ENV.var("SLACK_BOT_TOKEN", "Slack bot user OAuth token (xoxb-...).", secret=True)
 ENV.var("SLACK_SIGNING_SECRET", "HMAC secret for Slack webhook deliveries.", secret=True)
-ENV.var("SLACK_BOT_USER_ID", "Slack user id of the bot, for mention detection.")
-ENV.var("SLACK_BOT_USERNAME", "Slack handle of the bot, for plain-text mention detection.")
+ENV.var(
+    "SLACK_BOT_USER_ID",
+    "Slack user id of the bot, for mention detection; discovered via auth.test when unset.",
+)
+ENV.var(
+    "SLACK_BOT_USERNAME",
+    "Slack handle of the bot, for plain-text mention detection; discovered when unset.",
+)
 ENV.var("SLACK_CLIENT_ID", "Slack app client id for Sign in with Slack.")
 ENV.var("SLACK_CLIENT_SECRET", "Slack app client secret for Sign in with Slack.", secret=True)
 ENV.var("SLACK_TEAM_ID", "Restrict Sign in with Slack to one workspace.")

--- a/agent/config.py
+++ b/agent/config.py
@@ -193,8 +193,8 @@ ENV.var(
 )
 ENV.var(
     "LANGSMITH_GATEWAY_ENABLED",
-    "Route provider calls through the LangSmith LLM Gateway.",
-    default="false",
+    "Route provider calls through the LangSmith LLM Gateway; defaults to on when "
+    "LANGSMITH_GATEWAY_API_KEY is set and off otherwise.",
 )
 ENV.var(
     "LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES",

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 USER_MAPPINGS_NAMESPACE: list[str] = ["user_mappings"]
 
-MappingSource = Literal["slack_oauth", "profile_email"]
+MappingSource = Literal["slack_oauth", "profile_email", "slack_directory"]
 MappingStatus = Literal["active", "pending"]
 
 
@@ -279,11 +279,63 @@ async def _login_from_profile_email(email: str | None) -> str | None:
 
 
 async def login_for_slack_id(slack_user_id: str | None) -> str | None:
+    """Async Slack id→login, resolving unmapped users through Slack itself.
+
+    The bot has ``users:read.email``, so an unknown Slack user is looked up with
+    ``users.info`` and matched to a dashboard profile by email. The match is
+    stored as a mapping so later lookups by id or email need no Slack call.
+    """
     cached = cached_login_for_slack_id(slack_user_id)
     if cached is not None:
         return cached
     await _ensure_cache_loaded()
-    return cached_login_for_slack_id(slack_user_id)
+    cached = cached_login_for_slack_id(slack_user_id)
+    if cached is not None:
+        return cached
+    return await _login_from_slack_directory(slack_user_id)
+
+
+async def _slack_user_email(slack_user_id: str) -> str | None:
+    from agent.slack.client import get_slack_user_info  # noqa: PLC0415
+
+    user = await get_slack_user_info(slack_user_id)
+    email = ((user or {}).get("profile") or {}).get("email") if isinstance(user, dict) else None
+    return email if isinstance(email, str) else None
+
+
+async def _login_from_slack_directory(slack_user_id: str | None) -> str | None:
+    """Resolve a Slack user via ``users.info`` and persist the resulting mapping."""
+    slack_id = _norm_slack_id(slack_user_id)
+    if not slack_id:
+        return None
+    try:
+        email = await _slack_user_email(slack_id)
+    except Exception:  # noqa: BLE001
+        logger.warning("Slack users.info failed for %s", slack_id, exc_info=True)
+        return None
+    login = await login_for_email(email)
+    if not login:
+        return None
+    norm_email = _norm_email(email)
+    existing = await get_mapping(login)
+    if existing is None and norm_email:
+        # Persisted so the Admin → User mappings page shows how the user was
+        # recognised and so id lookups on other workers skip the Slack call.
+        await upsert_mapping(
+            github_login=login,
+            work_email=norm_email,
+            slack_user_id=slack_id,
+            source="slack_directory",
+        )
+    elif existing is not None and not _norm_slack_id(existing.get("slack_user_id")):
+        await upsert_mapping(
+            github_login=login,
+            work_email=existing.get("work_email") or norm_email,
+            slack_user_id=slack_id,
+            source=existing.get("source") or "slack_directory",
+            status=existing.get("status") or "active",
+        )
+    return login
 
 
 async def upsert_mapping(

--- a/agent/dashboard/user_mappings.py
+++ b/agent/dashboard/user_mappings.py
@@ -25,13 +25,20 @@ import logging
 import threading
 from typing import Any, Literal
 
-from agent.store import delete_value, get_value, now_iso, put_value, search_values
+from agent.store import (
+    delete_value,
+    get_value,
+    now_iso,
+    put_value,
+    search_all_values,
+    search_values,
+)
 
 logger = logging.getLogger(__name__)
 
 USER_MAPPINGS_NAMESPACE: list[str] = ["user_mappings"]
 
-MappingSource = Literal["slack_oauth"]
+MappingSource = Literal["slack_oauth", "profile_email"]
 MappingStatus = Literal["active", "pending"]
 
 
@@ -223,12 +230,52 @@ async def slack_id_for_login(login: str | None) -> str | None:
 
 
 async def login_for_email(email: str | None) -> str | None:
-    """Async email→login with cache fallthrough to the Store."""
+    """Async email→login with cache fallthrough to the Store, then to profiles.
+
+    A user who signed in to the dashboard already has their GitHub account email
+    on their profile, so when no explicit mapping exists that email is the
+    mapping: Slack and GitHub both verify the addresses they report, so matching
+    them needs no extra sign-in.
+    """
     cached = cached_login_for_email(email)
     if cached is not None:
         return cached
     await _ensure_cache_loaded()
-    return cached_login_for_email(email)
+    cached = cached_login_for_email(email)
+    if cached is not None:
+        return cached
+    return await _login_from_profile_email(email)
+
+
+async def _login_from_profile_email(email: str | None) -> str | None:
+    """Match ``email`` against dashboard profiles and cache the result as a mapping."""
+    from agent.dashboard.profiles import PROFILES_NAMESPACE  # noqa: PLC0415
+
+    norm = _norm_email(email)
+    if not norm:
+        return None
+    try:
+        profiles = await search_all_values(PROFILES_NAMESPACE)
+    except Exception:  # noqa: BLE001
+        logger.warning("Profile lookup for email mapping failed", exc_info=True)
+        return None
+    for profile in profiles:
+        login = _norm_login(profile.get("login"))
+        if login and _norm_email(profile.get("email")) == norm:
+            stamp = now_iso()
+            _index_record(
+                {
+                    "github_login": login,
+                    "work_email": norm,
+                    "slack_user_id": None,
+                    "source": "profile_email",
+                    "status": "active",
+                    "created_at": stamp,
+                    "updated_at": stamp,
+                }
+            )
+            return login
+    return None
 
 
 async def login_for_slack_id(slack_user_id: str | None) -> str | None:

--- a/agent/linear/routes.py
+++ b/agent/linear/routes.py
@@ -80,7 +80,8 @@ async def linear_webhook(  # noqa: PLR0911, PLR0912, PLR0915
         full_issue = issue
 
     repo_config = common.extract_repo_from_text(
-        comment_body, default_owner=common.DEFAULT_REPO_OWNER
+        comment_body,
+        default_owner=await common.default_repo_owner_hint(common.DEFAULT_REPO_OWNER),
     )
 
     if repo_config:

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -41,6 +41,24 @@ def _bounded_payload_text(label: str, payload: dict[str, Any]) -> str:
     return f"{label}\n```json\n{serialized[:8000]}\n```"
 
 
+async def _repo_config_or_reply(
+    channel_id: str, thread_ts: str, **kwargs: Any
+) -> dict[str, str] | None:
+    """Resolve the repository for a Slack turn, telling the thread what is missing.
+
+    Returns None after replying, so the caller answers Slack with 200: a 4xx would
+    only make Slack redeliver the event, and nobody would see why nothing happened.
+    """
+    try:
+        return await common.get_slack_repo_config(channel_id, thread_ts, **kwargs)
+    except common.SlackRepositoryNotConfigured:
+        common.logger.info("No repository for Slack channel=%s thread=%s", channel_id, thread_ts)
+        await common.post_slack_thread_reply(
+            channel_id, thread_ts, common.NO_REPOSITORY_SLACK_REPLY
+        )
+        return None
+
+
 async def _queue_code_channel_turn(
     background_tasks: common.BackgroundTasks,
     *,
@@ -67,13 +85,15 @@ async def _queue_code_channel_turn(
         return {"status": "ignored", "reason": "Duplicate code channel interaction"}
 
     channel_context = await common._get_slack_channel_context(channel_id)
-    repo_config = await common.get_slack_repo_config(
+    repo_config = await _repo_config_or_reply(
         channel_id,
         common.CODE_CHANNEL_SESSION_TS,
         slack_user_id=user_id,
         channel_context=channel_context,
         thread_id=thread_id,
     )
+    if repo_config is None:
+        return {"status": "ignored", "reason": "No repository configured"}
     background_tasks.add_task(
         service.process_slack_mention,
         {
@@ -155,13 +175,15 @@ async def _process_slack_message_update(
         return
     event_data["thread_id"] = thread_id
     event_data["channel_context"] = channel_context
-    repo_config = await common.get_slack_repo_config(
+    repo_config = await _repo_config_or_reply(
         channel_id,
         thread_ts,
         slack_user_id=user_id,
         channel_context=channel_context,
         thread_id=thread_id,
     )
+    if repo_config is None:
+        return
     await service.process_slack_mention(event_data, repo_config)
 
 
@@ -496,13 +518,15 @@ async def slack_webhook(
             "team_id": team_id,
             "app_context": updated_message.get("app_context") or event.get("app_context"),
         }
-        repo_config = await common.get_slack_repo_config(
+        repo_config = await _repo_config_or_reply(
             channel_id,
             thread_ts,
             slack_user_id=user_id,
             channel_context=channel_context,
             thread_id=thread_id,
         )
+        if repo_config is None:
+            return {"status": "ignored", "reason": "No repository configured"}
         if await common.claim_slack_event(event_id, channel_id, event_ts):
             background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
             return {"status": "accepted", "message": "Slack mention queued"}

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -54,8 +54,16 @@ def gateway_base_url() -> str:
 
 
 def gateway_env_default() -> bool:
-    """Deployment-level default for gateway routing (``LANGSMITH_GATEWAY_ENABLED``)."""
-    return _env_bool(ENV.LANGSMITH_GATEWAY_ENABLED.optional())
+    """Deployment-level default for gateway routing.
+
+    ``LANGSMITH_GATEWAY_ENABLED`` decides when set. Otherwise a dedicated
+    ``LANGSMITH_GATEWAY_API_KEY`` is the signal: that key exists for nothing
+    else, so configuring it means routing through the gateway.
+    """
+    explicit = ENV.LANGSMITH_GATEWAY_ENABLED.optional()
+    if explicit is not None:
+        return _env_bool(explicit)
+    return bool(ENV.LANGSMITH_GATEWAY_API_KEY.optional())
 
 
 def gateway_openai_use_responses() -> bool:

--- a/agent/utils/startup_config.py
+++ b/agent/utils/startup_config.py
@@ -1,0 +1,71 @@
+"""Startup report of the effective configuration and deprecated settings.
+
+Only variable *names* are ever logged; values never leave the environment.
+"""
+
+import logging
+import os
+from collections.abc import Mapping
+
+from agent.config import ENV
+
+logger = logging.getLogger(__name__)
+
+# Surface -> variables that must all be present for it to be enabled.
+_SURFACES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("LangSmith", ("LANGSMITH_API_KEY",)),
+    ("GitHub", ("GITHUB_APP_CLIENT_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_WEBHOOK_SECRET")),
+    ("Slack", ("SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET")),
+    ("Linear", ("LINEAR_API_KEY", "LINEAR_WEBHOOK_SECRET")),
+    (
+        "Dashboard",
+        (
+            "GITHUB_APP_CLIENT_SECRET",
+            "DASHBOARD_JWT_SECRET",
+            "TOKEN_ENCRYPTION_KEY",
+            "DASHBOARD_BASE_URL",
+            "DASHBOARD_API_BASE_URL",
+        ),
+    ),
+)
+
+# Discovery-backed values: listed as overrides only when explicitly set.
+_OVERRIDES: tuple[str, ...] = (
+    "GITHUB_APP_INSTALLATION_ID",
+    "SLACK_BOT_USER_ID",
+    "SLACK_BOT_USERNAME",
+    "DEFAULT_SANDBOX_SNAPSHOT_ID",
+)
+
+
+def _is_set(env: Mapping[str, str], name: str) -> bool:
+    return ENV[name].is_set(env)
+
+
+def deprecated_env_warnings(env: Mapping[str, str]) -> list[str]:
+    """Human-readable warnings for every deprecated variable present in ``env``."""
+    return [f"{name} is deprecated: {hint}" for name, hint in ENV.deprecated_in_use(env)]
+
+
+def configuration_summary(env: Mapping[str, str]) -> list[str]:
+    """One line per surface: enabled, disabled, or the variables still missing."""
+    lines: list[str] = []
+    for surface, names in _SURFACES:
+        missing = [name for name in names if not _is_set(env, name)]
+        if not missing:
+            lines.append(f"{surface}: enabled")
+        elif len(missing) == len(names):
+            lines.append(f"{surface}: disabled")
+        else:
+            lines.append(f"{surface}: missing {', '.join(missing)}")
+    overrides = [name for name in _OVERRIDES if _is_set(env, name)]
+    if overrides:
+        lines.append(f"Explicit overrides: {', '.join(overrides)}")
+    return lines
+
+
+def log_startup_configuration() -> None:
+    for line in configuration_summary(os.environ):
+        logger.info("config: %s", line)
+    for warning in deprecated_env_warnings(os.environ):
+        logger.warning("config: %s", warning)

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -943,15 +943,7 @@ async def get_slack_repo_config(
 
     if not repo_config and slack_user_id:
         try:
-            slack_user = await get_slack_user_info(slack_user_id)
-            slack_email = (
-                (slack_user or {}).get("profile", {}).get("email")
-                if isinstance(slack_user, dict)
-                else None
-            )
-            profile_repo = await get_profile_default_repo(
-                await resolve_login_from_email_async(slack_email)
-            )
+            profile_repo = await get_profile_default_repo(await login_for_slack_id(slack_user_id))
             if profile_repo:
                 logger.info(
                     "Applying dashboard default_repo for Slack user %s: %s/%s",

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -372,6 +372,22 @@ async def ensure_slack_bot_identity() -> None:
 
 
 DOCS_PLZ_SLACK_CHANNEL_NAME = "docs-plz"
+# Posted in the Slack thread when no repository can be resolved: a bare 4xx to
+# Slack is invisible to the person who asked.
+NO_REPOSITORY_SLACK_REPLY = (
+    "I don't know which repository to work in. Set a default in the dashboard under "
+    "Admin → Team settings → Default Repository (or in your own profile), or put "
+    "`repo:owner/name` in this channel's topic, then mention me again."
+)
+
+
+class SlackRepositoryNotConfigured(HTTPException):
+    """No repository could be resolved for a Slack-triggered run."""
+
+    def __init__(self) -> None:
+        super().__init__(400, "no default repository configured")
+
+
 DOCS_PLZ_SLACK_GATE_REPLY = (
     "Please don't use Open SWE here, instead ask the Fleet docs-plz agent to implement the docs"
 )
@@ -954,7 +970,7 @@ async def get_slack_repo_config(
         repo_config = {"owner": env_owner, "name": default_name}
 
     if not repo_config:
-        raise HTTPException(400, "no default repository configured")
+        raise SlackRepositoryNotConfigured()
 
     return repo_config
 

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -167,6 +167,7 @@ __all__ = [
     "DEFAULT_HTTP_TIMEOUT",
     "DEFAULT_REPO_OWNER",
     "DOCS_PLZ_SLACK_GATE_REPLY",
+    "default_repo_owner_hint",
     "FEEDBACK_REACTIONS",
     "GITHUB_WEBHOOK_SECRET",
     "HTTPException",
@@ -411,7 +412,11 @@ def get_repo_config_from_team_mapping(
     team_identifier: str, project_name: str = ""
 ) -> dict[str, str]:
     """Look up repository configuration from LINEAR_TEAM_TO_REPO mapping."""
-    fallback = {"owner": DEFAULT_REPO_OWNER, "name": DEFAULT_REPO_NAME} if DEFAULT_REPO_NAME else {}
+    fallback = (
+        {"owner": DEFAULT_REPO_OWNER, "name": DEFAULT_REPO_NAME}
+        if DEFAULT_REPO_OWNER and DEFAULT_REPO_NAME
+        else {}
+    )
 
     if not team_identifier or team_identifier not in LINEAR_TEAM_TO_REPO:
         return fallback
@@ -845,6 +850,21 @@ async def upsert_agent_thread_metadata(
         logger.exception("Failed to persist owner metadata for thread %s", thread_id)
 
 
+async def default_repo_owner_hint(env_owner: str = "") -> str:
+    """Owner assumed for ``repo:name`` shorthand.
+
+    The deprecated env default wins when set; otherwise the team default
+    repository's owner. Empty when neither is configured, in which case the
+    shorthand is ignored and a full ``owner/name`` is required.
+    """
+    owner = env_owner.strip()
+    if owner:
+        return owner
+    team_repo = await get_team_default_repo()
+    team_owner = (team_repo or {}).get("owner", "")
+    return team_owner.strip() if isinstance(team_owner, str) else ""
+
+
 async def get_slack_repo_config(
     channel_id: str,
     thread_ts: str,
@@ -859,10 +879,10 @@ async def get_slack_repo_config(
         2. A ``repo:owner/name`` token in the channel's topic/purpose.
         3. The triggering user's dashboard ``default_repo`` (if they have a
            profile and their Slack email maps to a known GitHub login).
-        4. Team default repo.
-        5. ``SLACK_REPO_*`` env defaults.
+        4. Team default repo (Admin → Team settings).
+        5. Deprecated ``SLACK_REPO_*`` / ``DEFAULT_REPO_*`` env defaults.
     """
-    default_owner = SLACK_REPO_OWNER.strip() or DEFAULT_REPO_OWNER
+    env_owner = SLACK_REPO_OWNER.strip() or DEFAULT_REPO_OWNER
     default_name = SLACK_REPO_NAME.strip() or DEFAULT_REPO_NAME
     langgraph_client = get_client(url=LANGGRAPH_URL)
 
@@ -884,6 +904,7 @@ async def get_slack_repo_config(
             )
 
     if not repo_config:
+        default_owner = await default_repo_owner_hint(env_owner)
         try:
             if channel_context is not None:
                 channel_description = get_slack_channel_context_description(channel_context)
@@ -929,8 +950,8 @@ async def get_slack_repo_config(
     if not repo_config:
         repo_config = await get_team_default_repo()
 
-    if not repo_config and default_owner and default_name:
-        repo_config = {"owner": default_owner, "name": default_name}
+    if not repo_config and env_owner and default_name:
+        repo_config = {"owner": env_owner, "name": default_name}
 
     if not repo_config:
         raise HTTPException(400, "no default repository configured")

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -205,8 +205,8 @@ Routing is opt-in and off by default. Enable it either way:
 
 | Env var | Default | Purpose |
 |---|---|---|
-| `LANGSMITH_GATEWAY_ENABLED` | `false` | Deployment-level default for gateway routing. |
-| `LANGSMITH_GATEWAY_API_KEY` | unset | Optional dedicated LangSmith key for Gateway calls. Prefer this in LangGraph Cloud if the platform-provided `LANGSMITH_API_KEY` lacks `gateway:invoke`. Falls back to `LANGSMITH_API_KEY`. |
+| `LANGSMITH_GATEWAY_ENABLED` | on when `LANGSMITH_GATEWAY_API_KEY` is set, else off | Deployment-level default for gateway routing; set explicitly to override. |
+| `LANGSMITH_GATEWAY_API_KEY` | unset | Dedicated LangSmith key for Gateway calls; setting it also turns routing on. Prefer this in LangGraph Cloud if the platform-provided `LANGSMITH_API_KEY` lacks `gateway:invoke`. Falls back to `LANGSMITH_API_KEY` when routing is enabled some other way. |
 | `LANGSMITH_GATEWAY_BASE_URL` | `https://gateway.smith.langchain.com` | Override for a regional or self-hosted gateway host. |
 | `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `true` | Use the OpenAI Responses API through the gateway. Set to `false` only to force Chat Completions for OpenAI models. |
 

--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -1,0 +1,338 @@
+"""Guided ``.env`` setup for the GitHub + Slack minimum installation.
+
+Run with ``make setup`` (or ``uv run python scripts/setup_env.py``). Prompts for
+the handful of credentials Open SWE cannot discover on its own, generates the
+local secrets, and writes ``.env`` with owner-only permissions. Existing values
+are kept unless ``--force`` is given; secrets are never echoed back.
+"""
+
+import argparse
+import getpass
+import os
+import re
+import secrets
+import sys
+from collections.abc import Callable, Iterable, Mapping
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+MINIMUM_KEYS: tuple[str, ...] = (
+    "LANGSMITH_API_KEY",
+    "GITHUB_APP_CLIENT_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_WEBHOOK_SECRET",
+    "SLACK_BOT_TOKEN",
+    "SLACK_SIGNING_SECRET",
+)
+MODEL_PROVIDER_KEYS: dict[str, str | None] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "gateway": None,
+}
+DASHBOARD_KEYS: tuple[str, ...] = (
+    "GITHUB_APP_CLIENT_SECRET",
+    "DASHBOARD_BASE_URL",
+    "DASHBOARD_API_BASE_URL",
+    "CONFIGURED_ADMINS",
+)
+GENERATED_KEYS: tuple[str, ...] = ("DASHBOARD_JWT_SECRET", "TOKEN_ENCRYPTION_KEY")
+SECRET_KEYS: frozenset[str] = frozenset(
+    {
+        "LANGSMITH_API_KEY",
+        "GITHUB_APP_PRIVATE_KEY",
+        "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_APP_CLIENT_SECRET",
+        "SLACK_BOT_TOKEN",
+        "SLACK_SIGNING_SECRET",
+        *GENERATED_KEYS,
+        *(key for key in MODEL_PROVIDER_KEYS.values() if key),
+    }
+)
+DEFAULT_DASHBOARD_BASE_URL = "http://localhost:3000"
+DEFAULT_DASHBOARD_API_BASE_URL = "http://localhost:2024"
+MARKER = "# Added by scripts/setup_env.py"
+
+_ENV_LINE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+
+Ask = Callable[[str, str], str]
+AskSecret = Callable[[str], str]
+
+
+class SetupError(Exception):
+    """A configuration problem the user has to fix; reported without a traceback."""
+
+
+def generate_dashboard_jwt_secret() -> str:
+    """HMAC secret for dashboard session cookies and OAuth state (64 hex chars)."""
+    return secrets.token_hex(32)
+
+
+def generate_token_encryption_key() -> str:
+    """Fernet key for stored OAuth tokens; drawn independently of the JWT secret."""
+    return Fernet.generate_key().decode()
+
+
+def generate_webhook_secret() -> str:
+    return secrets.token_hex(32)
+
+
+_ESCAPES = {"n": "\n", "\\": "\\", '"': '"'}
+
+
+def _decode_double_quoted(inner: str) -> str:
+    """Undo :func:`quote_value`; mirrors python-dotenv's double-quote escapes."""
+    out: list[str] = []
+    chars = iter(inner)
+    for char in chars:
+        if char != "\\":
+            out.append(char)
+            continue
+        nxt = next(chars, "")
+        out.append(_ESCAPES.get(nxt, "\\" + nxt))
+    return "".join(out)
+
+
+def _unquote(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        inner = value[1:-1]
+        return _decode_double_quoted(inner) if value[0] == '"' else inner
+    return value.split(" #", 1)[0].strip()
+
+
+def parse_env(text: str) -> dict[str, str]:
+    """``KEY=value`` pairs from a dotenv file; comments and blank lines are skipped."""
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = _ENV_LINE.match(line)
+        if match:
+            values[match.group(1)] = _unquote(match.group(2))
+    return values
+
+
+def quote_value(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def render_env(existing_text: str, updates: Mapping[str, str]) -> str:
+    """Return ``existing_text`` with ``updates`` applied in place and new keys appended.
+
+    Comments, ordering and unrelated keys are preserved; a key present in the
+    file is rewritten on its own line and never duplicated.
+    """
+    pending = dict(updates)
+    lines: list[str] = []
+    for line in existing_text.splitlines():
+        match = _ENV_LINE.match(line)
+        key = match.group(1) if match and not line.lstrip().startswith("#") else None
+        if key is not None and key in pending:
+            lines.append(f"{key}={quote_value(pending.pop(key))}")
+        else:
+            lines.append(line)
+    if pending:
+        if lines and lines[-1].strip():
+            lines.append("")
+        if MARKER not in lines:
+            lines.append(MARKER)
+        lines.extend(f"{key}={quote_value(value)}" for key, value in pending.items())
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def read_private_key(path: str) -> str:
+    """Load a GitHub App ``.pem`` as a single dotenv-safe line."""
+    pem = Path(path).expanduser()
+    try:
+        text = pem.read_text().strip()
+    except OSError as exc:
+        raise SetupError(f"Cannot read private key file {pem}: {exc.strerror}") from exc
+    if "PRIVATE KEY" not in text:
+        raise SetupError(f"{pem} does not look like a PEM private key")
+    return "\\n".join(line.strip() for line in text.splitlines())
+
+
+def write_env_file(path: Path, content: str) -> None:
+    """Write the file readable by the owner only, creating or truncating it."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(content)
+    os.chmod(path, 0o600)
+
+
+def missing_minimum(values: Mapping[str, str]) -> list[str]:
+    missing = [key for key in MINIMUM_KEYS if not values.get(key, "").strip()]
+    gateway = values.get("LANGSMITH_GATEWAY_ENABLED", "").strip().lower() in {"1", "true", "yes"}
+    has_model_key = any(values.get(key, "").strip() for key in MODEL_PROVIDER_KEYS.values() if key)
+    if not gateway and not has_model_key:
+        missing.append("a model provider key (or LANGSMITH_GATEWAY_ENABLED=true)")
+    return missing
+
+
+def collect_answers(
+    ask: Ask,
+    ask_secret: AskSecret,
+    *,
+    existing: Mapping[str, str],
+    dashboard: bool,
+) -> dict[str, str]:
+    """Prompt for every minimum value not already present in ``existing``."""
+    answers: dict[str, str] = {}
+
+    def want(key: str) -> bool:
+        return not existing.get(key, "").strip()
+
+    if want("LANGSMITH_API_KEY"):
+        answers["LANGSMITH_API_KEY"] = ask_secret("LangSmith API key (lsv2_...)")
+
+    has_model = any(existing.get(key, "").strip() for key in MODEL_PROVIDER_KEYS.values() if key)
+    gateway_on = existing.get("LANGSMITH_GATEWAY_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if not has_model and not gateway_on:
+        provider = ask("Model provider (anthropic / openai / google / gateway)", "anthropic")
+        provider = provider.strip().lower()
+        if provider not in MODEL_PROVIDER_KEYS:
+            raise SetupError(f"Unknown model provider {provider!r}")
+        key = MODEL_PROVIDER_KEYS[provider]
+        if key is None:
+            answers["LANGSMITH_GATEWAY_ENABLED"] = "true"
+        else:
+            answers[key] = ask_secret(f"{provider.title()} API key")
+
+    if want("GITHUB_APP_CLIENT_ID"):
+        answers["GITHUB_APP_CLIENT_ID"] = ask("GitHub App client ID (Iv1....)", "").strip()
+    if want("GITHUB_APP_PRIVATE_KEY"):
+        pem_path = ask("Path to the GitHub App private key (.pem)", "").strip()
+        answers["GITHUB_APP_PRIVATE_KEY"] = read_private_key(pem_path)
+    if want("GITHUB_WEBHOOK_SECRET"):
+        supplied = ask_secret("GitHub webhook secret (leave empty to generate one)")
+        answers["GITHUB_WEBHOOK_SECRET"] = supplied.strip() or generate_webhook_secret()
+        answers["_generated_webhook_secret"] = "" if supplied.strip() else "1"
+    if want("SLACK_BOT_TOKEN"):
+        answers["SLACK_BOT_TOKEN"] = ask_secret("Slack bot token (xoxb-...)")
+    if want("SLACK_SIGNING_SECRET"):
+        answers["SLACK_SIGNING_SECRET"] = ask_secret("Slack signing secret")
+
+    if dashboard:
+        if want("GITHUB_APP_CLIENT_SECRET"):
+            answers["GITHUB_APP_CLIENT_SECRET"] = ask_secret("GitHub App client secret")
+        if want("DASHBOARD_BASE_URL"):
+            answers["DASHBOARD_BASE_URL"] = ask("Dashboard URL", DEFAULT_DASHBOARD_BASE_URL)
+        if want("DASHBOARD_API_BASE_URL"):
+            answers["DASHBOARD_API_BASE_URL"] = ask(
+                "Backend URL browsers use", DEFAULT_DASHBOARD_API_BASE_URL
+            )
+        if want("CONFIGURED_ADMINS"):
+            answers["CONFIGURED_ADMINS"] = ask("Admin GitHub logins (comma-separated)", "")
+
+    return {key: value for key, value in answers.items() if value or key.startswith("_")}
+
+
+def generated_secrets(existing: Mapping[str, str], *, force: bool) -> dict[str, str]:
+    """Freshly generated local secrets for every key that is unset (or all, with ``force``)."""
+    generators = {
+        "DASHBOARD_JWT_SECRET": generate_dashboard_jwt_secret,
+        "TOKEN_ENCRYPTION_KEY": generate_token_encryption_key,
+    }
+    return {
+        key: make()
+        for key, make in generators.items()
+        if force or not existing.get(key, "").strip()
+    }
+
+
+def _values_from_environ(environ: Mapping[str, str], keys: Iterable[str]) -> dict[str, str]:
+    return {key: environ[key] for key in keys if environ.get(key, "").strip()}
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Guided .env setup for Open SWE")
+    parser.add_argument("--output", default=".env", help="dotenv file to write (default: .env)")
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="read values from the process environment instead of prompting",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="regenerate local secrets even if already set"
+    )
+    parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="also collect the optional dashboard settings",
+    )
+    return parser.parse_args(argv)
+
+
+def _interactive_ask(prompt: str, default: str) -> str:
+    suffix = f" [{default}]" if default else ""
+    answer = input(f"{prompt}{suffix}: ")
+    return answer if answer.strip() else default
+
+
+def _interactive_ask_secret(prompt: str) -> str:
+    return getpass.getpass(f"{prompt}: ")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    output = Path(args.output)
+    existing_text = output.read_text() if output.exists() else ""
+    existing = parse_env(existing_text)
+
+    if args.non_interactive:
+        keys = (*MINIMUM_KEYS, *DASHBOARD_KEYS, "LANGSMITH_GATEWAY_ENABLED")
+        keys = (*keys, *(key for key in MODEL_PROVIDER_KEYS.values() if key))
+        answers = _values_from_environ(os.environ, keys)
+        merged = {**existing, **answers}
+        if not merged.get("GITHUB_WEBHOOK_SECRET", "").strip():
+            answers["GITHUB_WEBHOOK_SECRET"] = generate_webhook_secret()
+            answers["_generated_webhook_secret"] = "1"
+    else:
+        try:
+            answers = collect_answers(
+                _interactive_ask,
+                _interactive_ask_secret,
+                existing=existing,
+                dashboard=args.dashboard,
+            )
+        except (SetupError, EOFError, KeyboardInterrupt) as exc:
+            print(f"\nSetup aborted: {exc}" if str(exc) else "\nSetup aborted.", file=sys.stderr)
+            return 2
+
+    generated_webhook = bool(answers.pop("_generated_webhook_secret", ""))
+    answers.update(generated_secrets(existing, force=args.force))
+    merged = {**existing, **answers}
+    missing = missing_minimum(merged)
+    if missing:
+        print("Still missing: " + ", ".join(missing), file=sys.stderr)
+        if args.non_interactive:
+            return 2
+
+    write_env_file(output, render_env(existing_text, answers))
+
+    written = sorted(answers)
+    kept = sorted(key for key in existing if key not in answers)
+    print(f"Wrote {output} (mode 600).")
+    if written:
+        print("  set:  " + ", ".join(written))
+    if kept:
+        print("  kept: " + ", ".join(kept))
+    if generated_webhook:
+        print(
+            f"\nGITHUB_WEBHOOK_SECRET was generated and saved to {output}. Copy it into the "
+            "GitHub App's Webhook secret field; the value is not shown here:\n"
+            f"  grep '^GITHUB_WEBHOOK_SECRET=' {output}"
+        )
+    print("\nNext: `make dev`, then mention the bot in Slack or a GitHub issue.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dashboard/test_user_mappings.py
+++ b/tests/dashboard/test_user_mappings.py
@@ -142,3 +142,24 @@ async def test_list_mappings_sorted(fake_store: _FakeStore) -> None:
     await um.upsert_mapping(github_login="alpha", work_email="a@x.com")
     listed = await um.list_mappings()
     assert [m["github_login"] for m in listed] == ["alpha", "zeta"]
+
+
+async def test_login_for_email_matches_a_dashboard_profile(fake_store: _FakeStore) -> None:
+    """No explicit mapping: the GitHub account email on the profile is the mapping."""
+    fake_store.items[(("profiles",), "octocat")] = {"login": "octocat", "email": "Octo@Example.com"}
+
+    assert await um.login_for_email("octo@example.com") == "octocat"
+    # Cached for the synchronous readers on hot paths.
+    assert um.cached_login_for_email("OCTO@example.com") == "octocat"
+    assert um.cached_login_for_email("nobody@example.com") is None
+
+
+async def test_explicit_mapping_wins_over_a_profile_email(fake_store: _FakeStore) -> None:
+    fake_store.items[(("profiles",), "octocat")] = {
+        "login": "octocat",
+        "email": "shared@example.com",
+    }
+    await um.upsert_mapping(github_login="mapped", work_email="shared@example.com")
+    um.clear_cache()
+
+    assert await um.login_for_email("shared@example.com") == "mapped"

--- a/tests/dashboard/test_user_mappings.py
+++ b/tests/dashboard/test_user_mappings.py
@@ -163,3 +163,58 @@ async def test_explicit_mapping_wins_over_a_profile_email(fake_store: _FakeStore
     um.clear_cache()
 
     assert await um.login_for_email("shared@example.com") == "mapped"
+
+
+async def test_login_for_slack_id_resolves_through_slack_and_persists(
+    fake_store: _FakeStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unmapped Slack user is looked up with users.info and matched to a profile."""
+    fake_store.items[(("profiles",), "octocat")] = {"login": "octocat", "email": "octo@example.com"}
+    calls: list[str] = []
+
+    async def fake_email(slack_user_id: str) -> str | None:
+        calls.append(slack_user_id)
+        return "Octo@Example.com"
+
+    monkeypatch.setattr(um, "_slack_user_email", fake_email)
+
+    assert await um.login_for_slack_id("U123") == "octocat"
+    mapping = await um.get_mapping("octocat")
+    assert mapping is not None
+    assert mapping["slack_user_id"] == "U123"
+    assert mapping["source"] == "slack_directory"
+    assert mapping["work_email"] == "octo@example.com"
+    # Cached and persisted: no second Slack call, and the email path resolves too.
+    assert await um.login_for_slack_id("U123") == "octocat"
+    assert await um.login_for_email("octo@example.com") == "octocat"
+    assert calls == ["U123"]
+
+
+async def test_login_for_slack_id_fills_the_slack_id_on_an_email_only_mapping(
+    fake_store: _FakeStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await um.upsert_mapping(github_login="octocat", work_email="octo@example.com")
+    um.clear_cache()
+
+    async def fake_email(slack_user_id: str) -> str | None:
+        return "octo@example.com"
+
+    monkeypatch.setattr(um, "_slack_user_email", fake_email)
+
+    assert await um.login_for_slack_id("U777") == "octocat"
+    mapping = await um.get_mapping("octocat")
+    assert mapping is not None
+    assert mapping["slack_user_id"] == "U777"
+    assert mapping["source"] == "slack_oauth"
+
+
+async def test_login_for_slack_id_unknown_user_stays_unmapped(
+    fake_store: _FakeStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_email(slack_user_id: str) -> str | None:
+        return "stranger@example.com"
+
+    monkeypatch.setattr(um, "_slack_user_email", fake_email)
+
+    assert await um.login_for_slack_id("U999") is None
+    assert await um.list_mappings() == []

--- a/tests/github/test_repo_extraction.py
+++ b/tests/github/test_repo_extraction.py
@@ -32,6 +32,15 @@ class TestExtractRepoFromText:
         result = extract_repo_from_text("repo:my-repo", default_owner="custom-org")
         assert result == {"owner": "custom-org", "name": "my-repo"}
 
+    def test_repo_name_only_without_default_owner_returns_none(self) -> None:
+        assert extract_repo_from_text("fix repo:widgets", default_owner="") is None
+
+    def test_repo_name_only_has_no_hardcoded_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import agent.utils.repo as repo_module
+
+        monkeypatch.setattr(repo_module, "_DEFAULT_REPO_OWNER", "")
+        assert extract_repo_from_text("fix repo:widgets") is None
+
     def test_github_url(self) -> None:
         result = extract_repo_from_text(
             "check https://github.com/langchain-ai/langgraph-api please"

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -505,3 +505,21 @@ def test_make_model_gateway_without_key_falls_back_direct(
     assert captured["store"] is False
     assert captured["include"] == ["reasoning.encrypted_content"]
     assert "api_key" not in captured
+
+
+def test_gateway_default_follows_the_dedicated_key(monkeypatch) -> None:
+    from agent.utils import gateway
+
+    for name in ("LANGSMITH_GATEWAY_ENABLED", "LANGSMITH_GATEWAY_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    assert gateway.gateway_env_default() is False
+
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "lsv2_sk_gateway")
+    assert gateway.gateway_env_default() is True
+
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "false")
+    assert gateway.gateway_env_default() is False
+
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
+    assert gateway.gateway_env_default() is True

--- a/tests/scripts/test_setup_env.py
+++ b/tests/scripts/test_setup_env.py
@@ -1,0 +1,278 @@
+"""Guided installer: secret generation, dotenv merging, prompts, and file mode."""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from scripts import setup_env
+
+_FAKE_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK\nabc==\n-----END RSA PRIVATE KEY-----\n"
+)
+
+
+def test_generated_secrets_are_distinct_and_well_formed() -> None:
+    jwt_a, jwt_b = (
+        setup_env.generate_dashboard_jwt_secret(),
+        setup_env.generate_dashboard_jwt_secret(),
+    )
+    key_a, key_b = (
+        setup_env.generate_token_encryption_key(),
+        setup_env.generate_token_encryption_key(),
+    )
+
+    assert jwt_a != jwt_b and key_a != key_b
+    assert len(jwt_a) == 64 and int(jwt_a, 16) >= 0
+    Fernet(key_a.encode())
+    assert jwt_a != key_a
+
+
+def test_generated_secrets_respect_existing_unless_forced() -> None:
+    existing = {"DASHBOARD_JWT_SECRET": "keep", "TOKEN_ENCRYPTION_KEY": ""}
+
+    fresh = setup_env.generated_secrets(existing, force=False)
+    assert set(fresh) == {"TOKEN_ENCRYPTION_KEY"}
+
+    forced = setup_env.generated_secrets(existing, force=True)
+    assert set(forced) == {"DASHBOARD_JWT_SECRET", "TOKEN_ENCRYPTION_KEY"}
+    assert forced["DASHBOARD_JWT_SECRET"] != "keep"
+
+
+def test_parse_env_handles_quotes_comments_and_export() -> None:
+    text = (
+        "# comment\n"
+        "FOO=bar\n"
+        'QUOTED="a b"\n'
+        "SINGLE='x'\n"
+        "export EXPORTED=1\n"
+        'MULTI="line1\\nline2"\n'
+        'ESCAPED="back\\\\slash \\"q\\""\n'
+        "\n"
+        "TRAILING=value # note\n"
+    )
+
+    assert setup_env.parse_env(text) == {
+        "FOO": "bar",
+        "QUOTED": "a b",
+        "SINGLE": "x",
+        "EXPORTED": "1",
+        "MULTI": "line1\nline2",
+        "ESCAPED": 'back\\slash "q"',
+        "TRAILING": "value",
+    }
+
+
+def test_render_env_replaces_in_place_and_appends_once() -> None:
+    existing = '# LangSmith\nLANGSMITH_API_KEY=""\nFOO=bar\n'
+    updates = {"LANGSMITH_API_KEY": "lsv2-x", "SLACK_BOT_TOKEN": "xoxb-x"}
+
+    first = setup_env.render_env(existing, updates)
+    second = setup_env.render_env(first, updates)
+
+    assert first.splitlines()[0] == "# LangSmith"
+    assert 'LANGSMITH_API_KEY="lsv2-x"' in first
+    assert "FOO=bar" in first
+    assert first.count("SLACK_BOT_TOKEN=") == 1
+    assert first.count(setup_env.MARKER) == 1
+    assert second == first
+    assert setup_env.parse_env(first)["SLACK_BOT_TOKEN"] == "xoxb-x"
+
+
+def test_render_env_round_trips_private_key() -> None:
+    key = "-----BEGIN RSA PRIVATE KEY-----\\nabc\\n-----END RSA PRIVATE KEY-----"
+    rendered = setup_env.render_env("", {"GITHUB_APP_PRIVATE_KEY": key})
+
+    assert setup_env.parse_env(rendered)["GITHUB_APP_PRIVATE_KEY"] == key
+
+
+def test_read_private_key_flattens_pem(tmp_path: Path) -> None:
+    pem = tmp_path / "app.pem"
+    pem.write_text(_FAKE_PEM)
+
+    value = setup_env.read_private_key(str(pem))
+
+    assert "\n" not in value
+    assert value.startswith("-----BEGIN RSA PRIVATE KEY-----\\n")
+    assert value.endswith("\\n-----END RSA PRIVATE KEY-----")
+
+
+def test_read_private_key_rejects_non_pem(tmp_path: Path) -> None:
+    other = tmp_path / "notes.txt"
+    other.write_text("hello")
+
+    with pytest.raises(setup_env.SetupError):
+        setup_env.read_private_key(str(other))
+    with pytest.raises(setup_env.SetupError):
+        setup_env.read_private_key(str(tmp_path / "missing.pem"))
+
+
+def _scripted(answers: dict[str, str], secrets_: dict[str, str]):
+    asked: list[str] = []
+
+    def ask(prompt: str, default: str) -> str:
+        asked.append(prompt)
+        return answers.get(prompt, default)
+
+    def ask_secret(prompt: str) -> str:
+        asked.append(prompt)
+        return secrets_.get(prompt, "")
+
+    return ask, ask_secret, asked
+
+
+def test_collect_answers_gateway_skips_model_key(tmp_path: Path) -> None:
+    pem = tmp_path / "app.pem"
+    pem.write_text(_FAKE_PEM)
+    ask, ask_secret, asked = _scripted(
+        {
+            "Model provider (anthropic / openai / google / gateway)": "gateway",
+            "GitHub App client ID (Iv1....)": "Iv1.abc",
+            "Path to the GitHub App private key (.pem)": str(pem),
+        },
+        {
+            "LangSmith API key (lsv2_...)": "lsv2-test",
+            "Slack bot token (xoxb-...)": "xoxb-test",
+            "Slack signing secret": "sig-test",
+        },
+    )
+
+    answers = setup_env.collect_answers(ask, ask_secret, existing={}, dashboard=False)
+
+    assert answers["LANGSMITH_GATEWAY_ENABLED"] == "true"
+    assert "ANTHROPIC_API_KEY" not in answers
+    assert answers["GITHUB_APP_CLIENT_ID"] == "Iv1.abc"
+    assert answers["GITHUB_APP_PRIVATE_KEY"].startswith("-----BEGIN")
+    assert len(answers["GITHUB_WEBHOOK_SECRET"]) == 64
+    assert answers["_generated_webhook_secret"] == "1"
+    assert not any("Dashboard" in prompt for prompt in asked)
+    assert setup_env.missing_minimum(answers) == []
+
+
+def test_collect_answers_skips_values_already_present(tmp_path: Path) -> None:
+    ask, ask_secret, asked = _scripted({}, {})
+    existing = {
+        "LANGSMITH_API_KEY": "x",
+        "ANTHROPIC_API_KEY": "x",
+        "GITHUB_APP_CLIENT_ID": "x",
+        "GITHUB_APP_PRIVATE_KEY": "x",
+        "GITHUB_WEBHOOK_SECRET": "x",
+        "SLACK_BOT_TOKEN": "x",
+        "SLACK_SIGNING_SECRET": "x",
+    }
+
+    assert setup_env.collect_answers(ask, ask_secret, existing=existing, dashboard=False) == {}
+    assert asked == []
+
+
+def test_collect_answers_dashboard_section_uses_defaults() -> None:
+    ask, ask_secret, _ = _scripted({}, {"GitHub App client secret": "gh-secret"})
+    existing = dict.fromkeys(setup_env.MINIMUM_KEYS, "x") | {"OPENAI_API_KEY": "x"}
+
+    answers = setup_env.collect_answers(ask, ask_secret, existing=existing, dashboard=True)
+
+    assert answers["GITHUB_APP_CLIENT_SECRET"] == "gh-secret"
+    assert answers["DASHBOARD_BASE_URL"] == setup_env.DEFAULT_DASHBOARD_BASE_URL
+    assert answers["DASHBOARD_API_BASE_URL"] == setup_env.DEFAULT_DASHBOARD_API_BASE_URL
+    assert "CONFIGURED_ADMINS" not in answers
+
+
+def test_missing_minimum_reports_names_only() -> None:
+    missing = setup_env.missing_minimum({"SLACK_BOT_TOKEN": "xoxb-secret"})
+
+    assert "SLACK_BOT_TOKEN" not in missing
+    assert "SLACK_SIGNING_SECRET" in missing
+    assert any("model provider" in item for item in missing)
+    assert "xoxb-secret" not in " ".join(missing)
+
+
+def test_main_non_interactive_writes_secure_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.DASHBOARD_KEYS, *setup_env.GENERATED_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    values = {
+        "LANGSMITH_API_KEY": "lsv2-secret",
+        "ANTHROPIC_API_KEY": "sk-ant-secret",
+        "GITHUB_APP_CLIENT_ID": "Iv1.abc",
+        "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\\nabc\\n-----END RSA PRIVATE KEY-----",
+        "GITHUB_WEBHOOK_SECRET": "hook-secret",
+        "SLACK_BOT_TOKEN": "xoxb-secret",
+        "SLACK_SIGNING_SECRET": "sig-secret",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    output = tmp_path / ".env"
+
+    assert setup_env.main(["--output", str(output), "--non-interactive"]) == 0
+
+    mode = stat.S_IMODE(os.stat(output).st_mode)
+    assert mode == 0o600
+    written = setup_env.parse_env(output.read_text())
+    for key, value in values.items():
+        assert written[key] == value
+    assert written["DASHBOARD_JWT_SECRET"] != written["TOKEN_ENCRYPTION_KEY"]
+    Fernet(written["TOKEN_ENCRYPTION_KEY"].encode())
+    out = capsys.readouterr().out
+    for secret in ("lsv2-secret", "sk-ant-secret", "xoxb-secret", "sig-secret", "hook-secret"):
+        assert secret not in out
+    assert written["DASHBOARD_JWT_SECRET"] not in out
+
+
+def test_main_second_run_keeps_generated_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.GENERATED_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    for key in setup_env.MINIMUM_KEYS:
+        monkeypatch.setenv(key, "x")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    output = tmp_path / ".env"
+
+    setup_env.main(["--output", str(output), "--non-interactive"])
+    first = setup_env.parse_env(output.read_text())
+    setup_env.main(["--output", str(output), "--non-interactive"])
+    second = setup_env.parse_env(output.read_text())
+    setup_env.main(["--output", str(output), "--non-interactive", "--force"])
+    third = setup_env.parse_env(output.read_text())
+
+    assert first["DASHBOARD_JWT_SECRET"] == second["DASHBOARD_JWT_SECRET"]
+    assert first["TOKEN_ENCRYPTION_KEY"] == second["TOKEN_ENCRYPTION_KEY"]
+    assert third["DASHBOARD_JWT_SECRET"] != first["DASHBOARD_JWT_SECRET"]
+
+
+def test_main_non_interactive_generates_webhook_secret_without_printing_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.GENERATED_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    for key in setup_env.MINIMUM_KEYS:
+        if key != "GITHUB_WEBHOOK_SECRET":
+            monkeypatch.setenv(key, "x")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    output = tmp_path / ".env"
+
+    assert setup_env.main(["--output", str(output), "--non-interactive"]) == 0
+
+    written = setup_env.parse_env(output.read_text())
+    out = capsys.readouterr().out
+    assert len(written["GITHUB_WEBHOOK_SECRET"]) == 64
+    assert written["GITHUB_WEBHOOK_SECRET"] not in out
+    assert "GITHUB_WEBHOOK_SECRET was generated" in out
+    assert "grep '^GITHUB_WEBHOOK_SECRET='" in out
+
+
+def test_main_non_interactive_fails_when_minimum_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.GENERATED_KEYS, "OPENAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-secret")
+
+    assert setup_env.main(["--output", str(tmp_path / ".env"), "--non-interactive"]) == 2
+
+    err = capsys.readouterr().err
+    assert "SLACK_SIGNING_SECRET" in err
+    assert "xoxb-secret" not in err

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -852,6 +852,100 @@ def test_get_slack_repo_config_applies_team_default_repo(
     assert repo == {"owner": "team-owner", "name": "team-repo"}
 
 
+def _team_default_repo(owner: str, name: str):
+    async def _get() -> dict[str, str]:
+        return {"owner": owner, "name": name}
+
+    return _get
+
+
+def _clear_env_repo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for attr in ("SLACK_REPO_OWNER", "SLACK_REPO_NAME", "DEFAULT_REPO_OWNER", "DEFAULT_REPO_NAME"):
+        monkeypatch.setattr(webhook_common, attr, "")
+
+
+def test_get_slack_repo_config_shorthand_uses_team_default_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(
+        webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
+    )
+
+    repo = asyncio.run(
+        webhook_common.get_slack_repo_config(
+            "C123", "1.234", channel_context={"topic": "repo:tools"}, thread_id="mapped-thread"
+        )
+    )
+
+    assert repo == {"owner": "acme", "name": "tools"}
+
+
+def test_get_slack_repo_config_shorthand_prefers_env_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "SLACK_REPO_OWNER", "env-owner")
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(
+        webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
+    )
+
+    repo = asyncio.run(
+        webhook_common.get_slack_repo_config(
+            "C123", "1.234", channel_context={"topic": "repo:tools"}, thread_id="mapped-thread"
+        )
+    )
+
+    assert repo == {"owner": "env-owner", "name": "tools"}
+
+
+def test_get_slack_repo_config_shorthand_without_any_owner_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+
+    with pytest.raises(webhook_common.HTTPException) as excinfo:
+        asyncio.run(
+            webhook_common.get_slack_repo_config(
+                "C123", "1.234", channel_context={"topic": "repo:tools"}, thread_id="t"
+            )
+        )
+
+    assert excinfo.value.status_code == 400
+
+
+def test_get_slack_repo_config_never_mixes_team_owner_with_env_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "SLACK_REPO_NAME", "env-repo")
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+
+    with pytest.raises(webhook_common.HTTPException):
+        asyncio.run(webhook_common.get_slack_repo_config("C123", "1.234", thread_id="t"))
+
+
+async def test_default_repo_owner_hint_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
+    )
+
+    assert await webhook_common.default_repo_owner_hint("env-owner") == "env-owner"
+    assert await webhook_common.default_repo_owner_hint("") == "acme"
+
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+    assert await webhook_common.default_repo_owner_hint("") == ""
+
+
 def _setup_slack_mention_fakes(
     monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]
 ) -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -806,10 +806,8 @@ def test_get_slack_repo_config_applies_profile_default_repo(
 ) -> None:
     threads_client = _FakeThreadsClient(thread={"metadata": {}})
 
-    async def fake_get_slack_user_info(user_id: str) -> dict:
-        return {"profile": {"email": "mason@example.com"}}
-
-    async def fake_resolve_login_from_email_async(email: str | None) -> str | None:
+    async def fake_login_for_slack_id(slack_user_id: str | None) -> str | None:
+        assert slack_user_id == "U123"
         return "mason"
 
     async def fake_get_profile_default_repo(login: str | None) -> dict[str, str] | None:
@@ -817,10 +815,7 @@ def test_get_slack_repo_config_applies_profile_default_repo(
         return {"owner": "profile-owner", "name": "profile-repo"}
 
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
-    monkeypatch.setattr(webhook_common, "get_slack_user_info", fake_get_slack_user_info)
-    monkeypatch.setattr(
-        webhook_common, "resolve_login_from_email_async", fake_resolve_login_from_email_async
-    )
+    monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "get_profile_default_repo", fake_get_profile_default_repo)
 
     repo = asyncio.run(

--- a/tests/slack/test_slack_no_repository.py
+++ b/tests/slack/test_slack_no_repository.py
@@ -1,0 +1,50 @@
+"""A Slack turn with no resolvable repository gets a reply, not a silent 400."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.slack import routes as slack_routes
+from agent.webhooks import common as webhook_common
+
+
+async def test_missing_repository_is_explained_in_the_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        webhook_common,
+        "get_slack_repo_config",
+        AsyncMock(side_effect=webhook_common.SlackRepositoryNotConfigured()),
+    )
+    reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", reply)
+
+    resolved = await slack_routes._repo_config_or_reply("C1", "123.45", slack_user_id="U1")
+
+    assert resolved is None
+    reply.assert_awaited_once()
+    channel_id, thread_ts, text = reply.await_args.args
+    assert (channel_id, thread_ts) == ("C1", "123.45")
+    assert "Team settings" in text and "repo:owner/name" in text
+
+
+async def test_resolved_repository_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        webhook_common,
+        "get_slack_repo_config",
+        AsyncMock(return_value={"owner": "acme", "name": "widgets"}),
+    )
+    reply = AsyncMock()
+    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", reply)
+
+    resolved = await slack_routes._repo_config_or_reply("C1", "123.45")
+
+    assert resolved == {"owner": "acme", "name": "widgets"}
+    reply.assert_not_awaited()
+
+
+def test_missing_repository_is_still_a_400_for_api_callers() -> None:
+    exc = webhook_common.SlackRepositoryNotConfigured()
+
+    assert exc.status_code == 400
+    assert exc.detail == "no default repository configured"

--- a/tests/utils/test_startup_config.py
+++ b/tests/utils/test_startup_config.py
@@ -1,0 +1,122 @@
+"""Startup configuration report and deprecation warnings."""
+
+import logging
+
+import pytest
+
+from agent.config import ENV
+from agent.utils import startup_config
+
+_MINIMUM = {
+    "LANGSMITH_API_KEY": "lsv2-secret",
+    "GITHUB_APP_CLIENT_ID": "Iv1.client",
+    "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\\nsecret",
+    "GITHUB_WEBHOOK_SECRET": "webhook-secret",
+    "SLACK_BOT_TOKEN": "xoxb-secret",
+    "SLACK_SIGNING_SECRET": "signing-secret",
+}
+
+
+def test_minimum_config_enables_github_and_slack_only() -> None:
+    lines = startup_config.configuration_summary(_MINIMUM)
+
+    assert "LangSmith: enabled" in lines
+    assert "GitHub: enabled" in lines
+    assert "Slack: enabled" in lines
+    assert "Linear: disabled" in lines
+    assert "Dashboard: disabled" in lines
+
+
+def test_partial_surface_lists_missing_names() -> None:
+    env = dict(_MINIMUM)
+    del env["GITHUB_WEBHOOK_SECRET"]
+
+    assert "GitHub: missing GITHUB_WEBHOOK_SECRET" in startup_config.configuration_summary(env)
+
+
+def test_blank_values_count_as_unset() -> None:
+    env = dict(_MINIMUM, SLACK_SIGNING_SECRET="   ")
+
+    assert "Slack: missing SLACK_SIGNING_SECRET" in startup_config.configuration_summary(env)
+
+
+def test_explicit_overrides_are_listed_by_name() -> None:
+    env = dict(_MINIMUM, GITHUB_APP_INSTALLATION_ID="123", SLACK_BOT_USER_ID="UBOT")
+
+    assert (
+        "Explicit overrides: GITHUB_APP_INSTALLATION_ID, SLACK_BOT_USER_ID"
+        in startup_config.configuration_summary(env)
+    )
+
+
+def test_summary_never_contains_secret_values() -> None:
+    env = dict(_MINIMUM, GITHUB_APP_INSTALLATION_ID="123")
+    text = "\n".join(startup_config.configuration_summary(env))
+
+    for value in env.values():
+        assert value not in text
+
+
+@pytest.mark.parametrize(
+    ("name", "fragment"),
+    [
+        ("GITHUB_APP_ID", "GITHUB_APP_CLIENT_ID"),
+        ("SLACK_REPO_OWNER", "Team settings"),
+        ("SLACK_REPO_NAME", "Team settings"),
+        ("DEFAULT_REPO_OWNER", "Team settings"),
+        ("DEFAULT_REPO_NAME", "Team settings"),
+        ("LANGSMITH_TRACING_PROJECT_ID_PROD", "LANGSMITH_TRACING_PROJECT_ID"),
+        ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY"),
+        ("LANGSMITH_API_KEY_PROD", "LANGSMITH_API_KEY"),
+        ("LANGSMITH_ENDPOINT_PROD", "LANGSMITH_ENDPOINT"),
+        ("LANGSMITH_URL_PROD", "LANGSMITH_ENDPOINT"),
+        ("LANGSMITH_TENANT_ID_PROD", "LANGSMITH_TENANT_ID"),
+        ("LANGGRAPH_URL_PROD", "LANGGRAPH_URL"),
+        ("LANGCHAIN_TRACING_V2", "LANGSMITH_TRACING"),
+    ],
+)
+def test_deprecated_variable_warns(name: str, fragment: str) -> None:
+    warnings = startup_config.deprecated_env_warnings({name: "x"})
+
+    assert len(warnings) == 1
+    assert warnings[0].startswith(f"{name} is deprecated")
+    assert fragment in warnings[0]
+
+
+def test_legacy_prod_key_still_enables_langsmith_with_a_warning() -> None:
+    env = dict(_MINIMUM)
+    env["LANGSMITH_API_KEY_PROD"] = env.pop("LANGSMITH_API_KEY")
+
+    assert "LangSmith: enabled" in startup_config.configuration_summary(env)
+    assert any(
+        w.startswith("LANGSMITH_API_KEY_PROD is deprecated")
+        for w in startup_config.deprecated_env_warnings(env)
+    )
+
+
+def test_no_deprecations_for_minimum_config() -> None:
+    assert startup_config.deprecated_env_warnings(_MINIMUM) == []
+
+
+def test_log_startup_configuration_uses_levels(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    for name in startup_config.__dict__["_SURFACES"]:
+        for var in name[1]:
+            monkeypatch.delenv(var, raising=False)
+    for var in ENV.variables():
+        if var.deprecated or var.aliases:
+            for name in (var.name, *var.aliases):
+                monkeypatch.delenv(name, raising=False)
+    for name, value in _MINIMUM.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+
+    with caplog.at_level(logging.INFO, logger="agent.utils.startup_config"):
+        startup_config.log_startup_configuration()
+
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert "config: GitHub: enabled" in infos
+    assert any("GITHUB_APP_ID is deprecated" in w for w in warnings)
+    assert all("xoxb-secret" not in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Third PR of the install-simplification stack.

- **Team default repository is canonical.** `repo:name` shorthand resolves against the team default's owner; the hardcoded `langchain-ai` owner default is gone. `DEFAULT_REPO_*` / `SLACK_REPO_*` keep working as deprecated fallbacks.
- **Startup configuration report.** At startup the API logs which surfaces are enabled (LangSmith, GitHub, Slack, Linear, Dashboard) or which variable each is missing, which discovery-backed values are explicitly overridden, and every deprecated variable present. Names only; values never reach the log. Deprecation hints come from the registry in `agent/config.py`, so a variable is described in exactly one place.
- **`make setup`.** Interactive `.env` writer for the GitHub + Slack minimum. Secrets are read without echo, `DASHBOARD_JWT_SECRET` and `TOKEN_ENCRYPTION_KEY` are generated independently when the dashboard is enabled, and a generated webhook secret is pointed to in `.env` rather than printed.

## Testing

- New: `tests/utils/test_startup_config.py`, `tests/scripts/test_setup_env.py`, team-default cases in `tests/slack/test_slack_context.py`.
- `uv run pytest tests/`: all green except the 8 Slack webhook cases that already fail on a clean `main`.
- `make setup` driven end to end with `expect` and fake values; a minimum-only `.env` boots with the expected report.

## Stack

1. #2463 unified config + standard LangSmith env
2. #2464 runtime discovery
3. **this PR** config cleanup + guided `make setup`
4. #2466 installation docs rewrite
