### PR TITLE
ci: dispatch stable desktop releases to Homebrew

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -197,6 +197,23 @@ jobs:
             ${{ steps.assets.outputs.update_metadata }}
             ${{ steps.assets.outputs.update_blockmap }}
 
+      - name: Generate tap token
+        if: steps.release.outputs.prerelease == 'false'
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: "Iv23liMFOFBcPTKFWi3S"
+          private-key: ${{ secrets.LANGCHAIN_ACTIONS_PR_BOT_PRIVATE_KEY }}
+          owner: langchain-ai
+          repositories: homebrew-tap
+
+      - name: Update Homebrew cask
+        if: steps.release.outputs.prerelease == 'false'
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: gh api repos/langchain-ai/homebrew-tap/dispatches --method POST -f event_type=open-swe-desktop-release -f "client_payload[tag]=$TAG"
+
       - name: Remove signing credentials
         if: always()
         run: |


### PR DESCRIPTION
### Summary

A set of PRs to package Open SWE Desktop in homebrew so that users can install via `brew install --cask langchain-ai/tap/open-swe-desktop`.

Merge in this order:
- https://github.com/langchain-ai/langchainplus/pull/37705
- https://github.com/langchain-ai/homebrew-tap/pull/56
- This PR

### What this PR does

- dispatch each successful stable desktop release to `langchain-ai/homebrew-tap`
- authenticate with the existing short-lived `langchain-actions-pr-bot` App token
- exclude nightly and prerelease builds

### Verification

- actionlint syntax validation
- YAML parse validation
- `git diff --check`

Made by [Open SWE](https://openswe.vercel.app/agents/03efd401-8b52-5de8-9ea5-a0e766428401)