### PR TITLE
fix(desktop): call Codex login a ChatGPT subscription

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -12,11 +12,11 @@ The composer's workspace selector chooses where a local thread runs. **Current c
 
 The packaged app bundles its Python runtime and locked Open SWE dependencies. Source development uses `uv run langgraph dev`. Provider credentials stay in the local LangGraph process and are not inherited by agent shell commands. Added projects and local thread history are persisted in the desktop app's local data.
 
-For local OpenAI models, the app can use either `OPENAI_API_KEY` or Sign in with ChatGPT. When no
-API key is configured, sending the first local task opens the system browser for sign-in. OAuth
-credentials are encrypted with the operating system's secure storage, refreshed by Electron, and
-made available to the local model client through an authenticated loopback broker. Refresh tokens
-are never placed in the local backend environment or inherited by agent shell commands.
+For local OpenAI models, the app can use either `OPENAI_API_KEY` or a ChatGPT subscription. When no
+API key is configured, sending the first local task opens the system browser for ChatGPT sign-in.
+OAuth credentials are encrypted with the operating system's secure storage, refreshed by Electron,
+and made available to the local model client through an authenticated loopback broker. Refresh
+tokens are never placed in the local backend environment or inherited by agent shell commands.
 
 Local model calls also honor `LANGSMITH_GATEWAY_*` configuration. On managed macOS installs, the
 app reads `LC_GATEWAY_KEY` from `launchctl` when no explicit gateway key is configured and enables

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -483,7 +483,7 @@ function configureDesktopIpc() {
   });
   ipcMain.handle("desktop:local-openai-sign-in", async (event) => {
     requireTrustedDesktopIpc(event);
-    if (!openAiOAuth) throw new Error("OpenAI sign-in is unavailable");
+    if (!openAiOAuth) throw new Error("ChatGPT sign-in is unavailable");
     return openAiOAuth.login((url) => shell.openExternal(url));
   });
   ipcMain.handle("desktop:start-local-thread", async (event, input) => {

--- a/desktop/src/openai-oauth.cts
+++ b/desktop/src/openai-oauth.cts
@@ -308,7 +308,7 @@ class OpenAiOAuthManager {
 
   async refresh() {
     const current = this.credentials;
-    if (!current) throw new Error("Sign in to use OpenAI models");
+    if (!current) throw new Error("Sign in with ChatGPT to use OpenAI models");
     const response = await this.fetch(TOKEN_URL, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -322,7 +322,7 @@ class OpenAiOAuthManager {
       if (response.status === 400 || response.status === 401)
         this.clearCredentials();
       throw new Error(
-        `The OpenAI session could not be refreshed (${response.status})`,
+        `The ChatGPT session could not be refreshed (${response.status})`,
       );
     }
     const payload = await response.json();
@@ -335,7 +335,7 @@ class OpenAiOAuthManager {
     if (refreshedAccountId && refreshedAccountId !== current.accountId) {
       this.clearCredentials();
       throw new Error(
-        "The OpenAI account changed during token refresh; sign in again",
+        "The ChatGPT account changed during token refresh; sign in again",
       );
     }
     return this.saveCredentials({
@@ -348,7 +348,8 @@ class OpenAiOAuthManager {
   }
 
   async accessToken() {
-    if (!this.credentials) throw new Error("Sign in to use OpenAI models");
+    if (!this.credentials)
+      throw new Error("Sign in with ChatGPT to use OpenAI models");
     if (this.needsRefresh(this.credentials)) {
       if (!this.refreshing) {
         this.refreshing = this.refresh().finally(() => {
@@ -375,7 +376,7 @@ class OpenAiOAuthManager {
         const accessToken = await this.accessToken();
         const accountId = this.credentials?.accountId;
         if (!accountId)
-          throw new Error("The OpenAI session included no account ID");
+          throw new Error("The ChatGPT session included no account ID");
         response.writeHead(200, {
           "content-type": "application/json",
           "cache-control": "no-store",

--- a/ui/src/features/agents/lib/desktopLocal.ts
+++ b/ui/src/features/agents/lib/desktopLocal.ts
@@ -52,7 +52,7 @@ export async function ensureDesktopModelCredential(
       const result = await desktop.signInLocalOpenAI()
       if (result.signedIn) return null
     } catch (cause) {
-      return cause instanceof Error ? cause.message : "OpenAI sign-in failed"
+      return cause instanceof Error ? cause.message : "ChatGPT sign-in failed"
     }
   }
   return credential.variable


### PR DESCRIPTION
Replace legacy or ambiguous OpenAI/Codex account wording in the desktop authentication path with the user-facing terms “ChatGPT subscription” and “ChatGPT sign-in.” Internal Codex endpoint and implementation names remain unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/cc26f1b1-5fb2-5758-bead-134456935e28)