### PR TITLE
fix: omit snapshot_id instead of sending "" for the root snapshot

### DIFF
--- a/agent/sandboxes/providers/langsmith.py
+++ b/agent/sandboxes/providers/langsmith.py
@@ -813,8 +813,12 @@ class LangSmithProvider(SandboxProvider):
 
             effective_snapshot_id = snapshot_id or ""
             extra_fields = _merge_sandbox_create_extra_fields(create_params)
-            if not effective_snapshot_id:
-                extra_fields["snapshot_id"] = ""
+            # The API boots from its default root snapshot only when the key is
+            # absent: `snapshot_id` is a UUID there, and "" fails to parse as one
+            # before any validation runs. The SDK already omits a falsy id, so
+            # only an injected empty value can put it back on the wire.
+            if not extra_fields.get("snapshot_id"):
+                extra_fields.pop("snapshot_id", None)
             _install_create_extra_fields(client, extra_fields)
 
             try:

--- a/agent/sandboxes/providers/langsmith.py
+++ b/agent/sandboxes/providers/langsmith.py
@@ -813,10 +813,8 @@ class LangSmithProvider(SandboxProvider):
 
             effective_snapshot_id = snapshot_id or ""
             extra_fields = _merge_sandbox_create_extra_fields(create_params)
-            # The API boots from its default root snapshot only when the key is
-            # absent: `snapshot_id` is a UUID there, and "" fails to parse as one
-            # before any validation runs. The SDK already omits a falsy id, so
-            # only an injected empty value can put it back on the wire.
+            # The API boots its default root snapshot only when the key is absent:
+            # `snapshot_id` is a UUID server-side, so "" is rejected with a 422.
             if not extra_fields.get("snapshot_id"):
                 extra_fields.pop("snapshot_id", None)
             _install_create_extra_fields(client, extra_fields)

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -240,21 +240,57 @@ class _FakeSandboxClient:
         return {"sandbox": kwargs["snapshot_id"]}
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("snapshot_id", [None, ""])
-async def test_provider_passes_empty_snapshot_id_to_api(snapshot_id: str | None) -> None:
+def _stub_create_response() -> tuple[AsyncSandboxClient, AsyncMock]:
     client = AsyncSandboxClient(api_key="key", api_endpoint="https://example.com/v2/sandboxes")
     response = MagicMock()
     response.raise_for_status.return_value = None
     response.json.return_value = {"name": "sandbox-new", "status": "ready"}
     post = AsyncMock(return_value=response)
     client._http.post = post
+    return client, post
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("snapshot_id", [None, ""])
+async def test_provider_omits_snapshot_id_when_unset(snapshot_id: str | None) -> None:
+    """No configured snapshot must send no `snapshot_id` key at all.
+
+    The API boots its default root snapshot only when the field is absent. It
+    is a UUID server-side, so sending "" is rejected with a 422 before any
+    validation runs, and no sandbox is created.
+    """
+    client, post = _stub_create_response()
 
     with patch("agent.sandboxes.providers.langsmith.AsyncSandboxClient", return_value=client):
         await LangSmithProvider(api_key="key").get_or_create(snapshot_id=snapshot_id)
 
     assert post.await_args is not None
-    assert post.await_args.kwargs["json"]["snapshot_id"] == ""
+    assert "snapshot_id" not in post.await_args.kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_provider_sends_explicit_snapshot_id() -> None:
+    client, post = _stub_create_response()
+
+    with patch("agent.sandboxes.providers.langsmith.AsyncSandboxClient", return_value=client):
+        await LangSmithProvider(api_key="key").get_or_create(snapshot_id="snap-1")
+
+    assert post.await_args is not None
+    assert post.await_args.kwargs["json"]["snapshot_id"] == "snap-1"
+
+
+@pytest.mark.asyncio
+async def test_provider_drops_empty_snapshot_id_from_create_params() -> None:
+    """An empty id reaching us through create_params must not be forwarded."""
+    client, post = _stub_create_response()
+
+    with patch("agent.sandboxes.providers.langsmith.AsyncSandboxClient", return_value=client):
+        await LangSmithProvider(api_key="key").get_or_create(
+            snapshot_id=None, create_params={"snapshot_id": ""}
+        )
+
+    assert post.await_args is not None
+    assert "snapshot_id" not in post.await_args.kwargs["json"]
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_langsmith_sandbox_config.py
+++ b/tests/sandbox/test_langsmith_sandbox_config.py
@@ -240,53 +240,30 @@ class _FakeSandboxClient:
         return {"sandbox": kwargs["snapshot_id"]}
 
 
-def _stub_create_response() -> tuple[AsyncSandboxClient, AsyncMock]:
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot_id", "create_params"),
+    [(None, None), ("", None), (None, {"snapshot_id": ""})],
+)
+async def test_provider_omits_snapshot_id_when_unset(
+    snapshot_id: str | None, create_params: dict[str, str] | None
+) -> None:
+    """No usable snapshot must send no `snapshot_id` key at all.
+
+    The API boots its default root snapshot only when the field is absent. It
+    is a UUID server-side, so sending "" is rejected with a 422 before any
+    validation runs, and no sandbox is created.
+    """
     client = AsyncSandboxClient(api_key="key", api_endpoint="https://example.com/v2/sandboxes")
     response = MagicMock()
     response.raise_for_status.return_value = None
     response.json.return_value = {"name": "sandbox-new", "status": "ready"}
     post = AsyncMock(return_value=response)
     client._http.post = post
-    return client, post
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("snapshot_id", [None, ""])
-async def test_provider_omits_snapshot_id_when_unset(snapshot_id: str | None) -> None:
-    """No configured snapshot must send no `snapshot_id` key at all.
-
-    The API boots its default root snapshot only when the field is absent. It
-    is a UUID server-side, so sending "" is rejected with a 422 before any
-    validation runs, and no sandbox is created.
-    """
-    client, post = _stub_create_response()
-
-    with patch("agent.sandboxes.providers.langsmith.AsyncSandboxClient", return_value=client):
-        await LangSmithProvider(api_key="key").get_or_create(snapshot_id=snapshot_id)
-
-    assert post.await_args is not None
-    assert "snapshot_id" not in post.await_args.kwargs["json"]
-
-
-@pytest.mark.asyncio
-async def test_provider_sends_explicit_snapshot_id() -> None:
-    client, post = _stub_create_response()
-
-    with patch("agent.sandboxes.providers.langsmith.AsyncSandboxClient", return_value=client):
-        await LangSmithProvider(api_key="key").get_or_create(snapshot_id="snap-1")
-
-    assert post.await_args is not None
-    assert post.await_args.kwargs["json"]["snapshot_id"] == "snap-1"
-
-
-@pytest.mark.asyncio
-async def test_provider_drops_empty_snapshot_id_from_create_params() -> None:
-    """An empty id reaching us through create_params must not be forwarded."""
-    client, post = _stub_create_response()
 
     with patch("agent.sandboxes.providers.langsmith.AsyncSandboxClient", return_value=client):
         await LangSmithProvider(api_key="key").get_or_create(
-            snapshot_id=None, create_params={"snapshot_id": ""}
+            snapshot_id=snapshot_id, create_params=create_params
         )
 
     assert post.await_args is not None


### PR DESCRIPTION
Fixes the root-snapshot path added in #2398. Every sandbox creation without a configured snapshot currently fails:

```
RuntimeError("Failed to create sandbox from snapshot '': Client error '422 unknown'
for url 'https://api.smith.langchain.com/v2/sandboxes/boxes'")
```

## Cause

#2398 signals "use the default root snapshot" by injecting an empty `snapshot_id` into the create payload:

```python
if not effective_snapshot_id:
    extra_fields["snapshot_id"] = ""
```

The API doesn't read it that way. The field is `SnapshotID *uuid.UUID` server-side, and the contract is: provide at most one of `snapshot_id` or `snapshot_name`; **if neither is provided**, the server uses the default snapshot. "Not provided" means the key is absent — `""` fails to parse as a UUID and is rejected with a 422 before validation runs, which is why the error carries no field name.

The langsmith SDK already omits a falsy id. The injection was re-adding a key the SDK had deliberately dropped, via the `_install_create_extra_fields` post-payload merge.

## Fix

Drop a falsy `snapshot_id` from the merged extra fields so the key is absent on the wire. This also covers an empty id arriving through an environment's `create_params`, which would fail the same way.

Deployments that set `DEFAULT_SANDBOX_SNAPSHOT_ID` (or the admin base snapshot) are unaffected — the explicit path never entered the injecting branch.

## Tests

`test_provider_passes_empty_snapshot_id_to_api` asserted `json["snapshot_id"] == ""`, locking in the broken wire format. It now asserts the key is absent, across an unset id, an empty id, and an empty id supplied via `create_params`. All three cases fail on `main`.
