### PR TITLE
fix: remove priority sidebar sorting

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -524,7 +524,6 @@ export function AgentsSidebar({
           value={prefs.sortChats}
           onValueChange={(value) => setView({ sortChats: value as ChatSort })}
         >
-          <MenuRadioItem value="priority">Priority</MenuRadioItem>
           <MenuRadioItem value="updated">Last updated</MenuRadioItem>
         </MenuRadioGroup>
       </MenuGroup>
@@ -728,9 +727,6 @@ export function AgentsSidebar({
                             setView({ sortPinned: value as PinnedSort })
                           }
                         >
-                          <MenuRadioItem value="priority">
-                            Priority
-                          </MenuRadioItem>
                           <MenuRadioItem value="updated">
                             Last updated
                           </MenuRadioItem>

--- a/ui/src/features/agents/lib/sidebarPrefs.ts
+++ b/ui/src/features/agents/lib/sidebarPrefs.ts
@@ -7,8 +7,8 @@ export const SIDEBAR_PREFS_STORAGE_KEY = "open-swe.agents.sidebar-prefs"
 const STORAGE_KEY = SIDEBAR_PREFS_STORAGE_KEY
 
 const ORGANIZE_MODES = ["project", "list"] as const
-const CHAT_SORTS = ["priority", "updated"] as const
-const PINNED_SORTS = ["priority", "updated", "manual"] as const
+const CHAT_SORTS = ["updated"] as const
+const PINNED_SORTS = ["updated", "manual"] as const
 
 export type OrganizeMode = (typeof ORGANIZE_MODES)[number]
 export type ChatSort = (typeof CHAT_SORTS)[number]
@@ -42,7 +42,7 @@ export const DEFAULT_SIDEBAR_PREFS: SidebarPrefs = {
   expandedProjectKeys: [],
   collapsedSectionKeys: [],
   organize: "project",
-  sortChats: "priority",
+  sortChats: "updated",
   sortPinned: "manual",
 }
 

--- a/ui/src/features/agents/lib/sidebarThreads.ts
+++ b/ui/src/features/agents/lib/sidebarThreads.ts
@@ -221,17 +221,7 @@ export function groupSidebarThreadsByProject(
   }
 }
 
-export type SidebarSort = "priority" | "updated" | "manual"
-
-/**
- * Priority ranks what still wants the user's attention: live runs first, then
- * anything unread, then everything else. Within a rank it falls back to
- * recency, so the ordering only ever reorders across those three bands.
- */
-function priorityRank(thread: SidebarThreadItem): number {
-  if (thread.status === "running") return 0
-  return thread.viewed ? 2 : 1
-}
+export type SidebarSort = "updated" | "manual"
 
 function byRecency(left: SidebarThreadItem, right: SidebarThreadItem): number {
   return (
@@ -248,11 +238,7 @@ export function sortSidebarThreads(
   // "manual" keeps the order the caller supplied — for pins that is the stored
   // pin order, which is the only manual ordering the user can actually set.
   if (mode === "manual") return [...threads]
-  if (mode === "updated") return [...threads].sort(byRecency)
-  return [...threads].sort(
-    (left, right) =>
-      priorityRank(left) - priorityRank(right) || byRecency(left, right)
-  )
+  return [...threads].sort(byRecency)
 }
 
 function localProjectName(cwd: string): string | null {


### PR DESCRIPTION
Removes priority sorting from sidebar chat and pinned-thread menus. Existing priority preferences fall back to last updated.

Checks: UI typecheck, focused oxlint, production build.

Made by [Open SWE](https://openswe.vercel.app/agents/01a06d4f-1614-762c-a325-533989fef15b)