### PR TITLE
Add per-turn thread analytics

### DIFF
--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -114,11 +114,15 @@ async def _mutate(
         await _client().store.put_item(namespace, key, update(await _get(namespace, key)))
 
 
-async def _all(namespace: list[str]) -> list[dict[str, Any]]:
+async def _all(
+    namespace: list[str], *, filter: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
     values: list[dict[str, Any]] = []
     offset = 0
     while True:
-        result = await _client().store.search_items(namespace, limit=_PAGE_SIZE, offset=offset)
+        result = await _client().store.search_items(
+            namespace, filter=filter, limit=_PAGE_SIZE, offset=offset
+        )
         items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
         page = list(items or [])
         values.extend(value for item in page if (value := _record(item)) is not None)
@@ -313,6 +317,7 @@ async def record_agent_run_usage(
     model_id: str,
     effort: str | None,
     source: str | None,
+    turn_key: str | None = None,
 ) -> None:
     """Record one actual Agent run, idempotently."""
     if not run_id or not thread_id:
@@ -324,6 +329,7 @@ async def record_agent_run_usage(
         return existing or {
             "run_id": run_id,
             "thread_id": thread_id,
+            "turn_key": turn_key or "",
             "github_login": _login(github_login),
             "user_email": _email(user_email),
             "model_id": model_id,
@@ -369,6 +375,37 @@ async def record_agent_run_cost(*, run_id: str, cost_usd: float) -> None:
         return {**existing, "cost_usd": cost_usd} if existing else {}
 
     await _mutate(AGENT_RUN_NAMESPACE, key, update)
+
+
+async def list_agent_thread_usage(thread_id: str) -> dict[str, Any]:
+    """List usage for a thread in run order."""
+    records = await _all(AGENT_RUN_NAMESPACE, filter={"thread_id": thread_id})
+    records.sort(key=lambda record: (_int(record.get("created_at_ms")), str(record.get("run_id"))))
+    return {
+        "runs": [
+            {
+                "run_id": str(record.get("run_id") or ""),
+                "model_id": str(record.get("model_id") or ""),
+                "turn_key": str(record.get("turn_key") or ""),
+                "created_at_ms": _int(record.get("created_at_ms")),
+                "finished_at_ms": _int(record.get("finished_at_ms")),
+                "input_tokens": _int(record.get("input_tokens"))
+                if record.get("finished_at_ms")
+                else None,
+                "output_tokens": _int(record.get("output_tokens"))
+                if record.get("finished_at_ms")
+                else None,
+                "total_tokens": _int(record.get("total_tokens"))
+                if record.get("finished_at_ms")
+                else None,
+                "cost_usd": record.get("cost_usd")
+                if isinstance(record.get("cost_usd"), int | float)
+                and not isinstance(record.get("cost_usd"), bool)
+                else None,
+            }
+            for record in records
+        ]
+    }
 
 
 async def record_agent_pr_usage(

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -181,6 +181,7 @@ from agent.dashboard.thread_api import (
     get_dashboard_thread_pull_request_status,
     get_dashboard_thread_recovery_patch,
     get_dashboard_thread_state,
+    get_dashboard_thread_usage,
     get_dashboard_thread_working_tree_diff,
     list_dashboard_pinned_threads,
     list_dashboard_thread_projects,
@@ -2059,6 +2060,14 @@ async def api_get_thread_pull_request_context(
         number=number,
         email=session.get("email"),
     )
+
+
+@router.get("/threads/{thread_id}/usage")
+async def api_get_thread_usage(
+    thread_id: str,
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    return await get_dashboard_thread_usage(thread_id, session["sub"], email=session.get("email"))
 
 
 @router.get("/threads/{thread_id}")

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent.dashboard.admin import is_admin
 from agent.dashboard.agent_overrides import normalize_profile_overrides
+from agent.dashboard.agent_usage import list_agent_thread_usage
 from agent.dashboard.environments import ENVIRONMENTS, slugify
 from agent.dashboard.options import (
     DEPRECATED_MODEL_IDS,
@@ -1634,6 +1635,11 @@ async def _enrich_run_start_command(
     client_message_id = _command_message_id(params)
     if client_message_id and client_message_id not in persisted_message_ids:
         structured[-1]["id"] = client_message_id
+    turn_key = structured[-1].get("id")
+    if not isinstance(turn_key, str) or not turn_key:
+        turn_key = str(uuid.uuid4())
+        structured[-1]["id"] = turn_key
+    overrides["turn_key"] = turn_key
     run_input = params.get("input")
     if isinstance(run_input, dict):
         run_input["messages"] = structured
@@ -2079,6 +2085,13 @@ async def _readable_thread_metadata(
     thread = await _readable_thread(thread_id, login=login, email=email)
     metadata = thread_metadata(thread)
     return metadata
+
+
+async def get_dashboard_thread_usage(
+    thread_id: str, login: str, *, email: str | None = None
+) -> dict[str, Any]:
+    await _readable_thread(thread_id, login=login, email=email)
+    return await list_agent_thread_usage(thread_id)
 
 
 async def get_dashboard_thread_state(

--- a/agent/run_config.py
+++ b/agent/run_config.py
@@ -97,6 +97,7 @@ class RunConfig(BaseModel):
     thread_id: str | None = None
     run_id: str | None = None
     prepare_run_id: str | None = None
+    turn_key: str | None = None
     source: str | None = None
     task: str | None = None
     environment: str | None = None

--- a/agent/server.py
+++ b/agent/server.py
@@ -723,6 +723,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         cfg = RunConfig.from_config(self._config)
         return {
             "prepare_run_id": cfg.prepare_run_id,
+            "turn_key": cfg.turn_key,
             "thread_id": self._thread_id,
             "source": self._source,
             "repo": cfg.repo.model_dump() if cfg.repo else None,
@@ -871,6 +872,15 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                         model_id=self._model_id,
                         effort=self._effort,
                         source=self._source,
+                        turn_key=cfg.turn_key
+                        or next(
+                            (
+                                str(message.id)
+                                for message in reversed(state.get("messages") or [])
+                                if isinstance(message, HumanMessage) and message.id
+                            ),
+                            None,
+                        ),
                     )
         except Exception:
             logger.debug(

--- a/tests/agent/test_agent_usage.py
+++ b/tests/agent/test_agent_usage.py
@@ -7,7 +7,7 @@ from agent.utils.run_usage import RunUsageSummary
 class FakeStore:
     def __init__(self):
         self.values: dict[tuple[tuple[str, ...], str], dict] = {}
-        self.search_calls: list[tuple[tuple[str, ...], int]] = []
+        self.search_calls: list[tuple[tuple[str, ...], dict | None, int]] = []
 
     async def get_item(self, namespace: list[str], key: str) -> dict | None:
         value = self.values.get((tuple(namespace), key))
@@ -16,12 +16,18 @@ class FakeStore:
     async def put_item(self, namespace: list[str], key: str, value: dict) -> None:
         self.values[(tuple(namespace), key)] = value
 
-    async def search_items(self, namespace: list[str], *, limit: int, offset: int) -> dict:
-        self.search_calls.append((tuple(namespace), offset))
+    async def search_items(
+        self, namespace: list[str], *, filter: dict | None = None, limit: int, offset: int
+    ) -> dict:
+        self.search_calls.append((tuple(namespace), filter, offset))
         values = [
             {"value": value}
             for (item_namespace, _), value in self.values.items()
             if item_namespace == tuple(namespace)
+            and (
+                filter is None
+                or all(value.get(key) == expected for key, expected in filter.items())
+            )
         ]
         return {"items": values[offset : offset + limit]}
 
@@ -73,7 +79,54 @@ async def test_usage_records_runs_and_reads_every_page(monkeypatch):
     )
 
     assert payload["rows"][0]["agent_runs"] == 2
-    assert (tuple(agent_usage.AGENT_RUN_NAMESPACE), 1) in store.search_calls
+    assert (tuple(agent_usage.AGENT_RUN_NAMESPACE), None, 1) in store.search_calls
+
+
+@pytest.mark.asyncio
+async def test_thread_usage_is_filtered_sorted_and_redacted(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(agent_usage, "_client", lambda: FakeClient(store))
+    namespace = tuple(agent_usage.AGENT_RUN_NAMESPACE)
+    store.values[(namespace, "later")] = {
+        "run_id": "run-2",
+        "thread_id": "thread-1",
+        "github_login": "octo",
+        "user_email": "octo@example.com",
+        "model_id": "claude",
+        "turn_key": "message-2",
+        "created_at_ms": 200,
+        "finished_at_ms": 250,
+        "input_tokens": 20,
+        "output_tokens": 5,
+        "total_tokens": 25,
+        "cost_usd": 0.25,
+    }
+    store.values[(namespace, "other")] = {
+        "run_id": "other",
+        "thread_id": "thread-2",
+        "created_at_ms": 50,
+    }
+    store.values[(namespace, "earlier")] = {
+        "run_id": "run-1",
+        "thread_id": "thread-1",
+        "model_id": "claude",
+        "created_at_ms": 100,
+        "finished_at_ms": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "cost_usd": None,
+    }
+
+    payload = await agent_usage.list_agent_thread_usage("thread-1")
+
+    assert [run["run_id"] for run in payload["runs"]] == ["run-1", "run-2"]
+    assert payload["runs"][0]["total_tokens"] is None
+    assert payload["runs"][1]["turn_key"] == "message-2"
+    assert payload["runs"][1]["cost_usd"] == 0.25
+    assert "github_login" not in payload["runs"][1]
+    assert "user_email" not in payload["runs"][1]
+    assert (namespace, {"thread_id": "thread-1"}, 0) in store.search_calls
 
 
 @pytest.mark.asyncio

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -255,6 +255,7 @@ async def test_enrich_run_start_command_creates_and_stamps_new_thread(monkeypatc
     assert configurable["agent_effort"] == "medium"
     assert configurable["prepare_run_id"] == enriched["params"]["metadata"]["prepare_run_id"]
     assert configurable["prepare_run_id"]
+    assert configurable["turn_key"] == enriched["params"]["input"]["messages"][-1]["id"]
     messages = enriched["params"]["input"]["messages"]
     assert messages[-1]["content"].startswith(
         '<input-message sender="github:octocat" surface="web" kind="human">'
@@ -825,7 +826,8 @@ async def test_enrich_run_start_command_adds_web_handoff_for_slack_thread(monkey
     assert "conversation has moved to Web" in (handoff.findtext("content") or "")
     assert user_message.attrib["sender"] == "github:teammate"
     assert user_message.findtext("content") == "continue here"
-    assert "id" not in messages[-1]
+    assert messages[-1]["id"] != "existing-message"
+    assert enriched["params"]["config"]["configurable"]["turn_key"] == messages[-1]["id"]
     assert enriched["params"]["config"]["configurable"]["source"] == "dashboard"
 
 
@@ -1437,6 +1439,48 @@ async def test_read_endpoints_reject_non_surfaced_source(monkeypatch) -> None:
     with pytest.raises(HTTPException) as exc_info:
         await thread_api.get_dashboard_thread_state("tid", "owner")
     assert exc_info.value.status_code == 404
+
+
+async def test_thread_usage_requires_a_readable_thread(monkeypatch) -> None:
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {"source": "unknown-source", "github_login": "owner"},
+            }
+
+    class FakeClient:
+        threads = FakeThreads()
+
+    usage = AsyncMock(return_value={"runs": []})
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+    monkeypatch.setattr(thread_api, "list_agent_thread_usage", usage)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await thread_api.get_dashboard_thread_usage("tid", "owner")
+
+    assert exc_info.value.status_code == 404
+    usage.assert_not_awaited()
+
+
+async def test_thread_usage_returns_authorized_records(monkeypatch) -> None:
+    class FakeThreads:
+        async def get(self, thread_id: str) -> dict[str, object]:
+            return {
+                "thread_id": thread_id,
+                "metadata": {"source": "dashboard", "github_login": "owner"},
+            }
+
+    class FakeClient:
+        threads = FakeThreads()
+
+    payload = {"runs": [{"run_id": "run-1"}]}
+    usage = AsyncMock(return_value=payload)
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: FakeClient())
+    monkeypatch.setattr(thread_api, "list_agent_thread_usage", usage)
+
+    assert await thread_api.get_dashboard_thread_usage("tid", "owner") == payload
+    usage.assert_awaited_once_with("tid")
 
 
 async def test_send_dashboard_message_returns_502_when_activity_unknown(monkeypatch) -> None:

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -25,6 +25,7 @@ import {
   writeStoredPanelCollapsed,
 } from "@/features/agents/lib/gitPanelPreferences"
 import { Messages } from "@/features/agents/components/messages"
+import { ThreadAnalytics } from "@/features/agents/components/messages/ThreadAnalytics"
 import type { MessagesScrollControl } from "@/features/agents/components/messages"
 import { OptimisticThreadHydrationRecovery } from "@/features/agents/components/OptimisticThreadHydrationRecovery"
 import { latestContextTokens } from "@/features/agents/lib/contextUsage"
@@ -35,6 +36,7 @@ import { useModelOptions } from "@/features/agents/lib/provider/useModelOptions"
 import {
   useAgentSkills,
   useAgentThreadPullRequestStatus,
+  useAgentThreadUsage,
 } from "@/features/agents/lib/queries"
 import { visibleQueuedMessages } from "@/features/agents/lib/queuedMessages"
 import { agentsApi } from "@/features/agents/lib/api"
@@ -98,6 +100,7 @@ export function AgentThreadView({
     thread.id,
     (thread.pullRequests?.length ?? 0) > 0
   )
+  const usage = useAgentThreadUsage(thread.id, thread.status === "running")
   const pullRequestHealth = pullRequestStatus.isError
     ? undefined
     : pullRequestStatus.data?.pullRequests
@@ -300,6 +303,12 @@ export function AgentThreadView({
           ) : (
             <Messages
               messages={baseMessages}
+              topContent={
+                <ThreadAnalytics
+                  messages={baseMessages}
+                  runs={usage.data?.runs ?? []}
+                />
+              }
               threadId={thread.id}
               showPlanArtifact={
                 thread.planStatus === "ready" || thread.planStatus === "shared"

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -66,6 +66,7 @@ function QueuedMessages({
 
 export const Messages = memo(function MessagesComponent({
   messages,
+  topContent,
   threadId,
   showPlanArtifact = false,
   emptyState,
@@ -277,6 +278,7 @@ export const Messages = memo(function MessagesComponent({
             className={`w-full ${contentWidthClass} mx-auto min-w-0 ${contentPaddingClass}`}
             style={bottomInset > 0 ? { paddingBottom: bottomInset } : undefined}
           >
+            {topContent}
             {visibleMessages.length === 0 && emptyState}
             {visibleMessages.map((message, index) => {
               const isLastMessage = index === visibleMessages.length - 1

--- a/ui/src/features/agents/components/messages/ThreadAnalytics.test.tsx
+++ b/ui/src/features/agents/components/messages/ThreadAnalytics.test.tsx
@@ -1,0 +1,166 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { ThreadAnalytics } from "./ThreadAnalytics"
+import type { AgentRunUsage, Message } from "@/features/agents/lib/types"
+
+afterEach(() => cleanup())
+
+const runs: Array<AgentRunUsage> = [
+  {
+    run_id: "run-1",
+    model_id: "claude",
+    turn_key: "user-1",
+    created_at_ms: 1,
+    finished_at_ms: 2,
+    input_tokens: 80,
+    output_tokens: 20,
+    total_tokens: 100,
+    cost_usd: 0.02,
+  },
+  {
+    run_id: "run-2",
+    model_id: "claude",
+    turn_key: "user-2",
+    created_at_ms: 3,
+    finished_at_ms: 4,
+    input_tokens: 120,
+    output_tokens: 30,
+    total_tokens: 150,
+    cost_usd: null,
+  },
+]
+
+const messages: Array<Message> = [
+  {
+    id: "user-1",
+    author: "user",
+    timestamp: "2026-01-01T00:00:00Z",
+    chunks: [{ kind: "text", text: "First" }],
+  },
+  {
+    id: "agent-1",
+    author: "agent",
+    timestamp: "2026-01-01T00:00:01Z",
+    turnKey: "user-1",
+    chunks: [
+      {
+        kind: "tool-execution",
+        toolCallId: "read",
+        title: "Read file",
+        toolKind: "read",
+        status: "completed",
+      },
+      {
+        kind: "tool-execution",
+        toolCallId: "edit",
+        title: "Edit file",
+        toolKind: "edit",
+        status: "error",
+      },
+    ],
+  },
+  {
+    id: "user-2",
+    author: "user",
+    timestamp: "2026-01-01T00:00:02Z",
+    chunks: [{ kind: "text", text: "Second" }],
+  },
+  {
+    id: "agent-2",
+    author: "agent",
+    timestamp: "2026-01-01T00:00:03Z",
+    turnKey: "user-2",
+    chunks: [
+      {
+        kind: "tool-execution",
+        toolCallId: "execute",
+        title: "Run tests",
+        toolKind: "execute",
+        status: "completed",
+      },
+    ],
+  },
+]
+
+describe("ThreadAnalytics", () => {
+  it("renders token and cost charts by turn", () => {
+    render(<ThreadAnalytics messages={messages} runs={runs} />)
+
+    expect(screen.getByRole("img", { name: "Tokens by turn" })).toBeTruthy()
+    expect(screen.getByRole("img", { name: "Cost by turn" })).toBeTruthy()
+    expect(screen.getByText("250 total")).toBeTruthy()
+    expect(screen.getByText("$0.02 total")).toBeTruthy()
+  })
+
+  it("renders tool calls in turn order", () => {
+    render(<ThreadAnalytics messages={messages} runs={runs} />)
+
+    const read = screen.getByText("Read file")
+    const edit = screen.getByText("Edit file")
+    const execute = screen.getByText("Run tests")
+    expect(
+      read.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      edit.compareDocumentPosition(execute) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("renders tool analytics without usage records", () => {
+    render(<ThreadAnalytics messages={messages} runs={[]} />)
+
+    expect(screen.queryByRole("img", { name: "Tokens by turn" })).toBeNull()
+    expect(screen.getByText("Tool call sequence")).toBeTruthy()
+  })
+
+  it("does not shift uncorrelated usage onto later turns", () => {
+    render(
+      <ThreadAnalytics
+        messages={messages}
+        runs={[{ ...runs[1]!, turn_key: "missing-turn" }]}
+      />
+    )
+
+    expect(
+      screen.getByRole("img", { name: "Tokens by turn" }).textContent
+    ).toContain("Turn 1: Unavailable")
+    expect(
+      screen.getByRole("img", { name: "Tokens by turn" }).textContent
+    ).toContain("Turn 2: Unavailable")
+  })
+
+  it("does not connect trend lines through unavailable values", () => {
+    const threeMessages = [
+      ...messages,
+      {
+        ...messages[3]!,
+        id: "agent-3",
+        turnKey: "user-3",
+        chunks: messages[3]!.chunks.map((chunk) =>
+          chunk.kind === "tool-execution"
+            ? { ...chunk, toolCallId: "execute-3" }
+            : chunk
+        ),
+      },
+    ]
+    render(
+      <ThreadAnalytics
+        messages={threeMessages}
+        runs={[
+          runs[0]!,
+          { ...runs[1]!, turn_key: "missing-turn" },
+          { ...runs[1]!, run_id: "run-3", turn_key: "user-3" },
+        ]}
+      />
+    )
+
+    expect(
+      screen
+        .getByRole("img", { name: "Tokens by turn" })
+        .querySelectorAll("polyline")
+    ).toHaveLength(2)
+  })
+})

--- a/ui/src/features/agents/components/messages/ThreadAnalytics.tsx
+++ b/ui/src/features/agents/components/messages/ThreadAnalytics.tsx
@@ -1,0 +1,246 @@
+import type {
+  AgentRunUsage,
+  Message,
+  ToolExecutionChunk,
+} from "@/features/agents/lib/types"
+import { cn } from "@/lib/utils"
+
+type ChartPoint = {
+  turn: number
+  value: number | null
+}
+
+type ChartProps = {
+  title: string
+  points: Array<ChartPoint>
+  format: (value: number) => string
+  color: string
+}
+
+function chartSegments(points: Array<ChartPoint>): Array<string> {
+  const max = Math.max(...points.map((point) => point.value ?? 0), 1)
+  const segments: Array<Array<string>> = []
+  let segment: Array<string> = []
+  points.forEach((point, index) => {
+    if (point.value === null) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+    const x =
+      points.length === 1 ? 160 : 20 + (index / (points.length - 1)) * 280
+    const y = 88 - (point.value / max) * 72
+    segment.push(`${x},${y}`)
+  })
+  if (segment.length) segments.push(segment)
+  return segments.map((coordinates) => coordinates.join(" "))
+}
+
+function TurnChart({ title, points, format, color }: ChartProps) {
+  const known = points.filter(
+    (point): point is ChartPoint & { value: number } => point.value !== null
+  )
+  const max = Math.max(...known.map((point) => point.value), 1)
+  const total = known.reduce((sum, point) => sum + point.value, 0)
+  return (
+    <div className="min-w-0 rounded-lg border border-border/70 bg-background/70 p-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-xs font-medium text-foreground">{title}</h3>
+        <span className="text-[11px] text-muted-foreground tabular-nums">
+          {known.length ? `${format(total)} total` : "Unavailable"}
+        </span>
+      </div>
+      <svg
+        viewBox="0 0 320 112"
+        className="mt-2 h-28 w-full overflow-visible"
+        role="img"
+        aria-label={`${title} by turn`}
+      >
+        <line x1="20" y1="88" x2="300" y2="88" className="stroke-border" />
+        {chartSegments(points).map((segment, index) => (
+          <polyline
+            key={`${title}-${index}`}
+            points={segment}
+            fill="none"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        ))}
+        {points.map((point, index) => {
+          const x =
+            points.length === 1 ? 160 : 20 + (index / (points.length - 1)) * 280
+          const y = point.value === null ? 88 : 88 - (point.value / max) * 72
+          const label =
+            point.value === null ? "Unavailable" : format(point.value)
+          return (
+            <g key={point.turn}>
+              <circle
+                cx={x}
+                cy={y}
+                r="3.5"
+                fill={
+                  point.value === null ? "var(--color-muted-foreground)" : color
+                }
+              >
+                <title>{`Turn ${point.turn}: ${label}`}</title>
+              </circle>
+              <text
+                x={x}
+                y="105"
+                textAnchor="middle"
+                className="fill-muted-foreground text-[9px]"
+              >
+                {point.turn}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+function formatTokens(value: number): string {
+  return new Intl.NumberFormat("en-US", { notation: "compact" }).format(value)
+}
+
+function formatCost(value: number): string {
+  return value < 0.01 && value > 0
+    ? `$${value.toFixed(4)}`
+    : `$${value.toFixed(2)}`
+}
+
+type ToolTurn = {
+  turn: number
+  tools: Array<ToolExecutionChunk>
+}
+
+function agentTurns(messages: Array<Message>): Array<Message> {
+  return messages.filter((message) => message.author === "agent")
+}
+
+function chartPoints(
+  messages: Array<Message>,
+  runs: Array<AgentRunUsage>,
+  value: (run: AgentRunUsage) => number | null
+): Array<ChartPoint> {
+  const turns = agentTurns(messages)
+  const runsByTurn = new Map(
+    runs.filter((run) => run.turn_key).map((run) => [run.turn_key, run])
+  )
+  const legacyOrderMatches =
+    runs.length === turns.length && runs.every((run) => !run.turn_key)
+  return turns.map((message, index) => {
+    const run = message.turnKey ? runsByTurn.get(message.turnKey) : undefined
+    const fallback = legacyOrderMatches ? runs[index] : undefined
+    return {
+      turn: index + 1,
+      value: run ? value(run) : fallback ? value(fallback) : null,
+    }
+  })
+}
+
+function toolTurns(messages: Array<Message>): Array<ToolTurn> {
+  return agentTurns(messages).flatMap((message, index) => {
+    const tools = message.chunks.filter(
+      (chunk): chunk is ToolExecutionChunk => chunk.kind === "tool-execution"
+    )
+    return tools.length ? [{ turn: index + 1, tools }] : []
+  })
+}
+
+function ToolSequence({ turns }: { turns: Array<ToolTurn> }) {
+  const tools = turns.flatMap(({ turn, tools: turnTools }) =>
+    turnTools.map((tool) => ({ turn, tool }))
+  )
+  return (
+    <div className="rounded-lg border border-border/70 bg-background/70 p-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-xs font-medium text-foreground">
+          Tool call sequence
+        </h3>
+        <span className="text-[11px] text-muted-foreground">
+          {tools.length} top-level call{tools.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div
+        className="mt-3 overflow-x-auto pb-1"
+        data-testid="tool-call-sequence"
+      >
+        <div className="flex w-max min-w-full items-center gap-1.5">
+          {tools.map(({ turn, tool }, index) => {
+            const startsTurn = index === 0 || tools[index - 1]?.turn !== turn
+            return (
+              <div key={tool.toolCallId} className="flex items-center gap-1.5">
+                {index > 0 && (
+                  <span className="text-muted-foreground/50">→</span>
+                )}
+                {startsTurn && (
+                  <span className="rounded bg-muted px-1.5 py-1 text-[10px] font-medium text-muted-foreground">
+                    Turn {turn}
+                  </span>
+                )}
+                <div
+                  className={cn(
+                    "max-w-48 rounded-md border px-2 py-1.5",
+                    tool.status === "error"
+                      ? "border-destructive/40 bg-destructive/5"
+                      : tool.status === "in_progress" ||
+                          tool.status === "pending"
+                        ? "border-amber-500/40 bg-amber-500/5"
+                        : "border-border bg-card"
+                  )}
+                  title={tool.title}
+                >
+                  <div className="truncate text-[11px] font-medium text-foreground">
+                    {tool.title}
+                  </div>
+                  <div className="text-[9px] tracking-wide text-muted-foreground uppercase">
+                    {tool.toolKind} · {tool.status.replace("_", " ")}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ThreadAnalytics({
+  messages,
+  runs,
+}: {
+  messages: Array<Message>
+  runs: Array<AgentRunUsage>
+}) {
+  const turns = toolTurns(messages)
+  const tokenPoints = chartPoints(messages, runs, (run) => run.total_tokens)
+  const costPoints = chartPoints(messages, runs, (run) => run.cost_usd)
+  if (!runs.length && !turns.length) return null
+
+  return (
+    <section className="mb-6 space-y-3" aria-label="Thread analytics">
+      {runs.length > 0 && tokenPoints.length > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <TurnChart
+            title="Tokens"
+            points={tokenPoints}
+            format={formatTokens}
+            color="var(--color-chart-1, #6366f1)"
+          />
+          <TurnChart
+            title="Cost"
+            points={costPoints}
+            format={formatCost}
+            color="var(--color-chart-2, #10b981)"
+          />
+        </div>
+      )}
+      {turns.length > 0 && <ToolSequence turns={turns} />}
+    </section>
+  )
+}

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -18,6 +18,7 @@ export type MessagesScrollControl = {
 
 export interface MessagesProps extends ApprovalCallbacks {
   messages: Array<Message>
+  topContent?: React.ReactNode
   /** Cloud threads only; enables the git-sourced changed-files card per turn. */
   threadId?: string
   showPlanArtifact?: boolean

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.test.tsx
@@ -14,6 +14,7 @@ interface ControllerOptions {
   threadId: string | null
   onThreadId: (threadId: string) => void
   onCreated: () => void
+  onCompleted?: () => void
 }
 
 class TestStore<T> {
@@ -199,6 +200,27 @@ describe("AgentThreadStreamProvider", () => {
     mocks.controllers[0]?.options.onCreated()
 
     expect(onThreadCreated).toHaveBeenCalledWith("created")
+  })
+
+  it("invalidates thread detail and usage when a cloud run completes", () => {
+    const client = new QueryClient()
+    const invalidateQueries = vi.spyOn(client, "invalidateQueries")
+    render(
+      <QueryClientProvider client={client}>
+        <AgentThreadStreamProvider threadId="completed">
+          <div />
+        </AgentThreadStreamProvider>
+      </QueryClientProvider>
+    )
+
+    mocks.controllers[0]?.options.onCompleted?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["agent-threads", "completed"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["agent-threads", "completed", "usage"],
+    })
   })
 
   it("cancels idle disposal when an inactive thread starts running", () => {

--- a/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
+++ b/ui/src/features/agents/lib/AgentThreadStreamProvider.tsx
@@ -145,6 +145,9 @@ function createRuntime(
         void queryClient.invalidateQueries({
           queryKey: agentThreadKeys.detail(id),
         })
+        void queryClient.invalidateQueries({
+          queryKey: agentThreadKeys.usage(id),
+        })
       }
       invalidateAgentThreadLists(queryClient)
     },

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   AgentPullRequestStatusResponse,
   AgentSchedule,
   AgentThread,
+  AgentThreadUsage,
   ImageChunk,
   Message,
   SlackNotificationMode,
@@ -315,6 +316,10 @@ export const agentsApi = {
       `/threads/${encodeURIComponent(threadId)}${
         options?.markViewed === false ? "?mark_viewed=false" : ""
       }`
+    ),
+  getThreadUsage: (threadId: string) =>
+    agentsRequest<AgentThreadUsage>(
+      `/threads/${encodeURIComponent(threadId)}/usage`
     ),
   getPullRequestChecks: (
     pullRequests: Array<{ repoFullName: string; number: number }>

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -34,6 +34,7 @@ export const agentThreadKeys = {
   sidebarActive: (threadId: string) =>
     ["agent-threads", "lists", "sidebar-active", threadId] as const,
   detail: (threadId: string) => ["agent-threads", threadId] as const,
+  usage: (threadId: string) => ["agent-threads", threadId, "usage"] as const,
   pullRequestStatus: (threadId: string) =>
     ["agent-threads", threadId, "pull-request-status"] as const,
   branchDiff: (threadId: string) =>
@@ -596,6 +597,26 @@ export function useAgentThread(threadId: string) {
     // proxied run.start stamps the server-side thread; an immediate refetch
     // would 404 and bounce the route back to /agents.
     staleTime: 30_000,
+  })
+}
+
+export function useAgentThreadUsage(threadId: string, running: boolean) {
+  return useQuery({
+    queryKey: agentThreadKeys.usage(threadId),
+    queryFn: () => agentsApi.getThreadUsage(threadId),
+    enabled: Boolean(threadId),
+    staleTime: running ? 0 : 30_000,
+    refetchInterval: (query) =>
+      running ||
+      query.state.data?.runs.some(
+        (run) =>
+          run.finished_at_ms > 0 &&
+          run.cost_usd === null &&
+          Date.now() - run.finished_at_ms < 10 * 60_000
+      )
+        ? 3000
+        : false,
+    retry: false,
   })
 }
 

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -383,7 +383,6 @@ export function streamMessagesToUi(
     if (HumanMessage.isInstance(raw)) {
       if (raw.additional_kwargs.lc_source === "summarization") return
       flushAgentTurn()
-      turnKey = typeof raw.id === "string" ? raw.id : undefined
       const content = (raw as unknown as { content?: unknown }).content
       const chunks = imageChunks(content)
       const parsed = parseStructuredInput(raw.text, structuredEntities)
@@ -403,6 +402,7 @@ export function streamMessagesToUi(
       const text = parsed.content
       if (text.trim()) chunks.push({ kind: "text", text })
       if (!chunks.length) return
+      turnKey = typeof raw.id === "string" ? raw.id : undefined
       uiMessages.push({
         id: msgId,
         author:

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -349,6 +349,22 @@ export interface AgentPullRequestContextResponse {
   prompt: string
 }
 
+export interface AgentRunUsage {
+  run_id: string
+  model_id: string
+  turn_key: string
+  created_at_ms: number
+  finished_at_ms: number
+  input_tokens: number | null
+  output_tokens: number | null
+  total_tokens: number | null
+  cost_usd: number | null
+}
+
+export interface AgentThreadUsage {
+  runs: Array<AgentRunUsage>
+}
+
 export interface AgentThread {
   id: string
   title: string


### PR DESCRIPTION
### Summary

- add authenticated thread-scoped usage telemetry with stable user-turn correlation
- show token and USD cost charts above cloud transcripts, preserving unavailable values
- visualize ordered top-level tool calls by turn with accessible status text
- refresh analytics while runs and deferred cost enrichment are active

### Screenshot

![Thread analytics](https://01a06d2c-14c6-7ae6-9785-0a963f985239--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGcxTkRFeE9URXNJbXAwYVNJNklqQXhZVEEyWkRWakxXTTNNbU10TjJJNE55MDVOREZpTFRZMU1HUTBNamd3TXpVd01pSXNJbk5wWkNJNklqQXhZVEEyWkRKakxURTBZell0TjJGbE5pMDVOemcxTFRCaE9UWXpaams0TlRJek9TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12ZEdoeVpXRmtMV0Z1WVd4NWRHbGpjeTV3Ym1jaUxDSmpkQ0k2SW1sdFlXZGxMM0J1WnlJc0ltTmtJam9pYVc1c2FXNWxJbjAubXpQVFE0Y1pqakhvSWlLTWl2R3B2b01FZkdONEdSdV9OUzd6bzExUHJ2VmEtRjh4c2V6OG4zSThPNEhfWE8ySTNIOGpiRlVZUnpHR3Ewa0EyRzM0QkE)

### Validation

- `pnpm --dir ui exec vitest run src/features/agents/components/messages/ThreadAnalytics.test.tsx src/features/agents/components/messages/Messages.test.tsx src/features/agents/lib/streamMessagesToUi.test.ts src/features/agents/lib/AgentThreadStreamProvider.test.tsx src/features/agents/lib/queries.test.tsx --no-color`
- `uv run pytest -q tests/dashboard/test_dashboard_thread_api.py tests/agent/test_agent_usage.py tests/agent/test_run_config.py`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- focused Ruff check and format check
- `pnpm --filter open-swe-dashboard run build`

Made by [Open SWE](https://openswe.vercel.app/agents/109a0df3-d632-5fa4-81e2-5283778f03b4)