### PR TITLE
feat(desktop): add stable and nightly update channels

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -166,17 +166,20 @@ jobs:
           echo "mac_zip=${mac_zips[0]}" >> "$GITHUB_OUTPUT"
           echo "mac_dmg=${mac_dmgs[0]}" >> "$GITHUB_OUTPUT"
           echo "app_zip=$app_zip" >> "$GITHUB_OUTPUT"
-          if [ "${{ steps.release.outputs.prerelease }}" = "false" ]; then
-            test -f desktop/dist/latest-mac.yml
-            test -f "${mac_zips[0]}.blockmap"
-            zip_name=$(basename "${mac_zips[0]}")
-            dmg_name=$(basename "${mac_dmgs[0]}")
-            grep -Fqx "path: ${zip_name}" desktop/dist/latest-mac.yml
-            grep -Fq "url: ${zip_name}" desktop/dist/latest-mac.yml
-            grep -Fq "url: ${dmg_name}" desktop/dist/latest-mac.yml
-            echo "update_metadata=desktop/dist/latest-mac.yml" >> "$GITHUB_OUTPUT"
-            echo "update_blockmap=${mac_zips[0]}.blockmap" >> "$GITHUB_OUTPUT"
+          test -f desktop/dist/latest-mac.yml
+          test -f "${mac_zips[0]}.blockmap"
+          zip_name=$(basename "${mac_zips[0]}")
+          dmg_name=$(basename "${mac_dmgs[0]}")
+          metadata_name=latest-mac.yml
+          if [ "${{ steps.release.outputs.prerelease }}" = "true" ]; then
+            metadata_name=nightly-mac.yml
+            mv desktop/dist/latest-mac.yml "desktop/dist/${metadata_name}"
           fi
+          grep -Fqx "path: ${zip_name}" "desktop/dist/${metadata_name}"
+          grep -Fq "url: ${zip_name}" "desktop/dist/${metadata_name}"
+          grep -Fq "url: ${dmg_name}" "desktop/dist/${metadata_name}"
+          echo "update_metadata=desktop/dist/${metadata_name}" >> "$GITHUB_OUTPUT"
+          echo "update_blockmap=${mac_zips[0]}.blockmap" >> "$GITHUB_OUTPUT"
 
       - name: Tag desktop version
         env:

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -49,6 +49,11 @@ const { beginLogin } = require("./login-server.cjs");
 const { OpenAiOAuthManager } = require("./openai-oauth.cjs");
 const { isDesktopCommandId } = require("./commands.cjs");
 const {
+  isUpdateChannel,
+  readUpdateChannel,
+  writeUpdateChannel,
+} = require("./update-channel.cjs");
+const {
   APP_ORIGIN,
   APP_URL,
   SESSION_COOKIE_NAME,
@@ -111,7 +116,79 @@ type DesktopUpdateState = {
   status: "idle" | "downloading" | "ready" | "installing";
   version?: string;
 };
+type DesktopUpdateChannel = "stable" | "nightly";
 let updateState: DesktopUpdateState = { status: "idle" };
+let updateChannel: DesktopUpdateChannel = "stable";
+let autoUpdaterConfigured = false;
+let updateCheckGeneration = 0;
+let updateCheckPromise: Promise<void> | undefined;
+let updateCancellationToken: { cancel: () => void } | undefined;
+const DESKTOP_RELEASES_API =
+  "https://api.github.com/repos/langchain-ai/open-swe/releases?per_page=100";
+const DESKTOP_RELEASES_DOWNLOAD =
+  "https://github.com/langchain-ai/open-swe/releases";
+
+function updateChannelPath() {
+  return path.join(app.getPath("userData"), "desktop-update-channel.json");
+}
+
+async function configureUpdateFeed(channel: DesktopUpdateChannel) {
+  autoUpdater.allowPrerelease = channel === "nightly";
+  autoUpdater.channel = channel === "nightly" ? "nightly" : "latest";
+  autoUpdater.allowDowngrade = true;
+  let url = `${DESKTOP_RELEASES_DOWNLOAD}/latest/download`;
+  if (channel === "nightly") {
+    const response = await net.fetch(DESKTOP_RELEASES_API, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error("Could not resolve the nightly release");
+    const releases = await response.json();
+    const release = Array.isArray(releases)
+      ? releases.find(
+          (item) =>
+            item?.prerelease === true &&
+            item?.draft === false &&
+            /^desktop-v\d+\.\d+\.\d+-nightly\.\d{14}$/.test(item?.tag_name) &&
+            item?.assets?.some((asset) => asset?.name === "nightly-mac.yml"),
+        )
+      : undefined;
+    if (!release) throw new Error("No nightly update feed is available");
+    url = `${DESKTOP_RELEASES_DOWNLOAD}/download/${encodeURIComponent(release.tag_name)}`;
+  }
+  autoUpdater.setFeedURL({ provider: "generic", url });
+}
+
+function checkForDesktopUpdates() {
+  const generation = updateCheckGeneration;
+  setUpdateState("idle", undefined);
+  const promise = autoUpdater
+    .checkForUpdates()
+    .then((result) => {
+      if (generation !== updateCheckGeneration) {
+        result?.cancellationToken?.cancel();
+        return result?.downloadPromise?.catch(() => undefined);
+      }
+      updateCancellationToken = result?.cancellationToken;
+      return result?.downloadPromise?.then(() => undefined);
+    })
+    .catch((error) => {
+      if (generation === updateCheckGeneration) {
+        console.warn("Could not check for desktop updates", error);
+      }
+    })
+    .finally(() => {
+      if (updateCheckPromise === promise) updateCheckPromise = undefined;
+    });
+  updateCheckPromise = promise;
+}
+
+async function cancelDesktopUpdateCheck() {
+  updateCheckGeneration += 1;
+  updateCancellationToken?.cancel();
+  updateCancellationToken = undefined;
+  await updateCheckPromise;
+}
 
 function setUpdateState(
   status: DesktopUpdateState["status"],
@@ -123,26 +200,25 @@ function setUpdateState(
   }
 }
 
-function configureAutoUpdater() {
+async function configureAutoUpdater() {
   if (!app.isPackaged) return;
   autoUpdater.autoDownload = true;
-  autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.allowPrerelease = false;
-  autoUpdater.on("update-available", (info) =>
-    setUpdateState("downloading", info.version),
-  );
-  autoUpdater.on("update-downloaded", (info) =>
-    setUpdateState("ready", info.version),
-  );
-  autoUpdater.on("error", (error) => {
-    console.warn("Desktop update failed", error);
-    setUpdateState("idle", undefined);
-  });
-  void autoUpdater
-    .checkForUpdates()
-    .catch((error) =>
-      console.warn("Could not check for desktop updates", error),
+  autoUpdater.autoInstallOnAppQuit = false;
+  if (!autoUpdaterConfigured) {
+    autoUpdaterConfigured = true;
+    autoUpdater.on("update-available", (info) =>
+      setUpdateState("downloading", info.version),
     );
+    autoUpdater.on("update-downloaded", (info) =>
+      setUpdateState("ready", info.version),
+    );
+    autoUpdater.on("error", (error) => {
+      console.warn("Desktop update failed", error);
+      setUpdateState("idle", undefined);
+    });
+  }
+  await configureUpdateFeed(updateChannel);
+  checkForDesktopUpdates();
 }
 
 function sendDesktopCommand(commandId) {
@@ -385,6 +461,31 @@ function configureDesktopIpc() {
   ipcMain.handle("desktop:version", (event) => {
     requireTrustedDesktopIpc(event);
     return app.getVersion();
+  });
+  ipcMain.handle("desktop:update-channel", (event) => {
+    requireTrustedDesktopIpc(event);
+    return updateChannel;
+  });
+  ipcMain.handle("desktop:set-update-channel", async (event, channel) => {
+    requireTrustedDesktopIpc(event);
+    if (!isUpdateChannel(channel)) throw new Error("Invalid update channel");
+    if (channel === updateChannel) return updateChannel;
+    if (updateState.status === "ready" || updateState.status === "installing") {
+      throw new Error(
+        "Install the pending desktop update before switching channels",
+      );
+    }
+    await cancelDesktopUpdateCheck();
+    if ((updateState as DesktopUpdateState).status === "ready") {
+      throw new Error(
+        "Install the pending desktop update before switching channels",
+      );
+    }
+    await configureUpdateFeed(channel);
+    writeUpdateChannel(updateChannelPath(), channel);
+    updateChannel = channel;
+    checkForDesktopUpdates();
+    return updateChannel;
   });
   ipcMain.handle("desktop:update-state", (event) => {
     requireTrustedDesktopIpc(event);
@@ -1394,12 +1495,15 @@ if (!hasSingleInstanceLock) {
         openAiOAuth?.status().signedIn === true &&
         Boolean(openAiOAuth?.backendEnv().OPEN_SWE_OPENAI_OAUTH_BROKER_URL),
     });
+    updateChannel = readUpdateChannel(updateChannelPath(), app.getVersion());
     protocol.handle("open-swe", serveBundledUi);
     configurePermissions();
     configureDesktopIpc();
     createMenu();
     createWindow();
-    configureAutoUpdater();
+    void configureAutoUpdater().catch((error) =>
+      console.warn("Could not configure desktop updates", error),
+    );
     configureTerminalIpc({
       ipcMain,
       requireTrusted: requireTrustedDesktopIpc,

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -133,9 +133,6 @@ function updateChannelPath() {
 }
 
 async function configureUpdateFeed(channel: DesktopUpdateChannel) {
-  autoUpdater.allowPrerelease = channel === "nightly";
-  autoUpdater.channel = channel === "nightly" ? "nightly" : "latest";
-  autoUpdater.allowDowngrade = true;
   let url = `${DESKTOP_RELEASES_DOWNLOAD}/latest/download`;
   if (channel === "nightly") {
     const response = await net.fetch(DESKTOP_RELEASES_API, {
@@ -156,6 +153,9 @@ async function configureUpdateFeed(channel: DesktopUpdateChannel) {
     if (!release) throw new Error("No nightly update feed is available");
     url = `${DESKTOP_RELEASES_DOWNLOAD}/download/${encodeURIComponent(release.tag_name)}`;
   }
+  autoUpdater.allowPrerelease = channel === "nightly";
+  autoUpdater.channel = channel === "nightly" ? "nightly" : "latest";
+  autoUpdater.allowDowngrade = true;
   autoUpdater.setFeedURL({ provider: "generic", url });
 }
 

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -30,6 +30,9 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   addProject: () => ipcRenderer.invoke("desktop:add-project"),
   removeProject: (cwd) => ipcRenderer.invoke("desktop:remove-project", cwd),
   getVersion: () => ipcRenderer.invoke("desktop:version"),
+  getUpdateChannel: () => ipcRenderer.invoke("desktop:update-channel"),
+  setUpdateChannel: (channel) =>
+    ipcRenderer.invoke("desktop:set-update-channel", channel),
   getUpdateState: () => ipcRenderer.invoke("desktop:update-state"),
   installUpdate: () => ipcRenderer.invoke("desktop:install-update"),
   onUpdateState: (callback) => {

--- a/desktop/src/update-channel.cts
+++ b/desktop/src/update-channel.cts
@@ -1,0 +1,37 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const UPDATE_CHANNELS = new Set(["stable", "nightly"]);
+
+function isUpdateChannel(value) {
+  return typeof value === "string" && UPDATE_CHANNELS.has(value);
+}
+
+function defaultUpdateChannel(version) {
+  return typeof version === "string" && version.includes("-nightly.")
+    ? "nightly"
+    : "stable";
+}
+
+function readUpdateChannel(filePath, version) {
+  try {
+    const stored = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    if (isUpdateChannel(stored.channel)) return stored.channel;
+  } catch {}
+  return defaultUpdateChannel(version);
+}
+
+function writeUpdateChannel(filePath, channel) {
+  if (!isUpdateChannel(channel)) throw new Error("Invalid update channel");
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify({ channel }, null, 2)}\n`);
+  fs.renameSync(temporaryPath, filePath);
+}
+
+module.exports = {
+  defaultUpdateChannel,
+  isUpdateChannel,
+  readUpdateChannel,
+  writeUpdateChannel,
+};

--- a/desktop/test/update-channel.test.cjs
+++ b/desktop/test/update-channel.test.cjs
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  defaultUpdateChannel,
+  isUpdateChannel,
+  readUpdateChannel,
+  writeUpdateChannel,
+} = require("../build/update-channel.cjs");
+
+test("defaults to the channel matching the installed version", () => {
+  assert.equal(defaultUpdateChannel("0.2.6"), "stable");
+  assert.equal(defaultUpdateChannel("0.2.6-nightly.20260904082449"), "nightly");
+});
+
+test("persists only supported update channels", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "open-swe-updates-"));
+  const filePath = path.join(directory, "channel.json");
+
+  assert.equal(readUpdateChannel(filePath, "0.2.6"), "stable");
+  writeUpdateChannel(filePath, "nightly");
+  assert.equal(readUpdateChannel(filePath, "0.2.6"), "nightly");
+  assert.equal(isUpdateChannel("preview"), false);
+  assert.throws(() => writeUpdateChannel(filePath, "preview"), /Invalid/);
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("ignores invalid stored channel state", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "open-swe-updates-"));
+  const filePath = path.join(directory, "channel.json");
+  fs.writeFileSync(filePath, JSON.stringify({ channel: "preview" }));
+
+  assert.equal(
+    readUpdateChannel(filePath, "0.2.6-nightly.20260904082449"),
+    "nightly",
+  );
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -113,6 +113,8 @@ export type DesktopTerminalMetadataEvent =
   | { type: "upsert"; terminal: DesktopTerminalSummary }
   | (DesktopTerminalTarget & { type: "remove" })
 
+export type DesktopUpdateChannel = "stable" | "nightly"
+
 export type DesktopUpdateState = {
   status: "idle" | "downloading" | "ready" | "installing"
   version?: string
@@ -174,6 +176,10 @@ declare global {
       addProject: () => Promise<DesktopProject | null>
       removeProject: (cwd: string) => Promise<boolean>
       getVersion: () => Promise<string>
+      getUpdateChannel: () => Promise<DesktopUpdateChannel>
+      setUpdateChannel: (
+        channel: DesktopUpdateChannel
+      ) => Promise<DesktopUpdateChannel>
       getUpdateState: () => Promise<DesktopUpdateState>
       installUpdate: () => Promise<boolean>
       onUpdateState: (

--- a/ui/src/features/settings/components/DesktopUpdatesSection.test.tsx
+++ b/ui/src/features/settings/components/DesktopUpdatesSection.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { DesktopUpdateChannel } from "@/desktop"
+import { DesktopUpdatesSection } from "./DesktopUpdatesSection"
+
+const originalDesktop = window.openSweDesktop
+
+afterEach(() => {
+  Object.defineProperty(window, "openSweDesktop", {
+    configurable: true,
+    value: originalDesktop,
+  })
+  vi.restoreAllMocks()
+})
+
+describe("DesktopUpdatesSection", () => {
+  it("shows the persisted desktop update channel", async () => {
+    Object.defineProperty(window, "openSweDesktop", {
+      configurable: true,
+      value: {
+        getUpdateChannel: vi
+          .fn<() => Promise<DesktopUpdateChannel>>()
+          .mockResolvedValue("nightly"),
+      },
+    })
+
+    render(<DesktopUpdatesSection />)
+
+    expect((await screen.findByRole("combobox")).textContent).toContain(
+      "nightly"
+    )
+    expect(screen.getByText(/latest desktop builds/)).toBeTruthy()
+  })
+
+  it("stays hidden outside the desktop app", () => {
+    Object.defineProperty(window, "openSweDesktop", {
+      configurable: true,
+      value: undefined,
+    })
+
+    const view = render(<DesktopUpdatesSection />)
+
+    expect(view.container.childElementCount).toBe(0)
+  })
+})

--- a/ui/src/features/settings/components/DesktopUpdatesSection.tsx
+++ b/ui/src/features/settings/components/DesktopUpdatesSection.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react"
+
+import type { DesktopUpdateChannel } from "@/desktop"
+import { SettingsRow, SettingsSection } from "@/components/AppShell"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+export function DesktopUpdatesSection() {
+  const desktop = window.openSweDesktop
+  const [channel, setChannel] = useState<DesktopUpdateChannel>()
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string>()
+
+  useEffect(() => {
+    void desktop
+      ?.getUpdateChannel()
+      .then(setChannel)
+      .catch(() => undefined)
+  }, [desktop])
+
+  if (!desktop || !channel) return null
+
+  const changeChannel = async (next: DesktopUpdateChannel) => {
+    const previous = channel
+    setChannel(next)
+    setSaving(true)
+    setError(undefined)
+    try {
+      setChannel(await desktop.setUpdateChannel(next))
+    } catch (cause) {
+      setChannel(previous)
+      setError(
+        cause instanceof Error ? cause.message : "Could not change channel"
+      )
+    }
+    setSaving(false)
+  }
+
+  return (
+    <SettingsSection title="Desktop updates">
+      <SettingsRow
+        label="Update channel"
+        description={
+          error ??
+          "Nightly receives the latest desktop builds and may be less stable."
+        }
+        control={
+          <Select
+            value={channel}
+            onValueChange={(value) =>
+              value && void changeChannel(value as DesktopUpdateChannel)
+            }
+            disabled={saving}
+          >
+            <SelectTrigger className="w-40" aria-label="Update channel">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="stable">Stable</SelectItem>
+              <SelectItem value="nightly">Nightly</SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+    </SettingsSection>
+  )
+}

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -5,6 +5,7 @@ import { AccountSection } from "@/features/settings/components/AccountSection"
 import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell"
 import { ConnectionsSection } from "@/features/settings/components/ConnectionsSection"
 import { EnvironmentsSection } from "@/features/settings/components/EnvironmentsSection"
+import { DesktopUpdatesSection } from "@/features/settings/components/DesktopUpdatesSection"
 import { PersonalInstructionsSection } from "@/features/settings/components/PersonalInstructionsSection"
 import { PreferencesSection } from "@/features/settings/components/PreferencesSection"
 import { PullRequestsSection } from "@/features/settings/components/PullRequestsSection"
@@ -58,6 +59,7 @@ function MySettingsPage() {
     >
       <AccountSection user={session.data} />
       <PreferencesSection />
+      <DesktopUpdatesSection />
       <PullRequestsSection />
       <EnvironmentsSection isAdmin={session.data.is_admin} />
       <ConnectionsSection user={session.data} />


### PR DESCRIPTION
- add a persisted Stable/Nightly update-channel selector to Desktop settings
- keep nightly installs on nightly by default and securely reconfigure trusted generic update feeds when channels change
- publish nightly updater metadata and blockmaps so Electron can discover and apply nightly releases
- cancel in-flight downloads before switching channels and require explicit installation of ready updates

### Screenshot
![Desktop update channel selector](https://01a06d7d-3f77-7ba9-916b-56efaa1aac36--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGcxTkRRM09EUXNJbXAwYVNJNklqQXhZVEEyWkRrekxUazRNemt0TjJSak5pMWlObVJsTFdJM05EQXlOR0kzWVRGak9DSXNJbk5wWkNJNklqQXhZVEEyWkRka0xUTm1OemN0TjJKaE9TMDVNVFppTFRVMlpXWmhZVEZoWVdNek5pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WkdWemEzUnZjQzExY0dSaGRHVXRZMmhoYm01bGJDMXpaV3hsWTNSdmNpNXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC5Sd2x5WWVudy1adDAxRHdVckF6U2U5eWZNZEZKNnlUbzBkZXcxak1lWEVMWnZTcEF4VlRlUERUQUtaMEZNbVc0cmVIVTFjRjAxYjhucUo4TUt4b0VEdw)

Made by [Open SWE](https://openswe.vercel.app/agents/bf52088c-77b4-53a2-85ee-3f482dca2527) · openai:gpt-5.6-sol (medium)
