### PR TITLE
feat: roll out adaptive model routing to all threads

### DIFF
--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -92,6 +92,12 @@ def profile_draft_prs(profile: dict[str, Any] | None) -> bool:
     return value if isinstance(value, bool) else True
 
 
+def profile_model_routing_enabled(profile: dict[str, Any] | None) -> bool:
+    """Return whether adaptive model routing is enabled. Defaults to True."""
+    value = profile.get("model_routing_enabled") if isinstance(profile, dict) else None
+    return value if isinstance(value, bool) else True
+
+
 def _normalize_profile_model_pair(
     profile: dict[str, Any],
     *,

--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -93,9 +93,9 @@ def profile_draft_prs(profile: dict[str, Any] | None) -> bool:
 
 
 def profile_model_routing_enabled(profile: dict[str, Any] | None) -> bool:
-    """Return whether adaptive model routing is enabled. Defaults to True."""
+    """Return whether adaptive model routing is enabled. Defaults to False."""
     value = profile.get("model_routing_enabled") if isinstance(profile, dict) else None
-    return value if isinstance(value, bool) else True
+    return value if isinstance(value, bool) else False
 
 
 def _normalize_profile_model_pair(

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -47,6 +47,7 @@ class ProfileUpdate(BaseModel):
     base_branch: str | None = None
     branch_prefix: str | None = None
     auto_fix_ci: bool = True
+    adaptive_model_routing: bool | None = None
     draft_prs: bool | None = None
     review_draft_prs: bool | None = None
 
@@ -150,6 +151,11 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "base_branch": update.base_branch,
         "branch_prefix": update.branch_prefix,
         "auto_fix_ci": update.auto_fix_ci,
+        "adaptive_model_routing": (
+            update.adaptive_model_routing
+            if update.adaptive_model_routing is not None
+            else existing.get("adaptive_model_routing", False)
+        ),
         "draft_prs": (
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)
         ),

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -154,7 +154,7 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "model_routing_enabled": (
             update.model_routing_enabled
             if update.model_routing_enabled is not None
-            else existing.get("model_routing_enabled", True)
+            else existing.get("model_routing_enabled", False)
         ),
         "draft_prs": (
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -47,6 +47,7 @@ class ProfileUpdate(BaseModel):
     base_branch: str | None = None
     branch_prefix: str | None = None
     auto_fix_ci: bool = True
+    model_routing_enabled: bool | None = None
     draft_prs: bool | None = None
     review_draft_prs: bool | None = None
 
@@ -150,6 +151,11 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "base_branch": update.base_branch,
         "branch_prefix": update.branch_prefix,
         "auto_fix_ci": update.auto_fix_ci,
+        "model_routing_enabled": (
+            update.model_routing_enabled
+            if update.model_routing_enabled is not None
+            else existing.get("model_routing_enabled", True)
+        ),
         "draft_prs": (
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)
         ),

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -47,7 +47,6 @@ class ProfileUpdate(BaseModel):
     base_branch: str | None = None
     branch_prefix: str | None = None
     auto_fix_ci: bool = True
-    adaptive_model_routing: bool | None = None
     draft_prs: bool | None = None
     review_draft_prs: bool | None = None
 
@@ -151,11 +150,6 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "base_branch": update.base_branch,
         "branch_prefix": update.branch_prefix,
         "auto_fix_ci": update.auto_fix_ci,
-        "adaptive_model_routing": (
-            update.adaptive_model_routing
-            if update.adaptive_model_routing is not None
-            else existing.get("adaptive_model_routing", False)
-        ),
         "draft_prs": (
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)
         ),

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -75,8 +75,8 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     default_agent_routing_fast_reasoning_effort: str | None = None
     default_agent_routing_balanced_model: str | None = None
     default_agent_routing_balanced_reasoning_effort: str | None = None
-    default_agent_routing_powerful_model: str | None = None
-    default_agent_routing_powerful_reasoning_effort: str | None = None
+    default_agent_routing_performance_model: str | None = None
+    default_agent_routing_performance_reasoning_effort: str | None = None
     default_repo: str | None = None
     default_reviewer_model: str | None = None
     default_reviewer_reasoning_effort: str | None = None
@@ -134,7 +134,7 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
                 self.default_agent_subagent_reasoning_effort,
             )
         )
-        for tier in ("fast", "balanced", "powerful"):
+        for tier in ("fast", "balanced", "performance"):
             model_field = f"default_agent_routing_{tier}_model"
             effort_field = f"default_agent_routing_{tier}_reasoning_effort"
             model, effort = _normalize_stale_model_pair(
@@ -179,7 +179,7 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
             self.default_agent_subagent_reasoning_effort,
             "agent subagent",
         )
-        for tier in ("fast", "balanced", "powerful"):
+        for tier in ("fast", "balanced", "performance"):
             _validate_model_effort_pair(
                 getattr(self, f"default_agent_routing_{tier}_model"),
                 getattr(self, f"default_agent_routing_{tier}_reasoning_effort"),
@@ -228,8 +228,8 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
                     "default_agent_routing_balanced_reasoning_effort",
                 ),
                 (
-                    "default_agent_routing_powerful_model",
-                    "default_agent_routing_powerful_reasoning_effort",
+                    "default_agent_routing_performance_model",
+                    "default_agent_routing_performance_reasoning_effort",
                 ),
                 ("default_reviewer_model", "default_reviewer_reasoning_effort"),
                 ("default_reviewer_subagent_model", "default_reviewer_subagent_reasoning_effort"),
@@ -278,8 +278,8 @@ _MODEL_PAIR_FIELDS: tuple[tuple[str, str], ...] = (
         "default_agent_routing_balanced_reasoning_effort",
     ),
     (
-        "default_agent_routing_powerful_model",
-        "default_agent_routing_powerful_reasoning_effort",
+        "default_agent_routing_performance_model",
+        "default_agent_routing_performance_reasoning_effort",
     ),
     ("default_reviewer_model", "default_reviewer_reasoning_effort"),
     ("default_reviewer_subagent_model", "default_reviewer_subagent_reasoning_effort"),
@@ -336,8 +336,8 @@ def _default_settings() -> dict[str, Any]:
         "default_agent_routing_fast_reasoning_effort": "high",
         "default_agent_routing_balanced_model": "openai:gpt-5.6-sol",
         "default_agent_routing_balanced_reasoning_effort": "medium",
-        "default_agent_routing_powerful_model": "openai:gpt-6-astra",
-        "default_agent_routing_powerful_reasoning_effort": "low",
+        "default_agent_routing_performance_model": "openai:gpt-6-astra",
+        "default_agent_routing_performance_reasoning_effort": "low",
         "default_repo": _env_default_repo(),
         "default_reviewer_model": fallback_model,
         "default_reviewer_reasoning_effort": fallback_effort,
@@ -404,8 +404,8 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "default_agent_routing_fast_reasoning_effort": update.default_agent_routing_fast_reasoning_effort,
         "default_agent_routing_balanced_model": update.default_agent_routing_balanced_model,
         "default_agent_routing_balanced_reasoning_effort": update.default_agent_routing_balanced_reasoning_effort,
-        "default_agent_routing_powerful_model": update.default_agent_routing_powerful_model,
-        "default_agent_routing_powerful_reasoning_effort": update.default_agent_routing_powerful_reasoning_effort,
+        "default_agent_routing_performance_model": update.default_agent_routing_performance_model,
+        "default_agent_routing_performance_reasoning_effort": update.default_agent_routing_performance_reasoning_effort,
         "default_repo": update.default_repo,
         "default_reviewer_model": update.default_reviewer_model,
         "default_reviewer_reasoning_effort": update.default_reviewer_reasoning_effort,
@@ -498,7 +498,7 @@ async def get_team_agent_routing_models() -> dict[str, tuple[str, str]]:
             settings.get(f"default_agent_routing_{tier}_model"),
             settings.get(f"default_agent_routing_{tier}_reasoning_effort"),
         )
-        for tier in ("fast", "balanced", "powerful")
+        for tier in ("fast", "balanced", "performance")
     }
 
 

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -71,6 +71,12 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     default_agent_reasoning_effort: str | None = None
     default_agent_subagent_model: str | None = None
     default_agent_subagent_reasoning_effort: str | None = None
+    default_agent_routing_fast_model: str | None = None
+    default_agent_routing_fast_reasoning_effort: str | None = None
+    default_agent_routing_balanced_model: str | None = None
+    default_agent_routing_balanced_reasoning_effort: str | None = None
+    default_agent_routing_powerful_model: str | None = None
+    default_agent_routing_powerful_reasoning_effort: str | None = None
     default_repo: str | None = None
     default_reviewer_model: str | None = None
     default_reviewer_reasoning_effort: str | None = None
@@ -128,6 +134,14 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
                 self.default_agent_subagent_reasoning_effort,
             )
         )
+        for tier in ("fast", "balanced", "powerful"):
+            model_field = f"default_agent_routing_{tier}_model"
+            effort_field = f"default_agent_routing_{tier}_reasoning_effort"
+            model, effort = _normalize_stale_model_pair(
+                getattr(self, model_field), getattr(self, effort_field)
+            )
+            setattr(self, model_field, model)
+            setattr(self, effort_field, effort)
         self.default_reviewer_model, self.default_reviewer_reasoning_effort = (
             _normalize_stale_model_pair(
                 self.default_reviewer_model,
@@ -165,6 +179,12 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
             self.default_agent_subagent_reasoning_effort,
             "agent subagent",
         )
+        for tier in ("fast", "balanced", "powerful"):
+            _validate_model_effort_pair(
+                getattr(self, f"default_agent_routing_{tier}_model"),
+                getattr(self, f"default_agent_routing_{tier}_reasoning_effort"),
+                f"agent routing {tier}",
+            )
         _validate_model_effort_pair(
             self.default_reviewer_model, self.default_reviewer_reasoning_effort, "reviewer"
         )
@@ -199,6 +219,18 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
             for model_field, effort_field in (
                 ("default_agent_model", "default_agent_reasoning_effort"),
                 ("default_agent_subagent_model", "default_agent_subagent_reasoning_effort"),
+                (
+                    "default_agent_routing_fast_model",
+                    "default_agent_routing_fast_reasoning_effort",
+                ),
+                (
+                    "default_agent_routing_balanced_model",
+                    "default_agent_routing_balanced_reasoning_effort",
+                ),
+                (
+                    "default_agent_routing_powerful_model",
+                    "default_agent_routing_powerful_reasoning_effort",
+                ),
                 ("default_reviewer_model", "default_reviewer_reasoning_effort"),
                 ("default_reviewer_subagent_model", "default_reviewer_subagent_reasoning_effort"),
                 ("default_grouping_model", "default_grouping_reasoning_effort"),
@@ -240,6 +272,15 @@ def _normalize_stale_model_pair(
 _MODEL_PAIR_FIELDS: tuple[tuple[str, str], ...] = (
     ("default_agent_model", "default_agent_reasoning_effort"),
     ("default_agent_subagent_model", "default_agent_subagent_reasoning_effort"),
+    ("default_agent_routing_fast_model", "default_agent_routing_fast_reasoning_effort"),
+    (
+        "default_agent_routing_balanced_model",
+        "default_agent_routing_balanced_reasoning_effort",
+    ),
+    (
+        "default_agent_routing_powerful_model",
+        "default_agent_routing_powerful_reasoning_effort",
+    ),
     ("default_reviewer_model", "default_reviewer_reasoning_effort"),
     ("default_reviewer_subagent_model", "default_reviewer_subagent_reasoning_effort"),
     ("default_grouping_model", "default_grouping_reasoning_effort"),
@@ -291,6 +332,12 @@ def _default_settings() -> dict[str, Any]:
         "default_agent_reasoning_effort": fallback_effort,
         "default_agent_subagent_model": fallback_model,
         "default_agent_subagent_reasoning_effort": fallback_effort,
+        "default_agent_routing_fast_model": "fireworks:accounts/fireworks/models/glm-5p3-flash",
+        "default_agent_routing_fast_reasoning_effort": "high",
+        "default_agent_routing_balanced_model": "openai:gpt-5.6-sol",
+        "default_agent_routing_balanced_reasoning_effort": "medium",
+        "default_agent_routing_powerful_model": "openai:gpt-6-astra",
+        "default_agent_routing_powerful_reasoning_effort": "low",
         "default_repo": _env_default_repo(),
         "default_reviewer_model": fallback_model,
         "default_reviewer_reasoning_effort": fallback_effort,
@@ -353,6 +400,12 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "default_agent_reasoning_effort": update.default_agent_reasoning_effort,
         "default_agent_subagent_model": update.default_agent_subagent_model,
         "default_agent_subagent_reasoning_effort": update.default_agent_subagent_reasoning_effort,
+        "default_agent_routing_fast_model": update.default_agent_routing_fast_model,
+        "default_agent_routing_fast_reasoning_effort": update.default_agent_routing_fast_reasoning_effort,
+        "default_agent_routing_balanced_model": update.default_agent_routing_balanced_model,
+        "default_agent_routing_balanced_reasoning_effort": update.default_agent_routing_balanced_reasoning_effort,
+        "default_agent_routing_powerful_model": update.default_agent_routing_powerful_model,
+        "default_agent_routing_powerful_reasoning_effort": update.default_agent_routing_powerful_reasoning_effort,
         "default_repo": update.default_repo,
         "default_reviewer_model": update.default_reviewer_model,
         "default_reviewer_reasoning_effort": update.default_reviewer_reasoning_effort,
@@ -436,6 +489,17 @@ async def get_team_default_model_pair(
             settings.get("default_reviewer_subagent_reasoning_effort"),
         )
     return main, subagent
+
+
+async def get_team_agent_routing_models() -> dict[str, tuple[str, str]]:
+    settings = await get_team_settings()
+    return {
+        tier: _resolve_default_pair(
+            settings.get(f"default_agent_routing_{tier}_model"),
+            settings.get(f"default_agent_routing_{tier}_reasoning_effort"),
+        )
+        for tier in ("fast", "balanced", "powerful")
+    }
 
 
 async def get_team_default_grouping_model() -> tuple[str, str]:

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -10,6 +10,7 @@ _MIDDLEWARE_MODULES = {
     "ModelCallTimeoutMiddleware": ".model_call_timeout",
     "ModelErrorMiddleware": ".model_errors",
     "ModelFallbackMiddleware": ".model_fallback",
+    "ModelSelectionMiddleware": ".model_selection",
     "notify_step_limit_reached": ".notify_step_limit",
     "PlanModeMiddleware": ".plan_mode",
     "PrepareRunState": ".prepare_run",
@@ -39,6 +40,7 @@ __all__ = [
     "ModelCallTimeoutMiddleware",
     "ModelErrorMiddleware",
     "ModelFallbackMiddleware",
+    "ModelSelectionMiddleware",
     "BasePrepareRunMiddleware",
     "PlanModeMiddleware",
     "PrepareRunState",
@@ -69,6 +71,7 @@ if TYPE_CHECKING:
     from agent.middleware.model_call_timeout import ModelCallTimeoutMiddleware
     from agent.middleware.model_errors import ModelErrorMiddleware
     from agent.middleware.model_fallback import ModelFallbackMiddleware
+    from agent.middleware.model_selection import ModelSelectionMiddleware
     from agent.middleware.notify_step_limit import notify_step_limit_reached
     from agent.middleware.plan_mode import PlanModeMiddleware
     from agent.middleware.pr_creation_guard import PullRequestCreationGuardMiddleware

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -1,24 +1,30 @@
 import logging
-import re
 from collections.abc import Awaitable, Callable, Mapping
+from typing import Literal
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-_SMALL_TASK_PATTERN = re.compile(
-    r"\b(explain|summari[sz]e|status|find|locate|rename|typo|format|lint|docs?|comment)\b",
-    re.IGNORECASE,
-)
-_COMPLEX_TASK_PATTERN = re.compile(
-    r"\b(plan|architect|design|migrat|security|auth|database|schema|distributed|"
-    r"multi[- ]?(?:repo|package|service)|large[- ]scale|codebase[- ]wide|cross[- ]cutting|"
-    r"refactor|investigat|root cause|performance|concurren|race condition)\w*\b",
-    re.IGNORECASE,
-)
+_CLASSIFIER_PROMPT = """Classify the software-engineering task for model routing.
+
+small: bounded, mechanical, read-only, formatting, documentation, or trivial edits
+medium: normal implementation, debugging, tests, or a contained multi-file change
+complex: ambiguous planning, architecture, broad migrations, security-sensitive work, difficult root-cause analysis, or large cross-cutting changes
+
+Choose the least capable tier likely to complete the full task successfully. Return only the structured result.
+
+Task:
+{task}
+"""
+
+
+class RouteDecision(BaseModel):
+    complexity: Literal["small", "medium", "complex"]
 
 
 def _message_text(message: HumanMessage) -> str:
@@ -31,11 +37,8 @@ def _message_text(message: HumanMessage) -> str:
     )
 
 
-def task_complexity(request: ModelRequest) -> str:
-    state = request.state if isinstance(request.state, Mapping) else {}
-    if state.get("plan_mode") is True:
-        return "complex"
-    prompt = next(
+def _latest_task(request: ModelRequest) -> str:
+    return next(
         (
             _message_text(message)
             for message in reversed(request.messages)
@@ -43,23 +46,46 @@ def task_complexity(request: ModelRequest) -> str:
         ),
         "",
     )
-    if len(prompt) >= 4_000 or _COMPLEX_TASK_PATTERN.search(prompt):
-        return "complex"
-    if len(prompt) <= 500 and _SMALL_TASK_PATTERN.search(prompt):
-        return "small"
-    return "medium"
 
 
 class ModelSelectionMiddleware(AgentMiddleware):
-    def __init__(self, models: Mapping[str, BaseChatModel]) -> None:
+    def __init__(
+        self,
+        models: Mapping[str, BaseChatModel],
+        classifier: BaseChatModel,
+        *,
+        initial_plan_mode: bool = False,
+    ) -> None:
         self._models = dict(models)
+        self._classifier = classifier.with_structured_output(RouteDecision)
+        self._initial_plan_mode = initial_plan_mode
+        self._task: str | None = None
+        self._complexity: Literal["small", "medium", "complex"] | None = None
+
+    async def _classify(self, task: str) -> Literal["small", "medium", "complex"]:
+        if self._initial_plan_mode:
+            return "complex"
+        try:
+            decision = await self._classifier.ainvoke(_CLASSIFIER_PROMPT.format(task=task[-8_000:]))
+        except Exception:  # noqa: BLE001
+            logger.exception("Model routing classifier failed")
+            return "medium"
+        if not isinstance(decision, RouteDecision):
+            logger.warning("Model routing classifier returned an unexpected result")
+            return "medium"
+        return decision.complexity
 
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        complexity = task_complexity(request)
-        model = self._models[complexity]
-        logger.info("Selected model for task complexity", extra={"task_complexity": complexity})
-        return await handler(request.override(model=model))
+        task = _latest_task(request)
+        if task != self._task or self._complexity is None:
+            self._task = task
+            self._complexity = await self._classify(task)
+        logger.info(
+            "Selected model for task complexity",
+            extra={"task_complexity": self._complexity},
+        )
+        return await handler(request.override(model=self._models[self._complexity]))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -1,11 +1,14 @@
+import hashlib
+import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Literal
+from typing import Any, Literal, NotRequired
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.middleware.types import AgentState, ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
+from langgraph.runtime import Runtime
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -27,6 +30,11 @@ class RouteDecision(BaseModel):
     complexity: Literal["small", "medium", "complex"]
 
 
+class ModelSelectionState(AgentState):
+    model_route: NotRequired[Literal["small", "medium", "complex"]]
+    model_route_for: NotRequired[str]
+
+
 def _message_text(message: HumanMessage) -> str:
     if isinstance(message.content, str):
         return message.content
@@ -37,18 +45,25 @@ def _message_text(message: HumanMessage) -> str:
     )
 
 
-def _latest_task(request: ModelRequest) -> str:
-    return next(
-        (
-            _message_text(message)
-            for message in reversed(request.messages)
-            if isinstance(message, HumanMessage)
-        ),
-        "",
-    )
+def _latest_task(state: Mapping[str, Any]) -> tuple[str, str]:
+    messages = state.get("messages")
+    if not isinstance(messages, list):
+        return "", ""
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, HumanMessage):
+            task = _message_text(message)
+            payload = {"index": index, "id": message.id, "task": task}
+            fingerprint = hashlib.sha256(
+                json.dumps(payload, sort_keys=True, default=str).encode()
+            ).hexdigest()
+            return task, fingerprint
+    return "", ""
 
 
-class ModelSelectionMiddleware(AgentMiddleware):
+class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
+    state_schema = ModelSelectionState
+
     def __init__(
         self,
         models: Mapping[str, BaseChatModel],
@@ -59,8 +74,6 @@ class ModelSelectionMiddleware(AgentMiddleware):
         self._models = dict(models)
         self._classifier = classifier.with_structured_output(RouteDecision)
         self._initial_plan_mode = initial_plan_mode
-        self._task: str | None = None
-        self._complexity: Literal["small", "medium", "complex"] | None = None
 
     async def _classify(self, task: str) -> Literal["small", "medium", "complex"]:
         if self._initial_plan_mode:
@@ -75,17 +88,26 @@ class ModelSelectionMiddleware(AgentMiddleware):
             return "medium"
         return decision.complexity
 
+    async def abefore_agent(
+        self,
+        state: ModelSelectionState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        task, fingerprint = _latest_task(state)
+        if state.get("model_route_for") == fingerprint and state.get("model_route") in self._models:
+            return None
+        return {
+            "model_route": await self._classify(task),
+            "model_route_for": fingerprint,
+        }
+
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        task = _latest_task(request)
-        if task != self._task or self._complexity is None:
-            self._task = task
-            self._complexity = await self._classify(task)
-        logger.info(
-            "Selected model for task complexity",
-            extra={"task_complexity": self._complexity},
-        )
-        return await handler(request.override(model=self._models[self._complexity]))
+        route = request.state.get("model_route")
+        if route not in self._models:
+            route = "medium"
+        logger.info("Selected model for task complexity", extra={"task_complexity": route})
+        return await handler(request.override(model=self._models[route]))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -1,0 +1,65 @@
+import logging
+import re
+from collections.abc import Awaitable, Callable, Mapping
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+
+logger = logging.getLogger(__name__)
+
+_SMALL_TASK_PATTERN = re.compile(
+    r"\b(explain|summari[sz]e|status|find|locate|rename|typo|format|lint|docs?|comment)\b",
+    re.IGNORECASE,
+)
+_COMPLEX_TASK_PATTERN = re.compile(
+    r"\b(plan|architect|design|migrat|security|auth|database|schema|distributed|"
+    r"multi[- ]?(?:repo|package|service)|large[- ]scale|codebase[- ]wide|cross[- ]cutting|"
+    r"refactor|investigat|root cause|performance|concurren|race condition)\w*\b",
+    re.IGNORECASE,
+)
+
+
+def _message_text(message: HumanMessage) -> str:
+    if isinstance(message.content, str):
+        return message.content
+    return " ".join(
+        block.get("text", "")
+        for block in message.content
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    )
+
+
+def task_complexity(request: ModelRequest) -> str:
+    state = request.state if isinstance(request.state, Mapping) else {}
+    if state.get("plan_mode") is True:
+        return "complex"
+    prompt = next(
+        (
+            _message_text(message)
+            for message in reversed(request.messages)
+            if isinstance(message, HumanMessage)
+        ),
+        "",
+    )
+    if len(prompt) >= 4_000 or _COMPLEX_TASK_PATTERN.search(prompt):
+        return "complex"
+    if len(prompt) <= 500 and _SMALL_TASK_PATTERN.search(prompt):
+        return "small"
+    return "medium"
+
+
+class ModelSelectionMiddleware(AgentMiddleware):
+    def __init__(self, models: Mapping[str, BaseChatModel]) -> None:
+        self._models = dict(models)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        complexity = task_complexity(request)
+        model = self._models[complexity]
+        logger.info("Selected model for task complexity", extra={"task_complexity": complexity})
+        return await handler(request.override(model=model))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -11,22 +11,20 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-Route = Literal["glm_flash", "sol_medium", "astra_low"]
+Route = Literal["fast", "balanced", "powerful"]
 
 _CLASSIFIER_PROMPT = """Choose one fixed model profile for this Open SWE turn. Use the least expensive profile likely to complete the whole turn safely.
 
 Profiles, from least to most capable and expensive:
 
-1. glm_flash
+1. fast
 - Use for direct lookup, extraction, status checks, test or log collection, mechanical PR or release operations, and localized changes with explicit targets and strong verification.
-- High effort increases persistence, not the base model's capability ceiling.
 
-2. sol_medium
+2. balanced
 - Use for ordinary bug fixes, bounded investigations, multi-file implementation, research synthesis, semantic PR maintenance, and partially specified localized work.
 
-3. astra_low
+3. powerful
 - Use for architecture or design, requirements disambiguation, subtle semantic review, novel root-cause reasoning, conflicting evidence, cross-component or multi-repository judgment, and high-stakes decisions.
-- Low is its configured reasoning effort; it remains the highest-capability profile.
 
 Explicit targets, clear acceptance criteria, reversibility, and strong tests lower the required capability. Ambiguous requirements, weak verification, architectural tradeoffs, broad scope, consequential security or data work, and conflicting assumptions raise it. Prompt length and eventual runtime are not difficulty signals.
 
@@ -65,7 +63,7 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         runtime: Runtime,
     ) -> dict[str, Route]:
         del runtime
-        route: Route = "astra_low" if self._initial_plan_mode else "sol_medium"
+        route: Route = "powerful" if self._initial_plan_mode else "balanced"
         if not self._initial_plan_mode:
             messages = state.get("messages", [])
             task = next(
@@ -91,6 +89,6 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        route = request.state.get("model_route", "sol_medium")
-        model = self._models.get(route, self._models["sol_medium"])
+        route = request.state.get("model_route", "balanced")
+        model = self._models.get(route, self._models["balanced"])
         return await handler(request.override(model=model))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -1,125 +1,37 @@
-import hashlib
-import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, Literal, NotRequired
+from typing import Literal, NotRequired
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import AgentState, ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langgraph.runtime import Runtime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 Route = Literal["sol_medium", "terra_high", "luna_xhigh"]
 
-_CLASSIFIER_PROMPT = """Route one Open SWE human turn to one fixed model profile. The selected model remains pinned for every parent-agent model call in this turn to preserve provider prompt-cache reuse. This router does not change the subagent model or switch models between design, implementation, and review inside one turn.
+_CLASSIFIER_PROMPT = """Choose the least expensive model profile likely to complete this Open SWE turn safely.
 
-Profiles, from least to most capable and expensive:
+- luna_xhigh: direct questions, routine operations, evidence gathering, and small explicit changes with strong verification.
+- terra_high: ordinary bug fixes, bounded investigations, multi-file implementation, and research synthesis.
+- sol_medium: architecture, ambiguous requirements, subtle review, novel diagnosis, conflicting evidence, or consequential security/data decisions.
 
-1. luna_xhigh
-- Use for direct lookup, extraction, status checks, test or log collection, mechanical PR or release operations, and localized changes with explicit targets and strong verification.
-- Xhigh effort increases persistence, not the base model's capability ceiling.
+Return one model_route for the whole turn.
 
-2. terra_high
-- Use for ordinary bug fixes, bounded investigations, multi-file implementation, research synthesis, semantic PR maintenance, and partially specified localized work.
-
-3. sol_medium
-- Use for architecture or design, requirements disambiguation, subtle semantic review, novel root-cause reasoning, conflicting evidence, cross-component or multi-repository judgment, and high-stakes decisions.
-- Medium is its configured reasoning effort; it remains the highest-capability profile.
-
-Choose the least expensive profile likely to complete the whole current turn safely. Prompt length and eventual runtime are not difficulty signals. Explicit file or symbol targets, clear acceptance criteria, reversibility, and strong tests lower the required capability. Missing reproductions, unclear ownership, weak tests, architectural tradeoffs, broad scope, and conflicting assumptions raise it.
-
-Security, authentication, authorization, secrets, production changes, migrations, destructive operations, and weakly reversible data work require sol_medium when this turn must design, diagnose, or review the risky behavior. A tightly specified, reversible implementation with strong verification may use terra_high, but not luna_xhigh merely because the diff is small.
-
-Broad research is usually decomposition-heavy rather than intrinsically a sol_medium task. Use luna_xhigh when this turn mainly gathers independent evidence, terra_high when it must synthesize a bounded body of evidence, and sol_medium only when synthesis is consequential, conflicting, or deeply sequential. Mark parallel or hybrid decomposition when independent subagent fanout would help, but do not assume this router controls worker models.
-
-Use these observed Open SWE workload priors only as tie-breakers, not hard rules: feature changes and bug fixes are the largest interactive categories and typically require several agent invocations; direct questions and routine operations are usually shorter; design, review, and investigation have long upper tails. Classify the request itself rather than predicting a percentile bucket.
-
-Escalate luna_xhigh to terra_high if the named scope expands, instructions prove incomplete, or verification fails unexpectedly. Escalate terra_high to sol_medium if architecture must be invented, assumptions conflict, root cause remains unclear, or risk becomes material.
-
-Current human turn:
+Current turn:
 {task}
 """
 
 
-class RouteSignals(BaseModel):
-    scope: Literal[
-        "answer_only", "localized", "multi_file", "multi_component", "multi_repo", "unknown"
-    ]
-    decomposition: Literal["none", "parallel", "sequential", "hybrid"]
-    specification: Literal["clear", "partial", "ambiguous"]
-    verification: Literal["strong", "partial", "weak", "unknown"]
-    risks: list[
-        Literal[
-            "security",
-            "auth",
-            "secrets",
-            "production",
-            "migration",
-            "data",
-            "destructive",
-            "external_api",
-        ]
-    ]
-    design_needed: bool
-    review_needed: bool
-
-
 class RouteDecision(BaseModel):
-    task_category: Literal[
-        "question_lookup",
-        "research",
-        "scoping_design",
-        "bug_fix",
-        "investigation_diagnosis",
-        "feature_change",
-        "review",
-        "pr_maintenance",
-        "release_operations",
-        "admin_communication",
-        "test_noop",
-        "other",
-    ]
-    initial_route: Route
-    signals: RouteSignals
-    escalation_conditions: list[str]
-    reason: str
-    confidence: float = Field(ge=0, le=1)
+    model_route: Route
 
 
 class ModelSelectionState(AgentState):
     model_route: NotRequired[Route]
-    model_route_for: NotRequired[str]
-    model_route_plan: NotRequired[dict[str, Any]]
-
-
-def _message_text(message: HumanMessage) -> str:
-    if isinstance(message.content, str):
-        return message.content
-    return " ".join(
-        block.get("text", "")
-        for block in message.content
-        if isinstance(block, dict) and isinstance(block.get("text"), str)
-    )
-
-
-def _latest_task(state: Mapping[str, Any]) -> tuple[str, str]:
-    messages = state.get("messages")
-    if not isinstance(messages, list):
-        return "", ""
-    for index in range(len(messages) - 1, -1, -1):
-        message = messages[index]
-        if isinstance(message, HumanMessage):
-            task = _message_text(message)
-            payload = {"index": index, "id": message.id, "task": task}
-            fingerprint = hashlib.sha256(
-                json.dumps(payload, sort_keys=True, default=str).encode()
-            ).hexdigest()
-            return task, fingerprint
-    return "", ""
 
 
 class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
@@ -127,7 +39,7 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
 
     def __init__(
         self,
-        models: Mapping[str, BaseChatModel],
+        models: Mapping[Route, BaseChatModel],
         classifier: BaseChatModel,
         *,
         initial_plan_mode: bool = False,
@@ -136,44 +48,38 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         self._classifier = classifier.with_structured_output(RouteDecision)
         self._initial_plan_mode = initial_plan_mode
 
-    async def _classify(self, task: str) -> RouteDecision | None:
-        if self._initial_plan_mode:
-            return None
-        try:
-            decision = await self._classifier.ainvoke(_CLASSIFIER_PROMPT.format(task=task[-8_000:]))
-        except Exception:  # noqa: BLE001
-            logger.exception("Model routing classifier failed")
-            return None
-        if not isinstance(decision, RouteDecision):
-            logger.warning("Model routing classifier returned an unexpected result")
-            return None
-        return decision
-
     async def abefore_agent(
         self,
         state: ModelSelectionState,
         runtime: Runtime,
-    ) -> dict[str, Any] | None:
-        task, fingerprint = _latest_task(state)
-        if state.get("model_route_for") == fingerprint and state.get("model_route") in self._models:
-            return None
-        decision = await self._classify(task)
-        route: Route = decision.initial_route if decision is not None else "terra_high"
-        if self._initial_plan_mode:
-            route = "sol_medium"
-        return {
-            "model_route": route,
-            "model_route_for": fingerprint,
-            "model_route_plan": decision.model_dump(mode="json") if decision is not None else {},
-        }
+    ) -> dict[str, Route]:
+        del runtime
+        route: Route = "sol_medium" if self._initial_plan_mode else "terra_high"
+        if not self._initial_plan_mode:
+            messages = state.get("messages", [])
+            task = next(
+                (
+                    message.text
+                    for message in reversed(messages)
+                    if isinstance(message, HumanMessage)
+                ),
+                "",
+            )
+            try:
+                decision = await self._classifier.ainvoke(
+                    _CLASSIFIER_PROMPT.format(task=task[-8_000:])
+                )
+                if isinstance(decision, RouteDecision):
+                    route = decision.model_route
+            except Exception:  # noqa: BLE001
+                logger.exception("Model routing classifier failed")
+        return {"model_route": route}
 
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        route = request.state.get("model_route")
-        if route not in self._models:
-            route = "terra_high"
-        logger.info("Selected model route", extra={"model_route": route})
-        return await handler(request.override(model=self._models[route]))
+        route = request.state.get("model_route", "terra_high")
+        model = self._models.get(route, self._models["terra_high"])
+        return await handler(request.override(model=model))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-Route = Literal["fast", "balanced", "powerful"]
+Route = Literal["fast", "balanced", "performance"]
 
 _CLASSIFIER_PROMPT = """Choose one fixed model profile for this Open SWE turn. Use the least expensive profile likely to complete the whole turn safely.
 
@@ -23,7 +23,7 @@ Profiles, from least to most capable and expensive:
 2. balanced
 - Use for ordinary bug fixes, bounded investigations, multi-file implementation, research synthesis, semantic PR maintenance, and partially specified localized work.
 
-3. powerful
+3. performance
 - Use for architecture or design, requirements disambiguation, subtle semantic review, novel root-cause reasoning, conflicting evidence, cross-component or multi-repository judgment, and high-stakes decisions.
 
 Explicit targets, clear acceptance criteria, reversibility, and strong tests lower the required capability. Ambiguous requirements, weak verification, architectural tradeoffs, broad scope, consequential security or data work, and conflicting assumptions raise it. Prompt length and eventual runtime are not difficulty signals.
@@ -63,7 +63,7 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         runtime: Runtime,
     ) -> dict[str, Route]:
         del runtime
-        route: Route = "powerful" if self._initial_plan_mode else "balanced"
+        route: Route = "performance" if self._initial_plan_mode else "balanced"
         if not self._initial_plan_mode:
             messages = state.get("messages", [])
             task = next(

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -15,80 +15,75 @@ logger = logging.getLogger(__name__)
 
 Route = Literal["sol_medium", "terra_high", "luna_xhigh"]
 
-_CLASSIFIER_PROMPT = """You are the routing planner for Open SWE. Classify the initial request and produce a phase-aware execution plan. Choose only from these fixed profiles:
+_CLASSIFIER_PROMPT = """Route one Open SWE human turn to one fixed model profile. The selected model remains pinned for every parent-agent model call in this turn to preserve provider prompt-cache reuse. This router does not change the subagent model or switch models between design, implementation, and review inside one turn.
 
-1. sol_medium
-- GPT-5.6 Sol is the flagship and highest-capability base model.
-- Use for judgment-heavy work: problem framing, architecture, requirements disambiguation, research strategy and synthesis, novel root-cause reasoning, consequential decisions, and adversarial code or security review.
-- Medium is its configured reasoning effort; do not downgrade it merely because another profile says high or xhigh.
+Profiles, from least to most capable and expensive:
+
+1. luna_xhigh
+- Use for direct lookup, extraction, status checks, test or log collection, mechanical PR or release operations, and localized changes with explicit targets and strong verification.
+- Xhigh effort increases persistence, not the base model's capability ceiling.
 
 2. terra_high
-- GPT-5.6 Terra balances intelligence and cost; high effort makes it a deliberate execution model.
-- Use for bounded multi-file implementation, ordinary debugging, semantic PR maintenance, and executing a design whose interfaces and acceptance criteria are already clear.
+- Use for ordinary bug fixes, bounded investigations, multi-file implementation, research synthesis, semantic PR maintenance, and partially specified localized work.
 
-3. luna_xhigh
-- GPT-5.6 Luna is the cost-sensitive, high-volume tier.
-- Use for clear and repeatable work: classification, extraction, lookup, independent research fanout, log or test collection, mechanical edits, and tightly specified tool workflows.
-- Xhigh effort increases persistence, not the base capability ceiling. Never choose Luna over Sol for architecture or nuanced review merely because xhigh is greater than medium.
+3. sol_medium
+- Use for architecture or design, requirements disambiguation, subtle semantic review, novel root-cause reasoning, conflicting evidence, cross-component or multi-repository judgment, and high-stakes decisions.
+- Medium is its configured reasoning effort; it remains the highest-capability profile.
 
-Route by phase and cognitive role, not one scalar complexity score. Prefer capable models for design and review; cheaper models for bounded implementation and parallel evidence collection. Risk changes required oversight and review; it does not automatically mean the implementer must be the most expensive model.
+Choose the least expensive profile likely to complete the whole current turn safely. Prompt length and eventual runtime are not difficulty signals. Explicit file or symbol targets, clear acceptance criteria, reversibility, and strong tests lower the required capability. Missing reproductions, unclear ownership, weak tests, architectural tradeoffs, broad scope, and conflicting assumptions raise it.
 
-Phase rules:
-- Direct lookup, extraction, status check, or categorization: luna_xhigh.
-- Codebase explanation or bounded technical analysis: terra_high; use sol_medium if architectural, ambiguous, or consequential.
-- Design or planning from a rough goal, API or schema decisions, and tradeoff analysis: sol_medium.
-- Implementation from an approved explicit plan: luna_xhigh if mechanical, localized, and strongly testable; terra_high if bounded multi-file or moderate debugging; sol_medium first if design remains unresolved or debugging requires novel system reasoning.
-- Broad research: sol_medium plans the questions, luna_xhigh workers search independently in parallel, and sol_medium synthesizes and resolves conflicts. Straightforward synthesis may use terra_high.
-- Review: luna_xhigh for formatting or checklist validation; terra_high for an ordinary bounded diff; sol_medium for subtle correctness, cross-file behavior, architecture, security, auth, data access, migrations, or high blast radius.
-- Rebase, dependency, or PR maintenance: luna_xhigh if mechanical; terra_high if conflicts or behavioral decisions are possible.
-- Escalate Luna to Terra when instructions are incomplete, tests fail unexpectedly, or edits expand beyond the named scope.
-- Escalate Terra to Sol when assumptions conflict, architecture must be invented, root cause remains unclear, or review risk is material.
+Security, authentication, authorization, secrets, production changes, migrations, destructive operations, and weakly reversible data work require sol_medium when this turn must design, diagnose, or review the risky behavior. A tightly specified, reversible implementation with strong verification may use terra_high, but not luna_xhigh merely because the diff is small.
 
-Use fanout only when subtasks are substantially independent, outputs can follow a shared evidence schema, and synthesis can detect conflicts. Set parallelism to 1 otherwise.
+Broad research is usually decomposition-heavy rather than intrinsically a sol_medium task. Use luna_xhigh when this turn mainly gathers independent evidence, terra_high when it must synthesize a bounded body of evidence, and sol_medium only when synthesis is consequential, conflicting, or deeply sequential. Mark parallel or hybrid decomposition when independent subagent fanout would help, but do not assume this router controls worker models.
 
-The initial route is the first phase. The selected route will run the entire current turn, so choose the model needed for the hardest judgment the same agent must perform. A request with an already-approved plan should not be routed as design work. Do not use eventual duration or number of turns as inputs, infer difficulty solely from task category or file count, or treat parallelism as a substitute for capable synthesis.
+Use these observed Open SWE workload priors only as tie-breakers, not hard rules: feature changes and bug fixes are the largest interactive categories and typically require several agent invocations; direct questions and routine operations are usually shorter; design, review, and investigation have long upper tails. Classify the request itself rather than predicting a percentile bucket.
 
-Initial request:
+Escalate luna_xhigh to terra_high if the named scope expands, instructions prove incomplete, or verification fails unexpectedly. Escalate terra_high to sol_medium if architecture must be invented, assumptions conflict, root cause remains unclear, or risk becomes material.
+
+Current human turn:
 {task}
 """
 
 
-class RoutePhase(BaseModel):
-    phase: Literal[
-        "design", "research_worker", "synthesis", "implementation", "verification", "review"
-    ]
-    route: Route
-    parallelism: int = Field(ge=1, le=8)
-    deliverable: str
-
-
 class RouteSignals(BaseModel):
+    scope: Literal[
+        "answer_only", "localized", "multi_file", "multi_component", "multi_repo", "unknown"
+    ]
+    decomposition: Literal["none", "parallel", "sequential", "hybrid"]
+    specification: Literal["clear", "partial", "ambiguous"]
+    verification: Literal["strong", "partial", "weak", "unknown"]
+    risks: list[
+        Literal[
+            "security",
+            "auth",
+            "secrets",
+            "production",
+            "migration",
+            "data",
+            "destructive",
+            "external_api",
+        ]
+    ]
     design_needed: bool
-    plan_already_specified: bool
-    fanoutable: bool
-    mechanical: bool
-    novel_reasoning: bool
-    review_depth: Literal["none", "checklist", "ordinary", "adversarial"]
-    risk: Literal["low", "medium", "high"]
+    review_needed: bool
 
 
 class RouteDecision(BaseModel):
     task_category: Literal[
-        "question",
+        "question_lookup",
         "research",
-        "design",
+        "scoping_design",
         "bug_fix",
-        "feature",
-        "implementation",
-        "investigation",
+        "investigation_diagnosis",
+        "feature_change",
         "review",
         "pr_maintenance",
-        "operations",
+        "release_operations",
+        "admin_communication",
+        "test_noop",
         "other",
     ]
-    work_shape: Literal["single_phase", "staged", "fanout"]
     initial_route: Route
-    phase_plan: list[RoutePhase]
     signals: RouteSignals
     escalation_conditions: list[str]
     reason: str

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -11,22 +11,22 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-Route = Literal["sol_medium", "terra_high", "luna_xhigh"]
+Route = Literal["glm_flash", "sol_medium", "astra_low"]
 
 _CLASSIFIER_PROMPT = """Choose one fixed model profile for this Open SWE turn. Use the least expensive profile likely to complete the whole turn safely.
 
 Profiles, from least to most capable and expensive:
 
-1. luna_xhigh
+1. glm_flash
 - Use for direct lookup, extraction, status checks, test or log collection, mechanical PR or release operations, and localized changes with explicit targets and strong verification.
-- Xhigh effort increases persistence, not the base model's capability ceiling.
+- High effort increases persistence, not the base model's capability ceiling.
 
-2. terra_high
+2. sol_medium
 - Use for ordinary bug fixes, bounded investigations, multi-file implementation, research synthesis, semantic PR maintenance, and partially specified localized work.
 
-3. sol_medium
+3. astra_low
 - Use for architecture or design, requirements disambiguation, subtle semantic review, novel root-cause reasoning, conflicting evidence, cross-component or multi-repository judgment, and high-stakes decisions.
-- Medium is its configured reasoning effort; it remains the highest-capability profile.
+- Low is its configured reasoning effort; it remains the highest-capability profile.
 
 Explicit targets, clear acceptance criteria, reversibility, and strong tests lower the required capability. Ambiguous requirements, weak verification, architectural tradeoffs, broad scope, consequential security or data work, and conflicting assumptions raise it. Prompt length and eventual runtime are not difficulty signals.
 
@@ -65,7 +65,7 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         runtime: Runtime,
     ) -> dict[str, Route]:
         del runtime
-        route: Route = "sol_medium" if self._initial_plan_mode else "terra_high"
+        route: Route = "astra_low" if self._initial_plan_mode else "sol_medium"
         if not self._initial_plan_mode:
             messages = state.get("messages", [])
             task = next(
@@ -91,6 +91,6 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        route = request.state.get("model_route", "terra_high")
-        model = self._models.get(route, self._models["terra_high"])
+        route = request.state.get("model_route", "sol_medium")
+        model = self._models.get(route, self._models["sol_medium"])
         return await handler(request.override(model=model))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -2,12 +2,13 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Literal, NotRequired
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import AgentState, ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langgraph.runtime import Runtime
 from pydantic import BaseModel
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class ModelSelectionState(AgentState):
     model_route: NotRequired[Route]
 
 
-class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
+class ModelSelectionMiddleware(OpenSWEMiddleware[ModelSelectionState]):
     state_schema = ModelSelectionState
 
     def __init__(

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -9,30 +9,96 @@ from langchain.agents.middleware.types import AgentState, ModelRequest, ModelRes
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langgraph.runtime import Runtime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-_CLASSIFIER_PROMPT = """Classify the software-engineering task for model routing.
+Route = Literal["sol_medium", "terra_high", "luna_xhigh"]
 
-small: bounded, mechanical, read-only, formatting, documentation, or trivial edits
-medium: normal implementation, debugging, tests, or a contained multi-file change
-complex: ambiguous planning, architecture, broad migrations, security-sensitive work, difficult root-cause analysis, or large cross-cutting changes
+_CLASSIFIER_PROMPT = """You are the routing planner for Open SWE. Classify the initial request and produce a phase-aware execution plan. Choose only from these fixed profiles:
 
-Choose the least capable tier likely to complete the full task successfully. Return only the structured result.
+1. sol_medium
+- GPT-5.6 Sol is the flagship and highest-capability base model.
+- Use for judgment-heavy work: problem framing, architecture, requirements disambiguation, research strategy and synthesis, novel root-cause reasoning, consequential decisions, and adversarial code or security review.
+- Medium is its configured reasoning effort; do not downgrade it merely because another profile says high or xhigh.
 
-Task:
+2. terra_high
+- GPT-5.6 Terra balances intelligence and cost; high effort makes it a deliberate execution model.
+- Use for bounded multi-file implementation, ordinary debugging, semantic PR maintenance, and executing a design whose interfaces and acceptance criteria are already clear.
+
+3. luna_xhigh
+- GPT-5.6 Luna is the cost-sensitive, high-volume tier.
+- Use for clear and repeatable work: classification, extraction, lookup, independent research fanout, log or test collection, mechanical edits, and tightly specified tool workflows.
+- Xhigh effort increases persistence, not the base capability ceiling. Never choose Luna over Sol for architecture or nuanced review merely because xhigh is greater than medium.
+
+Route by phase and cognitive role, not one scalar complexity score. Prefer capable models for design and review; cheaper models for bounded implementation and parallel evidence collection. Risk changes required oversight and review; it does not automatically mean the implementer must be the most expensive model.
+
+Phase rules:
+- Direct lookup, extraction, status check, or categorization: luna_xhigh.
+- Codebase explanation or bounded technical analysis: terra_high; use sol_medium if architectural, ambiguous, or consequential.
+- Design or planning from a rough goal, API or schema decisions, and tradeoff analysis: sol_medium.
+- Implementation from an approved explicit plan: luna_xhigh if mechanical, localized, and strongly testable; terra_high if bounded multi-file or moderate debugging; sol_medium first if design remains unresolved or debugging requires novel system reasoning.
+- Broad research: sol_medium plans the questions, luna_xhigh workers search independently in parallel, and sol_medium synthesizes and resolves conflicts. Straightforward synthesis may use terra_high.
+- Review: luna_xhigh for formatting or checklist validation; terra_high for an ordinary bounded diff; sol_medium for subtle correctness, cross-file behavior, architecture, security, auth, data access, migrations, or high blast radius.
+- Rebase, dependency, or PR maintenance: luna_xhigh if mechanical; terra_high if conflicts or behavioral decisions are possible.
+- Escalate Luna to Terra when instructions are incomplete, tests fail unexpectedly, or edits expand beyond the named scope.
+- Escalate Terra to Sol when assumptions conflict, architecture must be invented, root cause remains unclear, or review risk is material.
+
+Use fanout only when subtasks are substantially independent, outputs can follow a shared evidence schema, and synthesis can detect conflicts. Set parallelism to 1 otherwise.
+
+The initial route is the first phase. The selected route will run the entire current turn, so choose the model needed for the hardest judgment the same agent must perform. A request with an already-approved plan should not be routed as design work. Do not use eventual duration or number of turns as inputs, infer difficulty solely from task category or file count, or treat parallelism as a substitute for capable synthesis.
+
+Initial request:
 {task}
 """
 
 
+class RoutePhase(BaseModel):
+    phase: Literal[
+        "design", "research_worker", "synthesis", "implementation", "verification", "review"
+    ]
+    route: Route
+    parallelism: int = Field(ge=1, le=8)
+    deliverable: str
+
+
+class RouteSignals(BaseModel):
+    design_needed: bool
+    plan_already_specified: bool
+    fanoutable: bool
+    mechanical: bool
+    novel_reasoning: bool
+    review_depth: Literal["none", "checklist", "ordinary", "adversarial"]
+    risk: Literal["low", "medium", "high"]
+
+
 class RouteDecision(BaseModel):
-    complexity: Literal["small", "medium", "complex"]
+    task_category: Literal[
+        "question",
+        "research",
+        "design",
+        "bug_fix",
+        "feature",
+        "implementation",
+        "investigation",
+        "review",
+        "pr_maintenance",
+        "operations",
+        "other",
+    ]
+    work_shape: Literal["single_phase", "staged", "fanout"]
+    initial_route: Route
+    phase_plan: list[RoutePhase]
+    signals: RouteSignals
+    escalation_conditions: list[str]
+    reason: str
+    confidence: float = Field(ge=0, le=1)
 
 
 class ModelSelectionState(AgentState):
-    model_route: NotRequired[Literal["small", "medium", "complex"]]
+    model_route: NotRequired[Route]
     model_route_for: NotRequired[str]
+    model_route_plan: NotRequired[dict[str, Any]]
 
 
 def _message_text(message: HumanMessage) -> str:
@@ -75,18 +141,18 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         self._classifier = classifier.with_structured_output(RouteDecision)
         self._initial_plan_mode = initial_plan_mode
 
-    async def _classify(self, task: str) -> Literal["small", "medium", "complex"]:
+    async def _classify(self, task: str) -> RouteDecision | None:
         if self._initial_plan_mode:
-            return "complex"
+            return None
         try:
             decision = await self._classifier.ainvoke(_CLASSIFIER_PROMPT.format(task=task[-8_000:]))
         except Exception:  # noqa: BLE001
             logger.exception("Model routing classifier failed")
-            return "medium"
+            return None
         if not isinstance(decision, RouteDecision):
             logger.warning("Model routing classifier returned an unexpected result")
-            return "medium"
-        return decision.complexity
+            return None
+        return decision
 
     async def abefore_agent(
         self,
@@ -96,9 +162,14 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
         task, fingerprint = _latest_task(state)
         if state.get("model_route_for") == fingerprint and state.get("model_route") in self._models:
             return None
+        decision = await self._classify(task)
+        route: Route = decision.initial_route if decision is not None else "terra_high"
+        if self._initial_plan_mode:
+            route = "sol_medium"
         return {
-            "model_route": await self._classify(task),
+            "model_route": route,
             "model_route_for": fingerprint,
+            "model_route_plan": decision.model_dump(mode="json") if decision is not None else {},
         }
 
     async def awrap_model_call(
@@ -108,6 +179,6 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
     ) -> ModelResponse:
         route = request.state.get("model_route")
         if route not in self._models:
-            route = "medium"
-        logger.info("Selected model for task complexity", extra={"task_complexity": route})
+            route = "terra_high"
+        logger.info("Selected model route", extra={"model_route": route})
         return await handler(request.override(model=self._models[route]))

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -39,7 +39,7 @@ class ModelSelectionMiddleware(AgentMiddleware[ModelSelectionState]):
 
     def __init__(
         self,
-        models: Mapping[Route, BaseChatModel],
+        models: Mapping[str, BaseChatModel],
         classifier: BaseChatModel,
         *,
         initial_plan_mode: bool = False,

--- a/agent/middleware/model_selection.py
+++ b/agent/middleware/model_selection.py
@@ -13,11 +13,22 @@ logger = logging.getLogger(__name__)
 
 Route = Literal["sol_medium", "terra_high", "luna_xhigh"]
 
-_CLASSIFIER_PROMPT = """Choose the least expensive model profile likely to complete this Open SWE turn safely.
+_CLASSIFIER_PROMPT = """Choose one fixed model profile for this Open SWE turn. Use the least expensive profile likely to complete the whole turn safely.
 
-- luna_xhigh: direct questions, routine operations, evidence gathering, and small explicit changes with strong verification.
-- terra_high: ordinary bug fixes, bounded investigations, multi-file implementation, and research synthesis.
-- sol_medium: architecture, ambiguous requirements, subtle review, novel diagnosis, conflicting evidence, or consequential security/data decisions.
+Profiles, from least to most capable and expensive:
+
+1. luna_xhigh
+- Use for direct lookup, extraction, status checks, test or log collection, mechanical PR or release operations, and localized changes with explicit targets and strong verification.
+- Xhigh effort increases persistence, not the base model's capability ceiling.
+
+2. terra_high
+- Use for ordinary bug fixes, bounded investigations, multi-file implementation, research synthesis, semantic PR maintenance, and partially specified localized work.
+
+3. sol_medium
+- Use for architecture or design, requirements disambiguation, subtle semantic review, novel root-cause reasoning, conflicting evidence, cross-component or multi-repository judgment, and high-stakes decisions.
+- Medium is its configured reasoning effort; it remains the highest-capability profile.
+
+Explicit targets, clear acceptance criteria, reversibility, and strong tests lower the required capability. Ambiguous requirements, weak verification, architectural tradeoffs, broad scope, consequential security or data work, and conflicting assumptions raise it. Prompt length and eventual runtime are not difficulty signals.
 
 Return one model_route for the whole turn.
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -978,7 +978,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         routing_defaults = {
             "fast": default_model_pair(),
             "balanced": default_model_pair(),
-            "powerful": default_model_pair(),
+            "performance": default_model_pair(),
         }
         title_defaults = team_defaults[0]
         use_gateway = gateway_env_default()

--- a/agent/server.py
+++ b/agent/server.py
@@ -1020,12 +1020,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id = overridden_subagent_model
             subagent_effort = overridden_subagent_effort
 
-    stored_adaptive_routing = thread_settings.get("adaptive_model_routing")
-    adaptive_model_routing = (
-        stored_adaptive_routing
-        if isinstance(stored_adaptive_routing, bool)
-        else profile is not None and profile.get("adaptive_model_routing") is True
-    )
+    adaptive_model_routing = hashlib.sha256(thread_id.encode()).digest()[0] < 128
     stored_model = thread_settings.get("model_id")
     if isinstance(stored_model, str):
         model_id = stored_model
@@ -1076,7 +1071,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         "effort": profile_effort,
         "subagent_model_id": subagent_model_id,
         "subagent_effort": subagent_effort,
-        "adaptive_model_routing": adaptive_model_routing,
         "repo_instructions": repo_instructions,
     }
     if not local_run and (
@@ -1085,6 +1079,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         async with aphase(thread_id, "factory.store_settings"):
             await store_thread_settings(client, thread_id, {**thread_settings, **resolved_settings})
 
+    config["metadata"] = {
+        **(config.get("metadata") or {}),
+        "model_routing_applied": adaptive_model_routing,
+    }
     model_id, profile_effort = gate_fable_model(
         model_id, profile_effort, fable_enabled=fable_enabled
     )
@@ -1388,8 +1386,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 TimeoutWrapupMiddleware(),
                 notify_step_limit_reached,
                 record_run_usage,
-                *fallback_middleware,
                 *model_selection_middleware,
+                *fallback_middleware,
                 PlanModeMiddleware(
                     excluded=PLAN_MODE_EXCLUDED_TOOLS
                     | frozenset(tool.name for tool in workspace_mcp_tools),

--- a/agent/server.py
+++ b/agent/server.py
@@ -51,6 +51,7 @@ from agent.dashboard.agent_overrides import (
     normalize_profile_overrides,
     normalize_profile_subagent_overrides,
     profile_draft_prs,
+    profile_model_routing_enabled,
     resolve_github_login,
 )
 from agent.dashboard.agent_usage import record_agent_run_usage
@@ -1036,13 +1037,14 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id = overridden_subagent_model
             subagent_effort = overridden_subagent_effort
 
-    adaptive_model_routing = True
+    adaptive_model_routing = profile_model_routing_enabled(profile)
     stored_model = thread_settings.get("model_id")
     if isinstance(stored_model, str):
         model_id = stored_model
         profile_effort = thread_settings.get("effort")
         subagent_model_id = thread_settings.get("subagent_model_id") or stored_model
         subagent_effort = thread_settings.get("subagent_effort")
+        adaptive_model_routing = thread_settings.get("model_routing_enabled", True)
         logger.info("Using stored thread settings: model=%s effort=%s", model_id, profile_effort)
 
     # An explicit per-run model choice is the one thing allowed to move a thread
@@ -1087,6 +1089,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         "effort": profile_effort,
         "subagent_model_id": subagent_model_id,
         "subagent_effort": subagent_effort,
+        "model_routing_enabled": adaptive_model_routing,
         "repo_instructions": repo_instructions,
     }
     if not local_run and (

--- a/agent/server.py
+++ b/agent/server.py
@@ -1288,7 +1288,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     model_selection_middleware: list[Any] = []
     if adaptive_model_routing:
         routing_models = {
-            complexity: _make_model_or_defer(
+            route: _make_model_or_defer(
                 routed_model_id,
                 use_gateway=use_gateway,
                 **provider_model_kwargs(
@@ -1297,16 +1297,16 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     max_tokens=DEFAULT_LLM_MAX_TOKENS,
                 ),
             )
-            for complexity, routed_model_id, effort in (
-                ("small", "openai:gpt-5.6-luna", "low"),
-                ("medium", "openai:gpt-5.6-terra", "medium"),
-                ("complex", "openai:gpt-5.6-sol", "xhigh"),
+            for route, routed_model_id, effort in (
+                ("luna_xhigh", "openai:gpt-5.6-luna", "xhigh"),
+                ("terra_high", "openai:gpt-5.6-terra", "high"),
+                ("sol_medium", "openai:gpt-5.6-sol", "medium"),
             )
         }
         model_selection_middleware.append(
             ModelSelectionMiddleware(
                 routing_models,
-                routing_models["small"],
+                routing_models["luna_xhigh"],
                 initial_plan_mode=plan_mode,
             )
         )

--- a/agent/server.py
+++ b/agent/server.py
@@ -93,6 +93,7 @@ from agent.middleware import (
     ModelCallTimeoutMiddleware,
     ModelErrorMiddleware,
     ModelFallbackMiddleware,
+    ModelSelectionMiddleware,
     PlanModeMiddleware,
     PullRequestCreationGuardMiddleware,
     SanitizeFireworksMessagesMiddleware,
@@ -1019,6 +1020,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id = overridden_subagent_model
             subagent_effort = overridden_subagent_effort
 
+    stored_adaptive_routing = thread_settings.get("adaptive_model_routing")
+    adaptive_model_routing = (
+        stored_adaptive_routing
+        if isinstance(stored_adaptive_routing, bool)
+        else profile is not None and profile.get("adaptive_model_routing") is True
+    )
     stored_model = thread_settings.get("model_id")
     if isinstance(stored_model, str):
         model_id = stored_model
@@ -1069,6 +1076,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         "effort": profile_effort,
         "subagent_model_id": subagent_model_id,
         "subagent_effort": subagent_effort,
+        "adaptive_model_routing": adaptive_model_routing,
         "repo_instructions": repo_instructions,
     }
     if not local_run and (
@@ -1277,6 +1285,25 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             skill_sources.insert(0, USER_SKILLS_ROUTE)
     agent_backend = CompositeBackend(default=backend, routes=skill_routes)
     main_model = _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
+    model_selection_middleware: list[Any] = []
+    if adaptive_model_routing:
+        routing_models = {
+            complexity: _make_model_or_defer(
+                routed_model_id,
+                use_gateway=use_gateway,
+                **provider_model_kwargs(
+                    routed_model_id,
+                    effort,
+                    max_tokens=DEFAULT_LLM_MAX_TOKENS,
+                ),
+            )
+            for complexity, routed_model_id, effort in (
+                ("small", "openai:gpt-5.6-luna", "low"),
+                ("medium", "openai:gpt-5.6-terra", "medium"),
+                ("complex", "openai:gpt-5.6-sol", "xhigh"),
+            )
+        }
+        model_selection_middleware.append(ModelSelectionMiddleware(routing_models))
     subagent_model = _make_model_or_defer(
         subagent_model_id,
         use_gateway=use_gateway,
@@ -1356,6 +1383,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 notify_step_limit_reached,
                 record_run_usage,
                 *fallback_middleware,
+                *model_selection_middleware,
                 PlanModeMiddleware(
                     excluded=PLAN_MODE_EXCLUDED_TOOLS
                     | frozenset(tool.name for tool in workspace_mcp_tools),

--- a/agent/server.py
+++ b/agent/server.py
@@ -1303,7 +1303,13 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 ("complex", "openai:gpt-5.6-sol", "xhigh"),
             )
         }
-        model_selection_middleware.append(ModelSelectionMiddleware(routing_models))
+        model_selection_middleware.append(
+            ModelSelectionMiddleware(
+                routing_models,
+                routing_models["small"],
+                initial_plan_mode=plan_mode,
+            )
+        )
     subagent_model = _make_model_or_defer(
         subagent_model_id,
         use_gateway=use_gateway,

--- a/agent/server.py
+++ b/agent/server.py
@@ -1296,15 +1296,15 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 ),
             )
             for route, routed_model_id, effort in (
-                ("luna_xhigh", "openai:gpt-5.6-luna", "xhigh"),
-                ("terra_high", "openai:gpt-5.6-terra", "high"),
+                ("glm_flash", "fireworks:accounts/fireworks/models/glm-5p3-flash", "high"),
                 ("sol_medium", "openai:gpt-5.6-sol", "medium"),
+                ("astra_low", "openai:gpt-6-astra", "low"),
             )
         }
         model_selection_middleware.append(
             ModelSelectionMiddleware(
                 routing_models,
-                routing_models["luna_xhigh"],
+                routing_models["glm_flash"],
                 initial_plan_mode=plan_mode,
             )
         )

--- a/agent/server.py
+++ b/agent/server.py
@@ -66,6 +66,7 @@ from agent.dashboard.options import (
 from agent.dashboard.skills import ORGANIZATION_SKILLS_NAMESPACE, SKILLS_NAMESPACE
 from agent.dashboard.team_settings import (
     get_effective_gateway_enabled,
+    get_team_agent_routing_models,
     get_team_default_model_pair,
     get_team_default_repo,
     get_team_default_thread_title_model,
@@ -629,6 +630,14 @@ async def _cached_team_default_model_pair(kind: Literal["agent", "reviewer"]):
     )
 
 
+async def _cached_agent_routing_models() -> dict[str, tuple[str, str]]:
+    return await ttl_cache.cached(
+        "team:agent-routing-models",
+        60,
+        get_team_agent_routing_models,
+    )
+
+
 async def _cached_thread_title_model() -> tuple[str, str]:
     return await ttl_cache.cached(
         "team:thread-title-model",
@@ -966,6 +975,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         from agent.dashboard.options import default_model_pair
 
         team_defaults = (default_model_pair(), default_model_pair())
+        routing_defaults = {
+            "fast": default_model_pair(),
+            "balanced": default_model_pair(),
+            "powerful": default_model_pair(),
+        }
         title_defaults = team_defaults[0]
         use_gateway = gateway_env_default()
         profile = None
@@ -974,12 +988,14 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         async with aphase(thread_id, "factory.settings_defaults"):
             (
                 team_defaults,
+                routing_defaults,
                 title_defaults,
                 use_gateway,
                 profile,
                 fable_enabled,
             ) = await asyncio.gather(
                 _cached_team_default_model_pair("agent"),
+                _cached_agent_routing_models(),
                 _cached_thread_title_model(),
                 _cached_gateway_enabled(),
                 _cached_profile(None if thread_settings.get("model_id") else profile_login),
@@ -1295,16 +1311,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     max_tokens=DEFAULT_LLM_MAX_TOKENS,
                 ),
             )
-            for route, routed_model_id, effort in (
-                ("glm_flash", "fireworks:accounts/fireworks/models/glm-5p3-flash", "high"),
-                ("sol_medium", "openai:gpt-5.6-sol", "medium"),
-                ("astra_low", "openai:gpt-6-astra", "low"),
-            )
+            for route, (routed_model_id, effort) in routing_defaults.items()
         }
         model_selection_middleware.append(
             ModelSelectionMiddleware(
                 routing_models,
-                routing_models["glm_flash"],
+                routing_models["fast"],
                 initial_plan_mode=plan_mode,
             )
         )

--- a/agent/server.py
+++ b/agent/server.py
@@ -1044,7 +1044,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         profile_effort = thread_settings.get("effort")
         subagent_model_id = thread_settings.get("subagent_model_id") or stored_model
         subagent_effort = thread_settings.get("subagent_effort")
-        adaptive_model_routing = thread_settings.get("model_routing_enabled", True)
+        adaptive_model_routing = thread_settings.get("model_routing_enabled", False)
         logger.info("Using stored thread settings: model=%s effort=%s", model_id, profile_effort)
 
     # An explicit per-run model choice is the one thing allowed to move a thread

--- a/agent/server.py
+++ b/agent/server.py
@@ -1020,7 +1020,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id = overridden_subagent_model
             subagent_effort = overridden_subagent_effort
 
-    adaptive_model_routing = hashlib.sha256(thread_id.encode()).digest()[0] < 128
+    adaptive_model_routing = True
     stored_model = thread_settings.get("model_id")
     if isinstance(stored_model, str):
         model_id = stored_model

--- a/agent/utils/thread_settings.py
+++ b/agent/utils/thread_settings.py
@@ -29,6 +29,7 @@ class ThreadSettings(TypedDict, total=False):
     effort: str | None
     subagent_model_id: str
     subagent_effort: str | None
+    adaptive_model_routing: bool
     repo_instructions: str | None
 
 

--- a/agent/utils/thread_settings.py
+++ b/agent/utils/thread_settings.py
@@ -29,6 +29,7 @@ class ThreadSettings(TypedDict, total=False):
     effort: str | None
     subagent_model_id: str
     subagent_effort: str | None
+    model_routing_enabled: bool
     repo_instructions: str | None
 
 

--- a/agent/utils/thread_settings.py
+++ b/agent/utils/thread_settings.py
@@ -29,7 +29,6 @@ class ThreadSettings(TypedDict, total=False):
     effort: str | None
     subagent_model_id: str
     subagent_effort: str | None
-    adaptive_model_routing: bool
     repo_instructions: str | None
 
 

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -181,7 +181,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
 
 
 @pytest.mark.asyncio
-async def test_model_routing_is_applied_to_all_threads() -> None:
+async def test_model_routing_is_applied_when_enabled() -> None:
     config = _base_config()
     agent = await _capture_create_deep_agent_kwargs(config)
 
@@ -196,6 +196,48 @@ async def test_model_routing_is_applied_to_all_threads() -> None:
         "openai:gpt-5.6-sol",
         "anthropic:claude-opus-5",
     ]
+
+
+@pytest.mark.asyncio
+async def test_model_routing_can_be_disabled_in_profile() -> None:
+    config = _base_config()
+    agent = await _capture_create_deep_agent_kwargs(
+        config, profile={"model_routing_enabled": False}
+    )
+
+    middleware_names = [
+        type(middleware).__name__ for middleware in cast(list[object], agent["middleware"])
+    ]
+    assert "ModelSelectionMiddleware" not in middleware_names
+    assert config["metadata"]["model_routing_applied"] is False
+    calls = cast(list[tuple[str, dict[str, object]]], agent["make_model_calls"])
+    assert [model for model, _ in calls] == [
+        "openai:gpt-5.6-sol",
+        "openai:gpt-5.6-sol",
+        "openai:gpt-5.6-luna",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_model_routing_preference_is_snapshotted_for_existing_thread() -> None:
+    config = _base_config()
+    agent = await _capture_create_deep_agent_kwargs(
+        config,
+        profile={"model_routing_enabled": True},
+        thread_settings={
+            "model_id": "openai:gpt-5.6-sol",
+            "effort": "medium",
+            "subagent_model_id": "openai:gpt-5.6-sol",
+            "subagent_effort": "low",
+            "model_routing_enabled": False,
+        },
+    )
+
+    middleware_names = [
+        type(middleware).__name__ for middleware in cast(list[object], agent["middleware"])
+    ]
+    assert "ModelSelectionMiddleware" not in middleware_names
+    assert config["metadata"]["model_routing_applied"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -86,7 +86,7 @@ async def _capture_create_deep_agent_kwargs(
             return_value={
                 "fast": ("google_genai:gemini-3.8-flash", "low"),
                 "balanced": ("openai:gpt-5.6-sol", "medium"),
-                "powerful": ("anthropic:claude-opus-5", "high"),
+                "performance": ("anthropic:claude-opus-5", "high"),
             },
         ),
         patch("agent.server.load_profile", new_callable=AsyncMock, return_value=profile),
@@ -157,7 +157,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
             return_value={
                 "fast": ("openai:gpt-5.6-sol", "low"),
                 "balanced": ("openai:gpt-5.6-sol", "medium"),
-                "powerful": ("openai:gpt-5.6-sol", "high"),
+                "performance": ("openai:gpt-5.6-sol", "high"),
             },
         ),
         patch("agent.server._cached_gateway_enabled", new_callable=AsyncMock, return_value=False),

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -46,7 +46,7 @@ async def _capture_create_deep_agent_kwargs(
     captured: dict[str, object] = {}
     make_model_calls: list[tuple[str, dict[str, object]]] = []
     config = config or _base_config()
-    thread_id = "thread-ctx"
+    thread_id = str((config.get("configurable") or {}).get("thread_id"))
 
     def fake_create_deep_agent(**kwargs: object) -> _DummyAgent:
         captured.update(kwargs)
@@ -159,6 +159,24 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
         await agent_task
 
     SANDBOX_BACKENDS.pop("thread-ctx", None)
+
+
+@pytest.mark.asyncio
+async def test_model_routing_is_deterministically_applied_to_half_of_threads() -> None:
+    routed = _base_config()
+    routed["configurable"]["thread_id"] = "thread-1"
+    routed_agent = await _capture_create_deep_agent_kwargs(routed)
+
+    unrouted = _base_config()
+    unrouted["configurable"]["thread_id"] = "thread-0"
+    unrouted_agent = await _capture_create_deep_agent_kwargs(unrouted)
+
+    routed_names = [type(middleware).__name__ for middleware in routed_agent["middleware"]]
+    unrouted_names = [type(middleware).__name__ for middleware in unrouted_agent["middleware"]]
+    assert "ModelSelectionMiddleware" in routed_names
+    assert "ModelSelectionMiddleware" not in unrouted_names
+    assert routed["metadata"]["model_routing_applied"] is True
+    assert unrouted["metadata"]["model_routing_applied"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -80,6 +80,15 @@ async def _capture_create_deep_agent_kwargs(
             new_callable=AsyncMock,
             return_value=(("openai:gpt-5.6-sol", "medium"), ("openai:gpt-5.6-sol", "low")),
         ),
+        patch(
+            "agent.server.get_team_agent_routing_models",
+            new_callable=AsyncMock,
+            return_value={
+                "fast": ("google_genai:gemini-3.8-flash", "low"),
+                "balanced": ("openai:gpt-5.6-sol", "medium"),
+                "powerful": ("anthropic:claude-opus-5", "high"),
+            },
+        ),
         patch("agent.server.load_profile", new_callable=AsyncMock, return_value=profile),
         patch(
             "agent.server.load_thread_settings",
@@ -142,6 +151,15 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
             return_value=None,
         ),
         patch("agent.server._cached_team_default_model_pair", side_effect=load_defaults),
+        patch(
+            "agent.server._cached_agent_routing_models",
+            new_callable=AsyncMock,
+            return_value={
+                "fast": ("openai:gpt-5.6-sol", "low"),
+                "balanced": ("openai:gpt-5.6-sol", "medium"),
+                "powerful": ("openai:gpt-5.6-sol", "high"),
+            },
+        ),
         patch("agent.server._cached_gateway_enabled", new_callable=AsyncMock, return_value=False),
         patch("agent.server._cached_profile", new_callable=AsyncMock, return_value=None),
         patch("agent.server._cached_fable_enabled", new_callable=AsyncMock, return_value=True),
@@ -172,6 +190,12 @@ async def test_model_routing_is_applied_to_all_threads() -> None:
     ]
     assert "ModelSelectionMiddleware" in middleware_names
     assert config["metadata"]["model_routing_applied"] is True
+    calls = cast(list[tuple[str, dict[str, object]]], agent["make_model_calls"])
+    assert [model for model, _ in calls[1:4]] == [
+        "google_genai:gemini-3.8-flash",
+        "openai:gpt-5.6-sol",
+        "anthropic:claude-opus-5",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -163,25 +163,15 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
 
 
 @pytest.mark.asyncio
-async def test_model_routing_is_deterministically_applied_to_half_of_threads() -> None:
-    routed = _base_config()
-    routed["configurable"]["thread_id"] = "thread-1"
-    routed_agent = await _capture_create_deep_agent_kwargs(routed)
+async def test_model_routing_is_applied_to_all_threads() -> None:
+    config = _base_config()
+    agent = await _capture_create_deep_agent_kwargs(config)
 
-    unrouted = _base_config()
-    unrouted["configurable"]["thread_id"] = "thread-0"
-    unrouted_agent = await _capture_create_deep_agent_kwargs(unrouted)
-
-    routed_names = [
-        type(middleware).__name__ for middleware in cast(list[object], routed_agent["middleware"])
+    middleware_names = [
+        type(middleware).__name__ for middleware in cast(list[object], agent["middleware"])
     ]
-    unrouted_names = [
-        type(middleware).__name__ for middleware in cast(list[object], unrouted_agent["middleware"])
-    ]
-    assert "ModelSelectionMiddleware" in routed_names
-    assert "ModelSelectionMiddleware" not in unrouted_names
-    assert routed["metadata"]["model_routing_applied"] is True
-    assert unrouted["metadata"]["model_routing_applied"] is False
+    assert "ModelSelectionMiddleware" in middleware_names
+    assert config["metadata"]["model_routing_applied"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -8,6 +8,7 @@ is what makes deepagents auto-wire `FilesystemMiddleware` tool-result eviction a
 """
 
 import asyncio
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -171,8 +172,12 @@ async def test_model_routing_is_deterministically_applied_to_half_of_threads() -
     unrouted["configurable"]["thread_id"] = "thread-0"
     unrouted_agent = await _capture_create_deep_agent_kwargs(unrouted)
 
-    routed_names = [type(middleware).__name__ for middleware in routed_agent["middleware"]]
-    unrouted_names = [type(middleware).__name__ for middleware in unrouted_agent["middleware"]]
+    routed_names = [
+        type(middleware).__name__ for middleware in cast(list[object], routed_agent["middleware"])
+    ]
+    unrouted_names = [
+        type(middleware).__name__ for middleware in cast(list[object], unrouted_agent["middleware"])
+    ]
     assert "ModelSelectionMiddleware" in routed_names
     assert "ModelSelectionMiddleware" not in unrouted_names
     assert routed["metadata"]["model_routing_applied"] is True

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -183,7 +183,7 @@ async def test_agent_starts_sandbox_while_loading_settings() -> None:
 @pytest.mark.asyncio
 async def test_model_routing_is_applied_when_enabled() -> None:
     config = _base_config()
-    agent = await _capture_create_deep_agent_kwargs(config)
+    agent = await _capture_create_deep_agent_kwargs(config, profile={"model_routing_enabled": True})
 
     middleware_names = [
         type(middleware).__name__ for middleware in cast(list[object], agent["middleware"])
@@ -199,11 +199,9 @@ async def test_model_routing_is_applied_when_enabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_model_routing_can_be_disabled_in_profile() -> None:
+async def test_model_routing_is_disabled_by_default() -> None:
     config = _base_config()
-    agent = await _capture_create_deep_agent_kwargs(
-        config, profile={"model_routing_enabled": False}
-    )
+    agent = await _capture_create_deep_agent_kwargs(config)
 
     middleware_names = [
         type(middleware).__name__ for middleware in cast(list[object], agent["middleware"])

--- a/tests/agent/test_thread_settings.py
+++ b/tests/agent/test_thread_settings.py
@@ -21,6 +21,7 @@ def test_normalize_thread_settings_preserves_valid_values() -> None:
         "effort": None,
         "subagent_model_id": "subagent",
         "subagent_effort": "high",
+        "adaptive_model_routing": True,
         "repo_instructions": None,
     }
 

--- a/tests/agent/test_thread_settings.py
+++ b/tests/agent/test_thread_settings.py
@@ -21,6 +21,7 @@ def test_normalize_thread_settings_preserves_valid_values() -> None:
         "effort": None,
         "subagent_model_id": "subagent",
         "subagent_effort": "high",
+        "model_routing_enabled": False,
         "repo_instructions": None,
     }
 

--- a/tests/agent/test_thread_settings.py
+++ b/tests/agent/test_thread_settings.py
@@ -21,7 +21,6 @@ def test_normalize_thread_settings_preserves_valid_values() -> None:
         "effort": None,
         "subagent_model_id": "subagent",
         "subagent_effort": "high",
-        "adaptive_model_routing": True,
         "repo_instructions": None,
     }
 

--- a/tests/dashboard/test_profile_draft_preference.py
+++ b/tests/dashboard/test_profile_draft_preference.py
@@ -27,6 +27,27 @@ async def test_omitted_draft_preference_preserves_existing_value() -> None:
 
 
 @pytest.mark.asyncio
+async def test_adaptive_model_routing_is_persisted() -> None:
+    update = ProfileUpdate(
+        default_model="openai:gpt-5.6-sol",
+        reasoning_effort="medium",
+        adaptive_model_routing=True,
+    )
+    put_item = AsyncMock()
+
+    with (
+        patch("agent.dashboard.profiles.get_profile", new_callable=AsyncMock, return_value=None),
+        patch("agent.store.store_client") as client,
+    ):
+        client.return_value.store.put_item = put_item
+        profile = await upsert_profile("octocat", "octocat@example.com", update)
+
+    assert profile["adaptive_model_routing"] is True
+    assert put_item.await_args is not None
+    assert put_item.await_args.args[2]["adaptive_model_routing"] is True
+
+
+@pytest.mark.asyncio
 async def test_explicit_draft_preference_is_persisted() -> None:
     update = ProfileUpdate(
         default_model="openai:gpt-5.6-sol",

--- a/tests/dashboard/test_profile_draft_preference.py
+++ b/tests/dashboard/test_profile_draft_preference.py
@@ -14,7 +14,7 @@ async def test_omitted_draft_preference_preserves_existing_value() -> None:
         patch(
             "agent.dashboard.profiles.get_profile",
             new_callable=AsyncMock,
-            return_value={"draft_prs": False},
+            return_value={"draft_prs": False, "model_routing_enabled": False},
         ),
         patch("agent.store.store_client") as client,
     ):
@@ -22,8 +22,31 @@ async def test_omitted_draft_preference_preserves_existing_value() -> None:
         profile = await upsert_profile("octocat", "octocat@example.com", update)
 
     assert profile["draft_prs"] is False
+    assert profile["model_routing_enabled"] is False
     assert put_item.await_args is not None
     assert put_item.await_args.args[2]["draft_prs"] is False
+    assert put_item.await_args.args[2]["model_routing_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_routing_preference_is_persisted() -> None:
+    update = ProfileUpdate(
+        default_model="openai:gpt-5.6-sol",
+        reasoning_effort="medium",
+        model_routing_enabled=False,
+    )
+    put_item = AsyncMock()
+
+    with (
+        patch("agent.dashboard.profiles.get_profile", new_callable=AsyncMock, return_value=None),
+        patch("agent.store.store_client") as client,
+    ):
+        client.return_value.store.put_item = put_item
+        profile = await upsert_profile("octocat", "octocat@example.com", update)
+
+    assert profile["model_routing_enabled"] is False
+    assert put_item.await_args is not None
+    assert put_item.await_args.args[2]["model_routing_enabled"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/dashboard/test_profile_draft_preference.py
+++ b/tests/dashboard/test_profile_draft_preference.py
@@ -27,27 +27,6 @@ async def test_omitted_draft_preference_preserves_existing_value() -> None:
 
 
 @pytest.mark.asyncio
-async def test_adaptive_model_routing_is_persisted() -> None:
-    update = ProfileUpdate(
-        default_model="openai:gpt-5.6-sol",
-        reasoning_effort="medium",
-        adaptive_model_routing=True,
-    )
-    put_item = AsyncMock()
-
-    with (
-        patch("agent.dashboard.profiles.get_profile", new_callable=AsyncMock, return_value=None),
-        patch("agent.store.store_client") as client,
-    ):
-        client.return_value.store.put_item = put_item
-        profile = await upsert_profile("octocat", "octocat@example.com", update)
-
-    assert profile["adaptive_model_routing"] is True
-    assert put_item.await_args is not None
-    assert put_item.await_args.args[2]["adaptive_model_routing"] is True
-
-
-@pytest.mark.asyncio
 async def test_explicit_draft_preference_is_persisted() -> None:
     update = ProfileUpdate(
         default_model="openai:gpt-5.6-sol",

--- a/tests/dashboard/test_team_settings_grouping.py
+++ b/tests/dashboard/test_team_settings_grouping.py
@@ -5,11 +5,17 @@ from pydantic import ValidationError
 
 from agent.dashboard.team_settings import (
     TeamSettingsUpdate,
+    get_team_agent_routing_models,
     get_team_default_grouping_model,
 )
 
 _REVIEWER_SUBAGENT_PAIR = ("openai:gpt-5.6-sol", "low")
 _GROUPING_PAIR = ("google_genai:gemini-3.8-flash", "low")
+_ROUTING_PAIRS = {
+    "fast": ("google_genai:gemini-3.8-flash", "low"),
+    "balanced": ("openai:gpt-5.6-sol", "medium"),
+    "powerful": ("anthropic:claude-opus-5", "high"),
+}
 
 
 def _settings(**overrides: object) -> dict[str, object]:
@@ -57,6 +63,33 @@ async def test_grouping_inherits_when_configured_model_invalid() -> None:
         ),
     ):
         assert await get_team_default_grouping_model() == _REVIEWER_SUBAGENT_PAIR
+
+
+@pytest.mark.asyncio
+async def test_agent_routing_uses_configured_model_pairs() -> None:
+    settings = {
+        f"default_agent_routing_{tier}_{suffix}": value
+        for tier, pair in _ROUTING_PAIRS.items()
+        for suffix, value in zip(("model", "reasoning_effort"), pair, strict=True)
+    }
+    with patch(
+        "agent.dashboard.team_settings.get_team_settings",
+        new_callable=AsyncMock,
+        return_value=settings,
+    ):
+        assert await get_team_agent_routing_models() == _ROUTING_PAIRS
+
+
+def test_team_settings_update_accepts_routing_pairs() -> None:
+    update = TeamSettingsUpdate(
+        **{
+            f"default_agent_routing_{tier}_{suffix}": value
+            for tier, pair in _ROUTING_PAIRS.items()
+            for suffix, value in zip(("model", "reasoning_effort"), pair, strict=True)
+        }
+    )
+    assert update.default_agent_routing_fast_model == _ROUTING_PAIRS["fast"][0]
+    assert update.default_agent_routing_powerful_reasoning_effort == _ROUTING_PAIRS["powerful"][1]
 
 
 def test_team_settings_update_accepts_grouping_pair() -> None:

--- a/tests/dashboard/test_team_settings_grouping.py
+++ b/tests/dashboard/test_team_settings_grouping.py
@@ -14,7 +14,7 @@ _GROUPING_PAIR = ("google_genai:gemini-3.8-flash", "low")
 _ROUTING_PAIRS = {
     "fast": ("google_genai:gemini-3.8-flash", "low"),
     "balanced": ("openai:gpt-5.6-sol", "medium"),
-    "powerful": ("anthropic:claude-opus-5", "high"),
+    "performance": ("anthropic:claude-opus-5", "high"),
 }
 
 
@@ -89,7 +89,10 @@ def test_team_settings_update_accepts_routing_pairs() -> None:
         }
     )
     assert update.default_agent_routing_fast_model == _ROUTING_PAIRS["fast"][0]
-    assert update.default_agent_routing_powerful_reasoning_effort == _ROUTING_PAIRS["powerful"][1]
+    assert (
+        update.default_agent_routing_performance_reasoning_effort
+        == _ROUTING_PAIRS["performance"][1]
+    )
 
 
 def test_team_settings_update_accepts_grouping_pair() -> None:

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -1,47 +1,93 @@
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
-from agent.middleware.model_selection import ModelSelectionMiddleware, task_complexity
+from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDecision
 
 
-def _request(prompt: str, *, plan_mode: bool = False) -> ModelRequest[None]:
+def _request(prompt: str, *messages: Any) -> ModelRequest[None]:
     return ModelRequest(
         model=MagicMock(),
-        messages=[HumanMessage(content=prompt)],
-        state=cast(Any, {"plan_mode": plan_mode}),
+        messages=[HumanMessage(content=prompt), *messages],
+        state=cast(Any, {}),
     )
 
 
-@pytest.mark.parametrize(
-    ("prompt", "expected"),
-    [
-        ("Fix this typo in the README", "small"),
-        ("Add an endpoint that returns the current version", "medium"),
-        ("Plan a database migration across multiple services", "complex"),
-    ],
-)
-def test_task_complexity(prompt: str, expected: str) -> None:
-    assert task_complexity(_request(prompt)) == expected
+def _middleware(
+    complexity: str = "small", *, initial_plan_mode: bool = False
+) -> tuple[ModelSelectionMiddleware, dict[str, MagicMock], AsyncMock]:
+    models = {tier: MagicMock(name=tier) for tier in ("small", "medium", "complex")}
+    structured = AsyncMock(return_value=RouteDecision(complexity=complexity))
+    classifier = MagicMock()
+    classifier.with_structured_output.return_value.ainvoke = structured
+    return (
+        ModelSelectionMiddleware(
+            models,
+            classifier,
+            initial_plan_mode=initial_plan_mode,
+        ),
+        models,
+        structured,
+    )
 
 
-def test_plan_mode_uses_complex_tier() -> None:
-    assert task_complexity(_request("Update the docs", plan_mode=True)) == "complex"
+async def _invoke(middleware: ModelSelectionMiddleware, request: ModelRequest) -> ModelRequest:
+    seen: list[ModelRequest] = []
+
+    async def handler(routed: ModelRequest) -> ModelResponse:
+        seen.append(routed)
+        return MagicMock()
+
+    await middleware.awrap_model_call(request, handler)
+    return seen[0]
 
 
 @pytest.mark.asyncio
-async def test_middleware_overrides_model_for_selected_tier() -> None:
-    models = {tier: MagicMock(name=tier) for tier in ("small", "medium", "complex")}
-    middleware = ModelSelectionMiddleware(models)
-    seen: list[ModelRequest] = []
+async def test_middleware_uses_classifier_route_for_entire_turn() -> None:
+    middleware, models, classifier = _middleware("small")
+    first = _request("Update the README")
+    followup = _request("Update the README", AIMessage(content="Working"))
 
-    async def handler(request: ModelRequest) -> ModelResponse:
-        seen.append(request)
-        return MagicMock()
+    assert (await _invoke(middleware, first)).model is models["small"]
+    assert (await _invoke(middleware, followup)).model is models["small"]
+    classifier.assert_awaited_once()
 
-    await middleware.awrap_model_call(_request("Fix this typo"), handler)
 
-    assert seen[0].model is models["small"]
+@pytest.mark.asyncio
+async def test_new_human_turn_is_reclassified() -> None:
+    middleware, _, classifier = _middleware("medium")
+
+    await _invoke(middleware, _request("Add an endpoint"))
+    await _invoke(
+        middleware,
+        _request(
+            "Add an endpoint",
+            AIMessage(content="Done"),
+            HumanMessage(content="Now redesign the database schema"),
+        ),
+    )
+
+    assert classifier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_plan_mode_uses_complex_route_without_classifier() -> None:
+    middleware, models, classifier = _middleware(initial_plan_mode=True)
+
+    routed = await _invoke(middleware, _request("Update the docs"))
+
+    assert routed.model is models["complex"]
+    classifier.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_classifier_failure_falls_back_to_medium() -> None:
+    middleware, models, classifier = _middleware()
+    classifier.side_effect = RuntimeError("unavailable")
+
+    routed = await _invoke(middleware, _request("Do the task"))
+
+    assert routed.model is models["medium"]

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -1,0 +1,47 @@
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import HumanMessage
+
+from agent.middleware.model_selection import ModelSelectionMiddleware, task_complexity
+
+
+def _request(prompt: str, *, plan_mode: bool = False) -> ModelRequest[None]:
+    return ModelRequest(
+        model=MagicMock(),
+        messages=[HumanMessage(content=prompt)],
+        state=cast(Any, {"plan_mode": plan_mode}),
+    )
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        ("Fix this typo in the README", "small"),
+        ("Add an endpoint that returns the current version", "medium"),
+        ("Plan a database migration across multiple services", "complex"),
+    ],
+)
+def test_task_complexity(prompt: str, expected: str) -> None:
+    assert task_complexity(_request(prompt)) == expected
+
+
+def test_plan_mode_uses_complex_tier() -> None:
+    assert task_complexity(_request("Update the docs", plan_mode=True)) == "complex"
+
+
+@pytest.mark.asyncio
+async def test_middleware_overrides_model_for_selected_tier() -> None:
+    models = {tier: MagicMock(name=tier) for tier in ("small", "medium", "complex")}
+    middleware = ModelSelectionMiddleware(models)
+    seen: list[ModelRequest] = []
+
+    async def handler(request: ModelRequest) -> ModelResponse:
+        seen.append(request)
+        return MagicMock()
+
+    await middleware.awrap_model_call(_request("Fix this typo"), handler)
+
+    assert seen[0].model is models["small"]

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -8,14 +8,6 @@ from langchain_core.messages import AIMessage, HumanMessage
 from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDecision
 
 
-def _request(prompt: str, *messages: Any) -> ModelRequest[None]:
-    return ModelRequest(
-        model=MagicMock(),
-        messages=[HumanMessage(content=prompt), *messages],
-        state=cast(Any, {}),
-    )
-
-
 def _middleware(
     complexity: str = "small", *, initial_plan_mode: bool = False
 ) -> tuple[ModelSelectionMiddleware, dict[str, MagicMock], AsyncMock]:
@@ -34,7 +26,19 @@ def _middleware(
     )
 
 
-async def _invoke(middleware: ModelSelectionMiddleware, request: ModelRequest) -> ModelRequest:
+async def _route(middleware: ModelSelectionMiddleware, state: dict[str, Any]) -> dict[str, Any]:
+    update = await middleware.abefore_agent(cast(Any, state), MagicMock())
+    if update:
+        state.update(update)
+    return state
+
+
+async def _invoke(middleware: ModelSelectionMiddleware, state: dict[str, Any]) -> ModelRequest:
+    request = ModelRequest(
+        model=MagicMock(),
+        messages=state["messages"],
+        state=cast(Any, state),
+    )
     seen: list[ModelRequest] = []
 
     async def handler(routed: ModelRequest) -> ModelResponse:
@@ -46,29 +50,44 @@ async def _invoke(middleware: ModelSelectionMiddleware, request: ModelRequest) -
 
 
 @pytest.mark.asyncio
-async def test_middleware_uses_classifier_route_for_entire_turn() -> None:
+async def test_before_agent_stores_route_in_state() -> None:
     middleware, models, classifier = _middleware("small")
-    first = _request("Update the README")
-    followup = _request("Update the README", AIMessage(content="Working"))
+    state = {"messages": [HumanMessage(content="Update the README", id="human-1")]}
 
-    assert (await _invoke(middleware, first)).model is models["small"]
-    assert (await _invoke(middleware, followup)).model is models["small"]
+    await _route(middleware, state)
+
+    assert state["model_route"] == "small"
+    assert state["model_route_for"]
+    assert (await _invoke(middleware, state)).model is models["small"]
+    classifier.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_same_human_turn_reuses_state_route() -> None:
+    middleware, _, classifier = _middleware("small")
+    state = {"messages": [HumanMessage(content="Update the README", id="human-1")]}
+    await _route(middleware, state)
+    state["messages"].append(AIMessage(content="Working"))
+
+    update = await middleware.abefore_agent(cast(Any, state), MagicMock())
+
+    assert update is None
     classifier.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_new_human_turn_is_reclassified() -> None:
     middleware, _, classifier = _middleware("medium")
-
-    await _invoke(middleware, _request("Add an endpoint"))
-    await _invoke(
-        middleware,
-        _request(
-            "Add an endpoint",
+    state = {"messages": [HumanMessage(content="Add an endpoint", id="human-1")]}
+    await _route(middleware, state)
+    state["messages"].extend(
+        [
             AIMessage(content="Done"),
-            HumanMessage(content="Now redesign the database schema"),
-        ),
+            HumanMessage(content="Now redesign the database schema", id="human-2"),
+        ]
     )
+
+    await _route(middleware, state)
 
     assert classifier.await_count == 2
 
@@ -76,10 +95,12 @@ async def test_new_human_turn_is_reclassified() -> None:
 @pytest.mark.asyncio
 async def test_plan_mode_uses_complex_route_without_classifier() -> None:
     middleware, models, classifier = _middleware(initial_plan_mode=True)
+    state = {"messages": [HumanMessage(content="Update the docs")]}
 
-    routed = await _invoke(middleware, _request("Update the docs"))
+    await _route(middleware, state)
 
-    assert routed.model is models["complex"]
+    assert state["model_route"] == "complex"
+    assert (await _invoke(middleware, state)).model is models["complex"]
     classifier.assert_not_awaited()
 
 
@@ -87,7 +108,9 @@ async def test_plan_mode_uses_complex_route_without_classifier() -> None:
 async def test_classifier_failure_falls_back_to_medium() -> None:
     middleware, models, classifier = _middleware()
     classifier.side_effect = RuntimeError("unavailable")
+    state = {"messages": [HumanMessage(content="Do the task")]}
 
-    routed = await _invoke(middleware, _request("Do the task"))
+    await _route(middleware, state)
 
-    assert routed.model is models["medium"]
+    assert state["model_route"] == "medium"
+    assert (await _invoke(middleware, state)).model is models["medium"]

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -3,32 +3,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import HumanMessage
 
-from agent.middleware.model_selection import (
-    ModelSelectionMiddleware,
-    RouteDecision,
-    RouteSignals,
-)
-
-
-def _decision(route: str = "luna_xhigh") -> RouteDecision:
-    return RouteDecision(
-        task_category="feature_change",
-        initial_route=route,
-        signals=RouteSignals(
-            scope="localized",
-            decomposition="none",
-            specification="clear",
-            verification="strong",
-            risks=[],
-            design_needed=False,
-            review_needed=False,
-        ),
-        escalation_conditions=["tests fail unexpectedly"],
-        reason="The task is explicit and bounded.",
-        confidence=0.9,
-    )
+from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDecision
 
 
 def _middleware(
@@ -37,25 +14,18 @@ def _middleware(
     models = {
         profile: MagicMock(name=profile) for profile in ("luna_xhigh", "terra_high", "sol_medium")
     }
-    structured = AsyncMock(return_value=_decision(route))
+    structured = AsyncMock(return_value=RouteDecision(model_route=route))
     classifier = MagicMock()
     classifier.with_structured_output.return_value.ainvoke = structured
     return (
         ModelSelectionMiddleware(
-            models,
+            cast(Any, models),
             classifier,
             initial_plan_mode=initial_plan_mode,
         ),
         models,
         structured,
     )
-
-
-async def _route(middleware: ModelSelectionMiddleware, state: dict[str, Any]) -> dict[str, Any]:
-    update = await middleware.abefore_agent(cast(Any, state), MagicMock())
-    if update:
-        state.update(update)
-    return state
 
 
 async def _invoke(middleware: ModelSelectionMiddleware, state: dict[str, Any]) -> ModelRequest:
@@ -75,47 +45,15 @@ async def _invoke(middleware: ModelSelectionMiddleware, state: dict[str, Any]) -
 
 
 @pytest.mark.asyncio
-async def test_before_agent_stores_structured_route_plan_in_state() -> None:
+async def test_route_is_stored_in_state_and_used_for_model_calls() -> None:
     middleware, models, classifier = _middleware()
-    state = {"messages": [HumanMessage(content="Update the README", id="human-1")]}
+    state = {"messages": [HumanMessage(content="Update the README")]}
 
-    await _route(middleware, state)
+    state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
     assert state["model_route"] == "luna_xhigh"
-    assert state["model_route_for"]
-    assert state["model_route_plan"]["signals"]["scope"] == "localized"
     assert (await _invoke(middleware, state)).model is models["luna_xhigh"]
     classifier.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_same_human_turn_reuses_state_route() -> None:
-    middleware, _, classifier = _middleware()
-    state = {"messages": [HumanMessage(content="Update the README", id="human-1")]}
-    await _route(middleware, state)
-    state["messages"].append(AIMessage(content="Working"))
-
-    update = await middleware.abefore_agent(cast(Any, state), MagicMock())
-
-    assert update is None
-    classifier.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_new_human_turn_is_reclassified() -> None:
-    middleware, _, classifier = _middleware("terra_high")
-    state = {"messages": [HumanMessage(content="Add an endpoint", id="human-1")]}
-    await _route(middleware, state)
-    state["messages"].extend(
-        [
-            AIMessage(content="Done"),
-            HumanMessage(content="Now redesign the database schema", id="human-2"),
-        ]
-    )
-
-    await _route(middleware, state)
-
-    assert classifier.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -123,10 +61,9 @@ async def test_plan_mode_uses_sol_without_classifier() -> None:
     middleware, models, classifier = _middleware(initial_plan_mode=True)
     state = {"messages": [HumanMessage(content="Update the docs")]}
 
-    await _route(middleware, state)
+    state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
     assert state["model_route"] == "sol_medium"
-    assert state["model_route_plan"] == {}
     assert (await _invoke(middleware, state)).model is models["sol_medium"]
     classifier.assert_not_awaited()
 
@@ -137,8 +74,7 @@ async def test_classifier_failure_falls_back_to_terra() -> None:
     classifier.side_effect = RuntimeError("unavailable")
     state = {"messages": [HumanMessage(content="Do the task")]}
 
-    await _route(middleware, state)
+    state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
     assert state["model_route"] == "terra_high"
-    assert state["model_route_plan"] == {}
     assert (await _invoke(middleware, state)).model is models["terra_high"]

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -5,14 +5,49 @@ import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage
 
-from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDecision
+from agent.middleware.model_selection import (
+    ModelSelectionMiddleware,
+    RouteDecision,
+    RoutePhase,
+    RouteSignals,
+)
+
+
+def _decision(route: str = "luna_xhigh") -> RouteDecision:
+    return RouteDecision(
+        task_category="implementation",
+        work_shape="single_phase",
+        initial_route=route,
+        phase_plan=[
+            RoutePhase(
+                phase="implementation",
+                route=route,
+                parallelism=1,
+                deliverable="implemented change",
+            )
+        ],
+        signals=RouteSignals(
+            design_needed=False,
+            plan_already_specified=True,
+            fanoutable=False,
+            mechanical=True,
+            novel_reasoning=False,
+            review_depth="none",
+            risk="low",
+        ),
+        escalation_conditions=["tests fail unexpectedly"],
+        reason="The task is explicit and bounded.",
+        confidence=0.9,
+    )
 
 
 def _middleware(
-    complexity: str = "small", *, initial_plan_mode: bool = False
+    route: str = "luna_xhigh", *, initial_plan_mode: bool = False
 ) -> tuple[ModelSelectionMiddleware, dict[str, MagicMock], AsyncMock]:
-    models = {tier: MagicMock(name=tier) for tier in ("small", "medium", "complex")}
-    structured = AsyncMock(return_value=RouteDecision(complexity=complexity))
+    models = {
+        profile: MagicMock(name=profile) for profile in ("luna_xhigh", "terra_high", "sol_medium")
+    }
+    structured = AsyncMock(return_value=_decision(route))
     classifier = MagicMock()
     classifier.with_structured_output.return_value.ainvoke = structured
     return (
@@ -50,21 +85,22 @@ async def _invoke(middleware: ModelSelectionMiddleware, state: dict[str, Any]) -
 
 
 @pytest.mark.asyncio
-async def test_before_agent_stores_route_in_state() -> None:
-    middleware, models, classifier = _middleware("small")
+async def test_before_agent_stores_structured_route_plan_in_state() -> None:
+    middleware, models, classifier = _middleware()
     state = {"messages": [HumanMessage(content="Update the README", id="human-1")]}
 
     await _route(middleware, state)
 
-    assert state["model_route"] == "small"
+    assert state["model_route"] == "luna_xhigh"
     assert state["model_route_for"]
-    assert (await _invoke(middleware, state)).model is models["small"]
+    assert state["model_route_plan"]["phase_plan"][0]["route"] == "luna_xhigh"
+    assert (await _invoke(middleware, state)).model is models["luna_xhigh"]
     classifier.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_same_human_turn_reuses_state_route() -> None:
-    middleware, _, classifier = _middleware("small")
+    middleware, _, classifier = _middleware()
     state = {"messages": [HumanMessage(content="Update the README", id="human-1")]}
     await _route(middleware, state)
     state["messages"].append(AIMessage(content="Working"))
@@ -77,7 +113,7 @@ async def test_same_human_turn_reuses_state_route() -> None:
 
 @pytest.mark.asyncio
 async def test_new_human_turn_is_reclassified() -> None:
-    middleware, _, classifier = _middleware("medium")
+    middleware, _, classifier = _middleware("terra_high")
     state = {"messages": [HumanMessage(content="Add an endpoint", id="human-1")]}
     await _route(middleware, state)
     state["messages"].extend(
@@ -93,24 +129,26 @@ async def test_new_human_turn_is_reclassified() -> None:
 
 
 @pytest.mark.asyncio
-async def test_plan_mode_uses_complex_route_without_classifier() -> None:
+async def test_plan_mode_uses_sol_without_classifier() -> None:
     middleware, models, classifier = _middleware(initial_plan_mode=True)
     state = {"messages": [HumanMessage(content="Update the docs")]}
 
     await _route(middleware, state)
 
-    assert state["model_route"] == "complex"
-    assert (await _invoke(middleware, state)).model is models["complex"]
+    assert state["model_route"] == "sol_medium"
+    assert state["model_route_plan"] == {}
+    assert (await _invoke(middleware, state)).model is models["sol_medium"]
     classifier.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_classifier_failure_falls_back_to_medium() -> None:
+async def test_classifier_failure_falls_back_to_terra() -> None:
     middleware, models, classifier = _middleware()
     classifier.side_effect = RuntimeError("unavailable")
     state = {"messages": [HumanMessage(content="Do the task")]}
 
     await _route(middleware, state)
 
-    assert state["model_route"] == "medium"
-    assert (await _invoke(middleware, state)).model is models["medium"]
+    assert state["model_route"] == "terra_high"
+    assert state["model_route_plan"] == {}
+    assert (await _invoke(middleware, state)).model is models["terra_high"]

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -8,32 +8,22 @@ from langchain_core.messages import AIMessage, HumanMessage
 from agent.middleware.model_selection import (
     ModelSelectionMiddleware,
     RouteDecision,
-    RoutePhase,
     RouteSignals,
 )
 
 
 def _decision(route: str = "luna_xhigh") -> RouteDecision:
     return RouteDecision(
-        task_category="implementation",
-        work_shape="single_phase",
+        task_category="feature_change",
         initial_route=route,
-        phase_plan=[
-            RoutePhase(
-                phase="implementation",
-                route=route,
-                parallelism=1,
-                deliverable="implemented change",
-            )
-        ],
         signals=RouteSignals(
+            scope="localized",
+            decomposition="none",
+            specification="clear",
+            verification="strong",
+            risks=[],
             design_needed=False,
-            plan_already_specified=True,
-            fanoutable=False,
-            mechanical=True,
-            novel_reasoning=False,
-            review_depth="none",
-            risk="low",
+            review_needed=False,
         ),
         escalation_conditions=["tests fail unexpectedly"],
         reason="The task is explicit and bounded.",
@@ -93,7 +83,7 @@ async def test_before_agent_stores_structured_route_plan_in_state() -> None:
 
     assert state["model_route"] == "luna_xhigh"
     assert state["model_route_for"]
-    assert state["model_route_plan"]["phase_plan"][0]["route"] == "luna_xhigh"
+    assert state["model_route_plan"]["signals"]["scope"] == "localized"
     assert (await _invoke(middleware, state)).model is models["luna_xhigh"]
     classifier.assert_awaited_once()
 

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,11 +9,9 @@ from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDeci
 
 
 def _middleware(
-    route: str = "glm_flash", *, initial_plan_mode: bool = False
+    route: Literal["fast", "balanced", "powerful"] = "fast", *, initial_plan_mode: bool = False
 ) -> tuple[ModelSelectionMiddleware, dict[str, MagicMock], AsyncMock]:
-    models = {
-        profile: MagicMock(name=profile) for profile in ("glm_flash", "sol_medium", "astra_low")
-    }
+    models = {profile: MagicMock(name=profile) for profile in ("fast", "balanced", "powerful")}
     structured = AsyncMock(return_value=RouteDecision(model_route=route))
     classifier = MagicMock()
     classifier.with_structured_output.return_value.ainvoke = structured
@@ -51,30 +49,30 @@ async def test_route_is_stored_in_state_and_used_for_model_calls() -> None:
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "glm_flash"
-    assert (await _invoke(middleware, state)).model is models["glm_flash"]
+    assert state["model_route"] == "fast"
+    assert (await _invoke(middleware, state)).model is models["fast"]
     classifier.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_plan_mode_uses_astra_without_classifier() -> None:
+async def test_plan_mode_uses_powerful_route_without_classifier() -> None:
     middleware, models, classifier = _middleware(initial_plan_mode=True)
     state = {"messages": [HumanMessage(content="Update the docs")]}
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "astra_low"
-    assert (await _invoke(middleware, state)).model is models["astra_low"]
+    assert state["model_route"] == "powerful"
+    assert (await _invoke(middleware, state)).model is models["powerful"]
     classifier.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_classifier_failure_falls_back_to_sol() -> None:
+async def test_classifier_failure_falls_back_to_balanced_route() -> None:
     middleware, models, classifier = _middleware()
     classifier.side_effect = RuntimeError("unavailable")
     state = {"messages": [HumanMessage(content="Do the task")]}
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "sol_medium"
-    assert (await _invoke(middleware, state)).model is models["sol_medium"]
+    assert state["model_route"] == "balanced"
+    assert (await _invoke(middleware, state)).model is models["balanced"]

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -9,9 +9,9 @@ from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDeci
 
 
 def _middleware(
-    route: Literal["fast", "balanced", "powerful"] = "fast", *, initial_plan_mode: bool = False
+    route: Literal["fast", "balanced", "performance"] = "fast", *, initial_plan_mode: bool = False
 ) -> tuple[ModelSelectionMiddleware, dict[str, MagicMock], AsyncMock]:
-    models = {profile: MagicMock(name=profile) for profile in ("fast", "balanced", "powerful")}
+    models = {profile: MagicMock(name=profile) for profile in ("fast", "balanced", "performance")}
     structured = AsyncMock(return_value=RouteDecision(model_route=route))
     classifier = MagicMock()
     classifier.with_structured_output.return_value.ainvoke = structured
@@ -55,14 +55,14 @@ async def test_route_is_stored_in_state_and_used_for_model_calls() -> None:
 
 
 @pytest.mark.asyncio
-async def test_plan_mode_uses_powerful_route_without_classifier() -> None:
+async def test_plan_mode_uses_performance_route_without_classifier() -> None:
     middleware, models, classifier = _middleware(initial_plan_mode=True)
     state = {"messages": [HumanMessage(content="Update the docs")]}
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "powerful"
-    assert (await _invoke(middleware, state)).model is models["powerful"]
+    assert state["model_route"] == "performance"
+    assert (await _invoke(middleware, state)).model is models["performance"]
     classifier.assert_not_awaited()
 
 

--- a/tests/middleware/test_model_selection.py
+++ b/tests/middleware/test_model_selection.py
@@ -9,10 +9,10 @@ from agent.middleware.model_selection import ModelSelectionMiddleware, RouteDeci
 
 
 def _middleware(
-    route: str = "luna_xhigh", *, initial_plan_mode: bool = False
+    route: str = "glm_flash", *, initial_plan_mode: bool = False
 ) -> tuple[ModelSelectionMiddleware, dict[str, MagicMock], AsyncMock]:
     models = {
-        profile: MagicMock(name=profile) for profile in ("luna_xhigh", "terra_high", "sol_medium")
+        profile: MagicMock(name=profile) for profile in ("glm_flash", "sol_medium", "astra_low")
     }
     structured = AsyncMock(return_value=RouteDecision(model_route=route))
     classifier = MagicMock()
@@ -51,30 +51,30 @@ async def test_route_is_stored_in_state_and_used_for_model_calls() -> None:
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "luna_xhigh"
-    assert (await _invoke(middleware, state)).model is models["luna_xhigh"]
+    assert state["model_route"] == "glm_flash"
+    assert (await _invoke(middleware, state)).model is models["glm_flash"]
     classifier.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_plan_mode_uses_sol_without_classifier() -> None:
+async def test_plan_mode_uses_astra_without_classifier() -> None:
     middleware, models, classifier = _middleware(initial_plan_mode=True)
     state = {"messages": [HumanMessage(content="Update the docs")]}
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "sol_medium"
-    assert (await _invoke(middleware, state)).model is models["sol_medium"]
+    assert state["model_route"] == "astra_low"
+    assert (await _invoke(middleware, state)).model is models["astra_low"]
     classifier.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_classifier_failure_falls_back_to_terra() -> None:
+async def test_classifier_failure_falls_back_to_sol() -> None:
     middleware, models, classifier = _middleware()
     classifier.side_effect = RuntimeError("unavailable")
     state = {"messages": [HumanMessage(content="Do the task")]}
 
     state.update(await middleware.abefore_agent(cast(Any, state), MagicMock()))
 
-    assert state["model_route"] == "terra_high"
-    assert (await _invoke(middleware, state)).model is models["terra_high"]
+    assert state["model_route"] == "sol_medium"
+    assert (await _invoke(middleware, state)).model is models["sol_medium"]

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -150,6 +150,7 @@ export interface Profile {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
+  adaptive_model_routing?: boolean
   draft_prs?: boolean
   review_draft_prs?: boolean | null
   updated_at?: string
@@ -164,6 +165,7 @@ export interface ProfileUpdate {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
+  adaptive_model_routing?: boolean
   draft_prs?: boolean
   review_draft_prs?: boolean | null
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -186,8 +186,8 @@ export interface TeamSettings {
   default_agent_routing_fast_reasoning_effort?: string | null
   default_agent_routing_balanced_model?: string | null
   default_agent_routing_balanced_reasoning_effort?: string | null
-  default_agent_routing_powerful_model?: string | null
-  default_agent_routing_powerful_reasoning_effort?: string | null
+  default_agent_routing_performance_model?: string | null
+  default_agent_routing_performance_reasoning_effort?: string | null
   default_repo?: string | null
   default_reviewer_model?: string | null
   default_reviewer_reasoning_effort?: string | null

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -182,6 +182,12 @@ export interface TeamSettings {
   default_agent_reasoning_effort?: string | null
   default_agent_subagent_model?: string | null
   default_agent_subagent_reasoning_effort?: string | null
+  default_agent_routing_fast_model?: string | null
+  default_agent_routing_fast_reasoning_effort?: string | null
+  default_agent_routing_balanced_model?: string | null
+  default_agent_routing_balanced_reasoning_effort?: string | null
+  default_agent_routing_powerful_model?: string | null
+  default_agent_routing_powerful_reasoning_effort?: string | null
   default_repo?: string | null
   default_reviewer_model?: string | null
   default_reviewer_reasoning_effort?: string | null

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -150,7 +150,6 @@ export interface Profile {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
-  adaptive_model_routing?: boolean
   draft_prs?: boolean
   review_draft_prs?: boolean | null
   updated_at?: string
@@ -165,7 +164,6 @@ export interface ProfileUpdate {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
-  adaptive_model_routing?: boolean
   draft_prs?: boolean
   review_draft_prs?: boolean | null
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -150,6 +150,7 @@ export interface Profile {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
+  model_routing_enabled?: boolean
   draft_prs?: boolean
   review_draft_prs?: boolean | null
   updated_at?: string
@@ -164,6 +165,7 @@ export interface ProfileUpdate {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
+  model_routing_enabled?: boolean
   draft_prs?: boolean
   review_draft_prs?: boolean | null
 }

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -121,6 +121,7 @@ export function buildProfileUpdate(
     base_branch: current?.base_branch ?? null,
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
+    adaptive_model_routing: current?.adaptive_model_routing ?? false,
     draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -121,6 +121,7 @@ export function buildProfileUpdate(
     base_branch: current?.base_branch ?? null,
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
+    model_routing_enabled: current?.model_routing_enabled ?? true,
     draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -121,7 +121,6 @@ export function buildProfileUpdate(
     base_branch: current?.base_branch ?? null,
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
-    adaptive_model_routing: current?.adaptive_model_routing ?? false,
     draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -121,7 +121,7 @@ export function buildProfileUpdate(
     base_branch: current?.base_branch ?? null,
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
-    model_routing_enabled: current?.model_routing_enabled ?? true,
+    model_routing_enabled: current?.model_routing_enabled ?? false,
     draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -1067,20 +1067,20 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
           disabled={!settings.data || save.isPending}
         />
         <RolePicker
-          label="Agent routing: powerful"
+          label="Agent routing: performance"
           description="Model used for complex reasoning and plan-mode turns."
           models={models}
-          model={settings.data?.default_agent_routing_powerful_model ?? null}
+          model={settings.data?.default_agent_routing_performance_model ?? null}
           effort={
-            settings.data?.default_agent_routing_powerful_reasoning_effort ??
+            settings.data?.default_agent_routing_performance_reasoning_effort ??
             null
           }
           onChange={(model, effort) =>
             settings.data &&
             save.mutate({
               ...settings.data,
-              default_agent_routing_powerful_model: model,
-              default_agent_routing_powerful_reasoning_effort: effort,
+              default_agent_routing_performance_model: model,
+              default_agent_routing_performance_reasoning_effort: effort,
             })
           }
           disabled={!settings.data || save.isPending}

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -1030,6 +1030,62 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
           disabled={!settings.data || save.isPending}
         />
         <RolePicker
+          label="Agent routing: fast"
+          description="Model used for straightforward agent turns."
+          models={models}
+          model={settings.data?.default_agent_routing_fast_model ?? null}
+          effort={
+            settings.data?.default_agent_routing_fast_reasoning_effort ?? null
+          }
+          onChange={(model, effort) =>
+            settings.data &&
+            save.mutate({
+              ...settings.data,
+              default_agent_routing_fast_model: model,
+              default_agent_routing_fast_reasoning_effort: effort,
+            })
+          }
+          disabled={!settings.data || save.isPending}
+        />
+        <RolePicker
+          label="Agent routing: balanced"
+          description="Model used for ordinary implementation and investigation turns."
+          models={models}
+          model={settings.data?.default_agent_routing_balanced_model ?? null}
+          effort={
+            settings.data?.default_agent_routing_balanced_reasoning_effort ??
+            null
+          }
+          onChange={(model, effort) =>
+            settings.data &&
+            save.mutate({
+              ...settings.data,
+              default_agent_routing_balanced_model: model,
+              default_agent_routing_balanced_reasoning_effort: effort,
+            })
+          }
+          disabled={!settings.data || save.isPending}
+        />
+        <RolePicker
+          label="Agent routing: powerful"
+          description="Model used for complex reasoning and plan-mode turns."
+          models={models}
+          model={settings.data?.default_agent_routing_powerful_model ?? null}
+          effort={
+            settings.data?.default_agent_routing_powerful_reasoning_effort ??
+            null
+          }
+          onChange={(model, effort) =>
+            settings.data &&
+            save.mutate({
+              ...settings.data,
+              default_agent_routing_powerful_model: model,
+              default_agent_routing_powerful_reasoning_effort: effort,
+            })
+          }
+          disabled={!settings.data || save.isPending}
+        />
+        <RolePicker
           label="Thread title generation"
           description="Model used to name new agent threads in the background."
           models={models}

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -150,8 +150,18 @@ function CloudAgentsPage() {
       <SettingsSection title="Defaults">
         <div className="divide-y divide-border">
           <SettingsRow
+            label="Adaptive model routing"
+            description="Route routine work to Luna, standard implementation to Terra, and complex planning or large-scale work to Sol."
+            control={
+              <Switch
+                checked={profile.data?.adaptive_model_routing ?? false}
+                onCheckedChange={(v) => persist({ adaptive_model_routing: v })}
+              />
+            }
+          />
+          <SettingsRow
             label="Default Model"
-            description="Used when no model is specified"
+            description="Used when adaptive model routing is off"
             control={
               <Select value={modelId} onValueChange={(v) => v && setModelId(v)}>
                 <SelectTrigger className="w-40">

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -150,18 +150,8 @@ function CloudAgentsPage() {
       <SettingsSection title="Defaults">
         <div className="divide-y divide-border">
           <SettingsRow
-            label="Adaptive model routing"
-            description="Route routine work to Luna, standard implementation to Terra, and complex planning or large-scale work to Sol."
-            control={
-              <Switch
-                checked={profile.data?.adaptive_model_routing ?? false}
-                onCheckedChange={(v) => persist({ adaptive_model_routing: v })}
-              />
-            }
-          />
-          <SettingsRow
             label="Default Model"
-            description="Used when adaptive model routing is off"
+            description="Used when no model is specified"
             control={
               <Select value={modelId} onValueChange={(v) => v && setModelId(v)}>
                 <SelectTrigger className="w-40">

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -150,8 +150,18 @@ function CloudAgentsPage() {
       <SettingsSection title="Defaults">
         <div className="divide-y divide-border">
           <SettingsRow
+            label="Adaptive model routing"
+            description="Automatically choose a model for each turn; turn this off to always use your default model"
+            control={
+              <Switch
+                checked={profile.data?.model_routing_enabled ?? true}
+                onCheckedChange={(v) => persist({ model_routing_enabled: v })}
+              />
+            }
+          />
+          <SettingsRow
             label="Default Model"
-            description="Used when no model is specified"
+            description="Used when adaptive routing is off or no model is specified"
             control={
               <Select value={modelId} onValueChange={(v) => v && setModelId(v)}>
                 <SelectTrigger className="w-40">

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -154,7 +154,7 @@ function CloudAgentsPage() {
             description="Automatically choose a model for each turn; turn this off to always use your default model"
             control={
               <Switch
-                checked={profile.data?.model_routing_enabled ?? true}
+                checked={profile.data?.model_routing_enabled ?? false}
                 onCheckedChange={(v) => persist({ model_routing_enabled: v })}
                 disabled={profile.isLoading || save.isPending}
               />

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -156,6 +156,7 @@ function CloudAgentsPage() {
               <Switch
                 checked={profile.data?.model_routing_enabled ?? true}
                 onCheckedChange={(v) => persist({ model_routing_enabled: v })}
+                disabled={profile.isLoading || save.isPending}
               />
             }
           />


### PR DESCRIPTION
Adds adaptive model routing for all threads. A small classifier chooses a fast, balanced, or performance tier once per turn and stores that choice in agent state; routed traces are marked with `model_routing_applied` metadata for easy filtering.

Users can disable adaptive routing from Open SWE Agent settings. The preference defaults on, is snapshotted for new threads, and uses the selected default model directly when off.

Defaults:
- Fast: GLM 5.3 Flash through Fireworks
- Balanced: Sol Medium
- Performance: Astra Low

Admins can change each tier’s model and effort in workspace settings. Adaptive routing is off by default until users opt in; the router uses Performance in plan mode and falls back to Balanced if classification fails.

![Admin routing tier settings](https://01a08728-2024-7f32-b9e7-d47572b4fe66--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0psZUhBaU9qRTNPRGsxT0RNME9UQXNJbWxoZENJNk1UYzRPRGszT0RZNU1Dd2lhblJwSWpvaU1ERmhNRGczTnpBdE56aGhZeTAzTlRKbUxXRmpaRFV0TXpGa05EY3laalZqTURBNUlpd2ljMmxrSWpvaU1ERmhNRGczTWpndE1qQXlOQzAzWmpNeUxXSTVaVGN0WkRRM05UY3lZalJtWlRZMklpd2lkR2xrSWpvaVpXSmlZV1l5WldJdE56WTVZaTAwTlRBMUxXRmpZVEl0WkRFeFpHVXhNRE0zTW1FMElpd2ljR0YwYUNJNklpOTNiM0pyYzNCaFkyVXZibkJsYmkxemQyVXZMbTl3Wlc0dGMzZGxMMkZ5ZEdsbVlXTjBjeTl5YjNWMGFXNW5MWEJsY21admNtMWhibU5sTFhScFpYSXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkubDAxSFNsXzFZRlpRZUFXeklpc1NiVnlUTzZNSVIyS3FveGMweE80U1BJSWdjRlIwZDcyVHM0bjBVZ3pGYW5LWTZ0c3NWbndtTzlMejdpb2xhWjZoQ0E)

![Adaptive routing off by default](https://01a08728-2024-7f32-b9e7-d47572b4fe66--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0psZUhBaU9qRTNPRGsxT0RneE9Ua3NJbWxoZENJNk1UYzRPRGs0TXpNNU9Td2lhblJwSWpvaU1ERmhNRGczWWpndE5USmhaUzAzT0RNMExUZzBaRGd0TkRaaFlXWXpNelpqWkdFMklpd2ljMmxrSWpvaU1ERmhNRGczTWpndE1qQXlOQzAzWmpNeUxXSTVaVGN0WkRRM05UY3lZalJtWlRZMklpd2lkR2xrSWpvaVpXSmlZV1l5WldJdE56WTVZaTAwTlRBMUxXRmpZVEl0WkRFeFpHVXhNRE0zTW1FMElpd2ljR0YwYUNJNklpOTNiM0pyYzNCaFkyVXZiM0JsYmkxemQyVXZMbTl3Wlc0dGMzZGxMMkZ5ZEdsbVlXTjBjeTl5YjNWMGFXNW5MV1JsWm1GMWJIUXRiMlptTG5CdVp5SXNJbU4wSWpvaWFXMWhaMlV2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEuckZGSWlDMDlKNDNPT01Kd2stVTYzUE9iRmlqbGw5Nm1wUUFNRjJET2VKWkxRc1p0QkRqTTB0NXpCWHVNM3dlQWNLMEJ1azRWbXhBMndTLTBLeUNLQnc)

Made by [Open SWE](https://openswe.vercel.app/agents/8a99ef96-1e9a-5fe9-85b0-e790bb05fd43) · openai:gpt-5.6-sol (high)
