### PR TITLE
chore(desktop): bump version to 0.2.7

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",


### PR DESCRIPTION
Bumps the desktop app version from `0.2.6` to `0.2.7`.

Validation: parsed `desktop/package.json`, verified `0.2.7`, and ran `git diff --check`.

Made by [Open SWE](https://openswe.vercel.app/agents/a5e6c1c4-04f6-5b4e-8dde-0bded45768cb)