### PR TITLE
fix: default to Opus for Anthropic-only deployments

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -1,5 +1,6 @@
 """Supported models and reasoning efforts surfaced in the profile editor."""
 
+import os
 from collections.abc import Callable, Mapping, Sequence
 from functools import cache, lru_cache
 from importlib import import_module
@@ -246,7 +247,11 @@ def gate_fable_model(
     return model_id, effort
 
 
-DEFAULT_MODEL_ID: str = "openai:gpt-5.6-sol"
+DEFAULT_MODEL_ID: str = (
+    "anthropic:claude-opus-5"
+    if os.environ.get("ANTHROPIC_API_KEY") and not os.environ.get("OPENAI_API_KEY")
+    else "openai:gpt-5.6-sol"
+)
 DEFAULT_MODEL_EFFORT: str = "medium"
 
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -136,14 +136,14 @@ See `deepagents.backends.LangSmithSandbox` and `agent/sandboxes/providers/langsm
 
 ## 2. Model
 
-The model is configured in the `get_agent()` function in `agent/server.py`. By default it uses `openai:gpt-5.6-sol` with medium reasoning effort, but you can override the model with the `LLM_MODEL_ID` environment variable:
+The model is configured in the `get_agent()` function in `agent/server.py`. By default it uses `openai:gpt-5.6-sol` with medium reasoning effort. An Anthropic-only deployment—`ANTHROPIC_API_KEY` is set while `OPENAI_API_KEY` is unset or empty—uses `anthropic:claude-opus-5` instead. When both keys are set, OpenAI takes precedence. You can override the model with the `LLM_MODEL_ID` environment variable:
 
 ```bash
 # Set the model via environment variable (uses provider:model format)
 LLM_MODEL_ID="anthropic:claude-sonnet-5"
 ```
 
-If `LLM_MODEL_ID` is not set, the default model (`openai:gpt-5.6-sol`) is used.
+If `LLM_MODEL_ID` is not set, the credential-based default described above is used.
 
 `max_tokens` is a maximum completion/output token budget, not the model's total context window. For OpenAI reasoning models, this budget can include both internal reasoning tokens and final response tokens.
 

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -1,10 +1,11 @@
+import runpy
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from agent.dashboard import options
 from agent.dashboard.agent_overrides import normalize_profile_overrides
 from agent.dashboard.options import (
-    DEFAULT_MODEL_ID,
     FABLE_MODEL_IDS,
     SUPPORTED_MODEL_IDS,
     SUPPORTED_MODELS,
@@ -229,9 +230,22 @@ def test_profile_unknown_provider_defers_to_team_default() -> None:
     assert normalize_profile_overrides(profile) == (None, None)
 
 
-def test_global_default_is_gpt_5_6_sol() -> None:
-    model, _ = default_model_pair()
-    assert model == DEFAULT_MODEL_ID == SUPPORTED_OPENAI
+@pytest.mark.parametrize(
+    ("anthropic_key", "openai_key", "expected"),
+    [
+        ("key", "", SUPPORTED_ANTHROPIC),
+        ("key", "key", SUPPORTED_OPENAI),
+        ("", "", SUPPORTED_OPENAI),
+    ],
+)
+def test_global_default_matches_available_credentials(
+    monkeypatch: pytest.MonkeyPatch, anthropic_key: str, openai_key: str, expected: str
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", anthropic_key)
+    monkeypatch.setenv("OPENAI_API_KEY", openai_key)
+    defaults = runpy.run_path(options.__file__)
+    assert defaults["default_model_pair"]() == (expected, "medium")
+    assert defaults["default_vision_model_pair"]() == (expected, "medium")
 
 
 def test_gate_fable_passthrough_when_enabled() -> None:


### PR DESCRIPTION
Default to Opus 5 / medium at startup when `ANTHROPIC_API_KEY` is set and `OPENAI_API_KEY` is absent or empty. Otherwise retain Sol / medium. Explicit settings and saved thread choices remain unchanged.

Replaces the existing default assertion with a focused credential regression test, including vision defaults. Validation: Ruff format/lint and all 37 tests in `test_model_fallback_resolution.py` passed.

Made by [Open SWE](https://openswe.vercel.app/agents/01a06e76-cce5-7169-857f-9bb5187c742d)