### PR TITLE
fix: keep composer branch aligned with current checkout

### DIFF
--- a/desktop/src/git-diff.cts
+++ b/desktop/src/git-diff.cts
@@ -167,6 +167,24 @@ async function removeWorktree(repo, worktreePath) {
   await ok(git(repo, ["worktree", "prune"], null, 30_000));
 }
 
+async function watchProjectHead(cwd: string, onChange: () => void) {
+  const gitDir = text(
+    await git(cwd, ["rev-parse", "--absolute-git-dir"], null, 5_000),
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const watcher = fs.watch(gitDir, (_event, filename) => {
+    if (filename && filename.toString() !== "HEAD") return;
+    clearTimeout(timer);
+    timer = setTimeout(onChange, 100);
+  });
+  const close = () => {
+    clearTimeout(timer);
+    watcher.close();
+  };
+  watcher.on("error", close);
+  return close;
+}
+
 async function currentBranch(cwd) {
   try {
     return (
@@ -618,4 +636,5 @@ module.exports = {
   restoreWorktree,
   staleRefs,
   validBranchName,
+  watchProjectHead,
 };

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -34,6 +34,7 @@ const {
   repositoryMetadata,
   restoreWorktree,
   validBranchName,
+  watchProjectHead,
 } = require("./git-diff.cjs");
 const {
   closeAllTerminals,
@@ -415,6 +416,36 @@ function configureDesktopIpc() {
   ipcMain.handle("desktop:projects", (event) => {
     requireTrustedDesktopIpc(event);
     return listProjects();
+  });
+
+  const projectHeadWatches = new Map<number, () => void>();
+  ipcMain.handle("desktop:watch-project-head", async (event, cwd) => {
+    requireTrustedDesktopIpc(event);
+    const sender = event.sender;
+    projectHeadWatches.get(sender.id)?.();
+    const project = typeof cwd === "string" ? registeredProject(cwd) : null;
+    if (!project) return;
+    let disposed = false;
+    let stop: (() => void) | undefined;
+    const close = () => {
+      disposed = true;
+      stop?.();
+      projectHeadWatches.delete(sender.id);
+      sender.removeListener("destroyed", close);
+      sender.removeListener("did-start-navigation", close);
+    };
+    projectHeadWatches.set(sender.id, close);
+    sender.once("destroyed", close);
+    sender.once("did-start-navigation", close);
+    try {
+      stop = await watchProjectHead(project, () => {
+        if (!disposed && !sender.isDestroyed())
+          sender.send("desktop:project-head-changed", cwd);
+      });
+      if (disposed) stop();
+    } catch {
+      if (!disposed) close();
+    }
   });
 
   ipcMain.handle("desktop:project-branches", async (event, cwd) => {

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -23,6 +23,14 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   listProjects: () => ipcRenderer.invoke("desktop:projects"),
   getProjectBranches: (cwd) =>
     ipcRenderer.invoke("desktop:project-branches", cwd),
+  watchProjectHead: (cwd) =>
+    ipcRenderer.invoke("desktop:watch-project-head", cwd),
+  onProjectHeadChanged: (callback) => {
+    const listener = (_event, cwd) => callback(cwd);
+    ipcRenderer.on("desktop:project-head-changed", listener);
+    return () =>
+      ipcRenderer.removeListener("desktop:project-head-changed", listener);
+  },
   setLocalBranch: (input) =>
     ipcRenderer.invoke("desktop:set-local-branch", { ...input }),
   checkoutProjectBranch: (input) =>

--- a/desktop/test/git-diff.test.cjs
+++ b/desktop/test/git-diff.test.cjs
@@ -17,11 +17,51 @@ const {
   removeWorktree,
   repoRoot,
   restoreWorktree,
+  watchProjectHead,
 } = require("../build/git-diff.cjs");
 
 function git(cwd, args) {
   execFileSync("git", args, { cwd, stdio: "ignore" });
 }
+
+test("HEAD watcher follows atomic checkouts in repos and linked worktrees and cleans up", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "open-swe-head-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const repo = path.join(dir, "repo");
+  const worktree = path.join(dir, "worktree");
+  fs.mkdirSync(repo);
+  git(repo, ["init", "-q", "-b", "main"]);
+  git(repo, [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "commit",
+    "--allow-empty",
+    "-qm",
+    "init",
+  ]);
+  git(repo, ["worktree", "add", "-b", "worktree", worktree]);
+  for (const cwd of [repo, worktree]) {
+    let notifications = 0;
+    const close = await watchProjectHead(cwd, () => notifications++);
+    t.after(close);
+    for (const branch of ["alice", "bob"]) {
+      const expected = notifications + 1;
+      git(cwd, ["switch", "-c", `${branch}-${path.basename(cwd)}`]);
+      const deadline = Date.now() + 5_000;
+      while (notifications < expected && Date.now() < deadline)
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(notifications, expected);
+      assert.equal(await currentBranch(cwd), `${branch}-${path.basename(cwd)}`);
+    }
+    git(cwd, ["switch", "--detach"]);
+    close();
+    const count = notifications;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(notifications, count);
+  }
+});
 
 test("normalizes validated pull request metadata", () => {
   const pr = parsePullRequest(

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -163,6 +163,8 @@ declare global {
         current: string | null
         branches: Array<DesktopProjectRef>
       }>
+      watchProjectHead: (cwd: string | null) => Promise<void>
+      onProjectHeadChanged: (callback: (cwd: string) => void) => () => void
       checkoutProjectBranch: (input: {
         cwd: string
         branch: string

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -129,6 +129,11 @@ export function AgentsHome() {
   >([])
   const [localWorkspaceMode, setLocalWorkspaceMode] =
     useState<DesktopWorkspaceMode>("local")
+  const localWorkspaceModeRef = useRef(localWorkspaceMode)
+  useEffect(() => {
+    localWorkspaceModeRef.current = localWorkspaceMode
+  }, [localWorkspaceMode])
+  const branchRefreshId = useRef(0)
   const [localError, setLocalError] = useState<string | null>(null)
   const {
     projects: localProjects,
@@ -179,13 +184,19 @@ export function AgentsHome() {
 
   const refreshLocalProjectBranch = useCallback(async () => {
     const cwd = localProjectPathRef.current
+    const refreshId = ++branchRefreshId.current
     const result = cwd
       ? await window.openSweDesktop?.getProjectBranches(cwd)
       : undefined
-    if (localProjectPathRef.current === cwd) {
+    if (
+      localProjectPathRef.current === cwd &&
+      branchRefreshId.current === refreshId
+    ) {
       const branches = result?.branches ?? []
       setLocalProjectBranch((selected) =>
-        selected && branches.some((ref) => ref.name === selected)
+        localWorkspaceModeRef.current === "worktree" &&
+        selected &&
+        branches.some((ref) => ref.name === selected)
           ? selected
           : (result?.current ?? null)
       )
@@ -210,6 +221,7 @@ export function AgentsHome() {
         (candidate) => candidate.name === branch
       )
       if (ref?.worktreePath) {
+        localWorkspaceModeRef.current = "worktree"
         setLocalWorkspaceMode("worktree")
         setLocalProjectBranch(branch)
         return
@@ -237,6 +249,7 @@ export function AgentsHome() {
   // the project's own checkout has to fall back to whatever it is really on.
   const selectLocalWorkspaceMode = useCallback(
     (next: DesktopWorkspaceMode) => {
+      localWorkspaceModeRef.current = next
       setLocalWorkspaceMode(next)
       setLocalError(null)
       if (next === "local") setLocalProjectBranch(null)
@@ -246,7 +259,22 @@ export function AgentsHome() {
   )
 
   useEffect(() => {
+    const desktop = window.openSweDesktop
+    const refreshSequence = branchRefreshId
+    let disposed = false
+    const unsubscribe = desktop?.onProjectHeadChanged((cwd) => {
+      if (cwd === localProjectPath) void refreshLocalProjectBranch()
+    })
+    void desktop?.watchProjectHead(localProjectPath).then(() => {
+      if (!disposed) void refreshLocalProjectBranch()
+    })
     void refreshLocalProjectBranch()
+    return () => {
+      disposed = true
+      refreshSequence.current++
+      unsubscribe?.()
+      void desktop?.watchProjectHead(null)
+    }
   }, [localProjectPath, refreshLocalProjectBranch])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Follow actual HEAD in Current checkout mode; preserve selected worktree bases.
- Watch the resolved Git directory and refresh after terminal checkouts, with debounce and lifecycle cleanup.

## Verification
Desktop build, 5 focused Git tests, UI typecheck, focused lint, and formatting passed. One regression test covers HEAD watcher checkouts and cleanup. Verified in real Electron as Alice using the test backend: checkout to main updates the composer without reloading.

![Composer follows checkout to main](https://01a06ece-c819-71c1-ab01-22b98d10c952--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGcxTmpZeE9Ua3NJbXAwYVNJNklqQXhZVEEyWldSaExUVmtabUl0TjJOa1lTMDVOak16TFdZM1pqUmxOekZrT1dZek5TSXNJbk5wWkNJNklqQXhZVEEyWldObExXTTRNVGt0TnpGak1TMWhZakF4TFRJeVlqazRaREV3WXprMU1pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMk52YlhCdmMyVnlMV05oY0hSMWNtVXZZMjl0Y0c5elpYSXRZM1Z5Y21WdWRDMWphR1ZqYTI5MWRDMXRZV2x1TG5CdVp5SXNJbU4wSWpvaWFXMWhaMlV2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEud0IwcUVjTHhyeDZ6WjJXTzlOZG9DVmZZamttamdTVHZTaEtLdjNVal9KbVhVRlVnSGdIb2Q0MVlEcHNtbWZjZUVzRW1jNHVEb2V2c0tPSl9aeFFFQUE)

Made by [Open SWE](https://openswe.vercel.app/agents/01a06ece-c2a5-70a5-94ef-2deb5bd76c2a)