### PR TITLE
docs: state README quickstart prerequisites and dev ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Open SWE includes a LangGraph backend, a web dashboard, and an experimental desk
 - **[Customization Guide](docs/CUSTOMIZATION.md)** — Change models, sandboxes, tools, skills, prompts, triggers, and middleware
 - **[Open SWE Enhancement Proposals](oeps/README.md)** — Review consequential product, architecture, security, and process decisions
 
+Local development needs Python 3.14+, [uv](https://docs.astral.sh/uv/), and—only for the dashboard—Node 22.22.2+ with [pnpm](https://pnpm.io/).
+
 Complete the required `.env`, GitHub App, and sandbox setup in the [Installation Guide](docs/INSTALLATION.md), then install the backend and dashboard dependencies:
 
 ```bash
@@ -149,8 +151,8 @@ pnpm install
 Run the services in separate terminals:
 
 ```bash
-make dev  # terminal 1: backend
-make web  # terminal 2: dashboard
+make dev  # terminal 1: backend on http://localhost:2024
+make web  # terminal 2: dashboard on http://localhost:3000
 ```
 
 Production self-hosting uses the standalone LangGraph Agent Server and requires its license key.


### PR DESCRIPTION
## Why

The README's Getting started section jumps straight into `uv venv` / `uv sync` / `pnpm install` without saying which toolchain versions are required, and the `make dev` / `make web` comments don't say where each service listens. Both facts are documented in `docs/INSTALLATION.md`, but a reader following the README quickstart hits them the hard way.

## What

- Add one line naming the local development prerequisites (Python 3.14+, `uv`, and Node 22.22.2+ / pnpm for the dashboard), matching `pyproject.toml`'s `requires-python` and the installation guide's prerequisites.
- Annotate the `make dev` / `make web` comments with the backend (`:2024`) and dashboard (`:3000`) URLs.

Docs-only change; no code or behavior affected.

Made by [Open SWE](https://open-swe-staging-ff145e5fff2951c49ece1111c2175d16.us.langgraph.app/agents/ef997e10-d91a-5555-9b76-f5d8deb475a5)
