### PR TITLE
feat(dashboard): serve the bundled dashboard from the backend origin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ web:
 	pnpm run dev
 
 # Build the dashboard into ui/.output/public; `make dev` then serves it at /.
+# With a LangGraph http.mount_prefix, pass DASHBOARD_BASE_PATH=<prefix>/ so the
+# build's asset URLs and router match where the server mounts it.
 build-dashboard:
 	pnpm install --frozen-lockfile --filter open-swe-dashboard...
 	pnpm --filter open-swe-dashboard run build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web desktop install-desktop install-checkout
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web build-dashboard desktop install-desktop install-checkout
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -12,6 +12,11 @@ dev:
 
 web:
 	pnpm run dev
+
+# Build the dashboard into ui/.output/public; `make dev` then serves it at /.
+build-dashboard:
+	pnpm install --frozen-lockfile --filter open-swe-dashboard...
+	pnpm --filter open-swe-dashboard run build
 
 run:
 	uv run uvicorn agent.webapp:app --reload --port 8000

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -14,6 +14,7 @@ from agent.dashboard.workflow_approval_api import workflow_approval_router
 from agent.github.routes import router as github_webhook_router
 from agent.linear.routes import router as linear_webhook_router
 from agent.slack.routes import router as slack_webhook_router
+from agent.utils.dashboard_ui import mount_dashboard_ui
 from agent.utils.event_loop import pin_single_event_loop
 
 # Before the queue starts: it reads this when it builds its workers, and Open SWE
@@ -61,6 +62,7 @@ def create_app() -> FastAPI:
     app.include_router(slack_webhook_router)
     app.include_router(health_router)
     app.include_router(github_webhook_router)
+    mount_dashboard_ui(app)
     return app
 
 

--- a/agent/config.py
+++ b/agent/config.py
@@ -285,9 +285,19 @@ ENV.var("LINEAR_API_KEY", "Linear API key.", secret=True)
 ENV.var("LINEAR_WEBHOOK_SECRET", "HMAC secret for Linear webhook deliveries.", secret=True)
 
 # --- Dashboard ------------------------------------------------------------------------------
-ENV.var("DASHBOARD_BASE_URL", "Public URL of the dashboard frontend.")
 ENV.var(
-    "DASHBOARD_API_BASE_URL", "Public URL browsers use for /dashboard/api/* and OAuth callbacks."
+    "DASHBOARD_BASE_URL",
+    "Public URL of the dashboard frontend; defaults to LANGGRAPH_URL when the dashboard build "
+    "is bundled with the backend.",
+)
+ENV.var(
+    "DASHBOARD_API_BASE_URL",
+    "Public URL browsers use for /dashboard/api/* and OAuth callbacks; defaults to LANGGRAPH_URL.",
+)
+ENV.var(
+    "DASHBOARD_STATIC_DIR",
+    "Directory holding the dashboard build (ui/.output/public) served at /; defaults to the "
+    "in-repo build when present.",
 )
 ENV.var("DASHBOARD_ALLOWED_ORIGINS", "Comma-separated extra origins allowed for credentialed CORS.")
 ENV.var(

--- a/agent/dashboard/notion_oauth.py
+++ b/agent/dashboard/notion_oauth.py
@@ -11,6 +11,7 @@ import httpx
 from agent.config import ENV
 from agent.encryption import decrypt_token, encrypt_token
 from agent.store import delete_value, get_value, now_iso, put_value
+from agent.utils.dashboard_links import dashboard_base_url
 
 NOTION_MCP_URL = "https://mcp.notion.com/mcp"
 NOTION_STATE_COOKIE_NAME = "osw_notion_oauth_state"
@@ -141,7 +142,7 @@ async def register_notion_oauth_client(
         "response_types": ["code"],
         "token_endpoint_auth_method": "none",
     }
-    client_uri = ENV.DASHBOARD_BASE_URL.get().strip()
+    client_uri = dashboard_base_url()
     if client_uri:
         body["client_uri"] = client_uri
 

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -20,6 +20,7 @@ from starlette.requests import HTTPConnection
 from agent.config import ENV
 from agent.github.org_membership import is_user_active_org_member
 from agent.github.token_auth import bearer_github_token
+from agent.utils.dashboard_links import dashboard_base_url
 from agent.utils.http import DEFAULT_HTTP_TIMEOUT
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ def allowed_dashboard_origins() -> set[str]:
     else.
     """
     origins: set[str] = set()
-    base = ENV.DASHBOARD_BASE_URL.get().strip()
+    base = dashboard_base_url()
     if base:
         origins.add(_origin_of(base))
     for entry in ENV.DASHBOARD_ALLOWED_ORIGINS.get().split(","):
@@ -129,7 +130,7 @@ def _is_blocked_redirect_path(path: str) -> bool:
 
 def sanitize_redirect_to(redirect_to: str | None) -> str:
     """Return a safe post-login redirect URL."""
-    fallback = ENV.DASHBOARD_BASE_URL.get().strip()
+    fallback = dashboard_base_url()
     if not redirect_to:
         return fallback
     trimmed = redirect_to.strip()
@@ -393,7 +394,7 @@ def build_settings_url() -> str | None:
     safe to share in a public Slack thread. The user signs in with GitHub from
     their own session and connects Slack via verified OIDC on the settings page.
     """
-    frontend_base = ENV.DASHBOARD_BASE_URL.get().rstrip("/")
+    frontend_base = dashboard_base_url()
     if not frontend_base:
         return None
     return f"{frontend_base}{PROFILE_SETTINGS_PATH}"

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -254,6 +254,11 @@ from agent.slack.oauth import (
     slack_oauth_configured,
     verify_team,
 )
+from agent.utils.dashboard_links import (
+    dashboard_api_base_url,
+    dashboard_base_url,
+    dashboard_is_same_origin,
+)
 from agent.utils.thread_ops import langgraph_url
 from agent.utils.timing import server_timing_header
 
@@ -350,31 +355,29 @@ async def _filter_repo_models_for_user[RepoRecordT: _RepoScopedRecord](
 
 
 def _api_base_url() -> str:
-    v = ENV.DASHBOARD_API_BASE_URL.get().rstrip("/")
-    if not v:
-        raise HTTPException(500, "DASHBOARD_API_BASE_URL not configured")
-    return v
+    return dashboard_api_base_url()
 
 
 def _frontend_base_url() -> str:
-    v = ENV.DASHBOARD_BASE_URL.get().rstrip("/")
+    v = dashboard_base_url()
     if not v:
         raise HTTPException(500, "DASHBOARD_BASE_URL not configured")
     return v
 
 
 def _cookie_security() -> tuple[bool, Literal["lax", "none"]]:
-    """Cookie ``secure``/``samesite`` flags derived from the API scheme.
+    """Cookie ``secure``/``samesite`` flags derived from where the dashboard is served.
 
-    Production serves the API over HTTPS and the dashboard is a separate
-    (cross-site) origin, so the session cookie must be ``Secure; SameSite=None``.
-    Local dev runs over ``http://localhost`` where ``Secure`` cookies are
-    rejected and the frontend/API are same-site, so fall back to
-    ``SameSite=Lax`` without ``Secure``.
+    On the API's own origin (the bundled dashboard, or local dev) the session
+    cookie is ``SameSite=Lax``, ``Secure`` only over HTTPS since ``Secure``
+    cookies are rejected on ``http://localhost``. A dashboard on another origin
+    (the split deployment) needs ``Secure; SameSite=None`` for the browser to
+    send the cookie cross-site.
     """
-    if ENV.DASHBOARD_API_BASE_URL.get().startswith("https://"):
-        return True, "none"
-    return False, "lax"
+    secure = dashboard_api_base_url().startswith("https://")
+    if not secure or dashboard_is_same_origin():
+        return secure, "lax"
+    return True, "none"
 
 
 def _set_session_cookie(response: Response, jwt_token: str) -> None:

--- a/agent/utils/dashboard_links.py
+++ b/agent/utils/dashboard_links.py
@@ -1,15 +1,40 @@
 """Shared builders for dashboard ("Open in Web") URLs."""
 
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from agent.config import ENV
-
-_DEFAULT_DASHBOARD_BASE_URL = "https://openswe.vercel.app"
+from agent.utils.dashboard_ui import dashboard_static_dir
 
 
 def dashboard_base_url() -> str:
-    """Return the configured dashboard base URL."""
-    return ENV.DASHBOARD_BASE_URL.get(_DEFAULT_DASHBOARD_BASE_URL).strip().rstrip("/")
+    """Public base URL of the dashboard frontend, or ``""`` when there is none.
+
+    An explicit ``DASHBOARD_BASE_URL`` wins. Otherwise the dashboard lives on the
+    backend's own origin when its build is bundled, so ``LANGGRAPH_URL`` is the
+    base; with neither there is no dashboard to link to.
+    """
+    explicit = ENV.DASHBOARD_BASE_URL.optional()
+    if explicit:
+        return explicit.rstrip("/")
+    if dashboard_static_dir() is not None:
+        return ENV.LANGGRAPH_URL.get().rstrip("/")
+    return ""
+
+
+def dashboard_api_base_url() -> str:
+    """Public URL browsers use for ``/dashboard/api/*``; the backend's own unless overridden."""
+    return (ENV.DASHBOARD_API_BASE_URL.optional() or ENV.LANGGRAPH_URL.get()).rstrip("/")
+
+
+def _origin(url: str) -> str:
+    parts = urlsplit(url)
+    return f"{parts.scheme}://{parts.netloc}".lower()
+
+
+def dashboard_is_same_origin() -> bool:
+    """True when the dashboard is served from the API's own origin."""
+    frontend = dashboard_base_url()
+    return bool(frontend) and _origin(frontend) == _origin(dashboard_api_base_url())
 
 
 def dashboard_thread_url(thread_id: str) -> str | None:

--- a/agent/utils/dashboard_ui.py
+++ b/agent/utils/dashboard_ui.py
@@ -1,0 +1,148 @@
+"""Serve the built dashboard from the backend's own origin.
+
+A dashboard build (``ui/.output/public``: a client-only ``_shell.html`` plus
+hashed assets) mounted at ``/`` lets one LangGraph deployment serve both the API
+and the UI, so the browser reaches ``/dashboard/api/*`` with relative URLs and no
+cross-origin cookie or CORS setup. Paths the LangGraph server owns are left to
+it: the custom app's routes are matched ahead of the server's, so the catch-all
+declines them instead of shadowing them.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from starlette.requests import Request
+from starlette.responses import FileResponse, Response
+from starlette.routing import Match, Route
+from starlette.types import Scope
+
+from agent.config import ENV
+
+logger = logging.getLogger(__name__)
+
+SHELL_FILE = "_shell.html"
+ASSETS_DIR = "assets"
+_REPO_BUILD_DIR = Path(__file__).resolve().parents[2] / "ui" / ".output" / "public"
+
+# Owned by the LangGraph server or this API; never a UI route.
+RESERVED_PREFIXES: tuple[str, ...] = (
+    "/dashboard/api",
+    "/webhooks",
+    "/health",
+    "/assistants",
+    "/threads",
+    "/runs",
+    "/store",
+    "/mcp",
+    "/a2a",
+    "/ui",
+    "/docs",
+    "/openapi.json",
+    "/info",
+    "/metrics",
+    "/ok",
+    f"/{ASSETS_DIR}",
+)
+
+
+def dashboard_static_dir() -> Path | None:
+    """Directory holding a dashboard build, or None when there is none to serve.
+
+    ``DASHBOARD_STATIC_DIR`` names it explicitly, and a named directory without a
+    build means no UI (so images and tests behave the same everywhere); otherwise
+    the in-repo build from ``make build-dashboard`` is served when present.
+    """
+    configured = ENV.DASHBOARD_STATIC_DIR.optional()
+    candidate = Path(configured) if configured else _REPO_BUILD_DIR
+    if (candidate / SHELL_FILE).is_file():
+        return candidate.resolve()
+    return None
+
+
+def is_reserved_path(path: str) -> bool:
+    return any(path == prefix or path.startswith(prefix + "/") for prefix in RESERVED_PREFIXES)
+
+
+def _accepts_html(scope: Scope) -> bool:
+    for name, value in scope.get("headers", ()):
+        if name == b"accept":
+            accept = value.decode("latin-1").lower()
+            return "text/html" in accept or "application/xhtml+xml" in accept
+    return False
+
+
+class ImmutableStaticFiles(StaticFiles):
+    """Hashed build assets never change under the same name."""
+
+    def file_response(
+        self,
+        full_path: str | os.PathLike[str],
+        stat_result: os.stat_result,
+        scope: Scope,
+        status_code: int = 200,
+    ) -> Response:
+        response = super().file_response(full_path, stat_result, scope, status_code)
+        response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response
+
+
+class DashboardShellRoute(Route):
+    """Catch-all for the UI: files from the build, the shell for navigations.
+
+    ``matches`` declines reserved paths, and unknown paths unless the request
+    accepts HTML, so Starlette keeps looking and the LangGraph server's routes
+    (matched after the custom app's) still answer.
+    """
+
+    def __init__(self, static_dir: Path) -> None:
+        self.static_dir = static_dir
+        super().__init__(
+            "/{path:path}",
+            endpoint=self._serve,
+            methods=["GET", "HEAD"],
+            include_in_schema=False,
+            name="dashboard-ui",
+        )
+
+    def file_for(self, path: str) -> Path | None:
+        relative = path.lstrip("/")
+        if not relative:
+            return None
+        candidate = (self.static_dir / relative).resolve()
+        if candidate.is_relative_to(self.static_dir) and candidate.is_file():
+            return candidate
+        return None
+
+    def matches(self, scope: Scope) -> tuple[Match, Scope]:
+        if scope["type"] != "http" or is_reserved_path(scope["path"]):
+            return Match.NONE, {}
+        if self.file_for(scope["path"]) is None and not _accepts_html(scope):
+            return Match.NONE, {}
+        return super().matches(scope)
+
+    async def _serve(self, request: Request) -> Response:
+        file = self.file_for(request.url.path)
+        if file is not None:
+            return FileResponse(file)
+        # The shell is the entry point for every UI route, so browsers must
+        # revalidate it to pick up a new build's asset hashes.
+        return FileResponse(self.static_dir / SHELL_FILE, headers={"Cache-Control": "no-cache"})
+
+
+def mount_dashboard_ui(app: FastAPI) -> Path | None:
+    """Serve the dashboard build at ``/`` when one exists; returns its directory.
+
+    Register after every API router: the catch-all must come last.
+    """
+    static_dir = dashboard_static_dir()
+    if static_dir is None:
+        return None
+    assets = static_dir / ASSETS_DIR
+    if assets.is_dir():
+        app.mount(f"/{ASSETS_DIR}", ImmutableStaticFiles(directory=assets), name="dashboard-assets")
+    app.router.routes.append(DashboardShellRoute(static_dir))
+    logger.info("Serving the dashboard from %s", static_dir)
+    return static_dir

--- a/agent/utils/dashboard_ui.py
+++ b/agent/utils/dashboard_ui.py
@@ -5,7 +5,9 @@ hashed assets) mounted at ``/`` lets one LangGraph deployment serve both the API
 and the UI, so the browser reaches ``/dashboard/api/*`` with relative URLs and no
 cross-origin cookie or CORS setup. Paths the LangGraph server owns are left to
 it: the custom app's routes are matched ahead of the server's, so the catch-all
-declines them instead of shadowing them.
+declines them instead of shadowing them. Paths are taken relative to the mount,
+so a LangGraph ``http.mount_prefix`` serves the UI under that prefix as long as
+the build was made for it (``DASHBOARD_BASE_PATH``).
 """
 
 import logging
@@ -16,7 +18,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
 from starlette.responses import FileResponse, Response
-from starlette.routing import Match, Route
+from starlette.routing import Match, Route, get_route_path
 from starlette.types import Scope
 
 from agent.config import ENV
@@ -117,14 +119,17 @@ class DashboardShellRoute(Route):
         return None
 
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
-        if scope["type"] != "http" or is_reserved_path(scope["path"]):
+        if scope["type"] != "http":
             return Match.NONE, {}
-        if self.file_for(scope["path"]) is None and not _accepts_html(scope):
+        path = get_route_path(scope)
+        if is_reserved_path(path):
+            return Match.NONE, {}
+        if self.file_for(path) is None and not _accepts_html(scope):
             return Match.NONE, {}
         return super().matches(scope)
 
     async def _serve(self, request: Request) -> Response:
-        file = self.file_for(request.url.path)
+        file = self.file_for(get_route_path(request.scope))
         if file is not None:
             return FileResponse(file)
         # The shell is the entry point for every UI route, so browsers must

--- a/agent/utils/dashboard_ui.py
+++ b/agent/utils/dashboard_ui.py
@@ -140,7 +140,10 @@ class DashboardShellRoute(Route):
 def mount_dashboard_ui(app: FastAPI) -> Path | None:
     """Serve the dashboard build at ``/`` when one exists; returns its directory.
 
-    Register after every API router: the catch-all must come last.
+    Register after every API router: the catch-all must come last. Code that adds
+    routes to the app afterwards calls ``keep_dashboard_ui_last`` when done. The
+    route must not look at the live route table instead: the LangGraph server
+    rewrites the app's routes to append its own catch-all after this one.
     """
     static_dir = dashboard_static_dir()
     if static_dir is None:
@@ -151,3 +154,12 @@ def mount_dashboard_ui(app: FastAPI) -> Path | None:
     app.router.routes.append(DashboardShellRoute(static_dir))
     logger.info("Serving the dashboard from %s", static_dir)
     return static_dir
+
+
+def keep_dashboard_ui_last(app: FastAPI) -> None:
+    """Move the UI catch-all behind routes registered since ``mount_dashboard_ui``."""
+    routes = app.router.routes
+    for index, route in enumerate(routes):
+        if isinstance(route, DashboardShellRoute):
+            routes.append(routes.pop(index))
+            return

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -5,7 +5,6 @@ from langchain.chat_models import init_chat_model
 
 from agent.config import ENV
 from agent.dashboard.options import DEFAULT_MODEL_ID, model_profile_with_context_override
-from agent.utils.dashboard_links import dashboard_base_url
 from agent.utils.gateway import gateway_env_default, gateway_overrides
 from agent.utils.openai_oauth import (
     build_desktop_openai_oauth_model,
@@ -354,8 +353,13 @@ def validate_local_dev_llm_config() -> None:
     intended to catch missing credentials for the default model specified
     via LLM_MODEL_ID/DEFAULT_MODEL_ID. Runtime model selection may come
     from team, profile, or thread configuration and is not validated here.
+
+    Only an explicitly configured localhost dashboard URL counts: the derived
+    default follows LANGGRAPH_URL, which is unset (so localhost) on a fresh
+    LangGraph Platform deployment until its URL exists, and failing startup
+    there would leave the deployment unable to ever get one.
     """
-    dashboard_url = dashboard_base_url()
+    dashboard_url = ENV.DASHBOARD_BASE_URL.optional() or ""
     if not dashboard_url.startswith("http://localhost"):
         return
 

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -5,6 +5,7 @@ from langchain.chat_models import init_chat_model
 
 from agent.config import ENV
 from agent.dashboard.options import DEFAULT_MODEL_ID, model_profile_with_context_override
+from agent.utils.dashboard_links import dashboard_base_url
 from agent.utils.gateway import gateway_env_default, gateway_overrides
 from agent.utils.openai_oauth import (
     build_desktop_openai_oauth_model,
@@ -354,7 +355,7 @@ def validate_local_dev_llm_config() -> None:
     via LLM_MODEL_ID/DEFAULT_MODEL_ID. Runtime model selection may come
     from team, profile, or thread configuration and is not validated here.
     """
-    dashboard_url = ENV.DASHBOARD_BASE_URL.get()
+    dashboard_url = dashboard_base_url()
     if not dashboard_url.startswith("http://localhost"):
         return
 

--- a/langgraph.json
+++ b/langgraph.json
@@ -25,11 +25,12 @@
   "env": ".env",
   "dockerfile_lines": [
     "# Bundle the dashboard so the deployment serves it at / (docs/INSTALLATION.md, Dashboard).",
+    "# The build is made for http.mount_prefix from langgraph.json, so the UI's asset URLs and router match where the server mounts it.",
     "# Best effort: a failed UI build leaves the backend deployable without the bundled UI.",
-    "COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json /tmp/dashboard-src/",
+    "COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json langgraph.json /tmp/dashboard-src/",
     "COPY ui /tmp/dashboard-src/ui",
     "ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0",
-    "RUN ( set -e && apt-get update && apt-get install -y --no-install-recommends curl xz-utils ca-certificates && arch=$(uname -m) && case $arch in x86_64) node_arch=x64;; aarch64) node_arch=arm64;; *) echo unsupported arch $arch; exit 1;; esac && curl -fsSL https://nodejs.org/dist/v24.20.0/node-v24.20.0-linux-$node_arch.tar.xz | tar -xJ -C /usr/local --strip-components=1 && corepack enable && cd /tmp/dashboard-src && pnpm install --frozen-lockfile --filter open-swe-dashboard... && pnpm --filter open-swe-dashboard run build && mkdir -p /opt/open-swe-dashboard && cp -R ui/.output/public/. /opt/open-swe-dashboard/ ) || echo 'dashboard build failed; continuing without the bundled UI'; rm -rf /tmp/dashboard-src /usr/local/lib/node_modules /usr/local/bin/node /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm /usr/local/bin/pnpx /root/.cache /root/.local/share/pnpm /var/lib/apt/lists/*",
+    "RUN ( set -e && apt-get update && apt-get install -y --no-install-recommends curl xz-utils ca-certificates && arch=$(uname -m) && case $arch in x86_64) node_arch=x64;; aarch64) node_arch=arm64;; *) echo unsupported arch $arch; exit 1;; esac && curl -fsSL https://nodejs.org/dist/v24.20.0/node-v24.20.0-linux-$node_arch.tar.xz | tar -xJ -C /usr/local --strip-components=1 && corepack enable && cd /tmp/dashboard-src && pnpm install --frozen-lockfile --filter open-swe-dashboard... && export DASHBOARD_BASE_PATH=\"$(python3 -c 'import json; print(json.load(open(\"langgraph.json\")).get(\"http\", {}).get(\"mount_prefix\") or \"\")')/\" && pnpm --filter open-swe-dashboard run build && mkdir -p /opt/open-swe-dashboard && cp -R ui/.output/public/. /opt/open-swe-dashboard/ ) || echo 'dashboard build failed; continuing without the bundled UI'; rm -rf /tmp/dashboard-src /usr/local/lib/node_modules /usr/local/bin/node /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm /usr/local/bin/pnpx /root/.cache /root/.local/share/pnpm /var/lib/apt/lists/*",
     "ENV DASHBOARD_STATIC_DIR=/opt/open-swe-dashboard"
   ]
 }

--- a/langgraph.json
+++ b/langgraph.json
@@ -22,5 +22,14 @@
       "default_ttl": 43200
     }
   },
-  "env": ".env"
+  "env": ".env",
+  "dockerfile_lines": [
+    "# Bundle the dashboard so the deployment serves it at / (docs/INSTALLATION.md, Dashboard).",
+    "# Best effort: a failed UI build leaves the backend deployable without the bundled UI.",
+    "COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json /tmp/dashboard-src/",
+    "COPY ui /tmp/dashboard-src/ui",
+    "ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0",
+    "RUN ( set -e && apt-get update && apt-get install -y --no-install-recommends curl xz-utils ca-certificates && arch=$(uname -m) && case $arch in x86_64) node_arch=x64;; aarch64) node_arch=arm64;; *) echo unsupported arch $arch; exit 1;; esac && curl -fsSL https://nodejs.org/dist/v24.20.0/node-v24.20.0-linux-$node_arch.tar.xz | tar -xJ -C /usr/local --strip-components=1 && corepack enable && cd /tmp/dashboard-src && pnpm install --frozen-lockfile --filter open-swe-dashboard... && pnpm --filter open-swe-dashboard run build && mkdir -p /opt/open-swe-dashboard && cp -R ui/.output/public/. /opt/open-swe-dashboard/ ) || echo 'dashboard build failed; continuing without the bundled UI'; rm -rf /tmp/dashboard-src /usr/local/lib/node_modules /usr/local/bin/node /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm /usr/local/bin/pnpx /root/.cache /root/.local/share/pnpm /var/lib/apt/lists/*",
+    "ENV DASHBOARD_STATIC_DIR=/opt/open-swe-dashboard"
+  ]
 }

--- a/tests/agent/test_workflow_push_guard.py
+++ b/tests/agent/test_workflow_push_guard.py
@@ -231,6 +231,7 @@ async def test_workflow_change_for_push_rejects_non_current_refspec() -> None:
 async def test_unapproved_workflow_push_blocks_and_posts_slack(
     monkeypatch: pytest.MonkeyPatch, tool_name: str
 ) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
     guard.SANDBOX_BACKENDS["thread-1"] = SandboxBackendProxy(
         cast(SandboxBackendProtocol, _Backend()), thread_id="thread-1"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures."""
 
 from collections.abc import Iterator, Sequence
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -70,6 +71,12 @@ def fake_store(monkeypatch: pytest.MonkeyPatch) -> FakeStore:
     client = FakeStoreClient()
     monkeypatch.setattr(agent_store, "store_client", lambda: client)
     return client.store
+
+
+@pytest.fixture(autouse=True)
+def _no_bundled_dashboard(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Serve no dashboard build by default, whatever ``ui/.output`` holds locally."""
+    monkeypatch.setenv("DASHBOARD_STATIC_DIR", str(tmp_path / "no-dashboard-build"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/dashboard/test_dashboard_ui.py
+++ b/tests/dashboard/test_dashboard_ui.py
@@ -1,0 +1,126 @@
+"""Serving the bundled dashboard from the backend's own origin."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.routing import Match
+
+from agent.api import app as app_module
+from agent.utils.dashboard_ui import DashboardShellRoute, dashboard_static_dir
+
+HTML = {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
+SHELL = "<!doctype html><div id=root>shell</div>"
+
+
+@pytest.fixture
+def build_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "_shell.html").write_text(SHELL)
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "assets" / "app-abc123.js").write_text("console.log(1)")
+    (tmp_path / "favicon.png").write_bytes(b"\x89PNG")
+    monkeypatch.setenv("DASHBOARD_STATIC_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _shell_route(app) -> DashboardShellRoute:
+    return next(route for route in app.router.routes if isinstance(route, DashboardShellRoute))
+
+
+def _scope(path: str, accept: str | None = "text/html") -> dict:
+    headers = [(b"accept", accept.encode())] if accept else []
+    return {"type": "http", "method": "GET", "path": path, "headers": headers}
+
+
+def test_shell_answers_browser_navigations(build_dir: Path) -> None:
+    client = TestClient(app_module.create_app())
+
+    for path in ("/", "/agents/thread-1", "/admin/team?tab=repos"):
+        response = client.get(path, headers=HTML)
+        assert response.status_code == 200, path
+        assert response.text == SHELL
+        assert response.headers["cache-control"] == "no-cache"
+
+
+def test_build_files_are_served_as_themselves(build_dir: Path) -> None:
+    client = TestClient(app_module.create_app())
+
+    favicon = client.get("/favicon.png")
+    assert favicon.status_code == 200
+    assert favicon.content == b"\x89PNG"
+
+    asset = client.get("/assets/app-abc123.js")
+    assert asset.status_code == 200
+    assert asset.text == "console.log(1)"
+    assert asset.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/threads",
+        "/threads/abc/runs",
+        "/runs/stream",
+        "/assistants/search",
+        "/store/items",
+        "/docs",
+        "/openapi.json",
+        "/ok",
+        "/info",
+        "/metrics",
+        "/ui/agent",
+        "/mcp",
+        "/dashboard/api/session",
+        "/webhooks/github",
+        "/health",
+    ],
+)
+def test_reserved_paths_are_left_to_the_langgraph_server(build_dir: Path, path: str) -> None:
+    """The custom app's routes are matched first, so the catch-all must decline these."""
+    route = _shell_route(app_module.create_app())
+
+    assert route.matches(_scope(path))[0] is Match.NONE
+
+
+def test_root_without_html_accept_is_left_to_the_health_check(build_dir: Path) -> None:
+    route = _shell_route(app_module.create_app())
+
+    assert route.matches(_scope("/", accept=None))[0] is Match.NONE
+    assert route.matches(_scope("/", accept="*/*"))[0] is Match.NONE
+    assert route.matches(_scope("/", accept="text/html"))[0] is Match.FULL
+
+
+def test_api_routes_keep_precedence_over_the_shell(build_dir: Path) -> None:
+    client = TestClient(app_module.create_app())
+
+    response = client.get("/health", headers=HTML)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_unknown_paths_without_html_accept_fall_through(build_dir: Path) -> None:
+    client = TestClient(app_module.create_app())
+
+    assert client.get("/agents/x", headers={"Accept": "application/json"}).status_code == 404
+    assert client.post("/agents/x", headers=HTML).status_code in (404, 405)
+
+
+def test_files_outside_the_build_are_never_served(build_dir: Path) -> None:
+    outside = build_dir.parent / f"{build_dir.name}-outside.txt"
+    outside.write_text("secret")
+    route = _shell_route(app_module.create_app())
+
+    assert route.file_for(f"/../{outside.name}") is None
+    assert route.file_for("/_shell.html") == build_dir / "_shell.html"
+    assert route.file_for("/") is None
+
+
+def test_no_build_means_no_ui(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DASHBOARD_STATIC_DIR", str(tmp_path / "missing"))
+    app = app_module.create_app()
+
+    assert dashboard_static_dir() is None
+    assert not any(isinstance(route, DashboardShellRoute) for route in app.router.routes)
+    assert TestClient(app).get("/", headers=HTML).status_code == 404
+

--- a/tests/dashboard/test_dashboard_ui.py
+++ b/tests/dashboard/test_dashboard_ui.py
@@ -124,3 +124,17 @@ def test_no_build_means_no_ui(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     assert not any(isinstance(route, DashboardShellRoute) for route in app.router.routes)
     assert TestClient(app).get("/", headers=HTML).status_code == 404
 
+
+def test_serving_under_a_mount_prefix(build_dir: Path) -> None:
+    """``http.mount_prefix`` wraps the whole app in a Mount; paths are read relative to it."""
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    client = TestClient(Starlette(routes=[Mount("/open-swe", app=app_module.create_app())]))
+
+    assert client.get("/open-swe/", headers=HTML).text == SHELL
+    assert client.get("/open-swe/agents/t1", headers=HTML).text == SHELL
+    assert client.get("/open-swe/favicon.png").content == b"\x89PNG"
+    assert client.get("/open-swe/assets/app-abc123.js").status_code == 200
+    assert client.get("/open-swe/threads", headers=HTML).status_code == 404
+    assert client.get("/", headers=HTML).status_code == 404

--- a/tests/dashboard/test_dashboard_ui.py
+++ b/tests/dashboard/test_dashboard_ui.py
@@ -7,7 +7,11 @@ from fastapi.testclient import TestClient
 from starlette.routing import Match
 
 from agent.api import app as app_module
-from agent.utils.dashboard_ui import DashboardShellRoute, dashboard_static_dir
+from agent.utils.dashboard_ui import (
+    DashboardShellRoute,
+    dashboard_static_dir,
+    keep_dashboard_ui_last,
+)
 
 HTML = {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
 SHELL = "<!doctype html><div id=root>shell</div>"
@@ -97,6 +101,51 @@ def test_api_routes_keep_precedence_over_the_shell(build_dir: Path) -> None:
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
+
+
+def test_routes_added_after_the_ui_win_once_it_is_moved_last(build_dir: Path) -> None:
+    """The e2e harness composes its fake-SaaS pages onto the built app."""
+    from fastapi.responses import HTMLResponse
+
+    app = app_module.create_app()
+
+    @app.get("/mock/slack", response_class=HTMLResponse)
+    async def mock_slack() -> str:
+        return "<button id=reset>reset</button>"
+
+    assert TestClient(app).get("/mock/slack", headers=HTML).text == SHELL
+
+    keep_dashboard_ui_last(app)
+    client = TestClient(app)
+
+    assert client.get("/mock/slack", headers=HTML).text == "<button id=reset>reset</button>"
+    assert client.get("/agents/t1", headers=HTML).text == SHELL
+    assert isinstance(app.router.routes[-1], DashboardShellRoute)
+
+
+def test_server_routes_appended_after_the_ui_do_not_hide_it(build_dir: Path) -> None:
+    """The LangGraph server rewrites the app's route list and appends its own catch-all."""
+    from starlette.responses import JSONResponse
+    from starlette.routing import Mount, Route
+
+    async def health(_request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    async def protected(_request) -> JSONResponse:
+        return JSONResponse({"detail": "Missing authentication headers"}, status_code=403)
+
+    app = app_module.create_app()
+    app.router.routes = [
+        *app.router.routes,
+        Route("/", health),
+        Mount("", routes=[Route("/{path:path}", protected)]),
+    ]
+    client = TestClient(app)
+
+    assert client.get("/", headers=HTML).text == SHELL
+    assert client.get("/agents/t1", headers=HTML).text == SHELL
+    assert client.get("/").json() == {"ok": True}
+    assert client.get("/threads", headers=HTML).status_code == 403
 
 
 def test_unknown_paths_without_html_accept_fall_through(build_dir: Path) -> None:

--- a/tests/dashboard/test_dashboard_urls.py
+++ b/tests/dashboard/test_dashboard_urls.py
@@ -1,0 +1,76 @@
+"""Dashboard base URLs and the session cookie policy that follows from them."""
+
+from pathlib import Path
+
+import pytest
+
+from agent.dashboard import routes as dashboard_routes
+from agent.utils import dashboard_links
+
+
+@pytest.fixture
+def bundled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "_shell.html").write_text("<!doctype html>")
+    monkeypatch.setenv("DASHBOARD_STATIC_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_explicit_dashboard_base_url_wins(monkeypatch: pytest.MonkeyPatch, bundled: Path) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example/")
+    monkeypatch.setenv("LANGGRAPH_URL", "https://backend.example")
+
+    assert dashboard_links.dashboard_base_url() == "https://dashboard.example"
+
+
+def test_bundled_dashboard_lives_on_the_backend_origin(
+    monkeypatch: pytest.MonkeyPatch, bundled: Path
+) -> None:
+    monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+    monkeypatch.setenv("LANGGRAPH_URL", "https://backend.example/")
+
+    assert dashboard_links.dashboard_base_url() == "https://backend.example"
+    assert dashboard_links.dashboard_thread_url("t1") == "https://backend.example/agents/t1"
+
+
+def test_no_dashboard_means_no_links(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+
+    assert dashboard_links.dashboard_base_url() == ""
+    assert dashboard_links.dashboard_thread_url("t1") is None
+    assert dashboard_links.dashboard_review_url("o", "r", 1) is None
+
+
+def test_api_base_url_defaults_to_the_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DASHBOARD_API_BASE_URL", raising=False)
+    monkeypatch.setenv("LANGGRAPH_URL", "https://backend.example/")
+
+    assert dashboard_links.dashboard_api_base_url() == "https://backend.example"
+
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://api.example/")
+    assert dashboard_links.dashboard_api_base_url() == "https://api.example"
+
+
+def test_same_origin_https_session_cookie_is_lax(
+    monkeypatch: pytest.MonkeyPatch, bundled: Path
+) -> None:
+    monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+    monkeypatch.delenv("DASHBOARD_API_BASE_URL", raising=False)
+    monkeypatch.setenv("LANGGRAPH_URL", "https://backend.example")
+
+    assert dashboard_links.dashboard_is_same_origin() is True
+    assert dashboard_routes._cookie_security() == (True, "lax")
+
+
+def test_cross_origin_https_session_cookie_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "https://api.example")
+
+    assert dashboard_links.dashboard_is_same_origin() is False
+    assert dashboard_routes._cookie_security() == (True, "none")
+
+
+def test_local_http_session_cookie_is_lax_and_not_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://localhost:3000")
+    monkeypatch.setenv("DASHBOARD_API_BASE_URL", "http://localhost:2024")
+
+    assert dashboard_routes._cookie_security() == (False, "lax")

--- a/tests/dashboard/test_dashboard_urls.py
+++ b/tests/dashboard/test_dashboard_urls.py
@@ -74,3 +74,21 @@ def test_local_http_session_cookie_is_lax_and_not_secure(monkeypatch: pytest.Mon
     monkeypatch.setenv("DASHBOARD_API_BASE_URL", "http://localhost:2024")
 
     assert dashboard_routes._cookie_security() == (False, "lax")
+
+
+def test_local_dev_model_check_needs_an_explicit_localhost_dashboard(
+    monkeypatch: pytest.MonkeyPatch, bundled: Path
+) -> None:
+    """A fresh platform deployment has the bundled UI and no LANGGRAPH_URL yet; it must boot."""
+    from agent.utils import model
+
+    for name in ("DASHBOARD_BASE_URL", "LANGGRAPH_URL", "OPENAI_API_KEY", "LLM_MODEL_ID"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(model, "desktop_openai_oauth_available", lambda: False)
+
+    assert dashboard_links.dashboard_base_url() == "http://localhost:2024"
+    model.validate_local_dev_llm_config()
+
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://localhost:3000")
+    with pytest.raises(ValueError, match="_API_KEY is required"):
+        model.validate_local_dev_llm_config()

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -64,6 +64,7 @@ from langgraph_sdk import get_client  # noqa: E402
 from agent.api.app import app  # noqa: E402
 from agent.dashboard.oauth import COOKIE_NAME, issue_session  # noqa: E402
 from agent.slack.client import lookup_slack_thread_id  # noqa: E402
+from agent.utils.dashboard_ui import keep_dashboard_ui_last  # noqa: E402
 
 GITHUB_WEBHOOK_SECRET = os.environ["GITHUB_WEBHOOK_SECRET"]
 SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
@@ -907,6 +908,10 @@ async def slack_archive_code_channel(request: Request) -> JSONResponse:
 async def slack_get_permalink(channel: str = "", message_ts: str = "") -> JSONResponse:  # noqa: ARG001
     return _ok({"permalink": f"{BASE_URL}/mock/slack"})
 
+
+# A dashboard build under ui/.output puts the UI catch-all on the app before the
+# mock pages above were registered; keep it behind them.
+keep_dashboard_ui_last(app)
 
 # Quietly reference imports used only for env side effects.
 _ = (e2e_env, HUMAN_USER)

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -208,6 +208,7 @@ async def test_post_slack_thread_reply_with_ts_returns_http_error(
 async def test_post_slack_thread_reply_with_ts_sends_blocks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
     monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
 
     blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "Pick"}}]

--- a/tests/tools/test_threads.py
+++ b/tests/tools/test_threads.py
@@ -102,6 +102,7 @@ async def test_list_threads_defaults_to_triggering_user(monkeypatch: pytest.Monk
     )
     monkeypatch.setattr(threads_tool, "_actor", AsyncMock(return_value=actor))
     monkeypatch.setattr(threads_tool, "list_dashboard_threads_page", page)
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
 
     result = await threads_tool.list_threads()
 
@@ -110,7 +111,7 @@ async def test_list_threads_defaults_to_triggering_user(monkeypatch: pytest.Monk
         {
             "id": "thread-1",
             "title": "One",
-            "webUrl": "https://openswe.vercel.app/agents/thread-1",
+            "webUrl": "https://dashboard.example/agents/thread-1",
         }
     ]
     page.assert_awaited_once_with(
@@ -231,6 +232,7 @@ class _DetailClient:
 async def test_get_thread_returns_links_cost_last_message_and_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example")
     client = _DetailClient()
     monkeypatch.setattr(threads_tool, "_actor", AsyncMock(return_value=_actor()))
     monkeypatch.setattr(

--- a/ui/public/manifest.webmanifest
+++ b/ui/public/manifest.webmanifest
@@ -1,21 +1,21 @@
 {
-  "id": "/",
+  "id": "./",
   "name": "Open SWE",
   "short_name": "Open SWE",
   "description": "Open-source coding agents for Slack, Linear, and GitHub.",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff",
   "icons": [
     {
-      "src": "/favicon.png",
+      "src": "favicon.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/logo512.png",
+      "src": "logo512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -292,7 +292,7 @@ export function AgentThreadView({
           {isHydrating ? (
             <div className="flex flex-1 items-center justify-center px-6">
               <img
-                src="/logo-mark.png"
+                src={`${import.meta.env.BASE_URL}logo-mark.png`}
                 alt="Loading conversation"
                 className="size-12 animate-pulse"
               />

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -467,7 +467,7 @@ export function AgentsHome() {
           <div className="flex min-h-0 flex-1 overflow-y-auto px-3 py-6 sm:px-6 sm:py-8">
             <div className="mx-auto flex min-h-full w-full max-w-3xl flex-1 flex-col items-center justify-center gap-6">
               <img
-                src="/logo-mark.png"
+                src={`${import.meta.env.BASE_URL}logo-mark.png`}
                 alt=""
                 className="size-14 opacity-30 grayscale dark:opacity-20"
               />

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -604,7 +604,11 @@ export function AgentsSidebar({
           to={localOnly ? "/agents" : "/my-settings"}
           className="flex items-center gap-2 font-heading text-sm font-medium tracking-tight text-foreground"
         >
-          <img src="/logo-mark.png" alt="" className="size-5" />
+          <img
+            src={`${import.meta.env.BASE_URL}logo-mark.png`}
+            alt=""
+            className="size-5"
+          />
           Open SWE
         </Link>
         <div className="flex items-center gap-1">

--- a/ui/src/lib/api-base.test.ts
+++ b/ui/src/lib/api-base.test.ts
@@ -4,6 +4,17 @@ import { isCrossOriginApiBase, resolveDashboardApiBase } from "./api-base"
 
 describe("resolveDashboardApiBase", () => {
   it("uses the configured API for the web UI", () => {
+    expect(resolveDashboardApiBase(undefined, "https:")).toBe("")
+    expect(resolveDashboardApiBase("", "https:", "/open-swe/")).toBe(
+      "/open-swe"
+    )
+    expect(
+      resolveDashboardApiBase(
+        "https://backend.example/",
+        "https:",
+        "/open-swe/"
+      )
+    ).toBe("https://backend.example")
     expect(resolveDashboardApiBase("https://backend.example/", "https:")).toBe(
       "https://backend.example"
     )

--- a/ui/src/lib/api-base.ts
+++ b/ui/src/lib/api-base.ts
@@ -1,16 +1,24 @@
+/**
+ * Prefix for `/dashboard/api/*` requests: an explicit backend origin when the
+ * frontend is served elsewhere, otherwise the path the app itself is served
+ * under (Vite's `base`), which is "" for a root deployment and the mount prefix
+ * when the backend serves the build under one.
+ */
 export function resolveDashboardApiBase(
   configured: string | undefined,
-  protocol: string
+  protocol: string,
+  basePath = "/"
 ): string {
   if (protocol === "open-swe:") return ""
-  return (configured ?? "").replace(/\/$/, "")
+  return (configured || basePath).replace(/\/$/, "")
 }
 
 export function dashboardApiBase(): string {
   const protocol = typeof window === "undefined" ? "" : window.location.protocol
   return resolveDashboardApiBase(
     import.meta.env.VITE_DASHBOARD_API_BASE_URL,
-    protocol
+    protocol,
+    import.meta.env.BASE_URL
   )
 }
 

--- a/ui/src/lib/notifications.ts
+++ b/ui/src/lib/notifications.ts
@@ -52,7 +52,7 @@ export function showRunNotification(
   try {
     const n = new Notification(title, {
       body,
-      icon: "/logo-mark.png",
+      icon: `${import.meta.env.BASE_URL}logo-mark.png`,
       tag: `run-${thread.id}`,
     })
     n.onclick = () => {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -9,6 +9,8 @@ export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
     context: { queryClient },
+    // Vite's `base`, so a build made for a mount prefix routes under it.
+    basepath: import.meta.env.BASE_URL,
 
     scrollRestoration: true,
     defaultPreload: "intent",

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -38,9 +38,19 @@ export const Route = createRootRouteWithContext<{
     ],
     links: [
       { rel: "stylesheet", href: appCss },
-      { rel: "manifest", href: "/manifest.webmanifest" },
-      { rel: "icon", type: "image/png", href: "/favicon.png" },
-      { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
+      {
+        rel: "manifest",
+        href: `${import.meta.env.BASE_URL}manifest.webmanifest`,
+      },
+      {
+        rel: "icon",
+        type: "image/png",
+        href: `${import.meta.env.BASE_URL}favicon.png`,
+      },
+      {
+        rel: "apple-touch-icon",
+        href: `${import.meta.env.BASE_URL}apple-touch-icon.png`,
+      },
     ],
   }),
   notFoundComponent: () => (

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -165,8 +165,13 @@ const SHELL_PAGE = {
   sitemap: { exclude: true },
 }
 
+// Where the app is served from. "/" for the dev server and the standalone image;
+// a LangGraph `http.mount_prefix` (plus trailing slash) when the backend bundles
+// the build and serves it under that prefix.
+const BASE_PATH = process.env.DASHBOARD_BASE_PATH || "/"
+
 const config = defineConfig({
-  base: "/",
+  base: BASE_PATH,
   resolve: { tsconfigPaths: true },
   optimizeDeps: {
     include: [


### PR DESCRIPTION
## Summary

Single-origin deployments: the backend serves the dashboard itself, so one LangGraph Platform deployment (or `langgraph dev`) provides both the API and the web UI. Third PR of the install-simplification stack, on #2489.

Replaces #2482: GitHub marked that PR merged and deleted its branch when the docs branch above it was pushed already containing these commits during a stack reorder. Its review threads are resolved there; the code is unchanged apart from the base-path fix (`fix(ui): resolve public assets against the build's base path`).

- **Serving.** When a dashboard build is present (`DASHBOARD_STATIC_DIR`, defaulting to `ui/.output/public`), the FastAPI app serves it at `/`: hashed `/assets/*` with immutable caching, real files (favicon, manifest, `sw.js`) as themselves, and the client-only `_shell.html` for every other browser navigation, with `Cache-Control: no-cache` so a new build's asset hashes are picked up.
- **No shadowing.** `langgraph-api` matches the custom app's routes ahead of its own, so a plain catch-all would swallow `/threads`, `/runs`, `/assistants`, `/store`, `/docs`, `/ui`. The catch-all's `matches()` declines those prefixes and any unknown path whose request does not accept HTML, so they fall through to the server. `GET /` without an HTML `Accept` still reaches LangGraph's root health check.
- **Route order.** The catch-all is appended when the app is built; code that registers routes afterwards (the e2e harness's mock pages) calls `keep_dashboard_ui_last`. The route deliberately does not consult the live route table, because `langgraph-api` rewrites the app's routes and appends its own protected catch-all after it.
- **Same-origin by default.** `DASHBOARD_API_BASE_URL` defaults to `LANGGRAPH_URL`; `DASHBOARD_BASE_URL` defaults to `LANGGRAPH_URL` when the build is bundled and is otherwise empty, which replaces the hardcoded `openswe.vercel.app` in Slack/GitHub "Open in Web" links (no dashboard, no link). A session cookie whose dashboard and API share an origin is `SameSite=Lax`; the cross-origin split deployment keeps `Secure; SameSite=None`.
- **Image build.** `langgraph.json` gains `dockerfile_lines` that install Node 24, build `ui/` with pnpm, copy the output to `/opt/open-swe-dashboard`, set `DASHBOARD_STATIC_DIR`, and clean up in the same layer. The build is best effort: a failure logs and the backend still deploys without the UI, which the startup report states (`Dashboard UI: bundled from …` / `not bundled`).
- **Unchanged.** The UI code, `ui/Dockerfile`, and `DASHBOARD_API_URL` proxying are untouched; `make web` and the separate dashboard image work as before. `LANGGRAPH_URL` keeps its role for the backend's own calls to the LangGraph server.
- **Mount prefix.** With a LangGraph `http.mount_prefix`, the server wraps the whole app in a Mount; the shell route reads paths relative to it, and the UI takes its base path from Vite's `base` (`DASHBOARD_BASE_PATH` at build time) for asset URLs, the router `basepath`, and the default `/dashboard/api` prefix. The image build derives the base path from `langgraph.json`, so the bundled UI matches where the server mounts it.
- `make build-dashboard` builds the UI locally (`DASHBOARD_BASE_PATH=/<prefix>/` for a mounted server); `make dev` then serves it at `http://localhost:2024`.

## Test Plan

- [x] `tests/dashboard/test_dashboard_ui.py`: shell for navigations, files and immutable assets, reserved paths declined (checked through `Route.matches`), non-HTML unknown paths fall through, path traversal stays inside the build, no build means no UI.
- [x] `tests/dashboard/test_dashboard_urls.py`: URL defaults and the three cookie policies.
- [x] Real `ui/.output/public` served through the app: shell at `/`, referenced assets resolve, `/health` keeps precedence.
- [x] `langgraph build` locally (linux/amd64): the `dockerfile_lines` step completes in about 40s, `/opt/open-swe-dashboard` holds the build (18 MB, 450 assets), Node and pnpm are gone from the layer, `DASHBOARD_STATIC_DIR` is set.
- [x] UI built with `DASHBOARD_BASE_PATH=/open-swe/` and served behind `Mount("/open-swe")`: shell, prefixed assets, and `/open-swe/threads` left to the server.
- [x] LangGraph Platform: the `open-swe-staging` deployment serves the dashboard at `/`, with the API, webhooks, and `/dashboard/api/*` on the same origin.
- [x] GitHub login on the bundled dashboard with the callback URL `https://<backend>/dashboard/api/auth/callback`.
- [x] Split deployment still works: the standalone `ui/Dockerfile` image pointed at staging via `DASHBOARD_API_URL` proxies `/dashboard/api/*` and redirects login to GitHub with the backend's callback.

## Stack

1. #2463 unified config + standard LangSmith env (merged)
2. #2489 LangSmith tenant discovery and `LANGSMITH_PROJECT` tracing
3. **this PR** single-origin dashboard

The GitHub/Slack discovery and `make setup` PRs (#2464, #2487, #2488) and the docs rewrite (#2466) are parked as drafts; a first-boot setup flow (OEP draft) replaces that direction.
