### PR TITLE
feat(slack): discover the bot identity and make the team default repository canonical

### DIFF
--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application composition."""
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -15,6 +16,9 @@ from agent.github.routes import router as github_webhook_router
 from agent.linear.routes import router as linear_webhook_router
 from agent.slack.routes import router as slack_webhook_router
 from agent.utils.event_loop import pin_single_event_loop
+from agent.webhooks.common import ensure_slack_bot_identity
+
+logger = logging.getLogger(__name__)
 
 # Before the queue starts: it reads this when it builds its workers, and Open SWE
 # cannot survive them landing on different loops.
@@ -29,6 +33,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     pin_single_event_loop()
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
+    try:
+        await ensure_slack_bot_identity()
+    except Exception:  # noqa: BLE001
+        logger.debug("Slack bot identity discovery failed at startup", exc_info=True)
     try:
         yield
     finally:

--- a/agent/config.py
+++ b/agent/config.py
@@ -283,17 +283,35 @@ ENV.var("PUBLIC_REPO_ORG_GATE", "Single org whose members may trigger runs on pu
 ENV.var(
     "DEFAULT_REPO_OWNER",
     "Default GitHub owner when a run names no repository.",
-    default="langchain-ai",
+    deprecated="set the default repository in Admin → Team settings instead.",
 )
-ENV.var("DEFAULT_REPO_NAME", "Default GitHub repository when a run names none.")
-ENV.var("SLACK_REPO_OWNER", "Slack-specific default repository owner.")
-ENV.var("SLACK_REPO_NAME", "Slack-specific default repository name.")
+ENV.var(
+    "DEFAULT_REPO_NAME",
+    "Default GitHub repository when a run names none.",
+    deprecated="set the default repository in Admin → Team settings instead.",
+)
+ENV.var(
+    "SLACK_REPO_OWNER",
+    "Slack-specific default repository owner.",
+    deprecated="set the default repository in Admin → Team settings instead.",
+)
+ENV.var(
+    "SLACK_REPO_NAME",
+    "Slack-specific default repository name.",
+    deprecated="set the default repository in Admin → Team settings instead.",
+)
 
 # --- Slack and Linear ----------------------------------------------------------------------
 ENV.var("SLACK_BOT_TOKEN", "Slack bot user OAuth token (xoxb-...).", secret=True)
 ENV.var("SLACK_SIGNING_SECRET", "HMAC secret for Slack webhook deliveries.", secret=True)
-ENV.var("SLACK_BOT_USER_ID", "Slack user id of the bot, for mention detection.")
-ENV.var("SLACK_BOT_USERNAME", "Slack handle of the bot, for plain-text mention detection.")
+ENV.var(
+    "SLACK_BOT_USER_ID",
+    "Slack user id of the bot, for mention detection; discovered via auth.test when unset.",
+)
+ENV.var(
+    "SLACK_BOT_USERNAME",
+    "Slack handle of the bot, for plain-text mention detection; discovered when unset.",
+)
 ENV.var("SLACK_CLIENT_ID", "Slack app client id for Sign in with Slack.")
 ENV.var("SLACK_CLIENT_SECRET", "Slack app client secret for Sign in with Slack.", secret=True)
 ENV.var("SLACK_TEAM_ID", "Restrict Sign in with Slack to one workspace.")

--- a/agent/linear/routes.py
+++ b/agent/linear/routes.py
@@ -80,7 +80,8 @@ async def linear_webhook(  # noqa: PLR0911, PLR0912, PLR0915
         full_issue = issue
 
     repo_config = common.extract_repo_from_text(
-        comment_body, default_owner=common.DEFAULT_REPO_OWNER
+        comment_body,
+        default_owner=await common.default_repo_owner_hint(common.DEFAULT_REPO_OWNER),
     )
 
     if repo_config:

--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -62,6 +62,62 @@ class GitHubPrRef:
     url: str
 
 
+@dataclass(frozen=True)
+class SlackBotIdentity:
+    user_id: str
+    username: str
+    team_id: str | None
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+async def fetch_slack_bot_identity(token: str | None = None) -> SlackBotIdentity | None:
+    """Resolve the bot user behind a bot token via ``auth.test`` and ``users.info``.
+
+    ``auth.test`` needs no scopes and returns the bot's user id; ``users.info``
+    (``users:read``) supplies the handle people type as ``@name``. A missing
+    handle falls back to ``auth.test``'s ``user`` field.
+    """
+    bot_token = token or SLACK_BOT_TOKEN
+    if not bot_token:
+        return None
+    headers = {"Authorization": f"Bearer {bot_token}"}
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as client:
+            auth = await client.post(f"{SLACK_API_BASE_URL}/auth.test", headers=headers)
+            auth_payload = auth.json()
+            if not isinstance(auth_payload, dict) or not auth_payload.get("ok"):
+                error = auth_payload.get("error") if isinstance(auth_payload, dict) else None
+                logger.warning("Slack auth.test failed: %s", error or "unexpected response")
+                return None
+            user_id = _optional_str(auth_payload.get("user_id"))
+            if user_id is None:
+                logger.warning("Slack auth.test returned no user_id")
+                return None
+            username = _optional_str(auth_payload.get("user")) or ""
+            team_id = _optional_str(auth_payload.get("team_id"))
+            info = await client.get(
+                f"{SLACK_API_BASE_URL}/users.info", headers=headers, params={"user": user_id}
+            )
+            info_payload = info.json()
+            if isinstance(info_payload, dict) and info_payload.get("ok"):
+                user = info_payload.get("user")
+                user = user if isinstance(user, dict) else {}
+                profile = user.get("profile")
+                profile = profile if isinstance(profile, dict) else {}
+                username = (
+                    _optional_str(user.get("name"))
+                    or _optional_str(profile.get("display_name"))
+                    or username
+                )
+    except Exception:
+        logger.warning("Could not resolve the Slack bot identity", exc_info=True)
+        return None
+    return SlackBotIdentity(user_id=user_id, username=username, team_id=team_id)
+
+
 def _slack_headers() -> dict[str, str]:
     if not SLACK_BOT_TOKEN:
         return {}

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -54,7 +54,7 @@ async def _repo_config_or_reply(
     except common.SlackRepositoryNotConfigured:
         common.logger.info("No repository for Slack channel=%s thread=%s", channel_id, thread_ts)
         await common.post_slack_thread_reply(
-            channel_id, thread_ts, common.NO_REPOSITORY_SLACK_REPLY
+            channel_id, thread_ts, common.no_repository_slack_reply()
         )
         return None
 

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -41,6 +41,24 @@ def _bounded_payload_text(label: str, payload: dict[str, Any]) -> str:
     return f"{label}\n```json\n{serialized[:8000]}\n```"
 
 
+async def _repo_config_or_reply(
+    channel_id: str, thread_ts: str, **kwargs: Any
+) -> dict[str, str] | None:
+    """Resolve the repository for a Slack turn, telling the thread what is missing.
+
+    Returns None after replying, so the caller answers Slack with 200: a 4xx would
+    only make Slack redeliver the event, and nobody would see why nothing happened.
+    """
+    try:
+        return await common.get_slack_repo_config(channel_id, thread_ts, **kwargs)
+    except common.SlackRepositoryNotConfigured:
+        common.logger.info("No repository for Slack channel=%s thread=%s", channel_id, thread_ts)
+        await common.post_slack_thread_reply(
+            channel_id, thread_ts, common.NO_REPOSITORY_SLACK_REPLY
+        )
+        return None
+
+
 async def _queue_code_channel_turn(
     background_tasks: common.BackgroundTasks,
     *,
@@ -67,13 +85,15 @@ async def _queue_code_channel_turn(
         return {"status": "ignored", "reason": "Duplicate code channel interaction"}
 
     channel_context = await common._get_slack_channel_context(channel_id)
-    repo_config = await common.get_slack_repo_config(
+    repo_config = await _repo_config_or_reply(
         channel_id,
         common.CODE_CHANNEL_SESSION_TS,
         slack_user_id=user_id,
         channel_context=channel_context,
         thread_id=thread_id,
     )
+    if repo_config is None:
+        return {"status": "ignored", "reason": "No repository configured"}
     background_tasks.add_task(
         service.process_slack_mention,
         {
@@ -155,13 +175,15 @@ async def _process_slack_message_update(
         return
     event_data["thread_id"] = thread_id
     event_data["channel_context"] = channel_context
-    repo_config = await common.get_slack_repo_config(
+    repo_config = await _repo_config_or_reply(
         channel_id,
         thread_ts,
         slack_user_id=user_id,
         channel_context=channel_context,
         thread_id=thread_id,
     )
+    if repo_config is None:
+        return
     await service.process_slack_mention(event_data, repo_config)
 
 
@@ -496,13 +518,15 @@ async def slack_webhook(
             "team_id": team_id,
             "app_context": updated_message.get("app_context") or event.get("app_context"),
         }
-        repo_config = await common.get_slack_repo_config(
+        repo_config = await _repo_config_or_reply(
             channel_id,
             thread_ts,
             slack_user_id=user_id,
             channel_context=channel_context,
             thread_id=thread_id,
         )
+        if repo_config is None:
+            return {"status": "ignored", "reason": "No repository configured"}
         if await common.claim_slack_event(event_id, channel_id, event_ts):
             background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
             return {"status": "accepted", "message": "Slack mention queued"}

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -183,6 +183,7 @@ async def slack_webhook(
         common.logger.warning("Invalid Slack signature")
         raise common.HTTPException(status_code=401, detail="Invalid signature")
 
+    await common.ensure_slack_bot_identity()
     try:
         payload = common.json.loads(body)
     except common.json.JSONDecodeError:
@@ -576,6 +577,7 @@ async def slack_interactivity(
         common.logger.warning("Invalid Slack interactivity signature")
         raise common.HTTPException(status_code=401, detail="Invalid signature")
 
+    await common.ensure_slack_bot_identity()
     form = common.parse_qs(body.decode("utf-8"))
     payload_raw = (form.get("payload") or [""])[0]
     try:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -168,6 +168,7 @@ __all__ = [
     "DEFAULT_REPO_OWNER",
     "DOCS_PLZ_SLACK_GATE_REPLY",
     "default_repo_owner_hint",
+    "no_repository_slack_reply",
     "FEEDBACK_REACTIONS",
     "GITHUB_WEBHOOK_SECRET",
     "HTTPException",
@@ -379,6 +380,18 @@ NO_REPOSITORY_SLACK_REPLY = (
     "Admin → Team settings → Default Repository (or in your own profile), or put "
     "`repo:owner/name` in this channel's topic, then mention me again."
 )
+# Appended when Sign in with Slack is available: an unlinked person's profile
+# default cannot apply until their Slack account is linked to their GitHub login.
+LINK_SLACK_ACCOUNT_HINT = (
+    " Your own profile default is used once your Slack account is linked: in the "
+    "dashboard, My settings → Sign in with Slack."
+)
+
+
+def no_repository_slack_reply() -> str:
+    from agent.slack.oauth import slack_oauth_configured  # noqa: PLC0415
+
+    return NO_REPOSITORY_SLACK_REPLY + (LINK_SLACK_ACCOUNT_HINT if slack_oauth_configured() else "")
 
 
 class SlackRepositoryNotConfigured(HTTPException):

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -869,16 +869,15 @@ async def upsert_agent_thread_metadata(
 async def default_repo_owner_hint(env_owner: str = "") -> str:
     """Owner assumed for ``repo:name`` shorthand.
 
-    The deprecated env default wins when set; otherwise the team default
-    repository's owner. Empty when neither is configured, in which case the
+    The team default repository's owner; the deprecated env default only while
+    no team default is configured. Empty when neither is set, in which case the
     shorthand is ignored and a full ``owner/name`` is required.
     """
-    owner = env_owner.strip()
-    if owner:
-        return owner
     team_repo = await get_team_default_repo()
     team_owner = (team_repo or {}).get("owner", "")
-    return team_owner.strip() if isinstance(team_owner, str) else ""
+    if isinstance(team_owner, str) and team_owner.strip():
+        return team_owner.strip()
+    return env_owner.strip()
 
 
 async def get_slack_repo_config(

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import logging
+import time
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
@@ -94,6 +95,7 @@ from agent.slack.client import (
     GitHubPrRef,
     SlackThreadMappingError,  # noqa: F401
     _parse_ts,  # noqa: F401
+    fetch_slack_bot_identity,
     fetch_slack_thread_messages,  # noqa: F401
     format_slack_messages_for_prompt,  # noqa: F401
     get_slack_channel_context,
@@ -179,6 +181,7 @@ __all__ = [
     "SlackThreadMappingError",
     "_AGENT_VERSION_METADATA",
     "describe_open_swe_tags",
+    "ensure_slack_bot_identity",
     "mentions_open_swe",
     "_GH_PR_AGENT_STATE_ACTIONS",
     "_GH_PR_FIRST_REVIEW_ACTIONS",
@@ -334,6 +337,39 @@ DEFAULT_REPO_OWNER = ENV.DEFAULT_REPO_OWNER.get()
 DEFAULT_REPO_NAME = ENV.DEFAULT_REPO_NAME.get()
 SLACK_REPO_OWNER = ENV.SLACK_REPO_OWNER.get() or DEFAULT_REPO_OWNER
 SLACK_REPO_NAME = ENV.SLACK_REPO_NAME.get() or DEFAULT_REPO_NAME
+_SLACK_IDENTITY_RETRY_SECONDS = 60.0
+_SLACK_IDENTITY_ATTEMPTED_AT: float | None = None
+
+
+async def ensure_slack_bot_identity() -> None:
+    """Fill ``SLACK_BOT_USER_ID`` / ``SLACK_BOT_USERNAME`` from the bot token when unset.
+
+    An explicit ``SLACK_BOT_USER_ID`` disables discovery entirely (the username
+    is only a best-effort plain-text mention hint). Discovery is attempted at
+    most once a minute so a Slack outage cannot stall webhook handling.
+    """
+    global SLACK_BOT_USER_ID, SLACK_BOT_USERNAME, _SLACK_IDENTITY_ATTEMPTED_AT
+    if SLACK_BOT_USER_ID:
+        return
+    now = time.monotonic()
+    if (
+        _SLACK_IDENTITY_ATTEMPTED_AT is not None
+        and now - _SLACK_IDENTITY_ATTEMPTED_AT < _SLACK_IDENTITY_RETRY_SECONDS
+    ):
+        return
+    _SLACK_IDENTITY_ATTEMPTED_AT = now
+    identity = await fetch_slack_bot_identity()
+    if identity is None:
+        return
+    SLACK_BOT_USER_ID = SLACK_BOT_USER_ID or identity.user_id
+    SLACK_BOT_USERNAME = SLACK_BOT_USERNAME or identity.username
+    logger.info(
+        "Resolved Slack bot identity: user_id=%s username=%s",
+        SLACK_BOT_USER_ID,
+        SLACK_BOT_USERNAME,
+    )
+
+
 DOCS_PLZ_SLACK_CHANNEL_NAME = "docs-plz"
 DOCS_PLZ_SLACK_GATE_REPLY = (
     "Please don't use Open SWE here, instead ask the Fleet docs-plz agent to implement the docs"

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -372,6 +372,22 @@ async def ensure_slack_bot_identity() -> None:
 
 
 DOCS_PLZ_SLACK_CHANNEL_NAME = "docs-plz"
+# Posted in the Slack thread when no repository can be resolved: a bare 4xx to
+# Slack is invisible to the person who asked.
+NO_REPOSITORY_SLACK_REPLY = (
+    "I don't know which repository to work in. Set a default in the dashboard under "
+    "Admin → Team settings → Default Repository (or in your own profile), or put "
+    "`repo:owner/name` in this channel's topic, then mention me again."
+)
+
+
+class SlackRepositoryNotConfigured(HTTPException):
+    """No repository could be resolved for a Slack-triggered run."""
+
+    def __init__(self) -> None:
+        super().__init__(400, "no default repository configured")
+
+
 DOCS_PLZ_SLACK_GATE_REPLY = (
     "Please don't use Open SWE here, instead ask the Fleet docs-plz agent to implement the docs"
 )
@@ -954,7 +970,7 @@ async def get_slack_repo_config(
         repo_config = {"owner": env_owner, "name": default_name}
 
     if not repo_config:
-        raise HTTPException(400, "no default repository configured")
+        raise SlackRepositoryNotConfigured()
 
     return repo_config
 

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -167,6 +167,7 @@ __all__ = [
     "DEFAULT_HTTP_TIMEOUT",
     "DEFAULT_REPO_OWNER",
     "DOCS_PLZ_SLACK_GATE_REPLY",
+    "default_repo_owner_hint",
     "FEEDBACK_REACTIONS",
     "GITHUB_WEBHOOK_SECRET",
     "HTTPException",
@@ -411,7 +412,11 @@ def get_repo_config_from_team_mapping(
     team_identifier: str, project_name: str = ""
 ) -> dict[str, str]:
     """Look up repository configuration from LINEAR_TEAM_TO_REPO mapping."""
-    fallback = {"owner": DEFAULT_REPO_OWNER, "name": DEFAULT_REPO_NAME} if DEFAULT_REPO_NAME else {}
+    fallback = (
+        {"owner": DEFAULT_REPO_OWNER, "name": DEFAULT_REPO_NAME}
+        if DEFAULT_REPO_OWNER and DEFAULT_REPO_NAME
+        else {}
+    )
 
     if not team_identifier or team_identifier not in LINEAR_TEAM_TO_REPO:
         return fallback
@@ -845,6 +850,21 @@ async def upsert_agent_thread_metadata(
         logger.exception("Failed to persist owner metadata for thread %s", thread_id)
 
 
+async def default_repo_owner_hint(env_owner: str = "") -> str:
+    """Owner assumed for ``repo:name`` shorthand.
+
+    The deprecated env default wins when set; otherwise the team default
+    repository's owner. Empty when neither is configured, in which case the
+    shorthand is ignored and a full ``owner/name`` is required.
+    """
+    owner = env_owner.strip()
+    if owner:
+        return owner
+    team_repo = await get_team_default_repo()
+    team_owner = (team_repo or {}).get("owner", "")
+    return team_owner.strip() if isinstance(team_owner, str) else ""
+
+
 async def get_slack_repo_config(
     channel_id: str,
     thread_ts: str,
@@ -859,10 +879,10 @@ async def get_slack_repo_config(
         2. A ``repo:owner/name`` token in the channel's topic/purpose.
         3. The triggering user's dashboard ``default_repo`` (if they have a
            profile and their Slack email maps to a known GitHub login).
-        4. Team default repo.
-        5. ``SLACK_REPO_*`` env defaults.
+        4. Team default repo (Admin → Team settings).
+        5. Deprecated ``SLACK_REPO_*`` / ``DEFAULT_REPO_*`` env defaults.
     """
-    default_owner = SLACK_REPO_OWNER.strip() or DEFAULT_REPO_OWNER
+    env_owner = SLACK_REPO_OWNER.strip() or DEFAULT_REPO_OWNER
     default_name = SLACK_REPO_NAME.strip() or DEFAULT_REPO_NAME
     langgraph_client = get_client(url=LANGGRAPH_URL)
 
@@ -884,6 +904,7 @@ async def get_slack_repo_config(
             )
 
     if not repo_config:
+        default_owner = await default_repo_owner_hint(env_owner)
         try:
             if channel_context is not None:
                 channel_description = get_slack_channel_context_description(channel_context)
@@ -929,8 +950,8 @@ async def get_slack_repo_config(
     if not repo_config:
         repo_config = await get_team_default_repo()
 
-    if not repo_config and default_owner and default_name:
-        repo_config = {"owner": default_owner, "name": default_name}
+    if not repo_config and env_owner and default_name:
+        repo_config = {"owner": env_owner, "name": default_name}
 
     if not repo_config:
         raise HTTPException(400, "no default repository configured")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,16 @@ def fake_store(monkeypatch: pytest.MonkeyPatch) -> FakeStore:
 
 
 @pytest.fixture(autouse=True)
+def _no_slack_identity_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ``ensure_slack_bot_identity`` from calling Slack during tests.
+
+    A far-future attempt timestamp trips its retry throttle; tests of the
+    discovery itself reset it to ``None``.
+    """
+    monkeypatch.setattr(webhook_common, "_SLACK_IDENTITY_ATTEMPTED_AT", float("inf"))
+
+
+@pytest.fixture(autouse=True)
 def _reset_ttl_cache() -> Iterator[None]:
     """Keep the process-global TTL cache from leaking team settings between tests."""
     ttl_cache.clear()

--- a/tests/github/test_repo_extraction.py
+++ b/tests/github/test_repo_extraction.py
@@ -32,6 +32,15 @@ class TestExtractRepoFromText:
         result = extract_repo_from_text("repo:my-repo", default_owner="custom-org")
         assert result == {"owner": "custom-org", "name": "my-repo"}
 
+    def test_repo_name_only_without_default_owner_returns_none(self) -> None:
+        assert extract_repo_from_text("fix repo:widgets", default_owner="") is None
+
+    def test_repo_name_only_has_no_hardcoded_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import agent.utils.repo as repo_module
+
+        monkeypatch.setattr(repo_module, "_DEFAULT_REPO_OWNER", "")
+        assert extract_repo_from_text("fix repo:widgets") is None
+
     def test_github_url(self) -> None:
         result = extract_repo_from_text(
             "check https://github.com/langchain-ai/langgraph-api please"

--- a/tests/slack/test_slack_bot_identity.py
+++ b/tests/slack/test_slack_bot_identity.py
@@ -1,0 +1,210 @@
+"""Slack bot identity discovery from the bot token."""
+
+from typing import Any
+
+import pytest
+
+from agent.slack import client as slack_utils
+from agent.webhooks import common
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _client(routes: dict[str, dict[str, Any]]) -> type:
+    class Client:
+        calls: list[str] = []
+        headers: list[dict[str, str]] = []
+
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> _Response:
+            method = url.rsplit("/", 1)[1]
+            type(self).calls.append(method)
+            type(self).headers.append(dict(kwargs.get("headers") or {}))
+            return _Response(routes.get(method, {"ok": False, "error": "unknown_method"}))
+
+        async def get(self, url: str, **kwargs: Any) -> _Response:
+            method = url.rsplit("/", 1)[1].split("?", 1)[0]
+            type(self).calls.append(method)
+            type(self).headers.append(dict(kwargs.get("headers") or {}))
+            return _Response(routes.get(method, {"ok": False, "error": "unknown_method"}))
+
+    return Client
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(common, "SLACK_BOT_USER_ID", "")
+    monkeypatch.setattr(common, "SLACK_BOT_USERNAME", "")
+    monkeypatch.setattr(common, "_SLACK_IDENTITY_ATTEMPTED_AT", None)
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+
+
+async def test_fetch_identity_uses_auth_test_and_users_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(
+        {
+            "auth.test": {"ok": True, "user_id": "UBOT", "user": "bot", "team_id": "T1"},
+            "users.info": {
+                "ok": True,
+                "user": {"name": "open-swe", "profile": {"display_name": "Open SWE"}},
+            },
+        }
+    )
+    monkeypatch.setattr(slack_utils.httpx, "AsyncClient", client)
+
+    identity = await slack_utils.fetch_slack_bot_identity()
+
+    assert identity == slack_utils.SlackBotIdentity(
+        user_id="UBOT", username="open-swe", team_id="T1"
+    )
+    assert client.calls == ["auth.test", "users.info"]
+    assert all(h.get("Authorization") == "Bearer xoxb-test" for h in client.headers)
+
+
+async def test_fetch_identity_falls_back_to_auth_test_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(
+        {"auth.test": {"ok": True, "user_id": "UBOT", "user": "openswe-bot", "team_id": "T1"}}
+    )
+    monkeypatch.setattr(slack_utils.httpx, "AsyncClient", client)
+
+    identity = await slack_utils.fetch_slack_bot_identity()
+
+    assert identity is not None
+    assert identity.username == "openswe-bot"
+
+
+async def test_fetch_identity_returns_none_on_slack_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client({"auth.test": {"ok": False, "error": "invalid_auth"}})
+    monkeypatch.setattr(slack_utils.httpx, "AsyncClient", client)
+
+    assert await slack_utils.fetch_slack_bot_identity() is None
+
+
+async def test_fetch_identity_returns_none_on_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Client:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> _Response:
+            raise ConnectionError("no network")
+
+    monkeypatch.setattr(slack_utils.httpx, "AsyncClient", Client)
+
+    assert await slack_utils.fetch_slack_bot_identity() is None
+
+
+async def test_fetch_identity_without_token_makes_no_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "")
+    client = _client({})
+    monkeypatch.setattr(slack_utils.httpx, "AsyncClient", client)
+
+    assert await slack_utils.fetch_slack_bot_identity() is None
+    assert client.calls == []
+
+
+async def test_ensure_fills_empty_module_globals(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake() -> slack_utils.SlackBotIdentity:
+        return slack_utils.SlackBotIdentity("UBOT", "open-swe", "T1")
+
+    monkeypatch.setattr(common, "fetch_slack_bot_identity", fake)
+
+    await common.ensure_slack_bot_identity()
+
+    assert (common.SLACK_BOT_USER_ID, common.SLACK_BOT_USERNAME) == ("UBOT", "open-swe")
+
+
+async def test_ensure_respects_explicit_env_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(common, "SLACK_BOT_USER_ID", "UENV")
+    monkeypatch.setattr(common, "SLACK_BOT_USERNAME", "env-name")
+    called = False
+
+    async def fake() -> None:
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(common, "fetch_slack_bot_identity", fake)
+
+    await common.ensure_slack_bot_identity()
+
+    assert not called
+    assert (common.SLACK_BOT_USER_ID, common.SLACK_BOT_USERNAME) == ("UENV", "env-name")
+
+
+async def test_ensure_skips_when_user_id_is_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(common, "SLACK_BOT_USER_ID", "UENV")
+    called = False
+
+    async def fake() -> None:
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(common, "fetch_slack_bot_identity", fake)
+
+    await common.ensure_slack_bot_identity()
+
+    assert not called
+    assert (common.SLACK_BOT_USER_ID, common.SLACK_BOT_USERNAME) == ("UENV", "")
+
+
+async def test_ensure_keeps_explicit_username(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(common, "SLACK_BOT_USERNAME", "custom-name")
+
+    async def fake() -> slack_utils.SlackBotIdentity:
+        return slack_utils.SlackBotIdentity("UBOT", "open-swe", "T1")
+
+    monkeypatch.setattr(common, "fetch_slack_bot_identity", fake)
+
+    await common.ensure_slack_bot_identity()
+
+    assert (common.SLACK_BOT_USER_ID, common.SLACK_BOT_USERNAME) == ("UBOT", "custom-name")
+
+
+async def test_ensure_throttles_after_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    async def fake() -> None:
+        nonlocal calls
+        calls += 1
+        return None
+
+    monkeypatch.setattr(common, "fetch_slack_bot_identity", fake)
+
+    await common.ensure_slack_bot_identity()
+    await common.ensure_slack_bot_identity()
+
+    assert calls == 1

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -852,6 +852,100 @@ def test_get_slack_repo_config_applies_team_default_repo(
     assert repo == {"owner": "team-owner", "name": "team-repo"}
 
 
+def _team_default_repo(owner: str, name: str):
+    async def _get() -> dict[str, str]:
+        return {"owner": owner, "name": name}
+
+    return _get
+
+
+def _clear_env_repo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for attr in ("SLACK_REPO_OWNER", "SLACK_REPO_NAME", "DEFAULT_REPO_OWNER", "DEFAULT_REPO_NAME"):
+        monkeypatch.setattr(webhook_common, attr, "")
+
+
+def test_get_slack_repo_config_shorthand_uses_team_default_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(
+        webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
+    )
+
+    repo = asyncio.run(
+        webhook_common.get_slack_repo_config(
+            "C123", "1.234", channel_context={"topic": "repo:tools"}, thread_id="mapped-thread"
+        )
+    )
+
+    assert repo == {"owner": "acme", "name": "tools"}
+
+
+def test_get_slack_repo_config_shorthand_prefers_env_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "SLACK_REPO_OWNER", "env-owner")
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(
+        webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
+    )
+
+    repo = asyncio.run(
+        webhook_common.get_slack_repo_config(
+            "C123", "1.234", channel_context={"topic": "repo:tools"}, thread_id="mapped-thread"
+        )
+    )
+
+    assert repo == {"owner": "env-owner", "name": "tools"}
+
+
+def test_get_slack_repo_config_shorthand_without_any_owner_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+
+    with pytest.raises(webhook_common.HTTPException) as excinfo:
+        asyncio.run(
+            webhook_common.get_slack_repo_config(
+                "C123", "1.234", channel_context={"topic": "repo:tools"}, thread_id="t"
+            )
+        )
+
+    assert excinfo.value.status_code == 400
+
+
+def test_get_slack_repo_config_never_mixes_team_owner_with_env_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+    _clear_env_repo_defaults(monkeypatch)
+    monkeypatch.setattr(webhook_common, "SLACK_REPO_NAME", "env-repo")
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+
+    with pytest.raises(webhook_common.HTTPException):
+        asyncio.run(webhook_common.get_slack_repo_config("C123", "1.234", thread_id="t"))
+
+
+async def test_default_repo_owner_hint_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
+    )
+
+    assert await webhook_common.default_repo_owner_hint("env-owner") == "env-owner"
+    assert await webhook_common.default_repo_owner_hint("") == "acme"
+
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+    assert await webhook_common.default_repo_owner_hint("") == ""
+
+
 def _setup_slack_mention_fakes(
     monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]
 ) -> None:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -883,9 +883,10 @@ def test_get_slack_repo_config_shorthand_uses_team_default_owner(
     assert repo == {"owner": "acme", "name": "tools"}
 
 
-def test_get_slack_repo_config_shorthand_prefers_env_owner(
+def test_get_slack_repo_config_shorthand_prefers_team_owner_over_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The deprecated SLACK_REPO_OWNER only fills in while no team default exists."""
     threads_client = _FakeThreadsClient(thread={"metadata": {}})
     _clear_env_repo_defaults(monkeypatch)
     monkeypatch.setattr(webhook_common, "SLACK_REPO_OWNER", "env-owner")
@@ -900,7 +901,7 @@ def test_get_slack_repo_config_shorthand_prefers_env_owner(
         )
     )
 
-    assert repo == {"owner": "env-owner", "name": "tools"}
+    assert repo == {"owner": "acme", "name": "tools"}
 
 
 def test_get_slack_repo_config_shorthand_without_any_owner_falls_through(
@@ -939,10 +940,11 @@ async def test_default_repo_owner_hint_precedence(monkeypatch: pytest.MonkeyPatc
         webhook_common, "get_team_default_repo", _team_default_repo("acme", "widgets")
     )
 
-    assert await webhook_common.default_repo_owner_hint("env-owner") == "env-owner"
+    assert await webhook_common.default_repo_owner_hint("env-owner") == "acme"
     assert await webhook_common.default_repo_owner_hint("") == "acme"
 
     monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+    assert await webhook_common.default_repo_owner_hint("env-owner") == "env-owner"
     assert await webhook_common.default_repo_owner_hint("") == ""
 
 

--- a/tests/slack/test_slack_no_repository.py
+++ b/tests/slack/test_slack_no_repository.py
@@ -26,6 +26,21 @@ async def test_missing_repository_is_explained_in_the_thread(
     channel_id, thread_ts, text = reply.await_args.args
     assert (channel_id, thread_ts) == ("C1", "123.45")
     assert "Team settings" in text and "repo:owner/name" in text
+    assert "Sign in with Slack" not in text
+
+
+def test_reply_points_at_sign_in_with_slack_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.slack import oauth as slack_oauth
+
+    monkeypatch.setattr(slack_oauth, "SLACK_CLIENT_ID", "123.456")
+    monkeypatch.setattr(slack_oauth, "SLACK_CLIENT_SECRET", "secret")
+
+    text = webhook_common.no_repository_slack_reply()
+
+    assert text.startswith(webhook_common.NO_REPOSITORY_SLACK_REPLY)
+    assert "My settings → Sign in with Slack" in text
 
 
 async def test_resolved_repository_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/slack/test_slack_no_repository.py
+++ b/tests/slack/test_slack_no_repository.py
@@ -1,0 +1,50 @@
+"""A Slack turn with no resolvable repository gets a reply, not a silent 400."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.slack import routes as slack_routes
+from agent.webhooks import common as webhook_common
+
+
+async def test_missing_repository_is_explained_in_the_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        webhook_common,
+        "get_slack_repo_config",
+        AsyncMock(side_effect=webhook_common.SlackRepositoryNotConfigured()),
+    )
+    reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", reply)
+
+    resolved = await slack_routes._repo_config_or_reply("C1", "123.45", slack_user_id="U1")
+
+    assert resolved is None
+    reply.assert_awaited_once()
+    channel_id, thread_ts, text = reply.await_args.args
+    assert (channel_id, thread_ts) == ("C1", "123.45")
+    assert "Team settings" in text and "repo:owner/name" in text
+
+
+async def test_resolved_repository_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        webhook_common,
+        "get_slack_repo_config",
+        AsyncMock(return_value={"owner": "acme", "name": "widgets"}),
+    )
+    reply = AsyncMock()
+    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", reply)
+
+    resolved = await slack_routes._repo_config_or_reply("C1", "123.45")
+
+    assert resolved == {"owner": "acme", "name": "widgets"}
+    reply.assert_not_awaited()
+
+
+def test_missing_repository_is_still_a_400_for_api_callers() -> None:
+    exc = webhook_common.SlackRepositoryNotConfigured()
+
+    assert exc.status_code == 400
+    assert exc.detail == "no default repository configured"


### PR DESCRIPTION
## Summary

Third PR of the install-simplification stack, on the GitHub discovery PR. The Slack side needs only `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`.

- **Bot identity.** The bot user id and handle come from the token via `auth.test` and `users.info` at startup, retried on the first webhook (60s throttle) if Slack was unreachable. Setting `SLACK_BOT_USER_ID` disables discovery entirely, so scripted-fake tests are untouched.
- **Team default repository is canonical.** `repo:name` shorthand resolves against the team default's owner; the hardcoded `langchain-ai` owner default is gone. `DEFAULT_REPO_*` / `SLACK_REPO_*` keep working as deprecated fallbacks, and only fill in while no team default exists.
- **Repository resolution replies.** Thread → channel topic `repo:` → the mentioning user's profile default (for users linked through Sign in with Slack or an admin mapping) → team default. When nothing resolves, the bot replies in the thread instead of failing the webhook silently, and tells an unlinked person how to link their account when Sign in with Slack is configured.

## Testing

- New: `tests/slack/test_slack_bot_identity.py`, `tests/slack/test_slack_no_repository.py`; team-default and precedence cases in `tests/slack/test_slack_context.py` and `tests/github/test_repo_extraction.py`.
- `uv run pytest tests/`: green apart from the 8 Slack webhook cases that already fail on a clean `main`.
- Verified against the real API from a local checkout: Slack identity via `auth.test`/`users.info`, signed webhooks accepted, bad signatures 401. Running on the `open-swe-staging` deployment: mentions resolve the repository through the profile default and the reply appears when nothing resolves.

## Stack

1. #2463 unified config + standard LangSmith env (merged)
2. #2464 GitHub App discovery
3. **this PR** Slack bot discovery and repository defaults
4. #2488 startup report and `make setup`
5. #2489 LangSmith tenant discovery and `LANGSMITH_PROJECT` tracing
6. #2486 single-origin dashboard
7. #2466 installation docs rewrite
