### PR TITLE
feat: startup configuration report and guided make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web desktop install-desktop install-checkout
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev web desktop install-desktop install-checkout setup
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -30,6 +30,9 @@ install-checkout:
 
 install:
 	uv sync --extra dev
+
+setup:
+	uv run python scripts/setup_env.py
 
 ######################
 # TESTING
@@ -84,6 +87,7 @@ help:
 	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
 	@echo 'install-checkout             - install the current checkout of Open SWE Desktop on macOS'
 	@echo 'install                      - install dependencies (incl. dev extras)'
+	@echo 'setup                        - guided .env setup for the GitHub + Slack install'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'typecheck                    - run ty on agent/ and tests/'

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -17,6 +17,7 @@ from agent.github.routes import router as github_webhook_router
 from agent.linear.routes import router as linear_webhook_router
 from agent.slack.routes import router as slack_webhook_router
 from agent.utils.event_loop import pin_single_event_loop
+from agent.utils.startup_config import log_startup_configuration
 from agent.webhooks.common import ensure_slack_bot_identity
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     pin_single_event_loop()
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
+    log_startup_configuration()
     try:
         await ensure_slack_bot_identity()
     except Exception:  # noqa: BLE001

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from agent.api.health import router as health_router
 from agent.config import ENV
 from agent.dashboard import router as dashboard_router
+from agent.dashboard.oauth import allowed_dashboard_origins
 from agent.dashboard.plan_api import plan_router
 from agent.dashboard.workflow_approval_api import workflow_approval_router
 from agent.github.routes import router as github_webhook_router
@@ -45,15 +46,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
 def create_app() -> FastAPI:
     app = FastAPI(lifespan=lifespan)
-    allowed_origins = [
-        origin.strip()
-        for origin in ENV.DASHBOARD_ALLOWED_ORIGINS.get().split(",")
-        if origin.strip()
-    ]
-    if "*" in allowed_origins:
+    extra_origins = ENV.DASHBOARD_ALLOWED_ORIGINS.get().split(",")
+    if "*" in (origin.strip() for origin in extra_origins):
         raise RuntimeError(
             "DASHBOARD_ALLOWED_ORIGINS must not include '*' when allow_credentials=True"
         )
+    # The dashboard's own origin (DASHBOARD_BASE_URL) is always allowed;
+    # DASHBOARD_ALLOWED_ORIGINS only adds further cross-origin frontends.
+    allowed_origins = sorted(allowed_dashboard_origins())
     if allowed_origins:
         app.add_middleware(
             CORSMiddleware,

--- a/agent/utils/startup_config.py
+++ b/agent/utils/startup_config.py
@@ -16,6 +16,7 @@ _SURFACES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("LangSmith", ("LANGSMITH_API_KEY",)),
     ("GitHub", ("GITHUB_APP_CLIENT_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_WEBHOOK_SECRET")),
     ("Slack", ("SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET")),
+    ("Slack sign-in", ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET")),
     ("Linear", ("LINEAR_API_KEY", "LINEAR_WEBHOOK_SECRET")),
     (
         "Dashboard",

--- a/agent/utils/startup_config.py
+++ b/agent/utils/startup_config.py
@@ -1,0 +1,71 @@
+"""Startup report of the effective configuration and deprecated settings.
+
+Only variable *names* are ever logged; values never leave the environment.
+"""
+
+import logging
+import os
+from collections.abc import Mapping
+
+from agent.config import ENV
+
+logger = logging.getLogger(__name__)
+
+# Surface -> variables that must all be present for it to be enabled.
+_SURFACES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("LangSmith", ("LANGSMITH_API_KEY",)),
+    ("GitHub", ("GITHUB_APP_CLIENT_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_WEBHOOK_SECRET")),
+    ("Slack", ("SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET")),
+    ("Linear", ("LINEAR_API_KEY", "LINEAR_WEBHOOK_SECRET")),
+    (
+        "Dashboard",
+        (
+            "GITHUB_APP_CLIENT_SECRET",
+            "DASHBOARD_JWT_SECRET",
+            "TOKEN_ENCRYPTION_KEY",
+            "DASHBOARD_BASE_URL",
+            "DASHBOARD_API_BASE_URL",
+        ),
+    ),
+)
+
+# Discovery-backed values: listed as overrides only when explicitly set.
+_OVERRIDES: tuple[str, ...] = (
+    "GITHUB_APP_INSTALLATION_ID",
+    "SLACK_BOT_USER_ID",
+    "SLACK_BOT_USERNAME",
+    "DEFAULT_SANDBOX_SNAPSHOT_ID",
+)
+
+
+def _is_set(env: Mapping[str, str], name: str) -> bool:
+    return ENV[name].is_set(env)
+
+
+def deprecated_env_warnings(env: Mapping[str, str]) -> list[str]:
+    """Human-readable warnings for every deprecated variable present in ``env``."""
+    return [f"{name} is deprecated: {hint}" for name, hint in ENV.deprecated_in_use(env)]
+
+
+def configuration_summary(env: Mapping[str, str]) -> list[str]:
+    """One line per surface: enabled, disabled, or the variables still missing."""
+    lines: list[str] = []
+    for surface, names in _SURFACES:
+        missing = [name for name in names if not _is_set(env, name)]
+        if not missing:
+            lines.append(f"{surface}: enabled")
+        elif len(missing) == len(names):
+            lines.append(f"{surface}: disabled")
+        else:
+            lines.append(f"{surface}: missing {', '.join(missing)}")
+    overrides = [name for name in _OVERRIDES if _is_set(env, name)]
+    if overrides:
+        lines.append(f"Explicit overrides: {', '.join(overrides)}")
+    return lines
+
+
+def log_startup_configuration() -> None:
+    for line in configuration_summary(os.environ):
+        logger.info("config: %s", line)
+    for warning in deprecated_env_warnings(os.environ):
+        logger.warning("config: %s", warning)

--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -1,0 +1,338 @@
+"""Guided ``.env`` setup for the GitHub + Slack minimum installation.
+
+Run with ``make setup`` (or ``uv run python scripts/setup_env.py``). Prompts for
+the handful of credentials Open SWE cannot discover on its own, generates the
+local secrets, and writes ``.env`` with owner-only permissions. Existing values
+are kept unless ``--force`` is given; secrets are never echoed back.
+"""
+
+import argparse
+import getpass
+import os
+import re
+import secrets
+import sys
+from collections.abc import Callable, Iterable, Mapping
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+MINIMUM_KEYS: tuple[str, ...] = (
+    "LANGSMITH_API_KEY",
+    "GITHUB_APP_CLIENT_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_WEBHOOK_SECRET",
+    "SLACK_BOT_TOKEN",
+    "SLACK_SIGNING_SECRET",
+)
+MODEL_PROVIDER_KEYS: dict[str, str | None] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "gateway": None,
+}
+DASHBOARD_KEYS: tuple[str, ...] = (
+    "GITHUB_APP_CLIENT_SECRET",
+    "DASHBOARD_BASE_URL",
+    "DASHBOARD_API_BASE_URL",
+    "CONFIGURED_ADMINS",
+)
+GENERATED_KEYS: tuple[str, ...] = ("DASHBOARD_JWT_SECRET", "TOKEN_ENCRYPTION_KEY")
+SECRET_KEYS: frozenset[str] = frozenset(
+    {
+        "LANGSMITH_API_KEY",
+        "GITHUB_APP_PRIVATE_KEY",
+        "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_APP_CLIENT_SECRET",
+        "SLACK_BOT_TOKEN",
+        "SLACK_SIGNING_SECRET",
+        *GENERATED_KEYS,
+        *(key for key in MODEL_PROVIDER_KEYS.values() if key),
+    }
+)
+DEFAULT_DASHBOARD_BASE_URL = "http://localhost:3000"
+DEFAULT_DASHBOARD_API_BASE_URL = "http://localhost:2024"
+MARKER = "# Added by scripts/setup_env.py"
+
+_ENV_LINE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+
+Ask = Callable[[str, str], str]
+AskSecret = Callable[[str], str]
+
+
+class SetupError(Exception):
+    """A configuration problem the user has to fix; reported without a traceback."""
+
+
+def generate_dashboard_jwt_secret() -> str:
+    """HMAC secret for dashboard session cookies and OAuth state (64 hex chars)."""
+    return secrets.token_hex(32)
+
+
+def generate_token_encryption_key() -> str:
+    """Fernet key for stored OAuth tokens; drawn independently of the JWT secret."""
+    return Fernet.generate_key().decode()
+
+
+def generate_webhook_secret() -> str:
+    return secrets.token_hex(32)
+
+
+_ESCAPES = {"n": "\n", "\\": "\\", '"': '"'}
+
+
+def _decode_double_quoted(inner: str) -> str:
+    """Undo :func:`quote_value`; mirrors python-dotenv's double-quote escapes."""
+    out: list[str] = []
+    chars = iter(inner)
+    for char in chars:
+        if char != "\\":
+            out.append(char)
+            continue
+        nxt = next(chars, "")
+        out.append(_ESCAPES.get(nxt, "\\" + nxt))
+    return "".join(out)
+
+
+def _unquote(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        inner = value[1:-1]
+        return _decode_double_quoted(inner) if value[0] == '"' else inner
+    return value.split(" #", 1)[0].strip()
+
+
+def parse_env(text: str) -> dict[str, str]:
+    """``KEY=value`` pairs from a dotenv file; comments and blank lines are skipped."""
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = _ENV_LINE.match(line)
+        if match:
+            values[match.group(1)] = _unquote(match.group(2))
+    return values
+
+
+def quote_value(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def render_env(existing_text: str, updates: Mapping[str, str]) -> str:
+    """Return ``existing_text`` with ``updates`` applied in place and new keys appended.
+
+    Comments, ordering and unrelated keys are preserved; a key present in the
+    file is rewritten on its own line and never duplicated.
+    """
+    pending = dict(updates)
+    lines: list[str] = []
+    for line in existing_text.splitlines():
+        match = _ENV_LINE.match(line)
+        key = match.group(1) if match and not line.lstrip().startswith("#") else None
+        if key is not None and key in pending:
+            lines.append(f"{key}={quote_value(pending.pop(key))}")
+        else:
+            lines.append(line)
+    if pending:
+        if lines and lines[-1].strip():
+            lines.append("")
+        if MARKER not in lines:
+            lines.append(MARKER)
+        lines.extend(f"{key}={quote_value(value)}" for key, value in pending.items())
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def read_private_key(path: str) -> str:
+    """Load a GitHub App ``.pem`` as a single dotenv-safe line."""
+    pem = Path(path).expanduser()
+    try:
+        text = pem.read_text().strip()
+    except OSError as exc:
+        raise SetupError(f"Cannot read private key file {pem}: {exc.strerror}") from exc
+    if "PRIVATE KEY" not in text:
+        raise SetupError(f"{pem} does not look like a PEM private key")
+    return "\\n".join(line.strip() for line in text.splitlines())
+
+
+def write_env_file(path: Path, content: str) -> None:
+    """Write the file readable by the owner only, creating or truncating it."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(content)
+    os.chmod(path, 0o600)
+
+
+def missing_minimum(values: Mapping[str, str]) -> list[str]:
+    missing = [key for key in MINIMUM_KEYS if not values.get(key, "").strip()]
+    gateway = values.get("LANGSMITH_GATEWAY_ENABLED", "").strip().lower() in {"1", "true", "yes"}
+    has_model_key = any(values.get(key, "").strip() for key in MODEL_PROVIDER_KEYS.values() if key)
+    if not gateway and not has_model_key:
+        missing.append("a model provider key (or LANGSMITH_GATEWAY_ENABLED=true)")
+    return missing
+
+
+def collect_answers(
+    ask: Ask,
+    ask_secret: AskSecret,
+    *,
+    existing: Mapping[str, str],
+    dashboard: bool,
+) -> dict[str, str]:
+    """Prompt for every minimum value not already present in ``existing``."""
+    answers: dict[str, str] = {}
+
+    def want(key: str) -> bool:
+        return not existing.get(key, "").strip()
+
+    if want("LANGSMITH_API_KEY"):
+        answers["LANGSMITH_API_KEY"] = ask_secret("LangSmith API key (lsv2_...)")
+
+    has_model = any(existing.get(key, "").strip() for key in MODEL_PROVIDER_KEYS.values() if key)
+    gateway_on = existing.get("LANGSMITH_GATEWAY_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if not has_model and not gateway_on:
+        provider = ask("Model provider (anthropic / openai / google / gateway)", "anthropic")
+        provider = provider.strip().lower()
+        if provider not in MODEL_PROVIDER_KEYS:
+            raise SetupError(f"Unknown model provider {provider!r}")
+        key = MODEL_PROVIDER_KEYS[provider]
+        if key is None:
+            answers["LANGSMITH_GATEWAY_ENABLED"] = "true"
+        else:
+            answers[key] = ask_secret(f"{provider.title()} API key")
+
+    if want("GITHUB_APP_CLIENT_ID"):
+        answers["GITHUB_APP_CLIENT_ID"] = ask("GitHub App client ID (Iv1....)", "").strip()
+    if want("GITHUB_APP_PRIVATE_KEY"):
+        pem_path = ask("Path to the GitHub App private key (.pem)", "").strip()
+        answers["GITHUB_APP_PRIVATE_KEY"] = read_private_key(pem_path)
+    if want("GITHUB_WEBHOOK_SECRET"):
+        supplied = ask_secret("GitHub webhook secret (leave empty to generate one)")
+        answers["GITHUB_WEBHOOK_SECRET"] = supplied.strip() or generate_webhook_secret()
+        answers["_generated_webhook_secret"] = "" if supplied.strip() else "1"
+    if want("SLACK_BOT_TOKEN"):
+        answers["SLACK_BOT_TOKEN"] = ask_secret("Slack bot token (xoxb-...)")
+    if want("SLACK_SIGNING_SECRET"):
+        answers["SLACK_SIGNING_SECRET"] = ask_secret("Slack signing secret")
+
+    if dashboard:
+        if want("GITHUB_APP_CLIENT_SECRET"):
+            answers["GITHUB_APP_CLIENT_SECRET"] = ask_secret("GitHub App client secret")
+        if want("DASHBOARD_BASE_URL"):
+            answers["DASHBOARD_BASE_URL"] = ask("Dashboard URL", DEFAULT_DASHBOARD_BASE_URL)
+        if want("DASHBOARD_API_BASE_URL"):
+            answers["DASHBOARD_API_BASE_URL"] = ask(
+                "Backend URL browsers use", DEFAULT_DASHBOARD_API_BASE_URL
+            )
+        if want("CONFIGURED_ADMINS"):
+            answers["CONFIGURED_ADMINS"] = ask("Admin GitHub logins (comma-separated)", "")
+
+    return {key: value for key, value in answers.items() if value or key.startswith("_")}
+
+
+def generated_secrets(existing: Mapping[str, str], *, force: bool) -> dict[str, str]:
+    """Freshly generated local secrets for every key that is unset (or all, with ``force``)."""
+    generators = {
+        "DASHBOARD_JWT_SECRET": generate_dashboard_jwt_secret,
+        "TOKEN_ENCRYPTION_KEY": generate_token_encryption_key,
+    }
+    return {
+        key: make()
+        for key, make in generators.items()
+        if force or not existing.get(key, "").strip()
+    }
+
+
+def _values_from_environ(environ: Mapping[str, str], keys: Iterable[str]) -> dict[str, str]:
+    return {key: environ[key] for key in keys if environ.get(key, "").strip()}
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Guided .env setup for Open SWE")
+    parser.add_argument("--output", default=".env", help="dotenv file to write (default: .env)")
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="read values from the process environment instead of prompting",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="regenerate local secrets even if already set"
+    )
+    parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="also collect the optional dashboard settings",
+    )
+    return parser.parse_args(argv)
+
+
+def _interactive_ask(prompt: str, default: str) -> str:
+    suffix = f" [{default}]" if default else ""
+    answer = input(f"{prompt}{suffix}: ")
+    return answer if answer.strip() else default
+
+
+def _interactive_ask_secret(prompt: str) -> str:
+    return getpass.getpass(f"{prompt}: ")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    output = Path(args.output)
+    existing_text = output.read_text() if output.exists() else ""
+    existing = parse_env(existing_text)
+
+    if args.non_interactive:
+        keys = (*MINIMUM_KEYS, *DASHBOARD_KEYS, "LANGSMITH_GATEWAY_ENABLED")
+        keys = (*keys, *(key for key in MODEL_PROVIDER_KEYS.values() if key))
+        answers = _values_from_environ(os.environ, keys)
+        merged = {**existing, **answers}
+        if not merged.get("GITHUB_WEBHOOK_SECRET", "").strip():
+            answers["GITHUB_WEBHOOK_SECRET"] = generate_webhook_secret()
+            answers["_generated_webhook_secret"] = "1"
+    else:
+        try:
+            answers = collect_answers(
+                _interactive_ask,
+                _interactive_ask_secret,
+                existing=existing,
+                dashboard=args.dashboard,
+            )
+        except (SetupError, EOFError, KeyboardInterrupt) as exc:
+            print(f"\nSetup aborted: {exc}" if str(exc) else "\nSetup aborted.", file=sys.stderr)
+            return 2
+
+    generated_webhook = bool(answers.pop("_generated_webhook_secret", ""))
+    answers.update(generated_secrets(existing, force=args.force))
+    merged = {**existing, **answers}
+    missing = missing_minimum(merged)
+    if missing:
+        print("Still missing: " + ", ".join(missing), file=sys.stderr)
+        if args.non_interactive:
+            return 2
+
+    write_env_file(output, render_env(existing_text, answers))
+
+    written = sorted(answers)
+    kept = sorted(key for key in existing if key not in answers)
+    print(f"Wrote {output} (mode 600).")
+    if written:
+        print("  set:  " + ", ".join(written))
+    if kept:
+        print("  kept: " + ", ".join(kept))
+    if generated_webhook:
+        print(
+            f"\nGITHUB_WEBHOOK_SECRET was generated and saved to {output}. Copy it into the "
+            "GitHub App's Webhook secret field; the value is not shown here:\n"
+            f"  grep '^GITHUB_WEBHOOK_SECRET=' {output}"
+        )
+    print("\nNext: `make dev`, then mention the bot in Slack or a GitHub issue.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -36,6 +36,8 @@ DASHBOARD_KEYS: tuple[str, ...] = (
     "DASHBOARD_BASE_URL",
     "DASHBOARD_API_BASE_URL",
     "CONFIGURED_ADMINS",
+    "SLACK_CLIENT_ID",
+    "SLACK_CLIENT_SECRET",
 )
 GENERATED_KEYS: tuple[str, ...] = ("DASHBOARD_JWT_SECRET", "TOKEN_ENCRYPTION_KEY")
 SECRET_KEYS: frozenset[str] = frozenset(
@@ -46,6 +48,7 @@ SECRET_KEYS: frozenset[str] = frozenset(
         "GITHUB_APP_CLIENT_SECRET",
         "SLACK_BOT_TOKEN",
         "SLACK_SIGNING_SECRET",
+        "SLACK_CLIENT_SECRET",
         *GENERATED_KEYS,
         *(key for key in MODEL_PROVIDER_KEYS.values() if key),
     }
@@ -230,6 +233,14 @@ def collect_answers(
             )
         if want("CONFIGURED_ADMINS"):
             answers["CONFIGURED_ADMINS"] = ask("Admin GitHub logins (comma-separated)", "")
+        # Sign in with Slack: the verified GitHub <-> Slack link, on the same Slack app.
+        if want("SLACK_CLIENT_ID") and want("SLACK_CLIENT_SECRET"):
+            client_id = ask(
+                "Slack app client ID, for Sign in with Slack (leave empty to skip)", ""
+            ).strip()
+            if client_id:
+                answers["SLACK_CLIENT_ID"] = client_id
+                answers["SLACK_CLIENT_SECRET"] = ask_secret("Slack app client secret")
 
     return {key: value for key, value in answers.items() if value or key.startswith("_")}
 

--- a/tests/dashboard/test_app_cors.py
+++ b/tests/dashboard/test_app_cors.py
@@ -1,0 +1,56 @@
+"""CORS allowlist derivation for the FastAPI app."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from agent.api import app as app_module
+
+
+def _cors_origins(app: FastAPI) -> list[str] | None:
+    for middleware in app.user_middleware:
+        if middleware.cls is CORSMiddleware:
+            origins = middleware.kwargs["allow_origins"]
+            assert isinstance(origins, list)
+            return sorted(str(origin) for origin in origins)
+    return None
+
+
+def test_cors_uses_dashboard_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "https://dashboard.example/")
+    monkeypatch.delenv("DASHBOARD_ALLOWED_ORIGINS", raising=False)
+
+    assert _cors_origins(app_module.create_app()) == ["https://dashboard.example"]
+
+
+def test_cors_adds_extra_origins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://localhost:3000")
+    monkeypatch.setenv(
+        "DASHBOARD_ALLOWED_ORIGINS", "https://preview.example, http://localhost:3000"
+    )
+
+    assert _cors_origins(app_module.create_app()) == [
+        "http://localhost:3000",
+        "https://preview.example",
+    ]
+
+
+def test_cors_extra_origins_alone_still_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+    monkeypatch.setenv("DASHBOARD_ALLOWED_ORIGINS", "https://preview.example")
+
+    assert _cors_origins(app_module.create_app()) == ["https://preview.example"]
+
+
+def test_cors_disabled_without_dashboard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+    monkeypatch.delenv("DASHBOARD_ALLOWED_ORIGINS", raising=False)
+
+    assert _cors_origins(app_module.create_app()) is None
+
+
+def test_cors_rejects_wildcard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_ALLOWED_ORIGINS", "*")
+
+    with pytest.raises(RuntimeError):
+        app_module.create_app()

--- a/tests/scripts/test_setup_env.py
+++ b/tests/scripts/test_setup_env.py
@@ -177,6 +177,21 @@ def test_collect_answers_dashboard_section_uses_defaults() -> None:
     assert answers["DASHBOARD_BASE_URL"] == setup_env.DEFAULT_DASHBOARD_BASE_URL
     assert answers["DASHBOARD_API_BASE_URL"] == setup_env.DEFAULT_DASHBOARD_API_BASE_URL
     assert "CONFIGURED_ADMINS" not in answers
+    assert "SLACK_CLIENT_ID" not in answers and "SLACK_CLIENT_SECRET" not in answers
+
+
+def test_collect_answers_dashboard_section_offers_sign_in_with_slack() -> None:
+    ask, ask_secret, asked = _scripted(
+        {"Slack app client ID, for Sign in with Slack (leave empty to skip)": "123.456"},
+        {"GitHub App client secret": "gh-secret", "Slack app client secret": "slack-secret"},
+    )
+    existing = dict.fromkeys(setup_env.MINIMUM_KEYS, "x") | {"OPENAI_API_KEY": "x"}
+
+    answers = setup_env.collect_answers(ask, ask_secret, existing=existing, dashboard=True)
+
+    assert answers["SLACK_CLIENT_ID"] == "123.456"
+    assert answers["SLACK_CLIENT_SECRET"] == "slack-secret"
+    assert "SLACK_CLIENT_SECRET" in setup_env.SECRET_KEYS
 
 
 def test_missing_minimum_reports_names_only() -> None:

--- a/tests/scripts/test_setup_env.py
+++ b/tests/scripts/test_setup_env.py
@@ -1,0 +1,278 @@
+"""Guided installer: secret generation, dotenv merging, prompts, and file mode."""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from scripts import setup_env
+
+_FAKE_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK\nabc==\n-----END RSA PRIVATE KEY-----\n"
+)
+
+
+def test_generated_secrets_are_distinct_and_well_formed() -> None:
+    jwt_a, jwt_b = (
+        setup_env.generate_dashboard_jwt_secret(),
+        setup_env.generate_dashboard_jwt_secret(),
+    )
+    key_a, key_b = (
+        setup_env.generate_token_encryption_key(),
+        setup_env.generate_token_encryption_key(),
+    )
+
+    assert jwt_a != jwt_b and key_a != key_b
+    assert len(jwt_a) == 64 and int(jwt_a, 16) >= 0
+    Fernet(key_a.encode())
+    assert jwt_a != key_a
+
+
+def test_generated_secrets_respect_existing_unless_forced() -> None:
+    existing = {"DASHBOARD_JWT_SECRET": "keep", "TOKEN_ENCRYPTION_KEY": ""}
+
+    fresh = setup_env.generated_secrets(existing, force=False)
+    assert set(fresh) == {"TOKEN_ENCRYPTION_KEY"}
+
+    forced = setup_env.generated_secrets(existing, force=True)
+    assert set(forced) == {"DASHBOARD_JWT_SECRET", "TOKEN_ENCRYPTION_KEY"}
+    assert forced["DASHBOARD_JWT_SECRET"] != "keep"
+
+
+def test_parse_env_handles_quotes_comments_and_export() -> None:
+    text = (
+        "# comment\n"
+        "FOO=bar\n"
+        'QUOTED="a b"\n'
+        "SINGLE='x'\n"
+        "export EXPORTED=1\n"
+        'MULTI="line1\\nline2"\n'
+        'ESCAPED="back\\\\slash \\"q\\""\n'
+        "\n"
+        "TRAILING=value # note\n"
+    )
+
+    assert setup_env.parse_env(text) == {
+        "FOO": "bar",
+        "QUOTED": "a b",
+        "SINGLE": "x",
+        "EXPORTED": "1",
+        "MULTI": "line1\nline2",
+        "ESCAPED": 'back\\slash "q"',
+        "TRAILING": "value",
+    }
+
+
+def test_render_env_replaces_in_place_and_appends_once() -> None:
+    existing = '# LangSmith\nLANGSMITH_API_KEY=""\nFOO=bar\n'
+    updates = {"LANGSMITH_API_KEY": "lsv2-x", "SLACK_BOT_TOKEN": "xoxb-x"}
+
+    first = setup_env.render_env(existing, updates)
+    second = setup_env.render_env(first, updates)
+
+    assert first.splitlines()[0] == "# LangSmith"
+    assert 'LANGSMITH_API_KEY="lsv2-x"' in first
+    assert "FOO=bar" in first
+    assert first.count("SLACK_BOT_TOKEN=") == 1
+    assert first.count(setup_env.MARKER) == 1
+    assert second == first
+    assert setup_env.parse_env(first)["SLACK_BOT_TOKEN"] == "xoxb-x"
+
+
+def test_render_env_round_trips_private_key() -> None:
+    key = "-----BEGIN RSA PRIVATE KEY-----\\nabc\\n-----END RSA PRIVATE KEY-----"
+    rendered = setup_env.render_env("", {"GITHUB_APP_PRIVATE_KEY": key})
+
+    assert setup_env.parse_env(rendered)["GITHUB_APP_PRIVATE_KEY"] == key
+
+
+def test_read_private_key_flattens_pem(tmp_path: Path) -> None:
+    pem = tmp_path / "app.pem"
+    pem.write_text(_FAKE_PEM)
+
+    value = setup_env.read_private_key(str(pem))
+
+    assert "\n" not in value
+    assert value.startswith("-----BEGIN RSA PRIVATE KEY-----\\n")
+    assert value.endswith("\\n-----END RSA PRIVATE KEY-----")
+
+
+def test_read_private_key_rejects_non_pem(tmp_path: Path) -> None:
+    other = tmp_path / "notes.txt"
+    other.write_text("hello")
+
+    with pytest.raises(setup_env.SetupError):
+        setup_env.read_private_key(str(other))
+    with pytest.raises(setup_env.SetupError):
+        setup_env.read_private_key(str(tmp_path / "missing.pem"))
+
+
+def _scripted(answers: dict[str, str], secrets_: dict[str, str]):
+    asked: list[str] = []
+
+    def ask(prompt: str, default: str) -> str:
+        asked.append(prompt)
+        return answers.get(prompt, default)
+
+    def ask_secret(prompt: str) -> str:
+        asked.append(prompt)
+        return secrets_.get(prompt, "")
+
+    return ask, ask_secret, asked
+
+
+def test_collect_answers_gateway_skips_model_key(tmp_path: Path) -> None:
+    pem = tmp_path / "app.pem"
+    pem.write_text(_FAKE_PEM)
+    ask, ask_secret, asked = _scripted(
+        {
+            "Model provider (anthropic / openai / google / gateway)": "gateway",
+            "GitHub App client ID (Iv1....)": "Iv1.abc",
+            "Path to the GitHub App private key (.pem)": str(pem),
+        },
+        {
+            "LangSmith API key (lsv2_...)": "lsv2-test",
+            "Slack bot token (xoxb-...)": "xoxb-test",
+            "Slack signing secret": "sig-test",
+        },
+    )
+
+    answers = setup_env.collect_answers(ask, ask_secret, existing={}, dashboard=False)
+
+    assert answers["LANGSMITH_GATEWAY_ENABLED"] == "true"
+    assert "ANTHROPIC_API_KEY" not in answers
+    assert answers["GITHUB_APP_CLIENT_ID"] == "Iv1.abc"
+    assert answers["GITHUB_APP_PRIVATE_KEY"].startswith("-----BEGIN")
+    assert len(answers["GITHUB_WEBHOOK_SECRET"]) == 64
+    assert answers["_generated_webhook_secret"] == "1"
+    assert not any("Dashboard" in prompt for prompt in asked)
+    assert setup_env.missing_minimum(answers) == []
+
+
+def test_collect_answers_skips_values_already_present(tmp_path: Path) -> None:
+    ask, ask_secret, asked = _scripted({}, {})
+    existing = {
+        "LANGSMITH_API_KEY": "x",
+        "ANTHROPIC_API_KEY": "x",
+        "GITHUB_APP_CLIENT_ID": "x",
+        "GITHUB_APP_PRIVATE_KEY": "x",
+        "GITHUB_WEBHOOK_SECRET": "x",
+        "SLACK_BOT_TOKEN": "x",
+        "SLACK_SIGNING_SECRET": "x",
+    }
+
+    assert setup_env.collect_answers(ask, ask_secret, existing=existing, dashboard=False) == {}
+    assert asked == []
+
+
+def test_collect_answers_dashboard_section_uses_defaults() -> None:
+    ask, ask_secret, _ = _scripted({}, {"GitHub App client secret": "gh-secret"})
+    existing = dict.fromkeys(setup_env.MINIMUM_KEYS, "x") | {"OPENAI_API_KEY": "x"}
+
+    answers = setup_env.collect_answers(ask, ask_secret, existing=existing, dashboard=True)
+
+    assert answers["GITHUB_APP_CLIENT_SECRET"] == "gh-secret"
+    assert answers["DASHBOARD_BASE_URL"] == setup_env.DEFAULT_DASHBOARD_BASE_URL
+    assert answers["DASHBOARD_API_BASE_URL"] == setup_env.DEFAULT_DASHBOARD_API_BASE_URL
+    assert "CONFIGURED_ADMINS" not in answers
+
+
+def test_missing_minimum_reports_names_only() -> None:
+    missing = setup_env.missing_minimum({"SLACK_BOT_TOKEN": "xoxb-secret"})
+
+    assert "SLACK_BOT_TOKEN" not in missing
+    assert "SLACK_SIGNING_SECRET" in missing
+    assert any("model provider" in item for item in missing)
+    assert "xoxb-secret" not in " ".join(missing)
+
+
+def test_main_non_interactive_writes_secure_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.DASHBOARD_KEYS, *setup_env.GENERATED_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    values = {
+        "LANGSMITH_API_KEY": "lsv2-secret",
+        "ANTHROPIC_API_KEY": "sk-ant-secret",
+        "GITHUB_APP_CLIENT_ID": "Iv1.abc",
+        "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\\nabc\\n-----END RSA PRIVATE KEY-----",
+        "GITHUB_WEBHOOK_SECRET": "hook-secret",
+        "SLACK_BOT_TOKEN": "xoxb-secret",
+        "SLACK_SIGNING_SECRET": "sig-secret",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    output = tmp_path / ".env"
+
+    assert setup_env.main(["--output", str(output), "--non-interactive"]) == 0
+
+    mode = stat.S_IMODE(os.stat(output).st_mode)
+    assert mode == 0o600
+    written = setup_env.parse_env(output.read_text())
+    for key, value in values.items():
+        assert written[key] == value
+    assert written["DASHBOARD_JWT_SECRET"] != written["TOKEN_ENCRYPTION_KEY"]
+    Fernet(written["TOKEN_ENCRYPTION_KEY"].encode())
+    out = capsys.readouterr().out
+    for secret in ("lsv2-secret", "sk-ant-secret", "xoxb-secret", "sig-secret", "hook-secret"):
+        assert secret not in out
+    assert written["DASHBOARD_JWT_SECRET"] not in out
+
+
+def test_main_second_run_keeps_generated_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.GENERATED_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    for key in setup_env.MINIMUM_KEYS:
+        monkeypatch.setenv(key, "x")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    output = tmp_path / ".env"
+
+    setup_env.main(["--output", str(output), "--non-interactive"])
+    first = setup_env.parse_env(output.read_text())
+    setup_env.main(["--output", str(output), "--non-interactive"])
+    second = setup_env.parse_env(output.read_text())
+    setup_env.main(["--output", str(output), "--non-interactive", "--force"])
+    third = setup_env.parse_env(output.read_text())
+
+    assert first["DASHBOARD_JWT_SECRET"] == second["DASHBOARD_JWT_SECRET"]
+    assert first["TOKEN_ENCRYPTION_KEY"] == second["TOKEN_ENCRYPTION_KEY"]
+    assert third["DASHBOARD_JWT_SECRET"] != first["DASHBOARD_JWT_SECRET"]
+
+
+def test_main_non_interactive_generates_webhook_secret_without_printing_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.GENERATED_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    for key in setup_env.MINIMUM_KEYS:
+        if key != "GITHUB_WEBHOOK_SECRET":
+            monkeypatch.setenv(key, "x")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    output = tmp_path / ".env"
+
+    assert setup_env.main(["--output", str(output), "--non-interactive"]) == 0
+
+    written = setup_env.parse_env(output.read_text())
+    out = capsys.readouterr().out
+    assert len(written["GITHUB_WEBHOOK_SECRET"]) == 64
+    assert written["GITHUB_WEBHOOK_SECRET"] not in out
+    assert "GITHUB_WEBHOOK_SECRET was generated" in out
+    assert "grep '^GITHUB_WEBHOOK_SECRET='" in out
+
+
+def test_main_non_interactive_fails_when_minimum_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key in (*setup_env.MINIMUM_KEYS, *setup_env.GENERATED_KEYS, "OPENAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-secret")
+
+    assert setup_env.main(["--output", str(tmp_path / ".env"), "--non-interactive"]) == 2
+
+    err = capsys.readouterr().err
+    assert "SLACK_SIGNING_SECRET" in err
+    assert "xoxb-secret" not in err

--- a/tests/utils/test_startup_config.py
+++ b/tests/utils/test_startup_config.py
@@ -23,8 +23,18 @@ def test_minimum_config_enables_github_and_slack_only() -> None:
     assert "LangSmith: enabled" in lines
     assert "GitHub: enabled" in lines
     assert "Slack: enabled" in lines
+    assert "Slack sign-in: disabled" in lines
     assert "Linear: disabled" in lines
     assert "Dashboard: disabled" in lines
+
+
+def test_slack_sign_in_is_its_own_surface() -> None:
+    env = {**_MINIMUM, "SLACK_CLIENT_ID": "123.456", "SLACK_CLIENT_SECRET": "client-secret"}
+
+    lines = startup_config.configuration_summary(env)
+
+    assert "Slack sign-in: enabled" in lines
+    assert "client-secret" not in " ".join(lines)
 
 
 def test_partial_surface_lists_missing_names() -> None:

--- a/tests/utils/test_startup_config.py
+++ b/tests/utils/test_startup_config.py
@@ -1,0 +1,122 @@
+"""Startup configuration report and deprecation warnings."""
+
+import logging
+
+import pytest
+
+from agent.config import ENV
+from agent.utils import startup_config
+
+_MINIMUM = {
+    "LANGSMITH_API_KEY": "lsv2-secret",
+    "GITHUB_APP_CLIENT_ID": "Iv1.client",
+    "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\\nsecret",
+    "GITHUB_WEBHOOK_SECRET": "webhook-secret",
+    "SLACK_BOT_TOKEN": "xoxb-secret",
+    "SLACK_SIGNING_SECRET": "signing-secret",
+}
+
+
+def test_minimum_config_enables_github_and_slack_only() -> None:
+    lines = startup_config.configuration_summary(_MINIMUM)
+
+    assert "LangSmith: enabled" in lines
+    assert "GitHub: enabled" in lines
+    assert "Slack: enabled" in lines
+    assert "Linear: disabled" in lines
+    assert "Dashboard: disabled" in lines
+
+
+def test_partial_surface_lists_missing_names() -> None:
+    env = dict(_MINIMUM)
+    del env["GITHUB_WEBHOOK_SECRET"]
+
+    assert "GitHub: missing GITHUB_WEBHOOK_SECRET" in startup_config.configuration_summary(env)
+
+
+def test_blank_values_count_as_unset() -> None:
+    env = dict(_MINIMUM, SLACK_SIGNING_SECRET="   ")
+
+    assert "Slack: missing SLACK_SIGNING_SECRET" in startup_config.configuration_summary(env)
+
+
+def test_explicit_overrides_are_listed_by_name() -> None:
+    env = dict(_MINIMUM, GITHUB_APP_INSTALLATION_ID="123", SLACK_BOT_USER_ID="UBOT")
+
+    assert (
+        "Explicit overrides: GITHUB_APP_INSTALLATION_ID, SLACK_BOT_USER_ID"
+        in startup_config.configuration_summary(env)
+    )
+
+
+def test_summary_never_contains_secret_values() -> None:
+    env = dict(_MINIMUM, GITHUB_APP_INSTALLATION_ID="123")
+    text = "\n".join(startup_config.configuration_summary(env))
+
+    for value in env.values():
+        assert value not in text
+
+
+@pytest.mark.parametrize(
+    ("name", "fragment"),
+    [
+        ("GITHUB_APP_ID", "GITHUB_APP_CLIENT_ID"),
+        ("SLACK_REPO_OWNER", "Team settings"),
+        ("SLACK_REPO_NAME", "Team settings"),
+        ("DEFAULT_REPO_OWNER", "Team settings"),
+        ("DEFAULT_REPO_NAME", "Team settings"),
+        ("LANGSMITH_TRACING_PROJECT_ID_PROD", "LANGSMITH_TRACING_PROJECT_ID"),
+        ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY"),
+        ("LANGSMITH_API_KEY_PROD", "LANGSMITH_API_KEY"),
+        ("LANGSMITH_ENDPOINT_PROD", "LANGSMITH_ENDPOINT"),
+        ("LANGSMITH_URL_PROD", "LANGSMITH_ENDPOINT"),
+        ("LANGSMITH_TENANT_ID_PROD", "LANGSMITH_TENANT_ID"),
+        ("LANGGRAPH_URL_PROD", "LANGGRAPH_URL"),
+        ("LANGCHAIN_TRACING_V2", "LANGSMITH_TRACING"),
+    ],
+)
+def test_deprecated_variable_warns(name: str, fragment: str) -> None:
+    warnings = startup_config.deprecated_env_warnings({name: "x"})
+
+    assert len(warnings) == 1
+    assert warnings[0].startswith(f"{name} is deprecated")
+    assert fragment in warnings[0]
+
+
+def test_legacy_prod_key_still_enables_langsmith_with_a_warning() -> None:
+    env = dict(_MINIMUM)
+    env["LANGSMITH_API_KEY_PROD"] = env.pop("LANGSMITH_API_KEY")
+
+    assert "LangSmith: enabled" in startup_config.configuration_summary(env)
+    assert any(
+        w.startswith("LANGSMITH_API_KEY_PROD is deprecated")
+        for w in startup_config.deprecated_env_warnings(env)
+    )
+
+
+def test_no_deprecations_for_minimum_config() -> None:
+    assert startup_config.deprecated_env_warnings(_MINIMUM) == []
+
+
+def test_log_startup_configuration_uses_levels(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    for name in startup_config.__dict__["_SURFACES"]:
+        for var in name[1]:
+            monkeypatch.delenv(var, raising=False)
+    for var in ENV.variables():
+        if var.deprecated or var.aliases:
+            for name in (var.name, *var.aliases):
+                monkeypatch.delenv(name, raising=False)
+    for name, value in _MINIMUM.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+
+    with caplog.at_level(logging.INFO, logger="agent.utils.startup_config"):
+        startup_config.log_startup_configuration()
+
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert "config: GitHub: enabled" in infos
+    assert any("GITHUB_APP_ID is deprecated" in w for w in warnings)
+    assert all("xoxb-secret" not in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Fourth PR of the install-simplification stack, on the Slack discovery PR. Operator-facing pieces that belong to no single integration.

- **Startup configuration report.** At startup the API logs which surfaces are enabled (LangSmith, GitHub, Slack, Slack sign-in, Linear, Dashboard) or which variable each is missing, which discovery-backed values are explicitly overridden, and every deprecated variable present. Names only; values never reach the log. Deprecation hints come from the registry in `agent/config.py`.
- **`make setup`.** Interactive `.env` writer for the GitHub + Slack minimum. Secrets are read without echo, `DASHBOARD_JWT_SECRET` and `TOKEN_ENCRYPTION_KEY` are generated, and a generated webhook secret is pointed to in `.env` rather than printed. `--dashboard` also collects the dashboard settings and offers the Sign in with Slack client id and secret.
- **Dashboard CORS.** `DASHBOARD_BASE_URL` is always an allowed origin; `DASHBOARD_ALLOWED_ORIGINS` only adds extra ones.

## Testing

- New: `tests/utils/test_startup_config.py`, `tests/scripts/test_setup_env.py`, `tests/dashboard/test_app_cors.py`.
- `make setup` driven end to end with `expect` and fake values; a minimum-only `.env` boots with the expected report.

## Stack

1. #2463 unified config + standard LangSmith env (merged)
2. #2464 GitHub App discovery
3. #2487 Slack bot discovery and repository defaults
4. **this PR** startup report and `make setup`
5. #2489 LangSmith tenant discovery and `LANGSMITH_PROJECT` tracing
6. #2486 single-origin dashboard
7. #2466 installation docs rewrite
