### PR TITLE
feat(langsmith): discover the tenant and trace every run into LANGSMITH_PROJECT

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -60,7 +60,6 @@ from agent.utils import ttl_cache
 from agent.utils.analyzer_skills import SKILLS_ROUTE, skill_path_for_mode
 from agent.utils.deferred_model import make_deferred_error_model
 from agent.utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
-from agent.utils.tracing import REVIEW_TRACING_PROJECT, traced_graph_factory
 
 logger = logging.getLogger(__name__)
 
@@ -204,4 +203,5 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     ).with_config(config)
 
 
-traced_analyzer = traced_graph_factory(get_analyzer, REVIEW_TRACING_PROJECT)
+# langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.
+traced_analyzer = get_analyzer

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -71,7 +71,6 @@ from agent.tools import (
 from agent.utils import ttl_cache
 from agent.utils.deferred_model import make_deferred_error_model
 from agent.utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
-from agent.utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
 
 logger = logging.getLogger(__name__)
 
@@ -255,4 +254,5 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
     ).with_config(config)
 
 
-traced_chat_agent = traced_graph_factory(get_chat_agent, AGENT_TRACING_PROJECT)
+# langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.
+traced_chat_agent = get_chat_agent

--- a/agent/config.py
+++ b/agent/config.py
@@ -164,10 +164,10 @@ ENV.var(
     aliases=("LANGSMITH_TENANT_ID_PROD",),
 )
 ENV.var(
-    "LANGSMITH_TRACING_PROJECT_ID",
-    "Fallback tracing project id for trace links when the per-graph project cannot be "
-    "resolved by name.",
-    aliases=("LANGSMITH_TRACING_PROJECT_ID_PROD",),
+    "LANGSMITH_PROJECT",
+    "LangSmith project every run traces into and trace links point at; the SDK reads it and "
+    "LangGraph Platform sets it to the deployment name.",
+    default="default",
 )
 ENV.var(
     "LANGSMITH_URL_PROD",

--- a/agent/config.py
+++ b/agent/config.py
@@ -193,8 +193,8 @@ ENV.var(
 )
 ENV.var(
     "LANGSMITH_GATEWAY_ENABLED",
-    "Route provider calls through the LangSmith LLM Gateway.",
-    default="false",
+    "Route provider calls through the LangSmith LLM Gateway; defaults to on when "
+    "LANGSMITH_GATEWAY_API_KEY is set and off otherwise.",
 )
 ENV.var(
     "LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES",

--- a/agent/config.py
+++ b/agent/config.py
@@ -160,7 +160,7 @@ ENV.var(
 )
 ENV.var(
     "LANGSMITH_TENANT_ID",
-    "LangSmith workspace id used in trace links.",
+    "LangSmith workspace id used in trace links; discovered from the workspace when unset.",
     aliases=("LANGSMITH_TENANT_ID_PROD",),
 )
 ENV.var(

--- a/agent/config.py
+++ b/agent/config.py
@@ -168,6 +168,7 @@ ENV.var(
     "LangSmith project every run traces into and trace links point at; the SDK reads it and "
     "LangGraph Platform sets it to the deployment name.",
     default="default",
+    aliases=("LANGCHAIN_PROJECT",),
 )
 ENV.var(
     "LANGSMITH_URL_PROD",
@@ -232,12 +233,6 @@ ENV.var(
     deprecated="set LANGSMITH_TRACING=true instead; this legacy alias is ignored by Open SWE.",
     replaced_by="LANGSMITH_TRACING",
 )
-ENV.var(
-    "LANGCHAIN_PROJECT",
-    "Legacy SDK alias, ignored: graphs pin their own tracing projects. LangGraph Platform "
-    "injects it.",
-)
-
 # --- GitHub ------------------------------------------------------------------------------
 ENV.var("GITHUB_APP_ID", "Numeric GitHub App id used as the JWT issuer.")
 ENV.var("GITHUB_APP_CLIENT_ID", "GitHub App client id for the dashboard OAuth flow.")

--- a/agent/review/trace_context.py
+++ b/agent/review/trace_context.py
@@ -10,12 +10,11 @@ from typing import Any
 
 from deepagents.backends.protocol import SandboxBackendProtocol
 
-from agent.config import ENV
 from agent.dashboard.team_credentials import get_langsmith_credentials
 from agent.dashboard.team_settings import get_team_review_tracing_project
 from agent.run_config import RunConfig
 from agent.tool_loaders.langsmith import _client
-from agent.utils.langsmith import get_langsmith_trace_url, langsmith_host_url
+from agent.utils.langsmith import get_langsmith_trace_url, langsmith_host_url, resolve_tenant_id
 
 logger = logging.getLogger(__name__)
 
@@ -461,7 +460,7 @@ async def _trace_url(thread_id: str, project: str) -> str | None:
     resolved = await get_langsmith_trace_url(thread_id, project_name=project)
     if resolved:
         return resolved
-    tenant_id = ENV.LANGSMITH_TENANT_ID.optional()
+    tenant_id = await resolve_tenant_id()
     if tenant_id and _looks_uuid(project):
         return f"{langsmith_host_url()}/o/{tenant_id}/projects/p/{project}/t/{thread_id}"
     return None

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -119,7 +119,6 @@ from agent.utils.agents_md import fetch_agents_md, fetch_scoped_agents_md
 from agent.utils.api_standards_skill import fetch_api_standards_skill
 from agent.utils.deferred_model import make_deferred_error_model
 from agent.utils.model import DEFAULT_LLM_REASONING, make_model, provider_model_kwargs
-from agent.utils.tracing import REVIEW_TRACING_PROJECT, traced_graph_factory
 
 HISTORICAL_REVIEW_GUIDANCE = """- **Anything that overlaps an existing PR review thread.** A
   "Pre-existing PR review threads" block below (when present) lists every
@@ -1414,4 +1413,5 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     ).with_config(config)
 
 
-traced_reviewer_agent = traced_graph_factory(get_reviewer_agent, REVIEW_TRACING_PROJECT)
+# langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.
+traced_reviewer_agent = get_reviewer_agent

--- a/agent/server.py
+++ b/agent/server.py
@@ -228,7 +228,6 @@ from agent.utils.thread_settings import (
     normalize_thread_settings,
     store_thread_settings,
 )
-from agent.utils.tracing import AGENT_TRACING_PROJECT, traced_graph_factory
 
 client = get_client()
 
@@ -1353,4 +1352,5 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     ).with_config(config)
 
 
-traced_agent = traced_graph_factory(get_agent, AGENT_TRACING_PROJECT)
+# langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.
+traced_agent = get_agent

--- a/agent/tools/publish_review.py
+++ b/agent/tools/publish_review.py
@@ -63,7 +63,6 @@ from agent.run_config import RunConfig
 from agent.slack.client import post_slack_thread_reply
 from agent.utils.dashboard_links import dashboard_review_url
 from agent.utils.langsmith import get_langsmith_trace_url
-from agent.utils.tracing import REVIEW_TRACING_PROJECT
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +186,7 @@ async def _resolve_review_trace_url(thread_id: str, config_override: bool | None
         return None
     if not thread_id:
         return None
-    return await get_langsmith_trace_url(thread_id, project_name=REVIEW_TRACING_PROJECT)
+    return await get_langsmith_trace_url(thread_id)
 
 
 async def _publish_review_eval_dry_run_async(

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -54,8 +54,16 @@ def gateway_base_url() -> str:
 
 
 def gateway_env_default() -> bool:
-    """Deployment-level default for gateway routing (``LANGSMITH_GATEWAY_ENABLED``)."""
-    return _env_bool(ENV.LANGSMITH_GATEWAY_ENABLED.optional())
+    """Deployment-level default for gateway routing.
+
+    ``LANGSMITH_GATEWAY_ENABLED`` decides when set. Otherwise a dedicated
+    ``LANGSMITH_GATEWAY_API_KEY`` is the signal: that key exists for nothing
+    else, so configuring it means routing through the gateway.
+    """
+    explicit = ENV.LANGSMITH_GATEWAY_ENABLED.optional()
+    if explicit is not None:
+        return _env_bool(explicit)
+    return bool(ENV.LANGSMITH_GATEWAY_API_KEY.optional())
 
 
 def gateway_openai_use_responses() -> bool:

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -13,7 +13,7 @@ from langsmith import Client as LangSmithClient
 from langsmith.utils import LangSmithNotFoundError, get_host_url
 
 from agent.config import ENV
-from agent.utils.tracing import AGENT_TRACING_PROJECT
+from agent.utils.tracing import tracing_project
 
 logger = logging.getLogger(__name__)
 
@@ -133,24 +133,23 @@ async def _resolve_project_id_by_name(project_name: str) -> str | None:
     return resolved or None
 
 
-async def _compose_langsmith_project_url(project_name: str = AGENT_TRACING_PROJECT) -> str | None:
-    """Build the LangSmith project URL base, or None when tracing isn't configured
-    for the prod tenant."""
+async def _compose_langsmith_project_url(project_name: str | None = None) -> str | None:
+    """URL base of a LangSmith project, or None when tracing isn't configured.
+
+    Defaults to the project this deployment traces into; the review trace
+    context passes the team-configured project it searches for the reviewed
+    change's own traces.
+    """
     tenant_id = await resolve_tenant_id()
     if not tenant_id:
         return None
-    project_id = (
-        await _resolve_project_id_by_name(project_name)
-        or ENV.LANGSMITH_TRACING_PROJECT_ID.optional()
-    )
+    project_id = await _resolve_project_id_by_name(project_name or tracing_project())
     if not project_id:
         return None
     return f"{langsmith_host_url()}/o/{tenant_id}/projects/p/{project_id}"
 
 
-async def get_langsmith_trace_url(
-    thread_id: str, project_name: str = AGENT_TRACING_PROJECT
-) -> str | None:
+async def get_langsmith_trace_url(thread_id: str, project_name: str | None = None) -> str | None:
     """Build the LangSmith thread URL for a given thread ID, or None if tracing
     isn't configured. This is a best-effort convenience link, not an error path."""
     project_url = await _compose_langsmith_project_url(project_name)
@@ -182,7 +181,6 @@ def _langsmith_metadata_filter(key: str, value: str) -> str:
 async def get_langsmith_thread_cost(
     thread_id: str,
     prepare_run_id: str,
-    project_name: str = AGENT_TRACING_PROJECT,
     *,
     run_only: bool = False,
 ) -> LangSmithThreadCost | None:
@@ -190,10 +188,7 @@ async def get_langsmith_thread_cost(
     client = _build_langsmith_client()
     if client is None:
         raise LangSmithCostUnavailable("LangSmith credentials are not configured")
-    project_id = (
-        await _resolve_project_id_by_name(project_name)
-        or ENV.LANGSMITH_TRACING_PROJECT_ID.optional()
-    )
+    project_id = await _resolve_project_id_by_name(tracing_project())
     if not project_id:
         raise LangSmithCostUnavailable("LangSmith tracing project is unavailable")
     try:
@@ -281,16 +276,12 @@ async def create_langsmith_thread_feedback(
     score: float,
     comment: str | None = None,
     source_info: dict[str, Any] | None = None,
-    project_name: str = AGENT_TRACING_PROJECT,
 ) -> bool:
     client = _build_langsmith_client()
     if client is None:
         logger.warning("No LangSmith API key configured, skipping thread feedback")
         return False
-    project_id = (
-        await _resolve_project_id_by_name(project_name)
-        or ENV.LANGSMITH_TRACING_PROJECT_ID.optional()
-    )
+    project_id = await _resolve_project_id_by_name(tracing_project())
     if not project_id:
         logger.warning("LangSmith tracing project is unavailable, skipping thread feedback")
         return False

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -17,8 +17,11 @@ from agent.utils.tracing import tracing_project
 
 logger = logging.getLogger(__name__)
 
-_PROJECT_ID_CACHE: dict[str, str] = {}
-_TENANT_ID_CACHE: str | None = None
+# Both caches are keyed by the credentials that produced the ids, so a rotated
+# key or another endpoint (a different workspace) starts over instead of
+# building links with the previous workspace's tenant and project ids.
+_PROJECT_ID_CACHE: dict[tuple[tuple[str, str], str], str] = {}
+_TENANT_ID_CACHE: dict[tuple[str, str], str] = {}
 _ASYNC_CLIENTS: dict[tuple[str, str], AsyncLangSmithClient] = {}
 _SYNC_CLIENTS: dict[tuple[str, str], LangSmithClient] = {}
 
@@ -76,10 +79,13 @@ def _build_langsmith_client() -> AsyncLangSmithClient | None:
     return async_langsmith_client(api_key, ENV.LANGSMITH_ENDPOINT.get())
 
 
+def _workspace_key() -> tuple[str, str]:
+    return (ENV.LANGSMITH_API_KEY.optional() or "", ENV.LANGSMITH_ENDPOINT.get())
+
+
 def _remember_tenant_id(value: Any) -> None:
-    global _TENANT_ID_CACHE
-    if value and _TENANT_ID_CACHE is None:
-        _TENANT_ID_CACHE = str(value)
+    if value:
+        _TENANT_ID_CACHE.setdefault(_workspace_key(), str(value))
 
 
 def _discover_tenant_id() -> str | None:
@@ -100,35 +106,38 @@ async def resolve_tenant_id() -> str | None:
     explicit = ENV.LANGSMITH_TENANT_ID.optional()
     if explicit:
         return explicit
-    if _TENANT_ID_CACHE:
-        return _TENANT_ID_CACHE
+    workspace = _workspace_key()
+    cached = _TENANT_ID_CACHE.get(workspace)
+    if cached:
+        return cached
     try:
         discovered = await asyncio.to_thread(_discover_tenant_id)
     except Exception:  # noqa: BLE001
         logger.debug("Could not discover the LangSmith tenant id", exc_info=True)
         return None
     _remember_tenant_id(discovered)
-    return _TENANT_ID_CACHE
+    return _TENANT_ID_CACHE.get(workspace)
 
 
 async def _resolve_project_id_by_name(project_name: str) -> str | None:
     """Resolve a LangSmith project id from its name, caching definitive results."""
-    if project_name in _PROJECT_ID_CACHE:
-        return _PROJECT_ID_CACHE[project_name] or None
+    cache_key = (_workspace_key(), project_name)
+    if cache_key in _PROJECT_ID_CACHE:
+        return _PROJECT_ID_CACHE[cache_key] or None
     client = _build_langsmith_client()
     if client is None:
         return None
     try:
         project = await client.read_project(project_name=project_name)
     except LangSmithNotFoundError:
-        _PROJECT_ID_CACHE[project_name] = ""
+        _PROJECT_ID_CACHE[cache_key] = ""
         return None
     except Exception:  # noqa: BLE001
         logger.debug("Could not resolve LangSmith project id for %s", project_name, exc_info=True)
         return None
     project_id = getattr(project, "id", None)
     resolved = str(project_id) if project_id else ""
-    _PROJECT_ID_CACHE[project_name] = resolved
+    _PROJECT_ID_CACHE[cache_key] = resolved
     _remember_tenant_id(getattr(project, "tenant_id", None))
     return resolved or None
 

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -18,6 +18,7 @@ from agent.utils.tracing import AGENT_TRACING_PROJECT
 logger = logging.getLogger(__name__)
 
 _PROJECT_ID_CACHE: dict[str, str] = {}
+_TENANT_ID_CACHE: str | None = None
 _ASYNC_CLIENTS: dict[tuple[str, str], AsyncLangSmithClient] = {}
 _SYNC_CLIENTS: dict[tuple[str, str], LangSmithClient] = {}
 
@@ -57,7 +58,10 @@ def sync_langsmith_client(api_key: str, api_url: str) -> LangSmithClient:
 
 
 def langsmith_host_url() -> str:
-    """Web host for trace links, derived from the API endpoint unless overridden."""
+    """Web host for trace links, derived from the API endpoint.
+
+    ``LANGSMITH_URL_PROD`` is a deprecated explicit override.
+    """
     explicit = ENV.LANGSMITH_URL_PROD.optional()
     if explicit:
         return explicit.rstrip("/")
@@ -70,6 +74,41 @@ def _build_langsmith_client() -> AsyncLangSmithClient | None:
     if not api_key:
         return None
     return async_langsmith_client(api_key, ENV.LANGSMITH_ENDPOINT.get())
+
+
+def _remember_tenant_id(value: Any) -> None:
+    global _TENANT_ID_CACHE
+    if value and _TENANT_ID_CACHE is None:
+        _TENANT_ID_CACHE = str(value)
+
+
+def _discover_tenant_id() -> str | None:
+    """Any project in the workspace carries the tenant id; read the first one."""
+    api_key = ENV.LANGSMITH_API_KEY.optional()
+    if not api_key:
+        return None
+    client = sync_langsmith_client(api_key, ENV.LANGSMITH_ENDPOINT.get())
+    for project in client.list_projects(limit=1):
+        tenant_id = getattr(project, "tenant_id", None)
+        if tenant_id:
+            return str(tenant_id)
+    return None
+
+
+async def resolve_tenant_id() -> str | None:
+    """Discovered once and cached; ``LANGSMITH_TENANT_ID`` is an explicit override."""
+    explicit = ENV.LANGSMITH_TENANT_ID.optional()
+    if explicit:
+        return explicit
+    if _TENANT_ID_CACHE:
+        return _TENANT_ID_CACHE
+    try:
+        discovered = await asyncio.to_thread(_discover_tenant_id)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not discover the LangSmith tenant id", exc_info=True)
+        return None
+    _remember_tenant_id(discovered)
+    return _TENANT_ID_CACHE
 
 
 async def _resolve_project_id_by_name(project_name: str) -> str | None:
@@ -90,13 +129,14 @@ async def _resolve_project_id_by_name(project_name: str) -> str | None:
     project_id = getattr(project, "id", None)
     resolved = str(project_id) if project_id else ""
     _PROJECT_ID_CACHE[project_name] = resolved
+    _remember_tenant_id(getattr(project, "tenant_id", None))
     return resolved or None
 
 
 async def _compose_langsmith_project_url(project_name: str = AGENT_TRACING_PROJECT) -> str | None:
     """Build the LangSmith project URL base, or None when tracing isn't configured
-    for the prod tenant. Bails before any API call when the tenant id is unset."""
-    tenant_id = ENV.LANGSMITH_TENANT_ID.optional()
+    for the prod tenant."""
+    tenant_id = await resolve_tenant_id()
     if not tenant_id:
         return None
     project_id = (

--- a/agent/utils/tracing.py
+++ b/agent/utils/tracing.py
@@ -1,24 +1,12 @@
-"""Per-graph LangSmith tracing-project routing for langgraph.json entrypoints."""
+"""Where runs are traced: the LangSmith SDK's own ``LANGSMITH_PROJECT``."""
 
-import contextlib
-from collections.abc import AsyncIterator, Awaitable, Callable
-
-import langsmith as ls
-from langgraph.graph.state import RunnableConfig
-from langgraph.pregel import Pregel
-
-AGENT_TRACING_PROJECT = "open-swe-agent"
-REVIEW_TRACING_PROJECT = "open-swe-review"
+from agent.config import ENV
 
 
-def traced_graph_factory(
-    factory: Callable[[RunnableConfig], Awaitable[Pregel]],
-    project_name: str,
-) -> Callable[[RunnableConfig], contextlib.AbstractAsyncContextManager[Pregel]]:
-    @contextlib.asynccontextmanager
-    async def entrypoint(config: RunnableConfig) -> AsyncIterator[Pregel]:
-        graph = await factory(config)
-        with ls.tracing_context(project_name=project_name):
-            yield graph
+def tracing_project() -> str:
+    """LangSmith project every run traces into and trace links point at.
 
-    return entrypoint
+    The SDK reads the same variable, and LangGraph Platform sets it to the
+    deployment name, so each deployment's traces stay in its own project.
+    """
+    return ENV.LANGSMITH_PROJECT.get()

--- a/agent/utils/tracing.py
+++ b/agent/utils/tracing.py
@@ -1,4 +1,4 @@
-"""Where runs are traced: the LangSmith SDK's own ``LANGSMITH_PROJECT``."""
+"""Where runs are traced: the LangSmith SDK's own project setting."""
 
 from agent.config import ENV
 
@@ -6,7 +6,10 @@ from agent.config import ENV
 def tracing_project() -> str:
     """LangSmith project every run traces into and trace links point at.
 
-    The SDK reads the same variable, and LangGraph Platform sets it to the
-    deployment name, so each deployment's traces stay in its own project.
+    Read the way the SDK's tracer reads it, ``LANGSMITH_PROJECT`` with the legacy
+    ``LANGCHAIN_PROJECT`` as fallback (the registry aliases), else ``default``, so
+    links, cost lookups, and feedback query the project the runs actually went to.
+    LangGraph Platform sets both names to the deployment name. The SDK's own
+    helper is not used because it caches the first value it sees.
     """
     return ENV.LANGSMITH_PROJECT.get()

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -205,8 +205,8 @@ Routing is opt-in and off by default. Enable it either way:
 
 | Env var | Default | Purpose |
 |---|---|---|
-| `LANGSMITH_GATEWAY_ENABLED` | `false` | Deployment-level default for gateway routing. |
-| `LANGSMITH_GATEWAY_API_KEY` | unset | Optional dedicated LangSmith key for Gateway calls. Prefer this in LangGraph Cloud if the platform-provided `LANGSMITH_API_KEY` lacks `gateway:invoke`. Falls back to `LANGSMITH_API_KEY`. |
+| `LANGSMITH_GATEWAY_ENABLED` | on when `LANGSMITH_GATEWAY_API_KEY` is set, else off | Deployment-level default for gateway routing; set explicitly to override. |
+| `LANGSMITH_GATEWAY_API_KEY` | unset | Dedicated LangSmith key for Gateway calls; setting it also turns routing on. Prefer this in LangGraph Cloud if the platform-provided `LANGSMITH_API_KEY` lacks `gateway:invoke`. Falls back to `LANGSMITH_API_KEY` when routing is enabled some other way. |
 | `LANGSMITH_GATEWAY_BASE_URL` | `https://gateway.smith.langchain.com` | Override for a regional or self-hosted gateway host. |
 | `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `true` | Use the OpenAI Responses API through the gateway. Set to `false` only to force Chat Completions for OpenAI models. |
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -121,7 +121,7 @@ Open SWE uses [LangSmith](https://smith.langchain.com/) for:
 1. Create a [LangSmith account](https://smith.langchain.com/) if you don't have one
 2. Go to **Settings → API Keys → Create API Key**
 3. Save it as `LANGSMITH_API_KEY_PROD`
-4. Optionally pick a **tracing project**: every run traces into the LangSmith project named by `LANGSMITH_PROJECT` (`default` when unset; LangGraph Platform sets it to the deployment name), and "View trace" links point there.
+4. Optionally pick a **tracing project**: every run traces into the LangSmith project named by `LANGSMITH_PROJECT` (`default` when unset; the legacy `LANGCHAIN_PROJECT` is honored too, and LangGraph Platform sets both to the deployment name), and "View trace" links point there.
 
 > **Tenant and project ids are discovered.** Trace links find your workspace through the API key and the project by name, so nothing else needs to be copied. `LANGSMITH_TENANT_ID` remains an explicit override.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -121,10 +121,9 @@ Open SWE uses [LangSmith](https://smith.langchain.com/) for:
 1. Create a [LangSmith account](https://smith.langchain.com/) if you don't have one
 2. Go to **Settings → API Keys → Create API Key**
 3. Save it as `LANGSMITH_API_KEY_PROD`
-4. Get your **Tenant ID**: Visit LangSmith, login, then copy the UUID in the URL. Example: if your URL is `https://smith.langchain.com/o/72184268-01ea-4d29-98cc-6cfcf0f2abb0/agents/chat` -> the tenant ID would be `72184268-01ea-4d29-98cc-6cfcf0f2abb0`. Save it as `LANGSMITH_TENANT_ID_PROD`.
-5. Get your **Project ID**: open your tracing project in LangSmith, then click on the **ID** button in the top left, directly next to the project name. Save it as `LANGSMITH_TRACING_PROJECT_ID_PROD`
+4. Optionally pick a **tracing project**: every run traces into the LangSmith project named by `LANGSMITH_PROJECT` (`default` when unset; LangGraph Platform sets it to the deployment name), and "View trace" links point there.
 
-> **Note on per-graph tracing projects.** The graphs trace into separate projects by name — `open-swe-agent` (main agent) and `open-swe-review` (reviewer/analyzer). "View trace" links resolve the correct project ID from these names automatically (via the `LANGSMITH_API_KEY_PROD` client), so make sure projects with these names exist in your tenant. If a name can't be resolved, links fall back to `LANGSMITH_TRACING_PROJECT_ID_PROD`, so set it to whichever project you want links to point at by default.
+> **Tenant and project ids are discovered.** Trace links find your workspace through the API key and the project by name, so nothing else needs to be copied. `LANGSMITH_TENANT_ID` remains an explicit override.
 
 ### 4b. Sandbox snapshots
 
@@ -413,8 +412,8 @@ Create a `.env` file in the project root. Below is the full list — only fill i
 LANGSMITH_API_KEY_PROD=""              # From step 4a
 LANGCHAIN_TRACING_V2="true"
 LANGCHAIN_PROJECT=""                   # LangSmith project name for traces
-LANGSMITH_TENANT_ID_PROD=""           
-LANGSMITH_TRACING_PROJECT_ID_PROD=""   # Fallback project ID for "View trace" links; graphs trace into the open-swe-agent / open-swe-review projects by name
+LANGSMITH_PROJECT=""                  # LangSmith project every run traces into (default: "default"; LangGraph Platform sets the deployment name)
+LANGSMITH_TENANT_ID=""                # Optional override; discovered from the workspace when unset
 LANGSMITH_URL_PROD="https://smith.langchain.com"                 
 
 # === LLM ===

--- a/tests/agent/test_langsmith_trace_url.py
+++ b/tests/agent/test_langsmith_trace_url.py
@@ -3,10 +3,14 @@ import pytest
 from agent.utils import langsmith as ls_utils
 from agent.utils.tracing import AGENT_TRACING_PROJECT, REVIEW_TRACING_PROJECT
 
+_REAL_DISCOVER_TENANT_ID = ls_utils._discover_tenant_id
+
 
 @pytest.fixture(autouse=True)
-def _clear_cache() -> None:
+def _clear_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     ls_utils._PROJECT_ID_CACHE.clear()
+    ls_utils._TENANT_ID_CACHE = None
+    monkeypatch.setattr(ls_utils, "_discover_tenant_id", lambda: None)
 
 
 def _resolver(ids: dict[str, str], *, default: str | None = None):
@@ -18,7 +22,7 @@ def _resolver(ids: dict[str, str], *, default: str | None = None):
 
 def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_URL_PROD", "https://smith.example")
-    monkeypatch.setenv("LANGSMITH_TENANT_ID_PROD", "tenant-1")
+    monkeypatch.setenv("LANGSMITH_TENANT_ID", "tenant-1")
     monkeypatch.delenv("LANGSMITH_TRACING_PROJECT_ID_PROD", raising=False)
 
 
@@ -167,3 +171,119 @@ async def test_trace_url_none_when_tenant_unset(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(ls_utils, "_build_langsmith_client", _boom)
 
     assert await ls_utils.get_langsmith_trace_url("t5") is None
+
+
+async def test_tenant_id_prefers_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_TENANT_ID", "tenant-env")
+    ls_utils._TENANT_ID_CACHE = "tenant-cached"
+
+    assert await ls_utils.resolve_tenant_id() == "tenant-env"
+
+
+async def test_tenant_id_is_learned_from_project_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_TENANT_ID_PROD", raising=False)
+
+    class _Project:
+        id = "pid"
+        tenant_id = "tenant-from-project"
+
+    class _Client:
+        async def read_project(self, *, project_name: str) -> _Project:
+            return _Project()
+
+    monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: _Client())
+
+    assert await ls_utils._resolve_project_id_by_name("open-swe-agent") == "pid"
+    assert await ls_utils.resolve_tenant_id() == "tenant-from-project"
+
+
+async def test_tenant_id_falls_back_to_listing_projects(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_TENANT_ID_PROD", raising=False)
+    calls = 0
+
+    def _discover() -> str:
+        nonlocal calls
+        calls += 1
+        return "tenant-listed"
+
+    monkeypatch.setattr(ls_utils, "_discover_tenant_id", _discover)
+
+    assert await ls_utils.resolve_tenant_id() == "tenant-listed"
+    assert await ls_utils.resolve_tenant_id() == "tenant-listed"
+    assert calls == 1
+
+
+async def test_tenant_id_none_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "LANGSMITH_TENANT_ID",
+        "LANGSMITH_TENANT_ID_PROD",
+        "LANGSMITH_API_KEY_PROD",
+        "LANGSMITH_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(ls_utils, "_discover_tenant_id", _REAL_DISCOVER_TENANT_ID)
+
+    assert ls_utils._discover_tenant_id() is None
+    assert await ls_utils.resolve_tenant_id() is None
+
+
+async def test_tenant_discovery_failure_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_TENANT_ID_PROD", raising=False)
+
+    def _boom() -> str:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(ls_utils, "_discover_tenant_id", _boom)
+
+    assert await ls_utils.resolve_tenant_id() is None
+
+
+async def test_trace_url_uses_discovered_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_TENANT_ID_PROD", raising=False)
+    monkeypatch.setenv("LANGSMITH_URL_PROD", "https://smith.example")
+    monkeypatch.setattr(ls_utils, "_discover_tenant_id", lambda: "tenant-d")
+    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", _resolver({}, default="pid"))
+
+    assert await ls_utils.get_langsmith_trace_url("t9") == (
+        "https://smith.example/o/tenant-d/projects/p/pid/t/t9"
+    )
+
+
+def test_host_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_URL_PROD", "https://smith.example/")
+
+    assert ls_utils.langsmith_host_url() == "https://smith.example"
+
+
+def test_host_url_derived_from_self_hosted_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_URL_PROD", raising=False)
+    monkeypatch.delenv("LANGSMITH_ENDPOINT_PROD", raising=False)
+    monkeypatch.setenv("LANGSMITH_ENDPOINT", "https://langsmith.acme.internal/api")
+
+    assert ls_utils.langsmith_host_url() == "https://langsmith.acme.internal"
+
+
+def test_host_url_derived_from_regional_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_URL_PROD", raising=False)
+    monkeypatch.delenv("LANGSMITH_ENDPOINT", raising=False)
+    monkeypatch.setenv("LANGSMITH_ENDPOINT_PROD", "https://eu.api.smith.langchain.com")
+
+    assert ls_utils.langsmith_host_url() == "https://eu.smith.langchain.com"
+
+
+def test_host_url_default_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("LANGSMITH_URL_PROD", "LANGSMITH_ENDPOINT_PROD", "LANGSMITH_ENDPOINT"):
+        monkeypatch.delenv(name, raising=False)
+
+    assert ls_utils.langsmith_host_url() == "https://smith.langchain.com"
+
+
+def test_feedback_clients_use_a_single_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "standard")
+    monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "legacy")
+    monkeypatch.delenv("LANGSMITH_ENDPOINT", raising=False)
+    monkeypatch.delenv("LANGSMITH_ENDPOINT_PROD", raising=False)
+
+    assert ls_utils._build_langsmith_feedback_clients() == (
+        ("standard", "https://api.smith.langchain.com"),
+    )

--- a/tests/agent/test_langsmith_trace_url.py
+++ b/tests/agent/test_langsmith_trace_url.py
@@ -8,7 +8,7 @@ _REAL_DISCOVER_TENANT_ID = ls_utils._discover_tenant_id
 @pytest.fixture(autouse=True)
 def _clear_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     ls_utils._PROJECT_ID_CACHE.clear()
-    ls_utils._TENANT_ID_CACHE = None
+    ls_utils._TENANT_ID_CACHE.clear()
     monkeypatch.setattr(ls_utils, "_discover_tenant_id", lambda: None)
 
 
@@ -181,9 +181,33 @@ async def test_trace_url_none_when_tenant_unset(monkeypatch: pytest.MonkeyPatch)
 
 async def test_tenant_id_prefers_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_TENANT_ID", "tenant-env")
-    ls_utils._TENANT_ID_CACHE = "tenant-cached"
+    ls_utils._TENANT_ID_CACHE[ls_utils._workspace_key()] = "tenant-cached"
 
     assert await ls_utils.resolve_tenant_id() == "tenant-env"
+
+
+async def test_cached_ids_belong_to_the_credentials_that_produced_them(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rotating the key or pointing at another workspace must not reuse the old ids."""
+    monkeypatch.delenv("LANGSMITH_TENANT_ID", raising=False)
+    monkeypatch.delenv("LANGSMITH_TENANT_ID_PROD", raising=False)
+    monkeypatch.setenv("LANGSMITH_API_KEY", "key-a")
+    projects = {"key-a": ("pid-a", "tenant-a"), "key-b": ("pid-b", "tenant-b")}
+
+    class _Client:
+        async def read_project(self, *, project_name: str) -> object:
+            project_id, tenant_id = projects[ls_utils.ENV.LANGSMITH_API_KEY.get()]
+            return type("P", (), {"id": project_id, "tenant_id": tenant_id})()
+
+    monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: _Client())
+
+    assert await ls_utils._resolve_project_id_by_name("proj") == "pid-a"
+    assert await ls_utils.resolve_tenant_id() == "tenant-a"
+
+    monkeypatch.setenv("LANGSMITH_API_KEY", "key-b")
+    assert await ls_utils._resolve_project_id_by_name("proj") == "pid-b"
+    assert await ls_utils.resolve_tenant_id() == "tenant-b"
 
 
 async def test_tenant_id_is_learned_from_project_lookup(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/agent/test_langsmith_trace_url.py
+++ b/tests/agent/test_langsmith_trace_url.py
@@ -1,7 +1,6 @@
 import pytest
 
 from agent.utils import langsmith as ls_utils
-from agent.utils.tracing import AGENT_TRACING_PROJECT, REVIEW_TRACING_PROJECT
 
 _REAL_DISCOVER_TENANT_ID = ls_utils._discover_tenant_id
 
@@ -23,32 +22,38 @@ def _resolver(ids: dict[str, str], *, default: str | None = None):
 def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_URL_PROD", "https://smith.example")
     monkeypatch.setenv("LANGSMITH_TENANT_ID", "tenant-1")
-    monkeypatch.delenv("LANGSMITH_TRACING_PROJECT_ID_PROD", raising=False)
+    monkeypatch.setenv("LANGSMITH_PROJECT", "my-deployment")
 
 
-async def test_trace_url_resolves_project_id_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trace_url_uses_the_langsmith_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every link points at LANGSMITH_PROJECT: agent and review runs share the deployment's project."""
     _set_env(monkeypatch)
     monkeypatch.setattr(
-        ls_utils,
-        "_resolve_project_id_by_name",
-        _resolver({AGENT_TRACING_PROJECT: "agent-pid"}, default="review-pid"),
+        ls_utils, "_resolve_project_id_by_name", _resolver({"my-deployment": "deployment-pid"})
     )
 
-    agent_url = await ls_utils.get_langsmith_trace_url("t1")
-    review_url = await ls_utils.get_langsmith_trace_url("t2", project_name=REVIEW_TRACING_PROJECT)
-
-    assert agent_url == "https://smith.example/o/tenant-1/projects/p/agent-pid/t/t1"
-    assert review_url == "https://smith.example/o/tenant-1/projects/p/review-pid/t/t2"
+    assert await ls_utils.get_langsmith_trace_url("t1") == (
+        "https://smith.example/o/tenant-1/projects/p/deployment-pid/t/t1"
+    )
 
 
-async def test_trace_url_falls_back_to_env_project_id(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trace_url_defaults_to_the_sdk_default_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _set_env(monkeypatch)
-    monkeypatch.setenv("LANGSMITH_TRACING_PROJECT_ID_PROD", "env-pid")
-    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", _resolver({}))
+    monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
+    seen: list[str] = []
 
-    url = await ls_utils.get_langsmith_trace_url("t3")
+    async def _resolve(name: str) -> str | None:
+        seen.append(name)
+        return "default-pid"
 
-    assert url == "https://smith.example/o/tenant-1/projects/p/env-pid/t/t3"
+    monkeypatch.setattr(ls_utils, "_resolve_project_id_by_name", _resolve)
+
+    assert await ls_utils.get_langsmith_trace_url("t3") == (
+        "https://smith.example/o/tenant-1/projects/p/default-pid/t/t3"
+    )
+    assert seen == ["default"]
 
 
 async def test_trace_url_none_when_unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -77,12 +82,12 @@ async def test_resolve_project_id_caches_success(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: _FakeClient())
 
-    first = await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT)
-    second = await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT)
+    first = await ls_utils._resolve_project_id_by_name("my-deployment")
+    second = await ls_utils._resolve_project_id_by_name("my-deployment")
 
     assert first == "pid-123"
     assert second == "pid-123"
-    assert calls == [AGENT_TRACING_PROJECT]
+    assert calls == ["my-deployment"]
 
 
 async def test_resolve_project_id_retries_transient_failure(
@@ -103,15 +108,16 @@ async def test_resolve_project_id_retries_transient_failure(
 
     monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: _FakeClient())
 
-    assert await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT) is None
-    assert await ls_utils._resolve_project_id_by_name(AGENT_TRACING_PROJECT) is None
-    assert calls == [AGENT_TRACING_PROJECT, AGENT_TRACING_PROJECT]
+    assert await ls_utils._resolve_project_id_by_name("my-deployment") is None
+    assert await ls_utils._resolve_project_id_by_name("my-deployment") is None
+    assert calls == ["my-deployment", "my-deployment"]
 
 
 async def test_create_thread_feedback_posts_thread_scope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     requests: list[tuple[str, str, dict[str, object]]] = []
+    monkeypatch.setenv("LANGSMITH_PROJECT", "my-deployment")
 
     class _FakeClient:
         async def _arequest_with_retries(
@@ -123,7 +129,7 @@ async def test_create_thread_feedback_posts_thread_scope(
     monkeypatch.setattr(
         ls_utils,
         "_resolve_project_id_by_name",
-        _resolver({AGENT_TRACING_PROJECT: "project-id"}),
+        _resolver({"my-deployment": "project-id"}),
     )
 
     result = await ls_utils.create_langsmith_thread_feedback(

--- a/tests/agent/test_langsmith_trace_url.py
+++ b/tests/agent/test_langsmith_trace_url.py
@@ -41,7 +41,14 @@ async def test_trace_url_defaults_to_the_sdk_default_project(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _set_env(monkeypatch)
-    monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
+    for name in (
+        "LANGSMITH_PROJECT",
+        "LANGCHAIN_PROJECT",
+        "LANGSMITH_SESSION",
+        "LANGCHAIN_SESSION",
+        "HOSTED_LANGSERVE_PROJECT_NAME",
+    ):
+        monkeypatch.delenv(name, raising=False)
     seen: list[str] = []
 
     async def _resolve(name: str) -> str | None:
@@ -317,3 +324,16 @@ def test_feedback_clients_use_a_single_workspace(monkeypatch: pytest.MonkeyPatch
     assert ls_utils._build_langsmith_feedback_clients() == (
         ("standard", "https://api.smith.langchain.com"),
     )
+
+
+def test_tracing_project_follows_the_sdk_tracer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Links must query the project the tracer used, whichever legacy name supplied it."""
+    from agent.utils.tracing import tracing_project
+
+    for name in ("LANGSMITH_PROJECT", "LANGCHAIN_PROJECT", "HOSTED_LANGSERVE_PROJECT_NAME"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("LANGCHAIN_PROJECT", "legacy-name")
+    assert tracing_project() == "legacy-name"
+
+    monkeypatch.setenv("LANGSMITH_PROJECT", "current-name")
+    assert tracing_project() == "current-name"

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -505,3 +505,21 @@ def test_make_model_gateway_without_key_falls_back_direct(
     assert captured["store"] is False
     assert captured["include"] == ["reasoning.encrypted_content"]
     assert "api_key" not in captured
+
+
+def test_gateway_default_follows_the_dedicated_key(monkeypatch) -> None:
+    from agent.utils import gateway
+
+    for name in ("LANGSMITH_GATEWAY_ENABLED", "LANGSMITH_GATEWAY_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    assert gateway.gateway_env_default() is False
+
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "lsv2_sk_gateway")
+    assert gateway.gateway_env_default() is True
+
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "false")
+    assert gateway.gateway_env_default() is False
+
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "true")
+    assert gateway.gateway_env_default() is True

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -267,7 +267,7 @@ def test_missing_api_key_passes_through(monkeypatch: pytest.MonkeyPatch) -> None
     assert gateway.gateway_overrides("openai:gpt-5.6-sol") is None
 
 
-def test_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_deprecated_prod_key_used_as_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_API_KEY_PROD", "ls-prod-key")
     overrides = gateway.gateway_overrides("anthropic:claude-opus-5")
     assert overrides is not None

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -87,10 +87,18 @@ def test_deprecated_names_the_platform_injects_next_to_current_ones_stay_quiet()
         "LANGCHAIN_API_KEY": "k",
         "LANGSMITH_TRACING": "true",
         "LANGCHAIN_TRACING_V2": "true",
+        "LANGSMITH_PROJECT": "p",
         "LANGCHAIN_PROJECT": "p",
     }
 
     assert ENV.deprecated_in_use(env) == []
+
+
+def test_legacy_project_name_alone_is_read_and_flagged() -> None:
+    env = {"LANGCHAIN_PROJECT": "p"}
+
+    assert ENV.LANGSMITH_PROJECT.get(environ=env) == "p"
+    assert ("LANGCHAIN_PROJECT", "use LANGSMITH_PROJECT instead.") in ENV.deprecated_in_use(env)
 
 
 def test_deprecated_in_use_is_quiet_for_current_names() -> None:


### PR DESCRIPTION
## Summary

Second PR of the install-simplification stack, on main. Everything LangSmith needs comes from the injected `LANGSMITH_API_KEY`, `LANGSMITH_ENDPOINT`, and `LANGSMITH_PROJECT`.

- **Tenant and host discovery.** The tenant id is discovered from the workspace (`LANGSMITH_TENANT_ID` remains an override) and the trace-link web host is derived from `LANGSMITH_ENDPOINT` via the SDK's `get_host_url`. The tenant and project-id caches are keyed by the credentials that produced them, so a rotated key or another endpoint starts over.
- **Tracing follows `LANGSMITH_PROJECT`.** Every run traces into the project named by `LANGSMITH_PROJECT`, the SDK's own variable, instead of the hardcoded `open-swe-agent` / `open-swe-review` projects. LangGraph Platform sets it to the deployment name, so each deployment's traces stay in its own project. Trace links, thread cost lookups, and thread feedback resolve that same project by name. `LANGSMITH_TRACING_PROJECT_ID` and its `_PROD` alias are removed; `LANGSMITH_PROJECT` is declared in the registry with the SDK's `default`. The review trace context keeps its team-configured `review_tracing_project`, the project it searches for the reviewed change's own traces. The `traced_*` entrypoint names stay as plain aliases because `langgraph.json` and the e2e configs import them.
- **LLM Gateway on by default when its key is set.** `LANGSMITH_GATEWAY_ENABLED` still forces it either way, and the team setting overrides both.

## Testing

- The installation guide's LangSmith step no longer asks for tenant and project ids and documents `LANGSMITH_PROJECT`.
- `tests/agent/test_langsmith_trace_url.py`: tenant discovery and override, host derivation, links follow `LANGSMITH_PROJECT`, credential-keyed caches; `tests/sandbox/test_gateway.py`: gateway default.
- On the `open-swe-staging` deployment, agent and thread-title traces land in the `open-swe-staging` project and the "View trace" links open them.

## Stack

1. #2463 unified config + standard LangSmith env (merged)
2. #2489 LangSmith tenant discovery and `LANGSMITH_PROJECT` tracing
3. #2486 single-origin dashboard

The GitHub/Slack discovery and `make setup` PRs (#2464, #2487, #2488) and the docs rewrite (#2466) are parked as drafts; a first-boot setup flow (OEP draft) replaces that direction.
