### PR TITLE
fix(agent): keep the server's runtime out of the graphs factories bind

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -47,6 +47,7 @@ from agent.runtime import (
     DEFAULT_LLM_MAX_TOKENS,
     DEFAULT_LLM_MODEL_ID,
     DEFAULT_RECURSION_LIMIT,
+    bindable_config,
     ensure_sandbox_for_thread,
     get_cached_sandbox_backend,
     graph_loaded_for_execution,
@@ -163,7 +164,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     config["recursion_limit"] = DEFAULT_RECURSION_LIMIT
 
     if thread_id is None or not graph_loaded_for_execution(config):
-        return create_deep_agent(system_prompt="", tools=[]).with_config(config)
+        return create_deep_agent(system_prompt="", tools=[]).with_config(bindable_config(config))
 
     async def reconnect_backend(_thread_id: str = thread_id):
         return await ensure_sandbox_for_thread(_thread_id)
@@ -200,7 +201,7 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
                 SanitizeOpenAIResponsesMiddleware(),
             ],
         ),
-    ).with_config(config)
+    ).with_config(bindable_config(config))
 
 
 # langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -59,6 +59,7 @@ from agent.run_config import RunConfig
 from agent.runtime import (
     DEFAULT_LLM_MAX_TOKENS,
     DEFAULT_RECURSION_LIMIT,
+    bindable_config,
     graph_loaded_for_execution,
 )
 from agent.tools import (
@@ -212,7 +213,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
     cfg = RunConfig.parse(configurable)
 
     if cfg.thread_id is None or not graph_loaded_for_execution(config):
-        return create_deep_agent(system_prompt="", tools=[]).with_config(config)
+        return create_deep_agent(system_prompt="", tools=[]).with_config(bindable_config(config))
 
     model_id, effort = await _resolve_chat_model(cfg)
     model_id, effort = gate_fable_model(
@@ -251,7 +252,7 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
                 ModelCallTimeoutMiddleware(),
             ],
         ),
-    ).with_config(config)
+    ).with_config(bindable_config(config))
 
 
 # langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -95,6 +95,7 @@ from agent.runtime import (
     DEFAULT_LLM_MAX_TOKENS,
     DEFAULT_RECURSION_LIMIT,
     MODEL_CALL_RECURSION_LIMIT,
+    bindable_config,
     ensure_sandbox_for_thread,
     get_cached_sandbox_backend,
     graph_loaded_for_execution,
@@ -1309,7 +1310,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
 
     if thread_id is None or not graph_loaded_for_execution(config):
         logger.info("No thread_id or not for execution, returning reviewer agent without sandbox")
-        return create_deep_agent(system_prompt="", tools=[]).with_config(config)
+        return create_deep_agent(system_prompt="", tools=[]).with_config(bindable_config(config))
 
     if cfg.reviewer_model_id:
         model_id = cfg.reviewer_model_id
@@ -1410,7 +1411,7 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
                 settle_review_check_on_exit,
             ],
         ),
-    ).with_config(config)
+    ).with_config(bindable_config(config))
 
 
 # langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.

--- a/agent/runtime/__init__.py
+++ b/agent/runtime/__init__.py
@@ -4,7 +4,7 @@ from agent.runtime.constants import (
     DEFAULT_RECURSION_LIMIT,
     MODEL_CALL_RECURSION_LIMIT,
 )
-from agent.runtime.execution import graph_loaded_for_execution
+from agent.runtime.execution import bindable_config, graph_loaded_for_execution
 from agent.sandboxes.lifecycle import (
     configure_git_identity,
     ensure_sandbox_for_thread,
@@ -19,5 +19,6 @@ __all__ = [
     "configure_git_identity",
     "ensure_sandbox_for_thread",
     "get_cached_sandbox_backend",
+    "bindable_config",
     "graph_loaded_for_execution",
 ]

--- a/agent/runtime/execution.py
+++ b/agent/runtime/execution.py
@@ -5,3 +5,23 @@ from agent.run_config import RunConfig
 
 def graph_loaded_for_execution(config: RunnableConfig) -> bool:
     return RunConfig.from_config(config).get("__is_for_execution__") is True
+
+
+def bindable_config(config: RunnableConfig) -> RunnableConfig:
+    """``config`` without LangGraph's runtime-internal keys, for ``graph.with_config``.
+
+    The server hands a graph factory a config whose ``configurable`` carries its
+    own plumbing: the runtime (``__pregel_runtime``, a read-only runtime for state
+    reads and an execution runtime for runs), checkpointer, and store. Binding
+    those onto the graph bakes a read-time runtime into every later call, and the
+    platform's checkpointer cannot serialize it (it reads ``runtime.context``,
+    which the read runtime lacks), so ``GET /threads/{id}/state`` fails with a 500.
+    LangGraph re-injects these keys on each invocation, so the bound graph never
+    needs them.
+    """
+    configurable = {
+        key: value
+        for key, value in (config.get("configurable") or {}).items()
+        if not str(key).startswith("__pregel_")
+    }
+    return {**config, "configurable": configurable}

--- a/agent/server.py
+++ b/agent/server.py
@@ -127,7 +127,7 @@ from agent.runtime.constants import (
 from agent.runtime.constants import (
     DEFAULT_LLM_MODEL_ID as DEFAULT_LLM_MODEL_ID,
 )
-from agent.runtime.execution import graph_loaded_for_execution
+from agent.runtime.execution import bindable_config, graph_loaded_for_execution
 from agent.sandboxes.lifecycle import (
     ensure_sandbox_for_thread,
     get_cached_sandbox_backend,
@@ -915,7 +915,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         return create_deep_agent(
             system_prompt="",
             tools=[],
-        ).with_config(config)
+        ).with_config(bindable_config(config))
 
     profile_login = resolve_github_login(as_json_object(config))
 
@@ -1349,7 +1349,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 ModelCallTimeoutMiddleware(),
             ],
         ),
-    ).with_config(config)
+    ).with_config(bindable_config(config))
 
 
 # langgraph.json entrypoint. Runs trace into LANGSMITH_PROJECT like everything else.

--- a/tests/runtime/test_bindable_config.py
+++ b/tests/runtime/test_bindable_config.py
@@ -1,0 +1,40 @@
+"""Factories must not bake the server's runtime plumbing into the graphs they return."""
+
+from agent.chat import get_chat_agent
+from agent.runtime import bindable_config
+
+
+class _ReadOnlyRuntime:
+    """Stands in for the SDK's read runtime, which has no ``context`` attribute."""
+
+
+def test_bindable_config_drops_langgraph_internal_keys() -> None:
+    config = {
+        "recursion_limit": 7,
+        "configurable": {
+            "thread_id": "t1",
+            "model": "anthropic:claude-opus-5",
+            "__pregel_runtime": _ReadOnlyRuntime(),
+            "__pregel_checkpointer": object(),
+            "__pregel_store": object(),
+        },
+    }
+
+    bound = bindable_config(config)
+
+    assert bound["recursion_limit"] == 7
+    assert bound["configurable"] == {"thread_id": "t1", "model": "anthropic:claude-opus-5"}
+    # The caller's config is left alone.
+    assert "__pregel_runtime" in config["configurable"]
+
+
+async def test_factory_graph_carries_no_runtime_from_the_read_path() -> None:
+    """A state read hands the factory a read-only runtime; the bound graph must not keep it."""
+    config = {
+        "configurable": {"thread_id": "t1", "__pregel_runtime": _ReadOnlyRuntime()},
+    }
+
+    graph = await get_chat_agent(config)
+
+    assert "__pregel_runtime" not in (graph.config or {}).get("configurable", {})
+    assert graph.config["configurable"]["thread_id"] == "t1"


### PR DESCRIPTION
## Summary

On LangGraph Platform, `GET /threads/{id}/state` returned 500 for every thread that had run (and so did the dashboard's thread view, which proxies it). The server's checkpointer failed with `AttributeError: '_ReadRuntime' object has no attribute 'context'` inside `langgraph_grpc_common.conversion.config.runtime_to_proto`.

**Cause.** `langgraph_api` gives a graph factory a config whose `configurable` includes its own plumbing under `__pregel_*` keys: the runtime (a read-only `_ReadRuntime` for `threads.read`, an execution runtime for runs), the checkpointer, and the store. Our factories returned `graph.with_config(config)`, baking the read-only runtime into the graph's config; the next `aget_state` merged it back into the config handed to the gRPC checkpointer, whose proto conversion reads `runtime.context`.

**Fix.** `agent.runtime.bindable_config` strips the `__pregel_*` keys before `with_config` at all eight factory sites (agent, reviewer, analyzer, chat; loaded and not-loaded paths). LangGraph re-injects those keys on every invocation, so nothing is lost. The platform side should also guard `runtime.context` in `runtime_to_proto`; that is reported separately.

## Test plan

- [x] `tests/runtime/test_bindable_config.py`: the helper drops only `__pregel_*` keys and leaves the caller's config alone; `get_chat_agent` called with a read-only runtime in its config returns a graph without it.
- [x] `tests/agent`, `tests/reviewer`, `tests/test_thread_title.py` green.
- [ ] Staging: deploy this ref and confirm `GET /threads/{id}/state` returns 200 for a thread that has run.