### PR TITLE
fix(dashboard): treat the dev-proxied UI as living on the backend origin

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -287,8 +287,8 @@ ENV.var("LINEAR_WEBHOOK_SECRET", "HMAC secret for Linear webhook deliveries.", s
 # --- Dashboard ------------------------------------------------------------------------------
 ENV.var(
     "DASHBOARD_BASE_URL",
-    "Public URL of the dashboard frontend; defaults to LANGGRAPH_URL when the dashboard build "
-    "is bundled with the backend.",
+    "Public URL of the dashboard frontend; defaults to LANGGRAPH_URL when the backend serves "
+    "the dashboard (bundled build or DASHBOARD_DEV_SERVER_URL).",
 )
 ENV.var(
     "DASHBOARD_API_BASE_URL",

--- a/agent/utils/dashboard_links.py
+++ b/agent/utils/dashboard_links.py
@@ -3,7 +3,7 @@
 from urllib.parse import quote, urlsplit
 
 from agent.config import ENV
-from agent.utils.dashboard_ui import dashboard_on_this_origin
+from agent.utils.dashboard_ui import is_single_origin
 
 
 def dashboard_base_url() -> str:
@@ -17,7 +17,7 @@ def dashboard_base_url() -> str:
     explicit = ENV.DASHBOARD_BASE_URL.optional()
     if explicit:
         return explicit.rstrip("/")
-    if dashboard_on_this_origin():
+    if is_single_origin():
         return ENV.LANGGRAPH_URL.get().rstrip("/")
     return ""
 

--- a/agent/utils/dashboard_links.py
+++ b/agent/utils/dashboard_links.py
@@ -3,20 +3,21 @@
 from urllib.parse import quote, urlsplit
 
 from agent.config import ENV
-from agent.utils.dashboard_ui import dashboard_static_dir
+from agent.utils.dashboard_ui import dashboard_on_this_origin
 
 
 def dashboard_base_url() -> str:
     """Public base URL of the dashboard frontend, or ``""`` when there is none.
 
     An explicit ``DASHBOARD_BASE_URL`` wins. Otherwise the dashboard lives on the
-    backend's own origin when its build is bundled, so ``LANGGRAPH_URL`` is the
+    backend's own origin when the backend serves it (a bundled build, or the Vite
+    dev server behind ``DASHBOARD_DEV_SERVER_URL``), so ``LANGGRAPH_URL`` is the
     base; with neither there is no dashboard to link to.
     """
     explicit = ENV.DASHBOARD_BASE_URL.optional()
     if explicit:
         return explicit.rstrip("/")
-    if dashboard_static_dir() is not None:
+    if dashboard_on_this_origin():
         return ENV.LANGGRAPH_URL.get().rstrip("/")
     return ""
 

--- a/agent/utils/dashboard_ui.py
+++ b/agent/utils/dashboard_ui.py
@@ -72,6 +72,12 @@ def dashboard_static_dir() -> Path | None:
     return None
 
 
+def dashboard_on_this_origin() -> bool:
+    """True when this backend serves the dashboard itself: a bundled build, or the
+    Vite dev server it fronts. Then ``LANGGRAPH_URL`` is also the dashboard's URL."""
+    return bool(ENV.DASHBOARD_DEV_SERVER_URL.optional()) or dashboard_static_dir() is not None
+
+
 def is_reserved_path(path: str) -> bool:
     return any(path == prefix or path.startswith(prefix + "/") for prefix in RESERVED_PREFIXES)
 

--- a/agent/utils/dashboard_ui.py
+++ b/agent/utils/dashboard_ui.py
@@ -72,9 +72,10 @@ def dashboard_static_dir() -> Path | None:
     return None
 
 
-def dashboard_on_this_origin() -> bool:
-    """True when this backend serves the dashboard itself: a bundled build, or the
-    Vite dev server it fronts. Then ``LANGGRAPH_URL`` is also the dashboard's URL."""
+def is_single_origin() -> bool:
+    """True when the dashboard and the API share this backend's origin: a bundled
+    build, or the Vite dev server the backend fronts. ``LANGGRAPH_URL`` is then
+    also the dashboard's URL."""
     return bool(ENV.DASHBOARD_DEV_SERVER_URL.optional()) or dashboard_static_dir() is not None
 
 

--- a/tests/dashboard/test_dashboard_urls.py
+++ b/tests/dashboard/test_dashboard_urls.py
@@ -32,8 +32,23 @@ def test_bundled_dashboard_lives_on_the_backend_origin(
     assert dashboard_links.dashboard_thread_url("t1") == "https://backend.example/agents/t1"
 
 
+def test_dev_proxied_dashboard_lives_on_the_backend_origin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``make dev-ui``: no build on disk, the backend fronts Vite, links and logins still work."""
+    monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+    monkeypatch.setenv("DASHBOARD_STATIC_DIR", str(tmp_path / "no-build"))
+    monkeypatch.setenv("DASHBOARD_DEV_SERVER_URL", "http://localhost:3000")
+    monkeypatch.setenv("LANGGRAPH_URL", "http://localhost:2024")
+
+    assert dashboard_links.dashboard_base_url() == "http://localhost:2024"
+    assert dashboard_links.dashboard_is_same_origin() is True
+    assert dashboard_routes._frontend_base_url() == "http://localhost:2024"
+
+
 def test_no_dashboard_means_no_links(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DASHBOARD_BASE_URL", raising=False)
+    monkeypatch.delenv("DASHBOARD_DEV_SERVER_URL", raising=False)
 
     assert dashboard_links.dashboard_base_url() == ""
     assert dashboard_links.dashboard_thread_url("t1") is None


### PR DESCRIPTION
## Summary

Follow-up to #2493. `dashboard_base_url()` falls back to `LANGGRAPH_URL` so the bundled dashboard needs no `DASHBOARD_BASE_URL`, but the fallback was gated on a build existing on disk. Under `make dev-ui` the backend serves the Vite dev server instead of a build, so the fallback returned `""` and every route that needs the frontend URL (Slack and Notion sign-in, the default post-login redirect) failed with `500 DASHBOARD_BASE_URL not configured`.

`is_single_origin()` in `dashboard_ui.py` now says whether the backend serves the dashboard at all, build or dev proxy, and `dashboard_base_url()` uses it. The registry description of `DASHBOARD_BASE_URL` follows.

## Test plan

- [x] New test: no build on disk + `DASHBOARD_DEV_SERVER_URL` set → base URL is `LANGGRAPH_URL`, same-origin is true, `_frontend_base_url()` no longer raises
- [x] `tests/dashboard` pass; ruff and ty on the changed modules
- [x] Reproduced locally: `make dev-ui` with no build, Slack sign-in from the dashboard returned `{"detail":"DASHBOARD_BASE_URL not configured"}` until the variable was set by hand