### PR TITLE
fix: guard subagent workflow pushes

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -395,6 +395,7 @@ def _subagent_middleware(
     if dynamic_tools is not None:
         middleware.append(dynamic_tools)
     middleware.append(ExcludeToolsMiddleware(excluded=DEEP_AGENT_EXCLUDED_TOOLS))
+    middleware.append(WorkflowPushGuardMiddleware())
     middleware.extend(_subagent_model_middleware())
     return middleware
 

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -513,6 +513,15 @@ async def test_task_retry_wraps_inside_tool_error_middleware() -> None:
 
 
 @pytest.mark.asyncio
+async def test_general_purpose_subagent_guards_workflow_pushes() -> None:
+    captured = await _capture_create_deep_agent_kwargs()
+    subagents = captured["subagents"]
+    assert isinstance(subagents, list)
+    gp = next(s for s in subagents if s["name"] == "general-purpose")
+    assert any(type(m).__name__ == "WorkflowPushGuardMiddleware" for m in gp["middleware"])
+
+
+@pytest.mark.asyncio
 async def test_general_purpose_subagent_carries_open_swe_shared_base() -> None:
     from agent.prompt import OPEN_SWE_SHARED_BASE
 


### PR DESCRIPTION
The workflow push middleware was not applied to the general-purpose subagent. This applies the guard to the subagent and adds a regression test.

Made by [Open SWE](https://openswe.vercel.app/agents/0571af4f-546d-5bed-a036-80808943c287)