### PR TITLE
docs: installation guide for deploying a single-origin Open SWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Sandboxes can have network access and powerful tools. Deployments should use lea
 
 Open SWE includes a LangGraph backend, a web dashboard, and an experimental desktop client.
 
-- **[Installation Guide](docs/INSTALLATION.md)** — Set up local development, the GitHub App, LangSmith, integrations, and production deployment
+- **[Installation Guide](docs/INSTALLATION.md)** — Deploy Open SWE for a team: LangGraph Platform or Docker, the GitHub App, environment variables, and the optional Slack and Linear triggers
 - **[Customization Guide](docs/CUSTOMIZATION.md)** — Change models, sandboxes, tools, skills, prompts, triggers, and middleware
 - **[Open SWE Enhancement Proposals](oeps/README.md)** — Review consequential product, architecture, security, and process decisions
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,297 +1,125 @@
-
 # Installation Guide
 
-This guide walks you through setting up Open SWE end-to-end: local development, GitHub App creation, LangSmith configuration, webhooks, the web dashboard, and production deployment.
+This guide deploys Open SWE for a team. Running it on your own machine is summarized in [Local development](#local-development) at the end.
 
-Open SWE has two runnable pieces:
+Open SWE is one deployment: a LangGraph server that runs the graphs (`agent`, `reviewer`, `analyzer`, `chat`, `scheduler`), the FastAPI app (`agent.webapp:app`) that owns the webhooks and the dashboard API, and the web dashboard, served from the same origin at `/`. Webhooks, the dashboard, GitHub login, and the API all share the deployment's URL, so there is no second frontend deploy and no cross-origin cookie or CORS setup.
 
-- **The backend** — a LangGraph app (five graphs: `agent`, `reviewer`, `analyzer`, `chat`, `scheduler`) plus a FastAPI app (`agent.webapp:app`) that owns the webhooks and the dashboard API. Both are served together by `langgraph dev`.
-- **The dashboard** — a TanStack Start + Vite web app in `ui/` (package name `open-swe-dashboard`). It's a thin client over the FastAPI dashboard API (`/dashboard/api/*`): GitHub-login, per-user model/profile settings, team defaults, enabled-repo and review-style management, user mappings, and the Agents chat UI. It is also where users sign in with GitHub, which is how the deployment obtains the per-user tokens agent runs are resolved against — so it is part of the deployment, not an add-on.
+What a deployment needs:
 
-> **The steps are ordered to avoid forward references.** Each step only depends on things you've already completed.
+| Value | How you get it |
+|---|---|
+| `LANGSMITH_API_KEY` | LangSmith → Settings → API Keys. LangGraph Platform injects it. |
+| A model key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`; or `LANGSMITH_GATEWAY_API_KEY` to route through the LangSmith LLM Gateway | Your provider, or a LangSmith key with `gateway:invoke` |
+| `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_INSTALLATION_ID` | The GitHub App you create in step 3 |
+| `TOKEN_ENCRYPTION_KEY`, `DASHBOARD_JWT_SECRET` | Two random secrets you generate (step 4) |
+| `CONFIGURED_ADMINS` | The GitHub logins or emails of your admins (step 4) |
+| `LANGGRAPH_URL` | The deployment's own public URL |
 
-## Prerequisites
+Slack and Linear are optional triggers; see [Optional add-ons](#optional-add-ons). Every variable Open SWE reads is declared in `agent/config.py` with its description and default; that file is the complete reference.
 
-- **Python 3.14+**
-- [uv](https://docs.astral.sh/uv/) package manager
-- [LangGraph CLI](https://docs.langchain.com/langsmith/cli)
-- [ngrok](https://ngrok.com/) (for local development — exposes webhook endpoints to the internet)
-- Node 22.22.2+ and [pnpm](https://pnpm.io/) (only if you want to run the dashboard UI locally — see step 8). The root `pnpm-lock.yaml` is the canonical lockfile.
+## 1. Create the deployment
 
-## 1. Clone and install
+You need the deployment's public URL before the GitHub App can be created, so create the deployment first; it starts without the GitHub variables and picks them up in step 4.
 
-```bash
-git clone https://github.com/langchain-ai/open-swe.git
-cd open-swe
-uv venv
-source .venv/bin/activate
-uv sync --all-extras
-```
+**LangGraph Platform.** Connect the repository to a new deployment in LangSmith → Deployments. The image build bundles the dashboard (the `dockerfile_lines` in `langgraph.json`), so the deployment URL serves the UI at `/` and the API beneath it; a failed UI build is logged and the backend still deploys. The platform injects `LANGSMITH_API_KEY`, `LANGSMITH_TRACING`, and `LANGSMITH_PROJECT`. You will set the environment variables in step 4.
 
-## 2. Start ngrok
-
-You'll need the ngrok URL in subsequent steps when configuring webhooks, so start it first.
+**Standalone Docker.** The root `Dockerfile` builds a production LangGraph API server image (not the sandbox image):
 
 ```bash
-ngrok http 2024 --url https://some-url-you-configure.ngrok.dev
+docker build -t open-swe .
+
+docker run \
+  --env-file .env \
+  -p 8123:8000 \
+  --add-host=host.docker.internal:host-gateway \
+  -e DATABASE_URI="postgres://postgres:postgres@host.docker.internal:5432/postgres?sslmode=disable" \
+  -e REDIS_URI="redis://host.docker.internal:6379" \
+  -e LANGGRAPH_AUTH_TYPE="noop" \
+  -e LANGGRAPH_URL="https://<your-backend-url>" \
+  open-swe
 ```
 
-You don't need to pass the `--url` flag, however doing so will use the same subdomain each time you startup the server. Without this, you'll need to update the webhook URL in GitHub, Slack and Linear every time you restart your server for local development.
+The example assumes Postgres and Redis run on the Docker host; `--add-host` is what makes `host.docker.internal` resolve on a plain Linux Docker Engine. If they run as containers, drop the flag and point `DATABASE_URI` / `REDIS_URI` at their service names on a shared network. Add the standalone Agent Server requirements: `DATABASE_URI`, `REDIS_URI`, `LANGSMITH_API_KEY`, and `LANGGRAPH_CLOUD_LICENSE_KEY`. Expose port `8000` through your ingress, and do not use scale-to-zero hosting: background runs rely on the Redis- and Postgres-backed workers staying up. If the built-in LangGraph API routes are reachable from the public internet, put the service behind a private network, API gateway, or custom LangGraph auth before using `LANGGRAPH_AUTH_TYPE=noop`. Bundle the dashboard by building it (`make build-dashboard`) before `docker build`, or set `DASHBOARD_STATIC_DIR` to a directory holding the build.
 
-Copy the HTTPS URL you set, or if you didn't pass `--url`, the one ngrok gives you. You'll paste this into the webhook settings in steps 3 and 5.
+Either way, the URL browsers and webhooks use from here on is `<URL>`: `https://<name>-<hash>.<region>.langgraph.app` on the platform, or your ingress hostname in front of the container.
 
-> Keep this terminal open — ngrok needs to stay running during local development. Use a second terminal for the rest of the steps.
+## 2. LangSmith and a model
+
+1. Create a [LangSmith](https://smith.langchain.com/) API key under **Settings → API Keys** and save it as `LANGSMITH_API_KEY`. LangGraph Platform injects it into the deployment for you, along with `LANGSMITH_TRACING` and `LANGSMITH_PROJECT`; standalone deployments set it themselves. It is also what sandboxes and trace links use: trace links find your workspace through the key and the project by name, so no tenant or project ids are needed (`LANGSMITH_TENANT_ID` remains an override).
+2. Pick a model provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`. Or set `LANGSMITH_GATEWAY_API_KEY` (a LangSmith key with `gateway:invoke`) to route every provider call through the LangSmith LLM Gateway; `LANGSMITH_GATEWAY_ENABLED` forces that on or off, and admins can toggle it per team in the dashboard.
 
 ## 3. Create a GitHub App
 
-Open SWE authenticates as a [GitHub App](https://docs.github.com/en/apps/creating-github-apps) to clone repos, push branches, and open PRs.
+Open SWE authenticates as a [GitHub App](https://docs.github.com/en/apps/creating-github-apps) to clone repositories, push branches, open pull requests, and sign users in to the dashboard.
 
-### 3a. Create the app
+Go to **GitHub Settings → Developer settings → [GitHub Apps](https://github.com/settings/apps) → New GitHub App** and fill in:
 
-1. Go to **GitHub Settings → Developer settings → [GitHub Apps](https://github.com/settings/apps) → [New GitHub App](https://github.com/settings/apps/new)**
-2. Fill in:
-   - **App name**: `Open SWE` (or your preferred name)
-   - **Homepage URL**: This can be any valid URL — it's only shown on the GitHub Marketplace page (which you won't be using). Use something like `https://github.com/langchain-ai/open-swe`
-   - **Callback URL**: `http://localhost:2024/dashboard/api/auth/callback` — the dashboard OAuth callback (step 8). For production, also add `https://<your-dashboard-api-url>/dashboard/api/auth/callback`. If you distribute the desktop app, add `https://<your-backend-url>/dashboard/api/auth/callback` as well. GitHub Apps allow multiple callback URLs, one per line.
-   - **Request user authorization (OAuth) during installation**: ✅ Enable this
-   - **Webhook URL**: `https://<your-ngrok-url>/webhooks/github` — use the ngrok URL from step 2
-   - **Webhook secret**: generate one and save it — you'll need it later as `GITHUB_WEBHOOK_SECRET`:
-     ```bash
-     openssl rand -hex 32
-     ```
-3. Set permissions:
-   - **Repository permissions**:
-     - Contents: Read & write
-     - Pull requests: Read & write
-     - Issues: Read & write
-     - Checks: Read & write — reports an "Open SWE Review" check run on PRs while an auto-review runs and lets `/baby-sit` read third-party CI conclusions. Without it, check-run creation fails (logged, best-effort), reviews still work, and `/baby-sit` fails closed when it cannot read the complete check set.
-     - Commit statuses: Read-only — required for `/baby-sit` to evaluate the complete PR status set, including integrations that report via legacy commit statuses instead of check runs.
-     - Actions: Read-only — optional for CI diagnostics and log access. Grant **Read & write** only to enable `/baby-sit` to rerun evidence-backed flaky GitHub Actions jobs. Existing installations must approve this permission elevation. Actions write also permits rerunning, canceling, and deleting workflow runs at the token level; `/baby-sit` is instructed to use only failed-job reruns.
-     - Workflows: Read & write — required to let Open SWE directly push branches containing explicitly requested GitHub Actions workflow changes.
-     - Metadata: Read-only
-   - **Organization permissions** (required only if you plan to set `ALLOWED_GITHUB_ORGS` — see step 5 / Security):
-     - Members: Read-only — used to verify org membership for dashboard login and LangSmith trace-tool access via `GET /orgs/{org}/memberships/{username}`. Without this permission that call returns 403 and the check fails closed.
-4. Under **Subscribe to events**, enable:
-   - `Issue comment`
-   - `Pull request review`
-   - `Pull request review comment`
-   - `Check run` — required for immediate `/baby-sit` failure detection
-   - `Check suite` — required for immediate `/baby-sit` failure detection
-   - `Workflow run` — required for immediate `/baby-sit` failure detection
-   - `Status` — optional; covers integrations that report via the legacy commit-status API
-5. Click **Create GitHub App**
+- **Callback URL**: `<URL>/dashboard/api/auth/callback`. GitHub Apps take several, one per line; for local development add `http://localhost:2024/dashboard/api/auth/callback`.
+- **Request user authorization (OAuth) during installation**: off
+- **Webhook URL**: `<URL>/webhooks/github`, **Webhook secret**: the output of `openssl rand -hex 32`, saved as `GITHUB_WEBHOOK_SECRET`
+- **Repository permissions**:
+  - Contents: Read & write
+  - Pull requests: Read & write
+  - Issues: Read & write
+  - Checks: Read & write — reports an "Open SWE Review" check run on PRs while an auto-review runs and lets `/baby-sit` read third-party CI conclusions. Without it, check-run creation fails (logged, best-effort), reviews still work, and `/baby-sit` fails closed when it cannot read the complete check set.
+  - Commit statuses: Read-only — required for `/baby-sit` to evaluate the complete PR status set, including integrations that report via legacy commit statuses.
+  - Actions: Read-only — optional for CI diagnostics and log access. Grant **Read & write** only to enable `/baby-sit` to rerun evidence-backed flaky GitHub Actions jobs; existing installations must approve the elevation, and the token could then also cancel or delete runs.
+  - Workflows: Read & write — lets Open SWE push branches containing explicitly requested GitHub Actions workflow changes.
+  - Metadata: Read-only
+- **Organization permissions**: Members: Read-only — verifies org membership for dashboard login and LangSmith trace-tool access when `ALLOWED_GITHUB_ORGS` is set. Without it that check fails closed.
+- **Subscribe to events**: Issue comment, Pull request review, Pull request review comment, Check run, Check suite, Workflow run (the last three give `/baby-sit` immediate failure detection), and Status (optional; legacy commit-status integrations).
 
-### 3b. Collect credentials
+Click **Create GitHub App**, then collect from its settings page:
 
-After creating the app:
+- **App ID** → `GITHUB_APP_ID`
+- **Client ID** (starts with `Iv`) → `GITHUB_APP_CLIENT_ID`
+- **Client secrets → Generate a new client secret** → `GITHUB_APP_CLIENT_SECRET`
+- **Private keys → Generate a private key** downloads a `.pem`; its whole contents, BEGIN and END lines included → `GITHUB_APP_PRIVATE_KEY`
 
-1. **App ID** — shown at the top of the app's settings page. Save this as `GITHUB_APP_ID`.
-2. **Private key** — scroll down to **Private keys** → click **Generate a private key**. A `.pem` file will download. Save its contents as `GITHUB_APP_PRIVATE_KEY`.
-3. **Client ID** — shown near the top of the app's settings page (starts with `Iv...`). Save this as `GITHUB_APP_CLIENT_ID`.
-4. **Client secret** — under **Client secrets** → **Generate a new client secret**. Save it as `GITHUB_APP_CLIENT_SECRET`.
+Finally **Install App** in the sidebar: pick the account and the repositories Open SWE may work in. The number at the end of the resulting URL, `https://github.com/settings/installations/<id>` (or `/organizations/<org>/settings/installations/<id>`), is `GITHUB_APP_INSTALLATION_ID`.
 
-> `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET` are **required**, not optional. They drive the GitHub OAuth flow behind the callback URL above, which is how the dashboard obtains and stores each user's GitHub token. `resolve_github_token` reads that store on every run, so it is what lets Slack-, Linear-, and dashboard-triggered runs act as the person who triggered them. Without them the deployment can only ever act as the GitHub App bot.
+Give each deployment its own GitHub App, or at least a distinct mention handle (`OPEN_SWE_MENTION_TAGS`, see [Allowlists](#repository-allowlists-mention-handles-and-user-mapping)) when several share a GitHub organization.
 
-### 3c. Install the app on your repositories
-
-1. From your app's settings page, click **Install App** in the sidebar
-2. Select your org or personal account
-3. Choose which repositories Open SWE should have access to
-4. Click **Install**
-5. After installation, look at the URL in your browser — it will look like:
-   ```
-   https://github.com/settings/installations/12345678
-   ```
-   or for an org:
-   ```
-   https://github.com/organizations/YOUR-ORG/settings/installations/12345678
-   ```
-   The number at the end (`12345678`) is your **Installation ID**. Save this as `GITHUB_APP_INSTALLATION_ID`.
-
-> **Note**: The installation page may prompt you to authenticate with LangSmith. If you haven't set up LangSmith yet (step 4), that's fine — you can still grab the Installation ID from the URL and complete the OAuth setup later.
-
-## 4. Set up LangSmith
-
-Open SWE uses [LangSmith](https://smith.langchain.com/) for:
-- **Tracing**: all agent runs are logged for debugging and observability
-- **Sandboxes**: each task runs in an isolated LangSmith cloud sandbox
-
-### 4a. Get your API key, project and tenant IDs
-
-1. Create a [LangSmith account](https://smith.langchain.com/) if you don't have one
-2. Go to **Settings → API Keys → Create API Key**
-3. Save it as `LANGSMITH_API_KEY_PROD`
-4. Optionally pick a **tracing project**: every run traces into the LangSmith project named by `LANGSMITH_PROJECT` (`default` when unset; the legacy `LANGCHAIN_PROJECT` is honored too, and LangGraph Platform sets both to the deployment name), and "View trace" links point there.
-
-> **Tenant and project ids are discovered.** Trace links find your workspace through the API key and the project by name, so nothing else needs to be copied. `LANGSMITH_TENANT_ID` remains an explicit override.
-
-### 4b. Sandbox snapshots
-
-LangSmith sandboxes provide the isolated execution environment for each agent run. Open SWE boots each sandbox from a pre-built **snapshot** — you build the snapshot once (from a Docker image) and then reference it by UUID.
-
-The image must carry the toolchain agent runs expect — `git`, `gh`, `sfw`, the Docker CLI, and the language runtimes — and must be in a registry LangSmith can pull from. Run `sfw --version` while building the image to populate its binary cache, and set `SFW_SKIP_UPDATE_CHECK=1` at runtime so the sandbox proxy does not block its update request.
-
-Build a snapshot in the LangSmith UI (Sandboxes → Snapshots → New), or via the SDK:
-
-```python
-from langsmith.sandbox import SandboxClient
-
-client = SandboxClient(api_key="<your key>")
-snapshot = client.create_snapshot(
-    name="open-swe",
-    docker_image="johanneslangchain/open-swe-sandbox:gh-cli-amd64",
-    fs_capacity_bytes=128 * 1024**3,
-)
-print(snapshot.id)
-```
-
-You can also use the helper script:
+## 4. Set the environment variables
 
 ```bash
-uv run python scripts/create_sandbox_snapshot.py \
-  --name open-swe-gh-cli-amd64 \
-  --image johanneslangchain/open-swe-sandbox:gh-cli-amd64
+LANGGRAPH_URL="<URL>"                 # the deployment's own URL
+LANGSMITH_API_KEY=""                  # step 2; injected by LangGraph Platform
+LANGSMITH_TRACING="true"              # injected by LangGraph Platform
+ANTHROPIC_API_KEY=""                  # or OPENAI_API_KEY / GOOGLE_API_KEY, or LANGSMITH_GATEWAY_API_KEY
+
+GITHUB_APP_ID=""                      # step 3
+GITHUB_APP_CLIENT_ID=""
+GITHUB_APP_CLIENT_SECRET=""
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"   # one line with \n between the PEM lines, or the multi-line value your platform accepts
+GITHUB_WEBHOOK_SECRET=""
+GITHUB_APP_INSTALLATION_ID=""
+
+TOKEN_ENCRYPTION_KEY=""               # openssl rand -base64 32  (encrypts stored GitHub and Slack tokens)
+DASHBOARD_JWT_SECRET=""               # openssl rand -hex 32     (signs the session cookie and OAuth state)
+CONFIGURED_ADMINS=""                  # GitHub logins or emails, comma-separated; admins see the Admin pages
 ```
 
-Then set the resulting UUID in your environment:
+On LangGraph Platform, set them under the deployment's environment variables; saving rolls out a new revision. With Docker, put them in the file you pass as `--env-file`. `DASHBOARD_BASE_URL` and `DASHBOARD_API_BASE_URL` are not needed: they default to `LANGGRAPH_URL` because the dashboard is served from the same origin.
 
-```bash
-DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"
-# Optional; overrides the snapshot's root FS size at sandbox boot. Default is 128 GiB.
-DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES="137438953472"
-# Optional; number of vCPUs per sandbox. Default is 4.
-DEFAULT_SANDBOX_VCPUS="4"
-# Optional; memory in bytes per sandbox. Default is 16 GiB.
-DEFAULT_SANDBOX_MEM_BYTES="17179869184"
-# Optional; auto-stop a sandbox after this many seconds of inactivity. Default is 7200 (2 hours). 0 disables.
-DEFAULT_SANDBOX_IDLE_TTL_SECONDS="7200"
-# Optional; delete a stopped sandbox after this many seconds. Default is 2592000 (30 days). 0 disables.
-DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="2592000"
-```
+## 5. Verify it works
 
-`DEFAULT_SANDBOX_SNAPSHOT_ID` is optional when `SANDBOX_TYPE=langsmith`. When no selected environment snapshot, admin setting, or environment variable supplies one, LangSmith's root snapshot is used. Custom snapshots must include the GitHub CLI; Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy using runtime-minted GitHub App installation tokens, not deployment-stored GitHub access tokens.
+**Dashboard.** Open `<URL>`, click **Sign in with GitHub**, and you should land logged in. With your login in `CONFIGURED_ADMINS`, the **Admin** pages (Team settings, User mappings, Sandbox, Environments, …) appear. Set **Admin → Team settings → Default repository** so runs that name no repository have somewhere to go. Start a task from the composer.
 
-### Environments
+**GitHub.** Signing in once is also what lets GitHub-triggered runs act as you: they run as the commenting user and need the token the sign-in stored; an unmapped commenter is skipped with a warning in the server log. Comment `@openswe what files are in this repo?` on an issue in a repository where the App is installed. Within a few seconds you should see a 👀 reaction, a run in your LangSmith project, and a reply comment. GitHub lists every delivery and its response under the App's **Advanced** tab.
 
-An **environment** pairs a prompt with a snapshot every run boots from, and can span several repos. Admins build one from an **admin thread** (the **Admin** toggle in the composer, available when their login or email is in `CONFIGURED_ADMINS`): the agent provisions its own sandbox — cloning repos, installing toolchains, warming caches — and then captures it. The environment named `default` is the one runs use; any other name is a draft. Records are managed on the admin **Environments** page.
+---
 
-With more than one environment configured, a picker appears in the dashboard composer (any signed-in user, names only), and a Slack thread can pick one with an `env:<name>` tag on the message that opens it — `@Open SWE env:staging fix the flaky test`. Only the opening message can: the sandbox is created once, so a later tag would change the prompt but not the image. A run with no selection uses `default`.
+## Optional add-ons
 
-Captures are named `openswe-environment-<name>` (the platform appends its own `:latest` tag, and rejects a name that carries one); set `ENVIRONMENT_SNAPSHOT_PREFIX` to replace the `openswe` prefix when several deployments share one LangSmith workspace. Snapshot resolution for a new sandbox is: the run's environment, then the base snapshot below.
+Open a section when you want that feature; everything above keeps working without it.
 
-### Changing the base snapshot without a redeploy
+<details id="slack">
+<summary><strong>Slack</strong></summary>
 
-Admins can override `DEFAULT_SANDBOX_SNAPSHOT_ID` at runtime from the **Sandbox** page (**Base snapshot** field). The stored value wins; clearing it falls back to the env var. An environment with a ready snapshot still takes precedence.
+Slack posts events to your deployment's URL, so it needs the same public URL as the GitHub App (locally, the public hostname of a tunnel to your backend; see [Local development](#local-development)).
 
-The same setting is available over the API, which is how the repo that builds your sandbox image can roll a new snapshot out on its own:
-
-```bash
-curl -X PUT "$OPEN_SWE_BASE_URL/dashboard/api/sandbox-settings" \
-  -H "Authorization: Bearer $ADMIN_GITHUB_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"base_snapshot_id": "<snapshot-uuid>"}'
-```
-
-Admin-gated sandbox-settings requests accept two CI credentials in place of the browser session cookie, both as `Authorization: Bearer`:
-
-**GitHub Actions OIDC (preferred — no stored secret).** A workflow with `permissions: id-token: write` mints a short-lived token that GitHub signs and scopes to the repo, ref, and audience it requested. Allowlist it on the deployment:
-
-```bash
-ADMIN_OIDC_SUBJECTS="acme/sandbox-images"                       # any workflow/ref in this repo
-# or pin the ref with a full subject:
-# ADMIN_OIDC_SUBJECTS="repo:acme/sandbox-images:ref:refs/heads/main"
-ADMIN_OIDC_AUDIENCE="open-swe"                                  # optional; this is the default
-```
-
-`ADMIN_OIDC_SUBJECTS` is the on/off switch — while it is empty, OIDC auth is unavailable. Entries containing `:` are matched against the token's `sub` claim, and `owner/repo` entries against its `repository` claim. The audience is verified either way, defaulting to `open-swe`; override it only if you set the workflow's requested audience to match. Anyone who can run a workflow on an allowlisted repo/ref gets admin on these endpoints, so keep the list to internal repos.
-
-**Admin personal access token.** The token only needs to identify its owner (`GET /user`), and that login (or email) must appear in `CONFIGURED_ADMINS`. Matching by login needs no token permissions; matching by email needs a token that can read email addresses (classic `user:email`, or the fine-grained "Email addresses" read permission) when the account's email isn't public. Prefer a machine user over a human's token.
-
-`secrets.GITHUB_TOKEN` works for neither: installation tokens have no user identity, and they are not OIDC tokens. `examples/github-actions/set-base-snapshot.yml` is a copy-ready workflow using the OIDC path.
-
-## 5. Set up triggers
-
-Open SWE can be triggered from GitHub, Linear, and/or Slack. **Configure whichever surfaces your team uses — you don't need all of them.**
-
-### GitHub
-
-GitHub triggering works automatically once your GitHub App is set up (step 3). Users can:
-- Tag `@openswe` in issue titles or bodies to start a task
-- Tag `@openswe` in issue comments for follow-up instructions
-- Tag `@openswe` in PR review comments to have it address review feedback
-
-The handles this deployment answers to default to `@openswe,@open-swe,@openswe-dev` and are configurable — set `OPEN_SWE_MENTION_TAGS` to a comma-separated list. Handles are matched on a word boundary, so `@openswe` does not fire on `@openswe-staging`. Give each deployment a distinct handle when more than one shares a GitHub org, Slack workspace, or Linear workspace.
-
-Which GitHub users can trigger the agent is controlled by the **user mapping** (GitHub login ⇄ work email ⇄ optional Slack ID), stored in the LangGraph Store rather than in code. Manage it in the dashboard under **Admin → User mappings**:
-
-- **Add / update** a single mapping (GitHub login + work email, plus an optional Slack user ID). The list is paged (20 per page).
-- Users can also **self-onboard**: when an unmapped person tags Open SWE in Slack, the agent runs with limited (GitHub App installation) permissions and posts a "link your GitHub account" prompt. Completing the org-gated GitHub OAuth login records a `self` mapping (carrying the originating Slack ID and work email). Self-signup is therefore bounded by the same `ALLOWED_GITHUB_ORGS` gate as dashboard login.
-
-You should also configure which GitHub organizations and/or repositories the agent is allowed to operate on. You can specify allowed orgs, specific `owner/repo` pairs, or both:
-
-```bash
-# Allow all repos in these orgs
-ALLOWED_GITHUB_ORGS="langchain-ai,anthropics"
-
-# Allow specific repos (owner/repo format)
-ALLOWED_GITHUB_REPOS="some-user/their-repo,another-org/specific-repo"
-```
-
-A GitHub or Linear webhook is accepted if the resolved repo's org is in `ALLOWED_GITHUB_ORGS` **or** the `owner/repo` is in `ALLOWED_GITHUB_REPOS`. If both are empty, all repos are allowed.
-
-For Slack and dashboard requests, `ALLOWED_GITHUB_ORGS` also adds a prompt-level edit guard. To modify a repository outside those organizations, the user must explicitly request that exact repository with its full `https://github.com/<owner>/<repo>` URL. Repository hints, defaults, shorthand, and contextual links do not qualify. This does not bypass the server-side GitHub/Linear webhook filter above or GitHub credential and App installation permissions.
-
-`ALLOWED_GITHUB_ORGS` also gates **dashboard login**: when set, only GitHub accounts that are active members of one of the listed organizations can complete the OAuth login and receive a session. Membership is verified server-side with the GitHub App installation token (so private memberships are visible and no extra OAuth scope is required), and the check fails closed on any API error. When `ALLOWED_GITHUB_ORGS` is empty, dashboard login is open to any GitHub account (the prior behavior).
-
-> **Observability access**: when team LangSmith credentials are connected, every active member of an organization in `ALLOWED_GITHUB_ORGS` can use the read-only LangSmith trace tools. Only list organizations whose full active membership may access team-level trace data. This does not grant Datadog access.
-
-> **Required GitHub App installation and permission**: install the App in every organization listed in `ALLOWED_GITHUB_ORGS` and grant **Organization → Members: Read-only** (see step 3a). Membership checks resolve each organization's installation and call `GET /orgs/{org}/memberships/{username}`. Missing installations, unapproved permissions, and API errors fail closed. `GITHUB_APP_INSTALLATION_ID` remains the default installation for ordinary GitHub operations.
-
-### Linear (optional)
-
-Open SWE listens for Linear comments that mention `@openswe`.
-
-**Create a webhook:**
-
-1. In Linear, go to **Settings → API → Webhooks → New webhook**
-2. Fill in:
-   - **Label**: `Open SWE`
-   - **URL**: `https://<your-ngrok-url>/webhooks/linear` — use the ngrok URL from step 2
-   - **Secret**: generate with `openssl rand -hex 32` — save this as `LINEAR_WEBHOOK_SECRET`
-3. Under **Data change events**, enable **Comments → Create** only
-4. Click **Create webhook**
-
-**Get your API key:**
-
-1. Go to **Settings → API → Personal API keys → New API key**
-2. Name it `Open SWE`, select **All access**, and copy the key
-3. Save it as `LINEAR_API_KEY`
-
-**Configure team-to-repo mapping:**
-
-Open SWE routes Linear issues to GitHub repos based on the Linear team and project. Edit the mapping in `agent/linear/team_repo_map.py`:
-
-```python
-LINEAR_TEAM_TO_REPO = {
-    "My Team": {"owner": "my-org", "name": "my-repo"},
-    "Engineering": {
-        "projects": {
-            "backend": {"owner": "my-org", "name": "backend"},
-            "frontend": {"owner": "my-org", "name": "frontend"},
-        },
-        "default": {"owner": "my-org", "name": "monorepo"},
-    },
-}
-```
-
-Users can also override the team/project mapping per-comment by including `repo:owner/name` (or a GitHub URL) in their `@openswe` comment. The mapping is used as a fallback when no repo is specified in the comment text.
-
-### Slack (optional)
-
-**Create a Slack App:**
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From a manifest**
-2. Copy the manifest below, replacing `<your-ngrok-url>` with the backend URL from step 2 (or your deployed LangGraph/FastAPI URL in production)
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From a manifest**, and paste the manifest below with `<your-url>` replaced by that URL.
 
 <details>
 <summary>Slack App Manifest</summary>
@@ -316,7 +144,7 @@ Users can also override the team/project mapping per-comment by including `repo:
     },
     "oauth_config": {
         "redirect_urls": [
-            "http://localhost:2024/dashboard/api/slack/callback"
+            "https://<your-url>/dashboard/api/slack/callback"
         ],
         "scopes": {
             "bot": [
@@ -341,7 +169,7 @@ Users can also override the team/project mapping per-comment by including `repo:
     },
     "settings": {
         "event_subscriptions": {
-            "request_url": "https://<your-ngrok-url>/webhooks/slack",
+            "request_url": "https://<your-url>/webhooks/slack",
             "bot_events": [
                 "app_mention",
                 "message.im",
@@ -350,7 +178,7 @@ Users can also override the team/project mapping per-comment by including `repo:
         },
         "interactivity": {
             "is_enabled": true,
-            "request_url": "https://<your-ngrok-url>/webhooks/slack/interactivity"
+            "request_url": "https://<your-url>/webhooks/slack/interactivity"
         },
         "org_deploy_enabled": false,
         "socket_mode_enabled": false,
@@ -361,413 +189,232 @@ Users can also override the team/project mapping per-comment by including `repo:
 
 </details>
 
-3. Install the app to your workspace and copy the **Bot User OAuth Token** (`xoxb-...`). Existing installations must reinstall or re-authorize the app after adding `files:write`.
-
-**Slack URL checklist:**
-
-Both Slack URLs must point at the Open SWE backend that serves `agent.webapp:app` (locally, your ngrok URL forwarding to `langgraph dev`; in production, your LangGraph/FastAPI deployment URL), not the dashboard frontend URL.
-
-- **Event Subscriptions → Request URL:** `https://<your-backend-url>/webhooks/slack`
-- **Interactivity & Shortcuts → Interactivity Request URL:** `https://<your-backend-url>/webhooks/slack/interactivity`
-
-Slack Block Kit option buttons only work when Interactivity is enabled and pointed at `/webhooks/slack/interactivity`.
-
-**Code channels (early access):**
-
-The default manifest above uses the legacy Slack integration. To enable Slack [code channels](https://api.slack.com/partners/code-channels), open **Admin → Slack integration**, turn on **Slack Code Channels**, copy the generated manifest, update the existing Slack app, and reinstall or re-authorize it. The admin selection is browser-local and only controls which manifest is copied.
-
-In a code channel the whole channel is one Open SWE session, so Open SWE answers messages without requiring an `@`-mention, replies at the channel level by default (or in a thread the user started), reports its session status, and keeps the context bar current. The `manage_code_channel` tool covers channel creation and archival, status and title, context actions and external resources, runtime slash commands, HTML/diff/Block Kit/canvas views, view reconciliation, and canvas content/comments.
-
-This requires the `code_channels:manage` bot scope, the `agent_session_stopped` and `code_channel_action` bot events, and `features.code_channels.enabled`. The feature's `slash_command_url` delivers runtime-registered commands to the signed Open SWE endpoint above, while Block Kit view actions use the normal interactivity endpoint. Code channel messages arrive over the `message.channels` / `message.groups` subscriptions an app already uses; `message.session` is an alternative for apps that want *only* session messages, and subscribing to both does not duplicate deliveries. Code channels are in early access: if your workspace is not enrolled, leave the Admin toggle off — everything else keeps working unchanged.
-
-**Credentials you'll need:**
-
-- `SLACK_BOT_TOKEN`: the Bot User OAuth Token (`xoxb-...`)
-- `SLACK_SIGNING_SECRET`: found under **Basic Information → App Credentials**
-- `SLACK_BOT_USER_ID`: the bot's user ID (find it in Slack by clicking the bot's profile)
-- `SLACK_BOT_USERNAME`: the bot's display name (e.g. `open-swe`)
-
-**Default repo:**
-
-Slack messages are routed to the Slack default repo (`SLACK_REPO_OWNER`/`SLACK_REPO_NAME`, falling back to `DEFAULT_REPO_OWNER`/`DEFAULT_REPO_NAME` — see step 6) unless the user specifies one with `repo:owner/name` in their message.
-
-Open SWE refuses Slack Connect channels when `conversations.info` reports `is_ext_shared`, before starting an agent run. If Slack cannot verify a channel, it fails closed and does not operate there.
-
-**"Sign in with Slack" account linking (optional):**
-
-The dashboard can let a user link their Slack identity to their GitHub login via Slack OIDC ("Sign in with Slack"). This is what lets a Slack-triggered run resolve to the right GitHub user. To enable it:
-
-1. The manifest above already registers the OIDC redirect (`.../dashboard/api/slack/callback`). Under **OpenID Connect** (or **Sign in with Slack**) make sure the `openid`, `email`, and `profile` user scopes are available.
-2. From **Basic Information → App Credentials**, save the app's **Client ID** as `SLACK_CLIENT_ID` and **Client Secret** as `SLACK_CLIENT_SECRET`.
-3. (Optional) Set `SLACK_TEAM_ID` (your workspace ID, `T...`) to restrict linking to a single workspace.
-
-If `SLACK_CLIENT_ID`/`SLACK_CLIENT_SECRET` are unset, the "Sign in with Slack" link is simply disabled; the rest of Slack triggering still works.
-
-## 6. Environment variables
-
-Create a `.env` file in the project root. Below is the full list — only fill in the sections relevant to the triggers you configured.
+2. Install the app to your workspace.
+3. Add to the deployment's environment:
 
 ```bash
-# === LangSmith ===
-LANGSMITH_API_KEY_PROD=""              # From step 4a
-LANGCHAIN_TRACING_V2="true"
-LANGCHAIN_PROJECT=""                   # LangSmith project name for traces
-LANGSMITH_PROJECT=""                  # LangSmith project every run traces into (default: "default"; LangGraph Platform sets the deployment name)
-LANGSMITH_TENANT_ID=""                # Optional override; discovered from the workspace when unset
-LANGSMITH_URL_PROD="https://smith.langchain.com"                 
-
-# === LLM ===
-ANTHROPIC_API_KEY=""                   # Anthropic API key
-BASETEN_API_KEY=""                     # Baseten models when not using LangSmith Gateway
-OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dictation
-# OPENAI_BASE_URL="https://api.openai.com/v1"  # Optional OpenAI-compatible API base URL
-GOOGLE_API_KEY=""                      # Google AI API key (when using google_genai: models)
-FIREWORKS_API_KEY=""                   # Fireworks API key (when using fireworks: models)
-# Voice dictation uses this OpenAI configuration.
-# Admins choose its transcription model in the dashboard Admin page.
-
-# === GitHub App (required) ===
-GITHUB_APP_ID=""                       # From step 3b
-GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
-"
-GITHUB_APP_INSTALLATION_ID=""          # From step 3c
-
-# === GitHub Webhook (required) ===
-GITHUB_WEBHOOK_SECRET=""               # The secret you generated in step 3a
-
-# === Mention handles (optional) ===
-# Comma-separated handles this deployment answers to, across GitHub, Linear and Slack.
-# Defaults to "@openswe,@open-swe,@openswe-dev".
-OPEN_SWE_MENTION_TAGS=""               # e.g. "@openswe-staging"
-# Comma-separated bot logins to treat as internal rather than untrusted external
-# commenters. Set this to the bot logins of any other Open SWE deployments sharing
-# these repos.
-EXTRA_INTERNAL_BOT_LOGINS=""           # e.g. "openswe-staging[bot]"
-
-# === Dashboard GitHub OAuth (required) ===
-# Drives dashboard login and the per-user GitHub tokens agent runs are resolved
-# against. Without these the deployment can only act as the GitHub App bot.
-GITHUB_APP_CLIENT_ID=""                # From step 3b
-GITHUB_APP_CLIENT_SECRET=""            # From step 3b
-
-# === Repo Allowlist (optional) ===
-# Comma-separated list of GitHub orgs allowed by the GitHub/Linear webhook filter.
-# Also gates dashboard login and prompts the agent to require an explicit full repository
-# URL before editing outside these orgs (requires Organization -> Members: Read-only).
-# Leave empty to allow all orgs and disable the prompt-level edit guard.
-ALLOWED_GITHUB_ORGS=""                 # e.g. "my-org,my-other-org"
-# Comma-separated list of specific owner/repo pairs allowed by the GitHub/Linear webhook filter.
-# A repo is accepted if its org is in ALLOWED_GITHUB_ORGS OR its owner/repo is in ALLOWED_GITHUB_REPOS.
-# Slack/dashboard access remains bounded by GitHub credentials and App installation permissions.
-# Leave both empty to allow all repos.
-ALLOWED_GITHUB_REPOS=""                # e.g. "some-user/their-repo,another-org/specific-repo"
-
-# === Default Repository ===
-# Used across all triggers when no repo is specified.
-DEFAULT_REPO_OWNER=""                  # Default GitHub org (e.g. "my-org")
-DEFAULT_REPO_NAME=""                   # Default GitHub repo (e.g. "my-repo")
-
-# === Dashboard (required to run the web dashboard) ===
-# Public URL that browsers use for /dashboard/api/* and OAuth callbacks.
-# Use the FastAPI backend URL for local/cross-origin direct API calls.
-# Use the dashboard frontend URL when a same-origin frontend rewrite proxies /dashboard/api/*.
-# Its scheme drives cookie security: http:// => SameSite=Lax (local);
-# https:// => Secure + SameSite=None (production).
-DASHBOARD_API_BASE_URL="http://localhost:2024"
-# Public base URL of the dashboard frontend (the ui/ app). Default post-login redirect.
-DASHBOARD_BASE_URL="http://localhost:3000"
-# HMAC secret for dashboard JWTs (session cookie and OAuth state).
-DASHBOARD_JWT_SECRET=""                # Generate with: openssl rand -hex 32
-# Comma-separated origins allowed for credentialed CORS and post-login redirects.
-# Required whenever the frontend and API are on different origins — including local
-# dev (UI :3000 -> API :2024 is cross-origin). CORS is only enabled when this is set.
-DASHBOARD_ALLOWED_ORIGINS="http://localhost:3000"  # prod: your frontend origin(s)
-# Comma-separated GitHub login or email allowlist for admin dashboard endpoints.
-# Empty => nobody is an admin.
-CONFIGURED_ADMINS=""                   # e.g. "alice,bob@my-org.com"
-# Optional; lets a GitHub Actions workflow act as an admin over the API via OIDC
-# (see step 4b). Empty => off.
-ADMIN_OIDC_SUBJECTS=""                 # e.g. "acme/sandbox-images" or "repo:acme/sandbox-images:ref:refs/heads/main"
-ADMIN_OIDC_AUDIENCE=""                 # audience the workflow must request; defaults to "open-swe"
-# URL of the LangGraph server the FastAPI side calls to trigger/stream runs.
-# Defaults to http://localhost:2024 locally; set to your deployment URL in prod.
-LANGGRAPH_URL="http://localhost:2024"
-
-# === Linear (if using Linear trigger) ===
-LINEAR_API_KEY=""                      # From step 5
-LINEAR_WEBHOOK_SECRET=""               # From step 5
-
-# === Slack (if using Slack trigger) ===
-SLACK_BOT_TOKEN=""                     # From step 5
-SLACK_BOT_USER_ID=""
-SLACK_BOT_USERNAME=""
-SLACK_SIGNING_SECRET=""
-# Optional: Slack-specific default repo (falls back to DEFAULT_REPO_OWNER/NAME).
-SLACK_REPO_OWNER=""
-SLACK_REPO_NAME=""
-# Optional: "Sign in with Slack" account linking (GitHub <-> Slack). See step 5.
-SLACK_CLIENT_ID=""
-SLACK_CLIENT_SECRET=""
-SLACK_TEAM_ID=""                       # Optional; restrict linking to one workspace (T...)
-
-# === Exa (optional — enables web search tool) ===
-EXA_API_KEY=""                         # From https://dashboard.exa.ai
-
-# === Reviewer / Analyzer (optional) ===
-# LangSmith dataset where reviewer finding outcomes are recorded and read back by
-# the analyzer. Defaults to "openswe-reviewer-outcomes" if unset.
-REVIEWER_OUTCOMES_DATASET=""
-# Single GitHub org whose members may trigger the agent on *public* repos.
-# Empty => no public-repo gate (back-compat). Distinct from ALLOWED_GITHUB_ORGS.
-PUBLIC_REPO_ORG_GATE=""
-
-# === Sandbox (optional) ===
-# Provider: langsmith (default), modal, daytona, runloop, e2b, or local. See CUSTOMIZATION.md.
-SANDBOX_TYPE="langsmith"
-DEFAULT_SANDBOX_SNAPSHOT_ID=""         # Optional custom base snapshot; defaults to LangSmith's root snapshot
-DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES=""  # Root FS size in bytes (default: 128 GiB)
-DEFAULT_SANDBOX_VCPUS=""               # vCPUs per sandbox (default: 4)
-DEFAULT_SANDBOX_MEM_BYTES=""           # Memory in bytes per sandbox (default: 16 GiB)
-DEFAULT_SANDBOX_IDLE_TTL_SECONDS=""    # Auto-stop after N seconds idle (default: 7200; 0 disables)
-DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS=""  # Delete N seconds after stop (default: 2592000; 0 disables)
-ENVIRONMENT_SNAPSHOT_PREFIX=""         # Prefix for environment snapshot names (default: openswe)
-
-# === Token Encryption ===
-TOKEN_ENCRYPTION_KEY=""                # Generate with: openssl rand -base64 32
-                                       # Supports key rotation: see "Rotating TOKEN_ENCRYPTION_KEY" below
+SLACK_BOT_TOKEN=""        # OAuth & Permissions → Bot User OAuth Token (xoxb-...)
+SLACK_SIGNING_SECRET=""   # Basic Information → App Credentials → Signing Secret
+SLACK_BOT_USER_ID=""      # the bot's member id (open the bot's profile in Slack → ⋮ → Copy member ID)
+SLACK_BOT_USERNAME=""     # the bot's handle, e.g. open-swe
 ```
 
-### Rotating TOKEN_ENCRYPTION_KEY
+Both Slack URLs must point at the Open SWE deployment, and Block Kit buttons only work with Interactivity enabled and pointed at `/webhooks/slack/interactivity`. Slack messages are routed to the thread's repository, a `repo:owner/name` token in the message, or the team default repository. Open SWE refuses Slack Connect channels (`is_ext_shared`) and fails closed when it cannot verify a channel.
 
-`TOKEN_ENCRYPTION_KEY` accepts either a single Fernet key or a comma- or
-newline-separated **ordered list of keys, most-recent-first**. New writes always
-encrypt under the first key; reads try every key in order. To rotate without
-invalidating already-stored GitHub tokens:
+**Verify:** invite the bot to a channel and mention it: `@Open SWE what's in the repo?`. The agent replies in a thread.
 
-1. Generate a new key: `openssl rand -base64 32`.
-2. Prepend it to `TOKEN_ENCRYPTION_KEY`, keeping the old key second:
-   ```
-   TOKEN_ENCRYPTION_KEY="<new_key>,<old_key>"
-   ```
-   Restart the server. New encryptions use `<new_key>`; existing ciphertexts
-   still decrypt against `<old_key>`.
-3. Let active threads cycle (each fresh OAuth flow re-encrypts under the new
-   key). After every active thread has re-authed, drop the old key:
-   ```
-   TOKEN_ENCRYPTION_KEY="<new_key>"
-   ```
-   Any thread still holding ciphertext under `<old_key>` will fail to decrypt
-   and the user will be re-prompted to authenticate — same UX as if the thread
-   had never authed.
+**"Sign in with Slack" account linking.** Lets a user link their Slack identity to their GitHub login from **My settings**, so Slack-triggered runs resolve to the right GitHub user through Slack's verified claims. Without it, an admin links people under **Admin → User mappings**. The manifest already registers the OIDC redirect; make sure the `openid`, `email`, and `profile` user scopes are available, then set `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET` from **Basic Information → App Credentials**, and optionally `SLACK_TEAM_ID` (`T...`) to restrict linking to one workspace. When they are unset the link is simply hidden.
 
-## 7. Start the backend
+**Code channels (early access).** To enable Slack [code channels](https://api.slack.com/partners/code-channels), open **Admin → Slack integration**, turn on **Slack Code Channels**, copy the generated manifest, update the Slack app, and reinstall it. In a code channel the whole channel is one Open SWE session: it answers without an `@`-mention, replies at the channel level by default, reports session status, and keeps the context bar current; the `manage_code_channel` tool covers channel lifecycle, status, views, and canvases. This requires the `code_channels:manage` bot scope, the `agent_session_stopped` and `code_channel_action` bot events, and `features.code_channels.enabled`; `slash_command_url` delivers runtime-registered commands to the signed Open SWE endpoint. If your workspace is not enrolled, leave the toggle off.
 
-Make sure ngrok is still running from step 2, then start the backend in a second terminal:
+</details>
 
-```bash
-make dev          # uv run langgraph dev --no-browser --port 2024
-```
+<details id="linear">
+<summary><strong>Linear</strong></summary>
 
-`langgraph dev` serves **all five graphs** (`agent`, `reviewer`, `analyzer`, `chat`, `scheduler`) *and* the FastAPI app (`agent.webapp:app`) together on `http://localhost:2024`. The FastAPI app owns both the webhooks and the dashboard API:
+Open SWE listens for Linear comments that mention `@openswe`.
 
-| Endpoint | Purpose |
-|---|---|
-| `POST /webhooks/github` | GitHub issue/PR/comment webhooks |
-| `POST /webhooks/linear` | Linear comment webhooks |
-| `GET /webhooks/linear` | Linear webhook verification |
-| `POST /webhooks/slack` | Slack event webhooks |
-| `POST /webhooks/slack/interactivity` | Slack Block Kit button interactions |
-| `GET /webhooks/slack` | Slack webhook verification |
-| `GET /dashboard/api/auth/login` | Dashboard GitHub OAuth login |
-| `GET /dashboard/api/auth/callback` | Dashboard GitHub OAuth callback (registered on the App in step 3a) |
-| `GET /dashboard/api/*` | Dashboard API (profiles, team settings, repos, review styles, threads, …) |
-| `GET /health` | Health check |
+1. **Settings → API → Webhooks → New webhook**: label `Open SWE`, URL `<URL>/webhooks/linear`, a secret from `openssl rand -hex 32` saved as `LINEAR_WEBHOOK_SECRET`, and under **Data change events** only **Comments → Create**.
+2. **Settings → API → Personal API keys → New API key** with **All access**, saved as `LINEAR_API_KEY`.
+3. Map Linear teams and projects to repositories in `agent/linear/team_repo_map.py`:
 
-> `make run` (`uvicorn agent.webapp:app --port 8000`) serves the FastAPI app **without** the LangGraph runtime, on port 8000. The dashboard's Agents chat features call LangGraph, so for full local dev use `make dev` on `:2024`, not `make run`.
-
-## 8. Run the dashboard
-
-The dashboard is the web app in `ui/`. It's a server-rendered TanStack Start app that calls the FastAPI dashboard API from step 7.
-
-You can skip it while smoke-testing a webhook, but not in a real deployment: signing in here is what stores a user's GitHub token, and `resolve_github_token` reads that store on every run. Without it the agent can only act as the GitHub App bot, and there is no way to manage user mappings, model defaults, enabled repos, review styles, or environments.
-
-Run it in a third terminal:
-
-```bash
-pnpm install          # from the repo root: ui/ and desktop/ are one pnpm workspace
-make web             # pnpm run dev -> Vite on http://localhost:3000
-```
-
-No `ui/.env` is needed: the dev server proxies `/dashboard/api/*` to `DASHBOARD_API_URL`, which defaults to `http://localhost:2024`. Point it elsewhere by exporting that variable before `make web` or `pnpm run dev`. It is read at request time, so the same build can front any backend.
-
-**Same origin with hot reload.** Instead of opening the Vite server directly, let the backend front it: `make dev-ui` starts Vite and the backend together in one terminal, the backend with `DASHBOARD_DEV_SERVER_URL=http://localhost:3000`. Every UI request to `http://localhost:2024` is forwarded to Vite, which serves the modules and hot-reloads them, while `/dashboard/api/*` and the LangGraph routes are answered by the backend as usual. Ctrl-C stops both. The browser never leaves port 2024, so the cookie, CORS, and callback settings below are not needed and the GitHub App callback stays `http://localhost:2024/dashboard/api/auth/callback`. The HMR WebSocket connects straight to Vite's port; the UI's Vite config points the client there.
-
-The rest of this step is for opening the Vite server on `http://localhost:3000` directly.
-
-To enable Datadog browser RUM, set `VITE_DATADOG_APPLICATION_ID` and `VITE_DATADOG_CLIENT_TOKEN` when building the dashboard. Optional build-time settings are `VITE_DATADOG_SITE` (default `datadoghq.com`), `VITE_DATADOG_SERVICE` (default `open-swe-dashboard`), `VITE_DATADOG_ENV`, `VITE_DATADOG_VERSION`, `VITE_DATADOG_SESSION_SAMPLE_RATE` (default `100`), and `VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE` (default `100`). Session Replay is enabled by default for sampled RUM sessions with all content masked; telemetry also strips URL query strings and fragments. Values prefixed with `VITE_` are public in the browser bundle; use a Datadog client token, never an API or application key.
-
-Because the browser only ever talks to `http://localhost:3000`, no **CORS** preflight is involved. `DASHBOARD_ALLOWED_ORIGINS="http://localhost:3000"` is still required, though: the same allowlist is the backend's CSRF gate for every non-GET request, and it compares the browser's `Origin` — the dashboard's — against the origins it knows. Without it, the dashboard reads fine and every save returns `403 CSRF check failed`.
-
-The `osw_session` cookie has to be set on the dashboard origin too: set `DASHBOARD_API_BASE_URL="http://localhost:3000"` and register `http://localhost:3000/dashboard/api/auth/callback` as a GitHub App callback URL. Keep it on an `http://` URL locally so the cookie uses `SameSite=Lax` rather than `Secure`.
-
-For the dashboard login to succeed, you need (from steps 3b / 6): `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `DASHBOARD_JWT_SECRET`, `DASHBOARD_API_BASE_URL`, `DASHBOARD_BASE_URL`, and `DASHBOARD_ALLOWED_ORIGINS`. To reach the admin pages (user mappings, etc.), add your GitHub login or email to `CONFIGURED_ADMINS`.
-
-`pnpm run build`, `pnpm run typecheck` and `pnpm run test` run the same task across the workspace through Turborepo; scope one to a package with `pnpm --filter open-swe-dashboard run <script>`. `pnpm run lint` (oxlint) and `pnpm run format` / `pnpm run format:check` (oxfmt) are not Turborepo tasks — they run once from the root over every JS and TS file in the repo, `ui/`, `desktop/` and `tests/e2e/` alike, so there is no per-package variant to scope to.
-
-### Run the desktop app (optional)
-
-> **Experimental:** The desktop wrapper is an early-access convenience surface. The web UI is
-> the recommended way to use Open SWE.
-
-The Electron app in `desktop/` includes the compiled dashboard UI. Run it alongside the Open SWE
-backend (and, optionally, the web UI) in separate terminals:
-
-```bash
-pnpm install                  # from the repo root
-make dev                      # terminal 1
-pnpm run dev:desktop          # terminal 2
-make web                      # terminal 3, optional web UI
-```
-
-Development connects to `http://localhost:2024`. To use a hosted backend instead, run
-`pnpm --dir desktop run start -- --backend-url=https://your-backend.example.com` or set
-`OPEN_SWE_BACKEND_URL`. Create an unpacked application with `pnpm --dir desktop run pack`, or an
-installer with `pnpm --dir desktop run dist`. Packaged builds ask for the organization's backend
-URL on first launch and store it locally; they never default to the maintainers' deployment. The
-GitHub App must allow `<backend-url>/dashboard/api/auth/callback` for desktop login.
-
-## 9. Verify it works
-
-### GitHub
-
-1. Go to any issue in a repository where the app is installed
-2. Create or comment on an issue with: `@openswe what files are in this repo?`
-3. You should see:
-   - A 👀 reaction on your comment within a few seconds
-   - A new run in your LangSmith project
-   - The agent replies with a comment on the issue
-
-### Linear
-
-1. Go to any Linear issue in a team you configured in `LINEAR_TEAM_TO_REPO`
-2. Add a comment: `@openswe what files are in this repo?`
-3. You should see:
-   - A 👀 reaction on your comment within a few seconds
-   - A new run in your LangSmith project
-   - The agent replies with a comment on the issue
-
-### Slack
-
-1. In any channel where the bot is invited, start a thread
-2. Mention the bot: `@open-swe what's in the repo?`
-3. You should see a reply in the thread with the agent's response.
-
-### Dashboard
-
-1. With the backend (step 7) and UI (step 8) both running, open `http://localhost:3000`
-2. Click **Sign in with GitHub** — you'll be sent through the GitHub OAuth flow and back to the dashboard
-3. You should land logged-in and be able to see your profile/settings. If your GitHub login or email is in `CONFIGURED_ADMINS`, the **Admin** pages (e.g. User mappings) are available.
-
-## 10. Production deployment
-
-Production runs the backend and dashboard separately.
-
-**Backend — standalone Docker:** the root `Dockerfile` builds a production LangGraph API server image for Open SWE. It is not the sandbox image.
-
-```bash
-docker build -t open-swe .
-
-docker run \
-  --env-file .env \
-  -p 8123:8000 \
-  --add-host=host.docker.internal:host-gateway \
-  -e DATABASE_URI="postgres://postgres:postgres@host.docker.internal:5432/postgres?sslmode=disable" \
-  -e REDIS_URI="redis://host.docker.internal:6379" \
-  -e LANGGRAPH_AUTH_TYPE="noop" \
-  -e LANGGRAPH_URL="https://<your-backend-url>" \
-  -e DASHBOARD_API_BASE_URL="https://<your-dashboard-or-backend-url>" \
-  open-swe
-```
-
-The example above assumes Postgres and Redis run on the Docker host. `host.docker.internal` only resolves automatically on Docker Desktop, so `--add-host=host.docker.internal:host-gateway` is what makes it work on a plain Linux Docker Engine. If Postgres and Redis run as their own containers, drop the flag and point `DATABASE_URI` / `REDIS_URI` at their service names on a shared Docker network instead.
-
-Set all environment variables from step 6, plus the standalone Agent Server requirements: `DATABASE_URI`, `REDIS_URI`, `LANGSMITH_API_KEY` (unless tracing is disabled for your deployment), and `LANGGRAPH_CLOUD_LICENSE_KEY` for the production LangGraph server. Expose the container's port `8000` through your ingress. Do not use scale-to-zero hosting; background runs rely on Redis/Postgres-backed workers staying available. If the built-in LangGraph API routes are reachable from the public internet, put the service behind a private network, API gateway, or custom LangGraph auth before using `LANGGRAPH_AUTH_TYPE=noop`.
-
-Set `LANGGRAPH_URL` to the public backend URL so webhooks and the dashboard can create runs against this same server. Set `DASHBOARD_API_BASE_URL` to the URL browsers use for dashboard API requests and OAuth callbacks: either the backend URL for direct cross-origin calls, or the dashboard/Vercel URL when a same-origin rewrite proxies `/dashboard/api/*`. Update your webhook URLs (Linear, Slack, GitHub App) and the GitHub App / Slack OAuth callback URLs to your production URLs. The dashboard GitHub App callback must be `<DASHBOARD_API_BASE_URL>/dashboard/api/auth/callback`.
-
-The `langgraph.json` at the project root defines the graphs and HTTP app baked into the image:
-
-```json
-{
-  "graphs": {
-    "agent": "agent.graphs.agent:traced_agent",
-    "reviewer": "agent.graphs.reviewer:traced_reviewer_agent",
-    "analyzer": "agent.graphs.analyzer:traced_analyzer",
-    "chat": "agent.graphs.chat:traced_chat_agent",
-    "scheduler": "agent.graphs.scheduler:get_scheduler"
-  },
-  "http": {
-    "app": "agent.webapp:app"
-  }
+```python
+LINEAR_TEAM_TO_REPO = {
+    "My Team": {"owner": "my-org", "name": "my-repo"},
+    "Engineering": {
+        "projects": {
+            "backend": {"owner": "my-org", "name": "backend"},
+            "frontend": {"owner": "my-org", "name": "frontend"},
+        },
+        "default": {"owner": "my-org", "name": "monorepo"},
+    },
 }
 ```
 
-**Backend — LangGraph Cloud / Platform:** alternatively, push your code to a GitHub repository, connect the repo to LangGraph Cloud, set the same environment variables in the deployment config, and use the hosted deployment URL for `LANGGRAPH_URL` and webhook callbacks.
+A `repo:owner/name` token or GitHub URL in the comment overrides the mapping. **Verify:** comment `@openswe what files are in this repo?` on an issue in a mapped team.
 
-**Dashboard** — the `ui/` app builds to a Nitro server that renders routes on request. Set `DASHBOARD_API_URL` in its environment to your hosted backend URL; it is read per request, so one image serves any backend. Browser requests to `/dashboard/api/*` and webhook deliveries to `/webhooks/*` are proxied to it, and server renders call it directly with the request's `osw_session` cookie forwarded.
+</details>
 
-Requests are therefore **same-origin**: set both `DASHBOARD_API_BASE_URL` and the GitHub App dashboard callback URL to the Vercel/dashboard origin (for example, `https://your-dashboard.vercel.app/dashboard/api/auth/callback`). The OAuth callback response then sets the `osw_session` cookie on the dashboard host, and later `/dashboard/api/*` requests include it.
+<details id="dashboard-on-its-own-origin">
+<summary><strong>Dashboard on its own origin (separate frontend deployment)</strong></summary>
 
-Alternatively, you can have the browser call the backend cross-origin: set `VITE_DASHBOARD_API_BASE_URL` to the hosted backend origin, set `DASHBOARD_API_BASE_URL` to that same backend origin, and include the dashboard origin in `DASHBOARD_ALLOWED_ORIGINS`. Keep `DASHBOARD_API_URL` pointed at the same backend so server renders and the webhook proxy reach it too. In this mode `osw_session` belongs to the backend's origin, so the dashboard's own requests never carry it and the session is resolved on the client instead — pages render unauthenticated and fill in after hydration.
+The bundled dashboard needs none of this. Read on only if the dashboard is deployed separately from the backend.
+
+**A separate frontend deployment.** The `ui/` app also builds to a Nitro server (`ui/Dockerfile`) that renders on request. Set its `DASHBOARD_API_URL` to the backend URL; browser requests to `/dashboard/api/*` and webhook deliveries to `/webhooks/*` are proxied there, and server renders forward the `osw_session` cookie. Set `DASHBOARD_BASE_URL` and `DASHBOARD_API_BASE_URL` on the backend to the frontend origin and register `<frontend origin>/dashboard/api/auth/callback` on the GitHub App. To have the browser call the backend cross-origin instead, build the UI with `VITE_DASHBOARD_API_BASE_URL` set to the backend origin, keep `DASHBOARD_API_BASE_URL` on the backend origin, and add the frontend origin to `DASHBOARD_ALLOWED_ORIGINS`; the session is then resolved on the client after hydration.
+
+**Mount prefix.** If the server runs under a LangGraph `http.mount_prefix`, the Platform image builds the UI for that prefix automatically; locally pass it to the build (`DASHBOARD_BASE_PATH=/<prefix>/ make build-dashboard`) and keep `LANGGRAPH_URL` on the mounted URL.
+
+**Datadog RUM.** Set `VITE_DATADOG_APPLICATION_ID` and `VITE_DATADOG_CLIENT_TOKEN` when building. Optional: `VITE_DATADOG_SITE` (default `datadoghq.com`), `VITE_DATADOG_SERVICE` (default `open-swe-dashboard`), `VITE_DATADOG_ENV`, `VITE_DATADOG_VERSION`, `VITE_DATADOG_SESSION_SAMPLE_RATE` and `VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE` (default `100`). Session Replay masks all content and telemetry strips query strings and fragments. `VITE_` values are public in the bundle; use a client token, never an API or application key.
+
+</details>
+
+<details id="admin-api-credentials">
+<summary><strong>Admin API credentials (CI and scripts)</strong></summary>
+
+Admin-gated endpoints such as `PUT /dashboard/api/team-settings` and `PUT /dashboard/api/sandbox-settings` accept two credentials in place of the browser session cookie, both as `Authorization: Bearer`:
+
+**GitHub Actions OIDC (preferred, no stored secret).** A workflow with `permissions: id-token: write` mints a short-lived token that GitHub signs and scopes to the repo, ref, and audience. Allowlist it on the deployment:
+
+```bash
+ADMIN_OIDC_SUBJECTS="acme/sandbox-images"                       # any workflow/ref in this repo
+# or pin the ref with a full subject:
+# ADMIN_OIDC_SUBJECTS="repo:acme/sandbox-images:ref:refs/heads/main"
+ADMIN_OIDC_AUDIENCE="open-swe"                                  # optional; this is the default
+```
+
+`ADMIN_OIDC_SUBJECTS` is the on/off switch. Entries containing `:` match the token's `sub` claim, `owner/repo` entries match its `repository` claim, and the audience is verified either way. Anyone who can run a workflow on an allowlisted repo/ref gets admin on these endpoints, so keep the list to internal repos.
+
+**Admin personal access token.** The token only needs to identify its owner (`GET /user`), whose login or email must be in `CONFIGURED_ADMINS`. Matching by email needs a token that can read email addresses when the account's email is not public. Prefer a machine user.
+
+`secrets.GITHUB_TOKEN` works for neither. `examples/github-actions/set-base-snapshot.yml` is a copy-ready workflow using the OIDC path.
+
+</details>
+
+<details id="custom-sandbox-snapshot-and-environments">
+<summary><strong>Custom sandbox snapshot and environments</strong></summary>
+
+Each run executes in an isolated LangSmith sandbox booted from a **snapshot**. Without configuration that is LangSmith's root snapshot. Build your own (from a Docker image) when your repos need extra toolchains.
+
+The image must carry `git`, `gh`, `sfw`, the Docker CLI, and the language runtimes, and live in a registry LangSmith can pull from. Run `sfw --version` while building to populate its binary cache, and set `SFW_SKIP_UPDATE_CHECK=1` at runtime. Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy with runtime-minted installation tokens, so no GitHub token belongs in the image.
+
+Build a snapshot in the LangSmith UI (Sandboxes → Snapshots → New), via the SDK, or with the helper script:
+
+```bash
+uv run python scripts/create_sandbox_snapshot.py \
+  --name open-swe-gh-cli-amd64 \
+  --image johanneslangchain/open-swe-sandbox:gh-cli-amd64
+```
+
+Then set the UUID in the environment, or on **Admin → Sandbox → Base snapshot** (the stored value wins; clearing it falls back to the env var):
+
+```bash
+DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"
+# Optional sizing and TTL overrides. Defaults: 128 GiB root FS, 4 vCPUs, 16 GiB RAM,
+# 7200 s idle stop (0 disables), 2592000 s (30 d) delete-after-stop (0 disables).
+DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES="137438953472"
+DEFAULT_SANDBOX_VCPUS="4"
+DEFAULT_SANDBOX_MEM_BYTES="17179869184"
+DEFAULT_SANDBOX_IDLE_TTL_SECONDS="7200"
+DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="2592000"
+```
+
+The same setting is available over the API, which is how the repo that builds your sandbox image can roll a new snapshot out on its own (see [Admin API credentials](#admin-api-credentials)):
+
+```bash
+curl -X PUT "$OPEN_SWE_BASE_URL/dashboard/api/sandbox-settings" \
+  -H "Authorization: Bearer $ADMIN_GITHUB_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"base_snapshot_id": "<snapshot-uuid>"}'
+```
+
+**Environments.** An environment pairs a prompt with a snapshot every run boots from, and can span several repos. Admins build one from an **admin thread** (the **Admin** toggle in the composer): the agent provisions its own sandbox, cloning repos, installing toolchains, and warming caches, and then captures it. The environment named `default` is the one runs use; any other name is a draft. Records live on the admin **Environments** page. With more than one environment, a picker appears in the composer, and a Slack thread can pick one with an `env:<name>` tag on its opening message (`@Open SWE env:staging fix the flaky test`); only the opening message can, because the sandbox is created once. Captures are named `openswe-environment-<name>`; set `ENVIRONMENT_SNAPSHOT_PREFIX` to replace the prefix when several deployments share a workspace. Resolution for a new sandbox: the run's environment, then the admin base snapshot, then `DEFAULT_SANDBOX_SNAPSHOT_ID`, then LangSmith's root snapshot.
+
+**Other providers.** `SANDBOX_TYPE` defaults to `langsmith`; `modal`, `daytona`, `runloop`, `e2b`, and `local` are available with their own credentials, listed in [CUSTOMIZATION.md](CUSTOMIZATION.md). Only the LangSmith provider gets the GitHub proxy, so other providers see GitHub tokens inside the sandbox.
+
+</details>
+
+<details id="repository-allowlists-mention-handles-and-user-mapping">
+<summary><strong>Repository allowlists, mention handles, and user mapping</strong></summary>
+
+**Mention handles.** The handles this deployment answers to default to `@openswe,@open-swe,@openswe-dev`; set `OPEN_SWE_MENTION_TAGS` to change them. Handles match on a word boundary, so `@openswe` does not fire on `@openswe-staging`. Set `EXTRA_INTERNAL_BOT_LOGINS` (e.g. `openswe-staging[bot]`) to treat other Open SWE deployments' comments as internal rather than untrusted.
+
+**Allowlists.**
+
+```bash
+ALLOWED_GITHUB_ORGS="langchain-ai,anthropics"                        # all repos in these orgs
+ALLOWED_GITHUB_REPOS="some-user/their-repo,another-org/specific-repo"  # specific owner/repo pairs
+PUBLIC_REPO_ORG_GATE=""   # single org whose members may trigger runs on *public* repos; empty = no gate
+```
+
+A GitHub or Linear webhook is accepted if the repo's org is in `ALLOWED_GITHUB_ORGS` **or** the `owner/repo` is in `ALLOWED_GITHUB_REPOS`; both empty allows everything. For Slack and dashboard requests, `ALLOWED_GITHUB_ORGS` also adds a prompt-level guard: editing a repository outside those orgs requires the user to name it with its full `https://github.com/<owner>/<repo>` URL. It also gates **dashboard login** to active members of the listed organizations, verified server-side with the installation token and failing closed on any API error; install the App in every listed organization and grant **Organization → Members: Read-only**. When team LangSmith credentials are connected, every active member of a listed organization can use the read-only LangSmith trace tools, so only list organizations whose full membership may see team-level trace data.
+
+**User mapping.** Which GitHub users can trigger the agent is controlled by the user mapping (GitHub login ⇄ work email ⇄ optional Slack ID) in the LangGraph Store, managed under **Admin → User mappings**. Signing in to the dashboard records a mapping for that user. An unmapped person who tags Open SWE in Slack gets a run with the GitHub App's installation permissions and a "link your GitHub account" prompt; completing the org-gated login records a `self` mapping.
+
+**Default repository.** Runs that name no repository use **Admin → Team settings → Default repository**, seeded from `DEFAULT_REPO_OWNER` / `DEFAULT_REPO_NAME` when set; `SLACK_REPO_OWNER` / `SLACK_REPO_NAME` are a Slack-only fallback.
+
+</details>
+
+<details id="models-gateway-search-and-reviewer">
+<summary><strong>Models, LLM Gateway, web search, and reviewer settings</strong></summary>
+
+```bash
+ANTHROPIC_API_KEY=""
+OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dictation
+# OPENAI_BASE_URL="https://api.openai.com/v1"  # optional OpenAI-compatible base URL
+GOOGLE_API_KEY=""                      # google_genai: models
+FIREWORKS_API_KEY=""                   # fireworks: models
+BASETEN_API_KEY=""                     # Baseten models when not using the gateway
+LLM_MODEL_ID=""                        # default model in provider:model form (see CUSTOMIZATION.md)
+
+LANGSMITH_GATEWAY_API_KEY=""           # LangSmith key with gateway:invoke; enables the LLM Gateway
+LANGSMITH_GATEWAY_ENABLED=""           # force the gateway on or off regardless of the key
+
+EXA_API_KEY=""                         # enables the web search tool (https://dashboard.exa.ai)
+REVIEWER_OUTCOMES_DATASET=""           # LangSmith dataset for reviewer outcomes; default openswe-reviewer-outcomes
+```
+
+</details>
+
+<details id="rotating-token_encryption_key">
+<summary><strong>Rotating <code>TOKEN_ENCRYPTION_KEY</code></strong></summary>
+
+`TOKEN_ENCRYPTION_KEY` accepts a single Fernet key or a comma- or newline-separated **ordered list, most recent first**. Writes use the first key; reads try every key in order.
+
+1. Generate a new key: `openssl rand -base64 32`.
+2. Prepend it, keeping the old key second: `TOKEN_ENCRYPTION_KEY="<new_key>,<old_key>"`, and restart.
+3. Once every active user has signed in again (each fresh OAuth flow re-encrypts under the new key), drop the old key. Anything still encrypted under it fails to decrypt and that user is asked to sign in again.
+
+</details>
+
+## Local development
+
+The same application runs on your machine with `langgraph dev`, which serves the API, the webhooks, and the dashboard on `http://localhost:2024`:
+
+```bash
+uv sync --all-extras
+make build-dashboard   # pnpm install + Vite build of the dashboard
+make dev               # http://localhost:2024; make dev-ui instead while working on the UI, for hot reload
+```
+
+Put the variables from step 4 in a `.env` file in the repository root; `LANGGRAPH_URL` and the dashboard URLs default to `http://localhost:2024`, so they can be left out. Create a GitHub App as in step 3 with `http://localhost:2024/dashboard/api/auth/callback` as its callback URL. GitHub and Slack cannot deliver webhooks to `localhost`: for comment or Slack triggers you need a tunnel with a fixed public hostname forwarding to port 2024, and that hostname becomes the App's webhook URL and Slack's request URL. `langgraph dev` reloads on code changes only, so restart it after editing `.env`.
 
 ## Troubleshooting
 
 ### Webhook not receiving events
 
-- Verify ngrok is running and the URL matches what's configured in GitHub/Linear/Slack
-- Check the ngrok web inspector at `http://localhost:4040` for incoming requests
-- Ensure you enabled the correct event types (Comments → Create for Linear, `app_mention` for Slack, Issues + Issue comment for GitHub)
-- **Webhook secrets are required** — if `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or `SLACK_SIGNING_SECRET` is not set, all requests to that endpoint will be rejected with 401
+- The URL configured in GitHub, Slack, or Linear must be the deployment's URL; GitHub shows each delivery and its response under the App's **Advanced** tab. A new webhook or signing secret takes effect only after the deployment restarts with it; deliveries in between are rejected as `Invalid signature`, and Slack then needs **Retry** on its Request URL under **Event Subscriptions**.
+- Enable the right events: Issue comment and the pull request review events for GitHub, `app_mention` for Slack, Comments → Create for Linear.
+- Webhook secrets are required: without `GITHUB_WEBHOOK_SECRET`, `SLACK_SIGNING_SECRET`, or `LINEAR_WEBHOOK_SECRET`, every request to that endpoint is rejected with 401.
 
 ### GitHub authentication errors
 
-- Verify `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are set correctly
-- Ensure the GitHub App is installed on the target repositories
-- Check that the private key includes the full `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines
+- Check `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID`. The private key must include the full `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines; in a `.env` file write it as one double-quoted line with `\n` between the PEM lines.
+- Make sure the App is installed on the target repositories.
 
 ### Dashboard login fails or won't stay logged in
 
-- `500 GITHUB_APP_CLIENT_ID not configured` (or client secret): set `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET` (step 3b) and `DASHBOARD_JWT_SECRET`.
-- OAuth `redirect_uri` mismatch: the GitHub App must list `<DASHBOARD_API_BASE_URL>/dashboard/api/auth/callback` as a callback URL (step 3a). Locally that's `http://localhost:2024/dashboard/api/auth/callback`.
-- Login redirects but the session doesn't stick: this is almost always a cookie problem. Locally, keep `DASHBOARD_API_BASE_URL` on `http://` (so cookies are `SameSite=Lax`); in prod use `https://` for both API and frontend and add the frontend origin to `DASHBOARD_ALLOWED_ORIGINS`.
-- Login rejected with an org error: `ALLOWED_GITHUB_ORGS` gates dashboard login (and requires the App's Organization → Members: Read-only permission). See step 5.
+- `500 GITHUB_APP_CLIENT_ID not configured` (or client secret): set `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, and `DASHBOARD_JWT_SECRET`.
+- `redirect_uri is not associated with this application`: the App must list `<URL you opened the dashboard on>/dashboard/api/auth/callback`. Add it in the App's settings.
+- Login redirects but the session does not stick: use `https://` and open the dashboard on `LANGGRAPH_URL` itself.
+- `403 CSRF check failed` on saves: the request's `Origin` is neither `DASHBOARD_BASE_URL` (defaults to `LANGGRAPH_URL`) nor in `DASHBOARD_ALLOWED_ORIGINS`.
+- Login rejected with an org error: `ALLOWED_GITHUB_ORGS` gates login and needs the App's Organization → Members permission.
 - Admin pages 403: add your GitHub login or email to `CONFIGURED_ADMINS`.
 
-### Dashboard UI can't reach the backend
+### Dashboard shows the LangGraph JSON instead of the UI, or 404s at `/`
 
-- Confirm the backend is running via `make dev` on `:2024` (not `make run` on `:8000`).
-- Confirm the dev server is proxying: `curl -i http://localhost:3000/dashboard/api/me` should return the backend's `401`, not an HTML page. If the backend is on another port, export `DASHBOARD_API_URL` before `make web` or `pnpm run dev`.
+- The image has no dashboard build. On LangGraph Platform, check the build log for `dashboard build failed`; with Docker, run `make build-dashboard` before `docker build`, or set `DASHBOARD_STATIC_DIR` to a directory holding a build.
 
 ### Sandbox creation failures
 
-- Verify `LANGSMITH_API_KEY_PROD` is set and valid
-- Check LangSmith sandbox quotas in your workspace settings
-- If a custom sandbox snapshot fails to boot, verify that its UUID belongs to the workspace selected by the sandbox LangSmith credentials
-- If you see `Failed to create sandbox from snapshot '<id>'`, confirm the snapshot exists in your workspace and has status `ready`
-- If you get a 403 Forbidden error on the sandbox endpoints, your LangSmith workspace may not have sandbox access enabled — contact LangSmith support
+- `LANGSMITH_API_KEY` must be set and valid, and the workspace must have sandbox access (403 on the sandbox endpoints means it does not; contact LangSmith support).
+- `Failed to create sandbox from snapshot '<id>'`: the snapshot must exist in that workspace with status `ready`; clear the admin **Base snapshot** or `DEFAULT_SANDBOX_SNAPSHOT_ID` to fall back to LangSmith's root snapshot.
 
 ### Agent not responding to comments
 
-- For GitHub: ensure the comment or issue contains `@openswe` (case-insensitive), and the commenter has a user mapping (Admin → User mappings; see "Configure triggering surfaces"). Add any missing user with **Add / update** in that section.
-- For Linear: ensure the comment contains `@openswe` (case-insensitive)
-- For Slack: ensure the bot is invited to the channel and the message is an `@mention`
-- Check server logs for webhook processing errors
+- GitHub: the comment must contain a configured handle (`@openswe` by default, case-insensitive), and the commenter must have signed in to the dashboard once; otherwise the log says `No email mapping for GitHub user`.
+- Linear: the comment must contain the handle; Slack: the bot must be in the channel and `@`-mentioned.
+- Check the server log for webhook processing errors.
 
 ### Token encryption errors
 
-- Ensure `TOKEN_ENCRYPTION_KEY` is set (generate with `openssl rand -base64 32`)
-- The key must be a valid 32-byte Fernet-compatible base64 string
-- For key rotation, `TOKEN_ENCRYPTION_KEY` may be a comma- or newline-separated
-  list of keys (most-recent-first). See "Rotating TOKEN_ENCRYPTION_KEY" above.
+- `TOKEN_ENCRYPTION_KEY` must be set to a valid Fernet key (`openssl rand -base64 32`), or an ordered list of them; see [Rotating `TOKEN_ENCRYPTION_KEY`](#rotating-token_encryption_key).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,19 +9,19 @@ What a deployment needs:
 | Value | How you get it |
 |---|---|
 | `LANGSMITH_API_KEY` | LangSmith → Settings → API Keys. LangGraph Platform injects it. |
-| A model key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`; or `LANGSMITH_GATEWAY_API_KEY` to route through the LangSmith LLM Gateway | Your provider, or a LangSmith key with `gateway:invoke` |
+| A model provider key such as `ANTHROPIC_API_KEY`, or `LANGSMITH_GATEWAY_API_KEY` for the LangSmith LLM Gateway | Your provider, or a LangSmith key with `gateway:invoke` (step 4) |
 | `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_INSTALLATION_ID` | The GitHub App you create in step 3 |
-| `TOKEN_ENCRYPTION_KEY`, `DASHBOARD_JWT_SECRET` | Two random secrets you generate (step 4) |
-| `CONFIGURED_ADMINS` | The GitHub logins or emails of your admins (step 4) |
+| `TOKEN_ENCRYPTION_KEY`, `DASHBOARD_JWT_SECRET` | Two random secrets you generate (step 5) |
+| `CONFIGURED_ADMINS` | The GitHub logins or emails of your admins (step 5) |
 | `LANGGRAPH_URL` | The deployment's own public URL |
 
 Slack and Linear are optional triggers; see [Optional add-ons](#optional-add-ons). Every variable Open SWE reads is declared in `agent/config.py` with its description and default; that file is the complete reference.
 
 ## 1. Create the deployment
 
-You need the deployment's public URL before the GitHub App can be created, so create the deployment first; it starts without the GitHub variables and picks them up in step 4.
+You need the deployment's public URL before the GitHub App can be created, so create the deployment first; it starts without the GitHub variables and picks them up in step 5.
 
-**LangGraph Platform.** Connect the repository to a new deployment in LangSmith → Deployments. The image build bundles the dashboard (the `dockerfile_lines` in `langgraph.json`), so the deployment URL serves the UI at `/` and the API beneath it; a failed UI build is logged and the backend still deploys. The platform injects `LANGSMITH_API_KEY`, `LANGSMITH_TRACING`, and `LANGSMITH_PROJECT`. You will set the environment variables in step 4.
+**LangGraph Platform.** Connect the repository to a new deployment in LangSmith → Deployments. The image build bundles the dashboard (the `dockerfile_lines` in `langgraph.json`), so the deployment URL serves the UI at `/` and the API beneath it; a failed UI build is logged and the backend still deploys. The platform injects `LANGSMITH_API_KEY`, `LANGSMITH_TRACING`, and `LANGSMITH_PROJECT`. You will set the environment variables in step 5.
 
 **Standalone Docker.** The root `Dockerfile` builds a production LangGraph API server image (not the sandbox image):
 
@@ -43,10 +43,11 @@ The example assumes Postgres and Redis run on the Docker host; `--add-host` is w
 
 Either way, the URL browsers and webhooks use from here on is `<URL>`: `https://<name>-<hash>.<region>.langgraph.app` on the platform, or your ingress hostname in front of the container.
 
-## 2. LangSmith and a model
+## 2. LangSmith API key
 
-1. Create a [LangSmith](https://smith.langchain.com/) API key under **Settings → API Keys** and save it as `LANGSMITH_API_KEY`. LangGraph Platform injects it into the deployment for you, along with `LANGSMITH_TRACING` and `LANGSMITH_PROJECT`; standalone deployments set it themselves. It is also what sandboxes and trace links use: trace links find your workspace through the key and the project by name, so no tenant or project ids are needed (`LANGSMITH_TENANT_ID` remains an override).
-2. Pick a model provider: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`. Or set `LANGSMITH_GATEWAY_API_KEY` (a LangSmith key with `gateway:invoke`) to route every provider call through the LangSmith LLM Gateway; `LANGSMITH_GATEWAY_ENABLED` forces that on or off, and admins can toggle it per team in the dashboard.
+Create a [LangSmith](https://smith.langchain.com/) API key under **Settings → API Keys** and save it as `LANGSMITH_API_KEY`. LangGraph Platform injects it into the deployment for you, along with `LANGSMITH_TRACING` and `LANGSMITH_PROJECT`; standalone deployments set it themselves.
+
+The same key is used for tracing, sandboxes, and trace links. Trace links find your workspace through the key and the project by name, so no tenant or project ids are needed (`LANGSMITH_TENANT_ID` remains an override). Sandboxes boot from LangSmith's root snapshot, which ships `git`, `gh`, Python, `uv`, and Node, so there is nothing to configure; when your repositories need more, admins capture an **Environment** from the dashboard later (see step 6). Other sandbox providers are covered in [CUSTOMIZATION.md](CUSTOMIZATION.md).
 
 ## 3. Create a GitHub App
 
@@ -80,13 +81,32 @@ Finally **Install App** in the sidebar: pick the account and the repositories Op
 
 Give each deployment its own GitHub App, or at least a distinct mention handle (`OPEN_SWE_MENTION_TAGS`, see [Allowlists](#repository-allowlists-mention-handles-and-user-mapping)) when several share a GitHub organization.
 
-## 4. Set the environment variables
+## 4. Model providers and API keys
+
+Open SWE calls models through [LangChain](https://python.langchain.com/) chat models named `provider:model`, so any provider you give a key for is available. Set at least one:
+
+| Provider | Variable | Notes |
+|---|---|---|
+| Anthropic | `ANTHROPIC_API_KEY` | Provider of the default model |
+| OpenAI | `OPENAI_API_KEY` | Also used for voice dictation in the dashboard; `OPENAI_BASE_URL` points at an OpenAI-compatible API |
+| Google | `GOOGLE_API_KEY` | `google_genai:` models |
+| Fireworks | `FIREWORKS_API_KEY` | `fireworks:` models |
+| Groq | `GROQ_API_KEY` | `groq:` models |
+| Baseten | `BASETEN_API_KEY` | `baseten:` models |
+
+**LangSmith LLM Gateway.** Instead of per-provider keys, route every model call through the gateway with one LangSmith key that has the `gateway:invoke` permission, set as `LANGSMITH_GATEWAY_API_KEY`. Setting that key turns the gateway on; `LANGSMITH_GATEWAY_ENABLED=true|false` forces it either way (with `true` and no gateway key, `LANGSMITH_API_KEY` is used, which on LangGraph Platform may lack the permission). `LANGSMITH_GATEWAY_BASE_URL` points at a regional or self-hosted gateway. Admins can also toggle the gateway per team in the dashboard.
+
+**Which model runs.** The deployment default is `anthropic:claude-opus-5` at `medium` reasoning effort; override it with `LLM_MODEL_ID` (`provider:model`) and `LLM_REASONING_EFFORT` (`low`, `medium`, `high`, `max`), and name a `LLM_FALLBACK_MODEL_ID` for when the primary provider fails. Admins set a team default under **Admin → Team settings**, and each user can pick their own model and effort under **My settings**; the supported list lives in `agent/dashboard/options.py`. Model ids and their providers are described in [CUSTOMIZATION.md](CUSTOMIZATION.md).
+
+**Other API keys.** `EXA_API_KEY` (from [dashboard.exa.ai](https://dashboard.exa.ai)) enables the web search tool. `REVIEWER_OUTCOMES_DATASET` names the LangSmith dataset the reviewer records finding outcomes in (default `openswe-reviewer-outcomes`).
+
+## 5. Set the environment variables
 
 ```bash
 LANGGRAPH_URL="<URL>"                 # the deployment's own URL
 LANGSMITH_API_KEY=""                  # step 2; injected by LangGraph Platform
 LANGSMITH_TRACING="true"              # injected by LangGraph Platform
-ANTHROPIC_API_KEY=""                  # or OPENAI_API_KEY / GOOGLE_API_KEY, or LANGSMITH_GATEWAY_API_KEY
+ANTHROPIC_API_KEY=""                  # step 4: any provider key, or LANGSMITH_GATEWAY_API_KEY
 
 GITHUB_APP_ID=""                      # step 3
 GITHUB_APP_CLIENT_ID=""
@@ -102,9 +122,9 @@ CONFIGURED_ADMINS=""                  # GitHub logins or emails, comma-separated
 
 On LangGraph Platform, set them under the deployment's environment variables; saving rolls out a new revision. With Docker, put them in the file you pass as `--env-file`. `DASHBOARD_BASE_URL` and `DASHBOARD_API_BASE_URL` are not needed: they default to `LANGGRAPH_URL` because the dashboard is served from the same origin.
 
-## 5. Verify it works
+## 6. Verify it works
 
-**Dashboard.** Open `<URL>`, click **Sign in with GitHub**, and you should land logged in. With your login in `CONFIGURED_ADMINS`, the **Admin** pages (Team settings, User mappings, Sandbox, Environments, …) appear. Set **Admin → Team settings → Default repository** so runs that name no repository have somewhere to go. Start a task from the composer.
+**Dashboard.** Open `<URL>`, click **Sign in with GitHub**, and you should land logged in. With your login in `CONFIGURED_ADMINS`, the **Admin** pages (Team settings, User mappings, Sandbox, Environments, …) appear. Set **Admin → Team settings → Default repository** so runs that name no repository have somewhere to go. Start a task from the composer. Every run gets a sandbox booted from LangSmith's root snapshot; when your repositories need extra toolchains preinstalled, an admin can start an **admin thread** (the Admin toggle in the composer), have the agent set the sandbox up, and capture it under **Admin → Environments** as the environment named `default`, which later runs boot from.
 
 **GitHub.** Signing in once is also what lets GitHub-triggered runs act as you: they run as the commenting user and need the token the sign-in stored; an unmapped commenter is skipped with a warning in the server log. Comment `@openswe what files are in this repo?` on an issue in a repository where the App is installed. Within a few seconds you should see a 👀 reaction, a run in your LangSmith project, and a reply comment. GitHub lists every delivery and its response under the App's **Advanced** tab.
 
@@ -270,49 +290,6 @@ ADMIN_OIDC_AUDIENCE="open-swe"                                  # optional; this
 
 </details>
 
-<details id="custom-sandbox-snapshot-and-environments">
-<summary><strong>Custom sandbox snapshot and environments</strong></summary>
-
-Each run executes in an isolated LangSmith sandbox booted from a **snapshot**. Without configuration that is LangSmith's root snapshot. Build your own (from a Docker image) when your repos need extra toolchains.
-
-The image must carry `git`, `gh`, `sfw`, the Docker CLI, and the language runtimes, and live in a registry LangSmith can pull from. Run `sfw --version` while building to populate its binary cache, and set `SFW_SKIP_UPDATE_CHECK=1` at runtime. Open SWE authenticates `git` and `gh` through the LangSmith sandbox proxy with runtime-minted installation tokens, so no GitHub token belongs in the image.
-
-Build a snapshot in the LangSmith UI (Sandboxes → Snapshots → New), via the SDK, or with the helper script:
-
-```bash
-uv run python scripts/create_sandbox_snapshot.py \
-  --name open-swe-gh-cli-amd64 \
-  --image johanneslangchain/open-swe-sandbox:gh-cli-amd64
-```
-
-Then set the UUID in the environment, or on **Admin → Sandbox → Base snapshot** (the stored value wins; clearing it falls back to the env var):
-
-```bash
-DEFAULT_SANDBOX_SNAPSHOT_ID="<snapshot-uuid>"
-# Optional sizing and TTL overrides. Defaults: 128 GiB root FS, 4 vCPUs, 16 GiB RAM,
-# 7200 s idle stop (0 disables), 2592000 s (30 d) delete-after-stop (0 disables).
-DEFAULT_SANDBOX_SNAPSHOT_FS_CAPACITY_BYTES="137438953472"
-DEFAULT_SANDBOX_VCPUS="4"
-DEFAULT_SANDBOX_MEM_BYTES="17179869184"
-DEFAULT_SANDBOX_IDLE_TTL_SECONDS="7200"
-DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="2592000"
-```
-
-The same setting is available over the API, which is how the repo that builds your sandbox image can roll a new snapshot out on its own (see [Admin API credentials](#admin-api-credentials)):
-
-```bash
-curl -X PUT "$OPEN_SWE_BASE_URL/dashboard/api/sandbox-settings" \
-  -H "Authorization: Bearer $ADMIN_GITHUB_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"base_snapshot_id": "<snapshot-uuid>"}'
-```
-
-**Environments.** An environment pairs a prompt with a snapshot every run boots from, and can span several repos. Admins build one from an **admin thread** (the **Admin** toggle in the composer): the agent provisions its own sandbox, cloning repos, installing toolchains, and warming caches, and then captures it. The environment named `default` is the one runs use; any other name is a draft. Records live on the admin **Environments** page. With more than one environment, a picker appears in the composer, and a Slack thread can pick one with an `env:<name>` tag on its opening message (`@Open SWE env:staging fix the flaky test`); only the opening message can, because the sandbox is created once. Captures are named `openswe-environment-<name>`; set `ENVIRONMENT_SNAPSHOT_PREFIX` to replace the prefix when several deployments share a workspace. Resolution for a new sandbox: the run's environment, then the admin base snapshot, then `DEFAULT_SANDBOX_SNAPSHOT_ID`, then LangSmith's root snapshot.
-
-**Other providers.** `SANDBOX_TYPE` defaults to `langsmith`; `modal`, `daytona`, `runloop`, `e2b`, and `local` are available with their own credentials, listed in [CUSTOMIZATION.md](CUSTOMIZATION.md). Only the LangSmith provider gets the GitHub proxy, so other providers see GitHub tokens inside the sandbox.
-
-</details>
-
 <details id="repository-allowlists-mention-handles-and-user-mapping">
 <summary><strong>Repository allowlists, mention handles, and user mapping</strong></summary>
 
@@ -331,27 +308,6 @@ A GitHub or Linear webhook is accepted if the repo's org is in `ALLOWED_GITHUB_O
 **User mapping.** Which GitHub users can trigger the agent is controlled by the user mapping (GitHub login ⇄ work email ⇄ optional Slack ID) in the LangGraph Store, managed under **Admin → User mappings**. Signing in to the dashboard records a mapping for that user. An unmapped person who tags Open SWE in Slack gets a run with the GitHub App's installation permissions and a "link your GitHub account" prompt; completing the org-gated login records a `self` mapping.
 
 **Default repository.** Runs that name no repository use **Admin → Team settings → Default repository**, seeded from `DEFAULT_REPO_OWNER` / `DEFAULT_REPO_NAME` when set; `SLACK_REPO_OWNER` / `SLACK_REPO_NAME` are a Slack-only fallback.
-
-</details>
-
-<details id="models-gateway-search-and-reviewer">
-<summary><strong>Models, LLM Gateway, web search, and reviewer settings</strong></summary>
-
-```bash
-ANTHROPIC_API_KEY=""
-OPENAI_API_KEY=""                      # OpenAI models and dashboard voice dictation
-# OPENAI_BASE_URL="https://api.openai.com/v1"  # optional OpenAI-compatible base URL
-GOOGLE_API_KEY=""                      # google_genai: models
-FIREWORKS_API_KEY=""                   # fireworks: models
-BASETEN_API_KEY=""                     # Baseten models when not using the gateway
-LLM_MODEL_ID=""                        # default model in provider:model form (see CUSTOMIZATION.md)
-
-LANGSMITH_GATEWAY_API_KEY=""           # LangSmith key with gateway:invoke; enables the LLM Gateway
-LANGSMITH_GATEWAY_ENABLED=""           # force the gateway on or off regardless of the key
-
-EXA_API_KEY=""                         # enables the web search tool (https://dashboard.exa.ai)
-REVIEWER_OUTCOMES_DATASET=""           # LangSmith dataset for reviewer outcomes; default openswe-reviewer-outcomes
-```
 
 </details>
 
@@ -407,7 +363,8 @@ Put the variables from step 4 in a `.env` file in the repository root; `LANGGRAP
 ### Sandbox creation failures
 
 - `LANGSMITH_API_KEY` must be set and valid, and the workspace must have sandbox access (403 on the sandbox endpoints means it does not; contact LangSmith support).
-- `Failed to create sandbox from snapshot '<id>'`: the snapshot must exist in that workspace with status `ready`; clear the admin **Base snapshot** or `DEFAULT_SANDBOX_SNAPSHOT_ID` to fall back to LangSmith's root snapshot.
+- Check LangSmith sandbox quotas in your workspace settings.
+- `Failed to create sandbox from snapshot '<id>'` means an admin-captured environment or base snapshot no longer exists or is not `ready` in that workspace; delete or recapture it under **Admin → Environments** (or clear **Admin → Sandbox → Base snapshot**) to fall back to the root snapshot.
 
 ### Agent not responding to comments
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -87,8 +87,8 @@ Open SWE calls models through [LangChain](https://python.langchain.com/) chat mo
 
 | Provider | Variable | Notes |
 |---|---|---|
-| Anthropic | `ANTHROPIC_API_KEY` | Provider of the default model |
-| OpenAI | `OPENAI_API_KEY` | Also used for voice dictation in the dashboard; `OPENAI_BASE_URL` points at an OpenAI-compatible API |
+| Anthropic | `ANTHROPIC_API_KEY` | Default model when it is the only key set |
+| OpenAI | `OPENAI_API_KEY` | Default model otherwise; also used for voice dictation in the dashboard. `OPENAI_BASE_URL` points at an OpenAI-compatible API |
 | Google | `GOOGLE_API_KEY` | `google_genai:` models |
 | Fireworks | `FIREWORKS_API_KEY` | `fireworks:` models |
 | Groq | `GROQ_API_KEY` | `groq:` models |
@@ -96,7 +96,7 @@ Open SWE calls models through [LangChain](https://python.langchain.com/) chat mo
 
 **LangSmith LLM Gateway.** Instead of per-provider keys, route every model call through the gateway with one LangSmith key that has the `gateway:invoke` permission, set as `LANGSMITH_GATEWAY_API_KEY`. Setting that key turns the gateway on; `LANGSMITH_GATEWAY_ENABLED=true|false` forces it either way (with `true` and no gateway key, `LANGSMITH_API_KEY` is used, which on LangGraph Platform may lack the permission). `LANGSMITH_GATEWAY_BASE_URL` points at a regional or self-hosted gateway. Admins can also toggle the gateway per team in the dashboard.
 
-**Which model runs.** The deployment default is `anthropic:claude-opus-5` at `medium` reasoning effort; override it with `LLM_MODEL_ID` (`provider:model`) and `LLM_REASONING_EFFORT` (`low`, `medium`, `high`, `max`), and name a `LLM_FALLBACK_MODEL_ID` for when the primary provider fails. Admins set a team default under **Admin → Team settings**, and each user can pick their own model and effort under **My settings**; the supported list lives in `agent/dashboard/options.py`. Model ids and their providers are described in [CUSTOMIZATION.md](CUSTOMIZATION.md).
+**Which model runs.** The deployment default is `anthropic:claude-opus-5` when only an Anthropic key is configured and `openai:gpt-5.6-sol` otherwise, at `medium` reasoning effort; override it with `LLM_MODEL_ID` (`provider:model`) and `LLM_REASONING_EFFORT` (`low`, `medium`, `high`, `max`), and name a `LLM_FALLBACK_MODEL_ID` for when the primary provider fails. Admins set a team default under **Admin → Team settings**, and each user can pick their own model and effort under **My settings**; the supported list lives in `agent/dashboard/options.py`. Model ids and their providers are described in [CUSTOMIZATION.md](CUSTOMIZATION.md).
 
 **Other API keys.** `EXA_API_KEY` (from [dashboard.exa.ai](https://dashboard.exa.ai)) enables the web search tool. `REVIEWER_OUTCOMES_DATASET` names the LangSmith dataset the reviewer records finding outcomes in (default `openswe-reviewer-outcomes`).
 

--- a/langgraph.json
+++ b/langgraph.json
@@ -24,7 +24,7 @@
   },
   "env": ".env",
   "dockerfile_lines": [
-    "# Bundle the dashboard so the deployment serves it at / (docs/INSTALLATION.md, Dashboard).",
+    "# Bundle the dashboard so the deployment serves it at / (docs/INSTALLATION.md).",
     "# The build is made for http.mount_prefix from langgraph.json, so the UI's asset URLs and router match where the server mounts it.",
     "# Best effort: a failed UI build leaves the backend deployable without the bundled UI.",
     "COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json langgraph.json /tmp/dashboard-src/",


### PR DESCRIPTION
## Summary

Rewrites `docs/INSTALLATION.md` around the single-origin deployment that landed in #2486: one deployment serves the API, webhooks and dashboard from one URL, so the separate frontend deploy, CORS and `DASHBOARD_*` URL steps leave the main path.

Order of the guide: create the deployment first (LangGraph Platform or standalone Docker) so you have its URL, get a LangSmith key, create the GitHub App by hand with the full permission and event list, choose model providers and API keys (its own step: provider keys, the LLM Gateway, how the running model is chosen, other optional keys), set the environment variables, verify. Slack, Linear, a separately deployed dashboard, admin API credentials, allowlists and key rotation are collapsed add-on sections, followed by deployment troubleshooting. Sandbox snapshot configuration is gone from the guide: deployments boot from LangSmith's root snapshot, and admins capture Environments in the dashboard when repositories need more. The `#3-create-a-github-app` anchor that `agent/prompt.py` links to is preserved.

Local development is a short section at the end for now; the full local guide with the tunnel setup follows in a stacked PR.

Also: the README's Installation Guide bullet describes the new scope, and a comment in `langgraph.json` drops a stale section reference.

## Test plan

- [x] Internal anchors resolve; `docs/INSTALLATION.md#3-create-a-github-app` still exists
- [x] `langgraph.json` still valid JSON
- [x] The env-var behaviour described (dashboard URLs defaulting to `LANGGRAPH_URL`, no CORS setup on one origin) is what `agent/config.py` and `agent/utils/dashboard_links.py` implement on main, including #2495