### PR TITLE
perf: omit custom middleware trace inputs

### DIFF
--- a/agent/middleware/check_message_queue.py
+++ b/agent/middleware/check_message_queue.py
@@ -22,6 +22,7 @@ from agent.input_messages import (
     build_input_messages,
     visible_dynamic_context_hashes,
 )
+from agent.middleware.trace import scrub_middleware_inputs
 from agent.utils.dashboard_handoff import DASHBOARD_HANDOFF_BODY
 from agent.utils.http import DEFAULT_HTTP_TIMEOUT
 from agent.utils.multimodal import fetch_image_block, vision_not_supported_warning
@@ -176,6 +177,7 @@ async def _consume_pending_autofix_event(store: BaseStore, thread_id: str) -> st
     return message
 
 
+@scrub_middleware_inputs
 @before_model(state_schema=LinearNotifyState)
 async def check_message_queue_before_model(  # noqa: PLR0911
     state: LinearNotifyState,  # noqa: ARG001

--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 from typing import Annotated, Any, NotRequired
 
 from langchain.agents.middleware.types import (
-    AgentMiddleware,
     AgentState,
     ModelRequest,
     ModelResponse,
@@ -19,6 +18,8 @@ from langchain_core.tools import BaseTool, InjectedToolCallId, StructuredTool
 from langgraph.prebuilt import InjectedState
 from langgraph.runtime import Runtime
 from langgraph.types import Command, Overwrite
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class _Resolved:
     done: bool = False
 
 
-class DynamicToolMiddleware(AgentMiddleware[DynamicToolState]):
+class DynamicToolMiddleware(OpenSWEMiddleware[DynamicToolState]):
     """Expose connected integration schemas only after explicit loading."""
 
     state_schema = DynamicToolState

--- a/agent/middleware/exclude_tools.py
+++ b/agent/middleware/exclude_tools.py
@@ -9,12 +9,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware.types import (
-    AgentMiddleware,
     AgentState,
     ModelRequest,
     ModelResponse,
 )
 from langchain_core.tools import BaseTool
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 
 def _tool_name(tool: BaseTool | dict[str, Any] | Any) -> str | None:
@@ -25,7 +26,7 @@ def _tool_name(tool: BaseTool | dict[str, Any] | Any) -> str | None:
     return name if isinstance(name, str) else None
 
 
-class ExcludeToolsMiddleware(AgentMiddleware):
+class ExcludeToolsMiddleware(OpenSWEMiddleware):
     """Strip named tools from each model request.
 
     Place this AFTER tool-injecting middleware (FilesystemMiddleware,

--- a/agent/middleware/model_call_timeout.py
+++ b/agent/middleware/model_call_timeout.py
@@ -12,10 +12,10 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 
 from agent.config import ENV
+from agent.middleware.trace import OpenSWEMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def _configured_timeout_seconds() -> float:
     return value if value > 0 else DEFAULT_MODEL_CALL_TIMEOUT_SECONDS
 
 
-class ModelCallTimeoutMiddleware(AgentMiddleware):
+class ModelCallTimeoutMiddleware(OpenSWEMiddleware):
     """Fail a model call that exceeds the deadline instead of hanging forever."""
 
     def __init__(self, timeout_seconds: float | None = None) -> None:

--- a/agent/middleware/model_errors.py
+++ b/agent/middleware/model_errors.py
@@ -14,11 +14,11 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
+from agent.middleware.trace import OpenSWEMiddleware
 from agent.utils.errors import (
     LAST_MODEL_ERROR_KEY,
     classify_exception,
@@ -50,7 +50,7 @@ def _run_context() -> tuple[str | None, str | None]:
     )
 
 
-class ModelErrorMiddleware(AgentMiddleware):
+class ModelErrorMiddleware(OpenSWEMiddleware):
     """Log a model-call exception in full and record why, then re-raise it unchanged."""
 
     async def awrap_model_call(

--- a/agent/middleware/model_fallback.py
+++ b/agent/middleware/model_fallback.py
@@ -34,11 +34,11 @@ from typing import Any
 import anthropic
 import httpx
 import openai
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 
+from agent.middleware.trace import OpenSWEMiddleware
 from agent.utils.errors import error_tracking_fields, exception_fields
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,7 @@ def _provider_access_error_message(exc: BaseException) -> str | None:
     return None
 
 
-class ModelFallbackMiddleware(AgentMiddleware):
+class ModelFallbackMiddleware(OpenSWEMiddleware):
     """Retry the model call across primary and fallback providers on transient errors.
 
     Args:

--- a/agent/middleware/notify_step_limit.py
+++ b/agent/middleware/notify_step_limit.py
@@ -8,6 +8,7 @@ from langgraph.runtime import Runtime
 from langgraph_sdk import get_client
 
 from agent.middleware.message_content import content_to_text
+from agent.middleware.trace import scrub_middleware_inputs
 from agent.run_config import RunConfig
 from agent.slack.client import (
     LANGGRAPH_URL,
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 _LIMIT_MARKER = "Model call limits exceeded"
 
 
+@scrub_middleware_inputs
 @after_agent
 async def notify_step_limit_reached(
     state: AgentState,

--- a/agent/middleware/plan_mode.py
+++ b/agent/middleware/plan_mode.py
@@ -13,12 +13,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any, NotRequired
 
 from langchain.agents.middleware.types import (
-    AgentMiddleware,
     AgentState,
     ModelRequest,
     ModelResponse,
 )
 from langchain_core.tools import BaseTool
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 
 class PlanModeState(AgentState):
@@ -35,7 +36,7 @@ def _tool_name(tool: BaseTool | dict[str, Any] | Any) -> str | None:
     return name if isinstance(name, str) else None
 
 
-class PlanModeMiddleware(AgentMiddleware):
+class PlanModeMiddleware(OpenSWEMiddleware):
     """Strip disallowed tools from each model request while plan mode is active."""
 
     state_schema = PlanModeState

--- a/agent/middleware/pr_creation_guard.py
+++ b/agent/middleware/pr_creation_guard.py
@@ -7,10 +7,12 @@ import shlex
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.agents.middleware.types import AgentState
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 _SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
 _SHELL_EXECUTABLES = {"bash", "dash", "sh", "zsh"}
@@ -252,7 +254,7 @@ def _blocked_tool_message(request: ToolCallRequest, command: str) -> ToolMessage
     )
 
 
-class PullRequestCreationGuardMiddleware(AgentMiddleware):
+class PullRequestCreationGuardMiddleware(OpenSWEMiddleware):
     """Prevent attributed-PR failures from being hidden by shell fallbacks."""
 
     state_schema = AgentState

--- a/agent/middleware/prepare_run.py
+++ b/agent/middleware/prepare_run.py
@@ -4,7 +4,6 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, NotRequired, cast
 
 from langchain.agents.middleware.types import (
-    AgentMiddleware,
     AgentState,
     ModelRequest,
     ModelResponse,
@@ -13,6 +12,7 @@ from langchain_core.messages import SystemMessage
 from langgraph.runtime import Runtime
 
 from agent.input_messages import wrap_system_prompt
+from agent.middleware.trace import OpenSWEMiddleware
 from agent.utils.startup_trace import flush_phases
 
 
@@ -39,7 +39,7 @@ def _latest_message_fingerprint(state: Mapping[str, Any]) -> str | None:
     return hashlib.sha256(encoded).hexdigest()
 
 
-class BasePrepareRunMiddleware(AgentMiddleware):
+class BasePrepareRunMiddleware(OpenSWEMiddleware):
     """Checkpointed per-run setup.
 
     Subclasses must keep `_prepare` idempotent. LangGraph checkpoints the

--- a/agent/middleware/record_run_usage.py
+++ b/agent/middleware/record_run_usage.py
@@ -8,12 +8,14 @@ from langgraph.runtime import Runtime
 
 from agent.agent_cost import schedule_agent_cost_refresh
 from agent.dashboard.agent_usage import record_agent_run_completion
+from agent.middleware.trace import scrub_middleware_inputs
 from agent.run_config import RunConfig
 from agent.utils.run_usage import summarize_run_usage
 
 logger = logging.getLogger(__name__)
 
 
+@scrub_middleware_inputs
 @after_agent
 async def record_run_usage(state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
     """Persist completed-run tokens and schedule deferred cost enrichment."""

--- a/agent/middleware/refresh_github_proxy.py
+++ b/agent/middleware/refresh_github_proxy.py
@@ -15,10 +15,12 @@ from langgraph.config import get_config
 from langgraph.runtime import Runtime
 
 from agent.github.proxy import maybe_refresh_proxy_token
+from agent.middleware.trace import scrub_middleware_inputs
 
 logger = logging.getLogger(__name__)
 
 
+@scrub_middleware_inputs
 @before_model
 async def refresh_github_proxy_before_model(
     state: AgentState,  # noqa: ARG001

--- a/agent/middleware/repair_orphaned_tool_calls.py
+++ b/agent/middleware/repair_orphaned_tool_calls.py
@@ -18,9 +18,10 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, ToolMessage
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ def _repair_messages(messages: list[Any]) -> list[Any] | None:
     return repaired
 
 
-class RepairOrphanedToolCallsMiddleware(AgentMiddleware):
+class RepairOrphanedToolCallsMiddleware(OpenSWEMiddleware):
     """Insert synthetic tool results for interrupted tool calls before model calls."""
 
     async def awrap_model_call(

--- a/agent/middleware/sanitize_fireworks_messages.py
+++ b/agent/middleware/sanitize_fireworks_messages.py
@@ -16,7 +16,6 @@ they reach the Fireworks serializer, mirroring the thinking-block sanitizer.
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage
 
@@ -24,6 +23,9 @@ try:
     from langchain_fireworks.chat_models import ChatFireworks
 except ImportError:  # pragma: no cover
     ChatFireworks = None  # type: ignore[assignment, misc]
+
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 
 def _is_chat_fireworks(model: object) -> bool:
@@ -58,7 +60,7 @@ def _sanitize_messages(messages: list[Any]) -> None:
         additional_kwargs.pop("function_call", None)
 
 
-class SanitizeFireworksMessagesMiddleware(AgentMiddleware):
+class SanitizeFireworksMessagesMiddleware(OpenSWEMiddleware):
     """Drop legacy ``function_call`` fields before Fireworks provider calls."""
 
     async def awrap_model_call(

--- a/agent/middleware/sanitize_openai_responses.py
+++ b/agent/middleware/sanitize_openai_responses.py
@@ -3,10 +3,11 @@
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, AnyMessage
 from langchain_openai import ChatOpenAI
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 
 def _is_stateless_chat_openai(model: object) -> bool:
@@ -51,7 +52,7 @@ def _sanitize_messages(messages: list[AnyMessage]) -> list[AnyMessage]:
     return sanitized
 
 
-class SanitizeOpenAIResponsesMiddleware(AgentMiddleware):
+class SanitizeOpenAIResponsesMiddleware(OpenSWEMiddleware):
     """Drop reasoning item IDs that OpenAI cannot resolve with ``store=False``."""
 
     async def awrap_model_call(

--- a/agent/middleware/sanitize_thinking_blocks.py
+++ b/agent/middleware/sanitize_thinking_blocks.py
@@ -3,10 +3,11 @@
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 
 def _is_chat_anthropic(model: object) -> bool:
@@ -43,7 +44,7 @@ def _sanitize_messages(messages: list[Any]) -> None:
             message.content = content
 
 
-class SanitizeThinkingBlocksMiddleware(AgentMiddleware):
+class SanitizeThinkingBlocksMiddleware(OpenSWEMiddleware):
     """Drop empty Anthropic thinking blocks before provider validation."""
 
     async def awrap_model_call(

--- a/agent/middleware/sanitize_tool_inputs.py
+++ b/agent/middleware/sanitize_tool_inputs.py
@@ -11,10 +11,12 @@ import re
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.agents.middleware.types import AgentState
 from langchain_core.messages import ToolCall, ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ def _sanitize_read_file_args(args: dict[str, Any]) -> dict[str, Any]:
     return sanitized
 
 
-class SanitizeToolInputsMiddleware(AgentMiddleware):
+class SanitizeToolInputsMiddleware(OpenSWEMiddleware):
     """Intercept read_file calls and coerce malformed integer parameters.
 
     When the LLM produces a string value for an integer field (e.g.

--- a/agent/middleware/settle_review_check.py
+++ b/agent/middleware/settle_review_check.py
@@ -14,6 +14,7 @@ from langchain.agents.middleware import AgentState, after_agent
 from langgraph.runtime import Runtime
 
 from agent.github.thread_token import get_github_token
+from agent.middleware.trace import scrub_middleware_inputs
 from agent.review.findings import get_thread_metadata
 from agent.review.publish import settle_review_check_run
 from agent.run_config import RunConfig
@@ -21,6 +22,7 @@ from agent.run_config import RunConfig
 logger = logging.getLogger(__name__)
 
 
+@scrub_middleware_inputs
 @after_agent
 async def settle_review_check_on_exit(
     state: AgentState,

--- a/agent/middleware/stable_tool_order.py
+++ b/agent/middleware/stable_tool_order.py
@@ -10,9 +10,10 @@ first model call of every new run.
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+
+from agent.middleware.trace import OpenSWEMiddleware
 
 
 def _call_positions(message: AIMessage) -> dict[str, int]:
@@ -56,7 +57,7 @@ def _order_messages(messages: list[AnyMessage]) -> list[AnyMessage] | None:
     return ordered if changed else None
 
 
-class StableToolResultOrderMiddleware(AgentMiddleware):
+class StableToolResultOrderMiddleware(OpenSWEMiddleware):
     """Sort each parallel tool batch's results into their tool call order."""
 
     async def awrap_model_call(

--- a/agent/middleware/subdir_agents.py
+++ b/agent/middleware/subdir_agents.py
@@ -6,12 +6,13 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import Any
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.agents.middleware.types import AgentState
 from langchain_core.messages import ToolMessage
 from langgraph.config import get_config
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
+from agent.middleware.trace import OpenSWEMiddleware
 from agent.run_config import RunConfig
 from agent.sandboxes.state import SANDBOX_BACKENDS
 
@@ -133,7 +134,7 @@ def _append_reminder(result: ToolMessage | Command, reminder: str | None) -> Too
     return result
 
 
-class SubdirAgentsReadMiddleware(AgentMiddleware):
+class SubdirAgentsReadMiddleware(OpenSWEMiddleware):
     """Append applicable ancestor ``AGENTS.md`` files to ``read_file`` results."""
 
     state_schema = AgentState

--- a/agent/middleware/timeout_wrapup.py
+++ b/agent/middleware/timeout_wrapup.py
@@ -2,11 +2,12 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import BaseMessage, SystemMessage
 
 from agent.config import ENV
 from agent.input_messages import wrap_system_prompt
+from agent.middleware.trace import OpenSWEMiddleware
 
 _DEFAULT_TIMEOUT_SECONDS = 45 * 60
 _WRAPUP_INSTRUCTION = """
@@ -40,7 +41,7 @@ def _content_with_instruction(
     return f"{content}\n\n{instruction}" if content else instruction
 
 
-class TimeoutWrapupMiddleware(AgentMiddleware):
+class TimeoutWrapupMiddleware(OpenSWEMiddleware):
     def __init__(self, timeout_seconds: int | None = None) -> None:
         super().__init__()
         self._timeout_seconds = timeout_seconds or _configured_timeout_seconds()

--- a/agent/middleware/tool_error_handler.py
+++ b/agent/middleware/tool_error_handler.py
@@ -12,7 +12,6 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from langchain.agents.middleware.types import (
-    AgentMiddleware,
     AgentState,
 )
 from langchain_core.messages import ToolMessage
@@ -29,6 +28,7 @@ from agent.middleware.sandbox_circuit_breaker import (
     extract_sandbox_id,
     post_sandbox_unreachable_notification,
 )
+from agent.middleware.trace import OpenSWEMiddleware
 from agent.run_config import RunConfig
 from agent.sandboxes.retry import is_transient_sandbox_error
 
@@ -153,7 +153,7 @@ def _generic_error_tool_message(e: Exception, request: ToolCallRequest) -> ToolM
     )
 
 
-class ToolErrorMiddleware(AgentMiddleware):
+class ToolErrorMiddleware(OpenSWEMiddleware):
     """Normalize tool execution errors into predictable payloads.
 
     Catches any exception thrown during a tool call and converts it into

--- a/agent/middleware/trace.py
+++ b/agent/middleware/trace.py
@@ -1,0 +1,20 @@
+from typing import Protocol
+
+from langchain.agents.middleware import AgentMiddleware, AgentState, TracePolicy, omit_payload
+
+SCRUBBED_TRACE_POLICY = TracePolicy(process_inputs=omit_payload)
+
+
+class TraceableMiddleware(Protocol):
+    trace_policy: TracePolicy | None
+
+
+class OpenSWEMiddleware[StateT: AgentState](AgentMiddleware[StateT]):
+    trace_policy = SCRUBBED_TRACE_POLICY
+
+
+def scrub_middleware_inputs[MiddlewareT: TraceableMiddleware](
+    middleware: MiddlewareT,
+) -> MiddlewareT:
+    middleware.trace_policy = SCRUBBED_TRACE_POLICY
+    return middleware

--- a/agent/middleware/workflow_push_guard.py
+++ b/agent/middleware/workflow_push_guard.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.agents.middleware.types import AgentState
 from langchain_core.messages import ToolCall, ToolMessage
 from langgraph.config import get_config
 from langgraph.prebuilt.tool_node import ToolCallRequest
@@ -21,6 +21,7 @@ from agent.dashboard.workflow_approval import (
     mark_workflow_push_notified,
     workflow_push_approved,
 )
+from agent.middleware.trace import OpenSWEMiddleware
 from agent.run_config import RunConfig
 from agent.sandboxes.state import SANDBOX_BACKENDS
 from agent.slack.client import (
@@ -567,7 +568,7 @@ async def _approval_state(request: ToolCallRequest, change: WorkflowPushChange) 
         return "approval_error"
 
 
-class WorkflowPushGuardMiddleware(AgentMiddleware):
+class WorkflowPushGuardMiddleware(OpenSWEMiddleware):
     """Require approval before pushing `.github/workflows` changes."""
 
     state_schema = AgentState

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ dev = [
 
 [tool.uv]
 # The externally maintained langchain-e2b integration still declares
-# `deepagents<0.7.0`, but 0.7.11 keeps the sandbox API backward compatible. Its e2b
+# `deepagents<0.7.0`, but 0.7.13 keeps the sandbox API backward compatible. Its e2b
 # dependency also caps wcmatch<11.0 while deepagents requires wcmatch>=11.0, so
 # override both transitive bounds until langchain-e2b publishes compatible metadata.
-override-dependencies = ["deepagents==0.7.11", "wcmatch>=11.0"]
+override-dependencies = ["deepagents==0.7.13", "wcmatch>=11.0"]
 # Each langgraph-api release pins its langgraph-runtime-inmem peer to a single
 # minor window expressed in `.dev0` bounds (`>=0.32.0.dev0,<0.33.0.dev0`), which
 # uv's default pre-release policy shies away from, so a plain resolve lands on the

--- a/tests/middleware/test_trace_policy.py
+++ b/tests/middleware/test_trace_policy.py
@@ -1,0 +1,20 @@
+import inspect
+
+from langchain.agents.middleware import AgentMiddleware, omit_payload
+
+from agent import middleware
+
+
+def test_custom_middleware_scrubs_trace_inputs() -> None:
+    exports = [getattr(middleware, name) for name in middleware.__all__]
+    custom_middleware = [
+        value
+        for value in exports
+        if isinstance(value, AgentMiddleware)
+        or (inspect.isclass(value) and issubclass(value, AgentMiddleware))
+    ]
+
+    assert custom_middleware
+    for value in custom_middleware:
+        assert value.trace_policy is not None
+        assert value.trace_policy.process_inputs is omit_payload

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,7 @@ requires-python = ">=3.14"
 [manifest]
 constraints = [{ name = "langgraph-api", specifier = ">=0.13.3,<0.14" }]
 overrides = [
-    { name = "deepagents", specifier = "==0.7.11" },
+    { name = "deepagents", specifier = "==0.7.13" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]
 
@@ -536,7 +536,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.7.11"
+version = "0.7.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -547,9 +547,9 @@ dependencies = [
     { name = "packaging" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/e8/dfa6b3a4d43ad87ab28894a6edba167d909fbdd8d59fb356c8db0ebb53c9/deepagents-0.7.11.tar.gz", hash = "sha256:240e31cb60e4a8e3c4f9aa1ab706618bae4ea69ae6495d9fc0e3e773d551927e", size = 293354, upload-time = "2026-08-28T23:10:48.665Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/a7/18d5479456c5c4d47d6074a8af615f8b844d91ec4e7bd548f2b047953903/deepagents-0.7.13.tar.gz", hash = "sha256:99fc1855b1387c1c6e6035ba3600edbd933f59c39a4863ef3a7d5a0272ea67ab", size = 297293, upload-time = "2026-09-02T17:36:38.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/38/7d3eb8671cafefe8798d945c48bb664abbd92015446fc453093e44895788/deepagents-0.7.11-py3-none-any.whl", hash = "sha256:7f8ca58b7aa8b11fb8a18d054aa5da937700cba221b1104b5eda4469e9531382", size = 320468, upload-time = "2026-08-28T23:10:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/64/6881d1c040433a3c48a1556afa5e70bcd5a761b0f67f9162a311ca8ed91c/deepagents-0.7.13-py3-none-any.whl", hash = "sha256:d717ee8ee092a91c475a6124ed578d5e4154d54120769a1081bfe1aece87c248", size = 324274, upload-time = "2026-09-02T17:36:37.165Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Custom middleware hooks receive the full agent state, including a message history that grows throughout long runs. Recording that payload on every hook adds repeated serialization and ingestion work; [Deep Agents adopted the same input-omitting trace policy upstream](https://github.com/langchain-ai/deepagents/pull/5377).

- Upgrade Deep Agents from `0.7.11` to `0.7.13`.
- Keep middleware spans and timing while omitting their input payloads.
- Centralize the policy for class-based and decorator-based Open SWE middleware.
- Guard every exported custom middleware with coverage.

```mermaid
flowchart LR
    S[Agent state + message history] --> M[Custom middleware hook]
    M --> T[Trace span + timing]
    S -. omitted by trace policy .-> X[Middleware input payload]
```

```python
SCRUBBED_TRACE_POLICY = TracePolicy(process_inputs=omit_payload)

class OpenSWEMiddleware(AgentMiddleware):
    trace_policy = SCRUBBED_TRACE_POLICY
```

Made by [Open SWE](https://openswe.vercel.app/agents/b11aa0b5-2fde-5281-8b6b-081cfe1022de)
