### PR TITLE
fix(slack): never go silent on an addressed request, and stop requiring a repository

### DIFF
--- a/agent/github/webhook.py
+++ b/agent/github/webhook.py
@@ -344,7 +344,7 @@ async def trigger_pr_review_from_ref(
         source=source,
         input=review_input,
         assistant_id="reviewer",
-        metadata=common._AGENT_VERSION_METADATA,
+        metadata=common.AGENT_VERSION_METADATA,
         client=langgraph_client,
     )
     await common._store_current_reviewer_run_id(thread_id, run)
@@ -469,7 +469,7 @@ async def _dispatch_first_review_from_pr_payload(payload: dict[str, Any], *, sou
         source=source,
         input=run_input,
         assistant_id="reviewer",
-        metadata=common._AGENT_VERSION_METADATA,
+        metadata=common.AGENT_VERSION_METADATA,
         client=langgraph_client,
     )
     await common._store_current_reviewer_run_id(thread_id, run)
@@ -782,7 +782,7 @@ async def process_github_push_event(payload: dict[str, Any]) -> None:
             },
         ),
         assistant_id="reviewer",
-        metadata=common._AGENT_VERSION_METADATA,
+        metadata=common.AGENT_VERSION_METADATA,
         client=langgraph_client,
     )
     await common._store_current_reviewer_run_id(thread_id, run)
@@ -1067,7 +1067,7 @@ async def process_github_review_finding_reply(payload: dict[str, Any]) -> None:
             },
         ),
         assistant_id="reviewer",
-        metadata=common._AGENT_VERSION_METADATA,
+        metadata=common.AGENT_VERSION_METADATA,
         client=langgraph_client,
     )
     await common._store_current_reviewer_run_id(thread_id, run)
@@ -1109,7 +1109,7 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
         return
 
     thread_id = github_issue_thread_id(issue_id)
-    existing_thread = await common._thread_exists(thread_id)
+    existing_thread = await common.thread_exists(thread_id)
     github_token = await common._get_or_resolve_thread_github_token(thread_id, email)
     app_token = await common.get_github_app_installation_token()
     reaction_token = github_token or app_token
@@ -1252,7 +1252,7 @@ async def process_github_issue(payload: dict[str, Any], event_type: str) -> None
         configurable,
         source="github_issue",
         input=run_input,
-        metadata=common._AGENT_VERSION_METADATA,
+        metadata=common.AGENT_VERSION_METADATA,
         client=langgraph_client,
     )
     common.logger.info("LangGraph run dispatched for thread %s from GitHub issue", thread_id)

--- a/agent/linear/webhook.py
+++ b/agent/linear/webhook.py
@@ -326,7 +326,7 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         configurable,
         source="linear",
         input=run_input,
-        metadata=common._AGENT_VERSION_METADATA,
+        metadata=common.AGENT_VERSION_METADATA,
     )
     common.logger.info(
         "LangGraph run dispatched for thread %s (run=%s)",

--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -77,7 +77,7 @@ def _slack_auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {SLACK_BOT_TOKEN}"}
 
 
-def _parse_ts(ts: str | None) -> float:
+def parse_slack_ts(ts: str | None) -> float:
     try:
         return float(ts or "0")
     except TypeError, ValueError:
@@ -236,9 +236,9 @@ def select_slack_context_messages(
     if not messages:
         return [], "thread_start"
 
-    current_ts = _parse_ts(current_message_ts)
-    ordered = sorted(messages, key=lambda item: _parse_ts(item.get("ts")))
-    up_to_current = [item for item in ordered if _parse_ts(item.get("ts")) <= current_ts]
+    current_ts = parse_slack_ts(current_message_ts)
+    ordered = sorted(messages, key=lambda item: parse_slack_ts(item.get("ts")))
+    up_to_current = [item for item in ordered if parse_slack_ts(item.get("ts")) <= current_ts]
     if not up_to_current:
         up_to_current = ordered
 
@@ -1272,7 +1272,7 @@ async def fetch_slack_thread_messages(channel_id: str, thread_ts: str) -> list[d
             if not cursor:
                 break
 
-    messages.sort(key=lambda item: _parse_ts(item.get("ts")))
+    messages.sort(key=lambda item: parse_slack_ts(item.get("ts")))
     if truncated:
         messages = messages[-SLACK_THREAD_MAX_MESSAGES:]
     return messages

--- a/agent/slack/failures.py
+++ b/agent/slack/failures.py
@@ -1,0 +1,96 @@
+"""Slack requests never end in silence.
+
+Once an event is known to be addressed to Open SWE, every failure before the
+agent answers is posted back to the same thread under a fresh error id, and the
+same id is attached to the server log line so the failure can be looked up.
+"""
+
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+
+from pydantic import AliasChoices, BaseModel, Field
+
+from agent.slack.client import post_slack_thread_reply
+from agent.utils.user_messages import warning
+
+logger = logging.getLogger(__name__)
+
+_UNEXPECTED_FAILURE = (
+    "Open SWE hit an unexpected error and cannot respond to this message. Send it again to retry."
+)
+
+
+class SlackRequestError(Exception):
+    """A request Open SWE will not act on; ``user_message`` is posted to the thread verbatim."""
+
+    def __init__(self, user_message: str) -> None:
+        super().__init__(user_message)
+        self.user_message = user_message
+
+
+class SlackRequestTarget(BaseModel):
+    """The thread that must hear back, and what to attach to the log line."""
+
+    channel_id: str = ""
+    thread_ts: str = ""
+    event_id: str = ""
+    agent_thread_id: str | None = Field(
+        default=None, validation_alias=AliasChoices("agent_thread_id", "thread_id")
+    )
+
+
+async def report_slack_failure(target: SlackRequestTarget, exc: BaseException) -> str:
+    """Log ``exc`` under a new error id, reply to the thread with that id, and return it."""
+    error_id = str(uuid.uuid7())
+    fields = {
+        "error_id": error_id,
+        "slack_channel_id": target.channel_id,
+        "slack_thread_ts": target.thread_ts,
+        "slack_event_id": target.event_id,
+        "agent_thread_id": target.agent_thread_id,
+    }
+    if isinstance(exc, SlackRequestError):
+        logger.warning("Slack request rejected", extra=fields)
+        text = exc.user_message
+    else:
+        logger.error("Slack request failed", exc_info=exc, extra=fields)
+        text = _UNEXPECTED_FAILURE
+    if not target.channel_id or not target.thread_ts:
+        logger.error("Slack failure has no thread to reply to", extra=fields)
+        return error_id
+    try:
+        posted = await post_slack_thread_reply(
+            target.channel_id,
+            target.thread_ts,
+            warning(f"{text}\nError ID: `{error_id}`"),
+            agent_thread_id=target.agent_thread_id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Could not post Slack failure reply", extra=fields)
+        return error_id
+    if not posted:
+        logger.error("Slack failure reply was not delivered", extra=fields)
+    return error_id
+
+
+async def answer_slack_request(
+    target: SlackRequestTarget, handle: Callable[[], Awaitable[dict[str, str]]]
+) -> dict[str, str]:
+    """Run a webhook handler for an addressed request; a failure becomes a thread reply.
+
+    Slack sees 200 either way so it does not retry a request the user has
+    already been told about.
+    """
+    try:
+        return await handle()
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "error", "error_id": await report_slack_failure(target, exc)}
+
+
+async def run_slack_task(target: SlackRequestTarget, task: Awaitable[None]) -> None:
+    """Background-task form of :func:`answer_slack_request`."""
+    try:
+        await task
+    except Exception as exc:  # noqa: BLE001
+        await report_slack_failure(target, exc)

--- a/agent/slack/failures.py
+++ b/agent/slack/failures.py
@@ -9,9 +9,10 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import BaseModel
 
 from agent.slack.client import post_slack_thread_reply
+from agent.slack.responses import WebhookResponse, failed
 from agent.utils.user_messages import warning
 
 logger = logging.getLogger(__name__)
@@ -35,9 +36,7 @@ class SlackRequestTarget(BaseModel):
     channel_id: str = ""
     thread_ts: str = ""
     event_id: str = ""
-    agent_thread_id: str | None = Field(
-        default=None, validation_alias=AliasChoices("agent_thread_id", "thread_id")
-    )
+    agent_thread_id: str | None = None
 
 
 async def report_slack_failure(target: SlackRequestTarget, exc: BaseException) -> str:
@@ -75,8 +74,8 @@ async def report_slack_failure(target: SlackRequestTarget, exc: BaseException) -
 
 
 async def answer_slack_request(
-    target: SlackRequestTarget, handle: Callable[[], Awaitable[dict[str, str]]]
-) -> dict[str, str]:
+    target: SlackRequestTarget, handle: Callable[[], Awaitable[WebhookResponse]]
+) -> WebhookResponse:
     """Run a webhook handler for an addressed request; a failure becomes a thread reply.
 
     Slack sees 200 either way so it does not retry a request the user has
@@ -85,7 +84,7 @@ async def answer_slack_request(
     try:
         return await handle()
     except Exception as exc:  # noqa: BLE001
-        return {"status": "error", "error_id": await report_slack_failure(target, exc)}
+        return failed(await report_slack_failure(target, exc))
 
 
 async def run_slack_task(target: SlackRequestTarget, task: Awaitable[None]) -> None:

--- a/agent/slack/payloads.py
+++ b/agent/slack/payloads.py
@@ -1,0 +1,222 @@
+"""Typed views of what Slack posts to the webhooks.
+
+Only the fields Open SWE reads are declared; everything else is kept
+(``extra="allow"``) so nothing Slack sends is lost on the way through.
+"""
+
+import json
+import logging
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
+
+from agent.utils.json_types import JsonObject
+
+logger = logging.getLogger(__name__)
+
+
+class SlackPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    @classmethod
+    def parse(cls, raw: object) -> Self | None:
+        """``None`` when the payload does not have the declared shape."""
+        try:
+            return cls.model_validate(raw)
+        except ValidationError:
+            logger.warning("Slack payload has an unexpected shape", exc_info=True)
+            return None
+
+
+class SlackRef(SlackPayload):
+    """An object Slack sometimes sends as a bare id and sometimes as ``{"id": ...}``."""
+
+    id: str = ""
+
+
+class SlackItem(SlackPayload):
+    """``event.item``: the reacted-to message, or a code-channel context-bar item."""
+
+    channel: str = ""
+    ts: str = ""
+    key: str | None = None
+    label: str | None = None
+    value: JsonValue = None
+
+
+class SlackMessage(SlackPayload):
+    ts: str = ""
+    thread_ts: str = ""
+    user: str = ""
+    text: str | None = None
+    subtype: str = ""
+    bot_id: str = ""
+    attachments: list[JsonObject] = Field(default_factory=list)
+
+    @property
+    def is_from_bot(self) -> bool:
+        return self.subtype == "bot_message" or bool(self.bot_id)
+
+
+class SlackEvent(SlackPayload):
+    """The ``event`` of an Events API callback, across every event type Open SWE subscribes to."""
+
+    type: str = ""
+    subtype: str = ""
+    channel: str | SlackRef = ""
+    channel_id: str = ""
+    channel_type: str = ""
+    item: SlackItem | None = None
+    ts: str = ""
+    event_ts: str = ""
+    action_ts: str = ""
+    thread_ts: str = ""
+    user: str | SlackRef = ""
+    user_id: str = ""
+    text: str | None = None
+    bot_id: str = ""
+    attachments: list[JsonObject] = Field(default_factory=list)
+    message: SlackMessage | None = None
+    previous_message: SlackMessage | None = None
+    reaction: str = ""
+    action: SlackItem | None = None
+    key: str | None = None
+    label: str | None = None
+    value: JsonValue = None
+    team: str = ""
+
+    def resolve_channel_id(self) -> str:
+        if isinstance(self.channel, SlackRef):
+            return self.channel.id
+        if self.channel:
+            return self.channel
+        if self.item and self.item.channel:
+            return self.item.channel
+        return self.channel_id
+
+    def resolve_user_id(self) -> str:
+        if isinstance(self.user, SlackRef):
+            return self.user.id
+        return self.user or self.user_id
+
+    @property
+    def is_from_bot(self) -> bool:
+        return self.subtype == "bot_message" or bool(self.bot_id)
+
+
+class SlackAuthorization(SlackPayload):
+    user_id: str = ""
+
+
+class SlackEventEnvelope(SlackPayload):
+    """An Events API delivery."""
+
+    type: str = ""
+    event_id: str = ""
+    team_id: str = ""
+    challenge: str = ""
+    authorizations: list[SlackAuthorization] = Field(default_factory=list)
+    authed_users: list[str] = Field(default_factory=list)
+    event: SlackEvent | None = None
+
+    def bot_user_id(self, configured: str) -> str:
+        """The app's own user id: configured, else whichever the delivery names."""
+        if configured:
+            return configured
+        if self.authorizations and self.authorizations[0].user_id:
+            return self.authorizations[0].user_id
+        return self.authed_users[0] if self.authed_users else ""
+
+
+class SlackText(SlackPayload):
+    type: str = ""
+    text: str = ""
+
+
+class SlackBlockAction(SlackPayload):
+    action_id: str = ""
+    type: str = ""
+    value: str | None = None
+    action_ts: str = ""
+    text: SlackText | None = None
+    selected_option: JsonValue = None
+    selected_options: JsonValue = None
+    selected_user: JsonValue = None
+    selected_users: JsonValue = None
+    selected_conversation: JsonValue = None
+    selected_conversations: JsonValue = None
+    selected_channel: JsonValue = None
+    selected_channels: JsonValue = None
+    selected_date: JsonValue = None
+    selected_time: JsonValue = None
+    selected_date_time: JsonValue = None
+
+    def summary(self) -> JsonObject:
+        """The fields worth showing the agent, exactly as Slack sent them."""
+        return self.model_dump(
+            include=set(SlackBlockAction.model_fields), exclude_unset=True, mode="json"
+        )
+
+
+class SlackInteractionContainer(SlackPayload):
+    type: str = ""
+    channel_id: str = ""
+    view_id: str = ""
+    thread_ts: str = ""
+    message_ts: str = ""
+
+
+class SlackInteractionMessage(SlackPayload):
+    ts: str = ""
+    thread_ts: str = ""
+    text: str = ""
+    blocks: list[JsonObject] = Field(default_factory=list)
+
+
+class SlackInteractionUser(SlackPayload):
+    id: str = ""
+    name: str = ""
+    username: str = ""
+
+
+class SlackInteraction(SlackPayload):
+    """A Block Kit interaction (``block_actions``, ``block_suggestion``)."""
+
+    type: str = ""
+    trigger_id: str = ""
+    action_id: str = ""
+    value: str = ""
+    container: SlackInteractionContainer = Field(default_factory=SlackInteractionContainer)
+    actions: list[SlackBlockAction] = Field(default_factory=list)
+    user: SlackInteractionUser = Field(default_factory=SlackInteractionUser)
+    channel: SlackRef = Field(default_factory=SlackRef)
+    message: SlackInteractionMessage = Field(default_factory=SlackInteractionMessage)
+
+    @property
+    def channel_id(self) -> str:
+        return self.channel.id or self.container.channel_id
+
+    @property
+    def thread_ts(self) -> str:
+        return self.message.thread_ts or self.message.ts or self.container.thread_ts
+
+    @property
+    def message_ts(self) -> str:
+        return self.message.ts or self.container.message_ts
+
+
+class SlackButtonValue(SlackPayload):
+    """The JSON Open SWE packs into a button's ``value`` to know what was clicked."""
+
+    type: str = ""
+    action: str = ""
+    fingerprint: str = ""
+    response: str = ""
+
+
+def parse_json_object(body: bytes) -> JsonObject | None:
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/agent/slack/request.py
+++ b/agent/slack/request.py
@@ -1,0 +1,38 @@
+"""One Slack message or interaction addressed to Open SWE, as the routes hand it to processing."""
+
+from pydantic import BaseModel, Field
+
+from agent.slack.client import SlackChannelContext
+from agent.slack.failures import SlackRequestTarget
+from agent.utils.json_types import JsonObject
+
+
+class SlackRequest(BaseModel):
+    channel_id: str
+    thread_ts: str
+    event_ts: str = ""
+    original_message_ts: str = ""
+    event_id: str = ""
+    user_id: str = ""
+    user_name: str = ""
+    text: str = ""
+    attachments: list[JsonObject] = Field(default_factory=list)
+    bot_user_id: str = ""
+    thread_id: str | None = None
+    channel_context: SlackChannelContext | None = None
+    team_id: str = ""
+    reply_thread_ts: str = ""
+    treat_all_messages_as_mentions: bool = False
+    untagged_reply: bool = False
+    message_update: bool = False
+    code_channel: bool = False
+    explicit_request: bool = False
+
+    @property
+    def target(self) -> SlackRequestTarget:
+        return SlackRequestTarget(
+            channel_id=self.channel_id,
+            thread_ts=self.thread_ts,
+            event_id=self.event_id,
+            agent_thread_id=self.thread_id,
+        )

--- a/agent/slack/responses.py
+++ b/agent/slack/responses.py
@@ -1,0 +1,46 @@
+"""What the Slack webhook routes answer Slack with."""
+
+from typing import Literal, NotRequired, TypedDict
+
+from agent.utils.json_types import JsonObject
+
+
+class WebhookResponse(TypedDict):
+    status: Literal["accepted", "ignored", "error"]
+    message: NotRequired[str]
+    reason: NotRequired[str]
+    error_id: NotRequired[str]
+
+
+class SlashCommandResponse(TypedDict):
+    response_type: Literal["ephemeral", "in_channel"]
+    text: str
+
+
+class ChallengeResponse(TypedDict):
+    challenge: str
+
+
+class BlockSuggestionResponse(TypedDict):
+    options: list[JsonObject]
+
+
+class HealthResponse(TypedDict):
+    status: Literal["ok"]
+    message: str
+
+
+def accepted(message: str) -> WebhookResponse:
+    return {"status": "accepted", "message": message}
+
+
+def ignored(reason: str) -> WebhookResponse:
+    return {"status": "ignored", "reason": reason}
+
+
+def failed(error_id: str) -> WebhookResponse:
+    return {"status": "error", "error_id": error_id}
+
+
+def ephemeral(text: str) -> SlashCommandResponse:
+    return {"response_type": "ephemeral", "text": text}

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -147,6 +147,19 @@ async def _process_slack_message_update(
     message_ts: str,
     user_id: str,
 ) -> None:
+    await run_slack_task(
+        SlackRequestTarget(channel_id=channel_id, thread_ts=thread_ts),
+        _process_slack_message_update_impl(event_data, channel_id, thread_ts, message_ts, user_id),
+    )
+
+
+async def _process_slack_message_update_impl(
+    event_data: dict[str, Any],
+    channel_id: str,
+    thread_ts: str,
+    message_ts: str,
+    user_id: str,
+) -> None:
     langgraph_client = get_langgraph_client()
     thread_id, delivered_message = await _lookup_delivered_message_update(
         langgraph_client,
@@ -455,15 +468,12 @@ async def slack_webhook(
                     "reply_thread_ts": reply_thread_ts if in_code_channel else "",
                 }
                 background_tasks.add_task(
-                    run_slack_task,
-                    target,
-                    _process_slack_message_update(
-                        event_data,
-                        channel_id,
-                        thread_ts,
-                        original_message_ts,
-                        user_id,
-                    ),
+                    _process_slack_message_update,
+                    event_data,
+                    channel_id,
+                    thread_ts,
+                    original_message_ts,
+                    user_id,
                 )
                 return {"status": "accepted", "message": "Slack update queued"}
             return {"status": "ignored", "reason": "Duplicate Slack event delivery"}

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -3,18 +3,38 @@
 import asyncio
 import hashlib
 from time import time_ns
-from typing import Any
 
 from fastapi import APIRouter
 from langgraph_sdk.client import LangGraphClient
 
 from agent.slack import webhook as service
+from agent.slack.client import SlackChannelContext
 from agent.slack.failures import (
     SlackRequestError,
     SlackRequestTarget,
     answer_slack_request,
     run_slack_task,
 )
+from agent.slack.payloads import (
+    SlackBlockAction,
+    SlackButtonValue,
+    SlackEventEnvelope,
+    SlackInteraction,
+    SlackInteractionMessage,
+    parse_json_object,
+)
+from agent.slack.request import SlackRequest
+from agent.slack.responses import (
+    BlockSuggestionResponse,
+    ChallengeResponse,
+    HealthResponse,
+    SlashCommandResponse,
+    WebhookResponse,
+    accepted,
+    ephemeral,
+    ignored,
+)
+from agent.utils.json_types import JsonObject
 from agent.utils.thread_ops import langgraph_client as get_langgraph_client
 from agent.webhooks import common
 
@@ -22,19 +42,7 @@ router = APIRouter()
 
 _MESSAGE_UPDATE_RETRY_DELAYS = (0.1, 0.2, 0.5, 1, 2, 4, 8, 14)
 _EXTERNAL_CHANNEL_REFUSAL = "Open SWE does not operate in channels with external participants."
-
-
-def _event_channel_id(event: dict[str, Any]) -> str:
-    channel = event.get("channel")
-    if isinstance(channel, str):
-        return channel
-    if isinstance(channel, dict) and isinstance(channel.get("id"), str):
-        return channel["id"]
-    item = event.get("item")
-    if isinstance(item, dict) and isinstance(item.get("channel"), str):
-        return item["channel"]
-    channel_id = event.get("channel_id")
-    return channel_id if isinstance(channel_id, str) else ""
+_OPTION_ACTION_ID = "open_swe_option_select"
 
 
 def _synthetic_slack_ts() -> str:
@@ -42,9 +50,20 @@ def _synthetic_slack_ts() -> str:
     return f"{timestamp // 1_000_000_000}.{timestamp % 1_000_000_000:09d}"
 
 
-def _bounded_payload_text(label: str, payload: dict[str, Any]) -> str:
+def _bounded_payload_text(label: str, payload: JsonObject) -> str:
     serialized = common.json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
     return f"{label}\n```json\n{serialized[:8000]}\n```"
+
+
+def _verify_signature(request: common.Request, body: bytes, what: str) -> None:
+    if not common.verify_slack_signature(
+        body=body,
+        timestamp=request.headers.get("X-Slack-Request-Timestamp", ""),
+        signature=request.headers.get("X-Slack-Signature", ""),
+        secret=common.SLACK_SIGNING_SECRET,
+    ):
+        common.logger.warning("Invalid Slack signature", extra={"slack_endpoint": what})
+        raise common.HTTPException(status_code=401, detail="Invalid signature")
 
 
 async def _queue_code_channel_turn(
@@ -57,28 +76,28 @@ async def _queue_code_channel_turn(
     event_ts: str,
     explicit_request: bool,
     team_id: str = "",
-) -> dict[str, str]:
+) -> WebhookResponse:
     if not channel_id or not user_id or not text or not event_id or not event_ts:
-        return {"status": "ignored", "reason": "Missing code channel interaction fields"}
+        return ignored("Missing code channel interaction fields")
     if not await common.is_code_channel(channel_id):
-        return {"status": "ignored", "reason": "Not a code channel"}
+        return ignored("Not a code channel")
 
     target = SlackRequestTarget(
         channel_id=channel_id, thread_ts=common.CODE_CHANNEL_SESSION_TS, event_id=event_id
     )
 
-    async def dispatch() -> dict[str, str]:
+    async def dispatch() -> WebhookResponse:
         client = get_langgraph_client()
         thread_id = await common.lookup_slack_thread_id(
             client, channel_id, common.CODE_CHANNEL_SESSION_TS
         )
         if not thread_id:
-            return {"status": "ignored", "reason": "Code channel is not associated"}
+            return ignored("Code channel is not associated")
         if not await common.claim_slack_event(event_id, channel_id, event_ts):
-            return {"status": "ignored", "reason": "Duplicate code channel interaction"}
+            return ignored("Duplicate code channel interaction")
 
         channel_context = await common.resolve_slack_channel_context(channel_id)
-        repo_config = await common.get_slack_repo_config(
+        repo = await common.get_slack_repo_config(
             channel_id,
             common.CODE_CHANNEL_SESSION_TS,
             slack_user_id=user_id,
@@ -87,25 +106,25 @@ async def _queue_code_channel_turn(
         )
         background_tasks.add_task(
             service.process_slack_mention,
-            {
-                "channel_id": channel_id,
-                "channel_context": channel_context,
-                "thread_ts": common.CODE_CHANNEL_SESSION_TS,
-                "event_ts": event_ts,
-                "original_message_ts": event_ts,
-                "user_id": user_id,
-                "text": text,
-                "attachments": [],
-                "bot_user_id": common.SLACK_BOT_USER_ID,
-                "thread_id": thread_id,
-                "treat_all_messages_as_mentions": True,
-                "code_channel": True,
-                "explicit_request": explicit_request,
-                "team_id": team_id,
-            },
-            repo_config,
+            SlackRequest(
+                channel_id=channel_id,
+                channel_context=channel_context,
+                thread_ts=common.CODE_CHANNEL_SESSION_TS,
+                event_ts=event_ts,
+                original_message_ts=event_ts,
+                event_id=event_id,
+                user_id=user_id,
+                text=text,
+                bot_user_id=common.SLACK_BOT_USER_ID,
+                thread_id=thread_id,
+                treat_all_messages_as_mentions=True,
+                code_channel=True,
+                explicit_request=explicit_request,
+                team_id=team_id,
+            ),
+            repo,
         )
-        return {"status": "accepted", "message": "Code channel interaction queued"}
+        return accepted("Code channel interaction queued")
 
     return await answer_slack_request(target, dispatch)
 
@@ -116,7 +135,7 @@ async def _lookup_delivered_message_update(
     thread_ts: str,
     message_ts: str,
     user_id: str,
-) -> tuple[str | None, dict[str, Any] | None]:
+) -> tuple[str | None, JsonObject | None]:
     for delay in (*_MESSAGE_UPDATE_RETRY_DELAYS, None):
         try:
             thread_id = await common.lookup_slack_thread_id(langgraph_client, channel_id, thread_ts)
@@ -140,107 +159,90 @@ async def _lookup_delivered_message_update(
     return None, None
 
 
-async def _process_slack_message_update(
-    event_data: dict[str, Any],
-    channel_id: str,
-    thread_ts: str,
-    message_ts: str,
-    user_id: str,
-) -> None:
-    await run_slack_task(
-        SlackRequestTarget(channel_id=channel_id, thread_ts=thread_ts),
-        _process_slack_message_update_impl(event_data, channel_id, thread_ts, message_ts, user_id),
-    )
+async def _process_slack_message_update(request: SlackRequest) -> None:
+    await run_slack_task(request.target, _process_slack_message_update_impl(request))
 
 
-async def _process_slack_message_update_impl(
-    event_data: dict[str, Any],
-    channel_id: str,
-    thread_ts: str,
-    message_ts: str,
-    user_id: str,
-) -> None:
+async def _process_slack_message_update_impl(request: SlackRequest) -> None:
     langgraph_client = get_langgraph_client()
     thread_id, delivered_message = await _lookup_delivered_message_update(
         langgraph_client,
-        channel_id,
-        thread_ts,
-        message_ts,
-        user_id,
+        request.channel_id,
+        request.thread_ts,
+        request.original_message_ts,
+        request.user_id,
     )
     if not thread_id or not delivered_message:
         common.logger.info(
             "Ignoring undelivered Slack message update channel=%s message=%s",
-            channel_id,
-            message_ts,
+            request.channel_id,
+            request.original_message_ts,
         )
         return
-    channel_context = await common.resolve_slack_channel_context(channel_id, use_cache=False)
+    channel_context = await common.resolve_slack_channel_context(
+        request.channel_id, use_cache=False
+    )
     if not common.slack_channel_allows_operations(channel_context):
-        common.logger.warning("Blocked Slack message update in ineligible channel=%s", channel_id)
+        common.logger.warning(
+            "Blocked Slack message update in ineligible channel=%s", request.channel_id
+        )
         return
-    event_data["thread_id"] = thread_id
-    event_data["channel_context"] = channel_context
-    repo_config = await common.get_slack_repo_config(
-        channel_id,
-        thread_ts,
-        slack_user_id=user_id,
+    repo = await common.get_slack_repo_config(
+        request.channel_id,
+        request.thread_ts,
+        slack_user_id=request.user_id,
         channel_context=channel_context,
         thread_id=thread_id,
     )
-    await service.process_slack_mention(event_data, repo_config)
+    await service.process_slack_mention(
+        request.model_copy(update={"thread_id": thread_id, "channel_context": channel_context}),
+        repo,
+    )
 
 
 @router.post("/webhooks/slack")
 async def slack_webhook(
     request: common.Request, background_tasks: common.BackgroundTasks
-) -> dict[str, str]:
+) -> WebhookResponse | ChallengeResponse:
     """Handle Slack Event API webhooks for app mentions."""
     body = await request.body()
+    _verify_signature(request, body, "events")
 
-    signature = request.headers.get("X-Slack-Signature", "")
-    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
-    if not common.verify_slack_signature(
-        body=body,
-        timestamp=timestamp,
-        signature=signature,
-        secret=common.SLACK_SIGNING_SECRET,
-    ):
-        common.logger.warning("Invalid Slack signature")
-        raise common.HTTPException(status_code=401, detail="Invalid signature")
-
-    try:
-        payload = common.json.loads(body)
-    except common.json.JSONDecodeError:
-        common.logger.exception("Failed to parse Slack webhook JSON")
+    payload = parse_json_object(body)
+    if payload is None:
+        common.logger.warning("Failed to parse Slack webhook JSON")
         return {"status": "error", "message": "Invalid JSON"}
+    envelope = SlackEventEnvelope.parse(payload)
+    if envelope is None:
+        return ignored("Invalid Slack event")
 
-    if payload.get("type") == "url_verification":
-        challenge = payload.get("challenge", "")
-        return {"challenge": challenge}
+    if envelope.type == "url_verification":
+        return {"challenge": envelope.challenge}
+    if envelope.type != "event_callback":
+        return ignored("Not an event callback")
+    event = envelope.event
+    if event is None:
+        return ignored("Invalid Slack event")
+    raw_event = payload.get("event")
+    if not isinstance(raw_event, dict):
+        return ignored("Invalid Slack event")
 
-    if payload.get("type") != "event_callback":
-        return {"status": "ignored", "reason": "Not an event callback"}
-
-    event = payload.get("event", {})
-    if not isinstance(event, dict):
-        return {"status": "ignored", "reason": "Invalid Slack event"}
-
-    event_id = str(payload.get("event_id") or "")
-    team_id = str(payload.get("team_id") or event.get("team") or "")
-    channel_id = _event_channel_id(event)
-    channel_context: dict[str, Any] | None = None
+    event_id = envelope.event_id
+    team_id = envelope.team_id or event.team
+    channel_id = event.resolve_channel_id()
+    channel_context: SlackChannelContext | None = None
     if channel_id:
         channel_context = await common.resolve_slack_channel_context(channel_id, use_cache=False)
         if not common.slack_channel_allows_operations(channel_context):
             is_external = channel_context.get("is_ext_shared") is True
-            event_ts = str(event.get("event_ts") or event.get("ts") or "")
-            thread_ts = str(event.get("thread_ts") or event.get("ts") or "")
+            event_ts = event.event_ts or event.ts
+            thread_ts = event.thread_ts or event.ts
             if (
                 is_external
-                and event.get("type") == "app_mention"
-                and event.get("subtype") is None
-                and isinstance(event.get("user"), str)
+                and event.type == "app_mention"
+                and not event.subtype
+                and isinstance(event.user, str)
+                and event.user
                 and thread_ts
                 and await common.claim_slack_event(event_id, channel_id, event_ts)
             ):
@@ -255,138 +257,88 @@ async def slack_webhook(
                 "external" if is_external else "unverified",
                 channel_id,
             )
-            return {"status": "ignored", "reason": "Slack channel is not eligible"}
+            return ignored("Slack channel is not eligible")
 
-    if event.get("type") == "code_channel_action":
-        action_value = event.get("action")
-        item_value = event.get("item")
-        action: dict[str, Any] = action_value if isinstance(action_value, dict) else {}
-        item: dict[str, Any] = item_value if isinstance(item_value, dict) else {}
-        user = event.get("user")
-        user_id = str(
-            user.get("id") if isinstance(user, dict) else user or event.get("user_id") or ""
-        )
-        channel = event.get("channel")
-        action_channel_id = str(
-            channel.get("id")
-            if isinstance(channel, dict)
-            else channel or event.get("channel_id") or ""
-        )
-        event_ts = str(event.get("event_ts") or event.get("action_ts") or _synthetic_slack_ts())
-        action_payload = {
-            "key": event.get("key") or action.get("key") or item.get("key"),
-            "label": event.get("label") or action.get("label") or item.get("label"),
-            "value": event.get("value") or action.get("value") or item.get("value"),
+    if event.type == "code_channel_action":
+        action = event.action
+        item = event.item
+        event_ts = event.event_ts or event.action_ts or _synthetic_slack_ts()
+        action_payload: JsonObject = {
+            "key": event.key or (action and action.key) or (item and item.key),
+            "label": event.label or (action and action.label) or (item and item.label),
+            "value": event.value or (action and action.value) or (item and item.value),
         }
         return await _queue_code_channel_turn(
             background_tasks,
-            channel_id=action_channel_id,
-            user_id=user_id,
+            channel_id=channel_id,
+            user_id=event.resolve_user_id(),
             text=_bounded_payload_text(
                 "A code channel context-bar action was selected.", action_payload
             ),
-            event_id=event_id or f"code-channel-action:{action_channel_id}:{event_ts}",
+            event_id=event_id or f"code-channel-action:{channel_id}:{event_ts}",
             event_ts=event_ts,
             explicit_request=True,
             team_id=team_id,
         )
 
-    if event.get("type") == "reaction_added":
-        reaction = event.get("reaction")
-        if reaction == "x":
-            background_tasks.add_task(
-                common.process_slack_stop_reaction, event, payload.get("event_id", "")
-            )
-            return {"status": "accepted", "message": "Stop reaction queued"}
-        if reaction in common.FEEDBACK_REACTIONS:
-            background_tasks.add_task(
-                common.process_slack_reaction_added, event, payload.get("event_id", "")
-            )
-            return {"status": "accepted", "message": "Reaction feedback queued"}
-        return {"status": "ignored", "reason": "Reaction not tracked for feedback"}
+    if event.type == "reaction_added":
+        if event.reaction == "x":
+            background_tasks.add_task(common.process_slack_stop_reaction, raw_event, event_id)
+            return accepted("Stop reaction queued")
+        if event.reaction in common.FEEDBACK_REACTIONS:
+            background_tasks.add_task(common.process_slack_reaction_added, raw_event, event_id)
+            return accepted("Reaction feedback queued")
+        return ignored("Reaction not tracked for feedback")
 
-    if event.get("type") == "reaction_removed":
-        reaction = event.get("reaction")
-        if reaction in common.FEEDBACK_REACTIONS:
-            background_tasks.add_task(
-                common.process_slack_reaction_removed, event, payload.get("event_id", "")
-            )
-            return {"status": "accepted", "message": "Reaction removal queued"}
-        return {"status": "ignored", "reason": "Reaction not tracked for feedback"}
+    if event.type == "reaction_removed":
+        if event.reaction in common.FEEDBACK_REACTIONS:
+            background_tasks.add_task(common.process_slack_reaction_removed, raw_event, event_id)
+            return accepted("Reaction removal queued")
+        return ignored("Reaction not tracked for feedback")
 
-    if event.get("type") == "agent_session_stopped":
-        background_tasks.add_task(
-            common.process_agent_session_stopped, event, str(payload.get("event_id") or "")
-        )
-        return {"status": "accepted", "message": "Session stop queued"}
+    if event.type == "agent_session_stopped":
+        background_tasks.add_task(common.process_agent_session_stopped, raw_event, event_id)
+        return accepted("Session stop queued")
 
     retry_num = request.headers.get("X-Slack-Retry-Num", "")
     if retry_num and await common.slack_event_already_seen(event_id):
         common.logger.info(
             "Ignoring Slack retry %s of already-handled event %s", retry_num, event_id
         )
-        return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
+        return ignored("Duplicate Slack event delivery")
 
-    bot_user_id = common.SLACK_BOT_USER_ID
-    if not bot_user_id:
-        authorizations = payload.get("authorizations", [])
-        if isinstance(authorizations, list) and authorizations:
-            auth_user_id = authorizations[0].get("user_id")
-            if isinstance(auth_user_id, str):
-                bot_user_id = auth_user_id
-    if not bot_user_id:
-        authed_users = payload.get("authed_users", [])
-        if isinstance(authed_users, list) and authed_users:
-            first_user = authed_users[0]
-            if isinstance(first_user, str):
-                bot_user_id = first_user
+    bot_user_id = envelope.bot_user_id(common.SLACK_BOT_USER_ID)
 
-    is_message_update = event.get("type") == "message" and event.get("subtype") == "message_changed"
-    updated_message = event.get("message") if is_message_update else event
-    if not isinstance(updated_message, dict):
-        return {"status": "ignored", "reason": "Invalid updated message"}
-
-    event_ts = event.get("event_ts") or event.get("ts")
-    original_message_ts = updated_message.get("ts")
-    thread_ts = updated_message.get("thread_ts") or original_message_ts
-    reply_thread_ts = updated_message.get("thread_ts")
-    if not isinstance(reply_thread_ts, str):
-        reply_thread_ts = ""
-    user_id = updated_message.get("user")
-    text = updated_message.get("text")
-    attachments = updated_message.get("attachments", [])
-    if not (
-        isinstance(channel_id, str)
-        and channel_id
-        and isinstance(event_ts, str)
-        and event_ts
-        and isinstance(original_message_ts, str)
-        and original_message_ts
-        and isinstance(thread_ts, str)
-        and thread_ts
-        and isinstance(user_id, str)
-        and user_id
-        and isinstance(text, str)
+    is_message_update = event.type == "message" and event.subtype == "message_changed"
+    updated_message = event.message if is_message_update else event
+    if updated_message is None:
+        return ignored("Invalid updated message")
+    event_ts = event.event_ts or event.ts
+    original_message_ts = updated_message.ts
+    reply_thread_ts = updated_message.thread_ts
+    thread_ts = reply_thread_ts or original_message_ts
+    user_id = updated_message.user if isinstance(updated_message.user, str) else ""
+    text = updated_message.text
+    attachments = updated_message.attachments
+    if not (channel_id and event_ts and original_message_ts and thread_ts and user_id) or (
+        text is None
     ):
-        return {"status": "ignored", "reason": "Missing channel/message fields"}
-    if not isinstance(attachments, list):
-        attachments = []
+        return ignored("Missing channel/message fields")
     if is_message_update:
-        previous_message = event.get("previous_message")
-        if not isinstance(previous_message, dict):
-            return {"status": "ignored", "reason": "Invalid previous message"}
-        previous_ts = previous_message.get("ts")
-        previous_thread_ts = previous_message.get("thread_ts") or previous_ts
+        previous_message = event.previous_message
+        if previous_message is None:
+            return ignored("Invalid previous message")
+        previous_thread_ts = previous_message.thread_ts or previous_message.ts
         if (
-            previous_message.get("user") != user_id
-            or previous_ts != original_message_ts
+            previous_message.user != user_id
+            or previous_message.ts != original_message_ts
             or previous_thread_ts != thread_ts
         ):
-            return {"status": "ignored", "reason": "Updated message identity changed"}
+            return ignored("Updated message identity changed")
         # Link unfurls arrive as edits that only add `attachments`, so comparing
         # them starts a run for text the agent has already been given.
-        if text == previous_message.get("text"):
-            return {"status": "ignored", "reason": "No user-visible message changes"}
+        if text == previous_message.text:
+            return ignored("No user-visible message changes")
 
     # A code channel is one session for the whole channel, so every message in it
     # routes to the same agent thread and is treated as directed at the agent.
@@ -394,11 +346,9 @@ async def slack_webhook(
     if in_code_channel:
         thread_ts = common.CODE_CHANNEL_SESSION_TS
 
-    is_direct_message = (
-        not is_message_update and event.get("channel_type") == "im" and bool(user_id)
-    )
+    is_direct_message = not is_message_update and event.channel_type == "im" and bool(user_id)
     is_untagged_two_party_reply = False
-    if event.get("type") != "app_mention" and not is_message_update and not in_code_channel:
+    if event.type != "app_mention" and not is_message_update and not in_code_channel:
         has_username_mention = bool(
             common.SLACK_BOT_USERNAME and f"@{common.SLACK_BOT_USERNAME}" in text
         )
@@ -406,19 +356,17 @@ async def slack_webhook(
         is_ready_plan_reply = bool(
             not is_direct_message
             and await service.slack_user_can_reply_to_ready_plan(
-                channel_id,
-                str(event.get("thread_ts") or ""),
-                user_id,
+                channel_id, event.thread_ts, user_id
             )
         )
         is_untagged_two_party_reply = bool(
-            not event.get("subtype")
+            not event.subtype
             and not is_direct_message
             and not has_username_mention
             and not has_id_mention
             and await service.slack_thread_allows_untagged_reply(
                 channel_id,
-                str(event.get("thread_ts") or ""),
+                event.thread_ts,
                 text,
                 bot_user_id,
                 user_id,
@@ -435,103 +383,86 @@ async def slack_webhook(
             )
         )
         if not should_handle_message:
-            return {"status": "ignored", "reason": "Not an app mention, DM, or plan reply"}
+            return ignored("Not an app mention, DM, or plan reply")
 
-    if (
-        event.get("subtype") == "bot_message"
-        or event.get("bot_id")
-        or updated_message.get("subtype") == "bot_message"
-        or updated_message.get("bot_id")
-    ):
-        return {"status": "ignored", "reason": "Event from a bot"}
+    if event.is_from_bot or updated_message.is_from_bot:
+        return ignored("Event from a bot")
 
     if bot_user_id and user_id == bot_user_id:
-        return {"status": "ignored", "reason": "Event from this bot user"}
+        return ignored("Event from this bot user")
 
     # From here on the message is addressed to Open SWE: any failure is reported to the thread.
     target = SlackRequestTarget(channel_id=channel_id, thread_ts=thread_ts, event_id=event_id)
 
-    async def dispatch() -> dict[str, str]:
+    async def dispatch() -> WebhookResponse:
         if is_message_update:
             if await common.claim_slack_event(event_id, channel_id, event_ts):
-                event_data = {
-                    "channel_id": channel_id,
-                    "thread_ts": thread_ts,
-                    "event_ts": event_ts,
-                    "original_message_ts": original_message_ts,
-                    "user_id": user_id,
-                    "text": text,
-                    "attachments": attachments,
-                    "bot_user_id": bot_user_id,
-                    "message_update": True,
-                    "code_channel": in_code_channel,
-                    "reply_thread_ts": reply_thread_ts if in_code_channel else "",
-                }
                 background_tasks.add_task(
                     _process_slack_message_update,
-                    event_data,
-                    channel_id,
-                    thread_ts,
-                    original_message_ts,
-                    user_id,
+                    SlackRequest(
+                        channel_id=channel_id,
+                        thread_ts=thread_ts,
+                        event_ts=event_ts,
+                        original_message_ts=original_message_ts,
+                        event_id=event_id,
+                        user_id=user_id,
+                        text=text,
+                        attachments=attachments,
+                        bot_user_id=bot_user_id,
+                        message_update=True,
+                        code_channel=in_code_channel,
+                        reply_thread_ts=reply_thread_ts if in_code_channel else "",
+                    ),
                 )
-                return {"status": "accepted", "message": "Slack update queued"}
-            return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
+                return accepted("Slack update queued")
+            return ignored("Duplicate Slack event delivery")
 
         if channel_context is None:
-            return {"status": "ignored", "reason": "Slack channel is not eligible"}
+            return ignored("Slack channel is not eligible")
 
-        if await common.is_docs_plz_slack_channel(channel_id, channel_context):
-            if await common.claim_slack_event(event_id, channel_id, event_ts):
-                background_tasks.add_task(
-                    common.post_slack_thread_reply,
-                    channel_id,
-                    thread_ts,
-                    common.DOCS_PLZ_SLACK_GATE_REPLY,
-                )
-                return {"status": "accepted", "message": "Slack mention gated for docs-plz"}
-        else:
-            try:
-                thread_id = await common.resolve_slack_thread_id(
-                    get_langgraph_client(), channel_id, thread_ts
-                )
-            except common.SlackThreadMappingError as exc:
-                raise SlackRequestError(
-                    "Open SWE found conflicting state for this Slack thread and will not guess "
-                    "which agent thread to use."
-                ) from exc
-            event_data = {
-                "channel_id": channel_id,
-                "channel_context": channel_context,
-                "thread_ts": thread_ts,
-                "event_ts": event_ts,
-                "original_message_ts": original_message_ts,
-                "user_id": user_id,
-                "text": text,
-                "attachments": attachments,
-                "bot_user_id": bot_user_id,
-                "thread_id": thread_id,
-                "treat_all_messages_as_mentions": is_direct_message or in_code_channel,
-                "untagged_reply": is_untagged_two_party_reply,
-                "message_update": is_message_update,
-                "code_channel": in_code_channel,
-                "reply_thread_ts": reply_thread_ts if in_code_channel else "",
-                "team_id": team_id,
-                "app_context": updated_message.get("app_context") or event.get("app_context"),
-            }
-            repo_config = await common.get_slack_repo_config(
-                channel_id,
-                thread_ts,
-                slack_user_id=user_id,
-                channel_context=channel_context,
-                thread_id=thread_id,
+        try:
+            thread_id = await common.resolve_slack_thread_id(
+                get_langgraph_client(), channel_id, thread_ts
             )
-            if await common.claim_slack_event(event_id, channel_id, event_ts):
-                background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
-                return {"status": "accepted", "message": "Slack mention queued"}
+        except common.SlackThreadMappingError as exc:
+            raise SlackRequestError(
+                "Open SWE found conflicting state for this Slack thread and will not guess "
+                "which agent thread to use."
+            ) from exc
+        repo = await common.get_slack_repo_config(
+            channel_id,
+            thread_ts,
+            slack_user_id=user_id,
+            channel_context=channel_context,
+            thread_id=thread_id,
+        )
+        if await common.claim_slack_event(event_id, channel_id, event_ts):
+            background_tasks.add_task(
+                service.process_slack_mention,
+                SlackRequest(
+                    channel_id=channel_id,
+                    channel_context=channel_context,
+                    thread_ts=thread_ts,
+                    event_ts=event_ts,
+                    original_message_ts=original_message_ts,
+                    event_id=event_id,
+                    user_id=user_id,
+                    text=text,
+                    attachments=attachments,
+                    bot_user_id=bot_user_id,
+                    thread_id=thread_id,
+                    treat_all_messages_as_mentions=is_direct_message or in_code_channel,
+                    untagged_reply=is_untagged_two_party_reply,
+                    code_channel=in_code_channel,
+                    reply_thread_ts=reply_thread_ts if in_code_channel else "",
+                    team_id=team_id,
+                ),
+                repo,
+            )
+            return accepted("Slack mention queued")
 
         common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
-        return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
+        return ignored("Duplicate Slack event delivery")
 
     return await answer_slack_request(target, dispatch)
 
@@ -539,19 +470,10 @@ async def slack_webhook(
 @router.post("/webhooks/slack/code-channel-commands")
 async def slack_code_channel_command(
     request: common.Request, background_tasks: common.BackgroundTasks
-) -> dict[str, str]:
+) -> SlashCommandResponse:
     """Handle runtime slash commands registered for a Slack code channel."""
     body = await request.body()
-    signature = request.headers.get("X-Slack-Signature", "")
-    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
-    if not common.verify_slack_signature(
-        body=body,
-        timestamp=timestamp,
-        signature=signature,
-        secret=common.SLACK_SIGNING_SECRET,
-    ):
-        common.logger.warning("Invalid Slack code channel command signature")
-        raise common.HTTPException(status_code=401, detail="Invalid signature")
+    _verify_signature(request, body, "code-channel-commands")
 
     form = common.parse_qs(body.decode("utf-8"))
     value = lambda key: str((form.get(key) or [""])[0]).strip()  # noqa: E731
@@ -562,7 +484,7 @@ async def slack_code_channel_command(
     trigger_id = value("trigger_id")
     team_id = value("team_id")
     if not (channel_id and user_id and 1 <= len(command) <= 31 and len(command_text) <= 4000):
-        return {"response_type": "ephemeral", "text": "That code-channel command was invalid."}
+        return ephemeral("That code-channel command was invalid.")
 
     event_ts = _synthetic_slack_ts()
     event_id = f"code-channel-command:{trigger_id or hashlib.sha256(body).hexdigest()}"
@@ -578,148 +500,97 @@ async def slack_code_channel_command(
         team_id=team_id,
     )
     if result["status"] != "accepted":
-        return {
-            "response_type": "ephemeral",
-            "text": "Open SWE could not route that command to this code channel.",
-        }
-    return {"response_type": "ephemeral", "text": f"Working on /{command}…"}
+        return ephemeral("Open SWE could not route that command to this code channel.")
+    return ephemeral(f"Working on /{command}…")
 
 
 @router.post("/webhooks/slack/interactivity")
 async def slack_interactivity(
     request: common.Request, background_tasks: common.BackgroundTasks
-) -> dict[str, Any]:
+) -> WebhookResponse | BlockSuggestionResponse:
     """Handle Slack Block Kit interactions."""
     body = await request.body()
-    signature = request.headers.get("X-Slack-Signature", "")
-    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
-    if not common.verify_slack_signature(
-        body=body,
-        timestamp=timestamp,
-        signature=signature,
-        secret=common.SLACK_SIGNING_SECRET,
-    ):
-        common.logger.warning("Invalid Slack interactivity signature")
-        raise common.HTTPException(status_code=401, detail="Invalid signature")
+    _verify_signature(request, body, "interactivity")
 
     form = common.parse_qs(body.decode("utf-8"))
     payload_raw = (form.get("payload") or [""])[0]
-    try:
-        payload = common.json.loads(payload_raw)
-    except common.json.JSONDecodeError:
-        common.logger.exception("Failed to parse Slack interactivity payload")
+    payload = parse_json_object(payload_raw.encode("utf-8"))
+    if payload is None:
+        common.logger.warning("Failed to parse Slack interactivity payload")
         return {"status": "error", "message": "Invalid payload"}
+    interaction = SlackInteraction.parse(payload)
+    if interaction is None:
+        return ignored("Invalid Slack interaction")
 
-    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
-    if payload.get("type") == "block_suggestion" and container.get("type") == "code_channel_view":
-        channel_id = str(container.get("channel_id") or "")
-        view_id = str(container.get("view_id") or "")
-        action_id = str(payload.get("action_id") or "")
-        if not channel_id or not view_id or not action_id:
+    if interaction.type == "block_suggestion" and interaction.container.type == "code_channel_view":
+        if not (interaction.channel_id and interaction.container.view_id and interaction.action_id):
             return {"options": []}
         options = await common.get_block_suggestions(
             get_langgraph_client(),
-            channel_id,
-            view_id,
-            action_id,
-            str(payload.get("value") or "")[:200],
+            interaction.channel_id,
+            interaction.container.view_id,
+            interaction.action_id,
+            interaction.value[:200],
         )
         return {"options": options}
-    if payload.get("type") == "block_actions" and container.get("type") == "code_channel_view":
-        actions = payload.get("actions") if isinstance(payload.get("actions"), list) else []
-        user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
-        first_action = actions[0] if actions and isinstance(actions[0], dict) else {}
-        event_ts = str(first_action.get("action_ts") or _synthetic_slack_ts())
-        safe_actions = [
-            {
-                key: action[key]
-                for key in (
-                    "action_id",
-                    "type",
-                    "value",
-                    "selected_option",
-                    "selected_options",
-                    "selected_user",
-                    "selected_users",
-                    "selected_conversation",
-                    "selected_conversations",
-                    "selected_channel",
-                    "selected_channels",
-                    "selected_date",
-                    "selected_time",
-                    "selected_date_time",
-                )
-                if key in action
-            }
-            for action in actions[:10]
-            if isinstance(action, dict)
-        ]
-        interaction = {
-            "view_id": container.get("view_id"),
-            "actions": safe_actions,
+    if interaction.type == "block_actions" and interaction.container.type == "code_channel_view":
+        first_action = interaction.actions[0] if interaction.actions else None
+        event_ts = (first_action.action_ts if first_action else "") or _synthetic_slack_ts()
+        summary: JsonObject = {
+            "view_id": interaction.container.view_id,
+            "actions": [action.summary() for action in interaction.actions[:10]],
         }
         payload_fingerprint = hashlib.sha256(payload_raw.encode()).hexdigest()
         return await _queue_code_channel_turn(
             background_tasks,
-            channel_id=str(container.get("channel_id") or ""),
-            user_id=str(user.get("id") or ""),
+            channel_id=interaction.channel_id,
+            user_id=interaction.user.id,
             text=_bounded_payload_text(
-                "A user interacted with a code channel Block Kit view.", interaction
+                "A user interacted with a code channel Block Kit view.", summary
             ),
-            event_id=f"code-channel-view:{payload.get('trigger_id') or payload_fingerprint}",
+            event_id=f"code-channel-view:{interaction.trigger_id or payload_fingerprint}",
             event_ts=event_ts,
             explicit_request=True,
         )
 
-    action = _first_open_swe_option_action(payload.get("actions"))
+    action = _first_option_action(interaction.actions)
     if action is None:
-        return {"status": "ignored", "reason": "No Open SWE action"}
+        return ignored("No Open SWE action")
 
-    channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
-    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
-    channel_id = str(channel.get("id") or container.get("channel_id") or "")
+    channel_id = interaction.channel_id
     if not channel_id:
-        return {"status": "ignored", "reason": "Slack channel is not eligible"}
+        return ignored("Slack channel is not eligible")
     channel_context = await common.resolve_slack_channel_context(channel_id, use_cache=False)
     if not common.slack_channel_allows_operations(channel_context):
         common.logger.warning("Blocked Slack interaction in ineligible channel=%s", channel_id)
-        return {"status": "ignored", "reason": "Slack channel is not eligible"}
+        return ignored("Slack channel is not eligible")
 
-    try:
-        action_value = common.json.loads(str(action.get("value") or "{}"))
-    except common.json.JSONDecodeError:
-        return {"status": "ignored", "reason": "Invalid action value"}
+    button = SlackButtonValue.parse(parse_json_object((action.value or "{}").encode("utf-8")))
+    if button is None:
+        return ignored("Invalid action value")
 
-    message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
-    user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
-    user_id = str(user.get("id") or "")
-    action_ts = str(
-        action.get("action_ts") or message.get("ts") or container.get("message_ts") or ""
-    )
-    thread_ts = str(
-        message.get("thread_ts") or message.get("ts") or container.get("thread_ts") or ""
-    )
+    user_id = interaction.user.id
+    action_ts = action.action_ts or interaction.message_ts
+    thread_ts = interaction.thread_ts
 
     # From here on the interaction is addressed to Open SWE: any failure is reported to the thread.
     target = SlackRequestTarget(channel_id=channel_id, thread_ts=thread_ts or action_ts)
 
-    async def dispatch() -> dict[str, str]:
-        if action_value.get("type") == "workflow_push_approval":
-            workflow_action = str(action_value.get("action") or "").strip()
-            fingerprint = str(action_value.get("fingerprint") or "").strip()
-            if not channel_id or not thread_ts or not fingerprint:
-                return {"status": "ignored", "reason": "Missing workflow approval context"}
+    async def dispatch() -> WebhookResponse:
+        if button.type == "workflow_push_approval":
+            if not channel_id or not thread_ts or not button.fingerprint:
+                return ignored("Missing workflow approval context")
 
             thread_id = await common.lookup_slack_thread_id(
                 get_langgraph_client(), channel_id, thread_ts
             )
             if not thread_id:
-                return {"status": "ignored", "reason": "Slack thread is not associated"}
-            if workflow_action not in {"approve", "reject"}:
-                return {"status": "ignored", "reason": "Unknown workflow approval action"}
-            approved = workflow_action == "approve"
+                return ignored("Slack thread is not associated")
+            if button.action not in {"approve", "reject"}:
+                return ignored("Unknown workflow approval action")
+            approved = button.action == "approve"
             record = await common.decide_workflow_push_approval(
-                thread_id, fingerprint, approved=approved, actor=user_id
+                thread_id, button.fingerprint, approved=approved, actor=user_id
             )
             if record is None:
                 await common.post_slack_thread_reply(
@@ -728,10 +599,10 @@ async def slack_interactivity(
                     text="I couldn't find that workflow approval request. Trigger the push again to create a fresh approval.",
                     agent_thread_id=thread_id,
                 )
-                return {"status": "ignored", "reason": "workflow approval not found"}
+                return ignored("workflow approval not found")
             background_tasks.add_task(
                 _update_selected_option_message,
-                payload,
+                interaction,
                 action,
                 "Approve workflow push" if approved else "Reject workflow push",
             )
@@ -739,18 +610,18 @@ async def slack_interactivity(
                 await common.post_slack_thread_reply(
                     channel_id=channel_id,
                     thread_ts=thread_ts,
-                    text=f"Workflow push rejected for fingerprint `{fingerprint}`. No workflow files will be pushed.",
+                    text=f"Workflow push rejected for fingerprint `{button.fingerprint}`. No workflow files will be pushed.",
                     agent_thread_id=thread_id,
                 )
-                return {"status": "accepted", "message": "Workflow push rejected"}
+                return accepted("Workflow push rejected")
 
             await common.post_slack_thread_reply(
                 channel_id=channel_id,
                 thread_ts=thread_ts,
-                text=f"Workflow push approved for fingerprint `{fingerprint}`. Open SWE will retry the blocked push.",
+                text=f"Workflow push approved for fingerprint `{button.fingerprint}`. Open SWE will retry the blocked push.",
                 agent_thread_id=thread_id,
             )
-            repo_config = await common.get_slack_repo_config(
+            repo = await common.get_slack_repo_config(
                 channel_id,
                 thread_ts,
                 slack_user_id=user_id,
@@ -759,37 +630,36 @@ async def slack_interactivity(
             )
             background_tasks.add_task(
                 service.process_slack_mention,
-                {
-                    "channel_id": channel_id,
-                    "channel_context": channel_context,
-                    "thread_ts": thread_ts,
-                    "event_ts": str(message.get("ts") or ""),
-                    "user_id": user_id,
-                    "text": (
+                SlackRequest(
+                    channel_id=channel_id,
+                    channel_context=channel_context,
+                    thread_ts=thread_ts,
+                    event_ts=interaction.message.ts,
+                    user_id=user_id,
+                    text=(
                         "The workflow-file push approval was approved. Retry the blocked "
                         "git push now; do not alter workflow files before pushing."
                     ),
-                    "bot_user_id": common.SLACK_BOT_USER_ID,
-                    "thread_id": thread_id,
-                },
-                repo_config,
+                    bot_user_id=common.SLACK_BOT_USER_ID,
+                    thread_id=thread_id,
+                ),
+                repo,
             )
-            return {"status": "accepted", "message": "Workflow push approved, retry queued"}
+            return accepted("Workflow push approved, retry queued")
 
-        if action_value.get("type") == "plan_approval":
-            plan_action = str(action_value.get("action") or "").strip()
+        if button.type == "plan_approval":
             if not channel_id or not thread_ts:
-                return {"status": "ignored", "reason": "Missing Slack action context"}
+                return ignored("Missing Slack action context")
 
             thread_id = await common.lookup_slack_thread_id(
                 get_langgraph_client(), channel_id, thread_ts
             )
             if not thread_id:
-                return {"status": "ignored", "reason": "Slack thread is not associated"}
+                return ignored("Slack thread is not associated")
 
-            if plan_action == "cancel":
+            if button.action == "cancel":
                 background_tasks.add_task(
-                    _update_selected_option_message, payload, action, "Cancel plan"
+                    _update_selected_option_message, interaction, action, "Cancel plan"
                 )
                 await common.post_slack_thread_reply(
                     channel_id=channel_id,
@@ -797,98 +667,88 @@ async def slack_interactivity(
                     text="Plan cancelled. No changes will be made.",
                     agent_thread_id=thread_id,
                 )
-                return {"status": "accepted", "message": "Plan cancelled"}
+                return accepted("Plan cancelled")
 
-            if plan_action == "approve":
-                user_name = str(user.get("name") or user.get("username") or user_id)
+            if button.action == "approve":
+                user_name = interaction.user.name or interaction.user.username or user_id
                 background_tasks.add_task(
-                    _update_selected_option_message, payload, action, "Approve plan"
+                    _update_selected_option_message, interaction, action, "Approve plan"
                 )
-                repo_config = await common.get_slack_repo_config(
+                repo = await common.get_slack_repo_config(
                     channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
                 )
                 background_tasks.add_task(
                     service.process_slack_plan_approval,
-                    {
-                        "thread_id": thread_id,
-                        "channel_id": channel_id,
-                        "channel_context": channel_context,
-                        "thread_ts": thread_ts,
-                        "event_ts": str(message.get("ts") or ""),
-                        "user_id": user_id,
-                        "user_name": user_name,
-                        "text": "approve",
-                        "bot_user_id": common.SLACK_BOT_USER_ID,
-                    },
-                    repo_config,
+                    SlackRequest(
+                        thread_id=thread_id,
+                        channel_id=channel_id,
+                        channel_context=channel_context,
+                        thread_ts=thread_ts,
+                        event_ts=interaction.message.ts,
+                        user_id=user_id,
+                        user_name=user_name,
+                        text="approve",
+                        bot_user_id=common.SLACK_BOT_USER_ID,
+                    ),
+                    repo,
                 )
-                return {"status": "accepted", "message": "Plan approval queued"}
+                return accepted("Plan approval queued")
 
             background_tasks.add_task(
-                _update_selected_option_message, payload, action, "Request plan changes"
+                _update_selected_option_message, interaction, action, "Request plan changes"
             )
-            return {"status": "accepted", "message": "Reply to revise the plan"}
+            return accepted("Reply to revise the plan")
 
-        if action_value.get("type") != "open_swe_option":
-            return {"status": "ignored", "reason": "Unknown action type"}
+        if button.type != "open_swe_option":
+            return ignored("Unknown action type")
 
-        response = str(action_value.get("response") or "").strip()
+        response = button.response.strip()
         if not response:
-            return {"status": "ignored", "reason": "Empty response"}
+            return ignored("Empty response")
 
         option_thread_ts = thread_ts or action_ts
         if not channel_id or not option_thread_ts or not action_ts or not user_id:
-            return {"status": "ignored", "reason": "Missing Slack action context"}
+            return ignored("Missing Slack action context")
 
         thread_id = await common.lookup_slack_thread_id(
             get_langgraph_client(), channel_id, option_thread_ts
         )
         if not thread_id:
-            return {"status": "ignored", "reason": "Slack thread is not associated"}
-        repo_config = await common.get_slack_repo_config(
+            return ignored("Slack thread is not associated")
+        repo = await common.get_slack_repo_config(
             channel_id,
             option_thread_ts,
             slack_user_id=user_id,
             channel_context=channel_context,
             thread_id=thread_id,
         )
-        background_tasks.add_task(_update_selected_option_message, payload, action, response)
+        background_tasks.add_task(_update_selected_option_message, interaction, action, response)
         background_tasks.add_task(
             service.process_slack_mention,
-            {
-                "channel_id": channel_id,
-                "channel_context": channel_context,
-                "thread_ts": option_thread_ts,
-                "event_ts": action_ts,
-                "user_id": user_id,
-                "text": response,
-                "bot_user_id": common.SLACK_BOT_USER_ID,
-                "thread_id": thread_id,
-            },
-            repo_config,
+            SlackRequest(
+                channel_id=channel_id,
+                channel_context=channel_context,
+                thread_ts=option_thread_ts,
+                event_ts=action_ts,
+                user_id=user_id,
+                text=response,
+                bot_user_id=common.SLACK_BOT_USER_ID,
+                thread_id=thread_id,
+            ),
+            repo,
         )
-        return {"status": "accepted", "message": "Slack option queued"}
+        return accepted("Slack option queued")
 
     return await answer_slack_request(target, dispatch)
 
 
 async def _update_selected_option_message(
-    payload: dict[str, common.Any],
-    action: dict[str, common.Any],
-    fallback_label: str,
+    interaction: SlackInteraction, action: SlackBlockAction, fallback_label: str
 ) -> None:
-    channel_value = payload.get("channel")
-    channel = channel_value if isinstance(channel_value, dict) else {}
-    message_value = payload.get("message")
-    message = message_value if isinstance(message_value, dict) else {}
-    container_value = payload.get("container")
-    container = container_value if isinstance(container_value, dict) else {}
-    channel_id = str(channel.get("id") or container.get("channel_id") or "")
-    message_ts = str(message.get("ts") or container.get("message_ts") or "")
-    action_text_value = action.get("text")
-    action_text = action_text_value if isinstance(action_text_value, dict) else {}
-    label = str(action_text.get("text") or fallback_label).strip()[:150]
-    blocks = _selected_option_blocks(message, label)
+    channel_id = interaction.channel_id
+    message_ts = interaction.message_ts
+    label = ((action.text.text if action.text else "") or fallback_label).strip()[:150]
+    blocks = _selected_option_blocks(interaction.message, label)
     if not channel_id or not message_ts or not label or not blocks:
         return
 
@@ -896,7 +756,7 @@ async def _update_selected_option_message(
         ok, error = await common.update_slack_message(
             channel_id,
             message_ts,
-            str(message.get("text") or label),
+            interaction.message.text or label,
             blocks=blocks,
         )
     except Exception:
@@ -916,52 +776,50 @@ async def _update_selected_option_message(
         )
 
 
-def _selected_option_blocks(
-    message: dict[str, common.Any], label: str
-) -> list[dict[str, common.Any]]:
-    raw_blocks = message.get("blocks")
-    if not isinstance(raw_blocks, list):
-        return []
-
-    selected_block: dict[str, common.Any] = {
+def _selected_option_blocks(message: SlackInteractionMessage, label: str) -> list[JsonObject]:
+    selected_block: JsonObject = {
         "type": "context",
         "elements": [{"type": "plain_text", "text": f"Selected: {label}"}],
     }
-    updated_blocks: list[dict[str, common.Any]] = []
+    updated_blocks: list[JsonObject] = []
     replaced = False
-    for block in raw_blocks:
-        if not isinstance(block, dict):
-            continue
+    for block in message.blocks:
         elements = block.get("elements")
-        if block.get("type") != "actions" or _first_open_swe_option_action(elements) is None:
+        if block.get("type") != "actions" or not _has_option_element(elements):
             updated_blocks.append(block)
             continue
         if not replaced:
             updated_blocks.append(selected_block)
             replaced = True
         if isinstance(elements, list):
-            remaining = [
-                element for element in elements if _first_open_swe_option_action([element]) is None
-            ]
+            remaining = [element for element in elements if not _has_option_element([element])]
             if remaining:
                 updated_blocks.append({**block, "elements": remaining})
 
     return updated_blocks if replaced else []
 
 
-def _first_open_swe_option_action(actions: common.Any) -> dict[str, common.Any] | None:
-    if not isinstance(actions, list):
-        return None
-    for action in actions:
-        action_id = action.get("action_id") if isinstance(action, dict) else None
-        if isinstance(action_id, str) and (
-            action_id == "open_swe_option_select" or action_id.startswith("open_swe_option_select_")
-        ):
-            return action
-    return None
+def _is_option_action_id(action_id: object) -> bool:
+    return isinstance(action_id, str) and (
+        action_id == _OPTION_ACTION_ID or action_id.startswith(f"{_OPTION_ACTION_ID}_")
+    )
+
+
+def _first_option_action(actions: list[SlackBlockAction]) -> SlackBlockAction | None:
+    return next((action for action in actions if _is_option_action_id(action.action_id)), None)
+
+
+def _has_option_element(elements: object) -> bool:
+    """Whether a Block Kit ``elements`` list holds one of Open SWE's option buttons."""
+    if not isinstance(elements, list):
+        return False
+    return any(
+        isinstance(element, dict) and _is_option_action_id(element.get("action_id"))
+        for element in elements
+    )
 
 
 @router.get("/webhooks/slack")
-async def slack_webhook_verify() -> dict[str, str]:
+async def slack_webhook_verify() -> HealthResponse:
     """Verify endpoint for Slack webhook setup."""
     return {"status": "ok", "message": "Slack webhook endpoint is active"}

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -9,6 +9,12 @@ from fastapi import APIRouter
 from langgraph_sdk.client import LangGraphClient
 
 from agent.slack import webhook as service
+from agent.slack.failures import (
+    SlackRequestError,
+    SlackRequestTarget,
+    answer_slack_request,
+    run_slack_task,
+)
 from agent.utils.thread_ops import langgraph_client as get_langgraph_client
 from agent.webhooks import common
 
@@ -57,44 +63,51 @@ async def _queue_code_channel_turn(
     if not await common.is_code_channel(channel_id):
         return {"status": "ignored", "reason": "Not a code channel"}
 
-    client = get_langgraph_client()
-    thread_id = await common.lookup_slack_thread_id(
-        client, channel_id, common.CODE_CHANNEL_SESSION_TS
+    target = SlackRequestTarget(
+        channel_id=channel_id, thread_ts=common.CODE_CHANNEL_SESSION_TS, event_id=event_id
     )
-    if not thread_id:
-        return {"status": "ignored", "reason": "Code channel is not associated"}
-    if not await common.claim_slack_event(event_id, channel_id, event_ts):
-        return {"status": "ignored", "reason": "Duplicate code channel interaction"}
 
-    channel_context = await common._get_slack_channel_context(channel_id)
-    repo_config = await common.get_slack_repo_config(
-        channel_id,
-        common.CODE_CHANNEL_SESSION_TS,
-        slack_user_id=user_id,
-        channel_context=channel_context,
-        thread_id=thread_id,
-    )
-    background_tasks.add_task(
-        service.process_slack_mention,
-        {
-            "channel_id": channel_id,
-            "channel_context": channel_context,
-            "thread_ts": common.CODE_CHANNEL_SESSION_TS,
-            "event_ts": event_ts,
-            "original_message_ts": event_ts,
-            "user_id": user_id,
-            "text": text,
-            "attachments": [],
-            "bot_user_id": common.SLACK_BOT_USER_ID,
-            "thread_id": thread_id,
-            "treat_all_messages_as_mentions": True,
-            "code_channel": True,
-            "explicit_request": explicit_request,
-            "team_id": team_id,
-        },
-        repo_config,
-    )
-    return {"status": "accepted", "message": "Code channel interaction queued"}
+    async def dispatch() -> dict[str, str]:
+        client = get_langgraph_client()
+        thread_id = await common.lookup_slack_thread_id(
+            client, channel_id, common.CODE_CHANNEL_SESSION_TS
+        )
+        if not thread_id:
+            return {"status": "ignored", "reason": "Code channel is not associated"}
+        if not await common.claim_slack_event(event_id, channel_id, event_ts):
+            return {"status": "ignored", "reason": "Duplicate code channel interaction"}
+
+        channel_context = await common._get_slack_channel_context(channel_id)
+        repo_config = await common.get_slack_repo_config(
+            channel_id,
+            common.CODE_CHANNEL_SESSION_TS,
+            slack_user_id=user_id,
+            channel_context=channel_context,
+            thread_id=thread_id,
+        )
+        background_tasks.add_task(
+            service.process_slack_mention,
+            {
+                "channel_id": channel_id,
+                "channel_context": channel_context,
+                "thread_ts": common.CODE_CHANNEL_SESSION_TS,
+                "event_ts": event_ts,
+                "original_message_ts": event_ts,
+                "user_id": user_id,
+                "text": text,
+                "attachments": [],
+                "bot_user_id": common.SLACK_BOT_USER_ID,
+                "thread_id": thread_id,
+                "treat_all_messages_as_mentions": True,
+                "code_channel": True,
+                "explicit_request": explicit_request,
+                "team_id": team_id,
+            },
+            repo_config,
+        )
+        return {"status": "accepted", "message": "Code channel interaction queued"}
+
+    return await answer_slack_request(target, dispatch)
 
 
 async def _lookup_delivered_message_update(
@@ -422,10 +435,64 @@ async def slack_webhook(
     if bot_user_id and user_id == bot_user_id:
         return {"status": "ignored", "reason": "Event from this bot user"}
 
-    if is_message_update:
-        if await common.claim_slack_event(event_id, channel_id, event_ts):
+    # From here on the message is addressed to Open SWE: any failure is reported to the thread.
+    target = SlackRequestTarget(channel_id=channel_id, thread_ts=thread_ts, event_id=event_id)
+
+    async def dispatch() -> dict[str, str]:
+        if is_message_update:
+            if await common.claim_slack_event(event_id, channel_id, event_ts):
+                event_data = {
+                    "channel_id": channel_id,
+                    "thread_ts": thread_ts,
+                    "event_ts": event_ts,
+                    "original_message_ts": original_message_ts,
+                    "user_id": user_id,
+                    "text": text,
+                    "attachments": attachments,
+                    "bot_user_id": bot_user_id,
+                    "message_update": True,
+                    "code_channel": in_code_channel,
+                    "reply_thread_ts": reply_thread_ts if in_code_channel else "",
+                }
+                background_tasks.add_task(
+                    run_slack_task,
+                    target,
+                    _process_slack_message_update(
+                        event_data,
+                        channel_id,
+                        thread_ts,
+                        original_message_ts,
+                        user_id,
+                    ),
+                )
+                return {"status": "accepted", "message": "Slack update queued"}
+            return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
+
+        if channel_context is None:
+            return {"status": "ignored", "reason": "Slack channel is not eligible"}
+
+        if await common._is_docs_plz_slack_channel(channel_id, channel_context):
+            if await common.claim_slack_event(event_id, channel_id, event_ts):
+                background_tasks.add_task(
+                    common.post_slack_thread_reply,
+                    channel_id,
+                    thread_ts,
+                    common.DOCS_PLZ_SLACK_GATE_REPLY,
+                )
+                return {"status": "accepted", "message": "Slack mention gated for docs-plz"}
+        else:
+            try:
+                thread_id = await common.resolve_slack_thread_id(
+                    get_langgraph_client(), channel_id, thread_ts
+                )
+            except common.SlackThreadMappingError as exc:
+                raise SlackRequestError(
+                    "Open SWE found conflicting state for this Slack thread and will not guess "
+                    "which agent thread to use."
+                ) from exc
             event_data = {
                 "channel_id": channel_id,
+                "channel_context": channel_context,
                 "thread_ts": thread_ts,
                 "event_ts": event_ts,
                 "original_message_ts": original_message_ts,
@@ -433,81 +500,30 @@ async def slack_webhook(
                 "text": text,
                 "attachments": attachments,
                 "bot_user_id": bot_user_id,
-                "message_update": True,
+                "thread_id": thread_id,
+                "treat_all_messages_as_mentions": is_direct_message or in_code_channel,
+                "untagged_reply": is_untagged_two_party_reply,
+                "message_update": is_message_update,
                 "code_channel": in_code_channel,
                 "reply_thread_ts": reply_thread_ts if in_code_channel else "",
+                "team_id": team_id,
+                "app_context": updated_message.get("app_context") or event.get("app_context"),
             }
-            background_tasks.add_task(
-                _process_slack_message_update,
-                event_data,
+            repo_config = await common.get_slack_repo_config(
                 channel_id,
                 thread_ts,
-                original_message_ts,
-                user_id,
+                slack_user_id=user_id,
+                channel_context=channel_context,
+                thread_id=thread_id,
             )
-            return {"status": "accepted", "message": "Slack update queued"}
+            if await common.claim_slack_event(event_id, channel_id, event_ts):
+                background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
+                return {"status": "accepted", "message": "Slack mention queued"}
+
+        common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
         return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
 
-    langgraph_client = get_langgraph_client()
-    thread_id: str | None = None
-    if channel_context is None:
-        return {"status": "ignored", "reason": "Slack channel is not eligible"}
-
-    if await common._is_docs_plz_slack_channel(channel_id, channel_context):
-        if await common.claim_slack_event(event_id, channel_id, event_ts):
-            background_tasks.add_task(
-                common.post_slack_thread_reply,
-                channel_id,
-                thread_ts,
-                common.DOCS_PLZ_SLACK_GATE_REPLY,
-            )
-            return {"status": "accepted", "message": "Slack mention gated for docs-plz"}
-    else:
-        if not is_message_update:
-            try:
-                thread_id = await common.resolve_slack_thread_id(
-                    langgraph_client, channel_id, thread_ts
-                )
-            except common.SlackThreadMappingError:
-                common.logger.exception("Could not resolve explicit Slack thread mapping")
-                await common.post_slack_thread_reply(
-                    channel_id,
-                    thread_ts,
-                    "Open SWE found conflicting state for this Slack thread and will not guess which agent thread to use.",
-                )
-                return {"status": "error", "message": "Conflicting Slack thread mapping"}
-        event_data = {
-            "channel_id": channel_id,
-            "channel_context": channel_context,
-            "thread_ts": thread_ts,
-            "event_ts": event_ts,
-            "original_message_ts": original_message_ts,
-            "user_id": user_id,
-            "text": text,
-            "attachments": attachments,
-            "bot_user_id": bot_user_id,
-            "thread_id": thread_id,
-            "treat_all_messages_as_mentions": is_direct_message or in_code_channel,
-            "untagged_reply": is_untagged_two_party_reply,
-            "message_update": is_message_update,
-            "code_channel": in_code_channel,
-            "reply_thread_ts": reply_thread_ts if in_code_channel else "",
-            "team_id": team_id,
-            "app_context": updated_message.get("app_context") or event.get("app_context"),
-        }
-        repo_config = await common.get_slack_repo_config(
-            channel_id,
-            thread_ts,
-            slack_user_id=user_id,
-            channel_context=channel_context,
-            thread_id=thread_id,
-        )
-        if await common.claim_slack_event(event_id, channel_id, event_ts):
-            background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
-            return {"status": "accepted", "message": "Slack mention queued"}
-
-    common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
-    return {"status": "ignored", "reason": "Duplicate Slack event delivery"}
+    return await answer_slack_request(target, dispatch)
 
 
 @router.post("/webhooks/slack/code-channel-commands")
@@ -663,200 +679,187 @@ async def slack_interactivity(
         action_value = common.json.loads(str(action.get("value") or "{}"))
     except common.json.JSONDecodeError:
         return {"status": "ignored", "reason": "Invalid action value"}
-    if action_value.get("type") == "workflow_push_approval":
-        workflow_action = str(action_value.get("action") or "").strip()
-        fingerprint = str(action_value.get("fingerprint") or "").strip()
-        channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
-        message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
-        container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
-        user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
-        channel_id = str(channel.get("id") or container.get("channel_id") or "")
-        thread_ts = str(
-            message.get("thread_ts") or message.get("ts") or container.get("thread_ts") or ""
-        )
-        user_id = str(user.get("id") or "")
-        if not channel_id or not thread_ts or not fingerprint:
-            return {"status": "ignored", "reason": "Missing workflow approval context"}
 
-        thread_id = await common.lookup_slack_thread_id(
-            get_langgraph_client(), channel_id, thread_ts
-        )
-        if not thread_id:
-            return {"status": "ignored", "reason": "Slack thread is not associated"}
-        if workflow_action not in {"approve", "reject"}:
-            return {"status": "ignored", "reason": "Unknown workflow approval action"}
-        approved = workflow_action == "approve"
-        record = await common.decide_workflow_push_approval(
-            thread_id, fingerprint, approved=approved, actor=user_id
-        )
-        if record is None:
-            await common.post_slack_thread_reply(
-                channel_id=channel_id,
-                thread_ts=thread_ts,
-                text="I couldn't find that workflow approval request. Trigger the push again to create a fresh approval.",
-                agent_thread_id=thread_id,
+    message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
+    user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
+    user_id = str(user.get("id") or "")
+    action_ts = str(
+        action.get("action_ts") or message.get("ts") or container.get("message_ts") or ""
+    )
+    thread_ts = str(
+        message.get("thread_ts") or message.get("ts") or container.get("thread_ts") or ""
+    )
+
+    # From here on the interaction is addressed to Open SWE: any failure is reported to the thread.
+    target = SlackRequestTarget(channel_id=channel_id, thread_ts=thread_ts or action_ts)
+
+    async def dispatch() -> dict[str, str]:
+        if action_value.get("type") == "workflow_push_approval":
+            workflow_action = str(action_value.get("action") or "").strip()
+            fingerprint = str(action_value.get("fingerprint") or "").strip()
+            if not channel_id or not thread_ts or not fingerprint:
+                return {"status": "ignored", "reason": "Missing workflow approval context"}
+
+            thread_id = await common.lookup_slack_thread_id(
+                get_langgraph_client(), channel_id, thread_ts
             )
-            return {"status": "ignored", "reason": "workflow approval not found"}
-        background_tasks.add_task(
-            _update_selected_option_message,
-            payload,
-            action,
-            "Approve workflow push" if approved else "Reject workflow push",
-        )
-        if not approved:
-            await common.post_slack_thread_reply(
-                channel_id=channel_id,
-                thread_ts=thread_ts,
-                text=f"Workflow push rejected for fingerprint `{fingerprint}`. No workflow files will be pushed.",
-                agent_thread_id=thread_id,
+            if not thread_id:
+                return {"status": "ignored", "reason": "Slack thread is not associated"}
+            if workflow_action not in {"approve", "reject"}:
+                return {"status": "ignored", "reason": "Unknown workflow approval action"}
+            approved = workflow_action == "approve"
+            record = await common.decide_workflow_push_approval(
+                thread_id, fingerprint, approved=approved, actor=user_id
             )
-            return {"status": "accepted", "message": "Workflow push rejected"}
-
-        await common.post_slack_thread_reply(
-            channel_id=channel_id,
-            thread_ts=thread_ts,
-            text=f"Workflow push approved for fingerprint `{fingerprint}`. Open SWE will retry the blocked push.",
-            agent_thread_id=thread_id,
-        )
-        channel_context = await common._get_slack_channel_context(channel_id)
-        repo_config = await common.get_slack_repo_config(
-            channel_id,
-            thread_ts,
-            slack_user_id=user_id,
-            channel_context=channel_context,
-            thread_id=thread_id,
-        )
-        background_tasks.add_task(
-            service.process_slack_mention,
-            {
-                "channel_id": channel_id,
-                "channel_context": channel_context,
-                "thread_ts": thread_ts,
-                "event_ts": str(message.get("ts") or ""),
-                "user_id": user_id,
-                "text": (
-                    "The workflow-file push approval was approved. Retry the blocked "
-                    "git push now; do not alter workflow files before pushing."
-                ),
-                "bot_user_id": common.SLACK_BOT_USER_ID,
-                "thread_id": thread_id,
-            },
-            repo_config,
-        )
-        return {"status": "accepted", "message": "Workflow push approved, retry queued"}
-
-    if action_value.get("type") == "plan_approval":
-        plan_action = str(action_value.get("action") or "").strip()
-        channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
-        message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
-        container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
-        user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
-        channel_id = str(channel.get("id") or container.get("channel_id") or "")
-        thread_ts = str(
-            message.get("thread_ts") or message.get("ts") or container.get("thread_ts") or ""
-        )
-        user_id = str(user.get("id") or "")
-        if not channel_id or not thread_ts:
-            return {"status": "ignored", "reason": "Missing Slack action context"}
-
-        thread_id = await common.lookup_slack_thread_id(
-            get_langgraph_client(), channel_id, thread_ts
-        )
-        if not thread_id:
-            return {"status": "ignored", "reason": "Slack thread is not associated"}
-
-        if plan_action == "cancel":
+            if record is None:
+                await common.post_slack_thread_reply(
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    text="I couldn't find that workflow approval request. Trigger the push again to create a fresh approval.",
+                    agent_thread_id=thread_id,
+                )
+                return {"status": "ignored", "reason": "workflow approval not found"}
             background_tasks.add_task(
-                _update_selected_option_message, payload, action, "Cancel plan"
+                _update_selected_option_message,
+                payload,
+                action,
+                "Approve workflow push" if approved else "Reject workflow push",
             )
+            if not approved:
+                await common.post_slack_thread_reply(
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    text=f"Workflow push rejected for fingerprint `{fingerprint}`. No workflow files will be pushed.",
+                    agent_thread_id=thread_id,
+                )
+                return {"status": "accepted", "message": "Workflow push rejected"}
+
             await common.post_slack_thread_reply(
                 channel_id=channel_id,
                 thread_ts=thread_ts,
-                text="Plan cancelled. No changes will be made.",
+                text=f"Workflow push approved for fingerprint `{fingerprint}`. Open SWE will retry the blocked push.",
                 agent_thread_id=thread_id,
             )
-            return {"status": "accepted", "message": "Plan cancelled"}
-
-        if plan_action == "approve":
-            user_name = str(user.get("name") or user.get("username") or user_id)
-            background_tasks.add_task(
-                _update_selected_option_message, payload, action, "Approve plan"
-            )
-            channel_context = await common._get_slack_channel_context(channel_id)
             repo_config = await common.get_slack_repo_config(
-                channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
+                channel_id,
+                thread_ts,
+                slack_user_id=user_id,
+                channel_context=channel_context,
+                thread_id=thread_id,
             )
             background_tasks.add_task(
-                service.process_slack_plan_approval,
+                service.process_slack_mention,
                 {
-                    "thread_id": thread_id,
                     "channel_id": channel_id,
                     "channel_context": channel_context,
                     "thread_ts": thread_ts,
                     "event_ts": str(message.get("ts") or ""),
                     "user_id": user_id,
-                    "user_name": user_name,
-                    "text": "approve",
+                    "text": (
+                        "The workflow-file push approval was approved. Retry the blocked "
+                        "git push now; do not alter workflow files before pushing."
+                    ),
                     "bot_user_id": common.SLACK_BOT_USER_ID,
+                    "thread_id": thread_id,
                 },
                 repo_config,
             )
-            return {"status": "accepted", "message": "Plan approval queued"}
+            return {"status": "accepted", "message": "Workflow push approved, retry queued"}
 
-        background_tasks.add_task(
-            _update_selected_option_message, payload, action, "Request plan changes"
+        if action_value.get("type") == "plan_approval":
+            plan_action = str(action_value.get("action") or "").strip()
+            if not channel_id or not thread_ts:
+                return {"status": "ignored", "reason": "Missing Slack action context"}
+
+            thread_id = await common.lookup_slack_thread_id(
+                get_langgraph_client(), channel_id, thread_ts
+            )
+            if not thread_id:
+                return {"status": "ignored", "reason": "Slack thread is not associated"}
+
+            if plan_action == "cancel":
+                background_tasks.add_task(
+                    _update_selected_option_message, payload, action, "Cancel plan"
+                )
+                await common.post_slack_thread_reply(
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    text="Plan cancelled. No changes will be made.",
+                    agent_thread_id=thread_id,
+                )
+                return {"status": "accepted", "message": "Plan cancelled"}
+
+            if plan_action == "approve":
+                user_name = str(user.get("name") or user.get("username") or user_id)
+                background_tasks.add_task(
+                    _update_selected_option_message, payload, action, "Approve plan"
+                )
+                repo_config = await common.get_slack_repo_config(
+                    channel_id, thread_ts, slack_user_id=user_id, channel_context=channel_context
+                )
+                background_tasks.add_task(
+                    service.process_slack_plan_approval,
+                    {
+                        "thread_id": thread_id,
+                        "channel_id": channel_id,
+                        "channel_context": channel_context,
+                        "thread_ts": thread_ts,
+                        "event_ts": str(message.get("ts") or ""),
+                        "user_id": user_id,
+                        "user_name": user_name,
+                        "text": "approve",
+                        "bot_user_id": common.SLACK_BOT_USER_ID,
+                    },
+                    repo_config,
+                )
+                return {"status": "accepted", "message": "Plan approval queued"}
+
+            background_tasks.add_task(
+                _update_selected_option_message, payload, action, "Request plan changes"
+            )
+            return {"status": "accepted", "message": "Reply to revise the plan"}
+
+        if action_value.get("type") != "open_swe_option":
+            return {"status": "ignored", "reason": "Unknown action type"}
+
+        response = str(action_value.get("response") or "").strip()
+        if not response:
+            return {"status": "ignored", "reason": "Empty response"}
+
+        option_thread_ts = thread_ts or action_ts
+        if not channel_id or not option_thread_ts or not action_ts or not user_id:
+            return {"status": "ignored", "reason": "Missing Slack action context"}
+
+        thread_id = await common.lookup_slack_thread_id(
+            get_langgraph_client(), channel_id, option_thread_ts
         )
-        return {"status": "accepted", "message": "Reply to revise the plan"}
+        if not thread_id:
+            return {"status": "ignored", "reason": "Slack thread is not associated"}
+        repo_config = await common.get_slack_repo_config(
+            channel_id,
+            option_thread_ts,
+            slack_user_id=user_id,
+            channel_context=channel_context,
+            thread_id=thread_id,
+        )
+        background_tasks.add_task(_update_selected_option_message, payload, action, response)
+        background_tasks.add_task(
+            service.process_slack_mention,
+            {
+                "channel_id": channel_id,
+                "channel_context": channel_context,
+                "thread_ts": option_thread_ts,
+                "event_ts": action_ts,
+                "user_id": user_id,
+                "text": response,
+                "bot_user_id": common.SLACK_BOT_USER_ID,
+                "thread_id": thread_id,
+            },
+            repo_config,
+        )
+        return {"status": "accepted", "message": "Slack option queued"}
 
-    if action_value.get("type") != "open_swe_option":
-        return {"status": "ignored", "reason": "Unknown action type"}
-
-    response = str(action_value.get("response") or "").strip()
-    if not response:
-        return {"status": "ignored", "reason": "Empty response"}
-
-    channel = payload.get("channel") if isinstance(payload.get("channel"), dict) else {}
-    message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
-    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
-    user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
-    channel_id = str(channel.get("id") or container.get("channel_id") or "")
-    event_ts = str(
-        action.get("action_ts") or message.get("ts") or container.get("message_ts") or ""
-    )
-    thread_ts = str(
-        message.get("thread_ts") or message.get("ts") or container.get("thread_ts") or event_ts
-    )
-    user_id = str(user.get("id") or "")
-    if not channel_id or not thread_ts or not event_ts or not user_id:
-        return {"status": "ignored", "reason": "Missing Slack action context"}
-
-    thread_id = await common.lookup_slack_thread_id(get_langgraph_client(), channel_id, thread_ts)
-    if not thread_id:
-        return {"status": "ignored", "reason": "Slack thread is not associated"}
-    channel_context = await common._get_slack_channel_context(channel_id)
-    repo_config = await common.get_slack_repo_config(
-        channel_id,
-        thread_ts,
-        slack_user_id=user_id,
-        channel_context=channel_context,
-        thread_id=thread_id,
-    )
-    background_tasks.add_task(_update_selected_option_message, payload, action, response)
-    background_tasks.add_task(
-        service.process_slack_mention,
-        {
-            "channel_id": channel_id,
-            "channel_context": channel_context,
-            "thread_ts": thread_ts,
-            "event_ts": event_ts,
-            "user_id": user_id,
-            "text": response,
-            "bot_user_id": common.SLACK_BOT_USER_ID,
-            "thread_id": thread_id,
-        },
-        repo_config,
-    )
-    return {"status": "accepted", "message": "Slack option queued"}
+    return await answer_slack_request(target, dispatch)
 
 
 async def _update_selected_option_message(

--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -77,7 +77,7 @@ async def _queue_code_channel_turn(
         if not await common.claim_slack_event(event_id, channel_id, event_ts):
             return {"status": "ignored", "reason": "Duplicate code channel interaction"}
 
-        channel_context = await common._get_slack_channel_context(channel_id)
+        channel_context = await common.resolve_slack_channel_context(channel_id)
         repo_config = await common.get_slack_repo_config(
             channel_id,
             common.CODE_CHANNEL_SESSION_TS,
@@ -132,7 +132,7 @@ async def _lookup_delivered_message_update(
                 or delivered_message.get("agent_thread_id") != thread_id
             ):
                 return None, None
-            if await common._thread_exists(thread_id):
+            if await common.thread_exists(thread_id):
                 return thread_id, delivered_message
         if delay is None:
             break
@@ -175,7 +175,7 @@ async def _process_slack_message_update_impl(
             message_ts,
         )
         return
-    channel_context = await common._get_slack_channel_context(channel_id, use_cache=False)
+    channel_context = await common.resolve_slack_channel_context(channel_id, use_cache=False)
     if not common.slack_channel_allows_operations(channel_context):
         common.logger.warning("Blocked Slack message update in ineligible channel=%s", channel_id)
         return
@@ -231,7 +231,7 @@ async def slack_webhook(
     channel_id = _event_channel_id(event)
     channel_context: dict[str, Any] | None = None
     if channel_id:
-        channel_context = await common._get_slack_channel_context(channel_id, use_cache=False)
+        channel_context = await common.resolve_slack_channel_context(channel_id, use_cache=False)
         if not common.slack_channel_allows_operations(channel_context):
             is_external = channel_context.get("is_ext_shared") is True
             event_ts = str(event.get("event_ts") or event.get("ts") or "")
@@ -405,7 +405,7 @@ async def slack_webhook(
         has_id_mention = bool(bot_user_id and f"<@{bot_user_id}>" in text)
         is_ready_plan_reply = bool(
             not is_direct_message
-            and await service._slack_user_can_reply_to_ready_plan(
+            and await service.slack_user_can_reply_to_ready_plan(
                 channel_id,
                 str(event.get("thread_ts") or ""),
                 user_id,
@@ -416,7 +416,7 @@ async def slack_webhook(
             and not is_direct_message
             and not has_username_mention
             and not has_id_mention
-            and await service._slack_thread_allows_untagged_reply(
+            and await service.slack_thread_allows_untagged_reply(
                 channel_id,
                 str(event.get("thread_ts") or ""),
                 text,
@@ -481,7 +481,7 @@ async def slack_webhook(
         if channel_context is None:
             return {"status": "ignored", "reason": "Slack channel is not eligible"}
 
-        if await common._is_docs_plz_slack_channel(channel_id, channel_context):
+        if await common.is_docs_plz_slack_channel(channel_id, channel_context):
             if await common.claim_slack_event(event_id, channel_id, event_ts):
                 background_tasks.add_task(
                     common.post_slack_thread_reply,
@@ -680,7 +680,7 @@ async def slack_interactivity(
     channel_id = str(channel.get("id") or container.get("channel_id") or "")
     if not channel_id:
         return {"status": "ignored", "reason": "Slack channel is not eligible"}
-    channel_context = await common._get_slack_channel_context(channel_id, use_cache=False)
+    channel_context = await common.resolve_slack_channel_context(channel_id, use_cache=False)
     if not common.slack_channel_allows_operations(channel_context):
         common.logger.warning("Blocked Slack interaction in ineligible channel=%s", channel_id)
         return {"status": "ignored", "reason": "Slack channel is not eligible"}

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -24,6 +24,7 @@ from agent.input_messages import (
     system_input,
     system_introduction,
 )
+from agent.run_config import Repo
 from agent.slack import client as slack_utils
 from agent.slack.failures import SlackRequestTarget, report_slack_failure
 from agent.slack.thinking import stream_slack_thinking_steps
@@ -455,7 +456,7 @@ def _slack_context_input(
     return {"messages": run_messages}
 
 
-async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[str, str]) -> None:
+async def process_slack_mention(event_data: dict[str, Any], repo_config: Repo | None) -> None:
     """Process a Slack request by creating a run or queuing a mid-run message."""
     try:
         await _process_slack_mention_impl(event_data, repo_config)
@@ -463,9 +464,7 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
         await _notify_slack_processing_error(event_data, repo_config, exc)
 
 
-async def process_slack_plan_approval(
-    event_data: dict[str, Any], repo_config: dict[str, str]
-) -> None:
+async def process_slack_plan_approval(event_data: dict[str, Any], repo_config: Repo | None) -> None:
     from agent.dashboard.plan_api import approve_plan_for_thread
     from agent.dashboard.plan_store import make_plan_approver
 
@@ -485,7 +484,7 @@ async def process_slack_plan_approval(
 
 
 async def _notify_slack_processing_error(
-    event_data: dict[str, Any], repo_config: dict[str, str], exc: BaseException
+    event_data: dict[str, Any], repo_config: Repo | None, exc: BaseException
 ) -> None:
     """Mark the agent thread errored when one exists, then always tell the Slack thread."""
     channel_id = event_data.get("channel_id", "")
@@ -506,7 +505,7 @@ async def _notify_slack_processing_error(
 
 
 async def _mark_slack_thread_errored(
-    thread_id: str, event_data: dict[str, Any], repo_config: dict[str, str]
+    thread_id: str, event_data: dict[str, Any], repo_config: Repo | None
 ) -> None:
     channel_id = event_data.get("channel_id", "")
     thread_ts = event_data.get("thread_ts", "")
@@ -522,7 +521,7 @@ async def _mark_slack_thread_errored(
         await common.upsert_agent_thread_metadata(
             thread_id,
             source="slack",
-            repo_config=repo_config,
+            repo_config=repo_config.model_dump() if repo_config else None,
             title=clean_text,
             source_context=SourceContext(
                 slack_thread=SlackThreadRef(
@@ -550,9 +549,8 @@ async def _mark_slack_thread_errored(
         common.logger.warning("Could not mark Slack thread %s as errored", thread_id, exc_info=True)
 
 
-async def _process_slack_mention_impl(
-    event_data: dict[str, Any], repo_config: dict[str, str]
-) -> None:
+async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: Repo | None) -> None:
+    repo_dict = repo_config.model_dump() if repo_config else None
     channel_id = event_data.get("channel_id", "")
     thread_ts = event_data.get("thread_ts", "")
     event_ts = event_data.get("event_ts", "")
@@ -701,11 +699,16 @@ async def _process_slack_mention_impl(
     slack_thread_section = _format_slack_thread_section(
         channel_id, thread_ts, context_source, channel_context
     )
-    operational_context = (
-        _slack_prompt_preamble(untagged_reply, message_update) + "## Default Repository Hint\n"
-        f"{repo_config.get('owner')}/{repo_config.get('name')}\n"
+    repo_hint_section = (
+        f"## Default Repository Hint\n{repo_config.full_name}\n"
         "Use this only if the Slack conversation does not identify a different repository.\n\n"
-        f"## Triggered by\n{trigger_user}\n\n"
+        if repo_config
+        else ""
+    )
+    operational_context = (
+        _slack_prompt_preamble(untagged_reply, message_update)
+        + repo_hint_section
+        + f"## Triggered by\n{trigger_user}\n\n"
         f"{trigger_user_timezone_section}"
         f"{slack_thread_section}\n\n"
         f"{await _format_slack_run_links_section(thread_id)}"
@@ -817,7 +820,7 @@ async def _process_slack_mention_impl(
         slack_thread_context["reply_thread_ts"] = reply_thread_ts
 
     configurable: dict[str, Any] = {
-        "repo": repo_config,
+        "repo": repo_dict,
         "slack_thread": slack_thread_context,
         "user_email": user_email,
         "source": "slack",
@@ -841,14 +844,15 @@ async def _process_slack_mention_impl(
 
     is_first_mention = not await common._thread_exists(thread_id)
     langgraph_client = get_langgraph_client()
-    await common._upsert_slack_thread_repo_metadata(thread_id, repo_config, langgraph_client)
+    if repo_dict:
+        await common._upsert_slack_thread_repo_metadata(thread_id, repo_dict, langgraph_client)
     # Pass the login resolved above (from the stable Slack user id) so the thread is
     # always tagged with github_login — the key the dashboard searches by. Without
     # it, upsert re-resolves from the Slack profile email, which can miss.
     await common.upsert_agent_thread_metadata(
         thread_id,
         source="slack",
-        repo_config=repo_config,
+        repo_config=repo_dict,
         github_login=mapped_login or "",
         user_email=user_email or "",
         title=clean_text if is_first_mention else "",
@@ -892,7 +896,7 @@ async def _process_slack_mention_impl(
             await common.set_context_bar(
                 channel_id,
                 common.repo_context_bar_items(
-                    repo_config, dashboard_url=common.dashboard_thread_url(thread_id) or ""
+                    repo_dict, dashboard_url=common.dashboard_thread_url(thread_id) or ""
                 ),
             )
             await common.set_commands(channel_id, common.DEFAULT_CODE_CHANNEL_COMMANDS)

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -112,7 +112,7 @@ def _interrupts_active_run(
     )
 
 
-async def _slack_thread_allows_untagged_reply(
+async def slack_thread_allows_untagged_reply(
     channel_id: str,
     thread_ts: str,
     text: str,
@@ -130,12 +130,12 @@ async def _slack_thread_allows_untagged_reply(
 
     messages = await common.fetch_slack_thread_messages(channel_id, thread_ts)
     bot_last_ts = 0.0
-    current_ts = common._parse_ts(now_ts)
+    current_ts = common.parse_slack_ts(now_ts)
     latest_ts = current_ts
     last_message_ts: dict[str, float] = {}
     human_messages: list[tuple[float, str, str]] = []
     for message in messages:
-        message_ts = common._parse_ts(message.get("ts"))
+        message_ts = common.parse_slack_ts(message.get("ts"))
         latest_ts = max(latest_ts, message_ts)
         author = message.get("user")
         if author == bot_user_id:
@@ -210,14 +210,14 @@ async def _dispatch_or_queue_slack_run(
             configurable,
             source="slack",
             input=run_input,
-            metadata=common._AGENT_VERSION_METADATA,
+            metadata=common.AGENT_VERSION_METADATA,
             client=client,
             multitask_strategy="interrupt" if explicitly_tagged else "enqueue",
         )
     )
 
 
-async def _slack_user_can_reply_to_ready_plan(
+async def slack_user_can_reply_to_ready_plan(
     channel_id: str, thread_ts: str, slack_user_id: str
 ) -> bool:
     if not channel_id or not thread_ts or not slack_user_id:
@@ -668,7 +668,7 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
         common.strip_bot_mention(text, bot_user_id, bot_username=common.SLACK_BOT_USERNAME)
         or "(no text in mention)"
     )
-    is_first_mention = not await common._thread_exists(thread_id)
+    is_first_mention = not await common.thread_exists(thread_id)
     # `env:<name>` on the message that opens a thread picks the environment its
     # sandbox boots from. Only the opening message can: the sandbox is created
     # once, so honoring a later tag would change the prompt but not the image. The
@@ -795,7 +795,7 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
             reason,
         )
         if user_id:
-            await common._post_account_link_prompt(
+            await common.post_account_link_prompt(
                 channel_id,
                 thread_ts,
                 user_id,
@@ -831,21 +831,21 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
     # Later mentions carry no tag, so the thread's environment comes back from
     # metadata — a follow-up must not be told about `default` while its sandbox
     # was built from the environment the opening message picked.
-    thread_environment = environment_slug or await common._get_thread_environment(thread_id)
+    thread_environment = environment_slug or await common.get_thread_environment(thread_id)
     if thread_environment:
         configurable["environment"] = thread_environment
     if image_model_override:
         configurable["agent_model_id"] = image_model_override[0]
         configurable["agent_effort"] = image_model_override[1]
 
-    thread_plan_mode = await common._get_thread_plan_mode(thread_id)
+    thread_plan_mode = await common.get_thread_plan_mode(thread_id)
     if thread_plan_mode is not None:
         configurable["plan_mode"] = thread_plan_mode
 
-    is_first_mention = not await common._thread_exists(thread_id)
+    is_first_mention = not await common.thread_exists(thread_id)
     langgraph_client = get_langgraph_client()
     if repo_dict:
-        await common._upsert_slack_thread_repo_metadata(thread_id, repo_dict, langgraph_client)
+        await common.upsert_slack_thread_repo_metadata(thread_id, repo_dict, langgraph_client)
     # Pass the login resolved above (from the stable Slack user id) so the thread is
     # always tagged with github_login — the key the dashboard searches by. Without
     # it, upsert re-resolves from the Slack profile email, which can miss.
@@ -916,7 +916,7 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
         raise
     common.logger.info(
         "Slack LangGraph run %s dispatched for thread %s",
-        common._run_id_for_logging(run),
+        common.run_id_for_logging(run),
         thread_id,
     )
     run_id = run.get("run_id")

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -26,7 +26,8 @@ from agent.input_messages import (
 )
 from agent.run_config import Repo
 from agent.slack import client as slack_utils
-from agent.slack.failures import SlackRequestTarget, report_slack_failure
+from agent.slack.failures import report_slack_failure
+from agent.slack.request import SlackRequest
 from agent.slack.thinking import stream_slack_thinking_steps
 from agent.source_context import SlackThreadRef, SourceContext
 from agent.utils.json_types import as_json_object
@@ -456,79 +457,69 @@ def _slack_context_input(
     return {"messages": run_messages}
 
 
-async def process_slack_mention(event_data: dict[str, Any], repo_config: Repo | None) -> None:
+async def process_slack_mention(request: SlackRequest, repo: Repo | None) -> None:
     """Process a Slack request by creating a run or queuing a mid-run message."""
     try:
-        await _process_slack_mention_impl(event_data, repo_config)
+        await _process_slack_mention_impl(request, repo)
     except Exception as exc:  # noqa: BLE001
-        await _notify_slack_processing_error(event_data, repo_config, exc)
+        await _notify_slack_processing_error(request, repo, exc)
 
 
-async def process_slack_plan_approval(event_data: dict[str, Any], repo_config: Repo | None) -> None:
+async def process_slack_plan_approval(request: SlackRequest, repo: Repo | None) -> None:
     from agent.dashboard.plan_api import approve_plan_for_thread
     from agent.dashboard.plan_store import make_plan_approver
 
     try:
-        user_id = str(event_data.get("user_id") or "")
-        user_name = str(event_data.get("user_name") or "")
         await approve_plan_for_thread(
-            str(event_data.get("thread_id") or ""),
+            request.thread_id or "",
             approver=make_plan_approver(
-                actor_id=user_id,
-                name=user_name or user_id or "Slack user",
+                actor_id=request.user_id,
+                name=request.user_name or request.user_id or "Slack user",
                 source="slack",
             ),
         )
     except Exception as exc:  # noqa: BLE001
-        await _notify_slack_processing_error(event_data, repo_config, exc)
+        await _notify_slack_processing_error(request, repo, exc)
 
 
 async def _notify_slack_processing_error(
-    event_data: dict[str, Any], repo_config: Repo | None, exc: BaseException
+    request: SlackRequest, repo: Repo | None, exc: BaseException
 ) -> None:
     """Mark the agent thread errored when one exists, then always tell the Slack thread."""
-    channel_id = event_data.get("channel_id", "")
-    thread_ts = event_data.get("thread_ts", "")
-    thread_id = event_data.get("thread_id")
-    if channel_id and thread_ts and not (isinstance(thread_id, str) and thread_id):
+    thread_id = request.thread_id
+    if request.channel_id and request.thread_ts and not thread_id:
         try:
             thread_id = await common.lookup_slack_thread_id(
-                get_langgraph_client(), channel_id, thread_ts
+                get_langgraph_client(), request.channel_id, request.thread_ts
             )
         except Exception:  # noqa: BLE001
             thread_id = None
-    if isinstance(thread_id, str) and thread_id:
-        await _mark_slack_thread_errored(thread_id, event_data, repo_config)
-    await report_slack_failure(
-        SlackRequestTarget.model_validate({**event_data, "thread_id": thread_id}), exc
-    )
+    if thread_id:
+        await _mark_slack_thread_errored(thread_id, request, repo)
+    await report_slack_failure(request.model_copy(update={"thread_id": thread_id}).target, exc)
 
 
 async def _mark_slack_thread_errored(
-    thread_id: str, event_data: dict[str, Any], repo_config: Repo | None
+    thread_id: str, request: SlackRequest, repo: Repo | None
 ) -> None:
-    channel_id = event_data.get("channel_id", "")
-    thread_ts = event_data.get("thread_ts", "")
-    event_ts = event_data.get("event_ts", "")
-    user_id = event_data.get("user_id", "")
-    text = event_data.get("text", "")
-    bot_user_id = event_data.get("bot_user_id", "")
     try:
         clean_text = (
-            common.strip_bot_mention(text, bot_user_id, bot_username=common.SLACK_BOT_USERNAME)
+            common.strip_bot_mention(
+                request.text, request.bot_user_id, bot_username=common.SLACK_BOT_USERNAME
+            )
             or "Slack request"
         )
         await common.upsert_agent_thread_metadata(
             thread_id,
             source="slack",
-            repo_config=repo_config.model_dump() if repo_config else None,
+            repo_config=repo.model_dump() if repo else None,
             title=clean_text,
             source_context=SourceContext(
                 slack_thread=SlackThreadRef(
-                    channel_id=channel_id,
-                    thread_ts=thread_ts,
-                    triggering_user_id=user_id,
-                    triggering_event_ts=event_ts,
+                    channel_id=request.channel_id,
+                    thread_ts=request.thread_ts,
+                    triggering_user_id=request.user_id,
+                    triggering_event_ts=request.event_ts,
                 )
             ),
         )
@@ -549,28 +540,26 @@ async def _mark_slack_thread_errored(
         common.logger.warning("Could not mark Slack thread %s as errored", thread_id, exc_info=True)
 
 
-async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: Repo | None) -> None:
-    repo_dict = repo_config.model_dump() if repo_config else None
-    channel_id = event_data.get("channel_id", "")
-    thread_ts = event_data.get("thread_ts", "")
-    event_ts = event_data.get("event_ts", "")
-    user_id = event_data.get("user_id", "")
-    text = event_data.get("text", "")
-    attachments = event_data.get("attachments", [])
-    bot_user_id = event_data.get("bot_user_id", "")
-    message_update = bool(event_data.get("message_update"))
-    reply_thread_ts = event_data.get("reply_thread_ts")
-    if not isinstance(reply_thread_ts, str):
-        reply_thread_ts = ""
-    original_message_ts = event_data.get("original_message_ts")
-    if not isinstance(original_message_ts, str) or not original_message_ts:
-        original_message_ts = event_ts
-    channel_context_raw = event_data.get("channel_context")
+async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) -> None:
+    repo_dict = repo.model_dump() if repo else None
+    channel_id = request.channel_id
+    thread_ts = request.thread_ts
+    event_ts = request.event_ts
+    user_id = request.user_id
+    text = request.text
+    attachments = request.attachments
+    bot_user_id = request.bot_user_id
+    message_update = request.message_update
+    reply_thread_ts = request.reply_thread_ts
+    original_message_ts = request.original_message_ts or event_ts
     channel_context = (
-        channel_context_raw
-        if isinstance(channel_context_raw, dict)
+        request.channel_context
+        if request.channel_context is not None
         else common.normalize_slack_channel_context(channel_id, None)
     )
+    treat_all_messages_as_mentions = request.treat_all_messages_as_mentions
+    untagged_reply = request.untagged_reply
+    code_channel = request.code_channel
 
     if not channel_id or not thread_ts or not event_ts:
         common.logger.warning(
@@ -582,9 +571,9 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
         return
 
     langgraph_client = get_langgraph_client()
-    thread_id = event_data.get("thread_id")
-    if not isinstance(thread_id, str) or not thread_id:
-        thread_id = await common.resolve_slack_thread_id(langgraph_client, channel_id, thread_ts)
+    thread_id = request.thread_id or await common.resolve_slack_thread_id(
+        langgraph_client, channel_id, thread_ts
+    )
     # Prime the user-mapping cache so login/email/slack-id lookups below are warm.
     try:
         await common.refresh_user_mapping_cache()
@@ -633,9 +622,6 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
     elif current_message is not None and attachments and not current_message.get("attachments"):
         current_message["attachments"] = attachments
 
-    treat_all_messages_as_mentions = bool(event_data.get("treat_all_messages_as_mentions"))
-    untagged_reply = bool(event_data.get("untagged_reply"))
-    code_channel = bool(event_data.get("code_channel"))
     context_messages, context_mode = common.select_slack_context_messages(
         thread_messages,
         event_ts,
@@ -700,9 +686,9 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
         channel_id, thread_ts, context_source, channel_context
     )
     repo_hint_section = (
-        f"## Default Repository Hint\n{repo_config.full_name}\n"
+        f"## Default Repository Hint\n{repo.full_name}\n"
         "Use this only if the Slack conversation does not identify a different repository.\n\n"
-        if repo_config
+        if repo
         else ""
     )
     operational_context = (
@@ -876,7 +862,7 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
         treat_all_messages_as_mentions=treat_all_messages_as_mentions,
         code_channel=code_channel,
         message_update=message_update,
-        explicit_request=bool(event_data.get("explicit_request")),
+        explicit_request=request.explicit_request,
     )
     run_input = _slack_context_input(
         context_messages,
@@ -931,7 +917,7 @@ async def _process_slack_mention_impl(event_data: dict[str, Any], repo_config: R
             mapping_thread_ts=thread_ts,
             original_message_ts=original_message_ts,
             recipient_user_id=user_id,
-            recipient_team_id=str(event_data.get("team_id") or ""),
+            recipient_team_id=request.team_id,
         )
     if is_first_mention:
         if isinstance(run_id, str) and run_id:

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -25,6 +25,7 @@ from agent.input_messages import (
     system_introduction,
 )
 from agent.slack import client as slack_utils
+from agent.slack.failures import SlackRequestTarget, report_slack_failure
 from agent.slack.thinking import stream_slack_thinking_steps
 from agent.source_context import SlackThreadRef, SourceContext
 from agent.utils.json_types import as_json_object
@@ -33,7 +34,6 @@ from agent.utils.thread_ops import (
     langgraph_client as get_langgraph_client,
 )
 from agent.utils.thread_ops import queue_message_for_thread
-from agent.utils.user_messages import warning
 from agent.webhooks import common
 
 STALE_PARTICIPANT_SECONDS = 15 * 60
@@ -459,9 +459,8 @@ async def process_slack_mention(event_data: dict[str, Any], repo_config: dict[st
     """Process a Slack request by creating a run or queuing a mid-run message."""
     try:
         await _process_slack_mention_impl(event_data, repo_config)
-    except Exception:  # noqa: BLE001
-        common.logger.exception("Unexpected error while processing Slack mention")
-        await _notify_slack_processing_error(event_data, repo_config)
+    except Exception as exc:  # noqa: BLE001
+        await _notify_slack_processing_error(event_data, repo_config, exc)
 
 
 async def process_slack_plan_approval(
@@ -481,13 +480,33 @@ async def process_slack_plan_approval(
                 source="slack",
             ),
         )
-    except Exception:  # noqa: BLE001
-        common.logger.exception("Unexpected error while processing Slack plan approval")
-        await _notify_slack_processing_error(event_data, repo_config)
+    except Exception as exc:  # noqa: BLE001
+        await _notify_slack_processing_error(event_data, repo_config, exc)
 
 
 async def _notify_slack_processing_error(
-    event_data: dict[str, Any], repo_config: dict[str, str]
+    event_data: dict[str, Any], repo_config: dict[str, str], exc: BaseException
+) -> None:
+    """Mark the agent thread errored when one exists, then always tell the Slack thread."""
+    channel_id = event_data.get("channel_id", "")
+    thread_ts = event_data.get("thread_ts", "")
+    thread_id = event_data.get("thread_id")
+    if channel_id and thread_ts and not (isinstance(thread_id, str) and thread_id):
+        try:
+            thread_id = await common.lookup_slack_thread_id(
+                get_langgraph_client(), channel_id, thread_ts
+            )
+        except Exception:  # noqa: BLE001
+            thread_id = None
+    if isinstance(thread_id, str) and thread_id:
+        await _mark_slack_thread_errored(thread_id, event_data, repo_config)
+    await report_slack_failure(
+        SlackRequestTarget.model_validate({**event_data, "thread_id": thread_id}), exc
+    )
+
+
+async def _mark_slack_thread_errored(
+    thread_id: str, event_data: dict[str, Any], repo_config: dict[str, str]
 ) -> None:
     channel_id = event_data.get("channel_id", "")
     thread_ts = event_data.get("thread_ts", "")
@@ -495,19 +514,6 @@ async def _notify_slack_processing_error(
     user_id = event_data.get("user_id", "")
     text = event_data.get("text", "")
     bot_user_id = event_data.get("bot_user_id", "")
-    if not channel_id or not thread_ts:
-        return
-
-    thread_id = event_data.get("thread_id")
-    if not isinstance(thread_id, str) or not thread_id:
-        try:
-            thread_id = await common.lookup_slack_thread_id(
-                get_langgraph_client(), channel_id, thread_ts
-            )
-        except Exception:  # noqa: BLE001
-            thread_id = None
-    if not thread_id:
-        return
     try:
         clean_text = (
             common.strip_bot_mention(text, bot_user_id, bot_username=common.SLACK_BOT_USERNAME)
@@ -542,22 +548,6 @@ async def _notify_slack_processing_error(
         )
     except Exception:  # noqa: BLE001
         common.logger.warning("Could not mark Slack thread %s as errored", thread_id, exc_info=True)
-
-    dashboard_url = common.dashboard_thread_url(thread_id)
-    message = warning(
-        "Open SWE hit an unexpected error while handling this Slack thread. "
-        "Send another message and it will try again."
-    )
-    if dashboard_url:
-        message += f" You can view the error in <{dashboard_url}|Open SWE Web>."
-    try:
-        await common.post_slack_thread_reply(
-            channel_id, thread_ts, message, agent_thread_id=thread_id
-        )
-    except Exception:  # noqa: BLE001
-        common.logger.warning(
-            "Could not post Slack error notification for thread %s", thread_id, exc_info=True
-        )
 
 
 async def _process_slack_mention_impl(

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -132,6 +132,7 @@ from agent.slack.events import (
     claim_slack_event,
     slack_event_already_seen,
 )
+from agent.slack.failures import SlackRequestError
 from agent.slack.feedback import (
     FEEDBACK_REACTIONS,
     process_slack_reaction_added,
@@ -897,9 +898,20 @@ async def get_slack_repo_config(
         repo_config = {"owner": default_owner, "name": default_name}
 
     if not repo_config:
-        raise HTTPException(400, "no default repository configured")
+        raise SlackRequestError(_no_repository_message())
 
     return repo_config
+
+
+def _no_repository_message() -> str:
+    text = (
+        "Open SWE does not know which repository this request is about. Add `repo:owner/name` "
+        "to this channel's topic, set a default repository in your Open SWE profile"
+    )
+    settings_url = build_settings_url()
+    if settings_url:
+        text += f" (<{settings_url}|settings>)"
+    return text + ", or ask an admin to set the team default repository."
 
 
 async def _thread_exists(thread_id: str) -> bool:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -90,6 +90,7 @@ from agent.review.findings import (
 )
 from agent.review.publish import fetch_pr_review_threads, post_review_started_comment  # noqa: F401
 from agent.review.reconcile import reconcile_findings_with_review_threads  # noqa: F401
+from agent.run_config import Repo
 from agent.slack.client import (
     GitHubPrRef,
     SlackThreadMappingError,  # noqa: F401
@@ -132,7 +133,6 @@ from agent.slack.events import (
     claim_slack_event,
     slack_event_already_seen,
 )
-from agent.slack.failures import SlackRequestError
 from agent.slack.feedback import (
     FEEDBACK_REACTIONS,
     process_slack_reaction_added,
@@ -816,8 +816,8 @@ async def get_slack_repo_config(
     slack_user_id: str | None = None,
     channel_context: dict[str, Any] | None = None,
     thread_id: str | None = None,
-) -> dict[str, str]:
-    """Resolve repository configuration for Slack-triggered runs.
+) -> Repo | None:
+    """Resolve the default repository hint for a Slack-triggered run, if any source names one.
 
     Priority:
         1. Repo carried over from the existing Slack thread's metadata.
@@ -826,6 +826,9 @@ async def get_slack_repo_config(
            profile and their Slack email maps to a known GitHub login).
         4. Team default repo.
         5. ``SLACK_REPO_*`` env defaults.
+
+    ``None`` is not an error: the agent clones lazily and the message itself
+    usually names the repository when one matters.
     """
     default_owner = SLACK_REPO_OWNER.strip() or DEFAULT_REPO_OWNER
     default_name = SLACK_REPO_NAME.strip() or DEFAULT_REPO_NAME
@@ -897,21 +900,7 @@ async def get_slack_repo_config(
     if not repo_config and default_owner and default_name:
         repo_config = {"owner": default_owner, "name": default_name}
 
-    if not repo_config:
-        raise SlackRequestError(_no_repository_message())
-
-    return repo_config
-
-
-def _no_repository_message() -> str:
-    text = (
-        "Open SWE does not know which repository this request is about. Add `repo:owner/name` "
-        "to this channel's topic, set a default repository in your Open SWE profile"
-    )
-    settings_url = build_settings_url()
-    if settings_url:
-        text += f" (<{settings_url}|settings>)"
-    return text + ", or ask an admin to set the team default repository."
+    return Repo.model_validate(repo_config) if repo_config else None
 
 
 async def _thread_exists(thread_id: str) -> bool:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -94,7 +94,6 @@ from agent.run_config import Repo
 from agent.slack.client import (
     GitHubPrRef,
     SlackThreadMappingError,  # noqa: F401
-    _parse_ts,  # noqa: F401
     fetch_slack_thread_messages,  # noqa: F401
     format_slack_messages_for_prompt,  # noqa: F401
     get_slack_channel_context,
@@ -108,6 +107,7 @@ from agent.slack.client import (
     lookup_slack_run_mapping,  # noqa: F401
     lookup_slack_thread_id,  # noqa: F401
     normalize_slack_channel_context,  # noqa: F401
+    parse_slack_ts,  # noqa: F401
     post_slack_thread_reply,
     post_slack_trace_reply,  # noqa: F401
     resolve_slack_links_in_context,  # noqa: F401
@@ -178,7 +178,7 @@ __all__ = [
     "SLACK_BOT_USER_ID",
     "SLACK_SIGNING_SECRET",
     "SlackThreadMappingError",
-    "_AGENT_VERSION_METADATA",
+    "AGENT_VERSION_METADATA",
     "describe_open_swe_tags",
     "mentions_open_swe",
     "_GH_PR_AGENT_STATE_ACTIONS",
@@ -197,16 +197,16 @@ __all__ = [
     "_fetch_open_pr_for_branch",
     "_finding_comment_ids",
     "_get_or_resolve_thread_github_token",
-    "_get_slack_channel_context",
+    "resolve_slack_channel_context",
     "_get_thread_metadata_safe",
-    "_get_thread_environment",
-    "_get_thread_plan_mode",
-    "_is_docs_plz_slack_channel",
+    "get_thread_environment",
+    "get_thread_plan_mode",
+    "is_docs_plz_slack_channel",
     "_is_not_found_error",
     "_is_pr_diff_unchanged_since_last_review",
     "_is_repo_allowed",
     "_is_repo_auto_review_enabled",
-    "_post_account_link_prompt",
+    "post_account_link_prompt",
     "_refresh_thread_github_token_after_401",
     "_repo_id_from_payload",
     "_repo_id_from_pr_metadata",
@@ -214,12 +214,12 @@ __all__ = [
     "_repo_private_from_pr_metadata",
     "_review_comment_reply_parent_id",
     "_reviewer_token_for_repo",
-    "_run_id_for_logging",
+    "run_id_for_logging",
     "_set_thread_plan_mode",
     "_store_current_reviewer_run_id",
-    "_thread_exists",
+    "thread_exists",
     "_trigger_or_queue_run",
-    "_upsert_slack_thread_repo_metadata",
+    "upsert_slack_thread_repo_metadata",
     "append_finding_interaction",
     "build_pr_prompt",
     "claim_slack_event",
@@ -342,7 +342,7 @@ DOCS_PLZ_SLACK_GATE_REPLY = (
 
 LANGGRAPH_URL = ENV.LANGGRAPH_URL.get()
 
-_AGENT_VERSION_METADATA: dict[str, str] = (
+AGENT_VERSION_METADATA: dict[str, str] = (
     {"LANGSMITH_AGENT_VERSION": ENV.LANGCHAIN_REVISION_ID.require()}
     if ENV.LANGCHAIN_REVISION_ID.optional()
     else {}
@@ -537,7 +537,7 @@ def _is_not_found_error(exc: Exception) -> bool:
     return getattr(exc, "status_code", None) == 404
 
 
-def _run_id_for_logging(run: Any) -> str:
+def run_id_for_logging(run: Any) -> str:
     """Extract a run id from SDK response shapes for log messages."""
     if isinstance(run, dict):
         run_id = run.get("run_id")
@@ -546,7 +546,9 @@ def _run_id_for_logging(run: Any) -> str:
     return run_id if isinstance(run_id, str) and run_id else "<unknown>"
 
 
-async def _get_slack_channel_context(channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
+async def resolve_slack_channel_context(
+    channel_id: str, *, use_cache: bool = True
+) -> dict[str, Any]:
     """Fetch Slack channel context without blocking Slack-triggered runs on failure."""
     try:
         return await get_slack_channel_context(channel_id, use_cache=use_cache)
@@ -555,7 +557,7 @@ async def _get_slack_channel_context(channel_id: str, *, use_cache: bool = True)
         return normalize_slack_channel_context(channel_id, None)
 
 
-async def _is_docs_plz_slack_channel(
+async def is_docs_plz_slack_channel(
     channel_id: str, channel_context: dict[str, Any] | None = None
 ) -> bool:
     """Check whether a Slack channel is the docs-plz handoff channel."""
@@ -645,7 +647,7 @@ async def _enforce_public_repo_org_gate(
     return _PUBLIC_REPO_GATE_REJECTION
 
 
-async def _upsert_slack_thread_repo_metadata(
+async def upsert_slack_thread_repo_metadata(
     thread_id: str, repo_config: dict[str, str], langgraph_client: LangGraphClient
 ) -> None:
     """Persist the selected repo config on the thread metadata."""
@@ -903,7 +905,7 @@ async def get_slack_repo_config(
     return Repo.model_validate(repo_config) if repo_config else None
 
 
-async def _thread_exists(thread_id: str) -> bool:
+async def thread_exists(thread_id: str) -> bool:
     """Return whether a LangGraph thread already exists."""
     langgraph_client = get_client(url=LANGGRAPH_URL)
     try:
@@ -927,7 +929,7 @@ async def _ensure_thread_exists_for_metadata(
         return False
 
 
-async def _get_thread_plan_mode(thread_id: str) -> bool | None:
+async def get_thread_plan_mode(thread_id: str) -> bool | None:
     """Return the persisted plan-mode flag for a thread, or ``None`` if unset."""
     langgraph_client = get_client(url=LANGGRAPH_URL)
     try:
@@ -944,7 +946,7 @@ async def _get_thread_plan_mode(thread_id: str) -> bool | None:
     return value if isinstance(value, bool) else None
 
 
-async def _get_thread_environment(thread_id: str) -> str | None:
+async def get_thread_environment(thread_id: str) -> str | None:
     """Return the environment slug persisted for a thread, or ``None`` if unset."""
     langgraph_client = get_client(url=LANGGRAPH_URL)
     try:
@@ -981,7 +983,7 @@ async def _set_thread_plan_mode(thread_id: str, enabled: bool) -> None:
         logger.exception("Failed to persist plan_mode for thread %s", thread_id)
 
 
-async def _post_account_link_prompt(
+async def post_account_link_prompt(
     channel_id: str,
     thread_ts: str,
     user_id: str,
@@ -1150,7 +1152,7 @@ async def _trigger_or_queue_run(
         },
         source="github",
         input=input,
-        metadata=_AGENT_VERSION_METADATA,
+        metadata=AGENT_VERSION_METADATA,
     )
     logger.info("LangGraph run created for thread %s from GitHub PR comment", thread_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,22 @@ select = [
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
     "TID251",
+    "SLF",  # flake8-self: no cross-module access to _private names
 ]
 ignore = [
     "E501",  # line too long (handled by formatter)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["SLF001"]
+# Pre-existing private-member access; clean up when these modules are next touched.
+"agent/github/routes.py" = ["SLF001"]
+"agent/github/webhook.py" = ["SLF001"]
+"agent/linear/routes.py" = ["SLF001"]
+"agent/linear/webhook.py" = ["SLF001"]
+"agent/reviewer.py" = ["SLF001"]
+"agent/sandboxes/providers/langsmith.py" = ["SLF001"]
+"agent/utils/langsmith.py" = ["SLF001"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "__future__.annotations".msg = "Do not use postponed annotation evaluation."

--- a/tests/dashboard/test_account_link.py
+++ b/tests/dashboard/test_account_link.py
@@ -34,7 +34,7 @@ def test_account_link_prompt_posts_generic_token_free_link(
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", fake_reply)
 
     asyncio.run(
-        webhook_common._post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="unlinked")
+        webhook_common.post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="unlinked")
     )
     reply = calls["reply"]
     assert reply["channel_id"] == "C1"
@@ -57,7 +57,7 @@ def test_account_link_prompt_revoked_wording(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", fake_reply)
 
     asyncio.run(
-        webhook_common._post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="revoked")
+        webhook_common.post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="revoked")
     )
     text = calls["text"]
     assert "no longer valid" in text
@@ -80,6 +80,6 @@ def test_account_link_prompt_skips_when_dashboard_url_unset(
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", fake_reply)
 
     asyncio.run(
-        webhook_common._post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="unlinked")
+        webhook_common.post_account_link_prompt("C1", "1.1", "U1", "d@x.com", reason="unlinked")
     )
     assert posted is False

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -15,6 +15,7 @@ from agent.github import webhook as github_webhooks
 from agent.slack import client as slack_utils
 from agent.slack import webhook as slack_webhooks
 from agent.slack.client import GitHubPrRef
+from agent.slack.request import SlackRequest
 from agent.slack.tools.request_pr_review import request_pr_review as request_pr_review_tool
 from agent.thread_ids import github_issue_thread_id
 from agent.webhooks import common as webhook_common
@@ -738,9 +739,9 @@ def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
         "channel_context": channel_context,
     }
     event_data = captured["event_data"]
-    assert isinstance(event_data, dict)
-    assert event_data["channel_context"] == channel_context
-    assert event_data["text"] == "<@UBOT> review https://github.com/langchain-ai/open-swe/pull/1244"
+    assert isinstance(event_data, SlackRequest)
+    assert event_data.channel_context == channel_context
+    assert event_data.text == "<@UBOT> review https://github.com/langchain-ai/open-swe/pull/1244"
 
 
 def test_slack_webhook_malformed_review_command_starts_agent(monkeypatch) -> None:
@@ -783,10 +784,8 @@ def test_slack_webhook_malformed_review_command_starts_agent(monkeypatch) -> Non
     assert response.json()["message"] == "Slack mention queued"
     assert captured["repo_config"] == {"owner": "langchain-ai", "name": "open-swe"}
     event_data = captured["event_data"]
-    assert isinstance(event_data, dict)
-    assert (
-        event_data["text"] == "<@UBOT> review https://github.com/langchain-ai/open-swe/issues/1244"
-    )
+    assert isinstance(event_data, SlackRequest)
+    assert event_data.text == "<@UBOT> review https://github.com/langchain-ai/open-swe/issues/1244"
 
 
 def test_slack_webhook_non_pr_review_request_starts_agent(monkeypatch) -> None:
@@ -841,8 +840,8 @@ def test_slack_webhook_non_pr_review_request_starts_agent(monkeypatch) -> None:
     assert response.json()["message"] == "Slack mention queued"
     assert captured["repo_config"] == {"owner": "langchain-ai", "name": "open-swe"}
     event_data = captured["event_data"]
-    assert isinstance(event_data, dict)
-    assert event_data["text"] == "<@UBOT> review this branch"
+    assert isinstance(event_data, SlackRequest)
+    assert event_data.text == "<@UBOT> review this branch"
 
 
 def test_slack_webhook_threaded_followup_uses_parent_thread_ts(monkeypatch) -> None:
@@ -895,9 +894,9 @@ def test_slack_webhook_threaded_followup_uses_parent_thread_ts(monkeypatch) -> N
         "slack_user_id": "U123",
     }
     event_data = captured["event_data"]
-    assert isinstance(event_data, dict)
-    assert event_data["thread_ts"] == "1700000000.000100"
-    assert event_data["event_ts"] == "1700000000.000200"
+    assert isinstance(event_data, SlackRequest)
+    assert event_data.thread_ts == "1700000000.000100"
+    assert event_data.event_ts == "1700000000.000200"
 
 
 def test_slack_webhook_accepts_unmentioned_direct_message(monkeypatch) -> None:
@@ -953,7 +952,7 @@ def test_slack_webhook_accepts_unmentioned_direct_message(monkeypatch) -> None:
         "slack_user_id": "U123",
     }
     event_data = captured["event_data"]
-    assert isinstance(event_data, dict)
+    assert isinstance(event_data, SlackRequest)
     assert event_data["text"] == "please check my branch"
     assert event_data["treat_all_messages_as_mentions"] is True
 

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -38,7 +38,7 @@ def _explicit_slack_thread_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", resolve)
     monkeypatch.setattr(webhook_common, "lookup_slack_thread_id", lookup)
-    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
+    monkeypatch.setattr(webhook_common, "resolve_slack_channel_context", channel_context)
 
 
 def _sign_body(body: bytes, secret: str = _TEST_WEBHOOK_SECRET) -> str:
@@ -580,7 +580,7 @@ def test_is_docs_plz_slack_channel_matches_name(monkeypatch) -> None:
 
     monkeypatch.setattr(webhook_common, "get_slack_channel_info", fake_get_slack_channel_info)
 
-    assert asyncio.run(webhook_common._is_docs_plz_slack_channel("C_DOCS")) is True
+    assert asyncio.run(webhook_common.is_docs_plz_slack_channel("C_DOCS")) is True
 
 
 def test_is_docs_plz_slack_channel_matches_normalized_name(monkeypatch) -> None:
@@ -590,7 +590,7 @@ def test_is_docs_plz_slack_channel_matches_normalized_name(monkeypatch) -> None:
 
     monkeypatch.setattr(webhook_common, "get_slack_channel_info", fake_get_slack_channel_info)
 
-    assert asyncio.run(webhook_common._is_docs_plz_slack_channel("C_DOCS")) is True
+    assert asyncio.run(webhook_common.is_docs_plz_slack_channel("C_DOCS")) is True
 
 
 def test_slack_webhook_gates_docs_plz_channel(monkeypatch) -> None:
@@ -630,7 +630,7 @@ def test_slack_webhook_gates_docs_plz_channel(monkeypatch) -> None:
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "open-swe")
     monkeypatch.setattr(slack_utils.time, "time", lambda: 1700000000)
     monkeypatch.setattr(
-        webhook_common, "_get_slack_channel_context", fake_get_slack_channel_context
+        webhook_common, "resolve_slack_channel_context", fake_get_slack_channel_context
     )
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", fake_post_slack_thread_reply)
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", fail_get_slack_repo_config)
@@ -707,7 +707,7 @@ def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "open-swe")
     monkeypatch.setattr(slack_utils.time, "time", lambda: 1700000000)
     monkeypatch.setattr(
-        webhook_common, "_get_slack_channel_context", fake_get_slack_channel_context
+        webhook_common, "resolve_slack_channel_context", fake_get_slack_channel_context
     )
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", fake_get_slack_repo_config)
     monkeypatch.setattr(slack_webhooks, "process_slack_mention", fake_process_slack_mention)
@@ -976,9 +976,7 @@ def test_slack_webhook_accepts_unmentioned_ready_plan_reply(monkeypatch) -> None
     monkeypatch.setattr(webhook_common, "SLACK_SIGNING_SECRET", _TEST_SLACK_SECRET)
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "UBOT")
     monkeypatch.setattr(slack_utils.time, "time", lambda: 1700000000)
-    monkeypatch.setattr(
-        slack_webhooks, "_slack_user_can_reply_to_ready_plan", fake_ready_plan_reply
-    )
+    monkeypatch.setattr(slack_webhooks, "slack_user_can_reply_to_ready_plan", fake_ready_plan_reply)
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", fake_get_slack_repo_config)
     monkeypatch.setattr(slack_webhooks, "process_slack_mention", fake_process_slack_mention)
 
@@ -1011,9 +1009,7 @@ def test_slack_webhook_ignores_unmentioned_non_plan_reply(monkeypatch) -> None:
     monkeypatch.setattr(webhook_common, "SLACK_SIGNING_SECRET", _TEST_SLACK_SECRET)
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "UBOT")
     monkeypatch.setattr(slack_utils.time, "time", lambda: 1700000000)
-    monkeypatch.setattr(
-        slack_webhooks, "_slack_user_can_reply_to_ready_plan", fake_ready_plan_reply
-    )
+    monkeypatch.setattr(slack_webhooks, "slack_user_can_reply_to_ready_plan", fake_ready_plan_reply)
 
     response = _post_slack_webhook(
         TestClient(app),
@@ -1384,7 +1380,7 @@ def test_process_github_issue_uses_resolved_user_token_for_reaction(monkeypatch)
         webhook_common, "get_github_app_installation_token", fake_get_github_app_installation_token
     )
     monkeypatch.setattr(
-        webhook_common, "_thread_exists", lambda thread_id: asyncio.sleep(0, result=False)
+        webhook_common, "thread_exists", lambda thread_id: asyncio.sleep(0, result=False)
     )
     monkeypatch.setattr(webhook_common, "react_to_github_comment", fake_react_to_github_comment)
     monkeypatch.setattr(webhook_common, "fetch_issue_comments", fake_fetch_issue_comments)
@@ -1464,7 +1460,7 @@ def test_process_github_issue_existing_thread_uses_followup_prompt(monkeypatch) 
     monkeypatch.setattr(
         webhook_common, "get_github_app_installation_token", fake_get_github_app_installation_token
     )
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(webhook_common, "react_to_github_comment", fake_react_to_github_comment)
     monkeypatch.setattr(webhook_common, "fetch_issue_comments", fake_fetch_issue_comments)
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeLangGraphClient())

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -12,6 +12,7 @@ from agent.slack import code_channels as slack_code_channels
 from agent.slack import events as slack_events
 from agent.slack import routes as slack_routes
 from agent.slack import webhook as slack_service
+from agent.slack.request import SlackRequest
 from agent.webhooks import common as webhook_common
 
 
@@ -77,10 +78,10 @@ async def test_runtime_slash_command_routes_to_code_channel_session(
 
     assert response == {"response_type": "ephemeral", "text": "Working on /run-tests…"}
     assert code_channel_route.await_args is not None
-    event_data = code_channel_route.await_args.args[0]
-    assert event_data["thread_ts"] == "0"
-    assert event_data["explicit_request"] is True
-    assert "/run-tests tests/slack" in event_data["text"]
+    request = cast(SlackRequest, code_channel_route.await_args.args[0])
+    assert request.thread_ts == "0"
+    assert request.explicit_request is True
+    assert "/run-tests tests/slack" in request.text
 
 
 async def test_context_bar_action_routes_to_code_channel_session(
@@ -110,7 +111,7 @@ async def test_context_bar_action_routes_to_code_channel_session(
 
     assert response["status"] == "accepted"
     assert code_channel_route.await_args is not None
-    assert "create-pr" in code_channel_route.await_args.args[0]["text"]
+    assert "create-pr" in code_channel_route.await_args.args[0].text
 
 
 @pytest.mark.parametrize("is_private", [False, True])
@@ -238,11 +239,11 @@ async def test_untagged_code_channel_message_routes_to_the_channel_session(
     )
 
     assert response["status"] == "accepted", response
-    event_data = cast(dict[str, Any], background_tasks.tasks[0].args[0])
-    assert event_data["code_channel"] is True
-    assert event_data["treat_all_messages_as_mentions"] is True
-    assert event_data["thread_ts"] == webhook_common.CODE_CHANNEL_SESSION_TS
-    assert event_data["reply_thread_ts"] == "1786573300.000000"
+    request = cast(SlackRequest, background_tasks.tasks[0].args[0])
+    assert request.code_channel is True
+    assert request.treat_all_messages_as_mentions is True
+    assert request.thread_ts == webhook_common.CODE_CHANNEL_SESSION_TS
+    assert request.reply_thread_ts == "1786573300.000000"
 
 
 async def test_code_channel_replies_are_posted_top_level(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -36,7 +36,7 @@ def code_channel_route(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     monkeypatch.setattr(webhook_common, "claim_slack_event", AsyncMock(return_value=True))
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(
             return_value={
                 "name": "code-task",
@@ -204,9 +204,9 @@ async def test_untagged_code_channel_message_routes_to_the_channel_session(
     monkeypatch.setattr(webhook_common, "claim_slack_event", AsyncMock(return_value=True))
     monkeypatch.setattr(webhook_common, "is_code_channel", AsyncMock(return_value=True))
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", AsyncMock(return_value="t1"))
-    monkeypatch.setattr(webhook_common, "_thread_exists", AsyncMock(return_value=True))
-    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", AsyncMock(return_value=False))
+    monkeypatch.setattr(webhook_common, "thread_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(webhook_common, "resolve_slack_channel_context", channel_context)
+    monkeypatch.setattr(webhook_common, "is_docs_plz_slack_channel", AsyncMock(return_value=False))
     monkeypatch.setattr(
         webhook_common,
         "get_slack_repo_config",

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -970,7 +970,7 @@ def _setup_slack_mention_fakes(
     monkeypatch.setattr(webhook_common, "login_for_email", fake_login_for_email)
     monkeypatch.setattr(webhook_common, "refresh_user_mapping_cache", fake_refresh_cache)
     monkeypatch.setattr(webhook_common, "get_valid_access_token", fake_get_valid_access_token)
-    monkeypatch.setattr(webhook_common, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webhook_common, "post_account_link_prompt", fake_post_prompt)
 
 
 def test_process_slack_mention_runs_without_a_repository(
@@ -982,7 +982,7 @@ def test_process_slack_mention_runs_without_a_repository(
     async def fake_thread_exists(thread_id: str) -> bool:
         return True
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
@@ -1034,7 +1034,7 @@ def test_process_slack_mention_preserves_forwarded_attachment_from_event(
     monkeypatch.setattr(
         webhook_common, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages
     )
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
@@ -1076,7 +1076,7 @@ def test_process_slack_mention_creates_thread_first_run_without_trace_reply(
         captured["thread_exists_check"] = thread_id
         return False
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
 
     thread_ts = "1700000000.000100"
     event_ts = "1700000000.000200"
@@ -1174,7 +1174,7 @@ def test_process_slack_mention_treats_direct_message_as_implicit_mention(
             {"ts": "1700000000.000200", "text": "continue on the branch", "user": "U123"},
         ]
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(
         webhook_common, "fetch_slack_thread_messages", fake_fetch_slack_thread_messages
     )
@@ -1228,7 +1228,7 @@ def test_process_slack_mention_skips_trace_reply_on_followup_mention(
         captured["thread_exists_check"] = thread_id
         return True
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
 
     thread_ts = "1700000000.000100"
     event_ts = "1700000000.000300"
@@ -1279,10 +1279,10 @@ def test_process_slack_mention_unmapped_user_blocked_and_prompted(
     ):
         captured["prompt"] = {"user_id": user_id, "user_email": user_email, "reason": reason}
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "login_for_email", fake_login_for_email)
-    monkeypatch.setattr(webhook_common, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webhook_common, "post_account_link_prompt", fake_post_prompt)
     monkeypatch.setattr(webhook_common, "is_bot_token_only_mode", lambda: False)
 
     asyncio.run(
@@ -1331,11 +1331,11 @@ def test_process_slack_mention_mapped_user_no_token_record_prompts_setup(
     ):
         captured["prompt"] = {"reason": reason}
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(webhook_common, "has_access_token_record", fake_has_token_record)
-    monkeypatch.setattr(webhook_common, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webhook_common, "post_account_link_prompt", fake_post_prompt)
     monkeypatch.setattr(webhook_common, "is_bot_token_only_mode", lambda: False)
 
     asyncio.run(
@@ -1380,11 +1380,11 @@ def test_process_slack_mention_mapped_user_unusable_token_prompts_revoked(
     ):
         captured["prompt"] = {"reason": reason}
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(webhook_common, "has_access_token_record", fake_has_token_record)
-    monkeypatch.setattr(webhook_common, "_post_account_link_prompt", fake_post_prompt)
+    monkeypatch.setattr(webhook_common, "post_account_link_prompt", fake_post_prompt)
     monkeypatch.setattr(webhook_common, "is_bot_token_only_mode", lambda: False)
 
     asyncio.run(
@@ -1423,7 +1423,7 @@ def test_process_slack_mention_mapped_user_with_token_runs_as_user(
     async def fake_upsert_owner(thread_id: str, **kwargs: object) -> None:
         owner_meta.update(kwargs)
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "upsert_agent_thread_metadata", fake_upsert_owner)
 
@@ -1471,7 +1471,7 @@ def test_process_slack_mention_bot_only_mode_runs_without_user_token(
     async def fake_login_for_email(email):
         return None
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(webhook_common, "login_for_slack_id", fake_login_for_slack_id)
     monkeypatch.setattr(webhook_common, "login_for_email", fake_login_for_email)
     monkeypatch.setattr(webhook_common, "is_bot_token_only_mode", lambda: True)
@@ -1574,13 +1574,13 @@ def test_thread_environment_round_trips_through_metadata(
     )
     assert threads.thread is not None
     assert threads.thread["metadata"]["environment"] == "staging"
-    assert asyncio.run(webhook_common._get_thread_environment("thread-id")) == "staging"
+    assert asyncio.run(webhook_common.get_thread_environment("thread-id")) == "staging"
 
 
 def test_thread_environment_is_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     threads = _FakeThreadsClient({"metadata": {}})
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
-    assert asyncio.run(webhook_common._get_thread_environment("thread-id")) is None
+    assert asyncio.run(webhook_common.get_thread_environment("thread-id")) is None
 
 
 def test_thread_environment_is_none_for_a_missing_thread(
@@ -1588,7 +1588,7 @@ def test_thread_environment_is_none_for_a_missing_thread(
 ) -> None:
     threads = _FakeThreadsClient(raise_not_found=True)
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
-    assert asyncio.run(webhook_common._get_thread_environment("thread-id")) is None
+    assert asyncio.run(webhook_common.get_thread_environment("thread-id")) is None
 
 
 def _context_input(messages: list[dict], **kwargs: object) -> list[str]:
@@ -1806,7 +1806,7 @@ def test_process_slack_mention_queues_a_message_edit_instead_of_running(
         captured["queued"] = {"thread_id": thread_id, "content": content}
         return True
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(slack_webhooks, "queue_message_for_thread", fake_queue_message_for_thread)
 
     asyncio.run(
@@ -1849,7 +1849,7 @@ def test_process_slack_mention_runs_an_edit_when_queueing_fails(
     async def fake_queue_message_for_thread(thread_id: str, content: object) -> bool:
         return False
 
-    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+    monkeypatch.setattr(webhook_common, "thread_exists", fake_thread_exists)
     monkeypatch.setattr(slack_webhooks, "queue_message_for_thread", fake_queue_message_for_thread)
 
     asyncio.run(

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 
 import pytest
 
+from agent.run_config import Repo
 from agent.slack import client as slack_utils
 from agent.slack import webhook as slack_webhooks
 from agent.slack.client import (
@@ -741,7 +742,7 @@ def test_get_slack_repo_config_uses_existing_thread_repo(
         webhook_common.get_slack_repo_config("C123", "1.234", thread_id="mapped-thread")
     )
 
-    assert repo == {"owner": "saved-owner", "name": "saved-repo"}
+    assert repo == Repo(owner="saved-owner", name="saved-repo")
     assert threads_client.requested_thread_id == "mapped-thread"
     assert not posted
 
@@ -764,7 +765,7 @@ def test_get_slack_repo_config_new_thread_uses_default(
         webhook_common.get_slack_repo_config("C123", "1.234", thread_id="mapped-thread")
     )
 
-    assert repo == {"owner": "default-owner", "name": "default-repo"}
+    assert repo == Repo(owner="default-owner", name="default-repo")
 
 
 def test_get_slack_repo_config_existing_thread_without_repo_uses_default(
@@ -781,7 +782,7 @@ def test_get_slack_repo_config_existing_thread_without_repo_uses_default(
         webhook_common.get_slack_repo_config("C123", "1.234", thread_id="mapped-thread")
     )
 
-    assert repo == {"owner": "default-owner", "name": "default-repo"}
+    assert repo == Repo(owner="default-owner", name="default-repo")
     assert threads_client.requested_thread_id == "mapped-thread"
 
 
@@ -798,7 +799,7 @@ def test_get_slack_repo_config_ignores_repo_syntax_in_message(
         webhook_common.get_slack_repo_config("C123", "1.234", thread_id="mapped-thread")
     )
 
-    assert repo == {"owner": "saved-owner", "name": "saved-repo"}
+    assert repo == Repo(owner="saved-owner", name="saved-repo")
 
 
 def test_get_slack_repo_config_applies_profile_default_repo(
@@ -829,7 +830,7 @@ def test_get_slack_repo_config_applies_profile_default_repo(
         )
     )
 
-    assert repo == {"owner": "profile-owner", "name": "profile-repo"}
+    assert repo == Repo(owner="profile-owner", name="profile-repo")
 
 
 def test_get_slack_repo_config_applies_team_default_repo(
@@ -849,7 +850,26 @@ def test_get_slack_repo_config_applies_team_default_repo(
         webhook_common.get_slack_repo_config("C123", "1.234", thread_id="mapped-thread")
     )
 
-    assert repo == {"owner": "team-owner", "name": "team-repo"}
+    assert repo == Repo(owner="team-owner", name="team-repo")
+
+
+def test_get_slack_repo_config_is_none_when_nothing_names_a_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads_client = _FakeThreadsClient(thread={"metadata": {}})
+
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads_client))
+    monkeypatch.setattr(webhook_common, "get_team_default_repo", _no_team_default_repo)
+    monkeypatch.setattr(webhook_common, "SLACK_REPO_OWNER", "")
+    monkeypatch.setattr(webhook_common, "SLACK_REPO_NAME", "")
+    monkeypatch.setattr(webhook_common, "DEFAULT_REPO_OWNER", "")
+    monkeypatch.setattr(webhook_common, "DEFAULT_REPO_NAME", "")
+
+    repo = asyncio.run(
+        webhook_common.get_slack_repo_config("C123", "1.234", thread_id="mapped-thread")
+    )
+
+    assert repo is None
 
 
 def _setup_slack_mention_fakes(
@@ -953,6 +973,45 @@ def _setup_slack_mention_fakes(
     monkeypatch.setattr(webhook_common, "_post_account_link_prompt", fake_post_prompt)
 
 
+def test_process_slack_mention_runs_without_a_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    _setup_slack_mention_fakes(monkeypatch, captured)
+
+    async def fake_thread_exists(thread_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(webhook_common, "_thread_exists", fake_thread_exists)
+
+    asyncio.run(
+        slack_webhooks.process_slack_mention(
+            {
+                "channel_id": "C123",
+                "thread_ts": "1700000000.000100",
+                "event_ts": "1700000000.000200",
+                "user_id": "U123",
+                "text": "<@UBOT> hello",
+                "bot_user_id": "UBOT",
+            },
+            None,
+        )
+    )
+
+    run_create = captured["run_create"]
+    assert isinstance(run_create, dict)
+    kwargs = run_create["kwargs"]
+    assert kwargs["config"]["configurable"]["repo"] is None
+    prompt_message = next(
+        message
+        for message in kwargs["input"]["messages"]
+        if isinstance(message["content"], str)
+        and 'sender="system:slack-context"' in message["content"]
+    )
+    assert "Default Repository Hint" not in prompt_message["content"]
+    assert "metadata_update" not in captured
+
+
 def test_process_slack_mention_preserves_forwarded_attachment_from_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -994,7 +1053,7 @@ def test_process_slack_mention_preserves_forwarded_attachment_from_event(
                 ],
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1033,7 +1092,7 @@ def test_process_slack_mention_creates_thread_first_run_without_trace_reply(
                 "text": "<@UBOT> continue on the branch",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1131,7 +1190,7 @@ def test_process_slack_mention_treats_direct_message_as_implicit_mention(
                 "bot_user_id": "UBOT",
                 "treat_all_messages_as_mentions": True,
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1185,7 +1244,7 @@ def test_process_slack_mention_skips_trace_reply_on_followup_mention(
                 "text": "<@UBOT> follow up question",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1236,7 +1295,7 @@ def test_process_slack_mention_unmapped_user_blocked_and_prompted(
                 "text": "<@UBOT> do the thing",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1289,7 +1348,7 @@ def test_process_slack_mention_mapped_user_no_token_record_prompts_setup(
                 "text": "<@UBOT> do the thing",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1338,7 +1397,7 @@ def test_process_slack_mention_mapped_user_unusable_token_prompts_revoked(
                 "text": "<@UBOT> do the thing",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1378,7 +1437,7 @@ def test_process_slack_mention_mapped_user_with_token_runs_as_user(
                 "text": "<@UBOT> do the thing",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1427,7 +1486,7 @@ def test_process_slack_mention_bot_only_mode_runs_without_user_token(
                 "text": "<@UBOT> do the thing",
                 "bot_user_id": "UBOT",
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1761,7 +1820,7 @@ def test_process_slack_mention_queues_a_message_edit_instead_of_running(
                 "bot_user_id": "UBOT",
                 "message_update": True,
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 
@@ -1804,7 +1863,7 @@ def test_process_slack_mention_runs_an_edit_when_queueing_fails(
                 "bot_user_id": "UBOT",
                 "message_update": True,
             },
-            {"owner": "langchain-ai", "name": "open-swe"},
+            Repo(owner="langchain-ai", name="open-swe"),
         )
     )
 

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -17,6 +17,7 @@ from agent.slack.client import (
     select_slack_context_messages,
     strip_bot_mention,
 )
+from agent.slack.request import SlackRequest
 from agent.source_context import SourceContext
 from agent.utils.run_usage import RunUsageSummary
 from agent.webhooks import common as webhook_common
@@ -986,14 +987,16 @@ def test_process_slack_mention_runs_without_a_repository(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> hello",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> hello",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             None,
         )
     )
@@ -1038,21 +1041,23 @@ def test_process_slack_mention_preserves_forwarded_attachment_from_event(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> handle this",
-                "attachments": [
-                    {
-                        "is_share": True,
-                        "author_name": "Teammate",
-                        "text": "Forwarded requirements",
-                    }
-                ],
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> handle this",
+                    "attachments": [
+                        {
+                            "is_share": True,
+                            "author_name": "Teammate",
+                            "text": "Forwarded requirements",
+                        }
+                    ],
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1084,14 +1089,16 @@ def test_process_slack_mention_creates_thread_first_run_without_trace_reply(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": thread_ts,
-                "event_ts": event_ts,
-                "user_id": "U123",
-                "text": "<@UBOT> continue on the branch",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": thread_ts,
+                    "event_ts": event_ts,
+                    "user_id": "U123",
+                    "text": "<@UBOT> continue on the branch",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1181,15 +1188,17 @@ def test_process_slack_mention_treats_direct_message_as_implicit_mention(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "D123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "continue on the branch",
-                "bot_user_id": "UBOT",
-                "treat_all_messages_as_mentions": True,
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "D123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "continue on the branch",
+                    "bot_user_id": "UBOT",
+                    "treat_all_messages_as_mentions": True,
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1236,14 +1245,16 @@ def test_process_slack_mention_skips_trace_reply_on_followup_mention(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": thread_ts,
-                "event_ts": event_ts,
-                "user_id": "U123",
-                "text": "<@UBOT> follow up question",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": thread_ts,
+                    "event_ts": event_ts,
+                    "user_id": "U123",
+                    "text": "<@UBOT> follow up question",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1287,14 +1298,16 @@ def test_process_slack_mention_unmapped_user_blocked_and_prompted(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> do the thing",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> do the thing",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1340,14 +1353,16 @@ def test_process_slack_mention_mapped_user_no_token_record_prompts_setup(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> do the thing",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> do the thing",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1389,14 +1404,16 @@ def test_process_slack_mention_mapped_user_unusable_token_prompts_revoked(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> do the thing",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> do the thing",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1429,14 +1446,16 @@ def test_process_slack_mention_mapped_user_with_token_runs_as_user(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> do the thing",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> do the thing",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1478,14 +1497,16 @@ def test_process_slack_mention_bot_only_mode_runs_without_user_token(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000200",
-                "user_id": "U123",
-                "text": "<@UBOT> do the thing",
-                "bot_user_id": "UBOT",
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000200",
+                    "user_id": "U123",
+                    "text": "<@UBOT> do the thing",
+                    "bot_user_id": "UBOT",
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1811,15 +1832,17 @@ def test_process_slack_mention_queues_a_message_edit_instead_of_running(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000300",
-                "user_id": "U123",
-                "text": "<@UBOT> actually use PR 5889",
-                "bot_user_id": "UBOT",
-                "message_update": True,
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000300",
+                    "user_id": "U123",
+                    "text": "<@UBOT> actually use PR 5889",
+                    "bot_user_id": "UBOT",
+                    "message_update": True,
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )
@@ -1854,15 +1877,17 @@ def test_process_slack_mention_runs_an_edit_when_queueing_fails(
 
     asyncio.run(
         slack_webhooks.process_slack_mention(
-            {
-                "channel_id": "C123",
-                "thread_ts": "1700000000.000100",
-                "event_ts": "1700000000.000300",
-                "user_id": "U123",
-                "text": "<@UBOT> actually use PR 5889",
-                "bot_user_id": "UBOT",
-                "message_update": True,
-            },
+            SlackRequest.model_validate(
+                {
+                    "channel_id": "C123",
+                    "thread_ts": "1700000000.000100",
+                    "event_ts": "1700000000.000300",
+                    "user_id": "U123",
+                    "text": "<@UBOT> actually use PR 5889",
+                    "bot_user_id": "UBOT",
+                    "message_update": True,
+                }
+            ),
             Repo(owner="langchain-ai", name="open-swe"),
         )
     )

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -106,8 +106,8 @@ def _patch_slack_webhook(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
     monkeypatch.setattr(slack_events, "get_client", lambda url: client)
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **_kwargs: True)
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", AsyncMock(return_value="t1"))
-    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
+    monkeypatch.setattr(webhook_common, "resolve_slack_channel_context", channel_context)
+    monkeypatch.setattr(webhook_common, "is_docs_plz_slack_channel", not_docs_plz)
 
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
     return client
@@ -198,7 +198,7 @@ async def test_external_channel_refuses_without_starting_a_run(
     resolve_thread = cast(AsyncMock, webhook_common.resolve_slack_thread_id)
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": True}),
     )
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", post_reply)
@@ -224,7 +224,7 @@ async def test_unverified_channel_fails_closed_without_reply_or_run(
     resolve_thread = cast(AsyncMock, webhook_common.resolve_slack_thread_id)
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": None}),
     )
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", post_reply)

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -8,6 +8,7 @@ from fastapi import BackgroundTasks
 from starlette.requests import Request
 
 from agent.slack import events as slack_events
+from agent.slack import failures as slack_failures
 from agent.slack import routes as slack_routes
 from agent.slack import webhook as slack_service
 from agent.webhooks import common as webhook_common
@@ -236,16 +237,46 @@ async def test_unverified_channel_fails_closed_without_reply_or_run(
     resolve_thread.assert_not_awaited()
 
 
-async def test_preprocessing_failure_does_not_claim_event(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_preprocessing_failure_replies_and_does_not_claim_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     background_tasks = _FakeBackgroundTasks()
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
 
     async def failed_repo_config(*_args: Any, **_kwargs: Any) -> dict[str, str]:
         raise RuntimeError
 
     original_repo_config = webhook_common.get_slack_repo_config
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", failed_repo_config)
-    with pytest.raises(RuntimeError):
-        await _post(_mention_payload(), background_tasks)
+    response = await _post(_mention_payload(), background_tasks)
+
+    assert response["status"] == "error"
+    assert background_tasks.tasks == []
+    post_reply.assert_awaited_once()
+    await_args = post_reply.await_args
+    assert await_args is not None
+    assert await_args.args[:2] == ("C1", "1786573369.551099")
+    assert f"Error ID: `{response['error_id']}`" in await_args.args[2]
 
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", original_repo_config)
     assert (await _post(_mention_payload(), background_tasks))["status"] == "accepted"
+
+
+async def test_rejected_request_replies_with_its_own_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    background_tasks = _FakeBackgroundTasks()
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
+
+    async def no_repo(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        raise slack_failures.SlackRequestError("Pick a repository first.")
+
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", no_repo)
+    response = await _post(_mention_payload(), background_tasks)
+
+    assert response["status"] == "error"
+    await_args = post_reply.await_args
+    assert await_args is not None
+    assert await_args.args[2].startswith("⚠️ Pick a repository first.\nError ID: `")

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -263,6 +263,23 @@ async def test_preprocessing_failure_replies_and_does_not_claim_event(
     assert (await _post(_mention_payload(), background_tasks))["status"] == "accepted"
 
 
+async def test_mention_without_a_repository_is_still_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    background_tasks = _FakeBackgroundTasks()
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
+    monkeypatch.setattr(webhook_common, "get_slack_repo_config", AsyncMock(return_value=None))
+
+    response = await _post(_mention_payload(), background_tasks)
+
+    assert response["status"] == "accepted"
+    [(task, args)] = background_tasks.tasks
+    assert task is slack_service.process_slack_mention
+    assert args[1] is None
+    post_reply.assert_not_awaited()
+
+
 async def test_rejected_request_replies_with_its_own_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/slack/test_slack_failures.py
+++ b/tests/slack/test_slack_failures.py
@@ -1,0 +1,115 @@
+import logging
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.slack import failures
+
+
+def _target() -> failures.SlackRequestTarget:
+    return failures.SlackRequestTarget(channel_id="C1", thread_ts="1.0", event_id="Ev1")
+
+
+async def test_unexpected_failure_replies_with_a_uuid7_error_id_that_is_logged(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(failures, "post_slack_thread_reply", post_reply)
+
+    with caplog.at_level(logging.ERROR, logger=failures.logger.name):
+        error_id = await failures.report_slack_failure(_target(), RuntimeError("boom"))
+
+    assert uuid.UUID(error_id).version == 7
+    post_reply.assert_awaited_once()
+    await_args = post_reply.await_args
+    assert await_args is not None
+    assert await_args.args[:2] == ("C1", "1.0")
+    assert "unexpected error" in await_args.args[2]
+    assert f"Error ID: `{error_id}`" in await_args.args[2]
+
+    [record] = [r for r in caplog.records if r.getMessage() == "Slack request failed"]
+    assert record.error_id == error_id  # type: ignore[attr-defined]
+    assert record.slack_channel_id == "C1"  # type: ignore[attr-defined]
+    assert record.slack_thread_ts == "1.0"  # type: ignore[attr-defined]
+    assert record.slack_event_id == "Ev1"  # type: ignore[attr-defined]
+    assert record.exc_info is not None
+    assert isinstance(record.exc_info[1], RuntimeError)
+
+
+async def test_request_error_replies_with_its_own_message(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(failures, "post_slack_thread_reply", post_reply)
+
+    with caplog.at_level(logging.WARNING, logger=failures.logger.name):
+        error_id = await failures.report_slack_failure(
+            _target(), failures.SlackRequestError("Pick a repository first.")
+        )
+
+    await_args = post_reply.await_args
+    assert await_args is not None
+    assert await_args.args[2] == f"⚠️ Pick a repository first.\nError ID: `{error_id}`"
+    [record] = [r for r in caplog.records if r.getMessage() == "Slack request rejected"]
+    assert record.levelno == logging.WARNING
+    assert record.error_id == error_id  # type: ignore[attr-defined]
+
+
+async def test_failed_reply_still_returns_error_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        failures, "post_slack_thread_reply", AsyncMock(side_effect=RuntimeError("slack down"))
+    )
+
+    error_id = await failures.report_slack_failure(_target(), RuntimeError("boom"))
+
+    assert uuid.UUID(error_id).version == 7
+
+
+async def test_answer_slack_request_turns_failure_into_error_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(failures, "post_slack_thread_reply", post_reply)
+
+    async def handle() -> dict[str, str]:
+        raise RuntimeError("boom")
+
+    response = await failures.answer_slack_request(_target(), handle)
+
+    assert response["status"] == "error"
+    assert uuid.UUID(response["error_id"]).version == 7
+    post_reply.assert_awaited_once()
+
+
+async def test_answer_slack_request_passes_through_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(failures, "post_slack_thread_reply", post_reply)
+
+    async def handle() -> dict[str, str]:
+        return {"status": "accepted"}
+
+    assert await failures.answer_slack_request(_target(), handle) == {"status": "accepted"}
+    post_reply.assert_not_awaited()
+
+
+async def test_run_slack_task_reports_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(failures, "post_slack_thread_reply", post_reply)
+
+    async def task() -> None:
+        raise RuntimeError("boom")
+
+    await failures.run_slack_task(_target(), task())
+
+    post_reply.assert_awaited_once()
+
+
+def test_target_reads_agent_thread_from_event_data() -> None:
+    target = failures.SlackRequestTarget.model_validate(
+        {"channel_id": "C1", "thread_ts": "1.0", "thread_id": "t1", "text": "ignored"}
+    )
+    assert target.agent_thread_id == "t1"
+    assert failures.SlackRequestTarget.model_validate({"thread_id": None}).agent_thread_id is None

--- a/tests/slack/test_slack_failures.py
+++ b/tests/slack/test_slack_failures.py
@@ -106,10 +106,3 @@ async def test_run_slack_task_reports_failure(monkeypatch: pytest.MonkeyPatch) -
 
     post_reply.assert_awaited_once()
 
-
-def test_target_reads_agent_thread_from_event_data() -> None:
-    target = failures.SlackRequestTarget.model_validate(
-        {"channel_id": "C1", "thread_ts": "1.0", "thread_id": "t1", "text": "ignored"}
-    )
-    assert target.agent_thread_id == "t1"
-    assert failures.SlackRequestTarget.model_validate({"thread_id": None}).agent_thread_id is None

--- a/tests/slack/test_slack_feedback.py
+++ b/tests/slack/test_slack_feedback.py
@@ -228,7 +228,7 @@ async def test_slack_webhook_queues_reaction_added(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
@@ -250,7 +250,7 @@ async def test_slack_webhook_queues_stop_reaction(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
@@ -274,7 +274,7 @@ async def test_slack_webhook_queues_reaction_removed(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 
@@ -298,7 +298,7 @@ async def test_slack_webhook_ignores_untracked_reaction(monkeypatch: pytest.Monk
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **kwargs: True)
     monkeypatch.setattr(
         webhook_common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
 

--- a/tests/slack/test_slack_interactivity.py
+++ b/tests/slack/test_slack_interactivity.py
@@ -89,7 +89,7 @@ async def test_external_channel_interaction_is_blocked(
     monkeypatch.setattr(slack_routes.common, "lookup_slack_thread_id", lookup)
     monkeypatch.setattr(
         slack_routes.common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": True}),
     )
     background_tasks = BackgroundTasks()
@@ -115,7 +115,7 @@ async def test_option_interaction_schedules_update_before_agent_processing(
     )
     monkeypatch.setattr(
         slack_routes.common,
-        "_get_slack_channel_context",
+        "resolve_slack_channel_context",
         AsyncMock(
             return_value={
                 "name": "proj-open-swe",
@@ -173,7 +173,7 @@ async def test_code_channel_view_action_routes_to_channel_session(
     )
     monkeypatch.setattr(slack_routes.common, "claim_slack_event", AsyncMock(return_value=True))
     monkeypatch.setattr(
-        slack_routes.common, "_get_slack_channel_context", AsyncMock(return_value={})
+        slack_routes.common, "resolve_slack_channel_context", AsyncMock(return_value={})
     )
     monkeypatch.setattr(
         slack_routes.common,

--- a/tests/slack/test_slack_interactivity.py
+++ b/tests/slack/test_slack_interactivity.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import BackgroundTasks, Request
 
 from agent.slack import routes as slack_routes
+from agent.slack.payloads import SlackBlockAction, SlackInteraction
 
 
 def _request(payload: dict[str, Any]) -> Request:
@@ -59,7 +60,11 @@ async def test_selected_option_updates_original_message(monkeypatch: pytest.Monk
     update = AsyncMock(return_value=(True, None))
     monkeypatch.setattr(slack_routes.common, "update_slack_message", update)
 
-    await slack_routes._update_selected_option_message(payload, payload["actions"][0], "Option B")
+    await slack_routes._update_selected_option_message(
+        SlackInteraction.model_validate(payload),
+        SlackBlockAction.model_validate(payload["actions"][0]),
+        "Option B",
+    )
 
     update.assert_awaited_once_with(
         "C1",
@@ -138,7 +143,11 @@ async def test_option_interaction_schedules_update_before_agent_processing(
     assert result == {"status": "accepted", "message": "Slack option queued"}
     assert [task.func for task in background_tasks.tasks] == [update, process]
     await background_tasks()
-    update.assert_awaited_once_with(payload, payload["actions"][0], "Option B")
+    update.assert_awaited_once_with(
+        SlackInteraction.model_validate(payload),
+        SlackBlockAction.model_validate(payload["actions"][0]),
+        "Option B",
+    )
     process.assert_awaited_once()
 
 
@@ -189,9 +198,9 @@ async def test_code_channel_view_action_routes_to_channel_session(
     assert result["status"] == "accepted"
     assert process.await_args is not None
     event_data = process.await_args.args[0]
-    assert event_data["thread_ts"] == "0"
-    assert event_data["explicit_request"] is True
-    assert "approve-plan" in event_data["text"]
+    assert event_data.thread_ts == "0"
+    assert event_data.explicit_request is True
+    assert "approve-plan" in event_data.text
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_reply_tool.py
+++ b/tests/slack/test_slack_thread_reply_tool.py
@@ -7,6 +7,8 @@ from uuid import UUID
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
+from agent.slack.payloads import SlackBlockAction
+
 slack_reply_tool = importlib.import_module("agent.slack.tools.thread_reply")
 
 
@@ -317,10 +319,11 @@ def test_slack_action_ids_are_unique_and_recognized() -> None:
     actions = blocks[1]["elements"]
 
     assert len({action["action_id"] for action in actions}) == len(actions)
-    assert slack_routes._first_open_swe_option_action(actions) is actions[0]
-    legacy = {"action_id": "open_swe_option_select"}
-    assert slack_routes._first_open_swe_option_action([legacy]) is legacy
-    assert slack_routes._first_open_swe_option_action([{"action_id": "unrelated"}]) is None
+    parsed = [SlackBlockAction.model_validate(action) for action in actions]
+    assert slack_routes._first_option_action(parsed) is parsed[0]
+    legacy = SlackBlockAction(action_id="open_swe_option_select")
+    assert slack_routes._first_option_action([legacy]) is legacy
+    assert slack_routes._first_option_action([SlackBlockAction(action_id="unrelated")]) is None
 
 
 async def test_slack_thread_reply_passes_live_run_id(

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -123,15 +123,15 @@ def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
             }
         ),
     )
-    monkeypatch.setattr(webhook_common, "_thread_exists", AsyncMock(return_value=True))
-    monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
+    monkeypatch.setattr(webhook_common, "thread_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(webhook_common, "resolve_slack_channel_context", channel_context)
+    monkeypatch.setattr(webhook_common, "is_docs_plz_slack_channel", not_docs_plz)
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "BOT")
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "openswe")
     # The two-party gate would admit these messages on its own.
     monkeypatch.setattr(
-        slack_service, "_slack_thread_allows_untagged_reply", AsyncMock(return_value=True)
+        slack_service, "slack_thread_allows_untagged_reply", AsyncMock(return_value=True)
     )
 
 
@@ -215,7 +215,7 @@ async def test_root_message_update_uses_original_message_as_thread() -> None:
     ("patch_name", "patch_value"),
     [
         ("lookup_slack_thread_id", None),
-        ("_thread_exists", False),
+        ("thread_exists", False),
         ("lookup_slack_run_mapping", None),
     ],
 )
@@ -309,7 +309,7 @@ async def test_unassociated_message_update_does_not_trigger_docs_gate(
     monkeypatch.setattr(slack_routes, "_MESSAGE_UPDATE_RETRY_DELAYS", ())
     is_docs_plz = AsyncMock(return_value=True)
     post_reply = AsyncMock()
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", is_docs_plz)
+    monkeypatch.setattr(webhook_common, "is_docs_plz_slack_channel", is_docs_plz)
     monkeypatch.setattr(webhook_common, "post_slack_thread_reply", post_reply)
     background_tasks = _FakeBackgroundTasks()
 

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 from agent.slack import events as slack_events
 from agent.slack import routes as slack_routes
 from agent.slack import webhook as slack_service
+from agent.slack.request import SlackRequest
 from agent.webhooks import common as webhook_common
 
 
@@ -142,8 +143,7 @@ async def _untagged_flag_for(text: str, event_id: str) -> bool:
         cast(BackgroundTasks, background_tasks),
     )
     assert response["status"] == "accepted", response
-    event_data = background_tasks.tasks[0][1][0]
-    return bool(event_data["untagged_reply"])
+    return cast(SlackRequest, background_tasks.tasks[0][1][0]).untagged_reply
 
 
 async def test_id_mention_is_not_marked_untagged() -> None:
@@ -168,13 +168,13 @@ async def test_message_update_queues_only_the_new_text() -> None:
 
     assert response["status"] == "accepted"
     assert background_tasks.tasks[0][0] is slack_routes._process_slack_message_update
-    event_data = background_tasks.tasks[0][1][0]
-    assert event_data["message_update"] is True
-    assert event_data["event_ts"] == "1786573400.000000"
-    assert event_data["original_message_ts"] == "1786573369.551099"
-    assert event_data["thread_ts"] == "1786573300.000000"
-    assert event_data["text"] == "new corrected text"
-    assert "old text that must not be resent" not in str(event_data)
+    request = cast(SlackRequest, background_tasks.tasks[0][1][0])
+    assert request.message_update is True
+    assert request.event_ts == "1786573400.000000"
+    assert request.original_message_ts == "1786573369.551099"
+    assert request.thread_ts == "1786573300.000000"
+    assert request.text == "new corrected text"
+    assert "old text that must not be resent" not in str(request)
 
 
 async def _run_message_update_task(background_tasks: _FakeBackgroundTasks) -> None:
@@ -202,8 +202,8 @@ async def test_root_message_update_uses_original_message_as_thread() -> None:
     await _run_message_update_task(background_tasks)
 
     assert response["status"] == "accepted"
-    event_data = background_tasks.tasks[0][1][0]
-    assert event_data["thread_ts"] == "1786573369.551099"
+    request = cast(SlackRequest, background_tasks.tasks[0][1][0])
+    assert request.thread_ts == "1786573369.551099"
     lookup = cast(AsyncMock, webhook_common.lookup_slack_thread_id)
     lookup.assert_awaited_once()
     await_args = lookup.await_args

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -151,7 +151,7 @@ async def test_slack_plan_button_failure_notifies_user(
 
     await slack_webhook.process_slack_plan_approval(event_data, repo_config)
 
-    notify.assert_awaited_once_with(event_data, repo_config)
+    notify.assert_awaited_once_with(event_data, repo_config, approve.side_effect)
 
 
 def _thread(*users: str) -> list[dict[str, Any]]:

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -128,7 +128,7 @@ async def test_non_owner_can_send_untagged_ready_plan_reply(
     lookup_thread = AsyncMock(return_value="t1")
     monkeypatch.setattr(slack_webhook.common, "lookup_slack_thread_id", lookup_thread)
 
-    allowed = await slack_webhook._slack_user_can_reply_to_ready_plan("C1", "123.45", "U2")
+    allowed = await slack_webhook.slack_user_can_reply_to_ready_plan("C1", "123.45", "U2")
 
     assert allowed is True
     lookup_thread.assert_awaited_once()
@@ -168,7 +168,7 @@ async def test_untagged_reply_allowed_for_two_party_thread(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert await slack_webhook._slack_thread_allows_untagged_reply(
+    assert await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "no worries, keep going", "BOT"
     )
 
@@ -182,7 +182,7 @@ async def test_untagged_reply_blocked_when_mentioning_other_user(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "hey <@UOTHER> can you look?", "BOT"
     )
 
@@ -196,7 +196,7 @@ async def test_untagged_reply_mentioning_only_bot_allowed(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert await slack_webhook._slack_thread_allows_untagged_reply(
+    assert await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "<@BOT> keep going", "BOT"
     )
 
@@ -210,7 +210,7 @@ async def test_untagged_reply_blocked_for_three_party_thread(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "keep going", "BOT"
     )
 
@@ -224,7 +224,7 @@ async def test_untagged_reply_blocked_when_bot_absent(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "keep going", "BOT"
     )
 
@@ -243,7 +243,7 @@ async def test_untagged_reply_blocked_when_only_third_party_bot_present(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "keep going", "BOT"
     )
 
@@ -322,7 +322,7 @@ async def test_untagged_reply_ignores_a_third_party_who_went_quiet(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert await slack_webhook._slack_thread_allows_untagged_reply(
+    assert await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "why do you not see this message", "BOT", "URAMON", f"{base + 1423:.6f}"
     )
 
@@ -341,7 +341,7 @@ async def test_untagged_reply_blocked_while_a_third_party_is_still_active(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "how about now", "BOT", "URAMON", f"{base + 1423:.6f}"
     )
 
@@ -361,7 +361,7 @@ async def test_untagged_reply_blocked_when_third_party_spoke_after_the_bot(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "ping", "BOT", "URAMON", f"{base + 9999:.6f}"
     )
 
@@ -380,7 +380,7 @@ async def test_untagged_reply_ignores_joins_and_leaves(
         slack_webhook.common, "fetch_slack_thread_messages", AsyncMock(return_value=messages)
     )
 
-    assert await slack_webhook._slack_thread_allows_untagged_reply(
+    assert await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "keep going", "BOT", "URAMON", f"{base + 20:.6f}"
     )
 
@@ -396,7 +396,7 @@ async def test_untagged_reply_blocked_when_bot_never_posted(
         AsyncMock(return_value=[_msg(base, "URAMON")]),
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "hello", "BOT", "URAMON", f"{base + 5:.6f}"
     )
 
@@ -410,7 +410,7 @@ async def test_rapid_follow_up_allowed_before_bot_posts(monkeypatch: pytest.Monk
         AsyncMock(return_value=[_msg(base, "URAMON", text="<@BOT> start this")]),
     )
 
-    assert await slack_webhook._slack_thread_allows_untagged_reply(
+    assert await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "one more detail", "BOT", "URAMON", f"{base + 60:.6f}"
     )
 
@@ -429,7 +429,7 @@ async def test_each_rapid_follow_up_extends_the_window(monkeypatch: pytest.Monke
         AsyncMock(return_value=messages),
     )
 
-    assert await slack_webhook._slack_thread_allows_untagged_reply(
+    assert await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "third detail", "BOT", "URAMON", f"{base + 165:.6f}"
     )
 
@@ -449,7 +449,7 @@ async def test_rapid_follow_up_window_expires_after_latest_message(
         AsyncMock(return_value=messages),
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "too late", "BOT", "URAMON", f"{base + 116:.6f}"
     )
 
@@ -465,7 +465,7 @@ async def test_rapid_follow_up_blocked_for_another_sender(
         AsyncMock(return_value=[_msg(base, "URAMON", text="<@BOT> start this")]),
     )
 
-    assert not await slack_webhook._slack_thread_allows_untagged_reply(
+    assert not await slack_webhook.slack_thread_allows_untagged_reply(
         "C1", "123.45", "I have a detail", "BOT", "UOTHER", f"{base + 10:.6f}"
     )
 
@@ -493,12 +493,12 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
     )
     monkeypatch.setattr(slack_webhook.common, "login_for_slack_id", AsyncMock(return_value=None))
     monkeypatch.setattr(slack_webhook.common, "is_bot_token_only_mode", lambda: True)
-    monkeypatch.setattr(slack_webhook.common, "_thread_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(slack_webhook.common, "thread_exists", AsyncMock(return_value=True))
     monkeypatch.setattr(
-        slack_webhook.common, "_get_thread_environment", AsyncMock(return_value=None)
+        slack_webhook.common, "get_thread_environment", AsyncMock(return_value=None)
     )
-    monkeypatch.setattr(slack_webhook.common, "_get_thread_plan_mode", AsyncMock(return_value=None))
-    monkeypatch.setattr(slack_webhook.common, "_upsert_slack_thread_repo_metadata", AsyncMock())
+    monkeypatch.setattr(slack_webhook.common, "get_thread_plan_mode", AsyncMock(return_value=None))
+    monkeypatch.setattr(slack_webhook.common, "upsert_slack_thread_repo_metadata", AsyncMock())
     monkeypatch.setattr(slack_webhook.common, "upsert_agent_thread_metadata", AsyncMock())
     monkeypatch.setattr(slack_webhook, "_dispatch_or_queue_slack_run", dispatch)
     thinking = AsyncMock()

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -7,6 +7,7 @@ from agent.dashboard import plan_api
 from agent.run_config import Repo
 from agent.slack import failures as slack_failures
 from agent.slack import webhook as slack_webhook
+from agent.slack.request import SlackRequest
 
 
 class _FakeThreads:
@@ -22,15 +23,15 @@ class _FakeClient:
         self.threads = _FakeThreads()
 
 
-def _event_data() -> dict[str, Any]:
-    return {
-        "channel_id": "C1",
-        "thread_ts": "123.45",
-        "event_ts": "123.45",
-        "user_id": "U1",
-        "text": "help",
-        "bot_user_id": "BOT",
-    }
+def _event_data() -> SlackRequest:
+    return SlackRequest(
+        channel_id="C1",
+        thread_ts="123.45",
+        event_ts="123.45",
+        user_id="U1",
+        text="help",
+        bot_user_id="BOT",
+    )
 
 
 @pytest.mark.asyncio
@@ -103,13 +104,11 @@ async def test_slack_processing_error_replies_even_without_an_agent_thread(
 async def test_slack_plan_button_uses_verified_actor(monkeypatch: pytest.MonkeyPatch) -> None:
     approve = AsyncMock(return_value={"status": "approved", "run_id": "run-1"})
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve)
-    event_data = {
-        "thread_id": "t1",
-        "user_id": "U1",
-        "user_name": "Alice",
-    }
+    event_data = SlackRequest(
+        channel_id="C1", thread_ts="123.45", thread_id="t1", user_id="U1", user_name="Alice"
+    )
 
-    await slack_webhook.process_slack_plan_approval(event_data, {})
+    await slack_webhook.process_slack_plan_approval(event_data, None)
 
     approve.assert_awaited_once_with(
         "t1",
@@ -141,13 +140,9 @@ async def test_slack_plan_button_failure_notifies_user(
     notify = AsyncMock()
     monkeypatch.setattr(plan_api, "approve_plan_for_thread", approve)
     monkeypatch.setattr(slack_webhook, "_notify_slack_processing_error", notify)
-    event_data = {
-        "thread_id": "t1",
-        "channel_id": "C1",
-        "thread_ts": "123.45",
-        "user_id": "U1",
-        "user_name": "Alice",
-    }
+    event_data = SlackRequest(
+        thread_id="t1", channel_id="C1", thread_ts="123.45", user_id="U1", user_name="Alice"
+    )
     repo_config = Repo(owner="langchain-ai", name="open-swe")
 
     await slack_webhook.process_slack_plan_approval(event_data, repo_config)
@@ -506,18 +501,18 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
     monkeypatch.setattr(slack_webhook.common, "store_slack_run_mapping", store_mapping)
 
     await slack_webhook._process_slack_mention_impl(
-        {
-            "channel_id": "C1",
-            "channel_context": {},
-            "thread_ts": "1.0",
-            "event_ts": "2.0",
-            "original_message_ts": "1.0",
-            "user_id": "U1",
-            "text": "new corrected text",
-            "bot_user_id": "BOT",
-            "thread_id": "t1",
-            "message_update": True,
-        },
+        SlackRequest(
+            channel_id="C1",
+            channel_context={},
+            thread_ts="1.0",
+            event_ts="2.0",
+            original_message_ts="1.0",
+            user_id="U1",
+            text="new corrected text",
+            bot_user_id="BOT",
+            thread_id="t1",
+            message_update=True,
+        ),
         Repo(owner="langchain-ai", name="open-swe"),
     )
 

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from agent.dashboard import plan_api
+from agent.run_config import Repo
 from agent.slack import failures as slack_failures
 from agent.slack import webhook as slack_webhook
 
@@ -55,7 +56,7 @@ async def test_slack_processing_error_marks_thread_and_replies_with_error_id(
     monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
 
     await slack_webhook.process_slack_mention(
-        _event_data(), {"owner": "langchain-ai", "name": "open-swe"}
+        _event_data(), Repo(owner="langchain-ai", name="open-swe")
     )
 
     upsert.assert_awaited_once()
@@ -89,7 +90,7 @@ async def test_slack_processing_error_replies_even_without_an_agent_thread(
     monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
 
     await slack_webhook.process_slack_mention(
-        _event_data(), {"owner": "langchain-ai", "name": "open-swe"}
+        _event_data(), Repo(owner="langchain-ai", name="open-swe")
     )
 
     post_reply.assert_awaited_once()
@@ -147,7 +148,7 @@ async def test_slack_plan_button_failure_notifies_user(
         "user_id": "U1",
         "user_name": "Alice",
     }
-    repo_config = {"owner": "langchain-ai", "name": "open-swe"}
+    repo_config = Repo(owner="langchain-ai", name="open-swe")
 
     await slack_webhook.process_slack_plan_approval(event_data, repo_config)
 
@@ -517,7 +518,7 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
             "thread_id": "t1",
             "message_update": True,
         },
-        {"owner": "langchain-ai", "name": "open-swe"},
+        Repo(owner="langchain-ai", name="open-swe"),
     )
 
     fetch_messages.assert_not_awaited()

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from agent.dashboard import plan_api
+from agent.slack import failures as slack_failures
 from agent.slack import webhook as slack_webhook
 
 
@@ -20,8 +21,19 @@ class _FakeClient:
         self.threads = _FakeThreads()
 
 
+def _event_data() -> dict[str, Any]:
+    return {
+        "channel_id": "C1",
+        "thread_ts": "123.45",
+        "event_ts": "123.45",
+        "user_id": "U1",
+        "text": "help",
+        "bot_user_id": "BOT",
+    }
+
+
 @pytest.mark.asyncio
-async def test_slack_processing_error_posts_dashboard_link(
+async def test_slack_processing_error_marks_thread_and_replies_with_error_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def fail_processing(event_data: dict[str, Any], repo_config: dict[str, str]) -> None:
@@ -40,21 +52,10 @@ async def test_slack_processing_error_posts_dashboard_link(
     )
     monkeypatch.setattr(slack_webhook.common, "upsert_agent_thread_metadata", upsert)
     monkeypatch.setattr(slack_webhook, "get_langgraph_client", lambda: client)
-    monkeypatch.setattr(
-        slack_webhook.common, "dashboard_thread_url", lambda thread_id: f"https://ui/{thread_id}"
-    )
-    monkeypatch.setattr(slack_webhook.common, "post_slack_thread_reply", post_reply)
+    monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
 
     await slack_webhook.process_slack_mention(
-        {
-            "channel_id": "C1",
-            "thread_ts": "123.45",
-            "event_ts": "123.45",
-            "user_id": "U1",
-            "text": "help",
-            "bot_user_id": "BOT",
-        },
-        {"owner": "langchain-ai", "name": "open-swe"},
+        _event_data(), {"owner": "langchain-ai", "name": "open-swe"}
     )
 
     upsert.assert_awaited_once()
@@ -68,7 +69,34 @@ async def test_slack_processing_error_posts_dashboard_link(
     await_args = post_reply.await_args
     assert await_args is not None
     assert await_args.args[:2] == ("C1", "123.45")
-    assert "<https://ui/t1|Open SWE Web>" in await_args.args[2]
+    assert "Error ID: `" in await_args.args[2]
+    assert await_args.kwargs["agent_thread_id"] == "t1"
+
+
+@pytest.mark.asyncio
+async def test_slack_processing_error_replies_even_without_an_agent_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_processing(event_data: dict[str, Any], repo_config: dict[str, str]) -> None:
+        raise RuntimeError("boom")
+
+    post_reply = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_webhook, "_process_slack_mention_impl", fail_processing)
+    monkeypatch.setattr(
+        slack_webhook.common, "lookup_slack_thread_id", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(slack_webhook, "get_langgraph_client", lambda: _FakeClient())
+    monkeypatch.setattr(slack_failures, "post_slack_thread_reply", post_reply)
+
+    await slack_webhook.process_slack_mention(
+        _event_data(), {"owner": "langchain-ai", "name": "open-swe"}
+    )
+
+    post_reply.assert_awaited_once()
+    await_args = post_reply.await_args
+    assert await_args is not None
+    assert await_args.args[:2] == ("C1", "123.45")
+    assert await_args.kwargs["agent_thread_id"] is None
 
 
 async def test_slack_plan_button_uses_verified_actor(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

Tagging `@Open SWE (Preview)` in Slack today produced nothing — no reply, no reaction. Datadog (`service:openswe @git_ref:preview @path:/webhooks/slack`) shows every mention answered with `POST /webhooks/slack 400` and no other log line: `get_slack_repo_config` raised `HTTPException(400, "no default repository configured")` straight out of the webhook, Slack discarded the body, and the user heard nothing. Prod has a team default repository so it never hit this; preview and staging do not.

Two things were wrong, and this PR fixes both:

1. **Silence was possible at all.** Between "this message is addressed to us" and the agent run there was no single place that guaranteed a reply on failure. Background processing also gave up silently when no thread mapping existed yet — exactly the first-message case.
2. **A missing repository was treated as an error.** The repo is only ever a *hint* (a prompt section literally titled "Default Repository Hint … use this only if the Slack conversation does not identify a different repository"). The agent clones lazily, and a request that needs a repo names it. Requiring one up front is a leftover from when the sandbox pre-cloned.

## What

### A Slack request Open SWE accepts never ends in silence

`agent/slack/failures.py` owns the invariant:

- `report_slack_failure(target, exc)` mints a UUIDv7 `error_id`, logs the failure with `error_id`, `slack_channel_id`, `slack_thread_ts`, `slack_event_id`, `agent_thread_id` in `extra` (top-level fields in Datadog), and posts `⚠️ … Error ID: \`<id>\`` to the thread. If the thread cannot be reached, the id is still logged.
- `SlackRequestError(user_message)` is posted verbatim (a rejection the user can act on); any other exception gets a generic message.
- `answer_slack_request(target, handler)` wraps the webhook handlers; a failure becomes a 200 `{"status": "error", "error_id": …}` so Slack does not retry a request the user has already been told about. `run_slack_task` is the background-task form.

Applied at every boundary where the request is known to be addressed to Open SWE: the `/webhooks/slack` mention flow (including the message-edit background task), code-channel turns, all `/webhooks/slack/interactivity` actions, and `process_slack_mention` / `process_slack_plan_approval`. The interactivity route's three copies of channel/message/user extraction are hoisted once above the guard. The thread-mapping conflict reply goes through the same path.

Agent-run failures after the run starts were already reported by `agent/completion.py` and are unchanged.

### A repository is a hint, not a requirement

`get_slack_repo_config` returns `Repo | None` (the existing pydantic model from `agent/run_config.py`) instead of raising when none of its five sources names a repository. With `None`: the prompt omits the hint section, `configurable["repo"]` is `None`, and no repo metadata is written to the thread. The Slack path carries `Repo | None` instead of `dict[str, str]` end to end.

Preview and staging work again with no config change.

## Test Plan

- [x] `make lint` and `make typecheck` pass; `tests/slack/` passes locally (244 tests)
- [x] New `tests/slack/test_slack_failures.py` covers: UUIDv7 id present in both the reply and the log record's extra fields, `SlackRequestError` message posted verbatim, id returned even when posting to Slack fails, request/task wrappers
- [x] `tests/slack/test_slack_event_dedupe.py`: a pre-processing failure replies with an error id and returns 200 without claiming the event; a mention with no resolvable repository is accepted and queued with `None`
- [x] `tests/slack/test_slack_webhook_errors.py`: a background failure replies even when no agent thread exists yet
- [x] `tests/slack/test_slack_context.py`: `get_slack_repo_config` returns `None` when nothing names a repo; `process_slack_mention` with `None` runs with no hint section and `configurable["repo"] is None`
