### PR TITLE
fix: keep queued messages visible after refresh

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -1174,6 +1174,67 @@ async def get_dashboard_terminal_sandbox(
     return sandbox_id, repo_name
 
 
+async def _queued_dashboard_messages(client: Any, thread_id: str) -> list[dict[str, Any]]:
+    try:
+        item = await client.store.get_item(("queue", thread_id), "pending_messages")
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "Could not fetch queued messages",
+            extra={"thread_id": thread_id},
+            exc_info=True,
+        )
+        return []
+    value = item.get("value") if isinstance(item, Mapping) else None
+    messages = value.get("messages") if isinstance(value, Mapping) else None
+    if not isinstance(messages, list):
+        return []
+
+    queued: list[dict[str, Any]] = []
+    for entry in messages:
+        content = entry.get("content") if isinstance(entry, Mapping) else None
+        if not isinstance(content, Mapping) or content.get("source") != _DASHBOARD_SOURCE:
+            continue
+        queued_id = content.get("queue_id")
+        text = content.get("text")
+        created_at = content.get("created_at_ms")
+        if (
+            not isinstance(queued_id, str)
+            or not queued_id
+            or not isinstance(text, str)
+            or not isinstance(created_at, (int, float))
+            or isinstance(created_at, bool)
+        ):
+            continue
+        images = []
+        raw_images = content.get("images")
+        if isinstance(raw_images, list):
+            for image in raw_images:
+                if not isinstance(image, Mapping):
+                    continue
+                base64_data = image.get("base64")
+                mime_type = image.get("mime_type")
+                if not isinstance(base64_data, str) or not isinstance(mime_type, str):
+                    continue
+                mapped_image = {
+                    "kind": "image",
+                    "base64": base64_data,
+                    "mimeType": mime_type,
+                }
+                file_name = image.get("file_name")
+                if isinstance(file_name, str) and file_name:
+                    mapped_image["fileName"] = file_name
+                images.append(mapped_image)
+        queued.append(
+            {
+                "id": queued_id,
+                "content": text,
+                "images": images,
+                "createdAt": int(created_at),
+            }
+        )
+    return queued
+
+
 async def get_dashboard_thread(
     thread_id: str, login: str, *, email: str | None = None, mark_viewed: bool = True
 ) -> dict[str, Any]:
@@ -1210,11 +1271,14 @@ async def get_dashboard_thread(
         )
         thread = {**as_thread_dict(thread), "metadata": metadata}
 
-    return await _thread_summary(
+    summary = await _thread_summary(
         thread,
         latest_run_status=latest_run_status,
         latest_run_id=latest_run_id,
     )
+    if status == "running":
+        summary["queuedMessages"] = await _queued_dashboard_messages(client, thread_id)
+    return summary
 
 
 async def _resolve_requested_environment(requested: Any) -> str | None:
@@ -1801,6 +1865,8 @@ async def send_dashboard_message(
         "text": prompt,
         "source": _DASHBOARD_SOURCE,
         "surface": "web",
+        "queue_id": f"queued-{uuid.uuid4()}",
+        "created_at_ms": now_ms,
         "sender": {
             "id": f"github:{login}",
             "platform": "github",

--- a/tests/dashboard/test_dashboard_thread_api_activity.py
+++ b/tests/dashboard/test_dashboard_thread_api_activity.py
@@ -36,12 +36,28 @@ class FakeRuns:
         return [{"run_id": self.run_id, "status": self.status}]
 
 
+class FakeStore:
+    def __init__(self, queued: object = None) -> None:
+        self.queued = queued
+
+    async def get_item(self, namespace: tuple[str, str], key: str) -> object:
+        assert namespace == ("queue", "tid")
+        assert key == "pending_messages"
+        return self.queued
+
+
 class FakeClient:
     def __init__(
-        self, metadata: dict[str, Any], run_status: str, *, thread_status: str = "idle"
+        self,
+        metadata: dict[str, Any],
+        run_status: str,
+        *,
+        thread_status: str = "idle",
+        queued: object = None,
     ) -> None:
         self.threads = FakeThreads(metadata, status=thread_status)
         self.runs = FakeRuns(run_status)
+        self.store = FakeStore(queued)
 
 
 async def test_list_dashboard_threads_refreshes_finished_run_status(monkeypatch) -> None:
@@ -136,4 +152,61 @@ async def test_get_dashboard_thread_does_not_mark_running_thread_viewed(monkeypa
 
     assert result["status"] == "running"
     assert result["viewed"] is False
+    assert result["queuedMessages"] == []
     assert "last_viewed_run_id" not in client.threads.thread["metadata"]
+
+
+async def test_get_dashboard_thread_hydrates_queued_dashboard_messages(monkeypatch) -> None:
+    client = FakeClient(
+        {
+            "source": "dashboard",
+            "github_login": "octocat",
+            "latest_run_id": "run-1",
+            "latest_run_status": "running",
+        },
+        "running",
+        thread_status="busy",
+        queued={
+            "value": {
+                "messages": [
+                    {
+                        "content": {
+                            "source": "dashboard",
+                            "text": "queued follow-up",
+                            "queue_id": "queued-server-id",
+                            "created_at_ms": 1700000000123,
+                            "images": [
+                                {
+                                    "type": "image",
+                                    "base64": "image-data",
+                                    "mime_type": "image/png",
+                                    "file_name": "proof.png",
+                                }
+                            ],
+                        }
+                    },
+                    {"content": {"source": "slack", "text": "hidden"}},
+                    {"content": {"source": "dashboard", "text": "incomplete"}},
+                ]
+            }
+        },
+    )
+    monkeypatch.setattr(thread_api, "langgraph_client", lambda: client)
+
+    result = await thread_api.get_dashboard_thread("tid", "octocat")
+
+    assert result["queuedMessages"] == [
+        {
+            "id": "queued-server-id",
+            "content": "queued follow-up",
+            "createdAt": 1700000000123,
+            "images": [
+                {
+                    "kind": "image",
+                    "base64": "image-data",
+                    "mimeType": "image/png",
+                    "fileName": "proof.png",
+                }
+            ],
+        }
+    ]

--- a/tests/dashboard/test_dashboard_web_handoff.py
+++ b/tests/dashboard/test_dashboard_web_handoff.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from fastapi import HTTPException
@@ -55,6 +55,14 @@ async def _inactive_thread(thread_id: str) -> bool:
 
 async def _active_thread(thread_id: str) -> bool:
     return True
+
+
+def _queued_message_without_metadata(queued_messages: list[object]) -> dict[str, object]:
+    assert len(queued_messages) == 1
+    queued_message = cast(dict[str, object], queued_messages[0])
+    assert cast(str, queued_message.pop("queue_id")).startswith("queued-")
+    assert isinstance(queued_message.pop("created_at_ms"), int)
+    return queued_message
 
 
 async def _noop_token_check(login: str) -> None:
@@ -172,19 +180,17 @@ async def test_dashboard_followup_on_busy_thread_queues_dashboard_handoff(
     )
 
     assert client.threads.updates[0]["source"] == "dashboard"
-    assert queued_messages == [
-        {
-            "text": "continue in web",
-            "source": "dashboard",
-            "surface": "web",
-            "sender": {
-                "id": "github:octocat",
-                "platform": "github",
-                "github_login": "octocat",
-                "email": "octocat@example.com",
-            },
-        }
-    ]
+    assert _queued_message_without_metadata(queued_messages) == {
+        "text": "continue in web",
+        "source": "dashboard",
+        "surface": "web",
+        "sender": {
+            "id": "github:octocat",
+            "platform": "github",
+            "github_login": "octocat",
+            "email": "octocat@example.com",
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -231,19 +237,17 @@ async def test_dashboard_followup_on_busy_slack_thread_updates_trace_reply(
         email="octocat@example.com",
     )
 
-    assert queued_messages == [
-        {
-            "text": "continue in web",
-            "source": "dashboard",
-            "surface": "web",
-            "sender": {
-                "id": "github:octocat",
-                "platform": "github",
-                "github_login": "octocat",
-                "email": "octocat@example.com",
-            },
-        }
-    ]
+    assert _queued_message_without_metadata(queued_messages) == {
+        "text": "continue in web",
+        "source": "dashboard",
+        "surface": "web",
+        "sender": {
+            "id": "github:octocat",
+            "platform": "github",
+            "github_login": "octocat",
+            "email": "octocat@example.com",
+        },
+    }
     assert handoff_updates == [
         {"channel_id": "C1", "message_ts": "123.46", "thread_id": "thread-1"}
     ]
@@ -331,19 +335,17 @@ async def test_dashboard_followup_on_busy_thread_queues_images(
         ),
     )
 
-    assert queued_messages == [
-        {
-            "text": "continue in web",
-            "source": "dashboard",
-            "surface": "web",
-            "sender": {
-                "id": "github:octocat",
-                "platform": "github",
-                "github_login": "octocat",
-            },
-            "images": [{"type": "image", "data": "aW1hZ2U=", "mime_type": "image/png"}],
-        }
-    ]
+    assert _queued_message_without_metadata(queued_messages) == {
+        "text": "continue in web",
+        "source": "dashboard",
+        "surface": "web",
+        "sender": {
+            "id": "github:octocat",
+            "platform": "github",
+            "github_login": "octocat",
+        },
+        "images": [{"type": "image", "data": "aW1hZ2U=", "mime_type": "image/png"}],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -138,6 +138,8 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
       .getByTestId("queued-message")
       .filter({ hasText: queuedText });
     await expect(queuedMessage).toBeVisible();
+    await page.reload();
+    await expect(queuedMessage).toBeVisible();
     const screenshotPath = testInfo.outputPath("queued-messages-dashboard.png");
     await page.screenshot({ path: screenshotPath, fullPage: true });
     await testInfo.attach("queued-messages-dashboard", {


### PR DESCRIPTION
### Summary
- persist stable UI metadata alongside dashboard-queued follow-ups
- hydrate queued dashboard messages from the LangGraph store when loading a running thread
- verify the queued card remains visible after a browser refresh

### Verification
- `uv run --project /workspace/open-swe pytest -q /workspace/open-swe/tests/dashboard/test_dashboard_web_handoff.py /workspace/open-swe/tests/dashboard/test_dashboard_thread_api_activity.py`
- `pnpm --dir /workspace/open-swe/ui run typecheck`
- `pnpm --dir /workspace/open-swe exec oxfmt --check tests/e2e/tests/dashboard.spec.ts`
- `pnpm --dir /workspace/open-swe exec oxlint tests/e2e/tests/dashboard.spec.ts`
- `PATH="/tmp/open-swe-bin:$PATH" E2E_FORCE_UI_BUILD=1 E2E_ARTIFACTS=1 pnpm --dir /workspace/open-swe/tests/e2e exec playwright test tests/dashboard.spec.ts --project=chromium --workers=1 --grep "keeps follow-ups visible across the queued-to-transcript handoff"`

### Screenshot
![Queued message still visible after refresh](https://01a0814a-bbdb-776c-9a33-00c33ac3ee89--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc0TnpZMU9UZ3NJbXAwYVNJNklqQXhZVEE0TVRWaExXRmlZMk10TjJZeE1pMWLabU15TFdaak1ERTFNalpoWVRZeVl5SXNJbk5wWkNJNklqQXhZVEE0TVRSaExXSmlaR0l0TnpjMll5MDVZVE16TFRBd1l6TXpZV016WldVNE9TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMM1JsYzNSekwyVXlaUzkwWlhOMExYSmxjM1ZzZEhNdlpHRnphR0p2WVhKa0xWTnNZV05yTGVLR2tpMTNaV0l0YUdGdVpDMDJaakZrWVMxMVpYVmxaQzEwYnkxMGNtRnVjMk55YVhCMExXaGhibVJ2Wm1ZdFkyaHliMjFwZFcwdmNYVmxkV1ZrTFcxbGMzTmhaMlZ6TFdSaGMyaGliMkZ5WkM1d2JtY2lMQ0pqZENJNkltbHRZV2RsTDNCdVp5SXNJbU5rSWpvaWFXNXNhVzVsSW4wLmFVU0J3VDdORXJPcDBtZHpmTFdUUWFNTGdVU1NqNm1UU3c4WGFaci01eTZMOVZWMVlpeFZWZmZDTzBERWthSEEwcUg1eExFOHRBcmZvQmc3cUVqT0J3)

Made by [Open SWE](https://openswe.vercel.app/agents/75b8537f-2490-5236-aba7-e14f31c86c08)