### PR TITLE
fix: remove docs-plz Slack gate

### DIFF
--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -453,58 +453,48 @@ async def slack_webhook(
     if channel_context is None:
         return {"status": "ignored", "reason": "Slack channel is not eligible"}
 
-    if await common._is_docs_plz_slack_channel(channel_id, channel_context):
-        if await common.claim_slack_event(event_id, channel_id, event_ts):
-            background_tasks.add_task(
-                common.post_slack_thread_reply,
+    if not is_message_update:
+        try:
+            thread_id = await common.resolve_slack_thread_id(
+                langgraph_client, channel_id, thread_ts
+            )
+        except common.SlackThreadMappingError:
+            common.logger.exception("Could not resolve explicit Slack thread mapping")
+            await common.post_slack_thread_reply(
                 channel_id,
                 thread_ts,
-                common.DOCS_PLZ_SLACK_GATE_REPLY,
+                "Open SWE found conflicting state for this Slack thread and will not guess which agent thread to use.",
             )
-            return {"status": "accepted", "message": "Slack mention gated for docs-plz"}
-    else:
-        if not is_message_update:
-            try:
-                thread_id = await common.resolve_slack_thread_id(
-                    langgraph_client, channel_id, thread_ts
-                )
-            except common.SlackThreadMappingError:
-                common.logger.exception("Could not resolve explicit Slack thread mapping")
-                await common.post_slack_thread_reply(
-                    channel_id,
-                    thread_ts,
-                    "Open SWE found conflicting state for this Slack thread and will not guess which agent thread to use.",
-                )
-                return {"status": "error", "message": "Conflicting Slack thread mapping"}
-        event_data = {
-            "channel_id": channel_id,
-            "channel_context": channel_context,
-            "thread_ts": thread_ts,
-            "event_ts": event_ts,
-            "original_message_ts": original_message_ts,
-            "user_id": user_id,
-            "text": text,
-            "attachments": attachments,
-            "bot_user_id": bot_user_id,
-            "thread_id": thread_id,
-            "treat_all_messages_as_mentions": is_direct_message or in_code_channel,
-            "untagged_reply": is_untagged_two_party_reply,
-            "message_update": is_message_update,
-            "code_channel": in_code_channel,
-            "reply_thread_ts": reply_thread_ts if in_code_channel else "",
-            "team_id": team_id,
-            "app_context": updated_message.get("app_context") or event.get("app_context"),
-        }
-        repo_config = await common.get_slack_repo_config(
-            channel_id,
-            thread_ts,
-            slack_user_id=user_id,
-            channel_context=channel_context,
-            thread_id=thread_id,
-        )
-        if await common.claim_slack_event(event_id, channel_id, event_ts):
-            background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
-            return {"status": "accepted", "message": "Slack mention queued"}
+            return {"status": "error", "message": "Conflicting Slack thread mapping"}
+    event_data = {
+        "channel_id": channel_id,
+        "channel_context": channel_context,
+        "thread_ts": thread_ts,
+        "event_ts": event_ts,
+        "original_message_ts": original_message_ts,
+        "user_id": user_id,
+        "text": text,
+        "attachments": attachments,
+        "bot_user_id": bot_user_id,
+        "thread_id": thread_id,
+        "treat_all_messages_as_mentions": is_direct_message or in_code_channel,
+        "untagged_reply": is_untagged_two_party_reply,
+        "message_update": is_message_update,
+        "code_channel": in_code_channel,
+        "reply_thread_ts": reply_thread_ts if in_code_channel else "",
+        "team_id": team_id,
+        "app_context": updated_message.get("app_context") or event.get("app_context"),
+    }
+    repo_config = await common.get_slack_repo_config(
+        channel_id,
+        thread_ts,
+        slack_user_id=user_id,
+        channel_context=channel_context,
+        thread_id=thread_id,
+    )
+    if await common.claim_slack_event(event_id, channel_id, event_ts):
+        background_tasks.add_task(service.process_slack_mention, event_data, repo_config)
+        return {"status": "accepted", "message": "Slack mention queued"}
 
     common.logger.info("Ignoring duplicate delivery of Slack event %s", event_id)
     return {"status": "ignored", "reason": "Duplicate Slack event delivery"}

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -99,11 +99,9 @@ from agent.slack.client import (
     get_slack_channel_context,
     get_slack_channel_context_description,
     get_slack_channel_description,
-    get_slack_channel_info,
     get_slack_permalink,
     get_slack_user_info,
     get_slack_user_names,  # noqa: F401
-    is_slack_channel_named,
     lookup_slack_run_mapping,  # noqa: F401
     lookup_slack_thread_id,  # noqa: F401
     normalize_slack_channel_context,  # noqa: F401
@@ -164,7 +162,6 @@ __all__ = [
     "CODE_CHANNEL_SESSION_TS",
     "DEFAULT_HTTP_TIMEOUT",
     "DEFAULT_REPO_OWNER",
-    "DOCS_PLZ_SLACK_GATE_REPLY",
     "FEEDBACK_REACTIONS",
     "GITHUB_WEBHOOK_SECRET",
     "HTTPException",
@@ -200,7 +197,6 @@ __all__ = [
     "_get_thread_metadata_safe",
     "_get_thread_environment",
     "_get_thread_plan_mode",
-    "_is_docs_plz_slack_channel",
     "_is_not_found_error",
     "_is_pr_diff_unchanged_since_last_review",
     "_is_repo_allowed",
@@ -334,10 +330,6 @@ DEFAULT_REPO_OWNER = ENV.DEFAULT_REPO_OWNER.get()
 DEFAULT_REPO_NAME = ENV.DEFAULT_REPO_NAME.get()
 SLACK_REPO_OWNER = ENV.SLACK_REPO_OWNER.get() or DEFAULT_REPO_OWNER
 SLACK_REPO_NAME = ENV.SLACK_REPO_NAME.get() or DEFAULT_REPO_NAME
-DOCS_PLZ_SLACK_CHANNEL_NAME = "docs-plz"
-DOCS_PLZ_SLACK_GATE_REPLY = (
-    "Please don't use Open SWE here, instead ask the Fleet docs-plz agent to implement the docs"
-)
 
 LANGGRAPH_URL = ENV.LANGGRAPH_URL.get()
 
@@ -552,22 +544,6 @@ async def _get_slack_channel_context(channel_id: str, *, use_cache: bool = True)
     except Exception:  # noqa: BLE001
         logger.exception("Failed to resolve Slack channel context")
         return normalize_slack_channel_context(channel_id, None)
-
-
-async def _is_docs_plz_slack_channel(
-    channel_id: str, channel_context: dict[str, Any] | None = None
-) -> bool:
-    """Check whether a Slack channel is the docs-plz handoff channel."""
-    if channel_context is not None:
-        return is_slack_channel_named(channel_context, DOCS_PLZ_SLACK_CHANNEL_NAME)
-    try:
-        channel = await get_slack_channel_info(channel_id)
-    except Exception:  # noqa: BLE001
-        logger.exception("Failed to resolve Slack channel info for docs-plz gate")
-        return False
-    return is_slack_channel_named(
-        normalize_slack_channel_context(channel_id, channel), DOCS_PLZ_SLACK_CHANNEL_NAME
-    )
 
 
 def _is_repo_allowed(repo_config: dict[str, str]) -> bool:

--- a/tests/github/test_github_issue_webhook.py
+++ b/tests/github/test_github_issue_webhook.py
@@ -573,101 +573,13 @@ def test_github_webhook_ignores_review_requested(monkeypatch) -> None:
     }
 
 
-def test_is_docs_plz_slack_channel_matches_name(monkeypatch) -> None:
-    async def fake_get_slack_channel_info(channel_id: str) -> dict[str, object]:
-        assert channel_id == "C_DOCS"
-        return {"name": "docs-plz"}
-
-    monkeypatch.setattr(webhook_common, "get_slack_channel_info", fake_get_slack_channel_info)
-
-    assert asyncio.run(webhook_common._is_docs_plz_slack_channel("C_DOCS")) is True
-
-
-def test_is_docs_plz_slack_channel_matches_normalized_name(monkeypatch) -> None:
-    async def fake_get_slack_channel_info(channel_id: str) -> dict[str, object]:
-        assert channel_id == "C_DOCS"
-        return {"name": "Docs Plz", "name_normalized": "docs-plz"}
-
-    monkeypatch.setattr(webhook_common, "get_slack_channel_info", fake_get_slack_channel_info)
-
-    assert asyncio.run(webhook_common._is_docs_plz_slack_channel("C_DOCS")) is True
-
-
-def test_slack_webhook_gates_docs_plz_channel(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    async def fake_get_slack_channel_context(
-        channel_id: str, *, use_cache: bool = True
-    ) -> dict[str, str | bool]:
-        captured["checked_channel_id"] = channel_id
-        return {
-            "id": channel_id,
-            "name": "Docs Plz",
-            "name_normalized": "docs-plz",
-            "topic": "",
-            "purpose": "",
-            "description": "",
-            "is_ext_shared": False,
-            "is_pending_ext_shared": False,
-        }
-
-    async def fake_post_slack_thread_reply(channel_id: str, thread_ts: str, text: str) -> bool:
-        captured["reply"] = {"channel_id": channel_id, "thread_ts": thread_ts, "text": text}
-        return True
-
-    async def fail_get_slack_repo_config(
-        channel_id: str, thread_ts: str, slack_user_id: str | None = None, **kwargs: object
-    ) -> dict[str, str]:
-        raise AssertionError("docs-plz gate should skip repo resolution")
-
-    async def fail_process_slack_mention(
-        event_data: dict[str, object], repo_config: dict[str, str]
-    ) -> None:
-        raise AssertionError("docs-plz gate should not start the agent")
-
-    monkeypatch.setattr(webhook_common, "SLACK_SIGNING_SECRET", _TEST_SLACK_SECRET)
-    monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "UBOT")
-    monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "open-swe")
-    monkeypatch.setattr(slack_utils.time, "time", lambda: 1700000000)
-    monkeypatch.setattr(
-        webhook_common, "_get_slack_channel_context", fake_get_slack_channel_context
-    )
-    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", fake_post_slack_thread_reply)
-    monkeypatch.setattr(webhook_common, "get_slack_repo_config", fail_get_slack_repo_config)
-    monkeypatch.setattr(slack_webhooks, "process_slack_mention", fail_process_slack_mention)
-
-    client = TestClient(app)
-    response = _post_slack_webhook(
-        client,
-        {
-            "type": "event_callback",
-            "event": {
-                "type": "app_mention",
-                "channel": "C_DOCS",
-                "ts": "1700000000.000100",
-                "user": "U123",
-                "text": "<@UBOT> please update docs",
-            },
-        },
-    )
-
-    assert response.status_code == 200
-    assert response.json() == {"status": "accepted", "message": "Slack mention gated for docs-plz"}
-    assert captured["checked_channel_id"] == "C_DOCS"
-    assert captured["reply"] == {
-        "channel_id": "C_DOCS",
-        "thread_ts": "1700000000.000100",
-        "text": webhook_common.DOCS_PLZ_SLACK_GATE_REPLY,
-    }
-
-
-def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
+def test_slack_webhook_routes_docs_plz_channel_to_agent(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     channel_context = {
         "id": "C123",
-        "name": "eng-open-swe",
-        "name_normalized": "eng-open-swe",
+        "name": "docs-plz",
+        "name_normalized": "docs-plz",
         "topic": "Coordinate work",
         "purpose": "repo:langchain-ai/open-swe",
         "description": "Coordinate work\nrepo:langchain-ai/open-swe",
@@ -722,7 +634,7 @@ def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
                 "channel": "C123",
                 "ts": "1700000000.000100",
                 "user": "U123",
-                "text": "<@UBOT> review https://github.com/langchain-ai/open-swe/pull/1244",
+                "text": "<@UBOT> please update docs",
             },
         },
     )
@@ -740,7 +652,7 @@ def test_slack_webhook_routes_review_command_to_agent(monkeypatch) -> None:
     event_data = captured["event_data"]
     assert isinstance(event_data, dict)
     assert event_data["channel_context"] == channel_context
-    assert event_data["text"] == "<@UBOT> review https://github.com/langchain-ai/open-swe/pull/1244"
+    assert event_data["text"] == "<@UBOT> please update docs"
 
 
 def test_slack_webhook_malformed_review_command_starts_agent(monkeypatch) -> None:

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -206,7 +206,6 @@ async def test_untagged_code_channel_message_routes_to_the_channel_session(
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", AsyncMock(return_value="t1"))
     monkeypatch.setattr(webhook_common, "_thread_exists", AsyncMock(return_value=True))
     monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", AsyncMock(return_value=False))
     monkeypatch.setattr(
         webhook_common,
         "get_slack_repo_config",

--- a/tests/slack/test_slack_event_dedupe.py
+++ b/tests/slack/test_slack_event_dedupe.py
@@ -96,9 +96,6 @@ def _patch_slack_webhook(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
     async def channel_context(_channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
         return {"is_ext_shared": False, "is_pending_ext_shared": False}
 
-    async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
-        return False
-
     async def repo_config(*_args: Any, **_kwargs: Any) -> dict[str, str]:
         return {"owner": "langchain-ai", "name": "open-swe"}
 
@@ -106,8 +103,6 @@ def _patch_slack_webhook(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
     monkeypatch.setattr(webhook_common, "verify_slack_signature", lambda **_kwargs: True)
     monkeypatch.setattr(webhook_common, "resolve_slack_thread_id", AsyncMock(return_value="t1"))
     monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
-
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
     return client
 

--- a/tests/slack/test_slack_untagged_flag.py
+++ b/tests/slack/test_slack_untagged_flag.py
@@ -101,9 +101,6 @@ def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
     async def channel_context(_channel_id: str, *, use_cache: bool = True) -> dict[str, Any]:
         return {"is_ext_shared": False, "is_pending_ext_shared": False}
 
-    async def not_docs_plz(_channel_id: str, _context: dict[str, Any]) -> bool:
-        return False
-
     async def repo_config(*_args: Any, **_kwargs: Any) -> dict[str, str]:
         return {"owner": "langchain-ai", "name": "open-swe"}
 
@@ -125,7 +122,6 @@ def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(webhook_common, "_thread_exists", AsyncMock(return_value=True))
     monkeypatch.setattr(webhook_common, "_get_slack_channel_context", channel_context)
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", not_docs_plz)
     monkeypatch.setattr(webhook_common, "get_slack_repo_config", repo_config)
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USER_ID", "BOT")
     monkeypatch.setattr(webhook_common, "SLACK_BOT_USERNAME", "openswe")
@@ -300,28 +296,6 @@ async def test_message_update_retries_until_delivery_mapping_exists(
 
     sleep.assert_awaited_once_with(0.1)
     process.assert_awaited_once()
-
-
-async def test_unassociated_message_update_does_not_trigger_docs_gate(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(webhook_common, "lookup_slack_run_mapping", AsyncMock(return_value=None))
-    monkeypatch.setattr(slack_routes, "_MESSAGE_UPDATE_RETRY_DELAYS", ())
-    is_docs_plz = AsyncMock(return_value=True)
-    post_reply = AsyncMock()
-    monkeypatch.setattr(webhook_common, "_is_docs_plz_slack_channel", is_docs_plz)
-    monkeypatch.setattr(webhook_common, "post_slack_thread_reply", post_reply)
-    background_tasks = _FakeBackgroundTasks()
-
-    response = await slack_routes.slack_webhook(
-        cast(Request, _FakeRequest(_message_update_payload())),
-        cast(BackgroundTasks, background_tasks),
-    )
-    await _run_message_update_task(background_tasks)
-
-    assert response == {"status": "accepted", "message": "Slack update queued"}
-    is_docs_plz.assert_not_awaited()
-    post_reply.assert_not_awaited()
 
 
 async def test_message_update_rejects_changed_sender_identity() -> None:


### PR DESCRIPTION
## Description

Removes the installation-wide special case for Slack channels named `docs-plz`. Mentions in those channels now follow the standard Open SWE request flow instead of returning a hard-coded Fleet handoff.

## Test Plan

- `uv run pytest -q --disable-warnings --maxfail=1 tests/github/test_github_issue_webhook.py::test_slack_webhook_routes_docs_plz_channel_to_agent tests/slack/test_slack_event_dedupe.py tests/slack/test_slack_untagged_flag.py tests/slack/test_slack_code_channels.py`
- `make format`
- `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/616fab6b-bf3b-5579-9e9c-c7bdad5fcdb2)