### PR TITLE
chore: log usage leaderboard aggregation

### DIFF
--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import math
+import time
 import weakref
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
@@ -115,16 +116,43 @@ async def _mutate(
 
 
 async def _all(namespace: list[str]) -> list[dict[str, Any]]:
+    started_at = time.monotonic()
     values: list[dict[str, Any]] = []
     offset = 0
-    while True:
-        result = await _client().store.search_items(namespace, limit=_PAGE_SIZE, offset=offset)
-        items = result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-        page = list(items or [])
-        values.extend(value for item in page if (value := _record(item)) is not None)
-        if len(page) < _PAGE_SIZE:
-            return values
-        offset += len(page)
+    pages = 0
+    try:
+        while True:
+            result = await _client().store.search_items(namespace, limit=_PAGE_SIZE, offset=offset)
+            items = (
+                result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
+            )
+            page = list(items or [])
+            pages += 1
+            values.extend(value for item in page if (value := _record(item)) is not None)
+            if len(page) < _PAGE_SIZE:
+                logger.info(
+                    "Usage telemetry scan completed",
+                    extra={
+                        "usage_namespace": "/".join(namespace),
+                        "usage_pages": pages,
+                        "usage_records": len(values),
+                        "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
+                    },
+                )
+                return values
+            offset += len(page)
+    except Exception:
+        logger.exception(
+            "Usage telemetry scan failed",
+            extra={
+                "usage_namespace": "/".join(namespace),
+                "usage_pages": pages,
+                "usage_records": len(values),
+                "usage_offset": offset,
+                "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
+            },
+        )
+        raise
 
 
 def _login(value: object) -> str:
@@ -640,12 +668,25 @@ async def list_agent_usage_leaderboard(
     current_email: str | None,
 ) -> dict[str, Any]:
     """Aggregate current usage from complete, paginated telemetry."""
+    started_at = time.monotonic()
     normalized = _normalize_period(period)
+    logger.info(
+        "Usage leaderboard aggregation started",
+        extra={"usage_period": normalized, "usage_limit": limit},
+    )
     cache_key = (normalized, _login(current_login) or _email(current_email))
     cached = _USAGE_CACHE.get(cache_key)
     if cached and _now_ms() - cached[0] < _USAGE_CACHE_TTL_MS:
         payload = dict(cached[1])
         payload["rows"] = _limited_rows(payload["rows"], cached[2], limit)
+        logger.info(
+            "Usage leaderboard cache hit",
+            extra={
+                "usage_period": normalized,
+                "usage_rows": len(payload["rows"]),
+                "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
+            },
+        )
         return payload
     await _backfill_legacy_usage()
     cutoff_ms = _period_cutoff_ms(normalized)
@@ -807,4 +848,17 @@ async def list_agent_usage_leaderboard(
     _USAGE_CACHE[cache_key] = (now_ms, payload, current_row)
     result = dict(payload)
     result["rows"] = _limited_rows(rows, current_row, limit)
+    logger.info(
+        "Usage leaderboard aggregation completed",
+        extra={
+            "usage_period": normalized,
+            "usage_runs": len(runs),
+            "usage_prs": len(prs),
+            "usage_reviews": len(review_records),
+            "usage_findings": len(finding_records),
+            "usage_members": len(ordered),
+            "usage_rows": len(result["rows"]),
+            "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
+        },
+    )
     return result


### PR DESCRIPTION
### Summary

- log when usage leaderboard aggregation starts, hits its in-process cache, and completes
- log each paginated telemetry namespace scan with page count, record count, and elapsed time
- log failed scans with the namespace, pagination position, and elapsed time without exposing user/session data

### Context

Production returned `FUNCTION_INVOCATION_TIMEOUT` for `/dashboard/api/agent-usage-leaderboard`. These diagnostics will show whether the request is spending its time in legacy backfill or a specific Store namespace scan.

### Validation

- `make lint`
- `uv run pytest -q tests/agent/test_agent_usage.py --disable-warnings --no-header` (7 passed)

Made by [Open SWE](https://openswe.vercel.app/agents/01a06920-84e2-7658-8d0f-cbfef4d3c088)