### PR TITLE
feat(ui): add project compose shortcut

### DIFF
--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -143,6 +143,7 @@ export function AgentsHome({
   const [localError, setLocalError] = useState<string | null>(null)
   const {
     projects: localProjects,
+    loaded: localProjectsLoaded,
     addProject,
     removeProject,
   } = useDesktopProjects()
@@ -179,14 +180,14 @@ export function AgentsHome({
   }, [panelCollapsed, stream.threadId])
 
   useEffect(() => {
-    if (!isDesktop) return
+    if (!isDesktop || !localProjectsLoaded) return
     const stored = window.localStorage.getItem(LAST_LOCAL_PROJECT_KEY)
     const selected = localProjects.find(
       (project) => project.cwd === localProjectPath || project.cwd === stored
     )
     // oxlint-disable-next-line react/set-state-in-effect
     setLocalProjectPath(selected?.cwd ?? localProjects[0]?.cwd ?? null)
-  }, [isDesktop, localProjectPath, localProjects])
+  }, [isDesktop, localProjectPath, localProjects, localProjectsLoaded])
 
   const refreshLocalProjectBranch = useCallback(async () => {
     const cwd = localProjectPathRef.current

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -69,7 +69,13 @@ function promptContent(text: string, images: Array<ImageChunk>) {
   return [...imageBlocks, ...(trimmed ? [{ type: "text", text: trimmed }] : [])]
 }
 
-export function AgentsHome() {
+export function AgentsHome({
+  initialRepo,
+  initialLocalProject,
+}: {
+  initialRepo?: string
+  initialLocalProject?: string
+}) {
   const stream = useAgentThreadRuntime()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -111,12 +117,17 @@ export function AgentsHome() {
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
   const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
+  const [runTargetOverride, setRunTargetOverride] = useState<RunTarget | null>(
+    initialLocalProject ? "local" : initialRepo ? "cloud" : null
+  )
   const runTarget: RunTarget = isDesktop
     ? cloudEnabled
-      ? desktopThreadSource
+      ? (runTargetOverride ?? desktopThreadSource)
       : "local"
     : "cloud"
-  const [localProjectPath, setLocalProjectPath] = useState<string | null>(null)
+  const [localProjectPath, setLocalProjectPath] = useState<string | null>(
+    initialLocalProject ?? null
+  )
   const localProjectPathRef = useRef(localProjectPath)
   useEffect(() => {
     localProjectPathRef.current = localProjectPath
@@ -141,7 +152,7 @@ export function AgentsHome() {
   const skills = useAgentSkills({ enabled: cloudEnabled })
   // undefined = untouched (fall back to the profile default); null = explicitly "no repo".
   const [repoOverride, setRepoOverride] = useState<string | null | undefined>(
-    undefined
+    initialRepo
   )
   const repo =
     repoOverride === undefined
@@ -255,12 +266,14 @@ export function AgentsHome() {
   }, [refreshLocalProjectBranch])
 
   const handleRunTargetChange = (next: RunTarget) => {
+    setRunTargetOverride(next)
     setDesktopThreadSource(next)
     setLocalError(null)
   }
 
   const handleSelectLocalProject = (cwd: string) => {
     setLocalProjectPath(cwd)
+    setRunTargetOverride("local")
     window.localStorage.setItem(LAST_LOCAL_PROJECT_KEY, cwd)
     setDesktopThreadSource("local")
     setLocalError(null)

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -109,6 +109,7 @@ interface AgentsSidebarProps {
 
 interface HydratedProjectGroup extends SidebarProjectGroup {
   repoFullName: string | null
+  localProjectPath?: string
   updatedAt: number
   activeThread?: AgentThread
 }
@@ -397,6 +398,9 @@ export function AgentsSidebar({
           .map((group) => ({
             ...group,
             repoFullName: null,
+            localProjectPath: group.threads.find(
+              (thread) => thread.location === "local"
+            )?.thread.cwd,
             updatedAt: group.threads[0]?.updatedAt ?? 0,
           })),
       ].sort((left, right) => right.updatedAt - left.updatedAt)
@@ -568,6 +572,15 @@ export function AgentsSidebar({
       hydrate={hydrateProjectThreads}
       onToggleCollapsed={() => toggleProjectCollapsed(group.key)}
       onExpand={() => expandProject(group.key)}
+      onCompose={() => {
+        layout.closeOnMobile()
+        void navigate({
+          to: "/agents",
+          search: group.repoFullName
+            ? { repo: group.repoFullName }
+            : { localProject: group.localProjectPath },
+        })
+      }}
       onTogglePin={() => toggleProjectPin(group.key)}
       renderRow={(item, live) => (
         <SidebarThreadRow key={item.key} {...rowProps(item, live)} indent />
@@ -887,6 +900,7 @@ function ProjectGroup({
   hydrate,
   onToggleCollapsed,
   onExpand,
+  onCompose,
   onTogglePin,
   renderRow,
 }: {
@@ -903,6 +917,7 @@ function ProjectGroup({
   hydrate: (threads: Array<AgentThread>) => Array<SidebarThreadItem>
   onToggleCollapsed: () => void
   onExpand: () => void
+  onCompose: () => void
   onTogglePin: () => void
   renderRow: (
     item: SidebarThreadItem,
@@ -955,6 +970,15 @@ function ProjectGroup({
         >
           <Folder className="size-4 shrink-0" />
           <span className="min-w-0 flex-1 truncate">{group.label}</span>
+        </button>
+        <button
+          type="button"
+          aria-label={`Compose message in ${group.label}`}
+          title="Compose message"
+          onClick={onCompose}
+          className="hidden size-5 shrink-0 items-center justify-center rounded text-muted-foreground/80 group-hover/folder:flex hover:bg-accent hover:text-foreground"
+        >
+          <NotePencilIcon className="size-3.5" />
         </button>
         <button
           type="button"

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -973,15 +973,6 @@ function ProjectGroup({
         </button>
         <button
           type="button"
-          aria-label={`Compose message in ${group.label}`}
-          title="Compose message"
-          onClick={onCompose}
-          className="hidden size-5 shrink-0 items-center justify-center rounded text-muted-foreground/80 group-hover/folder:flex hover:bg-accent hover:text-foreground"
-        >
-          <NotePencilIcon className="size-3.5" />
-        </button>
-        <button
-          type="button"
           aria-label={pinned ? `Unpin ${group.label}` : `Pin ${group.label}`}
           title={pinned ? "Unpin project" : "Pin project"}
           onClick={onTogglePin}
@@ -992,6 +983,15 @@ function ProjectGroup({
           ) : (
             <PushPinIcon className="size-3.5" />
           )}
+        </button>
+        <button
+          type="button"
+          aria-label={`Compose message in ${group.label}`}
+          title="Compose message"
+          onClick={onCompose}
+          className="hidden size-5 shrink-0 items-center justify-center rounded text-muted-foreground/80 group-hover/folder:flex hover:bg-accent hover:text-foreground"
+        >
+          <NotePencilIcon className="size-3.5" />
         </button>
       </div>
       {!collapsed && (

--- a/ui/src/features/agents/lib/desktopProjects.ts
+++ b/ui/src/features/agents/lib/desktopProjects.ts
@@ -4,12 +4,16 @@ import type { DesktopProject } from "@/desktop"
 
 export function useDesktopProjects() {
   const [projects, setProjects] = useState<Array<DesktopProject>>([])
+  const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
     const desktop = window.openSweDesktop
     if (!desktop) return
     const unsubscribe = desktop.onProjectsChanged(setProjects)
-    void desktop.listProjects().then(setProjects)
+    void desktop.listProjects().then((nextProjects) => {
+      setProjects(nextProjects)
+      setLoaded(true)
+    })
     return unsubscribe
   }, [])
 
@@ -32,5 +36,5 @@ export function useDesktopProjects() {
     return removed
   }, [])
 
-  return { projects, addProject, removeProject }
+  return { projects, loaded, addProject, removeProject }
 }

--- a/ui/src/routes/agents/index.tsx
+++ b/ui/src/routes/agents/index.tsx
@@ -2,10 +2,30 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { AgentsHome } from "@/features/agents/components/AgentsHome"
 
+interface AgentsIndexSearch {
+  repo?: string
+  localProject?: string
+}
+
 export const Route = createFileRoute("/agents/")({
+  validateSearch: (search: Record<string, unknown>): AgentsIndexSearch => ({
+    ...(typeof search.repo === "string" && search.repo.trim()
+      ? { repo: search.repo.trim() }
+      : {}),
+    ...(typeof search.localProject === "string" && search.localProject.trim()
+      ? { localProject: search.localProject.trim() }
+      : {}),
+  }),
   component: AgentsIndexPage,
 })
 
 function AgentsIndexPage() {
-  return <AgentsHome />
+  const { repo, localProject } = Route.useSearch()
+  return (
+    <AgentsHome
+      key={`${repo ?? ""}:${localProject ?? ""}`}
+      initialRepo={repo}
+      initialLocalProject={localProject}
+    />
+  )
 }


### PR DESCRIPTION
Adds a hover-only compose action to project rows that opens a new thread with the selected cloud or local project preselected.

![Project rows show pin before compose on hover](https://01a083bb-a082-7f3e-a7ab-c8e5a9aed93b--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1TVRjd01EQXNJbXAwYVNJNklqQXhZVEE0TTJNekxUSTNZbU10TnpGaVl5MDRaakUwTFdGa1pHTXdNelJtTmpJNE5DSXNJbk5wWkNJNklqQXhZVEE0TTJKaUxXRXdPREl0TjJZelpTMWhOMkZpTFdNNFpUVmhPV0ZsWkRrellpSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Y0hJeU5URTBMWEJ5YjJwbFkzUXRZV04wYVc5dWN5NXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC5TRUx5eDdBa0hGQTN6QXpUWkRYRGZlMEQ4M29WNko0dzlXRVR0YXVtZE8xRTBrSFhmeEdEQXktQUpMNHlPd0R0R2dKd1ZLY2MyR3ExbHVHOVBiT2RCQQ)

Made by [Open SWE](https://openswe.vercel.app/agents/79bf7e4f-5041-5908-825c-9a2d6148a2f7)
