### PR TITLE
fix(ui): add fuzzy project search

### DIFF
--- a/ui/src/features/settings/components/RepoSelector.test.tsx
+++ b/ui/src/features/settings/components/RepoSelector.test.tsx
@@ -44,4 +44,16 @@ describe("RepoSelector", () => {
 
     expect(screen.getByText("langchain-ai/open-swe")).toBeTruthy()
   })
+
+  it("does not match every repository for separator-only queries", () => {
+    renderSelector()
+
+    fireEvent.change(screen.getByPlaceholderText("Search repositories…"), {
+      target: { value: "-" },
+    })
+
+    expect(screen.getByText("No matches")).toBeTruthy()
+    expect(screen.queryByText("langchain-ai/open-swe")).toBeNull()
+    expect(screen.queryByText("langchain-ai/langchain")).toBeNull()
+  })
 })

--- a/ui/src/features/settings/components/RepoSelector.test.tsx
+++ b/ui/src/features/settings/components/RepoSelector.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RepoSelector } from "./RepoSelector"
+
+afterEach(() => cleanup())
+
+function renderSelector() {
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <RepoSelector
+        repos={[
+          { full_name: "langchain-ai/langchain" },
+          { full_name: "langchain-ai/open-swe" },
+        ]}
+        onRepoChange={vi.fn()}
+      />
+    </QueryClientProvider>
+  )
+  fireEvent.click(screen.getByRole("button", { name: /Select repository/ }))
+}
+
+describe("RepoSelector", () => {
+  it("matches repository names across separators", () => {
+    renderSelector()
+
+    fireEvent.change(screen.getByPlaceholderText("Search repositories…"), {
+      target: { value: "openswe" },
+    })
+
+    expect(screen.getByText("langchain-ai/open-swe")).toBeTruthy()
+    expect(screen.queryByText("langchain-ai/langchain")).toBeNull()
+  })
+
+  it("matches repository names with fuzzy character gaps", () => {
+    renderSelector()
+
+    fireEvent.change(screen.getByPlaceholderText("Search repositories…"), {
+      target: { value: "opnswe" },
+    })
+
+    expect(screen.getByText("langchain-ai/open-swe")).toBeTruthy()
+  })
+})

--- a/ui/src/features/settings/components/RepoSelector.tsx
+++ b/ui/src/features/settings/components/RepoSelector.tsx
@@ -10,6 +10,25 @@ import { cn } from "@/lib/utils"
 
 type RepoOption = { full_name: string }
 
+function fuzzySearchScore(value: string, query: string) {
+  const candidate = value.toLowerCase().replaceAll(/[^a-z0-9]/g, "")
+  const needle = query.toLowerCase().replaceAll(/[^a-z0-9]/g, "")
+  if (!needle) return 0
+
+  const substringIndex = candidate.indexOf(needle)
+  if (substringIndex !== -1) return substringIndex
+
+  let position = -1
+  let gaps = 0
+  for (const character of needle) {
+    const nextPosition = candidate.indexOf(character, position + 1)
+    if (nextPosition === -1) return null
+    gaps += nextPosition - position - 1
+    position = nextPosition
+  }
+  return candidate.length + gaps
+}
+
 interface RepoSelectorProps {
   repos?: Array<RepoOption>
   selectedRepo?: string | null
@@ -48,9 +67,16 @@ export function RepoSelector({
 
   const filteredRepos = useMemo(() => {
     const all = repos ?? []
-    const q = query.trim().toLowerCase()
+    const q = query.trim()
     if (!q) return all
-    return all.filter((repo) => repo.full_name.toLowerCase().includes(q))
+    return all
+      .map((repo) => ({ repo, score: fuzzySearchScore(repo.full_name, q) }))
+      .filter(
+        (match): match is { repo: RepoOption; score: number } =>
+          match.score !== null
+      )
+      .sort((left, right) => left.score - right.score)
+      .map(({ repo }) => repo)
   }, [repos, query])
 
   useEffect(() => {

--- a/ui/src/features/settings/components/RepoSelector.tsx
+++ b/ui/src/features/settings/components/RepoSelector.tsx
@@ -13,7 +13,7 @@ type RepoOption = { full_name: string }
 function fuzzySearchScore(value: string, query: string) {
   const candidate = value.toLowerCase().replaceAll(/[^a-z0-9]/g, "")
   const needle = query.toLowerCase().replaceAll(/[^a-z0-9]/g, "")
-  if (!needle) return 0
+  if (!needle) return null
 
   const substringIndex = candidate.indexOf(needle)
   if (substringIndex !== -1) return substringIndex


### PR DESCRIPTION
Makes the project picker match repository names across separators and character gaps, so `openswe` finds `langchain-ai/open-swe`.

![Project picker showing `langchain-ai/open-swe` for the `openswe` query](https://01a0818b-060b-7971-b13a-154d4e3c18e7--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc0T0RBeU1UTXNJbXAwYVNJNklqQXhZVEE0TVRreExXUTJObVV0TnpZNE9DMDRNVE5sTFdJek1qSTJZamhoWTJFd1lpSXNJbk5wWkNJNklqQXhZVEE0TVRoaUxUQTJNR0l0TnprM01TMWlNVE5oTFRFMU5HUTBaVE5qTVRobE55SXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Wm5WNmVua3RjSEp2YW1WamRDMXpaV0Z5WTJndWNHNW5JaXdpWTNRaU9pSnBiV0ZuWlM5d2JtY2lMQ0pqWkNJNkltbHViR2x1WlNKOS43SmNsRXlDWWhmTnc5NzZtUkJIZGw4MDFMQ2hmaGVTQWZfQXJyUkZmbDlyQWREVDA1eDc5ckR4cV9YczEzdFhVdG9ydnJXTU1HSmtNRnhCbjFQOUtDdw)

Made by [Open SWE](https://openswe.vercel.app/agents/cbb211d5-3510-5994-ae48-33fe48677f0b)