### PR TITLE
fix(ui): unify dashboard typography

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       '@datadog/browser-rum':
         specifier: 7.9.0
         version: 7.9.0
-      '@fontsource-variable/ibm-plex-sans':
-        specifier: ^5.3.0
-        version: 5.3.0
       '@fontsource-variable/inter':
         specifier: ^5.3.0
         version: 5.3.0
@@ -755,9 +752,6 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
-
-  '@fontsource-variable/ibm-plex-sans@5.3.0':
-    resolution: {integrity: sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==}
 
   '@fontsource-variable/inter@5.3.0':
     resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
@@ -6507,8 +6501,6 @@ snapshots:
       tabbable: 6.5.0
 
   '@floating-ui/utils@0.2.12': {}
-
-  '@fontsource-variable/ibm-plex-sans@5.3.0': {}
 
   '@fontsource-variable/inter@5.3.0': {}
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@base-ui/react": "^1.7.0",
     "@datadog/browser-rum": "7.9.0",
-    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@langchain/core": "^1.2.9",
     "@langchain/langgraph-sdk": "^1.9.31",

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2,7 +2,6 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
-@import "@fontsource-variable/ibm-plex-sans";
 @import "./styles/agents.css";
 @import "./styles/markdown.css";
 @source "../node_modules/streamdown/dist/*.js";

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -111,9 +111,7 @@ html.dark[data-agents-theme] {
 
 .agents-ui,
 html[data-agents-theme] {
-  font-family:
-    "IBM Plex Sans Variable", "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
-    sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary

- use the shared Inter font token across agent routes and portaled menus
- remove the unused IBM Plex Sans import and dependency

## Screenshot

| After |
| --- |
| ![Agent home using consistent Inter typography](https://01a08188-d937-7854-b53b-99ebc3a93974--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc0T0RBMU1EY3NJbXAwYVNJNklqQXhZVEE0TVRrMkxUVXlPVEV0TnpSak9TMDVNell4TFRaak9UUTRaR1l5WVdJMFppSXNJbk5wWkNJNklqQXhZVEE0TVRnNExXUTVNemN0TnpnMU5DMWlOVE5pTFRrNVpXSmpNMkU1TXprM05DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WVdkbGJuUnpMV1p2Ym5RdFkyOXVjMmx6ZEdWdVkza3VjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuTnZuZF9hMWU4QkpUQ0RKQUZSNGxibkhZcENTM3FZTkUyOVR6ZC0wT1UyTHVaakh5M2REMkJTZ2tleEZNWEdLVHQtUDB6d28yQ2pQa0tMeVZlSGdYQmc) |

Made by [Open SWE](https://openswe.vercel.app/agents/3da2738f-2f8f-5dac-9fde-4a7807b344d8)