### PR TITLE
style: remove project paths from thread headers

### DIFF
--- a/ui/src/features/agents/components/AgentThreadHeader.tsx
+++ b/ui/src/features/agents/components/AgentThreadHeader.tsx
@@ -1,14 +1,10 @@
-import { FolderOpen } from "lucide-react"
-
 import { useSidebarCollapsed } from "@/components/sidebar-layout"
 import { cn } from "@/lib/utils"
 
 export function AgentThreadHeader({
-  project,
   target,
   panelCollapsed,
 }: {
-  project?: string | null
   target: "Cloud" | "This Mac"
   panelCollapsed: boolean
 }) {
@@ -28,14 +24,6 @@ export function AgentThreadHeader({
           panelCollapsed && "pr-14"
         )}
       >
-        {project && (
-          <span className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
-            <FolderOpen className="size-3.5 shrink-0" />
-            <span className="truncate" title={project}>
-              {project}
-            </span>
-          </span>
-        )}
         <span className="ml-auto shrink-0 text-xs text-muted-foreground">
           {target}
         </span>

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -244,11 +244,7 @@ export function AgentThreadView({
         )}
         style={isMobile ? undefined : { minWidth: SIBLING_COLUMN_MIN_WIDTH }}
       >
-        <AgentThreadHeader
-          project={thread.repoFullName}
-          target="Cloud"
-          panelCollapsed={panelCollapsed}
-        />
+        <AgentThreadHeader target="Cloud" panelCollapsed={panelCollapsed} />
         {thread.status === "error" && (
           <div className="mx-auto w-full max-w-3xl shrink-0 px-4 pt-3">
             <Alert variant="error" controlAlignment="first-line">

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -448,11 +448,6 @@ export function AgentsHome() {
         {session.data && !routePending && <OnboardingDialog />}
         {optimisticDraftThread && (
           <AgentThreadHeader
-            project={
-              runTarget === "local"
-                ? localProjectPath
-                : optimisticDraftThread.repoFullName
-            }
             target={runTarget === "local" ? "This Mac" : "Cloud"}
             panelCollapsed={panelCollapsed}
           />

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -502,11 +502,7 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
         className="flex min-w-0 flex-1 flex-col"
         style={isMobile ? undefined : { minWidth: SIBLING_COLUMN_MIN_WIDTH }}
       >
-        <AgentThreadHeader
-          project={thread.cwd}
-          target="This Mac"
-          panelCollapsed={panelCollapsed}
-        />
+        <AgentThreadHeader target="This Mac" panelCollapsed={panelCollapsed} />
         {(error || activity === "error") && (
           <div className="mx-auto w-full max-w-3xl px-4 pt-3">
             <Alert variant="error">


### PR DESCRIPTION
### Summary
- Remove the project path/repository label and its folder icon from the shared thread top bar.
- Skip the project-details popover; retain the Cloud / This Mac indicator.
- Remove unused project props from local, cloud, and optimistic thread headers.

### Validation
- Focused oxfmt and oxlint checks passed.
- UI TypeScript check passed.

Based on main; does not include the separate thread-title top-bar branch.