### PR TITLE
fix(dashboard): lower thread-search page size to cut LangGraph rate-limit cost

### DIFF
--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -661,7 +661,7 @@ async def _refresh_latest_run_metadata(
     return thread, latest_run_status, latest_run_id
 
 
-_THREADS_SEARCH_PAGE = 100
+_THREADS_SEARCH_PAGE = 50
 _THREADS_PAGE_SCAN_CAP = 5000
 _THREAD_LIST_SELECT = ["thread_id", "status", "metadata", "created_at", "updated_at"]
 _RUN_REFRESH_CONCURRENCY = 8

--- a/agent/dashboard/thread_api.py
+++ b/agent/dashboard/thread_api.py
@@ -661,7 +661,7 @@ async def _refresh_latest_run_metadata(
     return thread, latest_run_status, latest_run_id
 
 
-_THREADS_SEARCH_PAGE = 500
+_THREADS_SEARCH_PAGE = 100
 _THREADS_PAGE_SCAN_CAP = 5000
 _THREAD_LIST_SELECT = ["thread_id", "status", "metadata", "created_at", "updated_at"]
 _RUN_REFRESH_CONCURRENCY = 8


### PR DESCRIPTION
`_THREADS_SEARCH_PAGE`: 500 -> 50. No caller ever requests above 25 (sidebar: 10, palette: 20, `/threads/page` default: 25); `core_api_threads_search_cost` charges the raw `limit` sent, so this was pure waste on every call.

Found investigating why `open-swe-staging` was hitting ~78% would-limit under new LangGraph Cloud rate limits (langchain-ai/langchainplus#37538). Two other things came up that this PR doesn't fix:

1. **4x search fan-out for participant backcompat.** Each logical thread search issues 4 separate `threads.search` calls (current `participant_logins`/`participant_emails` + legacy `github_login`/`triggering_user_email`) and unions the results, because the metadata filter can't OR across differently-shaped predicates in one call. Real fix is backfilling `participants` onto old threads so legacy filters can be dropped.
2. **Unbounded scan for `viewed`/`status` filters.** These aren't in thread metadata, so `list_dashboard_threads_page` collects up to 5000 raw candidates per filter before summarizing+filtering, uncapped (`thread_api.py` ~line 1085). If this path is what's actually driving load, this page-size change won't touch it.

Neither is a blocker for this PR, just worth having filed.

## Test Plan
- [ ] Thread list/pagination still works (early-exit is size-agnostic, just more round-trips on a deep scan)