### PR TITLE
fix(models): align OpenAI context windows with Codex

### DIFF
--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -152,7 +152,7 @@ _PROFILE_LOADER_MODULES: dict[str, str] = {
     "openai": "langchain_openai.chat_models.base",
 }
 CODEX_CONTEXT_WINDOW_OVERRIDES: dict[str, int] = {
-    "openai:gpt-6-astra": 1_050_000,
+    "openai:gpt-6-astra": 272_000,
     "openai:gpt-5.6-sol": 272_000,
     "openai:gpt-5.6-terra": 272_000,
     "openai:gpt-5.6-luna": 272_000,

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -105,7 +105,7 @@ def test_supported_models_do_not_hardcode_context_windows() -> None:
 
 
 def test_model_profile_context_window_uses_codex_override() -> None:
-    assert model_profile_context_window(SUPPORTED_ASTRA) == 1_050_000
+    assert model_profile_context_window(SUPPORTED_ASTRA) == 272_000
 
 
 def test_model_profile_context_window_uses_fireworks_profile_for_kimi_k3() -> None:
@@ -121,7 +121,7 @@ def test_models_with_profile_context_windows_enriches_copies() -> None:
     enriched = models_with_profile_context_windows(models)
     assert all("context_window" not in model for model in models)
     assert {model["id"]: model.get("context_window") for model in enriched} == {
-        "openai:gpt-6-astra": 1_050_000,
+        "openai:gpt-6-astra": 272_000,
         "openai:gpt-5.6-sol": 272_000,
         "openai:gpt-5.6-terra": 272_000,
         "openai:gpt-5.6-luna": 272_000,

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -104,10 +104,6 @@ def test_supported_models_do_not_hardcode_context_windows() -> None:
     assert all("context_window" not in model for model in SUPPORTED_MODELS)
 
 
-def test_model_profile_context_window_uses_codex_override() -> None:
-    assert model_profile_context_window(SUPPORTED_ASTRA) == 272_000
-
-
 def test_model_profile_context_window_uses_fireworks_profile_for_kimi_k3() -> None:
     assert model_profile_context_window(SUPPORTED_KIMI) == 1_048_576
 


### PR DESCRIPTION
### Summary

- set GPT-6 Astra's context window to Codex's 272K default
- keep all supported OpenAI models aligned at 272K
- update model-profile coverage

### Testing

- `uv run pytest -q tests/models/test_model_request_timeout.py tests/models/test_model_fallback_resolution.py`
- `uv run ruff format --check agent/dashboard/options.py tests/models/test_model_fallback_resolution.py`
- `uv run ruff check agent/dashboard/options.py tests/models/test_model_fallback_resolution.py`

Made by [Open SWE](https://openswe.vercel.app/agents/9ffe45c0-a0c5-5354-a2d0-b10f62eaf7d1)