### PR TITLE
fix: filter agent costs by trace

### DIFF
--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -205,7 +205,6 @@ async def get_langsmith_thread_cost(
             is_root=True,
             filter=_langsmith_metadata_filter("prepare_run_id", prepare_run_id),
             select=["id", "end_time"],
-            limit=20,
         )
         matched_roots = [
             (str(root_id), parsed)

--- a/agent/utils/langsmith.py
+++ b/agent/utils/langsmith.py
@@ -181,6 +181,11 @@ def _langsmith_metadata_filter(key: str, value: str) -> str:
     return f'and(eq(metadata_key, "{escaped_key}"), eq(metadata_value, "{escaped_value}"))'
 
 
+def _langsmith_trace_filter(trace_ids: list[str]) -> str:
+    filters = [f'eq(trace_id, "{trace_id}")' for trace_id in trace_ids]
+    return filters[0] if len(filters) == 1 else f"or({', '.join(filters)})"
+
+
 async def get_langsmith_thread_cost(
     thread_id: str,
     prepare_run_id: str,
@@ -199,22 +204,25 @@ async def get_langsmith_thread_cost(
             project_id=project_id,
             is_root=True,
             filter=_langsmith_metadata_filter("prepare_run_id", prepare_run_id),
-            select=["end_time"],
+            select=["id", "end_time"],
             limit=20,
         )
-        target_times = [
-            parsed
+        matched_roots = [
+            (str(root_id), parsed)
             async for run in roots
-            if (parsed := _parse_langsmith_time(_langsmith_value(run, "end_time"))) is not None
+            if (root_id := _langsmith_value(run, "id"))
+            and (parsed := _parse_langsmith_time(_langsmith_value(run, "end_time"))) is not None
         ]
-        if not target_times:
+        if not matched_roots:
             return None
         stats_kwargs: dict[str, Any] = {
             "session_id": project_id,
             "selects": ["TOTAL_COST", "LAST_END_TIME"],
         }
         if run_only:
-            stats_kwargs["filter"] = _langsmith_metadata_filter("prepare_run_id", prepare_run_id)
+            stats_kwargs["filter"] = _langsmith_trace_filter(
+                [trace_id for trace_id, _ in matched_roots]
+            )
         stats = await client.threads.stats(thread_id, **stats_kwargs)
     except LangSmithNotFoundError as exc:
         raise LangSmithCostUnavailable("LangSmith thread stats are unsupported") from exc
@@ -233,7 +241,7 @@ async def get_langsmith_thread_cost(
     except TypeError, ValueError:
         return None
     last_end_time = _parse_langsmith_time(_langsmith_value(stats, "last_end_time"))
-    target_end_time = max(target_times)
+    target_end_time = max(end_time for _, end_time in matched_roots)
     if (
         not math.isfinite(total_cost)
         or total_cost < 0

--- a/tests/agent/test_session_cost.py
+++ b/tests/agent/test_session_cost.py
@@ -51,7 +51,7 @@ async def test_langsmith_cost_requires_correlated_fresh_aggregate(
     assert client.list_kwargs["is_root"] is True
     assert "prepare_run_id" in client.list_kwargs["filter"]
     assert client.list_kwargs["select"] == ["id", "end_time"]
-    assert client.list_kwargs["limit"] == 20
+    assert "limit" not in client.list_kwargs
     assert client.threads.calls == [
         {
             "thread_id": "thread-1",

--- a/tests/agent/test_session_cost.py
+++ b/tests/agent/test_session_cost.py
@@ -36,7 +36,7 @@ async def test_langsmith_cost_requires_correlated_fresh_aggregate(
 ) -> None:
     root_end = datetime(2026, 8, 18, 22, 0, tzinfo=UTC)
     client = _LangSmithClient(
-        [SimpleNamespace(end_time=root_end)],
+        [SimpleNamespace(id="trace-1", end_time=root_end)],
         SimpleNamespace(total_cost=1.234, last_end_time=root_end + timedelta(seconds=1)),
     )
     monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: client)
@@ -50,7 +50,7 @@ async def test_langsmith_cost_requires_correlated_fresh_aggregate(
     assert result.total_cost == 1.234
     assert client.list_kwargs["is_root"] is True
     assert "prepare_run_id" in client.list_kwargs["filter"]
-    assert client.list_kwargs["select"] == ["end_time"]
+    assert client.list_kwargs["select"] == ["id", "end_time"]
     assert client.list_kwargs["limit"] == 20
     assert client.threads.calls == [
         {
@@ -66,7 +66,7 @@ async def test_langsmith_run_cost_filters_thread_stats(
 ) -> None:
     root_end = datetime(2026, 8, 18, 22, 0, tzinfo=UTC)
     client = _LangSmithClient(
-        [SimpleNamespace(end_time=root_end)],
+        [SimpleNamespace(id="trace-1", end_time=root_end)],
         SimpleNamespace(total_cost=0.25, last_end_time=root_end),
     )
     monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: client)
@@ -78,7 +78,31 @@ async def test_langsmith_run_cost_filters_thread_stats(
 
     assert result is not None
     assert result.total_cost == 0.25
-    assert "prepare_run_id" in client.threads.calls[0]["filter"]
+    assert client.threads.calls[0]["filter"] == 'eq(trace_id, "trace-1")'
+
+
+async def test_langsmith_run_cost_filters_multiple_traces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_end = datetime(2026, 8, 18, 22, 0, tzinfo=UTC)
+    client = _LangSmithClient(
+        [
+            SimpleNamespace(id="trace-1", end_time=root_end),
+            SimpleNamespace(id="trace-2", end_time=root_end),
+        ],
+        SimpleNamespace(total_cost=0.5, last_end_time=root_end),
+    )
+    monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: client)
+    monkeypatch.setattr(
+        ls_utils, "_resolve_project_id_by_name", AsyncMock(return_value="project-id")
+    )
+
+    result = await ls_utils.get_langsmith_thread_cost("thread-1", "prepare-1", run_only=True)
+
+    assert result is not None
+    assert client.threads.calls[0]["filter"] == (
+        'or(eq(trace_id, "trace-1"), eq(trace_id, "trace-2"))'
+    )
 
 
 async def test_langsmith_cost_waits_for_thread_stats_freshness(
@@ -86,7 +110,7 @@ async def test_langsmith_cost_waits_for_thread_stats_freshness(
 ) -> None:
     root_end = datetime(2026, 8, 18, 22, 0, tzinfo=UTC)
     client = _LangSmithClient(
-        [SimpleNamespace(end_time=root_end)],
+        [SimpleNamespace(id="trace-1", end_time=root_end)],
         SimpleNamespace(total_cost=2.0, last_end_time=root_end - timedelta(seconds=1)),
     )
     monkeypatch.setattr(ls_utils, "_build_langsmith_client", lambda: client)


### PR DESCRIPTION
Agent run costs stayed `null` because the usage enrichment path sent a run-metadata filter to LangSmith's thread-stats API, which rejects that filter syntax. The usage leaderboard then rendered the missing cost as `$0.00` even when LangSmith had calculated a cost.

- find all root traces associated with the Agent run using `prepare_run_id`
- filter thread stats with the supported `trace_id` expressions
- let the SDK paginate every matching trace so large runs are not undercounted
- leave cumulative Slack thread-cost reporting unchanged

Made by [Open SWE](https://openswe.vercel.app/agents/01a081ef-a007-778b-baf7-87765067e4e2)
