### PR TITLE
feat: improve desktop changes navigation

### DIFF
--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -173,6 +173,26 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
       contentType: "image/png",
     });
 
+    writeFileSync(join(project, "local-change.py"), "print('changed')\n");
+    await page.getByRole("heading", { name: /What should we build/ }).click();
+    await page.keyboard.press("Control+d");
+    await expect(
+      page.getByText("local-change.py", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("print('changed')", { exact: true }),
+    ).toBeVisible();
+    await page.screenshot({
+      path: join(
+        repoRoot,
+        ".open-swe",
+        "artifacts",
+        "desktop-changes-list.png",
+      ),
+      fullPage: true,
+    });
+    await page.keyboard.press("Control+d");
+
     await typeIntoComposer(
       page,
       "E2E_DESKTOP_LOCAL please add a greet() helper and open a PR",

--- a/ui/src/features/agents/components/ChangesPanel.tsx
+++ b/ui/src/features/agents/components/ChangesPanel.tsx
@@ -26,6 +26,8 @@ interface ChangesPanelProps {
   pr?: AgentThread["pr"] | null
   revealFilePath?: string | null
   fullScreen: boolean
+  listFirst?: boolean
+  workingTreeLabel?: string
   onRefresh: () => void
   extraActions?: React.ReactNode
   scope: DiffScopeKind
@@ -64,10 +66,14 @@ const SCOPE_LABELS: Record<DiffScopeKind, string> = {
 function ScopeSwitcher(props: {
   scope: DiffScopeKind
   branchScopeAvailable: boolean
+  workingTreeLabel?: string
   onScopeChange: (scope: DiffScopeKind) => void
 }) {
   const [open, setOpen] = useState(false)
-  const label = SCOPE_LABELS[props.scope]
+  const workingTreeLabel =
+    props.workingTreeLabel ?? SCOPE_LABELS["working-tree"]
+  const label =
+    props.scope === "working-tree" ? workingTreeLabel : SCOPE_LABELS.branch
 
   const branchItem = (
     <MenuItem
@@ -99,7 +105,7 @@ function ScopeSwitcher(props: {
         className="min-w-52"
       >
         <MenuItem onClick={() => props.onScopeChange("working-tree")}>
-          {SCOPE_LABELS["working-tree"]}
+          {workingTreeLabel}
         </MenuItem>
         {props.branchScopeAvailable ? (
           branchItem
@@ -127,6 +133,8 @@ export function ChangesPanel({
   pr,
   revealFilePath,
   fullScreen,
+  listFirst,
+  workingTreeLabel,
   onRefresh,
   extraActions,
   scope,
@@ -182,6 +190,7 @@ export function ChangesPanel({
         files={files}
         revealFilePath={revealFilePath}
         fullScreen={fullScreen}
+        listFirst={listFirst}
         emptyLabel={emptyLabel}
         truncated={truncated}
         leading={
@@ -189,6 +198,7 @@ export function ChangesPanel({
             <ScopeSwitcher
               scope={scope}
               branchScopeAvailable={branchScopeAvailable}
+              workingTreeLabel={workingTreeLabel}
               onScopeChange={onScopeChange}
             />
             {branch && (

--- a/ui/src/features/agents/components/DiffFilesView.tsx
+++ b/ui/src/features/agents/components/DiffFilesView.tsx
@@ -131,6 +131,8 @@ interface DiffFilesViewProps {
   revealFilePath?: string | null
   /** Full-screen panels have room for the file tree alongside the diff. */
   fullScreen: boolean
+  /** Desktop mode uses a compact change list with one selected diff. */
+  listFirst?: boolean
   emptyLabel: string
   /** The change set was capped, so `files` is not everything that changed. */
   truncated?: boolean
@@ -150,6 +152,7 @@ export function DiffFilesView({
   files,
   revealFilePath,
   fullScreen,
+  listFirst,
   emptyLabel,
   truncated,
   hideHeader,
@@ -159,6 +162,8 @@ export function DiffFilesView({
   const isMobile = useIsMobile()
   const [selectedTreePath, setSelectedTreePath] = useState<string | null>(null)
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({})
+  const selectedFile =
+    files.find((file) => file.treePath === selectedTreePath) ?? files[0]
 
   const totals = useMemo(
     () =>
@@ -176,15 +181,19 @@ export function DiffFilesView({
   useEffect(() => {
     filesRef.current = files
   }, [files])
-  const selectTreePath = useCallback((path: string) => {
-    setSelectedTreePath(path)
-    const target = filesRef.current.find((file) => file.treePath === path)
-    if (!target) return
-    sectionRefs.current[target.filePath]?.scrollIntoView({
-      block: "start",
-      behavior: "smooth",
-    })
-  }, [])
+  const selectTreePath = useCallback(
+    (path: string) => {
+      setSelectedTreePath(path)
+      if (listFirst) return
+      const target = filesRef.current.find((file) => file.treePath === path)
+      if (!target) return
+      sectionRefs.current[target.filePath]?.scrollIntoView({
+        block: "start",
+        behavior: "smooth",
+      })
+    },
+    [listFirst]
+  )
 
   useEffect(() => {
     if (!revealFilePath) return
@@ -227,26 +236,42 @@ export function DiffFilesView({
       )}
 
       <div className="flex min-h-0 flex-1">
+        {listFirst && files.length > 0 && (
+          <div className="w-64 shrink-0 border-r border-border bg-card @max-[560px]:w-44">
+            <FileTreeExplorer
+              files={files}
+              selectedTreePath={selectedTreePath}
+              onSelect={selectTreePath}
+            />
+          </div>
+        )}
+
         {files.length > 0 ? (
           <WorkerPoolContextProvider
             poolOptions={DIFF_WORKER_POOL_OPTIONS}
             highlighterOptions={DIFF_WORKER_HIGHLIGHTER_OPTIONS}
           >
-            <Virtualizer
-              className="min-h-0 flex-1 overflow-y-auto"
-              contentClassName="p-0"
-              config={DIFF_VIRTUALIZER_CONFIG}
-            >
-              {files.map((file) => (
-                <FileDiffSection
-                  key={file.filePath}
-                  file={file}
-                  sectionRef={(node) => {
-                    sectionRefs.current[file.filePath] = node
-                  }}
-                />
-              ))}
-            </Virtualizer>
+            {listFirst && selectedFile ? (
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <FileDiffSection file={selectedFile} sectionRef={() => {}} />
+              </div>
+            ) : (
+              <Virtualizer
+                className="min-h-0 flex-1 overflow-y-auto"
+                contentClassName="p-0"
+                config={DIFF_VIRTUALIZER_CONFIG}
+              >
+                {files.map((file) => (
+                  <FileDiffSection
+                    key={file.filePath}
+                    file={file}
+                    sectionRef={(node) => {
+                      sectionRefs.current[file.filePath] = node
+                    }}
+                  />
+                ))}
+              </Virtualizer>
+            )}
           </WorkerPoolContextProvider>
         ) : (
           <div className="min-h-0 flex-1 overflow-y-auto p-6 text-center text-xs text-muted-foreground/70">
@@ -254,7 +279,7 @@ export function DiffFilesView({
           </div>
         )}
 
-        {fullScreen && !isMobile && files.length > 0 && (
+        {!listFirst && fullScreen && !isMobile && files.length > 0 && (
           <div className="w-72 shrink-0 border-l border-border bg-card">
             <FileTreeExplorer
               files={files}

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -251,6 +251,13 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
     () => toPanelFiles(diff.data?.files ?? []),
     [diff.data?.files]
   )
+  const refetchDiff = diff.refetch
+  useEffect(() => {
+    if (!diffVisible) return
+    const onFocus = () => void refetchDiff()
+    window.addEventListener("focus", onFocus)
+    return () => window.removeEventListener("focus", onFocus)
+  }, [diffVisible, refetchDiff])
   const messages = useMemo(() => {
     const live = streamMessagesToUi(
       stream.messages,
@@ -628,6 +635,8 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
             pr={pr}
             revealFilePath={revealFilePath}
             fullScreen={fullScreen}
+            listFirst
+            workingTreeLabel="Since session started"
             onRefresh={() => void diff.refetch()}
             scope={scope}
             branchScopeAvailable={branchScopeAvailable}

--- a/ui/src/features/agents/components/LocalProjectRightPanel.tsx
+++ b/ui/src/features/agents/components/LocalProjectRightPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 
 import { AgentRightPanel } from "@/features/agents/components/panel/AgentRightPanel"
 import { ChangesPanel } from "@/features/agents/components/ChangesPanel"
@@ -43,6 +43,13 @@ export function LocalProjectRightPanel({
     () => toPanelFiles(diff.data?.files ?? []),
     [diff.data?.files]
   )
+  const refetchDiff = diff.refetch
+  useEffect(() => {
+    if (collapsed || activeSurfaceId !== "diff") return
+    const onFocus = () => void refetchDiff()
+    window.addEventListener("focus", onFocus)
+    return () => window.removeEventListener("focus", onFocus)
+  }, [activeSurfaceId, collapsed, refetchDiff])
 
   return (
     <AgentRightPanel
@@ -65,6 +72,7 @@ export function LocalProjectRightPanel({
           branch={diff.data?.repository?.branch}
           pr={diff.data?.repository?.pr}
           fullScreen={fullScreen}
+          listFirst
           onRefresh={() => void diff.refetch()}
           scope="working-tree"
           branchScopeAvailable={false}


### PR DESCRIPTION
## Summary
- show a persistent changed-file list with one selected diff in desktop/local mode
- refresh local changes when the window regains focus
- label thread checkpoint changes as “Since session started”

## Test
- `pnpm --dir ui run typecheck`
- focused `oxlint`
- desktop Electron e2e under Xvfb

## Screenshot
![Desktop Changes panel](https://01a082e4-5dee-73d6-a221-fa13a78a059c--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1TURNME5qZ3NJbXAwYVNJNklqQXhZVTA0TW1ZMExXRmpOV010TnpSbFppMDVOekJsTFRBd1pHUXlOV0poTlRBME1TSXNJbk5wWkNJNklqQXhZVTA0TW1VMExUVmtaV1V0TnpOa05pMWhNakl4TFdaaE1UTmhOemhoTURVNVl5SXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WkdWemEzUnZjQzFqYUdGdVoyVnpMV3hwYzNRdWNHNW5JaXdpWTNRaU9pSnBiV0ZuWlM5d2JtY2lMQ0pqWkNJNkltbHViR2x1WlNKOS5NakxIRGhweVpxM0pic2s4WWhzMElreUdCaEk2bUhLVE9pdUlzSHFneGFmR0twM21ocUJOWlIzZTRhZjlsdEFDQkxIYzU4Y21LS0g2Y1I3bUZ0ZkZDdw)

Made by [Open SWE](https://openswe.vercel.app/agents/f5023ddc-e7b3-5f6f-8ee9-d49bcae54f40)