### PR TITLE
fix(tools): include the protocol id when the thread tool starts a run

### DIFF
--- a/agent/tools/threads.py
+++ b/agent/tools/threads.py
@@ -529,6 +529,7 @@ async def _send_message(
     if model_id and effort:
         configurable.update(agent_model_id=model_id, agent_effort=effort)
     command = {
+        "id": 1,
         "method": "run.start",
         "params": {
             "input": {"messages": [{"type": "human", "content": message}]},

--- a/tests/tools/test_threads.py
+++ b/tests/tools/test_threads.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -475,9 +476,10 @@ async def test_manage_thread_starts_idle_message_with_fixed_command(
     assert result["mode"] == "started"
     awaited = proxy.await_args
     assert awaited is not None
-    command = awaited.args[2]
-    assert b'"method": "run.start"' in command
-    assert b'"plan_mode": true' in command
+    command = json.loads(awaited.args[2])
+    assert isinstance(command["id"], int)
+    assert command["method"] == "run.start"
+    assert command["params"]["config"]["configurable"]["plan_mode"] is True
 
 
 async def test_manage_thread_update_plan_preserves_format_and_bounds_response(


### PR DESCRIPTION
When `manage_thread(action="send_message")` targets an idle thread, `send_dashboard_message` answers 409 and the tool falls back to a `run.start` command through `proxy_dashboard_thread_commands`. That command had no `id`, and the platform's `/threads/{thread_id}/commands` handler rejects any command without an integer `id`:

```
Rejected malformed event streaming command  payload_method=run.start
400 {"error":"invalid_argument","message":"Protocol commands must include an integer id and string method."}
```

The tool surfaced this as `Could not start thread run`, which is what the Slack bot posted in the thread-send investigation on Sep 8. The queued (busy-thread) path was unaffected; only the idle-thread fallback ever hit this. The command is a one-shot HTTP request, so a fixed `id` is sufficient.

## Test Plan

- [x] `make test TEST_FILE=tests/tools/test_threads.py` — the existing fallback test now parses the command and asserts an integer `id`
- [x] `make lint`, `make typecheck` (the two `ty` warnings are pre-existing in untouched files)
