### PR TITLE
feat: sign PRs with model details

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -399,12 +399,18 @@ If you forget the trailer on an unpushed commit, fix it with `git commit --amend
 def _render_collaboration_section(
     identity: CollaboratorIdentity | None,
     thread_url: str | None = None,
+    model_id: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> str:
     if identity is None:
         return ""
     return COLLABORATION_TEMPLATE.format(
         display_name=identity.display_name,
-        pr_attribution_footer=build_pr_attribution_footer(thread_url),
+        pr_attribution_footer=build_pr_attribution_footer(
+            thread_url,
+            model_id=model_id,
+            reasoning_effort=reasoning_effort,
+        ),
         bot_coauthor_trailer=f"Co-authored-by: {OPEN_SWE_BOT_NAME} <{OPEN_SWE_BOT_EMAIL}>",
     )
 
@@ -503,6 +509,8 @@ def construct_sender_context(
     user_custom_instructions: str | None = None,
     draft_prs: bool = True,
     thread_url: str | None = None,
+    model_id: str | None = None,
+    reasoning_effort: str | None = None,
     workspace_admin: bool = False,
     participant_identities: Sequence[CollaboratorIdentity] = (),
 ) -> str:
@@ -522,7 +530,12 @@ def construct_sender_context(
         f"Workspace admin: {'yes' if workspace_admin else 'no'}.",
         f"Sender's git identity command: `{_git_identity_command(resolved_identity)}`",
         _render_participant_identities(identities),
-        _render_collaboration_section(resolved_identity, thread_url),
+        _render_collaboration_section(
+            resolved_identity,
+            thread_url,
+            model_id,
+            reasoning_effort,
+        ),
         f"New PRs are created {'as drafts' if draft_prs else 'ready for review'} for this sender.",
         _render_user_instructions_section(user_custom_instructions),
     ]

--- a/agent/server.py
+++ b/agent/server.py
@@ -845,6 +845,8 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                 user_custom_instructions=sender_instructions,
                 draft_prs=self._draft_prs,
                 thread_url=dashboard_thread_url(self._thread_id),
+                model_id=self._model_id,
+                reasoning_effort=self._effort,
                 workspace_admin=await _workspace_admin(self._config or {}, self._profile_login),
                 participant_identities=participant_identities,
             )

--- a/agent/utils/authorship.py
+++ b/agent/utils/authorship.py
@@ -21,10 +21,22 @@ PR_ATTRIBUTION_DEFAULT_URL = "https://openswe.vercel.app"
 PR_ATTRIBUTION_FOOTER = f"{PR_ATTRIBUTION_TEXT}({PR_ATTRIBUTION_DEFAULT_URL})"
 
 
-def build_pr_attribution_footer(thread_url: str | None = None) -> str:
-    """Build the Open SWE PR footer, linking the run's thread when available."""
+def build_pr_attribution_footer(
+    thread_url: str | None = None,
+    *,
+    model_id: str | None = None,
+    reasoning_effort: str | None = None,
+) -> str:
+    """Build the Open SWE PR footer with the run's model details."""
     url = thread_url.strip() if isinstance(thread_url, str) and thread_url.strip() else ""
-    return f"{PR_ATTRIBUTION_TEXT}({url or PR_ATTRIBUTION_DEFAULT_URL})"
+    footer = f"{PR_ATTRIBUTION_TEXT}({url or PR_ATTRIBUTION_DEFAULT_URL})"
+    model = _normalize_text(model_id).replace("`", "")
+    effort = _normalize_text(reasoning_effort).replace("`", "")
+    if model:
+        footer += f" · Model: `{model}`"
+    if effort:
+        footer += f" · Reasoning: `{effort}`"
+    return footer
 
 
 @dataclass(frozen=True)

--- a/agent/utils/authorship.py
+++ b/agent/utils/authorship.py
@@ -33,9 +33,9 @@ def build_pr_attribution_footer(
     model = _normalize_text(model_id).replace("`", "")
     effort = _normalize_text(reasoning_effort).replace("`", "")
     if model:
-        footer += f" · Model: `{model}`"
-    if effort:
-        footer += f" · Reasoning: `{effort}`"
+        footer += f" · {model}"
+        if effort:
+            footer += f" ({effort})"
     return footer
 
 

--- a/tests/auth/test_authorship.py
+++ b/tests/auth/test_authorship.py
@@ -2,6 +2,7 @@ from agent.utils.authorship import (
     OPEN_SWE_BOT_EMAIL,
     OPEN_SWE_BOT_NAME,
     add_bot_coauthor_trailer,
+    build_pr_attribution_footer,
     resolve_triggering_user_identity,
 )
 
@@ -16,6 +17,17 @@ def test_add_bot_coauthor_trailer_appends_bot() -> None:
 def test_add_bot_coauthor_trailer_is_idempotent() -> None:
     once = add_bot_coauthor_trailer("fix: thing")
     assert add_bot_coauthor_trailer(once) == once
+
+
+def test_build_pr_attribution_footer_includes_model_details() -> None:
+    assert build_pr_attribution_footer(
+        "https://openswe.vercel.app/agents/abc-123",
+        model_id="openai:gpt-5.6-luna",
+        reasoning_effort="xhigh",
+    ) == (
+        "Made by [Open SWE](https://openswe.vercel.app/agents/abc-123)"
+        " · Model: `openai:gpt-5.6-luna` · Reasoning: `xhigh`"
+    )
 
 
 def test_resolve_identity_from_config_uses_user_noreply_email() -> None:

--- a/tests/auth/test_authorship.py
+++ b/tests/auth/test_authorship.py
@@ -26,7 +26,7 @@ def test_build_pr_attribution_footer_includes_model_details() -> None:
         reasoning_effort="xhigh",
     ) == (
         "Made by [Open SWE](https://openswe.vercel.app/agents/abc-123)"
-        " · Model: `openai:gpt-5.6-luna` · Reasoning: `xhigh`"
+        " · openai:gpt-5.6-luna (xhigh)"
     )
 
 

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -180,8 +180,7 @@ def test_construct_system_prompt_shell_escapes_user_name() -> None:
     assert f"git config user.name {shlex.quote(hostile)}" in sender_context
     assert f"git config user.name {hostile}" not in sender_context
     assert (
-        "Made by [Open SWE](https://openswe.vercel.app)"
-        " · Model: `openai:gpt-5.6-luna` · Reasoning: `xhigh`"
+        "Made by [Open SWE](https://openswe.vercel.app) · openai:gpt-5.6-luna (xhigh)"
     ) in sender_context
 
 

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -170,11 +170,19 @@ def test_construct_system_prompt_shell_escapes_user_name() -> None:
     )
 
     system_prompt = construct_system_prompt(working_dir="/workspace")
-    sender_context = construct_sender_context(identity)
+    sender_context = construct_sender_context(
+        identity,
+        model_id="openai:gpt-5.6-luna",
+        reasoning_effort="xhigh",
+    )
 
     assert hostile not in system_prompt
     assert f"git config user.name {shlex.quote(hostile)}" in sender_context
     assert f"git config user.name {hostile}" not in sender_context
+    assert (
+        "Made by [Open SWE](https://openswe.vercel.app)"
+        " · Model: `openai:gpt-5.6-luna` · Reasoning: `xhigh`"
+    ) in sender_context
 
 
 def test_add_pr_collaboration_note_replaces_legacy_footer() -> None:


### PR DESCRIPTION
Add the resolved main-agent model and reasoning level to Open SWE’s PR attribution signature.

The signature remains limited to model configuration: it does not include token counts or cost.

### Verification

- `uv run pytest -q tests/auth/test_authorship.py tests/github/test_github_comment_prompts.py`
- `make format`
- `make lint`
- `uv run ty check agent/prompt.py agent/server.py agent/utils/authorship.py`

Made by [Open SWE](https://openswe.vercel.app/agents/9a3e74bf-d832-59ff-82a1-523ebe800570)