### PR TITLE
feat: add workspace-scoped MCP connections

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -230,6 +230,14 @@ from agent.dashboard.user_mappings import (
     upsert_mapping,
 )
 from agent.dashboard.voice import transcribe_audio
+from agent.dashboard.workspace_mcps import (
+    WorkspaceMCPRoute,
+    WorkspaceMCPUpdate,
+    delete_workspace_mcp,
+    get_workspace_mcp,
+    list_workspace_mcps,
+    save_workspace_mcp,
+)
 from agent.github.pull_request_checks import PullRequestState
 from agent.github.token_auth import admin_session_for_github_token, bearer_github_token
 from agent.review.analyzer_cron import remove_continual_cron
@@ -256,6 +264,7 @@ from agent.slack.oauth import (
     slack_oauth_configured,
     verify_team,
 )
+from agent.tool_loaders.workspace_mcp import discover_workspace_mcp
 from agent.utils.dashboard_links import (
     dashboard_api_base_url,
     dashboard_base_url,
@@ -977,6 +986,61 @@ async def api_get_team_credentials(
     _admin: dict[str, Any] = _ADMIN_DEP,
 ) -> dict[str, Any]:
     return await get_team_credentials_status()
+
+
+workspace_mcp_router = APIRouter(route_class=WorkspaceMCPRoute)
+
+
+@workspace_mcp_router.get("/workspace-mcps")
+async def api_list_workspace_mcps(_admin: dict[str, Any] = _ADMIN_DEP) -> list[dict[str, Any]]:
+    return await list_workspace_mcps()
+
+
+@workspace_mcp_router.put("/workspace-mcps/{name}")
+async def api_save_workspace_mcp(
+    name: str,
+    update: WorkspaceMCPUpdate,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    try:
+        return await save_workspace_mcp(name, update)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from None
+
+
+@workspace_mcp_router.delete("/workspace-mcps/{name}", status_code=204)
+async def api_delete_workspace_mcp(name: str, _admin: dict[str, Any] = _ADMIN_DEP) -> None:
+    await delete_workspace_mcp(name)
+
+
+@workspace_mcp_router.post("/workspace-mcps/{name}/headers/reveal")
+async def api_reveal_workspace_mcp_headers(
+    name: str,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> JSONResponse:
+    record = await get_workspace_mcp(name)
+    if record is None:
+        raise HTTPException(404, "MCP connection not found")
+    try:
+        headers = record.connection_headers()
+    except ValueError:
+        raise HTTPException(400, "MCP authentication headers could not be decrypted") from None
+    return JSONResponse(content=headers, headers={"Cache-Control": "no-store"})
+
+
+@workspace_mcp_router.post("/workspace-mcps/{name}/discover")
+async def api_discover_workspace_mcp(
+    name: str,
+    update: WorkspaceMCPUpdate | None = None,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> list[dict[str, str]]:
+    try:
+        return await discover_workspace_mcp(name, update)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from None
+
+
+router.include_router(workspace_mcp_router)
 
 
 @router.put("/team-credentials/datadog")

--- a/agent/dashboard/workspace_mcps.py
+++ b/agent/dashboard/workspace_mcps.py
@@ -14,7 +14,7 @@ from fastapi.routing import APIRoute
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agent.encryption import decrypt_token, encrypt_token
-from agent.store import delete_value, get_value, now_iso, put_value, search_all_values
+from agent.store import TypedStore, now_iso
 
 WORKSPACE_MCPS_NAMESPACE = ["workspace_mcps"]
 _BLOCKED_HEADERS = {
@@ -138,6 +138,8 @@ class WorkspaceMCPUpdate(BaseModel):
 
 
 class WorkspaceMCP(BaseModel):
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     name: str
     url: str
     transport: Literal["streamable_http", "sse"] = "streamable_http"
@@ -160,14 +162,15 @@ class WorkspaceMCP(BaseModel):
         return json.loads(decrypted)
 
 
+_store = TypedStore(WORKSPACE_MCPS_NAMESPACE, WorkspaceMCP)
+
+
 async def get_workspace_mcp(name: str) -> WorkspaceMCP | None:
-    record = await get_value(WORKSPACE_MCPS_NAMESPACE, name)
-    return WorkspaceMCP.model_validate(record) if record else None
+    return await _store.get(name)
 
 
 async def list_workspace_mcp_records() -> list[WorkspaceMCP]:
-    records = await search_all_values(WORKSPACE_MCPS_NAMESPACE)
-    return sorted((WorkspaceMCP.model_validate(record) for record in records), key=lambda r: r.name)
+    return sorted(await _store.search_all(), key=lambda record: record.name)
 
 
 async def list_workspace_mcps() -> list[dict[str, Any]]:
@@ -197,9 +200,9 @@ async def prepare_workspace_mcp(name: str, update: WorkspaceMCPUpdate) -> Worksp
 
 async def save_workspace_mcp(name: str, update: WorkspaceMCPUpdate) -> dict[str, Any]:
     record = await prepare_workspace_mcp(name, update)
-    await put_value(WORKSPACE_MCPS_NAMESPACE, name, record.model_dump())
+    await _store.put(name, record)
     return record.public()
 
 
 async def delete_workspace_mcp(name: str) -> None:
-    await delete_value(WORKSPACE_MCPS_NAMESPACE, name)
+    await _store.delete(name)

--- a/agent/dashboard/workspace_mcps.py
+++ b/agent/dashboard/workspace_mcps.py
@@ -1,0 +1,200 @@
+"""Admin-managed MCP connections shared by one Open SWE workspace/deployment."""
+
+import json
+import re
+from collections.abc import Callable, Coroutine
+from typing import Any, Literal
+from urllib.parse import parse_qsl, urlsplit
+from uuid import uuid4
+
+from fastapi import Request, Response
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from agent.encryption import decrypt_token, encrypt_token
+from agent.store import delete_value, get_value, now_iso, put_value, search_all_values
+
+WORKSPACE_MCPS_NAMESPACE = ["workspace_mcps"]
+_BLOCKED_HEADERS = {
+    "host",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "proxy-authorization",
+}
+_SECRET_QUERY_KEYS = {
+    "key",
+    "token",
+    "api_key",
+    "apikey",
+    "access_token",
+    "authorization",
+    "password",
+    "secret",
+}
+_VALIDATION_MESSAGES = {
+    "name": (
+        "Connection name must start with a lowercase letter and contain only lowercase "
+        "letters, numbers, hyphens, or underscores (1-32 characters); for example, incident"
+    ),
+    "url": (
+        "Server URL must be HTTPS, at most 2048 characters, and contain no credentials, "
+        "whitespace, or fragments; put authentication in headers"
+    ),
+    "transport": "Transport must be Streamable HTTP or SSE",
+    "enabled": "Enabled must be true or false",
+    "headers": (
+        "Headers must have valid, unique names and plain-text values without line breaks; "
+        "use at most 20 headers and 8192 characters per value"
+    ),
+    "allowed_tools": "Allowed tools must be a list of at most 200 non-empty names (1-128 characters)",
+}
+
+
+class WorkspaceMCPRoute(APIRoute):
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        handler = super().get_route_handler()
+
+        async def redacted_handler(request: Request) -> Response:
+            try:
+                return await handler(request)
+            except RequestValidationError as exc:
+                # Error messages and nested locations can include submitted credentials.
+                messages = dict.fromkeys(
+                    _VALIDATION_MESSAGES.get(
+                        error["loc"][1] if len(error["loc"]) > 1 else "",
+                        "Invalid MCP connection settings",
+                    )
+                    for error in exc.errors()
+                )
+                return JSONResponse(status_code=422, content={"detail": "; ".join(messages)})
+
+        return redacted_handler
+
+
+class WorkspaceMCPUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,31}$")
+    url: str = Field(max_length=2048)
+    transport: Literal["streamable_http", "sse"] = "streamable_http"
+    enabled: bool = True
+    headers: dict[str, str] | None = Field(default=None, repr=False)
+    allowed_tools: list[str] = Field(default_factory=list, max_length=200)
+
+    @field_validator("url")
+    @classmethod
+    def _url(cls, value: str) -> str:
+        value = value.strip()
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.fragment
+            or any(ord(char) < 33 for char in value)
+            or any(key.lower() in _SECRET_QUERY_KEYS for key, _ in parse_qsl(parsed.query))
+        ):
+            raise ValueError(
+                "Use an HTTPS URL without credentials or fragments; put authentication in headers"
+            )
+        _ = parsed.port
+        return value
+
+    @field_validator("headers")
+    @classmethod
+    def _headers(cls, value: dict[str, str] | None) -> dict[str, str] | None:
+        if value is None:
+            return None
+        if len(value) > 20:
+            raise ValueError("Use at most 20 headers")
+        names: set[str] = set()
+        for name, content in value.items():
+            if (
+                not re.fullmatch(r"[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}", name)
+                or name.lower() in _BLOCKED_HEADERS
+                or name.lower() in names
+                or len(content) > 8192
+                or any(ord(char) < 32 or ord(char) > 126 for char in content)
+            ):
+                raise ValueError("Invalid or duplicate authentication header")
+            names.add(name.lower())
+        return value
+
+    @field_validator("allowed_tools")
+    @classmethod
+    def _tools(cls, value: list[str]) -> list[str]:
+        if any(not name.strip() or len(name) > 128 for name in value):
+            raise ValueError("Tool names must be non-empty and at most 128 characters")
+        return list(dict.fromkeys(name.strip() for name in value))
+
+
+class WorkspaceMCP(BaseModel):
+    name: str
+    url: str
+    transport: Literal["streamable_http", "sse"] = "streamable_http"
+    enabled: bool = True
+    allowed_tools: list[str] = Field(default_factory=list)
+    encrypted_headers: str = Field(default="", repr=False)
+    header_names: list[str] = Field(default_factory=list)
+    revision: str
+    updated_at: str
+
+    def public(self) -> dict[str, Any]:
+        return self.model_dump(exclude={"encrypted_headers"})
+
+    def connection_headers(self) -> dict[str, str]:
+        if not self.encrypted_headers:
+            return {}
+        decrypted = decrypt_token(self.encrypted_headers)
+        if not decrypted:
+            raise ValueError("MCP authentication headers could not be decrypted")
+        return json.loads(decrypted)
+
+
+async def get_workspace_mcp(name: str) -> WorkspaceMCP | None:
+    record = await get_value(WORKSPACE_MCPS_NAMESPACE, name)
+    return WorkspaceMCP.model_validate(record) if record else None
+
+
+async def list_workspace_mcp_records() -> list[WorkspaceMCP]:
+    records = await search_all_values(WORKSPACE_MCPS_NAMESPACE)
+    return sorted((WorkspaceMCP.model_validate(record) for record in records), key=lambda r: r.name)
+
+
+async def list_workspace_mcps() -> list[dict[str, Any]]:
+    return [record.public() for record in await list_workspace_mcp_records()]
+
+
+async def prepare_workspace_mcp(name: str, update: WorkspaceMCPUpdate) -> WorkspaceMCP:
+    """Validate a draft and resolve saved authentication without persisting it."""
+    if name != update.name:
+        raise ValueError("Connection name must match its URL path")
+    previous = await get_workspace_mcp(name)
+    if previous and previous.url != update.url and previous.header_names and update.headers is None:
+        raise ValueError("Replace or clear authentication headers when changing the server URL")
+    encrypted = previous.encrypted_headers if previous else ""
+    header_names = previous.header_names if previous else []
+    if update.headers is not None:
+        encrypted = encrypt_token(json.dumps(update.headers)) if update.headers else ""
+        header_names = sorted(update.headers)
+    return WorkspaceMCP(
+        **update.model_dump(exclude={"headers"}),
+        encrypted_headers=encrypted,
+        header_names=header_names,
+        revision=uuid4().hex,
+        updated_at=now_iso(),
+    )
+
+
+async def save_workspace_mcp(name: str, update: WorkspaceMCPUpdate) -> dict[str, Any]:
+    record = await prepare_workspace_mcp(name, update)
+    await put_value(WORKSPACE_MCPS_NAMESPACE, name, record.model_dump())
+    return record.public()
+
+
+async def delete_workspace_mcp(name: str) -> None:
+    await delete_value(WORKSPACE_MCPS_NAMESPACE, name)

--- a/agent/dashboard/workspace_mcps.py
+++ b/agent/dashboard/workspace_mcps.py
@@ -49,7 +49,7 @@ _VALIDATION_MESSAGES = {
         "Headers must have valid, unique names and plain-text values without line breaks; "
         "use at most 20 headers and 8192 characters per value"
     ),
-    "allowed_tools": "Allowed tools must be a list of at most 200 non-empty names (1-128 characters)",
+    "allowed_tools": "Allowed tools must be a list of non-empty names (1-128 characters)",
 }
 
 
@@ -87,7 +87,7 @@ class WorkspaceMCPUpdate(BaseModel):
     transport: Literal["streamable_http", "sse"] = "streamable_http"
     enabled: bool = True
     headers: dict[str, str] | None = Field(default=None, repr=False)
-    allowed_tools: list[str] = Field(default_factory=list, max_length=200)
+    allowed_tools: list[str] = Field(default_factory=list)
 
     @field_validator("url")
     @classmethod

--- a/agent/dashboard/workspace_mcps.py
+++ b/agent/dashboard/workspace_mcps.py
@@ -24,16 +24,16 @@ _BLOCKED_HEADERS = {
     "connection",
     "proxy-authorization",
 }
-_SECRET_QUERY_KEYS = {
-    "key",
-    "token",
-    "api_key",
+_SECRET_QUERY_SUFFIXES = (
     "apikey",
-    "access_token",
+    "apitoken",
+    "authtoken",
+    "accesstoken",
+    "refreshtoken",
     "authorization",
     "password",
     "secret",
-}
+)
 _VALIDATION_MESSAGES = {
     "name": (
         "Connection name must start with a lowercase letter and contain only lowercase "
@@ -51,6 +51,11 @@ _VALIDATION_MESSAGES = {
     ),
     "allowed_tools": "Allowed tools must be a list of at most 200 non-empty names (1-128 characters)",
 }
+
+
+def _is_secret_query_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    return normalized in {"key", "token"} or normalized.endswith(_SECRET_QUERY_SUFFIXES)
 
 
 class WorkspaceMCPRoute(APIRoute):
@@ -96,7 +101,7 @@ class WorkspaceMCPUpdate(BaseModel):
             or parsed.password is not None
             or parsed.fragment
             or any(ord(char) < 33 for char in value)
-            or any(key.lower() in _SECRET_QUERY_KEYS for key, _ in parse_qsl(parsed.query))
+            or any(_is_secret_query_key(key) for key, _ in parse_qsl(parsed.query))
         ):
             raise ValueError(
                 "Use an HTTPS URL without credentials or fragments; put authentication in headers"

--- a/agent/server.py
+++ b/agent/server.py
@@ -149,6 +149,7 @@ from agent.tool_loaders.datadog_mcp import load_datadog_tools
 from agent.tool_loaders.langsmith import load_langsmith_tools
 from agent.tool_loaders.notion_mcp import load_notion_tools
 from agent.tool_loaders.stagehand_browser import load_browser_tools
+from agent.tool_loaders.workspace_mcp import load_workspace_mcp_tools
 from agent.tools import (
     approve_plan,
     background_execute,
@@ -601,6 +602,12 @@ async def _load_integration_tools(profile_login: str | None) -> tuple[list[Any],
         ),
     )
     return currents_tools, notion_tools
+
+
+async def _workspace_mcp_tools_for(config: RunnableConfig, profile_login: str | None) -> list[Any]:
+    if not await _observability_authorized(config, profile_login):
+        return []
+    return await load_workspace_mcp_tools()
 
 
 async def _phase_result(thread_id: str | None, name: str, loader: Any) -> Any:
@@ -1131,14 +1138,24 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     stop_summary_mode = cfg.stop_summary is True
     sandbox_file_downloads = _sandbox_file_downloads_enabled(cfg)
     observability_tools: list[Any] = []
+    workspace_mcp_tools: list[Any] = []
     currents_tools: list[Any] = []
     notion_tools: list[Any] = []
     if not stop_summary_mode and not local_run:
-        observability_tools, (currents_tools, notion_tools) = await asyncio.gather(
+        (
+            observability_tools,
+            workspace_mcp_tools,
+            (currents_tools, notion_tools),
+        ) = await asyncio.gather(
             _phase_result(
                 thread_id,
                 "factory.observability_tools",
                 lambda: _observability_tools_for(config, profile_login),
+            ),
+            _phase_result(
+                thread_id,
+                "factory.workspace_mcp_tools",
+                lambda: _workspace_mcp_tools_for(config, profile_login),
             ),
             _phase_result(
                 thread_id,
@@ -1211,6 +1228,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     dynamic_tool_middleware: DynamicToolMiddleware | None = None
     integration_tool_groups: dict[str, IntegrationGroup | Sequence[Any]] = {
         "Observability": observability_tools,
+        "Workspace MCPs": workspace_mcp_tools,
         "Currents": currents_tools,
         "Notion": notion_tools,
     }

--- a/agent/server.py
+++ b/agent/server.py
@@ -1126,9 +1126,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     plan_mode = cfg.plan_mode is True
     if plan_mode:
         logger.info("Plan mode enabled for thread %s", thread_id)
-    plan_mode_middleware: list[Any] = [
-        PlanModeMiddleware(excluded=PLAN_MODE_EXCLUDED_TOOLS, initial=plan_mode)
-    ]
 
     async with aphase(thread_id, "factory.admin_thread"):
         admin_thread = await _admin_thread(config, profile_login)
@@ -1357,7 +1354,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 notify_step_limit_reached,
                 record_run_usage,
                 *fallback_middleware,
-                *plan_mode_middleware,
+                PlanModeMiddleware(
+                    excluded=PLAN_MODE_EXCLUDED_TOOLS
+                    | frozenset(tool.name for tool in workspace_mcp_tools),
+                    initial=plan_mode,
+                ),
                 SanitizeFireworksMessagesMiddleware(),
                 SanitizeOpenAIResponsesMiddleware(),
                 SanitizeThinkingBlocksMiddleware(),

--- a/agent/tool_loaders/mcp_transport.py
+++ b/agent/tool_loaders/mcp_transport.py
@@ -1,0 +1,66 @@
+"""Public HTTPS transport for admin-configured remote MCP connections."""
+
+import asyncio
+from urllib.parse import urlsplit
+
+import httpx
+
+from agent.utils.url_safety import pinned_url, resolve_and_validate
+
+
+class MCPTransport(httpx.AsyncBaseTransport):
+    def __init__(self, url: str) -> None:
+        parsed = urlsplit(url)
+        self._origin = (parsed.scheme, parsed.hostname, parsed.port or 443)
+        self._transport = httpx.AsyncHTTPTransport(trust_env=False)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme,
+            parsed.hostname,
+            parsed.port or 443,
+        ) != self._origin or parsed.scheme != "https":
+            raise ValueError("MCP requests must stay on the configured HTTPS origin")
+        safe, _, hostname, addresses = await asyncio.to_thread(resolve_and_validate, url)
+        if not safe or not hostname or not addresses:
+            raise ValueError("MCP server must resolve only to public addresses")
+        # Pin the checked address so a second DNS lookup cannot reach a private host.
+        headers = request.headers.copy()
+        headers["Host"] = parsed.netloc
+        public_ips = list(dict.fromkeys(address[4][0] for address in addresses))
+        for index, address in enumerate(public_ips):
+            pinned = httpx.Request(
+                request.method,
+                pinned_url(url, address),
+                headers=headers,
+                stream=request.stream,
+                extensions={**request.extensions, "sni_hostname": hostname},
+            )
+            try:
+                return await self._transport.handle_async_request(pinned)
+            except httpx.ConnectError, httpx.ConnectTimeout:
+                if index == len(public_ips) - 1:
+                    raise
+        raise httpx.ConnectError("MCP server has no public addresses")
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
+def mcp_http_client(
+    url: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """Synchronous factory required by the MCP adapter; all network I/O is async."""
+    return httpx.AsyncClient(
+        headers=headers,
+        timeout=timeout or httpx.Timeout(30),
+        auth=auth,
+        transport=MCPTransport(url),
+        follow_redirects=False,
+        trust_env=False,
+    )

--- a/agent/tool_loaders/workspace_mcp.py
+++ b/agent/tool_loaders/workspace_mcp.py
@@ -1,0 +1,183 @@
+"""Generic MCP discovery; execution requires an explicit workspace tool allowlist."""
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from functools import partial
+from typing import Any
+
+import httpx
+from langchain_core.tools import BaseTool, StructuredTool, ToolException
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest, MCPToolCallResult
+from langchain_mcp_adapters.sessions import (
+    Connection,
+    SSEConnection,
+    StreamableHttpConnection,
+    create_session,
+)
+from langchain_mcp_adapters.tools import convert_mcp_tool_to_langchain_tool
+from mcp.types import PaginatedRequestParams, Tool
+
+from agent.dashboard.workspace_mcps import (
+    WorkspaceMCP,
+    WorkspaceMCPUpdate,
+    get_workspace_mcp,
+    list_workspace_mcp_records,
+    prepare_workspace_mcp,
+)
+from agent.tool_loaders.mcp_transport import mcp_http_client
+from agent.utils import ttl_cache
+
+logger = logging.getLogger(__name__)
+_TIMEOUT_SECONDS = 30
+
+
+def _connection(record: WorkspaceMCP) -> Connection:
+    connection: SSEConnection | StreamableHttpConnection
+    if record.transport == "sse":
+        connection = {"transport": "sse", "url": record.url}
+    else:
+        connection = {"transport": "streamable_http", "url": record.url}
+    connection["headers"] = record.connection_headers()
+    connection["timeout"] = _TIMEOUT_SECONDS
+    connection["sse_read_timeout"] = _TIMEOUT_SECONDS
+    connection["httpx_client_factory"] = partial(mcp_http_client, record.url)
+    return connection
+
+
+async def _discover_tools(record: WorkspaceMCP) -> list[Tool]:
+    async with create_session(_connection(record)) as session:
+        await session.initialize()
+        page = await session.list_tools()
+        tools = list(page.tools)
+        cursors: set[str] = set()
+        while page.nextCursor:
+            if page.nextCursor in cursors:
+                raise ValueError("MCP server repeated a catalog cursor")
+            cursors.add(page.nextCursor)
+            page = await session.list_tools(params=PaginatedRequestParams(cursor=page.nextCursor))
+            tools.extend(page.tools)
+        return tools
+
+
+def _discovery_error(error: Exception) -> str:
+    pending: list[BaseException] = [error]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, BaseExceptionGroup):
+            pending.extend(reversed(current.exceptions))
+        elif isinstance(current, httpx.HTTPStatusError):
+            status = current.response.status_code
+            hint = {
+                401: "Check the authentication headers",
+                403: "Check credentials, permissions, the server region, and MCP access settings",
+                404: "Check the MCP server URL",
+                429: "Wait before retrying; the MCP server is rate limiting requests",
+            }.get(status, "Check the MCP server availability")
+            return f"MCP tool discovery failed (HTTP {status}). {hint}"
+        elif isinstance(current, (TimeoutError, httpx.TimeoutException)):
+            return "MCP tool discovery timed out; check the server and try again"
+    return "Could not discover MCP tools; check the URL and authentication headers"
+
+
+async def discover_workspace_mcp(
+    name: str, update: WorkspaceMCPUpdate | None = None
+) -> list[dict[str, str]]:
+    """List tool descriptions for an admin to choose; never execute any tools."""
+    record = (
+        await prepare_workspace_mcp(name, update)
+        if update is not None
+        else await get_workspace_mcp(name)
+    )
+    if record is None:
+        raise ValueError("Workspace MCP connection does not exist")
+    try:
+        definitions = await asyncio.wait_for(_discover_tools(record), timeout=_TIMEOUT_SECONDS)
+    except Exception as exc:
+        raise ValueError(_discovery_error(exc)) from None
+    return [{"name": tool.name, "description": tool.description or ""} for tool in definitions]
+
+
+def _tool_name(connection_name: str, tool_name: str) -> str:
+    full_name = f"mcp_{connection_name}_{tool_name}"
+    safe = re.sub(r"[^a-zA-Z0-9_-]", "_", full_name)
+    suffix = hashlib.sha256(json.dumps((connection_name, tool_name)).encode()).hexdigest()[:10]
+    return f"{safe[:53]}_{suffix}"
+
+
+def _wrap_tool(name: str, url: str, transport: str, definition: Tool) -> BaseTool:
+    async def invoke(**arguments: Any) -> Any:
+        try:
+            record = await get_workspace_mcp(name)
+            if record is None or not record.enabled:
+                raise ToolException("Workspace MCP is disabled or disconnected")
+            if record.url != url or record.transport != transport:
+                raise ToolException("Workspace MCP connection changed; start a new run")
+            if definition.name not in record.allowed_tools:
+                raise ToolException("This tool is no longer allowed by the workspace MCP settings")
+
+            async def forward_arguments(
+                request: MCPToolCallRequest,
+                handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+            ) -> MCPToolCallResult:
+                # Preserve remote arguments named `runtime`, reserved by the adapter.
+                return await handler(request.override(args=arguments))
+
+            fresh = convert_mcp_tool_to_langchain_tool(
+                None,
+                definition,
+                connection=_connection(record),
+                tool_interceptors=[forward_arguments],
+            )
+            if not isinstance(fresh, StructuredTool) or fresh.coroutine is None:
+                raise ToolException("Workspace MCP tool has no async implementation")
+            return await asyncio.wait_for(fresh.coroutine(), timeout=_TIMEOUT_SECONDS)
+        except ToolException:
+            raise
+        except Exception:
+            logger.warning("Workspace MCP call failed", extra={"mcp_name": name})
+            raise ToolException(
+                "Workspace MCP call failed; check its connection and credentials"
+            ) from None
+
+    return StructuredTool.from_function(
+        coroutine=invoke,
+        name=_tool_name(name, definition.name),
+        description=definition.description or definition.name,
+        args_schema=definition.inputSchema,
+        response_format="content_and_artifact",
+        handle_tool_error=True,
+    )
+
+
+async def _load_tools(record: WorkspaceMCP) -> list[BaseTool]:
+    async def discover() -> list[Tool]:
+        return await asyncio.wait_for(_discover_tools(record), timeout=_TIMEOUT_SECONDS)
+
+    try:
+        definitions = await ttl_cache.cached(
+            f"workspace-mcp:{record.name}:{record.revision}", 600, discover
+        )
+        return [
+            _wrap_tool(record.name, record.url, record.transport, definition)
+            for definition in definitions
+            if definition.name in record.allowed_tools
+        ]
+    except Exception:
+        logger.warning("Workspace MCP discovery failed", extra={"mcp_name": record.name})
+        return []
+
+
+async def load_workspace_mcp_tools() -> list[BaseTool]:
+    try:
+        records = await list_workspace_mcp_records()
+    except Exception:
+        logger.warning("Workspace MCP settings unavailable")
+        return []
+    groups = await asyncio.gather(
+        *(_load_tools(record) for record in records if record.enabled and record.allowed_tools)
+    )
+    return [tool for group in groups for tool in group]

--- a/agent/tool_loaders/workspace_mcp.py
+++ b/agent/tool_loaders/workspace_mcp.py
@@ -35,6 +35,18 @@ logger = logging.getLogger(__name__)
 _TIMEOUT_SECONDS = 30
 
 
+class _WorkspaceMCPTool(StructuredTool):
+    """Forward remote properties without consuming LangChain's reserved keywords."""
+
+    def _run(self, /, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("Workspace MCP tools require async invocation")
+
+    async def _arun(self, /, *args: Any, **kwargs: Any) -> Any:
+        if self.coroutine is None:
+            raise ToolException("Workspace MCP tool has no async implementation")
+        return await self.coroutine(*args, **kwargs)
+
+
 def _connection(record: WorkspaceMCP) -> Connection:
     connection: SSEConnection | StreamableHttpConnection
     if record.transport == "sse":
@@ -60,6 +72,8 @@ async def _discover_tools(record: WorkspaceMCP) -> list[Tool]:
             cursors.add(page.nextCursor)
             page = await session.list_tools(params=PaginatedRequestParams(cursor=page.nextCursor))
             tools.extend(page.tools)
+        if len({tool.name for tool in tools}) != len(tools):
+            raise ValueError("MCP server returned duplicate tool names")
         return tools
 
 
@@ -83,6 +97,14 @@ def _discovery_error(error: Exception) -> str:
     return "Could not discover MCP tools; check the URL and authentication headers"
 
 
+async def _discover_catalog(record: WorkspaceMCP) -> list[Tool]:
+    try:
+        return await asyncio.wait_for(_discover_tools(record), timeout=_TIMEOUT_SECONDS)
+    except Exception as exc:
+        # The shared cache logs refresh failures, so redact before handing errors to it.
+        raise ValueError(_discovery_error(exc)) from None
+
+
 async def discover_workspace_mcp(
     name: str, update: WorkspaceMCPUpdate | None = None
 ) -> list[dict[str, str]]:
@@ -94,10 +116,7 @@ async def discover_workspace_mcp(
     )
     if record is None:
         raise ValueError("Workspace MCP connection does not exist")
-    try:
-        definitions = await asyncio.wait_for(_discover_tools(record), timeout=_TIMEOUT_SECONDS)
-    except Exception as exc:
-        raise ValueError(_discovery_error(exc)) from None
+    definitions = await _discover_catalog(record)
     return [{"name": tool.name, "description": tool.description or ""} for tool in definitions]
 
 
@@ -143,7 +162,7 @@ def _wrap_tool(name: str, url: str, transport: str, definition: Tool) -> BaseToo
                 "Workspace MCP call failed; check its connection and credentials"
             ) from None
 
-    return StructuredTool.from_function(
+    return _WorkspaceMCPTool.from_function(
         coroutine=invoke,
         name=_tool_name(name, definition.name),
         description=definition.description or definition.name,
@@ -154,12 +173,11 @@ def _wrap_tool(name: str, url: str, transport: str, definition: Tool) -> BaseToo
 
 
 async def _load_tools(record: WorkspaceMCP) -> list[BaseTool]:
-    async def discover() -> list[Tool]:
-        return await asyncio.wait_for(_discover_tools(record), timeout=_TIMEOUT_SECONDS)
-
     try:
         definitions = await ttl_cache.cached(
-            f"workspace-mcp:{record.name}:{record.revision}", 600, discover
+            f"workspace-mcp:{record.name}:{record.revision}",
+            600,
+            partial(_discover_catalog, record),
         )
         return [
             _wrap_tool(record.name, record.url, record.transport, definition)

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -245,9 +245,11 @@ and remote coding-agent threads. The existing `CONFIGURED_ADMINS` and
    then the crossed-out eye to clear them from the editor. Entered or imported
    values also have an eye icon to show or hide them. Use headers
    for credentials, rather than URL query parameters.
-3. Choose **Save and discover tools**, select the tools to allow, then choose
-   **Save connection**. A connection with no selected tools exposes none. Newly
-   added tools on the remote server require explicit selection.
+3. Choose **Save and discover tools**. For new connections, all discovered tools
+   are selected by default. Review the selection, then choose **Save connection**
+   to enable those tools. Rediscovering an existing connection preserves its
+   selected tools, including an intentionally empty selection. Newly added tools
+   on the remote server require explicit selection.
    Discovery checks the draft before saving; if it fails, no connection is
    created and existing settings stay unchanged. Discovery only lists tools.
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -230,7 +230,85 @@ Open SWE ships with a small set of custom tools on top of the built-in Deep Agen
 | `slack_attach_html` | `agent/slack/tools/attach_html.py` | Attach sandbox HTML previews to Slack threads |
 | `slack_thread_reply` | `agent/slack/tools/thread_reply.py` | Reply in Slack threads |
 
-### Adding a tool
+### Workspace MCP servers
+
+Admins can connect generic remote MCP servers under **Admin → Workspace MCPs**.
+Connections belong to this Open SWE deployment and are shared across repositories
+and remote coding-agent threads. The existing `CONFIGURED_ADMINS` and
+`OBSERVABILITY_AUTHORIZED_EMAILS` access rules control which users can load them.
+
+1. Choose **Add MCP server** and enter a unique lowercase connection name, an
+   HTTPS server URL, and its transport (**Streamable HTTP** or **SSE**).
+2. Add authentication headers. Values are encrypted using `TOKEN_ENCRYPTION_KEY`
+   in the LangGraph Store; normal dashboard responses only return header names.
+   Admins can use the eye icon (**Show saved headers**) to reveal values on demand,
+   then the crossed-out eye to clear them from the editor. Entered or imported
+   values also have an eye icon to show or hide them. Use headers
+   for credentials, rather than URL query parameters.
+3. Choose **Save and discover tools**, select the tools to allow, then choose
+   **Save connection**. A connection with no selected tools exposes none. Newly
+   added tools on the remote server require explicit selection.
+   Discovery checks the draft before saving; if it fails, no connection is
+   created and existing settings stay unchanged. Discovery only lists tools.
+
+Alternatively, choose **Import JSON** and paste a Claude-style configuration:
+
+```json
+{
+  "mcpServers": {
+    "datadog": {
+      "type": "http",
+      "url": "https://mcp.us5.datadoghq.com/v1/mcp?toolsets=core",
+      "headers": {
+        "DD_API_KEY": "YOUR_API_KEY",
+        "DD_APPLICATION_KEY": "YOUR_APPLICATION_KEY"
+      }
+    }
+  }
+}
+```
+
+Use the endpoint for your Datadog site (this example uses US5). Replace the key
+placeholders directly in the dashboard. Import supports multiple named servers,
+optional `type` (`http` by default, or `sse`), and string authentication headers.
+It opens each connection for review without saving automatically. Existing
+connections keep their enabled state and selected tools. Local `command` servers
+and environment-variable expansion are not supported.
+
+Examples for the generic connection form:
+
+| Connection | URL | Authentication headers |
+|---|---|---|
+| `incident` | `https://mcp.incident.io/mcp` | `Authorization`: `Bearer <your incident.io API key>` |
+| `datadog` | `https://mcp.datadoghq.com/v1/mcp?toolsets=core` | `DD_API_KEY`: your API key; `DD_APPLICATION_KEY`: your application key |
+
+Both examples use Streamable HTTP. Choose the Datadog MCP hostname for your site
+(for example, `mcp.datadoghq.eu`). Use appropriately scoped provider keys and
+select the read tools you need for investigation. The incident.io authentication
+and catalog are documented in [its remote MCP guide](https://docs.incident.io/ai/remote-mcp).
+Datadog documents its headers and site-specific endpoints in the
+[MCP setup guide](https://docs.datadoghq.com/mcp_server/setup/#api-and-application-keys).
+Enter Datadog key values directly, without a `Bearer` prefix. The `core` toolset
+includes logs, metrics, traces, dashboards, monitors, and incidents.
+
+Allowed tools appear in the agent's **Workspace MCPs** tool group with connection
+prefixes such as `mcp_incident_incident_list_…` and a suffix to prevent naming
+collisions. Catalogs are cached for ten minutes
+per settings revision. Changing a connection causes the next run to discover its
+catalog again. Every tool call reloads the current headers and checks whether the
+connection and tool are still enabled. Disabling or deleting a connection blocks
+subsequent calls from already-loaded tools; it does not cancel an in-flight call.
+
+Editing keeps saved headers unless **Replace headers** is selected. Replacing
+with an empty header list clears authentication. Changing the URL requires
+explicitly replacing or clearing saved headers. Requests must remain on the
+configured public HTTPS origin; redirects, private addresses, local processes,
+and interactive OAuth login are not supported by this connection manager.
+An unavailable server omits its tools without preventing other connections from
+loading. This catalog is not attached to the separate read-only reviewer or
+Investigate graphs.
+
+### Adding a Python tool
 
 Create a new file in `agent/tools/`, define a function, and add it to the tools list.
 

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -126,7 +126,7 @@ async def test_tool_loaders_run_concurrently_and_gate_workspace_mcps(
             messages=[],
             tools=[],
             runtime=MagicMock(),
-            state={**state, "loaded_integration_tools": [mcp_tool.name]},
+            state={**state, "messages": [], "loaded_integration_tools": [mcp_tool.name]},
         )
         await dynamic.awrap_model_call(request, apply_plan_mode)
         assert captured == expected

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -36,7 +36,7 @@ def _config() -> RunnableConfig:
 
 @pytest.mark.asyncio
 async def test_tool_loaders_run_concurrently() -> None:
-    barrier = asyncio.Barrier(2)
+    barrier = asyncio.Barrier(3)
 
     def rendezvous(result: Any) -> Any:
         # Serial loaders never all reach the barrier, so a regression times out
@@ -78,6 +78,7 @@ async def test_tool_loaders_run_concurrently() -> None:
         patch("agent.server.construct_system_prompt", return_value="prompt"),
         patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
         patch("agent.server._observability_tools_for", side_effect=rendezvous([])),
+        patch("agent.server._workspace_mcp_tools_for", side_effect=rendezvous([])),
         patch("agent.server._load_integration_tools", side_effect=rendezvous(([], []))),
     ):
         await get_agent(_config())

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -10,8 +10,12 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.tools import StructuredTool
 from langgraph.graph.state import RunnableConfig
 
+from agent.middleware.dynamic_tools import DynamicToolMiddleware
+from agent.middleware.plan_mode import PlanModeMiddleware
 from agent.sandboxes.state import SANDBOX_BACKENDS
 from agent.server import get_agent
 
@@ -35,8 +39,21 @@ def _config() -> RunnableConfig:
 
 
 @pytest.mark.asyncio
-async def test_tool_loaders_run_concurrently() -> None:
+@pytest.mark.usefixtures("fake_store")
+@pytest.mark.parametrize("initial_plan_mode", [False, True])
+async def test_tool_loaders_run_concurrently_and_gate_workspace_mcps(
+    initial_plan_mode: bool,
+) -> None:
     barrier = asyncio.Barrier(3)
+
+    async def delete_incident() -> str:
+        return "deleted"
+
+    mcp_tool = StructuredTool.from_function(
+        coroutine=delete_incident,
+        name="mcp_incident_delete_0123456789",
+        description="Delete an incident",
+    )
 
     def rendezvous(result: Any) -> Any:
         # Serial loaders never all reach the barrier, so a regression times out
@@ -74,13 +91,44 @@ async def test_tool_loaders_run_concurrently() -> None:
         patch("agent.server.load_profile", new_callable=AsyncMock, return_value=None),
         patch("agent.server.load_thread_settings", new_callable=AsyncMock, return_value={}),
         patch("agent.server.fallback_model_id_for", return_value=None),
-        patch("agent.server.make_model", side_effect=[MagicMock(), MagicMock()]),
+        patch("agent.server.make_model", return_value=MagicMock()),
         patch("agent.server.construct_system_prompt", return_value="prompt"),
-        patch("agent.server.create_deep_agent", return_value=_DummyAgent()),
+        patch("agent.server.create_deep_agent", return_value=_DummyAgent()) as build_agent,
         patch("agent.server._observability_tools_for", side_effect=rendezvous([])),
-        patch("agent.server._workspace_mcp_tools_for", side_effect=rendezvous([])),
+        patch("agent.server._workspace_mcp_tools_for", side_effect=rendezvous([mcp_tool])),
         patch("agent.server._load_integration_tools", side_effect=rendezvous(([], []))),
     ):
-        await get_agent(_config())
+        config = _config()
+        config["configurable"]["plan_mode"] = initial_plan_mode
+        await get_agent(config)
+
+    middleware = build_agent.call_args.kwargs["middleware"]
+    dynamic = next(item for item in middleware if isinstance(item, DynamicToolMiddleware))
+    plan_mode = next(item for item in middleware if isinstance(item, PlanModeMiddleware))
+    assert middleware.index(dynamic) < middleware.index(plan_mode)
+    captured: list[str] = []
+
+    async def capture(request: ModelRequest) -> Any:
+        captured.extend(tool.name for tool in request.tools)
+        return MagicMock()
+
+    async def apply_plan_mode(request: ModelRequest) -> Any:
+        return await plan_mode.awrap_model_call(request, capture)
+
+    for state, expected in [
+        ({}, [] if initial_plan_mode else [mcp_tool.name]),
+        ({"plan_mode": True}, []),
+        ({"plan_mode": False}, [mcp_tool.name]),
+    ]:
+        captured.clear()
+        request = ModelRequest(
+            model=MagicMock(),
+            messages=[],
+            tools=[],
+            runtime=MagicMock(),
+            state={**state, "loaded_integration_tools": [mcp_tool.name]},
+        )
+        await dynamic.awrap_model_call(request, apply_plan_mode)
+        assert captured == expected
 
     SANDBOX_BACKENDS.pop(thread_id, None)

--- a/tests/dashboard/test_workspace_mcps.py
+++ b/tests/dashboard/test_workspace_mcps.py
@@ -182,6 +182,74 @@ async def test_validation_responses_never_echo_headers(monkeypatch, headers):
 
 
 @pytest.mark.parametrize(
+    "query_key",
+    [
+        "client_secret",
+        "auth_token",
+        "api-key",
+        "x-api-key",
+        "CLIENT_SECRET",
+        "clientSecret",
+        "AuthToken",
+        "X-API-Key",
+        "xApiKey",
+        "api.key",
+        "%63lient%5Fsecret",
+        "accessToken",
+        "refresh-token",
+        "apiToken",
+        "service_password",
+    ],
+)
+async def test_query_credentials_are_rejected_without_saving_or_echoing(
+    fake_store, monkeypatch, query_key
+):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/workspace-mcps/example",
+            json={
+                "name": "example",
+                "url": f"https://example.com/mcp?toolsets=core&{query_key}=test-secret",
+            },
+        )
+        assert response.status_code == 422
+        assert "test-secret" not in response.text
+        assert fake_store.values(["workspace_mcps"]) == {}
+        assert (await client.get("/dashboard/api/workspace-mcps")).json() == []
+
+
+async def test_ordinary_query_parameters_roundtrip_unchanged(fake_store, monkeypatch):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    url = (
+        "https://mcp.us5.datadoghq.com/v1/mcp"
+        "?toolsets=core&region=us5&page_token=next&token_budget=1000&monkey=banana"
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/workspace-mcps/example", json={"name": "example", "url": url}
+        )
+        assert response.status_code == 200
+        assert response.json()["url"] == url
+        assert fake_store.values(["workspace_mcps"])["example"]["url"] == url
+        assert (await client.get("/dashboard/api/workspace-mcps")).json()[0]["url"] == url
+
+
+@pytest.mark.parametrize(
     ("fields", "message"),
     [
         ({"name": "incident.io"}, "Connection name"),

--- a/tests/dashboard/test_workspace_mcps.py
+++ b/tests/dashboard/test_workspace_mcps.py
@@ -43,6 +43,23 @@ async def test_generic_connection_roundtrip_redacts_and_preserves_headers(fake_s
     assert await mcps.list_workspace_mcps() == []
 
 
+async def test_corrupt_record_does_not_hide_other_connections_or_log_values(fake_store, caplog):
+    saved = await mcps.save_workspace_mcp(
+        "example", mcps.WorkspaceMCPUpdate(name="example", url="https://example.com/mcp")
+    )
+    fake_store.values(["workspace_mcps"])["broken"] = {
+        **saved,
+        "name": "broken",
+        "encrypted_headers": {"Authorization": "test-secret"},
+    }
+
+    assert await mcps.list_workspace_mcps() == [saved]
+    with pytest.raises(ValidationError):
+        await mcps.get_workspace_mcp("broken")
+    assert "Skipping unreadable" in caplog.text
+    assert "test-secret" not in caplog.text
+
+
 async def test_url_change_requires_explicit_header_replacement(fake_store):
     await mcps.save_workspace_mcp(
         "example",

--- a/tests/dashboard/test_workspace_mcps.py
+++ b/tests/dashboard/test_workspace_mcps.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 from cryptography.fernet import Fernet
 from fastapi import FastAPI
+from mcp.types import Tool
 from pydantic import ValidationError
 
 from agent.dashboard import routes
@@ -89,12 +90,46 @@ async def test_url_change_requires_explicit_header_replacement(fake_store):
         {"headers": {"Authorization": "a", "authorization": "b"}},
         {"name": "invalid name"},
         {"transport": "stdio"},
+        {"allowed_tools": [""]},
+        {"allowed_tools": ["x" * 129]},
     ],
 )
 def test_invalid_connection_is_rejected(fields):
     values = {"name": "example", "url": "https://example.com/mcp", **fields}
     with pytest.raises(ValidationError):
         mcps.WorkspaceMCPUpdate(**values)
+
+
+async def test_all_discovered_tools_can_be_saved_for_large_catalogs(fake_store, monkeypatch):
+    tool_names = [f"tool_{index}" for index in range(201)]
+    monkeypatch.setattr(
+        loader,
+        "_discover_tools",
+        AsyncMock(return_value=[Tool(name=name, inputSchema={}) for name in tool_names]),
+    )
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    body = {"name": "example", "url": "https://example.com/mcp"}
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        catalog = await client.post("/dashboard/api/workspace-mcps/example/discover", json=body)
+        assert catalog.status_code == 200
+        selected = [tool["name"] for tool in catalog.json()]
+        assert selected == tool_names
+        saved = await client.put(
+            "/dashboard/api/workspace-mcps/example",
+            json={**body, "allowed_tools": selected},
+        )
+        assert saved.status_code == 200
+        assert saved.json()["allowed_tools"] == tool_names
+        assert (await client.get("/dashboard/api/workspace-mcps")).json()[0][
+            "allowed_tools"
+        ] == tool_names
 
 
 async def test_workspace_mcp_routes_are_admin_only_and_same_origin(fake_store, monkeypatch):

--- a/tests/dashboard/test_workspace_mcps.py
+++ b/tests/dashboard/test_workspace_mcps.py
@@ -1,0 +1,262 @@
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from pydantic import ValidationError
+
+from agent.dashboard import routes
+from agent.dashboard import workspace_mcps as mcps
+from agent.encryption import decrypt_token
+from agent.tool_loaders import workspace_mcp as loader
+
+
+@pytest.fixture(autouse=True)
+def encryption(monkeypatch):
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+async def test_generic_connection_roundtrip_redacts_and_preserves_headers(fake_store):
+    update = mcps.WorkspaceMCPUpdate(
+        name="incident",
+        url="https://mcp.incident.io/mcp",
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    saved = await mcps.save_workspace_mcp("incident", update)
+    assert saved["header_names"] == ["Authorization"]
+    assert "test-secret" not in json.dumps(saved)
+    raw = fake_store.values(["workspace_mcps"])["incident"]
+    assert "test-secret" not in json.dumps(raw)
+    assert json.loads(decrypt_token(raw["encrypted_headers"])) == {
+        "Authorization": "Bearer test-secret"
+    }
+    revised = await mcps.save_workspace_mcp(
+        "incident", mcps.WorkspaceMCPUpdate(name="incident", url=update.url, enabled=False)
+    )
+    assert revised["enabled"] is False
+    assert revised["header_names"] == ["Authorization"]
+    assert revised["revision"] != saved["revision"]
+    assert await mcps.list_workspace_mcps() == [revised]
+    await mcps.delete_workspace_mcp("incident")
+    assert await mcps.list_workspace_mcps() == []
+
+
+async def test_url_change_requires_explicit_header_replacement(fake_store):
+    await mcps.save_workspace_mcp(
+        "example",
+        mcps.WorkspaceMCPUpdate(
+            name="example", url="https://one.example/mcp", headers={"Authorization": "secret"}
+        ),
+    )
+    with pytest.raises(ValueError, match="headers"):
+        await mcps.save_workspace_mcp(
+            "example", mcps.WorkspaceMCPUpdate(name="example", url="https://two.example/mcp")
+        )
+    saved = await mcps.save_workspace_mcp(
+        "example",
+        mcps.WorkspaceMCPUpdate(name="example", url="https://two.example/mcp", headers={}),
+    )
+    assert saved["header_names"] == []
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"url": "http://example.com/mcp"},
+        {"url": "https://user:password@example.com/mcp"},
+        {"url": "https://example.com/mcp#fragment"},
+        {"headers": {"Host": "metadata.internal"}},
+        {"headers": {"Authorization": "secret\r\nHost: internal"}},
+        {"headers": {"Authorization": "a", "authorization": "b"}},
+        {"name": "invalid name"},
+        {"transport": "stdio"},
+    ],
+)
+def test_invalid_connection_is_rejected(fields):
+    values = {"name": "example", "url": "https://example.com/mcp", **fields}
+    with pytest.raises(ValidationError):
+        mcps.WorkspaceMCPUpdate(**values)
+
+
+async def test_workspace_mcp_routes_are_admin_only_and_same_origin(fake_store, monkeypatch):
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin@example.com")
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    app = FastAPI()
+    app.include_router(routes.router)
+    session = {"sub": "admin", "email": "admin@example.com"}
+    app.dependency_overrides[routes.require_session] = lambda: session
+    body = {
+        "name": "example",
+        "url": "https://example.com/mcp",
+        "headers": {"Authorization": "test-secret"},
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.put("/dashboard/api/workspace-mcps/example", json=body)
+        assert response.status_code == 200
+        assert "test-secret" not in response.text
+        assert len((await client.get("/dashboard/api/workspace-mcps")).json()) == 1
+        session = {"sub": "member", "email": "member@example.com"}
+        assert (await client.get("/dashboard/api/workspace-mcps")).status_code == 403
+        assert (
+            await client.put("/dashboard/api/workspace-mcps/example", json=body)
+        ).status_code == 403
+        assert (await client.delete("/dashboard/api/workspace-mcps/example")).status_code == 403
+        session = {"sub": "admin", "email": "admin@example.com"}
+        assert (
+            await client.delete(
+                "/dashboard/api/workspace-mcps/example", headers={"Origin": "http://attacker"}
+            )
+        ).status_code == 403
+        assert (await client.delete("/dashboard/api/workspace-mcps/example")).status_code == 204
+
+
+async def test_reveal_headers_requires_admin_and_same_origin_without_saving(
+    fake_store, monkeypatch
+):
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin@example.com")
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    saved = await mcps.save_workspace_mcp(
+        "example",
+        mcps.WorkspaceMCPUpdate(
+            name="example", url="https://example.com/mcp", headers={"Authorization": "test-secret"}
+        ),
+    )
+    app = FastAPI()
+    app.include_router(routes.router)
+    session = {"sub": "admin", "email": "admin@example.com"}
+    app.dependency_overrides[routes.require_session] = lambda: session
+    path = "/dashboard/api/workspace-mcps/example/headers/reveal"
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.post(path)
+        assert response.status_code == 200
+        assert response.json() == {"Authorization": "test-secret"}
+        assert response.headers["cache-control"] == "no-store"
+        assert await mcps.list_workspace_mcps() == [saved]
+        session = {"sub": "member", "email": "member@example.com"}
+        denied = await client.post(path)
+        assert denied.status_code == 403
+        assert "test-secret" not in denied.text
+        session = {"sub": "admin", "email": "admin@example.com"}
+        denied = await client.post(path, headers={"Origin": "http://attacker"})
+        assert denied.status_code == 403
+        assert "test-secret" not in denied.text
+        assert (
+            await client.post("/dashboard/api/workspace-mcps/missing/headers/reveal")
+        ).status_code == 404
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Authorization": "test-secret\n"},
+        {"Authorization": {"nested": "test-secret"}},
+        ["test-secret"],
+    ],
+)
+async def test_validation_responses_never_echo_headers(monkeypatch, headers):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/workspace-mcps/example",
+            json={"name": "example", "url": "https://example.com/mcp", "headers": headers},
+        )
+    assert response.status_code == 422
+    assert "test-secret" not in response.text
+
+
+@pytest.mark.parametrize(
+    ("fields", "message"),
+    [
+        ({"name": "incident.io"}, "Connection name"),
+        ({"url": "http://example.com/mcp"}, "Server URL"),
+        ({"transport": "stdio"}, "Transport"),
+        ({"headers": {"Authorization": {"test-secret": "test-secret"}}}, "Headers"),
+    ],
+)
+async def test_validation_identifies_fields_without_echoing_input(monkeypatch, fields, message):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/workspace-mcps/example",
+            json={
+                "name": "example",
+                "url": "https://example.com/mcp",
+                "headers": {"Authorization": "test-secret"},
+                **fields,
+            },
+        )
+    assert response.status_code == 422
+    assert message in response.json()["detail"]
+    assert "test-secret" not in response.text
+
+
+@pytest.mark.parametrize("existing", [False, True])
+@pytest.mark.parametrize("fails", [False, True])
+async def test_discover_draft_never_saves_settings(fake_store, monkeypatch, existing, fails):
+    previous = None
+    if existing:
+        previous = await mcps.save_workspace_mcp(
+            "example",
+            mcps.WorkspaceMCPUpdate(
+                name="example", url="https://example.com/old", headers={"Authorization": "old"}
+            ),
+        )
+    request = httpx.Request("POST", "https://example.com/mcp")
+    error = httpx.HTTPStatusError(
+        "test-secret", request=request, response=httpx.Response(403, request=request)
+    )
+    discover = AsyncMock(
+        side_effect=ExceptionGroup("test-secret", [error]) if fails else None,
+        return_value=[],
+    )
+    monkeypatch.setattr(loader, "_discover_tools", discover)
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://test")
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Origin": "http://test"},
+    ) as client:
+        response = await client.post(
+            "/dashboard/api/workspace-mcps/example/discover",
+            json={
+                "name": "example",
+                "url": "https://example.com/mcp",
+                "headers": {"Authorization": "test-secret"},
+            },
+        )
+    assert response.status_code == (400 if fails else 200)
+    if fails:
+        assert "HTTP 403" in response.json()["detail"]
+    assert "test-secret" not in response.text
+    candidate = discover.call_args.args[0]
+    assert candidate.url == "https://example.com/mcp"
+    assert candidate.connection_headers() == {"Authorization": "test-secret"}
+    current = await mcps.get_workspace_mcp("example")
+    assert (current.public() if current else None) == previous

--- a/tests/tools/test_mcp_transport.py
+++ b/tests/tools/test_mcp_transport.py
@@ -1,0 +1,74 @@
+import socket
+
+import httpx
+import pytest
+
+from agent.tool_loaders import mcp_transport
+
+
+async def test_public_address_is_pinned_and_tls_hostname_preserved(monkeypatch):
+    monkeypatch.setattr(
+        mcp_transport,
+        "resolve_and_validate",
+        lambda url: (
+            True,
+            "",
+            "example.com",
+            [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+        ),
+    )
+    seen = []
+
+    async def remote(request):
+        seen.append(request)
+        return httpx.Response(200)
+
+    transport = mcp_transport.MCPTransport("https://example.com/mcp")
+    await transport._transport.aclose()
+    transport._transport = httpx.MockTransport(remote)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await client.post("https://example.com/mcp", headers={"Authorization": "test-key"})
+    assert seen[0].url.host == "93.184.216.34"
+    assert seen[0].headers["Host"] == "example.com"
+    assert seen[0].extensions["sni_hostname"] == "example.com"
+
+
+@pytest.mark.parametrize("url", ["http://example.com/mcp", "https://other.example/mcp"])
+async def test_server_cannot_redirect_credentials_to_another_origin(url):
+    async with mcp_transport.mcp_http_client("https://example.com/mcp") as client:
+        with pytest.raises(ValueError, match="configured HTTPS origin"):
+            await client.get(url)
+        assert client.follow_redirects is False
+
+
+async def test_private_or_unresolved_address_is_blocked(monkeypatch):
+    monkeypatch.setattr(
+        mcp_transport, "resolve_and_validate", lambda url: (False, "blocked", "example.com", None)
+    )
+    async with mcp_transport.mcp_http_client("https://example.com/mcp") as client:
+        with pytest.raises(ValueError, match="public addresses"):
+            await client.get("https://example.com/mcp")
+
+
+async def test_connection_failure_tries_next_validated_address(monkeypatch):
+    addresses = [
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2606:4700:4700::1111", 443, 0, 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+    ]
+    monkeypatch.setattr(
+        mcp_transport, "resolve_and_validate", lambda url: (True, "", "example.com", addresses)
+    )
+    seen = []
+
+    async def remote(request):
+        seen.append(request.url.host)
+        if len(seen) == 1:
+            raise httpx.ConnectError("IPv6 unavailable")
+        return httpx.Response(200)
+
+    transport = mcp_transport.MCPTransport("https://example.com/mcp")
+    await transport._transport.aclose()
+    transport._transport = httpx.MockTransport(remote)
+    async with httpx.AsyncClient(transport=transport) as client:
+        assert (await client.get("https://example.com/mcp")).status_code == 200
+    assert seen == ["2606:4700:4700::1111", "93.184.216.34"]

--- a/tests/tools/test_workspace_mcp_tools.py
+++ b/tests/tools/test_workspace_mcp_tools.py
@@ -1,0 +1,148 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from cryptography.fernet import Fernet
+from mcp.types import CallToolResult, TextContent, Tool
+
+from agent import server
+from agent.dashboard import workspace_mcps as settings
+from agent.tool_loaders import workspace_mcp as loader
+
+
+@pytest.fixture(autouse=True)
+def encryption(monkeypatch):
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+async def save(name="example", **kwargs):
+    return await settings.save_workspace_mcp(
+        name, settings.WorkspaceMCPUpdate(name=name, url="https://example.com/mcp", **kwargs)
+    )
+
+
+async def test_generic_tools_are_namespaced_filtered_and_refresh_credentials(
+    fake_store, monkeypatch
+):
+    await save(headers={"Authorization": "old"}, allowed_tools=["search"])
+    definitions = [
+        Tool(
+            name=name,
+            description=name,
+            inputSchema={
+                "type": "object",
+                "properties": {"query": {"type": "string"}, "runtime": {"type": "string"}},
+                "required": ["query"],
+            },
+        )
+        for name in ["search", "delete"]
+    ]
+    monkeypatch.setattr(loader, "_discover_tools", AsyncMock(return_value=definitions))
+    tools = await loader.load_workspace_mcp_tools()
+    assert [tool.name for tool in tools] == ["mcp_example_search_8245e54055"]
+    calls = []
+
+    class Session:
+        async def initialize(self):
+            pass
+
+        async def call_tool(self, name, arguments, **kwargs):
+            calls.append((name, arguments))
+            return CallToolResult(content=[TextContent(type="text", text="found")])
+
+    @asynccontextmanager
+    async def session(connection, **kwargs):
+        assert connection["headers"] == {"X-Api-Key": "rotated"}
+        assert "httpx_client_factory" in connection
+        yield Session()
+
+    monkeypatch.setattr("langchain_mcp_adapters.tools.create_session", session)
+    await save(headers={"X-Api-Key": "rotated"}, allowed_tools=["search"])
+    result = await tools[0].ainvoke({"query": "incident", "runtime": "python"})
+    assert len(result) == 1
+    assert result[0]["type"] == "text"
+    assert result[0]["text"] == "found"
+    assert calls == [("search", {"query": "incident", "runtime": "python"})]
+    await save(enabled=False)
+    assert "disabled" in await tools[0].ainvoke({"query": "incident"})
+    assert len(calls) == 1
+
+
+async def test_delete_and_allowlist_changes_revoke_already_loaded_tools(fake_store, monkeypatch):
+    await save(allowed_tools=["search"])
+    monkeypatch.setattr(
+        loader,
+        "_discover_tools",
+        AsyncMock(return_value=[Tool(name="search", inputSchema={"type": "object"})]),
+    )
+    tool = (await loader.load_workspace_mcp_tools())[0]
+    await save(allowed_tools=[])
+    assert "allowed" in await tool.ainvoke({})
+    await settings.delete_workspace_mcp("example")
+    assert "disabled" in await tool.ainvoke({})
+
+
+async def test_new_connection_exposes_no_tools_until_admin_selects_them(fake_store, monkeypatch):
+    await save()
+    monkeypatch.setattr(
+        loader, "_discover_tools", AsyncMock(side_effect=AssertionError("must not connect"))
+    )
+    assert await loader.load_workspace_mcp_tools() == []
+
+
+async def test_one_failed_server_does_not_hide_other_servers(fake_store, monkeypatch, caplog):
+    await save("broken", allowed_tools=["search"])
+    await save("working", allowed_tools=["search"])
+
+    async def discover(record):
+        if record.name == "broken":
+            raise ValueError("secret upstream detail")
+        return [Tool(name="search", inputSchema={"type": "object"})]
+
+    monkeypatch.setattr(loader, "_discover_tools", discover)
+    assert [t.name for t in await loader.load_workspace_mcp_tools()] == [
+        "mcp_working_search_0ebe441dc6"
+    ]
+    assert "secret upstream detail" not in caplog.text
+
+
+async def test_workspace_mcp_catalog_is_reused_until_settings_change(fake_store, monkeypatch):
+    await save(allowed_tools=["search1", "search2"])
+    calls = 0
+
+    async def discover(record):
+        nonlocal calls
+        calls += 1
+        return [Tool(name=f"search{calls}", inputSchema={"type": "object"})]
+
+    monkeypatch.setattr(loader, "_discover_tools", discover)
+    assert (await loader.load_workspace_mcp_tools())[0].name == "mcp_example_search1_882c6b1452"
+    assert (await loader.load_workspace_mcp_tools())[0].name == "mcp_example_search1_882c6b1452"
+    await save(allowed_tools=["search1", "search2"])
+    assert (await loader.load_workspace_mcp_tools())[0].name == "mcp_example_search2_7f8eb9cd41"
+
+
+async def test_workspace_tools_use_existing_authorization_gate(monkeypatch):
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin@example.com")
+    monkeypatch.setenv("OBSERVABILITY_AUTHORIZED_EMAILS", "")
+    monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        server, "load_workspace_mcp_tools", AsyncMock(return_value=["mcp_example_search"])
+    )
+    authorized = {"configurable": {"user_email": "admin@example.com"}}
+    outsider = {"configurable": {"user_email": "outsider@example.com"}}
+    assert await server._workspace_mcp_tools_for(authorized, None) == ["mcp_example_search"]
+    assert await server._workspace_mcp_tools_for(outsider, None) == []
+
+
+def test_connection_tool_pairs_cannot_collide():
+    pairs = [
+        ("foo_bar", "baz"),
+        ("foo", "bar_baz"),
+        ("example", "a/b"),
+        ("example", "a_b"),
+        ("example", "a" * 128),
+    ]
+    names = [loader._tool_name(*pair) for pair in pairs]
+    assert len(set(names)) == len(pairs)
+    assert all(len(name) <= 64 for name in names)

--- a/tests/tools/test_workspace_mcp_tools.py
+++ b/tests/tools/test_workspace_mcp_tools.py
@@ -1,13 +1,16 @@
+import json
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
 
 import pytest
 from cryptography.fernet import Fernet
-from mcp.types import CallToolResult, TextContent, Tool
+from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 
 from agent import server
 from agent.dashboard import workspace_mcps as settings
+from agent.middleware.dynamic_tools import DynamicToolMiddleware
 from agent.tool_loaders import workspace_mcp as loader
+from agent.utils import ttl_cache
 
 
 @pytest.fixture(autouse=True)
@@ -120,6 +123,101 @@ async def test_workspace_mcp_catalog_is_reused_until_settings_change(fake_store,
     assert (await loader.load_workspace_mcp_tools())[0].name == "mcp_example_search1_882c6b1452"
     await save(allowed_tools=["search1", "search2"])
     assert (await loader.load_workspace_mcp_tools())[0].name == "mcp_example_search2_7f8eb9cd41"
+
+
+@pytest.mark.parametrize("paginated", [False, True])
+async def test_duplicate_catalog_is_isolated_from_other_connections(
+    fake_store, monkeypatch, paginated
+):
+    await settings.save_workspace_mcp(
+        "broken",
+        settings.WorkspaceMCPUpdate(
+            name="broken", url="https://broken.example/mcp", allowed_tools=["search"]
+        ),
+    )
+    await save("working", allowed_tools=["search"])
+    definition = Tool(name="search", inputSchema={"type": "object"})
+
+    class Session:
+        def __init__(self, broken):
+            self.broken = broken
+
+        async def initialize(self):
+            pass
+
+        async def list_tools(self, *, params=None):
+            if self.broken and paginated and params is None:
+                return ListToolsResult(tools=[definition], nextCursor="next")
+            tools = [definition, definition] if self.broken and not paginated else [definition]
+            return ListToolsResult(tools=tools)
+
+    @asynccontextmanager
+    async def session(connection):
+        yield Session(connection["url"] == "https://broken.example/mcp")
+
+    monkeypatch.setattr(loader, "create_session", session)
+    tools = await loader.load_workspace_mcp_tools()
+    middleware = DynamicToolMiddleware({"Workspace MCPs": tools})
+    assert middleware.has_groups
+    assert [tool.name for tool in tools] == ["mcp_working_search_0ebe441dc6"]
+    with pytest.raises(ValueError):
+        await loader.discover_workspace_mcp("broken")
+
+
+async def test_expired_catalog_failure_does_not_log_upstream_details(
+    fake_store, monkeypatch, caplog
+):
+    await save(allowed_tools=["search"])
+    now = 0
+    monkeypatch.setattr(ttl_cache, "_now", lambda: now)
+    monkeypatch.setattr(
+        loader,
+        "_discover_tools",
+        AsyncMock(
+            side_effect=[
+                [Tool(name="search", inputSchema={"type": "object"})],
+                ExceptionGroup("test-secret", [ValueError("test-secret")]),
+            ]
+        ),
+    )
+    assert len(await loader.load_workspace_mcp_tools()) == 1
+    now = 601
+    assert len(await loader.load_workspace_mcp_tools()) == 1
+    assert "test-secret" not in caplog.text
+
+
+@pytest.mark.parametrize("argument", ["config", "run_manager", "self", "runtime"])
+async def test_remote_arguments_survive_langchain_invocation(fake_store, monkeypatch, argument):
+    await save(allowed_tools=["search"])
+    definition = Tool(
+        name="search",
+        inputSchema={
+            "type": "object",
+            "properties": {argument: {"type": "string"}},
+            "required": [argument],
+        },
+    )
+    monkeypatch.setattr(loader, "_discover_tools", AsyncMock(return_value=[definition]))
+
+    class Session:
+        async def initialize(self):
+            pass
+
+        async def call_tool(self, name, arguments, **kwargs):
+            return CallToolResult(content=[TextContent(type="text", text=json.dumps(arguments))])
+
+    @asynccontextmanager
+    async def session(connection, **kwargs):
+        yield Session()
+
+    monkeypatch.setattr("langchain_mcp_adapters.tools.create_session", session)
+    tool = (await loader.load_workspace_mcp_tools())[0]
+    result = await tool.ainvoke(
+        {"name": tool.name, "args": {argument: "remote-value"}, "id": "call-1", "type": "tool_call"}
+    )
+    assert result.tool_call_id == "call-1"
+    assert result.status == "success"
+    assert json.loads(result.content[0]["text"]) == {argument: "remote-value"}
 
 
 async def test_workspace_tools_use_existing_authorization_gate(monkeypatch):

--- a/ui/src/features/settings/components/WorkspaceMCPImport.test.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPImport.test.tsx
@@ -1,0 +1,98 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, expect, it, vi } from "vitest"
+
+import { parseMCPConfig, WorkspaceMCPImport } from "./WorkspaceMCPImport"
+
+afterEach(cleanup)
+
+it("imports multiple remote Claude-style servers with headers and transports", () => {
+  expect(
+    parseMCPConfig(
+      JSON.stringify({
+        mcpServers: {
+          incident: {
+            url: "https://mcp.incident.io/mcp",
+            headers: { Authorization: "Bearer test-secret" },
+          },
+          datadog: {
+            type: "http",
+            url: "https://mcp.us5.datadoghq.com/v1/mcp",
+            headers: { DD_API_KEY: "test-api", DD_APPLICATION_KEY: "test-app" },
+          },
+          legacy: { type: "sse", url: "https://example.com/sse" },
+        },
+      })
+    )
+  ).toEqual([
+    {
+      name: "incident",
+      transport: "streamable_http",
+      url: "https://mcp.incident.io/mcp",
+      headers: { Authorization: "Bearer test-secret" },
+    },
+    {
+      name: "datadog",
+      transport: "streamable_http",
+      url: "https://mcp.us5.datadoghq.com/v1/mcp",
+      headers: { DD_API_KEY: "test-api", DD_APPLICATION_KEY: "test-app" },
+    },
+    {
+      name: "legacy",
+      transport: "sse",
+      url: "https://example.com/sse",
+      headers: undefined,
+    },
+  ])
+})
+
+it.each([
+  ['{"mcpServers": {"example": "test-secret"', "valid JSON"],
+  [
+    JSON.stringify({
+      mcpServers: { example: { command: "test-secret", args: [] } },
+    }),
+    "local command",
+  ],
+  [
+    JSON.stringify({
+      mcpServers: {
+        example: {
+          url: "https://example.com",
+          headers: { Authorization: "${test-secret}" },
+        },
+      },
+    }),
+    "environment-variable",
+  ],
+  [
+    JSON.stringify({
+      mcpServers: {
+        example: {
+          url: "https://example.com",
+          headers: { Authorization: { secret: "test-secret" } },
+        },
+      },
+    }),
+    "string values",
+  ],
+  [
+    JSON.stringify({
+      mcpServers: { example: { url: "https://example.com", type: ["http"] } },
+    }),
+    "type must",
+  ],
+])(
+  "rejects unsupported or malformed configuration without echoing secrets",
+  (input, message) => {
+    const onImport = vi.fn()
+    render(<WorkspaceMCPImport onImport={onImport} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText("MCP configuration JSON"), {
+      target: { value: input },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Review connections" }))
+    expect(screen.getByRole("alert").textContent).toContain(message)
+    expect(screen.getByRole("alert").textContent).not.toContain("test-secret")
+    expect(onImport).not.toHaveBeenCalled()
+  }
+)

--- a/ui/src/features/settings/components/WorkspaceMCPImport.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPImport.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import type { WorkspaceMCPUpdate } from "@/lib/api"
+
+export type ImportedMCP = Pick<
+  WorkspaceMCPUpdate,
+  "name" | "url" | "transport" | "headers"
+>
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function parseMCPConfig(text: string): ImportedMCP[] {
+  let config: unknown
+  try {
+    config = JSON.parse(text)
+  } catch {
+    throw new Error("Enter valid JSON with an mcpServers object.")
+  }
+  if (!isObject(config) || !isObject(config.mcpServers))
+    throw new Error("The JSON must contain an mcpServers object.")
+  const entries = Object.entries(config.mcpServers)
+  if (!entries.length) throw new Error("Add at least one server to mcpServers.")
+
+  return entries.map(([name, server], index) => {
+    const label = `Connection ${index + 1}`
+    if (!/^[a-z][a-z0-9_-]{0,31}$/.test(name))
+      throw new Error(
+        `${label}: use a lowercase name with letters, numbers, hyphens, or underscores (1-32 characters).`
+      )
+    if (!isObject(server))
+      throw new Error(`${label}: server settings must be an object.`)
+    if ("command" in server || server.type === "stdio")
+      throw new Error(
+        `${label}: local command servers are not supported. Use a remote HTTP or SSE server.`
+      )
+    if (
+      Object.keys(server).some(
+        (key) => !["url", "type", "headers"].includes(key)
+      )
+    )
+      throw new Error(
+        `${label}: supported settings are url, type, and headers.`
+      )
+    if (
+      typeof server.url !== "string" ||
+      !server.url.trim().startsWith("https://")
+    )
+      throw new Error(`${label}: provide an HTTPS server URL.`)
+    if (
+      server.type !== undefined &&
+      (typeof server.type !== "string" ||
+        !["http", "streamable_http", "streamable-http", "sse"].includes(
+          server.type
+        ))
+    )
+      throw new Error(`${label}: type must be http or sse.`)
+    let headers: Record<string, string> | undefined
+    if (server.headers !== undefined) {
+      if (
+        !isObject(server.headers) ||
+        Object.values(server.headers).some((value) => typeof value !== "string")
+      )
+        throw new Error(`${label}: headers must be an object of string values.`)
+      headers = server.headers as Record<string, string>
+      if (Object.values(headers).some((value) => /\$\{[^}]+\}/.test(value)))
+        throw new Error(
+          `${label}: replace environment-variable placeholders in headers with their values; this importer does not read local environment variables.`
+        )
+    }
+    return {
+      name,
+      url: server.url.trim(),
+      transport: server.type === "sse" ? "sse" : "streamable_http",
+      headers,
+    }
+  })
+}
+
+export function WorkspaceMCPImport({
+  onImport,
+  onCancel,
+}: {
+  onImport: (connections: ImportedMCP[]) => void
+  onCancel: () => void
+}) {
+  const [text, setText] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  return (
+    <form
+      className="space-y-3 rounded-md border p-4"
+      onSubmit={(event) => {
+        event.preventDefault()
+        try {
+          const connections = parseMCPConfig(text)
+          setText("")
+          onImport(connections)
+        } catch (cause) {
+          setError(
+            cause instanceof Error ? cause.message : "Unable to import JSON."
+          )
+        }
+      }}
+    >
+      <p className="text-sm font-medium">Import MCP JSON</p>
+      <p className="text-xs text-muted-foreground">
+        Paste a Claude-style mcpServers configuration. Review each connection
+        before saving; new connections start with no tools enabled.
+      </p>
+      <Textarea
+        aria-label="MCP configuration JSON"
+        className="h-48 max-h-64 resize-y font-mono"
+        value={text}
+        onChange={(event) => setText(event.target.value)}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={
+          '{\n  "mcpServers": {\n    "datadog": {\n      "type": "http",\n      "url": "https://mcp.us5.datadoghq.com/v1/mcp",\n      "headers": {\n        "DD_API_KEY": "YOUR_API_KEY",\n        "DD_APPLICATION_KEY": "YOUR_APPLICATION_KEY"\n      }\n    }\n  }\n}'
+        }
+      />
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={!text.trim()}>
+          Review connections
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
+          Cancel import
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/ui/src/features/settings/components/WorkspaceMCPImport.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPImport.tsx
@@ -108,7 +108,7 @@ export function WorkspaceMCPImport({
       <p className="text-sm font-medium">Import MCP JSON</p>
       <p className="text-xs text-muted-foreground">
         Paste a Claude-style mcpServers configuration. Review each connection
-        before saving; new connections start with no tools enabled.
+        before saving. New connections preselect all tools after discovery.
       </p>
       <Textarea
         aria-label="MCP configuration JSON"

--- a/ui/src/features/settings/components/WorkspaceMCPSection.test.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.test.tsx
@@ -113,7 +113,7 @@ it("saves generic authentication, discovers tools, and enables only selected too
   })
   const secret = screen.getByLabelText("Header 1 value")
   expect(secret.getAttribute("type")).toBe("password")
-  fireEvent.change(secret, { target: { value: "Bearer test-secret" } })
+  fireEvent.change(secret, { target: { value: "  Bearer test-secret  " } })
   fireEvent.click(screen.getByRole("button", { name: "Show header 1 value" }))
   expect(secret.getAttribute("type")).toBe("text")
   fireEvent.click(screen.getByRole("button", { name: "Hide header 1 value" }))
@@ -127,10 +127,12 @@ it("saves generic authentication, discovers tools, and enables only selected too
   expect((search as HTMLInputElement).checked).toBe(false)
   expect(operations).toEqual(["discover", "save"])
   expect(discoveries[0]?.headers).toEqual({
-    Authorization: "Bearer test-secret",
+    Authorization: "  Bearer test-secret  ",
   })
   expect(writes[0]?.allowed_tools).toEqual([])
-  expect(writes[0]?.headers).toEqual({ Authorization: "Bearer test-secret" })
+  expect(writes[0]?.headers).toEqual({
+    Authorization: "  Bearer test-secret  ",
+  })
   expect(screen.queryByLabelText("Header 1 value")).toBeNull()
   fireEvent.click(screen.getByRole("button", { name: "Select all" }))
   expect((search as HTMLInputElement).checked).toBe(true)
@@ -182,6 +184,67 @@ it("saves generic authentication, discovers tools, and enables only selected too
   await waitFor(() =>
     expect(screen.queryByRole("button", { name: "Edit incident" })).toBeNull()
   )
+  client.clear()
+})
+
+it("keeps a newly saved connection editable when refreshing the list fails", async () => {
+  let connection: WorkspaceMCP | null = null
+  const writes: WorkspaceMCPUpdate[] = []
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    if (String(input).endsWith("/discover")) {
+      return new Response(
+        JSON.stringify([{ name: "search", description: "Search incidents" }])
+      )
+    }
+    if (init?.method === "PUT") {
+      const update = JSON.parse(String(init.body)) as WorkspaceMCPUpdate
+      writes.push(update)
+      connection = {
+        name: update.name,
+        url: update.url,
+        transport: update.transport,
+        enabled: update.enabled,
+        allowed_tools: update.allowed_tools,
+        header_names: [],
+        revision: "v1",
+        updated_at: "now",
+      }
+      return new Response(JSON.stringify(connection))
+    }
+    return connection
+      ? new Response(JSON.stringify({ detail: "Settings unavailable" }), {
+          status: 503,
+        })
+      : new Response(JSON.stringify([]))
+  })
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  const add = screen.getByRole("button", { name: "Add MCP server" })
+  await waitFor(() => expect((add as HTMLButtonElement).disabled).toBe(false))
+  fireEvent.click(add)
+  fireEvent.change(screen.getByLabelText("Connection name"), {
+    target: { value: "incident" },
+  })
+  fireEvent.change(screen.getByLabelText("Server URL"), {
+    target: { value: "https://mcp.incident.io/mcp" },
+  })
+  fireEvent.click(
+    screen.getByRole("button", { name: "Save and discover tools" })
+  )
+  await screen.findByRole("alert")
+  const search = await screen.findByRole("checkbox", { name: "Allow search" })
+  expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy()
+  fireEvent.click(search)
+  fireEvent.click(screen.getByRole("button", { name: "Save connection" }))
+  await screen.findByRole("button", { name: "Add MCP server" })
+  expect(writes.at(-1)?.allowed_tools).toEqual(["search"])
+  expect(screen.getByText("· Enabled · 1 tools")).toBeTruthy()
   client.clear()
 })
 

--- a/ui/src/features/settings/components/WorkspaceMCPSection.test.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.test.tsx
@@ -1,0 +1,380 @@
+/** @vitest-environment jsdom */
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, expect, it, vi } from "vitest"
+
+import { WorkspaceMCPSection } from "./WorkspaceMCPSection"
+import type { WorkspaceMCP, WorkspaceMCPUpdate } from "@/lib/api"
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+it("validates the connection name before saving and discovering tools", async () => {
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(async () => new Response(JSON.stringify([])))
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  const add = screen.getByRole("button", { name: "Add MCP server" })
+  await waitFor(() => expect((add as HTMLButtonElement).disabled).toBe(false))
+  fireEvent.click(add)
+  fireEvent.change(screen.getByLabelText("Connection name"), {
+    target: { value: "incident.io" },
+  })
+  fireEvent.change(screen.getByLabelText("Server URL"), {
+    target: { value: "https://mcp.incident.io/mcp" },
+  })
+  fireEvent.click(
+    screen.getByRole("button", { name: "Save and discover tools" })
+  )
+  expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(
+    false
+  )
+  client.clear()
+})
+
+it("saves generic authentication, discovers tools, and enables only selected tools", async () => {
+  let connection: WorkspaceMCP | null = null
+  const writes: WorkspaceMCPUpdate[] = []
+  const discoveries: WorkspaceMCPUpdate[] = []
+  const operations: string[] = []
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input)
+    let result: unknown
+    if (url.endsWith("/discover")) {
+      operations.push("discover")
+      discoveries.push(JSON.parse(String(init?.body)))
+      result = [
+        { name: "search", description: "Search incidents" },
+        { name: "delete", description: "Delete incident" },
+      ]
+    } else if (init?.method === "PUT") {
+      operations.push("save")
+      const update = JSON.parse(String(init.body)) as WorkspaceMCPUpdate
+      writes.push(update)
+      connection = {
+        name: update.name,
+        url: update.url,
+        transport: update.transport,
+        enabled: update.enabled,
+        allowed_tools: update.allowed_tools,
+        header_names: update.headers
+          ? Object.keys(update.headers)
+          : (connection?.header_names ?? []),
+        revision: "v1",
+        updated_at: "now",
+      }
+      result = connection
+    } else if (init?.method === "DELETE") {
+      connection = null
+      return new Response(null, { status: 204 })
+    } else {
+      result = connection ? [connection] : []
+    }
+    return new Response(JSON.stringify(result), {
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  const add = screen.getByRole("button", { name: "Add MCP server" })
+  await waitFor(() => expect((add as HTMLButtonElement).disabled).toBe(false))
+  fireEvent.click(add)
+  fireEvent.change(screen.getByLabelText("Connection name"), {
+    target: { value: "incident" },
+  })
+  fireEvent.change(screen.getByLabelText("Server URL"), {
+    target: { value: "https://mcp.incident.io/mcp" },
+  })
+  fireEvent.click(screen.getByRole("button", { name: "Add header" }))
+  fireEvent.change(screen.getByLabelText("Header 1 name"), {
+    target: { value: "Authorization" },
+  })
+  const secret = screen.getByLabelText("Header 1 value")
+  expect(secret.getAttribute("type")).toBe("password")
+  fireEvent.change(secret, { target: { value: "Bearer test-secret" } })
+  fireEvent.click(screen.getByRole("button", { name: "Show header 1 value" }))
+  expect(secret.getAttribute("type")).toBe("text")
+  fireEvent.click(screen.getByRole("button", { name: "Hide header 1 value" }))
+  expect(secret.getAttribute("type")).toBe("password")
+  fireEvent.click(
+    screen.getByRole("button", { name: "Save and discover tools" })
+  )
+  const search = await screen.findByRole("checkbox", {
+    name: "Allow search",
+  })
+  expect((search as HTMLInputElement).checked).toBe(false)
+  expect(operations).toEqual(["discover", "save"])
+  expect(discoveries[0]?.headers).toEqual({
+    Authorization: "Bearer test-secret",
+  })
+  expect(writes[0]?.allowed_tools).toEqual([])
+  expect(writes[0]?.headers).toEqual({ Authorization: "Bearer test-secret" })
+  expect(screen.queryByLabelText("Header 1 value")).toBeNull()
+  fireEvent.click(screen.getByRole("button", { name: "Select all" }))
+  expect((search as HTMLInputElement).checked).toBe(true)
+  expect(
+    (screen.getByRole("checkbox", { name: "Allow delete" }) as HTMLInputElement)
+      .checked
+  ).toBe(true)
+  expect(screen.getByText("2 of 2 selected")).toBeTruthy()
+  fireEvent.click(screen.getByRole("button", { name: "Hide tools" }))
+  expect(screen.queryByRole("checkbox", { name: "Allow search" })).toBeNull()
+  fireEvent.click(screen.getByRole("button", { name: "Clear all" }))
+  expect(screen.getByText("0 of 2 selected")).toBeTruthy()
+  fireEvent.click(screen.getByRole("button", { name: "Show tools" }))
+  fireEvent.click(screen.getByRole("button", { name: "Select all" }))
+  fireEvent.click(screen.getByRole("checkbox", { name: "Allow delete" }))
+  expect(screen.getByText("1 of 2 selected")).toBeTruthy()
+  fireEvent.click(screen.getByRole("button", { name: "Save connection" }))
+  await screen.findByRole("button", { name: "Add MCP server" })
+  expect(writes[1]?.allowed_tools).toEqual(["search"])
+  expect(writes[1]?.headers).toBeNull()
+  fireEvent.click(screen.getByRole("button", { name: "Edit incident" }))
+  const incidentCard = screen.getByRole("region", {
+    name: "incident MCP connection",
+  })
+  expect(within(incidentCard).getByLabelText("Server URL")).toBeTruthy()
+  expect(
+    within(incidentCard)
+      .getByRole("button", { name: "Close incident" })
+      .getAttribute("aria-expanded")
+  ).toBe("true")
+  fireEvent.click(screen.getByRole("button", { name: "Clear all" }))
+  expect(screen.getByText("0 of 1 selected")).toBeTruthy()
+  fireEvent.click(screen.getByRole("button", { name: "Select all" }))
+  expect(
+    (screen.getByRole("checkbox", { name: "Allow search" }) as HTMLInputElement)
+      .checked
+  ).toBe(true)
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+  expect(within(incidentCard).queryByLabelText("Server URL")).toBeNull()
+  expect(
+    within(incidentCard)
+      .getByRole("button", { name: "Edit incident" })
+      .getAttribute("aria-expanded")
+  ).toBe("false")
+  fireEvent.click(screen.getByRole("button", { name: "Disable incident" }))
+  await screen.findByRole("button", { name: "Enable incident" })
+  expect(writes[2]?.enabled).toBe(false)
+  fireEvent.click(screen.getByRole("button", { name: "Delete incident" }))
+  await waitFor(() =>
+    expect(screen.queryByRole("button", { name: "Edit incident" })).toBeNull()
+  )
+  client.clear()
+})
+
+it("reveals saved headers on demand and discards them when hidden or closed", async () => {
+  const connection: WorkspaceMCP = {
+    name: "incident",
+    url: "https://mcp.incident.io/mcp",
+    transport: "streamable_http",
+    enabled: true,
+    allowed_tools: [],
+    header_names: ["Authorization"],
+    revision: "v1",
+    updated_at: "now",
+  }
+  const writes: WorkspaceMCPUpdate[] = []
+  let reveals = 0
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    if (String(input).endsWith("/headers/reveal")) {
+      reveals += 1
+      return new Response(JSON.stringify({ Authorization: "test-secret" }))
+    }
+    if (init?.method === "PUT") {
+      writes.push(JSON.parse(String(init.body)))
+      return new Response(JSON.stringify(connection))
+    }
+    return new Response(JSON.stringify([connection]))
+  })
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  fireEvent.click(await screen.findByRole("button", { name: "Edit incident" }))
+  expect(reveals).toBe(0)
+  fireEvent.click(screen.getByRole("button", { name: "Show saved headers" }))
+  const value = await screen.findByLabelText("Saved Authorization value")
+  expect((value as HTMLInputElement).value).toBe("test-secret")
+  expect((value as HTMLInputElement).readOnly).toBe(true)
+  fireEvent.click(screen.getByRole("button", { name: "Hide saved headers" }))
+  expect(screen.queryByDisplayValue("test-secret")).toBeNull()
+  fireEvent.click(screen.getByRole("button", { name: "Show saved headers" }))
+  await screen.findByDisplayValue("test-secret")
+  expect(reveals).toBe(2)
+  fireEvent.click(screen.getByRole("button", { name: "Close incident" }))
+  fireEvent.click(screen.getByRole("button", { name: "Edit incident" }))
+  expect(screen.queryByDisplayValue("test-secret")).toBeNull()
+  expect(reveals).toBe(2)
+  fireEvent.click(screen.getByRole("button", { name: "Show saved headers" }))
+  await screen.findByDisplayValue("test-secret")
+  fireEvent.click(screen.getByRole("button", { name: "Save connection" }))
+  await screen.findByRole("button", { name: "Add MCP server" })
+  expect(writes[0]?.headers).toBeNull()
+  expect(screen.queryByDisplayValue("test-secret")).toBeNull()
+  client.clear()
+})
+
+it("keeps an unsaved draft and its headers when discovery fails", async () => {
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(async (input) =>
+      String(input).endsWith("/discover")
+        ? new Response(
+            JSON.stringify({ detail: "MCP tool discovery failed (HTTP 403)" }),
+            { status: 400 }
+          )
+        : new Response(JSON.stringify([]))
+    )
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  const add = screen.getByRole("button", { name: "Add MCP server" })
+  await waitFor(() => expect((add as HTMLButtonElement).disabled).toBe(false))
+  fireEvent.click(add)
+  fireEvent.change(screen.getByLabelText("Connection name"), {
+    target: { value: "datadog" },
+  })
+  fireEvent.change(screen.getByLabelText("Server URL"), {
+    target: { value: "https://example.com/mcp" },
+  })
+  fireEvent.click(screen.getByRole("button", { name: "Add header" }))
+  fireEvent.change(screen.getByLabelText("Header 1 name"), {
+    target: { value: "DD_API_KEY" },
+  })
+  fireEvent.change(screen.getByLabelText("Header 1 value"), {
+    target: { value: "test-secret" },
+  })
+  fireEvent.click(
+    screen.getByRole("button", { name: "Save and discover tools" })
+  )
+  await screen.findByRole("alert")
+  expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(
+    false
+  )
+  expect(
+    (screen.getByLabelText("Header 1 value") as HTMLInputElement).value
+  ).toBe("test-secret")
+  expect(
+    screen.queryByRole("region", { name: "datadog MCP connection" })
+  ).toBeNull()
+  client.clear()
+})
+
+it("surfaces a settings error and prevents writing over an unknown list", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ detail: "Settings unavailable" }), {
+      status: 503,
+    })
+  )
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  await screen.findByRole("alert")
+  expect(
+    (
+      screen.getByRole("button", {
+        name: "Add MCP server",
+      }) as HTMLButtonElement
+    ).disabled
+  ).toBe(true)
+  client.clear()
+})
+
+it("reviews imported connections one at a time without writing on import or skip", async () => {
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response(JSON.stringify([])))
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <WorkspaceMCPSection />
+    </QueryClientProvider>
+  )
+  const importButton = screen.getByRole("button", { name: "Import JSON" })
+  await waitFor(() =>
+    expect((importButton as HTMLButtonElement).disabled).toBe(false)
+  )
+  fireEvent.click(importButton)
+  fireEvent.change(screen.getByLabelText("MCP configuration JSON"), {
+    target: {
+      value: JSON.stringify({
+        mcpServers: {
+          incident: {
+            url: "https://mcp.incident.io/mcp",
+            headers: { Authorization: "Bearer test-secret" },
+          },
+          datadog: {
+            type: "http",
+            url: "https://mcp.us5.datadoghq.com/v1/mcp",
+            headers: { DD_API_KEY: "test-api", DD_APPLICATION_KEY: "test-app" },
+          },
+        },
+      }),
+    },
+  })
+  fireEvent.click(screen.getByRole("button", { name: "Review connections" }))
+  expect(screen.queryByLabelText("MCP configuration JSON")).toBeNull()
+  expect(
+    (screen.getByLabelText("Connection name") as HTMLInputElement).value
+  ).toBe("incident")
+  expect(
+    (screen.getByLabelText("Header 1 value") as HTMLInputElement).type
+  ).toBe("password")
+  expect(
+    (screen.getByLabelText("Header 1 value") as HTMLInputElement).value
+  ).toBe("Bearer test-secret")
+  fireEvent.click(screen.getByRole("button", { name: "Skip connection" }))
+  expect(
+    (screen.getByLabelText("Connection name") as HTMLInputElement).value
+  ).toBe("datadog")
+  expect(
+    (screen.getByLabelText("Header 2 name") as HTMLInputElement).value
+  ).toBe("DD_APPLICATION_KEY")
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+  expect(screen.queryByLabelText("Header 1 value")).toBeNull()
+  expect(
+    fetchMock.mock.calls.some(
+      ([, init]) => init?.method === "PUT" || init?.method === "POST"
+    )
+  ).toBe(false)
+  client.clear()
+})

--- a/ui/src/features/settings/components/WorkspaceMCPSection.test.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.test.tsx
@@ -124,7 +124,7 @@ it("saves generic authentication, discovers tools, and enables only selected too
   const search = await screen.findByRole("checkbox", {
     name: "Allow search",
   })
-  expect((search as HTMLInputElement).checked).toBe(false)
+  expect((search as HTMLInputElement).checked).toBe(true)
   expect(operations).toEqual(["discover", "save"])
   expect(discoveries[0]?.headers).toEqual({
     Authorization: "  Bearer test-secret  ",
@@ -134,8 +134,6 @@ it("saves generic authentication, discovers tools, and enables only selected too
     Authorization: "  Bearer test-secret  ",
   })
   expect(screen.queryByLabelText("Header 1 value")).toBeNull()
-  fireEvent.click(screen.getByRole("button", { name: "Select all" }))
-  expect((search as HTMLInputElement).checked).toBe(true)
   expect(
     (screen.getByRole("checkbox", { name: "Allow delete" }) as HTMLInputElement)
       .checked
@@ -186,6 +184,70 @@ it("saves generic authentication, discovers tools, and enables only selected too
   )
   client.clear()
 })
+
+it.each([{ allowedTools: [] }, { allowedTools: ["search"] }])(
+  "preserves existing tool selections $allowedTools when rediscovering tools",
+  async ({ allowedTools }) => {
+    const connection: WorkspaceMCP = {
+      name: "incident",
+      url: "https://mcp.incident.io/mcp",
+      transport: "streamable_http",
+      enabled: true,
+      allowed_tools: allowedTools,
+      header_names: [],
+      revision: "v1",
+      updated_at: "now",
+    }
+    const writes: WorkspaceMCPUpdate[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/discover")) {
+        return new Response(
+          JSON.stringify([
+            { name: "search", description: "Search incidents" },
+            { name: "delete", description: "Delete incident" },
+          ])
+        )
+      }
+      if (init?.method === "PUT") {
+        writes.push(JSON.parse(String(init.body)))
+        return new Response(JSON.stringify(connection))
+      }
+      return new Response(JSON.stringify([connection]))
+    })
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    render(
+      <QueryClientProvider client={client}>
+        <WorkspaceMCPSection />
+      </QueryClientProvider>
+    )
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Edit incident" })
+    )
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save and discover tools" })
+    )
+    const deleteTool = await screen.findByRole("checkbox", {
+      name: "Allow delete",
+    })
+    expect((deleteTool as HTMLInputElement).checked).toBe(false)
+    expect(
+      (
+        screen.getByRole("checkbox", {
+          name: "Allow search",
+        }) as HTMLInputElement
+      ).checked
+    ).toBe(allowedTools.includes("search"))
+    fireEvent.click(screen.getByRole("button", { name: "Save connection" }))
+    await screen.findByRole("button", { name: "Add MCP server" })
+    expect(writes.map((update) => update.allowed_tools)).toEqual([
+      allowedTools,
+      allowedTools,
+    ])
+    client.clear()
+  }
+)
 
 it("keeps a newly saved connection editable when refreshing the list fails", async () => {
   let connection: WorkspaceMCP | null = null
@@ -240,7 +302,7 @@ it("keeps a newly saved connection editable when refreshing the list fails", asy
   await screen.findByRole("alert")
   const search = await screen.findByRole("checkbox", { name: "Allow search" })
   expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy()
-  fireEvent.click(search)
+  expect((search as HTMLInputElement).checked).toBe(true)
   fireEvent.click(screen.getByRole("button", { name: "Save connection" }))
   await screen.findByRole("button", { name: "Add MCP server" })
   expect(writes.at(-1)?.allowed_tools).toEqual(["search"])

--- a/ui/src/features/settings/components/WorkspaceMCPSection.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.tsx
@@ -169,7 +169,14 @@ export function WorkspaceMCPSection() {
         ),
         saved,
       ])
-      setDraft({ ...saved, existing: true })
+      setDraft({
+        ...saved,
+        existing: true,
+        allowed_tools:
+          discover && !draft.existing
+            ? discovered.map((tool) => tool.name)
+            : saved.allowed_tools,
+      })
       setHeaders([])
       setSavedHeaders(null)
       setReplaceHeaders(false)
@@ -415,8 +422,8 @@ export function WorkspaceMCPSection() {
         <div className="space-y-2">
           <p className="text-sm font-medium">Allowed tools</p>
           <p className="text-xs text-muted-foreground">
-            Save and discover the catalog, then select the tools this workspace
-            may use.
+            Discover tools, review the selection, then save. All discovered
+            tools are selected by default for new connections.
           </p>
           {toolNames.length > 0 && (
             <>
@@ -529,7 +536,7 @@ export function WorkspaceMCPSection() {
   return (
     <SettingsSection
       title="Workspace MCPs"
-      description="Connect remote MCP servers for authorized coding-agent runs. Choose the tools each connection can use; new connections start with no tools enabled."
+      description="Connect remote MCP servers for authorized coding-agent runs. New connections preselect all discovered tools; review the selection and save to enable them."
     >
       <div className="space-y-4 p-4">
         {connections.isLoading && (

--- a/ui/src/features/settings/components/WorkspaceMCPSection.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react"
 
 import { SettingsSection } from "@/components/AppShell"
-import { Button } from "@/components/ui/button"
+import { Button, IconButton } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { api } from "@/lib/api"
 import type { WorkspaceMCP, WorkspaceMCPUpdate } from "@/lib/api"
@@ -11,7 +11,7 @@ import { WorkspaceMCPImport } from "./WorkspaceMCPImport"
 import type { ImportedMCP } from "./WorkspaceMCPImport"
 
 type Header = { name: string; value: string; revealed?: boolean }
-type Draft = WorkspaceMCPUpdate & { existing: boolean }
+type Draft = Omit<WorkspaceMCPUpdate, "headers"> & { existing: boolean }
 const queryKey = ["workspaceMCPs"]
 
 export function WorkspaceMCPSection() {
@@ -34,20 +34,42 @@ export function WorkspaceMCPSection() {
   const [pendingImports, setPendingImports] = useState<ImportedMCP[]>([])
   const toolsId = useId()
   const editorId = useId()
+  const toolDescriptions = new Map(
+    catalog.map((tool) => [tool.name, tool.description])
+  )
+  const selectedTools = new Set(draft?.allowed_tools)
   const toolNames = [
     ...new Set([
-      ...catalog.map((tool) => tool.name),
+      ...toolDescriptions.keys(),
       ...(connections.data?.find(
         (connection) => connection.name === draft?.name
       )?.allowed_tools ?? []),
-      ...(draft?.allowed_tools ?? []),
+      ...selectedTools,
     ]),
   ].sort()
+
+  const openEditor = (
+    connection: Draft,
+    authentication?: Record<string, string> | null
+  ) => {
+    setDraft(connection)
+    setHeaders(
+      Object.entries(authentication ?? {}).map(([name, value]) => ({
+        name,
+        value,
+      }))
+    )
+    setSavedHeaders(null)
+    setReplaceHeaders(authentication != null || !connection.existing)
+    setCatalog([])
+    setToolsExpanded(true)
+    setError(null)
+  }
 
   const edit = (connection?: WorkspaceMCP) => {
     setImporting(false)
     setPendingImports([])
-    setDraft(
+    openEditor(
       connection
         ? { ...connection, existing: true }
         : {
@@ -59,35 +81,24 @@ export function WorkspaceMCPSection() {
             existing: false,
           }
     )
-    setHeaders([])
-    setSavedHeaders(null)
-    setReplaceHeaders(!connection)
-    setCatalog([])
-    setToolsExpanded(true)
-    setError(null)
   }
 
-  const openImported = (connection: ImportedMCP) => {
-    setSavedHeaders(null)
+  const openImported = ({
+    headers: authentication,
+    ...connection
+  }: ImportedMCP) => {
     const previous = connections.data?.find(
       (saved) => saved.name === connection.name
     )
-    setDraft({
-      ...connection,
-      enabled: previous?.enabled ?? true,
-      allowed_tools: previous?.allowed_tools ?? [],
-      existing: Boolean(previous),
-    })
-    setHeaders(
-      Object.entries(connection.headers ?? {}).map(([name, value]) => ({
-        name,
-        value,
-      }))
+    openEditor(
+      {
+        ...connection,
+        enabled: previous?.enabled ?? true,
+        allowed_tools: previous?.allowed_tools ?? [],
+        existing: Boolean(previous),
+      },
+      authentication
     )
-    setReplaceHeaders(connection.headers !== undefined || !previous)
-    setCatalog([])
-    setToolsExpanded(true)
-    setError(null)
   }
 
   const closeEditor = () => {
@@ -283,7 +294,7 @@ export function WorkspaceMCPSection() {
                 </div>
               )}
               <div className="flex flex-wrap gap-2">
-                <Button
+                <IconButton
                   type="button"
                   size="icon-sm"
                   variant="outline"
@@ -309,7 +320,7 @@ export function WorkspaceMCPSection() {
                   ) : (
                     <EyeIcon aria-hidden="true" />
                   )}
-                </Button>
+                </IconButton>
                 <Button
                   type="button"
                   size="sm"
@@ -347,7 +358,7 @@ export function WorkspaceMCPSection() {
                       updateHeader(index, "value", e.target.value)
                     }
                   />
-                  <Button
+                  <IconButton
                     type="button"
                     size="icon-sm"
                     variant="outline"
@@ -369,7 +380,7 @@ export function WorkspaceMCPSection() {
                     ) : (
                       <EyeIcon aria-hidden="true" />
                     )}
-                  </Button>
+                  </IconButton>
                   <Button
                     type="button"
                     size="sm"
@@ -458,7 +469,7 @@ export function WorkspaceMCPSection() {
                       type="checkbox"
                       className="mt-1 shrink-0"
                       aria-label={`Allow ${name}`}
-                      checked={draft.allowed_tools.includes(name)}
+                      checked={selectedTools.has(name)}
                       onChange={(e) =>
                         setDraft({
                           ...draft,
@@ -473,10 +484,7 @@ export function WorkspaceMCPSection() {
                     <span className="min-w-0 break-words">
                       {name}
                       <span className="block text-xs text-muted-foreground">
-                        {
-                          catalog.find((tool) => tool.name === name)
-                            ?.description
-                        }
+                        {toolDescriptions.get(name)}
                       </span>
                     </span>
                   </label>
@@ -532,90 +540,84 @@ export function WorkspaceMCPSection() {
             {connections.error?.message || error}
           </p>
         )}
-        {connections.data?.map((connection) => (
-          <section
-            key={connection.name}
-            aria-label={`${connection.name} MCP connection`}
-            className="rounded-md border"
-          >
-            <div className="flex flex-wrap items-center justify-between gap-3 p-3">
-              <div className="min-w-0">
-                <p className="text-sm font-medium">
-                  {connection.name}{" "}
-                  <span className="text-muted-foreground">
-                    · {connection.enabled ? "Enabled" : "Disabled"} ·{" "}
-                    {connection.allowed_tools.length} tools
-                  </span>
-                </p>
-                <p className="text-xs break-all text-muted-foreground">
-                  {connection.url}
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={busy}
-                  onClick={() => {
-                    if (draft?.existing && draft.name === connection.name) {
-                      closeEditor()
-                    } else edit(connection)
-                  }}
-                  aria-expanded={Boolean(
-                    draft?.existing && draft.name === connection.name
-                  )}
-                  aria-controls={
-                    draft?.existing && draft.name === connection.name
-                      ? editorId
-                      : undefined
-                  }
-                  aria-label={`${draft?.existing && draft.name === connection.name ? "Close" : "Edit"} ${connection.name}`}
-                >
-                  {draft?.existing && draft.name === connection.name
-                    ? "Close"
-                    : "Edit"}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={busy}
-                  onClick={() =>
-                    run(async () => {
-                      await api.saveWorkspaceMCP({
-                        name: connection.name,
-                        url: connection.url,
-                        transport: connection.transport,
-                        enabled: !connection.enabled,
-                        allowed_tools: connection.allowed_tools,
+        {connections.data?.map((connection) => {
+          const isEditing = draft?.existing && draft.name === connection.name
+          return (
+            <section
+              key={connection.name}
+              aria-label={`${connection.name} MCP connection`}
+              className="rounded-md border"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3 p-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">
+                    {connection.name}{" "}
+                    <span className="text-muted-foreground">
+                      · {connection.enabled ? "Enabled" : "Disabled"} ·{" "}
+                      {connection.allowed_tools.length} tools
+                    </span>
+                  </p>
+                  <p className="text-xs break-all text-muted-foreground">
+                    {connection.url}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() => {
+                      if (isEditing) closeEditor()
+                      else edit(connection)
+                    }}
+                    aria-expanded={Boolean(isEditing)}
+                    aria-controls={isEditing ? editorId : undefined}
+                    aria-label={`${isEditing ? "Close" : "Edit"} ${connection.name}`}
+                  >
+                    {isEditing ? "Close" : "Edit"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() =>
+                      run(async () => {
+                        await api.saveWorkspaceMCP({
+                          name: connection.name,
+                          url: connection.url,
+                          transport: connection.transport,
+                          enabled: !connection.enabled,
+                          allowed_tools: connection.allowed_tools,
+                        })
+                        await qc.invalidateQueries({ queryKey })
+                        if (draft?.name === connection.name) closeEditor()
                       })
-                      await qc.invalidateQueries({ queryKey })
-                      if (draft?.name === connection.name) closeEditor()
-                    })
-                  }
-                  aria-label={`${connection.enabled ? "Disable" : "Enable"} ${connection.name}`}
-                >
-                  {connection.enabled ? "Disable" : "Enable"}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={busy}
-                  onClick={() =>
-                    run(async () => {
-                      await api.deleteWorkspaceMCP(connection.name)
-                      await qc.invalidateQueries({ queryKey })
-                      if (draft?.name === connection.name) closeEditor()
-                    })
-                  }
-                  aria-label={`Delete ${connection.name}`}
-                >
-                  Delete
-                </Button>
+                    }
+                    aria-label={`${connection.enabled ? "Disable" : "Enable"} ${connection.name}`}
+                  >
+                    {connection.enabled ? "Disable" : "Enable"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() =>
+                      run(async () => {
+                        await api.deleteWorkspaceMCP(connection.name)
+                        await qc.invalidateQueries({ queryKey })
+                        if (draft?.name === connection.name) closeEditor()
+                      })
+                    }
+                    aria-label={`Delete ${connection.name}`}
+                  >
+                    Delete
+                  </Button>
+                </div>
               </div>
-            </div>
-            {draft?.existing && draft.name === connection.name && editor}
-          </section>
-        ))}
+              {isEditing && editor}
+            </section>
+          )
+        })}
         {importing ? (
           <WorkspaceMCPImport
             onImport={([first, ...rest]) => {

--- a/ui/src/features/settings/components/WorkspaceMCPSection.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.tsx
@@ -134,7 +134,7 @@ export function WorkspaceMCPSection() {
             )
           )
             throw new Error("Header names must be unique")
-          authentication[name] = header.value.trim()
+          authentication[name] = header.value
         }
       }
       if (
@@ -152,6 +152,12 @@ export function WorkspaceMCPSection() {
       }
       const discovered = discover ? await api.discoverWorkspaceMCP(update) : []
       const saved = await api.saveWorkspaceMCP(update)
+      qc.setQueryData<WorkspaceMCP[]>(queryKey, (current) => [
+        ...(current ?? []).filter(
+          (connection) => connection.name !== saved.name
+        ),
+        saved,
+      ])
       setDraft({ ...saved, existing: true })
       setHeaders([])
       setSavedHeaders(null)

--- a/ui/src/features/settings/components/WorkspaceMCPSection.tsx
+++ b/ui/src/features/settings/components/WorkspaceMCPSection.tsx
@@ -1,0 +1,650 @@
+import { useId, useState } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react"
+
+import { SettingsSection } from "@/components/AppShell"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { api } from "@/lib/api"
+import type { WorkspaceMCP, WorkspaceMCPUpdate } from "@/lib/api"
+import { WorkspaceMCPImport } from "./WorkspaceMCPImport"
+import type { ImportedMCP } from "./WorkspaceMCPImport"
+
+type Header = { name: string; value: string; revealed?: boolean }
+type Draft = WorkspaceMCPUpdate & { existing: boolean }
+const queryKey = ["workspaceMCPs"]
+
+export function WorkspaceMCPSection() {
+  const qc = useQueryClient()
+  const connections = useQuery({ queryKey, queryFn: api.getWorkspaceMCPs })
+  const [draft, setDraft] = useState<Draft | null>(null)
+  const [headers, setHeaders] = useState<Header[]>([])
+  const [replaceHeaders, setReplaceHeaders] = useState(false)
+  const [savedHeaders, setSavedHeaders] = useState<Record<
+    string,
+    string
+  > | null>(null)
+  const [catalog, setCatalog] = useState<
+    { name: string; description: string }[]
+  >([])
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [toolsExpanded, setToolsExpanded] = useState(true)
+  const [importing, setImporting] = useState(false)
+  const [pendingImports, setPendingImports] = useState<ImportedMCP[]>([])
+  const toolsId = useId()
+  const editorId = useId()
+  const toolNames = [
+    ...new Set([
+      ...catalog.map((tool) => tool.name),
+      ...(connections.data?.find(
+        (connection) => connection.name === draft?.name
+      )?.allowed_tools ?? []),
+      ...(draft?.allowed_tools ?? []),
+    ]),
+  ].sort()
+
+  const edit = (connection?: WorkspaceMCP) => {
+    setImporting(false)
+    setPendingImports([])
+    setDraft(
+      connection
+        ? { ...connection, existing: true }
+        : {
+            name: "",
+            url: "",
+            transport: "streamable_http",
+            enabled: true,
+            allowed_tools: [],
+            existing: false,
+          }
+    )
+    setHeaders([])
+    setSavedHeaders(null)
+    setReplaceHeaders(!connection)
+    setCatalog([])
+    setToolsExpanded(true)
+    setError(null)
+  }
+
+  const openImported = (connection: ImportedMCP) => {
+    setSavedHeaders(null)
+    const previous = connections.data?.find(
+      (saved) => saved.name === connection.name
+    )
+    setDraft({
+      ...connection,
+      enabled: previous?.enabled ?? true,
+      allowed_tools: previous?.allowed_tools ?? [],
+      existing: Boolean(previous),
+    })
+    setHeaders(
+      Object.entries(connection.headers ?? {}).map(([name, value]) => ({
+        name,
+        value,
+      }))
+    )
+    setReplaceHeaders(connection.headers !== undefined || !previous)
+    setCatalog([])
+    setToolsExpanded(true)
+    setError(null)
+  }
+
+  const closeEditor = () => {
+    setDraft(null)
+    setHeaders([])
+    setSavedHeaders(null)
+    setPendingImports([])
+    setError(null)
+  }
+
+  const finishEditing = () => {
+    const [next, ...rest] = pendingImports
+    if (next) {
+      setPendingImports(rest)
+      openImported(next)
+    } else closeEditor()
+  }
+
+  const run = async (action: () => Promise<void>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await action()
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Unable to update MCP connection"
+      )
+    }
+    setBusy(false)
+  }
+
+  const save = async (discover: boolean) => {
+    if (!draft) return
+    await run(async () => {
+      const authentication: Record<string, string> = {}
+      if (replaceHeaders) {
+        for (const header of headers) {
+          const name = header.name.trim()
+          if (!name || !header.value.trim())
+            throw new Error("Each header needs a name and value")
+          if (
+            Object.keys(authentication).some(
+              (key) => key.toLowerCase() === name.toLowerCase()
+            )
+          )
+            throw new Error("Header names must be unique")
+          authentication[name] = header.value.trim()
+        }
+      }
+      if (
+        !draft.existing &&
+        connections.data?.some((c) => c.name === draft.name)
+      )
+        throw new Error("A connection with this name already exists")
+      const update: WorkspaceMCPUpdate = {
+        name: draft.name,
+        url: draft.url,
+        transport: draft.transport,
+        enabled: draft.enabled,
+        allowed_tools: draft.allowed_tools,
+        headers: replaceHeaders ? authentication : null,
+      }
+      const discovered = discover ? await api.discoverWorkspaceMCP(update) : []
+      const saved = await api.saveWorkspaceMCP(update)
+      setDraft({ ...saved, existing: true })
+      setHeaders([])
+      setSavedHeaders(null)
+      setReplaceHeaders(false)
+      await qc.invalidateQueries({ queryKey })
+      if (discover) {
+        setCatalog(discovered)
+        setToolsExpanded(true)
+      } else finishEditing()
+    })
+  }
+
+  const updateHeader = (
+    index: number,
+    field: "name" | "value",
+    value: string
+  ) =>
+    setHeaders(
+      headers.map((header, i) =>
+        i === index ? { ...header, [field]: value } : header
+      )
+    )
+
+  const editor = draft ? (
+    <form
+      id={editorId}
+      className={
+        draft.existing
+          ? "space-y-4 border-t p-4"
+          : "space-y-4 rounded-md border p-4"
+      }
+      onSubmit={(event) => {
+        event.preventDefault()
+        void save(false)
+      }}
+    >
+      <fieldset disabled={busy} className="space-y-4">
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        {pendingImports.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {pendingImports.length} more{" "}
+            {pendingImports.length === 1 ? "connection" : "connections"} to
+            review after saving.
+          </p>
+        )}
+        <label className="block text-sm">
+          Connection name
+          <Input
+            aria-label="Connection name"
+            required
+            pattern={"[a-z][a-z0-9_\\-]{0,31}"}
+            maxLength={32}
+            title="Start with a lowercase letter; use lowercase letters, numbers, hyphens, or underscores."
+            placeholder="incident"
+            disabled={draft.existing}
+            value={draft.name}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+          />
+          <span className="text-xs text-muted-foreground">
+            Use a lowercase name such as incident. Dots and spaces are not
+            allowed.
+          </span>
+        </label>
+        <label className="block text-sm">
+          Server URL
+          <Input
+            aria-label="Server URL"
+            required
+            type="url"
+            placeholder="https://example.com/mcp"
+            value={draft.url}
+            onChange={(e) => setDraft({ ...draft, url: e.target.value })}
+          />
+        </label>
+        <label className="block text-sm">
+          Transport
+          <select
+            aria-label="Transport"
+            className="mt-1 block w-full rounded-md border bg-background p-2 text-sm"
+            value={draft.transport}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                transport: e.target.value as WorkspaceMCP["transport"],
+              })
+            }
+          >
+            <option value="streamable_http">Streamable HTTP</option>
+            <option value="sse">SSE</option>
+          </select>
+        </label>
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Authentication headers</p>
+          <p className="text-xs text-muted-foreground">
+            Values are encrypted and hidden by default. Use a header such as
+            Authorization or X-API-Key.
+          </p>
+          {!replaceHeaders ? (
+            <>
+              {savedHeaders && (
+                <div className="space-y-2" data-dd-privacy="hidden">
+                  {Object.entries(savedHeaders).map(([name, value]) => (
+                    <label key={name} className="block text-sm">
+                      {name}
+                      <Input
+                        aria-label={`Saved ${name} value`}
+                        value={value}
+                        readOnly
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                    </label>
+                  ))}
+                  {Object.keys(savedHeaders).length === 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      No saved headers.
+                    </p>
+                  )}
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="outline"
+                  aria-label={
+                    savedHeaders ? "Hide saved headers" : "Show saved headers"
+                  }
+                  title={
+                    savedHeaders ? "Hide saved headers" : "Show saved headers"
+                  }
+                  aria-expanded={savedHeaders !== null}
+                  onClick={() => {
+                    if (savedHeaders) setSavedHeaders(null)
+                    else
+                      void run(async () => {
+                        setSavedHeaders(
+                          await api.revealWorkspaceMCPHeaders(draft.name)
+                        )
+                      })
+                  }}
+                >
+                  {savedHeaders ? (
+                    <EyeSlashIcon aria-hidden="true" />
+                  ) : (
+                    <EyeIcon aria-hidden="true" />
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setSavedHeaders(null)
+                    setReplaceHeaders(true)
+                  }}
+                >
+                  Replace headers
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              {headers.map((header, index) => (
+                <div className="flex gap-2" key={index}>
+                  <Input
+                    aria-label={`Header ${index + 1} name`}
+                    placeholder="Authorization"
+                    value={header.name}
+                    onChange={(e) =>
+                      updateHeader(index, "name", e.target.value)
+                    }
+                  />
+                  <Input
+                    aria-label={`Header ${index + 1} value`}
+                    placeholder="Bearer …"
+                    type={header.revealed ? "text" : "password"}
+                    autoComplete="off"
+                    spellCheck={false}
+                    data-dd-privacy="hidden"
+                    value={header.value}
+                    onChange={(e) =>
+                      updateHeader(index, "value", e.target.value)
+                    }
+                  />
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="outline"
+                    aria-label={`${header.revealed ? "Hide" : "Show"} header ${index + 1} value`}
+                    title={header.revealed ? "Hide value" : "Show value"}
+                    aria-pressed={Boolean(header.revealed)}
+                    onClick={() =>
+                      setHeaders(
+                        headers.map((item, i) =>
+                          i === index
+                            ? { ...item, revealed: !item.revealed }
+                            : item
+                        )
+                      )
+                    }
+                  >
+                    {header.revealed ? (
+                      <EyeSlashIcon aria-hidden="true" />
+                    ) : (
+                      <EyeIcon aria-hidden="true" />
+                    )}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    aria-label={`Remove header ${index + 1}`}
+                    onClick={() =>
+                      setHeaders(headers.filter((_, i) => i !== index))
+                    }
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  setHeaders([...headers, { name: "", value: "" }])
+                }
+              >
+                Add header
+              </Button>
+              {draft.existing && headers.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Saving with no headers clears the saved authentication.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Allowed tools</p>
+          <p className="text-xs text-muted-foreground">
+            Save and discover the catalog, then select the tools this workspace
+            may use.
+          </p>
+          {toolNames.length > 0 && (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="mr-auto text-xs text-muted-foreground">
+                  {draft.allowed_tools.length} of {toolNames.length} selected
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={draft.allowed_tools.length === toolNames.length}
+                  onClick={() =>
+                    setDraft({ ...draft, allowed_tools: toolNames })
+                  }
+                >
+                  Select all
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={draft.allowed_tools.length === 0}
+                  onClick={() => setDraft({ ...draft, allowed_tools: [] })}
+                >
+                  Clear all
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-expanded={toolsExpanded}
+                  aria-controls={toolsId}
+                  onClick={() => setToolsExpanded(!toolsExpanded)}
+                >
+                  {toolsExpanded ? "Hide tools" : "Show tools"}
+                </Button>
+              </div>
+              <div
+                id={toolsId}
+                role="region"
+                aria-label="Available tools"
+                tabIndex={0}
+                hidden={!toolsExpanded}
+                className="max-h-80 space-y-3 overflow-y-auto overscroll-contain rounded-md border p-3"
+              >
+                {toolNames.map((name) => (
+                  <label key={name} className="flex items-start gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      className="mt-1 shrink-0"
+                      aria-label={`Allow ${name}`}
+                      checked={draft.allowed_tools.includes(name)}
+                      onChange={(e) =>
+                        setDraft({
+                          ...draft,
+                          allowed_tools: e.target.checked
+                            ? [...draft.allowed_tools, name]
+                            : draft.allowed_tools.filter(
+                                (tool) => tool !== name
+                              ),
+                        })
+                      }
+                    />
+                    <span className="min-w-0 break-words">
+                      {name}
+                      <span className="block text-xs text-muted-foreground">
+                        {
+                          catalog.find((tool) => tool.name === name)
+                            ?.description
+                        }
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={!draft.name || !draft.url}
+            onClick={(event) => {
+              if (event.currentTarget.form?.reportValidity()) void save(true)
+            }}
+          >
+            Save and discover tools
+          </Button>
+          <Button type="submit" size="sm">
+            Save connection
+          </Button>
+          {pendingImports.length > 0 && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={finishEditing}
+            >
+              Skip connection
+            </Button>
+          )}
+          <Button type="button" size="sm" variant="ghost" onClick={closeEditor}>
+            Cancel
+          </Button>
+        </div>
+      </fieldset>
+    </form>
+  ) : null
+
+  return (
+    <SettingsSection
+      title="Workspace MCPs"
+      description="Connect remote MCP servers for authorized coding-agent runs. Choose the tools each connection can use; new connections start with no tools enabled."
+    >
+      <div className="space-y-4 p-4">
+        {connections.isLoading && (
+          <p className="text-sm text-muted-foreground">Loading connections…</p>
+        )}
+        {((error && !draft) || connections.error) && (
+          <p role="alert" className="text-sm text-destructive">
+            {connections.error?.message || error}
+          </p>
+        )}
+        {connections.data?.map((connection) => (
+          <section
+            key={connection.name}
+            aria-label={`${connection.name} MCP connection`}
+            className="rounded-md border"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3 p-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">
+                  {connection.name}{" "}
+                  <span className="text-muted-foreground">
+                    · {connection.enabled ? "Enabled" : "Disabled"} ·{" "}
+                    {connection.allowed_tools.length} tools
+                  </span>
+                </p>
+                <p className="text-xs break-all text-muted-foreground">
+                  {connection.url}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => {
+                    if (draft?.existing && draft.name === connection.name) {
+                      closeEditor()
+                    } else edit(connection)
+                  }}
+                  aria-expanded={Boolean(
+                    draft?.existing && draft.name === connection.name
+                  )}
+                  aria-controls={
+                    draft?.existing && draft.name === connection.name
+                      ? editorId
+                      : undefined
+                  }
+                  aria-label={`${draft?.existing && draft.name === connection.name ? "Close" : "Edit"} ${connection.name}`}
+                >
+                  {draft?.existing && draft.name === connection.name
+                    ? "Close"
+                    : "Edit"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() =>
+                    run(async () => {
+                      await api.saveWorkspaceMCP({
+                        name: connection.name,
+                        url: connection.url,
+                        transport: connection.transport,
+                        enabled: !connection.enabled,
+                        allowed_tools: connection.allowed_tools,
+                      })
+                      await qc.invalidateQueries({ queryKey })
+                      if (draft?.name === connection.name) closeEditor()
+                    })
+                  }
+                  aria-label={`${connection.enabled ? "Disable" : "Enable"} ${connection.name}`}
+                >
+                  {connection.enabled ? "Disable" : "Enable"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() =>
+                    run(async () => {
+                      await api.deleteWorkspaceMCP(connection.name)
+                      await qc.invalidateQueries({ queryKey })
+                      if (draft?.name === connection.name) closeEditor()
+                    })
+                  }
+                  aria-label={`Delete ${connection.name}`}
+                >
+                  Delete
+                </Button>
+              </div>
+            </div>
+            {draft?.existing && draft.name === connection.name && editor}
+          </section>
+        ))}
+        {importing ? (
+          <WorkspaceMCPImport
+            onImport={([first, ...rest]) => {
+              if (!first) return
+              setImporting(false)
+              setPendingImports(rest)
+              openImported(first)
+            }}
+            onCancel={() => setImporting(false)}
+          />
+        ) : !draft ? (
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              disabled={connections.isPending || connections.isError}
+              onClick={() => edit()}
+            >
+              Add MCP server
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={connections.isPending || connections.isError}
+              onClick={() => {
+                setImporting(true)
+                setError(null)
+              }}
+            >
+              Import JSON
+            </Button>
+          </div>
+        ) : (
+          !draft.existing && editor
+        )}
+      </div>
+    </SettingsSection>
+  )
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -209,6 +209,26 @@ export interface TeamCredentialsStatus {
   langsmith: ProviderCredentialStatus
 }
 
+export interface WorkspaceMCP {
+  name: string
+  url: string
+  transport: "streamable_http" | "sse"
+  enabled: boolean
+  allowed_tools: string[]
+  header_names: string[]
+  revision: string
+  updated_at: string
+}
+
+export interface WorkspaceMCPUpdate {
+  name: string
+  url: string
+  transport: WorkspaceMCP["transport"]
+  enabled: boolean
+  allowed_tools: string[]
+  headers?: Record<string, string> | null
+}
+
 export interface DatadogConnectBody {
   site: string
   api_key: string
@@ -763,6 +783,26 @@ export const api = {
       body: JSON.stringify({ transcription_model }),
     }),
   getTeamCredentials: () => request<TeamCredentialsStatus>("/team-credentials"),
+  getWorkspaceMCPs: () => request<WorkspaceMCP[]>("/workspace-mcps"),
+  revealWorkspaceMCPHeaders: (name: string) =>
+    request<Record<string, string>>(
+      `/workspace-mcps/${encodeURIComponent(name)}/headers/reveal`,
+      { method: "POST", cache: "no-store" }
+    ),
+  saveWorkspaceMCP: (body: WorkspaceMCPUpdate) =>
+    request<WorkspaceMCP>(`/workspace-mcps/${encodeURIComponent(body.name)}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  deleteWorkspaceMCP: (name: string) =>
+    request<void>(`/workspace-mcps/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    }),
+  discoverWorkspaceMCP: (body: WorkspaceMCPUpdate) =>
+    request<{ name: string; description: string }[]>(
+      `/workspace-mcps/${encodeURIComponent(body.name)}/discover`,
+      { method: "POST", body: JSON.stringify(body) }
+    ),
   connectDatadog: (body: DatadogConnectBody) =>
     request<TeamCredentialsStatus>("/team-credentials/datadog", {
       method: "PUT",

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -31,6 +31,7 @@ import {
 import { RequireLogin } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
 import { slackAppManifestJson } from "@/lib/slack-manifest"
+import { WorkspaceMCPSection } from "@/features/settings/components/WorkspaceMCPSection"
 
 export const Route = createFileRoute("/admin")({ component: AdminPage })
 
@@ -66,6 +67,7 @@ function AdminPage() {
       />
 
       <SlackIntegrationSection />
+      <WorkspaceMCPSection />
 
       <LLMGatewaySection />
 


### PR DESCRIPTION
Admins can configure shared remote MCP servers under **Admin → Workspace MCPs**, including incident.io and Datadog, and choose which tools authorized remote coding-agent runs may use.

- Support HTTPS Streamable HTTP/SSE connections, encrypted authentication headers, and per-call checks of connection settings and allowed tools.
- Add Claude-style `mcpServers` JSON import, inline editing, bulk tool selection, and a collapsible, scrollable tool list. New connections preselect all discovered tools, including catalogs larger than 200 tools; Save connection applies the selection. Rediscovery preserves existing choices.
- Discover tools before saving so failed discovery preserves existing settings. Add eye icons for revealing entered or saved header values; saved values require an admin request and are not cached.
- Document setup, provider examples, and scope. Requests are restricted to the configured public HTTPS origin.
- Exclude workspace MCP tools from model calls during plan mode, including after entering plan mode mid-run.

Validation: 59 focused Python tests and all 15 workspace MCP UI tests passed, plus full Python/UI type checks, lint, and formatting. The local app was also checked on port 2024 during implementation.

[Loom walkthrough](https://www.loom.com/share/edbec74744d7435eb6debf3a70aaf892)
