### PR TITLE
fix(deps): patch hono and js-yaml security alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ overrides:
   fast-uri: 3.1.6
   '@xmldom/xmldom': 0.8.15
   qs: 6.16.0
-  hono: 4.13.3
+  hono: 4.13.5
   ip-address: 10.5.0
-  js-yaml: 4.3.1
+  js-yaml: 4.3.2
   mermaid: 11.17.0
   nanoid@>=3.0.0 <4.0.0: 3.3.18
   postcss: 8.5.26
@@ -3713,8 +3713,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.13.3:
-    resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -3949,8 +3949,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -6506,7 +6506,7 @@ snapshots:
 
   '@hono/node-server@2.1.1(hono@4.13.3)':
     dependencies:
-      hono: 4.13.3
+      hono: 4.13.5
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -6845,7 +6845,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1(supports-color@10.2.2)
       express-rate-limit: 8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
-      hono: 4.13.3
+      hono: 4.13.5
       jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -8237,7 +8237,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.6
@@ -8370,7 +8370,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -8536,7 +8536,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -8656,7 +8656,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       builder-util: 26.15.3(supports-color@10.2.2)
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -8740,7 +8740,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0(supports-color@10.2.2)
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -9376,7 +9376,7 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
-  hono@4.13.3: {}
+  hono@4.13.5: {}
 
   hookable@6.1.1: {}
 
@@ -9552,7 +9552,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -11650,7 +11650,7 @@ snapshots:
       '@oozcitak/dom': 2.0.2
       '@oozcitak/infra': 2.0.2
       '@oozcitak/util': 10.0.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   xmlbuilder@15.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,9 +20,9 @@ overrides:
   fast-uri: 3.1.6
   '@xmldom/xmldom': 0.8.15
   qs: 6.16.0
-  hono: 4.13.3
+  hono: 4.13.5
   ip-address: 10.5.0
-  js-yaml: 4.3.1
+  js-yaml: 4.3.2
   mermaid: 11.17.0
   'nanoid@>=3.0.0 <4.0.0': 3.3.18
   postcss: 8.5.26


### PR DESCRIPTION
## Summary

Patch all four currently open Dependabot alerts with two existing workspace override updates:

| Alerts | Advisory | Package update |
| --- | --- | --- |
| #242 | GHSA-crvj-82cr-hjcx | hono 4.13.3 → 4.13.5 |
| #243 | GHSA-g6gw-c38x-mqfc | hono 4.13.3 → 4.13.5 |
| #244 | GHSA-gqvv-2mrq-wpjv | hono 4.13.3 → 4.13.5 |
| #245 | GHSA-2883-xcg3-v3hh | js-yaml 4.3.1 → 4.3.2 |

Regenerated `pnpm-lock.yaml` with the repository-pinned pnpm 11.22.0. Only the existing overrides and their resolved dependency entries changed; no unrelated package updates or application changes.

Hono is pulled in through shadcn / the MCP SDK. js-yaml is used by desktop packaging/updater and UI tooling dependencies. This patches the installed versions without claiming every advisory has a reachable remote attack path in this application. No alerts dismissed; GitHub should clear these after merge and dependency-graph refresh.

## Test plan

- [x] `sfw pnpm --dir /workspace/open-swe install --lockfile-only --ignore-scripts`
- [x] `sfw pnpm --dir /workspace/open-swe install --lockfile-only --frozen-lockfile --ignore-scripts`
- [x] Full workspace frozen-lockfile install with lifecycle scripts disabled.
- [x] `pnpm -r why hono js-yaml` confirms one resolved version each: 4.13.5 and 4.3.2.
- [x] Parsed lockfile and mechanically compared every resolved target version against refreshed GitHub vulnerable ranges and first-patched versions: all four pass.
- [x] Hono request-routing and js-yaml parsing smoke tests.
- [x] `git diff --check`.
- Formatting checker excluded both YAML targets, so it did not provide a formatting validation result. Package-manager validation and YAML parsing passed.
- Full application tests / desktop native builds not run; CI pending.
