### PR TITLE
Add a dedicated Settings navigation link

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -13,6 +13,7 @@ import {
   PushPinIcon,
   PushPinSlashIcon,
   SparkleIcon,
+  GearIcon,
 } from "@phosphor-icons/react"
 import { Kanban } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -124,6 +125,7 @@ const NAV = [
   { to: "/agents/skills", label: "Skills", icon: SparkleIcon },
   { to: "/agents/automations", label: "Automations", icon: LightningIcon },
   { to: "/agents/reviews", label: "Reviews", icon: GitPullRequestIcon },
+  { to: "/my-settings", label: "Settings", icon: GearIcon },
 ] as const
 
 /** Threads shown per project before the group needs a "Show more". */
@@ -613,17 +615,14 @@ export function AgentsSidebar({
           isDesktop ? "pt-13" : "pt-5"
         )}
       >
-        <Link
-          to={localOnly ? "/agents" : "/my-settings"}
-          className="flex items-center gap-2 font-heading text-sm font-medium tracking-tight text-foreground"
-        >
+        <div className="flex items-center gap-2 font-heading text-sm font-medium tracking-tight text-foreground">
           <img
             src={`${import.meta.env.BASE_URL}logo-mark.png`}
             alt=""
             className="size-5"
           />
           Open SWE
-        </Link>
+        </div>
         <div className="flex items-center gap-1">
           <button
             type="button"


### PR DESCRIPTION
### Summary
- add Settings to the main agent navigation
- make the Open SWE logo and wordmark non-interactive

### Validation
- `pnpm --dir ui run typecheck`
- `pnpm exec oxlint ui/src/features/agents/components/AgentsSidebar.tsx`
- production UI build
- verified as Alice that Settings routes to `/my-settings` and the logo is not a link

### Screenshot
![Settings navigation](https://01a08643-6d70-7d71-9780-715f18d9e085--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1TlRrMU5qUXNJbXAwYVNJNklqQXhZVEE0TmpSakxXRXlNVFF0TnprNVlpMDVOREk1TFdGa05XUXdPRFF4WkRsbFpDSXNJbk5wWkNJNklqQXhZVEE0TmpRekxUWmtOekF0TjJRM01TMDVOemd3TFRjeE5XWXhPR1E1WlRBNE5TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12YzJWMGRHbHVaM010Ym1GMkxuQnVaeUlzSW1OMElqb2lhVzFoWjJVdmNHNW5JaXdpWTJRaU9pSnBibXhwYm1VaWZRLncxMy02T2Nhc3Y1NTBIRnJ6S25RRTMzdXN2aGRmN21jTUJ2UUkzZDNmcXRPLVJCQkdVckZWalBOM1JJTVZGTm1ZSzNTSlRvYUlaTHJNU0Zfa3ZZVUF3)

Made by [Open SWE](https://openswe.vercel.app/agents/bec08b02-d71c-55c9-9db1-7267513fd17b)