### PR TITLE
fix: render working directory in system prompt

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -138,7 +138,7 @@ def render_open_swe_shared_base(*, sandbox_file_downloads: bool) -> str:
 
 WORKING_ENV_SECTION = """### Working Environment
 
-You are operating in a remote Linux sandbox at `{working_dir}` — use it as your working directory for all operations. The sandbox starts clean; no repo is pre-cloned."""
+You are operating in a remote Linux sandbox at `{working_dir}` — use it as your working directory for all operations. Managed environments may preload repositories and tools, so inspect the existing contents before cloning or installing anything."""
 
 DESKTOP_WORKING_ENV_SECTION = """### Working Environment
 
@@ -600,7 +600,7 @@ def construct_system_prompt(
         working_dir=working_dir,
         working_environment_section=(
             DESKTOP_WORKING_ENV_SECTION if source == "desktop" else WORKING_ENV_SECTION
-        ),
+        ).format(working_dir=working_dir),
         dashboard_base_url=dashboard_base_url or "(dashboard URL unavailable)",
         source_guidance=_render_source_guidance(source, slack_context),
         linear_project_id=linear_project_id or "<PROJECT_ID>",

--- a/tests/github/test_github_comment_prompts.py
+++ b/tests/github/test_github_comment_prompts.py
@@ -88,6 +88,15 @@ def test_construct_system_prompt_includes_operational_safeguards() -> None:
     assert "do not call `schedule_thread_wakeup` again" in prompt
 
 
+def test_construct_system_prompt_renders_working_environment_path() -> None:
+    for source in ("slack", "desktop"):
+        prompt = construct_system_prompt(working_dir="/workspace/project", source=source)
+
+        working_environment = prompt.split("---", 1)[0]
+        assert "`/workspace/project`" in working_environment
+        assert "{working_dir}" not in working_environment
+
+
 def test_slack_information_only_response_uses_single_output_path() -> None:
     from agent.slack.tools.thread_reply import slack_thread_reply
 


### PR DESCRIPTION
### Summary
- render the selected working-environment section before injecting it into the system prompt template
- replace the inaccurate clean-sandbox claim with guidance that supports managed, preloaded environments
- cover hosted and desktop prompt rendering

### Testing
- `NO_COLOR=1 uv run pytest -q tests/github/test_github_comment_prompts.py`
- `make format`
- `make lint`

Made by [Open SWE](https://openswe.vercel.app/agents/ddd76aa2-6444-5f99-bd3e-4dd024a2599f) · openai:gpt-5.6-sol (high)