### PR TITLE
fix: allow concurrent local dev runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: help
 ######################
 
 dev:
-	uv run langgraph dev --no-browser --port 2024
+	uv run langgraph dev --no-browser --port 2024 --n-jobs-per-worker 10
 
 # UI development in one terminal: Vite (`make web`) and the backend fronting it, so
 # http://localhost:2024 hot-reloads without a build or any cross-origin setup. The two


### PR DESCRIPTION
Sets `make dev` to allow 10 concurrent jobs per worker.

Validation: `make -n dev`; `langgraph dev --help` confirms the option. Formatting is blocked by a pre-existing undefined `_slack_headers` reference in `agent/slack/client.py`.

Made by [Open SWE](https://openswe.vercel.app/agents/34f87d3a-645d-57b2-a879-40ae79f6ee5b) · openai:gpt-5.6-sol (medium)