### PR TITLE
chore(desktop): bump version to 0.2.8

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.3.0",
+  "version": "0.2.8",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",


### PR DESCRIPTION
Bumps the desktop app from `0.2.7` to `0.2.8`.

Made by [Open SWE](https://openswe.vercel.app/agents/a59cfda5-e326-56de-ac73-51b451459ba7) · openai:gpt-5.6-sol (medium)