### PR TITLE
fix: use Slack headers helper for modals

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -1004,7 +1004,7 @@ async def open_slack_modal(trigger_id: str, view: dict[str, Any]) -> bool:
         try:
             response = await http_client.post(
                 f"{SLACK_API_BASE_URL}/views.open",
-                headers=_slack_headers(),
+                headers=slack_headers(),
                 json={"trigger_id": trigger_id, "view": view},
             )
             error = _slack_response_error(response)


### PR DESCRIPTION
Fixes the undefined `_slack_headers` reference in the Slack modal request by using the existing `slack_headers` helper.

Made by [Open SWE](https://openswe.vercel.app/agents/a59cfda5-e326-56de-ac73-51b451459ba7) · openai:gpt-5.6-sol (medium)