### PR TITLE
fix(slack): unify thread feedback submission and completion

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -996,6 +996,43 @@ async def post_slack_ephemeral_message(
             return False
 
 
+async def respond_to_slack_interaction(response_url: str, payload: dict[str, Any]) -> bool:
+    """Update or delete an interaction's source message, including ephemeral messages."""
+    try:
+        parsed = urlparse(response_url)
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc not in {"hooks.slack.com", "hooks.slack-gov.com"}
+        or not parsed.path.startswith("/actions/")
+    ):
+        return False
+    request = httpx2.Request(
+        "POST",
+        response_url,
+        json=payload,
+        extensions={"timeout": httpx2.Timeout(5.0).as_dict()},
+    )
+    try:
+        # AsyncClient logs request URLs, which contain credentials for these callbacks.
+        async with httpx2.AsyncHTTPTransport() as transport:
+            response = await transport.handle_async_request(request)
+            try:
+                if not response.is_success:
+                    return False
+                await response.aread()
+                if response.text == "ok":
+                    return True
+                data = response.json()
+                return isinstance(data, dict) and data.get("ok") is True
+            finally:
+                await response.aclose()
+    except httpx2.HTTPError, ValueError:
+        logger.warning("Slack interaction response failed")
+        return False
+
+
 async def open_slack_modal(trigger_id: str, view: dict[str, Any]) -> bool:
     """Open a modal before Slack's short-lived interaction trigger expires."""
     if not SLACK_BOT_TOKEN:

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -16,6 +16,7 @@ from agent.slack.client import (
     lookup_slack_run_message_mapping,
     open_slack_modal,
     post_slack_ephemeral_message,
+    respond_to_slack_interaction,
     slack_channel_allows_operations,
     slack_thread_mutation_lock,
 )
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 _RATE_PREFIX = "open_swe_feedback_rate_"
 _COMMENT_ACTION = "open_swe_feedback_comment"
+_DISMISS_ACTION = "open_swe_feedback_dismiss"
 _COMMENT_BLOCK = "feedback_comment"
 _RATINGS = ("😡 Very Bad", "🙁 Bad", "😐 Okay", "🙂 Good", "😍 Great")
 
@@ -42,6 +44,7 @@ class ThreadFeedback(BaseModel):
     message_ts: str
     user_id: str
     prompted: bool = False
+    dismissed: bool = False
     rating: int | None = Field(default=None, ge=1, le=5)
     comment: str = Field(default="", max_length=3000)
     last_rating_ts: Decimal = Decimal(0)
@@ -62,6 +65,15 @@ async def _locked_feedback(
         langgraph_client(), record.channel_id, record.thread_ts, purpose=lock_purpose
     ):
         yield await _store(record.channel_id).get(record.run_id)
+
+
+def _dismiss_button(run_id: str) -> dict[str, Any]:
+    return {
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Dismiss"},
+        "action_id": _DISMISS_ACTION,
+        "value": run_id,
+    }
 
 
 def rating_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
@@ -91,7 +103,8 @@ def rating_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
                     "value": run_id,
                 }
                 for rating, label in enumerate(_RATINGS, start=1)
-            ],
+            ]
+            + [_dismiss_button(run_id)],
         },
     ]
 
@@ -201,7 +214,8 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
             action = _object(value)
             action_id = action.get("action_id")
             if isinstance(action_id, str) and (
-                action_id.startswith(_RATE_PREFIX) or action_id == _COMMENT_ACTION
+                action_id.startswith(_RATE_PREFIX)
+                or action_id in {_COMMENT_ACTION, _DISMISS_ACTION}
             ):
                 return action
     return {}
@@ -224,7 +238,7 @@ async def _load_feedback(channel_id: str, run_id: str, user_id: str) -> ThreadFe
     return record if slack_channel_allows_operations(context) else None
 
 
-def comment_modal(record: ThreadFeedback) -> dict[str, Any]:
+def comment_modal(record: ThreadFeedback, response_url: str = "") -> dict[str, Any]:
     element: dict[str, Any] = {
         "type": "plain_text_input",
         "action_id": "comment",
@@ -237,7 +251,9 @@ def comment_modal(record: ThreadFeedback) -> dict[str, Any]:
     return {
         "type": "modal",
         "callback_id": _COMMENT_ACTION,
-        "private_metadata": json.dumps({"channel_id": record.channel_id, "run_id": record.run_id}),
+        "private_metadata": json.dumps(
+            {"channel_id": record.channel_id, "run_id": record.run_id, "response_url": response_url}
+        ),
         "title": {"type": "plain_text", "text": "Open SWE feedback"},
         "submit": {"type": "plain_text", "text": "Save"},
         "close": {"type": "plain_text", "text": "Cancel"},
@@ -302,7 +318,27 @@ async def _export_current_feedback(record: ThreadFeedback) -> None:
         )
 
 
-async def _acknowledge(record: ThreadFeedback, *, with_comment_button: bool) -> None:
+async def _acknowledge(
+    record: ThreadFeedback, *, with_comment_button: bool, response_url: str
+) -> None:
+    try:
+        async with _locked_feedback(record, purpose="feedback_response") as current:
+            record = current or record
+            if record.dismissed:
+                return
+            async with asyncio.timeout(8):
+                await _update_prompt(
+                    record,
+                    with_comment_button=with_comment_button and not record.comment,
+                    response_url=response_url,
+                )
+    except Exception:
+        logger.warning("Could not acknowledge saved Slack feedback")
+
+
+async def _update_prompt(
+    record: ThreadFeedback, *, with_comment_button: bool, response_url: str
+) -> None:
     text = "Thanks — your feedback was saved."
     block: dict[str, Any] = {"type": "section", "text": {"type": "plain_text", "text": text}}
     if with_comment_button:
@@ -312,12 +348,51 @@ async def _acknowledge(record: ThreadFeedback, *, with_comment_button: bool) -> 
             "action_id": _COMMENT_ACTION,
             "value": record.run_id,
         }
+    blocks = [block]
+    if with_comment_button:
+        blocks.append({"type": "actions", "elements": [_dismiss_button(record.run_id)]})
+    if response_url:
+        await respond_to_slack_interaction(
+            response_url,
+            {
+                "replace_original": True,
+                "response_type": "ephemeral",
+                "text": text,
+                "blocks": blocks,
+            },
+        )
+        return
     await post_slack_ephemeral_message(
         record.channel_id,
         record.user_id,
         text,
         thread_ts=record.thread_ts if record.thread_ts != "0" else None,
-        blocks=[block],
+        blocks=blocks,
+    )
+
+
+async def _dismiss_feedback(payload: dict[str, Any]) -> None:
+    channel_id = str(_object(payload.get("channel")).get("id") or "")
+    user_id = str(_object(payload.get("user")).get("id") or "")
+    try:
+        record = await _load_feedback(channel_id, str(_action(payload).get("value") or ""), user_id)
+        if record is None:
+            return
+        async with _locked_feedback(record, purpose="feedback_response") as current:
+            if current is None:
+                return
+            if await respond_to_slack_interaction(
+                str(payload.get("response_url") or ""), {"delete_original": True}
+            ):
+                async with _locked_feedback(current) as latest:
+                    if latest is not None:
+                        latest.dismissed = True
+                        await _store(channel_id).put(latest.run_id, latest)
+                return
+    except Exception:
+        logger.warning("Could not dismiss Slack feedback prompt")
+    await post_slack_ephemeral_message(
+        channel_id, user_id, "The prompt could not be dismissed. Please click Dismiss again."
     )
 
 
@@ -355,7 +430,9 @@ async def _process_rating(payload: dict[str, Any]) -> None:
                 channel_id, user_id, "Your rating could not be saved. Please try again."
             )
         return
-    await _acknowledge(record, with_comment_button=True)
+    await _acknowledge(
+        record, with_comment_button=True, response_url=str(payload.get("response_url") or "")
+    )
     await _export_feedback(record)
 
 
@@ -397,11 +474,19 @@ async def handle_slack_feedback_interaction(
         except Exception:
             logger.warning("Could not save Slack feedback comment", exc_info=True)
             return _comment_error("Your comment could not be saved. Please try again.")
-        background_tasks.add_task(_acknowledge, record, with_comment_button=False)
+        background_tasks.add_task(
+            _acknowledge,
+            record,
+            with_comment_button=False,
+            response_url=str(metadata.get("response_url") or ""),
+        )
         background_tasks.add_task(_export_feedback, record)
         return {}
 
     action = _action(payload)
+    if action.get("action_id") == _DISMISS_ACTION:
+        background_tasks.add_task(_dismiss_feedback, payload)
+        return {}
     if action.get("action_id") != _COMMENT_ACTION:
         background_tasks.add_task(_process_rating, payload)
         return {}
@@ -416,7 +501,9 @@ async def handle_slack_feedback_interaction(
             if (
                 isinstance(trigger_id, str)
                 and trigger_id
-                and await open_slack_modal(trigger_id, comment_modal(record))
+                and await open_slack_modal(
+                    trigger_id, comment_modal(record, str(payload.get("response_url") or ""))
+                )
             ):
                 return {}
     except Exception:

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -5,7 +5,6 @@ import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from fastapi import BackgroundTasks
@@ -32,6 +31,9 @@ logger = logging.getLogger(__name__)
 _RATE_PREFIX = "open_swe_feedback_rate_"
 _COMMENT_ACTION = "open_swe_feedback_comment"
 _DISMISS_ACTION = "open_swe_feedback_dismiss"
+_SUBMIT_ACTION = "open_swe_feedback_submit"
+_RATING_ACTION = "open_swe_feedback_rating"
+_RATING_BLOCK = "feedback_rating"
 _COMMENT_BLOCK = "feedback_comment"
 _RATINGS = ("😡 Very Bad", "🙁 Bad", "😐 Okay", "🙂 Good", "😍 Great")
 
@@ -47,7 +49,7 @@ class ThreadFeedback(BaseModel):
     dismissed: bool = False
     rating: int | None = Field(default=None, ge=1, le=5)
     comment: str = Field(default="", max_length=3000)
-    last_rating_ts: Decimal = Decimal(0)
+    completed: bool = False
 
 
 def _store(channel_id: str) -> TypedStore[ThreadFeedback]:
@@ -76,35 +78,78 @@ def _dismiss_button(run_id: str) -> dict[str, Any]:
     }
 
 
-def rating_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
+def _feedback_inputs(rating: int | None = None, comment: str = "") -> list[dict[str, Any]]:
+    options = [
+        {"text": {"type": "plain_text", "text": label, "emoji": True}, "value": str(value)}
+        for value, label in enumerate(_RATINGS, start=1)
+    ]
+    rating_element: dict[str, Any] = {
+        "type": "radio_buttons",
+        "action_id": _RATING_ACTION,
+        "options": options,
+    }
+    if rating is not None:
+        rating_element["initial_option"] = options[rating - 1]
+    comment_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "comment",
+        "multiline": True,
+        "max_length": 3000,
+        "placeholder": {"type": "plain_text", "text": "What worked well? What could be better?"},
+    }
+    if comment:
+        comment_element["initial_value"] = comment
+    return [
+        {
+            "type": "input",
+            "block_id": _RATING_BLOCK,
+            "optional": True,
+            "dispatch_action": False,
+            "label": {"type": "plain_text", "text": "Rating"},
+            "element": rating_element,
+        },
+        {
+            "type": "input",
+            "block_id": _COMMENT_BLOCK,
+            "optional": True,
+            "dispatch_action": False,
+            "label": {"type": "plain_text", "text": "Comments"},
+            "element": comment_element,
+        },
+    ]
+
+
+def rating_blocks(
+    run_id: str, thread_id: str, *, rating: int | None = None, comment: str = "", error: str = ""
+) -> list[dict[str, Any]]:
     url = dashboard_thread_url(thread_id)
     thread_link = f"<{url}|this thread>" if url else "this thread"
-    return [
+    blocks = [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
                 "text": f"How did Open SWE do on {thread_link}?",
             },
-            "accessory": {
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Add comments"},
-                "action_id": _COMMENT_ACTION,
-                "value": run_id,
-            },
-        },
+        }
+    ]
+    if error:
+        blocks.append({"type": "section", "text": {"type": "plain_text", "text": error}})
+    return [
+        *blocks,
+        *_feedback_inputs(rating, comment),
         {
             "type": "actions",
             "elements": [
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": label, "emoji": True},
-                    "action_id": f"{_RATE_PREFIX}{rating}",
+                    "text": {"type": "plain_text", "text": "Submit feedback"},
+                    "action_id": _SUBMIT_ACTION,
                     "value": run_id,
-                }
-                for rating, label in enumerate(_RATINGS, start=1)
-            ]
-            + [_dismiss_button(run_id)],
+                    "style": "primary",
+                },
+                _dismiss_button(run_id),
+            ],
         },
     ]
 
@@ -170,7 +215,7 @@ async def post_slack_feedback_prompt(
             posted = await post_slack_ephemeral_message(
                 channel_id,
                 record.user_id,
-                "How did Open SWE do on this thread? Choose a rating or add comments.",
+                "How did Open SWE do on this thread? Add a rating or comment, then submit feedback.",
                 thread_ts=record.thread_ts if record.thread_ts != "0" else None,
                 blocks=rating_blocks(run_id, thread_id),
             )
@@ -215,7 +260,7 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
             action_id = action.get("action_id")
             if isinstance(action_id, str) and (
                 action_id.startswith(_RATE_PREFIX)
-                or action_id in {_COMMENT_ACTION, _DISMISS_ACTION}
+                or action_id in {_COMMENT_ACTION, _DISMISS_ACTION, _SUBMIT_ACTION, _RATING_ACTION}
             ):
                 return action
     return {}
@@ -239,44 +284,21 @@ async def _load_feedback(channel_id: str, run_id: str, user_id: str) -> ThreadFe
 
 
 def comment_modal(record: ThreadFeedback, response_url: str = "") -> dict[str, Any]:
-    element: dict[str, Any] = {
-        "type": "plain_text_input",
-        "action_id": "comment",
-        "multiline": True,
-        "max_length": 3000,
-        "placeholder": {"type": "plain_text", "text": "What worked well? What could be better?"},
-    }
-    if record.comment:
-        element["initial_value"] = record.comment
+    """Let already-posted rating/comment buttons open the combined feedback form."""
     return {
         "type": "modal",
         "callback_id": _COMMENT_ACTION,
         "private_metadata": json.dumps(
-            {"channel_id": record.channel_id, "run_id": record.run_id, "response_url": response_url}
+            {
+                "channel_id": record.channel_id,
+                "run_id": record.run_id,
+                "response_url": response_url,
+            }
         ),
         "title": {"type": "plain_text", "text": "Open SWE feedback"},
-        "submit": {"type": "plain_text", "text": "Save"},
+        "submit": {"type": "plain_text", "text": "Submit feedback"},
         "close": {"type": "plain_text", "text": "Cancel"},
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "plain_text",
-                    "text": (
-                        f"Your rating: {_RATINGS[record.rating - 1]}"
-                        if record.rating is not None
-                        else "Share your feedback on this thread. A rating is optional."
-                    ),
-                },
-            },
-            {
-                "type": "input",
-                "block_id": _COMMENT_BLOCK,
-                "optional": record.rating is not None,
-                "label": {"type": "plain_text", "text": "Comments"},
-                "element": element,
-            },
-        ],
+        "blocks": _feedback_inputs(record.rating, record.comment),
     }
 
 
@@ -296,7 +318,7 @@ async def _export_feedback(record: ThreadFeedback) -> None:
 
 
 async def _export_current_feedback(record: ThreadFeedback) -> None:
-    if record.rating is None and not record.comment:
+    if not record.completed:
         return
     synced = await create_langsmith_thread_feedback(
         record.agent_thread_id,
@@ -318,57 +340,26 @@ async def _export_current_feedback(record: ThreadFeedback) -> None:
         )
 
 
-async def _acknowledge(
-    record: ThreadFeedback, *, with_comment_button: bool, response_url: str
-) -> None:
+async def _acknowledge(record: ThreadFeedback, *, response_url: str) -> None:
     try:
         async with _locked_feedback(record, purpose="feedback_response") as current:
-            record = current or record
-            if record.dismissed:
+            if current is None or current.dismissed or not current.completed or not response_url:
                 return
+            text = "✅ Feedback completed. Thanks!"
             async with asyncio.timeout(8):
-                await _update_prompt(
-                    record,
-                    with_comment_button=with_comment_button and not record.comment,
-                    response_url=response_url,
+                await respond_to_slack_interaction(
+                    response_url,
+                    {
+                        "replace_original": True,
+                        "response_type": "ephemeral",
+                        "text": text,
+                        "blocks": [
+                            {"type": "section", "text": {"type": "plain_text", "text": text}}
+                        ],
+                    },
                 )
     except Exception:
         logger.warning("Could not acknowledge saved Slack feedback")
-
-
-async def _update_prompt(
-    record: ThreadFeedback, *, with_comment_button: bool, response_url: str
-) -> None:
-    text = "Thanks — your feedback was saved."
-    block: dict[str, Any] = {"type": "section", "text": {"type": "plain_text", "text": text}}
-    if with_comment_button:
-        block["accessory"] = {
-            "type": "button",
-            "text": {"type": "plain_text", "text": "Add comments"},
-            "action_id": _COMMENT_ACTION,
-            "value": record.run_id,
-        }
-    blocks = [block]
-    if with_comment_button:
-        blocks.append({"type": "actions", "elements": [_dismiss_button(record.run_id)]})
-    if response_url:
-        await respond_to_slack_interaction(
-            response_url,
-            {
-                "replace_original": True,
-                "response_type": "ephemeral",
-                "text": text,
-                "blocks": blocks,
-            },
-        )
-        return
-    await post_slack_ephemeral_message(
-        record.channel_id,
-        record.user_id,
-        text,
-        thread_ts=record.thread_ts if record.thread_ts != "0" else None,
-        blocks=blocks,
-    )
 
 
 async def _dismiss_feedback(payload: dict[str, Any]) -> None:
@@ -391,49 +382,109 @@ async def _dismiss_feedback(payload: dict[str, Any]) -> None:
                 return
     except Exception:
         logger.warning("Could not dismiss Slack feedback prompt")
-    await post_slack_ephemeral_message(
-        channel_id, user_id, "The prompt could not be dismissed. Please click Dismiss again."
+    logger.warning("Could not dismiss Slack feedback prompt")
+
+
+class _FeedbackInputError(ValueError):
+    pass
+
+
+def _form_values(
+    values: dict[str, Any], default_rating: int | None = None
+) -> tuple[int | None, str]:
+    selected = _object(_object(values.get(_RATING_BLOCK)).get(_RATING_ACTION)).get(
+        "selected_option"
     )
+    value = _object(selected).get("value")
+    if selected is not None and (
+        not isinstance(value, str) or value not in {"1", "2", "3", "4", "5"}
+    ):
+        raise _FeedbackInputError("Choose a rating from 1 to 5.")
+    rating = int(value) if value is not None else default_rating
+    comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
+    if comment is not None and (not isinstance(comment, str) or len(comment) > 3000):
+        raise _FeedbackInputError("Comments must be at most 3,000 characters.")
+    comment = comment.strip() if isinstance(comment, str) else ""
+    if rating is None and not comment:
+        raise _FeedbackInputError("Choose a rating or enter a comment before submitting.")
+    return rating, comment
 
 
-async def _process_rating(payload: dict[str, Any]) -> None:
-    action = _action(payload)
-    suffix = str(action.get("action_id", "")).removeprefix(_RATE_PREFIX)
-    if suffix not in {"1", "2", "3", "4", "5"}:
-        return
+async def _save_submission(
+    record: ThreadFeedback, values: dict[str, Any], *, legacy_modal: bool = False
+) -> ThreadFeedback:
+    async with _locked_feedback(record) as current:
+        if current is None:
+            raise _FeedbackInputError("This feedback is unavailable. Please reopen the prompt.")
+        if current.completed or current.dismissed:
+            return current
+        default_rating = current.rating if legacy_modal and _RATING_BLOCK not in values else None
+        rating, comment = _form_values(values, default_rating)
+        current.rating = rating
+        current.comment = comment
+        current.completed = True
+        await _store(current.channel_id).put(current.run_id, current)
+        return current
+
+
+async def _show_submission_error(
+    record: ThreadFeedback, values: dict[str, Any], response_url: str, error: str
+) -> None:
+    selected = _object(
+        _object(_object(values.get(_RATING_BLOCK)).get(_RATING_ACTION)).get("selected_option")
+    ).get("value")
+    rating = (
+        int(selected)
+        if isinstance(selected, str) and selected in {"1", "2", "3", "4", "5"}
+        else None
+    )
+    comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
+    comment = comment[:3000] if isinstance(comment, str) else ""
+    async with _locked_feedback(record, purpose="feedback_response") as current:
+        if current is None or current.completed or current.dismissed or not response_url:
+            return
+        await respond_to_slack_interaction(
+            response_url,
+            {
+                "replace_original": True,
+                "response_type": "ephemeral",
+                "text": error,
+                "blocks": rating_blocks(
+                    record.run_id,
+                    record.agent_thread_id,
+                    rating=rating,
+                    comment=comment,
+                    error=error,
+                ),
+            },
+        )
+
+
+async def _process_submission(payload: dict[str, Any]) -> None:
     channel_id = str(_object(payload.get("channel")).get("id") or "")
     user_id = str(_object(payload.get("user")).get("id") or "")
-    run_id = str(action.get("value") or "")
+    response_url = str(payload.get("response_url") or "")
+    values = _object(_object(payload.get("state")).get("values"))
+    record = None
+    error = "Your feedback could not be saved. Please submit again."
     try:
-        action_ts = Decimal(str(action.get("action_ts") or "0"))
-    except InvalidOperation:
-        return
-    if not action_ts.is_finite() or action_ts <= 0:
-        return
-    try:
-        record = await _load_feedback(channel_id, run_id, user_id)
+        record = await _load_feedback(channel_id, str(_action(payload).get("value") or ""), user_id)
         if record is None:
             return
-        async with _locked_feedback(record) as current:
-            if current is None or action_ts <= current.last_rating_ts:
-                return
-            record = current
-            record.rating = int(suffix)
-            record.last_rating_ts = action_ts
-            await _store(channel_id).put(run_id, record)
+        record = await _save_submission(record, values)
+    except _FeedbackInputError as exc:
+        error = str(exc)
     except Exception:
-        logger.warning(
-            "Could not save Slack rating", extra={"feedback_run_id": run_id}, exc_info=True
-        )
-        if channel_id and user_id:
-            await post_slack_ephemeral_message(
-                channel_id, user_id, "Your rating could not be saved. Please try again."
-            )
+        logger.warning("Could not save Slack feedback submission")
+    else:
+        await _acknowledge(record, response_url=response_url)
+        await _export_feedback(record)
         return
-    await _acknowledge(
-        record, with_comment_button=True, response_url=str(payload.get("response_url") or "")
-    )
-    await _export_feedback(record)
+    if record is not None:
+        try:
+            await _show_submission_error(record, values, response_url, error)
+        except Exception:
+            logger.warning("Could not show Slack feedback submission error")
 
 
 def _comment_error(text: str) -> FeedbackResponse:
@@ -458,45 +509,48 @@ async def handle_slack_feedback_interaction(
                         "This feedback is unavailable. Please reopen the form from the prompt."
                     )
                 values = _object(_object(view.get("state")).get("values"))
-                comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
-                if comment is not None and (not isinstance(comment, str) or len(comment) > 3000):
-                    return _comment_error("Comments must be at most 3,000 characters.")
-                async with _locked_feedback(record) as current:
-                    if current is None:
-                        return _comment_error(
-                            "This feedback is unavailable. Please reopen the form from the prompt."
-                        )
-                    record = current
-                    record.comment = comment.strip() if isinstance(comment, str) else ""
-                    if record.rating is None and not record.comment:
-                        return _comment_error("Enter a comment or choose a rating in the prompt.")
-                    await _store(record.channel_id).put(record.run_id, record)
+                record = await _save_submission(record, values, legacy_modal=True)
+        except _FeedbackInputError as exc:
+            return _comment_error(str(exc))
         except Exception:
-            logger.warning("Could not save Slack feedback comment", exc_info=True)
-            return _comment_error("Your comment could not be saved. Please try again.")
+            logger.warning("Could not save Slack feedback submission")
+            return _comment_error("Your feedback could not be saved. Please try again.")
         background_tasks.add_task(
-            _acknowledge,
-            record,
-            with_comment_button=False,
-            response_url=str(metadata.get("response_url") or ""),
+            _acknowledge, record, response_url=str(metadata.get("response_url") or "")
         )
         background_tasks.add_task(_export_feedback, record)
         return {}
 
     action = _action(payload)
-    if action.get("action_id") == _DISMISS_ACTION:
+    action_id = action.get("action_id")
+    if action_id == _DISMISS_ACTION:
         background_tasks.add_task(_dismiss_feedback, payload)
         return {}
-    if action.get("action_id") != _COMMENT_ACTION:
-        background_tasks.add_task(_process_rating, payload)
+    if action_id == _SUBMIT_ACTION:
+        background_tasks.add_task(_process_submission, payload)
         return {}
+    if action_id == _RATING_ACTION:
+        return {}
+    selected_rating = None
+    if isinstance(action_id, str) and action_id.startswith(_RATE_PREFIX):
+        suffix = action_id.removeprefix(_RATE_PREFIX)
+        if suffix not in {"1", "2", "3", "4", "5"}:
+            return {}
+        selected_rating = int(suffix)
     channel_id = str(_object(payload.get("channel")).get("id") or "")
     user_id = str(_object(payload.get("user")).get("id") or "")
     try:
         async with asyncio.timeout(2.5):
             record = await _load_feedback(channel_id, str(action.get("value") or ""), user_id)
-            if record is None:
+            if record is None or record.dismissed:
                 return {}
+            if record.completed:
+                background_tasks.add_task(
+                    _acknowledge, record, response_url=str(payload.get("response_url") or "")
+                )
+                return {}
+            if selected_rating is not None:
+                record = record.model_copy(update={"rating": selected_rating})
             trigger_id = payload.get("trigger_id")
             if (
                 isinstance(trigger_id, str)
@@ -507,12 +561,5 @@ async def handle_slack_feedback_interaction(
             ):
                 return {}
     except Exception:
-        logger.warning("Could not open Slack feedback modal", exc_info=True)
-    if channel_id and user_id:
-        background_tasks.add_task(
-            post_slack_ephemeral_message,
-            channel_id,
-            user_id,
-            "The comment form could not be opened. Please click Add comments again.",
-        )
+        logger.warning("Could not open Slack feedback form")
     return {}

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -20,6 +20,7 @@ from agent.slack.client import (
     slack_thread_mutation_lock,
 )
 from agent.slack.responses import FeedbackResponse
+from agent.source_context import SourceContext
 from agent.store import TypedStore
 from agent.utils.dashboard_links import dashboard_thread_url
 from agent.utils.langsmith import create_langsmith_thread_feedback
@@ -98,7 +99,7 @@ def rating_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
 async def post_slack_feedback_prompt(
     thread_id: str, run_id: str, channel_id: str, *, require_answer: bool = False
 ) -> None:
-    """Prompt each requester once per Slack thread, using the qualifying run's mapping."""
+    """Prompt the thread initiator once, using the qualifying run's response mapping."""
     try:
         store = _store(channel_id)
         record = await store.get(run_id)
@@ -110,21 +111,30 @@ async def post_slack_feedback_prompt(
                 return
             if require_answer and mapping.get("should_ask_for_feedback") is not True:
                 return
+        thread_ts = record.thread_ts if record else mapping.get("thread_ts")
+        if not isinstance(thread_ts, str) or not thread_ts:
+            return
+        thread = await langgraph_client().threads.get(thread_id)
+        origin = SourceContext.from_metadata(thread.get("metadata")).slack_thread
+        if (
+            origin is None
+            or not origin.is_at(channel_id, thread_ts)
+            or not origin.triggering_user_id
+        ):
+            return
+        if record is not None and record.user_id != origin.triggering_user_id:
+            return
         if record is None:
-            user_id = mapping.get("triggering_user_id")
-            thread_ts = mapping.get("thread_ts")
             message_ts = mapping.get("message_ts")
-            if not all(
-                isinstance(value, str) and value for value in (user_id, thread_ts, message_ts)
-            ):
+            if not isinstance(message_ts, str) or not message_ts:
                 return
             record = ThreadFeedback(
                 agent_thread_id=thread_id,
                 run_id=run_id,
                 channel_id=channel_id,
-                thread_ts=str(thread_ts),
-                message_ts=str(message_ts),
-                user_id=str(user_id),
+                thread_ts=thread_ts,
+                message_ts=message_ts,
+                user_id=origin.triggering_user_id,
             )
         context = await get_slack_channel_context(channel_id, use_cache=False)
         if not slack_channel_allows_operations(context):

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -37,7 +37,7 @@ _SUBMIT_ACTION = "open_swe_feedback_submit"
 _RATING_ACTION = "open_swe_feedback_rating"
 _RATING_BLOCK = "feedback_rating"
 _COMMENT_BLOCK = "feedback_comment"
-_RATINGS = ("😡 Very Bad", "🙁 Bad", "😐 Okay", "🙂 Good", "😍 Great")
+_RATINGS = ("😡 Very Bad", "💩 Bad", "😐 Okay", "🙂 Good", "😍 Great")
 
 
 class ThreadFeedback(BaseModel):

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -52,6 +52,7 @@ class ThreadFeedback(BaseModel):
     rating: int | None = Field(default=None, ge=1, le=5)
     comment: str = Field(default="", max_length=3000)
     completed: bool = False
+    submitted_at: Decimal | None = None
     draft_rating: int | None = Field(default=None, ge=1, le=5)
     last_selection_ts: Decimal = Decimal(0)
 
@@ -405,16 +406,25 @@ async def _dismiss_feedback(payload: dict[str, Any]) -> None:
         async with _locked_feedback(record, purpose="feedback_response") as current:
             if current is None:
                 return
+            async with _locked_feedback(current) as latest:
+                if latest is None:
+                    return
+                was_dismissed = latest.dismissed
+                if not was_dismissed:
+                    latest.dismissed = True
+                    await _store(channel_id).put(latest.run_id, latest)
             if await respond_to_slack_interaction(
                 str(payload.get("response_url") or ""), {"delete_original": True}
             ):
+                return
+            if not was_dismissed:
                 async with _locked_feedback(current) as latest:
                     if latest is not None:
-                        latest.dismissed = True
+                        latest.dismissed = False
                         await _store(channel_id).put(latest.run_id, latest)
-                return
     except Exception:
         logger.warning("Could not dismiss Slack feedback prompt")
+        return
     logger.warning("Could not dismiss Slack feedback prompt")
 
 
@@ -438,13 +448,16 @@ def _form_values(
     if comment is not None and (not isinstance(comment, str) or len(comment) > 3000):
         raise _FeedbackInputError("Comments must be at most 3,000 characters.")
     comment = comment.strip() if isinstance(comment, str) else ""
-    if rating is None and not comment:
-        raise _FeedbackInputError("Choose a rating or enter a comment before submitting.")
     return rating, comment
 
 
 async def _save_submission(
-    record: ThreadFeedback, values: dict[str, Any], *, legacy_modal: bool = False
+    record: ThreadFeedback,
+    values: dict[str, Any],
+    *,
+    legacy_modal: bool = False,
+    submitted_at: Decimal | None = None,
+    selection_ts: Decimal = Decimal(0),
 ) -> ThreadFeedback:
     async with _locked_feedback(record) as current:
         if current is None:
@@ -453,10 +466,17 @@ async def _save_submission(
             return current
         default_rating = current.rating if legacy_modal and _RATING_BLOCK not in values else None
         rating, comment = _form_values(values, default_rating)
+        completed = rating is not None or bool(comment)
+        if not completed and submitted_at is None:
+            raise _FeedbackInputError("Choose a rating or enter a comment before submitting.")
         current.rating = rating
         current.comment = comment
-        current.completed = True
+        current.completed = completed
+        current.submitted_at = submitted_at
+        current.last_selection_ts = max(current.last_selection_ts, selection_ts)
         await _store(current.channel_id).put(current.run_id, current)
+        if not completed:
+            raise _FeedbackInputError("Choose a rating or enter a comment before submitting.")
         return current
 
 
@@ -525,9 +545,15 @@ async def _process_submission(payload: dict[str, Any]) -> None:
             if current is None:
                 return
             action_ts = _action(payload).get("action_ts")
+            submitted_at = None
             if action_ts is not None:
                 submitted_at = Decimal(str(action_ts))
-                if not submitted_at.is_finite() or submitted_at < current.last_selection_ts:
+                if (
+                    not submitted_at.is_finite()
+                    or submitted_at <= 0
+                    or submitted_at < current.last_selection_ts
+                    or (current.submitted_at is not None and submitted_at < current.submitted_at)
+                ):
                     return
             # A Submit click can reach us before the preceding emoji update reaches Slack.
             if current.draft_rating is not None and current.last_selection_ts > selection_ts:
@@ -539,7 +565,9 @@ async def _process_submission(payload: dict[str, Any]) -> None:
                     },
                 }
             try:
-                record = await _save_submission(current, values)
+                record = await _save_submission(
+                    current, values, submitted_at=submitted_at, selection_ts=selection_ts
+                )
             except Exception as exc:
                 error = "Your feedback could not be saved. Please submit again."
                 if isinstance(exc, _FeedbackInputError):
@@ -574,40 +602,56 @@ async def _select_feedback_rating(payload: dict[str, Any]) -> None:
     response_url = str(payload.get("response_url") or "")
     try:
         record = await _load_feedback(channel_id, str(action.get("value") or ""), user_id)
-        if record is None or not response_url:
+        if record is None:
             return
         async with _locked_feedback(record, purpose="feedback_response") as current:
-            if (
-                current is None
-                or current.completed
-                or current.dismissed
-                or timestamp <= current.last_selection_ts
-            ):
+            if current is None or current.dismissed or timestamp <= current.last_selection_ts:
                 return
-            values = _object(_object(payload.get("state")).get("values"))
-            comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
-            comment = comment[:3000] if isinstance(comment, str) else ""
-            posted = await respond_to_slack_interaction(
-                response_url,
-                {
-                    "replace_original": True,
-                    "response_type": "ephemeral",
-                    "text": "Add a rating or comment, then submit feedback.",
-                    "blocks": rating_blocks(
-                        current.run_id,
-                        current.agent_thread_id,
-                        rating=int(suffix),
-                        comment=comment,
-                        selection_ts=timestamp,
-                    ),
-                },
-            )
-            if posted:
+            if current.submitted_at is not None and timestamp < current.submitted_at:
+                # Slack can deliver a pre-Submit click after the submission has been saved.
                 async with _locked_feedback(current) as latest:
-                    if latest is not None and not latest.completed and not latest.dismissed:
-                        latest.draft_rating = int(suffix)
-                        latest.last_selection_ts = timestamp
-                        await _store(channel_id).put(latest.run_id, latest)
+                    if (
+                        latest is None
+                        or latest.dismissed
+                        or latest.submitted_at is None
+                        or not latest.last_selection_ts < timestamp < latest.submitted_at
+                    ):
+                        return
+                    latest.rating = latest.draft_rating = int(suffix)
+                    latest.last_selection_ts = timestamp
+                    latest.completed = True
+                    record = await _store(channel_id).put(latest.run_id, latest)
+            else:
+                if current.completed or not response_url:
+                    return
+                values = _object(_object(payload.get("state")).get("values"))
+                comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
+                comment = comment[:3000] if isinstance(comment, str) else ""
+                posted = await respond_to_slack_interaction(
+                    response_url,
+                    {
+                        "replace_original": True,
+                        "response_type": "ephemeral",
+                        "text": "Add a rating or comment, then submit feedback.",
+                        "blocks": rating_blocks(
+                            current.run_id,
+                            current.agent_thread_id,
+                            rating=int(suffix),
+                            comment=comment,
+                            selection_ts=timestamp,
+                        ),
+                    },
+                )
+                if posted:
+                    async with _locked_feedback(current) as latest:
+                        if latest is not None and not latest.completed and not latest.dismissed:
+                            latest.draft_rating = int(suffix)
+                            latest.last_selection_ts = timestamp
+                            latest.submitted_at = None
+                            await _store(channel_id).put(latest.run_id, latest)
+                return
+        await _acknowledge(record, response_url=response_url)
+        await _export_feedback(record)
     except Exception:
         logger.warning("Could not update Slack feedback rating selection")
 

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -5,6 +5,7 @@ import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from fastapi import BackgroundTasks
@@ -29,6 +30,7 @@ from agent.utils.thread_ops import langgraph_client
 logger = logging.getLogger(__name__)
 
 _RATE_PREFIX = "open_swe_feedback_rate_"
+_SELECT_PREFIX = "open_swe_feedback_select_"
 _COMMENT_ACTION = "open_swe_feedback_comment"
 _DISMISS_ACTION = "open_swe_feedback_dismiss"
 _SUBMIT_ACTION = "open_swe_feedback_submit"
@@ -50,6 +52,8 @@ class ThreadFeedback(BaseModel):
     rating: int | None = Field(default=None, ge=1, le=5)
     comment: str = Field(default="", max_length=3000)
     completed: bool = False
+    draft_rating: int | None = Field(default=None, ge=1, le=5)
+    last_selection_ts: Decimal = Decimal(0)
 
 
 def _store(channel_id: str) -> TypedStore[ThreadFeedback]:
@@ -78,6 +82,26 @@ def _dismiss_button(run_id: str) -> dict[str, Any]:
     }
 
 
+def _comment_input(comment: str = "") -> dict[str, Any]:
+    comment_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "comment",
+        "multiline": True,
+        "max_length": 3000,
+        "placeholder": {"type": "plain_text", "text": "What worked well? What could be better?"},
+    }
+    if comment:
+        comment_element["initial_value"] = comment
+    return {
+        "type": "input",
+        "block_id": _COMMENT_BLOCK,
+        "optional": True,
+        "dispatch_action": False,
+        "label": {"type": "plain_text", "text": "Comments"},
+        "element": comment_element,
+    }
+
+
 def _feedback_inputs(rating: int | None = None, comment: str = "") -> list[dict[str, Any]]:
     options = [
         {"text": {"type": "plain_text", "text": label, "emoji": True}, "value": str(value)}
@@ -90,15 +114,6 @@ def _feedback_inputs(rating: int | None = None, comment: str = "") -> list[dict[
     }
     if rating is not None:
         rating_element["initial_option"] = options[rating - 1]
-    comment_element: dict[str, Any] = {
-        "type": "plain_text_input",
-        "action_id": "comment",
-        "multiline": True,
-        "max_length": 3000,
-        "placeholder": {"type": "plain_text", "text": "What worked well? What could be better?"},
-    }
-    if comment:
-        comment_element["initial_value"] = comment
     return [
         {
             "type": "input",
@@ -108,19 +123,18 @@ def _feedback_inputs(rating: int | None = None, comment: str = "") -> list[dict[
             "label": {"type": "plain_text", "text": "Rating"},
             "element": rating_element,
         },
-        {
-            "type": "input",
-            "block_id": _COMMENT_BLOCK,
-            "optional": True,
-            "dispatch_action": False,
-            "label": {"type": "plain_text", "text": "Comments"},
-            "element": comment_element,
-        },
+        _comment_input(comment),
     ]
 
 
 def rating_blocks(
-    run_id: str, thread_id: str, *, rating: int | None = None, comment: str = "", error: str = ""
+    run_id: str,
+    thread_id: str,
+    *,
+    rating: int | None = None,
+    comment: str = "",
+    error: str = "",
+    selection_ts: Decimal = Decimal(0),
 ) -> list[dict[str, Any]]:
     url = dashboard_thread_url(thread_id)
     thread_link = f"<{url}|this thread>" if url else "this thread"
@@ -137,7 +151,21 @@ def rating_blocks(
         blocks.append({"type": "section", "text": {"type": "plain_text", "text": error}})
     return [
         *blocks,
-        *_feedback_inputs(rating, comment),
+        {
+            "type": "actions",
+            "block_id": _RATING_BLOCK,
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": label, "emoji": True},
+                    "action_id": f"{_SELECT_PREFIX}{value}",
+                    "value": run_id,
+                    **({"style": "primary"} if value == rating else {}),
+                }
+                for value, label in enumerate(_RATINGS, start=1)
+            ],
+        },
+        _comment_input(comment),
         {
             "type": "actions",
             "elements": [
@@ -145,7 +173,11 @@ def rating_blocks(
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Submit feedback"},
                     "action_id": _SUBMIT_ACTION,
-                    "value": run_id,
+                    "value": json.dumps(
+                        {"run_id": run_id, "rating": rating, "selection_ts": str(selection_ts)}
+                    )
+                    if rating is not None
+                    else run_id,
                     "style": "primary",
                 },
                 _dismiss_button(run_id),
@@ -260,6 +292,7 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
             action_id = action.get("action_id")
             if isinstance(action_id, str) and (
                 action_id.startswith(_RATE_PREFIX)
+                or action_id.startswith(_SELECT_PREFIX)
                 or action_id in {_COMMENT_ACTION, _DISMISS_ACTION, _SUBMIT_ACTION, _RATING_ACTION}
             ):
                 return action
@@ -428,7 +461,11 @@ async def _save_submission(
 
 
 async def _show_submission_error(
-    record: ThreadFeedback, values: dict[str, Any], response_url: str, error: str
+    record: ThreadFeedback,
+    values: dict[str, Any],
+    response_url: str,
+    error: str,
+    selection_ts: Decimal,
 ) -> None:
     selected = _object(
         _object(_object(values.get(_RATING_BLOCK)).get(_RATING_ACTION)).get("selected_option")
@@ -440,24 +477,25 @@ async def _show_submission_error(
     )
     comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
     comment = comment[:3000] if isinstance(comment, str) else ""
-    async with _locked_feedback(record, purpose="feedback_response") as current:
-        if current is None or current.completed or current.dismissed or not response_url:
-            return
-        await respond_to_slack_interaction(
-            response_url,
-            {
-                "replace_original": True,
-                "response_type": "ephemeral",
-                "text": error,
-                "blocks": rating_blocks(
-                    record.run_id,
-                    record.agent_thread_id,
-                    rating=rating,
-                    comment=comment,
-                    error=error,
-                ),
-            },
-        )
+    current = await _store(record.channel_id).get(record.run_id)
+    if current is None or current.completed or current.dismissed or not response_url:
+        return
+    await respond_to_slack_interaction(
+        response_url,
+        {
+            "replace_original": True,
+            "response_type": "ephemeral",
+            "text": error,
+            "blocks": rating_blocks(
+                record.run_id,
+                record.agent_thread_id,
+                rating=rating,
+                comment=comment,
+                error=error,
+                selection_ts=selection_ts,
+            ),
+        },
+    )
 
 
 async def _process_submission(payload: dict[str, Any]) -> None:
@@ -465,30 +503,113 @@ async def _process_submission(payload: dict[str, Any]) -> None:
     user_id = str(_object(payload.get("user")).get("id") or "")
     response_url = str(payload.get("response_url") or "")
     values = _object(_object(payload.get("state")).get("values"))
-    record = None
-    error = "Your feedback could not be saved. Please submit again."
     try:
-        record = await _load_feedback(channel_id, str(_action(payload).get("value") or ""), user_id)
+        action_value = str(_action(payload).get("value") or "")
+        selection_ts = Decimal(0)
+        if action_value.startswith("{"):
+            selection = _object(json.loads(action_value))
+            action_value = str(selection.get("run_id") or "")
+            selection_ts = Decimal(str(selection.get("selection_ts") or "0"))
+            if not selection_ts.is_finite() or selection_ts < 0:
+                return
+            values = {
+                **values,
+                _RATING_BLOCK: {
+                    _RATING_ACTION: {"selected_option": {"value": str(selection.get("rating"))}}
+                },
+            }
+        record = await _load_feedback(channel_id, action_value, user_id)
         if record is None:
             return
-        record = await _save_submission(record, values)
-    except _FeedbackInputError as exc:
-        error = str(exc)
-    except Exception:
-        logger.warning("Could not save Slack feedback submission")
-    else:
+        async with _locked_feedback(record, purpose="feedback_response") as current:
+            if current is None:
+                return
+            action_ts = _action(payload).get("action_ts")
+            if action_ts is not None:
+                submitted_at = Decimal(str(action_ts))
+                if not submitted_at.is_finite() or submitted_at < current.last_selection_ts:
+                    return
+            # A Submit click can reach us before the preceding emoji update reaches Slack.
+            if current.draft_rating is not None and current.last_selection_ts > selection_ts:
+                selection_ts = current.last_selection_ts
+                values = {
+                    **values,
+                    _RATING_BLOCK: {
+                        _RATING_ACTION: {"selected_option": {"value": str(current.draft_rating)}}
+                    },
+                }
+            try:
+                record = await _save_submission(current, values)
+            except Exception as exc:
+                error = "Your feedback could not be saved. Please submit again."
+                if isinstance(exc, _FeedbackInputError):
+                    error = str(exc)
+                else:
+                    logger.warning("Could not save Slack feedback submission")
+                await _show_submission_error(current, values, response_url, error, selection_ts)
+                return
         await _acknowledge(record, response_url=response_url)
         await _export_feedback(record)
-        return
-    if record is not None:
-        try:
-            await _show_submission_error(record, values, response_url, error)
-        except Exception:
-            logger.warning("Could not show Slack feedback submission error")
+    except Exception:
+        logger.warning("Could not process Slack feedback submission")
 
 
 def _comment_error(text: str) -> FeedbackResponse:
     return {"response_action": "errors", "errors": {_COMMENT_BLOCK: text}}
+
+
+async def _select_feedback_rating(payload: dict[str, Any]) -> None:
+    action = _action(payload)
+    suffix = str(action.get("action_id", "")).removeprefix(_SELECT_PREFIX)
+    if suffix not in {"1", "2", "3", "4", "5"}:
+        return
+    try:
+        timestamp = Decimal(str(action.get("action_ts") or "0"))
+    except InvalidOperation:
+        return
+    if not timestamp.is_finite() or timestamp <= 0:
+        return
+    channel_id = str(_object(payload.get("channel")).get("id") or "")
+    user_id = str(_object(payload.get("user")).get("id") or "")
+    response_url = str(payload.get("response_url") or "")
+    try:
+        record = await _load_feedback(channel_id, str(action.get("value") or ""), user_id)
+        if record is None or not response_url:
+            return
+        async with _locked_feedback(record, purpose="feedback_response") as current:
+            if (
+                current is None
+                or current.completed
+                or current.dismissed
+                or timestamp <= current.last_selection_ts
+            ):
+                return
+            values = _object(_object(payload.get("state")).get("values"))
+            comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
+            comment = comment[:3000] if isinstance(comment, str) else ""
+            posted = await respond_to_slack_interaction(
+                response_url,
+                {
+                    "replace_original": True,
+                    "response_type": "ephemeral",
+                    "text": "Add a rating or comment, then submit feedback.",
+                    "blocks": rating_blocks(
+                        current.run_id,
+                        current.agent_thread_id,
+                        rating=int(suffix),
+                        comment=comment,
+                        selection_ts=timestamp,
+                    ),
+                },
+            )
+            if posted:
+                async with _locked_feedback(current) as latest:
+                    if latest is not None and not latest.completed and not latest.dismissed:
+                        latest.draft_rating = int(suffix)
+                        latest.last_selection_ts = timestamp
+                        await _store(channel_id).put(latest.run_id, latest)
+    except Exception:
+        logger.warning("Could not update Slack feedback rating selection")
 
 
 async def handle_slack_feedback_interaction(
@@ -530,6 +651,9 @@ async def handle_slack_feedback_interaction(
         background_tasks.add_task(_process_submission, payload)
         return {}
     if action_id == _RATING_ACTION:
+        return {}
+    if isinstance(action_id, str) and action_id.startswith(_SELECT_PREFIX):
+        background_tasks.add_task(_select_feedback_rating, payload)
         return {}
     selected_rating = None
     if isinstance(action_id, str) and action_id.startswith(_RATE_PREFIX):

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -54,8 +54,11 @@ def _store(channel_id: str) -> TypedStore[ThreadFeedback]:
 async def _locked_feedback(
     record: ThreadFeedback, *, purpose: str = "feedback"
 ) -> AsyncIterator[ThreadFeedback | None]:
+    lock_purpose = f"{purpose}:{record.user_id}"
+    if record.thread_ts == "0":
+        lock_purpose += f":{record.agent_thread_id}"
     async with slack_thread_mutation_lock(
-        langgraph_client(), record.channel_id, record.message_ts, purpose=purpose
+        langgraph_client(), record.channel_id, record.thread_ts, purpose=lock_purpose
     ):
         yield await _store(record.channel_id).get(record.run_id)
 
@@ -95,7 +98,7 @@ def rating_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
 async def post_slack_feedback_prompt(
     thread_id: str, run_id: str, channel_id: str, *, require_answer: bool = False
 ) -> None:
-    """Prompt the run's requester once, using its exact response mapping."""
+    """Prompt each requester once per Slack thread, using the qualifying run's mapping."""
     try:
         store = _store(channel_id)
         record = await store.get(run_id)
@@ -129,6 +132,16 @@ async def post_slack_feedback_prompt(
         async with _locked_feedback(record) as current:
             record = current or record
             if record.prompted:
+                return
+            prompt_filter: dict[str, Any] = {
+                "thread_ts": record.thread_ts,
+                "user_id": record.user_id,
+                "prompted": True,
+            }
+            # Code channel sessions share the "0" timestamp across agent threads.
+            if record.thread_ts == "0":
+                prompt_filter["agent_thread_id"] = record.agent_thread_id
+            if await store.search(filter=prompt_filter, limit=1):
                 return
             await store.put(run_id, record)
             posted = await post_slack_ephemeral_message(

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -1,5 +1,7 @@
 """Tests for Slack message API utilities."""
 
+import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx2
@@ -77,6 +79,75 @@ async def test_modal_sends_trigger_and_view(monkeypatch: pytest.MonkeyPatch) -> 
         assert await slack_utils.open_slack_modal("trigger-1", view)
     assert client_cm.post.await_args.args[0].endswith("/views.open")
     assert client_cm.post.await_args.kwargs["json"] == {"trigger_id": "trigger-1", "view": view}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,body,success",
+    [
+        (200, "ok", True),
+        (200, '{"ok":true}', True),
+        (200, '{"ok":false}', False),
+        (200, "invalid", False),
+        (410, "expired", False),
+        (302, "", False),
+    ],
+)
+async def test_interaction_response_replaces_private_message_without_bot_auth(
+    status: int, body: str, success: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    url = "https://hooks.slack.com/actions/T1/B1/test-response"
+    message = {"replace_original": True, "text": "Saved", "blocks": []}
+    requests: list[httpx2.Request] = []
+
+    async def handle(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(status, text=body)
+
+    transport = httpx2.MockTransport(handle)
+    caplog.set_level(logging.DEBUG, logger="httpx2")
+    with patch.object(slack_utils.httpx2, "AsyncHTTPTransport", return_value=transport):
+        assert await slack_utils.respond_to_slack_interaction(url, message) is success
+    assert len(requests) == 1
+    assert str(requests[0].url) == url
+    assert json.loads(requests[0].content) == message
+    assert "Authorization" not in requests[0].headers
+    assert "test-response" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://hooks.slack.com/actions/test",
+        "https://example.com/actions/test",
+        "https://hooks.slack.com.example.com/actions/test",
+        "https://hooks.slack.com/api/test",
+        "https://hooks.slack.com@127.0.0.1/actions/test",
+        "https://[invalid",
+    ],
+)
+async def test_interaction_response_rejects_non_slack_urls(url: str) -> None:
+    with patch.object(slack_utils.httpx2, "AsyncHTTPTransport") as client:
+        assert not await slack_utils.respond_to_slack_interaction(url, {"delete_original": True})
+    client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_interaction_response_failure_does_not_log_capability_url(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    url = "https://hooks.slack.com/actions/T1/B1/test-response"
+
+    async def handle(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError(f"Failed {url}")
+
+    caplog.set_level(logging.DEBUG, logger="httpx2")
+    with patch.object(
+        slack_utils.httpx2, "AsyncHTTPTransport", return_value=httpx2.MockTransport(handle)
+    ):
+        assert not await slack_utils.respond_to_slack_interaction(url, {"delete_original": True})
+    assert "test-response" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -36,7 +36,7 @@ async def test_emoji_selection_preserves_comment_and_submits_both(
     assert all(element["type"] == "button" for element in ratings)
     assert [element["text"]["text"].split()[0] for element in ratings] == [
         "😡",
-        "🙁",
+        "💩",
         "😐",
         "🙂",
         "😍",

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -483,10 +483,23 @@ async def test_older_rating_retry_does_not_revert_newer_feedback(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("second_run", ["run-1", "run-2"])
+@pytest.mark.parametrize("thread_ts", ["1.0", "0"])
 async def test_concurrent_completion_callbacks_post_one_prompt(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, second_run: str, thread_ts: str
 ) -> None:
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "prompted": False})
+    for run_id, message_ts in [("run-1", "2.0"), ("run-2", "3.0")]:
+        fake_store.seed(
+            ("slack_thread_feedback", "C1"),
+            run_id,
+            {
+                **context,
+                "run_id": run_id,
+                "message_ts": message_ts,
+                "thread_ts": thread_ts,
+                "prompted": False,
+            },
+        )
 
     async def post(*args: Any, **kwargs: Any) -> bool:
         await asyncio.sleep(0.01)
@@ -495,9 +508,59 @@ async def test_concurrent_completion_callbacks_post_one_prompt(
     post_mock = AsyncMock(side_effect=post)
     monkeypatch.setattr(feedback, "post_slack_ephemeral_message", post_mock)
     await asyncio.gather(
-        *[feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1") for _ in range(2)]
+        feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1"),
+        feedback.post_slack_feedback_prompt("thread-1", second_run, "C1"),
     )
     post_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "previous_changes,current_changes,should_prompt",
+    [
+        ({}, {}, False),
+        ({}, {"agent_thread_id": "thread-2"}, False),
+        ({}, {"thread_ts": "4.0"}, True),
+        ({}, {"user_id": "U2"}, True),
+        ({}, {"channel_id": "C2"}, True),
+        ({"thread_ts": "0"}, {"thread_ts": "0"}, False),
+        ({"thread_ts": "0"}, {"thread_ts": "0", "agent_thread_id": "thread-2"}, True),
+        ({"prompted": False}, {}, True),
+    ],
+)
+async def test_prompt_deduplicates_existing_records_by_requester_and_slack_thread(
+    context: Any,
+    fake_store: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    previous_changes: dict[str, Any],
+    current_changes: dict[str, Any],
+    should_prompt: bool,
+) -> None:
+    previous = {**context, "rating": 4, "comment": "Useful", **previous_changes}
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", previous)
+    current = {**context, "run_id": "run-2", "message_ts": "3.0", **current_changes}
+    monkeypatch.setattr(
+        feedback,
+        "lookup_slack_run_message_mapping",
+        AsyncMock(
+            return_value={
+                "run_id": current["run_id"],
+                "triggering_user_id": current["user_id"],
+                "thread_ts": current["thread_ts"],
+                "message_ts": current["message_ts"],
+            }
+        ),
+    )
+
+    await feedback.post_slack_feedback_prompt(
+        current["agent_thread_id"], current["run_id"], current["channel_id"]
+    )
+
+    assert feedback.post_slack_ephemeral_message.await_count == int(should_prompt)
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
+    assert ("run-2" in fake_store.values(("slack_thread_feedback", current["channel_id"]))) == (
+        should_prompt
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -11,11 +11,194 @@ from fastapi.testclient import TestClient
 from langgraph_sdk.errors import ConflictError
 
 from agent import completion
-from agent.slack import client as slack_client
 from agent.slack import routes
 from agent.slack import thread_feedback as feedback
 
 _RESPONSE_URL = "https://hooks.slack.com/actions/T1/B1/test-response"
+
+
+def _inline_submission(rating: int | None = 5, comment: str = "Helpful") -> dict[str, Any]:
+    payload = _action("open_swe_feedback_submit")
+    payload["state"] = {
+        "values": {
+            "feedback_rating": {
+                "open_swe_feedback_rating": {
+                    "selected_option": {"value": str(rating)} if rating is not None else None
+                }
+            },
+            "feedback_comment": {"comment": {"value": comment}},
+        }
+    }
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_inline_rating_and_comment_submit_together_and_complete(
+    context: Any, fake_store: Any
+) -> None:
+    blocks = feedback.rating_blocks("run-1", "thread-1")
+    assert {block["element"]["type"] for block in blocks if block["type"] == "input"} == {
+        "radio_buttons",
+        "plain_text_input",
+    }
+    tasks = BackgroundTasks()
+    assert (
+        await routes.slack_interactivity(_request(_inline_submission(4, "  Very helpful  ")), tasks)
+        == {}
+    )
+    await tasks()
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (record["rating"], record["comment"], record["completed"]) == (4, "Very helpful", True)
+    feedback.create_langsmith_thread_feedback.assert_awaited_once()
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.75
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == "Very helpful"
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    assert message["replace_original"] is True
+    assert "completed" in message["text"].lower()
+    assert all(
+        block["type"] not in {"input", "actions"} and "accessory" not in block
+        for block in message["blocks"]
+    )
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_completed_submission_cannot_be_overwritten(context: Any, fake_store: Any) -> None:
+    for rating, comment in [(5, "Great"), (1, "Stale submission")]:
+        tasks = BackgroundTasks()
+        await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
+        await tasks()
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (record["rating"], record["comment"], record["completed"]) == (5, "Great", True)
+
+
+@pytest.mark.asyncio
+async def test_inline_save_failure_keeps_draft_in_original_message(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fake_store, "put_item", AsyncMock(side_effect=RuntimeError("unavailable")))
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_inline_submission(3, "Keep this draft")), tasks)
+    await tasks()
+    assert not fake_store.values(("slack_thread_feedback", "C1"))["run-1"].get("completed")
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    inputs = {
+        block["block_id"]: block["element"]
+        for block in message["blocks"]
+        if block["type"] == "input"
+    }
+    assert inputs["feedback_rating"]["initial_option"]["value"] == "3"
+    assert inputs["feedback_comment"]["initial_value"] == "Keep this draft"
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rating,comment,score",
+    [
+        (1, "", 0.0),
+        (2, "", 0.25),
+        (3, "", 0.5),
+        (4, "", 0.75),
+        (5, "", 1.0),
+        (None, "Comment only", None),
+    ],
+)
+async def test_inline_optional_fields_and_rating_scale(
+    context: Any, fake_store: Any, rating: int | None, comment: str, score: float | None
+) -> None:
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
+    await tasks()
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (record["rating"], record["comment"], record["completed"]) == (rating, comment, True)
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == score
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["other_user", "other_channel", "unknown_run", "external"])
+async def test_inline_submission_requires_prompt_recipient(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, change: str
+) -> None:
+    payload = _inline_submission()
+    if change == "other_user":
+        payload["user"]["id"] = "U2"
+    elif change == "other_channel":
+        payload["channel"]["id"] = "C2"
+    elif change == "unknown_run":
+        payload["actions"][0]["value"] = "run-2"
+    else:
+        monkeypatch.setattr(
+            feedback, "get_slack_channel_context", AsyncMock(return_value={"is_ext_shared": True})
+        )
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rating,comment", [(None, "  "), (0, "Draft"), (6, "Draft"), (3, "x" * 3001)]
+)
+async def test_invalid_inline_submission_keeps_prompt_open(
+    context: Any, fake_store: Any, rating: int | None, comment: str
+) -> None:
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    assert message["replace_original"] is True
+    assert any(block["type"] == "input" for block in message["blocks"])
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_changing_rating_does_not_submit_feedback(context: Any, fake_store: Any) -> None:
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_action("open_swe_feedback_rating")), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_rating_button_opens_combined_form_without_saving(
+    context: Any, fake_store: Any
+) -> None:
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_action("open_swe_feedback_rate_4")), tasks)
+    await tasks()
+    view = feedback.open_slack_modal.await_args.args[1]
+    assert view["blocks"][0]["element"]["initial_option"]["value"] == "4"
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    payload = _submission("Combined")
+    payload["view"]["private_metadata"] = view["private_metadata"]
+    payload["view"]["state"] = _inline_submission(4, "Combined")["state"]
+    submit_tasks = BackgroundTasks()
+    assert await routes.slack_interactivity(_request(payload), submit_tasks) == {}
+    await submit_tasks()
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (record["rating"], record["comment"], record["completed"]) == (4, "Combined", True)
+
+
+@pytest.mark.asyncio
+async def test_dismissed_feedback_cannot_be_submitted(context: Any, fake_store: Any) -> None:
+    previous = {**context, "dismissed": True}
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", previous)
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_inline_submission()), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
 
 
 def _request(payload: dict[str, Any]) -> Request:
@@ -90,82 +273,6 @@ def _action(action_id: str = "open_swe_feedback_rate_5", value: str = "run-1") -
 
 
 @pytest.mark.asyncio
-async def test_rating_is_saved_privately_without_starting_agent(
-    context: Any, fake_store: Any
-) -> None:
-    tasks = BackgroundTasks()
-    result = await routes.slack_interactivity(_request(_action()), tasks)
-    assert result == {}
-    assert len(tasks.tasks) == 1
-    await tasks()
-
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert record["rating"] == 5
-    assert record["agent_thread_id"] == "thread-1"
-    feedback.create_langsmith_thread_feedback.assert_awaited_once_with(
-        "thread-1",
-        "slack_rating:C1:U1:run-1",
-        score=1.0,
-        comment=None,
-        source_info={
-            "source": "slack_thread_feedback",
-            "channel_id": "C1",
-            "message_ts": "2.0",
-            "user_id": "U1",
-            "run_id": "run-1",
-        },
-    )
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
-    url, message = feedback.respond_to_slack_interaction.await_args.args
-    assert url == _RESPONSE_URL
-    assert message["replace_original"] is True
-    assert message["response_type"] == "ephemeral"
-    assert message["blocks"][0]["accessory"]["action_id"] == "open_swe_feedback_comment"
-    assert not any(
-        element["action_id"].startswith("open_swe_feedback_rate_")
-        for block in message["blocks"]
-        for element in block.get("elements", [])
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("rating,score", [(1, 0.0), (2, 0.25), (3, 0.5), (4, 0.75), (5, 1.0)])
-async def test_rating_scale(context: Any, fake_store: Any, rating: int, score: float) -> None:
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action(f"open_swe_feedback_rate_{rating}")), tasks)
-    await tasks()
-    assert len(fake_store.values(("slack_thread_feedback", "C1"))) == 1
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == score
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "change", ["other_user", "other_channel", "unknown_run", "bad_rating", "external"]
-)
-async def test_invalid_rating_does_not_write(
-    context: Any, fake_store: Any, change: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    payload = _action()
-    if change == "other_user":
-        payload["user"]["id"] = "U2"
-    elif change == "other_channel":
-        payload["channel"]["id"] = "C2"
-    elif change == "unknown_run":
-        payload["actions"][0]["value"] = "run-2"
-    elif change == "bad_rating":
-        payload["actions"][0]["action_id"] = "open_swe_feedback_rate_6"
-    else:
-        monkeypatch.setattr(
-            feedback, "get_slack_channel_context", AsyncMock(return_value={"is_ext_shared": True})
-        )
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(payload), tasks)
-    await tasks()
-    assert "rating" not in fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_comment_modal_opens_with_saved_rating_and_comment(
     context: Any, fake_store: Any
 ) -> None:
@@ -184,20 +291,6 @@ async def test_comment_modal_opens_with_saved_rating_and_comment(
         "response_url": _RESPONSE_URL,
     }
     assert view["blocks"][-1]["element"]["initial_value"] == "Useful"
-
-
-@pytest.mark.asyncio
-async def test_original_prompt_opens_text_form_without_a_rating(context: Any) -> None:
-    blocks = feedback.rating_blocks("run-1", "thread-1")
-    button = blocks[0]["accessory"]
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action(button["action_id"], button["value"])), tasks)
-    feedback.open_slack_modal.assert_awaited_once()
-    view = feedback.open_slack_modal.await_args.args[1]
-    assert not view["blocks"][-1]["optional"]
-    assert all(
-        "Your rating:" not in block.get("text", {}).get("text", "") for block in view["blocks"]
-    )
 
 
 def _submission(comment: str = "Please run the tests next time.") -> dict[str, Any]:
@@ -252,39 +345,6 @@ async def test_comment_submission_updates_same_feedback(context: Any, fake_store
 
 
 @pytest.mark.asyncio
-async def test_comment_only_feedback_exports_without_inventing_rating(
-    context: Any, fake_store: Any
-) -> None:
-    tasks = BackgroundTasks()
-    assert (
-        await routes.slack_interactivity(_request(_submission("  Helpful explanation  ")), tasks)
-        == {}
-    )
-    await tasks()
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    assert message["replace_original"] is True
-    assert all("accessory" not in block and "elements" not in block for block in message["blocks"])
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert record["comment"] == "Helpful explanation"
-    assert record["rating"] is None
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] is None
-    assert (
-        feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
-        == "Helpful explanation"
-    )
-
-    rating_tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action()), rating_tasks)
-    await rating_tasks()
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 1.0
-    assert (
-        feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
-        == "Helpful explanation"
-    )
-
-
-@pytest.mark.asyncio
 async def test_empty_comment_without_rating_keeps_form_open(context: Any) -> None:
     tasks = BackgroundTasks()
     result = await routes.slack_interactivity(_request(_submission("  ")), tasks)
@@ -324,14 +384,11 @@ async def test_prompt_uses_exact_run_mapping_and_deduplicates(
         await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
     feedback.post_slack_ephemeral_message.assert_awaited_once()
     call = feedback.post_slack_ephemeral_message.await_args
-    buttons = [
-        element
-        for block in call.kwargs["blocks"]
-        for element in block.get("elements", [])
-        if element["action_id"].startswith("open_swe_feedback_rate_")
-    ]
-    assert len(buttons) == 5
-    assert [b["value"] for b in buttons] == ["run-1"] * 5
+    inputs = [block for block in call.kwargs["blocks"] if block["type"] == "input"]
+    assert {block["block_id"] for block in inputs} == {"feedback_rating", "feedback_comment"}
+    submit = call.kwargs["blocks"][-1]["elements"][0]
+    assert submit["value"] == "run-1"
+    assert submit["action_id"] == "open_swe_feedback_submit"
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["prompted"] is True
 
 
@@ -402,19 +459,6 @@ async def test_invalid_comment_keeps_modal_open(
 
 
 @pytest.mark.asyncio
-async def test_rating_failure_does_not_acknowledge_success(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(fake_store, "put_item", AsyncMock(side_effect=RuntimeError("unavailable")))
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action()), tasks)
-    await tasks()
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    assert "could not be saved" in feedback.post_slack_ephemeral_message.await_args.args[2]
-    feedback.respond_to_slack_interaction.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_comment_submission_replaces_the_prompt_that_opened_the_modal(context: Any) -> None:
     tasks = BackgroundTasks()
     await routes.slack_interactivity(_request(_action("open_swe_feedback_comment")), tasks)
@@ -469,7 +513,7 @@ async def test_dismiss_removes_prompt_without_saving_feedback(
 async def test_message_update_failure_preserves_feedback_without_posting_another_prompt(
     context: Any, fake_store: Any, missing_url: bool
 ) -> None:
-    payload = _action()
+    payload = _inline_submission()
     if missing_url:
         payload.pop("response_url")
     feedback.respond_to_slack_interaction.return_value = False
@@ -478,11 +522,7 @@ async def test_message_update_failure_preserves_feedback_without_posting_another
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
     feedback.create_langsmith_thread_feedback.assert_awaited_once()
-    if missing_url:
-        feedback.post_slack_ephemeral_message.assert_awaited_once()
-        assert "saved" in feedback.post_slack_ephemeral_message.await_args.args[2]
-    else:
-        feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -494,38 +534,12 @@ async def test_dismiss_failure_preserves_prompt_and_reports_retry(
     await routes.slack_interactivity(_request(_action("open_swe_feedback_dismiss")), tasks)
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
-    assert "could not be dismissed" in feedback.post_slack_ephemeral_message.await_args.args[2]
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_delayed_rating_ack_does_not_restore_buttons_after_comment_save(
-    context: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    started, finish = asyncio.Event(), asyncio.Event()
-
-    async def respond(*args: Any) -> bool:
-        if not started.is_set():
-            started.set()
-            await finish.wait()
-        return True
-
-    response_mock = AsyncMock(side_effect=respond)
-    monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
-    async with asyncio.timeout(2):
-        rating_task = asyncio.create_task(feedback._process_rating(_action()))
-        await started.wait()
-        tasks = BackgroundTasks()
-        assert await routes.slack_interactivity(_request(_submission("Helpful")), tasks) == {}
-        comment_task = asyncio.create_task(tasks())
-        finish.set()
-        await asyncio.gather(rating_task, comment_task)
-    message = response_mock.await_args.args[1]
-    assert all("accessory" not in block and "elements" not in block for block in message["blocks"])
-
-
-@pytest.mark.asyncio
-async def test_dismiss_during_failed_rating_update_prevents_later_acknowledgments(
+async def test_dismiss_during_failed_submission_update_prevents_later_acknowledgments(
     context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     started, finish = asyncio.Event(), asyncio.Event()
@@ -540,7 +554,7 @@ async def test_dismiss_during_failed_rating_update_prevents_later_acknowledgment
     response_mock = AsyncMock(side_effect=respond)
     monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
     async with asyncio.timeout(2):
-        rating_task = asyncio.create_task(feedback._process_rating(_action()))
+        rating_task = asyncio.create_task(feedback._process_submission(_inline_submission()))
         await started.wait()
         dismiss_task = asyncio.create_task(
             feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
@@ -551,8 +565,7 @@ async def test_dismiss_during_failed_rating_update_prevents_later_acknowledgment
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["dismissed"] is True
     response_mock.reset_mock()
     await feedback._acknowledge(
-        feedback.ThreadFeedback(**context, rating=5),
-        with_comment_button=True,
+        feedback.ThreadFeedback(**context, rating=5, completed=True),
         response_url=_RESPONSE_URL,
     )
     response_mock.assert_not_awaited()
@@ -593,21 +606,9 @@ async def test_langsmith_failure_preserves_saved_feedback(
 ) -> None:
     monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", AsyncMock(return_value=False))
     tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action()), tasks)
+    await routes.slack_interactivity(_request(_inline_submission()), tasks)
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
-
-
-@pytest.mark.asyncio
-async def test_modal_open_failure_offers_retry(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 5})
-    monkeypatch.setattr(feedback, "open_slack_modal", AsyncMock(return_value=False))
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action("open_swe_feedback_comment")), tasks)
-    await tasks()
-    assert "could not be opened" in feedback.post_slack_ephemeral_message.await_args.args[2]
 
 
 @pytest.mark.asyncio
@@ -678,20 +679,6 @@ async def test_ineligible_completion_does_not_prompt(
         {"thread_id": "thread-1", "run_id": "run-1", "status": status, "metadata": {"kind": kind}}
     )
     prompt.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_older_rating_retry_does_not_revert_newer_feedback(
-    context: Any, fake_store: Any
-) -> None:
-    for rating, timestamp in [(2, "3.0"), (5, "4.0"), (2, "3.0")]:
-        payload = _action(f"open_swe_feedback_rate_{rating}")
-        payload["actions"][0]["action_ts"] = timestamp
-        tasks = BackgroundTasks()
-        await routes.slack_interactivity(_request(payload), tasks)
-        await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
-    assert feedback.create_langsmith_thread_feedback.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -820,7 +807,7 @@ async def test_followup_prompts_only_thread_initiator(
     assert record["user_id"] == "U1"
     other_user_rating = _action()
     other_user_rating["user"]["id"] = "U2"
-    await feedback._process_rating(other_user_rating)
+    await feedback._process_submission({**_inline_submission(), "user": {"id": "U2"}})
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] is None
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
 
@@ -859,7 +846,7 @@ async def test_old_unsent_prompt_for_other_user_is_not_reassigned(
 
 
 @pytest.mark.asyncio
-async def test_rating_during_prompt_delivery_is_preserved(
+async def test_submission_during_prompt_delivery_is_preserved(
     context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "prompted": False})
@@ -878,7 +865,7 @@ async def test_rating_during_prompt_delivery_is_preserved(
             feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
         )
         await started.wait()
-        rating_task = asyncio.create_task(feedback._process_rating(_action()))
+        rating_task = asyncio.create_task(feedback._process_submission(_inline_submission()))
         finish_post.set()
         await asyncio.gather(prompt_task, rating_task)
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
@@ -886,75 +873,8 @@ async def test_rating_during_prompt_delivery_is_preserved(
     assert record["rating"] == 5
 
 
-@pytest.mark.asyncio
-async def test_slow_export_does_not_block_comment_save_or_revert_it(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 3})
-    stale_record = feedback.ThreadFeedback(**context, rating=3)
-    started = asyncio.Event()
-    finish_export = asyncio.Event()
-
-    async def export(*args: Any, **kwargs: Any) -> bool:
-        if not started.is_set():
-            started.set()
-            await finish_export.wait()
-        return True
-
-    export_mock = AsyncMock(side_effect=export)
-    monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", export_mock)
-    async with asyncio.timeout(2):
-        first = asyncio.create_task(feedback._export_feedback(stale_record))
-        await started.wait()
-        tasks = BackgroundTasks()
-        result = await routes.slack_interactivity(_request(_submission("Latest comment")), tasks)
-        assert result == {}
-        finish_export.set()
-        await asyncio.gather(first, tasks())
-    assert export_mock.await_args.kwargs["comment"] == "Latest comment"
-
-
 def test_prompt_without_dashboard_has_no_broken_link(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(feedback, "dashboard_thread_url", lambda _: None)
     text = feedback.rating_blocks("run-1", "thread-1")[0]["text"]["text"]
     assert "<" not in text
     assert "this thread" in text
-
-
-@pytest.mark.asyncio
-async def test_timed_out_export_releases_lock_for_newer_comment(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fake_store.seed(
-        ("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 3, "comment": "Original"}
-    )
-    original_timeout = asyncio.timeout
-    monkeypatch.setattr(asyncio, "timeout", lambda delay: original_timeout(delay / 100))
-    monkeypatch.setattr(
-        slack_client,
-        "_SLACK_THREAD_MUTATION_LOCK_TIMEOUT_SECONDS",
-        slack_client._SLACK_THREAD_MUTATION_LOCK_TIMEOUT_SECONDS / 100,
-    )
-    monkeypatch.setattr(slack_client, "_SLACK_THREAD_MUTATION_LOCK_RETRY_SECONDS", 0.001)
-    started = asyncio.Event()
-
-    async def export(*args: Any, **kwargs: Any) -> bool:
-        if not started.is_set():
-            started.set()
-            await asyncio.Event().wait()
-        return True
-
-    export_mock = AsyncMock(side_effect=export)
-    monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", export_mock)
-    stale_record = feedback.ThreadFeedback(**context, rating=3, comment="Original")
-    async with original_timeout(1):
-        first = asyncio.create_task(feedback._export_feedback(stale_record))
-        await started.wait()
-        fake_store.seed(
-            ("slack_thread_feedback", "C1"),
-            "run-1",
-            {**context, "rating": 3, "comment": "Latest comment"},
-        )
-        await asyncio.gather(first, feedback._export_feedback(stale_record))
-    assert export_mock.await_count == 2
-    assert export_mock.await_args.kwargs["comment"] == "Latest comment"

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -199,6 +199,105 @@ async def test_older_invalid_submit_cannot_replace_newer_emoji_selection(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "old_rating,comment", [(2, "Submitted comment"), (2, ""), (None, "Comment only"), (None, "")]
+)
+async def test_selection_delayed_before_lookup_reconciles_submitted_feedback(
+    context: Any,
+    fake_store: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    old_rating: int | None,
+    comment: str,
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+    original_load = feedback._load_feedback
+
+    async def load(channel_id: str, run_id: str, user_id: str) -> Any:
+        if not started.is_set():
+            started.set()
+            await finish.wait()
+        return await original_load(channel_id, run_id, user_id)
+
+    monkeypatch.setattr(feedback, "_load_feedback", load)
+    payload = _inline_submission(old_rating, comment)
+    payload["actions"][0]["action_ts"] = "4.0"
+    async with asyncio.timeout(2):
+        selection_task = asyncio.create_task(
+            feedback._select_feedback_rating(
+                _select_rating(5, "Unsubmitted draft", timestamp="3.0")
+            )
+        )
+        await started.wait()
+        await feedback._process_submission(payload)
+        finish.set()
+        await selection_task
+
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (saved["rating"], saved["comment"], saved["completed"]) == (5, comment, True)
+    assert saved["submitted_at"] == "4.0"
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 1.0
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == (
+        comment or None
+    )
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    assert "completed" in message["text"].lower()
+    assert all(block["type"] not in {"input", "actions"} for block in message["blocks"])
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_selection_after_submit_cannot_change_completed_feedback(
+    context: Any, fake_store: Any
+) -> None:
+    payload = _inline_submission(4, "Final comment")
+    payload["actions"][0]["action_ts"] = "4.0"
+    await feedback._process_submission(payload)
+    previous = dict(fake_store.values(("slack_thread_feedback", "C1"))["run-1"])
+    feedback.respond_to_slack_interaction.reset_mock()
+    feedback.create_langsmith_thread_feedback.reset_mock()
+
+    await feedback._select_feedback_rating(_select_rating(1, "Later draft", timestamp="5.0"))
+
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_older_empty_submit_cannot_replace_newer_pending_submission(
+    context: Any, fake_store: Any
+) -> None:
+    for timestamp in ("5.0", "4.0"):
+        payload = _inline_submission(None, "")
+        payload["actions"][0]["action_ts"] = timestamp
+        await feedback._process_submission(payload)
+    await feedback._select_feedback_rating(_select_rating(5, timestamp="4.5"))
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (saved["rating"], saved["completed"], saved["submitted_at"]) == (5, True, "5.0")
+
+
+@pytest.mark.asyncio
+async def test_retrying_completed_submit_cannot_extend_selection_cutoff(
+    context: Any, fake_store: Any
+) -> None:
+    original = _inline_submission(4, "Final comment")
+    original["actions"][0]["action_ts"] = "4.0"
+    await feedback._process_submission(original)
+    previous = dict(fake_store.values(("slack_thread_feedback", "C1"))["run-1"])
+
+    retry = _inline_submission(1, "Stale submission")
+    retry["actions"][0]["action_ts"] = "6.0"
+    await feedback._process_submission(retry)
+    await feedback._select_feedback_rating(_select_rating(5, timestamp="5.0"))
+
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved == previous
+    assert saved["submitted_at"] == "4.0"
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.75
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == "Final comment"
+
+
+@pytest.mark.asyncio
 async def test_failed_emoji_selection_can_be_retried(context: Any, fake_store: Any) -> None:
     feedback.respond_to_slack_interaction.side_effect = [False, True]
     payload = _select_rating(4, "Keep my draft")
@@ -375,7 +474,8 @@ async def test_invalid_inline_submission_keeps_prompt_open(
     tasks = BackgroundTasks()
     await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
     await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert not saved.get("completed") and not saved.get("rating") and not saved.get("comment")
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     message = feedback.respond_to_slack_interaction.await_args.args[1]
     assert message["replace_original"] is True
@@ -749,16 +849,66 @@ async def test_message_update_failure_preserves_feedback_without_posting_another
 
 
 @pytest.mark.asyncio
-async def test_dismiss_failure_preserves_prompt_and_reports_retry(
-    context: Any, fake_store: Any
-) -> None:
+async def test_dismiss_failure_keeps_feedback_submittable(context: Any, fake_store: Any) -> None:
     feedback.respond_to_slack_interaction.return_value = False
     tasks = BackgroundTasks()
     await routes.slack_interactivity(_request(_action("open_swe_feedback_dismiss")), tasks)
     await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert not saved.get("dismissed")
     feedback.post_slack_ephemeral_message.assert_not_awaited()
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    await feedback._process_submission(_inline_submission(4, "Retry after failed dismissal"))
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved["completed"] and saved["rating"] == 4
+
+
+@pytest.mark.asyncio
+async def test_dismiss_storage_failure_does_not_delete_prompt(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fake_store, "put_item", AsyncMock(side_effect=RuntimeError("unavailable")))
+    await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+
+
+@pytest.mark.asyncio
+async def test_dismiss_retry_after_failed_rollback_cannot_save_late_feedback(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_put = fake_store.put_item
+    writes = 0
+
+    async def put(*args: Any, **kwargs: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        if writes == 2:
+            raise RuntimeError("rollback unavailable")
+        return await original_put(*args, **kwargs)
+
+    monkeypatch.setattr(fake_store, "put_item", put)
+    feedback.respond_to_slack_interaction.side_effect = [False, True]
+    await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
+    await feedback._process_submission(_inline_submission())
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["dismissed"]
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
+    assert feedback.respond_to_slack_interaction.await_count == 2
+    assert feedback.respond_to_slack_interaction.await_args.args[1] == {"delete_original": True}
+
+
+@pytest.mark.asyncio
+async def test_dismiss_preserves_already_submitted_feedback(context: Any, fake_store: Any) -> None:
+    await feedback._process_submission(_inline_submission(4, "Submitted"))
+    await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (saved["rating"], saved["comment"], saved["completed"], saved["dismissed"]) == (
+        4,
+        "Submitted",
+        True,
+        True,
+    )
 
 
 @pytest.mark.asyncio
@@ -796,7 +946,7 @@ async def test_dismiss_during_failed_submission_update_prevents_later_acknowledg
 
 
 @pytest.mark.asyncio
-async def test_comment_saved_during_dismissal_is_preserved(
+async def test_late_comment_during_dismissal_is_not_saved(
     context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     started, finish = asyncio.Event(), asyncio.Event()
@@ -818,9 +968,9 @@ async def test_comment_saved_during_dismissal_is_preserved(
         finish.set()
         await asyncio.gather(dismiss_task, tasks())
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert saved["comment"] == "Helpful"
+    assert not saved["comment"]
     assert saved["dismissed"] is True
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == "Helpful"
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -17,7 +17,230 @@ from agent.slack import thread_feedback as feedback
 _RESPONSE_URL = "https://hooks.slack.com/actions/T1/B1/test-response"
 
 
+def _select_rating(rating: int, comment: str = "", timestamp: str = "3.0") -> dict[str, Any]:
+    payload = _action(f"open_swe_feedback_select_{rating}")
+    payload["actions"][0]["action_ts"] = timestamp
+    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": comment}}}}
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_emoji_selection_preserves_comment_and_submits_both(
+    context: Any, fake_store: Any
+) -> None:
+    blocks = feedback.rating_blocks("run-1", "thread-1")
+    ratings = next(
+        block["elements"] for block in blocks if block.get("block_id") == "feedback_rating"
+    )
+    assert len(ratings) == 5
+    assert all(element["type"] == "button" for element in ratings)
+    assert [element["text"]["text"].split()[0] for element in ratings] == [
+        "😡",
+        "🙁",
+        "😐",
+        "🙂",
+        "😍",
+    ]
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_select_rating(4, "Keep my comment")), tasks)
+    await tasks()
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    ratings = next(
+        block["elements"]
+        for block in message["blocks"]
+        if block.get("block_id") == "feedback_rating"
+    )
+    assert [button["action_id"] for button in ratings if button.get("style") == "primary"] == [
+        "open_swe_feedback_select_4"
+    ]
+    comment = next(block["element"] for block in message["blocks"] if block["type"] == "input")
+    assert comment["initial_value"] == "Keep my comment"
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert record.get("rating") is None
+    assert not record.get("comment") and not record.get("completed")
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    submit = message["blocks"][-1]["elements"][0]
+    payload = _action(submit["action_id"], submit["value"])
+    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": "Final comment"}}}}
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (record["rating"], record["comment"], record["completed"]) == (4, "Final comment", True)
+
+
+@pytest.mark.asyncio
+async def test_older_emoji_click_cannot_replace_newer_selection(context: Any) -> None:
+    for rating, timestamp in [(5, "4.0"), (2, "3.0")]:
+        tasks = BackgroundTasks()
+        await routes.slack_interactivity(
+            _request(_select_rating(rating, timestamp=timestamp)), tasks
+        )
+        await tasks()
+    feedback.respond_to_slack_interaction.assert_awaited_once()
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    selected = next(
+        button
+        for block in message["blocks"]
+        if block.get("block_id") == "feedback_rating"
+        for button in block["elements"]
+        if button.get("style") == "primary"
+    )
+    assert selected["action_id"] == "open_swe_feedback_select_5"
+
+
+@pytest.mark.asyncio
+async def test_submit_during_emoji_update_uses_latest_selection(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+
+    async def respond(url: str, message: dict[str, Any]) -> bool:
+        if not started.is_set():
+            started.set()
+            await finish.wait()
+        return True
+
+    monkeypatch.setattr(feedback, "respond_to_slack_interaction", AsyncMock(side_effect=respond))
+    writes = AsyncMock(wraps=fake_store.put_item)
+    monkeypatch.setattr(fake_store, "put_item", writes)
+    old_submit = feedback.rating_blocks("run-1", "thread-1", rating=2)[-1]["elements"][0]
+    payload = _action(old_submit["action_id"], old_submit["value"])
+    payload["actions"][0]["action_ts"] = "4.0"
+    payload["state"] = {
+        "values": {"feedback_comment": {"comment": {"value": "Final submitted comment"}}}
+    }
+    async with asyncio.timeout(2):
+        selection_task = asyncio.create_task(
+            feedback._select_feedback_rating(_select_rating(5, "Earlier draft", timestamp="3.0"))
+        )
+        await started.wait()
+        submit_task = asyncio.create_task(feedback._process_submission(payload))
+        await asyncio.sleep(0)
+        finish.set()
+        await asyncio.gather(selection_task, submit_task)
+
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (saved["rating"], saved["comment"], saved["completed"]) == (
+        5,
+        "Final submitted comment",
+        True,
+    )
+    assert sum(call.args[2].get("completed") is True for call in writes.await_args_list) == 1
+    feedback.create_langsmith_thread_feedback.assert_awaited_once()
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 1.0
+    assert (
+        feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
+        == "Final submitted comment"
+    )
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_emoji_selection_after_pending_error_preserves_new_draft(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+
+    async def respond(url: str, message: dict[str, Any]) -> bool:
+        if not started.is_set():
+            assert "before submitting" in message["text"]
+            started.set()
+            await finish.wait()
+        return True
+
+    response_mock = AsyncMock(side_effect=respond)
+    monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
+    invalid_payload = _inline_submission(None, "")
+    invalid_payload["actions"][0]["action_ts"] = "3.0"
+    async with asyncio.timeout(2):
+        invalid_task = asyncio.create_task(feedback._process_submission(invalid_payload))
+        await started.wait()
+        selection_task = asyncio.create_task(
+            feedback._select_feedback_rating(_select_rating(5, "Latest draft", timestamp="4.0"))
+        )
+        await asyncio.sleep(0)
+        finish.set()
+        await asyncio.gather(invalid_task, selection_task)
+
+    assert response_mock.await_count == 2
+    message = response_mock.await_args.args[1]
+    ratings = next(
+        block["elements"]
+        for block in message["blocks"]
+        if block.get("block_id") == "feedback_rating"
+    )
+    assert [button["action_id"] for button in ratings if button.get("style") == "primary"] == [
+        "open_swe_feedback_select_5"
+    ]
+    comment = next(block["element"] for block in message["blocks"] if block["type"] == "input")
+    assert comment["initial_value"] == "Latest draft"
+    assert json.loads(message["blocks"][-1]["elements"][0]["value"])["rating"] == 5
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert not saved.get("completed")
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_older_invalid_submit_cannot_replace_newer_emoji_selection(
+    context: Any, fake_store: Any
+) -> None:
+    await feedback._select_feedback_rating(_select_rating(5, "Latest draft", timestamp="4.0"))
+    invalid_payload = _inline_submission(None, "")
+    invalid_payload["actions"][0]["action_ts"] = "3.0"
+    await feedback._process_submission(invalid_payload)
+
+    feedback.respond_to_slack_interaction.assert_awaited_once()
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert not saved.get("completed")
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_emoji_selection_can_be_retried(context: Any, fake_store: Any) -> None:
+    feedback.respond_to_slack_interaction.side_effect = [False, True]
+    payload = _select_rating(4, "Keep my draft")
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    assert feedback.respond_to_slack_interaction.await_count == 2
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    submit = message["blocks"][-1]["elements"][0]
+    assert json.loads(submit["value"])["rating"] == 4
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["completed", "dismissed"])
+async def test_emoji_selection_cannot_reopen_finished_feedback(
+    context: Any, fake_store: Any, status: str
+) -> None:
+    record = {**context, status: True}
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", record)
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_select_rating(4)), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == record
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+
+
 def _inline_submission(rating: int | None = 5, comment: str = "Helpful") -> dict[str, Any]:
+    payload = _action(
+        "open_swe_feedback_submit",
+        json.dumps({"run_id": "run-1", "rating": rating}) if rating is not None else "run-1",
+    )
+    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": comment}}}}
+    return payload
+
+
+def _legacy_inline_submission(rating: int | None = 5, comment: str = "Helpful") -> dict[str, Any]:
     payload = _action("open_swe_feedback_submit")
     payload["state"] = {
         "values": {
@@ -33,18 +256,14 @@ def _inline_submission(rating: int | None = 5, comment: str = "Helpful") -> dict
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("legacy", [False, True])
 async def test_inline_rating_and_comment_submit_together_and_complete(
-    context: Any, fake_store: Any
+    context: Any, fake_store: Any, legacy: bool
 ) -> None:
-    blocks = feedback.rating_blocks("run-1", "thread-1")
-    assert {block["element"]["type"] for block in blocks if block["type"] == "input"} == {
-        "radio_buttons",
-        "plain_text_input",
-    }
     tasks = BackgroundTasks()
+    submission = _legacy_inline_submission if legacy else _inline_submission
     assert (
-        await routes.slack_interactivity(_request(_inline_submission(4, "  Very helpful  ")), tasks)
-        == {}
+        await routes.slack_interactivity(_request(submission(4, "  Very helpful  ")), tasks) == {}
     )
     await tasks()
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
@@ -87,7 +306,12 @@ async def test_inline_save_failure_keeps_draft_in_original_message(
         for block in message["blocks"]
         if block["type"] == "input"
     }
-    assert inputs["feedback_rating"]["initial_option"]["value"] == "3"
+    submit = message["blocks"][-1]["elements"][0]
+    assert json.loads(submit["value"]) == {
+        "run_id": "run-1",
+        "rating": 3,
+        "selection_ts": "0",
+    }
     assert inputs["feedback_comment"]["initial_value"] == "Keep this draft"
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     feedback.post_slack_ephemeral_message.assert_not_awaited()
@@ -118,10 +342,11 @@ async def test_inline_optional_fields_and_rating_scale(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("change", ["other_user", "other_channel", "unknown_run", "external"])
-async def test_inline_submission_requires_prompt_recipient(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, change: str
+@pytest.mark.parametrize("selecting", [False, True])
+async def test_feedback_interaction_requires_prompt_recipient(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, change: str, selecting: bool
 ) -> None:
-    payload = _inline_submission()
+    payload = _select_rating(4) if selecting else _inline_submission()
     if change == "other_user":
         payload["user"]["id"] = "U2"
     elif change == "other_channel":
@@ -181,7 +406,7 @@ async def test_legacy_rating_button_opens_combined_form_without_saving(
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     payload = _submission("Combined")
     payload["view"]["private_metadata"] = view["private_metadata"]
-    payload["view"]["state"] = _inline_submission(4, "Combined")["state"]
+    payload["view"]["state"] = _legacy_inline_submission(4, "Combined")["state"]
     submit_tasks = BackgroundTasks()
     assert await routes.slack_interactivity(_request(payload), submit_tasks) == {}
     await submit_tasks()
@@ -384,8 +609,6 @@ async def test_prompt_uses_exact_run_mapping_and_deduplicates(
         await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
     feedback.post_slack_ephemeral_message.assert_awaited_once()
     call = feedback.post_slack_ephemeral_message.await_args
-    inputs = [block for block in call.kwargs["blocks"] if block["type"] == "input"]
-    assert {block["block_id"] for block in inputs} == {"feedback_rating", "feedback_comment"}
     submit = call.kwargs["blocks"][-1]["elements"][0]
     assert submit["value"] == "run-1"
     assert submit["action_id"] == "open_swe_feedback_submit"

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -15,6 +15,8 @@ from agent.slack import client as slack_client
 from agent.slack import routes
 from agent.slack import thread_feedback as feedback
 
+_RESPONSE_URL = "https://hooks.slack.com/actions/T1/B1/test-response"
+
 
 def _request(payload: dict[str, Any]) -> Request:
     body = urlencode({"payload": json.dumps(payload)}).encode()
@@ -44,6 +46,7 @@ def context(monkeypatch: pytest.MonkeyPatch, fake_store: Any) -> dict[str, Any]:
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
     monkeypatch.setattr(feedback, "post_slack_ephemeral_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(feedback, "respond_to_slack_interaction", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "open_slack_modal", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", AsyncMock(return_value=True))
     client = AsyncMock()
@@ -79,6 +82,7 @@ def _action(action_id: str = "open_swe_feedback_rate_5", value: str = "run-1") -
     return {
         "type": "block_actions",
         "trigger_id": "trigger-1",
+        "response_url": _RESPONSE_URL,
         "channel": {"id": "C1"},
         "user": {"id": "U1"},
         "actions": [{"action_id": action_id, "value": value, "action_ts": "3.0"}],
@@ -111,10 +115,17 @@ async def test_rating_is_saved_privately_without_starting_agent(
             "run_id": "run-1",
         },
     )
-    call = feedback.post_slack_ephemeral_message.await_args
-    assert call.args[:2] == ("C1", "U1")
-    assert call.kwargs["thread_ts"] == "1.0"
-    assert call.kwargs["blocks"][0]["accessory"]["action_id"] == "open_swe_feedback_comment"
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    url, message = feedback.respond_to_slack_interaction.await_args.args
+    assert url == _RESPONSE_URL
+    assert message["replace_original"] is True
+    assert message["response_type"] == "ephemeral"
+    assert message["blocks"][0]["accessory"]["action_id"] == "open_swe_feedback_comment"
+    assert not any(
+        element["action_id"].startswith("open_swe_feedback_rate_")
+        for block in message["blocks"]
+        for element in block.get("elements", [])
+    )
 
 
 @pytest.mark.asyncio
@@ -167,7 +178,11 @@ async def test_comment_modal_opens_with_saved_rating_and_comment(
     feedback.open_slack_modal.assert_awaited_once()
     trigger_id, view = feedback.open_slack_modal.await_args.args
     assert trigger_id == "trigger-1"
-    assert json.loads(view["private_metadata"]) == {"channel_id": "C1", "run_id": "run-1"}
+    assert json.loads(view["private_metadata"]) == {
+        "channel_id": "C1",
+        "run_id": "run-1",
+        "response_url": _RESPONSE_URL,
+    }
     assert view["blocks"][-1]["element"]["initial_value"] == "Useful"
 
 
@@ -191,7 +206,9 @@ def _submission(comment: str = "Please run the tests next time.") -> dict[str, A
         "user": {"id": "U1"},
         "view": {
             "callback_id": "open_swe_feedback_comment",
-            "private_metadata": json.dumps({"channel_id": "C1", "run_id": "run-1"}),
+            "private_metadata": json.dumps(
+                {"channel_id": "C1", "run_id": "run-1", "response_url": _RESPONSE_URL}
+            ),
             "state": {"values": {"feedback_comment": {"comment": {"value": comment}}}},
         },
     }
@@ -244,6 +261,10 @@ async def test_comment_only_feedback_exports_without_inventing_rating(
         == {}
     )
     await tasks()
+    message = feedback.respond_to_slack_interaction.await_args.args[1]
+    assert message["replace_original"] is True
+    assert all("accessory" not in block and "elements" not in block for block in message["blocks"])
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert record["comment"] == "Helpful explanation"
     assert record["rating"] is None
@@ -282,6 +303,7 @@ async def test_storage_failure_keeps_comment_modal_open(
     assert result["response_action"] == "errors"
     assert "feedback_comment" in result["errors"]
     assert tasks.tasks == []
+    feedback.respond_to_slack_interaction.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -302,7 +324,12 @@ async def test_prompt_uses_exact_run_mapping_and_deduplicates(
         await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
     feedback.post_slack_ephemeral_message.assert_awaited_once()
     call = feedback.post_slack_ephemeral_message.await_args
-    buttons = call.kwargs["blocks"][-1]["elements"]
+    buttons = [
+        element
+        for block in call.kwargs["blocks"]
+        for element in block.get("elements", [])
+        if element["action_id"].startswith("open_swe_feedback_rate_")
+    ]
     assert len(buttons) == 5
     assert [b["value"] for b in buttons] == ["run-1"] * 5
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["prompted"] is True
@@ -384,6 +411,180 @@ async def test_rating_failure_does_not_acknowledge_success(
     await tasks()
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     assert "could not be saved" in feedback.post_slack_ephemeral_message.await_args.args[2]
+    feedback.respond_to_slack_interaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_comment_submission_replaces_the_prompt_that_opened_the_modal(context: Any) -> None:
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_action("open_swe_feedback_comment")), tasks)
+    view = feedback.open_slack_modal.await_args.args[1]
+    payload = _submission("Helpful")
+    payload["view"]["private_metadata"] = view["private_metadata"]
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    url, message = feedback.respond_to_slack_interaction.await_args.args
+    assert url == _RESPONSE_URL
+    assert message["replace_original"] is True
+    assert all("accessory" not in block and "elements" not in block for block in message["blocks"])
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("other_user", [False, True])
+async def test_dismiss_removes_prompt_without_saving_feedback(
+    context: Any, fake_store: Any, other_user: bool
+) -> None:
+    button = next(
+        element
+        for block in feedback.rating_blocks("run-1", "thread-1")
+        for element in block.get("elements", [])
+        if element["action_id"] == "open_swe_feedback_dismiss"
+    )
+    payload = _action(button["action_id"], button["value"])
+    if other_user:
+        payload["user"]["id"] = "U2"
+    tasks = BackgroundTasks()
+    assert await routes.slack_interactivity(_request(payload), tasks) == {}
+    await tasks()
+    if other_user:
+        feedback.respond_to_slack_interaction.assert_not_awaited()
+    else:
+        feedback.respond_to_slack_interaction.assert_awaited_once_with(
+            _RESPONSE_URL, {"delete_original": True}
+        )
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert all(saved[key] == value for key, value in context.items())
+    assert saved.get("dismissed", False) is not other_user
+    assert saved.get("rating") is None
+    assert not saved.get("comment")
+    await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing_url", [False, True])
+async def test_message_update_failure_preserves_feedback_without_posting_another_prompt(
+    context: Any, fake_store: Any, missing_url: bool
+) -> None:
+    payload = _action()
+    if missing_url:
+        payload.pop("response_url")
+    feedback.respond_to_slack_interaction.return_value = False
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
+    feedback.create_langsmith_thread_feedback.assert_awaited_once()
+    if missing_url:
+        feedback.post_slack_ephemeral_message.assert_awaited_once()
+        assert "saved" in feedback.post_slack_ephemeral_message.await_args.args[2]
+    else:
+        feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_failure_preserves_prompt_and_reports_retry(
+    context: Any, fake_store: Any
+) -> None:
+    feedback.respond_to_slack_interaction.return_value = False
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(_action("open_swe_feedback_dismiss")), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
+    assert "could not be dismissed" in feedback.post_slack_ephemeral_message.await_args.args[2]
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delayed_rating_ack_does_not_restore_buttons_after_comment_save(
+    context: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+
+    async def respond(*args: Any) -> bool:
+        if not started.is_set():
+            started.set()
+            await finish.wait()
+        return True
+
+    response_mock = AsyncMock(side_effect=respond)
+    monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
+    async with asyncio.timeout(2):
+        rating_task = asyncio.create_task(feedback._process_rating(_action()))
+        await started.wait()
+        tasks = BackgroundTasks()
+        assert await routes.slack_interactivity(_request(_submission("Helpful")), tasks) == {}
+        comment_task = asyncio.create_task(tasks())
+        finish.set()
+        await asyncio.gather(rating_task, comment_task)
+    message = response_mock.await_args.args[1]
+    assert all("accessory" not in block and "elements" not in block for block in message["blocks"])
+
+
+@pytest.mark.asyncio
+async def test_dismiss_during_failed_rating_update_prevents_later_acknowledgments(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+
+    async def respond(url: str, message: dict[str, Any]) -> bool:
+        if message.get("replace_original"):
+            started.set()
+            await finish.wait()
+            return False
+        return True
+
+    response_mock = AsyncMock(side_effect=respond)
+    monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
+    async with asyncio.timeout(2):
+        rating_task = asyncio.create_task(feedback._process_rating(_action()))
+        await started.wait()
+        dismiss_task = asyncio.create_task(
+            feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
+        )
+        await asyncio.sleep(0)
+        finish.set()
+        await asyncio.gather(rating_task, dismiss_task)
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["dismissed"] is True
+    response_mock.reset_mock()
+    await feedback._acknowledge(
+        feedback.ThreadFeedback(**context, rating=5),
+        with_comment_button=True,
+        response_url=_RESPONSE_URL,
+    )
+    response_mock.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_comment_saved_during_dismissal_is_preserved(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+
+    async def respond(url: str, message: dict[str, Any]) -> bool:
+        assert message == {"delete_original": True}
+        started.set()
+        await finish.wait()
+        return True
+
+    monkeypatch.setattr(feedback, "respond_to_slack_interaction", AsyncMock(side_effect=respond))
+    async with asyncio.timeout(2):
+        dismiss_task = asyncio.create_task(
+            feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
+        )
+        await started.wait()
+        tasks = BackgroundTasks()
+        assert await routes.slack_interactivity(_request(_submission("Helpful")), tasks) == {}
+        finish.set()
+        await asyncio.gather(dismiss_task, tasks())
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved["comment"] == "Helpful"
+    assert saved["dismissed"] is True
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == "Helpful"
 
 
 @pytest.mark.asyncio

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -47,6 +47,17 @@ def context(monkeypatch: pytest.MonkeyPatch, fake_store: Any) -> dict[str, Any]:
     monkeypatch.setattr(feedback, "open_slack_modal", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", AsyncMock(return_value=True))
     client = AsyncMock()
+    client.threads.get.return_value = {
+        "metadata": {
+            "source_context": {
+                "slack_thread": {
+                    "channel_id": "C1",
+                    "thread_ts": "1.0",
+                    "triggering_user_id": "U1",
+                }
+            }
+        }
+    }
     locks: set[str] = set()
 
     async def acquire(*, thread_id: str, **kwargs: Any) -> None:
@@ -417,7 +428,7 @@ async def test_failed_prompt_can_be_retried(
     [
         None,
         {"run_id": "run-2"},
-        {"run_id": "run-1", "thread_ts": "1.0", "message_ts": "2.0"},
+        {"run_id": "run-1", "message_ts": "2.0"},
         {"run_id": "run-1", "thread_ts": "1.0", "triggering_user_id": "U1"},
     ],
 )
@@ -488,6 +499,9 @@ async def test_older_rating_retry_does_not_revert_newer_feedback(
 async def test_concurrent_completion_callbacks_post_one_prompt(
     context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, second_run: str, thread_ts: str
 ) -> None:
+    feedback.langgraph_client().threads.get.return_value["metadata"]["source_context"][
+        "slack_thread"
+    ]["thread_ts"] = thread_ts
     for run_id, message_ts in [("run-1", "2.0"), ("run-2", "3.0")]:
         fake_store.seed(
             ("slack_thread_feedback", "C1"),
@@ -521,7 +535,7 @@ async def test_concurrent_completion_callbacks_post_one_prompt(
         ({}, {}, False),
         ({}, {"agent_thread_id": "thread-2"}, False),
         ({}, {"thread_ts": "4.0"}, True),
-        ({}, {"user_id": "U2"}, True),
+        ({}, {"user_id": "U2"}, False),
         ({}, {"channel_id": "C2"}, True),
         ({"thread_ts": "0"}, {"thread_ts": "0"}, False),
         ({"thread_ts": "0"}, {"thread_ts": "0", "agent_thread_id": "thread-2"}, True),
@@ -539,6 +553,10 @@ async def test_prompt_deduplicates_existing_records_by_requester_and_slack_threa
     previous = {**context, "rating": 4, "comment": "Useful", **previous_changes}
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", previous)
     current = {**context, "run_id": "run-2", "message_ts": "3.0", **current_changes}
+    origin = feedback.langgraph_client().threads.get.return_value["metadata"]["source_context"][
+        "slack_thread"
+    ]
+    origin.update(channel_id=current["channel_id"], thread_ts=current["thread_ts"])
     monkeypatch.setattr(
         feedback,
         "lookup_slack_run_message_mapping",
@@ -561,6 +579,82 @@ async def test_prompt_deduplicates_existing_records_by_requester_and_slack_threa
     assert ("run-2" in fake_store.values(("slack_thread_feedback", current["channel_id"]))) == (
         should_prompt
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("merged_pr", [False, True])
+async def test_followup_prompts_only_thread_initiator(
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, merged_pr: bool
+) -> None:
+    fake_store.values(("slack_thread_feedback", "C1")).clear()
+    monkeypatch.setattr(
+        feedback,
+        "lookup_slack_run_message_mapping",
+        AsyncMock(
+            return_value={
+                "run_id": "run-1",
+                "triggering_user_id": "U2",
+                "thread_ts": "1.0",
+                "message_ts": "2.0",
+                "should_ask_for_feedback": True,
+            }
+        ),
+    )
+    if merged_pr:
+        await feedback.post_slack_pr_feedback_prompt(
+            "thread-1",
+            {
+                "pull_requests": [
+                    {"url": "pr-url", "slack_feedback": {"run_id": "run-1", "channel_id": "C1"}}
+                ]
+            },
+            "pr-url",
+        )
+    else:
+        await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1", require_answer=True)
+
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    assert feedback.post_slack_ephemeral_message.await_args.args[:2] == ("C1", "U1")
+    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert record["user_id"] == "U1"
+    other_user_rating = _action()
+    other_user_rating["user"]["id"] = "U2"
+    await feedback._process_rating(other_user_rating)
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] is None
+    feedback.create_langsmith_thread_feedback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "origin",
+    [
+        None,
+        {},
+        {"channel_id": "C1", "thread_ts": "1.0"},
+        {"channel_id": "C2", "thread_ts": "1.0", "triggering_user_id": "U1"},
+        {"channel_id": "C1", "thread_ts": "9.0", "triggering_user_id": "U1"},
+    ],
+)
+async def test_prompt_requires_known_initiator_at_same_slack_location(
+    context: Any, fake_store: Any, origin: Any
+) -> None:
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "prompted": False})
+    feedback.langgraph_client().threads.get.return_value = {
+        "metadata": {"source_context": {"slack_thread": origin}}
+    }
+    await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_old_unsent_prompt_for_other_user_is_not_reassigned(
+    context: Any, fake_store: Any
+) -> None:
+    previous = {**context, "user_id": "U2", "prompted": False, "rating": 4}
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", previous)
+    await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Multiple successful runs or participants in one Slack thread could each trigger a feedback prompt. Rating and comments also used separate submissions, leaving controls active after feedback was saved.

Prompt only the person who originally started Open SWE in the thread, once, after an eligible answer or PR merge. The private message contains a horizontal row of emoji rating buttons, a comment field, Submit feedback, and Dismiss together. Selecting an emoji highlights the draft rating and preserves the comment. Submit saves both fields together and marks the feedback completed, then replaces the entire prompt with one completed confirmation. Rating-only and comment-only submissions are supported. Repeated submissions cannot overwrite completed feedback.

Dismiss persists the dismissal before removing the prompt, preserving the message if storage fails and restoring the active state if Slack cannot delete it. Failed saves preserve the draft in the same message, and delayed saves cannot make dismissed prompts reappear. Selection and submission updates are serialized; Slack click timestamps also reconcile earlier rating clicks that arrive after Submit, preserving the submitted comment and rejecting clicks made after submission. Only completed feedback is exported to LangSmith. Existing rating/comment buttons remain usable through a combined form, and already-open older comment forms remain supported. Slack interaction response URLs update the private message without being stored in feedback records or logged.

Initiator identity comes from the preserved thread source context and must match the qualifying Slack location. Missing identity skips the prompt. Locking and deduplication use the thread and recipient, including prompts from before this change; code-channel sessions remain scoped to their agent thread.

Follow-up to #2547.
