### PR TITLE
ci: isolate Playwright from broken Chrome apt feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         run: pnpm install --frozen-lockfile --filter open-swe-dashboard... --filter open-swe --filter open-swe-e2e
       - name: Install Chromium
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/microsoft-prod.list
           pnpm run test:e2e:install
       - name: Run browser E2E
         run: pnpm run test:e2e --shard=${{ matrix.shard }}/3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         run: pnpm install --frozen-lockfile --filter open-swe-dashboard... --filter open-swe --filter open-swe-e2e
       - name: Install Chromium
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/{azure-cli,google-chrome,microsoft-prod}.*
           pnpm run test:e2e:install
       - name: Run browser E2E
         run: pnpm run test:e2e --shard=${{ matrix.shard }}/3


### PR DESCRIPTION
The browser E2E shards are failing before tests start because the GitHub runner's Google Chrome apt source is serving package metadata that does not match its release manifest. Remove that unrelated preinstalled source alongside the other third-party sources before Playwright installs Chromium dependencies, so apt only consults the Ubuntu repositories Playwright needs.

Made by [Open SWE](https://openswe.vercel.app/agents/fff39373-6c76-5c6a-965d-26f784dcc7e3) · openai:gpt-5.6-sol (high)