### PR TITLE
fix(ui): recover stuck pooled agent streams

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -46,6 +46,7 @@ import { useSession } from "@/lib/session"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 import { useAgentStream } from "@/features/agents/lib/stream/AgentStreamProvider"
+import { useReconcileStream } from "@/features/agents/lib/stream/useReconcileStream"
 
 interface AgentThreadViewProps {
   thread: AgentThread
@@ -88,6 +89,7 @@ export function AgentThreadView({
   const renameThread = useRenameAgentThread()
   const sendMessage = useSubmitAgentMessage(thread.id)
   const stream = useAgentStream()
+  useReconcileStream(thread.id, thread.status === "running")
   const isMobile = useIsMobile()
   const skills = useAgentSkills()
   const session = useSession()

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -599,10 +599,9 @@ export function useAgentThread(threadId: string) {
         ...(pendingMessages?.length ? { pendingMessages } : {}),
       }
     },
-    // Server truth heartbeat while a run is live. The SDK's SSE transport does
-    // not reconnect once a custom `fetch` is supplied (it needs the dashboard
-    // session cookie), so a dropped event stream must not leave the view — and
-    // its stop button — believing the run already ended.
+    // Server truth heartbeat while a run is live. A dropped event stream must
+    // not leave the view — or its stop button — believing the run already
+    // ended, and `useReconcileStream` compares this against the stream.
     refetchInterval: (query) =>
       query.state.data?.status === "running" ? 3000 : false,
     // Lets the optimistic detail seeded by `AgentsHome` survive until the

--- a/ui/src/features/agents/lib/queries.ts
+++ b/ui/src/features/agents/lib/queries.ts
@@ -579,6 +579,10 @@ export function useSidebarProjectThreads({
   )
 }
 
+const RUNNING_THREAD_POLL_MS = 3_000
+/** Bounds how long a run started outside this tab stays invisible to the view. */
+const IDLE_THREAD_POLL_MS = 10_000
+
 export function useAgentThread(threadId: string) {
   const queryClient = useQueryClient()
   const queryKey = agentThreadKeys.detail(threadId)
@@ -599,11 +603,16 @@ export function useAgentThread(threadId: string) {
         ...(pendingMessages?.length ? { pendingMessages } : {}),
       }
     },
-    // Server truth heartbeat while a run is live. A dropped event stream must
-    // not leave the view — or its stop button — believing the run already
-    // ended, and `useReconcileStream` compares this against the stream.
+    // Server truth heartbeat, at two cadences. While a run is live a dropped
+    // event stream must not leave the view — or its stop button — believing
+    // the run already ended. While idle this is the only thing that observes a
+    // run started elsewhere (Slack, GitHub, the scheduler, another tab), since
+    // an idle stream defers its event subscription and would never see it;
+    // `useReconcileStream` compares both against the stream.
     refetchInterval: (query) =>
-      query.state.data?.status === "running" ? 3000 : false,
+      query.state.data?.status === "running"
+        ? RUNNING_THREAD_POLL_MS
+        : IDLE_THREAD_POLL_MS,
     // Lets the optimistic detail seeded by `AgentsHome` survive until the
     // proxied run.start stamps the server-side thread; an immediate refetch
     // would 404 and bounce the route back to /agents.

--- a/ui/src/features/agents/lib/stream/AgentStreamProvider.test.tsx
+++ b/ui/src/features/agents/lib/stream/AgentStreamProvider.test.tsx
@@ -79,6 +79,24 @@ describe("AgentStreamProvider", () => {
     expect(useStreamPool.getState().entries).toHaveLength(2)
   })
 
+  it("remounts a kicked thread's stream while keeping it served", () => {
+    const view = render(
+      wrapper(
+        <AgentStreamProvider threadId="one">
+          <Probe />
+        </AgentStreamProvider>
+      )
+    )
+    expect(mocks.streams).toHaveLength(1)
+
+    act(() => useStreamPool.getState().kick("cloud", "one"))
+
+    expect(mocks.streams).toHaveLength(2)
+    expect(mocks.streams[1]?.threadId).toBe("one")
+    expect(view.container.textContent).toBe("one")
+    expect(useStreamPool.getState().entries).toHaveLength(1)
+  })
+
   it("announces a lazy cloud thread only once the server accepts its run", () => {
     const onThreadCreated = vi.fn()
     render(

--- a/ui/src/features/agents/lib/stream/AgentStreamProvider.tsx
+++ b/ui/src/features/agents/lib/stream/AgentStreamProvider.tsx
@@ -18,6 +18,7 @@ import {
   createLocalGraphClient,
   dashboardFetch,
 } from "@/lib/langgraph-client"
+import { trackDatadogAction } from "@/lib/datadog"
 import { selectStreamFor, useStreamPool } from "./streamPool"
 import type { ReactNode } from "react"
 import type {
@@ -30,6 +31,10 @@ export type { AgentStream, AgentThreadTransport } from "./streamPool"
 
 const AGENT_ASSISTANT_ID = "agent"
 const SWEEP_INTERVAL_MS = 10_000
+// The SDK stops retrying after this many failed reconnects and the instance is
+// dead for good (isLoading frozen, no error). ~5 minutes of backoff covers a
+// wifi blip or a backend deploy; anything longer is caught by the reconcile kick.
+const MAX_RECONNECT_ATTEMPTS = 50
 
 const AgentStreamContext = createContext<AgentStream | null>(null)
 
@@ -57,6 +62,14 @@ function PooledStream({ entry }: { entry: StreamPoolEntry }) {
     assistantId: AGENT_ASSISTANT_ID,
     threadId: entry.threadId,
     fetch: dashboardFetch,
+    maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
+    onReconnect: ({ attempt, cause }) => {
+      trackDatadogAction("agent-stream.reconnect", {
+        threadId: entry.threadId,
+        attempt,
+        cause: cause instanceof Error ? cause.message : String(cause),
+      })
+    },
     onThreadId: (threadId) => pool().rekey(entry.id, threadId),
     onCreated: () => {
       pool().runAccepted(entry.id)
@@ -127,7 +140,7 @@ export function AgentStreamProvider({
   return (
     <>
       {entries.map((entry) => (
-        <PooledStream key={entry.id} entry={entry} />
+        <PooledStream key={`${entry.id}:${entry.generation}`} entry={entry} />
       ))}
       {stream && (
         <AgentStreamContext.Provider value={stream}>

--- a/ui/src/features/agents/lib/stream/streamPool.test.ts
+++ b/ui/src/features/agents/lib/stream/streamPool.test.ts
@@ -73,6 +73,18 @@ describe("streamPool", () => {
     expect(activeEntry()?.threadId).toBe("minted")
   })
 
+  it("kicks a thread by bumping its generation without dropping the handle", () => {
+    pool().activate("cloud", "stuck")
+    const entry = activeEntry()
+    if (!entry) throw new Error("no active entry")
+    pool().publish(entry.id, handle(true))
+
+    pool().kick("cloud", "stuck")
+
+    expect(activeEntry()?.generation).toBe(entry.generation + 1)
+    expect(pool().handles[entry.id]).toBeDefined()
+  })
+
   it("drops idle instances after the TTL but never a running one", () => {
     pool().activate("cloud", "running")
     const running = activeEntry()

--- a/ui/src/features/agents/lib/stream/streamPool.ts
+++ b/ui/src/features/agents/lib/stream/streamPool.ts
@@ -13,6 +13,8 @@ export interface StreamPoolEntry {
   threadId: string | null
   /** Created without a thread; its first accepted run is the thread's creation. */
   awaitingCreation: boolean
+  /** Bumped by `kick` to remount the SDK instance; the handle stays published until the replacement publishes. */
+  generation: number
   lastActiveAt: number
 }
 
@@ -40,6 +42,8 @@ export interface StreamPoolState {
   /** The server accepted a run on this instance. */
   runAccepted(id: string): void
   consumeCreatedThread(): void
+  /** Remount a thread's instance so it re-hydrates and reopens its event stream. */
+  kick(transport: AgentThreadTransport, threadId: string): void
   /** Drop idle instances past the TTL or cap; active and running ones stay. */
   sweep(now: number): void
 }
@@ -91,6 +95,7 @@ export const useStreamPool = create<StreamPoolState>((set, get) => ({
       transport,
       threadId,
       awaitingCreation: threadId === null,
+      generation: 0,
       lastActiveAt: now,
     }
     set((state) => ({
@@ -144,6 +149,16 @@ export const useStreamPool = create<StreamPoolState>((set, get) => ({
 
   consumeCreatedThread() {
     set({ createdThreadId: null })
+  },
+
+  kick(transport, threadId) {
+    set((state) => ({
+      entries: state.entries.map((entry) =>
+        entry.transport === transport && entry.threadId === threadId
+          ? { ...entry, generation: entry.generation + 1 }
+          : entry
+      ),
+    }))
   },
 
   sweep(now) {

--- a/ui/src/features/agents/lib/stream/useReconcileStream.test.tsx
+++ b/ui/src/features/agents/lib/stream/useReconcileStream.test.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RECONCILE_GRACE_MS, useReconcileStream } from "./useReconcileStream"
+import { useStreamPool } from "./streamPool"
+import type { AgentStream } from "./streamPool"
+
+const mocks = vi.hoisted(() => ({
+  stream: {} as Partial<AgentStream>,
+}))
+
+vi.mock("./AgentStreamProvider", () => ({
+  useAgentStream: () => mocks.stream,
+}))
+
+function setStream(stream: Partial<AgentStream>) {
+  mocks.stream = { threadId: "t", isThreadLoading: false, ...stream }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  useStreamPool.setState({
+    entries: [],
+    handles: {},
+    activeId: null,
+    binding: null,
+    createdThreadId: null,
+  })
+  useStreamPool.getState().activate("cloud", "t")
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+function generation() {
+  return useStreamPool.getState().entries[0]?.generation
+}
+
+describe("useReconcileStream", () => {
+  it("kicks once when the server runs but the stream never joined", () => {
+    setStream({ isLoading: false })
+    renderHook(() => useReconcileStream("t", true))
+
+    vi.advanceTimersByTime(RECONCILE_GRACE_MS - 1)
+    expect(generation()).toBe(0)
+
+    vi.advanceTimersByTime(1)
+    expect(generation()).toBe(1)
+
+    vi.advanceTimersByTime(RECONCILE_GRACE_MS * 3)
+    expect(generation()).toBe(1)
+  })
+
+  it("kicks when the stream is stuck loading after the server went idle", () => {
+    setStream({ isLoading: true })
+    renderHook(() => useReconcileStream("t", false))
+
+    vi.advanceTimersByTime(RECONCILE_GRACE_MS)
+    expect(generation()).toBe(1)
+  })
+
+  it("does nothing when the disagreement resolves within the grace period", () => {
+    setStream({ isLoading: false })
+    const hook = renderHook(({ running }) => useReconcileStream("t", running), {
+      initialProps: { running: true },
+    })
+
+    vi.advanceTimersByTime(RECONCILE_GRACE_MS / 2)
+    setStream({ isLoading: true })
+    hook.rerender({ running: true })
+
+    vi.advanceTimersByTime(RECONCILE_GRACE_MS * 2)
+    expect(generation()).toBe(0)
+  })
+
+  it("leaves a still-hydrating instance alone", () => {
+    setStream({ isLoading: false, isThreadLoading: true })
+    renderHook(() => useReconcileStream("t", true))
+
+    vi.advanceTimersByTime(RECONCILE_GRACE_MS * 2)
+    expect(generation()).toBe(0)
+  })
+})

--- a/ui/src/features/agents/lib/stream/useReconcileStream.ts
+++ b/ui/src/features/agents/lib/stream/useReconcileStream.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from "react"
+
+import { trackDatadogAction } from "@/lib/datadog"
+import { useAgentStream } from "./AgentStreamProvider"
+import { useStreamPool } from "./streamPool"
+
+/** How long server truth and the stream may disagree before the instance is remounted. */
+export const RECONCILE_GRACE_MS = 5_000
+
+/**
+ * Remount the pooled `useStream` instance for a cloud thread when it stops
+ * agreeing with the polled thread status. A retained instance is never
+ * re-hydrated on return, so two states are otherwise permanent: a run started
+ * elsewhere that an idle instance never subscribed to (server running, stream
+ * idle), and a dead event stream that froze `isLoading` on (server idle,
+ * stream loading). One kick per disagreement; a fresh instance that is still
+ * hydrating is left alone.
+ */
+export function useReconcileStream(threadId: string, running: boolean) {
+  const stream = useAgentStream()
+  const kick = useStreamPool((state) => state.kick)
+  const kicked = useRef(false)
+  const mismatch =
+    stream.threadId === threadId &&
+    !stream.isThreadLoading &&
+    running !== stream.isLoading
+
+  useEffect(() => {
+    if (!mismatch) {
+      kicked.current = false
+      return
+    }
+    if (kicked.current) return
+    const timer = setTimeout(() => {
+      kicked.current = true
+      trackDatadogAction("agent-stream.kick", {
+        threadId,
+        serverRunning: running,
+      })
+      kick("cloud", threadId)
+    }, RECONCILE_GRACE_MS)
+    return () => clearTimeout(timer)
+  }, [kick, mismatch, running, threadId])
+}

--- a/ui/src/lib/datadog.ts
+++ b/ui/src/lib/datadog.ts
@@ -4,6 +4,7 @@ type PublicEnv = Record<string, string | boolean | undefined>
 type RumClient = {
   init: (configuration: RumInitConfiguration) => void
   getInternalContext: () => { session_id?: string } | undefined
+  addAction?: (name: string, context?: Record<string, unknown>) => void
 }
 type RumLoader = () => Promise<RumClient>
 
@@ -40,6 +41,14 @@ export function getDatadogSessionLink(): string | undefined {
   if (!sessionId) return undefined
   const query = encodeURIComponent(`@session.id:${sessionId}`)
   return `${datadogAppOrigin(initializedSite)}/rum/explorer?query=${query}&tab=session`
+}
+
+/** Record a custom RUM action; a no-op until RUM is initialized. */
+export function trackDatadogAction(
+  name: string,
+  context?: Record<string, unknown>
+): void {
+  initializedRum?.addAction?.(name, context)
 }
 
 export function isDatadogRumInitialized(): boolean {


### PR DESCRIPTION
Switching back to a pooled agent thread sometimes showed a frozen transcript that only a page refresh fixed.

A retained `useStream` instance is never re-hydrated on return, so two states were permanent:

- **Blind idle instance.** A thread hydrated while idle defers its SSE pump until a local `submit()`. A run started anywhere else (Slack, GitHub, scheduler, another tab) was never observed.
- **Dead pump.** The SDK gives up after 5 reconnect attempts (~20s) and then leaves `isLoading` frozen on with no `error`. The pool retains any loading instance indefinitely, so the corpse was pinned precisely because it looked busy.

Changes:

- Raise `maxReconnectAttempts` to 50 (~5 minutes of backoff) and record each reconnect as a RUM action.
- `useReconcileStream`: when the polled `thread.status` disagrees with `stream.isLoading` for 5s, bump the entry's generation in the pool so that one `PooledStream` remounts and re-hydrates. One kick per disagreement; still-hydrating instances are left alone. Kicks are recorded as RUM actions.

SDK gap tracked in langchain-ai/langgraphjs#2817.


The reconcile compares against the thread detail query, which previously only polled while its data already said `running` — so an idle thread never observed an externally-started run and the kick never fired. That query now heartbeats at 3s while running and 10s while idle.
