### PR TITLE
feat: add workspace model provider controls

### DIFF
--- a/agent/chat.py
+++ b/agent/chat.py
@@ -36,9 +36,11 @@ from agent.dashboard.options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
     gate_fable_model,
+    gate_model_provider,
     model_supports_effort,
 )
 from agent.dashboard.team_settings import (
+    get_disabled_model_providers,
     get_effective_gateway_enabled,
     get_team_default_model,
     get_team_fable_enabled,
@@ -218,6 +220,12 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
     model_id, effort = await _resolve_chat_model(cfg)
     model_id, effort = gate_fable_model(
         model_id, effort, fable_enabled=await get_team_fable_enabled()
+    )
+    model_id, effort = gate_model_provider(
+        model_id,
+        effort,
+        disabled_providers=await get_disabled_model_providers(),
+        fallback=await _cached_team_chat_model(),
     )
     use_gateway = await _cached_gateway_enabled()
     model_kwargs = provider_model_kwargs(

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -18,6 +18,23 @@ class ModelOption(TypedDict):
     context_window: NotRequired[int | None]
 
 
+class ModelProviderOption(TypedDict):
+    id: str
+    label: str
+
+
+MODEL_PROVIDERS: list[ModelProviderOption] = [
+    {"id": "anthropic", "label": "Anthropic"},
+    {"id": "openai", "label": "OpenAI"},
+    {"id": "google_genai", "label": "Google"},
+    {"id": "fireworks", "label": "Fireworks"},
+    {"id": "baseten", "label": "Baseten"},
+]
+SUPPORTED_MODEL_PROVIDER_IDS: frozenset[str] = frozenset(
+    provider["id"] for provider in MODEL_PROVIDERS
+)
+
+
 SUPPORTED_MODELS: list[ModelOption] = [
     {
         "id": "anthropic:claude-opus-5",
@@ -54,14 +71,14 @@ SUPPORTED_MODELS: list[ModelOption] = [
         "id": "openai:gpt-6-astra",
         "label": "GPT-6 Astra",
         "efforts": ["low", "medium", "high", "xhigh", "max"],
-        "default_effort": "xhigh",
+        "default_effort": "low",
         "supports_images": True,
     },
     {
         "id": "openai:gpt-5.6-sol",
         "label": "GPT-5.6 Sol",
         "efforts": ["none", "low", "medium", "high", "xhigh"],
-        "default_effort": "xhigh",
+        "default_effort": "low",
         "supports_images": True,
     },
     {
@@ -270,9 +287,20 @@ def model_supports_images(model_id: str) -> bool:
     return False
 
 
-def _provider_of(model_id: str) -> str | None:
+def model_provider_id(model_id: str) -> str | None:
     provider, _, rest = model_id.partition(":")
     return provider if rest else None
+
+
+def model_provider_enabled(model_id: str, disabled_providers: Sequence[str]) -> bool:
+    provider = model_provider_id(model_id)
+    return provider is not None and provider not in disabled_providers
+
+
+def filter_models_by_provider(
+    models: Sequence[ModelOption], disabled_providers: Sequence[str]
+) -> list[ModelOption]:
+    return [model for model in models if model_provider_enabled(model["id"], disabled_providers)]
 
 
 def _claude_family_of(model_id: str) -> str | None:
@@ -332,16 +360,16 @@ def provider_fallback_pair(model_id: object, effort: object = None) -> tuple[str
     """
     if not isinstance(model_id, str) or model_id in DEPRECATED_MODEL_IDS:
         return None
-    provider = _provider_of(model_id)
+    provider = model_provider_id(model_id)
     if provider is None:
         return None
     family = _claude_family_of(model_id)
     if family is not None:
         for m in SUPPORTED_MODELS:
-            if _provider_of(m["id"]) == provider and _claude_family_of(m["id"]) == family:
+            if model_provider_id(m["id"]) == provider and _claude_family_of(m["id"]) == family:
                 return m["id"], _fallback_effort_for(m, effort) or m["default_effort"]
     for m in SUPPORTED_MODELS:
-        if _provider_of(m["id"]) == provider:
+        if model_provider_id(m["id"]) == provider:
             return m["id"], _fallback_effort_for(m, effort) or m["default_effort"]
     return None
 
@@ -363,16 +391,44 @@ def default_model_pair() -> tuple[str, str]:
     raise ValueError(f"Unsupported default LLM_MODEL_ID: {model_id!r}")
 
 
-def default_vision_model_pair() -> tuple[str, str]:
-    """Default OpenAI/Anthropic model pair to use when image input is required."""
+def enabled_default_model_pair(
+    disabled_providers: Sequence[str], effort: object = None
+) -> tuple[str, str]:
+    deployment_model, deployment_effort = default_model_pair()
+    if model_provider_enabled(deployment_model, disabled_providers):
+        return deployment_model, deployment_effort
+    for model in SUPPORTED_MODELS:
+        if model.get("can_be_default", True) and model_provider_enabled(
+            model["id"], disabled_providers
+        ):
+            return model["id"], _fallback_effort_for(model, effort) or model["default_effort"]
+    raise ValueError("at least one model provider must remain enabled")
+
+
+def gate_model_provider(
+    model_id: str,
+    effort: str | None,
+    *,
+    disabled_providers: Sequence[str],
+    fallback: tuple[str, str] | None = None,
+) -> tuple[str, str | None]:
+    if model_provider_enabled(model_id, disabled_providers):
+        return model_id, effort
+    return fallback or enabled_default_model_pair(disabled_providers, effort)
+
+
+def default_vision_model_pair(
+    disabled_providers: Sequence[str] = (),
+) -> tuple[str, str]:
+    """Default enabled model pair to use when image input is required."""
     if (
         DEFAULT_MODEL_ID in SUPPORTED_MODEL_IDS
         and model_supports_images(DEFAULT_MODEL_ID)
         and model_supports_effort(DEFAULT_MODEL_ID, DEFAULT_MODEL_EFFORT)
-        and DEFAULT_MODEL_ID.startswith(("openai:", "anthropic:"))
+        and model_provider_enabled(DEFAULT_MODEL_ID, disabled_providers)
     ):
         return DEFAULT_MODEL_ID, DEFAULT_MODEL_EFFORT
     for model in SUPPORTED_MODELS:
-        if model["id"].startswith(("openai:", "anthropic:")) and model["supports_images"]:
+        if model["supports_images"] and model_provider_enabled(model["id"], disabled_providers):
             return model["id"], model["default_effort"]
-    return default_model_pair()
+    return enabled_default_model_pair(disabled_providers)

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -26,6 +26,7 @@ from agent.dashboard.options import (
     DEPRECATED_MODEL_IDS,
     NON_DEFAULT_MODEL_IDS,
     SUPPORTED_MODEL_IDS,
+    model_provider_enabled,
     model_supports_effort,
     provider_fallback_pair,
 )
@@ -68,7 +69,10 @@ class ProfileUpdate(BaseModel):
             )
         return self
 
-    def validate_pairing(self) -> None:
+    def validate_pairing(self, disabled_providers: list[str] | None = None) -> None:
+        disabled = disabled_providers or []
+        if not model_provider_enabled(self.default_model, disabled):
+            raise ValueError(f"model provider is disabled for {self.default_model!r}")
         if self.default_model in NON_DEFAULT_MODEL_IDS:
             raise ValueError(f"{self.default_model!r} cannot be a default model")
         if self.default_subagent_model in NON_DEFAULT_MODEL_IDS:
@@ -81,6 +85,8 @@ class ProfileUpdate(BaseModel):
             return
         if self.default_subagent_model is None:
             raise ValueError("subagent reasoning effort set without a model")
+        if not model_provider_enabled(self.default_subagent_model, disabled):
+            raise ValueError(f"model provider is disabled for {self.default_subagent_model!r}")
         if self.default_subagent_model not in SUPPORTED_MODEL_IDS:
             raise ValueError(f"unsupported subagent model: {self.default_subagent_model}")
         if self.subagent_reasoning_effort is None or not model_supports_effort(
@@ -102,8 +108,11 @@ def _normalize_stale_model_pair(model: str, effort: str | None) -> tuple[str, st
     return fallback
 
 
-def normalize_profile_for_response(profile: dict[str, Any]) -> dict[str, Any]:
+def normalize_profile_for_response(
+    profile: dict[str, Any], disabled_providers: list[str] | None = None
+) -> dict[str, Any]:
     value = dict(profile)
+    disabled = disabled_providers or []
     value.pop("create_prs", None)
     for model_field, effort_field in (
         ("default_model", "reasoning_effort"),
@@ -111,7 +120,11 @@ def normalize_profile_for_response(profile: dict[str, Any]) -> dict[str, Any]:
     ):
         model = value.get(model_field)
         effort = value.get(effort_field)
-        if model in DEPRECATED_MODEL_IDS or model in NON_DEFAULT_MODEL_IDS:
+        if (
+            model in DEPRECATED_MODEL_IDS
+            or model in NON_DEFAULT_MODEL_IDS
+            or (isinstance(model, str) and not model_provider_enabled(model, disabled))
+        ):
             value.pop(model_field, None)
             value.pop(effort_field, None)
         elif isinstance(model, str):

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -81,7 +81,9 @@ from agent.dashboard.oauth import (
 from agent.dashboard.oidc_auth import admin_session_for_actions_oidc, is_actions_oidc_token
 from agent.dashboard.options import (
     FABLE_MODEL_IDS,
+    MODEL_PROVIDERS,
     SUPPORTED_MODELS,
+    filter_models_by_provider,
     gate_fable_model,
     models_with_profile_context_windows,
 )
@@ -160,6 +162,7 @@ from agent.dashboard.team_credentials import (
 from agent.dashboard.team_settings import (
     TeamSettingsUpdate,
     TranscriptionSettingsUpdate,
+    get_disabled_model_providers,
     get_team_default_model,
     get_team_default_subagent_model,
     get_team_fable_enabled,
@@ -628,6 +631,7 @@ async def options() -> dict[str, Any]:
     agent_model, agent_effort = await get_team_default_model("agent")
     subagent_model, subagent_effort = await get_team_default_subagent_model("agent")
     fable_enabled = await get_team_fable_enabled()
+    disabled_providers = await get_disabled_model_providers()
     # Never advertise a default that isn't in the selectable list: when Fable is
     # off, gate a stale Fable default down to its non-Fable fallback so the Cloud
     # Agents page (and the PUT /profile it drives) don't choke on it.
@@ -637,13 +641,15 @@ async def options() -> dict[str, Any]:
     subagent_model, subagent_effort = gate_fable_model(
         subagent_model, subagent_effort, fable_enabled=fable_enabled
     )
-    models = (
-        SUPPORTED_MODELS
-        if fable_enabled
-        else [m for m in SUPPORTED_MODELS if m["id"] not in FABLE_MODEL_IDS]
-    )
+    models = filter_models_by_provider(SUPPORTED_MODELS, disabled_providers)
+    if not fable_enabled:
+        models = [m for m in models if m["id"] not in FABLE_MODEL_IDS]
     return {
         "models": models_with_profile_context_windows(models),
+        "model_providers": [
+            {**provider, "enabled": provider["id"] not in disabled_providers}
+            for provider in MODEL_PROVIDERS
+        ],
         "default_agent_model": agent_model,
         "default_agent_reasoning_effort": agent_effort,
         "default_agent_subagent_model": subagent_model,
@@ -658,7 +664,7 @@ async def get_my_profile(
     profile = await get_profile(session["sub"])
     if not profile:
         return {}
-    return normalize_profile_for_response(profile)
+    return normalize_profile_for_response(profile, await get_disabled_model_providers())
 
 
 @router.put("/profile")
@@ -666,7 +672,7 @@ async def put_my_profile(
     update: ProfileUpdate,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
-    update.validate_pairing()
+    update.validate_pairing(await get_disabled_model_providers())
     return await upsert_profile(session["sub"], session.get("email") or "", update)
 
 

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -10,10 +10,14 @@ from langgraph_sdk.schema import Config
 from pydantic import BaseModel, Field, field_validator
 
 from agent.dashboard.admin import is_admin
-from agent.dashboard.options import gate_fable_model, normalize_model_choice
+from agent.dashboard.options import gate_fable_model, gate_model_provider, normalize_model_choice
 from agent.dashboard.profiles import get_profile, get_valid_access_token
 from agent.dashboard.repo_access import repo_config_for_user, require_repo_access_for_user
-from agent.dashboard.team_settings import get_team_fable_enabled
+from agent.dashboard.team_settings import (
+    get_disabled_model_providers,
+    get_team_default_model,
+    get_team_fable_enabled,
+)
 from agent.dashboard.threads.access import agent_version_metadata, resolve_run_email
 from agent.dashboard.user_mappings import slack_id_for_login
 from agent.dispatch import create_durable_run
@@ -544,6 +548,12 @@ async def _agent_run_config(
     if model and effort:
         model, effort = gate_fable_model(
             model, effort, fable_enabled=await get_team_fable_enabled()
+        )
+        model, effort = gate_model_provider(
+            model,
+            effort,
+            disabled_providers=await get_disabled_model_providers(),
+            fallback=await get_team_default_model("agent"),
         )
         configurable["agent_model_id"] = model
         configurable["agent_effort"] = effort

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -9,17 +9,22 @@ import logging
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from agent.config import ENV
 from agent.dashboard.options import (
     DEPRECATED_MODEL_IDS,
     FABLE_MODEL_IDS,
+    MODEL_PROVIDERS,
     NON_DEFAULT_MODEL_IDS,
     SUPPORTED_MODEL_IDS,
+    SUPPORTED_MODEL_PROVIDER_IDS,
     canonical_model_pair,
     default_model_pair,
+    enabled_default_model_pair,
     gate_fable_model,
+    gate_model_provider,
+    model_provider_enabled,
     model_supports_effort,
     provider_fallback_pair,
 )
@@ -65,6 +70,7 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     gateway_enabled: bool | None = None
     transcription_model: str = DEFAULT_TRANSCRIPTION_MODEL
     fable_enabled: bool = False
+    disabled_model_providers: list[str] = Field(default_factory=list)
     review_tracing_project: str | None = None
     org_guidelines: str | None = None
     default_agent_model: str | None = None
@@ -82,6 +88,16 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     default_chat_reasoning_effort: str | None = None
     default_thread_title_model: str | None = None
     default_thread_title_reasoning_effort: str | None = None
+
+    @field_validator("disabled_model_providers")
+    @classmethod
+    def _validate_disabled_model_providers(cls, value: list[str]) -> list[str]:
+        unknown = set(value) - SUPPORTED_MODEL_PROVIDER_IDS
+        if unknown:
+            raise ValueError(f"unsupported model providers: {', '.join(sorted(unknown))}")
+        normalized = [provider["id"] for provider in MODEL_PROVIDERS if provider["id"] in value]
+        enabled_default_model_pair(normalized)
+        return normalized
 
     @field_validator("org_guidelines", mode="before")
     @classmethod
@@ -157,6 +173,19 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
                 self.default_thread_title_reasoning_effort,
             )
         )
+        for model_field, effort_field in _MODEL_PAIR_FIELDS:
+            model = getattr(self, model_field)
+            effort = getattr(self, effort_field)
+            if isinstance(model, str) and not model_provider_enabled(
+                model, self.disabled_model_providers
+            ):
+                model, effort = gate_model_provider(
+                    model,
+                    effort,
+                    disabled_providers=self.disabled_model_providers,
+                )
+                setattr(self, model_field, model)
+                setattr(self, effort_field, effort)
         _validate_model_effort_pair(
             self.default_agent_model, self.default_agent_reasoning_effort, "agent"
         )
@@ -285,6 +314,7 @@ def _default_settings() -> dict[str, Any]:
         "gateway_enabled": None,
         "transcription_model": DEFAULT_TRANSCRIPTION_MODEL,
         "fable_enabled": False,
+        "disabled_model_providers": [],
         "review_tracing_project": None,
         "org_guidelines": None,
         "default_agent_model": fallback_model,
@@ -340,6 +370,17 @@ async def get_team_settings() -> dict[str, Any]:
 
 
 async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
+    disabled_providers = update.disabled_model_providers
+    if "disabled_model_providers" not in update.model_fields_set:
+        disabled_providers = await get_disabled_model_providers()
+        for model_field, effort_field in _MODEL_PAIR_FIELDS:
+            model, effort = gate_model_provider(
+                getattr(update, model_field),
+                getattr(update, effort_field),
+                disabled_providers=disabled_providers,
+            )
+            setattr(update, model_field, model)
+            setattr(update, effort_field, effort)
     value: dict[str, Any] = {
         "review_draft_prs": update.review_draft_prs,
         "pr_summaries": update.pr_summaries,
@@ -347,6 +388,7 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "gateway_enabled": update.gateway_enabled,
         "transcription_model": update.transcription_model,
         "fable_enabled": update.fable_enabled,
+        "disabled_model_providers": disabled_providers,
         "review_tracing_project": update.review_tracing_project,
         "org_guidelines": update.org_guidelines,
         "default_agent_model": update.default_agent_model,
@@ -390,6 +432,7 @@ async def get_team_default_model(
     admin setting is unset/invalid it inherits the team **agent** default.
     """
     settings = await get_team_settings()
+    disabled_providers = _disabled_providers(settings)
     if role == "chat":
         model = settings.get("default_chat_model")
         effort = settings.get("default_chat_reasoning_effort")
@@ -399,7 +442,7 @@ async def get_team_default_model(
             and model in SUPPORTED_MODEL_IDS
             and model_supports_effort(model, effort)
         ):
-            return _resolve_default_pair(model, effort)
+            return _resolve_default_pair(model, effort, disabled_providers=disabled_providers)
         # Inherit the Agent default when no chat-specific model is configured.
         model = settings.get("default_agent_model")
         effort = settings.get("default_agent_reasoning_effort")
@@ -409,7 +452,7 @@ async def get_team_default_model(
     else:
         model = settings.get("default_reviewer_model")
         effort = settings.get("default_reviewer_reasoning_effort")
-    return _resolve_default_pair(model, effort)
+    return _resolve_default_pair(model, effort, disabled_providers=disabled_providers)
 
 
 async def get_team_default_model_pair(
@@ -417,23 +460,28 @@ async def get_team_default_model_pair(
 ) -> tuple[tuple[str, str], tuple[str, str]]:
     """Return default ``(main, subagent)`` model pairs for ``role`` from one store read."""
     settings = await get_team_settings()
+    disabled_providers = _disabled_providers(settings)
     if role == "agent":
         main = _resolve_default_pair(
             settings.get("default_agent_model"),
             settings.get("default_agent_reasoning_effort"),
+            disabled_providers=disabled_providers,
         )
         subagent = _resolve_default_pair(
             settings.get("default_agent_subagent_model"),
             settings.get("default_agent_subagent_reasoning_effort"),
+            disabled_providers=disabled_providers,
         )
     else:
         main = _resolve_default_pair(
             settings.get("default_reviewer_model"),
             settings.get("default_reviewer_reasoning_effort"),
+            disabled_providers=disabled_providers,
         )
         subagent = _resolve_default_pair(
             settings.get("default_reviewer_subagent_model"),
             settings.get("default_reviewer_subagent_reasoning_effort"),
+            disabled_providers=disabled_providers,
         )
     return main, subagent
 
@@ -448,6 +496,7 @@ async def get_team_default_grouping_model() -> tuple[str, str]:
     cheaper tier rather than the primary reviewer model.
     """
     settings = await get_team_settings()
+    disabled_providers = _disabled_providers(settings)
     model = settings.get("default_grouping_model")
     effort = settings.get("default_grouping_reasoning_effort")
     if (
@@ -457,10 +506,11 @@ async def get_team_default_grouping_model() -> tuple[str, str]:
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
     ):
-        return _resolve_default_pair(model, effort)
+        return _resolve_default_pair(model, effort, disabled_providers=disabled_providers)
     return _resolve_default_pair(
         settings.get("default_reviewer_subagent_model"),
         settings.get("default_reviewer_subagent_reasoning_effort"),
+        disabled_providers=disabled_providers,
     )
 
 
@@ -488,6 +538,7 @@ def _gate_openai_title_model(pair: tuple[str, str], *, gateway_enabled: bool) ->
 
 async def get_team_default_thread_title_model() -> tuple[str, str]:
     settings = await get_team_settings()
+    disabled_providers = _disabled_providers(settings)
     model = settings.get("default_thread_title_model")
     effort = settings.get("default_thread_title_reasoning_effort")
     if (
@@ -497,12 +548,20 @@ async def get_team_default_thread_title_model() -> tuple[str, str]:
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
     ):
-        pair = _resolve_default_pair(model, effort)
-    else:
+        pair = _resolve_default_pair(model, effort, disabled_providers=disabled_providers)
+    elif model_provider_enabled(DEFAULT_THREAD_TITLE_MODEL, disabled_providers):
         pair = DEFAULT_THREAD_TITLE_MODEL, DEFAULT_THREAD_TITLE_REASONING_EFFORT
-    return _gate_openai_title_model(
+    else:
+        pair = enabled_default_model_pair(disabled_providers, effort)
+    pair = _gate_openai_title_model(
         pair, gateway_enabled=resolve_gateway_enabled(settings.get("gateway_enabled"))
     )
+    model, resolved_effort = gate_model_provider(
+        pair[0],
+        pair[1],
+        disabled_providers=disabled_providers,
+    )
+    return model, resolved_effort or enabled_default_model_pair(disabled_providers)[1]
 
 
 async def get_team_review_trace_links_enabled() -> bool:
@@ -543,6 +602,14 @@ async def get_team_fable_enabled() -> bool:
     return bool(value) if isinstance(value, bool) else False
 
 
+async def get_disabled_model_providers() -> list[str]:
+    settings = await get_team_settings()
+    value = settings.get("disabled_model_providers")
+    if not isinstance(value, list):
+        return []
+    return [provider for provider in value if provider in SUPPORTED_MODEL_PROVIDER_IDS]
+
+
 async def get_effective_gateway_enabled() -> bool:
     """Resolve whether LLM Gateway routing is on: team setting, else env default."""
     return resolve_gateway_enabled(await get_team_gateway_enabled())
@@ -577,20 +644,31 @@ async def get_team_default_subagent_model(
     else:
         model = settings.get("default_reviewer_subagent_model")
         effort = settings.get("default_reviewer_subagent_reasoning_effort")
-    return _resolve_default_pair(model, effort)
+    return _resolve_default_pair(model, effort, disabled_providers=_disabled_providers(settings))
 
 
-def _resolve_default_pair(model: object, effort: object) -> tuple[str, str]:
-    """Supported pair if valid, else same-provider fallback, else global default."""
+def _disabled_providers(settings: dict[str, Any]) -> list[str]:
+    value = settings.get("disabled_model_providers")
+    if not isinstance(value, list):
+        return []
+    return [provider for provider in value if provider in SUPPORTED_MODEL_PROVIDER_IDS]
+
+
+def _resolve_default_pair(
+    model: object, effort: object, *, disabled_providers: list[str] | None = None
+) -> tuple[str, str]:
+    """Supported pair if valid, else same-provider fallback, else enabled default."""
+    disabled = disabled_providers or []
     if (
         isinstance(model, str)
         and isinstance(effort, str)
         and model in SUPPORTED_MODEL_IDS
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
+        and model_provider_enabled(model, disabled)
     ):
         return model, effort
     provider_pair = provider_fallback_pair(model, effort)
-    if provider_pair is not None:
+    if provider_pair is not None and model_provider_enabled(provider_pair[0], disabled):
         return provider_pair
-    return default_model_pair()
+    return enabled_default_model_pair(disabled, effort)

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -18,11 +18,16 @@ from agent.dashboard.options import (
     DEPRECATED_MODEL_IDS,
     default_vision_model_pair,
     gate_fable_model,
+    gate_model_provider,
     model_supports_images,
     normalize_model_choice,
 )
 from agent.dashboard.profiles import get_profile
-from agent.dashboard.team_settings import get_team_default_model, get_team_fable_enabled
+from agent.dashboard.team_settings import (
+    get_disabled_model_providers,
+    get_team_default_model,
+    get_team_fable_enabled,
+)
 from agent.dashboard.threads.access import (
     _ensure_dashboard_github_token,
     agent_version_metadata,
@@ -120,15 +125,27 @@ async def _resolve_agent_model_choice(
     resolved_model, resolved_effort = gate_fable_model(
         resolved_model, resolved_effort, fable_enabled=await get_team_fable_enabled()
     )
+    resolved_model, resolved_effort = gate_model_provider(
+        resolved_model,
+        resolved_effort,
+        disabled_providers=await get_disabled_model_providers(),
+        fallback=await get_team_default_model("agent"),
+    )
     if not isinstance(resolved_effort, str):
         raise ValueError("team default model must include a reasoning effort")
     return resolved_model, resolved_effort
 
 
-def _with_vision_fallback(model_id: str, effort: str, *, has_images: bool) -> tuple[str, str]:
+def _with_vision_fallback(
+    model_id: str,
+    effort: str,
+    *,
+    has_images: bool,
+    disabled_providers: list[str] | None = None,
+) -> tuple[str, str]:
     if not has_images or model_supports_images(model_id):
         return model_id, effort
-    fallback_model_id, fallback_effort = default_vision_model_pair()
+    fallback_model_id, fallback_effort = default_vision_model_pair(disabled_providers or [])
     logger.info(
         "Using vision fallback model %s for dashboard image input; configured model %s "
         "does not support images",
@@ -226,6 +243,7 @@ async def _create_dashboard_thread_record(
         resolved_model,
         resolved_effort,
         has_images=bool(images),
+        disabled_providers=await get_disabled_model_providers(),
     )
     _user_message_content(prompt, images or [], model_id=resolved_model)
     chosen_model, chosen_effort = normalize_model_choice(model_id, effort)

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -39,8 +39,9 @@ from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models.chat_models import BaseChatModel
 
-from agent.dashboard.options import gate_fable_model
+from agent.dashboard.options import gate_fable_model, gate_model_provider
 from agent.dashboard.team_settings import (
+    get_disabled_model_providers,
     get_effective_gateway_enabled,
     get_org_review_guidelines,
     get_team_default_grouping_model,
@@ -886,6 +887,12 @@ async def _resolve_grouping_model(cfg: RunConfig, *, use_gateway: bool) -> BaseC
     model_id, effort = gate_fable_model(
         model_id, effort, fable_enabled=await get_team_fable_enabled()
     )
+    model_id, effort = gate_model_provider(
+        model_id,
+        effort,
+        disabled_providers=await get_disabled_model_providers(),
+        fallback=await get_team_default_grouping_model(),
+    )
     model_kwargs = provider_model_kwargs(
         model_id,
         effort,
@@ -1337,11 +1344,25 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
         subagent_model_id = cfg.reviewer_subagent_model_id
         subagent_effort = cfg.reviewer_subagent_reasoning_effort
     fable_enabled = await get_team_fable_enabled()
+    disabled_providers = await get_disabled_model_providers()
     model_id, reasoning_effort = gate_fable_model(
         model_id, reasoning_effort, fable_enabled=fable_enabled
     )
     subagent_model_id, subagent_effort = gate_fable_model(
         subagent_model_id, subagent_effort, fable_enabled=fable_enabled
+    )
+    team_defaults = await get_team_default_model_pair("reviewer")
+    model_id, reasoning_effort = gate_model_provider(
+        model_id,
+        reasoning_effort,
+        disabled_providers=disabled_providers,
+        fallback=team_defaults[0],
+    )
+    subagent_model_id, subagent_effort = gate_model_provider(
+        subagent_model_id,
+        subagent_effort,
+        disabled_providers=disabled_providers,
+        fallback=team_defaults[1],
     )
     model_kwargs = provider_model_kwargs(
         model_id,

--- a/agent/server.py
+++ b/agent/server.py
@@ -61,10 +61,13 @@ from agent.dashboard.options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
     gate_fable_model,
+    gate_model_provider,
+    model_provider_enabled,
     model_supports_effort,
 )
 from agent.dashboard.skills import ORGANIZATION_SKILLS_NAMESPACE, SKILLS_NAMESPACE
 from agent.dashboard.team_settings import (
+    get_disabled_model_providers,
     get_effective_gateway_enabled,
     get_team_default_model_pair,
     get_team_default_repo,
@@ -652,6 +655,14 @@ async def _cached_fable_enabled() -> bool:
     )
 
 
+async def _cached_disabled_model_providers() -> list[str]:
+    return await ttl_cache.cached(
+        "team:disabled-model-providers",
+        60,
+        get_disabled_model_providers,
+    )
+
+
 async def _cached_profile(profile_login: str | None):
     if not profile_login:
         return None
@@ -969,6 +980,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         use_gateway = gateway_env_default()
         profile = None
         fable_enabled = False
+        disabled_providers: list[str] = []
     else:
         async with aphase(thread_id, "factory.settings_defaults"):
             (
@@ -977,12 +989,14 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 use_gateway,
                 profile,
                 fable_enabled,
+                disabled_providers,
             ) = await asyncio.gather(
                 _cached_team_default_model_pair("agent"),
                 _cached_thread_title_model(),
                 _cached_gateway_enabled(),
                 _cached_profile(None if thread_settings.get("model_id") else profile_login),
                 _cached_fable_enabled(),
+                _cached_disabled_model_providers(),
             )
 
     linear_issue = as_json_object(cfg.linear_issue.model_dump() if cfg.linear_issue else None)
@@ -1086,6 +1100,24 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     title_model_id, title_effort = gate_fable_model(
         title_model_id, title_effort, fable_enabled=fable_enabled
     )
+    model_id, profile_effort = gate_model_provider(
+        model_id,
+        profile_effort,
+        disabled_providers=disabled_providers,
+        fallback=team_defaults[0],
+    )
+    subagent_model_id, subagent_effort = gate_model_provider(
+        subagent_model_id,
+        subagent_effort,
+        disabled_providers=disabled_providers,
+        fallback=team_defaults[1],
+    )
+    title_model_id, title_effort = gate_model_provider(
+        title_model_id,
+        title_effort,
+        disabled_providers=disabled_providers,
+        fallback=title_defaults,
+    )
 
     model_kwargs = provider_model_kwargs(
         model_id,
@@ -1105,6 +1137,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
     fallback_model_id = ENV.LLM_FALLBACK_MODEL_ID.optional() or fallback_model_id_for(model_id)
     fallback_middleware: list[Any] = []
+    if fallback_model_id and not model_provider_enabled(fallback_model_id, disabled_providers):
+        fallback_model_id = None
     if fallback_model_id and fallback_model_id != model_id:
         fallback_kwargs: ModelKwargs = {"max_tokens": DEFAULT_LLM_MAX_TOKENS}
         if fallback_model_id.startswith("openai:"):

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2490,13 +2490,20 @@ async def test_status_filter_refreshes_threads_missing_run_status(monkeypatch) -
 
 @pytest.mark.asyncio
 async def test_get_my_profile_drops_deprecated_models() -> None:
-    with patch(
-        "agent.dashboard.routes.get_profile",
-        new_callable=AsyncMock,
-        return_value={
-            "default_model": "fireworks:accounts/fireworks/models/glm-5p2",
-            "reasoning_effort": "high",
-        },
+    with (
+        patch(
+            "agent.dashboard.routes.get_profile",
+            new_callable=AsyncMock,
+            return_value={
+                "default_model": "fireworks:accounts/fireworks/models/glm-5p2",
+                "reasoning_effort": "high",
+            },
+        ),
+        patch(
+            "agent.dashboard.routes.get_disabled_model_providers",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
     ):
         payload = await routes.get_my_profile({"sub": "octocat"})
 
@@ -2511,6 +2518,11 @@ async def test_options_omits_fable_when_disabled() -> None:
             "agent.dashboard.routes.get_team_fable_enabled",
             new_callable=AsyncMock,
             return_value=False,
+        ),
+        patch(
+            "agent.dashboard.routes.get_disabled_model_providers",
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch(
             "agent.dashboard.routes.get_team_default_model",
@@ -2528,12 +2540,49 @@ async def test_options_omits_fable_when_disabled() -> None:
 
 
 @pytest.mark.asyncio
+async def test_options_omits_disabled_provider_and_reports_it() -> None:
+    with (
+        patch(
+            "agent.dashboard.routes.get_team_fable_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "agent.dashboard.routes.get_disabled_model_providers",
+            new_callable=AsyncMock,
+            return_value=["anthropic"],
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_default_model",
+            new_callable=AsyncMock,
+            return_value=_PAIR,
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_default_subagent_model",
+            new_callable=AsyncMock,
+            return_value=_PAIR,
+        ),
+    ):
+        payload = await routes.options()
+    assert all(not model["id"].startswith("anthropic:") for model in payload["models"])
+    anthropic = next(
+        provider for provider in payload["model_providers"] if provider["id"] == "anthropic"
+    )
+    assert anthropic["enabled"] is False
+
+
+@pytest.mark.asyncio
 async def test_options_includes_fable_when_enabled() -> None:
     with (
         patch(
             "agent.dashboard.routes.get_team_fable_enabled",
             new_callable=AsyncMock,
             return_value=True,
+        ),
+        patch(
+            "agent.dashboard.routes.get_disabled_model_providers",
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch(
             "agent.dashboard.routes.get_team_default_model",
@@ -2563,6 +2612,11 @@ async def test_options_gates_stale_fable_default_when_disabled() -> None:
             "agent.dashboard.routes.get_team_fable_enabled",
             new_callable=AsyncMock,
             return_value=False,
+        ),
+        patch(
+            "agent.dashboard.routes.get_disabled_model_providers",
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch(
             "agent.dashboard.routes.get_team_default_model",

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -10,8 +10,11 @@ from agent.dashboard.options import (
     SUPPORTED_MODEL_IDS,
     SUPPORTED_MODELS,
     default_model_pair,
+    enabled_default_model_pair,
     fable_disabled_fallback,
+    filter_models_by_provider,
     gate_fable_model,
+    gate_model_provider,
     is_deprecated_model,
     model_profile_context_window,
     models_with_profile_context_windows,
@@ -78,6 +81,35 @@ def test_supported_openai_models() -> None:
         ("openai:gpt-5.6-terra", "GPT-5.6 Terra"),
         ("openai:gpt-5.6-luna", "GPT-5.6 Luna"),
     ]
+
+
+def test_disabling_provider_filters_models_and_gates_existing_selection() -> None:
+    models = filter_models_by_provider(SUPPORTED_MODELS, ["anthropic"])
+    assert all(not model["id"].startswith("anthropic:") for model in models)
+    assert gate_model_provider(
+        SUPPORTED_ANTHROPIC,
+        "high",
+        disabled_providers=["anthropic"],
+    ) == (SUPPORTED_OPENAI, "medium")
+
+
+def test_disabled_deployment_default_uses_first_enabled_provider() -> None:
+    assert enabled_default_model_pair(["openai"]) == (SUPPORTED_ANTHROPIC, "high")
+
+
+def test_team_settings_rejects_unknown_or_all_disabled_providers() -> None:
+    with pytest.raises(ValueError, match="unsupported model providers"):
+        TeamSettingsUpdate(disabled_model_providers=["mystery"])
+    with pytest.raises(ValueError, match="at least one model provider"):
+        TeamSettingsUpdate(
+            disabled_model_providers=[
+                "anthropic",
+                "openai",
+                "google_genai",
+                "fireworks",
+                "baseten",
+            ]
+        )
 
 
 @pytest.mark.parametrize("model_id", [DEPRECATED_OPENAI, DEPRECATED_ANTHROPIC, DEPRECATED_GLM])
@@ -185,6 +217,22 @@ def test_profile_response_and_override_defer_deprecated_models() -> None:
     assert normalize_profile_overrides(
         {"default_model": DEPRECATED_GLM, "reasoning_effort": "high"}
     ) == (None, None)
+
+
+def test_disabling_provider_rewrites_team_defaults() -> None:
+    update = TeamSettingsUpdate(
+        disabled_model_providers=["anthropic"],
+        default_agent_model=SUPPORTED_ANTHROPIC,
+        default_agent_reasoning_effort="high",
+    )
+    assert update.default_agent_model == SUPPORTED_OPENAI
+    assert update.default_agent_reasoning_effort == "medium"
+
+
+def test_profile_update_rejects_disabled_provider() -> None:
+    update = ProfileUpdate(default_model=SUPPORTED_ANTHROPIC, reasoning_effort="high")
+    with pytest.raises(ValueError, match="provider is disabled"):
+        update.validate_pairing(["anthropic"])
 
 
 def test_team_settings_update_rejects_unknown_openai_model() -> None:

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -131,8 +131,15 @@ export interface ModelOption {
   context_window?: number | null
 }
 
+export interface ModelProviderOption {
+  id: string
+  label: string
+  enabled: boolean
+}
+
 export interface OptionsPayload {
   models: Array<ModelOption>
+  model_providers: Array<ModelProviderOption>
   default_agent_model: string
   default_agent_reasoning_effort: string
   default_agent_subagent_model: string
@@ -176,6 +183,7 @@ export interface TeamSettings {
   gateway_enabled?: boolean | null
   transcription_model?: string
   fable_enabled?: boolean
+  disabled_model_providers?: Array<string>
   review_tracing_project?: string | null
   org_guidelines?: string | null
   default_agent_model?: string | null

--- a/ui/src/routes/-admin.test.tsx
+++ b/ui/src/routes/-admin.test.tsx
@@ -1,9 +1,11 @@
 /** @vitest-environment jsdom */
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { SlackIntegrationSection } from "./admin"
+import { ModelProvidersSection, SlackIntegrationSection } from "./admin"
+import { api, type TeamSettings } from "@/lib/api"
 
 const STORAGE_KEY = "open-swe.admin.slack-code-channels-enabled"
 const storage = new Map<string, string>()
@@ -11,6 +13,30 @@ const localStorage = {
   clear: () => storage.clear(),
   getItem: (key: string) => storage.get(key) ?? null,
   setItem: (key: string, value: string) => storage.set(key, value),
+}
+
+const TEAM_SETTINGS: TeamSettings = {
+  review_draft_prs: false,
+  pr_summaries: true,
+  review_trace_links: true,
+  disabled_model_providers: [],
+}
+
+function renderModelProviders() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  client.setQueryData(["teamSettings"], TEAM_SETTINGS)
+  render(
+    <QueryClientProvider client={client}>
+      <ModelProvidersSection
+        providers={[
+          { id: "anthropic", label: "Anthropic", enabled: true },
+          { id: "openai", label: "OpenAI", enabled: true },
+        ]}
+      />
+    </QueryClientProvider>
+  )
 }
 
 describe("SlackIntegrationSection", () => {
@@ -52,5 +78,26 @@ describe("SlackIntegrationSection", () => {
     expect(
       JSON.parse(writeText.mock.calls[1]![0]).features.code_channels.enabled
     ).toBe(true)
+  })
+})
+
+describe("ModelProvidersSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("disables a provider through team settings", async () => {
+    const save = vi
+      .spyOn(api, "saveTeamSettings")
+      .mockImplementation(async (settings) => settings)
+    vi.spyOn(api, "getTeamSettings").mockResolvedValue(TEAM_SETTINGS)
+    renderModelProviders()
+
+    fireEvent.click(screen.getByRole("switch", { name: "Anthropic models" }))
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0]![0].disabled_model_providers).toEqual([
+      "anthropic",
+    ])
   })
 })

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -7,6 +7,7 @@ import type {
   DatadogConnectBody,
   LangSmithConnectBody,
   ModelOption,
+  ModelProviderOption,
   PRTraceResolutionResult,
   TeamSettings,
   UserMapping,
@@ -70,6 +71,8 @@ function AdminPage() {
       <WorkspaceMCPSection />
 
       <LLMGatewaySection />
+
+      <ModelProvidersSection providers={options.data?.model_providers ?? []} />
 
       <DictationSection />
 
@@ -919,6 +922,65 @@ function DictationSection() {
           }
         />
       )}
+      {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
+    </SettingsSection>
+  )
+}
+
+export function ModelProvidersSection({
+  providers,
+}: {
+  providers: Array<ModelProviderOption>
+}) {
+  const qc = useQueryClient()
+  const settings = useQuery({
+    queryKey: ["teamSettings"],
+    queryFn: api.getTeamSettings,
+  })
+  const [error, setError] = useState<string | null>(null)
+  const save = useMutation({
+    mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
+    onSuccess: (saved) => {
+      qc.setQueryData(["teamSettings"], saved)
+      qc.invalidateQueries({ queryKey: ["options"] })
+      setError(null)
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  const setEnabled = (providerId: string, enabled: boolean) => {
+    if (!settings.data) return
+    const disabled = new Set(settings.data.disabled_model_providers ?? [])
+    if (enabled) disabled.delete(providerId)
+    else disabled.add(providerId)
+    save.mutate({
+      ...settings.data,
+      disabled_model_providers: Array.from(disabled),
+    })
+  }
+
+  return (
+    <SettingsSection
+      title="Model providers"
+      description="Control which providers are available in model pickers and agent runs across this workspace."
+    >
+      <div className="divide-y divide-border">
+        {providers.map((provider) => (
+          <SettingsRow
+            key={provider.id}
+            label={provider.label}
+            description={`Allow models served by ${provider.label}.`}
+            control={
+              <Switch
+                aria-label={`${provider.label} models`}
+                checked={provider.enabled}
+                onCheckedChange={(enabled) => setEnabled(provider.id, enabled)}
+                disabled={!settings.data || save.isPending}
+              />
+            }
+          />
+        ))}
+      </div>
       {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
     </SettingsSection>
   )


### PR DESCRIPTION
### Summary

- default GPT-6 Astra and GPT-5.6 Sol reasoning effort to `low`
- add admin switches for enabling or disabling model providers
- filter disabled providers from model choices and gate saved/runtime selections to enabled defaults
- preserve existing settings compatibility and prevent disabling every provider

### Screenshot

![Model provider controls](https://01a08734-292d-711f-8817-5369981edb05--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1TnpjMk1qY3NJbXAwYVNJNklqQXhZVEE0TnpZd0xUUXlNalF0TjJVM1lTMWhNVEF4TFRZNU5qZzNaalV5Wm1WaU5pSXNJbk5wWkNJNklqQXhZVEE0TnpNMExUSTVNbVF0TnpFeFppMDRPREUzTFRVek5qazVPREZsWkdJd05TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Ylc5a1pXd3RjSEp2ZG1sa1pYSnpMV0ZrYldsdUxuQnVaeUlzSW1OMElqb2lhVzFoWjJVdmNHNW5JaXdpWTJRaU9pSnBibXhwYm1VaWZRLm5vak9qdlFBbTNQR3ZDSi1lRWp6dVEyb0w0enhpR1JaaWZvaV8tZVVyY2RmdE5hdDROaXVnNmdMRU41NVVsb2NJN0VPUWItRlU2Mk1SZzluZkpybkRR)

Made by [Open SWE](https://openswe.vercel.app/agents/e982cf3b-30e7-5256-8ae5-2ee2052f150d) · openai:gpt-5.6-sol (high)