### PR TITLE
fix: restore native macOS window controls

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1042,10 +1042,12 @@ function createMenu() {
         { role: "togglefullscreen" },
       ],
     },
-    {
-      label: "Window",
-      submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }],
-    },
+    process.platform === "darwin"
+      ? { role: "windowMenu" }
+      : {
+          label: "Window",
+          submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }],
+        },
     {
       role: "help",
       submenu: [


### PR DESCRIPTION
### Summary

- assign Electron’s native `windowMenu` role on macOS
- restore AppKit’s Move & Resize, tiling, and related `Fn-Control` shortcuts
- preserve the existing Window menu on Windows and Linux

Made by [Open SWE](https://openswe.vercel.app/agents/c92ced0c-0547-5adb-9fda-0868c695a19c) · openai:gpt-5.6-sol (high)