### PR TITLE
feat(desktop): add manual update check

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -42,6 +42,10 @@
     ],
     "extraResources": [
       {
+        "from": "resources/app-update.yml",
+        "to": "app-update.yml"
+      },
+      {
         "from": "resources/icon.png",
         "to": "icon.png"
       },

--- a/desktop/resources/app-update.yml
+++ b/desktop/resources/app-update.yml
@@ -1,0 +1,4 @@
+provider: github
+owner: langchain-ai
+repo: open-swe
+updaterCacheDirName: open-swe-desktop-updater

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -146,6 +146,31 @@ function configureAutoUpdater() {
     );
 }
 
+async function checkForDesktopUpdates() {
+  try {
+    const result = await autoUpdater.checkForUpdates();
+    if (result?.isUpdateAvailable) {
+      await dialog.showMessageBox({
+        type: "info",
+        message: `${appRuntime.name} ${result.updateInfo.version} is available`,
+        detail: "The update is downloading and will be ready to install soon.",
+      });
+      return;
+    }
+    await dialog.showMessageBox({
+      type: "info",
+      message: `${appRuntime.name} is up to date`,
+      detail: `Version ${app.getVersion()} is the latest available version.`,
+    });
+  } catch (error) {
+    console.warn("Could not check for desktop updates", error);
+    dialog.showErrorBox(
+      `Could not check for ${appRuntime.name} updates`,
+      error.message,
+    );
+  }
+}
+
 function sendDesktopCommand(commandId) {
   if (!isDesktopCommandId(commandId) || !mainWindow || mainWindow.isDestroyed())
     return;
@@ -962,6 +987,11 @@ function createMenu() {
     accelerator: "CmdOrCtrl+,",
     click: () => sendDesktopCommand("open-settings"),
   };
+  const checkForUpdatesItem = {
+    label: "Check for Updates…",
+    enabled: app.isPackaged,
+    click: () => void checkForDesktopUpdates(),
+  };
   const template = [
     ...(process.platform === "darwin"
       ? [
@@ -970,6 +1000,7 @@ function createMenu() {
             submenu: [
               { role: "about" },
               settingsItem,
+              checkForUpdatesItem,
               backendSettingsItem,
               { type: "separator" },
               { role: "services" },


### PR DESCRIPTION
Adds a native macOS “Check for Updates…” menu item immediately after “Settings…”. It runs the existing desktop updater and reports whether an update is downloading, the app is current, or the check failed.

<img width="300" height="136" alt="Screenshot" src="https://github.com/user-attachments/assets/fc3afc6c-1e96-4192-a539-138206025269" />


<img width="338" height="304" alt="Screenshot" src="https://github.com/user-attachments/assets/b512f650-4a1a-4683-bc8a-cca45fc9b59b" />


Made by [Open SWE](https://openswe.vercel.app/agents/3cf4f9d6-bee1-5dc4-91cb-6a60953230cd) · openai:gpt-5.6-sol (high)