### PR TITLE
fix(slack): dismiss saved feedback controls

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -789,6 +789,43 @@ async def stop_slack_stream(
             raise
 
 
+def _validate_slack_response_url(url: str) -> tuple[bool, str]:
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").lower() not in {"hooks.slack.com", "hooks.slack-gov.com"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port not in (None, 443)
+    ):
+        return False, "Slack returned an invalid response URL"
+    return True, ""
+
+
+async def replace_slack_interaction_message(response_url: str, text: str) -> bool:
+    """Replace the message that originated a Slack interaction."""
+    if not response_url:
+        return False
+    block = {"type": "section", "text": {"type": "plain_text", "text": text}}
+    try:
+        async with httpx2.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
+            response, blocked = await request_with_safe_redirects(
+                http_client,
+                "POST",
+                response_url,
+                json={"replace_original": True, "text": text, "blocks": [block]},
+                validate_url=_validate_slack_response_url,
+            )
+        if blocked or response is None:
+            logger.warning("Slack interaction response URL was blocked")
+            return False
+        response.raise_for_status()
+        return True
+    except httpx2.HTTPError:
+        logger.exception("Slack interaction message replacement failed")
+        return False
+
+
 async def update_slack_message(
     channel_id: str,
     message_ts: str,

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -16,6 +16,7 @@ from agent.slack.client import (
     lookup_slack_run_message_mapping,
     open_slack_modal,
     post_slack_ephemeral_message,
+    replace_slack_interaction_message,
     slack_channel_allows_operations,
     slack_thread_mutation_lock,
 )
@@ -201,7 +202,7 @@ async def _load_feedback(channel_id: str, run_id: str, user_id: str) -> ThreadFe
     return record if slack_channel_allows_operations(context) else None
 
 
-def comment_modal(record: ThreadFeedback) -> dict[str, Any]:
+def comment_modal(record: ThreadFeedback, response_url: str = "") -> dict[str, Any]:
     element: dict[str, Any] = {
         "type": "plain_text_input",
         "action_id": "comment",
@@ -214,7 +215,9 @@ def comment_modal(record: ThreadFeedback) -> dict[str, Any]:
     return {
         "type": "modal",
         "callback_id": _COMMENT_ACTION,
-        "private_metadata": json.dumps({"channel_id": record.channel_id, "run_id": record.run_id}),
+        "private_metadata": json.dumps(
+            {"channel_id": record.channel_id, "run_id": record.run_id, "response_url": response_url}
+        ),
         "title": {"type": "plain_text", "text": "Open SWE feedback"},
         "submit": {"type": "plain_text", "text": "Save"},
         "close": {"type": "plain_text", "text": "Cancel"},
@@ -279,16 +282,11 @@ async def _export_current_feedback(record: ThreadFeedback) -> None:
         )
 
 
-async def _acknowledge(record: ThreadFeedback, *, with_comment_button: bool) -> None:
+async def _acknowledge(record: ThreadFeedback, response_url: str = "") -> None:
     text = "Thanks — your feedback was saved."
-    block: dict[str, Any] = {"type": "section", "text": {"type": "plain_text", "text": text}}
-    if with_comment_button:
-        block["accessory"] = {
-            "type": "button",
-            "text": {"type": "plain_text", "text": "Add comments"},
-            "action_id": _COMMENT_ACTION,
-            "value": record.run_id,
-        }
+    if response_url and await replace_slack_interaction_message(response_url, text):
+        return
+    block = {"type": "section", "text": {"type": "plain_text", "text": text}}
     await post_slack_ephemeral_message(
         record.channel_id,
         record.user_id,
@@ -332,7 +330,7 @@ async def _process_rating(payload: dict[str, Any]) -> None:
                 channel_id, user_id, "Your rating could not be saved. Please try again."
             )
         return
-    await _acknowledge(record, with_comment_button=True)
+    await _acknowledge(record, str(payload.get("response_url") or ""))
     await _export_feedback(record)
 
 
@@ -374,7 +372,7 @@ async def handle_slack_feedback_interaction(
         except Exception:
             logger.warning("Could not save Slack feedback comment", exc_info=True)
             return _comment_error("Your comment could not be saved. Please try again.")
-        background_tasks.add_task(_acknowledge, record, with_comment_button=False)
+        background_tasks.add_task(_acknowledge, record, str(metadata.get("response_url") or ""))
         background_tasks.add_task(_export_feedback, record)
         return {}
 
@@ -393,7 +391,9 @@ async def handle_slack_feedback_interaction(
             if (
                 isinstance(trigger_id, str)
                 and trigger_id
-                and await open_slack_modal(trigger_id, comment_modal(record))
+                and await open_slack_modal(
+                    trigger_id, comment_modal(record, str(payload.get("response_url") or ""))
+                )
             ):
                 return {}
     except Exception:

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -69,6 +69,33 @@ async def test_ephemeral_feedback_sends_blocks_and_thread(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_replace_interaction_message_removes_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_cm = _async_client_cm(_ok_response())
+    safe_request = AsyncMock(return_value=(_ok_response(), None))
+    monkeypatch.setattr(slack_utils, "request_with_safe_redirects", safe_request)
+
+    with patch.object(slack_utils.httpx2, "AsyncClient", return_value=client_cm):
+        assert await slack_utils.replace_slack_interaction_message(
+            "https://hooks.slack.com/actions/T1/B1/token", "Feedback saved"
+        )
+
+    assert safe_request.await_args.args[1:3] == (
+        "POST",
+        "https://hooks.slack.com/actions/T1/B1/token",
+    )
+    assert safe_request.await_args.kwargs["json"] == {
+        "replace_original": True,
+        "text": "Feedback saved",
+        "blocks": [{"type": "section", "text": {"type": "plain_text", "text": "Feedback saved"}}],
+    }
+    validate = safe_request.await_args.kwargs["validate_url"]
+    assert validate("https://hooks.slack.com/actions/T1/B1/token")[0]
+    assert not validate("https://example.com/actions/T1/B1/token")[0]
+
+
+@pytest.mark.asyncio
 async def test_modal_sends_trigger_and_view(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
     client_cm = _async_client_cm(_ok_response())

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -44,6 +44,7 @@ def context(monkeypatch: pytest.MonkeyPatch, fake_store: Any) -> dict[str, Any]:
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
     monkeypatch.setattr(feedback, "post_slack_ephemeral_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(feedback, "replace_slack_interaction_message", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "open_slack_modal", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", AsyncMock(return_value=True))
     client = AsyncMock()
@@ -70,6 +71,7 @@ def _action(action_id: str = "open_swe_feedback_rate_5", value: str = "run-1") -
         "trigger_id": "trigger-1",
         "channel": {"id": "C1"},
         "user": {"id": "U1"},
+        "response_url": "https://hooks.slack.com/actions/T1/B1/token",
         "actions": [{"action_id": action_id, "value": value, "action_ts": "3.0"}],
     }
 
@@ -100,10 +102,10 @@ async def test_rating_is_saved_privately_without_starting_agent(
             "run_id": "run-1",
         },
     )
-    call = feedback.post_slack_ephemeral_message.await_args
-    assert call.args[:2] == ("C1", "U1")
-    assert call.kwargs["thread_ts"] == "1.0"
-    assert call.kwargs["blocks"][0]["accessory"]["action_id"] == "open_swe_feedback_comment"
+    feedback.replace_slack_interaction_message.assert_awaited_once_with(
+        "https://hooks.slack.com/actions/T1/B1/token", "Thanks — your feedback was saved."
+    )
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -156,7 +158,11 @@ async def test_comment_modal_opens_with_saved_rating_and_comment(
     feedback.open_slack_modal.assert_awaited_once()
     trigger_id, view = feedback.open_slack_modal.await_args.args
     assert trigger_id == "trigger-1"
-    assert json.loads(view["private_metadata"]) == {"channel_id": "C1", "run_id": "run-1"}
+    assert json.loads(view["private_metadata"]) == {
+        "channel_id": "C1",
+        "run_id": "run-1",
+        "response_url": "https://hooks.slack.com/actions/T1/B1/token",
+    }
     assert view["blocks"][-1]["element"]["initial_value"] == "Useful"
 
 
@@ -180,7 +186,13 @@ def _submission(comment: str = "Please run the tests next time.") -> dict[str, A
         "user": {"id": "U1"},
         "view": {
             "callback_id": "open_swe_feedback_comment",
-            "private_metadata": json.dumps({"channel_id": "C1", "run_id": "run-1"}),
+            "private_metadata": json.dumps(
+                {
+                    "channel_id": "C1",
+                    "run_id": "run-1",
+                    "response_url": "https://hooks.slack.com/actions/T1/B1/token",
+                }
+            ),
             "state": {"values": {"feedback_comment": {"comment": {"value": comment}}}},
         },
     }
@@ -216,6 +228,10 @@ async def test_comment_submission_updates_same_feedback(context: Any, fake_store
         == "Please run the tests next time."
     )
     await tasks()
+    feedback.replace_slack_interaction_message.assert_awaited_once_with(
+        "https://hooks.slack.com/actions/T1/B1/token", "Thanks — your feedback was saved."
+    )
+    feedback.post_slack_ephemeral_message.assert_not_awaited()
     assert feedback.create_langsmith_thread_feedback.await_args.args == (
         "thread-1",
         "slack_rating:C1:U1:run-1",
@@ -372,6 +388,7 @@ async def test_rating_failure_does_not_acknowledge_success(
     await routes.slack_interactivity(_request(_action()), tasks)
     await tasks()
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
+    feedback.replace_slack_interaction_message.assert_not_awaited()
     assert "could not be saved" in feedback.post_slack_ephemeral_message.await_args.args[2]
 
 


### PR DESCRIPTION
### Summary

Replace the original private Slack feedback prompt with its saved confirmation after a rating or comment is persisted, removing the now-stale rating and comment controls. If Slack cannot replace the prompt, preserve the confirmation fallback as a separate ephemeral message.

The interaction response URL is restricted to Slack-owned HTTPS hosts and requested through the existing SSRF-safe redirect helper.

Made by [Open SWE](https://openswe.vercel.app/agents/ade5b5ad-7d70-577b-b3a1-662d9ce7dac0) · openai:gpt-5.6-sol (high)