### PR TITLE
docs: hyphenate open-source in README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </div>
 
 <div align="center">
-  <h3>An open source software factory built on Deep Agents by LangChain.</h3>
+  <h3>An open-source software factory built on Deep Agents by LangChain.</h3>
 </div>
 
 <div align="center">


### PR DESCRIPTION
Hyphenate “open-source” in the README tagline for consistent compound-adjective punctuation.

Made by [Open SWE](https://dev.open-swe.langchain.dev/agents/a2c7357e-e9a9-57fd-a0f3-70b9e26ff64c) · openai:gpt-5.6-sol (high)