### PR TITLE
fix: respect no-project compose selection

### DIFF
--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -63,9 +63,11 @@ const NEW_AGENT_PANEL_REF = {
 export function AgentsHome({
   initialRepo,
   initialLocalProject,
+  initialNoProject,
 }: {
   initialRepo?: string
   initialLocalProject?: string
+  initialNoProject?: boolean
 }) {
   const stream = useAgentStream()
   const queryClient = useQueryClient()
@@ -149,7 +151,7 @@ export function AgentsHome({
   const skills = useAgentSkills({ enabled: cloudEnabled })
   // undefined = untouched (fall back to the profile default); null = explicitly "no repo".
   const [repoOverride, setRepoOverride] = useState<string | null | undefined>(
-    initialRepo
+    initialNoProject ? null : initialRepo
   )
   const repo =
     repoOverride === undefined

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -111,7 +111,11 @@ export function AgentsHome({
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
   const [desktopThreadSource, setDesktopThreadSource] = useDesktopThreadSource()
   const [runTargetOverride, setRunTargetOverride] = useState<RunTarget | null>(
-    initialLocalProject ? "local" : initialRepo ? "cloud" : null
+    initialLocalProject
+      ? "local"
+      : initialRepo || initialNoProject
+        ? "cloud"
+        : null
   )
   const runTarget: RunTarget = isDesktop
     ? cloudEnabled

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -591,7 +591,9 @@ export function AgentsSidebar({
           to: "/agents",
           search: group.repoFullName
             ? { repo: group.repoFullName }
-            : { localProject: group.localProjectPath },
+            : group.localProjectPath
+              ? { localProject: group.localProjectPath }
+              : { noProject: true },
         })
       }}
       onTogglePin={() => toggleProjectPin(group.key)}

--- a/ui/src/routes/agents/index.tsx
+++ b/ui/src/routes/agents/index.tsx
@@ -5,6 +5,7 @@ import { AgentsHome } from "@/features/agents/components/AgentsHome"
 interface AgentsIndexSearch {
   repo?: string
   localProject?: string
+  noProject?: boolean
 }
 
 export const Route = createFileRoute("/agents/")({
@@ -15,17 +16,21 @@ export const Route = createFileRoute("/agents/")({
     ...(typeof search.localProject === "string" && search.localProject.trim()
       ? { localProject: search.localProject.trim() }
       : {}),
+    ...(search.noProject === true || search.noProject === "true"
+      ? { noProject: true }
+      : {}),
   }),
   component: AgentsIndexPage,
 })
 
 function AgentsIndexPage() {
-  const { repo, localProject } = Route.useSearch()
+  const { repo, localProject, noProject } = Route.useSearch()
   return (
     <AgentsHome
-      key={`${repo ?? ""}:${localProject ?? ""}`}
+      key={`${repo ?? ""}:${localProject ?? ""}:${noProject ?? ""}`}
       initialRepo={repo}
       initialLocalProject={localProject}
+      initialNoProject={noProject}
     />
   )
 }


### PR DESCRIPTION
Clicking compose from the **No project** sidebar group now explicitly opens a composer without a project instead of falling back to the user's default project.

The screenshot shows the originating **No project** sidebar group and the resulting checked **Don't work in a project** selection together.

![No-project sidebar compose opens with “Don't work in a project” selected](https://01a08774-111d-7285-bdc9-5dc3fc0c2090--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1TnprNU56Y3NJbXAwYVNJNklqQXhZVEE0TnpnMExURmxaR0l0TnpreU55MDVOR1l5TFdVd1pURXhNamc1WlRNeE55SXNJbk5wWkNJNklqQXhZVEE0TnpjMExURXhNV1F0TnpJNE5TMWlaR001TFRWa1l6Tm1ZekJqTWpBNU1DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Ym04dGNISnZhbVZqZEMxamIyMXdiM05sTFhCeWIyOW1MbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5ReU16eWVqZy1DOUtuUHZXYVl2ekVtY0lEeGF6ZXNDeEVhVHlXTnhSY2NMcmd3d09mVGlfU2tHdFRJbTJTaXNsRDVTQUkzOHJ1QllVVXg5a1VWYWFEZw)

Made by [Open SWE](https://openswe.vercel.app/agents/1826d990-46bb-5555-b126-10ec4a62dce8) · openai:gpt-5.6-sol (high)
